### PR TITLE
Refactor the DateTime pattern parser to handle quotes.

### DIFF
--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -20,6 +20,7 @@ include = [
 [dependencies]
 icu_locid = { path = "../locid" }
 icu_provider = { path = "../provider" }
+smallstr = "0.2.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -20,7 +20,6 @@ include = [
 [dependencies]
 icu_locid = { path = "../locid" }
 icu_provider = { path = "../provider" }
-smallstr = "0.2.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/components/datetime/src/pattern/error.rs
+++ b/components/datetime/src/pattern/error.rs
@@ -3,11 +3,10 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::fields;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     FieldTooLong(fields::FieldSymbol),
-    UnknownSubstitution(u8),
-    IllegalCharacter(char),
+    UnknownSubstitution(char),
     UnclosedLiteral,
     UnclosedPlaceholder,
 }

--- a/components/datetime/src/pattern/error.rs
+++ b/components/datetime/src/pattern/error.rs
@@ -5,9 +5,11 @@ use crate::fields;
 
 #[derive(Debug)]
 pub enum Error {
-    Unknown,
     FieldTooLong(fields::FieldSymbol),
     UnknownSubstitution(u8),
+    IllegalCharacter(char),
+    UnclosedLiteral,
+    UnclosedPlaceholder,
 }
 
 impl From<fields::Error> for Error {

--- a/components/datetime/src/pattern/mod.rs
+++ b/components/datetime/src/pattern/mod.rs
@@ -37,6 +37,12 @@ impl<'p> From<&str> for PatternItem {
     }
 }
 
+impl<'p> From<String> for PatternItem {
+    fn from(input: String) -> Self {
+        Self::Literal(input)
+    }
+}
+
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct Pattern(pub Vec<PatternItem>);
 
