### PR TITLE
Turn off caching to fix macOS builds missing dep errors

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,24 +34,24 @@ jobs:
       with:
         path: ~/.cargo/registry
         key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
-      # # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
-      # if: runner.os != 'macOS'
+      # TODO(actions-rs/cargo#111): make caching/WF config consistent across all runner OSes
+      if: runner.os != 'macOS'
 
     - name: Cache cargo index
       uses: actions/cache@v1
       with:
         path: ~/.cargo/git
         key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
-      # # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
-      # if: runner.os != 'macOS'
+      # TODO(actions-rs/cargo#111): make caching/WF config consistent across all runner OSes
+      if: runner.os != 'macOS'
 
     - name: Cache cargo build
       uses: actions/cache@v1
       with:
         path: target
         key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
-      # # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
-      # if: runner.os != 'macOS'
+      # TODO(actions-rs/cargo#111): make caching/WF config consistent across all runner OSes
+      if: runner.os != 'macOS'
 
     # Build job > Build and run steps
         

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,32 +34,38 @@ jobs:
       with:
         path: ~/.cargo/registry
         key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
-      # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
-      if: runner.os != 'macOS'
+      # # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
+      # if: runner.os != 'macOS'
 
     - name: Cache cargo index
       uses: actions/cache@v1
       with:
         path: ~/.cargo/git
         key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
-      # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
-      if: runner.os != 'macOS'
+      # # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
+      # if: runner.os != 'macOS'
 
     - name: Cache cargo build
       uses: actions/cache@v1
       with:
         path: target
         key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
-      # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
-      if: runner.os != 'macOS'
+      # # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
+      # if: runner.os != 'macOS'
 
     # Build job > Build and run steps
         
     - name: Build
-      run: cargo build ${{ matrix.feature-set }} --verbose
+      uses: actions-rs/cargo@v1.0.1
+      with:
+        command: build
+        args: ${{ matrix.feature-set }} --verbose
 
     - name: Test
-      run: cargo test ${{ matrix.feature-set }} --verbose
+      uses: actions-rs/cargo@v1.0.1
+      with:
+        command: test
+        args: ${{ matrix.feature-set }} --verbose
 
   # Formatting job
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,18 +34,24 @@ jobs:
       with:
         path: ~/.cargo/registry
         key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
+      # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
+      if: runner.os != 'macOS'
 
     - name: Cache cargo index
       uses: actions/cache@v1
       with:
         path: ~/.cargo/git
         key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
+      # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
+      if: runner.os != 'macOS'
 
     - name: Cache cargo build
       uses: actions/cache@v1
       with:
         path: target
         key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
+      # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
+      if: runner.os != 'macOS'
 
     # Build job > Build and run steps
         

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,29 +29,29 @@ jobs:
 
     # Build job > Cache steps
       
-    # - name: Cache cargo registry
-    #   uses: actions/cache@v1
-    #   with:
-    #     path: ~/.cargo/registry
-    #     key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
-    #   # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
-    #   if: runner.os != 'macOS'
+    - name: Cache cargo registry
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
+      # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
+      if: runner.os != 'macOS'
 
-    # - name: Cache cargo index
-    #   uses: actions/cache@v1
-    #   with:
-    #     path: ~/.cargo/git
-    #     key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
-    #   # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
-    #   if: runner.os != 'macOS'
+    - name: Cache cargo index
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/git
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
+      # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
+      if: runner.os != 'macOS'
 
     - name: Cache cargo build
       uses: actions/cache@v1
       with:
         path: target
         key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
-      ## Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
-      #if: runner.os != 'macOS'
+      # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
+      if: runner.os != 'macOS'
 
     # Build job > Build and run steps
         

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,29 +29,29 @@ jobs:
 
     # Build job > Cache steps
       
-    - name: Cache cargo registry
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
-      # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
-      if: runner.os != 'macOS'
+    # - name: Cache cargo registry
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: ~/.cargo/registry
+    #     key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
+    #   # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
+    #   if: runner.os != 'macOS'
 
-    - name: Cache cargo index
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
-      # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
-      if: runner.os != 'macOS'
+    # - name: Cache cargo index
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: ~/.cargo/git
+    #     key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
+    #   # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
+    #   if: runner.os != 'macOS'
 
     - name: Cache cargo build
       uses: actions/cache@v1
       with:
         path: target
         key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
-      # Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
-      if: runner.os != 'macOS'
+      ## Skip caching on macOS to prevent ephemeral build errors due to missing dependency files
+      #if: runner.os != 'macOS'
 
     # Build job > Build and run steps
         


### PR DESCRIPTION
Initial testing using testing PR #209 indicates that this change to avoid the caching step in macos builds fixes the build errors.  The [first run](https://github.com/unicode-org/icu4x/actions/runs/214698665) was with a previous version of the commit that incorrectly checked `runner.os != 'macos-latest'`.  After changing `macos-latest` to `macOS` and force pushing, [subsequent runs](https://github.com/unicode-org/icu4x/actions?query=branch%3Amacos-nocache-sffc-dp1) have seemed fine.

Closes #201 