### PR TITLE
Use parsing iterator for Locale PartialEq<str> 

### DIFF
--- a/components/locid/src/extensions/transform/fields.rs
+++ b/components/locid/src/extensions/transform/fields.rs
@@ -140,6 +140,9 @@ impl Fields {
 
 impl std::fmt::Display for Fields {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if self.is_empty() {
+            return Ok(());
+        }
         let mut first = true;
         for (key, value) in self.iter() {
             if first {

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -1,7 +1,7 @@
 // This file is part of ICU4X. For terms of use, please see the file
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
-use crate::parser::{parse_locale, ParserError};
+use crate::parser::{get_subtag_iterator, parse_locale, ParserError};
 use crate::{extensions, subtags, LanguageIdentifier};
 use std::fmt::Write;
 use std::str::FromStr;
@@ -174,12 +174,52 @@ impl std::fmt::Display for Locale {
 
 impl PartialEq<&str> for Locale {
     fn eq(&self, other: &&str) -> bool {
-        self.to_string().eq(*other)
+        self == *other
     }
+}
+
+macro_rules! subtag_matches {
+    ($T:ty, $iter:ident, $expected:expr) => {
+        $iter
+            .next()
+            .map(|b| <$T>::from_bytes(b) == Ok($expected))
+            .unwrap_or(false)
+    };
 }
 
 impl PartialEq<str> for Locale {
     fn eq(&self, other: &str) -> bool {
-        self.to_string().eq(other)
+        let mut iter = get_subtag_iterator(other.as_bytes()).peekable();
+        if !subtag_matches!(subtags::Language, iter, self.language) {
+            return false;
+        }
+        if let Some(ref script) = self.script {
+            if !subtag_matches!(subtags::Script, iter, *script) {
+                return false;
+            }
+        }
+        if let Some(ref region) = self.region {
+            if !subtag_matches!(subtags::Region, iter, *region) {
+                return false;
+            }
+        }
+        for variant in self.variants.iter() {
+            if !subtag_matches!(subtags::Variant, iter, *variant) {
+                return false;
+            }
+        }
+        if !self.extensions.is_empty() {
+            match extensions::Extensions::try_from_iter(&mut iter) {
+                Ok(exts) => {
+                    if self.extensions != exts {
+                        return false;
+                    }
+                }
+                Err(_) => {
+                    return false;
+                }
+            }
+        }
+        iter.next() == None
     }
 }

--- a/components/locid/tests/locale.rs
+++ b/components/locid/tests/locale.rs
@@ -79,3 +79,18 @@ fn test_locale_canonicalize() {
         Locale::canonicalize("eN-latN-uS-macOS").unwrap()
     );
 }
+
+#[test]
+fn test_locale_partialeq_str() {
+    let path = "./tests/fixtures/locale.json";
+    let tests: Vec<fixtures::LocaleTest> =
+        helpers::read_fixture(path).expect("Failed to read a fixture");
+    for test in tests {
+        let parsed: Locale = test.input.try_into().expect("Parsing failed.");
+        assert_eq!(parsed, parsed.to_string().as_str());
+    }
+
+    // Check that trailing characters are not ignored
+    let locale: Locale = "en".parse().expect("Parsing failed.");
+    assert_ne!(locale, "en-US");
+}


### PR DESCRIPTION
Initial testing shows that this will improve performance quite a bit, similar to the results we saw for LanguageIdentifier.

I'm leaving this as a draft, because of the handling of `true` values. We currently remove the string when parsing values here: https://github.com/unicode-org/icu4x/blob/master/components/locid/src/extensions/transform/value.rs#L87. This means when we format the Locale as a string, we end up with blanks where the true used to be, which causes comparison between the serialized string and the original string to fail:

```
let tt: Locale = "en-US-t-h0-hybrid-k0-platform-s0-true".parse().expect("parsing failed");
assert_eq!(tt, "en-US-t-h0-hybrid-k0-platform-s0-true")
```

This causes problems with the unit tests. I can skip testing Locales including`true`, but I wanted to check if this is the expected behaviour for handling it before I do so, or if we should change the handling of `true` values instead.