### PR TITLE
Update failing generated-readme-check error message

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -109,7 +109,7 @@ output_length = length ${output.stdout}
 if greater_than ${output_length} 0
     if contains ${output.stdout} README.md
         msg = array "" ""
-        array_push ${msg} "A README.md file is out-of-sync with lib.rs!
+        array_push ${msg} "A README.md file is out-of-sync with lib.rs
         array_push ${msg} ""
         array_push ${msg} "If you modified a lib.rs file, please run `cargo make generate-readmes`. If you edited a"
         array_push ${msg} "README.md file directly, please also update the corresponding lib.rs."

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -109,10 +109,10 @@ output_length = length ${output.stdout}
 if greater_than ${output_length} 0
     if contains ${output.stdout} README.md
         msg = array "" ""
-        array_push ${msg} "The README.md files were re-generated, and they differed from the committed files."
+        array_push ${msg} "A README.md file is out-of-sync with lib.rs!
         array_push ${msg} ""
-        array_push ${msg} "If you modified the README.md file directly, then revert your changes. If the README.md"
-        array_push ${msg} "was automatically updated, then the changes need to be committed."
+        array_push ${msg} "If you modified a lib.rs file, please run `cargo make generate-readmes`. If you edited a"
+        array_push ${msg} "README.md file directly, please also update the corresponding lib.rs."
         array_push ${msg} ""
         array_push ${msg} "The modified files were:"
         array_push ${msg} "${output.stdout}"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -108,7 +108,16 @@ output = exec git status --porcelain=v1 -uno
 output_length = length ${output.stdout}
 if greater_than ${output_length} 0
     if contains ${output.stdout} README.md
-        trigger_error "Found non-automatically generated README.md:\n ${output.stdout}"
+        msg = array "" ""
+        array_push ${msg} "The README.md files were re-generated, and they differed from the committed files."
+        array_push ${msg} ""
+        array_push ${msg} "If you modified the README.md file directly, then revert your changes. If the README.md"
+        array_push ${msg} "was automatically updated, then the changes need to be committed."
+        array_push ${msg} ""
+        array_push ${msg} "The modified files were:"
+        array_push ${msg} "${output.stdout}"
+        msg = array_join ${msg} "\n"
+        trigger_error ${msg}
     end
 end
 '''

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -109,7 +109,7 @@ output_length = length ${output.stdout}
 if greater_than ${output_length} 0
     if contains ${output.stdout} README.md
         msg = array "" ""
-        array_push ${msg} "A README.md file is out-of-sync with lib.rs
+        array_push ${msg} "A README.md file is out-of-sync with lib.rs"
         array_push ${msg} ""
         array_push ${msg} "If you modified a lib.rs file, please run `cargo make generate-readmes`. If you edited a"
         array_push ${msg} "README.md file directly, please also update the corresponding lib.rs."


### PR DESCRIPTION
I was somewhat confused when this failed for me locally. I updated the error message a bit to make it clearer what actions needed to be taken. Here is the output on my machine:

![image](https://user-images.githubusercontent.com/1588648/114590031-ded75180-9c4d-11eb-8467-61f6bb7f20d4.png)

The duckscript syntax is weird, as it was the only way I could do multi-line strings in any sane way.