### PR TITLE
Bench overview

### DIFF
--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -25,6 +25,11 @@ icu-testdata = { path = "../../resources/testdata" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
+[features]
+default = []
+
+bench = []
+
 [[bench]]
 name = "datetime"
 harness = false
@@ -32,3 +37,4 @@ harness = false
 [[bench]]
 name = "pattern"
 harness = false
+required-features = ["bench"]

--- a/components/datetime/benches/datetime.rs
+++ b/components/datetime/benches/datetime.rs
@@ -11,6 +11,35 @@ fn datetime_benches(c: &mut Criterion) {
 
     let provider = icu_testdata::get_provider();
 
+    let mut group = c.benchmark_group("datetime");
+
+    group.bench_function("overview", |b| {
+        b.iter(|| {
+            for fx in &fxs.0 {
+                let datetimes: Vec<MockDateTime> = fx
+                    .values
+                    .iter()
+                    .map(|value| value.parse().unwrap())
+                    .collect();
+                for setup in &fx.setups {
+                    let langid = setup.locale.parse().unwrap();
+                    let options = fixtures::get_options(&setup.options);
+                    let dtf = DateTimeFormat::try_new(langid, &provider, &options).unwrap();
+
+                    let mut result = String::new();
+
+                    for dt in &datetimes {
+                        let fdt = dtf.format(dt);
+                        write!(result, "{}", fdt).unwrap();
+                        result.clear();
+                    }
+                }
+            }
+        })
+    });
+    group.finish();
+
+    #[cfg(feature = "bench")]
     {
         let mut group = c.benchmark_group("datetime");
 

--- a/components/locale/Cargo.toml
+++ b/components/locale/Cargo.toml
@@ -23,12 +23,15 @@ criterion = "0.3.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
-[lib]
-bench = false
+[features]
+default = []
+
+bench = []
 
 [[bench]]
 name = "subtags"
 harness = false
+required-features = ["bench"]
 
 [[bench]]
 name = "langid"

--- a/components/locale/benches/helpers/macros.rs
+++ b/components/locale/benches/helpers/macros.rs
@@ -1,4 +1,25 @@
 #[macro_export]
+macro_rules! overview {
+    ($c:expr, $struct:ident, $data_str:expr, $compare:expr) => {
+        $c.bench_function("overview", |b| {
+            b.iter(|| {
+                let mut values = vec![];
+                for s in $data_str {
+                    let value: Result<$struct, _> = black_box(s).parse();
+                    values.push(value.expect("Parsing failed"));
+                }
+                let _ = values.iter().filter(|v| *v == $compare).count();
+
+                let mut strings = vec![];
+                for value in &values {
+                    strings.push(value.to_string());
+                }
+            })
+        });
+    };
+}
+
+#[macro_export]
 macro_rules! construct {
     ($c:expr, $struct:ident, $struct_name:expr, $data_str:expr) => {
         $c.bench_function($struct_name, |b| {

--- a/components/locale/benches/langid.rs
+++ b/components/locale/benches/langid.rs
@@ -1,78 +1,93 @@
 mod fixtures;
 mod helpers;
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-use icu_locale::{LanguageIdentifier, Locale};
+use icu_locale::LanguageIdentifier;
 
 fn langid_benches(c: &mut Criterion) {
     let path = "./benches/fixtures/langid.json";
     let data: fixtures::LocaleList = helpers::read_fixture(path).expect("Failed to read a fixture");
 
-    // Construct
+    // Overview
     {
-        let mut group = c.benchmark_group("langid/construct");
+        let mut group = c.benchmark_group("langid");
 
-        construct!(group, LanguageIdentifier, "langid", &data.canonicalized);
-        construct!(group, Locale, "locale", &data.canonicalized);
+        overview!(group, LanguageIdentifier, &data.canonicalized, "en-US");
 
         group.finish();
     }
 
-    // Stringify
+    #[cfg(feature = "bench")]
     {
-        let mut group = c.benchmark_group("langid/to_string");
+        use criterion::BenchmarkId;
+        use icu_locale::Locale;
 
-        let langids: Vec<LanguageIdentifier> = data
-            .canonicalized
-            .iter()
-            .map(|s| s.parse().unwrap())
-            .collect();
+        // Construct
+        {
+            let mut group = c.benchmark_group("langid/construct");
 
-        to_string!(group, LanguageIdentifier, "langid", &langids);
-        to_string!(group, Locale, "locale", &langids);
+            construct!(group, LanguageIdentifier, "langid", &data.canonicalized);
+            construct!(group, Locale, "locale", &data.canonicalized);
 
-        group.finish();
-    }
+            group.finish();
+        }
 
-    // Compare
-    {
-        let mut group = c.benchmark_group("langid/compare");
+        // Stringify
+        {
+            let mut group = c.benchmark_group("langid/to_string");
 
-        let langids: Vec<LanguageIdentifier> = data
-            .canonicalized
-            .iter()
-            .map(|s| s.parse().unwrap())
-            .collect();
-        let langids2: Vec<LanguageIdentifier> = data
-            .canonicalized
-            .iter()
-            .map(|s| s.parse().unwrap())
-            .collect();
+            let langids: Vec<LanguageIdentifier> = data
+                .canonicalized
+                .iter()
+                .map(|s| s.parse().unwrap())
+                .collect();
 
-        compare_struct!(group, LanguageIdentifier, "langid", &langids, &langids2);
-        compare_struct!(group, Locale, "locale", &langids, &langids2);
+            to_string!(group, LanguageIdentifier, "langid", &langids);
+            to_string!(group, Locale, "locale", &langids);
 
-        compare_str!(
-            group,
-            LanguageIdentifier,
-            "langid",
-            &langids,
-            &data.canonicalized
-        );
-        compare_str!(group, Locale, "locale", &langids, &data.canonicalized);
+            group.finish();
+        }
 
-        group.finish();
-    }
+        // Compare
+        {
+            let mut group = c.benchmark_group("langid/compare");
 
-    // Canonicalize
-    {
-        let mut group = c.benchmark_group("langid/canonicalize");
+            let langids: Vec<LanguageIdentifier> = data
+                .canonicalized
+                .iter()
+                .map(|s| s.parse().unwrap())
+                .collect();
+            let langids2: Vec<LanguageIdentifier> = data
+                .canonicalized
+                .iter()
+                .map(|s| s.parse().unwrap())
+                .collect();
 
-        canonicalize!(group, LanguageIdentifier, "langid", &data.casing);
-        canonicalize!(group, Locale, "locale", &data.casing);
+            compare_struct!(group, LanguageIdentifier, "langid", &langids, &langids2);
+            compare_struct!(group, Locale, "locale", &langids, &langids2);
 
-        group.finish();
+            compare_str!(
+                group,
+                LanguageIdentifier,
+                "langid",
+                &langids,
+                &data.canonicalized
+            );
+            compare_str!(group, Locale, "locale", &langids, &data.canonicalized);
+
+            group.finish();
+        }
+
+        // Canonicalize
+        {
+            let mut group = c.benchmark_group("langid/canonicalize");
+
+            canonicalize!(group, LanguageIdentifier, "langid", &data.casing);
+            canonicalize!(group, Locale, "locale", &data.casing);
+
+            group.finish();
+        }
     }
 }
 

--- a/components/locale/benches/locale.rs
+++ b/components/locale/benches/locale.rs
@@ -1,7 +1,7 @@
 mod fixtures;
 mod helpers;
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use icu_locale::Locale;
 
@@ -9,59 +9,73 @@ fn locale_benches(c: &mut Criterion) {
     let path = "./benches/fixtures/locale.json";
     let data: fixtures::LocaleList = helpers::read_fixture(path).expect("Failed to read a fixture");
 
-    // Construct
+    // Overview
     {
-        let mut group = c.benchmark_group("locale/construct");
+        let mut group = c.benchmark_group("locale");
 
-        construct!(group, Locale, "locale", &data.canonicalized);
+        overview!(group, Locale, &data.canonicalized, "en-US");
 
         group.finish();
     }
 
-    // Stringify
+    #[cfg(feature = "bench")]
     {
-        let mut group = c.benchmark_group("locale/to_string");
+        use criterion::BenchmarkId;
 
-        let locales: Vec<Locale> = data
-            .canonicalized
-            .iter()
-            .map(|s| s.parse().unwrap())
-            .collect();
+        // Construct
+        {
+            let mut group = c.benchmark_group("locale/construct");
 
-        to_string!(group, Locale, "locale", &locales);
+            construct!(group, Locale, "locale", &data.canonicalized);
 
-        group.finish();
-    }
+            group.finish();
+        }
 
-    // Compare
-    {
-        let mut group = c.benchmark_group("locale/compare");
+        // Stringify
+        {
+            let mut group = c.benchmark_group("locale/to_string");
 
-        let locales: Vec<Locale> = data
-            .canonicalized
-            .iter()
-            .map(|s| s.parse().unwrap())
-            .collect();
-        let locales2: Vec<Locale> = data
-            .canonicalized
-            .iter()
-            .map(|s| s.parse().unwrap())
-            .collect();
+            let locales: Vec<Locale> = data
+                .canonicalized
+                .iter()
+                .map(|s| s.parse().unwrap())
+                .collect();
 
-        compare_struct!(group, Locale, "locale", &locales, &locales2);
+            to_string!(group, Locale, "locale", &locales);
 
-        compare_str!(group, Locale, "locale", &locales, &data.canonicalized);
+            group.finish();
+        }
 
-        group.finish();
-    }
+        // Compare
+        {
+            let mut group = c.benchmark_group("locale/compare");
 
-    // Canonicalize
-    {
-        let mut group = c.benchmark_group("locale/canonicalize");
+            let locales: Vec<Locale> = data
+                .canonicalized
+                .iter()
+                .map(|s| s.parse().unwrap())
+                .collect();
+            let locales2: Vec<Locale> = data
+                .canonicalized
+                .iter()
+                .map(|s| s.parse().unwrap())
+                .collect();
 
-        canonicalize!(group, Locale, "locale", &data.casing);
+            compare_struct!(group, Locale, "locale", &locales, &locales2);
 
-        group.finish();
+            compare_str!(group, Locale, "locale", &locales, &data.canonicalized);
+
+            group.finish();
+        }
+
+        // Canonicalize
+        {
+            let mut group = c.benchmark_group("locale/canonicalize");
+
+            canonicalize!(group, Locale, "locale", &data.casing);
+
+            group.finish();
+        }
     }
 }
 

--- a/components/locale/benches/subtags.rs
+++ b/components/locale/benches/subtags.rs
@@ -8,7 +8,7 @@ use icu_locale::ParserError;
 
 macro_rules! subtag_bench {
     ($c:expr, $name:expr, $subtag:ident, $data:expr) => {
-        $c.bench_function(&format!("{}_subtag_parse", $name), |b| {
+        $c.bench_function(&format!("subtags/{}/parse", $name), |b| {
             b.iter(|| {
                 for s in &$data.valid {
                     let _: $subtag = black_box(s).parse().unwrap();

--- a/components/locale/src/langid.rs
+++ b/components/locale/src/langid.rs
@@ -156,3 +156,9 @@ impl PartialEq<&str> for LanguageIdentifier {
         self.to_string().eq(*other)
     }
 }
+
+impl PartialEq<str> for LanguageIdentifier {
+    fn eq(&self, other: &str) -> bool {
+        self.to_string().eq(other)
+    }
+}

--- a/components/locale/src/locale.rs
+++ b/components/locale/src/locale.rs
@@ -175,3 +175,9 @@ impl PartialEq<&str> for Locale {
         self.to_string().eq(*other)
     }
 }
+
+impl PartialEq<str> for Locale {
+    fn eq(&self, other: &str) -> bool {
+        self.to_string().eq(other)
+    }
+}

--- a/components/plurals/benches/operands.rs
+++ b/components/plurals/benches/operands.rs
@@ -9,7 +9,7 @@ use std::convert::TryInto;
 fn operands(c: &mut Criterion) {
     let data = helpers::get_numbers_data();
 
-    c.bench_function("operands/overview", |b| {
+    c.bench_function("plurals/operands/overview", |b| {
         b.iter(|| {
             for s in &data.usize {
                 let _: PluralOperands = black_box(*s).into();
@@ -37,7 +37,7 @@ fn operands(c: &mut Criterion) {
     {
         use criterion::BenchmarkId;
 
-        c.bench_function("operands/create/usize", |b| {
+        c.bench_function("plurals/operands/create/usize", |b| {
             b.iter(|| {
                 for s in &data.usize {
                     let _: PluralOperands = black_box(*s).into();
@@ -45,7 +45,7 @@ fn operands(c: &mut Criterion) {
             })
         });
 
-        c.bench_function("operands/create/isize", |b| {
+        c.bench_function("plurals/operands/create/isize", |b| {
             b.iter(|| {
                 for s in &data.isize {
                     let _: PluralOperands = black_box(*s)
@@ -55,7 +55,7 @@ fn operands(c: &mut Criterion) {
             })
         });
 
-        c.bench_function("operands/create/string", |b| {
+        c.bench_function("plurals/operands/create/string", |b| {
             b.iter(|| {
                 for s in &data.string {
                     let _: PluralOperands = black_box(s)
@@ -66,7 +66,7 @@ fn operands(c: &mut Criterion) {
         });
 
         {
-            let mut group = c.benchmark_group("operands/create/string/samples");
+            let mut group = c.benchmark_group("plurals/operands/create/string/samples");
             for s in &data.string_samples {
                 group.bench_with_input(BenchmarkId::from_parameter(s), s, |b, s| {
                     b.iter(|| {
@@ -75,7 +75,7 @@ fn operands(c: &mut Criterion) {
                 });
             }
         }
-        c.bench_function("operands/eq/mostly_unequal", |b| {
+        c.bench_function("plurals/operands/eq/mostly_unequal", |b| {
             let p: PluralOperands = "1".parse().expect("Parse successful");
             b.iter(|| {
                 for s in &data.isize {
@@ -87,7 +87,7 @@ fn operands(c: &mut Criterion) {
             })
         });
 
-        c.bench_function("operands/eq/mostly_equal", |b| {
+        c.bench_function("plurals/operands/eq/mostly_equal", |b| {
             b.iter(|| {
                 for s in &data.isize {
                     let p: PluralOperands = black_box(*s)
@@ -101,7 +101,7 @@ fn operands(c: &mut Criterion) {
             })
         });
 
-        c.bench_function("operands/create/from_fixed_decimal", |b| {
+        c.bench_function("plurals/operands/create/from_fixed_decimal", |b| {
             b.iter(|| {
                 for s in &data.fixed_decimals {
                     let f: FixedDecimal = FixedDecimal::from(s.value)
@@ -118,7 +118,7 @@ fn operands(c: &mut Criterion) {
                 FixedDecimal::from(123450).multiplied_pow10(-4).unwrap(),
                 FixedDecimal::from(2500).multiplied_pow10(-2).unwrap(),
             ];
-            let mut group = c.benchmark_group("operands/create/from_fixed_decimal/samples");
+            let mut group = c.benchmark_group("plurals/operands/create/from_fixed_decimal/samples");
             for s in samples.iter() {
                 group.bench_with_input(
                     BenchmarkId::from_parameter(format!("{:?}", &s)),

--- a/components/plurals/benches/parser.rs
+++ b/components/plurals/benches/parser.rs
@@ -43,7 +43,7 @@ fn parser(c: &mut Criterion) {
         }
     }
 
-    c.bench_function("parser/overview", |b| {
+    c.bench_function("plurals/parser/overview", |b| {
         b.iter(|| {
             for rule in &rules {
                 let _ = parse_condition(black_box(rule.as_bytes()));
@@ -52,7 +52,7 @@ fn parser(c: &mut Criterion) {
     });
 
     #[cfg(feature = "bench")]
-    c.bench_function("parser/lex", |b| {
+    c.bench_function("plurals/parser/lex", |b| {
         use icu_plurals::rules::Lexer;
         b.iter(|| {
             for rule in &rules {

--- a/components/plurals/benches/pluralrules.rs
+++ b/components/plurals/benches/pluralrules.rs
@@ -11,7 +11,7 @@ fn pluralrules(c: &mut Criterion) {
 
     let provider = icu_testdata::get_provider();
 
-    c.bench_function("pluralrules/overview", |b| {
+    c.bench_function("plurals/pluralrules/overview", |b| {
         b.iter(|| {
             for lang in &plurals_data.langs {
                 let pr = PluralRules::try_new(lang.clone(), &provider, PluralRuleType::Cardinal)
@@ -28,7 +28,7 @@ fn pluralrules(c: &mut Criterion) {
         use criterion::black_box;
         use icu_locale::LanguageIdentifier;
 
-        c.bench_function("pluralrules/construct/fs", |b| {
+        c.bench_function("plurals/pluralrules/construct/fs", |b| {
             b.iter(|| {
                 for lang in &plurals_data.langs {
                     PluralRules::try_new(lang.clone(), &provider, PluralRuleType::Ordinal).unwrap();
@@ -40,7 +40,7 @@ fn pluralrules(c: &mut Criterion) {
 
         let loc: LanguageIdentifier = "pl".parse().unwrap();
         let pr = PluralRules::try_new(loc, &provider, PluralRuleType::Cardinal).unwrap();
-        c.bench_function("plurals/select/fs", |b| {
+        c.bench_function("plurals/pluralrules/select/fs", |b| {
             b.iter(|| {
                 for s in &numbers_data.usize {
                     let _ = pr.select(black_box(*s));

--- a/components/uniset/Cargo.toml
+++ b/components/uniset/Cargo.toml
@@ -16,8 +16,10 @@ include = [
 [dev-dependencies]
 criterion = "0.3.3"
 
-[lib]
-bench = false
+[features]
+default = []
+
+bench = []
 
 [[bench]]
 name = "inv_list"

--- a/components/uniset/benches/inv_list.rs
+++ b/components/uniset/benches/inv_list.rs
@@ -2,42 +2,60 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use icu_uniset::UnicodeSet;
 use std::char;
 
-fn contains_bench(c: &mut Criterion) {
+fn uniset_bench(c: &mut Criterion) {
     let best_ex = vec![65, 70];
     let best_sample = UnicodeSet::from_inversion_list(best_ex).unwrap();
     let worst_ex: Vec<u32> = (0..((char::MAX as u32) + 1)).collect();
     let worst_sample = UnicodeSet::from_inversion_list(worst_ex).unwrap();
 
-    let mut group = c.benchmark_group("uniset/contains");
-    group.bench_with_input("best", &best_sample, |b, sample| {
-        b.iter(|| sample.iter().map(|ch| sample.contains(ch)))
-    });
-    group.bench_with_input("worst", &worst_sample, |b, sample| {
-        b.iter(|| sample.iter().take(100).map(|ch| sample.contains(ch)))
-    });
-    group.finish();
-}
-
-fn contains_range_bench(c: &mut Criterion) {
-    let best_ex = vec![65, 70];
-    let best_sample = UnicodeSet::from_inversion_list(best_ex).unwrap();
-    let worst_ex: Vec<u32> = (0..((char::MAX as u32) + 1)).collect();
-    let worst_sample = UnicodeSet::from_inversion_list(worst_ex).unwrap();
-
-    let mut group = c.benchmark_group("uniset/contains_range");
-    group.bench_with_input("best", &best_sample, |b, sample| {
-        b.iter(|| sample.iter().map(|ch| sample.contains_range(&('A'..ch))))
-    });
-    group.bench_with_input("worst", &worst_sample, |b, sample| {
+    c.bench_function("uniset/overview", |b| {
         b.iter(|| {
-            sample
+            best_sample
+                .iter()
+                .map(|ch| best_sample.contains(ch))
+                .count();
+            worst_sample
+                .iter()
+                .map(|ch| worst_sample.contains(ch))
+                .count();
+            best_sample
+                .iter()
+                .map(|ch| best_sample.contains_range(&('A'..ch)))
+                .count();
+            worst_sample
                 .iter()
                 .take(100)
-                .map(|ch| sample.contains_range(&(char::from_u32(0).unwrap()..ch)))
+                .map(|ch| worst_sample.contains_range(&(char::from_u32(0).unwrap()..ch)))
+                .count();
         })
     });
-    group.finish();
+
+    #[cfg(feature = "bench")]
+    {
+        let mut group = c.benchmark_group("uniset/contains");
+        group.bench_with_input("best", &best_sample, |b, sample| {
+            b.iter(|| sample.iter().map(|ch| sample.contains(ch)))
+        });
+        group.bench_with_input("worst", &worst_sample, |b, sample| {
+            b.iter(|| sample.iter().take(100).map(|ch| sample.contains(ch)))
+        });
+        group.finish();
+
+        let mut group = c.benchmark_group("uniset/contains_range");
+        group.bench_with_input("best", &best_sample, |b, sample| {
+            b.iter(|| sample.iter().map(|ch| sample.contains_range(&('A'..ch))))
+        });
+        group.bench_with_input("worst", &worst_sample, |b, sample| {
+            b.iter(|| {
+                sample
+                    .iter()
+                    .take(100)
+                    .map(|ch| sample.contains_range(&(char::from_u32(0).unwrap()..ch)))
+            })
+        });
+        group.finish();
+    }
 }
 
-criterion_group!(benches, contains_bench, contains_range_bench);
+criterion_group!(benches, uniset_bench);
 criterion_main!(benches);

--- a/utils/fixed-decimal/Cargo.toml
+++ b/utils/fixed-decimal/Cargo.toml
@@ -24,8 +24,10 @@ criterion = "0.3.3"
 rand_pcg = "0.2"
 rand_distr = "0.2"
 
-[lib]
-bench = false
+[features]
+default = []
+
+bench = []
 
 [[bench]]
 name = "fixed_decimal"


### PR DESCRIPTION
This PR is on top of #323 and it fixes #324.

The goal is to separate benchmarks that are `overview` and have them available by default as `cargo bench` both in each component/util and from the main directory.

All other benchmarks are behind flag `bench`.

I also updated a couple benchmark names adding top level crate name to make it easier to recognize that `parser/overview` is part of plurals (so, renamed to `plurals/parser/overview`).

The choice of what's in `overview` is a bit arbitrary and I expect us to continue refining them, but much like `examples` I'd like the `overview` benchmarks to be a decent approximation of what we expect common users to use.