### PR TITLE
Update ICU Component Documentation Examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,6 +949,7 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "fixed_decimal",
+ "icu",
  "icu_benchmark_macros",
  "icu_locid",
  "icu_locid_macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,6 +925,7 @@ name = "icu_locid"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "icu",
  "icu_benchmark_macros",
  "serde",
  "serde_json",
@@ -936,6 +937,7 @@ dependencies = [
 name = "icu_locid_macros"
 version = "0.1.0"
 dependencies = [
+ "icu",
  "icu_locid",
  "proc-macro-crate",
  "tinystr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,6 +1073,7 @@ name = "icu_uniset"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "icu",
  "icu_benchmark_macros",
  "icu_provider",
  "litemap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "criterion",
+ "icu",
  "icu_benchmark_macros",
  "icu_locid",
  "icu_locid_macros",

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -35,6 +35,7 @@ smallvec = "1.4"
 
 [dev-dependencies]
 criterion = "0.3"
+icu = { path = "../icu" }
 icu_benchmark_macros = { version = "0.1", path = "../../tools/benchmark/macros" }
 icu_provider = { version = "0.1", path = "../provider" }
 icu_testdata = { version = "0.1", path = "../../resources/testdata" }

--- a/components/datetime/README.md
+++ b/components/datetime/README.md
@@ -11,9 +11,9 @@ used to quickly format any date and time provided.
 ## Examples
 
 ```rust
-use icu_locid::Locale;
-use icu_locid_macros::langid;
-use icu_datetime::{DateTimeFormat, DateTimeFormatOptions, mock::datetime::MockDateTime, options::length};
+use icu::locid::Locale;
+use icu::locid::macros::langid;
+use icu::datetime::{DateTimeFormat, DateTimeFormatOptions, mock::datetime::MockDateTime, options::length};
 
 let provider = icu_testdata::get_provider();
 
@@ -41,6 +41,9 @@ The options can be created more ergonomically using the `Into` trait to automati
 convert a [`options::length::Bag`] into a [`DateTimeFormatOptions::Length`].
 
 ```rust
+use icu::locid::Locale;
+use icu::locid::macros::langid;
+use icu::datetime::{DateTimeFormat, DateTimeFormatOptions, mock::datetime::MockDateTime, options::length};
 let options = length::Bag {
     date: Some(length::Date::Medium),
     time: Some(length::Time::Short),

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -266,7 +266,7 @@ pub struct DayOfYearInfo {
 /// # Example
 ///
 /// ```
-/// use icu_datetime::date::IsoWeekday;
+/// use icu::datetime::date::IsoWeekday;
 ///
 /// assert_eq!(1, IsoWeekday::Monday as usize);
 /// assert_eq!(7, IsoWeekday::Sunday as usize);
@@ -290,7 +290,7 @@ impl From<usize> for IsoWeekday {
     /// # Example
     ///
     /// ```
-    /// use icu_datetime::date::IsoWeekday;
+    /// use icu::datetime::date::IsoWeekday;
     ///
     /// assert_eq!(IsoWeekday::Sunday, IsoWeekday::from(0));
     /// assert_eq!(IsoWeekday::Monday, IsoWeekday::from(1));
@@ -484,7 +484,7 @@ impl FromStr for GmtOffset {
     /// # Examples
     ///
     /// ```
-    /// use icu_datetime::date::GmtOffset;
+    /// use icu::datetime::date::GmtOffset;
     ///
     /// let offset0: GmtOffset = "Z".parse().expect("Failed to parse a GMT offset.");
     /// let offset1: GmtOffset = "-09".parse().expect("Failed to parse a GMT offset.");

--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -27,10 +27,10 @@ use crate::{
 /// # Examples
 ///
 /// ```
-/// use icu_locid::Locale;
-/// use icu_locid_macros::langid;
-/// use icu_datetime::{DateTimeFormat, options::length};
-/// use icu_datetime::mock::datetime::MockDateTime;
+/// use icu::locid::Locale;
+/// use icu::locid::macros::langid;
+/// use icu::datetime::{DateTimeFormat, options::length};
+/// use icu::datetime::mock::datetime::MockDateTime;
 /// use icu_provider::inv::InvariantDataProvider;
 ///
 /// let locale: Locale = langid!("en").into();
@@ -67,10 +67,10 @@ impl<'d> DateTimeFormat<'d> {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::Locale;
-    /// use icu_locid_macros::langid;
-    /// use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
-    /// use icu_datetime::mock::datetime::MockDateTime;
+    /// use icu::locid::Locale;
+    /// use icu::locid::macros::langid;
+    /// use icu::datetime::{DateTimeFormat, DateTimeFormatOptions};
+    /// use icu::datetime::mock::datetime::MockDateTime;
     /// use icu_provider::inv::InvariantDataProvider;
     ///
     /// let locale: Locale = langid!("en").into();
@@ -159,11 +159,11 @@ impl<'d> DateTimeFormat<'d> {
     /// # Examples
     ///
     /// ```
-    /// # use icu_locid::Locale;
-    /// # use icu_locid_macros::langid;
-    /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
-    /// # use icu_datetime::mock::datetime::MockDateTime;
-    /// # use icu_provider::inv::InvariantDataProvider;
+    /// use icu::locid::Locale;
+    /// use icu::locid::macros::langid;
+    /// use icu::datetime::{DateTimeFormat, DateTimeFormatOptions};
+    /// use icu::datetime::mock::datetime::MockDateTime;
+    /// use icu_provider::inv::InvariantDataProvider;
     /// # let locale: Locale = langid!("en").into();
     /// # let provider = InvariantDataProvider;
     /// # let options = DateTimeFormatOptions::default();
@@ -199,11 +199,11 @@ impl<'d> DateTimeFormat<'d> {
     /// # Examples
     ///
     /// ```
-    /// # use icu_locid::Locale;
-    /// # use icu_locid_macros::langid;
-    /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
-    /// # use icu_datetime::mock::datetime::MockDateTime;
-    /// # use icu_provider::inv::InvariantDataProvider;
+    /// use icu::locid::Locale;
+    /// use icu::locid::macros::langid;
+    /// use icu::datetime::{DateTimeFormat, DateTimeFormatOptions};
+    /// use icu::datetime::mock::datetime::MockDateTime;
+    /// use icu_provider::inv::InvariantDataProvider;
     /// # let locale: Locale = langid!("en").into();
     /// # let provider = InvariantDataProvider;
     /// # let options = DateTimeFormatOptions::default();
@@ -234,11 +234,11 @@ impl<'d> DateTimeFormat<'d> {
     /// # Examples
     ///
     /// ```
-    /// # use icu_locid::Locale;
-    /// # use icu_locid_macros::langid;
-    /// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
-    /// # use icu_datetime::mock::datetime::MockDateTime;
-    /// # use icu_provider::inv::InvariantDataProvider;
+    /// use icu::locid::Locale;
+    /// use icu::locid::macros::langid;
+    /// use icu::datetime::{DateTimeFormat, DateTimeFormatOptions};
+    /// use icu::datetime::mock::datetime::MockDateTime;
+    /// use icu_provider::inv::InvariantDataProvider;
     /// # let locale: Locale = langid!("en").into();
     /// # let provider = InvariantDataProvider;
     /// # let options = DateTimeFormatOptions::default();

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -23,12 +23,12 @@ use writeable::Writeable;
 /// # Examples
 ///
 /// ```
-/// # use icu_locid::Locale;
-/// # use icu_locid_macros::langid;
-/// # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions};
-/// # use icu_datetime::mock::datetime::MockDateTime;
-/// # use icu_provider::inv::InvariantDataProvider;
-/// # let locale: Locale = langid!("en").into();
+/// use icu::locid::Locale;
+/// use icu::locid::macros::langid;
+/// use icu::datetime::{DateTimeFormat, DateTimeFormatOptions};
+/// use icu::datetime::mock::datetime::MockDateTime;
+/// use icu_provider::inv::InvariantDataProvider;
+/// let locale: Locale = langid!("en").into();
 /// # let provider = InvariantDataProvider;
 /// # let options = DateTimeFormatOptions::default();
 /// let dtf = DateTimeFormat::try_new(locale, &provider, &options)

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -14,9 +14,9 @@
 //!
 //! ```
 //! # #[cfg(feature = "provider_serde")] {
-//! use icu_locid::Locale;
-//! use icu_locid_macros::langid;
-//! use icu_datetime::{DateTimeFormat, DateTimeFormatOptions, mock::datetime::MockDateTime, options::length};
+//! use icu::locid::Locale;
+//! use icu::locid::macros::langid;
+//! use icu::datetime::{DateTimeFormat, DateTimeFormatOptions, mock::datetime::MockDateTime, options::length};
 //!
 //! let provider = icu_testdata::get_provider();
 //!
@@ -46,9 +46,9 @@
 //!
 //! ```
 //! # #[cfg(feature = "provider_serde")] {
-//! # use icu_locid::Locale;
-//! # use icu_locid_macros::langid;
-//! # use icu_datetime::{DateTimeFormat, DateTimeFormatOptions, mock::datetime::MockDateTime, options::length};
+//! use icu::locid::Locale;
+//! use icu::locid::macros::langid;
+//! use icu::datetime::{DateTimeFormat, DateTimeFormatOptions, mock::datetime::MockDateTime, options::length};
 //! # let provider = icu_testdata::get_provider();
 //! # let locale: Locale = langid!("en").into();
 //! let options = length::Bag {

--- a/components/datetime/src/mock/datetime.rs
+++ b/components/datetime/src/mock/datetime.rs
@@ -21,7 +21,7 @@ use tinystr::tinystr8;
 /// # Examples
 ///
 /// ```
-/// use icu_datetime::mock::datetime::MockDateTime;
+/// use icu::datetime::mock::datetime::MockDateTime;
 ///
 /// let dt1 = MockDateTime::try_new(2020, 9, 24, 13, 21, 0)
 ///     .expect("Failed to construct DateTime.");
@@ -76,7 +76,7 @@ impl MockDateTime {
     /// # Examples
     ///
     /// ```
-    /// use icu_datetime::mock::datetime::MockDateTime;
+    /// use icu::datetime::mock::datetime::MockDateTime;
     ///
     /// let dt = MockDateTime::try_new(2020, 9, 24, 13, 21, 0)
     ///     .expect("Failed to construct a DateTime");
@@ -112,7 +112,7 @@ impl FromStr for MockDateTime {
     /// string must take a specific form of the ISO 8601 format: `YYYY-MM-DDThh:mm:ss`.
     ///
     /// ```
-    /// use icu_datetime::mock::datetime::MockDateTime;
+    /// use icu::datetime::mock::datetime::MockDateTime;
     ///
     /// let date: MockDateTime = "2020-10-14T13:21:00".parse()
     ///     .expect("Failed to parse a date time.");

--- a/components/datetime/src/mock/timezone.rs
+++ b/components/datetime/src/mock/timezone.rs
@@ -16,8 +16,8 @@ use std::str::FromStr;
 /// # Examples
 ///
 /// ```
-/// use icu_datetime::mock::timezone::MockTimeZone;
-/// use icu_datetime::date::GmtOffset;
+/// use icu::datetime::mock::timezone::MockTimeZone;
+/// use icu::datetime::date::GmtOffset;
 ///
 /// let tz1 = MockTimeZone::new(
 ///     GmtOffset::default(),
@@ -80,7 +80,7 @@ impl FromStr for MockTimeZone {
     /// # Examples
     ///
     /// ```
-    /// use icu_datetime::mock::timezone::MockTimeZone;
+    /// use icu::datetime::mock::timezone::MockTimeZone;
     ///
     /// let tz0: MockTimeZone = "Z".parse().expect("Failed to parse a time zone.");
     /// let tz1: MockTimeZone = "+02".parse().expect("Failed to parse a time zone.");

--- a/components/datetime/src/mock/zoned_datetime.rs
+++ b/components/datetime/src/mock/zoned_datetime.rs
@@ -20,9 +20,9 @@ use super::{datetime::MockDateTime, timezone::MockTimeZone};
 /// # Examples
 ///
 /// ```
-/// use icu_datetime::mock::datetime::MockDateTime;
-/// use icu_datetime::mock::timezone::MockTimeZone;
-/// use icu_datetime::mock::zoned_datetime::MockZonedDateTime;
+/// use icu::datetime::mock::datetime::MockDateTime;
+/// use icu::datetime::mock::timezone::MockTimeZone;
+/// use icu::datetime::mock::zoned_datetime::MockZonedDateTime;
 ///
 /// let dt: MockDateTime = "2020-10-14T13:21:00".parse()
 ///     .expect("Failed to parse a datetime.");
@@ -67,7 +67,7 @@ impl FromStr for MockZonedDateTime {
     /// # Examples
     ///
     /// ```
-    /// use icu_datetime::mock::zoned_datetime::MockZonedDateTime;
+    /// use icu::datetime::mock::zoned_datetime::MockZonedDateTime;
     ///
     /// let date: MockZonedDateTime = "2020-10-14T13:21:00+05:30".parse()
     ///     .expect("Failed to parse a zoned datetime.");

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -41,8 +41,8 @@
 //! # Examples
 //!
 //! ```
-//! use icu_datetime::DateTimeFormatOptions;
-//! use icu_datetime::options::components;
+//! use icu::datetime::DateTimeFormatOptions;
+//! use icu::datetime::options::components;
 //!
 //! let bag = components::Bag {
 //!     year: Some(components::Numeric::Numeric),
@@ -64,8 +64,8 @@
 //! Or the options can be inferred through the `.into()` trait.
 //!
 //! ```
-//! # use icu_datetime::DateTimeFormatOptions;
-//! # use icu_datetime::options::components;
+//! use icu::datetime::DateTimeFormatOptions;
+//! use icu::datetime::options::components;
 //! let options: DateTimeFormatOptions = components::Bag::default().into();
 //! ```
 //!

--- a/components/datetime/src/options/length.rs
+++ b/components/datetime/src/options/length.rs
@@ -18,8 +18,8 @@
 //! # Examples
 //!
 //! ```
-//! use icu_datetime::DateTimeFormatOptions;
-//! use icu_datetime::options::length;
+//! use icu::datetime::DateTimeFormatOptions;
+//! use icu::datetime::options::length;
 //!
 //! let bag = length::Bag {
 //!      date: Some(length::Date::Medium), // `Medium` length connector will be used
@@ -33,8 +33,8 @@
 //! Or the options can be inferred through the `.into()` trait.
 //!
 //! ```
-//! # use icu_datetime::DateTimeFormatOptions;
-//! # use icu_datetime::options::length;
+//! use icu::datetime::DateTimeFormatOptions;
+//! use icu::datetime::options::length;
 //! let options: DateTimeFormatOptions = length::Bag::default().into();
 //! ```
 //!
@@ -52,8 +52,8 @@ use serde::{Deserialize, Serialize};
 /// # Examples
 ///
 /// ```
-/// use icu_datetime::DateTimeFormatOptions;
-/// use icu_datetime::options::length;
+/// use icu::datetime::DateTimeFormatOptions;
+/// use icu::datetime::options::length;
 ///
 /// let bag = length::Bag {
 ///      date: Some(length::Date::Medium),
@@ -67,8 +67,8 @@ use serde::{Deserialize, Serialize};
 /// Or the options can be inferred through the `.into()` trait.
 ///
 /// ```
-/// # use icu_datetime::DateTimeFormatOptions;
-/// # use icu_datetime::options::length;
+/// use icu::datetime::DateTimeFormatOptions;
+/// use icu::datetime::options::length;
 /// let options: DateTimeFormatOptions = length::Bag::default().into();
 /// ```
 ///
@@ -99,7 +99,7 @@ impl Default for Bag {
 /// # Examples
 ///
 /// ```
-/// use icu_datetime::options::length;
+/// use icu::datetime::options::length;
 ///
 /// let bag = length::Bag {
 ///     date: Some(length::Date::Long),
@@ -181,7 +181,7 @@ pub enum Date {
 /// # Examples
 ///
 /// ```
-/// use icu_datetime::options::length;
+/// use icu::datetime::options::length;
 ///
 /// let bag = length::Bag {
 ///     date: None,

--- a/components/datetime/src/options/mod.rs
+++ b/components/datetime/src/options/mod.rs
@@ -12,7 +12,7 @@
 //! # Examples
 //!
 //! ```
-//! use icu_datetime::{DateTimeFormatOptions, options::length};
+//! use icu::datetime::{DateTimeFormatOptions, options::length};
 //!
 //! let options = DateTimeFormatOptions::Length(
 //!     length::Bag {
@@ -39,7 +39,7 @@ pub mod preferences;
 /// # Examples
 ///
 /// ```
-/// use icu_datetime::{DateTimeFormatOptions, options::length};
+/// use icu::datetime::{DateTimeFormatOptions, options::length};
 ///
 /// let options = DateTimeFormatOptions::Length(
 ///     length::Bag {

--- a/components/datetime/src/options/preferences.rs
+++ b/components/datetime/src/options/preferences.rs
@@ -13,7 +13,7 @@
 //! # Examples
 //!
 //! ```
-//! use icu_datetime::options::preferences;
+//! use icu::datetime::options::preferences;
 //!
 //! let prefs = preferences::Bag {
 //!     hour_cycle: Some(preferences::HourCycle::H23)
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 /// # Examples
 ///
 /// ```
-/// use icu_datetime::options::preferences;
+/// use icu::datetime::options::preferences;
 ///
 /// let prefs = preferences::Bag {
 ///     hour_cycle: Some(preferences::HourCycle::H23)

--- a/components/datetime/src/timezone.rs
+++ b/components/datetime/src/timezone.rs
@@ -62,7 +62,7 @@ where
 /// ```
 /// // TODO(#622) Uncomment and update example once TimeZoneFormat is public.
 /// // use icu_locid::Locale;
-/// // use icu_locid_macros::langid;
+/// // use icu_locid::macros::langid;
 /// // use icu_datetime::TimeZoneFormat;
 /// // use icu_datetime::date::GmtOffset;
 /// // use icu_datetime::mock::timezone::MockTimeZone;
@@ -115,7 +115,7 @@ impl<'d> TimeZoneFormat<'d> {
     /// ```
     /// // TODO(#622) Uncomment and update example once TimeZoneFormat is public.
     /// // use icu_locid::Locale;
-    /// // use icu_locid_macros::langid;
+    /// // use icu_locid::macros::langid;
     /// // use icu_datetime::TimeZoneFormat;
     /// // use icu_datetime::mock::timezone::MockTimeZone;
     /// // use icu_provider::inv::InvariantDataProvider;
@@ -269,7 +269,7 @@ impl<'d> TimeZoneFormat<'d> {
     /// ```
     /// // TODO(#622) Uncomment and update example once TimeZoneFormat is public.
     /// // use icu_locid::Locale;
-    /// // use icu_locid_macros::langid;
+    /// // use icu_locid::macros::langid;
     /// // use icu_datetime::TimeZoneFormat;
     /// // use icu_datetime::date::GmtOffset;
     /// // use icu_datetime::mock::timezone::MockTimeZone;
@@ -312,7 +312,7 @@ impl<'d> TimeZoneFormat<'d> {
     /// ```
     /// // TODO(#622) Uncomment and update example once TimeZoneFormat is public.
     /// // use icu_locid::Locale;
-    /// // use icu_locid_macros::langid;
+    /// // use icu_locid::macros::langid;
     /// // use icu_datetime::TimeZoneFormat;
     /// // use icu_datetime::date::GmtOffset;
     /// // use icu_datetime::mock::timezone::MockTimeZone;
@@ -356,7 +356,7 @@ impl<'d> TimeZoneFormat<'d> {
     /// ```
     /// // TODO(#622) Uncomment and update example once TimeZoneFormat is public.
     /// // use icu_locid::Locale;
-    /// // use icu_locid_macros::langid;
+    /// // use icu_locid::macros::langid;
     /// // use icu_datetime::TimeZoneFormat;
     /// // use icu_datetime::date::GmtOffset;
     /// // use icu_datetime::mock::timezone::MockTimeZone;

--- a/components/datetime/src/zoned_datetime.rs
+++ b/components/datetime/src/zoned_datetime.rs
@@ -31,10 +31,10 @@ use crate::{
 /// # Examples
 ///
 /// ```
-/// use icu_locid::Locale;
-/// use icu_locid_macros::langid;
-/// use icu_datetime::{ZonedDateTimeFormat, options::length};
-/// use icu_datetime::mock::zoned_datetime::MockZonedDateTime;
+/// use icu::locid::Locale;
+/// use icu::locid::macros::langid;
+/// use icu::datetime::{ZonedDateTimeFormat, options::length};
+/// use icu::datetime::mock::zoned_datetime::MockZonedDateTime;
 /// use icu_provider::inv::InvariantDataProvider;
 ///
 /// let locale: Locale = langid!("en").into();
@@ -70,10 +70,10 @@ impl<'d> ZonedDateTimeFormat<'d> {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::Locale;
-    /// use icu_locid_macros::langid;
-    /// use icu_datetime::{ZonedDateTimeFormat, DateTimeFormatOptions};
-    /// use icu_datetime::mock::zoned_datetime::MockZonedDateTime;
+    /// use icu::locid::Locale;
+    /// use icu::locid::macros::langid;
+    /// use icu::datetime::{ZonedDateTimeFormat, DateTimeFormatOptions};
+    /// use icu::datetime::mock::zoned_datetime::MockZonedDateTime;
     /// use icu_provider::inv::InvariantDataProvider;
     ///
     /// let locale: Locale = langid!("en").into();
@@ -142,11 +142,11 @@ impl<'d> ZonedDateTimeFormat<'d> {
     /// # Examples
     ///
     /// ```
-    /// # use icu_locid::Locale;
-    /// # use icu_locid_macros::langid;
-    /// # use icu_datetime::{ZonedDateTimeFormat, DateTimeFormatOptions};
-    /// # use icu_datetime::mock::zoned_datetime::MockZonedDateTime;
-    /// # use icu_provider::inv::InvariantDataProvider;
+    /// use icu::locid::Locale;
+    /// use icu::locid::macros::langid;
+    /// use icu::datetime::{ZonedDateTimeFormat, DateTimeFormatOptions};
+    /// use icu::datetime::mock::zoned_datetime::MockZonedDateTime;
+    /// use icu_provider::inv::InvariantDataProvider;
     /// # let locale: Locale = langid!("en").into();
     /// # let date_provider = InvariantDataProvider;
     /// # let zone_provider = InvariantDataProvider;
@@ -182,11 +182,11 @@ impl<'d> ZonedDateTimeFormat<'d> {
     /// # Examples
     ///
     /// ```
-    /// # use icu_locid::Locale;
-    /// # use icu_locid_macros::langid;
-    /// # use icu_datetime::{ZonedDateTimeFormat, DateTimeFormatOptions};
-    /// # use icu_datetime::mock::zoned_datetime::MockZonedDateTime;
-    /// # use icu_provider::inv::InvariantDataProvider;
+    /// use icu::locid::Locale;
+    /// use icu::locid::macros::langid;
+    /// use icu::datetime::{ZonedDateTimeFormat, DateTimeFormatOptions};
+    /// use icu::datetime::mock::zoned_datetime::MockZonedDateTime;
+    /// use icu_provider::inv::InvariantDataProvider;
     /// # let locale: Locale = langid!("en").into();
     /// # let date_provider = InvariantDataProvider;
     /// # let zone_provider = InvariantDataProvider;
@@ -218,11 +218,11 @@ impl<'d> ZonedDateTimeFormat<'d> {
     /// # Examples
     ///
     /// ```
-    /// # use icu_locid::Locale;
-    /// # use icu_locid_macros::langid;
-    /// # use icu_datetime::{ZonedDateTimeFormat, DateTimeFormatOptions};
-    /// # use icu_datetime::mock::zoned_datetime::MockZonedDateTime;
-    /// # use icu_provider::inv::InvariantDataProvider;
+    /// use icu::locid::Locale;
+    /// use icu::locid::macros::langid;
+    /// use icu::datetime::{ZonedDateTimeFormat, DateTimeFormatOptions};
+    /// use icu::datetime::mock::zoned_datetime::MockZonedDateTime;
+    /// use icu_provider::inv::InvariantDataProvider;
     /// # let locale: Locale = langid!("en").into();
     /// # let date_provider = InvariantDataProvider;
     /// # let zone_provider = InvariantDataProvider;

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -32,8 +32,8 @@ serde = { version = "1.0", optional = true }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 
 [dev-dependencies]
-icu = { path = "../icu" }
 criterion = "0.3.3"
+icu = { path = "../icu" }
 icu_benchmark_macros = { version = "0.1", path = "../../tools/benchmark/macros" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -32,6 +32,7 @@ serde = { version = "1.0", optional = true }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 
 [dev-dependencies]
+icu = { path = "../icu" }
 criterion = "0.3.3"
 icu_benchmark_macros = { version = "0.1", path = "../../tools/benchmark/macros" }
 serde = { version = "1.0", features = ["derive"] }

--- a/components/locid/README.md
+++ b/components/locid/README.md
@@ -20,8 +20,8 @@ If in doubt, use [`Locale`].
 ## Examples
 
 ```rust
-use icu_locid::Locale;
-use icu_locid::subtags::{Language, Region};
+use icu::locid::Locale;
+use icu::locid::subtags::{Language, Region};
 
 let mut loc: Locale = "en-US".parse()
     .expect("Parsing failed.");

--- a/components/locid/macros/Cargo.toml
+++ b/components/locid/macros/Cargo.toml
@@ -29,3 +29,6 @@ proc_macro = true
 proc-macro-crate = "0.1.5"
 icu_locid = { version = "0.1", path = "../" }
 tinystr = "0.4"
+
+[dev-dependencies]
+icu = { path = "../../icu" }

--- a/components/locid/macros/README.md
+++ b/components/locid/macros/README.md
@@ -7,7 +7,7 @@ This API provides convenience macros for `icu_locid`.
 ## Examples
 
 ```rust
-use icu::locid::macros::{language, region, langid};
+use icu_locid_macros::{language, region, langid};
 
 let lid = langid!("EN_US");
 

--- a/components/locid/macros/README.md
+++ b/components/locid/macros/README.md
@@ -7,7 +7,7 @@ This API provides convenience macros for `icu_locid`.
 ## Examples
 
 ```rust
-use icu_locid_macros::{language, region, langid};
+use icu::locid::macros::{language, region, langid};
 
 let lid = langid!("EN_US");
 

--- a/components/locid/macros/src/lib.rs
+++ b/components/locid/macros/src/lib.rs
@@ -51,8 +51,8 @@ fn get_value_from_token_stream(input: TokenStream) -> String {
 /// # Examples
 ///
 /// ```
-/// use icu_locid::subtags::Language;
-/// use icu_locid_macros::language;
+/// use icu::locid::subtags::Language;
+/// use icu::locid::macros::language;
 ///
 /// const DE: Language = language!("DE");
 ///
@@ -82,8 +82,8 @@ pub fn language(input: TokenStream) -> TokenStream {
 /// # Examples
 ///
 /// ```
-/// use icu_locid::subtags::Script;
-/// use icu_locid_macros::script;
+/// use icu::locid::subtags::Script;
+/// use icu::locid::macros::script;
 ///
 /// const ARAB: Script = script!("aRAB");
 ///
@@ -113,8 +113,8 @@ pub fn script(input: TokenStream) -> TokenStream {
 /// # Examples
 ///
 /// ```
-/// use icu_locid::subtags::Region;
-/// use icu_locid_macros::region;
+/// use icu::locid::subtags::Region;
+/// use icu::locid::macros::region;
 ///
 /// const CN: Region = region!("cn");
 ///
@@ -144,8 +144,8 @@ pub fn region(input: TokenStream) -> TokenStream {
 /// # Examples
 ///
 /// ```
-/// use icu_locid::subtags::Variant;
-/// use icu_locid_macros::variant;
+/// use icu::locid::subtags::Variant;
+/// use icu::locid::macros::variant;
 ///
 /// const POSIX: Variant = variant!("Posix");
 ///
@@ -175,8 +175,8 @@ pub fn variant(input: TokenStream) -> TokenStream {
 /// # Examples
 ///
 /// ```
-/// use icu_locid::LanguageIdentifier;
-/// use icu_locid_macros::langid;
+/// use icu::locid::LanguageIdentifier;
+/// use icu::locid::macros::langid;
 ///
 /// const DE_AT: LanguageIdentifier = langid!("de_at");
 ///

--- a/components/locid/src/extensions/mod.rs
+++ b/components/locid/src/extensions/mod.rs
@@ -20,8 +20,8 @@
 //! # Examples
 //!
 //! ```
-//! use icu_locid::Locale;
-//! use icu_locid::extensions::unicode::{Key, Value};
+//! use icu::locid::Locale;
+//! use icu::locid::extensions::unicode::{Key, Value};
 //!
 //! let loc: Locale = "en-US-u-ca-buddhist-t-en-US-h0-hybrid-x-foo".parse()
 //!     .expect("Failed to parse.");
@@ -93,7 +93,7 @@ impl Extensions {
     /// # Example
     ///
     /// ```
-    /// use icu_locid::extensions::Extensions;
+    /// use icu::locid::extensions::Extensions;
     ///
     /// assert_eq!(Extensions::new(), Extensions::default());
     /// ```
@@ -111,7 +111,7 @@ impl Extensions {
     /// # Example
     ///
     /// ```
-    /// use icu_locid::Locale;
+    /// use icu::locid::Locale;
     ///
     /// let loc: Locale = "en-US-u-foo".parse()
     ///     .expect("Parsing failed.");

--- a/components/locid/src/extensions/private/key.rs
+++ b/components/locid/src/extensions/private/key.rs
@@ -16,7 +16,7 @@ use tinystr::TinyStr8;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::extensions::private::Key;
+/// use icu::locid::extensions::private::Key;
 ///
 /// let key1: Key = "Foo".parse()
 ///     .expect("Failed to parse a Key.");
@@ -35,7 +35,7 @@ impl Key {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::private::Key;
+    /// use icu::locid::extensions::private::Key;
     ///
     /// let key = Key::from_bytes(b"foobar")
     ///     .expect("Parsing failed.");
@@ -62,7 +62,7 @@ impl Key {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::private::Key;
+    /// use icu::locid::extensions::private::Key;
     ///
     /// let key = Key::from_bytes(b"foobar")
     ///     .expect("Parsing failed.");

--- a/components/locid/src/extensions/private/mod.rs
+++ b/components/locid/src/extensions/private/mod.rs
@@ -13,8 +13,8 @@
 //! # Examples
 //!
 //! ```
-//! use icu_locid::Locale;
-//! use icu_locid::extensions::private::{Private, Key};
+//! use icu::locid::Locale;
+//! use icu::locid::extensions::private::{Private, Key};
 //!
 //! let mut loc: Locale = "en-US-x-foo-faa".parse()
 //!     .expect("Parsing failed.");
@@ -44,7 +44,7 @@ use crate::parser::ParserError;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::extensions::private::{Private, Key};
+/// use icu::locid::extensions::private::{Private, Key};
 ///
 /// let key1: Key = "foo".parse()
 ///     .expect("Failed to parse a Key.");
@@ -66,7 +66,7 @@ impl Private {
     /// # Example
     ///
     /// ```
-    /// use icu_locid::extensions::private::Private;
+    /// use icu::locid::extensions::private::Private;
     ///
     /// assert_eq!(Private::new(), Private::default());
     /// ```
@@ -80,7 +80,7 @@ impl Private {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::private::{Private, Key};
+    /// use icu::locid::extensions::private::{Private, Key};
     ///
     /// let key1: Key = "foo".parse()
     ///     .expect("Failed to parse a Key.");
@@ -103,7 +103,7 @@ impl Private {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::private::{Private, Key};
+    /// use icu::locid::extensions::private::{Private, Key};
     ///
     /// let key1: Key = "foo".parse()
     ///     .expect("Failed to parse a Key.");

--- a/components/locid/src/extensions/transform/fields.rs
+++ b/components/locid/src/extensions/transform/fields.rs
@@ -23,7 +23,7 @@ use super::Value;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::extensions::transform::{Fields, Key, Value};
+/// use icu::locid::extensions::transform::{Fields, Key, Value};
 ///
 /// let key: Key = "h0".parse()
 ///     .expect("Failed to parse a Key.");
@@ -42,7 +42,7 @@ impl Fields {
     /// # Example
     ///
     /// ```
-    /// use icu_locid::extensions::transform::Fields;
+    /// use icu::locid::extensions::transform::Fields;
     ///
     /// assert_eq!(Fields::new(), Fields::default());
     /// ```
@@ -57,7 +57,7 @@ impl Fields {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::transform::{Fields, Key, Value};
+    /// use icu::locid::extensions::transform::{Fields, Key, Value};
     ///
     /// let key: Key = "h0".parse()
     ///     .expect("Failed to parse a Key.");
@@ -80,7 +80,7 @@ impl Fields {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::transform::{Fields, Key, Value};
+    /// use icu::locid::extensions::transform::{Fields, Key, Value};
     ///
     /// let key: Key = "h0".parse()
     ///     .expect("Failed to parse a Key.");
@@ -104,7 +104,7 @@ impl Fields {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::transform::{Fields, Key, Value};
+    /// use icu::locid::extensions::transform::{Fields, Key, Value};
     ///
     /// let key: Key = "h0".parse()
     ///     .expect("Failed to parse a Key.");
@@ -130,7 +130,7 @@ impl Fields {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::transform::{Fields, Key, Value};
+    /// use icu::locid::extensions::transform::{Fields, Key, Value};
     ///
     /// let key: Key = "h0".parse()
     ///     .expect("Failed to parse a Key.");

--- a/components/locid/src/extensions/transform/key.rs
+++ b/components/locid/src/extensions/transform/key.rs
@@ -15,7 +15,7 @@ use tinystr::TinyStr4;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::extensions::transform::Key;
+/// use icu::locid::extensions::transform::Key;
 ///
 /// let key1: Key = "k0".parse()
 ///     .expect("Failed to parse a Key.");
@@ -34,7 +34,7 @@ impl Key {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::transform::Key;
+    /// use icu::locid::extensions::transform::Key;
     ///
     /// let key = Key::from_bytes(b"i0")
     ///     .expect("Parsing failed.");
@@ -55,7 +55,7 @@ impl Key {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::transform::Key;
+    /// use icu::locid::extensions::transform::Key;
     ///
     /// let key: Key = "s0".parse()
     ///     .expect("Parsing failed.");

--- a/components/locid/src/extensions/transform/mod.rs
+++ b/components/locid/src/extensions/transform/mod.rs
@@ -12,8 +12,8 @@
 //! # Examples
 //!
 //! ```
-//! use icu_locid::{LanguageIdentifier, Locale};
-//! use icu_locid::extensions::transform::{Transform, Fields, Key, Value};
+//! use icu::locid::{LanguageIdentifier, Locale};
+//! use icu::locid::extensions::transform::{Transform, Fields, Key, Value};
 //!
 //! let mut loc: Locale = "en-US-t-es-AR-h0-hybrid".parse()
 //!     .expect("Parsing failed.");
@@ -56,8 +56,8 @@ use std::iter::Peekable;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::{Locale, LanguageIdentifier};
-/// use icu_locid::extensions::transform::{Key, Value};
+/// use icu::locid::{Locale, LanguageIdentifier};
+/// use icu::locid::extensions::transform::{Key, Value};
 ///
 /// let mut loc: Locale = "de-t-en-US-h0-hybrid".parse()
 ///     .expect("Parsing failed.");
@@ -88,7 +88,7 @@ impl Transform {
     /// # Example
     ///
     /// ```
-    /// use icu_locid::extensions::transform::Transform;
+    /// use icu::locid::extensions::transform::Transform;
     ///
     /// assert_eq!(Transform::new(), Transform::default());
     /// ```
@@ -106,7 +106,7 @@ impl Transform {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::Locale;
+    /// use icu::locid::Locale;
     ///
     /// let mut loc: Locale = "en-US-t-es-AR".parse()
     ///     .expect("Parsing failed.");

--- a/components/locid/src/extensions/transform/value.rs
+++ b/components/locid/src/extensions/transform/value.rs
@@ -24,7 +24,7 @@ const TRUE_TVALUE: TinyStr8 = tinystr::tinystr8!("true");
 /// # Examples
 ///
 /// ```
-/// use icu_locid::extensions::transform::Value;
+/// use icu::locid::extensions::transform::Value;
 ///
 /// let value1: Value = "hybrid".parse()
 ///     .expect("Failed to parse a Value.");
@@ -41,7 +41,7 @@ impl Value {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::transform::Value;
+    /// use icu::locid::extensions::transform::Value;
     ///
     /// let value = Value::from_bytes(b"hybrid")
     ///     .expect("Parsing failed.");

--- a/components/locid/src/extensions/unicode/attribute.rs
+++ b/components/locid/src/extensions/unicode/attribute.rs
@@ -17,7 +17,7 @@ use tinystr::TinyStr8;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::extensions::unicode::Attribute;
+/// use icu::locid::extensions::unicode::Attribute;
 ///
 /// let attr: Attribute = "buddhist".parse()
 ///     .expect("Failed to parse an Attribute.");
@@ -36,7 +36,7 @@ impl Attribute {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::unicode::Attribute;
+    /// use icu::locid::extensions::unicode::Attribute;
     ///
     /// let attribute = Attribute::from_bytes(b"foobar")
     ///     .expect("Parsing failed.");
@@ -65,7 +65,7 @@ impl Attribute {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::unicode::Attribute;
+    /// use icu::locid::extensions::unicode::Attribute;
     ///
     /// let attribute = Attribute::from_bytes(b"foobar")
     ///     .expect("Parsing failed.");

--- a/components/locid/src/extensions/unicode/attributes.rs
+++ b/components/locid/src/extensions/unicode/attributes.rs
@@ -12,7 +12,7 @@ use std::ops::Deref;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::extensions::unicode::{Attribute, Attributes};
+/// use icu::locid::extensions::unicode::{Attribute, Attributes};
 ///
 /// let attribute1: Attribute = "foobar".parse()
 ///     .expect("Failed to parse a variant subtag.");
@@ -36,7 +36,7 @@ impl Attributes {
     /// # Example
     ///
     /// ```
-    /// use icu_locid::extensions::unicode::Attributes;
+    /// use icu::locid::extensions::unicode::Attributes;
     ///
     /// assert_eq!(Attributes::new(), Attributes::default());
     /// ```
@@ -51,7 +51,7 @@ impl Attributes {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::unicode::{Attribute, Attributes};
+    /// use icu::locid::extensions::unicode::{Attribute, Attributes};
     ///
     /// let attribute1: Attribute = "foobar".parse()
     ///     .expect("Parsing failed.");
@@ -79,7 +79,7 @@ impl Attributes {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::unicode::{Attribute, Attributes};
+    /// use icu::locid::extensions::unicode::{Attribute, Attributes};
     ///
     /// let attribute1: Attribute = "foobar".parse()
     ///     .expect("Parsing failed.");

--- a/components/locid/src/extensions/unicode/key.rs
+++ b/components/locid/src/extensions/unicode/key.rs
@@ -16,7 +16,7 @@ use tinystr::TinyStr4;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::extensions::unicode::Key;
+/// use icu::locid::extensions::unicode::Key;
 ///
 /// let key1: Key = "ca".parse()
 ///     .expect("Failed to parse a Key.");
@@ -35,7 +35,7 @@ impl Key {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::unicode::Key;
+    /// use icu::locid::extensions::unicode::Key;
     ///
     /// let key = Key::from_bytes(b"ca")
     ///     .expect("Parsing failed.");
@@ -60,7 +60,7 @@ impl Key {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::unicode::Key;
+    /// use icu::locid::extensions::unicode::Key;
     ///
     /// let key: Key = "ca".parse().expect("Parsing failed.");
     ///

--- a/components/locid/src/extensions/unicode/keywords.rs
+++ b/components/locid/src/extensions/unicode/keywords.rs
@@ -23,7 +23,7 @@ use super::Value;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::extensions::unicode::{Keywords, Key, Value};
+/// use icu::locid::extensions::unicode::{Keywords, Key, Value};
 ///
 /// let key: Key = "hc".parse()
 ///     .expect("Failed to parse a Key.");
@@ -42,7 +42,7 @@ impl Keywords {
     /// # Example
     ///
     /// ```
-    /// use icu_locid::extensions::unicode::Keywords;
+    /// use icu::locid::extensions::unicode::Keywords;
     ///
     /// assert_eq!(Keywords::new(), Keywords::default());
     /// ```
@@ -55,7 +55,7 @@ impl Keywords {
     ///
     ///
     /// # Examples
-    /// use icu_locid::extensions::unicode::{Keywords, Key, Value};
+    /// use icu::locid::extensions::unicode::{Keywords, Key, Value};
     ///
     /// let key: Key = "ca".parse()
     ///     .expect("Failed to parse a Key.");
@@ -79,7 +79,7 @@ impl Keywords {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::unicode::{Keywords, Key, Value};
+    /// use icu::locid::extensions::unicode::{Keywords, Key, Value};
     ///
     /// let key: Key = "ca".parse()
     ///     .expect("Failed to parse a Key.");
@@ -105,7 +105,7 @@ impl Keywords {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::unicode::{Keywords, Key, Value};
+    /// use icu::locid::extensions::unicode::{Keywords, Key, Value};
     ///
     /// let key: Key = "ca".parse()
     ///     .expect("Failed to parse a Key.");

--- a/components/locid/src/extensions/unicode/mod.rs
+++ b/components/locid/src/extensions/unicode/mod.rs
@@ -11,8 +11,8 @@
 //! # Examples
 //!
 //! ```
-//! use icu_locid::{LanguageIdentifier, Locale};
-//! use icu_locid::extensions::unicode::{Unicode, Key, Value, Attribute};
+//! use icu::locid::{LanguageIdentifier, Locale};
+//! use icu::locid::extensions::unicode::{Unicode, Key, Value, Attribute};
 //!
 //! let mut loc: Locale = "en-US-u-foobar-hc-h12".parse()
 //!     .expect("Parsing failed.");
@@ -61,8 +61,8 @@ use std::iter::Peekable;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::Locale;
-/// use icu_locid::extensions::unicode::{Key, Value};
+/// use icu::locid::Locale;
+/// use icu::locid::extensions::unicode::{Key, Value};
 ///
 /// let mut loc: Locale = "de-u-hc-h12-ca-buddhist".parse()
 ///     .expect("Parsing failed.");
@@ -84,7 +84,7 @@ impl Unicode {
     /// # Example
     ///
     /// ```
-    /// use icu_locid::extensions::unicode::Unicode;
+    /// use icu::locid::extensions::unicode::Unicode;
     ///
     /// assert_eq!(Unicode::new(), Unicode::default());
     /// ```
@@ -101,7 +101,7 @@ impl Unicode {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::Locale;
+    /// use icu::locid::Locale;
     ///
     /// let loc: Locale = "en-US-u-foo".parse()
     ///     .expect("Parsing failed.");

--- a/components/locid/src/extensions/unicode/value.rs
+++ b/components/locid/src/extensions/unicode/value.rs
@@ -18,7 +18,7 @@ use tinystr::TinyStr8;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::extensions::unicode::Value;
+/// use icu::locid::extensions::unicode::Value;
 ///
 /// let value1: Value = "gregory".parse()
 ///     .expect("Failed to parse a Value.");
@@ -41,7 +41,7 @@ impl Value {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::extensions::unicode::Value;
+    /// use icu::locid::extensions::unicode::Value;
     ///
     /// let value = Value::from_bytes(b"buddhist")
     ///     .expect("Parsing failed.");

--- a/components/locid/src/langid.rs
+++ b/components/locid/src/langid.rs
@@ -12,7 +12,7 @@ use crate::subtags;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::LanguageIdentifier;
+/// use icu::locid::LanguageIdentifier;
 ///
 /// let li: LanguageIdentifier = "en-US".parse()
 ///     .expect("Failed to parse.");
@@ -41,7 +41,7 @@ use crate::subtags;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::LanguageIdentifier;
+/// use icu::locid::LanguageIdentifier;
 ///
 /// let li: LanguageIdentifier = "eN_latn_Us-Valencia".parse()
 ///     .expect("Failed to parse.");
@@ -72,7 +72,7 @@ impl LanguageIdentifier {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::LanguageIdentifier;
+    /// use icu::locid::LanguageIdentifier;
     ///
     /// let li = LanguageIdentifier::from_bytes(b"en-US")
     ///     .expect("Parsing failed.");
@@ -89,7 +89,7 @@ impl LanguageIdentifier {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::LanguageIdentifier;
+    /// use icu::locid::LanguageIdentifier;
     ///
     /// let li = LanguageIdentifier::from_locale_bytes(b"en-US-x-posix")
     ///     .expect("Parsing failed.");
@@ -108,7 +108,7 @@ impl LanguageIdentifier {
     /// # Example
     ///
     /// ```
-    /// use icu_locid::LanguageIdentifier;
+    /// use icu::locid::LanguageIdentifier;
     ///
     /// const langid: LanguageIdentifier = LanguageIdentifier::und();
     /// assert_eq!(LanguageIdentifier::default(), langid);
@@ -132,7 +132,7 @@ impl LanguageIdentifier {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::LanguageIdentifier;
+    /// use icu::locid::LanguageIdentifier;
     ///
     /// assert_eq!(LanguageIdentifier::canonicalize("pL_latn_pl"), Ok("pl-Latn-PL".to_string()));
     /// ```

--- a/components/locid/src/lib.rs
+++ b/components/locid/src/lib.rs
@@ -22,8 +22,8 @@
 //! # Examples
 //!
 //! ```
-//! use icu_locid::Locale;
-//! use icu_locid::subtags::{Language, Region};
+//! use icu::locid::Locale;
+//! use icu::locid::subtags::{Language, Region};
 //!
 //! let mut loc: Locale = "en-US".parse()
 //!     .expect("Parsing failed.");

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -19,8 +19,8 @@ use std::str::FromStr;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::Locale;
-/// use icu_locid::extensions::unicode::{Key, Value};
+/// use icu::locid::Locale;
+/// use icu::locid::extensions::unicode::{Key, Value};
 ///
 /// let loc: Locale = "en-US-u-ca-buddhist".parse()
 ///     .expect("Failed to parse.");
@@ -54,7 +54,7 @@ use std::str::FromStr;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::Locale;
+/// use icu::locid::Locale;
 ///
 /// let loc: Locale = "eN_latn_Us-Valencia_u-hC-H12".parse()
 ///     .expect("Failed to parse.");
@@ -80,7 +80,7 @@ impl Locale {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::Locale;
+    /// use icu::locid::Locale;
     ///
     /// let loc = Locale::from_bytes("en-US-u-hc-h12".as_bytes())
     ///     .expect("Parsing failed.");
@@ -96,7 +96,7 @@ impl Locale {
     /// # Example
     ///
     /// ```
-    /// use icu_locid::Locale;
+    /// use icu::locid::Locale;
     ///
     /// const loc: Locale = Locale::und();
     /// assert_eq!(Locale::default(), loc);
@@ -118,7 +118,7 @@ impl Locale {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::Locale;
+    /// use icu::locid::Locale;
     ///
     /// assert_eq!(Locale::canonicalize("pL_latn_pl-U-HC-H12"), Ok("pl-Latn-PL-u-hc-h12".to_string()));
     /// ```

--- a/components/locid/src/parser/errors.rs
+++ b/components/locid/src/parser/errors.rs
@@ -17,8 +17,8 @@ pub enum ParserError {
     /// ```
     /// use std::str::FromStr;
     ///
-    /// use icu_locid::subtags::Language;
-    /// use icu_locid::ParserError;
+    /// use icu::locid::subtags::Language;
+    /// use icu::locid::ParserError;
     ///
     /// assert_eq!(Language::from_str("x2"), Err(ParserError::InvalidLanguage));
     /// ```
@@ -31,8 +31,8 @@ pub enum ParserError {
     /// ```
     /// use std::str::FromStr;
     ///
-    /// use icu_locid::subtags::Region;
-    /// use icu_locid::ParserError;
+    /// use icu::locid::subtags::Region;
+    /// use icu::locid::ParserError;
     ///
     /// assert_eq!(Region::from_str("#@2X"), Err(ParserError::InvalidSubtag));
     /// ```
@@ -45,8 +45,8 @@ pub enum ParserError {
     /// ```
     /// use std::str::FromStr;
     ///
-    /// use icu_locid::extensions::unicode::Key;
-    /// use icu_locid::ParserError;
+    /// use icu::locid::extensions::unicode::Key;
+    /// use icu::locid::ParserError;
     ///
     /// assert_eq!(Key::from_str("#@2X"), Err(ParserError::InvalidExtension));
     /// ```

--- a/components/locid/src/subtags/language.rs
+++ b/components/locid/src/subtags/language.rs
@@ -16,7 +16,7 @@ use tinystr::{tinystr4, TinyStr4};
 /// # Examples
 ///
 /// ```
-/// use icu_locid::subtags::Language;
+/// use icu::locid::subtags::Language;
 ///
 /// let language: Language = "en".parse()
 ///     .expect("Failed to parse a language subtag.");
@@ -28,7 +28,7 @@ use tinystr::{tinystr4, TinyStr4};
 /// # Examples
 ///
 /// ```
-/// use icu_locid::subtags::Language;
+/// use icu::locid::subtags::Language;
 ///
 /// assert_eq!(Language::default().as_str(), "und");
 /// ```
@@ -51,7 +51,7 @@ impl Language {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::Language;
+    /// use icu::locid::subtags::Language;
     ///
     /// let lang = Language::from_bytes(b"en")
     ///     .expect("Parsing failed.");
@@ -86,7 +86,7 @@ impl Language {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::Language;
+    /// use icu::locid::subtags::Language;
     ///
     /// let lang = Language::from_bytes(b"en")
     ///     .expect("Parsing failed.");
@@ -105,7 +105,7 @@ impl Language {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::Language;
+    /// use icu::locid::subtags::Language;
     ///
     /// let lang = Language::from_bytes(b"en")
     ///     .expect("Parsing failed.");
@@ -131,7 +131,7 @@ impl Language {
     /// # Example
     ///
     /// ```
-    /// use icu_locid::subtags::Language;
+    /// use icu::locid::subtags::Language;
     ///
     /// const language: Language = Language::und();
     /// assert_eq!(Language::default(), language);
@@ -148,7 +148,7 @@ impl Language {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::Language;
+    /// use icu::locid::subtags::Language;
     ///
     /// let lang = Language::from_bytes(b"en")
     ///     .expect("Parsing failed.");
@@ -167,7 +167,7 @@ impl Language {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::Language;
+    /// use icu::locid::subtags::Language;
     ///
     /// let mut lang: Language = "csb".parse()
     ///     .expect("Parsing failed.");
@@ -187,7 +187,7 @@ impl Language {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::Language;
+    /// use icu::locid::subtags::Language;
     ///
     /// let mut lang: Language = "und".parse()
     ///     .expect("Parsing failed.");

--- a/components/locid/src/subtags/mod.rs
+++ b/components/locid/src/subtags/mod.rs
@@ -23,7 +23,7 @@
 //! # Examples
 //!
 //! ```
-//! use icu_locid::subtags::{Language, Script, Region, Variant};
+//! use icu::locid::subtags::{Language, Script, Region, Variant};
 //!
 //! let language: Language = "en".parse()
 //!     .expect("Failed to parse a lanuage subtag.");

--- a/components/locid/src/subtags/region.rs
+++ b/components/locid/src/subtags/region.rs
@@ -14,7 +14,7 @@ use tinystr::TinyStr4;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::subtags::Region;
+/// use icu::locid::subtags::Region;
 ///
 /// let region: Region = "DE".parse()
 ///     .expect("Failed to parse a region subtag.");
@@ -34,7 +34,7 @@ impl Region {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::Region;
+    /// use icu::locid::subtags::Region;
     ///
     /// let region = Region::from_bytes(b"fr")
     ///     .expect("Parsing failed.");
@@ -67,7 +67,7 @@ impl Region {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::Region;
+    /// use icu::locid::subtags::Region;
     ///
     /// let region = Region::from_bytes(b"us")
     ///     .expect("Parsing failed.");
@@ -86,7 +86,7 @@ impl Region {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::Region;
+    /// use icu::locid::subtags::Region;
     ///
     /// let region = Region::from_bytes(b"us")
     ///     .expect("Parsing failed.");
@@ -110,7 +110,7 @@ impl Region {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::Region;
+    /// use icu::locid::subtags::Region;
     ///
     /// let region = Region::from_bytes(b"it")
     ///     .expect("Parsing failed.");

--- a/components/locid/src/subtags/script.rs
+++ b/components/locid/src/subtags/script.rs
@@ -14,7 +14,7 @@ use tinystr::TinyStr4;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::subtags::Script;
+/// use icu::locid::subtags::Script;
 ///
 /// let script: Script = "Latn".parse()
 ///     .expect("Failed to parse a script subtag.");
@@ -33,7 +33,7 @@ impl Script {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::Script;
+    /// use icu::locid::subtags::Script;
     ///
     /// let script = Script::from_bytes(b"Latn")
     ///     .expect("Parsing failed.");
@@ -58,7 +58,7 @@ impl Script {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::Script;
+    /// use icu::locid::subtags::Script;
     ///
     /// let script = Script::from_bytes(b"Latn")
     ///     .expect("Parsing failed.");
@@ -77,7 +77,7 @@ impl Script {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::Script;
+    /// use icu::locid::subtags::Script;
     ///
     /// let script = Script::from_bytes(b"Latn")
     ///     .expect("Parsing failed.");
@@ -101,7 +101,7 @@ impl Script {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::Script;
+    /// use icu::locid::subtags::Script;
     ///
     /// let script = Script::from_bytes(b"Latn")
     ///     .expect("Parsing failed.");

--- a/components/locid/src/subtags/variant.rs
+++ b/components/locid/src/subtags/variant.rs
@@ -15,7 +15,7 @@ use tinystr::TinyStr8;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::subtags::Variant;
+/// use icu::locid::subtags::Variant;
 ///
 /// let variant: Variant = "macos".parse()
 ///     .expect("Failed to parse a variant subtag.");
@@ -35,7 +35,7 @@ impl Variant {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::Variant;
+    /// use icu::locid::subtags::Variant;
     ///
     /// let variant = Variant::from_bytes(b"posix")
     ///     .expect("Parsing failed.");
@@ -68,7 +68,7 @@ impl Variant {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::Variant;
+    /// use icu::locid::subtags::Variant;
     ///
     /// let variant = Variant::from_bytes(b"posix")
     ///     .expect("Parsing failed.");
@@ -87,7 +87,7 @@ impl Variant {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::Variant;
+    /// use icu::locid::subtags::Variant;
     ///
     /// let variant = Variant::from_bytes(b"posix")
     ///     .expect("Parsing failed.");
@@ -111,7 +111,7 @@ impl Variant {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::Variant;
+    /// use icu::locid::subtags::Variant;
     ///
     /// let variant = Variant::from_bytes(b"macos")
     ///     .expect("Parsing failed.");

--- a/components/locid/src/subtags/variants.rs
+++ b/components/locid/src/subtags/variants.rs
@@ -13,7 +13,7 @@ use std::ops::Deref;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::subtags::{Variant, Variants};
+/// use icu::locid::subtags::{Variant, Variants};
 ///
 /// let variant1: Variant = "posix".parse()
 ///     .expect("Failed to parse a variant subtag.");
@@ -37,7 +37,7 @@ impl Variants {
     /// # Example
     ///
     /// ```
-    /// use icu_locid::subtags::Variants;
+    /// use icu::locid::subtags::Variants;
     ///
     /// assert_eq!(Variants::new(), Variants::default());
     /// ```
@@ -53,7 +53,7 @@ impl Variants {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::{Variant, Variants};
+    /// use icu::locid::subtags::{Variant, Variants};
     ///
     /// let variant1: Variant = "posix".parse()
     ///     .expect("Parsing failed.");
@@ -82,7 +82,7 @@ impl Variants {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::{Variant, Variants};
+    /// use icu::locid::subtags::{Variant, Variants};
     ///
     /// let variant1: Variant = "posix".parse()
     ///     .expect("Parsing failed.");
@@ -108,7 +108,7 @@ impl Variants {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::{Variant, Variants};
+    /// use icu::locid::subtags::{Variant, Variants};
     ///
     /// let variant1: Variant = "posix".parse()
     ///     .expect("Parsing failed.");
@@ -141,7 +141,7 @@ impl Variants {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::subtags::{Variant, Variants};
+    /// use icu::locid::subtags::{Variant, Variants};
     ///
     /// let variant1: Variant = "posix".parse()
     ///     .expect("Parsing failed.");

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -31,6 +31,7 @@ icu_locid = { version = "0.1", path = "../locid" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
+icu = { path = "../icu" }
 criterion = "0.3"
 icu_benchmark_macros = { version = "0.1", path = "../../tools/benchmark/macros" }
 icu_provider = { version = "0.1", path = "../provider" }

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -31,8 +31,8 @@ icu_locid = { version = "0.1", path = "../locid" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
-icu = { path = "../icu" }
 criterion = "0.3"
+icu = { path = "../icu" }
 icu_benchmark_macros = { version = "0.1", path = "../../tools/benchmark/macros" }
 icu_provider = { version = "0.1", path = "../provider" }
 icu_locid = { version = "0.1", path = "../locid" }

--- a/components/plurals/README.md
+++ b/components/plurals/README.md
@@ -22,8 +22,8 @@ appropriate [`Plural Category`].
 ## Examples
 
 ```rust
-use icu_locid_macros::langid;
-use icu_plurals::{PluralRules, PluralRuleType, PluralCategory};
+use icu::locid::macros::langid;
+use icu::plurals::{PluralRules, PluralRuleType, PluralCategory};
 
 let lid = langid!("en");
 

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -25,8 +25,8 @@
 //!
 //! ```
 //! # #[cfg(feature = "provider_serde")] {
-//! use icu_locid_macros::langid;
-//! use icu_plurals::{PluralRules, PluralRuleType, PluralCategory};
+//! use icu::locid::macros::langid;
+//! use icu::plurals::{PluralRules, PluralRuleType, PluralCategory};
 //!
 //! let lid = langid!("en");
 //!
@@ -120,8 +120,8 @@ pub enum PluralRuleType {
 /// # Examples
 ///
 /// ```
-/// use icu_locid_macros::langid;
-/// use icu_plurals::{PluralRules, PluralRuleType, PluralCategory};
+/// use icu::locid::macros::langid;
+/// use icu::plurals::{PluralRules, PluralRuleType, PluralCategory};
 /// use icu_provider::inv::InvariantDataProvider;
 ///
 /// let lid = langid!("en");
@@ -196,7 +196,7 @@ impl PluralCategory {
     /// # Examples
     ///
     /// ```
-    /// use icu_plurals::PluralCategory;
+    /// use icu::plurals::PluralCategory;
     ///
     /// let mut categories = PluralCategory::all();
     ///
@@ -227,8 +227,8 @@ impl PluralCategory {
 /// # Examples
 ///
 /// ```
-/// use icu_locid_macros::langid;
-/// use icu_plurals::{PluralRules, PluralRuleType, PluralCategory};
+/// use icu::locid::macros::langid;
+/// use icu::plurals::{PluralRules, PluralRuleType, PluralCategory};
 /// use icu_provider::inv::InvariantDataProvider;
 ///
 /// let lid = langid!("en");
@@ -257,8 +257,8 @@ impl PluralRules {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid_macros::langid;
-    /// use icu_plurals::{PluralRules, PluralRuleType};
+    /// use icu::locid::macros::langid;
+    /// use icu::plurals::{PluralRules, PluralRuleType};
     /// use icu_provider::inv::InvariantDataProvider;
     ///
     /// let lid = langid!("en");
@@ -284,8 +284,8 @@ impl PluralRules {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid_macros::langid;
-    /// use icu_plurals::{PluralRules, PluralRuleType, PluralCategory};
+    /// use icu::locid::macros::langid;
+    /// use icu::plurals::{PluralRules, PluralRuleType, PluralCategory};
     /// use icu_provider::inv::InvariantDataProvider;
     ///
     /// let lid = langid!("en");
@@ -312,11 +312,11 @@ impl PluralRules {
     /// # Examples
     ///
     /// ```
-    /// # use std::convert::TryFrom;
-    /// # use icu_locid_macros::langid;
-    /// # use icu_plurals::{PluralRules, PluralRuleType};
-    /// use icu_plurals::{PluralCategory, PluralOperands};
-    /// # use icu_provider::inv::InvariantDataProvider;
+    /// use std::convert::TryFrom;
+    /// use icu::locid::macros::langid;
+    /// use icu::plurals::{PluralRules, PluralRuleType};
+    /// use icu::plurals::{PluralCategory, PluralOperands};
+    /// use icu_provider::inv::InvariantDataProvider;
     /// #
     /// # let lid = langid!("en");
     /// #

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 /// From int
 ///
 /// ```
-/// use icu_plurals::PluralOperands;
+/// use icu::plurals::PluralOperands;
 /// assert_eq!(PluralOperands {
 ///    i: 2,
 ///    v: 0,
@@ -34,7 +34,7 @@ use std::str::FromStr;
 ///
 /// ```
 /// use std::str::FromStr;
-/// use icu_plurals::PluralOperands;
+/// use icu::plurals::PluralOperands;
 /// assert_eq!(Ok(PluralOperands {
 ///    i: 1234,
 ///    v: 3,
@@ -49,7 +49,7 @@ use std::str::FromStr;
 ///
 /// ```
 /// use std::convert::TryFrom;
-/// use icu_plurals::PluralOperands;
+/// use icu::plurals::PluralOperands;
 /// assert_eq!(Ok(PluralOperands {
 ///    i: 123,
 ///    v: 2,

--- a/components/plurals/src/rules/ast.rs
+++ b/components/plurals/src/rules/ast.rs
@@ -9,8 +9,8 @@
 //! # Examples
 //!
 //! ```
-//! use icu_plurals::rules::parse_condition;
-//! use icu_plurals::rules::ast::*;
+//! use icu::plurals::rules::parse_condition;
+//! use icu::plurals::rules::ast::*;
 //!
 //! let input = "i = 1";
 //!
@@ -46,8 +46,8 @@ use std::ops::RangeInclusive;
 /// # Examples
 ///
 /// ```
-/// use icu_plurals::rules::ast::*;
-/// use icu_plurals::rules::{parse, parse_condition};
+/// use icu::plurals::rules::ast::*;
+/// use icu::plurals::rules::{parse, parse_condition};
 ///
 /// let condition = parse_condition(b"i = 5 or v = 2")
 ///     .expect("Parsing failed.");
@@ -91,8 +91,8 @@ pub struct Rule {
 /// # Examples
 ///
 /// ```
-/// use icu_plurals::rules::ast::*;
-/// use icu_plurals::rules::parse_condition;
+/// use icu::plurals::rules::ast::*;
+/// use icu::plurals::rules::parse_condition;
 ///
 /// let condition = Condition(Box::new([
 ///     AndCondition(Box::new([Relation {
@@ -135,7 +135,7 @@ pub struct Condition(pub Box<[AndCondition]>);
 /// Can be represented by the AST:
 ///
 /// ```
-/// use icu_plurals::rules::ast::*;
+/// use icu::plurals::rules::ast::*;
 ///
 /// AndCondition(Box::new([
 ///     Relation {
@@ -173,7 +173,7 @@ pub struct AndCondition(pub Box<[Relation]>);
 /// Can be represented by the AST:
 ///
 /// ```
-/// use icu_plurals::rules::ast::*;
+/// use icu::plurals::rules::ast::*;
 ///
 /// Relation {
 ///     expression: Expression {
@@ -220,7 +220,7 @@ pub enum Operator {
 /// Can be represented by the AST:
 ///
 /// ```
-/// use icu_plurals::rules::ast::*;
+/// use icu::plurals::rules::ast::*;
 ///
 /// Expression {
 ///     operand: Operand::I,
@@ -247,7 +247,7 @@ pub struct Expression {
 /// Can be represented by the AST:
 ///
 /// ```
-/// use icu_plurals::rules::ast::Operand;
+/// use icu::plurals::rules::ast::Operand;
 ///
 /// Operand::I;
 /// ```
@@ -285,7 +285,7 @@ pub enum Operand {
 /// Can be represented by the AST:
 ///
 /// ```
-/// use icu_plurals::rules::ast::*;
+/// use icu::plurals::rules::ast::*;
 ///
 /// RangeList(Box::new([
 ///     RangeListItem::Value(Value(5)),
@@ -311,7 +311,7 @@ pub struct RangeList(pub Box<[RangeListItem]>);
 /// Can be represented by the AST:
 ///
 /// ```
-/// use icu_plurals::rules::ast::*;
+/// use icu::plurals::rules::ast::*;
 ///
 /// let _ = RangeListItem::Value(Value(5));
 /// let _ = RangeListItem::Range(Value(11)..=Value(15));
@@ -335,7 +335,7 @@ pub enum RangeListItem {
 /// Can be represented by the AST:
 ///
 /// ```
-/// use icu_plurals::rules::ast::*;
+/// use icu::plurals::rules::ast::*;
 ///
 /// RangeListItem::Value(Value(99));
 /// ```
@@ -351,7 +351,7 @@ pub struct Value(pub u64);
 /// ```
 ///
 /// ```
-/// use icu_plurals::rules::ast::*;
+/// use icu::plurals::rules::ast::*;
 /// Samples {
 ///     integer: Some(SampleList {
 ///         sample_ranges: Box::new([SampleRange {
@@ -384,7 +384,7 @@ pub struct Samples {
 /// ```
 ///
 /// ```
-/// use icu_plurals::rules::ast::*;
+/// use icu::plurals::rules::ast::*;
 /// SampleList {
 ///     sample_ranges: Box::new([
 ///         SampleRange {
@@ -410,7 +410,7 @@ pub struct SampleList {
 /// ```
 ///
 /// ```
-/// use icu_plurals::rules::ast::*;
+/// use icu::plurals::rules::ast::*;
 /// SampleRange {
 ///     lower_val: DecimalValue("0.0".to_string()),
 ///     upper_val: Some(DecimalValue("1.5".to_string())),
@@ -431,7 +431,7 @@ pub struct SampleRange {
 /// ```
 ///
 /// ```
-/// use icu_plurals::rules::ast::*;
+/// use icu::plurals::rules::ast::*;
 /// DecimalValue("1.00".to_string());
 /// ```
 #[derive(Debug, Clone, PartialEq)]

--- a/components/plurals/src/rules/lexer.rs
+++ b/components/plurals/src/rules/lexer.rs
@@ -37,7 +37,7 @@ pub enum LexerError {
 /// # Examples
 ///
 /// ```
-/// use icu_plurals::rules::Lexer;
+/// use icu::plurals::rules::Lexer;
 ///
 /// let input = b"i = 5";
 /// let lexer = Lexer::new(input);
@@ -54,7 +54,7 @@ impl<'l> Lexer<'l> {
     /// # Examples
     ///
     /// ```
-    /// use icu_plurals::rules::Lexer;
+    /// use icu::plurals::rules::Lexer;
     ///
     /// Lexer::new(b"n = 1");
     /// ```

--- a/components/plurals/src/rules/mod.rs
+++ b/components/plurals/src/rules/mod.rs
@@ -30,7 +30,7 @@
 //! That value expanded into [`PluralOperands`] looks like this:
 //!
 //! ```
-//! use icu_plurals::PluralOperands;
+//! use icu::plurals::PluralOperands;
 //! PluralOperands {
 //!     i: 1,
 //!     v: 0,
@@ -55,8 +55,8 @@
 //! When parsed, the resulting [`AST`] will look like this:
 //!
 //! ```
-//! use icu_plurals::rules::parse_condition;
-//! use icu_plurals::rules::ast::*;
+//! use icu::plurals::rules::parse_condition;
+//! use icu::plurals::rules::ast::*;
 //!
 //! let input = "i = 1 and v = 0 @integer 1";
 //!
@@ -97,8 +97,8 @@
 //! matches:
 //!
 //! ```
-//! use icu_plurals::rules::{test_condition, parse_condition};
-//! use icu_plurals::PluralOperands;
+//! use icu::plurals::rules::{test_condition, parse_condition};
+//! use icu::plurals::PluralOperands;
 //!
 //! let input = "i = 1 and v = 0 @integer 1";
 //!

--- a/components/plurals/src/rules/parser.rs
+++ b/components/plurals/src/rules/parser.rs
@@ -50,7 +50,7 @@ impl fmt::Display for ParserError {
 /// # Examples
 ///
 /// ```
-/// use icu_plurals::rules::parse;
+/// use icu::plurals::rules::parse;
 ///
 /// let input = b"i = 0 or n = 1 @integer 0, 1 @decimal 0.0~1.0, 0.00~0.04";
 /// assert_eq!(parse(input).is_ok(), true);
@@ -78,7 +78,7 @@ pub fn parse(input: &[u8]) -> Result<ast::Rule, ParserError> {
 /// # Examples
 ///
 /// ```
-/// use icu_plurals::rules::parse_condition;
+/// use icu::plurals::rules::parse_condition;
 ///
 /// let input = b"i = 0 or n = 1";
 /// assert_eq!(parse_condition(input).is_ok(), true);

--- a/components/plurals/src/rules/resolver.rs
+++ b/components/plurals/src/rules/resolver.rs
@@ -11,8 +11,8 @@ use crate::operands::PluralOperands;
 /// # Examples
 ///
 /// ```
-/// use icu_plurals::PluralOperands;
-/// use icu_plurals::rules::{parse_condition, test_condition};
+/// use icu::plurals::PluralOperands;
+/// use icu::plurals::rules::{parse_condition, test_condition};
 ///
 /// let operands = PluralOperands::from(5_usize);
 /// let condition = parse_condition(b"i = 4..6")

--- a/components/plurals/src/rules/serializer.rs
+++ b/components/plurals/src/rules/serializer.rs
@@ -11,9 +11,9 @@ use std::ops::RangeInclusive;
 /// # Examples
 ///
 /// ```
-/// use icu_plurals::rules::parse;
-/// use icu_plurals::rules::ast;
-/// use icu_plurals::rules::serialize;
+/// use icu::plurals::rules::parse;
+/// use icu::plurals::rules::ast;
+/// use icu::plurals::rules::serialize;
 ///
 /// let input = "i = 0 or n = 1 @integer 0, 1 @decimal 0.0~1.0, 0.00~0.04";
 ///

--- a/components/uniset/Cargo.toml
+++ b/components/uniset/Cargo.toml
@@ -31,8 +31,8 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 tinystr = "0.4"
 
 [dev-dependencies]
-icu = { path = "../icu" }
 criterion = "0.3.3"
+icu = { path = "../icu" }
 icu_benchmark_macros = { version = "0.1", path = "../../tools/benchmark/macros" }
 
 [lib]

--- a/components/uniset/Cargo.toml
+++ b/components/uniset/Cargo.toml
@@ -31,6 +31,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 tinystr = "0.4"
 
 [dev-dependencies]
+icu = { path = "../icu" }
 criterion = "0.3.3"
 icu_benchmark_macros = { version = "0.1", path = "../../tools/benchmark/macros" }
 

--- a/components/uniset/README.md
+++ b/components/uniset/README.md
@@ -20,7 +20,7 @@ represented by [inversion lists](http://userguide.icu-project.org/strings/proper
 the [`UnicodeSetBuilder`], or from the TBA Properties API.
 
 ```rust
-use icu_uniset::{UnicodeSet, UnicodeSetBuilder};
+use icu::uniset::{UnicodeSet, UnicodeSetBuilder};
 
 let mut builder = UnicodeSetBuilder::new();
 builder.add_range(&('A'..'Z'));
@@ -34,7 +34,7 @@ assert!(set.contains('A'));
 Currently, you can check if a character/range of characters exists in the UnicodeSet, or iterate through the characters.
 
 ```rust
-use icu_uniset::{UnicodeSet, UnicodeSetBuilder};
+use icu::uniset::{UnicodeSet, UnicodeSetBuilder};
 
 let mut builder = UnicodeSetBuilder::new();
 builder.add_range(&('A'..'Z'));

--- a/components/uniset/src/builder.rs
+++ b/components/uniset/src/builder.rs
@@ -80,7 +80,7 @@ impl UnicodeSetBuilder {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::UnicodeSetBuilder;
+    /// use icu::uniset::UnicodeSetBuilder;
     /// let mut builder = UnicodeSetBuilder::new();
     /// builder.add_char('a');
     /// let check = builder.build();
@@ -101,7 +101,7 @@ impl UnicodeSetBuilder {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::UnicodeSetBuilder;
+    /// use icu::uniset::UnicodeSetBuilder;
     /// let mut builder = UnicodeSetBuilder::new();
     /// builder.add_u32(65);
     /// let check = builder.build();
@@ -119,7 +119,7 @@ impl UnicodeSetBuilder {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::UnicodeSetBuilder;
+    /// use icu::uniset::UnicodeSetBuilder;
     /// let mut builder = UnicodeSetBuilder::new();
     /// builder.add_range(&('A'..='Z'));
     /// let check = builder.build();
@@ -135,7 +135,7 @@ impl UnicodeSetBuilder {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::{UnicodeSet, UnicodeSetBuilder};
+    /// use icu::uniset::{UnicodeSet, UnicodeSetBuilder};
     /// let mut builder = UnicodeSetBuilder::new();
     /// let set = UnicodeSet::from_inversion_list(vec![65, 76]).unwrap();
     /// builder.add_set(&set);
@@ -170,7 +170,7 @@ impl UnicodeSetBuilder {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::UnicodeSetBuilder;
+    /// use icu::uniset::UnicodeSetBuilder;
     /// let mut builder = UnicodeSetBuilder::new();
     /// builder.add_range(&('A'..='Z'));
     /// builder.remove_char('A');
@@ -186,7 +186,7 @@ impl UnicodeSetBuilder {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::UnicodeSetBuilder;
+    /// use icu::uniset::UnicodeSetBuilder;
     /// let mut builder = UnicodeSetBuilder::new();
     /// builder.add_range(&('A'..='Z'));
     /// builder.remove_range(&('A'..='C'));
@@ -202,7 +202,7 @@ impl UnicodeSetBuilder {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::{UnicodeSet, UnicodeSetBuilder};
+    /// use icu::uniset::{UnicodeSet, UnicodeSetBuilder};
     /// let mut builder = UnicodeSetBuilder::new();
     /// let set = UnicodeSet::from_inversion_list(vec![65, 70]).unwrap();
     /// builder.add_range(&('A'..='Z'));
@@ -220,7 +220,7 @@ impl UnicodeSetBuilder {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::UnicodeSetBuilder;
+    /// use icu::uniset::UnicodeSetBuilder;
     /// let mut builder = UnicodeSetBuilder::new();
     /// builder.add_range(&('A'..='Z'));
     /// builder.retain_char('A');
@@ -240,7 +240,7 @@ impl UnicodeSetBuilder {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::UnicodeSetBuilder;
+    /// use icu::uniset::UnicodeSetBuilder;
     /// let mut builder = UnicodeSetBuilder::new();
     /// builder.add_range(&('A'..='Z'));
     /// builder.retain_range(&('A'..='B'));
@@ -261,7 +261,7 @@ impl UnicodeSetBuilder {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::{UnicodeSetBuilder, UnicodeSet};
+    /// use icu::uniset::{UnicodeSetBuilder, UnicodeSet};
     /// let mut builder = UnicodeSetBuilder::new();
     /// let set = UnicodeSet::from_inversion_list(vec![65, 70]).unwrap();
     /// builder.add_range(&('A'..='Z'));
@@ -323,7 +323,7 @@ impl UnicodeSetBuilder {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::{UnicodeSetBuilder, UnicodeSet};
+    /// use icu::uniset::{UnicodeSetBuilder, UnicodeSet};
     /// let mut builder = UnicodeSetBuilder::new();
     /// let set = UnicodeSet::from_inversion_list(vec![0, 65, 70, (std::char::MAX as u32) + 1]).unwrap();
     /// builder.add_set(&set);
@@ -351,7 +351,7 @@ impl UnicodeSetBuilder {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::UnicodeSetBuilder;
+    /// use icu::uniset::UnicodeSetBuilder;
     /// let mut builder = UnicodeSetBuilder::new();
     /// builder.add_range(&('A'..='D'));
     /// builder.complement_char('A');
@@ -372,7 +372,7 @@ impl UnicodeSetBuilder {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::UnicodeSetBuilder;
+    /// use icu::uniset::UnicodeSetBuilder;
     /// let mut builder = UnicodeSetBuilder::new();
     /// builder.add_range(&('A'..='D'));
     /// builder.complement_range(&('C'..='F'));
@@ -392,7 +392,7 @@ impl UnicodeSetBuilder {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::{UnicodeSetBuilder, UnicodeSet};
+    /// use icu::uniset::{UnicodeSetBuilder, UnicodeSet};
     /// let mut builder = UnicodeSetBuilder::new();
     /// let set = UnicodeSet::from_inversion_list(vec![65, 70, 75, 90]).unwrap();
     /// builder.add_range(&('C'..='N')); // 67 - 78
@@ -410,7 +410,7 @@ impl UnicodeSetBuilder {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::{UnicodeSetBuilder, UnicodeSet};
+    /// use icu::uniset::{UnicodeSetBuilder, UnicodeSet};
     /// let mut builder = UnicodeSetBuilder::new();
     /// let check = builder.build();
     /// assert!(check.is_empty());

--- a/components/uniset/src/lib.rs
+++ b/components/uniset/src/lib.rs
@@ -22,7 +22,7 @@
 //! the [`UnicodeSetBuilder`], or from the TBA Properties API.
 //!
 //! ```
-//! use icu_uniset::{UnicodeSet, UnicodeSetBuilder};
+//! use icu::uniset::{UnicodeSet, UnicodeSetBuilder};
 //!
 //! let mut builder = UnicodeSetBuilder::new();
 //! builder.add_range(&('A'..'Z'));
@@ -36,7 +36,7 @@
 //! Currently, you can check if a character/range of characters exists in the UnicodeSet, or iterate through the characters.
 //!
 //! ```
-//! use icu_uniset::{UnicodeSet, UnicodeSetBuilder};
+//! use icu::uniset::{UnicodeSet, UnicodeSetBuilder};
 //!
 //! let mut builder = UnicodeSetBuilder::new();
 //! builder.add_range(&('A'..'Z'));

--- a/components/uniset/src/uniset.rs
+++ b/components/uniset/src/uniset.rs
@@ -36,8 +36,8 @@ impl UnicodeSet {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::UnicodeSet;
-    /// use icu_uniset::UnicodeSetError;
+    /// use icu::uniset::UnicodeSet;
+    /// use icu::uniset::UnicodeSetError;
     /// let invalid: Vec<u32> = vec![0, 128, 3];
     /// let result = UnicodeSet::from_inversion_list(invalid.clone());
     /// assert!(matches!(result, Err(UnicodeSetError::InvalidSet(_))));
@@ -94,7 +94,7 @@ impl UnicodeSet {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::UnicodeSet;
+    /// use icu::uniset::UnicodeSet;
     /// let example_list = vec![65, 68, 69, 70];
     /// let example = UnicodeSet::from_inversion_list(example_list).unwrap();
     /// let mut example_iter = example.iter_chars();
@@ -152,7 +152,7 @@ impl UnicodeSet {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::UnicodeSet;
+    /// use icu::uniset::UnicodeSet;
     /// let example_list = vec![65, 67, 68, 69];
     /// let example = UnicodeSet::from_inversion_list(example_list).unwrap();
     /// assert!(example.contains('A'));
@@ -175,7 +175,7 @@ impl UnicodeSet {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::UnicodeSet;
+    /// use icu::uniset::UnicodeSet;
     /// let example_list = vec![65, 67, 68, 69];
     /// let example = UnicodeSet::from_inversion_list(example_list).unwrap();
     /// assert!(example.contains_u32(65));
@@ -194,7 +194,7 @@ impl UnicodeSet {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::UnicodeSet;
+    /// use icu::uniset::UnicodeSet;
     /// let example_list = vec![65, 67, 68, 69];
     /// let example = UnicodeSet::from_inversion_list(example_list).unwrap();
     /// assert!(example.contains_range(&('A'..'C')));
@@ -213,7 +213,7 @@ impl UnicodeSet {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::UnicodeSet;
+    /// use icu::uniset::UnicodeSet;
     /// use std::char;
     /// let check = char::from_u32(0xD7FE).unwrap() .. char::from_u32(0xE001).unwrap();
     /// let example_list = vec![0xD7FE, 0xD7FF, 0xE000, 0xE001];
@@ -236,7 +236,7 @@ impl UnicodeSet {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::UnicodeSet;
+    /// use icu::uniset::UnicodeSet;
     /// let example_list = vec![65, 70, 85, 91]; // A - E, U - Z
     /// let example = UnicodeSet::from_inversion_list(example_list).unwrap();
     /// let a_to_d = UnicodeSet::from_inversion_list(vec![65, 69]).unwrap();
@@ -271,7 +271,7 @@ impl UnicodeSet {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::UnicodeSet;
+    /// use icu::uniset::UnicodeSet;
     /// let example_list = vec![65, 68]; // {A, B, C}
     /// let example = UnicodeSet::from_inversion_list(example_list).unwrap();
     /// assert_eq!(example.span("CABXYZ", true), 3);
@@ -289,7 +289,7 @@ impl UnicodeSet {
     /// # Example
     ///
     /// ```
-    /// use icu_uniset::UnicodeSet;
+    /// use icu::uniset::UnicodeSet;
     /// let example_list = vec![65, 68]; // {A, B, C}
     /// let example = UnicodeSet::from_inversion_list(example_list).unwrap();
     /// assert_eq!(example.span_back("XYZCAB", true), 3);


### PR DESCRIPTION
Fixes #424 

This pull request updates all of the documentation examples for components that are exported as part of the `icu` crate to use the `icu` crate's syntax for `use` declarations. 

That is, the documentation examples will show `use icu::datetime::foo` instead of `use icu_datetime::foo`.

In order to achieve this, the `icu` crate is added as a dev-dependency to the relevant components.

This pull request also unhides any hidden `use` declarations in documentation examples by removing the leading `#` character. Hiding use declarations is a style that I originally suggested, but have since decided against in order to better match the documentation of the Rust standard library, which shows the use declarations inside of each example.