### PR TITLE
Update Rust nightly version in CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -293,12 +293,12 @@ jobs:
       # then this line is no longer needed.
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-03-08
+          toolchain: nightly-2021-03-15
           override: true
 
       - name: Run the example with dhat-rs to collect memory information
         run: |
-          cargo run --package icu_benchmark_memory -- --os ${{ matrix.os }} ${{ matrix.examples }} --toolchain nightly-2021-03-08
+          cargo run --package icu_benchmark_memory -- --os ${{ matrix.os }} ${{ matrix.examples }} --toolchain nightly-2021-03-15
 
       # Benchmarking & dashboards job > (unmerged PR only) Convert benchmark output into
       # dashboard HTML in a commit of a branch of the local repo.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses:                   actions-rs/toolchain@v1
         with:
-          toolchain:            nightly-2021-03-08
+          toolchain:            nightly-2021-03-01
           override:             true
 
       - uses:                   actions-rs/cargo@v1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses:                   actions-rs/toolchain@v1
         with:
-          toolchain:            nightly-2021-03-01
+          toolchain:            nightly-2021-03-15
           override:             true
 
       - uses:                   actions-rs/cargo@v1


### PR DESCRIPTION
Fixes #542

This PR changes `nightly-2021-03-08` to `nightly-2021-03-15`, which seems to be buggy for some unknown reason.