### PR TITLE
Add CI job for linting using cargo clippy

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -61,3 +61,51 @@ jobs:
     - name: Rust linter
       # make this command fail if cargo fmt had to make changes
       run: cargo fmt && git diff-index --exit-code HEAD
+
+  # Linting job (cargo-clippy)
+
+  lint:
+    runs-on: ubuntu-latest
+
+    needs: [build]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Linting job > Cache steps
+
+    - name: Cache cargo registry
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
+
+    - name: Cache cargo index
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/git
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
+
+    - name: Cache cargo build
+      uses: actions/cache@v1
+      with:
+        path: target
+        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
+
+    # Linting job > Install and run clippy steps
+
+    - name: Install clippy
+      run: rustup component add clippy
+
+    # Run clippy first time to get warnings inserted inline in PR
+    - uses: actions-rs/clippy-check@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: --all-targets --all-features
+
+    # Run clippy second time to fail job on warnings
+    - name: Fail clippy on warnings
+      uses: actions-rs/clippy-check@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: --all-targets --all-features -- -D warnings

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -62,7 +62,7 @@ jobs:
       # make this command fail if cargo fmt had to make changes
       run: cargo fmt && git diff-index --exit-code HEAD
 
-  # Linting job (cargo-clippy)
+  # Linting job permissive (cargo-clippy) - completes and puts warnings inline in PR
 
   lint:
     runs-on: ubuntu-latest
@@ -72,7 +72,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # Linting job > Cache steps
+    # Linting job permissive > Cache steps
 
     - name: Cache cargo registry
       uses: actions/cache@v1
@@ -92,7 +92,7 @@ jobs:
         path: target
         key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
 
-    # Linting job > Install and run clippy steps
+    # Linting job permissive > Install and run clippy steps
 
     - name: Install clippy
       run: rustup component add clippy
@@ -103,8 +103,43 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         args: --all-targets --all-features
 
+  # Linting job strict (cargo-clippy)
+
+  lint_strict:
+    runs-on: ubuntu-latest
+
+    needs: [build]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Linting job strict > Cache steps
+
+    - name: Cache cargo registry
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
+
+    - name: Cache cargo index
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/git
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
+
+    - name: Cache cargo build
+      uses: actions/cache@v1
+      with:
+        path: target
+        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
+
+    # Linting job strict > Install and run clippy steps
+
+    - name: Install clippy
+      run: rustup component add clippy
+
     # Run clippy second time to fail job on warnings
-    # cargo clean should not be necessary, but empirically, it is on Github 
+    # `cargo clean` should not be necessary, but empirically, it is needed during Github Actions
     # (but not locally in CLI?). poss ex: https://github.com/rust-lang/rust-clippy/issues/4612
     - name: Fail clippy on warnings
       run: cargo clean && cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -62,7 +62,7 @@ jobs:
       # make this command fail if cargo fmt had to make changes
       run: cargo fmt && git diff-index --exit-code HEAD
 
-  # Linting job permissive (cargo-clippy) - completes and puts warnings inline in PR
+  # Linting job (cargo-clippy) - completes and puts warnings inline in PR
 
   lint:
     runs-on: ubuntu-latest
@@ -72,7 +72,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # Linting job permissive > Cache steps
+    # Linting job > Cache steps
 
     - name: Cache cargo registry
       uses: actions/cache@v1
@@ -92,32 +92,12 @@ jobs:
         path: target
         key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
 
-    # Linting job permissive > Install and run clippy steps
+    # Linting job > Install and run clippy steps
 
     - name: Install clippy
       run: rustup component add clippy
 
-    # Run clippy first time to get warnings inserted inline in PR
-    - uses: actions-rs/clippy-check@v1
+    - uses: actions-rs/clippy-check@v1.0.7
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all-targets --all-features
-
-  # Linting job strict (cargo-clippy)
-
-  lint_strict:
-    runs-on: ubuntu-latest
-
-    needs: [build]
-
-    steps:
-    - uses: actions/checkout@v2
-
-    # Linting job strict > Install and run clippy steps
-
-    - name: Install clippy
-      run: rustup component add clippy
-
-    # avoid caching to prevent confusing cargo clippy
-    - name: Fail clippy on warnings
-      run: cargo clippy --all-targets --all-features -- -D warnings
+        args: --all-targets --all-features -- -D warnings

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -104,8 +104,7 @@ jobs:
         args: --all-targets --all-features
 
     # Run clippy second time to fail job on warnings
+    # cargo clean should not be necessary, but empirically, it is on Github 
+    # (but not locally in CLI?). poss ex: https://github.com/rust-lang/rust-clippy/issues/4612
     - name: Fail clippy on warnings
-      uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all-targets --all-features -- -D warnings
+      run: cargo clean && cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -113,33 +113,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # Linting job strict > Cache steps
-
-    - name: Cache cargo registry
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
-
-    - name: Cache cargo index
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
-
-    - name: Cache cargo build
-      uses: actions/cache@v1
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
-
     # Linting job strict > Install and run clippy steps
 
     - name: Install clippy
       run: rustup component add clippy
 
-    # Run clippy second time to fail job on warnings
-    # `cargo clean` should not be necessary, but empirically, it is needed during Github Actions
-    # (but not locally in CLI?). poss ex: https://github.com/rust-lang/rust-clippy/issues/4612
+    # avoid caching to prevent confusing cargo clippy
     - name: Fail clippy on warnings
-      run: cargo clean && cargo clippy --all-targets --all-features -- -D warnings
+      run: cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
According to the [landing page for this Github Action for Clippy](https://github.com/marketplace/actions/rust-clippy-check), it will insert clippy warnings inline into your PR.  In my [test case](https://github.com/echeran/icu4x/runs/812822780?check_suite_focus=true), it appended a separate pseudo-job called "clippy" into the Github Actions UI page for the workflow run that also lists the warning.

Closes #98 