### PR TITLE
Fix WASM build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
  "num-traits",
  "partial-min-max",
  "rand 0.7.3",
- "rand_distr",
+ "rand_distr 0.3.0",
  "rand_pcg 0.2.1",
  "strum",
  "writeable",
@@ -519,10 +519,11 @@ name = "fixed_decimal"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "getrandom 0.2.2",
  "icu_benchmark_macros",
- "rand 0.7.3",
- "rand_distr",
- "rand_pcg 0.2.1",
+ "rand 0.8.3",
+ "rand_distr 0.4.0",
+ "rand_pcg 0.3.0",
  "smallvec",
  "static_assertions",
  "writeable",
@@ -643,6 +644,19 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -876,14 +890,15 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "fixed_decimal",
+ "getrandom 0.2.2",
  "icu_benchmark_macros",
  "icu_locid",
  "icu_locid_macros",
  "icu_provider",
  "icu_testdata",
- "rand 0.7.3",
- "rand_distr",
- "rand_pcg 0.2.1",
+ "rand 0.8.3",
+ "rand_distr 0.4.0",
+ "rand_pcg 0.3.0",
  "serde",
  "smallstr",
  "thiserror",
@@ -1185,9 +1200,6 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 name = "litemap"
 version = "0.1.1"
 dependencies = [
- "icu_benchmark_macros",
- "icu_locid",
- "icu_locid_macros",
  "serde",
  "serde_json",
 ]
@@ -1596,11 +1608,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.2",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -1624,6 +1648,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.2",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,7 +1678,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -1655,6 +1698,16 @@ checksum = "c9e9532ada3929fb8b2e9dbe28d1e06c9b2cc65813f074fcb6bd5fbefeff9d56"
 dependencies = [
  "num-traits",
  "rand 0.7.3",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9e8f32ad24fb80d07d2323a9a2ce8b30d68a62b8cb4df88119ff49a698f038"
+dependencies = [
+ "num-traits",
+ "rand 0.8.3",
 ]
 
 [[package]]
@@ -1673,6 +1726,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1726,6 +1788,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de198537002b913568a3847e53535ace266f93526caf5c360ec41d72c5787f0"
+dependencies = [
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1789,7 +1860,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "redox_syscall",
  "rust-argon2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
  "num-traits",
  "partial-min-max",
  "rand 0.7.3",
- "rand_distr 0.3.0",
+ "rand_distr",
  "rand_pcg 0.2.1",
  "strum",
  "writeable",
@@ -520,9 +520,9 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "icu_benchmark_macros",
- "rand 0.8.3",
- "rand_distr 0.4.0",
- "rand_pcg 0.3.0",
+ "rand 0.7.3",
+ "rand_distr",
+ "rand_pcg 0.2.1",
  "smallvec",
  "static_assertions",
  "writeable",
@@ -643,17 +643,6 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -892,9 +881,9 @@ dependencies = [
  "icu_locid_macros",
  "icu_provider",
  "icu_testdata",
- "rand 0.8.3",
- "rand_distr 0.4.0",
- "rand_pcg 0.3.0",
+ "rand 0.7.3",
+ "rand_distr",
+ "rand_pcg 0.2.1",
  "serde",
  "smallstr",
  "thiserror",
@@ -1196,6 +1185,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 name = "litemap"
 version = "0.1.1"
 dependencies = [
+ "icu_benchmark_macros",
+ "icu_locid",
+ "icu_locid_macros",
  "serde",
  "serde_json",
 ]
@@ -1604,23 +1596,11 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
-dependencies = [
- "libc",
- "rand_chacha 0.3.0",
- "rand_core 0.6.2",
- "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -1644,16 +1624,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.2",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,16 +1644,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.15",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
-dependencies = [
- "getrandom 0.2.2",
+ "getrandom",
 ]
 
 [[package]]
@@ -1694,16 +1655,6 @@ checksum = "c9e9532ada3929fb8b2e9dbe28d1e06c9b2cc65813f074fcb6bd5fbefeff9d56"
 dependencies = [
  "num-traits",
  "rand 0.7.3",
-]
-
-[[package]]
-name = "rand_distr"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9e8f32ad24fb80d07d2323a9a2ce8b30d68a62b8cb4df88119ff49a698f038"
-dependencies = [
- "num-traits",
- "rand 0.8.3",
 ]
 
 [[package]]
@@ -1722,15 +1673,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
-dependencies = [
- "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1784,15 +1726,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de198537002b913568a3847e53535ace266f93526caf5c360ec41d72c5787f0"
-dependencies = [
- "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1856,7 +1789,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom",
  "redox_syscall",
  "rust-argon2",
 ]

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -34,9 +34,10 @@ criterion = "0.3"
 icu_benchmark_macros = { version = "0.1", path = "../../tools/benchmark/macros" }
 icu_locid_macros = { version = "0.1", path = "../locid/macros" }
 icu_testdata = { version = "0.1", path = "../../resources/testdata" }
-rand = "0.7"
-rand_pcg = "0.2"
-rand_distr = "0.3"
+rand = "0.8"
+rand_pcg = "0.3"
+rand_distr = "0.4"
+getrandom = { version = "0.2", features = ["js"] }
 
 [features]
 default = ["provider_serde"]

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -34,9 +34,9 @@ criterion = "0.3"
 icu_benchmark_macros = { version = "0.1", path = "../../tools/benchmark/macros" }
 icu_locid_macros = { version = "0.1", path = "../locid/macros" }
 icu_testdata = { version = "0.1", path = "../../resources/testdata" }
-rand = "0.8"
-rand_pcg = "0.3"
-rand_distr = "0.4"
+rand = "0.7"
+rand_pcg = "0.2"
+rand_distr = "0.3"
 
 [features]
 default = ["provider_serde"]

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -28,9 +28,9 @@ writeable = { version = "0.2", path = "../../utils/writeable" }
 [dev-dependencies]
 criterion = "0.3.3"
 icu_benchmark_macros = { version = "0.1", path = "../../tools/benchmark/macros" }
-rand = "0.8"
-rand_pcg = "0.3"
-rand_distr = "0.4"
+rand = "0.7"
+rand_pcg = "0.2"
+rand_distr = "0.3"
 
 [lib]
 bench = false  # This option is required for Benchmark CI

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -28,9 +28,10 @@ writeable = { version = "0.2", path = "../../utils/writeable" }
 [dev-dependencies]
 criterion = "0.3.3"
 icu_benchmark_macros = { version = "0.1", path = "../../tools/benchmark/macros" }
-rand = "0.7"
-rand_pcg = "0.2"
-rand_distr = "0.3"
+rand = "0.8"
+rand_pcg = "0.3"
+rand_distr = "0.4"
+getrandom = { version = "0.2", features = ["js"] }
 
 [lib]
 bench = false  # This option is required for Benchmark CI


### PR DESCRIPTION
Fixes #607

~I downgraded the `rand` crate because the new version does not build on WASM.  I filed https://github.com/rust-random/rand/issues/1110 for fixing the issue upstream.~

EDIT: I fixed the issue by passing the "js" feature to getrandom, as suggested in the above thread.