### PR TITLE
Fix deploying memory benchmarks to GitHub pages

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -369,6 +369,9 @@ jobs:
     - name: Create (ensure existence of) folder for benchmark data to copy
       run: mkdir -p copy-to-ext-repo/dev
 
+    - name: Create (ensure existence of) folder for memory benchmark data to copy
+      run: mkdir -p copy-to-ext-repo/benchmarks/memory
+
     # Doc-GH-Pages job > Download benchmark dashboard files from previous jobs into folder of files to copy to remote repo
 
     - name: Download previous content destined for GH pages
@@ -376,6 +379,13 @@ jobs:
       with:
         path: ./copy-to-ext-repo/dev
         name: benchmark-perf
+
+    # Doc-GH-Pages job > Download benchmark dashboard files from previous jobs into folder of files to copy to remote repo
+    - name: Download previous content destined for GH pages
+      uses: actions/download-artifact@v2
+      with:
+        path: ./copy-to-ext-repo/benchmarks/memory
+        name: benchmark-memory
 
     # Doc-GH-Pages job > Generate `cargo doc` step
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -258,6 +258,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    # Only run the memory benchmark if the main build succeeded. The memory benchmark does not
+    # rely on any of the build artifacts.
+    needs: [build]
+
     steps:
       - uses: actions/checkout@v2
 
@@ -291,7 +295,7 @@ jobs:
           fail-on-alert: true
           # Requires one-time-only creation of this branch on remote repo. This will
           # store the generated information.
-          gh-pages-branch: unmerged-pr-memory-data
+          gh-pages-branch: unmerged-pr-bench-data
 
           # Do not store historical benchmark info of unfinished PRs. Commits seem to get
           # made anyways, so make sure that the branch in `gh-pages-branch` is
@@ -352,7 +356,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    needs: [build, lint, benchmark]
+    needs: [build, lint, benchmark, memory]
 
     ## Only create docs for merges/pushes to master (skip PRs).
     ## Multiple unfinished PRs should not clobber docs from approved code.


### PR DESCRIPTION
I didn't have a way to easily test this in a separate branch, so I ended
up missing the instructions to transfer the uploaded artifact to GitHub
pages.