### PR TITLE
fix CI caching by pointing to correct manifest file

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,19 +26,19 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
 
     - name: Cache cargo index
       uses: actions/cache@v1
       with:
         path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
 
     - name: Cache cargo build
       uses: actions/cache@v1
       with:
         path: target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
 
     ## Build and run steps
         

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,19 +21,19 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Cache cargo index
         uses: actions/cache@v1
         with:
           path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Cache cargo build
         uses: actions/cache@v1
         with:
           path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
 
       ## Coverage steps
 


### PR DESCRIPTION
Caching hasn't been working as intended because I kept the defaults from the [starter cache action config for Rust](https://github.com/actions/cache/blob/master/examples.md#rust---cargo), but it points to `Cargo.lock` as the indicator of dep changes, and we use `Cargo.toml` only without having a .lock file checked in.  I learned that our setup [makes sense to do for a lib like ours](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html) (vs. a standalone app).

Pointing to a non-existent file meant that we were getting the same hash value (null / empty string) and causing spurious cache hits, so we weren't causing the post-workflow cache save to take place.

Making the appropriate changes sped up the "Build & Test" workflow because a lot of time was spent in both the `cargo build` and `cargo test` steps doing compilation of some of the downloaded crates.

The problem that still remains is that the "Coverage" workflow doesn't see a speed up.  Is this because it is configured to use the nightly build of Rust (which in turn may be required by the `grcov` code coverage tool)?  The Coverage workflow's `actions-rs/cargo` step invokes this command as a part of its work: `/usr/share/rust/.cargo/bin/cargo test --all-features --no-fail-fast`, which is triggering a fresh download and compile of dependencies, FWIW.

Runtime numbers have some variance, but here are some examples:

Before/After  |  Build & Test | Coverage
----------|------------------|------------------
Before PR fix | [1m56s](https://github.com/unicode-org/icu4x/runs/691122676?check_suite_focus=true) | [4m54s](https://github.com/unicode-org/icu4x/runs/691122725?check_suite_focus=true)
After PR fix | [33s](https://github.com/echeran/icu4x/runs/691108731?check_suite_focus=true) | [5m23s](https://github.com/echeran/icu4x/runs/691108769?check_suite_focus=true)