### PR TITLE
Run CI bench command per component

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -89,8 +89,11 @@ jobs:
       # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
       matrix:
         component:
+          - components/fs-data-provider
+          - components/cldr-json-data-provider
+          - components/datetime
           - components/locale
-          - components/num-util
+          - components/pluralrules
           - components/uniset
           - utils/fixed-decimal
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -89,11 +89,7 @@ jobs:
       # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
       matrix:
         component:
-          - components/fs-data-provider
-          - components/cldr-json-data-provider
-          - components/datetime
           - components/locale
-          - components/pluralrules
           - components/uniset
           - utils/fixed-decimal
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -111,7 +111,18 @@ jobs:
       # Benchmarking & dashboards job > Run benchmark.
 
       - name: Run benchmark
-        run: pushd $PWD && cd ${{ matrix.component }} && (cargo bench -- --output-format bencher | tee `dirs +1`/dev/${{ matrix.component }}/output.txt) && popd
+        run: |
+          pushd $PWD && cd ${{ matrix.component }} && dirs;
+          dirs;
+          dirs +1;
+          export REL_OUTPUT_PATH="`dirs +1`/dev/${{ matrix.component }}/output.txt" && export OUTPUT_PATH_CMD="ls -d $REL_OUTPUT_PATH";
+          echo $REL_OUTPUT_PATH;
+          echo $OUTPUT_PATH_CMD;
+          export OUTPUT_PATH=$(echo $OUTPUT_PATH_CMD | sh);
+          echo $OUTPUT_PATH;
+          ls $OUTPUT_PATH;
+          cargo bench -- --output-format bencher | tee $OUTPUT_PATH
+          popd
 
       # In the following step(s) regarding converting benchmark output to dashboards, the branch in `gh-pages-branch` needs to exist.
       # If it doesn't already exist, it should be created by someone with push permissions, like so:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -111,7 +111,7 @@ jobs:
       # Benchmarking & dashboards job > Run benchmark.
 
       - name: Run benchmark
-        run: pushd $PWD && cd ${{ matrix.component }} && (cargo bench -- --output-format bencher | tee "`dirs +1`/dev/output.txt") && popd
+        run: pushd $PWD && cd ${{ matrix.component }} && (cargo bench -- --output-format bencher | tee `dirs +1`/dev/${{ matrix.component }}/output.txt) && popd
 
       # In the following step(s) regarding converting benchmark output to dashboards, the branch in `gh-pages-branch` needs to exist.
       # If it doesn't already exist, it should be created by someone with push permissions, like so:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -108,7 +108,7 @@ jobs:
       # Benchmarking & dashboards job > Run benchmark.
 
       - name: Run benchmark
-        run: pushd $PWD && cd ./${{ matrix.component }} && (cargo bench -- --output-format bencher | tee "`dirs +1`/dev/output.txt") && popd
+        run: pushd $PWD && cd ${{ matrix.component }} && (cargo bench -- --output-format bencher | tee "`dirs +1`/dev/output.txt") && popd
 
       # In the following step(s) regarding converting benchmark output to dashboards, the branch in `gh-pages-branch` needs to exist.
       # If it doesn't already exist, it should be created by someone with push permissions, like so:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -108,16 +108,12 @@ jobs:
 
       - name: Run benchmark
         run: |
-          pushd $PWD && cd ${{ matrix.component }} && dirs;
-          dirs;
-          dirs +1;
-          export REL_OUTPUT_PATH="`dirs +1`/dev/${{ matrix.component }}/output.txt" && export OUTPUT_PATH_CMD="ls -d $REL_OUTPUT_PATH";
-          echo $REL_OUTPUT_PATH;
-          echo $OUTPUT_PATH_CMD;
+          pushd $PWD && cd ${{ matrix.component }};
+          export REL_OUTPUT_PATH="`dirs +1`/dev/${{ matrix.component }}";
+          mkdir -p $REL_OUTPUT_PATH;
+          export OUTPUT_PATH_CMD="ls -d $REL_OUTPUT_PATH";
           export OUTPUT_PATH=$(echo $OUTPUT_PATH_CMD | sh);
-          echo $OUTPUT_PATH;
-          ls $OUTPUT_PATH;
-          cargo bench -- --output-format bencher | tee $OUTPUT_PATH
+          cargo bench -- --output-format bencher | tee $OUTPUT_PATH/output.txt
           popd
 
       # In the following step(s) regarding converting benchmark output to dashboards, the branch in `gh-pages-branch` needs to exist.

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -108,7 +108,7 @@ jobs:
       # Benchmarking & dashboards job > Run benchmark.
 
       - name: Run benchmark
-        run: pushd $PWD && cd ./dev/${{ matrix.component }} && (cargo bench -- --output-format bencher | tee output.txt) && popd
+        run: pushd $PWD && cd ./${{ matrix.component }} && (cargo bench -- --output-format bencher | tee "`dirs +1`/dev/output.txt") && popd
 
       # In the following step(s) regarding converting benchmark output to dashboards, the branch in `gh-pages-branch` needs to exist.
       # If it doesn't already exist, it should be created by someone with push permissions, like so:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,5 @@ More information about the project can be found on our [wiki](https://github.com
 | Component     | Runtime                                                                  |
 |---------------|--------------------------------------------------------------------------|
 | locale        | [link](https://unicode-org.github.io/icu4x-docs/dev/components/locale)   |
-| num-util      | [link](https://unicode-org.github.io/icu4x-docs/dev/components/num-util) |
 | uniset        | [link](https://unicode-org.github.io/icu4x-docs/dev/components/uniset)   |
 | fixed-decimal | [link](https://unicode-org.github.io/icu4x-docs/dev/utils/fixed-decimal) |


### PR DESCRIPTION
Fixes #320 

The PR does the following:

- run benchmark individually on each component
- update list of components of components with benchmarks

The PR was tested using my personal fork and a [testing PR in the fork](https://github.com/echeran/icu4x/pull/13).

### Notes

This PR is changing code that is the related to issue #327, so until that is also fixed, this PR might fail some of the checks.

In order to test this PR, I reset `master` on my personal fork to a commit that comes before the change that introduced #327.  That is the only way for the testing PR in the personal fork to pass the checks, anyways.