### PR TITLE
Add code coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,35 @@
+name:                           Coverage
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: '*'
+
+jobs:
+  test:
+
+    name:                       Coverage
+    runs-on:                    ubuntu-latest
+
+    steps:
+      - name:                   Checkout repository
+        uses:                   actions/checkout@v2
+
+      - name:                   Install stable toolchain
+        uses:                   actions-rs/toolchain@v1
+        with:
+          toolchain:            stable
+          override:             true
+
+      - name:                   Generate code coverage
+        uses:                   actions-rs/tarpaulin@v0.1
+        with:
+          version:              '0.9.0'
+          args:                 '-- --test-threads 1'
+
+  
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds basic code coverage. I decided to give codecov a try, since I'm only familiar with coveralls.

Here's an example of a coverage generated from this PR - https://codecov.io/gh/zbraniecki/icu4x/src/830d86c39044b532186b6c4cddac8324e2ea4b82/components/locale/src/parser/langid.rs

Here's a comparable view for coveralls: https://coveralls.io/builds/30710032/source?filename=unic-langid-impl/src/parser/mod.rs

If anyone has a strong preference for the latter, I can switch this action.