### PR TITLE
Fix locale macros to remove dependency on TinyStr

### DIFF
--- a/components/locale/macros/src/token_stream.rs
+++ b/components/locale/macros/src/token_stream.rs
@@ -1,5 +1,4 @@
 use icu_locale::subtags;
-use tinystr::{TinyStr4, TinyStr8};
 
 extern crate proc_macro;
 
@@ -15,21 +14,15 @@ pub(crate) trait IntoTokenStream {
     }
 }
 
-impl IntoTokenStream for TinyStr8 {
+impl IntoTokenStream for u32 {
     fn into_token_stream_string(self) -> String {
-        format!(
-            "tinystr::TinyStr8::new_unchecked({})",
-            Into::<u64>::into(self)
-        )
+        format!("{}", self)
     }
 }
 
-impl IntoTokenStream for TinyStr4 {
+impl IntoTokenStream for u64 {
     fn into_token_stream_string(self) -> String {
-        format!(
-            "tinystr::TinyStr4::new_unchecked({})",
-            Into::<u32>::into(self)
-        )
+        format!("{}", self)
     }
 }
 

--- a/components/locale/src/subtags/language.rs
+++ b/components/locale/src/subtags/language.rs
@@ -82,8 +82,8 @@ impl Language {
     /// let lang = unsafe { Language::from_raw_unchecked(raw) };
     /// assert_eq!(lang, "en");
     /// ```
-    pub fn into_raw(self) -> Option<TinyStr8> {
-        self.0
+    pub fn into_raw(self) -> Option<u64> {
+        self.0.map(Into::<u64>::into)
     }
 
     /// Constructor which takes a raw value returned by
@@ -104,10 +104,13 @@ impl Language {
     ///
     /// # Safety
     ///
-    /// This function accepts any `TinyStr8` that is expected to be a
-    /// valid `Language` subtag in canonical syntax.
-    pub const unsafe fn from_raw_unchecked(v: Option<TinyStr8>) -> Self {
-        Self(v)
+    /// This function accepts a `u64` that is expected to be a valid `TinyStr8`
+    /// representing a `Language` subtag in canonical syntax.
+    pub const unsafe fn from_raw_unchecked(v: Option<u64>) -> Self {
+        Self(match v {
+            Some(v) => Some(TinyStr8::new_unchecked(v)),
+            None => None,
+        })
     }
 
     /// A helper function for displaying

--- a/components/locale/src/subtags/region.rs
+++ b/components/locale/src/subtags/region.rs
@@ -72,8 +72,8 @@ impl Region {
     /// let region = unsafe { Region::from_raw_unchecked(raw) };
     /// assert_eq!(region, "US");
     /// ```
-    pub fn into_raw(self) -> TinyStr4 {
-        self.0
+    pub fn into_raw(self) -> u32 {
+        self.0.into()
     }
 
     /// Constructor which takes a raw value returned by
@@ -94,10 +94,10 @@ impl Region {
     ///
     /// # Safety
     ///
-    /// This function accepts any `TinyStr4` that is expected to be a
-    /// valid `Region` subtag in canonical syntax.
-    pub const unsafe fn from_raw_unchecked(v: TinyStr4) -> Self {
-        Self(v)
+    /// This function accepts a `u32` that is expected to be a valid `TinyStr4`
+    /// representing a `Region` subtag in canonical syntax.
+    pub const unsafe fn from_raw_unchecked(v: u32) -> Self {
+        Self(TinyStr4::new_unchecked(v))
     }
 
     /// A helper function for displaying

--- a/components/locale/src/subtags/script.rs
+++ b/components/locale/src/subtags/script.rs
@@ -63,8 +63,8 @@ impl Script {
     /// let script = unsafe { Script::from_raw_unchecked(raw) };
     /// assert_eq!(script, "Latn");
     /// ```
-    pub fn into_raw(self) -> TinyStr4 {
-        self.0
+    pub fn into_raw(self) -> u32 {
+        self.0.into()
     }
 
     /// Constructor which takes a raw value returned by
@@ -85,10 +85,10 @@ impl Script {
     ///
     /// # Safety
     ///
-    /// This function accepts any `TinyStr4` that is expected to be a
-    /// valid `Script` subtag in canonical syntax.
-    pub const unsafe fn from_raw_unchecked(v: TinyStr4) -> Self {
-        Self(v)
+    /// This function accepts a `u32` that is expected to be a valid `TinyStr4`
+    /// representing a `Script` subtag in canonical syntax.
+    pub const unsafe fn from_raw_unchecked(v: u32) -> Self {
+        Self(TinyStr4::new_unchecked(v))
     }
 
     /// A helper function for displaying

--- a/components/locale/src/subtags/variant.rs
+++ b/components/locale/src/subtags/variant.rs
@@ -73,8 +73,8 @@ impl Variant {
     /// let variant = unsafe { Variant::from_raw_unchecked(raw) };
     /// assert_eq!(variant, "posix");
     /// ```
-    pub fn into_raw(self) -> TinyStr8 {
-        self.0
+    pub fn into_raw(self) -> u64 {
+        self.0.into()
     }
 
     /// Constructor which takes a raw value returned by
@@ -95,10 +95,10 @@ impl Variant {
     ///
     /// # Safety
     ///
-    /// This function accepts any `TinyStr8` that is expected to be a
-    /// valid `Variant` subtag in canonical syntax.
-    pub const unsafe fn from_raw_unchecked(v: TinyStr8) -> Self {
-        Self(v)
+    /// This function accepts a `u64` that is expected to be a valid `TinyStr8`
+    /// representing a `Variant` subtag in canonical syntax.
+    pub const unsafe fn from_raw_unchecked(v: u64) -> Self {
+        Self(TinyStr8::new_unchecked(v))
     }
 
     /// A helper function for displaying


### PR DESCRIPTION
I changed the raw format back to primitives in order to eliminate the tinystr lookup problem.

However, the proc macro still has problems:

- Does not work if `icu_locale` is not in scope
- Two crates instead of one

We will work on these problems in the context of #310.