### PR TITLE
Allow some clippy lints

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,7 +18,9 @@ fmt-check = "fmt -- --check"
 license-check = "make license-header-check"
 
 # Run Clippy on all code paths
-clippy-all = "clippy --all-features --all-targets"
+# unknown-clippy-lints: to allow us to work with nightly clippy lints that we don't CI
+# field-reassign-with-default: https://github.com/rust-lang/rust-clippy/issues/6559 (fixed in nightly but not stable)
+clippy-all = "clippy --all-features --all-targets -- -Aclippy::unknown-clippy-lints -Aclippy::field-reassign-with-default"
 
 ### META TASKS ###
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -107,7 +107,8 @@ jobs:
     - uses: actions-rs/clippy-check@v1.0.7
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all-targets --all-features -- -D warnings
+        # keep args in sync with `clippy-all` in .cargo/config.toml
+        args: --all-targets --all-features -- -Aclippy::unknown-clippy-lints -Aclippy::field-reassign-with-default
 
   # Benchmarking & dashboards job
 


### PR DESCRIPTION
This:

 - disables `clippy::unknown-clippy-lints` so that we can start working with nightly lints (without CI-gating them)
 - disables `clippy::field-reassign-with-default` until https://github.com/rust-lang/rust-clippy/pull/6375 reaches stable
 - documents them both

Note that these changes will not apply to local runs of `cargo clippy`, _only_ `cargo clippy-all`. I hope that is sufficient?