### PR TITLE
Add examples to LiteMap and improve WASM build tooling

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -37,7 +37,7 @@ bincode-gen-testdata = "make bincode-gen-testdata"
 ### WASM TASKS ###
 
 # Re-build standard library with panic=abort.
-wasm-build = "build -Z build-std=std,panic_abort --target wasm32-unknown-unknown --release"
+wasm-build = "build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target wasm32-unknown-unknown --release"
 
 [target.wasm32-unknown-unknown]
 rustflags = [

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -280,6 +280,7 @@ jobs:
               icu_uniset/unicode_bmp_blocks_selector
               fixed_decimal/permyriad
               writeable/writeable_message
+              litemap/language_names_lite_map
 
     runs-on: ${{ matrix.os }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
  "num-traits",
  "partial-min-max",
  "rand 0.7.3",
- "rand_distr",
+ "rand_distr 0.3.0",
  "rand_pcg 0.2.1",
  "strum",
  "writeable",
@@ -519,10 +519,11 @@ name = "fixed_decimal"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "getrandom 0.2.2",
  "icu_benchmark_macros",
- "rand 0.7.3",
- "rand_distr",
- "rand_pcg 0.2.1",
+ "rand 0.8.3",
+ "rand_distr 0.4.0",
+ "rand_pcg 0.3.0",
  "smallvec",
  "static_assertions",
  "writeable",
@@ -643,6 +644,19 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -876,14 +890,15 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "fixed_decimal",
+ "getrandom 0.2.2",
  "icu_benchmark_macros",
  "icu_locid",
  "icu_locid_macros",
  "icu_provider",
  "icu_testdata",
- "rand 0.7.3",
- "rand_distr",
- "rand_pcg 0.2.1",
+ "rand 0.8.3",
+ "rand_distr 0.4.0",
+ "rand_pcg 0.3.0",
  "serde",
  "smallstr",
  "thiserror",
@@ -1185,9 +1200,6 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 name = "litemap"
 version = "0.1.1"
 dependencies = [
- "icu_benchmark_macros",
- "icu_locid",
- "icu_locid_macros",
  "serde",
  "serde_json",
 ]
@@ -1596,11 +1608,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.2",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -1624,6 +1648,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.2",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,7 +1678,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -1655,6 +1698,16 @@ checksum = "c9e9532ada3929fb8b2e9dbe28d1e06c9b2cc65813f074fcb6bd5fbefeff9d56"
 dependencies = [
  "num-traits",
  "rand 0.7.3",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9e8f32ad24fb80d07d2323a9a2ce8b30d68a62b8cb4df88119ff49a698f038"
+dependencies = [
+ "num-traits",
+ "rand 0.8.3",
 ]
 
 [[package]]
@@ -1673,6 +1726,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1726,6 +1788,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de198537002b913568a3847e53535ace266f93526caf5c360ec41d72c5787f0"
+dependencies = [
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1789,7 +1860,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "redox_syscall",
  "rust-argon2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,6 +1200,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 name = "litemap"
 version = "0.1.1"
 dependencies = [
+ "icu_benchmark_macros",
+ "icu_locid",
+ "icu_locid_macros",
  "serde",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
  "num-traits",
  "partial-min-max",
  "rand 0.7.3",
- "rand_distr 0.3.0",
+ "rand_distr",
  "rand_pcg 0.2.1",
  "strum",
  "writeable",
@@ -520,9 +520,9 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "icu_benchmark_macros",
- "rand 0.8.3",
- "rand_distr 0.4.0",
- "rand_pcg 0.3.0",
+ "rand 0.7.3",
+ "rand_distr",
+ "rand_pcg 0.2.1",
  "smallvec",
  "static_assertions",
  "writeable",
@@ -643,17 +643,6 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -892,9 +881,9 @@ dependencies = [
  "icu_locid_macros",
  "icu_provider",
  "icu_testdata",
- "rand 0.8.3",
- "rand_distr 0.4.0",
- "rand_pcg 0.3.0",
+ "rand 0.7.3",
+ "rand_distr",
+ "rand_pcg 0.2.1",
  "serde",
  "smallstr",
  "thiserror",
@@ -1196,6 +1185,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 name = "litemap"
 version = "0.1.1"
 dependencies = [
+ "icu_benchmark_macros",
+ "icu_locid",
+ "icu_locid_macros",
  "serde",
  "serde_json",
 ]
@@ -1604,23 +1596,11 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
-dependencies = [
- "libc",
- "rand_chacha 0.3.0",
- "rand_core 0.6.2",
- "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -1644,16 +1624,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.2",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,16 +1644,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.15",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
-dependencies = [
- "getrandom 0.2.2",
+ "getrandom",
 ]
 
 [[package]]
@@ -1694,16 +1655,6 @@ checksum = "c9e9532ada3929fb8b2e9dbe28d1e06c9b2cc65813f074fcb6bd5fbefeff9d56"
 dependencies = [
  "num-traits",
  "rand 0.7.3",
-]
-
-[[package]]
-name = "rand_distr"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9e8f32ad24fb80d07d2323a9a2ce8b30d68a62b8cb4df88119ff49a698f038"
-dependencies = [
- "num-traits",
- "rand 0.8.3",
 ]
 
 [[package]]
@@ -1722,15 +1673,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
-dependencies = [
- "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1784,15 +1726,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de198537002b913568a3847e53535ace266f93526caf5c360ec41d72c5787f0"
-dependencies = [
- "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1856,7 +1789,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom",
  "redox_syscall",
  "rust-argon2",
 ]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -98,7 +98,7 @@ dependencies = [
 description = "Build all examples as WASM into the target directory"
 category = "ICU4X WASM"
 install_crate = { rustup_component_name = "rust-src" }
-toolchain = "nightly"
+toolchain = "nightly-2021-03-15"
 command = "cargo"
 args = ["wasm-build", "--examples"]
 
@@ -118,26 +118,65 @@ dependencies = ["wasm-build", "wasm-dir"]
 [tasks.wasm-wat]
 description = "Create WebAssembly Text files from the WASM files"
 category = "ICU4X WASM"
-command = "find"
-args = ["wasmpkg/", "-name", "*.wasm", "-exec", "wasm2wat", "{}", "-o", "{}.wat", ";"]
 dependencies = ["wasm-wasm"]
-install_script = ["which wasm2wat || npm install -g wabt"]
+script_runner = "@duckscript"
+script = '''
+exit_on_error true
+
+wasm2wat = which wasm2wat
+assert ${wasm2wat} "Could not find 'wasm2wat' in path.\n*** Please run 'npm install -g wabt' ***"
+
+handle = glob_array wasmpkg/*.wasm
+for path in ${handle}
+    basename = substring ${path} -5
+    out_path = concat ${basename} ".wat"
+    exec --fail-on-error ${wasm2wat} ${path} -o ${out_path}
+end
+'''
 
 [tasks.wasm-opt]
 description = "Create optimized WASM files from the WASM files"
 category = "ICU4X WASM"
-command = "find"
-args = ["wasmpkg/", "-name", "*.wasm", "-exec", "wasm-opt", "{}", "-o", "{}.opt", ";"]
 dependencies = ["wasm-wasm"]
-install_script = ["which wasm-opt || npm install -g wasm-opt"]
+script_runner = "@duckscript"
+script = '''
+exit_on_error true
+
+wasm-opt = which wasm-opt
+assert ${wasm-opt} "Could not find 'wasm-opt' in path.\n*** Please run 'npm install -g wasm-opt' ***"
+
+handle = glob_array wasmpkg/*.wasm
+for path in ${handle}
+    basename = substring ${path} -5
+    out_path = concat ${basename} "+opt.wasm"
+    output = exec ${wasm-opt} ${path} -o ${out_path}
+    stdout = trim ${output.stdout}
+    stderr = trim ${output.stderr}
+    if ${stdout} or ${stderr} or ${output.code}
+        echo ${stdout}\n${stderr}\nexit code: ${output.code}
+        assert_fail "wasm-opt printed warnings (shown above)"
+    end
+end
+'''
 
 [tasks.wasm-twiggy-dominators]
 description = "Create Twiggy Dominator files from the WASM files"
 category = "ICU4X WASM"
-command = "find"
-args = ["wasmpkg/", "-name", "*.wasm", "-exec", "twiggy", "dominators", "{}", "-o", "{}.txt", ";"]
+script_runner = "@duckscript"
+script = '''
+exit_on_error true
+
+twiggy = which twiggy
+assert ${twiggy} "Could not find 'twiggy' in path.\n*** Please run 'cargo install twiggy' ***"
+
+handle = glob_array wasmpkg/*.wasm
+for path in ${handle}
+    basename = substring ${path} -5
+    out_path = concat ${basename} "+twiggy.txt"
+    exec --fail-on-error ${twiggy} dominators ${path} -o ${out_path}
+end
+'''
 dependencies = ["wasm-wasm"]
-install_crate = "twiggy"
 
 [tasks.wasm]
 description = "All-in-one command to build examples and supplements to wasmpkg"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -155,6 +155,46 @@ for src_path in ${handle}
 end
 '''
 
+[tasks.wasm-dcmp]
+description = "Create WebAssembly decompiled code files from the WASM files"
+category = "ICU4X WASM"
+dependencies = ["wasm-wasm"]
+script_runner = "@duckscript"
+script = '''
+exit_on_error true
+
+wasm-decompile = which wasm-decompile
+assert ${wasm-decompile} "Could not find 'wasm-decompile' in path.\n*** Please run 'npm install -g wabt' ***"
+
+mkdir wasmpkg/wasm-decompile
+
+handle = glob_array wasmpkg/*.wasm
+for src_path in ${handle}
+    path_no_extension = substring ${src_path} -5
+    basename = substring ${path_no_extension} 8
+    out_path = concat wasmpkg/wasm-decompile/ ${basename} ".dcmp"
+
+    out_exists = is_path_exists ${out_path}
+    up_to_date = set false
+    if ${out_exists}
+        src_time = get_last_modified_time ${src_path}
+        out_time = get_last_modified_time ${out_path}
+        up_to_date = less_than ${src_time} ${out_time}
+    end
+
+    if not ${up_to_date}
+        echo Writing ${out_path}
+        output = exec ${wasm-decompile} ${src_path} -o ${out_path}
+        stdout = trim ${output.stdout}
+        stderr = trim ${output.stderr}
+        if ${stdout} or ${stderr} or ${output.code}
+            echo ${stdout}\n${stderr}\nexit code: ${output.code}
+            assert_fail "wasm-decompile printed warnings (shown above)"
+        end
+    end
+end
+'''
+
 [tasks.wasm-opt]
 description = "Create optimized WASM files from the WASM files"
 category = "ICU4X WASM"
@@ -235,6 +275,7 @@ category = "ICU4X WASM"
 dependencies = [
     "wasm-wasm",
     "wasm-wat",
+    "wasm-dcmp",
     "wasm-opt",
     "wasm-twiggy-dominators",
 ]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -98,7 +98,7 @@ dependencies = [
 description = "Build all examples as WASM into the target directory"
 category = "ICU4X WASM"
 install_crate = { rustup_component_name = "rust-src" }
-toolchain = "nightly-2021-03-15"
+toolchain = "nightly-2021-02-28"
 command = "cargo"
 args = ["wasm-build", "--examples"]
 
@@ -126,11 +126,32 @@ exit_on_error true
 wasm2wat = which wasm2wat
 assert ${wasm2wat} "Could not find 'wasm2wat' in path.\n*** Please run 'npm install -g wabt' ***"
 
+mkdir wasmpkg/wat
+
 handle = glob_array wasmpkg/*.wasm
-for path in ${handle}
-    basename = substring ${path} -5
-    out_path = concat ${basename} ".wat"
-    exec --fail-on-error ${wasm2wat} ${path} -o ${out_path}
+for src_path in ${handle}
+    path_no_extension = substring ${src_path} -5
+    basename = substring ${path_no_extension} 8
+    out_path = concat wasmpkg/wat/ ${basename} ".wat"
+
+    out_exists = is_path_exists ${out_path}
+    up_to_date = set false
+    if ${out_exists}
+        src_time = get_last_modified_time ${src_path}
+        out_time = get_last_modified_time ${out_path}
+        up_to_date = less_than ${src_time} ${out_time}
+    end
+
+    if not ${up_to_date}
+        echo Writing ${out_path}
+        output = exec ${wasm2wat} ${src_path} -o ${out_path}
+        stdout = trim ${output.stdout}
+        stderr = trim ${output.stderr}
+        if ${stdout} or ${stderr} or ${output.code}
+            echo ${stdout}\n${stderr}\nexit code: ${output.code}
+            assert_fail "wasm2wat printed warnings (shown above)"
+        end
+    end
 end
 '''
 
@@ -145,16 +166,31 @@ exit_on_error true
 wasm-opt = which wasm-opt
 assert ${wasm-opt} "Could not find 'wasm-opt' in path.\n*** Please run 'npm install -g wasm-opt' ***"
 
+mkdir wasmpkg/wasm-opt
+
 handle = glob_array wasmpkg/*.wasm
-for path in ${handle}
-    basename = substring ${path} -5
-    out_path = concat ${basename} "+opt.wasm"
-    output = exec ${wasm-opt} ${path} -o ${out_path}
-    stdout = trim ${output.stdout}
-    stderr = trim ${output.stderr}
-    if ${stdout} or ${stderr} or ${output.code}
-        echo ${stdout}\n${stderr}\nexit code: ${output.code}
-        assert_fail "wasm-opt printed warnings (shown above)"
+for src_path in ${handle}
+    path_no_extension = substring ${src_path} -5
+    basename = substring ${path_no_extension} 8
+    out_path = concat wasmpkg/wasm-opt/ ${basename} "+opt.wasm"
+
+    out_exists = is_path_exists ${out_path}
+    up_to_date = set false
+    if ${out_exists}
+        src_time = get_last_modified_time ${src_path}
+        out_time = get_last_modified_time ${out_path}
+        up_to_date = less_than ${src_time} ${out_time}
+    end
+
+    if not ${up_to_date}
+        echo Writing ${out_path}
+        output = exec ${wasm-opt} ${src_path} -o ${out_path}
+        stdout = trim ${output.stdout}
+        stderr = trim ${output.stderr}
+        if ${stdout} or ${stderr} or ${output.code}
+            echo ${stdout}\n${stderr}\nexit code: ${output.code}
+            assert_fail "wasm-opt printed warnings (shown above)"
+        end
     end
 end
 '''
@@ -169,11 +205,26 @@ exit_on_error true
 twiggy = which twiggy
 assert ${twiggy} "Could not find 'twiggy' in path.\n*** Please run 'cargo install twiggy' ***"
 
+mkdir wasmpkg/twiggy
+
 handle = glob_array wasmpkg/*.wasm
-for path in ${handle}
-    basename = substring ${path} -5
-    out_path = concat ${basename} "+twiggy.txt"
-    exec --fail-on-error ${twiggy} dominators ${path} -o ${out_path}
+for src_path in ${handle}
+    path_no_extension = substring ${src_path} -5
+    basename = substring ${path_no_extension} 8
+    out_path = concat wasmpkg/twiggy/ ${basename} "+twiggy.txt"
+
+    out_exists = is_path_exists ${out_path}
+    up_to_date = set false
+    if ${out_exists}
+        src_time = get_last_modified_time ${src_path}
+        out_time = get_last_modified_time ${out_path}
+        up_to_date = less_than ${src_time} ${out_time}
+    end
+
+    if not ${up_to_date}
+        echo Writing ${out_path}
+        exec --fail-on-error ${twiggy} dominators ${src_path} -o ${out_path}
+    end
 end
 '''
 dependencies = ["wasm-wasm"]

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -34,9 +34,10 @@ criterion = "0.3"
 icu_benchmark_macros = { version = "0.1", path = "../../tools/benchmark/macros" }
 icu_locid_macros = { version = "0.1", path = "../locid/macros" }
 icu_testdata = { version = "0.1", path = "../../resources/testdata" }
-rand = "0.7"
-rand_pcg = "0.2"
-rand_distr = "0.3"
+rand = "0.8"
+rand_pcg = "0.3"
+rand_distr = "0.4"
+getrandom = { version = "0.2", features = ["js"] }
 
 [features]
 default = ["provider_serde"]

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -34,9 +34,9 @@ criterion = "0.3"
 icu_benchmark_macros = { version = "0.1", path = "../../tools/benchmark/macros" }
 icu_locid_macros = { version = "0.1", path = "../locid/macros" }
 icu_testdata = { version = "0.1", path = "../../resources/testdata" }
-rand = "0.8"
-rand_pcg = "0.3"
-rand_distr = "0.4"
+rand = "0.7"
+rand_pcg = "0.2"
+rand_distr = "0.3"
 
 [features]
 default = ["provider_serde"]

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -28,9 +28,9 @@ writeable = { version = "0.2", path = "../../utils/writeable" }
 [dev-dependencies]
 criterion = "0.3.3"
 icu_benchmark_macros = { version = "0.1", path = "../../tools/benchmark/macros" }
-rand = "0.8"
-rand_pcg = "0.3"
-rand_distr = "0.4"
+rand = "0.7"
+rand_pcg = "0.2"
+rand_distr = "0.3"
 
 [lib]
 bench = false  # This option is required for Benchmark CI

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -28,9 +28,10 @@ writeable = { version = "0.2", path = "../../utils/writeable" }
 [dev-dependencies]
 criterion = "0.3.3"
 icu_benchmark_macros = { version = "0.1", path = "../../tools/benchmark/macros" }
-rand = "0.7"
-rand_pcg = "0.2"
-rand_distr = "0.3"
+rand = "0.8"
+rand_pcg = "0.3"
+rand_distr = "0.4"
+getrandom = { version = "0.2", features = ["js"] }
 
 [lib]
 bench = false  # This option is required for Benchmark CI

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -21,6 +21,9 @@ serde = {version = "1", optional = true}
 [dev-dependencies]
 serde = "1"
 serde_json = "1"
+icu_locid = { version = "0.1", path = "../../components/locid" }
+icu_locid_macros = { version = "0.1", path = "../../components/locid/macros" }
+icu_benchmark_macros = { version = "0.1", path = "../../tools/benchmark/macros" }
 
 [[test]]
 name = "serde"

--- a/utils/litemap/examples/language_names_hash_map.rs
+++ b/utils/litemap/examples/language_names_hash_map.rs
@@ -9,8 +9,23 @@
 
 icu_benchmark_macros::static_setup!();
 
-use std::collections::HashMap;
+use icu_locid::subtags::Language;
 use icu_locid_macros::language;
+use std::collections::HashMap;
+
+const DATA: [(Language, &'static str); 11] = [
+    (language!("ar"), "Arabic"),
+    (language!("bn"), "Bangla"),
+    (language!("ccp"), "Chakma"),
+    (language!("en"), "English"),
+    (language!("es"), "Spanish"),
+    (language!("fr"), "French"),
+    (language!("ja"), "Japanese"),
+    (language!("ru"), "Russian"),
+    (language!("sr"), "Serbian"),
+    (language!("th"), "Thai"),
+    (language!("tr"), "Turkish"),
+];
 
 #[no_mangle]
 fn main(_argc: isize, _argv: *const *const u8) -> isize {
@@ -18,20 +33,12 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
 
     let mut map = HashMap::new();
     // https://github.com/rust-lang/rust/issues/62633 was declined :(
-    map.insert(language!("ar"), "Arabic").ok_or(()).unwrap_err();
-    map.insert(language!("bn"), "Bangla").ok_or(()).unwrap_err();
-    map.insert(language!("ccp"), "Chakma").ok_or(()).unwrap_err();
-    map.insert(language!("en"), "English").ok_or(()).unwrap_err();
-    map.insert(language!("es"), "Spanish").ok_or(()).unwrap_err();
-    map.insert(language!("fr"), "French").ok_or(()).unwrap_err();
-    map.insert(language!("ja"), "Japanese").ok_or(()).unwrap_err();
-    map.insert(language!("ru"), "Russian").ok_or(()).unwrap_err();
-    map.insert(language!("sr"), "Serbian").ok_or(()).unwrap_err();
-    map.insert(language!("th"), "Thai").ok_or(()).unwrap_err();
-    map.insert(language!("tr"), "Turkish").ok_or(()).unwrap_err();
+    for (lang, name) in DATA.iter() {
+        map.insert(lang, name).ok_or(()).unwrap_err();
+    }
 
     debug_assert_eq!(11, map.len());
-    debug_assert_eq!(Some(&"Thai"), map.get(&language!("th")));
+    debug_assert_eq!(Some(&&"Thai"), map.get(&language!("th")));
     debug_assert_eq!(None, map.get(&language!("de")));
 
     0

--- a/utils/litemap/examples/language_names_hash_map.rs
+++ b/utils/litemap/examples/language_names_hash_map.rs
@@ -1,0 +1,38 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+// LiteMap is intended as a small and low-memory drop-in replacement for
+// HashMap. This example demonstrates how it compares to HashMap.
+
+#![no_main] // https://github.com/unicode-org/icu4x/issues/395
+
+icu_benchmark_macros::static_setup!();
+
+use std::collections::HashMap;
+use icu_locid_macros::language;
+
+#[no_mangle]
+fn main(_argc: isize, _argv: *const *const u8) -> isize {
+    icu_benchmark_macros::main_setup!();
+
+    let mut map = HashMap::new();
+    // https://github.com/rust-lang/rust/issues/62633 was declined :(
+    map.insert(language!("ar"), "Arabic").ok_or(()).unwrap_err();
+    map.insert(language!("bn"), "Bangla").ok_or(()).unwrap_err();
+    map.insert(language!("ccp"), "Chakma").ok_or(()).unwrap_err();
+    map.insert(language!("en"), "English").ok_or(()).unwrap_err();
+    map.insert(language!("es"), "Spanish").ok_or(()).unwrap_err();
+    map.insert(language!("fr"), "French").ok_or(()).unwrap_err();
+    map.insert(language!("ja"), "Japanese").ok_or(()).unwrap_err();
+    map.insert(language!("ru"), "Russian").ok_or(()).unwrap_err();
+    map.insert(language!("sr"), "Serbian").ok_or(()).unwrap_err();
+    map.insert(language!("th"), "Thai").ok_or(()).unwrap_err();
+    map.insert(language!("tr"), "Turkish").ok_or(()).unwrap_err();
+
+    debug_assert_eq!(11, map.len());
+    debug_assert_eq!(Some(&"Thai"), map.get(&language!("th")));
+    debug_assert_eq!(None, map.get(&language!("de")));
+
+    0
+}

--- a/utils/litemap/examples/language_names_hash_map.rs
+++ b/utils/litemap/examples/language_names_hash_map.rs
@@ -2,8 +2,10 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-// LiteMap is intended as a small and low-memory drop-in replacement for
-// HashMap. This example demonstrates how it compares to HashMap.
+// LiteMap is intended as a small and low-memory drop-in replacement for HashMap.
+//
+// This example does not use LiteMap. The reader may compare this HashMap example to the
+// LiteMap example to showcase analogous operations between HashMap and LiteMap.
 
 #![no_main] // https://github.com/unicode-org/icu4x/issues/395
 

--- a/utils/litemap/examples/language_names_lite_map.rs
+++ b/utils/litemap/examples/language_names_lite_map.rs
@@ -1,0 +1,38 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+// LiteMap is intended as a small and low-memory drop-in replacement for
+// HashMap. This example demonstrates its use.
+
+#![no_main] // https://github.com/unicode-org/icu4x/issues/395
+
+icu_benchmark_macros::static_setup!();
+
+use litemap::LiteMap;
+use icu_locid_macros::language;
+
+#[no_mangle]
+fn main(_argc: isize, _argv: *const *const u8) -> isize {
+    icu_benchmark_macros::main_setup!();
+
+    let mut map = LiteMap::new();
+    // https://github.com/rust-lang/rust/issues/62633 was declined :(
+    map.try_append(language!("ar"), "Arabic").ok_or(()).unwrap_err();
+    map.try_append(language!("bn"), "Bangla").ok_or(()).unwrap_err();
+    map.try_append(language!("ccp"), "Chakma").ok_or(()).unwrap_err();
+    map.try_append(language!("en"), "English").ok_or(()).unwrap_err();
+    map.try_append(language!("es"), "Spanish").ok_or(()).unwrap_err();
+    map.try_append(language!("fr"), "French").ok_or(()).unwrap_err();
+    map.try_append(language!("ja"), "Japanese").ok_or(()).unwrap_err();
+    map.try_append(language!("ru"), "Russian").ok_or(()).unwrap_err();
+    map.try_append(language!("sr"), "Serbian").ok_or(()).unwrap_err();
+    map.try_append(language!("th"), "Thai").ok_or(()).unwrap_err();
+    map.try_append(language!("tr"), "Turkish").ok_or(()).unwrap_err();
+
+    debug_assert_eq!(11, map.len());
+    debug_assert_eq!(Some(&"Thai"), map.get(&language!("th")));
+    debug_assert_eq!(None, map.get(&language!("de")));
+
+    0
+}

--- a/utils/litemap/examples/language_names_lite_map.rs
+++ b/utils/litemap/examples/language_names_lite_map.rs
@@ -2,8 +2,10 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-// LiteMap is intended as a small and low-memory drop-in replacement for
-// HashMap. This example demonstrates its use.
+// LiteMap is intended as a small and low-memory drop-in replacement for HashMap.
+//
+// The reader may compare this LiteMap example with the HashMap example to see analogous
+// operations between LiteMap and HashMap.
 
 #![no_main] // https://github.com/unicode-org/icu4x/issues/395
 

--- a/utils/litemap/examples/language_names_lite_map.rs
+++ b/utils/litemap/examples/language_names_lite_map.rs
@@ -9,8 +9,23 @@
 
 icu_benchmark_macros::static_setup!();
 
-use litemap::LiteMap;
+use icu_locid::subtags::Language;
 use icu_locid_macros::language;
+use litemap::LiteMap;
+
+const DATA: [(Language, &'static str); 11] = [
+    (language!("ar"), "Arabic"),
+    (language!("bn"), "Bangla"),
+    (language!("ccp"), "Chakma"),
+    (language!("en"), "English"),
+    (language!("es"), "Spanish"),
+    (language!("fr"), "French"),
+    (language!("ja"), "Japanese"),
+    (language!("ru"), "Russian"),
+    (language!("sr"), "Serbian"),
+    (language!("th"), "Thai"),
+    (language!("tr"), "Turkish"),
+];
 
 #[no_mangle]
 fn main(_argc: isize, _argv: *const *const u8) -> isize {
@@ -18,20 +33,12 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
 
     let mut map = LiteMap::new();
     // https://github.com/rust-lang/rust/issues/62633 was declined :(
-    map.try_append(language!("ar"), "Arabic").ok_or(()).unwrap_err();
-    map.try_append(language!("bn"), "Bangla").ok_or(()).unwrap_err();
-    map.try_append(language!("ccp"), "Chakma").ok_or(()).unwrap_err();
-    map.try_append(language!("en"), "English").ok_or(()).unwrap_err();
-    map.try_append(language!("es"), "Spanish").ok_or(()).unwrap_err();
-    map.try_append(language!("fr"), "French").ok_or(()).unwrap_err();
-    map.try_append(language!("ja"), "Japanese").ok_or(()).unwrap_err();
-    map.try_append(language!("ru"), "Russian").ok_or(()).unwrap_err();
-    map.try_append(language!("sr"), "Serbian").ok_or(()).unwrap_err();
-    map.try_append(language!("th"), "Thai").ok_or(()).unwrap_err();
-    map.try_append(language!("tr"), "Turkish").ok_or(()).unwrap_err();
+    for (lang, name) in DATA.iter() {
+        map.try_append(lang, name).ok_or(()).unwrap_err();
+    }
 
     debug_assert_eq!(11, map.len());
-    debug_assert_eq!(Some(&"Thai"), map.get(&language!("th")));
+    debug_assert_eq!(Some(&&"Thai"), map.get(&language!("th")));
     debug_assert_eq!(None, map.get(&language!("de")));
 
     0


### PR DESCRIPTION
Fixes #607

I created two example files, one with litemap and one with hashmap.

LiteMap is smaller and lower memory, as expected, ~but not by as much of a margin as I had been expecting, especially on code size.  It may be worth investigating how we could reduce it further.~

UPDATE: After enabling `panic_immediate_abort`, the diffs are:

| | HashMap | LiteMap | Diff |
|---|---|---|---|
| Max Heap Memory Used | 632 B | 384 B | -39% |
| Code Size | 11268 B | 8550 B | -24% |

Memory benchmark output:

```
[memory] >      Running `target/release/examples/language_names_lite_map`
[memory] > Feature
[memory] > dhat: Total:     672 bytes in 3 blocks
[memory] > dhat: At t-gmax: 384 bytes in 1 blocks
[memory] > dhat: At t-end:  0 bytes in 0 blocks
...
[memory] >      Running `target/release/examples/language_names_hash_map`
[memory] > Feature
[memory] > dhat: Total:     748 bytes in 3 blocks
[memory] > dhat: At t-gmax: 632 bytes in 2 blocks
[memory] > dhat: At t-end:  0 bytes in 0 blocks
```

~WASM code size:~

```
33669  language_names_hash_map.wasm
33386  language_names_lite_map.wasm
```

~My build of twiggy isn't working on this machine.  I'll take a look on Monday to see if I can determine what is making the litemap wasm file so bloated.~