### PR TITLE
Adds the `rust_icu` effort to the ecosystem.

### DIFF
--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -5,22 +5,29 @@ This document tracks the crates that already exist in the ecosystem that cover f
 
 Where multiple maintainers are listed, the first name is the primary maintainer: e.g. Manish is a member of the Servo org but does not primarily maintain some of these crates.
 
-| **API**               | **Rust Eqivalent**                                             | **Maintainer**      | **CLDR-Aware**   | **Action** | **Notes**                                                          |
-|-----------------------|----------------------------------------------------------------|---------------------|------------------|------------|--------------------------------------------------------------------|
-| icu::DateTimeFormat   | [unic-datetime](https://github.com/zbraniecki/unic-datetime)   | Zibi                | Yes              | Import     |                                                                    |
-| icu::Locale           | [unic-locale](https://github.com/zbraniecki/unic-locale)       | Zibi                | Yes              | Import     |                                                                    |
-| icu::Bidi             | [unicode-bidi](http://docs.rs/unicode-bidi)                    | Servo / Manish      | N/A              | No Action  | Bidi and text layout are unlikely to be coming to ECMA-402         |
-| icu::Normalization    | [unicode-normalization](http://docs.rs/unicode-normalization/) | Manish / unicode-rs | No               | Uncertain  | Main issue: [#40](https://github.com/unicode-org/omnicu/issues/40) |
-| icu::Script           | [unicode-script](http://docs.rs/unicode-script/)               | Manish              | N/A              | No Action  | ICU4X should expose UCD data through its own custom pipeline       |
-| icu::IDNa             | [idna](http://docs.rs/idna/)                                   | Servo / Manish      | CLDR confusables | Uncertain  | Main issue: [#42](https://github.com/unicode-org/omnicu/issues/42) |
-| icu::PluralRules      | [intl-pluralrules](https://github.com/zbraniecki/pluralrules)  | Zibi                | Yes              | Import     |                                                                    |
-| icu::BreakIterator    | [unicode-segmentation](https://docs.rs/unicode-segmentation/)  | Manish / unicode-rs | No               | No Action  | No line segmentation. Wait for clear user demand outside Rust      |
-| icu::Collator         | -                                                              |                     |                  |            |                                                                    |
-| icu::NumberFormatter  | [Early Google POC](https://github.com/sffc/rust-wasm-i18n)     | Shane               | ?                | Import     |                                                                    |
-| icu::CharConversion   | -                                                              |                     |                  |            |                                                                    |
-| icu::Char             | -                                                              |                     |                  |            |                                                                    |
-| icu::TimeZone         | -                                                              |                     |                  |            |                                                                    |
-| icu::Regex            | [regex](https://docs.rs/regex/1.3.7/regex/)                    | Core Rust Team      | ?                | No Action  | Main issue: [#37](https://github.com/unicode-org/omnicu/issues/37) |
-| icu::Calendar         | -                                                              |                     |                  |            |                                                                    |
-| icu::ListFormatter    | -                                                              |                     |                  |            |                                                                    |
-| icu::RelativeDateTime | -                                                              |                     |                  |            |                                                                    |
+| **API**                 | **Rust Eqivalent**                                             | **Maintainer**      | **CLDR-Aware**   | **Action** | **Notes**                                                          |
+|-------------------------|----------------------------------------------------------------|---------------------|------------------|------------|--------------------------------------------------------------------|
+| `icu::DateTimeFormat`   | [unic-datetime](https://github.com/zbraniecki/unic-datetime)   | Zibi                | Yes              | Import     |                                                                    |
+|                         | [rust_icu_udat](https://crates.io/crates/rust_icu_udat)        | filmil, kpozin      | Yes              | Uncertain  | Rust wrapper around ICU4C                                          |
+| `icu::Locale`           | [unic-locale](https://github.com/zbraniecki/unic-locale)       | Zibi                | Yes              | Import     |                                                                    |
+|                         | [rust_icu_uloc](https://crates.io/crates/rust_icu_uloc)        | filmil, kpozin      | Yes              | Uncertain  | Rust wrapper around ICU4C                                          |
+| `icu::Bidi`             | [unicode-bidi](http://docs.rs/unicode-bidi)                    | Servo / Manish      | N/A              | No Action  | Bidi and text layout are unlikely to be coming to ECMA-402         |
+| `icu::Normalization`    | [unicode-normalization](http://docs.rs/unicode-normalization/) | Manish / unicode-rs | No               | Uncertain  | Main issue: [#40](https://github.com/unicode-org/icu4x/issues/40) |
+| `icu::Script`           | [unicode-script](http://docs.rs/unicode-script/)               | Manish              | N/A              | No Action  | ICU4X should expose UCD data through its own custom pipeline       |
+| `icu::IDNa`             | [idna](http://docs.rs/idna/)                                   | Servo / Manish      | CLDR confusables | Uncertain  | Main issue: [#42](https://github.com/unicode-org/icu4x/issues/42) |
+| `icu::PluralRules`      | [intl-pluralrules](https://github.com/zbraniecki/pluralrules)  | Zibi                | Yes              | Import     |                                                                    |
+|                         | [rust_icu_intl][1]                                             | filmil, kpozin      | Yes              | Uncertain  |                                                                    |
+| `icu::BreakIterator`    | [unicode-segmentation](https://docs.rs/unicode-segmentation/)  | Manish / unicode-rs | No               | No Action  | No line segmentation. Wait for clear user demand outside Rust      |
+| `icu::Collator`         | -                                                              |                     |                  |            |                                                                    |
+| `icu::NumberFormatter`  | [Early Google POC](https://github.com/sffc/rust-wasm-i18n)     | Shane               | ?                | Import     |                                                                    |
+| `icu::CharConversion`   | -                                                              |                     |                  |            |                                                                    |
+| `icu::Char`             | [rust_icu_ustring](https://crates.io/crates/rust_icu_ustring)  | filmil, kpozin      | Yes              | Uncertain  |                                                                    |
+| `icu::TimeZone`         | -                                                              |                     |                  |            |                                                                    |
+| `icu::Regex`            | [regex](https://docs.rs/regex/1.3.7/regex/)                    | Core Rust Team      | ?                | No Action  | Main issue: [#37](https://github.com/unicode-org/icu4x/issues/37) |
+| `icu::Calendar`         | [rust_icu_ucal](https://crates.io/crates/rust_icu_ucal)        | filmil, kpozin      | Yes              | Uncertain  | Rust wrapper around ICU4C                                          |
+| `icu::ListFormatter`    | -                                                              |                     |                  |            |                                                                    |
+| `icu::RelativeDateTime` | -                                                              |                     |                  |            |                                                                    |
+| `icu::MessageFormat`    | [rust_icu_umsg][2]                                             | filmil, kpozin      | Yes              | Uncertain  |                                                                    |
+
+[1]: https://github.com/google/rust_icu/tree/master/rust_icu_intl
+[2]: https://crates.io/crates/rust_icu_umsg


### PR DESCRIPTION
Added the crates that exist in `rust_icu` and are relevant to the
ICU4X's ecosystem.

`rust_icu` is at this time a fairly easy way to bring in ICU functionality
into your rust code.  This has value for teams that need ICU
functionality *now*, and even when ICU4X becomes widely available still
have a way to go to transition to the use of ICU4X from ICU.

Fixes: #33