### PR TITLE
Use cargo-all-features for all feature sets (incl. no features)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,10 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        feature-set: [ "", "--all-features" ]  # no feature options ("") uses default.
-                                               # --no-default-features is not allowed
-                                               #     at root of virtual workspace for
-                                               #     both build and test.
         
 
     runs-on: ${{ matrix.os }}
@@ -54,20 +50,16 @@ jobs:
       if: runner.os != 'macOS'
 
     # Build job > Build and run steps
+
+    ## build / test against all subsets of features, including null set (no features)
+    - name: Install cargo-all-features
+      run: cargo install cargo-all-features
         
     - name: Build
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: build
-        args: ${{ matrix.feature-set }} --verbose
+      run: cargo build-all-features --verbose
 
     - name: Test
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: test
-        args: ${{ matrix.feature-set }} --verbose
-
-  # Formatting job
+      run: cargo test-all-features --verbose
 
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Summary:
* Using `cargo-all-features` appears to build and test against all subsets of features (including no features) as expected
* The build step (`cargo build-all-features`) ends early with an error
* The test step (`cargo test-all-features`), when run locally, shows some of the combinations in its output
* The reported errors may not be the exhaustive list, since the process exits early on error
* [example workflow run](https://github.com/echeran/icu4x/runs/848285822?check_suite_focus=true)

Fixes #63 


Selected lines from build run:
```
    Building crate=icu-data-provider features=[]

error[E0432]: unresolved import `std::error`
  --> components/data-provider/src/lib.rs:16:10
   |
16 | use std::error::Error;
   |          ^^^^^ help: a similar path exists: `downcast_rs::std::error`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: could not compile `icu-data-provider`.
```

Selected lines from test run:
```
     Testing crate=icu4x features=[]

     Testing crate=icu-data-provider-json features=[]

     Testing crate=icu-data-provider-json features=[std]

     Testing crate=icu features=[]

     Testing crate=icu-data-provider features=[]

error[E0432]: unresolved import `std::error`
  --> components/data-provider/src/lib.rs:16:10
   |
16 | use std::error::Error;
   |          ^^^^^ help: a similar path exists: `downcast_rs::std::error`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: could not compile `icu-data-provider`.
```