### PR TITLE
temporarily disable benchmark test for utils/fixed-decimal

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -91,7 +91,10 @@ jobs:
         component:
           - components/locale
           - components/uniset
-          - utils/fixed-decimal
+
+          # TODO(#320): re-enable
+          # - utils/fixed-decimal
+
 
     # If you are modifying and debugging is required, don't be afraid to get
     # messy in a personal fork, if no better way to do it.


### PR DESCRIPTION
This short-term workaround is related to #320 and #327.  Both issues are held open because the only component whose benchmark check wasn't fixed by the previous PRs is `utils/fixed-decimal`.

We need the workaround to re-activate the creation of benchmark dashboards.