### PR TITLE
Make the DateTime bags more explicit

### DIFF
--- a/components/datetime/README.md
+++ b/components/datetime/README.md
@@ -12,17 +12,17 @@ used to quickly format any date and time provided.
 
 ```rust
 use icu_locid_macros::langid;
-use icu_datetime::{DateTimeFormat, date::MockDateTime, options::style};
+use icu_datetime::{DateTimeFormat, DateTimeFormatOptions, date::MockDateTime, options::style};
 
 let provider = icu_testdata::get_provider();
 
 let lid = langid!("en");
 
-let options = style::Bag {
+let options = DateTimeFormatOptions::Style(style::Bag {
     date: Some(style::Date::Medium),
     time: Some(style::Time::Short),
     ..Default::default()
-}.into();
+});
 
 let dtf = DateTimeFormat::try_new(lid, &provider, &options)
     .expect("Failed to create DateTimeFormat instance.");

--- a/components/datetime/README.md
+++ b/components/datetime/README.md
@@ -12,17 +12,17 @@ used to quickly format any date and time provided.
 
 ```rust
 use icu_locid_macros::langid;
-use icu_datetime::{DateTimeFormat, DateTimeFormatOptions, date::MockDateTime, options::style};
+use icu_datetime::{DateTimeFormat, date::MockDateTime, options::style};
 
 let provider = icu_testdata::get_provider();
 
 let lid = langid!("en");
 
-let options = DateTimeFormatOptions::Style(style::Bag {
+let options = style::Bag {
     date: Some(style::Date::Medium),
     time: Some(style::Time::Short),
     ..Default::default()
-});
+}.into();
 
 let dtf = DateTimeFormat::try_new(lid, &provider, &options)
     .expect("Failed to create DateTimeFormat instance.");

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -13,17 +13,17 @@
 //!
 //! ```
 //! use icu_locid_macros::langid;
-//! use icu_datetime::{DateTimeFormat, date::MockDateTime, options::style};
+//! use icu_datetime::{DateTimeFormat, DateTimeFormatOptions, date::MockDateTime, options::style};
 //!
 //! let provider = icu_testdata::get_provider();
 //!
 //! let lid = langid!("en");
 //!
-//! let options = style::Bag {
+//! let options = DateTimeFormatOptions::Style(style::Bag {
 //!     date: Some(style::Date::Medium),
 //!     time: Some(style::Time::Short),
 //!     ..Default::default()
-//! }.into();
+//! });
 //!
 //! let dtf = DateTimeFormat::try_new(lid, &provider, &options)
 //!     .expect("Failed to create DateTimeFormat instance.");

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -19,6 +19,7 @@
 //!
 //! let lid = langid!("en");
 //!
+//! // See the next code example for a more ergonomic example with .into().
 //! let options = DateTimeFormatOptions::Style(style::Bag {
 //!     date: Some(style::Date::Medium),
 //!     time: Some(style::Time::Short),
@@ -34,6 +35,23 @@
 //!
 //! let formatted_date = dtf.format(&date);
 //! assert_eq!(formatted_date.to_string(), "Sep 12, 2020, 12:35 PM");
+//! ```
+//!
+//! The options can be created more ergonomically using the `Into` trait to automatically
+//! convert a [`options::style::Bag`] into a [`DateTimeFormatOptions::Style`].
+//!
+//! ```
+//! # use icu_locid_macros::langid;
+//! # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions, date::MockDateTime, options::style};
+//! # let provider = icu_testdata::get_provider();
+//! # let lid = langid!("en");
+//! let options = style::Bag {
+//!     date: Some(style::Date::Medium),
+//!     time: Some(style::Time::Short),
+//!     ..Default::default()
+//! }.into();
+//!
+//! let dtf = DateTimeFormat::try_new(lid, &provider, &options);
 //! ```
 //!
 //! At the moment, the crate provides only options using the [`Style`] bag, but in the future,

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -22,9 +22,10 @@
 //! # Examples
 //!
 //! ```
+//! use icu_datetime::DateTimeFormatOptions;
 //! use icu_datetime::options::components;
 //!
-//! let options = components::Bag {
+//! let bag = components::Bag {
 //!     year: Some(components::Numeric::Numeric),
 //!     month: Some(components::Month::Long),
 //!     day: Some(components::Numeric::Numeric),
