### PR TITLE
retrofit files with ICU4X license header

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,3 +1,6 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 ignore:
   - "/*"
   - "C:/*"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,3 +1,6 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 name: Build and Test
 
 on:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,3 +1,6 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 name:                           Coverage
 
 on:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 [workspace]
 
 members = [

--- a/components/cldr-json-data-provider/Cargo.toml
+++ b/components/cldr-json-data-provider/Cargo.toml
@@ -1,3 +1,6 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 [package]
 name = "icu-cldr-json-data-provider"
 description = "Data provider that reads from a CLDR JSON data source"

--- a/components/cldr-json-data-provider/src/cldr_langid.rs
+++ b/components/cldr-json-data-provider/src/cldr_langid.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use icu_locale::LanguageIdentifier;
 use serde::{Deserialize, Deserializer};
 use std::str::FromStr;

--- a/components/cldr-json-data-provider/src/cldr_paths.rs
+++ b/components/cldr-json-data-provider/src/cldr_paths.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::error::{Error, MissingSourceError};
 use std::default::Default;
 use std::path::PathBuf;

--- a/components/cldr-json-data-provider/src/download/cldr_paths_download.rs
+++ b/components/cldr-json-data-provider/src/download/cldr_paths_download.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use super::error::Error;
 use super::io_util;
 use crate::CldrPaths;

--- a/components/cldr-json-data-provider/src/download/error.rs
+++ b/components/cldr-json-data-provider/src/download/error.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::error;
 use std::fmt;
 use std::io;

--- a/components/cldr-json-data-provider/src/download/io_util.rs
+++ b/components/cldr-json-data-provider/src/download/io_util.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use super::error::Error;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};

--- a/components/cldr-json-data-provider/src/download/mod.rs
+++ b/components/cldr-json-data-provider/src/download/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod cldr_paths_download;
 mod error;
 mod io_util;

--- a/components/cldr-json-data-provider/src/error.rs
+++ b/components/cldr-json-data-provider/src/error.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::error;
 use std::fmt;
 use std::path::{Path, PathBuf};

--- a/components/cldr-json-data-provider/src/lib.rs
+++ b/components/cldr-json-data-provider/src/lib.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! `icu-cldr-json-data-provider` is one of the [`ICU4X`] components.
 //!
 //! It contains implementations of the [`DataProvider`] interface based on the JSON files

--- a/components/cldr-json-data-provider/src/reader.rs
+++ b/components/cldr-json-data-provider/src/reader.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::error::Error;
 use std::fs;
 use std::fs::File;

--- a/components/cldr-json-data-provider/src/support.rs
+++ b/components/cldr-json-data-provider/src/support.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::CldrPaths;
 use icu_data_provider::iter::DataEntryCollection;
 use icu_data_provider::prelude::*;

--- a/components/cldr-json-data-provider/src/transform/dates.rs
+++ b/components/cldr-json-data-provider/src/transform/dates.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::cldr_langid::CldrLangID;
 use crate::error::Error;
 use crate::reader::{get_subdirectories, open_reader};

--- a/components/cldr-json-data-provider/src/transform/mod.rs
+++ b/components/cldr-json-data-provider/src/transform/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod dates;
 mod plurals;
 

--- a/components/cldr-json-data-provider/src/transform/plurals.rs
+++ b/components/cldr-json-data-provider/src/transform/plurals.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::error::Error;
 use crate::reader::open_reader;
 use crate::support::DataKeySupport;

--- a/components/data-provider/Cargo.toml
+++ b/components/data-provider/Cargo.toml
@@ -1,3 +1,6 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 [package]
 name = "icu-data-provider"
 description = "Trait and struct definitions for the ICU data provider"

--- a/components/data-provider/src/cloneable_any.rs
+++ b/components/data-provider/src/cloneable_any.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use downcast_rs::impl_downcast;
 use downcast_rs::Downcast;
 use std::fmt::Debug;

--- a/components/data-provider/src/data_entry.rs
+++ b/components/data-provider/src/data_entry.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use icu_locale::LanguageIdentifier;
 use std::borrow::Borrow;
 use std::borrow::Cow;

