### PR TITLE
Fix CI clippy check by removing caching

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -72,26 +72,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # Linting job > Cache steps
-
-    - name: Cache cargo registry
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
-
-    - name: Cache cargo index
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
-
-    - name: Cache cargo build
-      uses: actions/cache@v1
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
-
     # Linting job > Install and run clippy steps
 
     - name: Install clippy


### PR DESCRIPTION
This PR fixes a bug in the CI clippy action.  Lost in the iterations on the original clippy PR (#161) was the fact that we don't want to include the cache step in the clippy action since it restores code from cache that subsequently gets picked up by cargo.

I did some local testing, then verified by testing using a draft PR (#178) to test for real, and the [fix works](https://github.com/unicode-org/icu4x/pull/178/checks?check_run_id=882907017) to address the [original problem](https://github.com/unicode-org/icu4x/pull/141/checks?check_run_id=880283508) of clippy errors on non-existent code.

What should remain in the clippy output for the PR in question (#141) after this fix are the real clippy errors on the actual existing code of that PR.