### PR TITLE
Make all crates use the same `include` keys

### DIFF
--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -12,10 +12,11 @@ readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
 categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
     "examples/**/*",
-    "benches/**/*",
+    "tests/**/*",
     "Cargo.toml",
     "README.md"
 ]

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -10,9 +10,11 @@ edition = "2018"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
 categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
-    "benches/**/*",
+    "tests/**/*",
+    "examples/**/*",
     "Cargo.toml",
     "README.md"
 ]

--- a/components/ecma402/Cargo.toml
+++ b/components/ecma402/Cargo.toml
@@ -12,10 +12,11 @@ readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
 categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
     "examples/**/*",
-    "benches/**/*",
+    "tests/**/*",
     "Cargo.toml",
     "README.md"
 ]

--- a/components/icu/Cargo.toml
+++ b/components/icu/Cargo.toml
@@ -12,10 +12,11 @@ readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
 categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
     "examples/**/*",
-    "benches/**/*",
+    "tests/**/*",
     "Cargo.toml",
     "README.md"
 ]

--- a/components/icu4x/Cargo.toml
+++ b/components/icu4x/Cargo.toml
@@ -12,10 +12,11 @@ readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
 categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
     "examples/**/*",
-    "benches/**/*",
+    "tests/**/*",
     "Cargo.toml",
     "README.md"
 ]

--- a/components/locale_canonicalizer/Cargo.toml
+++ b/components/locale_canonicalizer/Cargo.toml
@@ -10,9 +10,11 @@ edition = "2018"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
 categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
-    "benches/**/*",
+    "examples/**/*",
+    "tests/**/*",
     "Cargo.toml",
     "README.md"
 ]

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -12,10 +12,11 @@ readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
 categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
     "examples/**/*",
-    "benches/**/*",
+    "tests/**/*",
     "Cargo.toml",
     "README.md"
 ]

--- a/components/locid/macros/Cargo.toml
+++ b/components/locid/macros/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../../LICENSE"
 categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
     "examples/**/*",

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -12,10 +12,11 @@ readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
 categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
     "examples/**/*",
-    "benches/**/*",
+    "tests/**/*",
     "Cargo.toml",
     "README.md"
 ]

--- a/components/provider/Cargo.toml
+++ b/components/provider/Cargo.toml
@@ -12,10 +12,11 @@ readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
 categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
     "examples/**/*",
-    "benches/**/*",
+    "tests/**/*",
     "Cargo.toml",
     "README.md"
 ]

--- a/components/provider_cldr/Cargo.toml
+++ b/components/provider_cldr/Cargo.toml
@@ -12,10 +12,11 @@ readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
 categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
     "examples/**/*",
-    "benches/**/*",
+    "tests/**/*",
     "Cargo.toml",
     "README.md"
 ]

--- a/components/provider_fs/Cargo.toml
+++ b/components/provider_fs/Cargo.toml
@@ -12,10 +12,11 @@ readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
 categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
     "examples/**/*",
-    "benches/**/*",
+    "tests/**/*",
     "Cargo.toml",
     "README.md"
 ]

--- a/components/provider_ppucd/Cargo.toml
+++ b/components/provider_ppucd/Cargo.toml
@@ -11,10 +11,11 @@ edition = "2018"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
 categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
     "examples/**/*",
-    "benches/**/*",
+    "tests/**/*",
     "Cargo.toml",
     "README.md"
 ]

--- a/components/uniset/Cargo.toml
+++ b/components/uniset/Cargo.toml
@@ -12,11 +12,13 @@ readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
 categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
     "examples/**/*",
-    "benches/**/*",
+    "tests/**/*",
     "Cargo.toml",
+    "README.md"
 ]
 
 [package.metadata.cargo-all-features]

--- a/experimental/bies/Cargo.toml
+++ b/experimental/bies/Cargo.toml
@@ -11,10 +11,11 @@ edition = "2018"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
     "examples/**/*",
-    "benches/**/*",
+    "tests/**/*",
     "Cargo.toml",
     "README.md"
 ]

--- a/experimental/segmenter_lstm/Cargo.toml
+++ b/experimental/segmenter_lstm/Cargo.toml
@@ -12,11 +12,13 @@ readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
 categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
     "examples/**/*",
-    "benches/**/*",
+    "tests/**/*",
     "Cargo.toml",
+    "README.md"
 ]
 
 [dependencies]

--- a/resources/testdata/Cargo.toml
+++ b/resources/testdata/Cargo.toml
@@ -12,13 +12,13 @@ readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
 categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
-    "data/json/**/*",
     "examples/**/*",
-    "benches/**/*",
+    "tests/**/*",
     "Cargo.toml",
-    "README.md"
+    "README.md",
 ]
 
 # icu4x_testdata metadata: schema defined in ./src/metadata.rs

--- a/resources/testdata/Cargo.toml
+++ b/resources/testdata/Cargo.toml
@@ -19,6 +19,9 @@ include = [
     "tests/**/*",
     "Cargo.toml",
     "README.md",
+    # Exception: We want to be able to run tests, so
+    # we include the test data
+    "data/**/*",
 ]
 
 # icu4x_testdata metadata: schema defined in ./src/metadata.rs

--- a/tools/benchmark/macros/Cargo.toml
+++ b/tools/benchmark/macros/Cargo.toml
@@ -7,6 +7,14 @@ name = "icu_benchmark_macros"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 version = "0.1.0"
+# Keep this in sync with other crates unless there are exceptions
+include = [
+    "src/**/*",
+    "examples/**/*",
+    "tests/**/*",
+    "Cargo.toml",
+    "README.md"
+]
 
 [dependencies]
 dhat = { version = "0.2", optional = true }

--- a/tools/benchmark/memory/Cargo.toml
+++ b/tools/benchmark/memory/Cargo.toml
@@ -7,6 +7,14 @@ name = "icu_benchmark_memory"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 version = "0.1.0"
+# Keep this in sync with other crates unless there are exceptions
+include = [
+    "src/**/*",
+    "examples/**/*",
+    "tests/**/*",
+    "Cargo.toml",
+    "README.md"
+]
 
 [dependencies]
 serde_json = "1.0"

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -12,10 +12,11 @@ readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
 categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
     "examples/**/*",
-    "benches/**/*",
+    "tests/**/*",
     "Cargo.toml",
     "README.md"
 ]

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -13,7 +13,14 @@ keywords = ["sorted", "vec", "map", "hashmap", "btreemap"]
 description = "A key-value Map implementation based on a flat, sorted Vec."
 documentation = "https://docs.rs/litemap"
 readme = "./README.md"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+# Keep this in sync with other crates unless there are exceptions
+include = [
+    "src/**/*",
+    "examples/**/*",
+    "tests/**/*",
+    "Cargo.toml",
+    "README.md"
+]
 
 [dependencies]
 serde = {version = "1", optional = true}

--- a/utils/writeable/Cargo.toml
+++ b/utils/writeable/Cargo.toml
@@ -11,10 +11,11 @@ edition = "2018"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
+# Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
     "examples/**/*",
-    "benches/**/*",
+    "tests/**/*",
     "Cargo.toml",
     "README.md"
 ]


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/569

This makes all crates publish tests and examples, but not benches. Crates without these folders will still contain these keys in case the folders are added in the future (cargo is okay with this).