### PR TITLE
Make the DateTime bags more explicit

### DIFF
--- a/components/datetime/README.md
+++ b/components/datetime/README.md
@@ -12,17 +12,17 @@ used to quickly format any date and time provided.
 
 ```rust
 use icu_locid_macros::langid;
-use icu_datetime::{DateTimeFormat, date::MockDateTime, options::style};
+use icu_datetime::{DateTimeFormat, DateTimeFormatOptions, date::MockDateTime, options::style};
 
 let provider = icu_testdata::get_provider();
 
 let lid = langid!("en");
 
-let options = style::Bag {
+let options = DateTimeFormatOptions::Style(style::Bag {
     date: Some(style::Date::Medium),
     time: Some(style::Time::Short),
     ..Default::default()
-}.into();
+});
 
 let dtf = DateTimeFormat::try_new(lid, &provider, &options)
     .expect("Failed to create DateTimeFormat instance.");

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -13,17 +13,17 @@
 //!
 //! ```
 //! use icu_locid_macros::langid;
-//! use icu_datetime::{DateTimeFormat, date::MockDateTime, options::style};
+//! use icu_datetime::{DateTimeFormat, DateTimeFormatOptions, date::MockDateTime, options::style};
 //!
 //! let provider = icu_testdata::get_provider();
 //!
 //! let lid = langid!("en");
 //!
-//! let options = style::Bag {
+//! let options = DateTimeFormatOptions::Style(style::Bag {
 //!     date: Some(style::Date::Medium),
 //!     time: Some(style::Time::Short),
 //!     ..Default::default()
-//! }.into();
+//! });
 //!
 //! let dtf = DateTimeFormat::try_new(lid, &provider, &options)
 //!     .expect("Failed to create DateTimeFormat instance.");

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -22,9 +22,10 @@
 //! # Examples
 //!
 //! ```
+//! use icu_datetime::DateTimeFormatOptions;
 //! use icu_datetime::options::components;
 //!
-//! let options = components::Bag {
+//! let bag = components::Bag {
 //!     year: Some(components::Numeric::Numeric),
 //!     month: Some(components::Month::Long),
 //!     day: Some(components::Numeric::Numeric),
@@ -36,6 +37,8 @@
 //!
 //!     ..Default::default()
 //! };
+//!
+//! let options = DateTimeFormatOptions::Components(bag);
 //! ```
 //!
 //! *Note*: The exact result returned from [`DateTimeFormat`](crate::DateTimeFormat) is a subject to change over

--- a/components/datetime/src/options/style.rs
+++ b/components/datetime/src/options/style.rs
@@ -17,13 +17,16 @@
 //! # Examples
 //!
 //! ```
+//! use icu_datetime::DateTimeFormatOptions;
 //! use icu_datetime::options::style;
 //!
-//! let options = style::Bag {
+//! let bag = style::Bag {
 //!      date: Some(style::Date::Medium), // `Medium` length connector will be used
 //!      time: Some(style::Time::Short),
 //!      preferences: None,
 //! };
+//!
+//! let options = DateTimeFormatOptions::Style(bag);
 //! ```
 //!
 //! *Note*: The exact result returned from [`DateTimeFormat`](crate::DateTimeFormat) is a subject to change over
@@ -38,13 +41,16 @@ use super::preferences;
 /// # Examples
 ///
 /// ```
+/// use icu_datetime::DateTimeFormatOptions;
 /// use icu_datetime::options::style;
 ///
-/// let options = style::Bag {
+/// let bag = style::Bag {
 ///      date: Some(style::Date::Medium),
 ///      time: Some(style::Time::Short),
 ///      preferences: None,
 /// };
+///
+/// let options = DateTimeFormatOptions::Style(bag);
 /// ```
 ///
 /// [`UTS #35: Unicode LDML 4. Dates`]: https://unicode.org/reports/tr35/tr35-dates.html


### PR DESCRIPTION
I found myself confused on the usage of the bags and the difference between them and the options provided to the date time. I felt that it was better to be explicit in the examples, rather than giving more terse, but potentially misleading examples.

This change is a bit more of an opinionated change for the examples explicit in how they are used, rather than relying on the `.into()` trait. I'm pretty open to feedback on it, as I was mostly trying to find a way to solve my confusion around the use of these data structures and their relationship to each other. I have a follow-up PR on updating some of the docs and explanations as well.