### PR TITLE
Regenerate readmes after landing generated-readme-check

### DIFF
--- a/components/datetime/README.md
+++ b/components/datetime/README.md
@@ -13,7 +13,7 @@ used to quickly format any date and time provided.
 ```rust
 use icu_locid::Locale;
 use icu_locid_macros::langid;
-use icu_datetime::{DateTimeFormat, DateTimeFormatOptions, mock::MockDateTime, options::length};
+use icu_datetime::{DateTimeFormat, DateTimeFormatOptions, mock::datetime::MockDateTime, options::length};
 
 let provider = icu_testdata::get_provider();
 
@@ -61,7 +61,7 @@ to develop core date and time APIs that will work as an input for this component
 [`DataProvider`]: icu_provider::DataProvider
 [`ICU4X`]: ../icu/index.html
 [`Length`]: options::length
-[`MockDateTime`]: mock::MockDateTime
+[`MockDateTime`]: mock::datetime::MockDateTime
 
 ## More Information
 

--- a/components/icu/README.md
+++ b/components/icu/README.md
@@ -36,7 +36,7 @@ an [`FsDataProvider`] with locally available subset of data.
 ```rust
 use icu::locid::Locale;
 use icu::locid::macros::langid;
-use icu::datetime::{DateTimeFormat, mock::MockDateTime, options::length};
+use icu::datetime::{DateTimeFormat, mock::datetime::MockDateTime, options::length};
 
 let provider = icu_testdata::get_provider();
 


### PR DESCRIPTION
There were some changes to the docs during the last review for https://github.com/unicode-org/icu4x/pull/601, this regenerates the README.md files to pick those up and fix the failing lint job.