### PR TITLE
Attempt to make a const DataKey

### DIFF
--- a/components/data-provider/Cargo.toml
+++ b/components/data-provider/Cargo.toml
@@ -21,6 +21,7 @@ invariant = []
 [dependencies]
 icu-locale = { path = "../locale" }
 tinystr = "0.3"
+tinystr-macros = "0.1"
 erased-serde = "0.3"
 smallstr = { version = "0.2", features = ["serde"] }
 downcast-rs = "1.2"

--- a/components/data-provider/src/data_key.rs
+++ b/components/data-provider/src/data_key.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Write;
 use tinystr::TinyStr16;
+use tinystr_macros::tinystr16;
 
 /// A top-level collection of related data keys.
 #[non_exhaustive]
@@ -79,8 +80,7 @@ macro_rules! icu_data_key {
     ($category:expr, $sub_category:tt, $version:tt) => {
         $crate::DataKey {
             category: $category,
-            // TODO: Parse to TinyStr at compile time
-            sub_category: stringify!($sub_category).parse().unwrap(),
+            sub_category: tinystr_macros::tinystr16!(stringify!($sub_category)),
             version: $version,
         }
     };

--- a/components/data-provider/src/structs/decimal.rs
+++ b/components/data-provider/src/structs/decimal.rs
@@ -1,9 +1,11 @@
 // Decimal types
+use crate::prelude::*;
 use serde::{Deserialize, Serialize};
 use smallstr::SmallString;
 
-#[cfg(feature = "invariant")]
-use crate::prelude::*;
+pub const KNOWN_KEYS: [DataKey; 1] = [
+    icu_data_key!(decimal: symbols@1)
+];
 
 /// Gets a locale-invariant default struct given a data key in this module's category.
 #[cfg(feature = "invariant")]


### PR DESCRIPTION
This is currently failing to compile:

```
error: proc macro panicked
  --> components/data-provider/src/data_key.rs:83:27
   |
83 |             sub_category: tinystr_macros::tinystr16!(stringify!($sub_category)),
   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   | 
  ::: components/data-provider/src/structs/decimal.rs:7:5
   |
7  |     icu_data_key!(decimal: symbols@1)
   |     --------------------------------- in this macro invocation
   |
   = help: message: Argument must be a string literal.
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```
