### PR TITLE
Fix link warnings for the docs

### DIFF
--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -33,7 +33,7 @@ impl From<std::num::ParseIntError> for DateTimeError {
 /// This type represents all data that the formatted needs in order to produced formatted string.
 ///
 /// *Note*: At the moment we support only `gregorian` calendar, and plan to extend support to
-/// other calendars in the upcoming releases. See https://github.com/unicode-org/icu4x/issues/355
+/// other calendars in the upcoming releases. See <https://github.com/unicode-org/icu4x/issues/355>
 ///
 /// [`DateTimeFormat`]: super::DateTimeFormat
 pub trait DateTimeType: FromStr {

--- a/components/provider/src/structs/plurals.rs
+++ b/components/provider/src/structs/plurals.rs
@@ -28,7 +28,7 @@ pub(crate) fn get_invariant(data_key: &DataKey) -> Option<DataResponse<'static>>
 /// Plural rule strings conforming to UTS 35 syntax. Includes separate fields for five of the six
 /// standard plural forms. If none of the rules match, the "other" category is assumed.
 ///
-/// More information: https://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules
+/// More information: <https://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules>
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "invariant", derive(Default))]
 pub struct PluralRuleStringsV1 {

--- a/components/provider_cldr/src/cldr_paths.rs
+++ b/components/provider_cldr/src/cldr_paths.rs
@@ -9,11 +9,11 @@ use std::path::PathBuf;
 /// The fields should be Ok if present. They default to Err when not present.
 pub trait CldrPaths: std::fmt::Debug {
     /// Path to checkout of cldr-core:
-    /// https://github.com/unicode-cldr/cldr-core
+    /// <https://github.com/unicode-cldr/cldr-core>
     fn cldr_core(&self) -> Result<PathBuf, Error>;
 
     /// Path to checkout of cldr-dates:
-    /// https://github.com/unicode-cldr/cldr-dates-full
+    /// <https://github.com/unicode-cldr/cldr-dates-full>
     fn cldr_dates(&self) -> Result<PathBuf, Error>;
 }
 

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -58,7 +58,7 @@ pub trait Writeable {
     /// number of bytes may be slightly different than what this function returns.
     ///
     /// This function may return an enumeration in the future. See:
-    /// https://github.com/unicode-org/icu4x/issues/370
+    /// <https://github.com/unicode-org/icu4x/issues/370>
     fn write_len(&self) -> usize;
 
     /// Creates a new String with the data from this Writeable. Like ToString, but faster.


### PR DESCRIPTION
These link warnings were generated while running `cargo doc` on the root of the project.

e.g.

```
warning: this URL is not a hyperlink
  --> components/provider_cldr/src/cldr_paths.rs:16:9
   |
16 |     /// https://github.com/unicode-cldr/cldr-dates-full
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://github.com/unicode-cldr/cldr-dates-full>`
```