### PR TITLE
Use parsing iterator for LanguageIdentifier PartialEq

### DIFF
--- a/components/locid/src/extensions/transform/value.rs
+++ b/components/locid/src/extensions/transform/value.rs
@@ -1,7 +1,7 @@
 // This file is part of ICU4X. For terms of use, please see the file
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
-use crate::parser::ParserError;
+use crate::parser::{get_subtag_iterator, ParserError};
 use std::ops::RangeInclusive;
 use std::str::FromStr;
 use tinystr::TinyStr8;
@@ -52,7 +52,7 @@ impl Value {
         let mut v = vec![];
         let mut has_value = false;
 
-        for subtag in input.split(|c| *c == b'-' || *c == b'_') {
+        for subtag in get_subtag_iterator(input) {
             if !Self::is_type_subtag(subtag) {
                 return Err(ParserError::InvalidExtension);
             }

--- a/components/locid/src/extensions/unicode/value.rs
+++ b/components/locid/src/extensions/unicode/value.rs
@@ -1,7 +1,7 @@
 // This file is part of ICU4X. For terms of use, please see the file
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
-use crate::parser::ParserError;
+use crate::parser::{get_subtag_iterator, ParserError};
 use std::ops::RangeInclusive;
 use std::str::FromStr;
 use tinystr::TinyStr8;
@@ -52,7 +52,7 @@ impl Value {
         let mut v = vec![];
 
         if !input.is_empty() {
-            for subtag in input.split(|c| *c == b'-' || *c == b'_') {
+            for subtag in get_subtag_iterator(input) {
                 if !Self::is_type_subtag(subtag) {
                     return Err(ParserError::InvalidExtension);
                 }

--- a/components/locid/src/parser/langid.rs
+++ b/components/locid/src/parser/langid.rs
@@ -4,6 +4,7 @@
 use std::iter::Peekable;
 
 pub use super::errors::ParserError;
+use crate::parser::get_subtag_iterator;
 use crate::subtags;
 use crate::LanguageIdentifier;
 
@@ -98,6 +99,6 @@ pub fn parse_language_identifier(
     t: &[u8],
     mode: ParserMode,
 ) -> Result<LanguageIdentifier, ParserError> {
-    let mut iter = t.split(|c| *c == b'-' || *c == b'_').peekable();
+    let mut iter = get_subtag_iterator(t).peekable();
     parse_language_identifier_from_iter(&mut iter, mode)
 }

--- a/components/locid/src/parser/locale.rs
+++ b/components/locid/src/parser/locale.rs
@@ -3,11 +3,11 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::extensions::Extensions;
 use crate::parser::errors::ParserError;
-use crate::parser::{parse_language_identifier_from_iter, ParserMode};
+use crate::parser::{get_subtag_iterator, parse_language_identifier_from_iter, ParserMode};
 use crate::Locale;
 
 pub fn parse_locale(t: &[u8]) -> Result<Locale, ParserError> {
-    let mut iter = t.split(|c| *c == b'-' || *c == b'_').peekable();
+    let mut iter = get_subtag_iterator(t).peekable();
 
     let langid = parse_language_identifier_from_iter(&mut iter, ParserMode::Locale)?;
     let extensions = if iter.peek().is_some() {

--- a/components/locid/src/parser/mod.rs
+++ b/components/locid/src/parser/mod.rs
@@ -8,3 +8,7 @@ mod locale;
 pub use errors::ParserError;
 pub use langid::{parse_language_identifier, parse_language_identifier_from_iter, ParserMode};
 pub use locale::parse_locale;
+
+pub fn get_subtag_iterator(t: &[u8]) -> impl Iterator<Item = &[u8]> {
+    t.split(|c| *c == b'-' || *c == b'_')
+}

--- a/components/locid/tests/langid.rs
+++ b/components/locid/tests/langid.rs
@@ -116,3 +116,18 @@ fn test_langid_subtag_variants() {
     variants.clear();
     assert_eq!(variants.len(), 0);
 }
+
+#[test]
+fn test_langid_partialeq_str() {
+    let path = "./tests/fixtures/langid.json";
+    let tests: Vec<fixtures::LocaleTest> =
+        helpers::read_fixture(path).expect("Failed to read a fixture");
+    for test in tests {
+        let parsed: LanguageIdentifier = test.input.try_into().expect("Parsing failed.");
+        assert_eq!(parsed, &parsed.to_string() as &str);
+    }
+
+    // Check that trailing characters are not ignored
+    let lang: LanguageIdentifier = "en".parse().expect("Parsing failed.");
+    assert_ne!(lang, "en-US");
+}

--- a/components/locid/tests/langid.rs
+++ b/components/locid/tests/langid.rs
@@ -124,7 +124,7 @@ fn test_langid_partialeq_str() {
         helpers::read_fixture(path).expect("Failed to read a fixture");
     for test in tests {
         let parsed: LanguageIdentifier = test.input.try_into().expect("Parsing failed.");
-        assert_eq!(parsed, &parsed.to_string() as &str);
+        assert_eq!(parsed, parsed.to_string().as_str());
     }
 
     // Check that trailing characters are not ignored


### PR DESCRIPTION
It looks like this does result in a modest performance improvement:

```
galadriel:benches dminor$ cargo bench
   Compiling icu_locid v0.1.0 (/Users/dminor/src/icu4x/components/locid)
    Finished bench [optimized] target(s) in 6.64s
     Running /Users/dminor/src/icu4x/target/release/deps/langid-d11caf6e06c29960
Gnuplot not found, using plotters backend
Benchmarking langid/overview: Collecting 100 samples in estimated 5.0106 s (737k iterati                                                                                        langid/overview         time:   [6.7043 us 6.7271 us 6.7552 us]
                        change: [-26.828% -26.415% -25.966%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  5 (5.00%) high mild
  8 (8.00%) high severe

     Running /Users/dminor/src/icu4x/target/release/deps/locale-f87be7e62ab6d9ae
Gnuplot not found, using plotters backend
Benchmarking locale/overview: Collecting 100 samples in estimated 5.0348 s (364k iterati                                                                                        locale/overview         time:   [13.732 us 13.759 us 13.790 us]
                        change: [+0.9791% +1.5204% +2.0666%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe
```