### PR TITLE
Pass FieldLength by value in Field trait

### DIFF
--- a/components/datetime/src/fields/mod.rs
+++ b/components/datetime/src/fields/mod.rs
@@ -40,14 +40,14 @@ pub struct Field {
 impl Field {
     pub fn get_length_type(&self) -> TextOrNumeric {
         match self.symbol {
-            FieldSymbol::Year(year) => year.get_length_type(&self.length),
-            FieldSymbol::Month(month) => month.get_length_type(&self.length),
-            FieldSymbol::Day(day) => day.get_length_type(&self.length),
-            FieldSymbol::Weekday(weekday) => weekday.get_length_type(&self.length),
-            FieldSymbol::DayPeriod(day_period) => day_period.get_length_type(&self.length),
-            FieldSymbol::Hour(hour) => hour.get_length_type(&self.length),
+            FieldSymbol::Year(year) => year.get_length_type(self.length),
+            FieldSymbol::Month(month) => month.get_length_type(self.length),
+            FieldSymbol::Day(day) => day.get_length_type(self.length),
+            FieldSymbol::Weekday(weekday) => weekday.get_length_type(self.length),
+            FieldSymbol::DayPeriod(day_period) => day_period.get_length_type(self.length),
+            FieldSymbol::Hour(hour) => hour.get_length_type(self.length),
             FieldSymbol::Minute => TextOrNumeric::Numeric,
-            FieldSymbol::Second(second) => second.get_length_type(&self.length),
+            FieldSymbol::Second(second) => second.get_length_type(self.length),
         }
     }
 }

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -38,7 +38,7 @@ pub enum TextOrNumeric {
 /// FieldSymbols can be either text or numeric. This categorization is important when matching
 /// skeletons with a components::Bag.
 pub trait LengthType {
-    fn get_length_type(&self, length: &FieldLength) -> TextOrNumeric;
+    fn get_length_type(&self, length: FieldLength) -> TextOrNumeric;
 }
 
 impl FieldSymbol {
@@ -172,7 +172,7 @@ pub enum Year {
 }
 
 impl LengthType for Year {
-    fn get_length_type(&self, _length: &FieldLength) -> TextOrNumeric {
+    fn get_length_type(&self, _length: FieldLength) -> TextOrNumeric {
         TextOrNumeric::Numeric
     }
 }
@@ -205,7 +205,7 @@ pub enum Month {
 }
 
 impl LengthType for Month {
-    fn get_length_type(&self, length: &FieldLength) -> TextOrNumeric {
+    fn get_length_type(&self, length: FieldLength) -> TextOrNumeric {
         match length {
             FieldLength::One => TextOrNumeric::Numeric,
             FieldLength::TwoDigit => TextOrNumeric::Numeric,
@@ -247,7 +247,7 @@ pub enum Day {
 }
 
 impl LengthType for Day {
-    fn get_length_type(&self, _length: &FieldLength) -> TextOrNumeric {
+    fn get_length_type(&self, _length: FieldLength) -> TextOrNumeric {
         TextOrNumeric::Numeric
     }
 }
@@ -284,7 +284,7 @@ pub enum Hour {
 }
 
 impl LengthType for Hour {
-    fn get_length_type(&self, _length: &FieldLength) -> TextOrNumeric {
+    fn get_length_type(&self, _length: FieldLength) -> TextOrNumeric {
         TextOrNumeric::Numeric
     }
 }
@@ -320,7 +320,7 @@ pub enum Second {
 }
 
 impl LengthType for Second {
-    fn get_length_type(&self, _length: &FieldLength) -> TextOrNumeric {
+    fn get_length_type(&self, _length: FieldLength) -> TextOrNumeric {
         TextOrNumeric::Numeric
     }
 }
@@ -355,7 +355,7 @@ pub enum Weekday {
 }
 
 impl LengthType for Weekday {
-    fn get_length_type(&self, length: &FieldLength) -> TextOrNumeric {
+    fn get_length_type(&self, length: FieldLength) -> TextOrNumeric {
         match self {
             Weekday::Format => TextOrNumeric::Text,
             Weekday::Local | Weekday::StandAlone => match length {
@@ -395,7 +395,7 @@ pub enum DayPeriod {
 }
 
 impl LengthType for DayPeriod {
-    fn get_length_type(&self, _length: &FieldLength) -> TextOrNumeric {
+    fn get_length_type(&self, _length: FieldLength) -> TextOrNumeric {
         TextOrNumeric::Text
     }
 }


### PR DESCRIPTION
@gregtatum while I was rebasing my time zones patch on top of main after you merged #587, I noticed that `FieldLength` is getting passed by reference in your `Field` trait function. 

`FieldLength` is a simple numeric enum, and a `Copy` type. We should utilize that quality and pass it by value when possible.

```rust
pub enum FieldLength {
    One = 1,
    TwoDigit = 2,
    Abbreviated = 3,
    Wide = 4,
    Narrow = 5,
    Six = 6,
}
```

This should be a quick and easy review.