### PR TITLE
Implements ecma402_traits with icu4x.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,15 @@
 members = [
     "components/cldr-json-data-provider",
     "components/data-provider",
+    "components/datetime",
+    "components/ecma402",
     "components/fs-data-provider",
     "components/icu",
     "components/icu4x",
-    "components/uniset",
     "components/locale",
     "components/locale/macros",
     "components/plurals",
-    "components/datetime",
+    "components/uniset",
     "resources/testdata",
     "utils/fixed-decimal",
 ]

--- a/components/ecma402/Cargo.toml
+++ b/components/ecma402/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "icu4x_ecma402"
+version = "0.0.1"
+authors = ["The ICU4X Project Developers"]
+edition = "2018"
+readme = "README.md"
+repository = "https://github.com/unicode-org/icu4x"
+license-file = "../../LICENSE"
+categories = ["internationalization"]
+include = [
+    "src/**/*",
+    "Cargo.toml",
+    "README.md"
+]
+
+[dependencies]
+ecma402_traits = { version = "0.2.0" }
+icu = { path = "../icu" }
+icu-data-provider = { path = "../data-provider", features = ["invariant"] }
+
+
+[dev-dependencies]
+criterion = "0.3"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = {version = "1.0" }
+icu-locale = { path = "../locale", features = ["serde"] }
+icu-data-provider = { path = "../data-provider", features = ["invariant"] }
+icu-testdata = { path = "../../resources/testdata"  }

--- a/components/ecma402/README.md
+++ b/components/ecma402/README.md
@@ -1,0 +1,1 @@
+# ECMA402 implementation.

--- a/components/ecma402/src/lib.rs
+++ b/components/ecma402/src/lib.rs
@@ -1,0 +1,35 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE )
+
+use icu::locale::LanguageIdentifier;
+
+/// Implements ECMA-402 [`Intl.PluralRules`][link].
+///
+/// [link]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRulres/PluralRules
+pub mod pluralrules;
+
+/// An adapter between `icu_locale` and `ecma402_traits`.
+///
+/// Specifically, adds an implementation of [ecma402_traits::Locale], which is
+/// rudimentary at the moment.
+#[derive(Debug, Hash, Clone, PartialEq)]
+pub enum Locale {
+    /// An ECMA402 compatible [Locale] created from icu4x [LanguageIdentifier].
+    FromLangid(LanguageIdentifier),
+    /// An ECMA402 [Locale] created from icu4x [icu_locale::Locale].
+    FromLocale(icu::locale::Locale),
+}
+
+impl ecma402_traits::Locale for crate::Locale {}
+
+impl std::fmt::Display for crate::Locale {
+    /// Delegates the implementation to one of the underlying constituent elements
+    /// without any custom additions.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Locale::FromLangid(ref l) => write!(f, "{}", l),
+            Locale::FromLocale(ref l) => write!(f, "{}", l),
+        }
+    }
+}

