### PR TITLE
Some speed improvements to FixedDecimal parsing

### DIFF
--- a/components/num-util/src/fixed_decimal.rs
+++ b/components/num-util/src/fixed_decimal.rs
@@ -385,13 +385,13 @@ impl FromStr for FixedDecimal {
         if input_str == "" || input_str == "-" {
             return Err(Error::Syntax);
         }
-        let mut is_negative = false;
         let input_str = input_str.as_bytes();
-        let mut no_sign_str = input_str;
-        if input_str[0] == b'-' {
-            is_negative = true;
-            no_sign_str = &input_str[1..];
-        }
+        let is_negative = input_str[0] == b'-';
+        let no_sign_str = if is_negative {
+            &input_str[1..]
+        } else {
+            input_str
+        };
         // Compute length of each string once and store it, so if you use that multiple times,
         // you don't compute it multiple times
         // has_dot: shows if your input has dot in it

--- a/components/num-util/src/fixed_decimal.rs
+++ b/components/num-util/src/fixed_decimal.rs
@@ -392,7 +392,6 @@ impl FromStr for FixedDecimal {
             is_negative = true;
             no_sign_str = &input_str[1..];
         }
-        let no_sign_str = no_sign_str;
         // Compute length of each string once and store it, so if you use that multiple times,
         // you don't compute it multiple times
         // has_dot: shows if your input has dot in it

--- a/components/num-util/src/fixed_decimal.rs
+++ b/components/num-util/src/fixed_decimal.rs
@@ -385,15 +385,14 @@ impl FromStr for FixedDecimal {
         if input_str == "" || input_str == "-" {
             return Err(Error::Syntax);
         }
-        let no_sign_str: &str;
         let mut is_negative = false;
-        if &input_str[0..1] == "-" {
+        let input_str = input_str.as_bytes();
+        let mut no_sign_str = input_str;
+        if input_str[0] == b'-' {
             is_negative = true;
             no_sign_str = &input_str[1..];
-        } else {
-            no_sign_str = input_str;
         }
-
+        let no_sign_str = no_sign_str;
         // Compute length of each string once and store it, so if you use that multiple times,
         // you don't compute it multiple times
         // has_dot: shows if your input has dot in it
@@ -406,8 +405,8 @@ impl FromStr for FixedDecimal {
         // characters are digits and if you have at most one dot
         // Note: Input of format 111_123 is detected as syntax error here
         // Note: Input starting or ending with a dot is detected as syntax error here (Ex: .123, 123.)
-        for (i, c) in no_sign_str.bytes().enumerate() {
-            if c == b'.' {
+        for (i, c) in no_sign_str.iter().enumerate() {
+            if *c == b'.' {
                 match has_dot {
                     false => {
                         dot_index = i;
@@ -420,13 +419,13 @@ impl FromStr for FixedDecimal {
                         return Err(Error::Syntax);
                     }
                 }
-            } else if c < b'0' || c > b'9' {
+            } else if *c < b'0' || *c > b'9' {
                 return Err(Error::Syntax);
             }
         }
 
         // defining the output dec here and set its sign
-        let mut dec: FixedDecimal = 0.into();
+        let mut dec: FixedDecimal = FixedDecimal::default();
         dec.is_negative = is_negative;
 
         // no_dot_str_len: shows length of the string after removing the dot
@@ -460,11 +459,11 @@ impl FromStr for FixedDecimal {
         //     001230.00             2                  5
         // Compute leftmost_digit
         let mut leftmost_digit = no_sign_str_len;
-        for (i, c) in no_sign_str.bytes().enumerate() {
-            if c == b'.' {
+        for (i, c) in no_sign_str.iter().enumerate() {
+            if *c == b'.' {
                 continue;
             }
-            if c != b'0' {
+            if *c != b'0' {
                 leftmost_digit = i;
                 break;
             }
@@ -486,11 +485,11 @@ impl FromStr for FixedDecimal {
 
         // Compute rightmost_digit
         let mut rightmost_digit = no_sign_str_len;
-        for (i, c) in no_sign_str.bytes().rev().enumerate() {
-            if c == b'.' {
+        for (i, c) in no_sign_str.iter().rev().enumerate() {
+            if *c == b'.' {
                 continue;
             }
-            if c != b'0' {
+            if *c != b'0' {
                 rightmost_digit = no_sign_str_len - i;
                 break;
             }
@@ -504,8 +503,8 @@ impl FromStr for FixedDecimal {
 
         // Constructing DecimalFixed.digits
         let mut v: SmallVec<[u8; 8]> = SmallVec::with_capacity(digits_str_len);
-        for c in no_sign_str[leftmost_digit..rightmost_digit].bytes() {
-            if c == b'.' {
+        for c in no_sign_str[leftmost_digit..rightmost_digit].iter() {
+            if *c == b'.' {
                 continue;
             }
             v.push(c - b'0');


### PR DESCRIPTION
* Change str iteration into bytes iteration.  Since the input alphabet
  is only single bytes, this should be OK.

* Use `FixedDecimal::default()` instead of zero for initialization.

Seems to make a 7% improvement in some microbenchmarks, going roughly
from 35ns to 31ns.

```
from_string/0012.3400   time:   [30.871 ns 30.887 ns 30.907 ns]
                        change: [-9.2063% -9.1540% -9.1054%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
from_string/00.0012216734340
                        time:   [67.715 ns 67.778 ns 67.844 ns]
                        change: [-1.4520% -0.4672% +0.4506%] (p = 0.35 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
from_string/00002342561123400.0
                        time:   [72.554 ns 72.708 ns 72.854 ns]
                        change: [-1.1182% -0.8930% -0.6325%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
from_string/-00123400   time:   [30.959 ns 30.971 ns 30.984 ns]
                        change: [-10.060% -9.6862% -9.4502%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
from_string/922337203685477580898230948203840239384.9823094820384023938423424
                        time:   [215.19 ns 215.40 ns 215.63 ns]
                        change: [+3.1132% +3.6683% +4.0742%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe
from_string/0.000000001 time:   [29.235 ns 29.268 ns 29.308 ns]
                        change: [-9.7930% -9.7035% -9.6051%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe
from_string/1000000001  time:   [60.990 ns 61.038 ns 61.088 ns]
                        change: [+5.0850% +5.2075% +5.3511%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
from_string/0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000...
                        time:   [71.210 us 71.251 us 71.306 us]
                        change: [-1.7824% -1.7383% -1.6889%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  6 (6.00%) high mild
  7 (7.00%) high severe

```