### PR TITLE
Make CI build & test use default and all feature sets

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,6 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
+        feature-set: [ "", "--all-features" ]  # no feature options ("") uses default.
+                                               # --no-default-features is not allowed
+                                               #     at root of virtual workspace for
+                                               #     both build and test.
         
 
     runs-on: ${{ matrix.os }}
@@ -43,10 +47,10 @@ jobs:
     ## Build and run steps
         
     - name: Build
-      run: cargo build --verbose
+      run: cargo build ${{ matrix.feature-set }} --verbose
 
     - name: Test
-      run: cargo test --verbose
+      run: cargo test ${{ matrix.feature-set }} --verbose
 
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is to allow both the build and test commands in cargo to run both with default features enabled and with `--all-features`.

I was not able to use `--no-default-features`:
```
$ cargo build --no-default-features
error: --no-default-features is not allowed in the root of a virtual workspace
note: while this was previously accepted, it didn't actually do anything
$ cargo test --no-default-features
error: --no-default-features is not allowed in the root of a virtual workspace
note: while this was previously accepted, it didn't actually do anything
```

A [test run](https://github.com/echeran/icu4x/runs/763677671?check_suite_focus=true) shows the locale component's serde unit tests running when all features (including the serde feature) are enabled, and they don't run in the default setting, as expected.

Is the lack of `--no-default-features` okay for this PR, or should I continue looking into [cargo-all-features](https://github.com/frewsxcv/cargo-all-features) as @zbraniecki mentioned in order to address the scenario of testing with `std` disabled?