### PR TITLE
Make docs for provider module consistent

### DIFF
--- a/components/datetime/src/provider/mod.rs
+++ b/components/datetime/src/provider/mod.rs
@@ -2,9 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-//! The `provider` module contains struct definitions for ICU4X [`DataProvider`].
+//! Data provider struct definitions for this ICU4X component.
 //!
-//! [`DataProvider`]: icu_provider::DataProvider
+//! Read more about data providers: [`icu_provider`]
 
 pub mod gregory;
 pub(crate) mod helpers;

--- a/components/decimal/src/provider.rs
+++ b/components/decimal/src/provider.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-//! Data provider struct definitions for [`icu_decimal`](crate).
+//! Data provider struct definitions for this ICU4X component.
 //!
 //! Read more about data providers: [`icu_provider`]
 

--- a/components/locale_canonicalizer/src/provider.rs
+++ b/components/locale_canonicalizer/src/provider.rs
@@ -2,6 +2,10 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+//! Data provider struct definitions for this ICU4X component.
+//!
+//! Read more about data providers: [`icu_provider`]
+
 use icu_locid::LanguageIdentifier;
 use tinystr::TinyStr4;
 

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -2,6 +2,10 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+//! Data provider struct definitions for this ICU4X component.
+//!
+//! Read more about data providers: [`icu_provider`]
+
 use std::borrow::Cow;
 
 pub mod key {

--- a/components/uniset/src/provider.rs
+++ b/components/uniset/src/provider.rs
@@ -2,6 +2,10 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+//! Data provider struct definitions for this ICU4X component.
+//!
+//! Read more about data providers: [`icu_provider`]
+
 use crate::uniset::UnicodeSet;
 use std::borrow::Cow;
 use std::convert::TryInto;


### PR DESCRIPTION
See #681

This adds basic docs for the `provider` modules in each component.