### PR TITLE
Fix README links following documentation move

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ The design goals of `ICU4X` are:
 
 ## Documentation
 
-For an introduction the project, please visit [`Introduction to ICU4X for Rust`](https://github.com/unicode-org/icu4x/wiki/Introduction-to-ICU4X-for-Rust) tutorial.
+For an introduction the project, please visit [`Introduction to ICU4X for Rust`](docs/tutorials/intro.md) tutorial.
 
 For technical information on how to use ICU4X, visit our [API docs](https://unicode-org.github.io/icu4x-docs/doc/icu/index.html).
 
-More information about the project can be found on our [wiki](https://github.com/unicode-org/icu4x/wiki) and in [the docs subdirectory](docs/index.md).
+More information about the project can be found in [the docs subdirectory](docs/README.md).
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The design goals of `ICU4X` are:
 
 ## Documentation
 
-For an introduction the project, please visit [`Introduction to ICU4X for Rust`](docs/tutorials/intro.md) tutorial.
+For an introduction to the project, please visit [`Introduction to ICU4X for Rust`](docs/tutorials/intro.md) tutorial.
 
 For technical information on how to use ICU4X, visit our [API docs](https://unicode-org.github.io/icu4x-docs/doc/icu/index.html).
 


### PR DESCRIPTION
The docs move in #382 led to invalid URL's on the project README.  This PR updates the documentation links and removes the reference/link to the wiki.