### PR TITLE
Make LanguageIdentifier a field of Locale

### DIFF
--- a/components/datetime/benches/datetime.rs
+++ b/components/datetime/benches/datetime.rs
@@ -57,7 +57,7 @@ fn datetime_benches(c: &mut Criterion) {
                         .collect();
 
                     for setup in &fx.setups {
-                        let langid = setup.locale.parse().unwrap();
+                        let locale: Locale = setup.locale.parse().unwrap();
                         let options = fixtures::get_options(&setup.options);
                         let dtf = DateTimeFormat::try_new(langid, &provider, &options).unwrap();
 
@@ -82,9 +82,9 @@ fn datetime_benches(c: &mut Criterion) {
                         .collect();
 
                     for setup in &fx.setups {
-                        let langid = setup.locale.parse().unwrap();
+                        let locale: Locale = setup.locale.parse().unwrap();
                         let options = fixtures::get_options(&setup.options);
-                        let dtf = DateTimeFormat::try_new(langid, &provider, &options).unwrap();
+                        let dtf = DateTimeFormat::try_new(locale, &provider, &options).unwrap();
 
                         for dt in &datetimes {
                             let _ = dtf.format_to_string(dt);
@@ -104,9 +104,9 @@ fn datetime_benches(c: &mut Criterion) {
                         .collect();
 
                     for setup in &fx.setups {
-                        let langid = setup.locale.parse().unwrap();
+                        let locale: Locale = setup.locale.parse().unwrap();
                         let options = fixtures::get_options(&setup.options);
-                        let dtf = DateTimeFormat::try_new(langid, &provider, &options).unwrap();
+                        let dtf = DateTimeFormat::try_new(locale, &provider, &options).unwrap();
 
                         let mut result = String::new();
 
@@ -130,9 +130,9 @@ fn datetime_benches(c: &mut Criterion) {
                         .collect();
 
                     for setup in &fx.setups {
-                        let langid = setup.locale.parse().unwrap();
+                        let locale: Locale = setup.locale.parse().unwrap();
                         let options = fixtures::get_options(&setup.options);
-                        let dtf = DateTimeFormat::try_new(langid, &provider, &options).unwrap();
+                        let dtf = DateTimeFormat::try_new(locale, &provider, &options).unwrap();
 
                         for dt in &datetimes {
                             let fdt = dtf.format(dt);

--- a/components/datetime/benches/datetime.rs
+++ b/components/datetime/benches/datetime.rs
@@ -59,7 +59,7 @@ fn datetime_benches(c: &mut Criterion) {
                     for setup in &fx.setups {
                         let locale: Locale = setup.locale.parse().unwrap();
                         let options = fixtures::get_options(&setup.options);
-                        let dtf = DateTimeFormat::try_new(langid, &provider, &options).unwrap();
+                        let dtf = DateTimeFormat::try_new(locale, &provider, &options).unwrap();
 
                         let mut result = String::new();
 

--- a/components/datetime/benches/datetime.rs
+++ b/components/datetime/benches/datetime.rs
@@ -8,6 +8,7 @@ use std::fmt::Write;
 
 use icu_datetime::date::MockDateTime;
 use icu_datetime::DateTimeFormat;
+use icu_locid::Locale;
 
 fn datetime_benches(c: &mut Criterion) {
     let fxs = fixtures::get_fixture("styles").unwrap();
@@ -25,9 +26,9 @@ fn datetime_benches(c: &mut Criterion) {
                     .map(|value| value.parse().unwrap())
                     .collect();
                 for setup in &fx.setups {
-                    let langid = setup.locale.parse().unwrap();
+                    let locale: Locale = setup.locale.parse().unwrap();
                     let options = fixtures::get_options(&setup.options);
-                    let dtf = DateTimeFormat::try_new(langid, &provider, &options).unwrap();
+                    let dtf = DateTimeFormat::try_new(locale, &provider, &options).unwrap();
 
                     let mut result = String::new();
 

--- a/components/datetime/examples/work_log.rs
+++ b/components/datetime/examples/work_log.rs
@@ -38,7 +38,7 @@ fn print(_input: &str, _value: Option<usize>) {
 fn main(_argc: isize, _argv: *const *const u8) -> isize {
     icu_benchmark_macros::main_setup!();
 
-    let locale = langid!("en").into();
+    let langid = langid!("en");
 
     let provider = icu_testdata::get_provider();
 
@@ -54,7 +54,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
         ..Default::default()
     };
 
-    let dtf = DateTimeFormat::try_new(locale, &provider, &options.into())
+    let dtf = DateTimeFormat::try_new(langid, &provider, &options.into())
         .expect("Failed to create DateTimeFormat instance.");
     {
         print("\n====== Work Log (en) example ============", None);

--- a/components/datetime/examples/work_log.rs
+++ b/components/datetime/examples/work_log.rs
@@ -10,6 +10,7 @@ icu_benchmark_macros::static_setup!();
 
 use icu_datetime::date::MockDateTime;
 use icu_datetime::{options::style, DateTimeFormat};
+use icu_locid::Locale;
 use icu_locid_macros::langid;
 
 const DATES_ISO: &[&str] = &[
@@ -38,7 +39,7 @@ fn print(_input: &str, _value: Option<usize>) {
 fn main(_argc: isize, _argv: *const *const u8) -> isize {
     icu_benchmark_macros::main_setup!();
 
-    let langid = langid!("en");
+    let locale: Locale = langid!("en").into();
 
     let provider = icu_testdata::get_provider();
 
@@ -54,7 +55,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
         ..Default::default()
     };
 
-    let dtf = DateTimeFormat::try_new(langid, &provider, &options.into())
+    let dtf = DateTimeFormat::try_new(locale, &provider, &options.into())
         .expect("Failed to create DateTimeFormat instance.");
     {
         print("\n====== Work Log (en) example ============", None);

--- a/components/datetime/src/format.rs
+++ b/components/datetime/src/format.rs
@@ -25,10 +25,10 @@ use writeable::Writeable;
 /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
 /// # use icu_datetime::date::MockDateTime;
 /// # use icu_provider::inv::InvariantDataProvider;
-/// # let locale = langid!("en").into();
+/// # let langid = langid!("en");
 /// # let provider = InvariantDataProvider;
 /// # let options = DateTimeFormatOptions::default();
-/// let dtf = DateTimeFormat::try_new(locale, &provider, &options)
+/// let dtf = DateTimeFormat::try_new(langid, &provider, &options)
 ///     .expect("Failed to create DateTimeFormat instance.");
 ///
 /// let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)

--- a/components/datetime/src/format.rs
+++ b/components/datetime/src/format.rs
@@ -21,14 +21,15 @@ use writeable::Writeable;
 /// # Examples
 ///
 /// ```
+/// # use icu_locid::Locale;
 /// # use icu_locid_macros::langid;
 /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
 /// # use icu_datetime::date::MockDateTime;
 /// # use icu_provider::inv::InvariantDataProvider;
-/// # let langid = langid!("en");
+/// # let locale: Locale = langid!("en").into();
 /// # let provider = InvariantDataProvider;
 /// # let options = DateTimeFormatOptions::default();
-/// let dtf = DateTimeFormat::try_new(langid, &provider, &options)
+/// let dtf = DateTimeFormat::try_new(locale, &provider, &options)
 ///     .expect("Failed to create DateTimeFormat instance.");
 ///
 /// let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! let provider = icu_testdata::get_provider();
 //!
-//! let locale = langid!("en").into();
+//! let langid = langid!("en");
 //!
 //! // See the next code example for a more ergonomic example with .into().
 //! let options = DateTimeFormatOptions::Style(style::Bag {
@@ -28,7 +28,7 @@
 //!     ..Default::default()
 //! });
 //!
-//! let dtf = DateTimeFormat::try_new(locale, &provider, &options)
+//! let dtf = DateTimeFormat::try_new(langid, &provider, &options)
 //!     .expect("Failed to create DateTimeFormat instance.");
 //!
 //!
@@ -48,14 +48,14 @@
 //! # use icu_locid_macros::langid;
 //! # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions, date::MockDateTime, options::style};
 //! # let provider = icu_testdata::get_provider();
-//! # let locale = langid!("en").into();
+//! # let langid = langid!("en");
 //! let options = style::Bag {
 //!     date: Some(style::Date::Medium),
 //!     time: Some(style::Time::Short),
 //!     ..Default::default()
 //! }.into();
 //!
-//! let dtf = DateTimeFormat::try_new(locale, &provider, &options);
+//! let dtf = DateTimeFormat::try_new(langid, &provider, &options);
 //! # } // feature = "provider_serde"
 //! ```
 //!
@@ -107,7 +107,7 @@ use std::borrow::Cow;
 /// use icu_datetime::date::MockDateTime;
 /// use icu_provider::inv::InvariantDataProvider;
 ///
-/// let locale = langid!("en").into();
+/// let langid = langid!("en");
 ///
 /// let provider = InvariantDataProvider;
 ///
@@ -116,7 +116,7 @@ use std::borrow::Cow;
 ///     time: Some(style::Time::Short),
 ///     ..Default::default()
 /// };
-/// let dtf = DateTimeFormat::try_new(locale, &provider, &options.into())
+/// let dtf = DateTimeFormat::try_new(langid, &provider, &options.into())
 ///     .expect("Failed to create DateTimeFormat instance.");
 ///
 ///
@@ -146,7 +146,7 @@ impl<'d> DateTimeFormat<'d> {
     /// use icu_datetime::date::MockDateTime;
     /// use icu_provider::inv::InvariantDataProvider;
     ///
-    /// let locale = langid!("en").into();
+    /// let locale = langid!("en");
     ///
     /// let provider = InvariantDataProvider;
     ///
@@ -156,11 +156,12 @@ impl<'d> DateTimeFormat<'d> {
     ///
     /// assert_eq!(dtf.is_ok(), true);
     /// ```
-    pub fn try_new<D: DataProvider<'d, provider::gregory::DatesV1> + ?Sized>(
-        locale: Locale,
+    pub fn try_new<T: Into<Locale>, D: DataProvider<'d, provider::gregory::DatesV1> + ?Sized>(
+        locale: T,
         data_provider: &D,
         options: &DateTimeFormatOptions,
     ) -> Result<Self, DateTimeFormatError> {
+        let locale = locale.into();
         let data = data_provider
             .load_payload(&DataRequest {
                 resource_path: ResourcePath {
@@ -192,10 +193,10 @@ impl<'d> DateTimeFormat<'d> {
     /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
     /// # use icu_datetime::date::MockDateTime;
     /// # use icu_provider::inv::InvariantDataProvider;
-    /// # let locale = langid!("en").into();
+    /// # let langid = langid!("en");
     /// # let provider = InvariantDataProvider;
     /// # let options = DateTimeFormatOptions::default();
-    /// let dtf = DateTimeFormat::try_new(locale, &provider, &options)
+    /// let dtf = DateTimeFormat::try_new(langid, &provider, &options)
     ///     .expect("Failed to create DateTimeFormat instance.");
     ///
     /// let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)
@@ -230,10 +231,10 @@ impl<'d> DateTimeFormat<'d> {
     /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
     /// # use icu_datetime::date::MockDateTime;
     /// # use icu_provider::inv::InvariantDataProvider;
-    /// # let locale = langid!("en").into();
+    /// # let langid = langid!("en");
     /// # let provider = InvariantDataProvider;
     /// # let options = DateTimeFormatOptions::default();
-    /// let dtf = DateTimeFormat::try_new(locale, &provider, &options.into())
+    /// let dtf = DateTimeFormat::try_new(langid, &provider, &options.into())
     ///     .expect("Failed to create DateTimeFormat instance.");
     ///
     /// let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)
@@ -262,10 +263,10 @@ impl<'d> DateTimeFormat<'d> {
     /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
     /// # use icu_datetime::date::MockDateTime;
     /// # use icu_provider::inv::InvariantDataProvider;
-    /// # let locale = langid!("en").into();
+    /// # let langid = langid!("en");
     /// # let provider = InvariantDataProvider;
     /// # let options = DateTimeFormatOptions::default();
-    /// let dtf = DateTimeFormat::try_new(locale, &provider, &options.into())
+    /// let dtf = DateTimeFormat::try_new(langid, &provider, &options.into())
     ///     .expect("Failed to create DateTimeFormat instance.");
     ///
     /// let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -14,12 +14,13 @@
 //!
 //! ```
 //! # #[cfg(feature = "provider_serde")] {
+//! use icu_locid::Locale;
 //! use icu_locid_macros::langid;
 //! use icu_datetime::{DateTimeFormat, DateTimeFormatOptions, date::MockDateTime, options::style};
 //!
 //! let provider = icu_testdata::get_provider();
 //!
-//! let langid = langid!("en");
+//! let locale: Locale = langid!("en").into();
 //!
 //! // See the next code example for a more ergonomic example with .into().
 //! let options = DateTimeFormatOptions::Style(style::Bag {
@@ -28,7 +29,7 @@
 //!     ..Default::default()
 //! });
 //!
-//! let dtf = DateTimeFormat::try_new(langid, &provider, &options)
+//! let dtf = DateTimeFormat::try_new(locale, &provider, &options)
 //!     .expect("Failed to create DateTimeFormat instance.");
 //!
 //!
@@ -45,17 +46,18 @@
 //!
 //! ```
 //! # #[cfg(feature = "provider_serde")] {
+//! # use icu_locid::Locale;
 //! # use icu_locid_macros::langid;
 //! # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions, date::MockDateTime, options::style};
 //! # let provider = icu_testdata::get_provider();
-//! # let langid = langid!("en");
+//! # let locale: Locale = langid!("en").into();
 //! let options = style::Bag {
 //!     date: Some(style::Date::Medium),
 //!     time: Some(style::Time::Short),
 //!     ..Default::default()
 //! }.into();
 //!
-//! let dtf = DateTimeFormat::try_new(langid, &provider, &options);
+//! let dtf = DateTimeFormat::try_new(locale, &provider, &options);
 //! # } // feature = "provider_serde"
 //! ```
 //!
@@ -102,12 +104,13 @@ use std::borrow::Cow;
 /// # Examples
 ///
 /// ```
+/// use icu_locid::Locale;
 /// use icu_locid_macros::langid;
 /// use icu_datetime::{DateTimeFormat, options::style};
 /// use icu_datetime::date::MockDateTime;
 /// use icu_provider::inv::InvariantDataProvider;
 ///
-/// let langid = langid!("en");
+/// let locale: Locale = langid!("en").into();
 ///
 /// let provider = InvariantDataProvider;
 ///
@@ -116,7 +119,7 @@ use std::borrow::Cow;
 ///     time: Some(style::Time::Short),
 ///     ..Default::default()
 /// };
-/// let dtf = DateTimeFormat::try_new(langid, &provider, &options.into())
+/// let dtf = DateTimeFormat::try_new(locale, &provider, &options.into())
 ///     .expect("Failed to create DateTimeFormat instance.");
 ///
 ///
@@ -141,12 +144,13 @@ impl<'d> DateTimeFormat<'d> {
     /// # Examples
     ///
     /// ```
+    /// use icu_locid::Locale;
     /// use icu_locid_macros::langid;
     /// use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
     /// use icu_datetime::date::MockDateTime;
     /// use icu_provider::inv::InvariantDataProvider;
     ///
-    /// let locale = langid!("en");
+    /// let locale: Locale = langid!("en").into();
     ///
     /// let provider = InvariantDataProvider;
     ///
@@ -189,14 +193,15 @@ impl<'d> DateTimeFormat<'d> {
     /// # Examples
     ///
     /// ```
+    /// # use icu_locid::Locale;
     /// # use icu_locid_macros::langid;
     /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
     /// # use icu_datetime::date::MockDateTime;
     /// # use icu_provider::inv::InvariantDataProvider;
-    /// # let langid = langid!("en");
+    /// # let locale: Locale = langid!("en").into();
     /// # let provider = InvariantDataProvider;
     /// # let options = DateTimeFormatOptions::default();
-    /// let dtf = DateTimeFormat::try_new(langid, &provider, &options)
+    /// let dtf = DateTimeFormat::try_new(locale, &provider, &options)
     ///     .expect("Failed to create DateTimeFormat instance.");
     ///
     /// let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)
@@ -227,14 +232,15 @@ impl<'d> DateTimeFormat<'d> {
     /// # Examples
     ///
     /// ```
+    /// # use icu_locid::Locale;
     /// # use icu_locid_macros::langid;
     /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
     /// # use icu_datetime::date::MockDateTime;
     /// # use icu_provider::inv::InvariantDataProvider;
-    /// # let langid = langid!("en");
+    /// # let locale: Locale = langid!("en").into();
     /// # let provider = InvariantDataProvider;
     /// # let options = DateTimeFormatOptions::default();
-    /// let dtf = DateTimeFormat::try_new(langid, &provider, &options.into())
+    /// let dtf = DateTimeFormat::try_new(locale, &provider, &options.into())
     ///     .expect("Failed to create DateTimeFormat instance.");
     ///
     /// let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)
@@ -259,14 +265,15 @@ impl<'d> DateTimeFormat<'d> {
     /// # Examples
     ///
     /// ```
+    /// # use icu_locid::Locale;
     /// # use icu_locid_macros::langid;
     /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
     /// # use icu_datetime::date::MockDateTime;
     /// # use icu_provider::inv::InvariantDataProvider;
-    /// # let langid = langid!("en");
+    /// # let locale: Locale = langid!("en").into();
     /// # let provider = InvariantDataProvider;
     /// # let options = DateTimeFormatOptions::default();
-    /// let dtf = DateTimeFormat::try_new(langid, &provider, &options.into())
+    /// let dtf = DateTimeFormat::try_new(locale, &provider, &options.into())
     ///     .expect("Failed to create DateTimeFormat instance.");
     ///
     /// let date_time = MockDateTime::try_new(2020, 9, 1, 12, 34, 28)

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -11,7 +11,7 @@ use icu_datetime::{
     provider::{gregory::DatesV1, key::GREGORY_V1},
     DateTimeFormat,
 };
-use icu_locid::LanguageIdentifier;
+use icu_locid::{LanguageIdentifier, Locale};
 use icu_provider::{
     struct_provider::StructProvider, DataProvider, DataRequest, ResourceOptions, ResourcePath,
 };
@@ -21,9 +21,9 @@ fn test_fixture(fixture_name: &str) {
     let provider = icu_testdata::get_provider();
 
     for fx in fixtures::get_fixture(fixture_name).unwrap().0 {
-        let langid = fx.input.locale.parse().unwrap();
+        let locale: Locale = fx.input.locale.parse().unwrap();
         let options = fixtures::get_options(&fx.input.options);
-        let dtf = DateTimeFormat::try_new(langid, &provider, &options).unwrap();
+        let dtf = DateTimeFormat::try_new(locale, &provider, &options).unwrap();
 
         let value: MockDateTime = fx.input.value.parse().unwrap();
 
@@ -74,12 +74,9 @@ fn test_dayperiod_patterns() {
                             key: GREGORY_V1,
                             data: data.as_ref(),
                         };
-                        let dtf = DateTimeFormat::try_new(
-                            langid.clone().into(),
-                            &provider,
-                            &format_options,
-                        )
-                        .unwrap();
+                        let dtf =
+                            DateTimeFormat::try_new(langid.clone(), &provider, &format_options)
+                                .unwrap();
                         assert_eq!(
                             dtf.format(&date_time).to_string(),
                             *expected,

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -39,7 +39,7 @@
 //!
 //! let provider = icu_testdata::get_provider();
 //!
-//! let locale = langid!("en").into();
+//! let langid = langid!("en");
 //!
 //! let options = style::Bag {
 //!     date: Some(style::Date::Long),
@@ -47,7 +47,7 @@
 //!     ..Default::default()
 //! }.into();
 //!
-//! let dtf = DateTimeFormat::try_new(locale, &provider, &options)
+//! let dtf = DateTimeFormat::try_new(langid, &provider, &options)
 //!     .expect("Failed to create DateTimeFormat instance.");
 //!
 //! let date: MockDateTime = "2020-09-12T12:35:00".parse()
@@ -77,7 +77,7 @@ pub mod datetime {
     //!
     //! let provider = icu_testdata::get_provider();
     //!
-    //! let locale = langid!("en").into();
+    //! let langid = langid!("en");
     //!
     //! let options = style::Bag {
     //!     date: Some(style::Date::Medium),
@@ -85,7 +85,7 @@ pub mod datetime {
     //!     ..Default::default()
     //! }.into();
     //!
-    //! let dtf = DateTimeFormat::try_new(locale, &provider, &options)
+    //! let dtf = DateTimeFormat::try_new(langid, &provider, &options)
     //!     .expect("Failed to create DateTimeFormat instance.");
     //!
     //! let date: MockDateTime = "2020-09-12T12:35:00".parse()

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -130,13 +130,13 @@ pub mod locid {
     //! let region: Region = "US".parse()
     //!     .expect("Parsing failed.");
     //!
-    //! assert_eq!(loc.language, lang);
-    //! assert_eq!(loc.script, None);
-    //! assert_eq!(loc.region, Some(region));
-    //! assert_eq!(loc.variants.len(), 0);
+    //! assert_eq!(loc.langid.language, lang);
+    //! assert_eq!(loc.langid.script, None);
+    //! assert_eq!(loc.langid.region, Some(region));
+    //! assert_eq!(loc.langid.variants.len(), 0);
     //!
     //! let region: Region = "GB".parse().expect("Parsing failed.");
-    //! loc.region = Some(region);
+    //! loc.langid.region = Some(region);
     //!
     //! assert_eq!(loc.to_string(), "en-GB");
     //! ```

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -34,12 +34,13 @@
 //! # Examples
 //!
 //! ```
+//! use icu::locid::Locale;
 //! use icu::locid::macros::langid;
 //! use icu::datetime::{DateTimeFormat, date::MockDateTime, options::style};
 //!
 //! let provider = icu_testdata::get_provider();
 //!
-//! let langid = langid!("en");
+//! let locale: Locale = langid!("en").into();
 //!
 //! let options = style::Bag {
 //!     date: Some(style::Date::Long),
@@ -47,7 +48,7 @@
 //!     ..Default::default()
 //! }.into();
 //!
-//! let dtf = DateTimeFormat::try_new(langid, &provider, &options)
+//! let dtf = DateTimeFormat::try_new(locale, &provider, &options)
 //!     .expect("Failed to create DateTimeFormat instance.");
 //!
 //! let date: MockDateTime = "2020-09-12T12:35:00".parse()
@@ -72,12 +73,13 @@ pub mod datetime {
     //! # Examples
     //!
     //! ```
+    //! use icu::locid::Locale;
     //! use icu::locid::macros::langid;
     //! use icu::datetime::{DateTimeFormat, date::MockDateTime, options::style};
     //!
     //! let provider = icu_testdata::get_provider();
     //!
-    //! let langid = langid!("en");
+    //! let locale: Locale = langid!("en").into();
     //!
     //! let options = style::Bag {
     //!     date: Some(style::Date::Medium),
@@ -85,7 +87,7 @@ pub mod datetime {
     //!     ..Default::default()
     //! }.into();
     //!
-    //! let dtf = DateTimeFormat::try_new(langid, &provider, &options)
+    //! let dtf = DateTimeFormat::try_new(locale, &provider, &options)
     //!     .expect("Failed to create DateTimeFormat instance.");
     //!
     //! let date: MockDateTime = "2020-09-12T12:35:00".parse()

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -130,13 +130,13 @@ pub mod locid {
     //! let region: Region = "US".parse()
     //!     .expect("Parsing failed.");
     //!
-    //! assert_eq!(loc.langid.language, lang);
-    //! assert_eq!(loc.langid.script, None);
-    //! assert_eq!(loc.langid.region, Some(region));
-    //! assert_eq!(loc.langid.variants.len(), 0);
+    //! assert_eq!(loc.id.language, lang);
+    //! assert_eq!(loc.id.script, None);
+    //! assert_eq!(loc.id.region, Some(region));
+    //! assert_eq!(loc.id.variants.len(), 0);
     //!
     //! let region: Region = "GB".parse().expect("Parsing failed.");
-    //! loc.langid.region = Some(region);
+    //! loc.id.region = Some(region);
     //!
     //! assert_eq!(loc.to_string(), "en-GB");
     //! ```

--- a/components/locale_canonicalizer/src/locale_canonicalizer.rs
+++ b/components/locale_canonicalizer/src/locale_canonicalizer.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/master/LICENSE ).
 use crate::provider::*;
-use icu_locid::{LanguageIdentifier, Locale};
+use icu_locid::LanguageIdentifier;
 use icu_provider::prelude::*;
 use std::borrow::Cow;
 
@@ -62,91 +62,94 @@ impl LocaleCanonicalizer<'_> {
     /// assert_eq!(locale.to_string(), "en-Latn-DE");
     /// # } // feature = "provider_serde"
     /// ```
-    pub fn maximize(&self, locale: &mut Locale) -> CanonicalizationResult {
-        let update_locale =
-            |entry: &LanguageIdentifier, locale: &mut Locale| -> CanonicalizationResult {
-                if locale.language.is_empty() {
-                    locale.language = entry.language;
+    pub fn maximize<T: AsMut<LanguageIdentifier>>(&self, mut langid: T) -> CanonicalizationResult {
+        let update_langid = |entry: &LanguageIdentifier,
+                             langid: &mut LanguageIdentifier|
+         -> CanonicalizationResult {
+            if langid.language.is_empty() {
+                langid.language = entry.language;
+            }
+            langid.script = langid.script.or(entry.script);
+            langid.region = langid.region.or(entry.region);
+            CanonicalizationResult::Modified
+        };
+
+        |langid: &mut LanguageIdentifier| -> CanonicalizationResult {
+            if !langid.language.is_empty() && langid.script.is_some() && langid.region.is_some() {
+                return CanonicalizationResult::Unmodified;
+            }
+
+            if !langid.language.is_empty() {
+                if langid.script.is_some() {
+                    let key = (&langid.language, &langid.script);
+                    if let Ok(index) = self
+                        .likely_subtags
+                        .language_script
+                        .binary_search_by_key(&key, |(l, _)| (&l.language, &l.script))
+                    {
+                        let entry = &self.likely_subtags.language_script[index].1;
+                        return update_langid(entry, langid);
+                    }
                 }
-                locale.script = locale.script.or(entry.script);
-                locale.region = locale.region.or(entry.region);
-                CanonicalizationResult::Modified
-            };
 
-        if !locale.language.is_empty() && locale.script.is_some() && locale.region.is_some() {
-            return CanonicalizationResult::Unmodified;
-        }
+                if langid.region.is_some() {
+                    let key = (&langid.language, &langid.region);
+                    if let Ok(index) = self
+                        .likely_subtags
+                        .language_region
+                        .binary_search_by_key(&key, |(l, _)| (&l.language, &l.region))
+                    {
+                        let entry = &self.likely_subtags.language_region[index].1;
+                        return update_langid(entry, langid);
+                    }
+                }
 
-        if !locale.language.is_empty() {
-            if locale.script.is_some() {
-                let key = (&locale.language, &locale.script);
+                let key = &langid.language;
                 if let Ok(index) = self
                     .likely_subtags
-                    .language_script
-                    .binary_search_by_key(&key, |(l, _)| (&l.language, &l.script))
+                    .language
+                    .binary_search_by_key(key, |(l, _)| l.language)
                 {
-                    let entry = &self.likely_subtags.language_script[index].1;
-                    return update_locale(entry, locale);
+                    let entry = &self.likely_subtags.language[index].1;
+                    return update_langid(entry, langid);
                 }
-            }
+            } else if langid.script.is_some() {
+                if langid.region.is_some() {
+                    let key = (&langid.script, &langid.region);
+                    if let Ok(index) = self
+                        .likely_subtags
+                        .script_region
+                        .binary_search_by_key(&key, |(l, _)| (&l.script, &l.region))
+                    {
+                        let entry = &self.likely_subtags.script_region[index].1;
+                        return update_langid(entry, langid);
+                    }
+                }
 
-            if locale.region.is_some() {
-                let key = (&locale.language, &locale.region);
+                let key = &langid.script;
                 if let Ok(index) = self
                     .likely_subtags
-                    .language_region
-                    .binary_search_by_key(&key, |(l, _)| (&l.language, &l.region))
+                    .script
+                    .binary_search_by_key(&key, |(l, _)| &l.script)
                 {
-                    let entry = &self.likely_subtags.language_region[index].1;
-                    return update_locale(entry, locale);
+                    let entry = &self.likely_subtags.script[index].1;
+                    return update_langid(entry, langid);
                 }
-            }
-
-            let key = &locale.language;
-            if let Ok(index) = self
-                .likely_subtags
-                .language
-                .binary_search_by_key(key, |(l, _)| l.language)
-            {
-                let entry = &self.likely_subtags.language[index].1;
-                return update_locale(entry, locale);
-            }
-        } else if locale.script.is_some() {
-            if locale.region.is_some() {
-                let key = (&locale.script, &locale.region);
+            } else if langid.region.is_some() {
+                let key = &langid.region;
                 if let Ok(index) = self
                     .likely_subtags
-                    .script_region
-                    .binary_search_by_key(&key, |(l, _)| (&l.script, &l.region))
+                    .region
+                    .binary_search_by_key(&key, |(l, _)| &l.region)
                 {
-                    let entry = &self.likely_subtags.script_region[index].1;
-                    return update_locale(entry, locale);
+                    let entry = &self.likely_subtags.region[index].1;
+                    return update_langid(entry, langid);
                 }
+            } else {
+                return update_langid(&self.likely_subtags.und, langid);
             }
-
-            let key = &locale.script;
-            if let Ok(index) = self
-                .likely_subtags
-                .script
-                .binary_search_by_key(&key, |(l, _)| &l.script)
-            {
-                let entry = &self.likely_subtags.script[index].1;
-                return update_locale(entry, locale);
-            }
-        } else if locale.region.is_some() {
-            let key = &locale.region;
-            if let Ok(index) = self
-                .likely_subtags
-                .region
-                .binary_search_by_key(&key, |(l, _)| &l.region)
-            {
-                let entry = &self.likely_subtags.region[index].1;
-                return update_locale(entry, locale);
-            }
-        } else {
-            return update_locale(&self.likely_subtags.und, locale);
-        }
-        CanonicalizationResult::Unmodified
+            CanonicalizationResult::Unmodified
+        }(langid.as_mut())
     }
 
     /// This returns a new Locale that is the result of running the
@@ -178,57 +181,59 @@ impl LocaleCanonicalizer<'_> {
     /// assert_eq!(locale.to_string(), "en");
     /// # } // feature = "provider_serde"
     /// ```
-    pub fn minimize(&self, locale: &mut Locale) -> CanonicalizationResult {
-        let mut max = locale.clone();
-        self.maximize(&mut max);
-        max.variants.clear();
-        let mut trial = max.clone();
+    pub fn minimize<T: AsMut<LanguageIdentifier>>(&self, mut langid: T) -> CanonicalizationResult {
+        |langid: &mut LanguageIdentifier| -> CanonicalizationResult {
+            let mut max = langid.clone();
+            self.maximize(&mut max);
+            max.variants.clear();
+            let mut trial = max.clone();
 
-        trial.script = None;
-        trial.region = None;
-        self.maximize(&mut trial);
-        if trial == max {
-            if locale.script.is_some() || locale.script.is_some() {
-                locale.script = None;
-                locale.region = None;
-                return CanonicalizationResult::Modified;
-            } else {
-                return CanonicalizationResult::Unmodified;
+            trial.script = None;
+            trial.region = None;
+            self.maximize(&mut trial);
+            if trial == max {
+                if langid.script.is_some() || langid.script.is_some() {
+                    langid.script = None;
+                    langid.region = None;
+                    return CanonicalizationResult::Modified;
+                } else {
+                    return CanonicalizationResult::Unmodified;
+                }
             }
-        }
 
-        trial.script = None;
-        trial.region = max.region;
-        self.maximize(&mut trial);
-        if trial == max {
-            if locale.script.is_some() || locale.region != max.region {
-                locale.script = None;
-                locale.region = max.region;
-                return CanonicalizationResult::Modified;
-            } else {
-                return CanonicalizationResult::Unmodified;
+            trial.script = None;
+            trial.region = max.region;
+            self.maximize(&mut trial);
+            if trial == max {
+                if langid.script.is_some() || langid.region != max.region {
+                    langid.script = None;
+                    langid.region = max.region;
+                    return CanonicalizationResult::Modified;
+                } else {
+                    return CanonicalizationResult::Unmodified;
+                }
             }
-        }
 
-        trial.script = max.script;
-        trial.region = None;
-        self.maximize(&mut trial);
-        if trial == max {
-            if locale.script != max.script || locale.region.is_some() {
-                locale.script = max.script;
-                locale.region = None;
-                return CanonicalizationResult::Modified;
-            } else {
-                return CanonicalizationResult::Unmodified;
+            trial.script = max.script;
+            trial.region = None;
+            self.maximize(&mut trial);
+            if trial == max {
+                if langid.script != max.script || langid.region.is_some() {
+                    langid.script = max.script;
+                    langid.region = None;
+                    return CanonicalizationResult::Modified;
+                } else {
+                    return CanonicalizationResult::Unmodified;
+                }
             }
-        }
 
-        if locale.script != max.script || locale.region != max.region {
-            locale.script = max.script;
-            locale.region = max.region;
-            CanonicalizationResult::Modified
-        } else {
-            CanonicalizationResult::Unmodified
-        }
+            if langid.script != max.script || langid.region != max.region {
+                langid.script = max.script;
+                langid.region = max.region;
+                CanonicalizationResult::Modified
+            } else {
+                CanonicalizationResult::Unmodified
+            }
+        }(langid.as_mut())
     }
 }

--- a/components/locale_canonicalizer/src/locale_canonicalizer.rs
+++ b/components/locale_canonicalizer/src/locale_canonicalizer.rs
@@ -18,6 +18,18 @@ pub struct LocaleCanonicalizer<'a> {
     likely_subtags: Cow<'a, LikelySubtagsV1>,
 }
 
+fn update_langid(
+    entry: &LanguageIdentifier,
+    langid: &mut LanguageIdentifier,
+) -> CanonicalizationResult {
+    if langid.language.is_empty() {
+        langid.language = entry.language;
+    }
+    langid.script = langid.script.or(entry.script);
+    langid.region = langid.region.or(entry.region);
+    CanonicalizationResult::Modified
+}
+
 impl LocaleCanonicalizer<'_> {
     /// A constructor which takes a DataProvider and creates a
     /// LocaleCanonicalizer.
@@ -63,17 +75,6 @@ impl LocaleCanonicalizer<'_> {
     /// # } // feature = "provider_serde"
     /// ```
     pub fn maximize<T: AsMut<LanguageIdentifier>>(&self, mut langid: T) -> CanonicalizationResult {
-        let update_langid = |entry: &LanguageIdentifier,
-                             langid: &mut LanguageIdentifier|
-         -> CanonicalizationResult {
-            if langid.language.is_empty() {
-                langid.language = entry.language;
-            }
-            langid.script = langid.script.or(entry.script);
-            langid.region = langid.region.or(entry.region);
-            CanonicalizationResult::Modified
-        };
-
         let langid = langid.as_mut();
 
         if !langid.language.is_empty() && langid.script.is_some() && langid.region.is_some() {

--- a/components/locid/src/extensions/mod.rs
+++ b/components/locid/src/extensions/mod.rs
@@ -25,10 +25,10 @@
 //! let loc: Locale = "en-US-u-ca-buddhist-t-en-US-h0-hybrid-x-foo".parse()
 //!     .expect("Failed to parse.");
 //!
-//! assert_eq!(loc.language, "en");
-//! assert_eq!(loc.script, None);
-//! assert_eq!(loc.region, Some("US".parse().unwrap()));
-//! assert_eq!(loc.variants.len(), 0);
+//! assert_eq!(loc.langid.language, "en");
+//! assert_eq!(loc.langid.script, None);
+//! assert_eq!(loc.langid.region, Some("US".parse().unwrap()));
+//! assert_eq!(loc.langid.variants.len(), 0);
 //!
 //!
 //! let key: Key = "ca".parse().expect("Parsing key failed.");

--- a/components/locid/src/extensions/mod.rs
+++ b/components/locid/src/extensions/mod.rs
@@ -25,10 +25,10 @@
 //! let loc: Locale = "en-US-u-ca-buddhist-t-en-US-h0-hybrid-x-foo".parse()
 //!     .expect("Failed to parse.");
 //!
-//! assert_eq!(loc.langid.language, "en");
-//! assert_eq!(loc.langid.script, None);
-//! assert_eq!(loc.langid.region, Some("US".parse().unwrap()));
-//! assert_eq!(loc.langid.variants.len(), 0);
+//! assert_eq!(loc.id.language, "en");
+//! assert_eq!(loc.id.script, None);
+//! assert_eq!(loc.id.region, Some("US".parse().unwrap()));
+//! assert_eq!(loc.id.variants.len(), 0);
 //!
 //!
 //! let key: Key = "ca".parse().expect("Parsing key failed.");

--- a/components/locid/src/langid.rs
+++ b/components/locid/src/langid.rs
@@ -142,6 +142,18 @@ impl LanguageIdentifier {
     }
 }
 
+impl AsRef<LanguageIdentifier> for LanguageIdentifier {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        self
+    }
+}
+
+impl AsMut<LanguageIdentifier> for LanguageIdentifier {
+    fn as_mut(&mut self) -> &mut LanguageIdentifier {
+        self
+    }
+}
+
 impl std::fmt::Debug for LanguageIdentifier {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         std::fmt::Display::fmt(&self, f)

--- a/components/locid/src/lib.rs
+++ b/components/locid/src/lib.rs
@@ -32,13 +32,13 @@
 //! let region: Region = "US".parse()
 //!     .expect("Parsing failed.");
 //!
-//! assert_eq!(loc.language, lang);
-//! assert_eq!(loc.script, None);
-//! assert_eq!(loc.region, Some(region));
-//! assert_eq!(loc.variants.len(), 0);
+//! assert_eq!(loc.langid.language, lang);
+//! assert_eq!(loc.langid.script, None);
+//! assert_eq!(loc.langid.region, Some(region));
+//! assert_eq!(loc.langid.variants.len(), 0);
 //!
 //! let region: Region = "GB".parse().expect("Parsing failed.");
-//! loc.region = Some(region);
+//! loc.langid.region = Some(region);
 //!
 //! assert_eq!(loc.to_string(), "en-GB");
 //! ```

--- a/components/locid/src/lib.rs
+++ b/components/locid/src/lib.rs
@@ -32,13 +32,13 @@
 //! let region: Region = "US".parse()
 //!     .expect("Parsing failed.");
 //!
-//! assert_eq!(loc.langid.language, lang);
-//! assert_eq!(loc.langid.script, None);
-//! assert_eq!(loc.langid.region, Some(region));
-//! assert_eq!(loc.langid.variants.len(), 0);
+//! assert_eq!(loc.id.language, lang);
+//! assert_eq!(loc.id.script, None);
+//! assert_eq!(loc.id.region, Some(region));
+//! assert_eq!(loc.id.variants.len(), 0);
 //!
 //! let region: Region = "GB".parse().expect("Parsing failed.");
-//! loc.langid.region = Some(region);
+//! loc.id.region = Some(region);
 //!
 //! assert_eq!(loc.to_string(), "en-GB");
 //! ```

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -24,10 +24,10 @@ use std::str::FromStr;
 /// let loc: Locale = "en-US-u-ca-buddhist".parse()
 ///     .expect("Failed to parse.");
 ///
-/// assert_eq!(loc.langid.language, "en");
-/// assert_eq!(loc.langid.script, None);
-/// assert_eq!(loc.langid.region, Some("US".parse().unwrap()));
-/// assert_eq!(loc.langid.variants.len(), 0);
+/// assert_eq!(loc.id.language, "en");
+/// assert_eq!(loc.id.script, None);
+/// assert_eq!(loc.id.region, Some("US".parse().unwrap()));
+/// assert_eq!(loc.id.variants.len(), 0);
 /// assert_eq!(loc, "en-US-u-ca-buddhist");
 ///
 /// let key: Key = "ca".parse().expect("Parsing key failed.");
@@ -58,16 +58,16 @@ use std::str::FromStr;
 /// let loc: Locale = "eN_latn_Us-Valencia_u-hC-H12".parse()
 ///     .expect("Failed to parse.");
 ///
-/// assert_eq!(loc.langid.language, "en");
-/// assert_eq!(loc.langid.script, Some("Latn".parse().unwrap()));
-/// assert_eq!(loc.langid.region, Some("US".parse().unwrap()));
-/// assert_eq!(loc.langid.variants.get(0).unwrap(), "valencia");
+/// assert_eq!(loc.id.language, "en");
+/// assert_eq!(loc.id.script, Some("Latn".parse().unwrap()));
+/// assert_eq!(loc.id.region, Some("US".parse().unwrap()));
+/// assert_eq!(loc.id.variants.get(0).unwrap(), "valencia");
 /// ```
 /// [`Unicode Locale Identifier`]: https://unicode.org/reports/tr35/tr35.html#Unicode_locale_identifier
 #[derive(Default, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 pub struct Locale {
     // Language component of the Locale
-    pub langid: LanguageIdentifier,
+    pub id: LanguageIdentifier,
     // Unicode Locale Extensions
     pub extensions: extensions::Extensions,
 }
@@ -104,7 +104,7 @@ impl Locale {
     #[inline]
     pub const fn und() -> Self {
         Self {
-            langid: LanguageIdentifier::und(),
+            id: LanguageIdentifier::und(),
             extensions: extensions::Extensions::new(),
         }
     }
@@ -138,7 +138,7 @@ impl FromStr for Locale {
 impl From<LanguageIdentifier> for Locale {
     fn from(id: LanguageIdentifier) -> Self {
         Self {
-            langid: id,
+            id,
             extensions: extensions::Extensions::default(),
         }
     }
@@ -146,19 +146,19 @@ impl From<LanguageIdentifier> for Locale {
 
 impl From<Locale> for LanguageIdentifier {
     fn from(loc: Locale) -> Self {
-        loc.langid
+        loc.id
     }
 }
 
 impl AsRef<LanguageIdentifier> for Locale {
     fn as_ref(&self) -> &LanguageIdentifier {
-        &self.langid
+        &self.id
     }
 }
 
 impl AsMut<LanguageIdentifier> for Locale {
     fn as_mut(&mut self) -> &mut LanguageIdentifier {
-        &mut self.langid
+        &mut self.id
     }
 }
 
@@ -176,13 +176,13 @@ impl std::fmt::Display for Locale {
 
 impl writeable::Writeable for Locale {
     fn write_to<W: std::fmt::Write + ?Sized>(&self, sink: &mut W) -> std::fmt::Result {
-        writeable::Writeable::write_to(&self.langid, sink)?;
+        writeable::Writeable::write_to(&self.id, sink)?;
         writeable::Writeable::write_to(&self.extensions, sink)?;
         Ok(())
     }
 
     fn write_len(&self) -> writeable::LengthHint {
-        let mut result = writeable::Writeable::write_len(&self.langid);
+        let mut result = writeable::Writeable::write_len(&self.id);
         result += writeable::Writeable::write_len(&self.extensions);
         result
     }
@@ -235,20 +235,20 @@ macro_rules! subtag_matches {
 impl PartialEq<str> for Locale {
     fn eq(&self, other: &str) -> bool {
         let mut iter = get_subtag_iterator(other.as_bytes()).peekable();
-        if !subtag_matches!(subtags::Language, iter, self.langid.language) {
+        if !subtag_matches!(subtags::Language, iter, self.id.language) {
             return false;
         }
-        if let Some(ref script) = self.langid.script {
+        if let Some(ref script) = self.id.script {
             if !subtag_matches!(subtags::Script, iter, *script) {
                 return false;
             }
         }
-        if let Some(ref region) = self.langid.region {
+        if let Some(ref region) = self.id.region {
             if !subtag_matches!(subtags::Region, iter, *region) {
                 return false;
             }
         }
-        for variant in self.langid.variants.iter() {
+        for variant in self.id.variants.iter() {
             if !subtag_matches!(subtags::Variant, iter, *variant) {
                 return false;
             }

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -24,10 +24,10 @@ use std::str::FromStr;
 /// let loc: Locale = "en-US-u-ca-buddhist".parse()
 ///     .expect("Failed to parse.");
 ///
-/// assert_eq!(loc.language, "en");
-/// assert_eq!(loc.script, None);
-/// assert_eq!(loc.region, Some("US".parse().unwrap()));
-/// assert_eq!(loc.variants.len(), 0);
+/// assert_eq!(loc.langid.language, "en");
+/// assert_eq!(loc.langid.script, None);
+/// assert_eq!(loc.langid.region, Some("US".parse().unwrap()));
+/// assert_eq!(loc.langid.variants.len(), 0);
 /// assert_eq!(loc, "en-US-u-ca-buddhist");
 ///
 /// let key: Key = "ca".parse().expect("Parsing key failed.");
@@ -58,22 +58,16 @@ use std::str::FromStr;
 /// let loc: Locale = "eN_latn_Us-Valencia_u-hC-H12".parse()
 ///     .expect("Failed to parse.");
 ///
-/// assert_eq!(loc.language, "en");
-/// assert_eq!(loc.script, Some("Latn".parse().unwrap()));
-/// assert_eq!(loc.region, Some("US".parse().unwrap()));
-/// assert_eq!(loc.variants.get(0).unwrap(), "valencia");
+/// assert_eq!(loc.langid.language, "en");
+/// assert_eq!(loc.langid.script, Some("Latn".parse().unwrap()));
+/// assert_eq!(loc.langid.region, Some("US".parse().unwrap()));
+/// assert_eq!(loc.langid.variants.get(0).unwrap(), "valencia");
 /// ```
 /// [`Unicode Locale Identifier`]: https://unicode.org/reports/tr35/tr35.html#Unicode_locale_identifier
 #[derive(Default, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 pub struct Locale {
-    /// Language subtag of the Locale
-    pub language: subtags::Language,
-    /// Script subtag of the Locale
-    pub script: Option<subtags::Script>,
-    /// Region subtag of the Locale
-    pub region: Option<subtags::Region>,
-    /// Variant subtags of the Locale
-    pub variants: subtags::Variants,
+    // Language component of the Locale
+    pub langid: LanguageIdentifier,
     // Unicode Locale Extensions
     pub extensions: extensions::Extensions,
 }
@@ -110,10 +104,7 @@ impl Locale {
     #[inline]
     pub const fn und() -> Self {
         Self {
-            language: subtags::Language::und(),
-            script: None,
-            region: None,
-            variants: subtags::Variants::new(),
+            langid: LanguageIdentifier::und(),
             extensions: extensions::Extensions::new(),
         }
     }
@@ -147,10 +138,7 @@ impl FromStr for Locale {
 impl From<LanguageIdentifier> for Locale {
     fn from(id: LanguageIdentifier) -> Self {
         Self {
-            language: id.language,
-            script: id.script,
-            region: id.region,
-            variants: id.variants,
+            langid: id,
             extensions: extensions::Extensions::default(),
         }
     }
@@ -158,12 +146,19 @@ impl From<LanguageIdentifier> for Locale {
 
 impl From<Locale> for LanguageIdentifier {
     fn from(loc: Locale) -> Self {
-        Self {
-            language: loc.language,
-            script: loc.script,
-            region: loc.region,
-            variants: loc.variants,
-        }
+        loc.langid
+    }
+}
+
+impl AsRef<LanguageIdentifier> for Locale {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        &self.langid
+    }
+}
+
+impl AsMut<LanguageIdentifier> for Locale {
+    fn as_mut(&mut self) -> &mut LanguageIdentifier {
+        &mut self.langid
     }
 }
 
@@ -181,34 +176,13 @@ impl std::fmt::Display for Locale {
 
 impl writeable::Writeable for Locale {
     fn write_to<W: std::fmt::Write + ?Sized>(&self, sink: &mut W) -> std::fmt::Result {
-        writeable::Writeable::write_to(&self.language, sink)?;
-        if let Some(ref script) = self.script {
-            sink.write_char('-')?;
-            writeable::Writeable::write_to(script, sink)?;
-        }
-        if let Some(ref region) = self.region {
-            sink.write_char('-')?;
-            writeable::Writeable::write_to(region, sink)?;
-        }
-        if !self.variants.is_empty() {
-            sink.write_char('-')?;
-            writeable::Writeable::write_to(&self.variants, sink)?;
-        }
+        writeable::Writeable::write_to(&self.langid, sink)?;
         writeable::Writeable::write_to(&self.extensions, sink)?;
         Ok(())
     }
 
     fn write_len(&self) -> writeable::LengthHint {
-        let mut result = writeable::Writeable::write_len(&self.language);
-        if let Some(ref script) = self.script {
-            result += writeable::Writeable::write_len(script) + 1;
-        }
-        if let Some(ref region) = self.region {
-            result += writeable::Writeable::write_len(region) + 1;
-        }
-        if !self.variants.is_empty() {
-            result += writeable::Writeable::write_len(&self.variants) + 1;
-        }
+        let mut result = writeable::Writeable::write_len(&self.langid);
         result += writeable::Writeable::write_len(&self.extensions);
         result
     }
@@ -261,20 +235,20 @@ macro_rules! subtag_matches {
 impl PartialEq<str> for Locale {
     fn eq(&self, other: &str) -> bool {
         let mut iter = get_subtag_iterator(other.as_bytes()).peekable();
-        if !subtag_matches!(subtags::Language, iter, self.language) {
+        if !subtag_matches!(subtags::Language, iter, self.langid.language) {
             return false;
         }
-        if let Some(ref script) = self.script {
+        if let Some(ref script) = self.langid.script {
             if !subtag_matches!(subtags::Script, iter, *script) {
                 return false;
             }
         }
-        if let Some(ref region) = self.region {
+        if let Some(ref region) = self.langid.region {
             if !subtag_matches!(subtags::Region, iter, *region) {
                 return false;
             }
         }
-        for variant in self.variants.iter() {
+        for variant in self.langid.variants.iter() {
             if !subtag_matches!(subtags::Variant, iter, *variant) {
                 return false;
             }

--- a/components/locid/src/parser/locale.rs
+++ b/components/locid/src/parser/locale.rs
@@ -9,11 +9,11 @@ use crate::Locale;
 pub fn parse_locale(t: &[u8]) -> Result<Locale, ParserError> {
     let mut iter = get_subtag_iterator(t).peekable();
 
-    let langid = parse_language_identifier_from_iter(&mut iter, ParserMode::Locale)?;
+    let id = parse_language_identifier_from_iter(&mut iter, ParserMode::Locale)?;
     let extensions = if iter.peek().is_some() {
         Extensions::try_from_iter(&mut iter)?
     } else {
         Extensions::default()
     };
-    Ok(Locale { langid, extensions })
+    Ok(Locale { id, extensions })
 }

--- a/components/locid/src/parser/locale.rs
+++ b/components/locid/src/parser/locale.rs
@@ -15,11 +15,5 @@ pub fn parse_locale(t: &[u8]) -> Result<Locale, ParserError> {
     } else {
         Extensions::default()
     };
-    Ok(Locale {
-        language: langid.language,
-        script: langid.script,
-        region: langid.region,
-        variants: langid.variants,
-        extensions,
-    })
+    Ok(Locale { langid, extensions })
 }

--- a/components/locid/tests/fixtures/mod.rs
+++ b/components/locid/tests/fixtures/mod.rs
@@ -233,7 +233,7 @@ impl TryFrom<LocaleSubtags> for Locale {
             Extensions::default()
         };
         Ok(Locale {
-            langid: LanguageIdentifier {
+            id: LanguageIdentifier {
                 language,
                 script,
                 region,

--- a/components/locid/tests/fixtures/mod.rs
+++ b/components/locid/tests/fixtures/mod.rs
@@ -233,10 +233,12 @@ impl TryFrom<LocaleSubtags> for Locale {
             Extensions::default()
         };
         Ok(Locale {
-            language,
-            script,
-            region,
-            variants: subtags::Variants::from_vec_unchecked(variants),
+            langid: LanguageIdentifier {
+                language,
+                script,
+                region,
+                variants: subtags::Variants::from_vec_unchecked(variants),
+            },
             extensions,
         })
     }


### PR DESCRIPTION
Some initial work in case anyone has feedback.

One thing I had not expected when I started is that because the LocaleCanonicalizer modifies in place, we need to pass in AsMut rather than AsRef. The restrictions on having multiple mutable references made the existing code awkward, so I worked around this by wrapping the existing code in a closure and passing in the reference from as_mut() as an argument. I'm interested to know if there is a better way of handling this.

Fixes #447