### PR TITLE
Pin rust default

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Load the default Rust toolchain via the rust-toolchain file.
+      run: rustup show
     - name: Check
       uses: actions-rs/cargo@v1.0.1
       with:
@@ -35,6 +37,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Load the default Rust toolchain via the rust-toolchain file.
+      run: rustup show
     - name: Build
       uses: actions-rs/cargo@v1.0.1
       with:
@@ -57,6 +61,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Load the default Rust toolchain via the rust-toolchain file.
+      run: rustup show
     - name: Install cargo-all-features
       uses: actions-rs/cargo@v1.0.1
       with:
@@ -74,6 +80,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
+    - name: Load the default Rust toolchain via the rust-toolchain file.
+      run: rustup show
+
+    - name: Install rustfmt
+      run: rustup component add rustfmt
 
     - name: Install cargo-make
       uses: actions-rs/install@v0.1.2
@@ -103,6 +115,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Load the default Rust toolchain via the rust-toolchain file.
+      run: rustup show
+
     - name: Install cargo-make
       uses: actions-rs/install@v0.1.2
       with:
@@ -122,6 +137,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Load the default Rust toolchain via the rust-toolchain file.
+      run: rustup show
 
     # Clippy job > Install and run clippy steps
 
@@ -161,6 +179,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Load the default Rust toolchain via the rust-toolchain file.
+        run: rustup show
 
       - name: Create output dir
         run: mkdir -p ./benchmarks/perf/${{ matrix.component }}
@@ -392,6 +413,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Load the default Rust toolchain via the rust-toolchain file.
+      run: rustup show
 
     # TODO(#234) re-include cache steps, also using Rust version in cache key
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+# Version updated on 2021-04-07
+channel = "1.51.0"


### PR DESCRIPTION
Resolves #374 

This pins the Rust version both _locally_ and in CI. It uses the rust-format file as defined here: https://rust-lang.github.io/rustup/overrides.html

If you run `rustup show` locally, this will activate the toolchain locally for a stable local environment as well. We can bump the number for our build as needed. This does not affect the Nighty configurations for certain tasks in CI. This should make for a more stable experience overall.

Note that I opted for the `rust-format` file without a `.toml` extension, as the latter was not activating properly in CI, even though it is documented as working.

[Here is an example of an existing rust-format file](https://github.com/rust-lang/rust-clippy/blob/master/rust-toolchain) in another repo.