### PR TITLE
Add subset of dates data to DataProvider

### DIFF
--- a/components/data-provider/src/data_key.rs
+++ b/components/data-provider/src/data_key.rs
@@ -10,6 +10,7 @@ use tinystr::TinyStr16;
 pub enum DataCategory {
     Decimal,
     Plurals,
+    Dates,
     PrivateUse(TinyStr16),
 }
 
@@ -19,6 +20,7 @@ impl DataCategory {
         match self {
             DataCategory::Decimal => Cow::Borrowed("decimal"),
             DataCategory::Plurals => Cow::Borrowed("plurals"),
+            DataCategory::Dates => Cow::Borrowed("dates"),
             DataCategory::PrivateUse(id) => {
                 let mut result = String::from("x-");
                 result.push_str(id.as_str());
@@ -64,6 +66,9 @@ macro_rules! icu_data_key {
     (plurals: $sub_category:tt @ $version:tt) => {
         icu_data_key!($crate::DataCategory::Plurals, $sub_category, $version)
     };
+    (dates: $sub_category:tt @ $version:tt) => {
+        icu_data_key!($crate::DataCategory::Dates, $sub_category, $version)
+    };
     (x-$private_use:tt: $sub_category:tt @ $version:tt) => {
         icu_data_key!(
             $crate::DataCategory::PrivateUse(stringify!($private_use).parse().unwrap()),
@@ -86,6 +91,7 @@ fn test_data_key_macro(category: DataCategory) {
     let data_key_1 = match category {
         DataCategory::Decimal => icu_data_key!(decimal: foo@1),
         DataCategory::Plurals => icu_data_key!(plurals: foo@1),
+        DataCategory::Dates => icu_data_key!(dates: foo@1),
         DataCategory::PrivateUse(_) => icu_data_key!(x-private: foo@1),
     };
     let data_key_2 = DataKey {
@@ -100,6 +106,7 @@ fn test_data_key_macro(category: DataCategory) {
 fn test_all_data_key_macros() {
     test_data_key_macro(DataCategory::Decimal);
     test_data_key_macro(DataCategory::Plurals);
+    test_data_key_macro(DataCategory::Dates);
     test_data_key_macro(DataCategory::PrivateUse("private".parse().unwrap()));
 }
 

--- a/components/data-provider/src/structs/dates.rs
+++ b/components/data-provider/src/structs/dates.rs
@@ -83,8 +83,7 @@ pub mod gregory {
 
             #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
             pub struct ContextsV1 {
-                #[serde(skip_serializing_if = "Option::is_none")]
-                pub format: Option<WidthsV1>,
+                pub format: WidthsV1,
 
                 #[serde(skip_serializing_if = "Option::is_none")]
                 pub stand_alone: Option<WidthsV1>,
@@ -96,11 +95,7 @@ pub mod gregory {
 
     symbols!(weekdays, [Cow<'static, str>; 7]);
 
-    symbols!(
-        day_periods,
-        am: Cow<'static, str>,
-        pm: Cow<'static, str>
-    );
+    symbols!(day_periods, am: Cow<'static, str>, pm: Cow<'static, str>);
 
     pub mod patterns {
         use super::*;

--- a/components/data-provider/src/structs/dates.rs
+++ b/components/data-provider/src/structs/dates.rs
@@ -72,6 +72,7 @@ pub mod gregory {
             pub struct FormatWidthsV1 {
                 pub abbreviated: SymbolsV1,
                 pub narrow: SymbolsV1,
+                #[serde(skip_serializing_if = "Option::is_none")]
                 pub short: Option<SymbolsV1>,
                 pub wide: SymbolsV1,
             }

--- a/components/data-provider/src/structs/dates.rs
+++ b/components/data-provider/src/structs/dates.rs
@@ -18,14 +18,14 @@ pub(crate) fn get_invariant(data_key: &DataKey) -> Option<DataResponse<'static>>
 pub mod gregory {
     use serde::{Deserialize, Serialize};
     use std::borrow::Cow;
-    #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+    #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
     pub struct DatesV1 {
         pub symbols: DateSymbolsV1,
 
         pub patterns: PatternsV1,
     }
 
-    #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+    #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
     pub struct DateSymbolsV1 {
         pub months: months::ContextsV1,
 
@@ -48,7 +48,7 @@ pub mod gregory {
             pub mod $name {
                 use super::*;
 
-                #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+                #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
                 pub struct SymbolsV1(pub $expr);
 
                 symbols!();
@@ -58,7 +58,7 @@ pub mod gregory {
             pub mod $name {
                 use super::*;
 
-                #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+                #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
                 pub struct SymbolsV1 {
                     $(pub $element: $ty),*
                 }
@@ -68,7 +68,7 @@ pub mod gregory {
         () => {
             // UTS 35 specifies that `format` widths are mandatory
             // except of `short`.
-            #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+            #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
             pub struct FormatWidthsV1 {
                 pub abbreviated: SymbolsV1,
                 pub narrow: SymbolsV1,
@@ -93,7 +93,7 @@ pub mod gregory {
                 pub wide: Option<SymbolsV1>,
             }
 
-            #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+            #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
             pub struct ContextsV1 {
                 pub format: FormatWidthsV1,
 

--- a/components/data-provider/src/structs/dates.rs
+++ b/components/data-provider/src/structs/dates.rs
@@ -18,14 +18,14 @@ pub(crate) fn get_invariant(data_key: &DataKey) -> Option<DataResponse<'static>>
 pub mod gregory {
     use serde::{Deserialize, Serialize};
     use std::borrow::Cow;
-    #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
+    #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
     pub struct DatesV1 {
         pub symbols: DateSymbolsV1,
 
         pub patterns: PatternsV1,
     }
 
-    #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
+    #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
     pub struct DateSymbolsV1 {
         pub months: months::ContextsV1,
 
@@ -66,8 +66,18 @@ pub mod gregory {
             }
         };
         () => {
+            // UTS35 specifies that `format` widths are mandatory
+            #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+            pub struct FormatWidthsV1 {
+                pub abbreviated: SymbolsV1,
+                pub narrow: SymbolsV1,
+                pub short: SymbolsV1,
+                pub wide: SymbolsV1,
+            }
+
+            // UTS35 specifies that `stand_alone` widths are optional
             #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
-            pub struct WidthsV1 {
+            pub struct StandAloneWidthsV1 {
                 #[serde(skip_serializing_if = "Option::is_none")]
                 pub abbreviated: Option<SymbolsV1>,
 
@@ -81,12 +91,12 @@ pub mod gregory {
                 pub wide: Option<SymbolsV1>,
             }
 
-            #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
+            #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
             pub struct ContextsV1 {
-                pub format: WidthsV1,
+                pub format: FormatWidthsV1,
 
                 #[serde(skip_serializing_if = "Option::is_none")]
-                pub stand_alone: Option<WidthsV1>,
+                pub stand_alone: Option<StandAloneWidthsV1>,
             }
         };
     }

--- a/components/data-provider/src/structs/dates.rs
+++ b/components/data-provider/src/structs/dates.rs
@@ -66,16 +66,17 @@ pub mod gregory {
             }
         };
         () => {
-            // UTS35 specifies that `format` widths are mandatory
+            // UTS 35 specifies that `format` widths are mandatory
+            // except of `short`.
             #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
             pub struct FormatWidthsV1 {
                 pub abbreviated: SymbolsV1,
                 pub narrow: SymbolsV1,
-                pub short: SymbolsV1,
+                pub short: Option<SymbolsV1>,
                 pub wide: SymbolsV1,
             }
 
-            // UTS35 specifies that `stand_alone` widths are optional
+            // UTS 35 specifies that `stand_alone` widths are optional
             #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
             pub struct StandAloneWidthsV1 {
                 #[serde(skip_serializing_if = "Option::is_none")]

--- a/components/data-provider/src/structs/dates.rs
+++ b/components/data-provider/src/structs/dates.rs
@@ -20,38 +20,27 @@ pub mod gregory {
     use std::borrow::Cow;
     #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
     pub struct DatesV1 {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub symbols: Option<DateSymbolsV1>,
+        pub symbols: DateSymbolsV1,
 
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub patterns: Option<PatternsV1>,
+        pub patterns: PatternsV1,
     }
 
     #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
     pub struct DateSymbolsV1 {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub months: Option<months::ContextsV1>,
+        pub months: months::ContextsV1,
 
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub weekdays: Option<weekdays::ContextsV1>,
+        pub weekdays: weekdays::ContextsV1,
 
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub day_periods: Option<day_periods::ContextsV1>,
+        pub day_periods: day_periods::ContextsV1,
     }
 
     #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
     pub struct PatternsV1 {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub date: Option<patterns::StylePatternsV1>,
+        pub date: patterns::StylePatternsV1,
 
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub time: Option<patterns::StylePatternsV1>,
+        pub time: patterns::StylePatternsV1,
 
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub date_time: Option<patterns::StylePatternsV1>,
-
-        #[serde(skip_serializing_if = "Vec::is_empty")]
-        pub skeletons: Vec<(Cow<'static, str>, Cow<'static, str>)>,
+        pub date_time: patterns::StylePatternsV1,
     }
 
     macro_rules! symbols {
@@ -107,11 +96,15 @@ pub mod gregory {
 
     symbols!(weekdays, [Cow<'static, str>; 7]);
 
-    symbols!(day_periods, am: Cow<'static, str>, pm: Cow<'static, str>);
+    symbols!(
+        day_periods,
+        am: Cow<'static, str>,
+        pm: Cow<'static, str>
+    );
 
     pub mod patterns {
         use super::*;
-        #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+        #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
         pub struct StylePatternsV1 {
             pub full: Cow<'static, str>,
             pub long: Cow<'static, str>,

--- a/components/data-provider/src/structs/mod.rs
+++ b/components/data-provider/src/structs/mod.rs
@@ -1,3 +1,4 @@
+pub mod dates;
 pub mod decimal;
 pub mod plurals;
 
@@ -12,4 +13,5 @@ pub(crate) fn get_invariant(data_key: &DataKey) -> Option<DataResponse<'static>>
     None //
         .or_else(|| decimal::get_invariant(data_key)) //
         .or_else(|| plurals::get_invariant(data_key)) //
+        .or_else(|| dates::get_invariant(data_key)) //
 }

--- a/components/data-provider/src/structs/plurals.rs
+++ b/components/data-provider/src/structs/plurals.rs
@@ -25,6 +25,7 @@ pub(crate) fn get_invariant(data_key: &DataKey) -> Option<DataResponse<'static>>
 ///
 /// More information: https://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "invariant", derive(Default))]
 pub struct PluralRuleStringsV1 {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub zero: Option<Cow<'static, str>>,
@@ -36,17 +37,4 @@ pub struct PluralRuleStringsV1 {
     pub few: Option<Cow<'static, str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub many: Option<Cow<'static, str>>,
-}
-
-#[cfg(feature = "invariant")]
-impl Default for PluralRuleStringsV1 {
-    fn default() -> Self {
-        Self {
-            zero: None,
-            one: None,
-            two: None,
-            few: None,
-            many: None,
-        }
-    }
 }


### PR DESCRIPTION
This PR introduces a subset of ca-gregorian from cldr-dates that will be needed for initial `DateTimeFormat`.

See: https://github.com/unicode-cldr/cldr-dates-modern/blob/master/main/en/ca-gregorian.json

The PR operates on `Cow` everywhere, but once we land `DateTime` we may want to switch some of them to `Pattern` structs if we measure performance wins with no significant payload growth.