### PR TITLE
Adding DataReceiver with DataProviderV2

### DIFF
--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -133,20 +133,24 @@ impl<'d> DateTimeFormat<'d> {
     ///
     /// assert_eq!(dtf.is_ok(), true);
     /// ```
-    pub fn try_new<D: DataProvider<'d>>(
+    pub fn try_new<D: DataProviderV2<'d>>(
         langid: LanguageIdentifier,
         data_provider: &D,
         options: &DateTimeFormatOptions,
     ) -> Result<Self, DateTimeFormatError> {
         let data_key = structs::dates::key::GREGORY_V1;
-        let response = data_provider.load(&DataRequest {
-            data_key,
-            data_entry: DataEntry {
-                variant: None,
-                langid: langid.clone(),
+        let mut receiver = DataReceiverForType::<structs::dates::gregory::DatesV1>::new();
+        data_provider.load_v2(
+            &DataRequest {
+                data_key,
+                data_entry: DataEntry {
+                    variant: None,
+                    langid: langid.clone(),
+                },
             },
-        })?;
-        let data: Cow<structs::dates::gregory::DatesV1> = response.take_payload()?;
+            &mut receiver,
+        )?;
+        let data = receiver.payload.expect("Load was successful");
 
         let pattern = data.get_pattern_for_options(options)?.unwrap_or_default();
 

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -133,7 +133,7 @@ impl<'d> DateTimeFormat<'d> {
     ///
     /// assert_eq!(dtf.is_ok(), true);
     /// ```
-    pub fn try_new<D: DataProviderV2<'d>>(
+    pub fn try_new<D: DataProvider<'d>>(
         langid: LanguageIdentifier,
         data_provider: &D,
         options: &DateTimeFormatOptions,

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -140,7 +140,7 @@ impl<'d> DateTimeFormat<'d> {
     ) -> Result<Self, DateTimeFormatError> {
         let data_key = structs::dates::key::GREGORY_V1;
         let mut receiver = DataReceiverForType::<structs::dates::gregory::DatesV1>::new();
-        data_provider.load_v2(
+        data_provider.load_to_receiver(
             &DataRequest {
                 data_key,
                 data_entry: DataEntry {

--- a/components/ecma402/src/pluralrules.rs
+++ b/components/ecma402/src/pluralrules.rs
@@ -261,7 +261,7 @@ impl PluralRules {
     ) -> Result<Self, PluralRulesError>
     where
         L: ecma402_traits::Locale,
-        P: icu_provider::DataProviderV2<'static>,
+        P: icu_provider::DataProvider<'static>,
         Self: Sized,
     {
         let locale: String = format!("{}", l);

--- a/components/ecma402/src/pluralrules.rs
+++ b/components/ecma402/src/pluralrules.rs
@@ -261,7 +261,7 @@ impl PluralRules {
     ) -> Result<Self, PluralRulesError>
     where
         L: ecma402_traits::Locale,
-        P: icu_provider::DataProvider<'static>,
+        P: icu_provider::DataProviderV2<'static>,
         Self: Sized,
     {
         let locale: String = format!("{}", l);

--- a/components/plurals/benches/parser.rs
+++ b/components/plurals/benches/parser.rs
@@ -6,7 +6,7 @@ mod helpers;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-use icu_provider::{structs, DataEntry, DataProviderV2, DataRequest};
+use icu_provider::{structs, DataEntry, DataProvider, DataRequest};
 use std::borrow::Cow;
 
 fn parser(c: &mut Criterion) {
@@ -19,7 +19,7 @@ fn parser(c: &mut Criterion) {
     let mut rules = vec![];
 
     for langid in &plurals_data.langs {
-        let response = (&provider as &dyn DataProviderV2)
+        let response = (&provider as &dyn DataProvider)
             .load_payload(&DataRequest {
                 data_key: structs::plurals::key::CARDINAL_V1,
                 data_entry: DataEntry {

--- a/components/plurals/benches/parser.rs
+++ b/components/plurals/benches/parser.rs
@@ -6,7 +6,7 @@ mod helpers;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-use icu_provider::{structs, DataEntry, DataProvider, DataRequest};
+use icu_provider::{structs, DataEntry, DataProviderV2, DataRequest};
 use std::borrow::Cow;
 
 fn parser(c: &mut Criterion) {
@@ -19,8 +19,8 @@ fn parser(c: &mut Criterion) {
     let mut rules = vec![];
 
     for langid in &plurals_data.langs {
-        let response = provider
-            .load(&DataRequest {
+        let response = (&provider as &dyn DataProviderV2)
+            .load_v2a(&DataRequest {
                 data_key: structs::plurals::key::CARDINAL_V1,
                 data_entry: DataEntry {
                     variant: None,
@@ -28,8 +28,7 @@ fn parser(c: &mut Criterion) {
                 },
             })
             .unwrap();
-        let plurals_data: Cow<structs::plurals::PluralRuleStringsV1> =
-            response.take_payload().unwrap();
+        let plurals_data: Cow<structs::plurals::PluralRuleStringsV1> = response.payload.unwrap();
 
         let r = &[
             &plurals_data.zero,

--- a/components/plurals/benches/parser.rs
+++ b/components/plurals/benches/parser.rs
@@ -20,7 +20,7 @@ fn parser(c: &mut Criterion) {
 
     for langid in &plurals_data.langs {
         let response = (&provider as &dyn DataProviderV2)
-            .load_v2a(&DataRequest {
+            .load_payload(&DataRequest {
                 data_key: structs::plurals::key::CARDINAL_V1,
                 data_entry: DataEntry {
                     variant: None,

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -266,7 +266,7 @@ impl PluralRules {
     ///
     /// [`type`]: PluralRuleType
     /// [`data provider`]: icu_provider::DataProvider
-    pub fn try_new<'d, D: DataProviderV2<'d>>(
+    pub fn try_new<'d, D: DataProvider<'d>>(
         langid: LanguageIdentifier,
         data_provider: &D,
         type_: PluralRuleType,

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -276,7 +276,7 @@ impl PluralRules {
             PluralRuleType::Ordinal => structs::plurals::key::ORDINAL_V1,
         };
         let mut receiver = DataReceiverForType::<structs::plurals::PluralRuleStringsV1>::new();
-        data_provider.load_v2(
+        data_provider.load_to_receiver(
             &DataRequest {
                 data_key,
                 data_entry: DataEntry {

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -276,13 +276,16 @@ impl PluralRules {
             PluralRuleType::Ordinal => structs::plurals::key::ORDINAL_V1,
         };
         let mut receiver = DataReceiverForType::<structs::plurals::PluralRuleStringsV1>::new();
-        data_provider.load_v2(&DataRequest {
-            data_key,
-            data_entry: DataEntry {
-                variant: None,
-                langid: langid.clone(),
+        data_provider.load_v2(
+            &DataRequest {
+                data_key,
+                data_entry: DataEntry {
+                    variant: None,
+                    langid: langid.clone(),
+                },
             },
-        }, &mut receiver)?;
+            &mut receiver,
+        )?;
         let plurals_data = receiver.payload.expect("Load was successful");
 
         let list: data::PluralRuleList = (&*plurals_data).try_into()?;

--- a/components/provider/src/data_provider.rs
+++ b/components/provider/src/data_provider.rs
@@ -35,7 +35,7 @@ pub struct DataResponse {
 }
 
 /// An abstract data provider that loads a payload given a request object.
-pub trait DataProviderV2<'d> {
+pub trait DataProvider<'d> {
     /// Query the provider for data, loading it into a DataReceiver.
     ///
     /// Returns Ok if the request successfully loaded data. If data failed to load, returns an
@@ -59,7 +59,7 @@ where
     pub payload: Option<Cow<'d, T>>,
 }
 
-impl<'d> dyn DataProviderV2<'d> + 'd {
+impl<'d> dyn DataProvider<'d> + 'd {
     /// Query the provider for data, returning the result.
     ///
     /// Returns Ok if the request successfully loaded data. If data failed to load, returns an

--- a/components/provider/src/data_provider.rs
+++ b/components/provider/src/data_provider.rs
@@ -45,7 +45,7 @@ impl<'d> DataResponse<'d> {
             .as_any()
             .downcast_ref::<T>()
             .ok_or_else(|| Error::MismatchedType {
-                actual: borrowed.as_any().type_id(),
+                actual: Some(borrowed.as_any().type_id()),
                 generic: Some(TypeId::of::<T>()),
             })
     }
@@ -66,7 +66,7 @@ impl<'d> DataResponse<'d> {
             .as_any_mut()
             .downcast_mut::<T>()
             .ok_or_else(|| Error::MismatchedType {
-                actual: type_id,
+                actual: Some(type_id),
                 generic: Some(TypeId::of::<T>()),
             })
     }
@@ -77,14 +77,14 @@ impl<'d> DataResponse<'d> {
             Cow::Borrowed(borrowed) => match borrowed.as_any().downcast_ref::<T>() {
                 Some(v) => Ok(Cow::Borrowed(v)),
                 None => Err(Error::MismatchedType {
-                    actual: borrowed.as_any().type_id(),
+                    actual: Some(borrowed.as_any().type_id()),
                     generic: Some(TypeId::of::<T>()),
                 }),
             },
             Cow::Owned(boxed) => match boxed.into_any().downcast::<T>() {
                 Ok(boxed_t) => Ok(Cow::Owned(*boxed_t)),
                 Err(boxed_any) => Err(Error::MismatchedType {
-                    actual: boxed_any.type_id(),
+                    actual: Some(boxed_any.type_id()),
                     generic: Some(TypeId::of::<T>()),
                 }),
             },

--- a/components/provider/src/data_provider.rs
+++ b/components/provider/src/data_provider.rs
@@ -91,6 +91,12 @@ impl<'d> DataResponse<'d> {
         }
     }
 
+    /// Take ownership of the payload without downcasting. May clone the payload.
+    pub fn take_as_boxed_any(self) -> Box<dyn Any> {
+        let owned: Box<dyn CloneableAny> = self.payload.into_owned();
+        owned.into_any()
+    }
+
     /// Get the `TypeId` of the payload.
     pub fn get_payload_type_id(&self) -> TypeId {
         let borrowed: &dyn CloneableAny = self.payload.borrow();

--- a/components/provider/src/data_receiver.rs
+++ b/components/provider/src/data_receiver.rs
@@ -1,0 +1,263 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
+
+use crate::error::Error;
+use std::any::Any;
+use std::any::TypeId;
+use std::borrow::Borrow;
+use std::borrow::Cow;
+use std::fmt::Debug;
+
+#[cfg(feature = "invariant")]
+use std::default::Default;
+
+/// An object capable of accepting data from a variety of forms.
+/// Lifetimes:
+/// - 'd = lifetime of borrowed data (Cow::Borrowed)
+/// - 'de = lifetime parameter of owned data (Cow::Owned)
+pub trait DataReceiver<'d, 'de> {
+    /// Consumes a Serde Deserializer into this DataReceiver as owned data.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_provider::prelude::*;
+    ///
+    /// const JSON: &'static str = "\"hello world\"";
+    ///
+    /// let mut receiver = DataReceiverForType::<String>::new();
+    /// let mut d = serde_json::Deserializer::from_str(JSON);
+    /// receiver.receive_deserializer(&mut erased_serde::Deserializer::erase(&mut d))?;
+    ///
+    /// assert_eq!(receiver.payload, Some(Cow::Owned("hello world".to_string())));
+    /// ```
+    fn receive_deserializer(
+        &mut self,
+        deserializer: &mut dyn erased_serde::Deserializer<'de>,
+    ) -> Result<(), erased_serde::Error>;
+
+    /// Sets this DataReceiver to a borrowed value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_provider::prelude::*;
+    ///
+    /// const DATA: &'static str = "hello world";
+    ///
+    /// let mut receiver = DataReceiverForType::<String>::new();
+    /// receiver.receive_borrow(DATA);
+    ///
+    /// assert_eq!(receiver.payload, Some(Cow::Borrowed("hello world")));
+    /// ```
+    fn receive_borrow(&mut self, borrowed_any: &'d dyn Any) -> Result<(), Error>;
+
+    /// Takes a Box into this DataReceiver as owned data.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_provider::prelude::*;
+    ///
+    /// let mut receiver = DataReceiverForType::<String>::new();
+    /// let boxed = Box::new("hello world".to_string());
+    /// receiver.receive_box(boxed);
+    ///
+    /// assert_eq!(receiver.payload, Some(Cow::Owned("hello world".to_string())));
+    /// ```
+    fn receive_box(&mut self, boxed_any: Box<dyn Any>) -> Result<(), Error>;
+
+    /// Takes the value out of an Option into this DataReceiver as owned data.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_provider::prelude::*;
+    ///
+    /// let mut receiver = DataReceiverForType::<String>::new();
+    /// let mut option = Some("hello world".to_string());
+    /// receiver.receive_option(&mut option);
+    ///
+    /// assert!(option, None);
+    /// assert_eq!(receiver.payload, Some(Cow::Owned("hello world".to_string())));
+    /// ```
+    fn receive_option(&mut self, option_any: &mut dyn Any) -> Result<(), Error>;
+
+    /// Borrows the value in this DataReceiver as a Serialize trait object.
+    fn as_serialize(&self) -> Option<&dyn erased_serde::Serialize>;
+}
+
+impl<'a, 'd, 'de> dyn DataReceiver<'d, 'de> + 'a {
+    /// Sets this DataReceiver to the default value of the given type.
+    #[cfg(feature = "invariant")]
+    pub fn receive_invariant<T: Default + Any>(&mut self) -> Result<(), Error> {
+        let mut option = Some(T::default());
+        self.receive_option(&mut option)
+    }
+}
+
+/// Concrete implementation of DataReceiver parameterized for a certain type.
+///
+/// # Example
+///
+/// ```
+/// let mut string_receiver = DataReceiverForType::<String>::new();
+/// ```
+#[derive(Debug)]
+pub struct DataReceiverForType<'d, T>
+where
+    T: Clone + Debug,
+{
+    pub payload: Option<Cow<'d, T>>,
+}
+
+#[cfg(feature = "invariant")]
+impl<'d, T> Default for DataReceiverForType<'d, T>
+where
+    T: Clone + Debug + Default,
+{
+    /// Creates a new DataReceiver with the Default data pre-loaded.
+    fn default() -> Self {
+        Self {
+            payload: Default::default(),
+        }
+    }
+}
+
+impl<'d, T> DataReceiverForType<'d, T>
+where
+    T: Clone + Debug,
+{
+    /// Creates a new, empty DataReceiver.
+    pub fn new() -> Self {
+        Self { payload: None }
+    }
+
+    /// Borrows the payload from the underlying Cow.
+    pub fn borrow_payload(&self) -> Option<&T> {
+        self.payload.as_ref().map(|cow| cow.borrow())
+    }
+}
+
+impl<'d, T> DataReceiverForType<'d, T>
+where
+    T: serde::Deserialize<'static> + erased_serde::Serialize + Any + Clone + Debug,
+{
+    /// Creates a new, empty DataReceiver, returning it as a boxed trait object.
+    pub fn new_boxed() -> Box<dyn DataReceiver<'d, 'static> + 'd> {
+        let receiver: DataReceiverForType<'d, T> = Self::new();
+        Box::new(receiver)
+    }
+}
+
+impl<'d, T> DataReceiver<'d, 'static> for DataReceiverForType<'d, T>
+where
+    T: serde::Deserialize<'static> + erased_serde::Serialize + Any + Clone + Debug,
+{
+    fn receive_deserializer(
+        &mut self,
+        deserializer: &mut dyn erased_serde::Deserializer<'static>,
+    ) -> Result<(), erased_serde::Error> {
+        let obj: T = erased_serde::deserialize(deserializer)?;
+        self.payload = Some(Cow::Owned(obj));
+        Ok(())
+    }
+
+    fn receive_borrow(&mut self, borrowed_any: &'d dyn Any) -> Result<(), Error> {
+        let borrowed: &T = borrowed_any
+            .downcast_ref()
+            .ok_or_else(|| Error::MismatchedType {
+                actual: Some(borrowed_any.type_id()),
+                generic: Some(TypeId::of::<T>()),
+            })?;
+        self.payload = Some(Cow::Borrowed(borrowed));
+        Ok(())
+    }
+
+    fn receive_box(&mut self, boxed_any: Box<dyn Any>) -> Result<(), Error> {
+        let boxed: Box<T> = boxed_any.downcast().map_err(|any| Error::MismatchedType {
+            actual: Some(any.type_id()),
+            generic: Some(TypeId::of::<T>()),
+        })?;
+        self.payload = Some(Cow::Owned(*boxed));
+        Ok(())
+    }
+
+    fn receive_option(&mut self, option_any: &mut dyn Any) -> Result<(), Error> {
+        let option: &mut Option<T> =
+            option_any
+                .downcast_mut()
+                .ok_or_else(|| Error::MismatchedType {
+                    actual: None,
+                    generic: Some(TypeId::of::<T>()),
+                })?;
+        self.payload = option.take().map(Cow::Owned);
+        Ok(())
+    }
+
+    fn as_serialize(&self) -> Option<&dyn erased_serde::Serialize> {
+        match &self.payload {
+            Some(cow) => {
+                let borrowed: &T = cow.borrow();
+                Some(borrowed as &dyn erased_serde::Serialize)
+            }
+            None => None,
+        }
+    }
+}
+
+/// Concrete implementation of DataReceiver that records whether or not it received data, but
+/// throws away any data it receives.
+///
+/// Can be used for checking whether a DataProvider supports a particular data key.
+pub struct DataReceiverThrowAway {
+    flag: bool,
+}
+
+impl Default for DataReceiverThrowAway {
+    fn default() -> Self {
+        Self { flag: false }
+    }
+}
+
+impl DataReceiverThrowAway {
+    /// Whether any receive function has been called on this DataReceiver.
+    pub fn has_received_data(&self) -> bool {
+        self.flag
+    }
+
+    /// Resets this DataReceiver to its initial state.
+    pub fn reset(&mut self) {
+        self.flag = false;
+    }
+}
+
+impl<'d> DataReceiver<'d, 'static> for DataReceiverThrowAway {
+    fn receive_deserializer(
+        &mut self,
+        _: &mut dyn erased_serde::Deserializer<'static>,
+    ) -> Result<(), erased_serde::Error> {
+        self.flag = true;
+        Ok(())
+    }
+
+    fn receive_borrow(&mut self, _: &'d dyn Any) -> Result<(), Error> {
+        self.flag = true;
+        Ok(())
+    }
+
+    fn receive_box(&mut self, _: Box<dyn Any>) -> Result<(), Error> {
+        self.flag = true;
+        Ok(())
+    }
+
+    fn receive_option(&mut self, _: &mut dyn Any) -> Result<(), Error> {
+        self.flag = true;
+        Ok(())
+    }
+
+    fn as_serialize(&self) -> Option<&dyn erased_serde::Serialize> {
+        None
+    }
+}

--- a/components/provider/src/data_receiver.rs
+++ b/components/provider/src/data_receiver.rs
@@ -23,12 +23,14 @@ pub trait DataReceiver<'d, 'de> {
     ///
     /// ```
     /// use icu_provider::prelude::*;
+    /// use std::borrow::Cow;
     ///
     /// const JSON: &'static str = "\"hello world\"";
     ///
     /// let mut receiver = DataReceiverForType::<String>::new();
     /// let mut d = serde_json::Deserializer::from_str(JSON);
-    /// receiver.receive_deserializer(&mut erased_serde::Deserializer::erase(&mut d))?;
+    /// receiver.receive_deserializer(&mut erased_serde::Deserializer::erase(&mut d))
+    ///     .expect("Deserialization should be successful");
     ///
     /// assert_eq!(receiver.payload, Some(Cow::Owned("hello world".to_string())));
     /// ```
@@ -43,13 +45,14 @@ pub trait DataReceiver<'d, 'de> {
     ///
     /// ```
     /// use icu_provider::prelude::*;
+    /// use std::borrow::Cow;
     ///
-    /// const DATA: &'static str = "hello world";
+    /// let borrowed_data: String = "hello world".to_string();
     ///
     /// let mut receiver = DataReceiverForType::<String>::new();
-    /// receiver.receive_borrow(DATA);
+    /// receiver.receive_borrow(&borrowed_data).expect("Types should match");
     ///
-    /// assert_eq!(receiver.payload, Some(Cow::Borrowed("hello world")));
+    /// assert_eq!(receiver.payload, Some(Cow::Borrowed(&borrowed_data)));
     /// ```
     fn receive_borrow(&mut self, borrowed_any: &'d dyn Any) -> Result<(), Error>;
 
@@ -59,10 +62,11 @@ pub trait DataReceiver<'d, 'de> {
     ///
     /// ```
     /// use icu_provider::prelude::*;
+    /// use std::borrow::Cow;
     ///
     /// let mut receiver = DataReceiverForType::<String>::new();
     /// let boxed = Box::new("hello world".to_string());
-    /// receiver.receive_box(boxed);
+    /// receiver.receive_box(boxed).expect("Types should match");
     ///
     /// assert_eq!(receiver.payload, Some(Cow::Owned("hello world".to_string())));
     /// ```
@@ -74,12 +78,13 @@ pub trait DataReceiver<'d, 'de> {
     ///
     /// ```
     /// use icu_provider::prelude::*;
+    /// use std::borrow::Cow;
     ///
     /// let mut receiver = DataReceiverForType::<String>::new();
     /// let mut option = Some("hello world".to_string());
-    /// receiver.receive_option(&mut option);
+    /// receiver.receive_option(&mut option).expect("Types should match");
     ///
-    /// assert!(option, None);
+    /// assert!(option.is_none());
     /// assert_eq!(receiver.payload, Some(Cow::Owned("hello world".to_string())));
     /// ```
     fn receive_option(&mut self, option_any: &mut dyn Any) -> Result<(), Error>;
@@ -102,6 +107,8 @@ impl<'a, 'd, 'de> dyn DataReceiver<'d, 'de> + 'a {
 /// # Example
 ///
 /// ```
+/// use icu_provider::prelude::*;
+///
 /// let mut string_receiver = DataReceiverForType::<String>::new();
 /// ```
 #[derive(Debug)]

--- a/components/provider/src/error.rs
+++ b/components/provider/src/error.rs
@@ -19,9 +19,6 @@ pub enum Error {
     /// (variant or language identifier).
     UnavailableEntry(DataRequest),
 
-    /// An error occurred when deserializing data.
-    Serde(erased_serde::Error),
-
     /// The TypeID of the payload does not match the expected TypeID.
     MismatchedType {
         /// The actual TypeID of the payload.
@@ -53,12 +50,6 @@ impl From<DataRequest> for Error {
     }
 }
 
-impl From<erased_serde::Error> for Error {
-    fn from(err: erased_serde::Error) -> Self {
-        Self::Serde(err)
-    }
-}
-
 impl From<Box<dyn std::error::Error>> for Error {
     fn from(err: Box<dyn std::error::Error>) -> Self {
         Self::Resource(err)
@@ -80,7 +71,6 @@ impl fmt::Display for Error {
             Self::UnsupportedCategory(category) => write!(f, "Unsupported category: {}", category),
             Self::UnsupportedDataKey(data_key) => write!(f, "Unsupported data key: {}", data_key),
             Self::UnavailableEntry(request) => write!(f, "Unavailable data entry: {}", request),
-            Self::Serde(err) => write!(f, "Serde error: {}", err),
             Self::MismatchedType { actual, generic } => {
                 write!(f, "Mismatched type: payload is {:?}", actual)?;
                 if let Some(type_id) = generic {
@@ -96,7 +86,6 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::Serde(error) => Some(error),
             Self::Resource(error) => Some(error.deref()),
             _ => None,
         }

--- a/components/provider/src/error.rs
+++ b/components/provider/src/error.rs
@@ -19,6 +19,9 @@ pub enum Error {
     /// (variant or language identifier).
     UnavailableEntry(DataRequest),
 
+    /// An error occurred when deserializing data.
+    Serde(erased_serde::Error),
+
     /// The TypeID of the payload does not match the expected TypeID.
     MismatchedType {
         /// The actual TypeID of the payload.
@@ -50,6 +53,12 @@ impl From<DataRequest> for Error {
     }
 }
 
+impl From<erased_serde::Error> for Error {
+    fn from(err: erased_serde::Error) -> Self {
+        Self::Serde(err)
+    }
+}
+
 impl From<Box<dyn std::error::Error>> for Error {
     fn from(err: Box<dyn std::error::Error>) -> Self {
         Self::Resource(err)
@@ -70,6 +79,8 @@ impl fmt::Display for Error {
         match self {
             Self::UnsupportedCategory(category) => write!(f, "Unsupported category: {}", category),
             Self::UnsupportedDataKey(data_key) => write!(f, "Unsupported data key: {}", data_key),
+            Self::UnavailableEntry(request) => write!(f, "Unavailable data entry: {}", request),
+            Self::Serde(err) => write!(f, "Serde error: {}", err),
             Self::MismatchedType { actual, generic } => {
                 write!(f, "Mismatched type: payload is {:?}", actual)?;
                 if let Some(type_id) = generic {
@@ -77,7 +88,6 @@ impl fmt::Display for Error {
                 }
                 Ok(())
             }
-            Self::UnavailableEntry(request) => write!(f, "Unavailable data entry: {}", request),
             Self::Resource(err) => write!(f, "Failed to load resource: {}", err),
         }
     }
@@ -86,6 +96,7 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
+            Self::Serde(error) => Some(error),
             Self::Resource(error) => Some(error.deref()),
             _ => None,
         }

--- a/components/provider/src/error.rs
+++ b/components/provider/src/error.rs
@@ -21,8 +21,8 @@ pub enum Error {
 
     /// The TypeID of the payload does not match the expected TypeID.
     MismatchedType {
-        /// The actual TypeID of the payload.
-        actual: TypeId,
+        /// The actual TypeID of the payload, if available.
+        actual: Option<TypeId>,
 
         /// The expected TypeID derived from the generic type parameter at the call site.
         generic: Option<TypeId>,

--- a/components/provider/src/invariant.rs
+++ b/components/provider/src/invariant.rs
@@ -80,31 +80,6 @@ impl DataEntryCollection for InvariantDataProvider {
 }
 
 #[test]
-fn test_basic() {
-    let provider = InvariantDataProvider;
-    let response = provider
-        .load(&DataRequest {
-            data_key: structs::plurals::key::CARDINAL_V1,
-            data_entry: DataEntry {
-                variant: None,
-                langid: LanguageIdentifier::default(),
-            },
-        })
-        .unwrap();
-    let plurals_data: &structs::plurals::PluralRuleStringsV1 = response.borrow_payload().unwrap();
-    assert_eq!(
-        plurals_data,
-        &structs::plurals::PluralRuleStringsV1 {
-            zero: None,
-            one: None,
-            two: None,
-            few: None,
-            many: None,
-        }
-    );
-}
-
-#[test]
 fn test_v2() {
     let provider = InvariantDataProvider;
     let mut receiver =

--- a/components/provider/src/invariant.rs
+++ b/components/provider/src/invariant.rs
@@ -114,11 +114,6 @@ fn test_basic() {
 fn test_v2() {
     use std::any::TypeId;
 
-    println!(
-        "{:?}",
-        TypeId::of::<structs::plurals::PluralRuleStringsV1>()
-    );
-
     let provider = InvariantDataProvider;
     let mut receiver: DataReceiverImpl<structs::plurals::PluralRuleStringsV1> =
         DataReceiverImpl { payload: None };

--- a/components/provider/src/invariant.rs
+++ b/components/provider/src/invariant.rs
@@ -49,12 +49,6 @@ where
 /// ```
 pub struct InvariantDataProvider;
 
-impl DataProvider<'static> for InvariantDataProvider {
-    fn load<'a>(&'a self, req: &DataRequest) -> Result<DataResponse<'static>, Error> {
-        structs::get_invariant(&req.data_key).ok_or(Error::UnsupportedDataKey(req.data_key))
-    }
-}
-
 impl DataProviderV2<'static> for InvariantDataProvider {
     fn load_v2<'a>(
         &'a self,

--- a/components/provider/src/invariant.rs
+++ b/components/provider/src/invariant.rs
@@ -38,13 +38,13 @@ use icu_locid::LanguageIdentifier;
 pub struct InvariantDataProvider;
 
 impl<'d> DataProviderV2<'d> for InvariantDataProvider {
-    fn load_v2(
+    fn load_to_receiver(
         &self,
         req: &DataRequest,
         receiver: &mut dyn DataReceiver<'d, 'static>,
-    ) -> Result<DataResponseV2, Error> {
+    ) -> Result<DataResponse, Error> {
         structs::get_invariant(&req.data_key, receiver)?;
-        Ok(DataResponseV2 {
+        Ok(DataResponse {
             data_langid: LanguageIdentifier::default(),
         })
     }
@@ -71,7 +71,7 @@ fn test_v2() {
     let mut receiver =
         DataReceiverForType::<structs::plurals::PluralRuleStringsV1> { payload: None };
     provider
-        .load_v2(
+        .load_to_receiver(
             &DataRequest {
                 data_key: structs::plurals::key::CARDINAL_V1,
                 data_entry: DataEntry {

--- a/components/provider/src/invariant.rs
+++ b/components/provider/src/invariant.rs
@@ -113,8 +113,8 @@ fn test_basic() {
 #[test]
 fn test_v2() {
     let provider = InvariantDataProvider;
-    let mut receiver: DataReceiverImpl<structs::plurals::PluralRuleStringsV1> =
-        DataReceiverImpl { payload: None };
+    let mut receiver =
+        DataReceiverForType::<structs::plurals::PluralRuleStringsV1> { payload: None };
     provider
         .load_v2(
             &DataRequest {

--- a/components/provider/src/invariant.rs
+++ b/components/provider/src/invariant.rs
@@ -64,7 +64,7 @@ impl DataProviderV2<'static> for InvariantDataProvider {
         // TODO: Re-work get_invariant to be optimized for DataProviderV2
         let response =
             structs::get_invariant(&req.data_key).ok_or(Error::UnsupportedDataKey(req.data_key))?;
-        receiver.set_to_boxed(response.take_as_boxed_any())?;
+        receiver.receive_box(response.take_as_boxed_any())?;
         Ok(DataResponseV2 {
             data_langid: LanguageIdentifier::default(),
         })

--- a/components/provider/src/invariant.rs
+++ b/components/provider/src/invariant.rs
@@ -37,7 +37,7 @@ use icu_locid::LanguageIdentifier;
 /// ```
 pub struct InvariantDataProvider;
 
-impl<'d> DataProviderV2<'d> for InvariantDataProvider {
+impl<'d> DataProvider<'d> for InvariantDataProvider {
     fn load_to_receiver(
         &self,
         req: &DataRequest,

--- a/components/provider/src/invariant.rs
+++ b/components/provider/src/invariant.rs
@@ -112,8 +112,6 @@ fn test_basic() {
 
 #[test]
 fn test_v2() {
-    use std::any::TypeId;
-
     let provider = InvariantDataProvider;
     let mut receiver: DataReceiverImpl<structs::plurals::PluralRuleStringsV1> =
         DataReceiverImpl { payload: None };

--- a/components/provider/src/iter.rs
+++ b/components/provider/src/iter.rs
@@ -17,7 +17,7 @@ pub trait DataEntryCollection {
 }
 
 /// Auto-implemented trait: A data provider that allows for iteration over `DataEntry` instances.
-pub trait IterableDataProvider<'d>: DataProviderV2<'d> + DataEntryCollection {
+pub trait IterableDataProvider<'d>: DataProvider<'d> + DataEntryCollection {
     /// Dump all data in this data provider for the specified key into the sink.
     fn export_key(&self, data_key: &DataKey, sink: &mut dyn DataExporter) -> Result<(), Error>;
 }
@@ -38,7 +38,7 @@ pub trait DataExporter {
 
 impl<'d, T> IterableDataProvider<'d> for T
 where
-    T: DataProviderV2<'d> + DataEntryCollection,
+    T: DataProvider<'d> + DataEntryCollection,
 {
     fn export_key(&self, data_key: &DataKey, sink: &mut dyn DataExporter) -> Result<(), Error> {
         for data_entry in self.iter_for_key(data_key)? {

--- a/components/provider/src/iter.rs
+++ b/components/provider/src/iter.rs
@@ -45,8 +45,7 @@ where
             if !sink.includes(&data_entry) {
                 continue;
             }
-            // TODO: Make a custom receiver that can accept anything implementing Serialize.
-            let mut receiver = structs::get_receiver(data_key).unwrap();
+            let mut receiver = structs::get_receiver(data_key)?;
             let req = DataRequest {
                 data_key: *data_key,
                 data_entry,

--- a/components/provider/src/iter.rs
+++ b/components/provider/src/iter.rs
@@ -50,7 +50,7 @@ where
                 data_key: *data_key,
                 data_entry,
             };
-            self.load_v2(&req, receiver.as_mut())?;
+            self.load_to_receiver(&req, receiver.as_mut())?;
             let payload = receiver.as_serialize();
             sink.put(&req, &payload)?;
         }

--- a/components/provider/src/iter.rs
+++ b/components/provider/src/iter.rs
@@ -45,6 +45,7 @@ where
             if !sink.includes(&data_entry) {
                 continue;
             }
+            // TODO: Make a custom receiver that can accept anything implementing Serialize.
             let mut receiver = structs::get_receiver(data_key).unwrap();
             let req = DataRequest {
                 data_key: *data_key,

--- a/components/provider/src/lib.rs
+++ b/components/provider/src/lib.rs
@@ -92,7 +92,7 @@ pub mod prelude {
 
     pub use crate::v2::DataProviderV2;
     pub use crate::v2::DataReceiver;
-    pub use crate::v2::DataReceiverImpl;
+    pub use crate::v2::DataReceiverForType;
     pub use crate::v2::DataResponseV2;
 }
 
@@ -123,14 +123,36 @@ pub mod v2 {
     }
 
     #[derive(Debug)]
-    pub struct DataReceiverImpl<'d, T>
+    pub struct DataReceiverForType<'d, T>
     where
-        T: serde::Deserialize<'static> + erased_serde::Serialize + Any + Clone + Debug,
+        T: Clone + Debug,
     {
         pub payload: Option<Cow<'d, T>>,
     }
 
-    impl<'d, T> DataReceiver<'d, 'static> for DataReceiverImpl<'d, T>
+    impl<'d, T> Default for DataReceiverForType<'d, T>
+    where
+        T: Clone + Debug,
+    {
+        fn default() -> Self {
+            Self { payload: None }
+        }
+    }
+
+    impl<'d, T> DataReceiverForType<'d, T>
+    where
+        T: Clone + Debug,
+    {
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        pub fn borrow_payload(&self) -> Option<&T> {
+            self.payload.as_ref().map(|cow| cow.borrow())
+        }
+    }
+
+    impl<'d, T> DataReceiver<'d, 'static> for DataReceiverForType<'d, T>
     where
         T: serde::Deserialize<'static> + erased_serde::Serialize + Any + Clone + Debug,
     {

--- a/components/provider/src/lib.rs
+++ b/components/provider/src/lib.rs
@@ -19,17 +19,6 @@
 //!
 //! ```
 //! use icu_provider::prelude::*;
-//! use std::any::TypeId;
-//!
-//! // Types included:
-//! println!("{:?}", TypeId::of::<dyn DataProvider>());
-//! println!("{:?}", TypeId::of::<DataError>());
-//! println!("{:?}", TypeId::of::<DataKey>());
-//! println!("{:?}", TypeId::of::<DataEntry>());
-//! println!("{:?}", TypeId::of::<DataCategory>());
-//! println!("{:?}", TypeId::of::<DataRequest>());
-//! println!("{:?}", TypeId::of::<DataResponse>());
-//! println!("{:?}", TypeId::of::<DataResponseBuilder>());
 //! ```
 //!
 //! ## Types of Data Providers

--- a/components/provider/src/lib.rs
+++ b/components/provider/src/lib.rs
@@ -84,7 +84,7 @@ pub mod prelude {
     pub use crate::data_entry::DataEntry;
     pub use crate::data_key::DataCategory;
     pub use crate::data_key::DataKey;
-    pub use crate::data_provider::DataProvider;
+    // pub use crate::data_provider::DataProvider;
     pub use crate::data_provider::DataRequest;
     pub use crate::data_provider::DataResponse;
     pub use crate::data_provider::DataResponseBuilder;
@@ -232,5 +232,27 @@ pub mod v2 {
             req: &DataRequest,
             receiver: &mut dyn DataReceiver<'d, 'static>,
         ) -> Result<DataResponseV2, Error>;
+    }
+
+    pub struct DataResponseV2a<'d, T>
+    where
+        T: Clone + Debug,
+    {
+        pub response: DataResponseV2,
+        pub payload: Option<Cow<'d, T>>,
+    }
+
+    impl<'d> dyn DataProviderV2<'d> + 'd {
+        pub fn load_v2a<T>(&self, req: &DataRequest) -> Result<DataResponseV2a<'d, T>, Error>
+        where
+            T: serde::Deserialize<'static> + erased_serde::Serialize + Any + Clone + Debug,
+        {
+            let mut receiver = DataReceiverForType::<T>::new();
+            let response = self.load_v2(req, &mut receiver)?;
+            Ok(DataResponseV2a {
+                response,
+                payload: receiver.payload,
+            })
+        }
     }
 }

--- a/components/provider/src/lib.rs
+++ b/components/provider/src/lib.rs
@@ -87,7 +87,8 @@ pub mod prelude {
     pub use crate::data_key::DataKey;
     pub use crate::data_provider::DataProviderV2;
     pub use crate::data_provider::DataRequest;
-    pub use crate::data_provider::DataResponseV2;
+    pub use crate::data_provider::DataResponse;
+    pub use crate::data_provider::DataResponseWithPayload;
     pub use crate::data_receiver::DataReceiver;
     pub use crate::data_receiver::DataReceiverForType;
     pub use crate::data_receiver::DataReceiverThrowAway;

--- a/components/provider/src/lib.rs
+++ b/components/provider/src/lib.rs
@@ -112,14 +112,14 @@ pub mod v2 {
     use std::fmt::Debug;
 
     pub trait DataReceiver<'d, 'de> {
-        fn set_to(
+        fn receive_deserializer(
             &mut self,
             deserializer: &mut dyn erased_serde::Deserializer<'de>,
         ) -> Result<(), erased_serde::Error>;
 
-        fn set_to_any(&mut self, any: &'d dyn Any) -> Result<(), Error>;
+        fn receive_borrow(&mut self, any: &'d dyn Any) -> Result<(), Error>;
 
-        fn set_to_boxed(&mut self, boxed: Box<dyn Any>) -> Result<(), Error>;
+        fn receive_box(&mut self, boxed: Box<dyn Any>) -> Result<(), Error>;
 
         fn borrow_payload_as_any(&self) -> Option<&dyn Any>;
 
@@ -168,7 +168,7 @@ pub mod v2 {
     where
         T: serde::Deserialize<'static> + erased_serde::Serialize + Any + Clone + Debug,
     {
-        fn set_to(
+        fn receive_deserializer(
             &mut self,
             deserializer: &mut dyn erased_serde::Deserializer<'static>,
         ) -> Result<(), erased_serde::Error> {
@@ -177,7 +177,7 @@ pub mod v2 {
             Ok(())
         }
 
-        fn set_to_any(&mut self, any: &'d dyn Any) -> Result<(), Error> {
+        fn receive_borrow(&mut self, any: &'d dyn Any) -> Result<(), Error> {
             self.payload = Some(Cow::Borrowed(any.downcast_ref().ok_or_else(|| {
                 Error::MismatchedType {
                     actual: any.type_id(),
@@ -187,7 +187,7 @@ pub mod v2 {
             Ok(())
         }
 
-        fn set_to_boxed(&mut self, boxed: Box<dyn Any>) -> Result<(), Error> {
+        fn receive_box(&mut self, boxed: Box<dyn Any>) -> Result<(), Error> {
             self.payload = Some(Cow::Owned(
                 *(boxed.downcast().map_err(|any| Error::MismatchedType {
                     actual: any.type_id(),

--- a/components/provider/src/lib.rs
+++ b/components/provider/src/lib.rs
@@ -85,7 +85,7 @@ pub mod prelude {
     pub use crate::data_entry::DataEntry;
     pub use crate::data_key::DataCategory;
     pub use crate::data_key::DataKey;
-    pub use crate::data_provider::DataProviderV2;
+    pub use crate::data_provider::DataProvider;
     pub use crate::data_provider::DataRequest;
     pub use crate::data_provider::DataResponse;
     pub use crate::data_provider::DataResponseWithPayload;

--- a/components/provider/src/lib.rs
+++ b/components/provider/src/lib.rs
@@ -154,6 +154,16 @@ pub mod v2 {
         }
     }
 
+    impl<'d, T> DataReceiverForType<'d, T>
+    where
+        T: serde::Deserialize<'static> + erased_serde::Serialize + Any + Clone + Debug,
+    {
+        pub fn new_boxed() -> Box<dyn DataReceiver<'d, 'static> + 'd> {
+            let receiver: DataReceiverForType<'d, T> = Self::new();
+            Box::new(receiver)
+        }
+    }
+
     impl<'d, T> DataReceiver<'d, 'static> for DataReceiverForType<'d, T>
     where
         T: serde::Deserialize<'static> + erased_serde::Serialize + Any + Clone + Debug,
@@ -196,7 +206,7 @@ pub mod v2 {
                         actual: None,
                         generic: Some(TypeId::of::<T>()),
                     })?;
-            self.payload = option.take().map(|t| Cow::Owned(t));
+            self.payload = option.take().map(Cow::Owned);
             Ok(())
         }
 

--- a/components/provider/src/lib.rs
+++ b/components/provider/src/lib.rs
@@ -115,7 +115,7 @@ pub mod v2 {
         fn set_to(
             &mut self,
             deserializer: &mut dyn erased_serde::Deserializer<'de>,
-        ) -> Result<(), Error>;
+        ) -> Result<(), erased_serde::Error>;
 
         fn set_to_any(&mut self, any: &'d dyn Any) -> Result<(), Error>;
 
@@ -171,7 +171,7 @@ pub mod v2 {
         fn set_to(
             &mut self,
             deserializer: &mut dyn erased_serde::Deserializer<'static>,
-        ) -> Result<(), Error> {
+        ) -> Result<(), erased_serde::Error> {
             let obj: T = erased_serde::deserialize(deserializer)?;
             self.payload = Some(Cow::Owned(obj));
             Ok(())

--- a/components/provider/src/structs/dates.rs
+++ b/components/provider/src/structs/dates.rs
@@ -1,8 +1,8 @@
 // This file is part of ICU4X. For terms of use, please see the file
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
+
 // Date
-#[cfg(feature = "invariant")]
 use crate::prelude::*;
 
 pub mod key {
@@ -16,6 +16,13 @@ pub(crate) fn get_invariant(data_key: &DataKey) -> Option<DataResponse<'static>>
     use crate::invariant::make_inv_response;
     match *data_key {
         key::GREGORY_V1 => make_inv_response::<gregory::DatesV1>(),
+        _ => None,
+    }
+}
+
+pub fn get_receiver<'d>(data_key: &DataKey) -> Option<Box<dyn DataReceiver<'d, 'static> + 'd>> {
+    match *data_key {
+        key::GREGORY_V1 => Some(DataReceiverForType::<gregory::DatesV1>::new_boxed()),
         _ => None,
     }
 }

--- a/components/provider/src/structs/dates.rs
+++ b/components/provider/src/structs/dates.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 
 // Date
+
 use crate::prelude::*;
 
 pub mod key {
@@ -12,14 +13,17 @@ pub mod key {
 
 /// Gets a locale-invariant default struct given a data key in this module's category.
 #[cfg(feature = "invariant")]
-pub(crate) fn get_invariant(data_key: &DataKey) -> Option<DataResponse<'static>> {
-    use crate::invariant::make_inv_response;
+pub fn get_invariant<'d>(
+    data_key: &DataKey,
+    receiver: &mut dyn DataReceiver<'d, 'static>,
+) -> Result<(), DataError> {
     match *data_key {
-        key::GREGORY_V1 => make_inv_response::<gregory::DatesV1>(),
-        _ => None,
+        key::GREGORY_V1 => receiver.receive_invariant::<gregory::DatesV1>(),
+        _ => Err(DataError::UnsupportedDataKey(*data_key)),
     }
 }
 
+/// Gets a boxed DataReceiver capable of receiving a data key in this module's category.
 pub fn get_receiver<'d>(data_key: &DataKey) -> Option<Box<dyn DataReceiver<'d, 'static> + 'd>> {
     match *data_key {
         key::GREGORY_V1 => Some(DataReceiverForType::<gregory::DatesV1>::new_boxed()),

--- a/components/provider/src/structs/decimal.rs
+++ b/components/provider/src/structs/decimal.rs
@@ -4,8 +4,6 @@
 // Decimal types
 use serde::{Deserialize, Serialize};
 use smallstr::SmallString;
-
-#[cfg(feature = "invariant")]
 use crate::prelude::*;
 
 pub mod key {
@@ -19,6 +17,13 @@ pub(crate) fn get_invariant(data_key: &DataKey) -> Option<DataResponse<'static>>
     use crate::invariant::make_inv_response;
     match *data_key {
         key::SYMBOLS_V1 => make_inv_response::<SymbolsV1>(),
+        _ => None,
+    }
+}
+
+pub fn get_receiver<'d>(data_key: &DataKey) -> Option<Box<dyn DataReceiver<'d, 'static> + 'd>> {
+    match *data_key {
+        key::SYMBOLS_V1 => Some(DataReceiverForType::<SymbolsV1>::new_boxed()),
         _ => None,
     }
 }

--- a/components/provider/src/structs/decimal.rs
+++ b/components/provider/src/structs/decimal.rs
@@ -13,14 +13,17 @@ pub mod key {
 
 /// Gets a locale-invariant default struct given a data key in this module's category.
 #[cfg(feature = "invariant")]
-pub(crate) fn get_invariant(data_key: &DataKey) -> Option<DataResponse<'static>> {
-    use crate::invariant::make_inv_response;
+pub fn get_invariant<'d>(
+    data_key: &DataKey,
+    receiver: &mut dyn DataReceiver<'d, 'static>,
+) -> Result<(), DataError> {
     match *data_key {
-        key::SYMBOLS_V1 => make_inv_response::<SymbolsV1>(),
-        _ => None,
+        key::SYMBOLS_V1 => receiver.receive_invariant::<SymbolsV1>(),
+        _ => Err(DataError::UnsupportedDataKey(*data_key)),
     }
 }
 
+/// Gets a boxed DataReceiver capable of receiving a data key in this module's category.
 pub fn get_receiver<'d>(data_key: &DataKey) -> Option<Box<dyn DataReceiver<'d, 'static> + 'd>> {
     match *data_key {
         key::SYMBOLS_V1 => Some(DataReceiverForType::<SymbolsV1>::new_boxed()),

--- a/components/provider/src/structs/decimal.rs
+++ b/components/provider/src/structs/decimal.rs
@@ -2,9 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 // Decimal types
+use crate::prelude::*;
 use serde::{Deserialize, Serialize};
 use smallstr::SmallString;
-use crate::prelude::*;
 
 pub mod key {
     use crate::data_key::DataKey;

--- a/components/provider/src/structs/mod.rs
+++ b/components/provider/src/structs/mod.rs
@@ -6,7 +6,6 @@ pub mod dates;
 pub mod decimal;
 pub mod plurals;
 
-#[cfg(feature = "invariant")]
 use crate::prelude::*;
 
 /// Gets a locale-invariant default struct given a data key in this module's category.

--- a/components/provider/src/structs/mod.rs
+++ b/components/provider/src/structs/mod.rs
@@ -19,3 +19,10 @@ pub(crate) fn get_invariant(data_key: &DataKey) -> Option<DataResponse<'static>>
         .or_else(|| plurals::get_invariant(data_key)) //
         .or_else(|| dates::get_invariant(data_key)) //
 }
+
+pub fn get_receiver<'d>(data_key: &DataKey) -> Option<Box<dyn DataReceiver<'d, 'static> + 'd>> {
+    None //
+        .or_else(|| decimal::get_receiver(data_key)) //
+        .or_else(|| plurals::get_receiver(data_key)) //
+        .or_else(|| dates::get_receiver(data_key)) //
+}

--- a/components/provider/src/structs/mod.rs
+++ b/components/provider/src/structs/mod.rs
@@ -12,16 +12,23 @@ use crate::prelude::*;
 /// For example, if the data key is `plurals/cardinal@1`, a Response with an object of type
 /// `PluralRuleStringsV1` will be returned.
 #[cfg(feature = "invariant")]
-pub(crate) fn get_invariant(data_key: &DataKey) -> Option<DataResponse<'static>> {
-    None //
-        .or_else(|| decimal::get_invariant(data_key)) //
-        .or_else(|| plurals::get_invariant(data_key)) //
-        .or_else(|| dates::get_invariant(data_key)) //
+pub fn get_invariant<'d>(
+    data_key: &DataKey,
+    receiver: &mut dyn DataReceiver<'d, 'static>,
+) -> Result<(), DataError> {
+    Err(DataError::UnsupportedDataKey(*data_key)) //
+        .or_else(|_| decimal::get_invariant(data_key, receiver)) //
+        .or_else(|_| plurals::get_invariant(data_key, receiver)) //
+        .or_else(|_| dates::get_invariant(data_key, receiver)) //
 }
 
-pub fn get_receiver<'d>(data_key: &DataKey) -> Option<Box<dyn DataReceiver<'d, 'static> + 'd>> {
+/// Gets a boxed DataReceiver capable of receiving any known data struct.
+pub fn get_receiver<'d>(
+    data_key: &DataKey,
+) -> Result<Box<dyn DataReceiver<'d, 'static> + 'd>, DataError> {
     None //
         .or_else(|| decimal::get_receiver(data_key)) //
         .or_else(|| plurals::get_receiver(data_key)) //
         .or_else(|| dates::get_receiver(data_key)) //
+        .ok_or_else(|| DataError::UnsupportedDataKey(*data_key)) //
 }

--- a/components/provider/src/structs/plurals.rs
+++ b/components/provider/src/structs/plurals.rs
@@ -2,9 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 // Plural types
+use crate::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use crate::prelude::*;
 
 pub mod key {
     use crate::data_key::DataKey;

--- a/components/provider/src/structs/plurals.rs
+++ b/components/provider/src/structs/plurals.rs
@@ -14,15 +14,18 @@ pub mod key {
 
 /// Gets a locale-invariant default struct given a data key in this module's category.
 #[cfg(feature = "invariant")]
-pub(crate) fn get_invariant(data_key: &DataKey) -> Option<DataResponse<'static>> {
-    use crate::invariant::make_inv_response;
+pub fn get_invariant<'d>(
+    data_key: &DataKey,
+    receiver: &mut dyn DataReceiver<'d, 'static>,
+) -> Result<(), DataError> {
     match *data_key {
-        key::CARDINAL_V1 => make_inv_response::<PluralRuleStringsV1>(),
-        key::ORDINAL_V1 => make_inv_response::<PluralRuleStringsV1>(),
-        _ => None,
+        key::CARDINAL_V1 => receiver.receive_invariant::<PluralRuleStringsV1>(),
+        key::ORDINAL_V1 => receiver.receive_invariant::<PluralRuleStringsV1>(),
+        _ => Err(DataError::UnsupportedDataKey(*data_key)),
     }
 }
 
+/// Gets a boxed DataReceiver capable of receiving a data key in this module's category.
 pub fn get_receiver<'d>(data_key: &DataKey) -> Option<Box<dyn DataReceiver<'d, 'static> + 'd>> {
     match *data_key {
         key::CARDINAL_V1 => Some(DataReceiverForType::<PluralRuleStringsV1>::new_boxed()),

--- a/components/provider/src/structs/plurals.rs
+++ b/components/provider/src/structs/plurals.rs
@@ -4,8 +4,6 @@
 // Plural types
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-
-#[cfg(feature = "invariant")]
 use crate::prelude::*;
 
 pub mod key {
@@ -21,6 +19,14 @@ pub(crate) fn get_invariant(data_key: &DataKey) -> Option<DataResponse<'static>>
     match *data_key {
         key::CARDINAL_V1 => make_inv_response::<PluralRuleStringsV1>(),
         key::ORDINAL_V1 => make_inv_response::<PluralRuleStringsV1>(),
+        _ => None,
+    }
+}
+
+pub fn get_receiver<'d>(data_key: &DataKey) -> Option<Box<dyn DataReceiver<'d, 'static> + 'd>> {
+    match *data_key {
+        key::CARDINAL_V1 => Some(DataReceiverForType::<PluralRuleStringsV1>::new_boxed()),
+        key::ORDINAL_V1 => Some(DataReceiverForType::<PluralRuleStringsV1>::new_boxed()),
         _ => None,
     }
 }

--- a/components/provider/tests/json_warehouse.rs
+++ b/components/provider/tests/json_warehouse.rs
@@ -11,7 +11,6 @@ use std::str::FromStr;
 use icu_provider::prelude::*;
 use icu_provider::structs;
 use icu_provider::v2;
-use icu_provider::v2::DataProviderV2;
 
 // This file tests DataProvider borrow semantics with a dummy data provider based on a JSON string.
 
@@ -79,10 +78,12 @@ impl<'d> DataProviderV2<'d> for JsonDataProvider<'d> {
     fn load_v2(
         &self,
         _request: &DataRequest,
-        receiver: &mut dyn v2::DataReceiver<'d, 'static>,
-    ) -> Result<(), DataError> {
+        receiver: &mut dyn DataReceiver<'d, 'static>,
+    ) -> Result<DataResponseV2, DataError> {
         receiver.set_to_any(&self.borrowed_data.decimal.symbols_v1_a)?;
-        Ok(())
+        Ok(DataResponseV2 {
+            data_langid: LanguageIdentifier::default(),
+        })
     }
 }
 
@@ -101,8 +102,8 @@ fn get_warehouse() -> JsonDataWarehouse {
     JsonDataWarehouse::from_str(DATA).unwrap()
 }
 
-fn get_receiver<'d>() -> v2::DataReceiverImpl<'d, structs::decimal::SymbolsV1> {
-    v2::DataReceiverImpl { payload: None }
+fn get_receiver<'d>() -> DataReceiverImpl<'d, structs::decimal::SymbolsV1> {
+    DataReceiverImpl { payload: None }
 }
 
 fn get_request() -> DataRequest {

--- a/components/provider/tests/json_warehouse.rs
+++ b/components/provider/tests/json_warehouse.rs
@@ -62,13 +62,13 @@ impl<'d> From<&'d JsonDataWarehouse> for JsonDataProvider<'d> {
 
 impl<'d> DataProviderV2<'d> for JsonDataProvider<'d> {
     /// Loads JSON data. Returns borrowed data.
-    fn load_v2(
+    fn load_to_receiver(
         &self,
         _request: &DataRequest,
         receiver: &mut dyn DataReceiver<'d, 'static>,
-    ) -> Result<DataResponseV2, DataError> {
+    ) -> Result<DataResponse, DataError> {
         receiver.receive_borrow(&self.borrowed_data.decimal.symbols_v1_a)?;
-        Ok(DataResponseV2 {
+        Ok(DataResponse {
             data_langid: LanguageIdentifier::default(),
         })
     }
@@ -120,7 +120,7 @@ fn test_data_receiver() {
     let mut receiver = get_receiver();
     warehouse
         .provider()
-        .load_v2(&get_request(), &mut receiver)
+        .load_to_receiver(&get_request(), &mut receiver)
         .unwrap();
     let decimal_data: &SymbolsV1 = &receiver.payload.unwrap();
     check_data(decimal_data);
@@ -130,5 +130,5 @@ fn test_data_receiver() {
 // fn test_receiver_dyn_impl<'d>() {
 //     let warehouse = get_warehouse();
 //     let provider: &dyn DataProviderV2<'d> = &warehouse.provider();
-//     let response = provider.load_v2a::<SymbolsV1>(&get_request()).unwrap();
+//     let response = provider.load_payload::<SymbolsV1>(&get_request()).unwrap();
 // }

--- a/components/provider/tests/json_warehouse.rs
+++ b/components/provider/tests/json_warehouse.rs
@@ -80,7 +80,7 @@ impl<'d> DataProviderV2<'d> for JsonDataProvider<'d> {
         _request: &DataRequest,
         receiver: &mut dyn DataReceiver<'d, 'static>,
     ) -> Result<DataResponseV2, DataError> {
-        receiver.set_to_any(&self.borrowed_data.decimal.symbols_v1_a)?;
+        receiver.receive_borrow(&self.borrowed_data.decimal.symbols_v1_a)?;
         Ok(DataResponseV2 {
             data_langid: LanguageIdentifier::default(),
         })

--- a/components/provider/tests/json_warehouse.rs
+++ b/components/provider/tests/json_warehouse.rs
@@ -4,7 +4,6 @@
 use icu_locid::LanguageIdentifier;
 use icu_locid_macros::langid;
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
 use std::prelude::v1::*;
 use std::str::FromStr;
 
@@ -61,17 +60,6 @@ impl<'d> From<&'d JsonDataWarehouse> for JsonDataProvider<'d> {
     }
 }
 
-impl<'d> DataProvider<'d> for JsonDataProvider<'d> {
-    /// Loads JSON data. Returns borrowed data.
-    fn load(&self, _request: &DataRequest) -> Result<DataResponse<'d>, DataError> {
-        let response = DataResponseBuilder {
-            data_langid: LanguageIdentifier::default(),
-        }
-        .with_borrowed_payload(&self.borrowed_data.decimal.symbols_v1_a);
-        Ok(response)
-    }
-}
-
 impl<'d> DataProviderV2<'d> for JsonDataProvider<'d> {
     /// Loads JSON data. Returns borrowed data.
     fn load_v2(
@@ -115,10 +103,6 @@ fn get_request() -> DataRequest {
     }
 }
 
-fn get_response(warehouse: &JsonDataWarehouse) -> DataResponse {
-    warehouse.provider().load(&get_request()).unwrap()
-}
-
 fn check_data(decimal_data: &SymbolsV1) {
     assert_eq!(
         decimal_data,
@@ -128,41 +112,6 @@ fn check_data(decimal_data: &SymbolsV1) {
             grouping_separator: ",".into(),
         }
     );
-}
-
-#[test]
-fn test_read_string() {
-    let warehouse = get_warehouse();
-    let response = get_response(&warehouse);
-    let decimal_data: &SymbolsV1 = response.borrow_payload().unwrap();
-    check_data(decimal_data);
-}
-
-#[test]
-fn test_borrow_payload_mut() {
-    let warehouse = get_warehouse();
-    let mut response = get_response(&warehouse);
-    let decimal_data: &mut SymbolsV1 = response.borrow_payload_mut().unwrap();
-    check_data(decimal_data);
-}
-
-#[test]
-fn test_take_payload() {
-    let warehouse = get_warehouse();
-    let response = get_response(&warehouse);
-    let decimal_data: Cow<SymbolsV1> = response.take_payload().unwrap();
-    check_data(&decimal_data);
-}
-
-#[test]
-fn test_clone_payload() {
-    let final_data = {
-        let warehouse = get_warehouse();
-        let response = get_response(&warehouse);
-        let decimal_data: Cow<SymbolsV1> = response.take_payload().unwrap();
-        decimal_data.into_owned()
-    };
-    check_data(&final_data);
 }
 
 #[test]

--- a/components/provider/tests/json_warehouse.rs
+++ b/components/provider/tests/json_warehouse.rs
@@ -199,6 +199,7 @@ fn test_data_receiver_borrow_mut() {
         .load_v2(&get_request(), &mut receiver)
         .unwrap();
     let mut decoder_mut = v2::DataReceiverDecoderMut(&mut receiver);
-    let decimal_data: &mut structs::decimal::SymbolsV1 = decoder_mut.borrow_payload_mut().unwrap().unwrap();
+    let decimal_data: &mut structs::decimal::SymbolsV1 =
+        decoder_mut.borrow_payload_mut().unwrap().unwrap();
     check_data(decimal_data);
 }

--- a/components/provider/tests/json_warehouse.rs
+++ b/components/provider/tests/json_warehouse.rs
@@ -60,7 +60,7 @@ impl<'d> From<&'d JsonDataWarehouse> for JsonDataProvider<'d> {
     }
 }
 
-impl<'d> DataProviderV2<'d> for JsonDataProvider<'d> {
+impl<'d> DataProvider<'d> for JsonDataProvider<'d> {
     /// Loads JSON data. Returns borrowed data.
     fn load_to_receiver(
         &self,
@@ -129,6 +129,6 @@ fn test_data_receiver() {
 // #[test]
 // fn test_receiver_dyn_impl<'d>() {
 //     let warehouse = get_warehouse();
-//     let provider: &dyn DataProviderV2<'d> = &warehouse.provider();
+//     let provider: &dyn DataProvider<'d> = &warehouse.provider();
 //     let response = provider.load_payload::<SymbolsV1>(&get_request()).unwrap();
 // }

--- a/components/provider/tests/json_warehouse.rs
+++ b/components/provider/tests/json_warehouse.rs
@@ -10,7 +10,6 @@ use std::str::FromStr;
 
 use icu_provider::prelude::*;
 use icu_provider::structs;
-use icu_provider::v2;
 
 // This file tests DataProvider borrow semantics with a dummy data provider based on a JSON string.
 
@@ -175,31 +174,5 @@ fn test_data_receiver() {
         .load_v2(&get_request(), &mut receiver)
         .unwrap();
     let decimal_data: &structs::decimal::SymbolsV1 = &receiver.payload.unwrap();
-    check_data(decimal_data);
-}
-
-#[test]
-fn test_data_receiver_borrow() {
-    let warehouse = get_warehouse();
-    let mut receiver = get_receiver();
-    warehouse
-        .provider()
-        .load_v2(&get_request(), &mut receiver)
-        .unwrap();
-    let decimal_data: &structs::decimal::SymbolsV1 =
-        v2::borrow_payload(&receiver).unwrap().unwrap();
-    check_data(decimal_data);
-}
-
-#[test]
-fn test_data_receiver_borrow_mut() {
-    let warehouse = get_warehouse();
-    let mut receiver = get_receiver();
-    warehouse
-        .provider()
-        .load_v2(&get_request(), &mut receiver)
-        .unwrap();
-    let decimal_data: &mut structs::decimal::SymbolsV1 =
-        v2::borrow_payload_mut(&mut receiver).unwrap().unwrap();
     check_data(decimal_data);
 }

--- a/components/provider/tests/json_warehouse.rs
+++ b/components/provider/tests/json_warehouse.rs
@@ -185,8 +185,8 @@ fn test_data_receiver_borrow() {
         .provider()
         .load_v2(&get_request(), &mut receiver)
         .unwrap();
-    let decoder = v2::DataReceiverDecoder(&receiver);
-    let decimal_data: &structs::decimal::SymbolsV1 = decoder.borrow_payload().unwrap().unwrap();
+    let decimal_data: &structs::decimal::SymbolsV1 =
+        v2::borrow_payload(&receiver).unwrap().unwrap();
     check_data(decimal_data);
 }
 
@@ -198,8 +198,7 @@ fn test_data_receiver_borrow_mut() {
         .provider()
         .load_v2(&get_request(), &mut receiver)
         .unwrap();
-    let mut decoder_mut = v2::DataReceiverDecoderMut(&mut receiver);
     let decimal_data: &mut structs::decimal::SymbolsV1 =
-        decoder_mut.borrow_payload_mut().unwrap().unwrap();
+        v2::borrow_payload_mut(&mut receiver).unwrap().unwrap();
     check_data(decimal_data);
 }

--- a/components/provider/tests/json_warehouse.rs
+++ b/components/provider/tests/json_warehouse.rs
@@ -12,7 +12,6 @@ use icu_provider::prelude::*;
 use icu_provider::structs;
 use icu_provider::v2;
 use icu_provider::v2::DataProviderV2;
-use icu_provider::v2::DataReceiverPart;
 
 // This file tests DataProvider borrow semantics with a dummy data provider based on a JSON string.
 
@@ -186,7 +185,8 @@ fn test_data_receiver_borrow() {
         .provider()
         .load_v2(&get_request(), &mut receiver)
         .unwrap();
-    let decimal_data: &structs::decimal::SymbolsV1 = receiver.borrow_payload().unwrap().unwrap();
+    let decoder = v2::DataReceiverDecoder(&receiver);
+    let decimal_data: &structs::decimal::SymbolsV1 = decoder.borrow_payload().unwrap().unwrap();
     check_data(decimal_data);
 }
 
@@ -198,7 +198,7 @@ fn test_data_receiver_borrow_mut() {
         .provider()
         .load_v2(&get_request(), &mut receiver)
         .unwrap();
-    let decimal_data: &mut structs::decimal::SymbolsV1 =
-        receiver.borrow_payload_mut().unwrap().unwrap();
+    let mut decoder_mut = v2::DataReceiverDecoderMut(&mut receiver);
+    let decimal_data: &mut structs::decimal::SymbolsV1 = decoder_mut.borrow_payload_mut().unwrap().unwrap();
     check_data(decimal_data);
 }

--- a/components/provider/tests/ownership.rs
+++ b/components/provider/tests/ownership.rs
@@ -1,6 +1,5 @@
 use icu_provider::prelude::*;
 use icu_provider::structs::decimal::SymbolsV1;
-use icu_provider::v2;
 use std::borrow::Cow;
 use std::default::Default;
 
@@ -11,23 +10,23 @@ const DATA: &'static str = r#"{
     "grouping_separator": ","
 }"#;
 
-fn check_zero_digit<'d, 'de>(receiver: &dyn DataReceiver<'d, 'de>, expected: char) {
-    let data: &SymbolsV1 = v2::borrow_payload(receiver)
-        .expect("Data should be present")
-        .expect("Type should be correct");
+fn check_zero_digit<'d>(data: &Option<Cow<'d, SymbolsV1>>, expected: char) {
+    use std::borrow::Borrow;
+    let data: &SymbolsV1 = data.as_ref().expect("Data should be present").borrow();
     assert_eq!(data.zero_digit, expected);
 }
 
+#[cfg(feature = "invariant")]
 #[test]
 fn test_basic() {
     let mut receiver: DataReceiverImpl<'_, SymbolsV1> = DataReceiverImpl {
         payload: Some(Cow::Owned(SymbolsV1::default())),
     };
-    check_zero_digit(&receiver, '0');
+    check_zero_digit(&receiver.payload, '0');
 
     let json = &mut serde_json::Deserializer::from_str(DATA);
     receiver
         .receive_deserializer(&mut erased_serde::Deserializer::erase(json))
         .expect("Data should be well-formed");
-    check_zero_digit(&receiver, 'a');
+    check_zero_digit(&receiver.payload, 'a');
 }

--- a/components/provider/tests/ownership.rs
+++ b/components/provider/tests/ownership.rs
@@ -1,0 +1,44 @@
+use icu_provider::structs::decimal::SymbolsV1;
+use icu_provider::v2::*;
+use icu_provider::DataError;
+use std::any::Any;
+use std::any::TypeId;
+use std::borrow::Cow;
+use std::default::Default;
+
+#[allow(clippy::redundant_static_lifetimes)]
+const DATA: &'static str = r#"{
+    "zero_digit": "a",
+    "decimal_separator": ".",
+    "grouping_separator": ","
+}"#;
+
+fn borrow_payload<'a, T: Any>(receiver: &'a dyn DataReceiver) -> Option<Result<&'a T, DataError>> {
+    receiver.borrow_payload_as_any().map(|any| {
+        any.downcast_ref().ok_or_else(|| DataError::MismatchedType {
+            actual: any.type_id(),
+            generic: Some(TypeId::of::<T>()),
+        })
+    })
+}
+
+fn check_zero_digit<'d, 'de>(receiver: &dyn DataReceiver<'d, 'de>, expected: char) {
+    let data: &SymbolsV1 = borrow_payload(receiver)
+        .expect("Data should be present")
+        .expect("Type should be correct");
+    assert_eq!(data.zero_digit, expected);
+}
+
+#[test]
+fn test_basic() {
+    let mut receiver: DataReceiverImpl<'_, SymbolsV1> = DataReceiverImpl {
+        payload: Some(Cow::Owned(SymbolsV1::default())),
+    };
+    check_zero_digit(&receiver, '0');
+
+    let json = &mut serde_json::Deserializer::from_str(DATA);
+    receiver
+        .set_to(&mut erased_serde::Deserializer::erase(json))
+        .expect("Data should be well-formed");
+    check_zero_digit(&receiver, 'a');
+}

--- a/components/provider/tests/ownership.rs
+++ b/components/provider/tests/ownership.rs
@@ -29,3 +29,17 @@ fn test_basic() {
         .expect("Data should be well-formed");
     check_zero_digit(&receiver, 'a');
 }
+
+#[cfg(feature = "invariant")]
+#[test]
+fn test_receive_option() {
+    let mut option = Some(SymbolsV1::default());
+    let mut receiver = DataReceiverForType::<SymbolsV1>::new();
+    assert!(option.is_some());
+    assert!(receiver.payload.is_none());
+
+    receiver.receive_option(&mut option).expect("Types should match");
+    assert!(option.is_none());
+    assert!(receiver.payload.is_some());
+    check_zero_digit(&receiver, '0');
+}

--- a/components/provider/tests/ownership.rs
+++ b/components/provider/tests/ownership.rs
@@ -1,5 +1,6 @@
+use icu_provider::prelude::*;
 use icu_provider::structs::decimal::SymbolsV1;
-use icu_provider::v2::*;
+use icu_provider::v2;
 use std::borrow::Cow;
 use std::default::Default;
 
@@ -11,7 +12,7 @@ const DATA: &'static str = r#"{
 }"#;
 
 fn check_zero_digit<'d, 'de>(receiver: &dyn DataReceiver<'d, 'de>, expected: char) {
-    let data: &SymbolsV1 = borrow_payload(receiver)
+    let data: &SymbolsV1 = v2::borrow_payload(receiver)
         .expect("Data should be present")
         .expect("Type should be correct");
     assert_eq!(data.zero_digit, expected);

--- a/components/provider/tests/ownership.rs
+++ b/components/provider/tests/ownership.rs
@@ -1,5 +1,6 @@
 use icu_provider::structs::decimal::SymbolsV1;
 use icu_provider::v2::*;
+use std::borrow::Borrow;
 use std::borrow::Cow;
 use std::default::Default;
 
@@ -12,10 +13,16 @@ const DATA: &'static str = r#"{
 
 fn check_zero_digit<'d, 'de>(receiver: &dyn DataReceiver<'d, 'de>, expected: char) {
     let decoder = DataReceiverDecoder(receiver);
-    let data: &SymbolsV1 = decoder.borrow_payload()
+    let data: &SymbolsV1 = decoder
+        .borrow_payload()
         .expect("Data should be present")
         .expect("Type should be correct");
     assert_eq!(data.zero_digit, expected);
+
+    let decoder2 =
+        DataReceiverDecoder2::try_new(receiver).expect("Data should be present and correct");
+    let data2: &SymbolsV1 = decoder2.borrow();
+    assert_eq!(data2.zero_digit, expected);
 }
 
 #[test]

--- a/components/provider/tests/ownership.rs
+++ b/components/provider/tests/ownership.rs
@@ -10,23 +10,22 @@ const DATA: &'static str = r#"{
     "grouping_separator": ","
 }"#;
 
-fn check_zero_digit<'d>(data: &Option<Cow<'d, SymbolsV1>>, expected: char) {
-    use std::borrow::Borrow;
-    let data: &SymbolsV1 = data.as_ref().expect("Data should be present").borrow();
+fn check_zero_digit<'d>(receiver: &DataReceiverForType<'d, SymbolsV1>, expected: char) {
+    let data: &SymbolsV1 = receiver.borrow_payload().expect("Data should be present");
     assert_eq!(data.zero_digit, expected);
 }
 
 #[cfg(feature = "invariant")]
 #[test]
 fn test_basic() {
-    let mut receiver: DataReceiverImpl<'_, SymbolsV1> = DataReceiverImpl {
+    let mut receiver: DataReceiverForType<'_, SymbolsV1> = DataReceiverForType {
         payload: Some(Cow::Owned(SymbolsV1::default())),
     };
-    check_zero_digit(&receiver.payload, '0');
+    check_zero_digit(&receiver, '0');
 
     let json = &mut serde_json::Deserializer::from_str(DATA);
     receiver
         .receive_deserializer(&mut erased_serde::Deserializer::erase(json))
         .expect("Data should be well-formed");
-    check_zero_digit(&receiver.payload, 'a');
+    check_zero_digit(&receiver, 'a');
 }

--- a/components/provider/tests/ownership.rs
+++ b/components/provider/tests/ownership.rs
@@ -1,6 +1,5 @@
 use icu_provider::structs::decimal::SymbolsV1;
 use icu_provider::v2::*;
-use std::borrow::Borrow;
 use std::borrow::Cow;
 use std::default::Default;
 
@@ -12,17 +11,10 @@ const DATA: &'static str = r#"{
 }"#;
 
 fn check_zero_digit<'d, 'de>(receiver: &dyn DataReceiver<'d, 'de>, expected: char) {
-    let decoder = DataReceiverDecoder(receiver);
-    let data: &SymbolsV1 = decoder
-        .borrow_payload()
+    let data: &SymbolsV1 = borrow_payload(receiver)
         .expect("Data should be present")
         .expect("Type should be correct");
     assert_eq!(data.zero_digit, expected);
-
-    let decoder2 =
-        DataReceiverDecoder2::try_new(receiver).expect("Data should be present and correct");
-    let data2: &SymbolsV1 = decoder2.borrow();
-    assert_eq!(data2.zero_digit, expected);
 }
 
 #[test]

--- a/components/provider/tests/ownership.rs
+++ b/components/provider/tests/ownership.rs
@@ -38,7 +38,9 @@ fn test_receive_option() {
     assert!(option.is_some());
     assert!(receiver.payload.is_none());
 
-    receiver.receive_option(&mut option).expect("Types should match");
+    receiver
+        .receive_option(&mut option)
+        .expect("Types should match");
     assert!(option.is_none());
     assert!(receiver.payload.is_some());
     check_zero_digit(&receiver, '0');

--- a/components/provider/tests/ownership.rs
+++ b/components/provider/tests/ownership.rs
@@ -1,8 +1,5 @@
 use icu_provider::structs::decimal::SymbolsV1;
 use icu_provider::v2::*;
-use icu_provider::DataError;
-use std::any::Any;
-use std::any::TypeId;
 use std::borrow::Cow;
 use std::default::Default;
 
@@ -13,17 +10,9 @@ const DATA: &'static str = r#"{
     "grouping_separator": ","
 }"#;
 
-fn borrow_payload<'a, T: Any>(receiver: &'a dyn DataReceiver) -> Option<Result<&'a T, DataError>> {
-    receiver.borrow_payload_as_any().map(|any| {
-        any.downcast_ref().ok_or_else(|| DataError::MismatchedType {
-            actual: any.type_id(),
-            generic: Some(TypeId::of::<T>()),
-        })
-    })
-}
-
 fn check_zero_digit<'d, 'de>(receiver: &dyn DataReceiver<'d, 'de>, expected: char) {
-    let data: &SymbolsV1 = borrow_payload(receiver)
+    let decoder = DataReceiverDecoder(receiver);
+    let data: &SymbolsV1 = decoder.borrow_payload()
         .expect("Data should be present")
         .expect("Type should be correct");
     assert_eq!(data.zero_digit, expected);

--- a/components/provider/tests/ownership.rs
+++ b/components/provider/tests/ownership.rs
@@ -27,7 +27,7 @@ fn test_basic() {
 
     let json = &mut serde_json::Deserializer::from_str(DATA);
     receiver
-        .set_to(&mut erased_serde::Deserializer::erase(json))
+        .receive_deserializer(&mut erased_serde::Deserializer::erase(json))
         .expect("Data should be well-formed");
     check_zero_digit(&receiver, 'a');
 }

--- a/components/provider/tests/ownership.rs
+++ b/components/provider/tests/ownership.rs
@@ -1,3 +1,7 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
+
 use icu_provider::prelude::*;
 use icu_provider::structs::decimal::SymbolsV1;
 use std::borrow::Cow;

--- a/components/provider_cldr/src/download/cldr_paths_download.rs
+++ b/components/provider_cldr/src/download/cldr_paths_download.rs
@@ -13,6 +13,7 @@ use std::path::PathBuf;
 /// # Example
 ///
 /// ```
+/// use icu_provider::prelude::*;
 /// use icu_provider_cldr::download::CldrPathsDownload;
 /// use icu_provider_cldr::CldrJsonDataProvider;
 /// use icu_locid_macros::langid;
@@ -28,8 +29,9 @@ use std::path::PathBuf;
 ///     use icu_provider::prelude::*;
 ///     use icu_provider::structs;
 ///
-///     let data: Cow<structs::plurals::PluralRuleStringsV1> = data_provider
-///         .load(&DataRequest {
+///     let data: Cow<structs::plurals::PluralRuleStringsV1> =
+///         (data_provider as &dyn DataProvider)
+///         .load_payload(&DataRequest {
 ///             data_entry: DataEntry {
 ///                 langid: langid!("uk"),
 ///                 variant: None,
@@ -37,7 +39,7 @@ use std::path::PathBuf;
 ///             data_key: structs::plurals::key::ORDINAL_V1,
 ///         })
 ///         .unwrap()
-///         .take_payload()
+///         .payload
 ///         .unwrap();
 ///     assert_eq!(data.few, Some(Cow::Borrowed("n % 10 = 3 and n % 100 != 13")));
 /// }

--- a/components/provider_cldr/src/support.rs
+++ b/components/provider_cldr/src/support.rs
@@ -41,12 +41,12 @@ where
         req: &DataRequest,
         receiver: &mut dyn DataReceiver<'d, 'static>,
         cldr_paths: &'b dyn CldrPaths,
-    ) -> Result<Option<DataResponseV2>, DataError> {
+    ) -> Result<Option<DataResponse>, DataError> {
         if T::supports_key(&req.data_key).is_err() {
             return Ok(None);
         }
         if let Some(data_provider) = self.src.read().map_err(map_poison)?.as_ref() {
-            return data_provider.load_v2(req, receiver).map(Some);
+            return data_provider.load_to_receiver(req, receiver).map(Some);
         }
         let mut src = self.src.write().map_err(map_poison)?;
         if src.is_none() {
@@ -55,7 +55,7 @@ where
         let data_provider = src
             .as_ref()
             .expect("The RwLock must be populated at this point.");
-        data_provider.load_v2(req, receiver).map(Some)
+        data_provider.load_to_receiver(req, receiver).map(Some)
     }
 
     /// Call `T::iter_for_key`, initializing T if necessary.

--- a/components/provider_cldr/src/support.rs
+++ b/components/provider_cldr/src/support.rs
@@ -32,7 +32,7 @@ fn map_poison<E>(_err: E) -> DataError {
 /// A lazy-initialized CLDR JSON data provider.
 impl<'b, 'd, T> LazyCldrProvider<T>
 where
-    T: DataProviderV2<'d> + DataKeySupport + DataEntryCollection + TryFrom<&'b dyn CldrPaths>,
+    T: DataProvider<'d> + DataKeySupport + DataEntryCollection + TryFrom<&'b dyn CldrPaths>,
     <T as TryFrom<&'b dyn CldrPaths>>::Error: 'static + std::error::Error,
 {
     /// Call `T::load`, initializing T if necessary.

--- a/components/provider_cldr/src/transform/dates.rs
+++ b/components/provider_cldr/src/transform/dates.rs
@@ -93,17 +93,17 @@ impl<'d> DatesProvider<'d> {
 }
 
 impl<'d> DataProviderV2<'d> for DatesProvider<'d> {
-    fn load_v2(
+    fn load_to_receiver(
         &self,
         req: &DataRequest,
         receiver: &mut dyn DataReceiver<'d, 'static>,
-    ) -> Result<DataResponseV2, DataError> {
+    ) -> Result<DataResponse, DataError> {
         let cldr_langid = req.data_entry.langid.clone().into();
 
         let dates = self.get_dates_for(&req.data_key, &cldr_langid)?;
         let mut option = Some(gregory::DatesV1::from(dates));
         receiver.receive_option(&mut option)?;
-        Ok(DataResponseV2 {
+        Ok(DataResponse {
             data_langid: req.data_entry.langid.clone(),
         })
     }
@@ -440,7 +440,7 @@ fn test_basic() {
     let provider = DatesProvider::try_from(json_str.as_str()).unwrap();
 
     let cs_dates: Cow<gregory::DatesV1> = (&provider as &dyn DataProviderV2)
-        .load_v2a(&DataRequest {
+        .load_payload(&DataRequest {
             data_key: key::GREGORY_V1,
             data_entry: DataEntry {
                 variant: None,
@@ -470,7 +470,7 @@ fn test_with_numbering_system() {
     let provider = DatesProvider::try_from(json_str.as_str()).unwrap();
 
     let cs_dates: Cow<gregory::DatesV1> = (&provider as &dyn DataProviderV2)
-        .load_v2a(&DataRequest {
+        .load_payload(&DataRequest {
             data_key: key::GREGORY_V1,
             data_entry: DataEntry {
                 variant: None,
@@ -495,7 +495,7 @@ fn unalias_contexts() {
     let provider = DatesProvider::try_from(json_str.as_str()).unwrap();
 
     let cs_dates: Cow<gregory::DatesV1> = (&provider as &dyn DataProviderV2)
-        .load_v2a(&DataRequest {
+        .load_payload(&DataRequest {
             data_key: key::GREGORY_V1,
             data_entry: DataEntry {
                 variant: None,

--- a/components/provider_cldr/src/transform/dates.rs
+++ b/components/provider_cldr/src/transform/dates.rs
@@ -92,7 +92,7 @@ impl<'d> DatesProvider<'d> {
     }
 }
 
-impl<'d> DataProviderV2<'d> for DatesProvider<'d> {
+impl<'d> DataProvider<'d> for DatesProvider<'d> {
     fn load_to_receiver(
         &self,
         req: &DataRequest,
@@ -439,7 +439,7 @@ fn test_basic() {
     let json_str = std::fs::read_to_string("tests/testdata/cs-ca-gregorian.json").unwrap();
     let provider = DatesProvider::try_from(json_str.as_str()).unwrap();
 
-    let cs_dates: Cow<gregory::DatesV1> = (&provider as &dyn DataProviderV2)
+    let cs_dates: Cow<gregory::DatesV1> = (&provider as &dyn DataProvider)
         .load_payload(&DataRequest {
             data_key: key::GREGORY_V1,
             data_entry: DataEntry {
@@ -469,7 +469,7 @@ fn test_with_numbering_system() {
     let json_str = std::fs::read_to_string("tests/testdata/haw-ca-gregorian.json").unwrap();
     let provider = DatesProvider::try_from(json_str.as_str()).unwrap();
 
-    let cs_dates: Cow<gregory::DatesV1> = (&provider as &dyn DataProviderV2)
+    let cs_dates: Cow<gregory::DatesV1> = (&provider as &dyn DataProvider)
         .load_payload(&DataRequest {
             data_key: key::GREGORY_V1,
             data_entry: DataEntry {
@@ -494,7 +494,7 @@ fn unalias_contexts() {
     let json_str = std::fs::read_to_string("tests/testdata/cs-ca-gregorian.json").unwrap();
     let provider = DatesProvider::try_from(json_str.as_str()).unwrap();
 
-    let cs_dates: Cow<gregory::DatesV1> = (&provider as &dyn DataProviderV2)
+    let cs_dates: Cow<gregory::DatesV1> = (&provider as &dyn DataProvider)
         .load_payload(&DataRequest {
             data_key: key::GREGORY_V1,
             data_entry: DataEntry {

--- a/components/provider_cldr/src/transform/dates.rs
+++ b/components/provider_cldr/src/transform/dates.rs
@@ -92,15 +92,20 @@ impl<'d> DatesProvider<'d> {
     }
 }
 
-impl<'d> DataProvider<'d> for DatesProvider<'d> {
-    fn load(&self, req: &DataRequest) -> Result<DataResponse<'d>, DataError> {
+impl<'d> DataProviderV2<'d> for DatesProvider<'d> {
+    fn load_v2(
+        &self,
+        req: &DataRequest,
+        receiver: &mut dyn DataReceiver<'d, 'static>,
+    ) -> Result<DataResponseV2, DataError> {
         let cldr_langid = req.data_entry.langid.clone().into();
 
         let dates = self.get_dates_for(&req.data_key, &cldr_langid)?;
-        Ok(DataResponseBuilder {
+        let mut option = Some(gregory::DatesV1::from(dates));
+        receiver.receive_option(&mut option)?;
+        Ok(DataResponseV2 {
             data_langid: req.data_entry.langid.clone(),
-        }
-        .with_owned_payload(gregory::DatesV1::from(dates)))
+        })
     }
 }
 
@@ -434,8 +439,8 @@ fn test_basic() {
     let json_str = std::fs::read_to_string("tests/testdata/cs-ca-gregorian.json").unwrap();
     let provider = DatesProvider::try_from(json_str.as_str()).unwrap();
 
-    let cs_dates: Cow<gregory::DatesV1> = provider
-        .load(&DataRequest {
+    let cs_dates: Cow<gregory::DatesV1> = (&provider as &dyn DataProviderV2)
+        .load_v2a(&DataRequest {
             data_key: key::GREGORY_V1,
             data_entry: DataEntry {
                 variant: None,
@@ -443,7 +448,7 @@ fn test_basic() {
             },
         })
         .unwrap()
-        .take_payload()
+        .payload
         .unwrap();
 
     assert_eq!("srpna", cs_dates.symbols.months.format.wide.0[7]);
@@ -464,8 +469,8 @@ fn test_with_numbering_system() {
     let json_str = std::fs::read_to_string("tests/testdata/haw-ca-gregorian.json").unwrap();
     let provider = DatesProvider::try_from(json_str.as_str()).unwrap();
 
-    let cs_dates: Cow<gregory::DatesV1> = provider
-        .load(&DataRequest {
+    let cs_dates: Cow<gregory::DatesV1> = (&provider as &dyn DataProviderV2)
+        .load_v2a(&DataRequest {
             data_key: key::GREGORY_V1,
             data_entry: DataEntry {
                 variant: None,
@@ -473,7 +478,7 @@ fn test_with_numbering_system() {
             },
         })
         .unwrap()
-        .take_payload()
+        .payload
         .unwrap();
 
     assert_eq!("d MMM y", cs_dates.patterns.date.medium);
@@ -489,8 +494,8 @@ fn unalias_contexts() {
     let json_str = std::fs::read_to_string("tests/testdata/cs-ca-gregorian.json").unwrap();
     let provider = DatesProvider::try_from(json_str.as_str()).unwrap();
 
-    let cs_dates: Cow<gregory::DatesV1> = provider
-        .load(&DataRequest {
+    let cs_dates: Cow<gregory::DatesV1> = (&provider as &dyn DataProviderV2)
+        .load_v2a(&DataRequest {
             data_key: key::GREGORY_V1,
             data_entry: DataEntry {
                 variant: None,
@@ -498,7 +503,7 @@ fn unalias_contexts() {
             },
         })
         .unwrap()
-        .take_payload()
+        .payload
         .unwrap();
 
     // Czech months are not unaliased because `wide` differs.

--- a/components/provider_cldr/src/transform/mod.rs
+++ b/components/provider_cldr/src/transform/mod.rs
@@ -37,7 +37,7 @@ impl<'a, 'd> CldrJsonDataProvider<'a, 'd> {
     }
 }
 
-impl<'a, 'd> DataProviderV2<'d> for CldrJsonDataProvider<'a, 'd> {
+impl<'a, 'd> DataProvider<'d> for CldrJsonDataProvider<'a, 'd> {
     fn load_to_receiver(
         &self,
         req: &DataRequest,

--- a/components/provider_cldr/src/transform/mod.rs
+++ b/components/provider_cldr/src/transform/mod.rs
@@ -37,12 +37,16 @@ impl<'a, 'd> CldrJsonDataProvider<'a, 'd> {
     }
 }
 
-impl<'a, 'd> DataProvider<'d> for CldrJsonDataProvider<'a, 'd> {
-    fn load(&self, req: &DataRequest) -> Result<DataResponse<'d>, DataError> {
-        if let Some(result) = self.plurals.try_load(req, self.cldr_paths)? {
+impl<'a, 'd> DataProviderV2<'d> for CldrJsonDataProvider<'a, 'd> {
+    fn load_v2(
+        &self,
+        req: &DataRequest,
+        receiver: &mut dyn DataReceiver<'d, 'static>,
+    ) -> Result<DataResponseV2, DataError> {
+        if let Some(result) = self.plurals.try_load(req, receiver, self.cldr_paths)? {
             return Ok(result);
         }
-        if let Some(result) = self.dates.try_load(req, self.cldr_paths)? {
+        if let Some(result) = self.dates.try_load(req, receiver, self.cldr_paths)? {
             return Ok(result);
         }
         Err(DataError::UnsupportedDataKey(req.data_key))

--- a/components/provider_cldr/src/transform/mod.rs
+++ b/components/provider_cldr/src/transform/mod.rs
@@ -38,11 +38,11 @@ impl<'a, 'd> CldrJsonDataProvider<'a, 'd> {
 }
 
 impl<'a, 'd> DataProviderV2<'d> for CldrJsonDataProvider<'a, 'd> {
-    fn load_v2(
+    fn load_to_receiver(
         &self,
         req: &DataRequest,
         receiver: &mut dyn DataReceiver<'d, 'static>,
-    ) -> Result<DataResponseV2, DataError> {
+    ) -> Result<DataResponse, DataError> {
         if let Some(result) = self.plurals.try_load(req, receiver, self.cldr_paths)? {
             return Ok(result);
         }

--- a/components/provider_cldr/src/transform/plurals.rs
+++ b/components/provider_cldr/src/transform/plurals.rs
@@ -94,7 +94,7 @@ impl<'d> PluralsProvider<'d> {
     }
 }
 
-impl<'d> DataProviderV2<'d> for PluralsProvider<'d> {
+impl<'d> DataProvider<'d> for PluralsProvider<'d> {
     fn load_to_receiver(
         &self,
         req: &DataRequest,
@@ -206,7 +206,7 @@ fn test_basic() {
     let provider = PluralsProvider::try_from(json_str.as_str()).unwrap();
 
     // Spot-check locale 'cs' since it has some interesting entries
-    let cs_rules: Cow<PluralRuleStringsV1> = (&provider as &dyn DataProviderV2)
+    let cs_rules: Cow<PluralRuleStringsV1> = (&provider as &dyn DataProvider)
         .load_payload(&DataRequest {
             data_key: key::CARDINAL_V1,
             data_entry: DataEntry {

--- a/components/provider_cldr/src/transform/plurals.rs
+++ b/components/provider_cldr/src/transform/plurals.rs
@@ -95,11 +95,11 @@ impl<'d> PluralsProvider<'d> {
 }
 
 impl<'d> DataProviderV2<'d> for PluralsProvider<'d> {
-    fn load_v2(
+    fn load_to_receiver(
         &self,
         req: &DataRequest,
         receiver: &mut dyn DataReceiver<'d, 'static>,
-    ) -> Result<DataResponseV2, DataError> {
+    ) -> Result<DataResponse, DataError> {
         let cldr_rules = self.get_rules_for(&req.data_key)?;
         // TODO: Implement language fallback?
         // TODO: Avoid the clone
@@ -110,7 +110,7 @@ impl<'d> DataProviderV2<'d> for PluralsProvider<'d> {
         };
         let mut option = Some(PluralRuleStringsV1::from(r));
         receiver.receive_option(&mut option)?;
-        Ok(DataResponseV2 {
+        Ok(DataResponse {
             data_langid: req.data_entry.langid.clone(),
         })
     }
@@ -207,7 +207,7 @@ fn test_basic() {
 
     // Spot-check locale 'cs' since it has some interesting entries
     let cs_rules: Cow<PluralRuleStringsV1> = (&provider as &dyn DataProviderV2)
-        .load_v2a(&DataRequest {
+        .load_payload(&DataRequest {
             data_key: key::CARDINAL_V1,
             data_entry: DataEntry {
                 variant: None,

--- a/components/provider_fs/Cargo.toml
+++ b/components/provider_fs/Cargo.toml
@@ -35,6 +35,7 @@ extra_features = [
 icu_provider = { version = "0.1", path = "../provider" }
 icu_locid = { version = "0.1", path = "../locid", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
+erased-serde = { version = "0.3" }
 
 # Serializers
 # Note: serde_json is always included because it is used for parsing manifest.json
@@ -42,7 +43,6 @@ serde_json = { version = "1.0" }
 bincode = { version = "1.3", optional = true }
 
 # Dependencies for the export module
-erased-serde = { version = "0.3", optional = true }
 log = { version = "0.4", optional = true }
 static_assertions = { version = "1.1", optional = true }
 
@@ -55,7 +55,7 @@ simple_logger = { version = "1.11", optional = true }
 icu_locid_macros = { version = "0.1", path = "../locid/macros" }
 
 [features]
-export = ["erased-serde", "icu_provider/invariant", "static_assertions", "log"]
+export = ["icu_provider/invariant", "static_assertions", "log"]
 export-bin = ["export", "clap", "icu_provider_cldr", "simple_logger"]
 serialize_none = ["icu_provider/serialize_none"]
 

--- a/components/provider_fs/src/deserializer.rs
+++ b/components/provider_fs/src/deserializer.rs
@@ -2,8 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::manifest::SyntaxOption;
-use icu_provider::DataError;
 use icu_provider::v2::DataReceiver;
+use icu_provider::DataError;
 use std::io;
 use std::path::Path;
 
@@ -70,7 +70,11 @@ where
     }
 }
 
-pub fn deserialize_into_receiver<R>(rdr: R, syntax_option: &SyntaxOption, receiver: &mut dyn DataReceiver) -> Result<(), Error>
+pub fn deserialize_into_receiver<R>(
+    rdr: R,
+    syntax_option: &SyntaxOption,
+    receiver: &mut dyn DataReceiver,
+) -> Result<(), Error>
 where
     R: io::Read,
 {
@@ -79,7 +83,7 @@ where
             let mut d = serde_json::Deserializer::from_reader(rdr);
             receiver.set_to(&mut erased_serde::Deserializer::erase(&mut d))?;
             Ok(())
-        },
+        }
         #[cfg(feature = "bincode")]
         SyntaxOption::Bincode => {
             use bincode::Options;
@@ -89,7 +93,7 @@ where
             let mut d = bincode::de::Deserializer::with_reader(rdr, options);
             receiver.set_to(&mut erased_serde::Deserializer::erase(&mut d))?;
             Ok(())
-        },
+        }
         #[cfg(not(feature = "bincode"))]
         SyntaxOption::Bincode => Err(Error::UnknownSyntax(syntax_option.clone())),
     }

--- a/components/provider_fs/src/deserializer.rs
+++ b/components/provider_fs/src/deserializer.rs
@@ -2,8 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::manifest::SyntaxOption;
-use icu_provider::v2::DataReceiver;
-use icu_provider::DataError;
+use icu_provider::prelude::*;
 use std::io;
 use std::path::Path;
 

--- a/components/provider_fs/src/deserializer.rs
+++ b/components/provider_fs/src/deserializer.rs
@@ -56,20 +56,6 @@ impl Error {
     }
 }
 
-pub fn deserialize_from_reader<R, T>(rdr: R, syntax_option: &SyntaxOption) -> Result<T, Error>
-where
-    R: io::Read,
-    T: serde::de::DeserializeOwned,
-{
-    match syntax_option {
-        SyntaxOption::Json => serde_json::from_reader(rdr).map_err(|e| e.into()),
-        #[cfg(feature = "bincode")]
-        SyntaxOption::Bincode => bincode::deserialize_from(rdr).map_err(|e| e.into()),
-        #[cfg(not(feature = "bincode"))]
-        SyntaxOption::Bincode => Err(Error::UnknownSyntax(syntax_option.clone())),
-    }
-}
-
 pub fn deserialize_into_receiver<R>(
     rdr: R,
     syntax_option: &SyntaxOption,

--- a/components/provider_fs/src/deserializer.rs
+++ b/components/provider_fs/src/deserializer.rs
@@ -81,7 +81,7 @@ where
     match syntax_option {
         SyntaxOption::Json => {
             let mut d = serde_json::Deserializer::from_reader(rdr);
-            receiver.set_to(&mut erased_serde::Deserializer::erase(&mut d))?;
+            receiver.receive_deserializer(&mut erased_serde::Deserializer::erase(&mut d))?;
             Ok(())
         }
         #[cfg(feature = "bincode")]
@@ -91,7 +91,7 @@ where
                 .with_fixint_encoding()
                 .allow_trailing_bytes();
             let mut d = bincode::de::Deserializer::with_reader(rdr, options);
-            receiver.set_to(&mut erased_serde::Deserializer::erase(&mut d))?;
+            receiver.receive_deserializer(&mut erased_serde::Deserializer::erase(&mut d))?;
             Ok(())
         }
         #[cfg(not(feature = "bincode"))]

--- a/components/provider_fs/src/export/mod.rs
+++ b/components/provider_fs/src/export/mod.rs
@@ -48,13 +48,16 @@
 //!         langid: Default::default(),
 //!     }
 //! };
-//! let inv_response = inv_provider.load(&req).unwrap();
-//! let fs_response = fs_provider.load(&req)
+//! let inv_response = (&inv_provider as &DataProvider)
+//!     .load_payload::<structs::plurals::PluralRuleStringsV1>(&req)
+//!     .unwrap();
+//! let fs_response = (&fs_provider as &DataProvider)
+//!     .load_payload::<structs::plurals::PluralRuleStringsV1>(&req)
 //!     .expect("Should successfully read from filesystem");
 //!
 //! assert_eq!(
-//!     inv_response.borrow_payload::<structs::plurals::PluralRuleStringsV1>().unwrap(),
-//!     fs_response.borrow_payload::<structs::plurals::PluralRuleStringsV1>().unwrap(),
+//!     inv_response.payload,
+//!     fs_response.payload,
 //! );
 //!
 //! // Clean up from demo

--- a/components/provider_fs/src/fs_data_provider.rs
+++ b/components/provider_fs/src/fs_data_provider.rs
@@ -52,11 +52,11 @@ impl FsDataProvider {
 }
 
 impl<'de> DataProviderV2<'de> for FsDataProvider {
-    fn load_v2(
+    fn load_to_receiver(
         &self,
         req: &DataRequest,
         receiver: &mut dyn DataReceiver<'de, 'static>,
-    ) -> Result<DataResponseV2, DataError> {
+    ) -> Result<DataResponse, DataError> {
         type Error = DataError;
         let mut path_buf = self.res_root.clone();
         path_buf.extend(req.data_key.get_components().iter());
@@ -81,7 +81,7 @@ impl<'de> DataProviderV2<'de> for FsDataProvider {
         let reader = BufReader::new(file);
         deserializer::deserialize_into_receiver(reader, &self.manifest.syntax, receiver)
             .map_err(|err| err.into_resource_error(&path_buf))?;
-        Ok(DataResponseV2 {
+        Ok(DataResponse {
             data_langid: req.data_entry.langid.clone(),
         })
     }

--- a/components/provider_fs/src/fs_data_provider.rs
+++ b/components/provider_fs/src/fs_data_provider.rs
@@ -51,7 +51,7 @@ impl FsDataProvider {
     }
 }
 
-impl<'de> DataProviderV2<'de> for FsDataProvider {
+impl<'de> DataProvider<'de> for FsDataProvider {
     fn load_to_receiver(
         &self,
         req: &DataRequest,

--- a/components/provider_fs/src/fs_data_provider.rs
+++ b/components/provider_fs/src/fs_data_provider.rs
@@ -138,9 +138,8 @@ impl<'de> DataProviderV2<'de> for FsDataProvider {
             Err(err) => return Err(Error::Resource(Box::new(err))),
         };
         let reader = BufReader::new(file);
-        let mut deserializer = deserializer::deserializer_from_reader_v2(reader, &self.manifest.syntax)
+        deserializer::deserialize_into_receiver(reader, &self.manifest.syntax, receiver)
             .map_err(|err| err.into_resource_error(&path_buf))?;
-        receiver.set_to(&mut deserializer.as_erased_deserializer())?;
         Ok(DataResponseV2 {
             data_langid: req.data_entry.langid.clone(),
         })

--- a/components/provider_fs/tests/test_file_io.rs
+++ b/components/provider_fs/tests/test_file_io.rs
@@ -103,3 +103,34 @@ fn test_read_bincode() {
         }
     );
 }
+
+#[test]
+#[cfg(feature = "bincode")]
+fn test_read_bincode_v2() {
+    let provider = FsDataProvider::try_new("./tests/testdata/bincode")
+        .expect("Loading file from testdata directory");
+
+    let mut receiver: DataReceiverImpl<structs::plurals::PluralRuleStringsV1> =
+        DataReceiverImpl { payload: None };
+    provider
+        .load_v2(&DataRequest {
+            data_key: structs::plurals::key::CARDINAL_V1,
+            data_entry: DataEntry {
+                variant: None,
+                langid: langid!("sr"),
+            },
+        }, &mut receiver)
+        .expect("The data should be valid");
+    let plurals_data: &structs::plurals::PluralRuleStringsV1 = &receiver.payload
+        .expect("The data should be present");
+    assert_eq!(
+        plurals_data,
+        &structs::plurals::PluralRuleStringsV1 {
+            zero: None,
+            one: Some(Cow::Borrowed("v = 0 and i % 10 = 1 and i % 100 != 11 or f % 10 = 1 and f % 100 != 11")),
+            two: None,
+            few: Some(Cow::Borrowed("v = 0 and i % 10 = 2..4 and i % 100 != 12..14 or f % 10 = 2..4 and f % 100 != 12..14")),
+            many: None,
+        }
+    );
+}

--- a/components/provider_fs/tests/test_file_io.rs
+++ b/components/provider_fs/tests/test_file_io.rs
@@ -12,57 +12,20 @@ fn test_read_json() {
     let provider = FsDataProvider::try_new("./tests/testdata/json")
         .expect("Loading file from testdata directory");
 
-    let response = provider
-        .load(&DataRequest {
+    let response = (&provider as &dyn DataProviderV2)
+        .load_v2a(&DataRequest {
             data_key: structs::plurals::key::CARDINAL_V1,
             data_entry: DataEntry {
                 variant: None,
                 langid: langid!("ru"),
             },
         })
-        .expect("The key should be present in the testdata");
-    let plurals_data: &structs::plurals::PluralRuleStringsV1 = response
-        .borrow_payload()
-        .expect("The JSON should match the struct definition");
-    assert_eq!(
-        plurals_data,
-        &structs::plurals::PluralRuleStringsV1 {
-            zero: None,
-            one: Some(Cow::Borrowed("v = 0 and i % 10 = 1 and i % 100 != 11")),
-            two: None,
-            few: Some(Cow::Borrowed(
-                "v = 0 and i % 10 = 2..4 and i % 100 != 12..14"
-            )),
-            many: Some(Cow::Borrowed(
-                "v = 0 and i % 10 = 0 or v = 0 and i % 10 = 5..9 or v = 0 and i % 100 = 11..14"
-            )),
-        }
-    );
-}
-
-#[test]
-fn test_read_json_v2() {
-    let provider = FsDataProvider::try_new("./tests/testdata/json")
-        .expect("Loading file from testdata directory");
-
-    let mut receiver = DataReceiverForType::<structs::plurals::PluralRuleStringsV1>::new();
-    provider
-        .load_v2(
-            &DataRequest {
-                data_key: structs::plurals::key::CARDINAL_V1,
-                data_entry: DataEntry {
-                    variant: None,
-                    langid: langid!("ru"),
-                },
-            },
-            &mut receiver,
-        )
         .expect("The data should be valid");
-    let plurals_data: &structs::plurals::PluralRuleStringsV1 =
-        &receiver.payload.expect("The data should be present");
+    let plurals_data: Cow<structs::plurals::PluralRuleStringsV1> =
+        response.payload.expect("The data should be present");
     assert_eq!(
-        plurals_data,
-        &structs::plurals::PluralRuleStringsV1 {
+        *plurals_data,
+        structs::plurals::PluralRuleStringsV1 {
             zero: None,
             one: Some(Cow::Borrowed("v = 0 and i % 10 = 1 and i % 100 != 11")),
             two: None,
@@ -82,54 +45,20 @@ fn test_read_bincode() {
     let provider = FsDataProvider::try_new("./tests/testdata/bincode")
         .expect("Loading file from testdata directory");
 
-    let response = provider
-        .load(&DataRequest {
+    let response = (&provider as &dyn DataProviderV2)
+        .load_v2a(&DataRequest {
             data_key: structs::plurals::key::CARDINAL_V1,
             data_entry: DataEntry {
                 variant: None,
                 langid: langid!("sr"),
             },
         })
-        .expect("The key should be present in the testdata");
-    let plurals_data: &structs::plurals::PluralRuleStringsV1 = response
-        .borrow_payload()
-        .expect("The Bincode should match the struct definition");
-    assert_eq!(
-        plurals_data,
-        &structs::plurals::PluralRuleStringsV1 {
-            zero: None,
-            one: Some(Cow::Borrowed("v = 0 and i % 10 = 1 and i % 100 != 11 or f % 10 = 1 and f % 100 != 11")),
-            two: None,
-            few: Some(Cow::Borrowed("v = 0 and i % 10 = 2..4 and i % 100 != 12..14 or f % 10 = 2..4 and f % 100 != 12..14")),
-            many: None,
-        }
-    );
-}
-
-#[test]
-#[cfg(feature = "bincode")]
-fn test_read_bincode_v2() {
-    let provider = FsDataProvider::try_new("./tests/testdata/bincode")
-        .expect("Loading file from testdata directory");
-
-    let mut receiver = DataReceiverForType::<structs::plurals::PluralRuleStringsV1>::new();
-    provider
-        .load_v2(
-            &DataRequest {
-                data_key: structs::plurals::key::CARDINAL_V1,
-                data_entry: DataEntry {
-                    variant: None,
-                    langid: langid!("sr"),
-                },
-            },
-            &mut receiver,
-        )
         .expect("The data should be valid");
-    let plurals_data: &structs::plurals::PluralRuleStringsV1 =
-        &receiver.payload.expect("The data should be present");
+    let plurals_data: Cow<structs::plurals::PluralRuleStringsV1> =
+        response.payload.expect("The data should be present");
     assert_eq!(
-        plurals_data,
-        &structs::plurals::PluralRuleStringsV1 {
+        *plurals_data,
+        structs::plurals::PluralRuleStringsV1 {
             zero: None,
             one: Some(Cow::Borrowed("v = 0 and i % 10 = 1 and i % 100 != 11 or f % 10 = 1 and f % 100 != 11")),
             two: None,

--- a/components/provider_fs/tests/test_file_io.rs
+++ b/components/provider_fs/tests/test_file_io.rs
@@ -45,8 +45,7 @@ fn test_read_json_v2() {
     let provider = FsDataProvider::try_new("./tests/testdata/json")
         .expect("Loading file from testdata directory");
 
-    let mut receiver: DataReceiverImpl<structs::plurals::PluralRuleStringsV1> =
-        DataReceiverImpl { payload: None };
+    let mut receiver = DataReceiverForType::<structs::plurals::PluralRuleStringsV1>::new();
     provider
         .load_v2(
             &DataRequest {
@@ -113,8 +112,7 @@ fn test_read_bincode_v2() {
     let provider = FsDataProvider::try_new("./tests/testdata/bincode")
         .expect("Loading file from testdata directory");
 
-    let mut receiver: DataReceiverImpl<structs::plurals::PluralRuleStringsV1> =
-        DataReceiverImpl { payload: None };
+    let mut receiver = DataReceiverForType::<structs::plurals::PluralRuleStringsV1>::new();
     provider
         .load_v2(
             &DataRequest {

--- a/components/provider_fs/tests/test_file_io.rs
+++ b/components/provider_fs/tests/test_file_io.rs
@@ -13,7 +13,7 @@ fn test_read_json() {
         .expect("Loading file from testdata directory");
 
     let response = (&provider as &dyn DataProviderV2)
-        .load_v2a(&DataRequest {
+        .load_payload(&DataRequest {
             data_key: structs::plurals::key::CARDINAL_V1,
             data_entry: DataEntry {
                 variant: None,
@@ -46,7 +46,7 @@ fn test_read_bincode() {
         .expect("Loading file from testdata directory");
 
     let response = (&provider as &dyn DataProviderV2)
-        .load_v2a(&DataRequest {
+        .load_payload(&DataRequest {
             data_key: structs::plurals::key::CARDINAL_V1,
             data_entry: DataEntry {
                 variant: None,

--- a/components/provider_fs/tests/test_file_io.rs
+++ b/components/provider_fs/tests/test_file_io.rs
@@ -48,16 +48,19 @@ fn test_read_json_v2() {
     let mut receiver: DataReceiverImpl<structs::plurals::PluralRuleStringsV1> =
         DataReceiverImpl { payload: None };
     provider
-        .load_v2(&DataRequest {
-            data_key: structs::plurals::key::CARDINAL_V1,
-            data_entry: DataEntry {
-                variant: None,
-                langid: langid!("ru"),
+        .load_v2(
+            &DataRequest {
+                data_key: structs::plurals::key::CARDINAL_V1,
+                data_entry: DataEntry {
+                    variant: None,
+                    langid: langid!("ru"),
+                },
             },
-        }, &mut receiver)
+            &mut receiver,
+        )
         .expect("The data should be valid");
-    let plurals_data: &structs::plurals::PluralRuleStringsV1 = &receiver.payload
-        .expect("The data should be present");
+    let plurals_data: &structs::plurals::PluralRuleStringsV1 =
+        &receiver.payload.expect("The data should be present");
     assert_eq!(
         plurals_data,
         &structs::plurals::PluralRuleStringsV1 {
@@ -113,16 +116,19 @@ fn test_read_bincode_v2() {
     let mut receiver: DataReceiverImpl<structs::plurals::PluralRuleStringsV1> =
         DataReceiverImpl { payload: None };
     provider
-        .load_v2(&DataRequest {
-            data_key: structs::plurals::key::CARDINAL_V1,
-            data_entry: DataEntry {
-                variant: None,
-                langid: langid!("sr"),
+        .load_v2(
+            &DataRequest {
+                data_key: structs::plurals::key::CARDINAL_V1,
+                data_entry: DataEntry {
+                    variant: None,
+                    langid: langid!("sr"),
+                },
             },
-        }, &mut receiver)
+            &mut receiver,
+        )
         .expect("The data should be valid");
-    let plurals_data: &structs::plurals::PluralRuleStringsV1 = &receiver.payload
-        .expect("The data should be present");
+    let plurals_data: &structs::plurals::PluralRuleStringsV1 =
+        &receiver.payload.expect("The data should be present");
     assert_eq!(
         plurals_data,
         &structs::plurals::PluralRuleStringsV1 {

--- a/components/provider_fs/tests/test_file_io.rs
+++ b/components/provider_fs/tests/test_file_io.rs
@@ -41,6 +41,40 @@ fn test_read_json() {
 }
 
 #[test]
+fn test_read_json_v2() {
+    let provider = FsDataProvider::try_new("./tests/testdata/json")
+        .expect("Loading file from testdata directory");
+
+    let mut receiver: DataReceiverImpl<structs::plurals::PluralRuleStringsV1> =
+        DataReceiverImpl { payload: None };
+    provider
+        .load_v2(&DataRequest {
+            data_key: structs::plurals::key::CARDINAL_V1,
+            data_entry: DataEntry {
+                variant: None,
+                langid: langid!("ru"),
+            },
+        }, &mut receiver)
+        .expect("The data should be valid");
+    let plurals_data: &structs::plurals::PluralRuleStringsV1 = &receiver.payload
+        .expect("The data should be present");
+    assert_eq!(
+        plurals_data,
+        &structs::plurals::PluralRuleStringsV1 {
+            zero: None,
+            one: Some(Cow::Borrowed("v = 0 and i % 10 = 1 and i % 100 != 11")),
+            two: None,
+            few: Some(Cow::Borrowed(
+                "v = 0 and i % 10 = 2..4 and i % 100 != 12..14"
+            )),
+            many: Some(Cow::Borrowed(
+                "v = 0 and i % 10 = 0 or v = 0 and i % 10 = 5..9 or v = 0 and i % 100 = 11..14"
+            )),
+        }
+    );
+}
+
+#[test]
 #[cfg(feature = "bincode")]
 fn test_read_bincode() {
     let provider = FsDataProvider::try_new("./tests/testdata/bincode")

--- a/components/provider_fs/tests/test_file_io.rs
+++ b/components/provider_fs/tests/test_file_io.rs
@@ -12,7 +12,7 @@ fn test_read_json() {
     let provider = FsDataProvider::try_new("./tests/testdata/json")
         .expect("Loading file from testdata directory");
 
-    let response = (&provider as &dyn DataProviderV2)
+    let response = (&provider as &dyn DataProvider)
         .load_payload(&DataRequest {
             data_key: structs::plurals::key::CARDINAL_V1,
             data_entry: DataEntry {
@@ -45,7 +45,7 @@ fn test_read_bincode() {
     let provider = FsDataProvider::try_new("./tests/testdata/bincode")
         .expect("Loading file from testdata directory");
 
-    let response = (&provider as &dyn DataProviderV2)
+    let response = (&provider as &dyn DataProvider)
         .load_payload(&DataRequest {
             data_key: structs::plurals::key::CARDINAL_V1,
             data_entry: DataEntry {

--- a/resources/testdata/src/lib.rs
+++ b/resources/testdata/src/lib.rs
@@ -18,8 +18,9 @@
 //!
 //! let data_provider = icu_testdata::get_provider();
 //!
-//! let data: Cow<structs::plurals::PluralRuleStringsV1> = data_provider
-//!     .load(&DataRequest {
+//! let data: Cow<structs::plurals::PluralRuleStringsV1> =
+//!     (&data_provider as &dyn DataProvider)
+//!     .load_payload(&DataRequest {
 //!         data_entry: DataEntry {
 //!             langid: langid!("ru"),
 //!             variant: None,
@@ -27,7 +28,7 @@
 //!         data_key: structs::plurals::key::CARDINAL_V1,
 //!     })
 //!     .unwrap()
-//!     .take_payload()
+//!     .payload
 //!     .unwrap();
 //! assert_eq!(data.few, Some(Cow::Borrowed("v = 0 and i % 10 = 2..4 and i % 100 != 12..14")));
 //! ```


### PR DESCRIPTION
Will Fix #196

This PR essentially implements option 2 from that issue.  Instead of DataProvider returning an opaque Any type, it takes a mutable reference argument that deserializes the data directly into the final container.

Before, where you had:

```rust
    let response = provider
        .load(&req)
        .expect("The key should be present");
    let plurals_data: &structs::plurals::PluralRuleStringsV1 = response
        .borrow_payload()
        .expect("The data should be valid");
```

Now you have:

```rust
    let mut receiver: DataReceiverImpl<structs::plurals::PluralRuleStringsV1> =
        DataReceiverImpl { payload: None };
    provider
        .load_v2(&req, &mut receiver)
        .expect("The data should be valid");
    let plurals_data: &structs::plurals::PluralRuleStringsV1 = &receiver.payload
        .expect("The data should be present");
```

I left the requirement that the struct implement Any, i.e., all data must be owned data.  I believe this condition is still required in order to allow already-deserialized data to cross the trait object boundary.  For example, DataReceiver has three methods to set the data:

```rust
pub trait DataReceiver<'d, 'de> {
    fn set_to(
        &mut self,
        deserializer: &mut dyn erased_serde::Deserializer<'de>,
    ) -> Result<(), erased_serde::Error>;

    fn set_to_any(&mut self, any: &'d dyn Any) -> Result<(), Error>;

    fn set_to_boxed(&mut self, boxed: Box<dyn Any>) -> Result<(), Error>;
}
```

I don't know how to enable DataReceiver to be a trait object but also allow it to accept a borrowed or owned object outside of the deserializer function.