### PR TITLE
Optimize parsing Language::from_bytes()

### DIFF
--- a/components/locid/src/subtags/language.rs
+++ b/components/locid/src/subtags/language.rs
@@ -56,8 +56,13 @@ impl Language {
     pub fn from_bytes(v: &[u8]) -> Result<Self, ParserError> {
         let slen = v.len();
 
+        if !LANGUAGE_LENGTH.contains(&slen) || slen == SCRIPT_LENGTH {
+            return Err(ParserError::InvalidLanguage);
+        }
+
         let s = TinyStr8::from_bytes(v).map_err(|_| ParserError::InvalidLanguage)?;
-        if !LANGUAGE_LENGTH.contains(&slen) || slen == SCRIPT_LENGTH || !s.is_ascii_alphabetic() {
+
+        if !s.is_ascii_alphabetic() {
             return Err(ParserError::InvalidLanguage);
         }
 


### PR DESCRIPTION
Fixes #71 

Changes the `Language::from_bytes()` function to return
an Err if the length is not valid before creating a
`TinyStr` and checking `is_ascii_alphabetic()`.

This is a small optimization, and the change is congruent
with `Region::from_bytes()` and `Script::from_bytes()`