### PR TITLE
Fix name category for one pluralrules test.

### DIFF
--- a/components/pluralrules/benches/pluralrules.rs
+++ b/components/pluralrules/benches/pluralrules.rs
@@ -25,7 +25,7 @@ fn plurals_bench(c: &mut Criterion) {
 
     let loc: LanguageIdentifier = "pl".parse().unwrap();
     let pr = PluralRules::try_new(loc, PluralRuleType::Cardinal, &provider).unwrap();
-    c.bench_function("plurals/select/fs", |b| {
+    c.bench_function("pluralrules/select/fs", |b| {
         b.iter(|| {
             for s in &numbers_data.usize {
                 let _ = pr.select(black_box(*s));


### PR DESCRIPTION
Minor fix to a name of one benchmark.

I generally used the term `plurals` for high-level benchmarks, and `pluralrules` for specific `deeper` benchmarks of `PluralRules` struct API.

I think it's a bit confusing and I'll want to clean it up later - I'm also planning to write guideline for adding benchmarks and how to split `high-level` from `deeper` view. In this PR I only want to fix the mistake from the previous one :)