--- a/components/ecma402/src/pluralrules.rs
+++ b/components/ecma402/src/pluralrules.rs
@@ -1,0 +1,345 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE )
+
+//! Implements the traits found in [ecma402_traits::pluralrules].
+
+use icu::plurals as ipr;
+use icu::plurals::PluralRulesError;
+
+pub(crate) mod internal {
+    use ecma402_traits::pluralrules::options::Type;
+    use ecma402_traits::pluralrules::Options;
+    use icu::plurals::{PluralCategory, PluralOperands, PluralRuleType};
+    use std::cmp::{max, min};
+
+    // The difference between `first` and `second`, clamped on the bottom by zero.
+    fn clamp_diff(first: usize, second: usize) -> usize {
+        match first > second {
+            true => first - second,
+            false => 0,
+        }
+    }
+
+    /// Converts the trait style option to an equivalent ICU4X type.
+    pub fn to_icu4x_type(style: &Type) -> PluralRuleType {
+        match style {
+            Type::Ordinal => PluralRuleType::Ordinal,
+            Type::Cardinal => PluralRuleType::Cardinal,
+        }
+    }
+
+    /// Formats `n` as a string representation of fixed decimal, based on the supplied options.
+    // TODO: Push this implementation into FixedDecimal.
+    // See: https://github.com/unicode-org/icu4x/issues/340
+    pub fn fixed_format(n: f64, opts: &Options) -> String {
+        // n = 1234.5
+
+        // 1234.5 -> "1234"
+        // -1234.5 -> "1234"
+        let int_part = format!("{}", n.abs().floor());
+
+        // 5 -> ""
+        // 0.4 -> "4"
+        // 0.43 -> "43"
+        let raw_frac_part = format!("{}", n.fract()); // 0.5
+        let frac_part = if n.fract() == 0.0 {
+            ""
+        } else {
+            &raw_frac_part[2..]
+        };
+
+        dbg!("--> frac={}, fracf={}", &frac_part, &raw_frac_part);
+        dbg!("int_part='{}'; frac_part='{}'", &int_part, &frac_part);
+        dbg!("opts={:?}", opts);
+
+        // Limit the min and max display digits first by individual field.
+        let display_integer_digits = max(int_part.len(), opts.minimum_integer_digits as usize);
+        let display_fraction_digits = max(
+            min(frac_part.len(), opts.maximum_fraction_digits as usize),
+            opts.minimum_fraction_digits as usize,
+        );
+        let total_significant_digits = max(
+            opts.minimum_significant_digits as usize,
+            min(
+                opts.maximum_significant_digits as usize,
+                frac_part.len() + int_part.len(),
+            ),
+        );
+
+        let significant_digits_in_fraction = clamp_diff(total_significant_digits, int_part.len());
+        dbg!(
+            "did={}; dfd={}; sd={}; rsd={}",
+            display_integer_digits,
+            display_fraction_digits,
+            total_significant_digits,
+            significant_digits_in_fraction
+        );
+
+        // Integer fragment.
+        let leading_zeros = clamp_diff(display_integer_digits, int_part.len());
+        let trailing_zeros_in_int_part = clamp_diff(int_part.len(), total_significant_digits);
+        let i = std::iter::repeat('0')
+            .take(leading_zeros)
+            .chain(int_part.chars().take(total_significant_digits))
+            .chain(std::iter::repeat('0').take(trailing_zeros_in_int_part));
+
+        // Decimal dot is printed only if decimals will follow.
+        let dd = match display_fraction_digits == 0 {
+            true => "",
+            false => ".",
+        }
+        .chars();
+
+        // Fractional fragment.
+        let f = frac_part
+            .chars()
+            // At most the number of significant digits.
+            .take(significant_digits_in_fraction)
+            // Fill the rest with zeros.
+            .chain(std::iter::repeat('0'))
+            // Take at most the number of fraction digits we're required to display.
+            .take(display_fraction_digits);
+        // "001234.500"
+        let nstr = i.chain(dd).chain(f).collect::<String>();
+        dbg!("nstr={}", &nstr);
+        nstr
+    }
+
+    /// Converts the number to format into the operands representation.
+    pub fn to_icu4x_operands(n: f64, opts: Options) -> PluralOperands {
+        dbg!("n={}", n);
+        let nstr = fixed_format(n, &opts);
+        let ret = nstr.parse().unwrap();
+        dbg!("ret={:?}\n---\n", &ret);
+        ret
+    }
+
+    /// Expresses the [PluralCategory] as a `str`.
+    pub fn as_str(c: PluralCategory) -> &'static str {
+        match c {
+            PluralCategory::Few => "few",
+            PluralCategory::Many => "many",
+            PluralCategory::One => "one",
+            PluralCategory::Other => "other",
+            PluralCategory::Two => "two",
+            PluralCategory::Zero => "zero",
+        }
+    }
+
+    #[cfg(test)]
+    mod testing {
+        use super::*;
+        use ecma402_traits::pluralrules::options::Type;
+
+        fn opt(
+            minimum_integer_digits: u8,
+            minimum_fraction_digits: u8,
+            maximum_fraction_digits: u8,
+            minimum_significant_digits: u8,
+            maximum_significant_digits: u8,
+        ) -> Options {
+            Options {
+                in_type: Type::Cardinal,
+                minimum_integer_digits,
+                minimum_fraction_digits,
+                maximum_fraction_digits,
+                minimum_significant_digits,
+                maximum_significant_digits,
+            }
+        }
+
+        #[test]
+        fn string_conversion() {
+            #[derive(Debug)]
+            struct TestCase {
+                n: f64,
+                opts: Options,
+                expected: &'static str,
+            };
+            let tests = vec![
+                TestCase {
+                    n: 0.0,
+                    opts: opt(3, 2, 3, 3, 4),
+                    expected: "000.00",
+                },
+                TestCase {
+                    n: 1.5,
+                    opts: opt(3, 2, 3, 3, 4),
+                    expected: "001.50",
+                },
+                TestCase {
+                    n: 1.5,
+                    opts: opt(5, 5, 8, 3, 4),
+                    expected: "00001.50000",
+                },
+                TestCase {
+                    n: 123456.5,
+                    opts: opt(5, 5, 8, 3, 4),
+                    expected: "123400.00000",
+                },
+                TestCase {
+                    n: 123456.5432112345,
+                    opts: opt(5, 5, 8, 3, 4),
+                    expected: "123400.00000000",
+                },
+            ];
+            for test in tests {
+                let actual = fixed_format(test.n, &test.opts);
+                assert_eq!(test.expected, actual.as_str(), "test: {:?}", &test);
+            }
+        }
+
+        #[test]
+        fn format_conversion() {
+            #[derive(Debug)]
+            struct TestCase {
+                n: f64,
+                opts: Options,
+                expected: PluralOperands,
+            };
+            let tests = vec![TestCase {
+                n: 1.5,
+                opts: Options {
+                    in_type: Type::Cardinal,
+                    minimum_integer_digits: 3,
+                    minimum_fraction_digits: 2,
+                    maximum_fraction_digits: 3,
+                    minimum_significant_digits: 3,
+                    maximum_significant_digits: 4,
+                },
+                expected: PluralOperands {
+                    i: 1,
+                    v: 2,
+                    w: 1,
+                    f: 50,
+                    t: 5,
+                },
+            }];
+            for test in tests {
+                let actual = to_icu4x_operands(test.n, test.opts.clone());
+                assert_eq!(test.expected, actual, "test: {:?}", &test);
+            }
+        }
+    }
+}
+
+pub struct PluralRules {
+    opts: ecma402_traits::pluralrules::Options,
+    rep: ipr::PluralRules,
+}
+
+impl ecma402_traits::pluralrules::PluralRules for PluralRules {
+    type Error = PluralRulesError;
+
+    fn try_new<L>(l: L, opts: ecma402_traits::pluralrules::Options) -> Result<Self, Self::Error>
+    where
+        L: ecma402_traits::Locale,
+        Self: Sized,
+    {
+        // TODO: introduce a global data provider here.
+        let dp = icu_data_provider::InvariantDataProvider;
+        PluralRules::try_new_with_provider(l, opts, &dp)
+    }
+
+    fn select<W>(&self, number: f64, writer: &mut W) -> std::fmt::Result
+    where
+        W: std::fmt::Write,
+    {
+        let op = internal::to_icu4x_operands(number, self.opts.clone());
+        let result = self.rep.select(op);
+        write!(writer, "{}", internal::as_str(result))
+    }
+}
+
+impl PluralRules {
+    /// Creates a new [PluralRules], using the specified data provider.
+    pub fn try_new_with_provider<L, P>(
+        l: L,
+        opts: ecma402_traits::pluralrules::Options,
+        provider: &P,
+    ) -> Result<Self, PluralRulesError>
+    where
+        L: ecma402_traits::Locale,
+        P: icu_data_provider::DataProvider<'static>,
+        Self: Sized,
+    {
+        let locale: String = format!("{}", l);
+        let locale: icu::locale::Locale = locale
+            .parse()
+            .expect("Converting from locale string to locale should always succeed");
+        let rule_type = internal::to_icu4x_type(&opts.in_type);
+
+        // Oops, there is no slot in the ECMA 402 APIs to add the data provider.  What to do?
+        let rep = ipr::PluralRules::try_new(locale.into(), provider, rule_type)?;
+        Ok(PluralRules { opts, rep })
+    }
+}
+
+#[cfg(test)]
+mod testing {
+    use ecma402_traits::pluralrules;
+    use ecma402_traits::pluralrules::PluralRules;
+    use icu::locale::Locale;
+    use icu::plurals::PluralRulesError;
+
+    #[test]
+    fn plurals_per_locale() -> Result<(), PluralRulesError> {
+        #[derive(Debug, Clone)]
+        struct TestCase {
+            locale: &'static str,
+            opts: pluralrules::Options,
+            numbers: Vec<f64>,
+            expected: Vec<&'static str>,
+        };
+        let tests = vec![
+            TestCase {
+                locale: "ar",
+                opts: Default::default(),
+                numbers: vec![0.0, 1.0, 2.0, 5.0, 6.0, 18.0],
+                expected: vec!["zero", "one", "two", "few", "few", "many"],
+            },
+            TestCase {
+                locale: "ar",
+                opts: pluralrules::Options {
+                    in_type: pluralrules::options::Type::Ordinal,
+                    ..Default::default()
+                },
+                numbers: vec![0.0, 1.0, 2.0, 5.0, 6.0, 18.0],
+                expected: vec!["other", "other", "other", "other", "other", "other"],
+            },
+            TestCase {
+                locale: "sr",
+                opts: Default::default(),
+                numbers: vec![0.0, 1.0, 2.0, 5.0, 6.0, 18.0],
+                expected: vec!["other", "one", "few", "other", "other", "other"],
+            },
+            TestCase {
+                locale: "sr",
+                opts: pluralrules::Options {
+                    in_type: pluralrules::options::Type::Ordinal,
+                    ..Default::default()
+                },
+                numbers: vec![0.0, 1.0, 2.0, 5.0, 6.0, 18.0],
+                expected: vec!["other", "other", "other", "other", "other", "other"],
+            },
+        ];
+        let provider = icu_testdata::get_provider();
+        for test in tests {
+            let l: Locale = test.locale.parse().expect("locale exists");
+            let l = crate::Locale::FromLocale(l);
+            let plr = super::PluralRules::try_new_with_provider(l, test.clone().opts, &provider)?;
+            let actual = test
+                .numbers
+                .iter()
+                .map(|n| {
+                    let mut result = String::new();
+                    plr.select(*n, &mut result).unwrap();
+                    result
+                })
+                .collect::<Vec<String>>();
+            assert_eq!(test.expected, actual, "for test case: {:?}", &test);
+        }
+        Ok(())
+    }
+}

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -18,18 +18,18 @@ include = [
 ]
 
 [dependencies]
