### PR TITLE
UnicodeSet L1 Span & Contains Set

### DIFF
--- a/components/uniset/src/lib.rs
+++ b/components/uniset/src/lib.rs
@@ -13,3 +13,9 @@ pub enum UnicodeSetError {
     InvalidSet(Vec<u32>),
     InvalidRange(u32, u32),
 }
+
+#[derive(PartialEq)]
+pub enum UnicodeSetSpanCondition {
+    Contained,
+    NotContained,
+}

--- a/components/uniset/src/uniset.rs
+++ b/components/uniset/src/uniset.rs
@@ -189,7 +189,7 @@ impl UnicodeSet {
         }
     }
 
-    /// Check if the calling Unicodeset contains all the characters of the given UnicodeSet
+    /// Check if the calling UnicodeSet contains all the characters of the given UnicodeSet
     ///
     /// # Example:
     ///
@@ -205,16 +205,17 @@ impl UnicodeSet {
     /// assert!(!example.contains_set(&r_to_x)); // contains some
     /// ```
     pub fn contains_set(&self, set: &UnicodeSet) -> bool {
-        if set.as_inversion_list().len() > self.inv_list.len() {
+        if set.size() > self.size() {
             return false;
         }
         let s = set.as_inversion_list().len() as f32;
         let u = self.inv_list.len() as f32;
         if s * u.log2() < u {
             set.inv_list.chunks(2).all(|range| {
-                self.contains_range(
-                    &(char::from_u32(range[0]).unwrap()..char::from_u32(range[1]).unwrap()),
-                )
+                match self.contains_query(range[0]){
+                    Some(pos) => range[1] <= self.inv_list[pos + 1],
+                    None => false
+                }
             })
         } else {
             let mut set_ranges: Chunks<u32> = set.as_inversion_list().chunks(2);

--- a/components/uniset/src/uniset.rs
+++ b/components/uniset/src/uniset.rs
@@ -208,30 +208,19 @@ impl UnicodeSet {
         if set.size() > self.size() {
             return false;
         }
-        let s = set.as_inversion_list().len() as f32;
-        let u = self.inv_list.len() as f32;
-        if s * u.log2() < u {
-            set.inv_list
-                .chunks(2)
-                .all(|range| match self.contains_query(range[0]) {
-                    Some(pos) => range[1] <= self.inv_list[pos + 1],
-                    None => false,
-                })
-        } else {
-            let mut set_ranges: Chunks<u32> = set.as_inversion_list().chunks(2);
-            let mut check = set_ranges.next();
-            for range in self.inv_list.chunks(2) {
-                match check {
-                    Some(r) => {
-                        if r[0] >= range[0] && r[1] <= range[1] {
-                            check = set_ranges.next();
-                        }
+        let mut set_ranges: Chunks<u32> = set.as_inversion_list().chunks(2);
+        let mut check = set_ranges.next();
+        for range in self.inv_list.chunks(2) {
+            match check {
+                Some(r) => {
+                    if r[0] >= range[0] && r[1] <= range[1] {
+                        check = set_ranges.next();
                     }
-                    _ => break,
                 }
+                _ => break,
             }
-            check.is_none()
         }
+        check.is_none()
     }
 
     /// Returns the end of the initial substring where the characters are either contained/not contained
@@ -357,28 +346,12 @@ mod tests {
         assert!(!check.contains_range(&('A'..'A')));
     }
     #[test]
-    fn test_unicodeset_contains_set_slogu() {
-        let ex = vec![10, 20, 40, 50, 70, 80, 100, 110];
-        let u = UnicodeSet::from_inversion_list(ex).unwrap();
-        let inside = vec![45, 49];
-        let s = UnicodeSet::from_inversion_list(inside).unwrap();
-        assert!(u.contains_set(&s));
-    }
-    #[test]
     fn test_unicodeset_contains_set_u() {
         let ex = vec![10, 20, 40, 50, 70, 80, 100, 110];
         let u = UnicodeSet::from_inversion_list(ex).unwrap();
         let inside = vec![15, 20, 44, 49, 70, 80, 100, 109];
         let s = UnicodeSet::from_inversion_list(inside).unwrap();
         assert!(u.contains_set(&s));
-    }
-    #[test]
-    fn test_unicodeset_contains_set_slogu_false() {
-        let ex = vec![10, 20, 40, 50, 70, 80, 100, 110];
-        let u = UnicodeSet::from_inversion_list(ex).unwrap();
-        let outside = vec![10, 24];
-        let s = UnicodeSet::from_inversion_list(outside).unwrap();
-        assert!(!u.contains_set(&s));
     }
     #[test]
     fn test_unicodeset_contains_set_u_false() {

--- a/components/uniset/src/uniset.rs
+++ b/components/uniset/src/uniset.rs
@@ -211,12 +211,12 @@ impl UnicodeSet {
         let s = set.as_inversion_list().len() as f32;
         let u = self.inv_list.len() as f32;
         if s * u.log2() < u {
-            set.inv_list.chunks(2).all(|range| {
-                match self.contains_query(range[0]){
+            set.inv_list
+                .chunks(2)
+                .all(|range| match self.contains_query(range[0]) {
                     Some(pos) => range[1] <= self.inv_list[pos + 1],
-                    None => false
-                }
-            })
+                    None => false,
+                })
         } else {
             let mut set_ranges: Chunks<u32> = set.as_inversion_list().chunks(2);
             let mut check = set_ranges.next();

--- a/components/uniset/src/uniset.rs
+++ b/components/uniset/src/uniset.rs
@@ -1,6 +1,6 @@
 use std::{char, ops::RangeBounds, slice::Chunks};
 
-use super::{UnicodeSetError, UnicodeSetSpanCondition};
+use super::UnicodeSetError;
 use crate::utils::{deconstruct_range, is_valid};
 /// Represents the end code point of the Basic Multilingual Plane range, starting from code point 0 , inclusive
 const BMP_MAX: u32 = 0xFFFF;
@@ -125,10 +125,6 @@ impl UnicodeSet {
         }
     }
 
-    pub fn ranges(&self) -> Chunks<u32> {
-        self.inv_list.chunks(2)
-    }
-
     /// Checks to see the query is in the UnicodeSet
     ///
     /// Runs a binary search in `O(log(n))` where `n` is the number of start and end points
@@ -145,6 +141,13 @@ impl UnicodeSet {
     /// ```
     pub fn contains(&self, query: char) -> bool {
         self.contains_query(query as u32).is_some()
+    }
+
+    /// Returns the inversion list as a slice
+    ///
+    /// Public only to the crate, not exposed to public
+    pub(crate) fn as_inversion_list(&self) -> &[u32] {
+        &self.inv_list
     }
 
     /// Checks to see if the range is in the UnicodeSet, returns a Result
@@ -188,30 +191,37 @@ impl UnicodeSet {
         }
     }
 
-    /// Check if the UnicodeSet parameter is entirely in the calling UnicodeSet
+    /// Check if the calling Unicodeset contains all the characters of the given UnicodeSet
     ///
-    /// where U is the UnicodeSet calling the function and S is the
-    /// UnicodeSet in the argument position  
-    ///     Since we know S < U, for S ranges we need to call log_2(U) for O(Slog_2(U))
-    ///     If we decide a linear time, it becomes O(U)
-    ///     If S <<<< U then O(U) > O(Slog_2(U))
-    ///     If S <= U then O(U) < O(Slog_2(U))
+    /// # Example:
+    ///
+    /// ```
+    /// use icu_unicodeset::UnicodeSet;
+    /// let example_list = vec![65, 70, 85, 91]; // A - E, U - Z
+    /// let example = UnicodeSet::from_inversion_list(example_list).unwrap();
+    /// let a_to_d = UnicodeSet::from_inversion_list(vec![65, 69]).unwrap();
+    /// let f_to_t = UnicodeSet::from_inversion_list(vec![70, 85]).unwrap();
+    /// let r_to_x = UnicodeSet::from_inversion_list(vec![82, 88]).unwrap();
+    /// assert!(example.contains_set(&a_to_d)); // contains all
+    /// assert!(!example.contains_set(&f_to_t)); // contains none
+    /// assert!(!example.contains_set(&r_to_x)); // contains some
+    /// ```
     pub fn contains_set(&self, set: &UnicodeSet) -> bool {
-        if set.size() > self.size() {
+        if set.as_inversion_list().len() > self.inv_list.len() {
             return false;
         }
-        let s = set.size() as f32;
-        let u = self.size() as f32;
+        let s = set.as_inversion_list().len() as f32;
+        let u = self.inv_list.len() as f32;
         if s * u.log2() < u {
-            set.ranges().all(|range| {
+            set.inv_list.chunks(2).all(|range| {
                 self.contains_range(
                     &(char::from_u32(range[0]).unwrap()..char::from_u32(range[1]).unwrap()),
                 )
             })
         } else {
-            let mut set_ranges: Chunks<u32> = set.ranges();
+            let mut set_ranges: Chunks<u32> = set.as_inversion_list().chunks(2);
             let mut check = set_ranges.next();
-            for range in self.ranges() {
+            for range in self.inv_list.chunks(2) {
                 match check {
                     Some(r) => {
                         if r[0] >= range[0] && r[1] <= range[1] {
@@ -221,26 +231,53 @@ impl UnicodeSet {
                     _ => break,
                 }
             }
-            match set_ranges.next() {
+            match check {
                 Some(_) => false,
                 None => true,
             }
         }
     }
 
-    pub fn span(&self, span_str: &str, contains: bool) -> usize {
+    /// Returns the end of the initial substring where the characters are either contained/not contained
+    /// in the set.
+    ///
+    /// # Example:
+    ///
+    /// ```
+    /// use icu_unicodeset::UnicodeSet;
+    /// let example_list = vec![65, 68]; // {A, B, C}
+    /// let example = UnicodeSet::from_inversion_list(example_list).unwrap();
+    /// assert_eq!(example.span("CABXYZ", true), 3);
+    /// assert_eq!(example.span("XYZC", false), 3);
+    /// assert_eq!(example.span("XYZ", true), 0);
+    /// assert_eq!(example.span("ABC", false), 0);
+    /// ```
+    pub fn span(&self, span_str: &str, contained: bool) -> usize {
         span_str
             .chars()
-            .take_while(|&x| self.contains(x) == contains)
+            .take_while(|&x| self.contains(x) == contained)
             .count()
     }
 
-    pub fn span_back(&self, span_str: &str, contains: bool) -> usize {
+    /// Returns the start of the trailing substring (starting from end of string) where the characters are
+    /// either contained/not contained in the set. Returns the length of the string if no valid return.
+    ///
+    /// # Example:
+    ///
+    /// ```
+    /// use icu_unicodeset::UnicodeSet;
+    /// let example_list = vec![65, 68]; // {A, B, C}
+    /// let example = UnicodeSet::from_inversion_list(example_list).unwrap();
+    /// assert_eq!(example.span_back("XYZCAB", true), 3);
+    /// assert_eq!(example.span_back("ABCXYZ", true), 6);
+    /// assert_eq!(example.span_back("CABXYZ", false), 3);
+    /// ```
+    pub fn span_back(&self, span_str: &str, contained: bool) -> usize {
         span_str.len()
             - span_str
                 .chars()
                 .rev()
-                .take_while(|&x| self.contains(x) == contains)
+                .take_while(|&x| self.contains(x) == contained)
                 .count()
     }
 }
@@ -324,6 +361,38 @@ mod tests {
         assert!(!check.contains_range(&('A'..'A')));
     }
     #[test]
+    fn test_unicodeset_contains_set_slogu() {
+        let ex = vec![10, 20, 40, 50, 70, 80, 100, 110];
+        let u = UnicodeSet::from_inversion_list(ex).unwrap();
+        let inside = vec![45, 49];
+        let s = UnicodeSet::from_inversion_list(inside).unwrap();
+        assert!(u.contains_set(&s));
+    }
+    #[test]
+    fn test_unicodeset_contains_set_u() {
+        let ex = vec![10, 20, 40, 50, 70, 80, 100, 110];
+        let u = UnicodeSet::from_inversion_list(ex).unwrap();
+        let inside = vec![15, 20, 44, 49, 70, 80, 100, 109];
+        let s = UnicodeSet::from_inversion_list(inside).unwrap();
+        assert!(u.contains_set(&s));
+    }
+    #[test]
+    fn test_unicodeset_contains_set_slogu_false() {
+        let ex = vec![10, 20, 40, 50, 70, 80, 100, 110];
+        let u = UnicodeSet::from_inversion_list(ex).unwrap();
+        let outside = vec![10, 24];
+        let s = UnicodeSet::from_inversion_list(outside).unwrap();
+        assert!(!u.contains_set(&s));
+    }
+    #[test]
+    fn test_unicodeset_contains_set_u_false() {
+        let ex = vec![10, 20, 40, 50, 70, 80, 100, 110];
+        let u = UnicodeSet::from_inversion_list(ex).unwrap();
+        let outside = vec![0, 10, 22, 44, 50, 70, 79, 81, 109, 111];
+        let s = UnicodeSet::from_inversion_list(outside).unwrap();
+        assert!(!u.contains_set(&s));
+    }
+    #[test]
     fn test_unicodeset_size() {
         let ex = vec![2, 5, 10, 15];
         let check = UnicodeSet::from_inversion_list(ex).unwrap();
@@ -360,5 +429,33 @@ mod tests {
         assert_eq!(Some('C'), iter.next());
         assert_eq!(Some('E'), iter.next());
         assert_eq!(None, iter.next());
+    }
+    #[test]
+    fn test_unicodeset_span_contains() {
+        let ex = vec![65, 68, 70, 75]; // A - D, F - K
+        let check = UnicodeSet::from_inversion_list(ex).unwrap();
+        assert_eq!(check.span("ABCDE", true), 3);
+        assert_eq!(check.span("E", true), 0);
+    }
+    #[test]
+    fn test_unicodeset_span_does_not_contain() {
+        let ex = vec![65, 68, 70, 75]; // A - D, F - K
+        let check = UnicodeSet::from_inversion_list(ex).unwrap();
+        assert_eq!(check.span("DEF", false), 2);
+        assert_eq!(check.span("KLMA", false), 3);
+    }
+    #[test]
+    fn test_unicodeset_span_back_contains() {
+        let ex = vec![65, 68, 70, 75]; // A - D, F - K
+        let check = UnicodeSet::from_inversion_list(ex).unwrap();
+        assert_eq!(check.span_back("XYZABFH", true), 3);
+        assert_eq!(check.span_back("ABCXYZ", true), 6);
+    }
+    #[test]
+    fn test_unicodeset_span_back_does_not_contain() {
+        let ex = vec![65, 68, 70, 75]; // A - D, F - K
+        let check = UnicodeSet::from_inversion_list(ex).unwrap();
+        assert_eq!(check.span_back("ABCXYZ", false), 3);
+        assert_eq!(check.span_back("XYZABC", false), 6);
     }
 }

--- a/components/uniset/src/uniset.rs
+++ b/components/uniset/src/uniset.rs
@@ -144,8 +144,6 @@ impl UnicodeSet {
     }
 
     /// Returns the inversion list as a slice
-    ///
-    /// Public only to the crate, not exposed to public
     pub(crate) fn as_inversion_list(&self) -> &[u32] {
         &self.inv_list
     }
@@ -231,10 +229,7 @@ impl UnicodeSet {
                     _ => break,
                 }
             }
-            match check {
-                Some(_) => false,
-                None => true,
-            }
+            check.is_none()
         }
     }
 


### PR DESCRIPTION
### Remaining [UnicodeSet L1](https://docs.google.com/document/d/1usXoudAnwCx19pQ18qoNMLTAcHW7IuAE6CuosnmtS5s/edit#heading=h.1o8ojscexytf) functions
- span(str, contained)
- span_back(str, contained)
- contains_set(UnicodeSet)
- Refer to ICU4C [`span`](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1UnicodeSet.html#a81c5da08ac066dcca2f3574352d3cfd0), [`span_back`](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1UnicodeSet.html#ac7f0dc56611d37663d6650482fca5b5c), and [`containsAll`](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1UnicodeSet.html#a69e4af354f7ba37f9c9750f824402493) for API  

#### Notes regarding `span/back(str, contained)` 
- After looking through the span conditions, realized they can be resolved easily with just an aptly named boolean parameter in the function (`contained`), where if `true` will check for characters contained within the set, and otherwise if `false`.

