### PR TITLE
Improve performance of From<FixedDecimal> for PluralOperands

### DIFF
--- a/components/pluralrules/src/operands.rs
+++ b/components/pluralrules/src/operands.rs
@@ -202,48 +202,36 @@ impl_signed_integer_type!(i8 i16 i32 i64 i128 isize);
 
 impl From<&FixedDecimal> for PluralOperands {
     /// Converts a [icu_num_util::FixedDecimal] to [PluralOperands]
-    fn from(f: &FixedDecimal) -> Self {
-        let mag_range = f.magnitude_range();
+    fn from(dec: &FixedDecimal) -> Self {
+        let mag_range = dec.magnitude_range();
         let mag_high = *mag_range.end();
         let mag_low = *mag_range.start();
 
-        let mut integer_part: u64 = 0;
-        let integer_range = 0..=mag_high;
-        for magnitude in integer_range.rev() {
-            integer_part *= 10;
-            integer_part += f.digit_at(magnitude) as u64;
+        let mut i: u64 = 0;
+        for magnitude in (0..=mag_high).rev() {
+            i *= 10;
+            i += dec.digit_at(magnitude) as u64;
         }
 
-        // The fractional part of the number, expressed as an integer to preserve trailing zeroes.
-        // For example, could be "100" if the stored number is "0.100".
-        let mut fraction_part_full: u64 = 0;
-        // A running total of the number of trailing zeros seen in the fractional part of the
-        // number.
-        let mut num_trailing_zeros = 0;
-        // 10^num_trailing_zeros.
-        let mut weight_trailing_zeros = 1;
-        let fractional_magnitude_range = mag_low..=-1;
-        for magnitude in fractional_magnitude_range.rev() {
-            let digit = f.digit_at(magnitude);
-            if digit == 0 {
-                num_trailing_zeros += 1;
-                weight_trailing_zeros *= 10;
-            } else {
-                num_trailing_zeros = 0;
-                weight_trailing_zeros = 1;
+        let mut f: u64 = 0;
+        let mut t: u64 = 0;
+        let mut w: usize = 0;
+        for magnitude in (mag_low..=-1).rev() {
+            let digit = dec.digit_at(magnitude) as u64;
+            f *= 10;
+            f += digit;
+            if digit != 0 {
+                t = f;
+                w = (-magnitude) as usize;
             }
-            fraction_part_full *= 10;
-            fraction_part_full += digit as u64;
         }
-        let fraction_part_nozeros = fraction_part_full / weight_trailing_zeros;
-        let num_fractional_digits = (-std::cmp::min(0, mag_low)) as usize;
 
         PluralOperands {
-            i: integer_part,
-            v: num_fractional_digits,
-            w: num_fractional_digits - num_trailing_zeros,
-            f: fraction_part_full,
-            t: fraction_part_nozeros,
+            i,
+            v: (-mag_low) as usize,
+            w,
+            f,
+            t,
         }
     }
 }


### PR DESCRIPTION
Before this change, I got:

```
operands/create/from_fixed_decimal
                        time:   [246.59 ns 249.77 ns 253.38 ns]
Found 24 outliers among 100 measurements (24.00%)
  16 (16.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
  5 (5.00%) high severe
```

After this change, I get:

```
operands/create/from_fixed_decimal
                        time:   [213.19 ns 214.49 ns 216.01 ns]
                        change: [-17.609% -16.706% -15.829%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  5 (5.00%) high mild
  7 (7.00%) high severe
```