### PR TITLE
Rename DummyDateTime to MockDateTime

### DIFF
--- a/components/datetime/benches/datetime.rs
+++ b/components/datetime/benches/datetime.rs
@@ -4,7 +4,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use std::fmt::Write;
 
 use icu_datetime::DateTimeFormat;
-use icu_datetime::DummyDateTime;
+use icu_datetime::MockDateTime;
 use icu_fs_data_provider::FsDataProvider;
 
 fn datetime_benches(c: &mut Criterion) {
@@ -19,7 +19,7 @@ fn datetime_benches(c: &mut Criterion) {
         group.bench_function("DateTimeFormat/format_to_write", |b| {
             b.iter(|| {
                 for fx in &fxs.0 {
-                    let datetimes: Vec<DummyDateTime> = fx
+                    let datetimes: Vec<MockDateTime> = fx
                         .values
                         .iter()
                         .map(|value| value.parse().unwrap())
@@ -44,7 +44,7 @@ fn datetime_benches(c: &mut Criterion) {
         group.bench_function("DateTimeFormat/format_to_string", |b| {
             b.iter(|| {
                 for fx in &fxs.0 {
-                    let datetimes: Vec<DummyDateTime> = fx
+                    let datetimes: Vec<MockDateTime> = fx
                         .values
                         .iter()
                         .map(|value| value.parse().unwrap())
@@ -66,7 +66,7 @@ fn datetime_benches(c: &mut Criterion) {
         group.bench_function("FormattedDateTime/format", |b| {
             b.iter(|| {
                 for fx in &fxs.0 {
-                    let datetimes: Vec<DummyDateTime> = fx
+                    let datetimes: Vec<MockDateTime> = fx
                         .values
                         .iter()
                         .map(|value| value.parse().unwrap())
@@ -92,7 +92,7 @@ fn datetime_benches(c: &mut Criterion) {
         group.bench_function("FormattedDateTime/to_string", |b| {
             b.iter(|| {
                 for fx in &fxs.0 {
-                    let datetimes: Vec<DummyDateTime> = fx
+                    let datetimes: Vec<MockDateTime> = fx
                         .values
                         .iter()
                         .map(|value| value.parse().unwrap())

--- a/components/datetime/examples/work_log.rs
+++ b/components/datetime/examples/work_log.rs
@@ -1,6 +1,6 @@
 // An example application which uses icu_datetime to format entries
 // from a work log into human readable dates and times.
-use icu_datetime::date::DummyDateTime;
+use icu_datetime::date::MockDateTime;
 use icu_datetime::{options::style, DateTimeFormat};
 use icu_fs_data_provider::FsDataProvider;
 use icu_locale::LanguageIdentifier;
@@ -36,7 +36,7 @@ fn main() {
     let dates = DATES_ISO
         .iter()
         .map(|date| date.parse())
-        .collect::<Result<Vec<DummyDateTime>, _>>()
+        .collect::<Result<Vec<MockDateTime>, _>>()
         .expect("Failed to parse dates.");
 
     let options = style::Bag {

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -45,13 +45,13 @@ pub trait DateTimeType: FromStr {
 /// # Examples
 ///
 /// ```
-/// use icu_datetime::DummyDateTime;
+/// use icu_datetime::MockDateTime;
 ///
-/// let dt = DummyDateTime::try_new(2020, 9, 24, 13, 21, 0)
+/// let dt = MockDateTime::try_new(2020, 9, 24, 13, 21, 0)
 ///     .expect("Failed to construct DateTime.");
 /// ```
 #[derive(Debug, Default)]
-pub struct DummyDateTime {
+pub struct MockDateTime {
     pub year: usize,
     pub month: Month,
     pub day: Day,
@@ -60,7 +60,7 @@ pub struct DummyDateTime {
     pub second: Second,
 }
 
-impl DummyDateTime {
+impl MockDateTime {
     pub fn new(
         year: usize,
         month: Month,
@@ -79,14 +79,14 @@ impl DummyDateTime {
         }
     }
 
-    /// Constructor for the `DummyDateTime`.
+    /// Constructor for the `MockDateTime`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use icu_datetime::DummyDateTime;
+    /// use icu_datetime::MockDateTime;
     ///
-    /// let dt = DummyDateTime::try_new(2020, 9, 24, 13, 21, 0)
+    /// let dt = MockDateTime::try_new(2020, 9, 24, 13, 21, 0)
     ///     .expect("Failed to construct a DateTime");
     /// ```
     pub fn try_new(
@@ -108,7 +108,7 @@ impl DummyDateTime {
     }
 }
 
-impl DateTimeType for DummyDateTime {
+impl DateTimeType for MockDateTime {
     fn year(&self) -> usize {
         self.year
     }
@@ -129,7 +129,7 @@ impl DateTimeType for DummyDateTime {
     }
 }
 
-impl FromStr for DummyDateTime {
+impl FromStr for MockDateTime {
     type Err = DateTimeError;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
@@ -139,7 +139,7 @@ impl FromStr for DummyDateTime {
         let hour: Hour = input[11..13].parse()?;
         let minute: Minute = input[14..16].parse()?;
         let second: Second = input[17..19].parse()?;
-        Ok(DummyDateTime {
+        Ok(MockDateTime {
             year,
             month: month - 1,
             day: day - 1,

--- a/components/datetime/src/format.rs
+++ b/components/datetime/src/format.rs
@@ -18,7 +18,7 @@ use std::fmt;
 /// ```
 /// # use icu_locale::LanguageIdentifier;
 /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
-/// # use icu_datetime::DummyDateTime;
+/// # use icu_datetime::MockDateTime;
 /// # use icu_data_provider::InvariantDataProvider;
 /// # let langid: LanguageIdentifier = "en".parse()
 /// #     .expect("Failed to parse a language identifier.");
@@ -27,7 +27,7 @@ use std::fmt;
 /// let dtf = DateTimeFormat::try_new(langid, &provider, &options)
 ///     .expect("Failed to create DateTimeFormat instance.");
 ///
-/// let date_time = DummyDateTime::try_new(2020, 9, 1, 12, 34, 28)
+/// let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)
 ///     .expect("Failed to construct DateTime.");
 ///
 /// let formatted_date = dtf.format(&date_time);

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -11,7 +11,7 @@
 //! ```
 //! use icu_locale::LanguageIdentifier;
 //! use icu_datetime::{DateTimeFormat, options::style};
-//! use icu_datetime::DummyDateTime;
+//! use icu_datetime::MockDateTime;
 //! use icu_data_provider::InvariantDataProvider;
 //!
 //! let langid: LanguageIdentifier = "en".parse()
@@ -28,7 +28,7 @@
 //!     .expect("Failed to create DateTimeFormat instance.");
 //!
 //!
-//! let date_time = DummyDateTime::try_new(2020, 9, 1, 12, 34, 28)
+//! let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)
 //!     .expect("Failed to construct DateTime.");
 //!
 //! let value = dtf.format_to_string(&date_time);
@@ -38,7 +38,7 @@
 //! we expect to add more ways to customize the output, like skeletons, and components.
 //!
 //! *Notice:* Rust at the moment does not have a canonical way to represent date and time. We are introducing
-//! `date::DummyDateTime` as a reference example of the data necessary for ICU DateTimeFormat to work, and
+//! `date::MockDateTime` as a reference example of the data necessary for ICU DateTimeFormat to work, and
 //! we hope to work with the community to develop core date and time APIs that will work as an input for this component.
 //!
 //! [`DateTimeFormat`]: ./struct.DateTimeFormat.html
@@ -52,7 +52,7 @@ pub mod options;
 pub mod pattern;
 mod provider;
 
-pub use date::{DateTimeType, DummyDateTime};
+pub use date::{DateTimeType, MockDateTime};
 pub use error::DateTimeFormatError;
 use format::write_pattern;
 pub use format::FormattedDateTime;
@@ -76,7 +76,7 @@ use std::borrow::Cow;
 /// ```
 /// use icu_locale::LanguageIdentifier;
 /// use icu_datetime::{DateTimeFormat, options::style};
-/// use icu_datetime::DummyDateTime;
+/// use icu_datetime::MockDateTime;
 /// use icu_data_provider::InvariantDataProvider;
 ///
 /// let langid: LanguageIdentifier = "en".parse()
@@ -93,7 +93,7 @@ use std::borrow::Cow;
 ///     .expect("Failed to create DateTimeFormat instance.");
 ///
 ///
-/// let date_time = DummyDateTime::try_new(2020, 9, 1, 12, 34, 28)
+/// let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)
 ///     .expect("Failed to construct DateTime.");
 ///
 /// let value = dtf.format_to_string(&date_time);
@@ -116,7 +116,7 @@ impl<'d> DateTimeFormat<'d> {
     /// ```
     /// use icu_locale::LanguageIdentifier;
     /// use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
-    /// use icu_datetime::DummyDateTime;
+    /// use icu_datetime::MockDateTime;
     /// use icu_data_provider::InvariantDataProvider;
     ///
     /// let langid: LanguageIdentifier = "en".parse()
@@ -162,7 +162,7 @@ impl<'d> DateTimeFormat<'d> {
     /// ```
     /// # use icu_locale::LanguageIdentifier;
     /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
-    /// # use icu_datetime::DummyDateTime;
+    /// # use icu_datetime::MockDateTime;
     /// # use icu_data_provider::InvariantDataProvider;
     /// # let langid: LanguageIdentifier = "en".parse()
     /// #     .expect("Failed to parse a language identifier.");
@@ -171,7 +171,7 @@ impl<'d> DateTimeFormat<'d> {
     /// let dtf = DateTimeFormat::try_new(langid, &provider, &options)
     ///     .expect("Failed to create DateTimeFormat instance.");
     ///
-    /// let date_time = DummyDateTime::try_new(2020, 9, 1, 12, 34, 28)
+    /// let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)
     ///     .expect("Failed to construct DateTime.");
     ///
     /// let formatted_date = dtf.format(&date_time);
@@ -201,7 +201,7 @@ impl<'d> DateTimeFormat<'d> {
     /// ```
     /// # use icu_locale::LanguageIdentifier;
     /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
-    /// # use icu_datetime::DummyDateTime;
+    /// # use icu_datetime::MockDateTime;
     /// # use icu_data_provider::InvariantDataProvider;
     /// # let langid: LanguageIdentifier = "en".parse()
     /// #     .expect("Failed to parse a language identifier.");
@@ -210,7 +210,7 @@ impl<'d> DateTimeFormat<'d> {
     /// let dtf = DateTimeFormat::try_new(langid, &provider, &options.into())
     ///     .expect("Failed to create DateTimeFormat instance.");
     ///
-    /// let date_time = DummyDateTime::try_new(2020, 9, 1, 12, 34, 28)
+    /// let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)
     ///     .expect("Failed to construct DateTime.");
     ///
     /// let mut buffer = String::new();
@@ -234,7 +234,7 @@ impl<'d> DateTimeFormat<'d> {
     /// ```
     /// # use icu_locale::LanguageIdentifier;
     /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
-    /// # use icu_datetime::DummyDateTime;
+    /// # use icu_datetime::MockDateTime;
     /// # use icu_data_provider::InvariantDataProvider;
     /// # let langid: LanguageIdentifier = "en".parse()
     /// #     .expect("Failed to parse a language identifier.");
@@ -243,7 +243,7 @@ impl<'d> DateTimeFormat<'d> {
     /// let dtf = DateTimeFormat::try_new(langid, &provider, &options.into())
     ///     .expect("Failed to create DateTimeFormat instance.");
     ///
-    /// let date_time = DummyDateTime::try_new(2020, 9, 1, 12, 34, 28)
+    /// let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)
     ///     .expect("Failed to construct DateTime.");
     ///
     /// let _ = dtf.format_to_string(&date_time);

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -1,7 +1,7 @@
 mod fixtures;
 
 use icu_datetime::DateTimeFormat;
-use icu_datetime::DummyDateTime;
+use icu_datetime::MockDateTime;
 use icu_fs_data_provider::FsDataProvider;
 use std::fmt::Write;
 
@@ -15,7 +15,7 @@ fn test_fixtures() {
         let options = fixtures::get_options(&fx.input.options);
         let dtf = DateTimeFormat::try_new(langid, &provider, &options).unwrap();
 
-        let value: DummyDateTime = fx.input.value.parse().unwrap();
+        let value: MockDateTime = fx.input.value.parse().unwrap();
 
         let result = dtf.format_to_string(&value);
         assert_eq!(result, fx.output.value);


### PR DESCRIPTION
This is a pure rename to get rid of the `Dummy` term.

I remember there were multiple options floating around. If you can settle on a different word than `Mock`, I'm happy to use it. If not, I suggest we land with Mock.