--- a/components/data-provider/src/data_key.rs
+++ b/components/data-provider/src/data_key.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::borrow::Borrow;
 use std::borrow::Cow;
 use std::fmt;

--- a/components/data-provider/src/data_provider.rs
+++ b/components/data-provider/src/data_provider.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::cloneable_any::CloneableAny;
 use crate::data_entry::DataEntry;
 use crate::data_key::DataKey;

--- a/components/data-provider/src/error.rs
+++ b/components/data-provider/src/error.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::prelude::*;
 use core::ops::Deref;
 use std::any::TypeId;

--- a/components/data-provider/src/invariant.rs
+++ b/components/data-provider/src/invariant.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::error::Error;
 use crate::iter::DataEntryCollection;
 use crate::prelude::*;

--- a/components/data-provider/src/iter.rs
+++ b/components/data-provider/src/iter.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::error::Error;
 use crate::prelude::*;
 

--- a/components/data-provider/src/lib.rs
+++ b/components/data-provider/src/lib.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! `icu-data-provider` is one of the [`ICU4X`] components.
 //!
 //! It defines traits and structs for transmitting data through the ICU4X locale data pipeline.

--- a/components/data-provider/src/structs/dates.rs
+++ b/components/data-provider/src/structs/dates.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 // Date
 #[cfg(feature = "invariant")]
 use crate::prelude::*;

--- a/components/data-provider/src/structs/decimal.rs
+++ b/components/data-provider/src/structs/decimal.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 // Decimal types
 use serde::{Deserialize, Serialize};
 use smallstr::SmallString;

--- a/components/data-provider/src/structs/mod.rs
+++ b/components/data-provider/src/structs/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 pub mod dates;
 pub mod decimal;
 pub mod plurals;

--- a/components/data-provider/src/structs/plurals.rs
+++ b/components/data-provider/src/structs/plurals.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 // Plural types
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;

--- a/components/data-provider/tests/json_warehouse.rs
+++ b/components/data-provider/tests/json_warehouse.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use icu_locale::LanguageIdentifier;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -1,3 +1,6 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 [package]
 name = "icu-datetime"
 description = "API for managing Unicode Language and Locale Identifiers"

--- a/components/datetime/benches/datetime.rs
+++ b/components/datetime/benches/datetime.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod fixtures;
 
 use criterion::{criterion_group, criterion_main, Criterion};

--- a/components/datetime/benches/fixtures/mod.rs
+++ b/components/datetime/benches/fixtures/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 pub mod structs;
 
 use icu_datetime::options::{style, DateTimeFormatOptions};

--- a/components/datetime/benches/fixtures/structs.rs
+++ b/components/datetime/benches/fixtures/structs.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/components/datetime/benches/pattern.rs
+++ b/components/datetime/benches/pattern.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod fixtures;
 
 use criterion::{criterion_group, criterion_main, Criterion};

--- a/components/datetime/examples/work_log.rs
+++ b/components/datetime/examples/work_log.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 // An example application which uses icu_datetime to format entries
 // from a work log into human readable dates and times.
 use icu_datetime::date::MockDateTime;

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::ops::{Add, Sub};

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::pattern;
 use icu_data_provider::prelude::DataError;
 

--- a/components/datetime/src/fields/length.rs
+++ b/components/datetime/src/fields/length.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::convert::TryFrom;
 
 #[derive(Debug)]

--- a/components/datetime/src/fields/mod.rs
+++ b/components/datetime/src/fields/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod length;
 mod symbols;
 

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::convert::TryFrom;
 
 #[derive(Debug)]

--- a/components/datetime/src/format.rs
+++ b/components/datetime/src/format.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::date::{self, DateTimeType};
 use crate::error::DateTimeFormatError;
 use crate::fields::{self, FieldLength, FieldSymbol};

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! `icu-datetime` is one of the [`ICU4X`] components.
 //!
 //! It is a core API for formatting date and time to user readable textual representation.

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! Components is a model of encoding information on how to format date and time by specifying a list of components
 //! the user wants to be visible in the formatted string and how each field should be displayed.
 //!