@@ -105,6 +111,44 @@ mod tests {
                 "月".into(),
                 (fields::Day::DayOfMonth.into(), FieldLength::One).into(),
                 "日".into(),
+            ]
+            .into_iter()
+            .collect()
+        );
+
+        assert_eq!(
+            Pattern::from_bytes("y'My'M").expect("Parsing pattern failed."),
+            vec![
+                (fields::Year::Calendar.into(), FieldLength::One).into(),
+                "My".into(),
+                (fields::Month::Format.into(), FieldLength::One).into(),
+            ]
+            .into_iter()
+            .collect()
+        );
+
+        assert_eq!(
+            Pattern::from_bytes("y 'My' M").expect("Parsing pattern failed."),
+            vec![
+                (fields::Year::Calendar.into(), FieldLength::One).into(),
+                " My ".into(),
+                (fields::Month::Format.into(), FieldLength::One).into(),
+            ]
+            .into_iter()
+            .collect()
+        );
+
+        assert_eq!(
+            Pattern::from_bytes(" 'r'. 'y'. ").expect("Parsing pattern failed."),
+            vec![" r. y. ".into(),].into_iter().collect()
+        );
+
+        assert_eq!(
+            Pattern::from_bytes("hh 'o''clock' a").expect("Parsing pattern failed."),
+            vec![
+                (fields::Hour::H12.into(), FieldLength::TwoDigit).into(),
+                " o'clock ".into(),
+                (fields::DayPeriod::AmPm.into(), FieldLength::One).into(),
             ]
             .into_iter()
             .collect()

--- a/components/datetime/src/pattern/mod.rs
+++ b/components/datetime/src/pattern/mod.rs
@@ -7,6 +7,7 @@ mod parser;
 use crate::fields::{self, Field, FieldLength, FieldSymbol};
 pub use error::Error;
 use parser::Parser;
+use std::convert::TryFrom;
 use std::iter::FromIterator;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -15,19 +16,23 @@ pub enum PatternItem {
     Literal(String),
 }
 
-impl From<Field> for PatternItem {
-    fn from(input: Field) -> Self {
-        Self::Field(input)
+impl From<(FieldSymbol, FieldLength)> for PatternItem {
+    fn from(input: (FieldSymbol, FieldLength)) -> Self {
+        PatternItem::Field(Field {
+            symbol: input.0,
+            length: input.1,
+        })
     }
 }
 
-impl From<(FieldSymbol, FieldLength)> for PatternItem {
-    fn from(input: (FieldSymbol, FieldLength)) -> Self {
-        Field {
+impl TryFrom<(FieldSymbol, u8)> for PatternItem {
+    type Error = Error;
+    fn try_from(input: (FieldSymbol, u8)) -> Result<Self, Self::Error> {
+        let length = FieldLength::try_from(input.1).map_err(|_| Error::FieldTooLong(input.0))?;
+        Ok(PatternItem::Field(Field {
             symbol: input.0,
-            length: input.1,
-        }
-        .into()
+            length,
+        }))
     }
 }
 
@@ -67,91 +72,5 @@ impl FromIterator<PatternItem> for Pattern {
     fn from_iter<I: IntoIterator<Item = PatternItem>>(iter: I) -> Self {
         let items: Vec<PatternItem> = iter.into_iter().collect();
         Self(items)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn pattern_parse() {
-        assert_eq!(
-            Pattern::from_bytes("dd/MM/y").expect("Parsing pattern failed."),
-            vec![
-                (fields::Day::DayOfMonth.into(), FieldLength::TwoDigit).into(),
-                "/".into(),
-                (fields::Month::Format.into(), FieldLength::TwoDigit).into(),
-                "/".into(),
-                (fields::Year::Calendar.into(), FieldLength::One).into(),
-            ]
-            .into_iter()
-            .collect()
-        );
-
-        assert_eq!(
-            Pattern::from_bytes("HH:mm:ss").expect("Parsing pattern failed."),
-            vec![
-                (fields::Hour::H23.into(), FieldLength::TwoDigit).into(),
-                ":".into(),
-                (FieldSymbol::Minute, FieldLength::TwoDigit).into(),
-                ":".into(),
-                (fields::Second::Second.into(), FieldLength::TwoDigit).into(),
-            ]
-            .into_iter()
-            .collect()
-        );
-
-        assert_eq!(
-            Pattern::from_bytes("y年M月d日").expect("Parsing pattern failed."),
-            vec![
-                (fields::Year::Calendar.into(), FieldLength::One).into(),
-                "年".into(),
-                (fields::Month::Format.into(), FieldLength::One).into(),
-                "月".into(),
-                (fields::Day::DayOfMonth.into(), FieldLength::One).into(),
-                "日".into(),
-            ]
-            .into_iter()
-            .collect()
-        );
-
-        assert_eq!(
-            Pattern::from_bytes("y'My'M").expect("Parsing pattern failed."),
-            vec![
-                (fields::Year::Calendar.into(), FieldLength::One).into(),
-                "My".into(),
-                (fields::Month::Format.into(), FieldLength::One).into(),
-            ]
-            .into_iter()
-            .collect()
-        );
-
-        assert_eq!(
-            Pattern::from_bytes("y 'My' M").expect("Parsing pattern failed."),
-            vec![
-                (fields::Year::Calendar.into(), FieldLength::One).into(),
-                " My ".into(),
-                (fields::Month::Format.into(), FieldLength::One).into(),
-            ]
-            .into_iter()
-            .collect()
-        );
-
-        assert_eq!(
-            Pattern::from_bytes(" 'r'. 'y'. ").expect("Parsing pattern failed."),
-            vec![" r. y. ".into(),].into_iter().collect()
-        );
-
-        assert_eq!(
-            Pattern::from_bytes("hh 'o''clock' a").expect("Parsing pattern failed."),
-            vec![
-                (fields::Hour::H12.into(), FieldLength::TwoDigit).into(),
-                " o'clock ".into(),
-                (fields::DayPeriod::AmPm.into(), FieldLength::One).into(),
-            ]
-            .into_iter()
-            .collect()
-        );
     }
 }

--- a/components/datetime/src/pattern/mod.rs
+++ b/components/datetime/src/pattern/mod.rs
@@ -18,7 +18,7 @@ pub enum PatternItem {
 
 impl From<(FieldSymbol, FieldLength)> for PatternItem {
     fn from(input: (FieldSymbol, FieldLength)) -> Self {
-        PatternItem::Field(Field {
+        Self::Field(Field {
             symbol: input.0,
             length: input.1,
         })
@@ -29,7 +29,7 @@ impl TryFrom<(FieldSymbol, u8)> for PatternItem {
     type Error = Error;
     fn try_from(input: (FieldSymbol, u8)) -> Result<Self, Self::Error> {
         let length = FieldLength::try_from(input.1).map_err(|_| Error::FieldTooLong(input.0))?;
-        Ok(PatternItem::Field(Field {
+        Ok(Self::Field(Field {
             symbol: input.0,
             length,
         }))
@@ -53,18 +53,18 @@ pub struct Pattern(pub Vec<PatternItem>);
 
 impl Pattern {
     pub fn from_bytes(input: &str) -> Result<Self, Error> {
-        Parser::new(input).parse().map(Pattern)
+        Parser::new(input).parse().map(Self)
     }
 
     // TODO(#277): This should be turned into a utility for all ICU4X.
     pub fn from_bytes_combination(
         input: &str,
-        date: Pattern,
-        time: Pattern,
+        date: Self,
+        time: Self,
     ) -> Result<Self, Error> {
         Parser::new(input)
             .parse_placeholders(vec![time, date])
-            .map(Pattern)
+            .map(Self)
     }
 }
 

--- a/components/datetime/src/pattern/parser.rs
+++ b/components/datetime/src/pattern/parser.rs
@@ -4,22 +4,28 @@
 use super::error::Error;
 use super::{Pattern, PatternItem};
 use crate::fields::{Field, FieldSymbol};
+use smallstr::SmallString;
 use std::convert::{TryFrom, TryInto};
 
+#[derive(Debug, PartialEq)]
 enum Segment {
     Symbol { symbol: FieldSymbol, byte: u8 },
     Literal,
+    QuotedLiteral,
 }
 
+#[derive(Debug, PartialEq)]
 struct State {
     segment: Segment,
     start_idx: usize,
 }
 
+#[derive(Debug, PartialEq)]
 pub struct Parser<'p> {
     source: &'p str,
     state: State,
     items: Vec<PatternItem>,
+    literal_buffer: SmallString<[u8; 2]>,
 }
 
 impl<'p> Parser<'p> {
@@ -31,15 +37,16 @@ impl<'p> Parser<'p> {
                 start_idx: 0,
             },
             items: Vec::with_capacity(source.len()),
+            literal_buffer: SmallString::new(),
         }
     }
 
     fn collect_item(&mut self, idx: usize) -> Result<(), Error> {
         match self.state.segment {
-            Segment::Symbol { symbol, .. } => self.collect_symbol(symbol, idx)?,
+            Segment::Symbol { symbol, .. } => self.collect_symbol(symbol, idx),
             Segment::Literal => self.collect_literal(idx),
+            Segment::QuotedLiteral => Err(Error::UnclosedLiteral),
         }
-        Ok(())
     }
 
     fn collect_symbol(&mut self, symbol: FieldSymbol, idx: usize) -> Result<(), Error> {
@@ -48,20 +55,50 @@ impl<'p> Parser<'p> {
         Ok(())
     }
 
-    fn collect_literal(&mut self, idx: usize) {
-        if idx > self.state.start_idx {
-            let slice = &self.source[self.state.start_idx..idx];
-            let item = PatternItem::Literal(slice.to_string());
+    fn collect_literal(&mut self, idx: usize) -> Result<(), Error> {
+        self.dump_buffer(idx);
+        if !self.literal_buffer.is_empty() {
+            let item = PatternItem::Literal(self.literal_buffer.drain().collect());
             self.items.push(item);
         }
+        Ok(())
+    }
+
+    fn dump_buffer(&mut self, idx: usize) {
+        if idx > self.state.start_idx {
+            let slice = &self.source[self.state.start_idx..idx];
+            self.literal_buffer.push_str(slice);
+        }
+        self.state.start_idx = idx;
+    }
+
+    fn quoted_literal<I: Iterator<Item = u8>>(
+        &mut self,
+        idx: usize,
+        bytes: &mut std::iter::Peekable<std::iter::Enumerate<I>>,
+    ) {
+        self.dump_buffer(idx);
+        if let Some(&(_, b'\'')) = bytes.peek() {
+            self.literal_buffer.push('\'');
+            self.state.start_idx = idx + 2;
+            bytes.next();
+            return;
+        }
+        if self.state.segment == Segment::QuotedLiteral {
+            self.state.segment = Segment::Literal;
+        } else {
+            self.state.segment = Segment::QuotedLiteral;
+        }
+        self.state.start_idx = idx + 1;
     }
 
     pub fn parse(mut self) -> Result<Vec<PatternItem>, Error> {
-        for (idx, b) in self.source.bytes().enumerate() {
-            if let Segment::Symbol { byte, .. } = self.state.segment {
-                if b == byte {
-                    continue;
-                }
+        let mut bytes = self.source.bytes().enumerate().peekable();
+        while let Some((idx, b)) = bytes.next() {
+            match self.state.segment {
+                Segment::QuotedLiteral if b != b'\'' => continue,
+                Segment::Symbol { byte, .. } if byte == b => continue,
+                _ => {}
             }
 
             if let Ok(symbol) = FieldSymbol::try_from(b) {
@@ -72,10 +109,19 @@ impl<'p> Parser<'p> {
                 };
             } else if let Segment::Symbol { symbol, .. } = self.state.segment {
                 self.collect_symbol(symbol, idx)?;
-                self.state = State {
-                    segment: Segment::Literal,
-                    start_idx: idx,
+                self.state = if b == b'\'' {
+                    State {
+                        segment: Segment::QuotedLiteral,
+                        start_idx: idx + 1,
+                    }
+                } else {
+                    State {
+                        segment: Segment::Literal,
+                        start_idx: idx,
+                    }
                 };
+            } else if b == b'\'' {
+                self.quoted_literal(idx, &mut bytes);
             }
         }
         self.collect_item(self.source.len())?;
@@ -86,22 +132,33 @@ impl<'p> Parser<'p> {
         mut self,
         mut replacements: Vec<Pattern>,
     ) -> Result<Vec<PatternItem>, Error> {
-        let mut bytes = self.source.bytes().enumerate();
+        let mut bytes = self.source.bytes().enumerate().peekable();
         while let Some((idx, b)) = bytes.next() {
             if b == b'{' {
-                if let Segment::Literal = self.state.segment {
-                    self.collect_literal(idx);
+                match self.state.segment {
+                    Segment::Literal => {
+                        self.collect_literal(idx)?;
+                    }
+                    Segment::QuotedLiteral => {
+                        return Err(Error::UnclosedLiteral);
+                    }
+                    _ => {}
                 }
-                let (_, b) = bytes.next().ok_or(Error::Unknown)?;
+                let (_, b) = bytes.next().ok_or(Error::UnclosedPlaceholder)?;
                 let replacement = replacements
                     .get_mut(b as usize - 48)
                     .ok_or(Error::UnknownSubstitution(b))?;
                 self.items.append(&mut replacement.0);
-                bytes.next().ok_or(Error::Unknown)?;
+                let (_, b) = bytes.next().ok_or(Error::UnclosedPlaceholder)?;
+                if b != b'}' {
+                    return Err(Error::UnclosedPlaceholder);
+                }
                 self.state = State {
                     segment: Segment::Literal,
                     start_idx: idx + 3,
                 };
+            } else if b == b'\'' {
+                self.quoted_literal(idx, &mut bytes);
             }
         }
         self.collect_item(self.source.len())?;

--- a/components/datetime/src/pattern/parser.rs
+++ b/components/datetime/src/pattern/parser.rs
@@ -1,167 +1,430 @@
-// This file is part of ICU4X. For terms of use, please see the file
-// called LICENSE at the top level of the ICU4X source tree
-// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use super::error::Error;
 use super::{Pattern, PatternItem};
-use crate::fields::{Field, FieldSymbol};
-use smallstr::SmallString;
+use crate::fields::FieldSymbol;
 use std::convert::{TryFrom, TryInto};
 
 #[derive(Debug, PartialEq)]
 enum Segment {
-    Symbol { symbol: FieldSymbol, byte: u8 },
-    Literal,
-    QuotedLiteral,
+    Symbol { symbol: FieldSymbol, length: u8 },
+    Literal { literal: String, quoted: bool },
 }
 
-#[derive(Debug, PartialEq)]
-struct State {
-    segment: Segment,
-    start_idx: usize,
-}
-
-#[derive(Debug, PartialEq)]
 pub struct Parser<'p> {
     source: &'p str,
-    state: State,
-    items: Vec<PatternItem>,
-    literal_buffer: SmallString<[u8; 2]>,
+    state: Segment,
 }
 
 impl<'p> Parser<'p> {
     pub fn new(source: &'p str) -> Self {
         Self {
             source,
-            state: State {
-                segment: Segment::Literal,
-                start_idx: 0,
+            state: Segment::Literal {
+                literal: String::new(),
+                quoted: false,
             },
-            items: Vec::with_capacity(source.len()),
-            literal_buffer: SmallString::new(),
         }
     }
 
-    fn collect_item(&mut self, idx: usize) -> Result<(), Error> {
-        match self.state.segment {
-            Segment::Symbol { symbol, .. } => self.collect_symbol(symbol, idx),
-            Segment::Literal => self.collect_literal(idx),
-            Segment::QuotedLiteral => Err(Error::UnclosedLiteral),
-        }
-    }
-
-    fn collect_symbol(&mut self, symbol: FieldSymbol, idx: usize) -> Result<(), Error> {
-        let field: Field = (symbol, idx - self.state.start_idx).try_into()?;
-        self.items.push(field.into());
-        Ok(())
-    }
-
-    fn collect_literal(&mut self, idx: usize) -> Result<(), Error> {
-        self.dump_buffer(idx);
-        if !self.literal_buffer.is_empty() {
-            let item = PatternItem::Literal(self.literal_buffer.drain().collect());
-            self.items.push(item);
-        }
-        Ok(())
-    }
-
-    fn dump_buffer(&mut self, idx: usize) {
-        if idx > self.state.start_idx {
-            let slice = &self.source[self.state.start_idx..idx];
-            self.literal_buffer.push_str(slice);
-        }
-        self.state.start_idx = idx;
-    }
-
-    fn quoted_literal<I: Iterator<Item = u8>>(
+    fn handle_quoted_literal(
         &mut self,
-        idx: usize,
-        bytes: &mut std::iter::Peekable<std::iter::Enumerate<I>>,
-    ) {
-        self.dump_buffer(idx);
-        if let Some(&(_, b'\'')) = bytes.peek() {
-            self.literal_buffer.push('\'');
-            self.state.start_idx = idx + 2;
-            bytes.next();
-            return;
-        }
-        if self.state.segment == Segment::QuotedLiteral {
-            self.state.segment = Segment::Literal;
+        ch: char,
+        chars: &mut std::iter::Peekable<std::str::Chars>,
+        result: &mut Vec<PatternItem>,
+    ) -> Result<bool, Error> {
+        if ch == '\'' {
+            match (&mut self.state, chars.peek() == Some(&'\'')) {
+                (
+                    Segment::Literal {
+                        ref mut literal, ..
+                    },
+                    true,
+                ) => {
+                    literal.push('\'');
+                    chars.next();
+                }
+                (Segment::Literal { ref mut quoted, .. }, false) => {
+                    *quoted = !*quoted;
+                }
+                (Segment::Symbol { symbol, length }, true) => {
+                    result.push((*symbol, *length).try_into()?);
+                    self.state = Segment::Literal {
+                        literal: String::from(ch),
+                        quoted: false,
+                    };
+                    chars.next();
+                },
+                (Segment::Symbol { symbol, length }, false) => {
+                    result.push((*symbol, *length).try_into()?);
+                    self.state = Segment::Literal {
+                        literal: String::new(),
+                        quoted: true,
+                    };
+                },
+            }
+            Ok(true)
+        } else if let Segment::Literal {
+            ref mut literal,
+            quoted: true,
+        } = self.state
+        {
+            literal.push(ch);
+            Ok(true)
         } else {
-            self.state.segment = Segment::QuotedLiteral;
+            Ok(false)
         }
-        self.state.start_idx = idx + 1;
+    }
+
+    fn collect_segment(state: Segment, result: &mut Vec<PatternItem>) -> Result<(), Error> {
+        match state {
+            Segment::Symbol { symbol, length } => {
+                result.push((symbol, length).try_into()?);
+            }
+            Segment::Literal { quoted, .. } if quoted => {
+                return Err(Error::UnclosedLiteral);
+            }
+            Segment::Literal { literal, .. } => {
+                if !literal.is_empty() {
+                    result.push(literal.into());
+                }
+            }
+        }
+        Ok(())
     }
 
     pub fn parse(mut self) -> Result<Vec<PatternItem>, Error> {
-        let mut bytes = self.source.bytes().enumerate().peekable();
-        while let Some((idx, b)) = bytes.next() {
-            match self.state.segment {
-                Segment::QuotedLiteral if b != b'\'' => continue,
-                Segment::Symbol { byte, .. } if byte == b => continue,
-                _ => {}
-            }
+        let mut chars = self.source.chars().peekable();
+        let mut result = vec![];
 
-            if let Ok(symbol) = FieldSymbol::try_from(b) {
-                self.collect_item(idx)?;
-                self.state = State {
-                    segment: Segment::Symbol { symbol, byte: b },
-                    start_idx: idx,
-                };
-            } else if let Segment::Symbol { symbol, .. } = self.state.segment {
-                self.collect_symbol(symbol, idx)?;
-                self.state = if b == b'\'' {
-                    State {
-                        segment: Segment::QuotedLiteral,
-                        start_idx: idx + 1,
+        while let Some(ch) = chars.next() {
+            if !self.handle_quoted_literal(ch, &mut chars, &mut result)? {
+                if let Ok(new_symbol) = FieldSymbol::try_from(ch as u8) {
+                    match self.state {
+                        Segment::Symbol {
+                            ref symbol,
+                            ref mut length,
+                        } if new_symbol == *symbol => {
+                            *length += 1;
+                        }
+                        segment => {
+                            Self::collect_segment(segment, &mut result)?;
+                            self.state = Segment::Symbol {
+                                symbol: new_symbol,
+                                length: 1,
+                            };
+                        }
                     }
                 } else {
-                    State {
-                        segment: Segment::Literal,
-                        start_idx: idx,
+                    match self.state {
+                        Segment::Symbol { symbol, length } => {
+                            result.push((symbol, length).try_into()?);
+                            self.state = Segment::Literal {
+                                literal: String::from(ch),
+                                quoted: false,
+                            };
+                        }
+                        Segment::Literal {
+                            ref mut literal, ..
+                        } => literal.push(ch),
                     }
-                };
-            } else if b == b'\'' {
-                self.quoted_literal(idx, &mut bytes);
+                }
             }
         }
-        self.collect_item(self.source.len())?;
-        Ok(self.items)
+
+        Self::collect_segment(self.state, &mut result)?;
+
+        Ok(result)
     }
 
     pub fn parse_placeholders(
         mut self,
         mut replacements: Vec<Pattern>,
     ) -> Result<Vec<PatternItem>, Error> {
-        let mut bytes = self.source.bytes().enumerate().peekable();
-        while let Some((idx, b)) = bytes.next() {
-            if b == b'{' {
-                match self.state.segment {
-                    Segment::Literal => {
-                        self.collect_literal(idx)?;
+        let mut chars = self.source.chars().peekable();
+        let mut result = vec![];
+
+        while let Some(ch) = chars.next() {
+            if !self.handle_quoted_literal(ch, &mut chars, &mut result)? {
+                if ch == '{' {
+                    Self::collect_segment(self.state, &mut result)?;
+
+                    let ch = chars.next().ok_or(Error::UnclosedPlaceholder)?;
+                    let idx: u32 = ch.to_digit(10).ok_or(Error::UnknownSubstitution(ch))?;
+                    let replacement = replacements
+                        .get_mut(idx as usize)
+                        .ok_or(Error::UnknownSubstitution(ch))?;
+                    result.append(&mut replacement.0);
+                    let ch = chars.next().ok_or(Error::UnclosedPlaceholder)?;
+                    if ch != '}' {
+                        return Err(Error::UnclosedPlaceholder);
                     }
-                    Segment::QuotedLiteral => {
-                        return Err(Error::UnclosedLiteral);
-                    }
-                    _ => {}
+                    self.state = Segment::Literal {
+                        literal: String::new(),
+                        quoted: false,
+                    };
+                } else if let Segment::Literal {
+                    ref mut literal, ..
+                } = self.state
+                {
+                    literal.push(ch);
+                } else {
+                    unreachable!()
                 }
-                let (_, b) = bytes.next().ok_or(Error::UnclosedPlaceholder)?;
-                let replacement = replacements
-                    .get_mut(b as usize - 48)
-                    .ok_or(Error::UnknownSubstitution(b))?;
-                self.items.append(&mut replacement.0);
-                let (_, b) = bytes.next().ok_or(Error::UnclosedPlaceholder)?;
-                if b != b'}' {
-                    return Err(Error::UnclosedPlaceholder);
-                }
-                self.state = State {
-                    segment: Segment::Literal,
-                    start_idx: idx + 3,
-                };
-            } else if b == b'\'' {
-                self.quoted_literal(idx, &mut bytes);
             }
         }
-        self.collect_item(self.source.len())?;
-        Ok(self.items)
+
+        Self::collect_segment(self.state, &mut result)?;
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fields::{self, FieldLength};
+    use crate::pattern::Pattern;
+
+    #[test]
+    fn pattern_parse_simple() {
+        let samples = vec![
+            (
+                "dd/MM/y",
+                vec![
+                    (fields::Day::DayOfMonth.into(), FieldLength::TwoDigit).into(),
+                    "/".into(),
+                    (fields::Month::Format.into(), FieldLength::TwoDigit).into(),
+                    "/".into(),
+                    (fields::Year::Calendar.into(), FieldLength::One).into(),
+                ],
+            ),
+            (
+                "HH:mm:ss",
+                vec![
+                    (fields::Hour::H23.into(), FieldLength::TwoDigit).into(),
+                    ":".into(),
+                    (FieldSymbol::Minute, FieldLength::TwoDigit).into(),
+                    ":".into(),
+                    (fields::Second::Second.into(), FieldLength::TwoDigit).into(),
+                ],
+            ),
+            (
+                "y年M月d日",
+                vec![
+                    (fields::Year::Calendar.into(), FieldLength::One).into(),
+                    "年".into(),
+                    (fields::Month::Format.into(), FieldLength::One).into(),
+                    "月".into(),
+                    (fields::Day::DayOfMonth.into(), FieldLength::One).into(),
+                    "日".into(),
+                ],
+            ),
+        ];
+
+        for (string, pattern) in samples {
+            assert_eq!(
+                Pattern::from_bytes(string).expect("Parsing pattern failed."),
+                pattern.into_iter().collect()
+            );
+        }
+    }
+
+    #[test]
+    fn pattern_parse_literals() {
+        let samples = vec![
+            ("", vec![]),
+            (" ", vec![" ".into()]),
+            ("  ", vec!["  ".into()]),
+            (" żółć ", vec![" żółć ".into()]),
+            ("''", vec!["'".into()]),
+            (" ''", vec![" '".into()]),
+            (" '' ", vec![" ' ".into()]),
+            ("''''", vec!["''".into()]),
+            (" '' '' ", vec![" ' ' ".into()]),
+            ("ż'ół'ć", vec!["żółć".into()]),
+            ("ż'ó''ł'ć", vec!["żó'łć".into()]),
+            (" 'Ymd' ", vec![" Ymd ".into()]),
+        ];
+
+        for (string, pattern) in samples {
+            assert_eq!(
+                Parser::new(string)
+                    .parse()
+                    .expect("Parsing pattern failed."),
+                pattern,
+            );
+
+            assert_eq!(
+                Parser::new(string)
+                    .parse_placeholders(vec![])
+                    .expect("Parsing pattern failed."),
+                pattern,
+            );
+        }
+
+        let broken = vec![(" 'foo ", Error::UnclosedLiteral)];
+
+        for (string, error) in broken {
+            assert_eq!(Parser::new(string).parse(), Err(error),);
+        }
+    }
+
+    #[test]
+    fn pattern_parse_symbols() {
+        let samples = vec![
+            (
+                "y",
+                vec![(fields::Year::Calendar.into(), FieldLength::One).into()],
+            ),
+            (
+                "yy",
+                vec![(fields::Year::Calendar.into(), FieldLength::TwoDigit).into()],
+            ),
+            (
+                "yyy",
+                vec![(fields::Year::Calendar.into(), FieldLength::Abbreviated).into()],
+            ),
+            (
+                "yyyy",
+                vec![(fields::Year::Calendar.into(), FieldLength::Wide).into()],
+            ),
+            (
+                "yyyyy",
+                vec![(fields::Year::Calendar.into(), FieldLength::Narrow).into()],
+            ),
+            (
+                "yyyyyy",
+                vec![(fields::Year::Calendar.into(), FieldLength::Six).into()],
+            ),
+            (
+                "yM",
+                vec![
+                    (fields::Year::Calendar.into(), FieldLength::One).into(),
+                    (fields::Month::Format.into(), FieldLength::One).into(),
+                ],
+            ),
+            (
+                "y ",
+                vec![
+                    (fields::Year::Calendar.into(), FieldLength::One).into(),
+                    " ".into(),
+                ],
+            ),
+            (
+                "y M",
+                vec![
+                    (fields::Year::Calendar.into(), FieldLength::One).into(),
+                    " ".into(),
+                    (fields::Month::Format.into(), FieldLength::One).into(),
+                ],
+            ),
+            (
+                "hh''a",
+                vec![
+                    (fields::Hour::H12.into(), FieldLength::TwoDigit).into(),
+                    "'".into(),
+                    (fields::DayPeriod::AmPm.into(), FieldLength::One).into(),
+                ],
+            ),
+            (
+                "y'My'M",
+                vec![
+                (fields::Year::Calendar.into(), FieldLength::One).into(),
+                "My".into(),
+                (fields::Month::Format.into(), FieldLength::One).into(),
+                ],
+            ),
+            (
+                "y 'My' M",
+                vec![
+                (fields::Year::Calendar.into(), FieldLength::One).into(),
+                " My ".into(),
+                (fields::Month::Format.into(), FieldLength::One).into(),
+                ],
+            ),
+            (" 'r'. 'y'. ", vec![
+             " r. y. ".into(),
+            ]),
+            ("hh 'o''clock' a", vec![
+             (fields::Hour::H12.into(), FieldLength::TwoDigit).into(),
+             " o'clock ".into(),
+             (fields::DayPeriod::AmPm.into(), FieldLength::One).into(),
+            ]),
+            ("hh''a", vec![
+             (fields::Hour::H12.into(), FieldLength::TwoDigit).into(),
+             "'".into(),
+             (fields::DayPeriod::AmPm.into(), FieldLength::One).into(),
+            ]),
+        ];
+
+        for (string, pattern) in samples {
+            assert_eq!(
+                Parser::new(string)
+                    .parse()
+                    .expect("Parsing pattern failed."),
+                pattern,
+            );
+        }
+
+        let broken = vec![(
+            "yyyyyyy",
+            Error::FieldTooLong(FieldSymbol::Year(fields::Year::Calendar)),
+        )];
+
+        for (string, error) in broken {
+            assert_eq!(Parser::new(string).parse(), Err(error),);
+        }
+    }
+
+    #[test]
+    fn pattern_parse_placeholders() {
+        let samples = vec![
+            ("{0}", vec![Pattern(vec!["ONE".into()])], vec!["ONE".into()]),
+            (
+                "{0}{1}",
+                vec![Pattern(vec!["ONE".into()]), Pattern(vec!["TWO".into()])],
+                vec!["ONE".into(), "TWO".into()],
+            ),
+            (
+                "{0} 'at' {1}",
+                vec![Pattern(vec!["ONE".into()]), Pattern(vec!["TWO".into()])],
+                vec!["ONE".into(), " at ".into(), "TWO".into()],
+            ),
+            (
+                "{0}'at'{1}",
+                vec![Pattern(vec!["ONE".into()]), Pattern(vec!["TWO".into()])],
+                vec!["ONE".into(), "at".into(), "TWO".into()],
+            ),
+            (
+                "'{0}' 'at' '{1}'",
+                vec![Pattern(vec!["ONE".into()]), Pattern(vec!["TWO".into()])],
+                vec!["{0} at {1}".into()],
+            ),
+        ];
+
+        for (string, replacements, pattern) in samples {
+            assert_eq!(
+                Parser::new(string)
+                    .parse_placeholders(replacements)
+                    .expect("Parsing pattern failed."),
+                pattern,
+            );
+        }
+
+        let broken = vec![
+            ("{0}", vec![], Error::UnknownSubstitution('0')),
+            ("{a}", vec![], Error::UnknownSubstitution('a')),
+            ("{", vec![], Error::UnclosedPlaceholder),
+            ("{0", vec![Pattern(vec![])], Error::UnclosedPlaceholder),
+            ("{01", vec![Pattern(vec![])], Error::UnclosedPlaceholder),
+            ("{00}", vec![Pattern(vec![])], Error::UnclosedPlaceholder),
+            ("'{00}", vec![Pattern(vec![])], Error::UnclosedLiteral),
+        ];
+
+        for (string, replacements, error) in broken {
+            assert_eq!(
+                Parser::new(string).parse_placeholders(replacements),
+                Err(error),
+            );
+        }
     }
 }

--- a/components/datetime/tests/fixtures/tests/styles.json
+++ b/components/datetime/tests/fixtures/tests/styles.json
@@ -11,7 +11,7 @@
             }
         },
         "output": {
-            "value": "Tuesday, January 21, 2020 'at' 8:25:07 AM zzzz"
+            "value": "Tuesday, January 21, 2020 at 8:25:07 AM zzzz"
         }
     },
     {
@@ -26,7 +26,7 @@
             }
         },
         "output": {
-            "value": "September 10, 2020 'at' 1:34:59 PM z"
+            "value": "September 10, 2020 at 1:34:59 PM z"
         }
     },
     {
@@ -101,7 +101,7 @@
             }
         },
         "output": {
-            "value": "субота, 21 сакавіка 2020 'г'. 'у' 08:25:07, zzzz"
+            "value": "субота, 21 сакавіка 2020 г. у 08:25:07, zzzz"
         }
     }
 ]

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -54,7 +54,7 @@
 //!     .expect("Failed to parse date.");
 //!
 //! let formatted_date = dtf.format(&date);
-//! assert_eq!(formatted_date.to_string(), "September 12, 2020 \'at\' 12:35:00 PM");
+//! assert_eq!(formatted_date.to_string(), "September 12, 2020 at 12:35:00 PM");
 //! ```
 //!
 //! [`DataProvider`]: ../icu_data_provider/prelude/trait.DataProvider.html


### PR DESCRIPTION
This fixes the handling of quotes as per #319.

The parser is not super easy to read, but that's because logic is not super trivial. I think it can be refactored, but it's beyond trivial and I'd prefer not to do this for 0.1.

The performance change is substantial for parsing, but doesn't show in overview benchmark.

Here's parser bench change:

```
/home/zbraniecki/projects/icu4x/components/datetime/(master)> cargo criterion parse --features bench
    Finished bench [optimized] target(s) in 0.06s
Gnuplot not found, using plotters backend
Gnuplot not found, using plotters backend
pattern/parse           time:   [3.7337 us 3.7855 us 3.8576 us]                           
                        change: [-3.1854% -1.6618% -0.2719%] (p = 0.03 < 0.05)
                        Change within noise threshold.

/home/zbraniecki/projects/icu4x/components/datetime/(dt-quotes)> cargo criterion parse --features bench
   Compiling icu-datetime v0.0.1 (/home/zbraniecki/projects/icu4x/components/datetime)
    Finished bench [optimized] target(s) in 6.53s
Gnuplot not found, using plotters backend
Gnuplot not found, using plotters backend
pattern/parse           time:   [5.3184 us 5.3504 us 5.3978 us]                           
                        change: [+41.717% +43.624% +45.458%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

overview benchmark:

```
/home/zbraniecki/projects/icu4x/components/datetime/(master)> cargo criterion
    Finished bench [optimized] target(s) in 0.06s
Gnuplot not found, using plotters backend
datetime/overview       time:   [775.14 us 778.64 us 782.66 us]                              
                        change: [-1.3153% -0.0217% +1.2655%] (p = 0.97 > 0.05)
                        No change in performance detected.

/home/zbraniecki/projects/icu4x/components/datetime/(dt-quotes)> cargo criterion
   Compiling icu-datetime v0.0.1 (/home/zbraniecki/projects/icu4x/components/datetime)
    Finished bench [optimized] target(s) in 4.79s
Gnuplot not found, using plotters backend
datetime/overview       time:   [761.82 us 766.17 us 772.84 us]                              
                        change: [-2.1411% -1.0638% +0.2405%] (p = 0.08 > 0.05)
                        No change in performance detected.
```

`smallstr` gives us ~10% on the parser benchmark, but if you prefer not to add a dependency, I can remove it. My hope is that Rust stdlib will eventually get a hybrid vector (stack+heap) and we'll use it for things like that.