### PR TITLE
Switch to use Rust intra-doc

### DIFF
--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -35,7 +35,7 @@ impl From<std::num::ParseIntError> for DateTimeError {
 /// *Note*: At the moment we support only `gregorian` calendar, and plan to extend support to
 /// other calendars in the upcoming releases. See https://github.com/unicode-org/icu4x/issues/355
 ///
-/// [`DateTimeFormat`]: ../struct.DateTimeFormat.html
+/// [`DateTimeFormat`]: super::DateTimeFormat
 pub trait DateTimeType: FromStr {
     fn year(&self) -> usize;
     fn month(&self) -> Month;
@@ -56,7 +56,6 @@ pub trait DateTimeType: FromStr {
 /// let dt = MockDateTime::try_new(2020, 9, 24, 13, 21, 0)
 ///     .expect("Failed to construct DateTime.");
 /// ```
-/// [`DateTimeType`]: ./trait.DateTimeType.html
 #[derive(Debug, Default)]
 pub struct MockDateTime {
     pub year: usize,

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -4,9 +4,8 @@
 use crate::pattern;
 use icu_provider::prelude::DataError;
 
-/// A list of possible error outcomes for the [`DateTimeFormat`] struct.
+/// A list of possible error outcomes for the [`DateTimeFormat`](crate::DateTimeFormat) struct.
 ///
-/// [`DateTimeFormat`]: ./struct.DateTimeFormat.html
 #[derive(Debug)]
 pub enum DateTimeFormatError {
     /// An error coming from a pattern parsing

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -43,11 +43,10 @@
 //! [`MockDateTime`] as an example of the data necessary for ICU [`DateTimeFormat`] to work, and
 //! we hope to work with the community to develop core date and time APIs that will work as an input for this component.
 //!
-//! [`DateTimeFormat`]: ./struct.DateTimeFormat.html
-//! [`DataProvider`]: ../icu_provider/index.html
+//! [`DataProvider`]: icu_provider::DataProvider
 //! [`ICU4X`]: ../icu/index.html
-//! [`Style`]: ./options/style/index.html
-//! [`MockDateTime`]: ./date/struct.MockDateTime.html
+//! [`Style`]: options::style
+//! [`MockDateTime`]: date::MockDateTime
 pub mod date;
 mod error;
 mod fields;

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -38,7 +38,7 @@
 //! };
 //! ```
 //!
-//! *Note*: The exact result returned from [`DateTimeFormat`] is a subject to change over
+//! *Note*: The exact result returned from [`DateTimeFormat`](crate::DateTimeFormat) is a subject to change over
 //! time. Formatted result should be treated as opaque and displayed to the user as-is,
 //! and it is strongly recommended to never write tests that expect a particular formatted output.
 use super::preferences;

--- a/components/datetime/src/options/style.rs
+++ b/components/datetime/src/options/style.rs
@@ -26,7 +26,7 @@
 //! };
 //! ```
 //!
-//! *Note*: The exact result returned from [`DateTimeFormat`] is a subject to change over
+//! *Note*: The exact result returned from [`DateTimeFormat`](crate::DateTimeFormat) is a subject to change over
 //! time. Formatted result should be treated as opaque and displayed to the user as-is,
 //! and it is strongly recommended to never write tests that expect a particular formatted output.
 use super::preferences;
@@ -90,7 +90,7 @@ impl Default for Bag {
 ///
 /// [`UTS #35: Unicode LDML 4. Dates`]: https://unicode.org/reports/tr35/tr35-dates.html
 /// [`Element dateFormats`]: https://unicode.org/reports/tr35/tr35-dates.html#dateFormats
-/// [`DateTimeFormat`]: ../../struct.DateTimeFormat.html
+/// [`DateTimeFormat`]: super::super::DateTimeFormat
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Date {
     /// Full length, usually with weekday name.
@@ -167,7 +167,7 @@ pub enum Date {
 ///
 /// [`UTS #35: Unicode LDML 4. Dates`]: https://unicode.org/reports/tr35/tr35-dates.html
 /// [`Element dateFormats`]: https://unicode.org/reports/tr35/tr35-dates.html#timeFormats
-/// [`DateTimeFormat`]: ../../struct.DateTimeFormat.html
+/// [`DateTimeFormat`]: super::super::DateTimeFormat
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Time {
     /// Full length, with spelled out time zone name.

--- a/components/ecma402/src/lib.rs
+++ b/components/ecma402/src/lib.rs
@@ -17,7 +17,7 @@ pub mod pluralrules;
 pub enum Locale {
     /// An ECMA402 compatible [Locale] created from icu4x [LanguageIdentifier].
     FromLangid(LanguageIdentifier),
-    /// An ECMA402 [Locale] created from icu4x [icu_locid::Locale].
+    /// An ECMA402 [Locale] created from icu4x [icu::locid::Locale].
     FromLocale(icu::locid::Locale),
 }
 

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -94,7 +94,6 @@ pub mod datetime {
     //! let formatted_date = dtf.format(&date);
     //! assert_eq!(formatted_date.to_string(), "Sep 12, 2020, 12:35 PM");
     //! ```
-    //! [`DateTimeFormat`]: ./struct.DateTimeFormat.html
     //! [`DataProvider`]: ../../icu_provider/index.html
     pub use icu_datetime::*;
 }
@@ -145,10 +144,8 @@ pub mod locid {
     //! For more details, see [`Locale`] and [`LanguageIdentifier`].
     //!
     //! [`UTS #35: Unicode LDML 3. Unicode Language and Locale Identifiers`]: https://unicode.org/reports/tr35/tr35.html#Unicode_Language_and_Locale_Identifiers
-    //! [`LanguageIdentifier`]: ./struct.LanguageIdentifier.html
-    //! [`Locale`]: ./struct.Locale.html
     //! [`ICU4X`]: https://github.com/unicode-org/icu4x
-    //! [`Unicode Extensions`]: ./extensions/index.html
+    //! [`Unicode Extensions`]: extensions
     pub use icu_locid::*;
 
     pub mod macros {
@@ -202,36 +199,23 @@ pub mod plurals {
     //! Every number in every language belongs to a certain [`Plural Category`].
     //! For example, Polish language uses four:
     //!
-    //! * [`One`](./enum.PluralCategory.html#variant.One): `1 miesiąc`
-    //! * [`Few`](./enum.PluralCategory.html#variant.Few): `2 miesiące`
-    //! * [`Many`](./enum.PluralCategory.html#variant.Many): `5 miesięcy`
-    //! * [`Other`](./enum.PluralCategory.html#variant.Other): `1.5 miesiąca`
+    //! * [`One`](PluralCategory::One): `1 miesiąc`
+    //! * [`Few`](PluralCategory::Few): `2 miesiące`
+    //! * [`Many`](PluralCategory::Many): `5 miesięcy`
+    //! * [`Other`](PluralCategory::Other): `1.5 miesiąca`
     //!
     //! ## Plural Rule Type
     //!
     //! Plural rules depend on the use case. This crate supports two types of plural rules:
     //!
-    //! * [`Cardinal`](./enum.PluralRuleType.html#variant.Cardinal): `3 doors`, `1 month`, `10 dollars`
-    //! * [`Ordinal`](./enum.PluralRuleType.html#variant.Ordinal): `1st place`, `10th day`, `11th floor`
-    //!
-    //! ## Data Provider
-    //!
-    //! In order to function, the API requires data from [`CLDR`].
-    //!
-    //! [`ICU4X`] is going to use a special API for handling data management called `DataProvider`.
-    //! Until that happens, this crate will provide a simple `JSON` and `bincode` providers behind a
-    //! flag.
-    //! For tests and documentation examples, there is also a `DummyDataProvider`.
-    //!
-    //! All of the content of the [`data`] module is heavily experimental and subject to change.
+    //! * [`Cardinal`](PluralRuleType::Cardinal): `3 doors`, `1 month`, `10 dollars`
+    //! * [`Ordinal`](PluralRuleType::Ordinal): `1st place`, `10th day`, `11th floor`
     //!
     //! [`ICU4X`]: https://github.com/unicode-org/icu4x
-    //! [`PluralRules`]: ./struct.PluralRules.html
-    //! [`Plural Type`]: ./enum.PluralRuleType.html
-    //! [`Plural Category`]: ./enum.PluralCategory.html
+    //! [`Plural Type`]: PluralRuleType
+    //! [`Plural Category`]: PluralCategory
     //! [`Language Plural Rules`]: https://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules
     //! [`CLDR`]: http://cldr.unicode.org/
-    //! [`data`]: ./data/index.html
     pub use icu_plurals::*;
 }
 
@@ -243,8 +227,8 @@ pub mod uniset {
     //! It is an implementation of the existing [ICU4C UnicodeSet API](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1UnicodeSet.html).
     //!
     //! # Architecture
-    //! ICU4X `UnicodeSet` is split up into independent levels, with [`UnicodeSet`](struct.UnicodeSet.html) representing the membership/query API,
-    //! and [`UnicodeSetBuilder`](struct.UnicodeSetBuilder.html) representing the builder API. A [Properties API](http://userguide.icu-project.org/strings/properties)
+    //! ICU4X `UnicodeSet` is split up into independent levels, with [`UnicodeSet`] representing the membership/query API,
+    //! and [`UnicodeSetBuilder`] representing the builder API. A [Properties API](http://userguide.icu-project.org/strings/properties)
     //! is in future works.
     //!
     //! # Examples:
@@ -253,7 +237,7 @@ pub mod uniset {
     //!
     //! UnicodeSets are created from either serialized UnicodeSets,
     //! represented by [inversion lists](http://userguide.icu-project.org/strings/properties),
-    //! the [`UnicodeSetBuilder`](struct.UnicodeSetBuilder.html), or from the TBA Properties API.
+    //! the [`UnicodeSetBuilder`], or from the TBA Properties API.
     //!
     //! ```
     //! use icu::uniset::{UnicodeSet, UnicodeSetBuilder};

--- a/components/locid/macros/src/lib.rs
+++ b/components/locid/macros/src/lib.rs
@@ -47,7 +47,7 @@ fn get_value_from_token_stream(input: TokenStream) -> String {
 /// assert_eq!(DE, de);
 /// ```
 ///
-/// [`Language`]: ../icu_locid/subtags/struct.Language.html
+/// [`Language`]: icu_locid::subtags::Language
 #[proc_macro]
 pub fn language(input: TokenStream) -> TokenStream {
     let val = get_value_from_token_stream(input);
@@ -78,7 +78,7 @@ pub fn language(input: TokenStream) -> TokenStream {
 /// assert_eq!(ARAB, arab);
 /// ```
 ///
-/// [`Script`]: ../icu_locid/subtags/struct.Script.html
+/// [`Script`]: icu_locid::subtags::Script
 #[proc_macro]
 pub fn script(input: TokenStream) -> TokenStream {
     let val = get_value_from_token_stream(input);
@@ -109,7 +109,7 @@ pub fn script(input: TokenStream) -> TokenStream {
 /// assert_eq!(CN, cn);
 /// ```
 ///
-/// [`Region`]: ../icu_locid/subtags/struct.Region.html
+/// [`Region`]: icu_locid::subtags::Region
 #[proc_macro]
 pub fn region(input: TokenStream) -> TokenStream {
     let val = get_value_from_token_stream(input);
@@ -140,7 +140,7 @@ pub fn region(input: TokenStream) -> TokenStream {
 /// assert_eq!(POSIX, posix);
 /// ```
 ///
-/// [`Variant`]: ../icu_locid/subtags/struct.Variant.html
+/// [`Variant`]: icu_locid::subtags::Variant
 #[proc_macro]
 pub fn variant(input: TokenStream) -> TokenStream {
     let val = get_value_from_token_stream(input);
@@ -174,7 +174,7 @@ pub fn variant(input: TokenStream) -> TokenStream {
 /// *Note*: As of Rust 1.47, the macro cannot produce language identifier
 /// with variants in the const mode pending [`Heap Allocations in Constants`].
 ///
-/// [`LanguageIdentifier`]: ../icu_locid/struct.LanguageIdentifier.html
+/// [`LanguageIdentifier`]: icu_locid::LanguageIdentifier
 /// [`Heap Allocations in Constants`]: https://github.com/rust-lang/const-eval/issues/20
 #[proc_macro]
 pub fn langid(input: TokenStream) -> TokenStream {

--- a/components/locid/src/extensions/mod.rs
+++ b/components/locid/src/extensions/mod.rs
@@ -37,12 +37,12 @@
 //!            Some(&value));
 //! ```
 //!
-//! [`LanguageIdentifier`]: ../struct.LanguageIdentifier.html
-//! [`Locale`]: ../struct.Locale.html
-//! [`subtags`]: ../subtags/index.html
-//! [`Unicode Extensions`]: ./unicode/index.html
-//! [`Transform Extensions`]: ./transform/index.html
-//! [`Private Use Extensions`]: ./private/index.html
+//! [`LanguageIdentifier`]: super::LanguageIdentifier
+//! [`Locale`]: super::Locale
+//! [`subtags`]: super::subtags
+//! [`Unicode Extensions`]: unicode
+//! [`Transform Extensions`]: transform
+//! [`Private Use Extensions`]: private
 pub mod private;
 pub mod transform;
 pub mod unicode;

--- a/components/locid/src/extensions/private/key.rs
+++ b/components/locid/src/extensions/private/key.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use crate::parser::errors::ParserError;
 use tinystr::TinyStr8;
 
-/// A single item used in a list of [`Private`] extensions.
+/// A single item used in a list of [`Private`](super::Private) extensions.
 ///
 /// The key has to be an ASCII alphanumerical string no shorter than
 /// one character and no longer than eight.
@@ -22,7 +22,6 @@ use tinystr::TinyStr8;
 ///
 /// assert_eq!(key1.as_str(), "foo");
 /// ```
-/// [`Private`]: ./struct.Private.html
 #[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord, Copy)]
 pub struct Key(TinyStr8);
 

--- a/components/locid/src/extensions/private/mod.rs
+++ b/components/locid/src/extensions/private/mod.rs
@@ -26,8 +26,7 @@
 //! assert_eq!(loc.to_string(), "en-US");
 //! ```
 //!
-//! [`Private`]: ./struct.Private.html
-//! [`Keys`]: ./struct.Key.html
+//! [`Keys`]: Key
 mod key;
 use std::ops::Deref;
 

--- a/components/locid/src/extensions/transform/fields.rs
+++ b/components/locid/src/extensions/transform/fields.rs
@@ -17,8 +17,6 @@ use super::Value;
 ///
 /// You can find the full list in [`Unicode BCP 47 T Extension`] section of LDML.
 ///
-/// [`Key`]: ./struct.Key.html
-/// [`Value`]: ./struct.Value.html
 /// [`Unicode BCP 47 T Extension`]: https://unicode.org/reports/tr35/tr35.html#BCP47_T_Extension
 ///
 /// # Examples
@@ -40,8 +38,6 @@ pub struct Fields(Box<[(Key, Value)]>);
 impl Fields {
     /// A constructor which takes a pre-sorted list of `(Key, Value)` tuples.
     ///
-    /// [`Key`]: ./struct.Key.html
-    /// [`Value`]: ./struct.Value.html
     ///
     /// # Examples
     ///
@@ -85,8 +81,6 @@ impl Fields {
 
     /// Returns `true` if the list contains a [`Value`] for the specified [`Key`].
     ///
-    /// [`Key`]: ./struct.Key.html
-    /// [`Value`]: ./struct.Value.html
     ///
     /// # Examples
     ///
@@ -113,8 +107,6 @@ impl Fields {
 
     /// Returns a reference to the [`Value`] corresponding to the [`Key`].
     ///
-    /// [`Key`]: ./struct.Key.html
-    /// [`Value`]: ./struct.Value.html
     ///
     /// # Examples
     ///

--- a/components/locid/src/extensions/transform/key.rs
+++ b/components/locid/src/extensions/transform/key.rs
@@ -5,12 +5,11 @@ use crate::parser::errors::ParserError;
 use std::str::FromStr;
 use tinystr::TinyStr4;
 
-/// A key used in a list of [`Fields`].
+/// A key used in a list of [`Fields`](super::Fields).
 ///
 /// The key has to be a two ASCII characters long, with the first
 /// character being alphabetic, and the second being a number.
 ///
-/// [`Fields`]: ./struct.Fields.html
 ///
 /// # Examples
 ///

--- a/components/locid/src/extensions/transform/mod.rs
+++ b/components/locid/src/extensions/transform/mod.rs
@@ -6,9 +6,7 @@
 //! The main struct for this extension is [`Transform`] which contains [`Fields`] and an
 //! optional [`LanguageIdentifier`].
 //!
-//! [`Transform`]: ./struct.Transform.html
-//! [`Fields`]: ./struct.Fields.html
-//! [`LanguageIdentifier`]: ../../struct.LanguageIdentifier.html
+//! [`LanguageIdentifier`]: super::super::LanguageIdentifier
 //!
 //! # Examples
 //!

--- a/components/locid/src/extensions/transform/value.rs
+++ b/components/locid/src/extensions/transform/value.rs
@@ -12,14 +12,13 @@ pub struct Value(Box<[TinyStr8]>);
 const TYPE_LENGTH: RangeInclusive<usize> = 3..=8;
 const TRUE_TVALUE: TinyStr8 = unsafe { TinyStr8::new_unchecked(1_702_195_828_u64) }; // "true"
 
-/// A value used in a list of [`Fields`].
+/// A value used in a list of [`Fields`](super::Fields).
 ///
 /// The value has to be a sequence of one or more alphanumerical strings
 /// separated by `-`.
 /// Each part of the sequence has to be no shorter than three characters and no
 /// longer than 8.
 ///
-/// [`Fields`]: ./struct.Fields.html
 ///
 /// # Examples
 ///

--- a/components/locid/src/extensions/unicode/attribute.rs
+++ b/components/locid/src/extensions/unicode/attribute.rs
@@ -7,12 +7,11 @@ use std::str::FromStr;
 use crate::parser::errors::ParserError;
 use tinystr::TinyStr8;
 
-/// An attribute used in a set of [`Attributes`].
+/// An attribute used in a set of [`Attributes`](super::Attributes).
 ///
 /// An attribute has to be a sequence of alphanumerical characters no
 /// shorter than three and no longer than eight characters.
 ///
-/// [`Attributes`]: ./struct.Attributes.html
 ///
 /// # Examples
 ///

--- a/components/locid/src/extensions/unicode/attributes.rs
+++ b/components/locid/src/extensions/unicode/attributes.rs
@@ -7,7 +7,6 @@ use std::ops::Deref;
 
 /// A set of [`Attribute`] elements as defined in [`Unicode Extension Attributes`].
 ///
-/// [`Attribute`]: ./struct.Attribute.html
 /// [`Unicode Extension Attributes`]: https://unicode.org/reports/tr35/tr35.html#u_Extension
 ///
 /// # Examples
@@ -28,14 +27,12 @@ use std::ops::Deref;
 /// assert_eq!(attributes.to_string(), "foobar-testing");
 /// ```
 ///
-/// [`Attribute`]: ./struct.Attribute.html
 #[derive(Default, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 pub struct Attributes(Box<[Attribute]>);
 
 impl Attributes {
     /// A constructor which takes a pre-sorted list of [`Attribute`] elements.
     ///
-    /// [`Attribute`]: ./struct.Attribute.html
     ///
     /// # Examples
     ///

--- a/components/locid/src/extensions/unicode/key.rs
+++ b/components/locid/src/extensions/unicode/key.rs
@@ -6,12 +6,11 @@ use std::str::FromStr;
 use crate::parser::errors::ParserError;
 use tinystr::TinyStr4;
 
-/// A key used in a list of [`Keywords`].
+/// A key used in a list of [`Keywords`](super::Keywords).
 ///
 /// The key has to be a two ASCII alphanumerical characters long, with the first
 /// character being alphanumeric, and the second being alphabetic.
 ///
-/// [`Keywords`]: ./struct.Keywords.html
 ///
 /// # Examples
 ///

--- a/components/locid/src/extensions/unicode/keywords.rs
+++ b/components/locid/src/extensions/unicode/keywords.rs
@@ -18,8 +18,6 @@ use super::Value;
 ///
 /// You can find the full list in [`Unicode BCP 47 U Extension`] section of LDML.
 ///
-/// [`Key`]: ./struct.Key.html
-/// [`Value`]: ./struct.Value.html
 /// [`Unicode BCP 47 U Extension`]: https://unicode.org/reports/tr35/tr35.html#Key_And_Type_Definitions_
 ///
 /// # Examples
@@ -41,8 +39,6 @@ pub struct Keywords(Box<[(Key, Value)]>);
 impl Keywords {
     /// A constructor which takes a pre-sorted list of `(Key, Value)` tuples.
     ///
-    /// [`Key`]: ./struct.Key.html
-    /// [`Value`]: ./struct.Value.html
     ///
     /// # Examples
     ///
@@ -63,8 +59,6 @@ impl Keywords {
 
     /// Returns `true` if the list contains a [`Value`] for the specified [`Key`].
     ///
-    /// [`Key`]: ./struct.Key.html
-    /// [`Value`]: ./struct.Value.html
     ///
     /// # Examples
     ///
@@ -91,8 +85,6 @@ impl Keywords {
 
     /// Returns a reference to the [`Value`] corresponding to the [`Key`].
     ///
-    /// [`Key`]: ./struct.Key.html
-    /// [`Value`]: ./struct.Value.html
     ///
     /// # Examples
     ///

--- a/components/locid/src/extensions/unicode/mod.rs
+++ b/components/locid/src/extensions/unicode/mod.rs
@@ -6,9 +6,6 @@
 //! The main struct for this extension is [`Unicode`] which contains [`Keywords`] and
 //! [`Attributes`].
 //!
-//! [`Unicode`]: ./struct.Unicode.html
-//! [`Keywords`]: ./struct.Keywords.html
-//! [`Attributes`]: ./struct.Attributes.html
 //!
 //! # Examples
 //!

--- a/components/locid/src/extensions/unicode/value.rs
+++ b/components/locid/src/extensions/unicode/value.rs
@@ -6,14 +6,13 @@ use std::ops::RangeInclusive;
 use std::str::FromStr;
 use tinystr::TinyStr8;
 
-/// A value used in a list of [`Keywords`].
+/// A value used in a list of [`Keywords`](super::Keywords).
 ///
 /// The value has to be a sequence of one or more alphanumerical strings
 /// separated by `-`.
 /// Each part of the sequence has to be no shorter than three characters and no
 /// longer than 8.
 ///
-/// [`Keywords`]: ./struct.Keywords.html
 ///
 /// # Examples
 ///

--- a/components/locid/src/lib.rs
+++ b/components/locid/src/lib.rs
@@ -46,10 +46,8 @@
 //! For more details, see [`Locale`] and [`LanguageIdentifier`].
 //!
 //! [`UTS #35: Unicode LDML 3. Unicode Language and Locale Identifiers`]: https://unicode.org/reports/tr35/tr35.html#Unicode_Language_and_Locale_Identifiers
-//! [`LanguageIdentifier`]: ./struct.LanguageIdentifier.html
-//! [`Locale`]: ./struct.Locale.html
 //! [`ICU4X`]: ../icu/index.html
-//! [`Unicode Extensions`]: ./extensions/index.html
+//! [`Unicode Extensions`]: extensions
 pub mod extensions;
 mod langid;
 mod locale;

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -15,7 +15,6 @@ use std::str::FromStr;
 /// `Locale` exposes all of the same fields and methods as [`LanguageIdentifier`], and
 /// on top of that is able to parse, manipulate and serialize unicode extension fields.
 ///
-/// [`LanguageIdentifier`]: ./struct.LanguageIdentifier.html
 ///
 /// # Examples
 ///

--- a/components/locid/src/parser/errors.rs
+++ b/components/locid/src/parser/errors.rs
@@ -5,12 +5,8 @@ use std::error::Error;
 use std::fmt::{self, Display};
 
 /// List of parser errors that can be generated
-/// while parsing [`LanguageIdentifier`], [`Locale`], [`subtags`] or [`extensions`].
+/// while parsing [`LanguageIdentifier`](crate::LanguageIdentifier), [`Locale`](crate::Locale), [`subtags`](crate::subtags) or [`extensions`](crate::extensions).
 ///
-/// [`LanguageIdentifier`]: ./struct.LanguageIdentifier.html
-/// [`Locale`]: ./struct.Locale.html
-/// [`subtags`]: ./subtags/index.html
-/// [`extensions`]: ./extensions/index.html
 #[derive(Debug, PartialEq)]
 pub enum ParserError {
     /// Invalid language subtag.

--- a/components/locid/src/subtags/mod.rs
+++ b/components/locid/src/subtags/mod.rs
@@ -43,12 +43,7 @@
 //! that all operations work on a canonicalized version of the subtag
 //! and serialization is very cheap.
 //!
-//! [`Language`]: ./struct.Language.html
-//! [`Script`]: ./struct.Script.html
-//! [`Region`]: ./struct.Region.html
-//! [`Variants`]: ./struct.Variants.html
-//! [`Variant`]: ./struct.Variant.html
-//! [`LanguageIdentifier`]: ../struct.LanguageIdentifier.html
+//! [`LanguageIdentifier`]: super::LanguageIdentifier
 mod language;
 mod region;
 mod script;

--- a/components/locid/src/subtags/variants.rs
+++ b/components/locid/src/subtags/variants.rs
@@ -28,7 +28,6 @@ use std::ops::Deref;
 /// assert_eq!(variants.to_string(), "macos-posix");
 /// ```
 ///
-/// [`Variant`]: ./struct.Variant.html
 #[derive(Default, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 pub struct Variants(
     // The internal representation of the struct uses `Option` to workaround

--- a/components/plurals/src/data.rs
+++ b/components/plurals/src/data.rs
@@ -9,13 +9,13 @@ use icu_provider::structs::plurals::PluralRuleStringsV1;
 use std::borrow::Cow;
 use std::convert::TryInto;
 
-/// A raw function pointer to a [`PluralRulesFn`](./type.PluralRulesFn.html)
+/// A raw function pointer to a [`PluralRulesFn`]
 // pub type PluralRulesFn = fn(&PluralOperands) -> PluralCategory;
 
 /// A structure holding a list of [`ast::Condition`] for a given locale and type.
 ///
-/// [`PluralCategory`]: ../enum.PluralCategory.html
-/// [`ast::Condition`]: ../rules/ast/struct.Condition.html
+/// [`PluralCategory`]: super::PluralCategory
+/// [`ast::Condition`]: super::rules::ast::Condition
 #[derive(Default, Debug)]
 pub struct PluralRuleList {
     zero: Option<ast::Condition>,
@@ -62,7 +62,7 @@ impl TryInto<PluralRuleList> for &PluralRuleStringsV1 {
 /// An enum storing models of
 /// handling plural rules selection.
 pub enum RulesSelector {
-    /// A raw function pointer to a [`PluralRulesFn`](./type.PluralRulesFn.html)
+    /// A raw function pointer to a [`PluralRulesFn`]
     ///
     /// This variant is used by providers which store rules as native Rust functions.
     // Function(PluralRulesFn),
@@ -71,8 +71,8 @@ pub enum RulesSelector {
     /// This variant is used by providers which parse the list of conditions out
     /// of source strings.
     ///
-    /// [`PluralCategory`]: ../enum.PluralCategory.html
-    /// [`ast::Condition`]: ../rules/ast/struct.Condition.html
+    /// [`PluralCategory`]: super::PluralCategory
+    /// [`ast::Condition`]: super::rules::ast::Condition
     Conditions(PluralRuleList),
 }
 

--- a/components/plurals/src/error.rs
+++ b/components/plurals/src/error.rs
@@ -6,9 +6,8 @@ use crate::rules::parser::ParserError;
 use icu_provider::prelude::DataError;
 use std::fmt;
 
-/// A list of possible error outcomes for the [`PluralRules`] struct.
+/// A list of possible error outcomes for the [`PluralRules`](crate::PluralRules) struct.
 ///
-/// [`PluralRules`]: ./struct.PluralRules.html
 #[derive(Debug)]
 pub enum PluralRulesError {
     Parser(ParserError),

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -46,22 +46,21 @@
 //! Every number in every language belongs to a certain [`Plural Category`].
 //! For example, Polish language uses four:
 //!
-//! * [`One`](./enum.PluralCategory.html#variant.One): `1 miesiąc`
-//! * [`Few`](./enum.PluralCategory.html#variant.Few): `2 miesiące`
-//! * [`Many`](./enum.PluralCategory.html#variant.Many): `5 miesięcy`
-//! * [`Other`](./enum.PluralCategory.html#variant.Other): `1.5 miesiąca`
+//! * [`One`](PluralCategory::One): `1 miesiąc`
+//! * [`Few`](PluralCategory::Few): `2 miesiące`
+//! * [`Many`](PluralCategory::Many): `5 miesięcy`
+//! * [`Other`](PluralCategory::Other): `1.5 miesiąca`
 //!
 //! ## Plural Rule Type
 //!
 //! Plural rules depend on the use case. This crate supports two types of plural rules:
 //!
-//! * [`Cardinal`](./enum.PluralRuleType.html#variant.Cardinal): `3 doors`, `1 month`, `10 dollars`
-//! * [`Ordinal`](./enum.PluralRuleType.html#variant.Ordinal): `1st place`, `10th day`, `11th floor`
+//! * [`Cardinal`](PluralRuleType::Cardinal): `3 doors`, `1 month`, `10 dollars`
+//! * [`Ordinal`](PluralRuleType::Ordinal): `1st place`, `10th day`, `11th floor`
 //!
 //! [`ICU4X`]: ../icu/index.html
-//! [`PluralRules`]: ./struct.PluralRules.html
-//! [`Plural Type`]: ./enum.PluralRuleType.html
-//! [`Plural Category`]: ./enum.PluralCategory.html
+//! [`Plural Type`]: PluralRuleType
+//! [`Plural Category`]: PluralCategory
 //! [`Language Plural Rules`]: https://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules
 //! [`CLDR`]: http://cldr.unicode.org/
 mod data;
@@ -79,7 +78,6 @@ use std::convert::TryInto;
 
 /// A type of a plural rule which can be associated with the [`PluralRules`] struct.
 ///
-/// [`PluralRules`]: ./struct.PluralRules.html
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum PluralRuleType {
     /// Cardinal plural forms express quantities of units such as time, currency or distance,
@@ -90,8 +88,8 @@ pub enum PluralRuleType {
     /// * [`One`]: `1 day`
     /// * [`Other`]: `0 days`, `2 days`, `10 days`, `0.3 days`
     ///
-    /// [`One`]: ./enum.PluralCategory.html#variant.One
-    /// [`Other`]: ./enum.PluralCategory.html#variant.Other
+    /// [`One`]: PluralCategory::One
+    /// [`Other`]: PluralCategory::Other
     Cardinal,
     /// Ordinal plural forms denote the order of items in a set and are always integers.
     ///
@@ -102,10 +100,10 @@ pub enum PluralRuleType {
     /// * [`Few`]: `3rd floor`, `23rd floor`, `103rd floor`
     /// * [`Other`]: `4th floor`, `11th floor`, `96th floor`
     ///
-    /// [`One`]: ./enum.PluralCategory.html#variant.One
-    /// [`Two`]: ./enum.PluralCategory.html#variant.Two
-    /// [`Few`]: ./enum.PluralCategory.html#variant.Few
-    /// [`Other`]: ./enum.PluralCategory.html#variant.Other
+    /// [`One`]: PluralCategory::One
+    /// [`Two`]: PluralCategory::Two
+    /// [`Few`]: PluralCategory::Few
+    /// [`Other`]: PluralCategory::Other
     Ordinal,
 }
 
@@ -241,9 +239,8 @@ impl PluralCategory {
 /// ```
 ///
 /// [`ICU4X`]: ../icu/index.html
-/// [`PluralRules`]: ./struct.PluralRules.html
-/// [`Plural Type`]: ./enum.PluralRuleType.html
-/// [`Plural Category`]: ./enum.PluralCategory.html
+/// [`Plural Type`]: PluralRuleType
+/// [`Plural Category`]: PluralCategory
 pub struct PluralRules {
     _langid: LanguageIdentifier,
     selector: data::RulesSelector,
@@ -268,8 +265,8 @@ impl PluralRules {
     /// let _ = PluralRules::try_new(lid, &dp, PluralRuleType::Cardinal);
     /// ```
     ///
-    /// [`type`]: ./enum.PluralRuleType.html
-    /// [`data provider`]: ./data/trait.DataProviderType.html
+    /// [`type`]: PluralRuleType
+    /// [`data provider`]: icu_provider::DataProvider
     pub fn try_new<'d, D: DataProvider<'d>>(
         langid: LanguageIdentifier,
         data_provider: &D,
@@ -351,8 +348,8 @@ impl PluralRules {
     /// assert_eq!(pr.select(operands2), PluralCategory::Other);
     /// ```
     ///
-    /// [`Plural Category`]: ./enum.PluralCategory.html
-    /// [`Plural Operands`]: ./operands/struct.PluralOperands.html
+    /// [`Plural Category`]: PluralCategory
+    /// [`Plural Operands`]: operands::PluralOperands
     pub fn select<I: Into<PluralOperands>>(&self, input: I) -> PluralCategory {
         self.selector.select(&input.into())
     }

--- a/components/plurals/src/rules/ast.rs
+++ b/components/plurals/src/rules/ast.rs
@@ -34,9 +34,9 @@
 //! ])));
 //! ```
 //!
-//! [`PluralCategory`]: ../enum.PluralCategory.html
-//! [`parse`]: ../fn.parse.html
-//! [`test_condition`]: ../fn.test_condition.html
+//! [`PluralCategory`]: crate::PluralCategory
+//! [`parse`]: super::parse()
+//! [`test_condition`]: super::test_condition()
 use std::ops::RangeInclusive;
 
 /// A complete AST representation of a plural rule.

--- a/components/plurals/src/rules/mod.rs
+++ b/components/plurals/src/rules/mod.rs
@@ -128,19 +128,19 @@
 //!
 //! For example, in Russian [`PluralCategory::One`] matches numbers such as `11`, `21`, `121` etc.
 //!
-//! [`PluralCategory`]: ../enum.PluralCategory.html
-//! [`PluralCategories`]: ../enum.PluralCategory.html
-//! [`PluralCategory::One`]: ../enum.PluralCategory.html#variant.One
-//! [`PluralCategory::Other`]: ../enum.PluralCategory.html#variant.Other
-//! [`PluralOperands`]: ../struct.PluralOperands.html
-//! [`PluralOperands::i`]: ../struct.PluralOperands.html#structfield.i
-//! [`PluralOperands::v`]: ../struct.PluralOperands.html#structfield.v
-//! [`PluralRuleType::Cardinal`]: ../enum.PluralRuleType.html#variant.Cardinal
-//! [`Rule`]: ../rules/ast/struct.Rule.html
-//! [`Rules`]: ../rules/ast/struct.Rule.html
-//! [`Condition`]: ../rules/ast/struct.Condition.html
-//! [`Sample`]: ../rules/ast/struct.Sample.html
-//! [`AST`]: ../rules/ast/index.html
+//! [`PluralCategory`]: super::PluralCategory
+//! [`PluralCategories`]: super::PluralCategory
+//! [`PluralCategory::One`]: super::PluralCategory::One
+//! [`PluralCategory::Other`]: super::PluralCategory::Other
+//! [`PluralOperands`]: super::PluralOperands
+//! [`PluralOperands::i`]: super::PluralOperands::i
+//! [`PluralOperands::v`]: super::PluralOperands::v
+//! [`PluralRuleType::Cardinal`]: super::PluralRuleType::Cardinal
+//! [`Rule`]: super::rules::ast::Rule
+//! [`Rules`]: super::rules::ast::Rule
+//! [`Condition`]: super::rules::ast::Condition
+//! [`Sample`]: super::rules::ast::Samples
+//! [`AST`]: super::rules::ast
 pub mod ast;
 pub(crate) mod lexer;
 pub(crate) mod parser;

--- a/components/plurals/src/rules/parser.rs
+++ b/components/plurals/src/rules/parser.rs
@@ -38,7 +38,7 @@ impl fmt::Display for ParserError {
 /// A single [`Rule`] contains a [`Condition`] and optionally a set of
 /// [`Samples`].
 ///
-/// A [`Condition`] can be then used by the [`resolver`] to test
+/// A [`Condition`] can be then used by the [`test_condition`] to test
 /// against [`PluralOperands`], to find the appropriate [`PluralCategory`].
 ///
 /// [`Samples`] are useful for tooling to help translators understand examples of numbers
@@ -55,14 +55,14 @@ impl fmt::Display for ParserError {
 /// assert_eq!(parse(input).is_ok(), true);
 /// ```
 ///
-/// [`AST`]: ../rules/ast/index.html
-/// [`resolver`]: ../rules/resolver/index.html
-/// [`PluralOperands`]: ../struct.PluralOperands.html
-/// [`PluralCategory`]: ../enum.PluralCategory.html
-/// [`Rule`]: ../rules/ast/struct.Rule.html
-/// [`Samples`]: ../rules/ast/struct.Samples.html
-/// [`Condition`]:  ../rules/ast/struct.Condition.html
-/// [`parse_condition`]: ./fn.parse_condition.html
+/// [`AST`]: super::ast
+/// [`test_condition`]: super::test_condition
+/// [`PluralOperands`]: crate::PluralOperands
+/// [`PluralCategory`]: crate::PluralCategory
+/// [`Rule`]: super::ast::Rule
+/// [`Samples`]: super::ast::Samples
+/// [`Condition`]:  super::ast::Condition
+/// [`parse_condition`]: parse_condition()
 pub fn parse(input: &[u8]) -> Result<ast::Rule, ParserError> {
     let parser = Parser::new(input);
     parser.parse()
@@ -71,7 +71,7 @@ pub fn parse(input: &[u8]) -> Result<ast::Rule, ParserError> {
 /// Unicode Plural Rule parser converts an
 /// input string into an [`AST`].
 ///
-/// That [`AST`] can be then used by the [`resolver`] to test
+/// That [`AST`] can be then used by the [`test_condition`] to test
 /// against [`PluralOperands`], to find the appropriate [`PluralCategory`].
 ///
 /// # Examples
@@ -83,10 +83,10 @@ pub fn parse(input: &[u8]) -> Result<ast::Rule, ParserError> {
 /// assert_eq!(parse_condition(input).is_ok(), true);
 /// ```
 ///
-/// [`AST`]: ../rules/ast/index.html
-/// [`resolver`]: ../rules/resolver/index.html
-/// [`PluralOperands`]: ../struct.PluralOperands.html
-/// [`PluralCategory`]: ../enum.PluralCategory.html
+/// [`AST`]: super::ast
+/// [`test_condition`]: super::test_condition
+/// [`PluralOperands`]: crate::PluralOperands
+/// [`PluralCategory`]: crate::PluralCategory
 pub fn parse_condition(input: &[u8]) -> Result<ast::Condition, ParserError> {
     let parser = Parser::new(input);
     parser.parse_condition()

--- a/components/plurals/src/rules/resolver.rs
+++ b/components/plurals/src/rules/resolver.rs
@@ -20,9 +20,9 @@ use crate::operands::PluralOperands;
 /// assert_eq!(test_condition(&condition, &operands), true);
 /// ```
 ///
-/// [`PluralCategory`]: ../enum.PluralCategory.html
-/// [`PluralOperands`]: ../struct.PluralOperands.html
-/// [`Condition`]: ../rules/ast/struct.Condition.html
+/// [`PluralCategory`]: crate::PluralCategory
+/// [`PluralOperands`]: crate::PluralOperands
+/// [`Condition`]: super::ast::Condition
 pub fn test_condition(condition: &ast::Condition, operands: &PluralOperands) -> bool {
     condition.0.is_empty() || condition.0.iter().any(|c| test_and_condition(c, operands))
 }

--- a/components/plurals/src/rules/serializer.rs
+++ b/components/plurals/src/rules/serializer.rs
@@ -29,14 +29,14 @@ use std::ops::RangeInclusive;
 /// assert_eq!(input, result);
 /// ```
 ///
-/// [`AST`]: ../rules/ast/index.html
-/// [`resolver`]: ../rules/resolver/index.html
-/// [`PluralOperands`]: ../struct.PluralOperands.html
-/// [`PluralCategory`]: ../enum.PluralCategory.html
-/// [`Rule`]: ../rules/ast/struct.Rule.html
-/// [`Samples`]: ../rules/ast/struct.Samples.html
-/// [`Condition`]:  ../rules/ast/struct.Condition.html
-/// [`parse_condition`]: ./fn.parse_condition.html
+/// [`AST`]: super::ast
+/// [`resolver`]: super::rules::resolver
+/// [`PluralOperands`]: super::PluralOperands
+/// [`PluralCategory`]: super::PluralCategory
+/// [`Rule`]: super::rules::ast::Rule
+/// [`Samples`]: super::rules::ast::Samples
+/// [`Condition`]:  super::rules::ast::Condition
+/// [`parse_condition`]: parse_condition()
 pub fn serialize(rule: &ast::Rule, w: &mut impl fmt::Write) -> fmt::Result {
     serialize_condition(&rule.condition, w)?;
     if let Some(samples) = &rule.samples {

--- a/components/provider/src/lib.rs
+++ b/components/provider/src/lib.rs
@@ -56,15 +56,14 @@
 //! `"invariant"` feature in your Cargo.toml file.
 //!
 //! [`ICU4X`]: ../icu/index.html
-//! [`DataProvider`]: ./prelude/trait.DataProvider.html
-//! [`Request`]: ./prelude/struct.DataRequest.html
-//! [`Response`]: ./prelude/struct.DataResponse.html
-//! [`DataKey`]: ./prelude/struct.DataKey.html
-//! [`Category`]: ./prelude/enum.DataCategory.html
-//! [`DataEntry`]: ./prelude/struct.DataEntry.html
-//! [`DataEntryCollection`]: ./iter/trait.DataEntryCollection.html
-//! [`IterableDataProvider`]: ./iter/trait.IterableDataProvider.html
-//! [`iter`]: ./iter/index.html
+//! [`DataProvider`]: prelude::DataProvider
+//! [`Request`]: prelude::DataRequest
+//! [`Response`]: prelude::DataResponse
+//! [`DataKey`]: prelude::DataKey
+//! [`Category`]: prelude::DataCategory
+//! [`DataEntry`]: prelude::DataEntry
+//! [`DataEntryCollection`]: iter::DataEntryCollection
+//! [`IterableDataProvider`]: iter::IterableDataProvider
 mod cloneable_any;
 mod data_entry;
 #[macro_use]

--- a/components/provider_cldr/src/lib.rs
+++ b/components/provider_cldr/src/lib.rs
@@ -16,10 +16,9 @@
 //! It is much more efficient if you use [`FsDataProvider`] instead.
 //!
 //! [`ICU4X`]: ../icu/index.html
-//! [`DataProvider`]: ../icu_provider/prelude/trait.DataProvider.html
-//! [`CldrPaths`]: ./trait.CldrPaths.html
+//! [`DataProvider`]: icu_provider::prelude::DataProvider
 //! [`FsDataProvider`]: ../icu_provider_fs/struct.FsDataProvider.html
-//! [`CldrJsonDataProvider`]: ./transform/struct.CldrJsonDataProvider.html
+//! [`CldrJsonDataProvider`]: transform::CldrJsonDataProvider
 
 mod cldr_langid;
 mod cldr_paths;

--- a/components/provider_fs/src/lib.rs
+++ b/components/provider_fs/src/lib.rs
@@ -85,7 +85,6 @@
 //! added with `bincode` feature.
 //!
 //! [`ICU4X`]: ../icu/index.html
-//! [`FsDataProvider`]: ./struct.FsDataProvider.html
 
 mod deserializer;
 mod error;

--- a/components/uniset/src/lib.rs
+++ b/components/uniset/src/lib.rs
@@ -8,8 +8,8 @@
 //! It is an implementation of the existing [ICU4C UnicodeSet API](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1UnicodeSet.html).
 //!
 //! # Architecture
-//! ICU4X `UnicodeSet` is split up into independent levels, with [`UnicodeSet`](struct.UnicodeSet.html) representing the membership/query API,
-//! and [`UnicodeSetBuilder`](struct.UnicodeSetBuilder.html) representing the builder API. A [Properties API](http://userguide.icu-project.org/strings/properties)
+//! ICU4X `UnicodeSet` is split up into independent levels, with [`UnicodeSet`] representing the membership/query API,
+//! and [`UnicodeSetBuilder`] representing the builder API. A [Properties API](http://userguide.icu-project.org/strings/properties)
 //! is in future works.
 //!
 //! # Examples:
@@ -18,7 +18,7 @@
 //!
 //! UnicodeSets are created from either serialized UnicodeSets,
 //! represented by [inversion lists](http://userguide.icu-project.org/strings/properties),
-//! the [`UnicodeSetBuilder`](struct.UnicodeSetBuilder.html), or from the TBA Properties API.
+//! the [`UnicodeSetBuilder`], or from the TBA Properties API.
 //!
 //! ```
 //! use icu_uniset::{UnicodeSet, UnicodeSetBuilder};

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -39,7 +39,7 @@ const_assert!(std::mem::size_of::<usize>() >= std::mem::size_of::<u16>());
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct FixedDecimal {
-    /// List of digits; digits[0] is the most significant.
+    /// List of digits; digits\[0\] is the most significant.
     ///
     /// Invariants:
     /// - Must not include leading or trailing zeros
@@ -47,7 +47,7 @@ pub struct FixedDecimal {
     // TODO: Consider using a nibble array
     digits: SmallVec<[u8; 8]>,
 
-    /// Power of 10 of digits[0].
+    /// Power of 10 of digits\[0\].
     ///
     /// Invariants:
     /// - <= upper_magnitude

--- a/utils/fixed_decimal/src/lib.rs
+++ b/utils/fixed_decimal/src/lib.rs
@@ -35,7 +35,6 @@
 //! );
 //! ```
 //!
-//! [`FixedDecimal`]: ./struct.FixedDecimal.html
 //! [`ICU4X`]: ../icu/index.html
 
 pub mod decimal;

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -15,7 +15,6 @@
 //! Types implementing Writeable automatically implement ToString. Because of this, you cannot
 //! implement both Writeable and std::fmt::Display on the same type.
 //!
-//! [`Writeable`]: ./trait.Writeable.html
 //! [`ICU4X`]: ../icu/index.html
 
 use std::fmt;


### PR DESCRIPTION
For most of the work I used https://crates.io/crates/cargo-intraconv - I then called `cargo doc` and fixed warnings.