--- a/components/datetime/src/options/mod.rs
+++ b/components/datetime/src/options/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! `DateTimeFormatOptions` is a bag of options which, together with `LanguageIdentifier`,
 //! define how dates will be formatted be a `DateTimeFormat` instance.
 //!

--- a/components/datetime/src/options/preferences.rs
+++ b/components/datetime/src/options/preferences.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! Preferences is a bag of options to be associated with either `Style` or `Components` bag which provides
 //! information on user preferences that can affect the result of the formatting.
 //!

--- a/components/datetime/src/options/style.rs
+++ b/components/datetime/src/options/style.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! Style is a model of encoding information on how to format date and time by specifying the preferred length
 //! of date and time fields.
 //!

--- a/components/datetime/src/pattern/error.rs
+++ b/components/datetime/src/pattern/error.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::fields;
 
 #[derive(Debug)]

--- a/components/datetime/src/pattern/mod.rs
+++ b/components/datetime/src/pattern/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod error;
 mod parser;
 

--- a/components/datetime/src/pattern/parser.rs
+++ b/components/datetime/src/pattern/parser.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use super::error::Error;
 use super::{Pattern, PatternItem};
 use crate::fields::{Field, FieldSymbol};

--- a/components/datetime/src/provider.rs
+++ b/components/datetime/src/provider.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::date;
 use crate::error::DateTimeFormatError;
 use crate::fields;

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod fixtures;
 
 use icu_datetime::DateTimeFormat;

--- a/components/datetime/tests/fixtures/mod.rs
+++ b/components/datetime/tests/fixtures/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 pub mod structs;
 
 use icu_datetime::options::style;

--- a/components/datetime/tests/fixtures/structs.rs
+++ b/components/datetime/tests/fixtures/structs.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/components/fs-data-provider/Cargo.toml
+++ b/components/fs-data-provider/Cargo.toml
@@ -1,3 +1,6 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 [package]
 name = "icu-fs-data-provider"
 description = "ICU4X data provider that reads from structured data files"

--- a/components/fs-data-provider/src/bin/icu4x-cldr-export.rs
+++ b/components/fs-data-provider/src/bin/icu4x-cldr-export.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::manifest::LocalesOption;
 use clap::{App, Arg, ArgGroup};
 use icu_cldr_json_data_provider::download::CldrPathsDownload;

--- a/components/fs-data-provider/src/error.rs
+++ b/components/fs-data-provider/src/error.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::fmt;
 use std::path::{Path, PathBuf};
 

--- a/components/fs-data-provider/src/export/aliasing.rs
+++ b/components/fs-data-provider/src/export/aliasing.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::error::Error;
 use std::collections::HashMap;
 use std::fmt;

--- a/components/fs-data-provider/src/export/fs_exporter.rs
+++ b/components/fs-data-provider/src/export/fs_exporter.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use super::aliasing::{self, AliasCollection};
 use super::serializers::Serializer;
 use crate::error::Error;

--- a/components/fs-data-provider/src/export/mod.rs
+++ b/components/fs-data-provider/src/export/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! The `export` feature enables you to pull all data from some other data provider and persist it
 //! on the filesystem to be read by an FsDataProvider at runtime.
 //!

--- a/components/fs-data-provider/src/export/serializers.rs
+++ b/components/fs-data-provider/src/export/serializers.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::manifest::SyntaxOption;
 use std::io;
 use std::ops::Deref;

--- a/components/fs-data-provider/src/fs_data_provider.rs
+++ b/components/fs-data-provider/src/fs_data_provider.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::error::Error;
 use crate::manifest::Manifest;
 use crate::manifest::MANIFEST_FILE;

--- a/components/fs-data-provider/src/lib.rs
+++ b/components/fs-data-provider/src/lib.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! `icu-fs-data-provider` is one of the [`ICU4X`] components.
 //!
 //! It reads ICU4X data files from the filesystem in a given directory. It can also export data to

