### PR TITLE
Add icu_string util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_string"
+version = "0.1.0"
+
+[[package]]
 name = "icu_testdata"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "utils/fixed_decimal",
     "utils/litemap",
     "utils/writeable",
+    "utils/string",
 ]
 
 # Enable lto for WASM.

--- a/utils/string/Cargo.toml
+++ b/utils/string/Cargo.toml
@@ -1,0 +1,20 @@
+# this file is part of icu4x. for terms of use, please see the file
+# called license at the top level of the icu4x source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/main/license ).
+
+[package]
+name = "icu_string"
+description = "A collection of string related utilties used by ICU4X"
+version = "0.1.0"
+authors = ["The ICU4X Project Developers"]
+edition = "2018"
+readme = "README.md"
+repository = "https://github.com/unicode-org/icu4x"
+license-file = "../../LICENSE"
+include = [
+    "src/**/*",
+    "examples/**/*",
+    "benches/**/*",
+    "Cargo.toml",
+    "README.md"
+]

--- a/utils/string/README.md
+++ b/utils/string/README.md
@@ -1,0 +1,33 @@
+`icu_string` is a utility crate of the [`ICU4X`] project.
+
+It provides a collection of helper utilities for handling Rust strings.
+
+## Example
+
+```rust
+use icu_string::Slice;
+
+/// Parse an input string slice and return a name parsed out of it.
+///
+/// # Type parameters
+///
+/// - `S`: A type of a slice provided as an input: `&str`, `String` or `Cow<str>`.
+/// - `RS`: Return slice: `&str`, `String` or `Cow<str>`.
+///
+/// # Lifetimes
+///
+/// - `slice`: The life time of the slice used for scenarios where the input slice has a lifetime,
+///   or when the output slice has to live for as long as the input slice.
+fn parse_name<'slice, S, RS>(input: &'slice S) -> RS
+where
+    S: Slice<'slice, RS> + ?Sized,
+{
+    let len = input.length();
+    input.get_slice(6..len)
+}
+
+let input = "name: Example Name";
+let name: &str = parse_name(&input);
+
+assert_eq!(name, "Example Name");
+```

--- a/utils/string/examples/parse_slice.rs
+++ b/utils/string/examples/parse_slice.rs
@@ -1,0 +1,62 @@
+//! This example shows a very trivial parser that can take one of the supported
+//! implementations of `Slice` and return one of the supported outputs. The example
+//! is very abstract, but exemplifies ability to write parsers that operate on wide
+//! range of ownership/lifetime models of the input slice and can produce a range of
+//! outputs that maintain lifetimes and ownership.
+use icu_string::Slice;
+use std::borrow::Cow;
+
+fn parse_name<'s, S, RS>(input: &'s S) -> RS
+where
+    S: Slice<'s, RS> + ?Sized,
+{
+    let len = input.length();
+    input.get_slice(6..len)
+}
+
+fn main() {
+    // Input types: `&str`, `String`, owned and borrowed `Cow<str>`.
+    let str_input = "name: Example Name";
+    let string_input = str_input.to_string();
+    let owned_cow: Cow<str> = string_input.clone().into();
+    let borrowed_cow: Cow<str> = str_input.into();
+
+    // Use the input types to produce a `&str`.
+    let name: &str = parse_name(&str_input);
+    assert_eq!(name, "Example Name");
+
+    let name: &str = parse_name(&string_input);
+    assert_eq!(name, "Example Name");
+
+    let name: &str = parse_name(&owned_cow);
+    assert_eq!(name, "Example Name");
+
+    let name: &str = parse_name(&borrowed_cow);
+    assert_eq!(name, "Example Name");
+
+    // Use the input types to produce a `String`.
+    let name: String = parse_name(&str_input);
+    assert_eq!(name, "Example Name");
+
+    let name: String = parse_name(&string_input);
+    assert_eq!(name, "Example Name");
+
+    let name: String = parse_name(&owned_cow);
+    assert_eq!(name, "Example Name");
+
+    let name: String = parse_name(&borrowed_cow);
+    assert_eq!(name, "Example Name");
+
+    // Use the input types to produce a `Cow<str>`.
+    let name: Cow<str> = parse_name(&str_input);
+    assert_eq!(name, "Example Name");
+
+    let name: Cow<str> = parse_name(&string_input);
+    assert_eq!(name, "Example Name");
+
+    let name: Cow<str> = parse_name(&owned_cow);
+    assert_eq!(name, "Example Name");
+
+    let name: Cow<str> = parse_name(&borrowed_cow);
+    assert_eq!(name, "Example Name");
+}

