### PR TITLE
Hide Skeleton docs

### DIFF
--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -84,6 +84,7 @@ pub mod options;
 #[doc(hidden)]
 pub mod pattern;
 pub mod provider;
+#[doc(hidden)]
 pub mod skeleton;
 // TODO(#622) make the time_zone module public once TimeZoneFormat is public.
 pub(crate) mod time_zone;

--- a/components/datetime/src/provider/gregory.rs
+++ b/components/datetime/src/provider/gregory.rs
@@ -188,11 +188,11 @@ pub mod patterns {
         }
     }
 
-    /// This struct is a public wrapper around the internal [`Skeleton`] struct. This allows
+    /// This struct is a public wrapper around the internal `Skeleton` struct. This allows
     /// access to the serialization and deserialization capabilities, without exposing the
     /// internals of the skeleton machinery.
     ///
-    /// The [`Skeleton`] is an "exotic type" in the serialization process, and handles its own
+    /// The `Skeleton` is an "exotic type" in the serialization process, and handles its own
     /// custom serialization practices.
     #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
     #[cfg_attr(


### PR DESCRIPTION
In issue #681, Zibi audited our docs. Skeleton must be exposed for the Data Provider machinery, but it's not really a public API that our users should directly use (unless we decide otherwise). I _could_ make the `skeleton` mod `pub(mod)`, and only re-export the `Skeleton` and `SkeletonError` types, but I figured it would be better to not even expose them to user-facing documentation.

This would be the same way that the `pattern` module is working.