### PR TITLE
Uniset contains bugfix

### DIFF
--- a/components/uniset/src/uniset.rs
+++ b/components/uniset/src/uniset.rs
@@ -343,7 +343,7 @@ mod tests {
         let ex = vec![65, 70, 75, 85];
         let check = UnicodeSet::from_inversion_list(ex).unwrap();
         assert!(check.contains_range(&('A'..='E'))); // 65 - 69
-        assert!(check.contains_range(&('C'..'D'))); // 65 - 69
+        assert!(check.contains_range(&('C'..'D'))); // 67 - 67
         assert!(check.contains_range(&('L'..'P'))); // 76 - 80
         assert!(!check.contains_range(&('L'..='U'))); // 76 - 85
     }
@@ -353,13 +353,13 @@ mod tests {
         let check = UnicodeSet::from_inversion_list(ex).unwrap();
         assert!(!check.contains_range(&('!'..'A'))); // 33 - 65
         assert!(!check.contains_range(&('F'..'K'))); // 70 - 74
-        assert!(!check.contains_range(&('U'..)));
+        assert!(!check.contains_range(&('U'..))); // 85 - ..
     }
     #[test]
     fn test_unicodeset_contains_range_invalid() {
         let check = UnicodeSet::all();
         assert!(!check.contains_range(&('A'..'!'))); // 65 - 33
-        assert!(!check.contains_range(&('A'..'A')));
+        assert!(!check.contains_range(&('A'..'A'))); // 65 - 65
     }
     #[test]
     fn test_unicodeset_contains_set_u() {

--- a/components/uniset/src/uniset.rs
+++ b/components/uniset/src/uniset.rs
@@ -186,11 +186,7 @@ impl UnicodeSet {
             return false;
         }
         match self.contains_query(from) {
-            Some(pos) => {
-                println!("{:?}", self.inv_list);
-                println!("{}", pos);
-                return (till) <= self.inv_list[pos + 1];
-            }
+            Some(pos) => (till) <= self.inv_list[pos + 1]
             None => false,
         }
     }

--- a/components/uniset/src/uniset.rs
+++ b/components/uniset/src/uniset.rs
@@ -186,7 +186,7 @@ impl UnicodeSet {
             return false;
         }
         match self.contains_query(from) {
-            Some(pos) => (till) <= self.inv_list[pos + 1]
+            Some(pos) => (till) <= self.inv_list[pos + 1],
             None => false,
         }
     }

--- a/components/uniset/src/uniset.rs
+++ b/components/uniset/src/uniset.rs
@@ -124,7 +124,7 @@ impl UnicodeSet {
             }
             Err(pos) => {
                 if pos % 2 != 0 && pos < self.inv_list.len() {
-                    Some(pos)
+                    Some(pos - 1)
                 } else {
                     None
                 }
@@ -186,7 +186,11 @@ impl UnicodeSet {
             return false;
         }
         match self.contains_query(from) {
-            Some(pos) => (till) <= self.inv_list[pos + 1],
+            Some(pos) => {
+                println!("{:?}", self.inv_list);
+                println!("{}", pos);
+                return (till) <= self.inv_list[pos + 1];
+            }
             None => false,
         }
     }
@@ -308,6 +312,18 @@ mod tests {
 
     // UnicodeSet membership functions
     #[test]
+    fn test_unicodeset_contains_query() {
+        let ex = vec![65, 70, 75, 85];
+        let check = UnicodeSet::from_inversion_list(ex).unwrap();
+        assert!(check.contains_query(64).is_none());
+        assert_eq!(check.contains_query(65).unwrap(), 0);
+        assert_eq!(check.contains_query(68).unwrap(), 0);
+        assert!(check.contains_query(70).is_none());
+        assert_eq!(check.contains_query(76).unwrap(), 2);
+        assert!(check.contains_query(86).is_none());
+    }
+
+    #[test]
     fn test_unicodeset_contains() {
         let ex = vec![2, 5, 10, 15];
         let check = UnicodeSet::from_inversion_list(ex).unwrap();
@@ -331,7 +347,9 @@ mod tests {
         let ex = vec![65, 70, 75, 85];
         let check = UnicodeSet::from_inversion_list(ex).unwrap();
         assert!(check.contains_range(&('A'..='E'))); // 65 - 69
-        assert!(check.contains_range(&('K'..'U'))); // 75 - 84
+        assert!(check.contains_range(&('C'..'D'))); // 65 - 69
+        assert!(check.contains_range(&('L'..'P'))); // 76 - 80
+        assert!(!check.contains_range(&('L'..='U'))); // 76 - 85
     }
     #[test]
     fn test_unicodeset_contains_range_false() {


### PR DESCRIPTION
Fixes #268 

TLDR: Off by one error

The documentation for `contains_query` is that the value in the returned `Option` will be the _start_ index of the range that contains the query. 

When performing `std::Vec::Vec::binary_search(&T)`, the index returned is the upper bound index of where the query should be:

E.g.
```rust
let test = vec![0, 10, 15, 20];
assert_eq!(test.binary_search(&1), Err(1))
```

In the implementation of `contains_query`, the issue of dropping the index back to the lower bound of the range was ignored, causing #268 .

Before this PR:
```rust
let check = UnicodeSet::from_inversion_list(vec![65, 70, 75, 80]);
assert_eq!(check.contains_query(66), Some(1)); // INCORRECT BEHAVIOR
```

After after PR:
```rust
let check = UnicodeSet::from_inversion_list(vec![65, 70, 75, 80]);
assert_eq!(check.contains_query(66), Some(0)); // INTENDED BEHAVIOR
```