### PR TITLE
Adding an example to locid section.

### DIFF
--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -53,5 +53,5 @@ name = "filter_langids"
 test = true
 
 [[example]]
-name = "canonicalize_locales"
+name = "syntatically_canonicalize_locales"
 test = true

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -51,3 +51,7 @@ harness = false
 [[example]]
 name = "filter_langids"
 test = true
+
+[[example]]
+name = "canonicalize_locales"
+test = true

--- a/components/locid/examples/canonicalize_locales.rs
+++ b/components/locid/examples/canonicalize_locales.rs
@@ -6,7 +6,7 @@
 
 use std::env;
 
-use icu_locid::{Locale};
+use icu_locid::Locale;
 
 const DEFAULT_INPUT: &str = "sr-cyrL-rS, es-mx, und-arab-u-ca-Buddhist";
 

--- a/components/locid/examples/canonicalize_locales.rs
+++ b/components/locid/examples/canonicalize_locales.rs
@@ -1,0 +1,53 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
+// A sample application which takes a comma separated list of locales,
+// makes them canonical and serializes the list back into a comma separated list.
+
+use std::env;
+
+use icu_locid::{Locale};
+
+const DEFAULT_INPUT: &str = "sr-cyrL-rS, es-mx, und-arab-u-ca-Buddhist";
+
+fn canonicalize_locales(input: &str) -> String {
+    // 1. Parse the input string into a list of locales.
+    let locales: Vec<Locale> = input
+        .split(',')
+        .filter_map(|s| s.trim().parse().ok())
+        .collect();
+
+    // 2. Canonicalize and serialize the output.
+    let canonical_locales: Vec<String> = locales
+        .into_iter()
+        .filter_map(|locale| icu_locid::Locale::canonicalize(locale.to_string()).ok())
+        .collect();
+
+    canonical_locales.join(", ")
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    let input = if let Some(input) = args.get(1) {
+        input.as_str()
+    } else {
+        DEFAULT_INPUT
+    };
+    let _output = canonicalize_locales(&input);
+
+    #[cfg(debug_assertions)]
+    println!("\nInput: {}\nOutput: {}", input, _output);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DEFAULT_OUTPUT: &str = "sr-Cyrl-RS, es-MX, und-Arab-u-ca-buddhist";
+
+    #[test]
+    fn ensure_default_output() {
+        assert_eq!(canonicalize_locales(DEFAULT_INPUT), DEFAULT_OUTPUT);
+    }
+}

--- a/components/locid/examples/canonicalize_locales.rs
+++ b/components/locid/examples/canonicalize_locales.rs
@@ -11,16 +11,10 @@ use icu_locid::Locale;
 const DEFAULT_INPUT: &str = "sr-cyrL-rS, es-mx, und-arab-u-ca-Buddhist";
 
 fn canonicalize_locales(input: &str) -> String {
-    // 1. Parse the input string into a list of locales.
-    let locales: Vec<Locale> = input
+    // Split input string and canonicalize each locale identifier.
+    let canonical_locales: Vec<String> = input
         .split(',')
-        .filter_map(|s| s.trim().parse().ok())
-        .collect();
-
-    // 2. Canonicalize and serialize the output.
-    let canonical_locales: Vec<String> = locales
-        .into_iter()
-        .filter_map(|locale| icu_locid::Locale::canonicalize(locale.to_string()).ok())
+        .filter_map(|s| Locale::canonicalize(s.trim()).ok())
         .collect();
 
     canonical_locales.join(", ")

--- a/components/locid/examples/syntatically_canonicalize_locales.rs
+++ b/components/locid/examples/syntatically_canonicalize_locales.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 // A sample application which takes a comma separated list of locales,
-// makes them canonical and serializes the list back into a comma separated list.
+// makes them syntatically canonical and serializes the list back into a comma separated list.
 
 use std::env;
 
@@ -10,7 +10,7 @@ use icu_locid::Locale;
 
 const DEFAULT_INPUT: &str = "sr-cyrL-rS, es-mx, und-arab-u-ca-Buddhist";
 
-fn canonicalize_locales(input: &str) -> String {
+fn syntatically_canonicalize_locales(input: &str) -> String {
     // Split input string and canonicalize each locale identifier.
     let canonical_locales: Vec<String> = input
         .split(',')
@@ -28,7 +28,7 @@ fn main() {
     } else {
         DEFAULT_INPUT
     };
-    let _output = canonicalize_locales(&input);
+    let _output = syntatically_canonicalize_locales(&input);
 
     #[cfg(debug_assertions)]
     println!("\nInput: {}\nOutput: {}", input, _output);
@@ -42,6 +42,9 @@ mod tests {
 
     #[test]
     fn ensure_default_output() {
-        assert_eq!(canonicalize_locales(DEFAULT_INPUT), DEFAULT_OUTPUT);
+        assert_eq!(
+            syntatically_canonicalize_locales(DEFAULT_INPUT),
+            DEFAULT_OUTPUT
+        );
     }
 }


### PR DESCRIPTION
After our CI binary size discussion today, I made another locid example, to make sure that both parse() and canonicalize() methods are covered separately, so that we can track their sizes independently.