### PR TITLE
Add per-component benchmark tests in CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -116,7 +116,7 @@ jobs:
           mkdir -p $REL_OUTPUT_PATH;
           export OUTPUT_PATH_CMD="ls -d $REL_OUTPUT_PATH";
           export OUTPUT_PATH=$(echo $OUTPUT_PATH_CMD | sh);
-          cargo bench -- --output-format bencher | tee $OUTPUT_PATH/output.txt
+          cargo bench -- --output-format bencher | tee $OUTPUT_PATH/output.txt;
           popd
 
       # In the following step(s) regarding converting benchmark output to dashboards, the branch in `gh-pages-branch` needs to exist.

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -91,9 +91,10 @@ jobs:
         component:
           - components/locid
           - components/uniset
-
-          # TODO(#320): re-enable
-          # - utils/fixed_decimal
+          - components/plurals
+          - components/uniset
+          - components/datetime
+          - utils/fixed_decimal
 
 
     # If you are modifying and debugging is required, don't be afraid to get

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -92,7 +92,6 @@ jobs:
           - components/locid
           - components/uniset
           - components/plurals
-          - components/uniset
           - components/datetime
           - utils/fixed_decimal
 

--- a/README.md
+++ b/README.md
@@ -83,5 +83,8 @@ ICU4X will provide an ECMA-402-compatible API surface in the target client-side 
 
 | Component     | Runtime                                                                  |
 |---------------|--------------------------------------------------------------------------|
-| locale        | [link](https://unicode-org.github.io/icu4x-docs/dev/components/locid)   |
+| locid         | [link](https://unicode-org.github.io/icu4x-docs/dev/components/locid)   |
 | uniset        | [link](https://unicode-org.github.io/icu4x-docs/dev/components/uniset)   |
+| fixed_decimal | [link](https://unicode-org.github.io/icu4x-docs/dev/utils/fixed_decimal) |
+| plurals       | [link](https://unicode-org.github.io/icu4x-docs/dev/utils/plurals)       |
+| datetime      | [link](https://unicode-org.github.io/icu4x-docs/dev/utils/datetime)      |

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ ICU4X will provide an ECMA-402-compatible API surface in the target client-side 
 
 | Component     | Runtime                                                                  |
 |---------------|--------------------------------------------------------------------------|
-| locid         | [link](https://unicode-org.github.io/icu4x-docs/dev/components/locid)   |
+| locid         | [link](https://unicode-org.github.io/icu4x-docs/dev/components/locid)    |
 | uniset        | [link](https://unicode-org.github.io/icu4x-docs/dev/components/uniset)   |
 | fixed_decimal | [link](https://unicode-org.github.io/icu4x-docs/dev/utils/fixed_decimal) |
 | plurals       | [link](https://unicode-org.github.io/icu4x-docs/dev/utils/plurals)       |


### PR DESCRIPTION
After the upstream fixes to the components and benchmark configs and commands, the benchmark commands seem to work now for all of the components, including for `utils/fixed_decimal`.

I [tested it in my personal fork](https://github.com/echeran/icu4x/pull/17).  In my personal fork, I can now get dashboards for `utils/fixed_decimal`, `datetime`, `plurals`.
https://echeran.github.io/icu4x-docs/dev/utils/fixed_decimal/
https://echeran.github.io/icu4x-docs/dev/components/plurals/
https://echeran.github.io/icu4x-docs/dev/components/datetime/

The charts aren't exciting with only 1 or 2 data points, but I believe they exist as expected.