-icu-locale = { path = "../locale" }
-icu-data-provider = { path = "../data-provider" }
 fixed-decimal = { path = "../../utils/fixed-decimal" }
+icu-data-provider = { path = "../data-provider" }
+icu-locale = { path = "../locale" }
 
 [dev-dependencies]
 criterion = "0.3"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = {version = "1.0" }
+icu-data-provider = { path = "../data-provider", features = ["invariant"] }
 icu-locale = { path = "../locale", features = ["serde"] }
 icu-locale-macros = { path = "../locale/macros" }
-icu-data-provider = { path = "../data-provider", features = ["invariant"] }
 icu-testdata = { path = "../../resources/testdata" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = {version = "1.0" }
 
 [lib]
 bench = false  # This option is required for Benchmark CI

--- a/components/plurals/src/data.rs
+++ b/components/plurals/src/data.rs
@@ -61,7 +61,7 @@ pub type PluralRulesFn = fn(&PluralOperands) -> PluralCategory;
 ///
 /// [`PluralCategory`]: ../enum.PluralCategory.html
 /// [`ast::Condition`]: ../rules/ast/struct.Condition.html
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct PluralRuleList {
     zero: Option<ast::Condition>,
     one: Option<ast::Condition>,

--- a/components/plurals/src/error.rs
+++ b/components/plurals/src/error.rs
@@ -1,8 +1,10 @@
 // This file is part of ICU4X. For terms of use, please see the file
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
+
 use crate::rules::parser::ParserError;
 use icu_data_provider::prelude::DataError;
+use std::fmt;
 
 /// A list of possible error outcomes for the [`PluralRules`] struct.
 ///
@@ -23,5 +25,23 @@ impl From<DataError> for PluralRulesError {
 impl From<ParserError> for PluralRulesError {
     fn from(err: ParserError) -> Self {
         Self::Parser(err)
+    }
+}
+
+impl fmt::Display for PluralRulesError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            PluralRulesError::Parser(error) => write!(f, "Parser error: {}", error),
+            PluralRulesError::DataProvider(error) => write!(f, "Data provider error: {}", error),
+        }
+    }
+}
+
+impl std::error::Error for PluralRulesError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            PluralRulesError::Parser(error) => Some(error),
+            PluralRulesError::DataProvider(error) => Some(error),
+        }
     }
 }

