### PR TITLE
Keep icu_datetime compatible and bump crate versions to 0.1.1

### DIFF
--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "icu_datetime"
 description = "API for formatting date and time to user readable textual representation"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -9,6 +9,8 @@ use std::ops::{Add, Sub};
 use std::str::FromStr;
 use tinystr::TinyStr8;
 
+pub use super::mock::MockDateTime;
+
 #[derive(Debug)]
 pub enum DateTimeError {
     Parse(std::num::ParseIntError),

--- a/resources/testdata/Cargo.toml
+++ b/resources/testdata/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "icu_testdata"
 description = "Test data for ICU4X, generated from CLDR"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"

--- a/resources/testdata/Cargo.toml
+++ b/resources/testdata/Cargo.toml
@@ -13,6 +13,7 @@ license-file = "../../LICENSE"
 categories = ["internationalization"]
 include = [
     "src/**/*",
+    "data/json/**/*",
     "examples/**/*",
     "benches/**/*",
     "Cargo.toml",


### PR DESCRIPTION
`icu_datetime` changed the location of `MockDateTime` structure, so I put it back on the `icu_datetime::date` module. Also, if possible, would like if you could publish it (and `icu_testdata`) to crates.io.