### PR TITLE
Add metadata fields to icu_benchmark_macros

### DIFF
--- a/tools/benchmark/macros/Cargo.toml
+++ b/tools/benchmark/macros/Cargo.toml
@@ -7,6 +7,9 @@ name = "icu_benchmark_macros"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 version = "0.1.0"
+repository = "https://github.com/unicode-org/icu4x"
+license-file = "../../../LICENSE"
+description = "Internal ICU4X benchmarking crate"
 # Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",


### PR DESCRIPTION
This lets us publish this crate, which unblocks publishing zerovec. Unfortunately Cargo does not allow ignoring dev-dependencies for publishing.

(I'd prefer to publish utilities as we write them so that we don't lose the name if I share them in a wider context and someone decides to squat the name)