--- a/components/fs-data-provider/src/manifest.rs
+++ b/components/fs-data-provider/src/manifest.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use icu_locale::LanguageIdentifier;
 use serde::{Deserialize, Serialize};
 

--- a/components/fs-data-provider/tests/test_file_io.rs
+++ b/components/fs-data-provider/tests/test_file_io.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use icu_data_provider::prelude::*;
 use icu_data_provider::structs;
 use icu_fs_data_provider::FsDataProvider;

--- a/components/icu/Cargo.toml
+++ b/components/icu/Cargo.toml
@@ -1,3 +1,6 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 [package]
 name = "icu"
 description = "International Components for Unicode"

--- a/components/icu/examples/tui.rs
+++ b/components/icu/examples/tui.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 // An example program making use of a number of ICU components
 // in a pseudo-real-world application of Textual User Interface.
 use icu::datetime::{date::MockDateTime, DateTimeFormat, DateTimeFormatOptions};

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! `ICU` is the main meta-package of the `ICU4X` project.
 //!
 //! It provides a comperhensive selection of Unicode Internationalization Components

--- a/components/icu4x/Cargo.toml
+++ b/components/icu4x/Cargo.toml
@@ -1,3 +1,6 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 [package]
 name = "icu4x"
 description = "International Components for Unicode"

--- a/components/icu4x/src/lib.rs
+++ b/components/icu4x/src/lib.rs
@@ -1,4 +1,3 @@
 // This file is part of ICU4X. For terms of use, please see the file
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
-

--- a/components/icu4x/src/lib.rs
+++ b/components/icu4x/src/lib.rs
@@ -1,1 +1,4 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 

--- a/components/locale/Cargo.toml
+++ b/components/locale/Cargo.toml
@@ -1,3 +1,6 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 [package]
 name = "icu-locale"
 description = "API for managing Unicode Language and Locale Identifiers"

--- a/components/locale/benches/fixtures/mod.rs
+++ b/components/locale/benches/fixtures/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use serde::Deserialize;
 
 #[derive(Deserialize)]