@@ -36,6 +37,8 @@
 //!
 //!     ..Default::default()
 //! };
+//!
+//! let options = DateTimeFormatOptions::Components(bag);
 //! ```
 //!
 //! *Note*: The exact result returned from [`DateTimeFormat`](crate::DateTimeFormat) is a subject to change over

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -38,7 +38,16 @@
 //!     ..Default::default()
 //! };
 //!
+//! // The options can be created manually.
 //! let options = DateTimeFormatOptions::Components(bag);
+//! ```
+//!
+//! Or the options can be inferred through the `.into()` trait.
+//!
+//! ```
+//! # use icu_datetime::DateTimeFormatOptions;
+//! # use icu_datetime::options::components;
+//! let options: DateTimeFormatOptions = components::Bag::default().into();
 //! ```
 //!
 //! *Note*: The exact result returned from [`DateTimeFormat`](crate::DateTimeFormat) is a subject to change over

--- a/components/datetime/src/options/style.rs
+++ b/components/datetime/src/options/style.rs
@@ -17,13 +17,16 @@
 //! # Examples
 //!
 //! ```
+//! use icu_datetime::DateTimeFormatOptions;
 //! use icu_datetime::options::style;
 //!
-//! let options = style::Bag {
+//! let bag = style::Bag {
 //!      date: Some(style::Date::Medium), // `Medium` length connector will be used
 //!      time: Some(style::Time::Short),
 //!      preferences: None,
 //! };
+//!
+//! let options = DateTimeFormatOptions::Style(bag);
 //! ```
 //!
 //! *Note*: The exact result returned from [`DateTimeFormat`](crate::DateTimeFormat) is a subject to change over
@@ -38,13 +41,16 @@ use super::preferences;
 /// # Examples
 ///
 /// ```
+/// use icu_datetime::DateTimeFormatOptions;
 /// use icu_datetime::options::style;
 ///
-/// let options = style::Bag {
+/// let bag = style::Bag {
 ///      date: Some(style::Date::Medium),
 ///      time: Some(style::Time::Short),
 ///      preferences: None,
 /// };
+///
+/// let options = DateTimeFormatOptions::Style(bag);
 /// ```
 ///
 /// [`UTS #35: Unicode LDML 4. Dates`]: https://unicode.org/reports/tr35/tr35-dates.html

--- a/components/datetime/src/options/style.rs
+++ b/components/datetime/src/options/style.rs
@@ -29,6 +29,14 @@
 //! let options = DateTimeFormatOptions::Style(bag);
 //! ```
 //!
+//! Or the options can be inferred through the `.into()` trait.
+//!
+//! ```
+//! # use icu_datetime::DateTimeFormatOptions;
+//! # use icu_datetime::options::style;
+//! let options: DateTimeFormatOptions = style::Bag::default().into();
+//! ```
+//!
 //! *Note*: The exact result returned from [`DateTimeFormat`](crate::DateTimeFormat) is a subject to change over
 //! time. Formatted result should be treated as opaque and displayed to the user as-is,
 //! and it is strongly recommended to never write tests that expect a particular formatted output.
@@ -51,6 +59,14 @@ use super::preferences;
 /// };
 ///
 /// let options = DateTimeFormatOptions::Style(bag);
+/// ```
+///
+/// Or the options can be inferred through the `.into()` trait.
+///
+/// ```
+/// # use icu_datetime::DateTimeFormatOptions;
+/// # use icu_datetime::options::style;
+/// let options: DateTimeFormatOptions = style::Bag::default().into();
 /// ```
 ///
 /// [`UTS #35: Unicode LDML 4. Dates`]: https://unicode.org/reports/tr35/tr35-dates.html


### PR DESCRIPTION
I found myself confused on the usage of the bags and the difference between them and the options provided to the date time. I felt that it was better to be explicit in the examples, rather than giving more terse, but potentially misleading examples.

This change is a bit more of an opinionated change for the examples explicit in how they are used, rather than relying on the `.into()` trait. I'm pretty open to feedback on it, as I was mostly trying to find a way to solve my confusion around the use of these data structures and their relationship to each other. I have a follow-up PR on updating some of the docs and explanations as well.