--- a/utils/string/src/cow.rs
+++ b/utils/string/src/cow.rs
@@ -1,0 +1,140 @@
+use crate::Slice;
+use std::{borrow::Cow, ops::Range};
+
+impl<'s> Slice<'s, &'s str> for Cow<'s, str> {
+    fn get_byte(&self, idx: usize) -> Option<u8> {
+        self.as_bytes().get(idx).copied()
+    }
+
+    fn get_str_slice(&self, range: Range<usize>) -> &str {
+        &self[range]
+    }
+
+    fn get_slice(&'s self, range: Range<usize>) -> &'s str {
+        match self {
+            Self::Borrowed(b) => &b[range],
+            Self::Owned(o) => &o[range],
+        }
+    }
+
+    fn length(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<'s> Slice<'s, String> for Cow<'s, str> {
+    fn get_byte(&self, idx: usize) -> Option<u8> {
+        self.as_bytes().get(idx).copied()
+    }
+
+    fn get_str_slice(&self, range: Range<usize>) -> &str {
+        &self[range]
+    }
+
+    fn get_slice(&'s self, range: Range<usize>) -> String {
+        self[range].to_string()
+    }
+
+    fn length(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<'s> Slice<'s, Cow<'s, str>> for Cow<'s, str> {
+    fn get_byte(&self, idx: usize) -> Option<u8> {
+        self.as_bytes().get(idx).copied()
+    }
+
+    fn get_str_slice(&self, range: Range<usize>) -> &str {
+        &self[range]
+    }
+
+    fn get_slice(&'s self, range: Range<usize>) -> Cow<'s, str> {
+        match self {
+            Self::Borrowed(b) => Cow::Borrowed(&b[range]),
+            Self::Owned(o) => Cow::Owned(o[range].to_owned()),
+        }
+    }
+
+    fn length(&self) -> usize {
+        self.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_cow_owned<T>(input: &Cow<T>) -> bool
+    where
+        T: ToOwned + ?Sized,
+    {
+        match input {
+            Cow::Borrowed(_) => false,
+            Cow::Owned(_) => true,
+        }
+    }
+
+    #[test]
+    fn cow_borrowed_from_cow_borrowed() {
+        let slice = Cow::Borrowed("Hello World");
+        let result: Cow<str> = slice.get_slice(0..5);
+        assert_eq!(result, "Hello");
+        assert!(!is_cow_owned(&result));
+    }
+
+    #[test]
+    fn cow_owned_from_cow_owned<'s>() {
+        let slice: Cow<str> = Cow::Owned("Hello World".to_string());
+        let result: Cow<str> = slice.get_slice(0..5);
+        assert_eq!(result, "Hello");
+        assert!(is_cow_owned(&result));
+    }
+
+    #[test]
+    fn str_from_cow_borrowed() {
+        let slice = Cow::Borrowed("Hello World");
+        let result: &str = slice.get_slice(0..5);
+        assert_eq!(result, "Hello");
+    }
+
+    #[test]
+    fn str_from_cow_owned() {
+        let slice: Cow<str> = Cow::Owned("Hello World".to_string());
+        let result: &str = slice.get_slice(0..5);
+        assert_eq!(result, "Hello");
+    }
+
+    #[test]
+    fn string_from_cow_borrowed() {
+        let slice = Cow::Borrowed("Hello World");
+        let result: String = slice.get_slice(0..5);
+        assert_eq!(result, "Hello");
+    }
+
+    #[test]
+    fn string_from_cow_owned() {
+        let slice: Cow<str> = Cow::Owned("Hello World".to_string());
+        let result: String = slice.get_slice(0..5);
+        assert_eq!(result, "Hello");
+    }
+
+    #[test]
+    fn cow_get_byte() {
+        let slice = "Hello World";
+        assert_eq!(Slice::<Cow<str>>::get_byte(&slice, 0), Some(b'H'));
+        assert_eq!(Slice::<Cow<str>>::get_byte(&slice, 12), None);
+    }
+
+    #[test]
+    fn string_get_str_slice() {
+        let slice = "Hello World";
+        assert_eq!(Slice::<Cow<str>>::get_str_slice(&slice, 0..5), "Hello");
+    }
+
+    #[test]
+    fn string_length() {
+        let slice = "Hello World";
+        assert_eq!(Slice::<Cow<str>>::length(&slice), 11);
+    }
+}

--- a/utils/string/src/lib.rs
+++ b/utils/string/src/lib.rs
@@ -1,0 +1,165 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+//! `icu_string` is a utility crate of the [`ICU4X`] project.
+//!
+//! It includes [`Slice`], a core trait that allows to build parsers that can be
+//! generalized over different ownership and lifetime models of the input string and produce
+//! a range of slice outputs.
+//! This allows to generate parsers that depending on the desired input can be zero-copy, or
+//! can perpetuate the ownership model of the input.
+//!
+//! # Example
+//!
+//! ```
+//! use icu_string::Slice;
+//!
+//! /// Parse an input string slice and return a name parsed out of it.
+//! ///
+//! /// # Type parameters
+//! ///
+//! /// - `S`: A type of a slice provided as an input: `&str`, `String` or `Cow<str>`.
+//! /// - `RS`: Return slice: `&str`, `String` or `Cow<str>`.
+//! ///
+//! /// # Lifetimes
+//! ///
+//! /// - `slice`: The life time used for scenarios where the input slice is borrowed,
+//! ///            or when the output slice has to live for as long as the input slice.
+//! fn parse_name<'slice, S, RS>(input: &'slice S) -> RS
+//! where
+//!     S: Slice<'slice, RS> + ?Sized,
+//! {
+//!     let len = input.length();
+//!     input.get_slice(6..len)
+//! }
+//!
+//! let input = "name: Example Name";
+//! let name: &str = parse_name(&input);
+//!
+//! assert_eq!(name, "Example Name");
+//! ```
+//!
+//! The example above will work over any combination of input and output `str`, `String` or
+//! `Cow<str>` types allowing the author to write a parser and the caller decide what ownership
+//! and life time models to use.
+//!
+//! For a more complete example of how the input/output pairs work, see `parse_slice` example.
+//!
+//! [`ICU4X`]: ../icu/index.html
+mod cow;
+mod str;
+mod string;
+
+use std::ops::Range;
+
+/// A trait used to allow producing parsers generic over different ownership models of a string.
+///
+/// # Example
+///
+/// ```
+/// use icu_string::Slice;
+///
+/// /// Parse an input string slice and return a name parsed out of it.
+/// ///
+/// /// # Type parameters
+/// ///
+/// /// - `S`: A type of a slice provided as an input: `&str`, `String` or `Cow<str>`.
+/// /// - `RS`: Return slice: `&str`, `String` or `Cow<str>`.
+/// ///
+/// /// # Lifetimes
+/// ///
+/// /// - `slice`: The life time used for scenarios where the input slice is borrowed,
+/// ///            or when the output slice has to live for as long as the input slice.
+/// fn parse_name<'slice, S, RS>(input: &'slice S) -> RS
+/// where
+///     S: Slice<'slice, RS> + ?Sized,
+/// {
+///     let len = input.length();
+///     input.get_slice(6..len)
+/// }
+///
+/// let input = "name: Example Name";
+/// let name: &str = parse_name(&input);
+///
+/// assert_eq!(name, "Example Name");
+/// ```
+pub trait Slice<'s, RS> {
+    /// Retrieves a single byte at a given position, or `None` if the requested
+    /// `idx` is out of string bounds.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_string::Slice;
+    ///
+    /// fn is_first_byte_H<'s, S: Slice<'s, &'s str>>(input: S) -> bool {
+    ///     input.get_byte(0) == Some(b'H')
+    /// }
+    ///
+    /// assert_eq!(is_first_byte_H("Hello World"), true);
+    /// ```
+    fn get_byte(&self, idx: usize) -> Option<u8>;
+
+    /// Retrieves an `&str` of a range of bytes.
+    ///
+    /// This is useful for scenarios where the function operating on the slice
+    /// needs to perform an internal operation that doesn't need to return the sliced
+    /// value.
+    ///
+    /// For cases where the output is itended to preserve the ownership/lifetime model,
+    /// see `get_slice`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_string::Slice;
+    ///
+    /// fn starts_with_hello<'s, S: Slice<'s, &'s str>>(input: S) -> bool {
+    ///     input.get_str_slice(0..5) == "Hello"
+    /// }
+    ///
+    /// assert_eq!(starts_with_hello("Hello World"), true);
+    /// ```
+    fn get_str_slice(&self, range: Range<usize>) -> &str;
+
+    /// Retrieves a slice of the input string perpetuating the
+    /// ownership and lifetime model.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_string::Slice;
+    ///
+    /// fn get_word<'s, S: Slice<'s, &'s str>>(input: &'s S) -> &'s str {
+    ///     input.get_slice(0..5)
+    /// }
+    ///
+    /// assert_eq!(get_word(&"Hello World"), "Hello");
+    /// ```
+    fn get_slice(&'s self, range: Range<usize>) -> RS;
+
+    /// Retrieves a length of the input slice.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_string::Slice;
+    ///
+    /// fn iterate<'s, S: Slice<'s, &'s str>>(input: S) -> impl Iterator<Item = u8> {
+    ///     let mut idx = 0;
+    ///     std::iter::from_fn(move || {
+    ///         let result = input.get_byte(idx)?;
+    ///         idx += 1;
+    ///         Some(result)
+    ///     })
+    /// }
+    ///
+    /// assert_eq!(iterate("Hello").collect::<Vec<_>>(), vec![b'H', b'e', b'l', b'l', b'o']);
+    /// ```
+    fn length(&self) -> usize;
+}
+
+pub use crate::cow::*;
+pub use crate::str::*;
+pub use crate::string::*;

--- a/utils/string/src/str.rs
+++ b/utils/string/src/str.rs
@@ -1,0 +1,113 @@
+use crate::Slice;
+use std::borrow::Cow;
+use std::ops::Range;
+
+impl<'s> Slice<'s, &'s str> for &'s str {
+    fn get_byte(&self, idx: usize) -> Option<u8> {
+        self.as_bytes().get(idx).copied()
+    }
+
+    fn get_str_slice(&self, range: Range<usize>) -> &str {
+        &self[range]
+    }
+
+    fn get_slice(&'s self, range: Range<usize>) -> &'s str {
+        &self[range]
+    }
+
+    fn length(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<'s> Slice<'s, String> for &'s str {
+    fn get_byte(&self, idx: usize) -> Option<u8> {
+        self.as_bytes().get(idx).copied()
+    }
+
+    fn get_str_slice(&self, range: Range<usize>) -> &str {
+        &self[range]
+    }
+
+    fn get_slice(&'s self, range: Range<usize>) -> String {
+        self[range].to_string()
+    }
+
+    fn length(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<'s> Slice<'s, Cow<'s, str>> for &'s str {
+    fn get_byte(&self, idx: usize) -> Option<u8> {
+        self.as_bytes().get(idx).copied()
+    }
+
+    fn get_str_slice(&self, range: Range<usize>) -> &str {
+        &self[range]
+    }
+
+    fn get_slice(&'s self, range: Range<usize>) -> Cow<'s, str> {
+        Cow::Borrowed(&self[range])
+    }
+
+    fn length(&self) -> usize {
+        self.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_cow_owned<T>(input: &Cow<T>) -> bool
+    where
+        T: ToOwned + ?Sized,
+    {
+        match input {
+            Cow::Borrowed(_) => false,
+            Cow::Owned(_) => true,
+        }
+    }
+
+    #[test]
+    fn str_from_str() {
+        let slice = "Hello World";
+        let result: &str = slice.get_slice(0..5);
+        assert_eq!(result, "Hello");
+    }
+
+    #[test]
+    fn string_from_str() {
+        let slice = "Hello World";
+        let slice: String = slice.get_slice(0..5);
+        assert_eq!(slice, "Hello");
+    }
+
+    #[test]
+    fn cow_borrowed_from_str() {
+        let slice = "Hello World";
+        let result: Cow<str> = slice.get_slice(0..5);
+        assert_eq!(result, "Hello");
+        assert!(!is_cow_owned(&result));
+    }
+
+    #[test]
+    fn string_get_byte() {
+        let slice = "Hello World";
+        assert_eq!(Slice::<&str>::get_byte(&slice, 0), Some(b'H'));
+        assert_eq!(Slice::<&str>::get_byte(&slice, 12), None);
+    }
+
+    #[test]
+    fn string_get_str_slice() {
+        let slice = "Hello World";
+        assert_eq!(Slice::<&str>::get_str_slice(&slice, 0..5), "Hello");
+    }
+
+    #[test]
+    fn string_length() {
+        let slice = "Hello World";
+        assert_eq!(Slice::<&str>::length(&slice), 11);
+    }
+}

--- a/utils/string/src/string.rs
+++ b/utils/string/src/string.rs
@@ -1,0 +1,112 @@
+use crate::Slice;
+use std::{borrow::Cow, ops::Range};
+
+impl<'s> Slice<'s, String> for String {
+    fn get_byte(&self, idx: usize) -> Option<u8> {
+        self.as_bytes().get(idx).copied()
+    }
+
+    fn get_str_slice(&self, range: Range<usize>) -> &str {
+        &self[range]
+    }
+
+    fn get_slice(&'s self, range: Range<usize>) -> String {
+        self[range].to_string()
+    }
+
+    fn length(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<'s> Slice<'s, Cow<'s, str>> for String {
+    fn get_byte(&self, idx: usize) -> Option<u8> {
+        self.as_bytes().get(idx).copied()
+    }
+
+    fn get_str_slice(&self, range: Range<usize>) -> &str {
+        &self[range]
+    }
+
+    fn get_slice(&'s self, range: Range<usize>) -> Cow<'s, str> {
+        Cow::Borrowed(&self[range])
+    }
+
+    fn length(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<'s> Slice<'s, &'s str> for String {
+    fn get_byte(&self, idx: usize) -> Option<u8> {
+        self.as_bytes().get(idx).copied()
+    }
+
+    fn get_str_slice(&self, range: Range<usize>) -> &str {
+        &self[range]
+    }
+
+    fn get_slice(&'s self, range: Range<usize>) -> &'s str {
+        &self[range]
+    }
+
+    fn length(&self) -> usize {
+        self.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_cow_owned<T>(input: &Cow<T>) -> bool
+    where
+        T: ToOwned + ?Sized,
+    {
+        match input {
+            Cow::Borrowed(_) => false,
+            Cow::Owned(_) => true,
+        }
+    }
+
+    #[test]
+    fn string_from_string() {
+        let slice = String::from("Hello World");
+        let result: String = slice.get_slice(0..5);
+        assert_eq!(result, String::from("Hello"));
+    }
+
+    #[test]
+    fn str_from_string() {
+        let slice = String::from("Hello World");
+        let result: &str = slice.get_slice(0..5);
+        assert_eq!(result, "Hello");
+    }
+
+    #[test]
+    fn cow_owned_from_string() {
+        let slice = String::from("Hello World");
+        let result: Cow<str> = slice.get_slice(0..5);
+        assert_eq!(result, "Hello");
+        assert!(!is_cow_owned(&result));
+    }
+
+    #[test]
+    fn string_get_byte() {
+        let slice = String::from("Hello World");
+        assert_eq!(Slice::<&str>::get_byte(&slice, 0), Some(b'H'));
+        assert_eq!(Slice::<&str>::get_byte(&slice, 12), None);
+    }
+
+    #[test]
+    fn string_get_str_slice() {
+        let slice = String::from("Hello World");
+        assert_eq!(Slice::<&str>::get_str_slice(&slice, 0..5), "Hello");
+    }
+
+    #[test]
+    fn string_length() {
+        let slice = String::from("Hello World");
+        assert_eq!(Slice::<&str>::length(&slice), 11);
+    }
+}


### PR DESCRIPTION
This is the first utility tool for the work around pattern parsers.

The inspiration for the util comes from https://github.com/projectfluent/fluent-rs/blob/master/fluent-syntax/src/parser/slice.rs although this is a generic version of it and the methods are tailored to the current needs.
My expectation is that as we grow the number of parsers we'll add methods to the trait as needed.

The value of the trait comes from how it models the parsers, as seen in two (POC completeness) parsers I've been using it on:
 - https://github.com/zbraniecki/icu4x/tree/pattern_formatter2/utils/pattern/src - simple format parser
 - https://github.com/zbraniecki/icu4x/blob/pattern_formatter2/components/datetime/src/pattern/parser.rs#L28 - DTF pattern parser

The value here comes from the fact that the parsers will be used on different types of inputs, and should produce different type of outputs depending on it.

Two particular cases that we'll often face is the current model, where we get a `Cow<'s, str>` (owned) from the DataProvider and will want to produce `Pattern(Vec<PatternItem>)` with lifetimes matching the borrow lifetime of the input, and the model where we will move the parser to the provider production and will want to store the `Pattern` in resource files, load it with its `Cow<'s, str>` (borrowed) and use directly.

The presence of `&str` specializations is mostly a convenience for testing and for completeness, while the String specialization is at the moment just for completeness.

I'm going to keep it as a Draft for the first round since I hope there's a way to use macros to reduce the repetitions (although my initial attempt hit the roadblock with `self`), and I'd like to first get to the point where we either have a mutual understanding on the value of this utility, or we find a better way to approach the problem.