### PR TITLE
Change DateTimeFormat constructor to take Locale instead of LangID

### DIFF
--- a/components/datetime/examples/work_log.rs
+++ b/components/datetime/examples/work_log.rs
@@ -38,7 +38,7 @@ fn print(_input: &str, _value: Option<usize>) {
 fn main(_argc: isize, _argv: *const *const u8) -> isize {
     icu_benchmark_macros::main_setup!();
 
-    let lid = langid!("en");
+    let locale = langid!("en").into();
 
     let provider = icu_testdata::get_provider();
 
@@ -54,7 +54,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
         ..Default::default()
     };
 
-    let dtf = DateTimeFormat::try_new(lid, &provider, &options.into())
+    let dtf = DateTimeFormat::try_new(locale, &provider, &options.into())
         .expect("Failed to create DateTimeFormat instance.");
     {
         print("\n====== Work Log (en) example ============", None);

--- a/components/datetime/src/format.rs
+++ b/components/datetime/src/format.rs
@@ -25,10 +25,10 @@ use writeable::Writeable;
 /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
 /// # use icu_datetime::date::MockDateTime;
 /// # use icu_provider::inv::InvariantDataProvider;
-/// # let lid = langid!("en");
+/// # let locale = langid!("en").into();
 /// # let provider = InvariantDataProvider;
 /// # let options = DateTimeFormatOptions::default();
-/// let dtf = DateTimeFormat::try_new(lid, &provider, &options)
+/// let dtf = DateTimeFormat::try_new(locale, &provider, &options)
 ///     .expect("Failed to create DateTimeFormat instance.");
 ///
 /// let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -73,9 +73,12 @@ fn test_dayperiod_patterns() {
                             key: GREGORY_V1,
                             data: data.as_ref(),
                         };
-                        let dtf =
-                            DateTimeFormat::try_new(langid.clone(), &provider, &format_options)
-                                .unwrap();
+                        let dtf = DateTimeFormat::try_new(
+                            langid.clone().into(),
+                            &provider,
+                            &format_options,
+                        )
+                        .unwrap();
                         assert_eq!(
                             dtf.format(&date_time).to_string(),
                             *expected,

--- a/components/icu/examples/tui.rs
+++ b/components/icu/examples/tui.rs
@@ -7,7 +7,7 @@
 #![no_main] // https://github.com/unicode-org/icu4x/issues/395
 
 use icu::datetime::{date::MockDateTime, DateTimeFormat, DateTimeFormatOptions};
-use icu::locid::{macros::langid, LanguageIdentifier};
+use icu::locid::{macros::langid, Locale};
 use icu::plurals::{PluralCategory, PluralRuleType, PluralRules};
 use icu::uniset::UnicodeSetBuilder;
 use std::env;
@@ -23,10 +23,10 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
 
     let args: Vec<String> = env::args().collect();
 
-    let langid: LanguageIdentifier = args
+    let locale: Locale = args
         .get(1)
         .map(|s| s.parse().expect("Failed to parse language identifier"))
-        .unwrap_or(langid!("en"));
+        .unwrap_or_else(|| langid!("en").into());
 
     let user_name = args.get(2).cloned().unwrap_or_else(|| "John".to_string());
 
@@ -36,12 +36,12 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
         .parse()
         .expect("Could not parse unread email count as unsigned integer.");
 
-    print(format!("\nTextual User Interface Example ({})", langid));
+    print(format!("\nTextual User Interface Example ({})", locale));
     print("===================================");
     print(format!("User: {}", user_name));
 
     {
-        let dtf = DateTimeFormat::try_new(langid, &provider, &DateTimeFormatOptions::default())
+        let dtf = DateTimeFormat::try_new(locale, &provider, &DateTimeFormatOptions::default())
             .expect("Failed to create DateTimeFormat.");
         let today: MockDateTime = "2020-10-10T18:56:00".parse().expect("Failed to parse date");
 

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -39,7 +39,7 @@
 //!
 //! let provider = icu_testdata::get_provider();
 //!
-//! let lid = langid!("en");
+//! let locale = langid!("en").into();
 //!
 //! let options = style::Bag {
 //!     date: Some(style::Date::Long),
@@ -47,7 +47,7 @@
 //!     ..Default::default()
 //! }.into();
 //!
-//! let dtf = DateTimeFormat::try_new(lid, &provider, &options)
+//! let dtf = DateTimeFormat::try_new(locale, &provider, &options)
 //!     .expect("Failed to create DateTimeFormat instance.");
 //!
 //! let date: MockDateTime = "2020-09-12T12:35:00".parse()
@@ -77,7 +77,7 @@ pub mod datetime {
     //!
     //! let provider = icu_testdata::get_provider();
     //!
-    //! let lid = langid!("en");
+    //! let locale = langid!("en").into();
     //!
     //! let options = style::Bag {
     //!     date: Some(style::Date::Medium),
@@ -85,7 +85,7 @@ pub mod datetime {
     //!     ..Default::default()
     //! }.into();
     //!
-    //! let dtf = DateTimeFormat::try_new(lid, &provider, &options)
+    //! let dtf = DateTimeFormat::try_new(locale, &provider, &options)
     //!     .expect("Failed to create DateTimeFormat instance.");
     //!
     //! let date: MockDateTime = "2020-09-12T12:35:00".parse()


### PR DESCRIPTION
Split off from #445

This PR changes DateTimeFormat to take a Locale instead of LanguageIdentifier.  This is necessary for week-of-year calculations, since the first day of the week is dependent on Unicode extensions.