### PR TITLE
Refactor Variant subtag to be a single field.

### DIFF
--- a/components/locale/src/langid.rs
+++ b/components/locale/src/langid.rs
@@ -58,7 +58,7 @@ pub struct LanguageIdentifier {
     /// Region subtag of the LanguageIdentifier
     pub region: Option<subtags::Region>,
     /// Variant subtags of the LanguageIdentifier
-    pub variants: subtags::Variants,
+    pub variant: Option<subtags::Variant>,
 }
 
 impl LanguageIdentifier {
@@ -136,9 +136,9 @@ impl std::fmt::Display for LanguageIdentifier {
             f.write_char('-')?;
             region.fmt(f)?;
         }
-        if !self.variants.is_empty() {
+        if let Some(ref variant) = self.variant {
             f.write_char('-')?;
-            self.variants.fmt(f)?;
+            variant.fmt(f)?;
         }
         Ok(())
     }

--- a/components/locale/src/subtags/mod.rs
+++ b/components/locale/src/subtags/mod.rs
@@ -50,10 +50,8 @@ mod language;
 mod region;
 mod script;
 mod variant;
-mod variants;
 
 pub use language::Language;
 pub use region::Region;
 pub use script::Script;
 pub use variant::Variant;
-pub use variants::Variants;

--- a/components/locale/tests/fixtures/canonicalize.json
+++ b/components/locale/tests/fixtures/canonicalize.json
@@ -13,6 +13,6 @@
   },
   {
     "input": "en-scouse-fonipa",
-    "output": "en-fonipa-scouse"
+    "output": "en-scouse-fonipa"
   }
 ]

--- a/components/locale/tests/fixtures/langid.json
+++ b/components/locale/tests/fixtures/langid.json
@@ -54,7 +54,7 @@
       "language": "en",
       "script": "Latn",
       "region": "US",
-      "variants": ["windows"]
+      "variant": "windows"
     }
   },
   {
@@ -64,7 +64,7 @@
       "language": "lij",
       "script": "Arab",
       "region": "FA",
-      "variants": ["linux"]
+      "variant": "linux"
     }
   },
   {
@@ -74,7 +74,7 @@
       "language": "lij",
       "script": "Arab",
       "region": "FA",
-      "variants": ["linux", "nedis"]
+      "variant": "linux-nedis"
     }
   },
   {
@@ -91,7 +91,7 @@
     "output": {
       "type": "LanguageIdentifier",
       "language": "sl",
-      "variants": ["nedis"]
+      "variant": "nedis"
     }
   },
   {
@@ -100,7 +100,7 @@
       "type": "LanguageIdentifier",
       "language": "de",
       "region": "CH",
-      "variants": ["1996"]
+      "variant": "1996"
     }
   },
   {
@@ -145,7 +145,7 @@
     "output": {
       "type": "LanguageIdentifier",
       "language": "pl",
-      "variants": ["arabic", "macos", "nedis", "windows"]
+      "variant": "macos-windows-nedis-macos-nedis-arabic"
     }
   },
   {
@@ -153,7 +153,7 @@
     "output": {
       "type": "LanguageIdentifier",
       "script": "Latn",
-      "variants": ["macos"]
+      "variant": "macos"
     }
   },
   {

--- a/components/locale/tests/fixtures/mod.rs
+++ b/components/locale/tests/fixtures/mod.rs
@@ -18,7 +18,7 @@ pub struct LocaleSubtags {
     pub script: Option<String>,
     pub region: Option<String>,
     #[serde(default)]
-    pub variants: Vec<String>,
+    pub variant: Option<String>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -72,16 +72,14 @@ impl TryFrom<LocaleSubtags> for LanguageIdentifier {
         let region = subtags
             .region
             .map(|s| s.parse().expect("Failed to parse region subtag."));
-        let variants = subtags
-            .variants
-            .iter()
-            .map(|v| v.parse().expect("Failed to parse variant subtag."))
-            .collect::<Vec<_>>();
+        let variant = subtags
+            .variant
+            .map(|v| v.parse().expect("Failed to parse variant subtag."));
         Ok(LanguageIdentifier {
             language,
             script,
             region,
-            variants: subtags::Variants::from_vec_unchecked(variants),
+            variant,
         })
     }
 }

--- a/components/locale/tests/langid.rs
+++ b/components/locale/tests/langid.rs
@@ -95,16 +95,6 @@ fn test_langid_subtag_script() {
 #[test]
 fn test_langid_subtag_variant() {
     let variant: subtags::Variant = "macos".parse().expect("Failed to parse a variant.");
-    let s: &str = (&variant).into();
+    let s: &str = &variant.to_string();
     assert_eq!(s, "macos");
-    assert_eq!(variant, "macos");
-}
-
-#[test]
-fn test_langid_subtag_variants() {
-    let variant: subtags::Variant = "macos".parse().expect("Failed to parse a variant.");
-    let mut variants = subtags::Variants::from_vec_unchecked(vec![variant]);
-    assert_eq!(variants.get(0).unwrap(), "macos");
-    variants.clear();
-    assert_eq!(variants.len(), 0);
 }


### PR DESCRIPTION
This is a draft of how the change to how we treat variants may look like.

Performance and memory wise this change doesn't affect the numbers, but it makes us treat `Variant` as a single field.
I currently use `Box<[TinyStr8]>` to store it. Alternatively, we could try with `TinyStr16` and make a case that we don't support variants longer than 16 chars, but unfortunately IIRC `TinyStr` doesn't allow for `-` in them, so that may be a blocker.
We could also just store it as `String` or `Box<[u8]>`...

The main benefit is that we wouldn't deal with sorting/deduplicating of the variants and all comparisons are basically `string == string`.

I'm not sure if it's worth it, or which path to take, but wanted to dump the PR for consideration and experimentation.