--- a/components/plurals/src/rules/parser.rs
+++ b/components/plurals/src/rules/parser.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use super::ast;
 use super::lexer::{Lexer, Token};
+use std::fmt;
 use std::iter::Peekable;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -13,6 +14,22 @@ pub enum ParserError {
     ExpectedOperand,
     ExpectedValue,
     ExpectedSampleType,
+}
+
+impl std::error::Error for ParserError {}
+
+impl fmt::Display for ParserError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use ParserError::*;
+        match self {
+            ExpectedAndCondition => write!(f, "expected 'AND' condition"),
+            ExpectedRelation => write!(f, "expected relation"),
+            ExpectedOperator => write!(f, "expected operator"),
+            ExpectedOperand => write!(f, "expected operand"),
+            ExpectedValue => write!(f, "expected value"),
+            ExpectedSampleType => write!(f, "expected sample type"),
+        }
+    }
 }
 
 /// Unicode Plural Rule parser converts an


### PR DESCRIPTION
This allows (almost) seamless switching between rust_icu and
icu4x for plural formatting.

The API surface is a bit different with ecma402 than icu4x, which
may be a necessary concession to API uniformity.

For the time being, the significant digits in the formatted number
are not handled completely, so, for example, excessive precision will
not be handled correctly.

Also for the time being, no other APIs defined in ecma402_traits have
a icu4x implementation. Plural rules formatting was chosen as an easy
demo of the common ECMA402 API.