### PR TITLE
Implementing const Locale::und() and LanguageIdentifier::und()

### DIFF
--- a/components/locid/src/extensions/mod.rs
+++ b/components/locid/src/extensions/mod.rs
@@ -78,7 +78,7 @@ impl ExtensionType {
     }
 }
 
-/// A map of extensions associated with a given `Locale.
+/// A map of extensions associated with a given `Locale`.
 #[derive(Debug, Default, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 pub struct Extensions {
     pub unicode: Unicode,
@@ -87,6 +87,36 @@ pub struct Extensions {
 }
 
 impl Extensions {
+    /// Returns a new empty map of extensions. Same as `Default`, but is `const`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_locid::extensions::Extensions;
+    ///
+    /// assert_eq!(Extensions::const_default(), Extensions::default());
+    /// ```
+    #[inline]
+    pub const fn const_default() -> Self {
+        Self {
+            unicode: Unicode::const_default(),
+            transform: Transform::const_default(),
+            private: Private::const_default(),
+        }
+    }
+
+    /// Returns whether there are no extensions present.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_locid::Locale;
+    ///
+    /// let loc: Locale = "en-US-u-foo".parse()
+    ///     .expect("Parsing failed.");
+    ///
+    /// assert_eq!(loc.extensions.is_empty(), false);
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.unicode.is_empty() && self.transform.is_empty() && self.private.is_empty()
     }

