### PR TITLE
Use langid macros everywhere.

### DIFF
--- a/components/cldr-json-data-provider/Cargo.toml
+++ b/components/cldr-json-data-provider/Cargo.toml
@@ -36,6 +36,7 @@ log = { version = "0.4", optional = true }
 
 [dev-dependencies]
 mktemp = "0.4"
+icu-locale-macros = { path = "../locale/macros" }
 
 [features]
 # Automatically download CLDR data from a host

--- a/components/cldr-json-data-provider/src/cldr_langid.rs
+++ b/components/cldr-json-data-provider/src/cldr_langid.rs
@@ -22,7 +22,7 @@ impl CldrLangID {
         // TODO: Use LanguageIdentifier::default()
         Self {
             cldr_language: "root".parse().unwrap(),
-            langid: "und".parse().unwrap(),
+            langid: LanguageIdentifier::default(),
         }
     }
 }
@@ -84,6 +84,8 @@ impl<'de> Deserialize<'de> for CldrLangID {
 
 #[test]
 fn test_deserialize() -> Result<(), Box<dyn std::error::Error>> {
+    use icu_locale_macros::langid;
+
     let fr = serde_json::from_str::<CldrLangID>(r#""fr""#)?;
     let en = serde_json::from_str::<CldrLangID>(r#""en-US""#)?;
     let root = serde_json::from_str::<CldrLangID>(r#""root""#)?;
@@ -92,21 +94,21 @@ fn test_deserialize() -> Result<(), Box<dyn std::error::Error>> {
         fr,
         CldrLangID {
             cldr_language: "fr".parse().unwrap(),
-            langid: "fr".parse()?
+            langid: langid!("fr"),
         }
     );
     assert_eq!(
         en,
         CldrLangID {
             cldr_language: "en".parse().unwrap(),
-            langid: "en-US".parse()?
+            langid: langid!("en-US"),
         }
     );
     assert_eq!(
         root,
         CldrLangID {
             cldr_language: "root".parse().unwrap(),
-            langid: "und".parse()?
+            langid: langid!("und"),
         }
     );
 
@@ -150,7 +152,7 @@ fn test_order() {
 fn test_und_root() {
     CldrLangID::from_str("und").expect_err("und should not be allowed as a string");
 
-    let und2 = CldrLangID::from(LanguageIdentifier::from_str("und").unwrap());
+    let und = CldrLangID::from(LanguageIdentifier::default());
     let root = CldrLangID::from_str("root").unwrap();
-    assert_eq!(und2, root);
+    assert_eq!(und, root);
 }

--- a/components/cldr-json-data-provider/src/download/cldr_paths_download.rs
+++ b/components/cldr-json-data-provider/src/download/cldr_paths_download.rs
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 /// ```
 /// use icu_cldr_json_data_provider::download::CldrPathsDownload;
 /// use icu_cldr_json_data_provider::CldrJsonDataProvider;
+/// use icu_locale_macros::langid;
 /// use std::path::PathBuf;
 ///
 /// let paths = CldrPathsDownload::try_from_github_tag("36.0.0")
@@ -30,7 +31,7 @@ use std::path::PathBuf;
 ///     let data: Cow<PluralRuleStringsV1> = data_provider
 ///         .load(&DataRequest {
 ///             data_entry: DataEntry {
-///                 langid: "uk".parse().unwrap(),
+///                 langid: langid!("uk"),
 ///                 variant: None,
 ///             },
 ///             data_key: icu_data_key!(plurals: ordinal@1),

--- a/components/cldr-json-data-provider/src/transform/dates.rs
+++ b/components/cldr-json-data-provider/src/transform/dates.rs
@@ -423,6 +423,7 @@ pub(self) mod cldr_json {
 
 #[test]
 fn test_basic() {
+    use icu_locale_macros::langid;
     use std::borrow::Cow;
 
     let json_str = std::fs::read_to_string("tests/testdata/cs-ca-gregorian.json").unwrap();
@@ -433,7 +434,7 @@ fn test_basic() {
             data_key: icu_data_key!(dates: gregory@1),
             data_entry: DataEntry {
                 variant: None,
-                langid: "cs".parse().unwrap(),
+                langid: langid!("cs"),
             },
         })
         .unwrap()
@@ -452,6 +453,7 @@ fn test_basic() {
 
 #[test]
 fn test_with_numbering_system() {
+    use icu_locale_macros::langid;
     use std::borrow::Cow;
 
     let json_str = std::fs::read_to_string("tests/testdata/haw-ca-gregorian.json").unwrap();
@@ -462,7 +464,7 @@ fn test_with_numbering_system() {
             data_key: icu_data_key!(dates: gregory@1),
             data_entry: DataEntry {
                 variant: None,
-                langid: "haw".parse().unwrap(),
+                langid: langid!("haw"),
             },
         })
         .unwrap()
@@ -476,6 +478,7 @@ fn test_with_numbering_system() {
 
 #[test]
 fn unalias_contexts() {
+    use icu_locale_macros::langid;
     use std::borrow::Cow;
 
     let json_str = std::fs::read_to_string("tests/testdata/cs-ca-gregorian.json").unwrap();
@@ -486,7 +489,7 @@ fn unalias_contexts() {
             data_key: icu_data_key!(dates: gregory@1),
             data_entry: DataEntry {
                 variant: None,
-                langid: "cs".parse().unwrap(),
+                langid: langid!("cs"),
             },
         })
         .unwrap()

--- a/components/cldr-json-data-provider/src/transform/plurals.rs
+++ b/components/cldr-json-data-provider/src/transform/plurals.rs
@@ -188,6 +188,7 @@ pub(self) mod cldr_json {
 
 #[test]
 fn test_basic() {
+    use icu_locale_macros::langid;
     use std::borrow::Borrow;
 
     let json_str = std::fs::read_to_string("tests/testdata/plurals.json").unwrap();
@@ -199,7 +200,7 @@ fn test_basic() {
             data_key: icu_data_key!(plurals: cardinal@1),
             data_entry: DataEntry {
                 variant: None,
-                langid: "cs".parse().unwrap(),
+                langid: langid!("cs"),
             },
         })
         .unwrap()

--- a/components/data-provider/Cargo.toml
+++ b/components/data-provider/Cargo.toml
@@ -31,3 +31,4 @@ serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "1.0"
+icu-locale-macros = { path = "../locale/macros" }

--- a/components/data-provider/src/data_entry.rs
+++ b/components/data-provider/src/data_entry.rs
@@ -47,10 +47,11 @@ impl DataEntry {
     /// ```
     /// use std::borrow::Cow;
     /// use icu_data_provider::prelude::*;
+    /// use icu_locale_macros::langid;
     ///
     /// let data_entry = DataEntry {
     ///     variant: Some(Cow::Borrowed("GBP")),
-    ///     langid: "pt_BR".parse().unwrap(),
+    ///     langid: langid!("pt_BR"),
     /// };
     /// let components = data_entry.get_components();
     ///
@@ -95,6 +96,8 @@ impl From<&DataEntry> for DataEntryComponents {
 
 #[test]
 fn test_to_string() {
+    use icu_locale_macros::langid;
+
     struct TestCase {
         pub data_entry: DataEntry,
         pub expected: &'static str,
@@ -103,21 +106,21 @@ fn test_to_string() {
         TestCase {
             data_entry: DataEntry {
                 variant: None,
-                langid: "und".parse().unwrap(),
+                langid: LanguageIdentifier::default(),
             },
             expected: "und",
         },
         TestCase {
             data_entry: DataEntry {
                 variant: Some(Cow::Borrowed("GBP")),
-                langid: "und".parse().unwrap(),
+                langid: LanguageIdentifier::default(),
             },
             expected: "GBP/und",
         },
         TestCase {
             data_entry: DataEntry {
                 variant: Some(Cow::Borrowed("GBP")),
-                langid: "en-ZA".parse().unwrap(),
+                langid: langid!("en-ZA"),
             },
             expected: "GBP/en-ZA",
         },

--- a/components/data-provider/src/invariant.rs
+++ b/components/data-provider/src/invariant.rs
@@ -33,11 +33,12 @@ where
 /// use icu_data_provider::prelude::*;
 /// use icu_data_provider::InvariantDataProvider;
 /// use icu_data_provider::iter::DataEntryCollection;
+/// use icu_locale_macros::langid;
 ///
 /// let provider = InvariantDataProvider;
 /// let expected_entries = vec![DataEntry {
 ///     variant: None,
-///     langid: "und".parse().unwrap(),
+///     langid: langid!("und"),
 /// }];
 /// let actual_entries: Vec<DataEntry> = provider
 ///     .iter_for_key(&icu_data_key!(plurals: cardinal@1))

--- a/components/data-provider/tests/json_warehouse.rs
+++ b/components/data-provider/tests/json_warehouse.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use icu_locale::LanguageIdentifier;
+use icu_locale_macros::langid;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::prelude::v1::*;
@@ -93,7 +94,7 @@ fn get_response(warehouse: &JsonDataWarehouse) -> DataResponse {
             data_key: icu_data_key!(decimal: symbols@1),
             data_entry: DataEntry {
                 variant: None,
-                langid: "en-US".parse().unwrap(),
+                langid: langid!("en-US"),
             },
         })
         .unwrap()

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -25,6 +25,7 @@ icu-data-provider = { path = "../data-provider" }
 criterion = "0.3"
 icu-data-provider = { path = "../data-provider", features = ["invariant"] }
 icu-testdata = { path = "../../resources/testdata" }
+icu-locale-macros = { path = "../locale/macros" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/components/datetime/examples/work_log.rs
+++ b/components/datetime/examples/work_log.rs
@@ -5,7 +5,7 @@
 // from a work log into human readable dates and times.
 use icu_datetime::date::MockDateTime;
 use icu_datetime::{options::style, DateTimeFormat};
-use icu_locale::LanguageIdentifier;
+use icu_locale_macros::langid;
 
 const DATES_ISO: &[&str] = &[
     "2001-09-08T18:46:40:000",
@@ -30,7 +30,7 @@ fn print(_input: &str, _value: Option<usize>) {
 }
 
 fn main() {
-    let langid: LanguageIdentifier = "en".parse().expect("Failed to parse Language Identifier.");
+    let lid = langid!("en");
 
     let provider = icu_testdata::get_provider();
 
@@ -46,7 +46,7 @@ fn main() {
         ..Default::default()
     };
 
-    let dtf = DateTimeFormat::try_new(langid, &provider, &options.into())
+    let dtf = DateTimeFormat::try_new(lid, &provider, &options.into())
         .expect("Failed to create DateTimeFormat instance.");
     {
         print("\n====== Work Log (en) example ============", None);

--- a/components/datetime/src/format.rs
+++ b/components/datetime/src/format.rs
@@ -19,15 +19,14 @@ use std::fmt;
 /// # Examples
 ///
 /// ```
-/// # use icu_locale::LanguageIdentifier;
+/// # use icu_locale_macros::langid;
 /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
 /// # use icu_datetime::MockDateTime;
 /// # use icu_data_provider::InvariantDataProvider;
-/// # let langid: LanguageIdentifier = "en".parse()
-/// #     .expect("Failed to parse a language identifier.");
+/// # let lid = langid!("en");
 /// # let provider = InvariantDataProvider;
 /// # let options = DateTimeFormatOptions::default();
-/// let dtf = DateTimeFormat::try_new(langid, &provider, &options)
+/// let dtf = DateTimeFormat::try_new(lid, &provider, &options)
 ///     .expect("Failed to create DateTimeFormat instance.");
 ///
 /// let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -12,13 +12,12 @@
 //! # Examples
 //!
 //! ```
-//! use icu_locale::LanguageIdentifier;
+//! use icu_locale_macros::langid;
 //! use icu_datetime::{DateTimeFormat, options::style};
 //! use icu_datetime::MockDateTime;
 //! use icu_data_provider::InvariantDataProvider;
 //!
-//! let langid: LanguageIdentifier = "en".parse()
-//!     .expect("Failed to parse a language identifier.");
+//! let lid = langid!("en");
 //!
 //! let provider = InvariantDataProvider;
 //!
@@ -27,7 +26,7 @@
 //!     time: Some(style::Time::Short),
 //!     ..Default::default()
 //! };
-//! let dtf = DateTimeFormat::try_new(langid, &provider, &options.into())
+//! let dtf = DateTimeFormat::try_new(lid, &provider, &options.into())
 //!     .expect("Failed to create DateTimeFormat instance.");
 //!
 //!
@@ -77,13 +76,12 @@ use std::borrow::Cow;
 /// # Examples
 ///
 /// ```
-/// use icu_locale::LanguageIdentifier;
+/// use icu_locale_macros::langid;
 /// use icu_datetime::{DateTimeFormat, options::style};
 /// use icu_datetime::MockDateTime;
 /// use icu_data_provider::InvariantDataProvider;
 ///
-/// let langid: LanguageIdentifier = "en".parse()
-///     .expect("Failed to parse a language identifier.");
+/// let lid = langid!("en");
 ///
 /// let provider = InvariantDataProvider;
 ///
@@ -92,7 +90,7 @@ use std::borrow::Cow;
 ///     time: Some(style::Time::Short),
 ///     ..Default::default()
 /// };
-/// let dtf = DateTimeFormat::try_new(langid, &provider, &options.into())
+/// let dtf = DateTimeFormat::try_new(lid, &provider, &options.into())
 ///     .expect("Failed to create DateTimeFormat instance.");
 ///
 ///
@@ -117,19 +115,18 @@ impl<'d> DateTimeFormat<'d> {
     /// # Examples
     ///
     /// ```
-    /// use icu_locale::LanguageIdentifier;
+    /// use icu_locale_macros::langid;
     /// use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
     /// use icu_datetime::MockDateTime;
     /// use icu_data_provider::InvariantDataProvider;
     ///
-    /// let langid: LanguageIdentifier = "en".parse()
-    ///     .expect("Failed to parse a language identifier.");
+    /// let lid = langid!("en");
     ///
     /// let provider = InvariantDataProvider;
     ///
     /// let options = DateTimeFormatOptions::default();
     ///
-    /// let dtf = DateTimeFormat::try_new(langid, &provider, &options);
+    /// let dtf = DateTimeFormat::try_new(lid, &provider, &options);
     ///
     /// assert_eq!(dtf.is_ok(), true);
     /// ```
@@ -163,15 +160,14 @@ impl<'d> DateTimeFormat<'d> {
     /// # Examples
     ///
     /// ```
-    /// # use icu_locale::LanguageIdentifier;
+    /// # use icu_locale_macros::langid;
     /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
     /// # use icu_datetime::MockDateTime;
     /// # use icu_data_provider::InvariantDataProvider;
-    /// # let langid: LanguageIdentifier = "en".parse()
-    /// #     .expect("Failed to parse a language identifier.");
+    /// # let lid = langid!("en");
     /// # let provider = InvariantDataProvider;
     /// # let options = DateTimeFormatOptions::default();
-    /// let dtf = DateTimeFormat::try_new(langid, &provider, &options)
+    /// let dtf = DateTimeFormat::try_new(lid, &provider, &options)
     ///     .expect("Failed to create DateTimeFormat instance.");
     ///
     /// let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)
@@ -202,15 +198,14 @@ impl<'d> DateTimeFormat<'d> {
     /// # Examples
     ///
     /// ```
-    /// # use icu_locale::LanguageIdentifier;
+    /// # use icu_locale_macros::langid;
     /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
     /// # use icu_datetime::MockDateTime;
     /// # use icu_data_provider::InvariantDataProvider;
-    /// # let langid: LanguageIdentifier = "en".parse()
-    /// #     .expect("Failed to parse a language identifier.");
+    /// # let lid = langid!("en");
     /// # let provider = InvariantDataProvider;
     /// # let options = DateTimeFormatOptions::default();
-    /// let dtf = DateTimeFormat::try_new(langid, &provider, &options.into())
+    /// let dtf = DateTimeFormat::try_new(lid, &provider, &options.into())
     ///     .expect("Failed to create DateTimeFormat instance.");
     ///
     /// let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)
@@ -235,15 +230,14 @@ impl<'d> DateTimeFormat<'d> {
     /// # Examples
     ///
     /// ```
-    /// # use icu_locale::LanguageIdentifier;
+    /// # use icu_locale_macros::langid;
     /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
     /// # use icu_datetime::MockDateTime;
     /// # use icu_data_provider::InvariantDataProvider;
-    /// # let langid: LanguageIdentifier = "en".parse()
-    /// #     .expect("Failed to parse a language identifier.");
+    /// # let lid = langid!("en");
     /// # let provider = InvariantDataProvider;
     /// # let options = DateTimeFormatOptions::default();
-    /// let dtf = DateTimeFormat::try_new(langid, &provider, &options.into())
+    /// let dtf = DateTimeFormat::try_new(lid, &provider, &options.into())
     ///     .expect("Failed to create DateTimeFormat instance.");
     ///
     /// let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)

--- a/components/fs-data-provider/Cargo.toml
+++ b/components/fs-data-provider/Cargo.toml
@@ -32,6 +32,9 @@ clap = { version = "2.33", optional = true }
 icu-cldr-json-data-provider = { path = "../cldr-json-data-provider", features = ["download"], optional = true }
 simple_logger = { version = "1.10", optional = true }
 
+[dev-dependencies]
+icu-locale-macros = { path = "../locale/macros" }
+
 [features]
 export = ["erased-serde", "icu-data-provider/invariant", "log"]
 export-bin = ["export", "clap", "icu-cldr-json-data-provider", "simple_logger"]

--- a/components/fs-data-provider/src/export/mod.rs
+++ b/components/fs-data-provider/src/export/mod.rs
@@ -45,7 +45,7 @@
 //!     data_key: DATA_KEY,
 //!     data_entry: DataEntry {
 //!         variant: None,
-//!         langid: "und".parse().unwrap(),
+//!         langid: Default::default(),
 //!     }
 //! };
 //! let inv_response = inv_provider.load(&req).unwrap();

--- a/components/fs-data-provider/tests/test_file_io.rs
+++ b/components/fs-data-provider/tests/test_file_io.rs
@@ -4,6 +4,7 @@
 use icu_data_provider::prelude::*;
 use icu_data_provider::structs;
 use icu_fs_data_provider::FsDataProvider;
+use icu_locale_macros::langid;
 use std::borrow::Cow;
 
 #[test]
@@ -16,8 +17,7 @@ fn test_read_json() {
             data_key: icu_data_key!(plurals: cardinal@1),
             data_entry: DataEntry {
                 variant: None,
-                // TODO: Migrate to LanguageIdentifier macro
-                langid: "sr".parse().expect("Valid language tag"),
+                langid: langid!("sr"),
             },
         })
         .expect("The key should be present in the testdata");

--- a/components/icu/examples/tui.rs
+++ b/components/icu/examples/tui.rs
@@ -4,7 +4,7 @@
 // An example program making use of a number of ICU components
 // in a pseudo-real-world application of Textual User Interface.
 use icu::datetime::{date::MockDateTime, DateTimeFormat, DateTimeFormatOptions};
-use icu::locale::LanguageIdentifier;
+use icu::locale::{macros::langid, LanguageIdentifier};
 use icu::plurals::{PluralCategory, PluralRuleType, PluralRules};
 use icu::uniset::UnicodeSetBuilder;
 use std::env;
@@ -21,9 +21,8 @@ fn main() {
 
     let langid: LanguageIdentifier = args
         .get(1)
-        .unwrap_or(&"en".to_string())
-        .parse()
-        .expect("Failed to parse language identifier.");
+        .map(|s| s.parse().expect("Failed to parse language identifier"))
+        .unwrap_or(langid!("en"));
 
     let user_name = args.get(2).cloned().unwrap_or_else(|| "John".to_string());
 
@@ -62,7 +61,7 @@ fn main() {
     }
 
     {
-        let en: LanguageIdentifier = "en".parse().expect("Failed to parse Language Identifier.");
+        let en = langid!("en");
         let pr = PluralRules::try_new(en, &provider, PluralRuleType::Cardinal)
             .expect("Failed to create PluralRules.");
 

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -34,13 +34,12 @@
 //! # Examples
 //!
 //! ```
-//! use icu::locale::LanguageIdentifier;
+//! use icu::locale::macros::langid;
 //! use icu::datetime::{DateTimeFormat, date::MockDateTime, options::style};
 //!
 //! let provider = icu_testdata::get_provider();
 //!
-//! let langid: LanguageIdentifier = "en".parse()
-//!     .expect("Failed to parse a Language Identifier.");
+//! let lid = langid!("en");
 //!
 //! let options = style::Bag {
 //!     date: Some(style::Date::Long),
@@ -48,7 +47,7 @@
 //!     ..Default::default()
 //! };
 //!
-//! let dtf = DateTimeFormat::try_new(langid, &provider, &options.into())
+//! let dtf = DateTimeFormat::try_new(lid, &provider, &options.into())
 //!     .expect("Failed to create DateTimeFormat instance.");
 //!
 //! let date: MockDateTime = "2020-09-12T12:35:00".parse()

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -27,6 +27,7 @@ criterion = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = {version = "1.0" }
 icu-locale = { path = "../locale", features = ["serde"] }
+icu-locale-macros = { path = "../locale/macros" }
 icu-data-provider = { path = "../data-provider", features = ["invariant"] }
 icu-testdata = { path = "../../resources/testdata" }
 

--- a/components/plurals/benches/pluralrules.rs
+++ b/components/plurals/benches/pluralrules.rs
@@ -29,7 +29,7 @@ fn pluralrules(c: &mut Criterion) {
     #[cfg(feature = "bench")]
     {
         use criterion::black_box;
-        use icu_locale::LanguageIdentifier;
+        use icu_locale_macros::langid;
 
         c.bench_function("plurals/pluralrules/construct/fs", |b| {
             b.iter(|| {
@@ -41,8 +41,8 @@ fn pluralrules(c: &mut Criterion) {
             });
         });
 
-        let loc: LanguageIdentifier = "pl".parse().unwrap();
-        let pr = PluralRules::try_new(loc, &provider, PluralRuleType::Cardinal).unwrap();
+        let lid = langid!("pl");
+        let pr = PluralRules::try_new(lid, &provider, PluralRuleType::Cardinal).unwrap();
         c.bench_function("plurals/pluralrules/select/fs", |b| {
             b.iter(|| {
                 for s in &numbers_data.usize {

--- a/components/plurals/examples/elevator_floors.rs
+++ b/components/plurals/examples/elevator_floors.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 // An example application which uses icu_plurals to construct a correct
 // sentence for English based on the numerical value in Ordinal category.
-use icu_locale::LanguageIdentifier;
+use icu_locale_macros::langid;
 use icu_plurals::{PluralCategory, PluralRuleType, PluralRules};
 
 const VALUES: &[usize] = &[0, 2, 25, 1, 3, 2, 4, 10, 7, 0];
@@ -18,13 +18,13 @@ fn print(_input: &str, _value: Option<usize>) {
 }
 
 fn main() {
-    let langid: LanguageIdentifier = "en".parse().expect("Failed to parse Language Identifier.");
+    let lid = langid!("en");
 
     let provider = icu_testdata::get_provider();
 
     {
         print("\n====== Elevator Floor (en) example ============", None);
-        let pr = PluralRules::try_new(langid, &provider, PluralRuleType::Ordinal)
+        let pr = PluralRules::try_new(lid, &provider, PluralRuleType::Ordinal)
             .expect("Failed to create a PluralRules instance.");
 
         for value in VALUES {

--- a/components/plurals/examples/unread_emails.rs
+++ b/components/plurals/examples/unread_emails.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 // An example application which uses icu_plurals to construct a correct
 // sentence for English based on the numerical value in Cardinal category.
-use icu_locale::LanguageIdentifier;
+use icu_locale_macros::langid;
 use icu_plurals::{PluralCategory, PluralRuleType, PluralRules};
 
 const VALUES: &[usize] = &[0, 2, 25, 1, 3, 2, 4, 10, 7, 0];
@@ -18,12 +18,12 @@ fn print(_input: &str, _value: Option<usize>) {
 }
 
 fn main() {
-    let langid: LanguageIdentifier = "en".parse().expect("Failed to parse Language Identifier.");
+    let lid = langid!("en");
     let provider = icu_testdata::get_provider();
 
     {
         print("\n====== Unread Emails (en) example ============", None);
-        let pr = PluralRules::try_new(langid, &provider, PluralRuleType::Cardinal)
+        let pr = PluralRules::try_new(lid, &provider, PluralRuleType::Cardinal)
             .expect("Failed to create a PluralRules instance.");
 
         for value in VALUES {

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -24,16 +24,15 @@
 //! # Examples
 //!
 //! ```
-//! use icu_locale::LanguageIdentifier;
+//! use icu_locale_macros::langid;
 //! use icu_plurals::{PluralRules, PluralRuleType, PluralCategory};
 //! use icu_data_provider::InvariantDataProvider;
 //!
-//! let lang: LanguageIdentifier = "en".parse()
-//!     .expect("Failed to parse a language identifier.");
+//! let lid = langid!("en");
 //!
 //! let dp = InvariantDataProvider;
 //!
-//! let pr = PluralRules::try_new(lang, &dp, PluralRuleType::Cardinal)
+//! let pr = PluralRules::try_new(lid, &dp, PluralRuleType::Cardinal)
 //!     .expect("Failed to construct a PluralRules struct.");
 //!
 //! assert_eq!(pr.select(5_usize), PluralCategory::Other);
@@ -134,16 +133,15 @@ pub enum PluralRuleType {
 /// # Examples
 ///
 /// ```
-/// use icu_locale::LanguageIdentifier;
+/// use icu_locale_macros::langid;
 /// use icu_plurals::{PluralRules, PluralRuleType, PluralCategory};
 /// use icu_data_provider::InvariantDataProvider;
 ///
-/// let lang: LanguageIdentifier = "en".parse()
-///     .expect("Failed to parse a language identifier.");
+/// let lid = langid!("en");
 ///
 /// let dp = InvariantDataProvider;
 ///
-/// let pr = PluralRules::try_new(lang, &dp, PluralRuleType::Cardinal)
+/// let pr = PluralRules::try_new(lid, &dp, PluralRuleType::Cardinal)
 ///     .expect("Failed to construct a PluralRules struct.");
 ///
 /// assert_eq!(pr.select(5_usize), PluralCategory::Other);
@@ -242,16 +240,15 @@ impl PluralCategory {
 /// # Examples
 ///
 /// ```
-/// use icu_locale::LanguageIdentifier;
+/// use icu_locale_macros::langid;
 /// use icu_plurals::{PluralRules, PluralRuleType, PluralCategory};
 /// use icu_data_provider::InvariantDataProvider;
 ///
-/// let lang: LanguageIdentifier = "en".parse()
-///     .expect("Failed to parse a language identifier.");
+/// let lid = langid!("en");
 ///
 /// let dp = InvariantDataProvider;
 ///
-/// let pr = PluralRules::try_new(lang, &dp, PluralRuleType::Cardinal)
+/// let pr = PluralRules::try_new(lid, &dp, PluralRuleType::Cardinal)
 ///     .expect("Failed to construct a PluralRules struct.");
 ///
 /// assert_eq!(pr.select(5_usize), PluralCategory::Other);
@@ -274,16 +271,15 @@ impl PluralRules {
     /// # Examples
     ///
     /// ```
-    /// use icu_locale::LanguageIdentifier;
+    /// use icu_locale_macros::langid;
     /// use icu_plurals::{PluralRules, PluralRuleType};
     /// use icu_data_provider::InvariantDataProvider;
     ///
-    /// let lang: LanguageIdentifier = "en".parse()
-    ///     .expect("Failed to parse a language identifier.");
+    /// let lid = langid!("en");
     ///
     /// let dp = InvariantDataProvider;
     ///
-    /// let _ = PluralRules::try_new(lang, &dp, PluralRuleType::Cardinal);
+    /// let _ = PluralRules::try_new(lid, &dp, PluralRuleType::Cardinal);
     /// ```
     ///
     /// [`type`]: ./enum.PluralRuleType.html
@@ -319,16 +315,15 @@ impl PluralRules {
     /// # Examples
     ///
     /// ```
-    /// use icu_locale::LanguageIdentifier;
+    /// use icu_locale_macros::langid;
     /// use icu_plurals::{PluralRules, PluralRuleType, PluralCategory};
     /// use icu_data_provider::InvariantDataProvider;
     ///
-    /// let lang: LanguageIdentifier = "en".parse()
-    ///     .expect("Failed to parse a language identifier.");
+    /// let lid = langid!("en");
     ///
     /// let dp = InvariantDataProvider;
     ///
-    /// let pr = PluralRules::try_new(lang, &dp, PluralRuleType::Cardinal)
+    /// let pr = PluralRules::try_new(lid, &dp, PluralRuleType::Cardinal)
     ///     .expect("Failed to construct a PluralRules struct.");
     ///
     /// match pr.select(1_usize) {
@@ -349,17 +344,16 @@ impl PluralRules {
     ///
     /// ```
     /// # use std::convert::TryFrom;
-    /// # use icu_locale::LanguageIdentifier;
+    /// # use icu_locale_macros::langid;
     /// # use icu_plurals::{PluralRules, PluralRuleType};
     /// use icu_plurals::{PluralCategory, PluralOperands};
     /// # use icu_data_provider::InvariantDataProvider;
     /// #
-    /// # let lang: LanguageIdentifier = "en".parse()
-    /// #     .expect("Failed to parse a language identifier.");
+    /// # let lid = langid!("en");
     /// #
     /// # let dp = InvariantDataProvider;
     /// #
-    /// # let pr = PluralRules::try_new(lang, &dp, PluralRuleType::Cardinal)
+    /// # let pr = PluralRules::try_new(lid, &dp, PluralRuleType::Cardinal)
     /// #     .expect("Failed to construct a PluralRules struct.");
     ///
     /// let operands = PluralOperands::try_from(-5)

--- a/components/plurals/tests/plurals.rs
+++ b/components/plurals/tests/plurals.rs
@@ -1,16 +1,16 @@
 // This file is part of ICU4X. For terms of use, please see the file
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
-use icu_locale::LanguageIdentifier;
+use icu_locale_macros::langid;
 use icu_plurals::{PluralCategory, PluralRuleType, PluralRules};
 
 #[test]
 fn test_plural_rules() {
     let provider = icu_testdata::get_provider();
 
-    let lang: LanguageIdentifier = "en".parse().unwrap();
+    let lid = langid!("en");
 
-    let pr = PluralRules::try_new(lang, &provider, PluralRuleType::Cardinal).unwrap();
+    let pr = PluralRules::try_new(lid, &provider, PluralRuleType::Cardinal).unwrap();
 
     assert_eq!(pr.select(5_usize), PluralCategory::Other);
 }
@@ -19,9 +19,9 @@ fn test_plural_rules() {
 fn test_plural_rules_missing() {
     let provider = icu_testdata::get_provider();
 
-    let lang: LanguageIdentifier = "xx".parse().unwrap();
+    let lid = langid!("xx");
 
-    let pr = PluralRules::try_new(lang, &provider, PluralRuleType::Cardinal);
+    let pr = PluralRules::try_new(lid, &provider, PluralRuleType::Cardinal);
 
     assert!(pr.is_err());
 }

--- a/resources/testdata/Cargo.toml
+++ b/resources/testdata/Cargo.toml
@@ -103,6 +103,9 @@ icu-cldr-json-data-provider = { path = "../../components/cldr-json-data-provider
 log = { version = "0.4", optional = true }
 simple_logger = { version = "1.10", optional = true }
 
+[dev-dependencies]
+icu-locale-macros = { path = "../../components/locale/macros" }
+
 [features]
 metadata = ["serde", "serde_json", "icu-locale/serde"]
 icu4x-gen-testdata = [

--- a/resources/testdata/src/lib.rs
+++ b/resources/testdata/src/lib.rs
@@ -14,13 +14,14 @@
 //! use std::borrow::Cow;
 //! use icu_data_provider::prelude::*;
 //! use icu_data_provider::structs::plurals::PluralRuleStringsV1;
+//! use icu_locale_macros::langid;
 //!
 //! let data_provider = icu_testdata::get_provider();
 //!
 //! let data: Cow<PluralRuleStringsV1> = data_provider
 //!     .load(&DataRequest {
 //!         data_entry: DataEntry {
-//!             langid: "be".parse().unwrap(),
+//!             langid: langid!("be"),
 //!             variant: None,
 //!         },
 //!         data_key: icu_data_key!(plurals: cardinal@1),

--- a/resources/testdata/src/metadata.rs
+++ b/resources/testdata/src/metadata.rs
@@ -86,10 +86,11 @@ pub fn load() -> Result<PackageInfo, Error> {
 
 #[test]
 fn test_metadata() {
+    use icu_locale_macros::langid;
     let package_info = load().expect("Failed to load metadata");
     assert!(package_info
         .package_metadata
         .locales
-        .contains(&("und".parse().unwrap())));
+        .contains(&(langid!("und"))));
     assert!(package_info.package_metadata.locales.len() > 10);
 }


### PR DESCRIPTION
This is a fairly trivial replacement to use macros. I also swapped in a couple places for `LanguageIdentifier::default()` because that's the best way to get `und` without vendoring in macros.