### PR TITLE
Style Guide revision 2

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -153,7 +153,7 @@ fn main() {
 Since the `date_style` and `time_style` fields can accept only valid values, and the getter/setter methods
 would not perform any additional operations, those fields can be exposed as public.
 
-In all other situations, where the getter/setter are fallible, or perform additional computations or optimizations, the equivalent getter/setter model is advised:
+In all other situations, where the getter/setter are fallible, perform additional computations or optimizations, or an invariant between the fields has to be achieved, it is advised to use an equivalent getter/setter model:
 
 ```rust
 enum DateTimeStyle {
@@ -191,7 +191,8 @@ fn main() {
 Note: Any change to field visibility constitute a breaking change to the public API.
 Note: Even if the setter is infallible, the getter/setter model is useful when optimized type is used internally while public API exposes a standard type, like in the case of `meta` field in the example above.
 
-One suggested situation in which public fields would be acceptable is for user-facing "bag of options" structs. These would have no inbuilt semantics and no consistency guarantees, so the superior ergonomics of the public fields can be benefited from.
+One suggested situation in which public fields would be acceptable is for user-facing "bag of options" structs. These would have no inbuilt semantics and no consistency guarantees, so the superior ergonomics of the public fields can be benefited from. In that case, it is recommended to also implement or derive the `Default` trait. See `Constructor` section below for details.
+
 See [this issue](https://github.com/unicode-org/rust-discuss/issues/15) for more.
 
 ## Derived Traits
@@ -307,17 +308,17 @@ struct ListFormat {
 }
 
 impl ListFormat {
-    // GOOD
-    pub fn try_new(locale: Locale) -> Result<Self, ()> {
-      Ok(Self {
-        locale
-      })
-    }
-
     // BAD
     pub fn try_new(locale: &Locale) -> Result<Self, ()> {
       Ok(Self {
         locale: locale.clone()
+      })
+    }
+
+    // GOOD
+    pub fn try_new(locale: Locale) -> Result<Self, ()> {
+      Ok(Self {
+        locale
       })
     }
 }

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -489,13 +489,13 @@ fn main() {
     let mut options = MyStructOptions::default();
     options_max_fraction_digits = 10;
     // Optional debug time validation of the options
-    assert!(options.validate());
+    debug_assert!(options.validate());
 
     let s = MyStruct::try_new(locale, options).expect("Construction failed.");
 }
 ```
 
-It is also recommended that such structs implement `Default` trait to simplify common construction models:
+All such structs should also implement `Default` trait to simplify common construction models:
 
 ```rust
 fn main() {

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -323,8 +323,8 @@ impl ListFormat {
 }
 ```
 
-This rule may become a tradeoff in rare cases of APIs which optionally allocates. For example an API that in 95% of cases only needs a reference, but in the remaining 5% it needs to allocate, should be explicitly marked as such.
-An example of such API in the `stdlib` is `HashSet::get_or_insert` and `HashSet::get_or_insert_owned`:
+This rule may become a tradeoff in rare cases of APIs which optionally allocate. For example, if an API only needs a reference in 95% of cases, but in the remaining 5% needs to allocate, it should be explicitly marked as such.
+An example of such an API in the `stdlib` is `HashSet::get_or_insert` and `HashSet::get_or_insert_owned`:
 
 ```rust
 impl HashSet {
@@ -336,8 +336,8 @@ impl HashSet {
 }
 ```
 
-In this example, the `get_or_insert` method accepts an owned value, in order to use it if the set does not contain it.
-The `get_or_insert_owned` method, allows the user to pass a reference to a value that can implements `ToOwned`, and
+In this example, the `get_or_insert` method accepts an owned value, in order to use it if the set does not contain it already.
+The `get_or_insert_owned` method allows the user to pass a reference to a value that implements `ToOwned`, and
 this trait will be used in the scenario of allocation.
 
 ### Pass Option<T> by value where possible :: suggested

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -163,6 +163,7 @@ In all other situations, where the getter/setter are fallible, perform additiona
 
 ```rust
 #[derive(Default)]
+#[non_exhaustive]
 struct DateTimeOptions {
     meta: Option<TinyStr8>,
 }
@@ -183,7 +184,7 @@ fn main() {
 Note: Any change to field visibility constitute a breaking change to the public API.
 Note: Even if the setter is infallible, the getter/setter model is useful when optimized type is used internally while public API exposes a standard type, like in the case of `meta` field in the example above.
 
-One suggested situation in which public fields would be acceptable is for user-facing "bag of options" structs. These would have no inbuilt semantics and no consistency guarantees, so the superior ergonomics of the public fields can be benefited from. In that case, it is recommended to also implement or derive the `Default` trait. See `Constructor` section below for details.
+One suggested situation in which public fields would be acceptable is for user-facing "bag of options" structs. These would have no inbuilt semantics and no consistency guarantees, so the superior ergonomics of the public fields can be benefited from. In that case, such struct should also implement or derive the `Default` trait. See `Constructor` section below for details.
 
 See [this issue](https://github.com/unicode-org/rust-discuss/issues/15) for more.
 
@@ -457,6 +458,7 @@ Many ICU related constructors require a number of options to be passed. In such 
 
 ```rust
 #[derive(Default)]
+#[non_exhaustive]
 struct MyStructOptions {
     pub min_fraction_digits: usize,
     pub max_fraction_digits: usize,
@@ -495,7 +497,7 @@ fn main() {
 }
 ```
 
-All such structs should also implement `Default` trait to simplify common construction models:
+All such structs should also implement `Default` trait with `#[non_exhaustive]` attribute to simplify common construction models:
 
 ```rust
 fn main() {
@@ -506,6 +508,8 @@ fn main() {
 This model provides a good separation between the `options` struct which most likely will be mutable while used, and the final struct which can be optimized to only contain the final set of computed fields and remain immutable.
 
 If mutability is needed, one can always add `Struct::extend_with(&mut self);` method or a constructor which takes a previous instance and constructs a new instance based on the old one and additional data.
+
+The `#[non_exhaustive]` attribute disabled users ability to construct the Options struct manually, which enables us to extend the struct with additional features without breaking changes.
 
 # Error Handling
 


### PR DESCRIPTION
Fixes #112.

I shied away from extending the `errors` bit because the changes are large enough as is, and I'd prefer to keep #118 for another revision later.