### PR TITLE
Update tinytemplate to fix nightly breakage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,9 +2179,9 @@ checksum = "b975dd2af5824896acaeebf7336471fcafebfa417da0a290ded5509f297ccedb"
 
 [[package]]
 name = "tinytemplate"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3dc76004a03cec1c5932bca4cdc2e39aaa798e3f82363dd94f9adf6098c12f"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",


### PR DESCRIPTION
The fix for this has landed (https://github.com/rust-lang/rust/pull/82702) but did not make it into the nightly. Fortunately, `tinytemplate` fixed the breakage on their end (https://github.com/bheisler/TinyTemplate/pull/17).

This should fix CI.