--- a/components/locale/benches/helpers/macros.rs
+++ b/components/locale/benches/helpers/macros.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 #[macro_export]
 macro_rules! overview {
     ($c:expr, $struct:ident, $data_str:expr, $compare:expr) => {

--- a/components/locale/benches/helpers/mod.rs
+++ b/components/locale/benches/helpers/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod macros;
 
 use std::fs::File;

--- a/components/locale/benches/langid.rs
+++ b/components/locale/benches/langid.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod fixtures;
 mod helpers;
 

--- a/components/locale/benches/locale.rs
+++ b/components/locale/benches/locale.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod fixtures;
 mod helpers;
 

--- a/components/locale/benches/subtags.rs
+++ b/components/locale/benches/subtags.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod fixtures;
 mod helpers;
 

--- a/components/locale/examples/filter_langids.rs
+++ b/components/locale/examples/filter_langids.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 // A sample application which takes a comma separated list of language identifiers,
 // filters out identifiers with language subtags different than `en` and serializes
 // the list back into a comma separated list in canonical syntax.

--- a/components/locale/macros/Cargo.toml
+++ b/components/locale/macros/Cargo.toml
@@ -1,3 +1,6 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 [package]
 name = "icu-locale-macros"
 description = "proc-macros for icu-locale"

--- a/components/locale/macros/src/lib.rs
+++ b/components/locale/macros/src/lib.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod token_stream;
 
 extern crate proc_macro;

--- a/components/locale/macros/src/token_stream.rs
+++ b/components/locale/macros/src/token_stream.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use icu_locale::subtags;
 use tinystr::{TinyStr4, TinyStr8};
 

--- a/components/locale/macros/tests/macros.rs
+++ b/components/locale/macros/tests/macros.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use icu_locale::subtags;
 use icu_locale::LanguageIdentifier;
 use icu_locale_macros::*;

--- a/components/locale/src/extensions/mod.rs
+++ b/components/locale/src/extensions/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! Unicode Extensions provide a mechanism to extend the [`LanguageIdentifier`] with
 //! additional bits of information - a combination of a [`LanguageIdentifier`] and `Extensions`
 //! is called [`Locale`].

--- a/components/locale/src/extensions/private/key.rs
+++ b/components/locale/src/extensions/private/key.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::ops::RangeInclusive;
 use std::str::FromStr;
 

--- a/components/locale/src/extensions/private/mod.rs
+++ b/components/locale/src/extensions/private/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! Private Use Extensions is a list of extensions intended for
 //! private use.
 //!

--- a/components/locale/src/extensions/transform/fields.rs
+++ b/components/locale/src/extensions/transform/fields.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::borrow::Borrow;
 use std::ops::Deref;
 

--- a/components/locale/src/extensions/transform/key.rs
+++ b/components/locale/src/extensions/transform/key.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::parser::errors::ParserError;
 use std::str::FromStr;
 use tinystr::TinyStr4;

--- a/components/locale/src/extensions/transform/mod.rs
+++ b/components/locale/src/extensions/transform/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! Transform Extensions provide information on content transformations in a given locale.
 //!
 //! The main struct for this extension is [`Transform`] which contains [`Fields`] and an

--- a/components/locale/src/extensions/transform/value.rs
+++ b/components/locale/src/extensions/transform/value.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::parser::ParserError;
 use std::ops::RangeInclusive;
 use std::str::FromStr;

--- a/components/locale/src/extensions/unicode/attribute.rs
+++ b/components/locale/src/extensions/unicode/attribute.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::ops::RangeInclusive;
 use std::str::FromStr;
 

--- a/components/locale/src/extensions/unicode/attributes.rs
+++ b/components/locale/src/extensions/unicode/attributes.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use super::Attribute;
 use std::ops::Deref;
 

--- a/components/locale/src/extensions/unicode/key.rs
+++ b/components/locale/src/extensions/unicode/key.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::str::FromStr;
 
 use crate::parser::errors::ParserError;

--- a/components/locale/src/extensions/unicode/keywords.rs
+++ b/components/locale/src/extensions/unicode/keywords.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::borrow::Borrow;
 use std::ops::Deref;
 

--- a/components/locale/src/extensions/unicode/mod.rs
+++ b/components/locale/src/extensions/unicode/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! Unicode Extensions provide information about user preferences in a given locale.
 //!
 //! The main struct for this extension is [`Unicode`] which contains [`Keywords`] and

--- a/components/locale/src/extensions/unicode/value.rs
+++ b/components/locale/src/extensions/unicode/value.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::parser::ParserError;
 use std::ops::RangeInclusive;
 use std::str::FromStr;

--- a/components/locale/src/langid.rs
+++ b/components/locale/src/langid.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::fmt::Write;
 use std::str::FromStr;
 

--- a/components/locale/src/lib.rs
+++ b/components/locale/src/lib.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! `icu-locale` is one of the [`ICU4X`] components.
 //!
 //! It is a core API for parsing, manipulating, and serializing Unicode Language

--- a/components/locale/src/locale.rs
+++ b/components/locale/src/locale.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::parser::{parse_locale, ParserError};
 use crate::{extensions, subtags, LanguageIdentifier};
 use std::fmt::Write;

--- a/components/locale/src/parser/errors.rs
+++ b/components/locale/src/parser/errors.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::error::Error;
 use std::fmt::{self, Display};
 

--- a/components/locale/src/parser/langid.rs
+++ b/components/locale/src/parser/langid.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::iter::Peekable;
 
 pub use super::errors::ParserError;

--- a/components/locale/src/parser/locale.rs
+++ b/components/locale/src/parser/locale.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::extensions::Extensions;
 use crate::parser::errors::ParserError;
 use crate::parser::{parse_language_identifier_from_iter, ParserMode};

--- a/components/locale/src/parser/mod.rs
+++ b/components/locale/src/parser/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 pub(crate) mod errors;
 mod langid;
 mod locale;

--- a/components/locale/src/serde/langid.rs
+++ b/components/locale/src/serde/langid.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::LanguageIdentifier;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 

--- a/components/locale/src/serde/mod.rs
+++ b/components/locale/src/serde/mod.rs
@@ -1,1 +1,4 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod langid;

--- a/components/locale/src/subtags/language.rs
+++ b/components/locale/src/subtags/language.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use super::script::SCRIPT_LENGTH;
 use crate::parser::errors::ParserError;
 use std::ops::RangeInclusive;

--- a/components/locale/src/subtags/mod.rs
+++ b/components/locale/src/subtags/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! Language Identifier and Locale contains a set of subtags
 //! which represent different fields of the structure.
 //!

--- a/components/locale/src/subtags/region.rs
+++ b/components/locale/src/subtags/region.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::parser::errors::ParserError;
 use std::str::FromStr;
 use tinystr::TinyStr4;

--- a/components/locale/src/subtags/script.rs
+++ b/components/locale/src/subtags/script.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::parser::errors::ParserError;
 use std::str::FromStr;
 use tinystr::TinyStr4;

--- a/components/locale/src/subtags/variant.rs
+++ b/components/locale/src/subtags/variant.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::parser::errors::ParserError;
 use std::ops::RangeInclusive;
 use std::str::FromStr;

--- a/components/locale/src/subtags/variants.rs
+++ b/components/locale/src/subtags/variants.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use super::Variant;
 use std::ops::Deref;
 

--- a/components/locale/tests/fixtures/mod.rs
+++ b/components/locale/tests/fixtures/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 

--- a/components/locale/tests/helpers/mod.rs
+++ b/components/locale/tests/helpers/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::fs::File;
 use std::io::{BufReader, Error};
 

--- a/components/locale/tests/langid.rs
+++ b/components/locale/tests/langid.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod fixtures;
 mod helpers;
 

--- a/components/locale/tests/locale.rs
+++ b/components/locale/tests/locale.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod fixtures;
 mod helpers;
 

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -1,3 +1,6 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 [package]
 name = "icu-plurals"
 description = "Unicode Plural Rules categorizer for numeric input."

--- a/components/plurals/benches/fixtures/mod.rs
+++ b/components/plurals/benches/fixtures/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use icu_locale::LanguageIdentifier;
 use icu_plurals::PluralCategory;
 

--- a/components/plurals/benches/helpers/mod.rs
+++ b/components/plurals/benches/helpers/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::fs::File;
 use std::io::{BufReader, Error};
 

--- a/components/plurals/benches/operands.rs
+++ b/components/plurals/benches/operands.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod fixtures;
 mod helpers;
 

--- a/components/plurals/benches/parser.rs
+++ b/components/plurals/benches/parser.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod fixtures;
 mod helpers;
 

--- a/components/plurals/benches/pluralrules.rs
+++ b/components/plurals/benches/pluralrules.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod fixtures;
 mod helpers;
 

--- a/components/plurals/examples/elevator_floors.rs
+++ b/components/plurals/examples/elevator_floors.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 // An example application which uses icu_plurals to construct a correct
 // sentence for English based on the numerical value in Ordinal category.
 use icu_locale::LanguageIdentifier;

--- a/components/plurals/examples/unread_emails.rs
+++ b/components/plurals/examples/unread_emails.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 // An example application which uses icu_plurals to construct a correct
 // sentence for English based on the numerical value in Cardinal category.
 use icu_locale::LanguageIdentifier;

--- a/components/plurals/src/data.rs
+++ b/components/plurals/src/data.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! Module with data used by [`PluralRules`].
 //!
 //! # Examples

--- a/components/plurals/src/error.rs
+++ b/components/plurals/src/error.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::rules::parser::ParserError;
 use icu_data_provider::prelude::DataError;
 

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -1,3 +1,7 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
+//! `icu-pluralrules` is one of the [`ICU4X`] components.
 //! `icu-plurals` is one of the [`ICU4X`] components.
 //!
 //! This API provides functionality to determine the plural category

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use fixed_decimal::FixedDecimal;
 use std::convert::TryFrom;
 use std::io::Error as IOError;

--- a/components/plurals/src/rules/ast.rs
+++ b/components/plurals/src/rules/ast.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! `AST` provides a set of Syntax Tree Nodes used to store
 //! the output of [`parse`] method that is used in [`test_condition`] method
 //! to evaluate whether a given [`PluralCategory`] should be used.

--- a/components/plurals/src/rules/lexer.rs
+++ b/components/plurals/src/rules/lexer.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use super::ast;
 
 #[derive(Debug, PartialEq)]

--- a/components/plurals/src/rules/mod.rs
+++ b/components/plurals/src/rules/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! A single Plural Rule is an expression which tests the value of [`PluralOperands`]
 //! against a condition. If the condition is truthful, then the [`PluralCategory`]
 //! to which the Rule is assigned should be used.

--- a/components/plurals/src/rules/parser.rs
+++ b/components/plurals/src/rules/parser.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use super::ast;
 use super::lexer::{Lexer, Token};
 use std::iter::Peekable;

--- a/components/plurals/src/rules/resolver.rs
+++ b/components/plurals/src/rules/resolver.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use super::ast;
 use crate::operands::PluralOperands;
 

--- a/components/plurals/src/rules/serializer.rs
+++ b/components/plurals/src/rules/serializer.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::rules::ast;
 use std::fmt;
 use std::ops::RangeInclusive;

--- a/components/plurals/tests/fixtures/mod.rs
+++ b/components/plurals/tests/fixtures/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use fixed_decimal::FixedDecimal;
 use icu_plurals::PluralOperands;
 use serde::Deserialize;

--- a/components/plurals/tests/helpers.rs
+++ b/components/plurals/tests/helpers.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::fs::File;
 use std::io::{BufReader, Error};
 

--- a/components/plurals/tests/operands.rs
+++ b/components/plurals/tests/operands.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod fixtures;
 mod helpers;
 

--- a/components/plurals/tests/plurals.rs
+++ b/components/plurals/tests/plurals.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use icu_locale::LanguageIdentifier;
 use icu_plurals::{PluralCategory, PluralRuleType, PluralRules};
 

--- a/components/plurals/tests/rules.rs
+++ b/components/plurals/tests/rules.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 mod fixtures;
 mod helpers;
 

--- a/components/uniset/Cargo.toml
+++ b/components/uniset/Cargo.toml
@@ -1,3 +1,6 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 [package]
 name = "icu-uniset"
 description = "API for managing Unicode Language and Locale Identifiers"

--- a/components/uniset/benches/inv_list.rs
+++ b/components/uniset/benches/inv_list.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use criterion::{criterion_group, criterion_main, Criterion};
 use icu_uniset::UnicodeSet;
 use std::char;

--- a/components/uniset/examples/unicode_bmp_blocks_selector.rs
+++ b/components/uniset/examples/unicode_bmp_blocks_selector.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 // An example application which uses icu_uniset to test what blocks of
 // Basic Multilingual Plane a character belongs to.
 //

--- a/components/uniset/src/builder.rs
+++ b/components/uniset/src/builder.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::{char, cmp::Ordering, ops::RangeBounds};
 
 use crate::{uniset::UnicodeSet, utils::deconstruct_range};

--- a/components/uniset/src/conversions.rs
+++ b/components/uniset/src/conversions.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::{
     convert::TryFrom,
     ops::{Range, RangeBounds, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive},

--- a/components/uniset/src/lib.rs
+++ b/components/uniset/src/lib.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! # UnicodeSet
 //! This crate is the [ICU4X](https://github.com/unicode-org/icu4x) implementation of the existing [ICU4C UnicodeSet API](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1UnicodeSet.html).
 //!

--- a/components/uniset/src/uniset.rs
+++ b/components/uniset/src/uniset.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::{char, ops::RangeBounds, slice::Chunks};
 
 use super::UnicodeSetError;

--- a/components/uniset/src/utils.rs
+++ b/components/uniset/src/utils.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use std::{
     char,
     ops::{Bound::*, RangeBounds},

--- a/resources/testdata/Cargo.toml
+++ b/resources/testdata/Cargo.toml
@@ -1,3 +1,6 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 [package]
 name = "icu-testdata"
 description = "Test data for ICU4X, generated from CLDR."

--- a/resources/testdata/src/bin/icu4x-gen-testdata.rs
+++ b/resources/testdata/src/bin/icu4x-gen-testdata.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use clap::{App, Arg};
 use icu_cldr_json_data_provider::download::CldrPathsDownload;
 use icu_cldr_json_data_provider::CldrJsonDataProvider;

--- a/resources/testdata/src/lib.rs
+++ b/resources/testdata/src/lib.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! `icu-testdata` is a unit testing package for [`ICU4X`].
 //!
 //! The package exposes a DataProvider with stable data useful for unit testing. The data is

--- a/resources/testdata/src/metadata.rs
+++ b/resources/testdata/src/metadata.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use cargo_metadata::{self, MetadataCommand};
 use icu_locale::LanguageIdentifier;
 use serde::Deserialize;

--- a/resources/testdata/src/test_data_provider.rs
+++ b/resources/testdata/src/test_data_provider.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use icu_fs_data_provider::FsDataProvider;
 use std::path::PathBuf;
 

--- a/utils/fixed-decimal/Cargo.toml
+++ b/utils/fixed-decimal/Cargo.toml
@@ -1,3 +1,6 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 [package]
 name = "fixed-decimal"
 description = "An API for representing numbers in a human-readable form"

--- a/utils/fixed-decimal/benches/fixed_decimal.rs
+++ b/utils/fixed-decimal/benches/fixed_decimal.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use rand::SeedableRng;
 use rand_distr::{Distribution, Triangular};
 use rand_pcg::Lcg64Xsh32;

--- a/utils/fixed-decimal/examples/permyriad.rs
+++ b/utils/fixed-decimal/examples/permyriad.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 // In computers, monetary values are sometimes stored as integers representing one ten-thousandth
 // (one permyriad) of a monetary unit. FixedDecimal enables a cheap representation of these
 // amounts, also while retaining trailing zeros.

--- a/utils/fixed-decimal/src/decimal.rs
+++ b/utils/fixed-decimal/src/decimal.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use smallvec::SmallVec;
 
 use std::cmp;

--- a/utils/fixed-decimal/src/lib.rs
+++ b/utils/fixed-decimal/src/lib.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 //! `fixed-decimal` is a utility crate of the [`ICU4X`] project.
 //!
 //! It includes [`FixedDecimal`], a core API for representing numbers in a human-readable form

--- a/utils/fixed-decimal/src/uint_iterator.rs
+++ b/utils/fixed-decimal/src/uint_iterator.rs
@@ -1,3 +1,6 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 /// An iterator over the decimal digits of an integer, from least to most significant
 pub(crate) struct IntIterator<T> {
     /// Digits remaining to be returned from the iterator


### PR DESCRIPTION
Applied to `*.rs`, `*.toml`, and `*.yml` files using the following commands, when run at the root of the project:

```
find . -name "*.rs" | egrep -v "deletemetest" | ruby -lane 'file=$F[0]; puts "sed -i " + 39.chr + "1i // This file is part of ICU4X. For terms of use, please see the file\\n// called LICENSE at the top level of the ICU4X source tree\\n// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE )." + 39.chr + " " +file' | sh
```

```
find . -name "*.toml" | egrep -v "deletemetest" | ruby -lane 'file=$F[0]; puts "sed -i " + 39.chr + "1i # This file is part of ICU4X. For terms of use, please see the file\\n# called LICENSE at the top level of the ICU4X source tree\\n# (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE )." + 39.chr + " " +file' | sh
```

```
find . -name "*yml" | egrep -v "deletemetest" | ruby -lane 'file=$F[0]; puts "sed -i " + 39.chr + "1i # This file is part of ICU4X. For terms of use, please see the file\\n# called LICENSE at the top level of the ICU4X source tree\\n# (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE )." + 39.chr + " " +file' | sh
```

cc @hsivonen 

Closes #255 .