### PR TITLE
Add serde Serialize/Deserialize for LanguageIdentifier.

### DIFF
--- a/components/locale/Cargo.toml
+++ b/components/locale/Cargo.toml
@@ -16,6 +16,7 @@ include = [
 
 [dependencies]
 tinystr = "0.3"
+serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/components/locale/src/lib.rs
+++ b/components/locale/src/lib.rs
@@ -38,6 +38,8 @@
 //! [`ICU4X`]: https://github.com/unicode-org/icu4x
 mod langid;
 mod parser;
+#[cfg(feature = "serde")]
+mod serde;
 pub mod subtags;
 
 pub use langid::LanguageIdentifier;

--- a/components/locale/src/serde/langid.rs
+++ b/components/locale/src/serde/langid.rs
@@ -1,0 +1,69 @@
+use crate::LanguageIdentifier;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+impl Serialize for LanguageIdentifier {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for LanguageIdentifier {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct LanguageIdentifierVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for LanguageIdentifierVisitor {
+            type Value = LanguageIdentifier;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(formatter, "a valid Unicode Language Identifier")
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                s.parse::<LanguageIdentifier>()
+                    .map_err(serde::de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_string(LanguageIdentifierVisitor)
+    }
+}
+
+#[test]
+fn serialize() -> Result<(), Box<dyn std::error::Error>> {
+    let fr = serde_json::json!("fr".parse::<LanguageIdentifier>()?);
+    let en = serde_json::json!("en-US".parse::<LanguageIdentifier>()?);
+
+    assert_eq!(serde_json::to_string(&fr)?, r#""fr""#);
+    assert_eq!(serde_json::to_string(&en)?, r#""en-US""#);
+
+    Ok(())
+}
+
+#[test]
+fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
+    let fr = serde_json::from_str::<LanguageIdentifier>(r#""fr""#)?;
+    let en = serde_json::from_str::<LanguageIdentifier>(r#""en-US""#)?;
+
+    assert_eq!(fr, "fr".parse::<LanguageIdentifier>()?);
+    assert_eq!(en, "en-US".parse::<LanguageIdentifier>()?);
+
+    let failed = serde_json::from_str::<LanguageIdentifier>(r#""2Xs""#);
+    assert!(failed.is_err());
+    let err = failed.unwrap_err();
+    assert!(err.is_data());
+    assert_eq!(
+        err.to_string(),
+        "The given language subtag is invalid at line 1 column 5".to_string()
+    );
+
+    Ok(())
+}

--- a/components/locale/src/serde/mod.rs
+++ b/components/locale/src/serde/mod.rs
@@ -1,0 +1,1 @@
+mod langid;


### PR DESCRIPTION
This is a simple port of https://github.com/zbraniecki/unic-locale/pull/57 which adds serializer/deserializer for `LanguageIdentifier` enabled when the crate is compiled with `serde`.