### PR TITLE
Adding Valgrind build task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ wasmpkg/
 # Benchmarking output
 dhat-heap.json
 /benchmarks
-/valgrind_out
 
 # Do not check-in bincode test data
 resources/testdata/data/bincode

--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,10 @@
 # Ephemeral output of `cargo make wasm`
 wasmpkg/
 
-# Memory benchmarking output
+# Benchmarking output
 dhat-heap.json
 /benchmarks
+/valgrind_out
 
 # Do not check-in bincode test data
 resources/testdata/data/bincode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlmalloc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332570860c2edf2d57914987bf9e24835425f75825086b6ba7d1e6a3e4f1f254"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +853,7 @@ name = "icu_benchmark_macros"
 version = "0.1.0"
 dependencies = [
  "dhat",
+ "dlmalloc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,4 @@ lto = true
 # https://github.com/rust-lang/cargo/issues/6988
 [profile.bench]
 debug = true
+debug-assertions = false

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -288,31 +288,47 @@ args = ["-rf", "wasmpkg"]
 
 ### VALGRIND TASKS ###
 
+[tasks.valgrind-build]
+description = "Pre-build artifacts for use with the Valgrind task"
+category = "ICU4X Valgrind"
+command = "cargo"
+toolchain = "nightly-2021-02-28"
+args = ["build", "--examples", "--features", "icu_benchmark_macros/rust_global_allocator", "--profile", "bench", "-Z", "unstable-options"]
+
 [tasks.valgrind]
 description = "Build ICU4X example files with default features and run through Valgrind"
 category = "ICU4X Valgrind"
+dependencies = [
+    "valgrind-build",
+]
 script_runner = "@duckscript"
 script = '''
 exit_on_error true
 
 valgrind = which valgrind
-assert ${valgrind} "Could not find 'valgrind' in path.\n*** Please run 'apt-get install valgrind' ***"
+assert ${valgrind} "Could not find 'valgrind' in path.\n***\nRead about Valgrind: https://valgrind.org/\nInstall on Ubuntu: `apt-get install valgrind`\n***"
 
 mkdir benchmarks
 mkdir benchmarks/valgrind
 
+# Re-run the build command only to generate the JSON output (--message-format=json)
 output = exec cargo +nightly-2021-02-28 build --examples --message-format=json --features icu_benchmark_macros/rust_global_allocator --profile bench -Z unstable-options
 if ${output.code}
     trigger_error "Build failed! To debug, build examples with `--features icu_benchmark_macros/rust_global_allocator`"
 end
+
+# Parse the JSON messages from --message-format=json line by line
 trimmed_stdout = trim ${output.stdout}
 json_messages = split ${trimmed_stdout} "\n"
 for json_message in ${json_messages}
     json_obj = json_parse ${json_message}
 
+    # The following two JSON keys determine whether this is an example artifact
     is_compiler_artifact = eq ${json_obj.reason} "compiler-artifact"
     is_example = eq ${json_obj.target.kind[0]} "example"
     if ${is_compiler_artifact} and ${is_example}
+
+        # Run the example through Valgrind and save the output in the benchmarks folder
         out_file = concat "benchmarks/valgrind/" ${json_obj.target.name} ".out"
         set_env LD_BIND_NOW "y"
         vg_output = exec ${valgrind} --tool=callgrind --zero-before=_start --callgrind-out-file=${out_file} ${json_obj.executable}
@@ -321,6 +337,7 @@ for json_message in ${json_messages}
             echo ${vg_output.stderr}
             trigger_error "Valgrind failed; see output above"
         else
+            # Display the summary line
             grep_output = exec grep "summary" ${out_file}
             summary_line = trim ${grep_output.stdout}
             ir_count = substring ${summary_line} 9

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -298,7 +298,8 @@ exit_on_error true
 valgrind = which valgrind
 assert ${valgrind} "Could not find 'valgrind' in path.\n*** Please run 'apt-get install valgrind' ***"
 
-mkdir valgrind_out
+mkdir benchmarks
+mkdir benchmarks/valgrind
 
 output = exec cargo +nightly-2021-02-28 build --examples --message-format=json --features icu_benchmark_macros/rust_global_allocator --profile bench -Z unstable-options
 if ${output.code}
@@ -312,7 +313,7 @@ for json_message in ${json_messages}
     is_compiler_artifact = eq ${json_obj.reason} "compiler-artifact"
     is_example = eq ${json_obj.target.kind[0]} "example"
     if ${is_compiler_artifact} and ${is_example}
-        out_file = concat "valgrind_out/" ${json_obj.target.name} ".out"
+        out_file = concat "benchmarks/valgrind/" ${json_obj.target.name} ".out"
         set_env LD_BIND_NOW "y"
         vg_output = exec ${valgrind} --tool=callgrind --zero-before=_start --callgrind-out-file=${out_file} ${json_obj.executable}
         if ${vg_output.code}

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -300,7 +300,10 @@ assert ${valgrind} "Could not find 'valgrind' in path.\n*** Please run 'apt-get 
 
 mkdir valgrind_out
 
-output = exec cargo build --examples --message-format=json
+output = exec cargo +nightly-2021-02-28 build --examples --message-format=json --features icu_benchmark_macros/rust_global_allocator --profile bench -Z unstable-options
+if ${output.code}
+    trigger_error "Build failed! To debug, build examples with `--features icu_benchmark_macros/rust_global_allocator`"
+end
 trimmed_stdout = trim ${output.stdout}
 json_messages = split ${trimmed_stdout} "\n"
 for json_message in ${json_messages}
@@ -309,9 +312,19 @@ for json_message in ${json_messages}
     is_compiler_artifact = eq ${json_obj.reason} "compiler-artifact"
     is_example = eq ${json_obj.target.kind[0]} "example"
     if ${is_compiler_artifact} and ${is_example}
-        echo "Running" ${json_obj.target.name}
+        out_file = concat "valgrind_out/" ${json_obj.target.name} ".out"
         set_env LD_BIND_NOW "y"
-        vg_output = exec ${valgrind} --tool=callgrind --zero-before=_start --callgrind-out-file=valgrind_out/${json_obj.target.name}.out ${json_obj.executable}
+        vg_output = exec ${valgrind} --tool=callgrind --zero-before=_start --callgrind-out-file=${out_file} ${json_obj.executable}
+        if ${vg_output.code}
+            echo ${vg_output.stdout}
+            echo ${vg_output.stderr}
+            trigger_error "Valgrind failed; see output above"
+        else
+            grep_output = exec grep "summary" ${out_file}
+            summary_line = trim ${grep_output.stdout}
+            ir_count = substring ${summary_line} 9
+            echo ${ir_count} "Ir:" ${json_obj.target.name}
+        end
     end
 end
 '''

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -286,6 +286,38 @@ category = "ICU4X WASM"
 command = "rm"
 args = ["-rf", "wasmpkg"]
 
+### VALGRIND TASKS ###
+
+[tasks.valgrind]
+description = "Build ICU4X example files with default features and run through Valgrind"
+category = "ICU4X Valgrind"
+script_runner = "@duckscript"
+script = '''
+exit_on_error true
+
+valgrind = which valgrind
+assert ${valgrind} "Could not find 'valgrind' in path.\n*** Please run 'apt-get install valgrind' ***"
+
+mkdir valgrind_out
+
+output = exec cargo build --examples --message-format=json
+trimmed_stdout = trim ${output.stdout}
+json_messages = split ${trimmed_stdout} "\n"
+for json_message in ${json_messages}
+    json_obj = json_parse ${json_message}
+
+    is_compiler_artifact = eq ${json_obj.reason} "compiler-artifact"
+    is_example = eq ${json_obj.target.kind[0]} "example"
+    if ${is_compiler_artifact} and ${is_example}
+        echo "Running" ${json_obj.target.name}
+        set_env LD_BIND_NOW "y"
+        vg_output = exec ${valgrind} --tool=callgrind --zero-before=_start --callgrind-out-file=valgrind_out/${json_obj.target.name}.out ${json_obj.executable}
+    end
+end
+'''
+
+### BINCODE TASKS ###
+
 [tasks.bincode-clean]
 description = "Clean out the bincode data."
 category = "ICU4X Bincode"

--- a/components/decimal/examples/code_line_diff.rs
+++ b/components/decimal/examples/code_line_diff.rs
@@ -41,6 +41,8 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
         let decimals: (FixedDecimal, FixedDecimal) = (line.0.into(), line.1.into());
         let removed = fdf.format(&decimals.0);
         let added = fdf.format(&decimals.1);
+        assert_ne!("", removed.writeable_to_string());
+        assert_ne!("", added.writeable_to_string());
         #[cfg(debug_assertions)]
         println!(
             "Added/Removed: {}/{}",

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -37,6 +37,66 @@ official support.
 * [dhat-rs](https://github.com/nnethercote/dhat-rs) for instrumentation.
 * [benchmarking action](https://github.com/gregtatum/github-action-benchmark) – This is a fork that allows collecting [ndjson](http://ndjson.org/) benchmark data.
 
+## Valgrind / Callgrind
+
+ICU4X examples are also intrumented to produce Callgrind artifacts demonstrating the call graph and instruction reads.
+
+To generate callgrind artifacts for all examples, run from the root directory:
+
+```bash
+$ cargo make valgrind
+12410 Ir: filter_langids 
+3912 Ir: permyriad 
+84194 Ir: language_names_hash_map 
+209698 Ir: syntatically_canonicalize_locales 
+3946 Ir: language_names_lite_map 
+24874 Ir: unicode_bmp_blocks_selector 
+201246 Ir: writeable_message 
+153702 Ir: code_line_diff 
+794477 Ir: work_log 
+785178 Ir: tui 
+123768 Ir: elevator_floors 
+105762 Ir: unread_emails 
+```
+
+To view a call graph, use the `kcachegrind` or `gprof2dot` tools, as suggested [here](https://stackoverflow.com/questions/9279144/interpreting-callgrind-data). For example:
+
+```bash
+$ kcachegrind benchmarks/valgrind/code_line_diff.out
+```
+
+To generate a png file:
+
+```bash
+$ pip install gprof2dot
+$ gprof2dot --format=callgrind --output=out.dot benchmarks/valgrind/tui.out
+$ dot -Tpng out.dot -o graph.png
+$ open graph.png
+```
+
 ## Benchmark Macros
 
 The macros contain helpers for examples so that they can be instrumented them tersely.
+
+### Feature: benchmark_memory
+
+This feature enables the dhat-rs instrumentation described above. To enable it for any example in the ICU4X tree, add `--features icu_benchmark_macros/benchmark_memory`. For example, run this from the top level:
+
+```bash
+$ cargo run --example code_line_diff --features icu_benchmark_macros/benchmark_memory
+Added/Removed: -৫০/+৭২
+Added/Removed: ০/+৩,৭৫০
+Added/Removed: -১,২০১/০
+Added/Removed: -৯,৮৭৬/+৫,৪৩২
+Added/Removed: -৫০,০০,০০০/+৩০,০০,০০০
+dhat: Total:     13,793 bytes in 69 blocks
+dhat: At t-gmax: 8,973 bytes in 6 blocks
+dhat: At t-end:  1,112 bytes in 3 blocks
+dhat: The data in dhat-heap.json is viewable with dhat/dh_view.html
+```
+
+### Feature: rust_global_allocator
+
+This feature replaces the default system allocator with `dlmalloc`, the same Rust-based allocator used in the `wasm32-unknown-unknown` build target.  This results in more reliable benchmarks by removing the platform-dependent allocator.
+
+This feature is used by the `cargo make valgrind` build task.

--- a/tools/benchmark/macros/Cargo.toml
+++ b/tools/benchmark/macros/Cargo.toml
@@ -10,6 +10,9 @@ version = "0.1.0"
 
 [dependencies]
 dhat = { version = "0.2", optional = true }
+
+# This cfg originates in dlmalloc/lib.rs
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_arch = "wasm32"))'.dependencies]
 dlmalloc = { version = "0.2", optional = true, features = ["global"] }
 
 [features]

--- a/tools/benchmark/macros/Cargo.toml
+++ b/tools/benchmark/macros/Cargo.toml
@@ -16,7 +16,9 @@ dhat = { version = "0.2", optional = true }
 dlmalloc = { version = "0.2", optional = true, features = ["global"] }
 
 [features]
-# Enables `dhat` in example files to analyze memory allocations
+
+# Enables `dhat` in example files to analyze memory allocations.
 benchmark_memory = ["dhat"]
-# Enables `dlmalloc` in example files to bypass the system allocator
+
+# Enables `dlmalloc` in example files to bypass the system allocator.
 rust_global_allocator = ["dlmalloc"]

--- a/tools/benchmark/macros/Cargo.toml
+++ b/tools/benchmark/macros/Cargo.toml
@@ -10,6 +10,8 @@ version = "0.1.0"
 
 [dependencies]
 dhat = { version = "0.2", optional = true }
+dlmalloc = { version = "0.2", optional = true, features = ["global"] }
 
 [features]
 benchmark_memory = ["dhat"]
+rust_global_allocator = ["dlmalloc"]

--- a/tools/benchmark/macros/Cargo.toml
+++ b/tools/benchmark/macros/Cargo.toml
@@ -16,5 +16,7 @@ dhat = { version = "0.2", optional = true }
 dlmalloc = { version = "0.2", optional = true, features = ["global"] }
 
 [features]
+# Enables `dhat` in example files to analyze memory allocations
 benchmark_memory = ["dhat"]
+# Enables `dlmalloc` in example files to bypass the system allocator
 rust_global_allocator = ["dlmalloc"]

--- a/tools/benchmark/macros/src/lib.rs
+++ b/tools/benchmark/macros/src/lib.rs
@@ -2,17 +2,25 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-// Re-export dhat so that macros can access it without needing dhat as a dependency.
+// Re-export tools so that macros can access it without needing a dependency.
 #[cfg(feature = "benchmark_memory")]
 pub use dhat;
+#[cfg(feature = "rust_global_allocator")]
+pub use dlmalloc;
 
-#[cfg(not(feature = "benchmark_memory"))]
+#[cfg(not(any(feature = "benchmark_memory", feature = "rust_global_allocator")))]
 #[macro_export]
 macro_rules! static_setup {
     () => {};
 }
 
-#[cfg(feature = "benchmark_memory")]
+#[cfg(all(feature = "benchmark_memory", feature = "rust_global_allocator"))]
+#[macro_export]
+macro_rules! static_setup {
+    () => {};
+}
+
+#[cfg(all(feature = "benchmark_memory", not(feature = "rust_global_allocator")))]
 #[macro_export]
 macro_rules! static_setup {
     () => {
@@ -21,6 +29,18 @@ macro_rules! static_setup {
         // Use the DhatAlloc global allocator to instrument memory usage.
         #[global_allocator]
         static ALLOCATOR: DhatAlloc = DhatAlloc;
+    };
+}
+
+#[cfg(all(feature = "rust_global_allocator", not(feature = "benchmark_memory")))]
+#[macro_export]
+macro_rules! static_setup {
+    () => {
+        use icu_benchmark_macros::dlmalloc::GlobalDlmalloc;
+
+        // Use Dlmalloc to remove the system allocator dependency
+        #[global_allocator]
+        static ALLOCATOR: GlobalDlmalloc = GlobalDlmalloc;
     };
 }
 

--- a/tools/benchmark/macros/src/lib.rs
+++ b/tools/benchmark/macros/src/lib.rs
@@ -2,61 +2,63 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-// Re-export tools so that macros can access it without needing a dependency.
-#[cfg(feature = "benchmark_memory")]
-pub use dhat;
-#[cfg(feature = "rust_global_allocator")]
-pub use dlmalloc;
-
-#[cfg(not(any(feature = "benchmark_memory", feature = "rust_global_allocator")))]
-#[macro_export]
-macro_rules! static_setup {
-    () => {};
+// If no features or all features are present, define empty macros
+#[cfg(any(
+    not(any(feature = "benchmark_memory", feature = "rust_global_allocator")),
+    all(feature = "benchmark_memory", feature = "rust_global_allocator"),
+))]
+mod default {
+    #[macro_export]
+    macro_rules! static_setup {
+        () => {};
+    }
+    #[macro_export]
+    macro_rules! main_setup {
+        () => {};
+    }
 }
 
-#[cfg(all(feature = "benchmark_memory", feature = "rust_global_allocator"))]
-#[macro_export]
-macro_rules! static_setup {
-    () => {};
-}
-
+// Enable DHat if the "benchmark_memory" feature is present alone
 #[cfg(all(feature = "benchmark_memory", not(feature = "rust_global_allocator")))]
-#[macro_export]
-macro_rules! static_setup {
-    () => {
-        use icu_benchmark_macros::dhat::{Dhat, DhatAlloc};
-
-        // Use the DhatAlloc global allocator to instrument memory usage.
-        #[global_allocator]
-        static ALLOCATOR: DhatAlloc = DhatAlloc;
-    };
+mod benchmark_memory {
+    // Re-export tools so that macros can access it without needing a dependency.
+    pub use dhat;
+    #[macro_export]
+    macro_rules! static_setup {
+        () => {
+            use icu_benchmark_macros::dhat::{Dhat, DhatAlloc};
+            // Use the DhatAlloc global allocator to instrument memory usage.
+            #[global_allocator]
+            static ALLOCATOR: DhatAlloc = DhatAlloc;
+        };
+    }
+    #[macro_export]
+    macro_rules! main_setup {
+        () => {
+            // The dhat instance will be alive for the life of the main function, and when dropped,
+            // it will output heap usage information.
+            let _dhat = Dhat::start_heap_profiling();
+            eprintln!("Feature");
+        };
+    }
 }
 
+// Enable Dlmalloc if the "rust_global_allocator" feature is present alone
 #[cfg(all(feature = "rust_global_allocator", not(feature = "benchmark_memory")))]
-#[macro_export]
-macro_rules! static_setup {
-    () => {
-        use icu_benchmark_macros::dlmalloc::GlobalDlmalloc;
-
-        // Use Dlmalloc to remove the system allocator dependency
-        #[global_allocator]
-        static ALLOCATOR: GlobalDlmalloc = GlobalDlmalloc;
-    };
-}
-
-#[cfg(not(feature = "benchmark_memory"))]
-#[macro_export]
-macro_rules! main_setup {
-    () => {};
-}
-
-#[cfg(feature = "benchmark_memory")]
-#[macro_export]
-macro_rules! main_setup {
-    () => {
-        // The dhat instance will be alive for the life of the main function, and when dropped,
-        // it will output heap usage information.
-        let _dhat = Dhat::start_heap_profiling();
-        eprintln!("Feature");
-    };
+mod rust_global_allocator {
+    // Re-export tools so that macros can access it without needing a dependency.
+    pub use dlmalloc;
+    #[macro_export]
+    macro_rules! static_setup {
+        () => {
+            use icu_benchmark_macros::dlmalloc::GlobalDlmalloc;
+            // Use Dlmalloc to remove the system allocator dependency
+            #[global_allocator]
+            static ALLOCATOR: GlobalDlmalloc = GlobalDlmalloc;
+        };
+    }
+    #[macro_export]
+    macro_rules! main_setup {
+        () => {};
+    }
 }

--- a/tools/benchmark/macros/src/lib.rs
+++ b/tools/benchmark/macros/src/lib.rs
@@ -20,13 +20,13 @@ mod default {
 
 // Enable DHat if the "benchmark_memory" feature is present alone
 #[cfg(all(feature = "benchmark_memory", not(feature = "rust_global_allocator")))]
-mod benchmark_memory {
-    // Re-export tools so that macros can access it without needing a dependency.
+pub mod benchmark_memory {
+    /// Re-export tools so that macros can access it without needing a dependency.
     pub use dhat;
     #[macro_export]
     macro_rules! static_setup {
         () => {
-            use icu_benchmark_macros::dhat::{Dhat, DhatAlloc};
+            use $crate::benchmark_memory::dhat::{Dhat, DhatAlloc};
             // Use the DhatAlloc global allocator to instrument memory usage.
             #[global_allocator]
             static ALLOCATOR: DhatAlloc = DhatAlloc;
@@ -45,13 +45,13 @@ mod benchmark_memory {
 
 // Enable Dlmalloc if the "rust_global_allocator" feature is present alone
 #[cfg(all(feature = "rust_global_allocator", not(feature = "benchmark_memory")))]
-mod rust_global_allocator {
-    // Re-export tools so that macros can access it without needing a dependency.
+pub mod rust_global_allocator {
+    /// Re-export tools so that macros can access it without needing a dependency.
     pub use dlmalloc;
     #[macro_export]
     macro_rules! static_setup {
         () => {
-            use icu_benchmark_macros::dlmalloc::GlobalDlmalloc;
+            use $crate::rust_global_allocator::dlmalloc::GlobalDlmalloc;
             // Use Dlmalloc to remove the system allocator dependency
             #[global_allocator]
             static ALLOCATOR: GlobalDlmalloc = GlobalDlmalloc;

--- a/utils/fixed_decimal/examples/permyriad.rs
+++ b/utils/fixed_decimal/examples/permyriad.rs
@@ -26,7 +26,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
         .write_to(&mut output)
         .expect("Writing to a string is infallible");
 
-    debug_assert_eq!("19.9500", fixed_decimal.to_string());
+    assert_eq!("19.9500", fixed_decimal.to_string());
 
     0
 }

--- a/utils/litemap/examples/language_names_hash_map.rs
+++ b/utils/litemap/examples/language_names_hash_map.rs
@@ -39,9 +39,9 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
         map.insert(lang, name).ok_or(()).unwrap_err();
     }
 
-    debug_assert_eq!(11, map.len());
-    debug_assert_eq!(Some(&&"Thai"), map.get(&language!("th")));
-    debug_assert_eq!(None, map.get(&language!("de")));
+    assert_eq!(11, map.len());
+    assert_eq!(Some(&&"Thai"), map.get(&language!("th")));
+    assert_eq!(None, map.get(&language!("de")));
 
     0
 }

--- a/utils/litemap/examples/language_names_lite_map.rs
+++ b/utils/litemap/examples/language_names_lite_map.rs
@@ -39,9 +39,9 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
         map.try_append(lang, name).ok_or(()).unwrap_err();
     }
 
-    debug_assert_eq!(11, map.len());
-    debug_assert_eq!(Some(&&"Thai"), map.get(&language!("th")));
-    debug_assert_eq!(None, map.get(&language!("de")));
+    assert_eq!(11, map.len());
+    assert_eq!(Some(&&"Thai"), map.get(&language!("th")));
+    assert_eq!(None, map.get(&language!("de")));
 
     0
 }


### PR DESCRIPTION
I wrote a build task that runs the examples through Valgrind Callgrind and saves the results.  This can be used as another source of instruction count measurements.  It obviously only works on platforms where Valgrind is available.  I added it to Makefile.toml so it is available for anyone who wants it, but I haven't yet added it to the CI.