### PR TITLE
Store only symbols on DateTimeFormat

### DIFF
--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -136,7 +136,7 @@ use std::borrow::Cow;
 pub struct DateTimeFormat<'d> {
     locale: Locale,
     pattern: Pattern,
-    data: Cow<'d, provider::gregory::DatesV1>,
+    symbols: Cow<'d, provider::gregory::DateSymbolsV1>,
 }
 
 impl<'d> DateTimeFormat<'d> {
@@ -185,10 +185,15 @@ impl<'d> DateTimeFormat<'d> {
             .get_pattern_for_options(options)?
             .unwrap_or_default();
 
+        let symbols = match data {
+            Cow::Borrowed(data) => Cow::Borrowed(&data.symbols),
+            Cow::Owned(data) => Cow::Owned(data.symbols),
+        };
+
         Ok(Self {
             locale,
             pattern,
-            data,
+            symbols,
         })
     }
 
@@ -226,7 +231,7 @@ impl<'d> DateTimeFormat<'d> {
     {
         FormattedDateTime {
             pattern: &self.pattern,
-            data: &self.data,
+            symbols: &self.symbols,
             date_time: value,
             locale: &self.locale,
         }
@@ -263,7 +268,7 @@ impl<'d> DateTimeFormat<'d> {
         w: &mut impl std::fmt::Write,
         value: &impl DateTimeInput,
     ) -> std::fmt::Result {
-        write_pattern(&self.pattern, &self.data, value, &self.locale, w)
+        write_pattern(&self.pattern, &self.symbols, value, &self.locale, w)
             .map_err(|_| std::fmt::Error)
     }
 


### PR DESCRIPTION
Builds upon #517 by switching our struct to store only symbols.

I'm not super attached to it, and I believe we'll want to store more than symbols, which I think should end up being a custom struct like:

```rust
struct DTFData<'d> {
    symbols: Cow<'d, DateSymbolsV1>,
    timezones: Cow<'d, TimezonesV1>,
    ...
}

struct DateTimeFormat {
    data: DTFDAta,
}
```

but for now I think it should do and fortunately refactoring this is trivial.

The main value of this is that we're avoiding storing all patterns we don't need but also, it allows us to just parse the pattern if needed and store just the parsed pattern.
This, on the other hands opens up possibility of storing borrowed strings in pattern, and zero-alloc parsing of patterns.