### PR TITLE
Update tinystr to 0.4.5 for perf wins on locid and locale_canonicalizer.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,9 +2306,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee467db1c915b3bf44b0740d5f143ed0bcab3a8b96e71f40c502ead75dcf8ad4"
+checksum = "5b0bc8f45dc08e13992f1596a7cbd410e3cdcac1d165ca909ab6ae5568566cbb"
 dependencies = [
  "serde",
  "tinystr-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,9 +2306,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27aaed4540fcc2440c36fe3a98ca56450ee3da6d166da64369f40dc980aba459"
+checksum = "ee467db1c915b3bf44b0740d5f143ed0bcab3a8b96e71f40c502ead75dcf8ad4"
 dependencies = [
  "serde",
  "tinystr-macros",

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -29,7 +29,7 @@ icu_locid = { version = "0.1", path = "../locid" }
 icu_provider = { version = "0.1", path = "../provider" }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 litemap = { version = "0.1.1", path = "../../utils/litemap", features = ["serde"] }
-tinystr = { version = "0.4.4" }
+tinystr = { version = "0.4.5" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 smallvec = "1.4"
 

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -29,7 +29,7 @@ icu_locid = { version = "0.1", path = "../locid" }
 icu_provider = { version = "0.1", path = "../provider" }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 litemap = { version = "0.1.1", path = "../../utils/litemap", features = ["serde"] }
-tinystr = { version = "0.4.1" }
+tinystr = { version = "0.4.4" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 smallvec = "1.4"
 

--- a/components/locale_canonicalizer/Cargo.toml
+++ b/components/locale_canonicalizer/Cargo.toml
@@ -26,7 +26,7 @@ skip_optional_dependencies = true
 icu_locid = { version = "0.1", path = "../locid" }
 icu_provider = { version = "0.1", path = "../provider" }
 serde = { version = "1.0", features = ["derive"], optional = true }
-tinystr = { version = "0.4.1", features = ["serde"] }
+tinystr = { version = "0.4.4", features = ["serde"] }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/components/locale_canonicalizer/Cargo.toml
+++ b/components/locale_canonicalizer/Cargo.toml
@@ -26,7 +26,7 @@ skip_optional_dependencies = true
 icu_locid = { version = "0.1", path = "../locid" }
 icu_provider = { version = "0.1", path = "../provider" }
 serde = { version = "1.0", features = ["derive"], optional = true }
-tinystr = { version = "0.4.4", features = ["serde"] }
+tinystr = { version = "0.4.5", features = ["serde"] }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -27,7 +27,7 @@ skip_optional_dependencies = true
 extra_features = ["serde"]
 
 [dependencies]
-tinystr = "0.4"
+tinystr = "0.4.4"
 serde = { version = "1.0", optional = true }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -27,7 +27,7 @@ skip_optional_dependencies = true
 extra_features = ["serde"]
 
 [dependencies]
-tinystr = "0.4.4"
+tinystr = "0.4.5"
 serde = { version = "1.0", optional = true }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 

--- a/components/provider/Cargo.toml
+++ b/components/provider/Cargo.toml
@@ -29,7 +29,7 @@ provider_serde = ["serde", "erased-serde"]
 
 [dependencies]
 icu_locid = { version = "0.1", path = "../locid" }
-tinystr = "0.4.4"
+tinystr = "0.4.5"
 writeable = { version = "0.2", path = "../../utils/writeable" }
 
 # For "provider_serde" feature

--- a/components/provider/Cargo.toml
+++ b/components/provider/Cargo.toml
@@ -29,7 +29,7 @@ provider_serde = ["serde", "erased-serde"]
 
 [dependencies]
 icu_locid = { version = "0.1", path = "../locid" }
-tinystr = "0.4"
+tinystr = "0.4.4"
 writeable = { version = "0.2", path = "../../utils/writeable" }
 
 # For "provider_serde" feature

--- a/components/provider_cldr/Cargo.toml
+++ b/components/provider_cldr/Cargo.toml
@@ -44,7 +44,7 @@ serde_json = "1.0"
 serde-tuple-vec-map = "1.0"
 smallstr = { version = "0.2", features = ["serde"] }
 smallvec = "1.4"
-tinystr = { version = "0.4.3", features = ["serde"] }
+tinystr = { version = "0.4.4", features = ["serde"] }
 
 # Dependencies for the download feature
 urlencoding = { version = "1.1", optional = true }

--- a/components/provider_cldr/Cargo.toml
+++ b/components/provider_cldr/Cargo.toml
@@ -44,7 +44,7 @@ serde_json = "1.0"
 serde-tuple-vec-map = "1.0"
 smallstr = { version = "0.2", features = ["serde"] }
 smallvec = "1.4"
-tinystr = { version = "0.4.4", features = ["serde"] }
+tinystr = { version = "0.4.5", features = ["serde"] }
 
 # Dependencies for the download feature
 urlencoding = { version = "1.1", optional = true }

--- a/components/uniset/Cargo.toml
+++ b/components/uniset/Cargo.toml
@@ -28,7 +28,7 @@ skip_optional_dependencies = true
 icu_provider = { version = "0.1", path = "../provider" }
 litemap = { version = "0.1", path = "../../utils/litemap" }
 serde = { version = "1.0", features = ["derive"], optional = true }
-tinystr = "0.4"
+tinystr = "0.4.4"
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/components/uniset/Cargo.toml
+++ b/components/uniset/Cargo.toml
@@ -28,7 +28,7 @@ skip_optional_dependencies = true
 icu_provider = { version = "0.1", path = "../provider" }
 litemap = { version = "0.1", path = "../../utils/litemap" }
 serde = { version = "1.0", features = ["derive"], optional = true }
-tinystr = "0.4.4"
+tinystr = "0.4.5"
 
 [dev-dependencies]
 criterion = "0.3.3"


### PR DESCRIPTION
I bumped it for crates where it matters, and confirmed nice win on canonicalizer (27%) and some wins on locid as well (~10% in places).