### PR TITLE
Reorder constructor arguments in PluralRules to align with DateTimeFormat.

### DIFF
--- a/components/pluralrules/benches/pluralrules.rs
+++ b/components/pluralrules/benches/pluralrules.rs
@@ -16,7 +16,7 @@ fn pluralrules(c: &mut Criterion) {
     c.bench_function("pluralrules/overview", |b| {
         b.iter(|| {
             for lang in &plurals_data.langs {
-                let pr = PluralRules::try_new(lang.clone(), PluralRuleType::Cardinal, &provider)
+                let pr = PluralRules::try_new(lang.clone(), &provider, PluralRuleType::Cardinal)
                     .unwrap();
                 for s in &numbers_data.usize {
                     let _ = pr.select(*s);
@@ -33,15 +33,15 @@ fn pluralrules(c: &mut Criterion) {
         c.bench_function("pluralrules/construct/fs", |b| {
             b.iter(|| {
                 for lang in &plurals_data.langs {
-                    PluralRules::try_new(lang.clone(), PluralRuleType::Ordinal, &provider).unwrap();
-                    PluralRules::try_new(lang.clone(), PluralRuleType::Cardinal, &provider)
+                    PluralRules::try_new(lang.clone(), &provider, PluralRuleType::Ordinal).unwrap();
+                    PluralRules::try_new(lang.clone(), &provider, PluralRuleType::Cardinal)
                         .unwrap();
                 }
             });
         });
 
         let loc: LanguageIdentifier = "pl".parse().unwrap();
-        let pr = PluralRules::try_new(loc, PluralRuleType::Cardinal, &provider).unwrap();
+        let pr = PluralRules::try_new(loc, &provider, PluralRuleType::Cardinal).unwrap();
         c.bench_function("plurals/select/fs", |b| {
             b.iter(|| {
                 for s in &numbers_data.usize {

--- a/components/pluralrules/examples/elevator_floors.rs
+++ b/components/pluralrules/examples/elevator_floors.rs
@@ -22,7 +22,7 @@ fn main() {
 
     {
         print("\n====== Elevator Floor (en) example ============", None);
-        let pr = PluralRules::try_new(langid, PluralRuleType::Ordinal, &dtp)
+        let pr = PluralRules::try_new(langid, &dtp, PluralRuleType::Ordinal)
             .expect("Failed to create a PluralRules instance.");
 
         for value in VALUES {

--- a/components/pluralrules/examples/unread_emails.rs
+++ b/components/pluralrules/examples/unread_emails.rs
@@ -22,7 +22,7 @@ fn main() {
 
     {
         print("\n====== Unread Emails (en) example ============", None);
-        let pr = PluralRules::try_new(langid, PluralRuleType::Cardinal, &dtp)
+        let pr = PluralRules::try_new(langid, &dtp, PluralRuleType::Cardinal)
             .expect("Failed to create a PluralRules instance.");
 
         for value in VALUES {

--- a/components/pluralrules/src/lib.rs
+++ b/components/pluralrules/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! let dp = InvariantDataProvider;
 //!
-//! let pr = PluralRules::try_new(lang, PluralRuleType::Cardinal, &dp)
+//! let pr = PluralRules::try_new(lang, &dp, PluralRuleType::Cardinal)
 //!     .expect("Failed to construct a PluralRules struct.");
 //!
 //! assert_eq!(pr.select(5_usize), PluralCategory::Other);
@@ -139,7 +139,7 @@ pub enum PluralRuleType {
 ///
 /// let dp = InvariantDataProvider;
 ///
-/// let pr = PluralRules::try_new(lang, PluralRuleType::Cardinal, &dp)
+/// let pr = PluralRules::try_new(lang, &dp, PluralRuleType::Cardinal)
 ///     .expect("Failed to construct a PluralRules struct.");
 ///
 /// assert_eq!(pr.select(5_usize), PluralCategory::Other);
@@ -247,7 +247,7 @@ impl PluralCategory {
 ///
 /// let dp = InvariantDataProvider;
 ///
-/// let pr = PluralRules::try_new(lang, PluralRuleType::Cardinal, &dp)
+/// let pr = PluralRules::try_new(lang, &dp, PluralRuleType::Cardinal)
 ///     .expect("Failed to construct a PluralRules struct.");
 ///
 /// assert_eq!(pr.select(5_usize), PluralCategory::Other);
@@ -279,15 +279,15 @@ impl PluralRules {
     ///
     /// let dp = InvariantDataProvider;
     ///
-    /// let _ = PluralRules::try_new(lang, PluralRuleType::Cardinal, &dp);
+    /// let _ = PluralRules::try_new(lang, &dp, PluralRuleType::Cardinal);
     /// ```
     ///
     /// [`type`]: ./enum.PluralRuleType.html
     /// [`data provider`]: ./data/trait.DataProviderType.html
     pub fn try_new<'d, D: DataProvider<'d>>(
         langid: LanguageIdentifier,
-        type_: PluralRuleType,
         data_provider: &D,
+        type_: PluralRuleType,
     ) -> Result<Self, PluralRulesError> {
         let data_key = match type_ {
             PluralRuleType::Cardinal => icu_data_key!(plurals: cardinal@1),
@@ -324,7 +324,7 @@ impl PluralRules {
     ///
     /// let dp = InvariantDataProvider;
     ///
-    /// let pr = PluralRules::try_new(lang, PluralRuleType::Cardinal, &dp)
+    /// let pr = PluralRules::try_new(lang, &dp, PluralRuleType::Cardinal)
     ///     .expect("Failed to construct a PluralRules struct.");
     ///
     /// match pr.select(1_usize) {
@@ -355,7 +355,7 @@ impl PluralRules {
     /// #
     /// # let dp = InvariantDataProvider;
     /// #
-    /// # let pr = PluralRules::try_new(lang, PluralRuleType::Cardinal, &dp)
+    /// # let pr = PluralRules::try_new(lang, &dp, PluralRuleType::Cardinal)
     /// #     .expect("Failed to construct a PluralRules struct.");
     ///
     /// let operands = PluralOperands::try_from(-5)

--- a/components/pluralrules/tests/plurals.rs
+++ b/components/pluralrules/tests/plurals.rs
@@ -9,7 +9,7 @@ fn test_plural_rules() {
 
     let lang: LanguageIdentifier = "en".parse().unwrap();
 
-    let pr = PluralRules::try_new(lang, PluralRuleType::Cardinal, &dp).unwrap();
+    let pr = PluralRules::try_new(lang, &dp, PluralRuleType::Cardinal).unwrap();
 
     assert_eq!(pr.select(5_usize), PluralCategory::Other);
 }
@@ -21,7 +21,7 @@ fn test_plural_rules_missing() {
 
     let lang: LanguageIdentifier = "xx".parse().unwrap();
 
-    let pr = PluralRules::try_new(lang, PluralRuleType::Cardinal, &dp);
+    let pr = PluralRules::try_new(lang, &dp, PluralRuleType::Cardinal);
 
     assert!(pr.is_err());
 }


### PR DESCRIPTION
While working on the meta package I noticed an inconsistency between the order of arguments in a constructor of `PluralRules` and `DateTimeFormat`.

I think the choice is arbitrary, but since options are, well, optional, and langid+provider are mandatory, I settled for:

`Struct::method(langid, provider, ...)`