### PR TITLE
Exclude CI jobs from fork runs that are intended for upstream merges

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -351,6 +351,7 @@ jobs:
           output-file-path: ./benchmarks/memory/${{ matrix.os }}/output.ndjson
           # Show alert with commit comment on detecting possible memory regression
           alert-threshold: '200%'
+          fail-on-alert: true
           # Requires one-time-only creation of this branch on remote repo. This will
           # store the generated information.
           gh-pages-branch: unmerged-pr-bench-data

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -230,6 +230,7 @@ jobs:
           benchmark-data-dir-path: ./benchmarks/perf/${{ matrix.component }}
           # Show alert with commit comment on detecting possible performance regression
           alert-threshold: '200%'  # If for nothing else, enabling the possibility of alerts with meaningful thresholds requires this job to be done per-component
+          fail-on-alert: true
           gh-pages-branch: unmerged-pr-bench-data  # Requires one-time-only creation of this branch on remote repo.
                                                    # We could use another branch besides `gh-pages` to store this historical benchmark info.
           auto-push: false  # Do not store historical benchmark info of unfinished PRs. Commits seem to get made anyways, so make sure

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -243,7 +243,7 @@ jobs:
 
       - name: Store benchmark result & create dashboard (merge to main only)
         # only merges to main (implies PR is finished and approved by this point)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
         uses: rhysd/github-action-benchmark@v1.8.1
         with:
           name: Rust Benchmark
@@ -263,11 +263,11 @@ jobs:
       # Benchmarking & dashboards job > Upload output dashboard HTML to "persist" the files across jobs within the same workflow.
 
       - name: Switch branch to get result of benchmark pages output (merge to main only)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
         run: git checkout gh-pages
 
       - name: Upload updated benchmark data (merge to main only)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
         uses: actions/upload-artifact@v2
         with:
           path: ./benchmarks/perf/**  # use wildcard pattern to preserve dir structure of uploaded files
@@ -371,7 +371,7 @@ jobs:
 
       - name: Store benchmark result & create dashboard (merge to main only)
         # only merges to main (implies PR is finished and approved by this point)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
         # The gregtatum fork of rhysd/github-action-benchmark contains support for ndjson.
         # If the PR gets merged, this can be switched back to the main project.
         # https://github.com/rhysd/github-action-benchmark/pull/54
@@ -398,11 +398,11 @@ jobs:
       # files across jobs within the same workflow.
 
       - name: Switch branch to get result of benchmark pages output (merge to main only)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
         run: git checkout gh-pages
 
       - name: Upload updated benchmark data (merge to main only)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
         uses: actions/upload-artifact@v2
         with:
           # Use wildcard pattern to preserve dir structure of uploaded files:
@@ -420,7 +420,7 @@ jobs:
 
     ## Only create docs for merges/pushes to main (skip PRs).
     ## Multiple unfinished PRs should not clobber docs from approved code.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -230,14 +230,12 @@ jobs:
           benchmark-data-dir-path: ./benchmarks/perf/${{ matrix.component }}
           # Show alert with commit comment on detecting possible performance regression
           alert-threshold: '200%'  # If for nothing else, enabling the possibility of alerts with meaningful thresholds requires this job to be done per-component
-          fail-on-alert: true
           gh-pages-branch: unmerged-pr-bench-data  # Requires one-time-only creation of this branch on remote repo.
                                                    # We could use another branch besides `gh-pages` to store this historical benchmark info.
           auto-push: false  # Do not store historical benchmark info of unfinished PRs. Commits seem to get made anyways, so make sure
                             # that the branch in `gh-pages-branch` is different from the branch used for merges to main branch.
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
-          alert-comment-cc-users: '@sffc,@zbraniecki,@echeran'
 
       # Benchmarking & dashboards job > (PR merge to main only) Convert benchmark output into dashboard HTML in a commit of a branch of the local repo.
 
@@ -352,7 +350,6 @@ jobs:
           output-file-path: ./benchmarks/memory/${{ matrix.os }}/output.ndjson
           # Show alert with commit comment on detecting possible memory regression
           alert-threshold: '200%'
-          fail-on-alert: true
           # Requires one-time-only creation of this branch on remote repo. This will
           # store the generated information.
           gh-pages-branch: unmerged-pr-bench-data
@@ -364,7 +361,6 @@ jobs:
 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
-          alert-comment-cc-users: '@sffc,@zbraniecki,@echeran,@gregtatum'
 
       # Benchmarking & dashboards job > (PR merge to main only) Convert benchmark output
       # into dashboard HTML in a commit of a branch of the local repo.


### PR DESCRIPTION
Created a PR on my personal fork to pre-test this PR: https://github.com/echeran/icu4x/pull/23