--- a/components/locid/src/extensions/mod.rs
+++ b/components/locid/src/extensions/mod.rs
@@ -94,14 +94,14 @@ impl Extensions {
     /// ```
     /// use icu_locid::extensions::Extensions;
     ///
-    /// assert_eq!(Extensions::const_default(), Extensions::default());
+    /// assert_eq!(Extensions::new(), Extensions::default());
     /// ```
     #[inline]
-    pub const fn const_default() -> Self {
+    pub const fn new() -> Self {
         Self {
-            unicode: Unicode::const_default(),
-            transform: Transform::const_default(),
-            private: Private::const_default(),
+            unicode: Unicode::new(),
+            transform: Transform::new(),
+            private: Private::new(),
         }
     }
 

--- a/components/locid/src/extensions/private/mod.rs
+++ b/components/locid/src/extensions/private/mod.rs
@@ -67,10 +67,10 @@ impl Private {
     /// ```
     /// use icu_locid::extensions::private::Private;
     ///
-    /// assert_eq!(Private::const_default(), Private::default());
+    /// assert_eq!(Private::new(), Private::default());
     /// ```
     #[inline]
-    pub const fn const_default() -> Self {
+    pub const fn new() -> Self {
         Self(None)
     }
 

--- a/components/locid/src/extensions/private/mod.rs
+++ b/components/locid/src/extensions/private/mod.rs
@@ -57,9 +57,23 @@ use crate::parser::ParserError;
 /// [`Private Use Extensions`]: https://unicode.org/reports/tr35/#pu_extensions
 /// [`Unicode Locale Identifier`]: https://unicode.org/reports/tr35/#Unicode_locale_identifier
 #[derive(Clone, PartialEq, Eq, Debug, Default, Hash, PartialOrd, Ord)]
-pub struct Private(Box<[Key]>);
+pub struct Private(Option<Box<[Key]>>);
 
 impl Private {
+    /// Returns a new empty list of private-use extensions. Same as `Default`, but is `const`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_locid::extensions::private::Private;
+    ///
+    /// assert_eq!(Private::const_default(), Private::default());
+    /// ```
+    #[inline]
+    pub const fn const_default() -> Self {
+        Self(None)
+    }
+
     /// A constructor which takes a pre-sorted list of `Key`.
     ///
     /// # Examples
@@ -75,8 +89,12 @@ impl Private {
     /// let private = Private::from_vec_unchecked(vec![key1, key2]);
     /// assert_eq!(&private.to_string(), "-x-foo-bar");
     /// ```
-    pub fn from_vec_unchecked(v: Vec<Key>) -> Self {
-        Self(v.into_boxed_slice())
+    pub fn from_vec_unchecked(input: Vec<Key>) -> Self {
+        if input.is_empty() {
+            Self(None)
+        } else {
+            Self(Some(input.into_boxed_slice()))
+        }
     }
 
     /// Empties the `Private` list.
@@ -99,7 +117,7 @@ impl Private {
     /// assert_eq!(&private.to_string(), "");
     /// ```
     pub fn clear(&mut self) {
-        self.0 = Box::new([]);
+        self.0 = None;
     }
 
     pub(crate) fn try_from_iter<'a>(
@@ -109,7 +127,7 @@ impl Private {
             .map(|subtag| Key::from_bytes(subtag))
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(Self(keys.into_boxed_slice()))
+        Ok(Self::from_vec_unchecked(keys))
     }
 }
 
@@ -132,6 +150,10 @@ impl Deref for Private {
     type Target = [Key];
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        if let Some(ref data) = self.0 {
+            data
+        } else {
+            &[]
+        }
     }
 }

--- a/components/locid/src/extensions/transform/fields.rs
+++ b/components/locid/src/extensions/transform/fields.rs
@@ -43,10 +43,10 @@ impl Fields {
     /// ```
     /// use icu_locid::extensions::transform::Fields;
     ///
-    /// assert_eq!(Fields::const_default(), Fields::default());
+    /// assert_eq!(Fields::new(), Fields::default());
     /// ```
     #[inline]
-    pub const fn const_default() -> Self {
+    pub const fn new() -> Self {
         Self(None)
     }
 

--- a/components/locid/src/extensions/transform/fields.rs
+++ b/components/locid/src/extensions/transform/fields.rs
@@ -33,9 +33,23 @@ use super::Value;
 /// assert_eq!(&fields.to_string(), "h0-hybrid");
 /// ```
 #[derive(Clone, PartialEq, Eq, Debug, Default, Hash, PartialOrd, Ord)]
-pub struct Fields(Box<[(Key, Value)]>);
+pub struct Fields(Option<Box<[(Key, Value)]>>);
 
 impl Fields {
+    /// Returns a new empty list of key-value pairs. Same as `Default`, but is `const`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_locid::extensions::transform::Fields;
+    ///
+    /// assert_eq!(Fields::const_default(), Fields::default());
+    /// ```
+    #[inline]
+    pub const fn const_default() -> Self {
+        Self(None)
+    }
+
     /// A constructor which takes a pre-sorted list of `(Key, Value)` tuples.
     ///
     ///
@@ -53,7 +67,11 @@ impl Fields {
     /// assert_eq!(&fields.to_string(), "h0-hybrid");
     /// ```
     pub fn from_vec_unchecked(input: Vec<(Key, Value)>) -> Self {
-        Self(input.into_boxed_slice())
+        if input.is_empty() {
+            Self(None)
+        } else {
+            Self(Some(input.into_boxed_slice()))
+        }
     }
 
     /// Empties the `Fields` list.
@@ -76,7 +94,7 @@ impl Fields {
     /// assert_eq!(&fields.to_string(), "");
     /// ```
     pub fn clear(&mut self) {
-        self.0 = Box::new([]);
+        self.0 = None;
     }
 
     /// Returns `true` if the list contains a [`Value`] for the specified [`Key`].
@@ -131,7 +149,7 @@ impl Fields {
         Q: Borrow<Key>,
     {
         if let Ok(idx) = self.binary_search_by_key(key.borrow(), |(key, _)| *key) {
-            self.0.get(idx).map(|(_, v)| v)
+            self.deref().get(idx).map(|(_, v)| v)
         } else {
             None
         }
@@ -160,6 +178,10 @@ impl Deref for Fields {
     type Target = [(Key, Value)];
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        if let Some(ref data) = self.0 {
+            data
+        } else {
+            &[]
+        }
     }
 }

--- a/components/locid/src/extensions/transform/mod.rs
+++ b/components/locid/src/extensions/transform/mod.rs
@@ -89,13 +89,13 @@ impl Transform {
     /// ```
     /// use icu_locid::extensions::transform::Transform;
     ///
-    /// assert_eq!(Transform::const_default(), Transform::default());
+    /// assert_eq!(Transform::new(), Transform::default());
     /// ```
     #[inline]
-    pub const fn const_default() -> Self {
+    pub const fn new() -> Self {
         Self {
             lang: None,
-            fields: Fields::const_default(),
+            fields: Fields::new(),
         }
     }
 

--- a/components/locid/src/extensions/transform/mod.rs
+++ b/components/locid/src/extensions/transform/mod.rs
@@ -82,6 +82,23 @@ pub struct Transform {
 }
 
 impl Transform {
+    /// Returns a new empty map of Transform extensions. Same as `Default`, but is `const`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_locid::extensions::transform::Transform;
+    ///
+    /// assert_eq!(Transform::const_default(), Transform::default());
+    /// ```
+    #[inline]
+    pub const fn const_default() -> Self {
+        Self {
+            lang: None,
+            fields: Fields::const_default(),
+        }
+    }
+
     /// Returns `true` if there are no tfields and no tlang in
     /// the `TransformExtensionList`.
     ///

--- a/components/locid/src/extensions/unicode/attributes.rs
+++ b/components/locid/src/extensions/unicode/attributes.rs
@@ -38,10 +38,10 @@ impl Attributes {
     /// ```
     /// use icu_locid::extensions::unicode::Attributes;
     ///
-    /// assert_eq!(Attributes::const_default(), Attributes::default());
+    /// assert_eq!(Attributes::new(), Attributes::default());
     /// ```
     #[inline]
-    pub const fn const_default() -> Self {
+    pub const fn new() -> Self {
         Self(None)
     }
 

--- a/components/locid/src/extensions/unicode/attributes.rs
+++ b/components/locid/src/extensions/unicode/attributes.rs
@@ -28,9 +28,23 @@ use std::ops::Deref;
 /// ```
 ///
 #[derive(Default, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
-pub struct Attributes(Box<[Attribute]>);
+pub struct Attributes(Option<Box<[Attribute]>>);
 
 impl Attributes {
+    /// Returns a new empty set of attributes. Same as `Default`, but is `const`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_locid::extensions::unicode::Attributes;
+    ///
+    /// assert_eq!(Attributes::const_default(), Attributes::default());
+    /// ```
+    #[inline]
+    pub const fn const_default() -> Self {
+        Self(None)
+    }
+
     /// A constructor which takes a pre-sorted list of [`Attribute`] elements.
     ///
     ///
@@ -53,7 +67,11 @@ impl Attributes {
     /// Notice: For performance and memory constraint environments, it is recommended
     /// for the caller to use `slice::binary_search` instead of `sort` and `dedup`.
     pub fn from_vec_unchecked(input: Vec<Attribute>) -> Self {
-        Self(input.into_boxed_slice())
+        if input.is_empty() {
+            Self(None)
+        } else {
+            Self(Some(input.into_boxed_slice()))
+        }
     }
 
     /// Empties the `Attributes` list.
@@ -78,14 +96,14 @@ impl Attributes {
     /// assert_eq!(attributes.to_string(), "");
     /// ```
     pub fn clear(&mut self) {
-        self.0 = Box::new([]);
+        self.0 = None;
     }
 }
 
 impl std::fmt::Display for Attributes {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let mut initial = true;
-        for variant in self.0.iter() {
+        for variant in self.iter() {
             if initial {
                 initial = false;
             } else {
@@ -101,6 +119,10 @@ impl Deref for Attributes {
     type Target = [Attribute];
 
     fn deref(&self) -> &[Attribute] {
-        &self.0
+        if let Some(ref data) = self.0 {
+            data
+        } else {
+            &[]
+        }
     }
 }

--- a/components/locid/src/extensions/unicode/keywords.rs
+++ b/components/locid/src/extensions/unicode/keywords.rs
@@ -34,15 +34,27 @@ use super::Value;
 /// assert_eq!(&keywords.to_string(), "hc-h23");
 /// ```
 #[derive(Clone, PartialEq, Eq, Debug, Default, Hash, PartialOrd, Ord)]
-pub struct Keywords(Box<[(Key, Value)]>);
+pub struct Keywords(Option<Box<[(Key, Value)]>>);
 
 impl Keywords {
+    /// Returns a new empty list of key-value pairs. Same as `Default`, but is `const`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_locid::extensions::unicode::Keywords;
+    ///
+    /// assert_eq!(Keywords::const_default(), Keywords::default());
+    /// ```
+    #[inline]
+    pub const fn const_default() -> Self {
+        Self(None)
+    }
+
     /// A constructor which takes a pre-sorted list of `(Key, Value)` tuples.
     ///
     ///
     /// # Examples
-    ///
-    /// ```
     /// use icu_locid::extensions::unicode::{Keywords, Key, Value};
     ///
     /// let key: Key = "ca".parse()
@@ -54,7 +66,11 @@ impl Keywords {
     /// assert_eq!(&keywords.to_string(), "ca-buddhist");
     /// ```
     pub fn from_vec_unchecked(input: Vec<(Key, Value)>) -> Self {
-        Self(input.into_boxed_slice())
+        if input.is_empty() {
+            Self(None)
+        } else {
+            Self(Some(input.into_boxed_slice()))
+        }
     }
 
     /// Returns `true` if the list contains a [`Value`] for the specified [`Key`].
@@ -108,8 +124,8 @@ impl Keywords {
     where
         Q: Borrow<Key>,
     {
-        if let Ok(idx) = self.0.binary_search_by_key(key.borrow(), |(key, _)| *key) {
-            self.0.get(idx).map(|(_, v)| v)
+        if let Ok(idx) = self.binary_search_by_key(key.borrow(), |(key, _)| *key) {
+            self.deref().get(idx).map(|(_, v)| v)
         } else {
             None
         }
@@ -140,6 +156,10 @@ impl Deref for Keywords {
     type Target = [(Key, Value)];
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        if let Some(ref data) = self.0 {
+            data
+        } else {
+            &[]
+        }
     }
 }

--- a/components/locid/src/extensions/unicode/keywords.rs
+++ b/components/locid/src/extensions/unicode/keywords.rs
@@ -44,10 +44,10 @@ impl Keywords {
     /// ```
     /// use icu_locid::extensions::unicode::Keywords;
     ///
-    /// assert_eq!(Keywords::const_default(), Keywords::default());
+    /// assert_eq!(Keywords::new(), Keywords::default());
     /// ```
     #[inline]
-    pub const fn const_default() -> Self {
+    pub const fn new() -> Self {
         Self(None)
     }
 

--- a/components/locid/src/extensions/unicode/mod.rs
+++ b/components/locid/src/extensions/unicode/mod.rs
@@ -85,13 +85,13 @@ impl Unicode {
     /// ```
     /// use icu_locid::extensions::unicode::Unicode;
     ///
-    /// assert_eq!(Unicode::const_default(), Unicode::default());
+    /// assert_eq!(Unicode::new(), Unicode::default());
     /// ```
     #[inline]
-    pub const fn const_default() -> Self {
+    pub const fn new() -> Self {
         Self {
-            keywords: Keywords::const_default(),
-            attributes: Attributes::const_default(),
+            keywords: Keywords::new(),
+            attributes: Attributes::new(),
         }
     }
 

--- a/components/locid/src/extensions/unicode/mod.rs
+++ b/components/locid/src/extensions/unicode/mod.rs
@@ -78,6 +78,23 @@ pub struct Unicode {
 }
 
 impl Unicode {
+    /// Returns a new empty map of Unicode extensions. Same as `Default`, but is `const`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_locid::extensions::unicode::Unicode;
+    ///
+    /// assert_eq!(Unicode::const_default(), Unicode::default());
+    /// ```
+    #[inline]
+    pub const fn const_default() -> Self {
+        Self {
+            keywords: Keywords::const_default(),
+            attributes: Attributes::const_default(),
+        }
+    }
+
     /// Returns `true` if there list of keywords and attributes is empty.
     ///
     /// # Examples
@@ -85,7 +102,7 @@ impl Unicode {
     /// ```
     /// use icu_locid::Locale;
     ///
-    /// let mut loc: Locale = "en-US-u-foo".parse()
+    /// let loc: Locale = "en-US-u-foo".parse()
     ///     .expect("Parsing failed.");
     ///
     /// assert_eq!(loc.extensions.unicode.is_empty(), false);

--- a/components/locid/src/langid.rs
+++ b/components/locid/src/langid.rs
@@ -103,6 +103,26 @@ impl LanguageIdentifier {
         parse_language_identifier(v, ParserMode::Locale)
     }
 
+    /// Returns the default undefined language "und". Same as `Default`, but is `const`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_locid::LanguageIdentifier;
+    ///
+    /// assert_eq!(LanguageIdentifier::und(), LanguageIdentifier::default());
+    /// assert_eq!("und", LanguageIdentifier::und().to_string());
+    /// ```
+    #[inline]
+    pub const fn und() -> Self {
+        Self {
+            language: subtags::Language::und(),
+            script: None,
+            region: None,
+            variants: subtags::Variants::const_default(),
+        }
+    }
+
     /// This is a best-effort operation that performs all available levels of canonicalization.
     ///
     /// At the moment the operation will normalize casing and the separator, but in the future

--- a/components/locid/src/langid.rs
+++ b/components/locid/src/langid.rs
@@ -119,7 +119,7 @@ impl LanguageIdentifier {
             language: subtags::Language::und(),
             script: None,
             region: None,
-            variants: subtags::Variants::const_default(),
+            variants: subtags::Variants::new(),
         }
     }
 

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -108,7 +108,7 @@ impl Locale {
     /// assert_eq!("und", Locale::und().to_string());
     /// ```
     #[inline]
-    pub fn und() -> Self {
+    pub const fn und() -> Self {
         Self {
             language: subtags::Language::und(),
             script: None,

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -113,8 +113,8 @@ impl Locale {
             language: subtags::Language::und(),
             script: None,
             region: None,
-            variants: subtags::Variants::const_default(),
-            extensions: extensions::Extensions::const_default(),
+            variants: subtags::Variants::new(),
+            extensions: extensions::Extensions::new(),
         }
     }
 

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -97,6 +97,27 @@ impl Locale {
         parse_locale(v)
     }
 
+    /// Returns the default undefined locale "und". Same as `Default`, but is `const`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_locid::Locale;
+    ///
+    /// assert_eq!(Locale::und(), Locale::default());
+    /// assert_eq!("und", Locale::und().to_string());
+    /// ```
+    #[inline]
+    pub fn und() -> Self {
+        Self {
+            language: subtags::Language::und(),
+            script: None,
+            region: None,
+            variants: subtags::Variants::const_default(),
+            extensions: extensions::Extensions::const_default(),
+        }
+    }
+
     /// This is a best-effort operation that performs all available levels of canonicalization.
     ///
     /// At the moment the operation will normalize casing and the separator, but in the future

--- a/components/locid/src/subtags/language.rs
+++ b/components/locid/src/subtags/language.rs
@@ -121,6 +121,21 @@ impl Language {
         })
     }
 
+    /// Returns the default undefined language "und". Same as `Default`, but is `const`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_locid::subtags::Language;
+    ///
+    /// assert_eq!(Language::und(), Language::default());
+    /// assert_eq!("und", Language::und().to_string());
+    /// ```
+    #[inline]
+    pub const fn und() -> Self {
+        Self(None)
+    }
+
     /// A helper function for displaying
     /// a `Language` subtag as a `&str`.
     ///

--- a/components/locid/src/subtags/variants.rs
+++ b/components/locid/src/subtags/variants.rs
@@ -39,10 +39,10 @@ impl Variants {
     /// ```
     /// use icu_locid::subtags::Variants;
     ///
-    /// assert_eq!(Variants::const_default(), Variants::default());
+    /// assert_eq!(Variants::new(), Variants::default());
     /// ```
     #[inline]
-    pub const fn const_default() -> Self {
+    pub const fn new() -> Self {
         Self(None)
     }
 

--- a/components/locid/src/subtags/variants.rs
+++ b/components/locid/src/subtags/variants.rs
@@ -29,16 +29,23 @@ use std::ops::Deref;
 /// ```
 ///
 #[derive(Default, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
-pub struct Variants(
-    // The internal representation of the struct uses `Option` to workaround
-    // the limitation of `const fn` in Rust at the time of writing.
-    //
-    // Once Rust supports boxed slices in const fn, we should remove the
-    // wrapping `Option`.
-    Option<Box<[Variant]>>,
-);
+pub struct Variants(Option<Box<[Variant]>>);
 
 impl Variants {
+    /// Returns a new empty list of variants. Same as `Default`, but is `const`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_locid::subtags::Variants;
+    ///
+    /// assert_eq!(Variants::const_default(), Variants::default());
+    /// ```
+    #[inline]
+    pub const fn const_default() -> Self {
+        Self(None)
+    }
+
     /// Creates a new `Variants` set from a vector.
     /// The caller is expected to provide sorted and deduplicated vector as
     /// an input.

--- a/components/provider/src/resource.rs
+++ b/components/provider/src/resource.rs
@@ -362,14 +362,14 @@ mod tests {
             TestCase {
                 resc_options: ResourceOptions {
                     variant: None,
-                    langid: Some(LanguageIdentifier::default()),
+                    langid: Some(LanguageIdentifier::und()),
                 },
                 expected: "und",
             },
             TestCase {
                 resc_options: ResourceOptions {
                     variant: Some(Cow::Borrowed("GBP")),
-                    langid: Some(LanguageIdentifier::default()),
+                    langid: Some(LanguageIdentifier::und()),
                 },
                 expected: "GBP/und",
             },

--- a/components/provider_cldr/src/cldr_langid.rs
+++ b/components/provider_cldr/src/cldr_langid.rs
@@ -19,10 +19,9 @@ pub struct CldrLangID {
 impl CldrLangID {
     /// Return the `CldrLangID` for "root"
     pub fn root() -> Self {
-        // TODO: Use LanguageIdentifier::default()
         Self {
             cldr_language: "root".parse().unwrap(),
-            langid: LanguageIdentifier::default(),
+            langid: LanguageIdentifier::und(),
         }
     }
 }
@@ -30,7 +29,7 @@ impl CldrLangID {
 impl From<LanguageIdentifier> for CldrLangID {
     /// Return a `CldrLangID` for a generic `LanguageIdentifier`. "und" becomes "root".
     fn from(langid: LanguageIdentifier) -> Self {
-        if langid == LanguageIdentifier::default() {
+        if langid == LanguageIdentifier::und() {
             Self::root()
         } else {
             Self {
@@ -152,7 +151,7 @@ fn test_order() {
 fn test_und_root() {
     CldrLangID::from_str("und").expect_err("und should not be allowed as a string");
 
-    let und = CldrLangID::from(LanguageIdentifier::default());
+    let und = CldrLangID::from(LanguageIdentifier::und());
     let root = CldrLangID::from_str("root").unwrap();
     assert_eq!(und, root);
 }

--- a/resources/testdata/src/metadata.rs
+++ b/resources/testdata/src/metadata.rs
@@ -86,11 +86,10 @@ pub fn load() -> Result<PackageInfo, Error> {
 
 #[test]
 fn test_metadata() {
-    use icu_locid_macros::langid;
     let package_info = load().expect("Failed to load metadata");
     assert!(package_info
         .package_metadata
         .locales
-        .contains(&(langid!("und"))));
+        .contains(&(LanguageIdentifier::und())));
     assert!(package_info.package_metadata.locales.len() > 10);
 }


### PR DESCRIPTION
Fixes #222

I changed the remaining instances of `Box<[...]>` to `Option<Box<[...]>>` so that they can be used in a const function.  I think this is actually a net improvement, because with `Box<[...]>`, you incur a heap allocation even if the list is empty (common case).