### PR TITLE
Switch to use thiserror for errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,7 @@ dependencies = [
  "rand_pcg",
  "smallvec",
  "static_assertions",
+ "thiserror",
  "writeable",
 ]
 
@@ -839,6 +840,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "thiserror",
  "tinystr",
  "writeable",
 ]
@@ -888,6 +890,7 @@ dependencies = [
  "icu_benchmark_macros",
  "serde",
  "serde_json",
+ "thiserror",
  "tinystr",
  "writeable",
 ]
@@ -925,6 +928,7 @@ dependencies = [
  "icu_testdata",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -938,6 +942,7 @@ dependencies = [
  "serde",
  "serde_json",
  "static_assertions",
+ "thiserror",
  "tinystr",
  "writeable",
 ]
@@ -967,6 +972,7 @@ dependencies = [
  "serde_json",
  "smallstr",
  "smallvec",
+ "thiserror",
  "tinystr",
  "unzip",
  "urlencoding",
@@ -991,6 +997,7 @@ dependencies = [
  "serde_json",
  "simple_logger",
  "static_assertions",
+ "thiserror",
 ]
 
 [[package]]
@@ -1001,6 +1008,7 @@ dependencies = [
  "icu_locid_macros",
  "icu_provider",
  "icu_uniset",
+ "thiserror",
  "tinystr",
 ]
 
@@ -1033,6 +1041,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_logger",
+ "thiserror",
  "walkdir",
  "writeable",
 ]
@@ -1047,6 +1056,7 @@ dependencies = [
  "icu_provider",
  "litemap",
  "serde",
+ "thiserror",
  "tinystr",
 ]
 

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -33,6 +33,7 @@ litemap = { version = "0.2", path = "../../utils/litemap", features = ["serde"] 
 tinystr = { version = "0.4.5" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 smallvec = "1.6"
+thiserror = "1.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -4,34 +4,21 @@
 
 use icu_locid::Locale;
 use std::convert::TryFrom;
-use std::fmt;
 use std::ops::{Add, Sub};
 use std::str::FromStr;
+use thiserror::Error;
 use tinystr::TinyStr8;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum DateTimeError {
-    Parse(std::num::ParseIntError),
+    #[error(transparent)]
+    Parse(#[from] std::num::ParseIntError),
+    #[error("{field} must be between 0-{max}")]
     Overflow { field: &'static str, max: usize },
+    #[error("{field} must be between {min}-0")]
     Underflow { field: &'static str, min: isize },
+    #[error("Failed to parse time-zone offset")]
     InvalidTimeZoneOffset,
-}
-
-impl fmt::Display for DateTimeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Parse(err) => write!(f, "{}", err),
-            Self::Overflow { field, max } => write!(f, "{} must be between 0-{}", field, max),
-            Self::Underflow { field, min } => write!(f, "{} must be between {}-0", field, min),
-            Self::InvalidTimeZoneOffset => write!(f, "Failed to parse time-zone offset"),
-        }
-    }
-}
-
-impl From<std::num::ParseIntError> for DateTimeError {
-    fn from(input: std::num::ParseIntError) -> Self {
-        Self::Parse(input)
-    }
 }
 
 /// Representation of a formattable calendar date. Supports dates in any calendar system that uses

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -6,39 +6,28 @@ use crate::fields::FieldSymbol;
 use crate::pattern;
 use crate::skeleton::SkeletonError;
 use icu_provider::prelude::DataError;
+use thiserror::Error;
 
 /// A list of possible error outcomes for the [`DateTimeFormat`](crate::DateTimeFormat) struct.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum DateTimeFormatError {
     /// An error originating from parsing a pattern.
-    Pattern(pattern::Error),
+    #[error(transparent)]
+    Pattern(#[from] pattern::Error),
     /// An error originating from the [`Write`](std::fmt::Write) trait.
-    Format(std::fmt::Error),
+    #[error(transparent)]
+    Format(#[from] std::fmt::Error),
     /// An error originating inside of the [`DataProvider`](icu_provider::DataProvider).
-    DataProvider(DataError),
+    #[error(transparent)]
+    DataProvider(#[from] DataError),
     /// An error originating from a missing field in datetime input.
     /// TODO: How can we return which field was missing?
+    #[error("Missing input field")]
     MissingInputField,
     /// An error originating from skeleton matching.
+    #[error(transparent)]
     Skeleton(SkeletonError),
     /// An error originating from an unsupported field in a datetime format.
+    #[error("Unsupported field: {0:?}")]
     UnsupportedField(FieldSymbol),
-}
-
-impl From<DataError> for DateTimeFormatError {
-    fn from(err: DataError) -> Self {
-        Self::DataProvider(err)
-    }
-}
-
-impl From<pattern::Error> for DateTimeFormatError {
-    fn from(err: pattern::Error) -> Self {
-        Self::Pattern(err)
-    }
-}
-
-impl From<std::fmt::Error> for DateTimeFormatError {
-    fn from(err: std::fmt::Error) -> Self {
-        Self::Format(err)
-    }
 }

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -26,7 +26,7 @@ pub enum DateTimeFormatError {
     MissingInputField,
     /// An error originating from skeleton matching.
     #[error(transparent)]
-    Skeleton(SkeletonError),
+    Skeleton(#[source] SkeletonError),
     /// An error originating from an unsupported field in a datetime format.
     #[error("Unsupported field: {0:?}")]
     UnsupportedField(FieldSymbol),

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -26,7 +26,7 @@ pub enum DateTimeFormatError {
     MissingInputField,
     /// An error originating from skeleton matching.
     #[error(transparent)]
-    Skeleton(#[source] SkeletonError),
+    Skeleton(#[from] SkeletonError),
     /// An error originating from an unsupported field in a datetime format.
     #[error("Unsupported field: {0:?}")]
     UnsupportedField(FieldSymbol),

--- a/components/datetime/src/fields/length.rs
+++ b/components/datetime/src/fields/length.rs
@@ -6,9 +6,11 @@ use std::{
     cmp::{Ord, PartialOrd},
     convert::TryFrom,
 };
+use thiserror::Error;
 
-#[derive(Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq)]
 pub enum LengthError {
+    #[error("Invalid length")]
     InvalidLength,
 }
 

--- a/components/datetime/src/fields/mod.rs
+++ b/components/datetime/src/fields/mod.rs
@@ -7,26 +7,17 @@ pub(crate) mod symbols;
 
 pub use length::{FieldLength, LengthError};
 pub use symbols::*;
+use thiserror::Error;
 
 use std::{
     cmp::{Ord, PartialOrd},
     convert::{TryFrom, TryInto},
-    fmt,
 };
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
+    #[error("Field {0:?} is not a valid length")]
     InvalidLength(FieldSymbol),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::InvalidLength(symbol) => {
-                write!(f, "field {:?} is is not a valid length", symbol)
-            }
-        }
-    }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -4,12 +4,15 @@
 
 use crate::fields::FieldLength;
 use std::{cmp::Ordering, convert::TryFrom};
+use thiserror::Error;
 
-#[derive(Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq)]
 pub enum SymbolError {
     /// Unknown field symbol.
+    #[error("Unknown field symbol: {0}")]
     Unknown(u8),
     /// Invalid character for a field symbol.
+    #[error("Invalid character for a field symbol: {0}")]
     Invalid(char),
 }
 

--- a/components/datetime/src/pattern/error.rs
+++ b/components/datetime/src/pattern/error.rs
@@ -3,32 +3,23 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::fields;
-use std::fmt;
-
-#[derive(Debug, PartialEq)]
-pub enum Error {
-    FieldLengthInvalid(fields::FieldSymbol),
-    UnknownSubstitution(char),
-    UnclosedLiteral,
-    UnclosedPlaceholder,
-}
+use thiserror::Error;
 
 /// These strings follow the recommendations for the serde::de::Unexpected::Other type.
 /// https://docs.serde.rs/serde/de/enum.Unexpected.html#variant.Other
 ///
 /// Serde will generate an error such as:
 /// "invalid value: unclosed literal in pattern, expected a valid UTS 35 pattern string at line 1 column 12"
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::FieldLengthInvalid(symbol) => {
-                write!(f, "{:?} invalid field length in pattern", symbol)
-            }
-            Self::UnknownSubstitution(ch) => write!(f, "unknown substitution {} in pattern", ch),
-            Self::UnclosedLiteral => write!(f, "unclosed literal in pattern"),
-            Self::UnclosedPlaceholder => write!(f, "unclosed placeholder in pattern"),
-        }
-    }
+#[derive(Error, Debug, PartialEq)]
+pub enum Error {
+    #[error("{0:?} invalid field length in pattern")]
+    FieldLengthInvalid(fields::FieldSymbol),
+    #[error("unknown substitution {0} in pattern")]
+    UnknownSubstitution(char),
+    #[error("unclosed literal in pattern")]
+    UnclosedLiteral,
+    #[error("unclosed placeholder in pattern")]
+    UnclosedPlaceholder,
 }
 
 impl From<fields::Error> for Error {

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -31,6 +31,7 @@ extra_features = ["serde"]
 tinystr = "0.4.5"
 serde = { version = "1.0", optional = true }
 writeable = { version = "0.2", path = "../../utils/writeable" }
+thiserror = "1.0"
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/components/locid/src/parser/errors.rs
+++ b/components/locid/src/parser/errors.rs
@@ -2,13 +2,12 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use std::error::Error;
-use std::fmt::{self, Display};
+use thiserror::Error;
 
 /// List of parser errors that can be generated
 /// while parsing [`LanguageIdentifier`](crate::LanguageIdentifier), [`Locale`](crate::Locale),
 /// [`subtags`](crate::subtags) or [`extensions`](crate::extensions).
-#[derive(Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq)]
 pub enum ParserError {
     /// Invalid language subtag.
     ///
@@ -22,6 +21,7 @@ pub enum ParserError {
     ///
     /// assert_eq!(Language::from_str("x2"), Err(ParserError::InvalidLanguage));
     /// ```
+    #[error("The given language subtag is invalid")]
     InvalidLanguage,
 
     /// Invalid script, region or variant subtag.
@@ -36,6 +36,7 @@ pub enum ParserError {
     ///
     /// assert_eq!(Region::from_str("#@2X"), Err(ParserError::InvalidSubtag));
     /// ```
+    #[error("Invalid subtag")]
     InvalidSubtag,
 
     /// Invalid extension subtag.
@@ -50,18 +51,6 @@ pub enum ParserError {
     ///
     /// assert_eq!(Key::from_str("#@2X"), Err(ParserError::InvalidExtension));
     /// ```
+    #[error("Invalid extension")]
     InvalidExtension,
-}
-
-impl Error for ParserError {}
-
-impl Display for ParserError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let value = match self {
-            Self::InvalidLanguage => "The given language subtag is invalid",
-            Self::InvalidSubtag => "Invalid subtag",
-            Self::InvalidExtension => "Invalid extension",
-        };
-        f.write_str(value)
-    }
 }

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -30,6 +30,7 @@ fixed_decimal = { version = "0.2", path = "../../utils/fixed_decimal" }
 icu_provider = { version = "0.2", path = "../provider" }
 icu_locid = { version = "0.2", path = "../locid" }
 serde = { version = "1.0", features = ["derive"], optional = true }
+thiserror = "1.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/components/plurals/src/error.rs
+++ b/components/plurals/src/error.rs
@@ -4,43 +4,15 @@
 
 use crate::rules::parser::ParserError;
 use icu_provider::prelude::DataError;
-use std::fmt;
+use thiserror::Error;
 
 /// A list of possible error outcomes for the [`PluralRules`](crate::PluralRules) struct.
 ///
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum PluralRulesError {
-    Parser(ParserError),
+    #[error("Parser error: {0}")]
+    Parser(#[from] ParserError),
     /// An error originating inside of the [`DataProvider`](icu_provider::DataProvider)
-    DataProvider(DataError),
-}
-
-impl From<DataError> for PluralRulesError {
-    fn from(err: DataError) -> Self {
-        Self::DataProvider(err)
-    }
-}
-
-impl From<ParserError> for PluralRulesError {
-    fn from(err: ParserError) -> Self {
-        Self::Parser(err)
-    }
-}
-
-impl fmt::Display for PluralRulesError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Parser(error) => write!(f, "Parser error: {}", error),
-            Self::DataProvider(error) => write!(f, "Data provider error: {}", error),
-        }
-    }
-}
-
-impl std::error::Error for PluralRulesError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Parser(error) => Some(error),
-            Self::DataProvider(error) => Some(error),
-        }
-    }
+    #[error("Data provider error: {0}")]
+    DataProvider(#[from] DataError),
 }

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -8,6 +8,7 @@ use std::io::Error as IOError;
 use std::isize;
 use std::num::ParseIntError;
 use std::str::FromStr;
+use thiserror::Error;
 
 /// A full plural operands representation of a number. See [CLDR Plural Rules](http://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules) for complete operands description.
 /// Plural operands in compliance with [CLDR Plural Rules](http://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules).
@@ -85,11 +86,13 @@ impl PluralOperands {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum OperandsError {
     /// Input to the Operands parsing was empty.
+    #[error("Input to the Operands parsing was empty")]
     Empty,
     /// Input to the Operands parsing was invalid.
+    #[error("Input to the Operands parsing was invalid")]
     Invalid,
 }
 

--- a/components/plurals/src/rules/lexer.rs
+++ b/components/plurals/src/rules/lexer.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use super::ast;
+use thiserror::Error;
 
 #[derive(Debug, PartialEq)]
 pub enum Token {
@@ -25,9 +26,11 @@ pub enum Token {
     E,
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum LexerError {
+    #[error("Expected byte: {0}")]
     ExpectedByte(u8),
+    #[error("Unknown token: {0}")]
     UnknownToken(u8),
 }
 

--- a/components/plurals/src/rules/parser.rs
+++ b/components/plurals/src/rules/parser.rs
@@ -4,33 +4,23 @@
 
 use super::ast;
 use super::lexer::{Lexer, Token};
-use std::fmt;
 use std::iter::Peekable;
+use thiserror::Error;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum ParserError {
+    #[error("expected 'AND' condition")]
     ExpectedAndCondition,
+    #[error("expected relation")]
     ExpectedRelation,
+    #[error("expected operator")]
     ExpectedOperator,
+    #[error("expected operand")]
     ExpectedOperand,
+    #[error("expected value")]
     ExpectedValue,
+    #[error("expected sample type")]
     ExpectedSampleType,
-}
-
-impl std::error::Error for ParserError {}
-
-impl fmt::Display for ParserError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use ParserError::*;
-        match self {
-            ExpectedAndCondition => write!(f, "expected 'AND' condition"),
-            ExpectedRelation => write!(f, "expected relation"),
-            ExpectedOperator => write!(f, "expected operator"),
-            ExpectedOperand => write!(f, "expected operand"),
-            ExpectedValue => write!(f, "expected value"),
-            ExpectedSampleType => write!(f, "expected sample type"),
-        }
-    }
 }
 
 /// Unicode Plural Rule parser converts an

--- a/components/provider/Cargo.toml
+++ b/components/provider/Cargo.toml
@@ -32,6 +32,7 @@ provider_serde = ["serde", "erased-serde"]
 icu_locid = { version = "0.2", path = "../locid" }
 tinystr = "0.4.5"
 writeable = { version = "0.2", path = "../../utils/writeable" }
+thiserror = "1.0"
 
 # For "provider_serde" feature
 erased-serde = { version = "0.3", optional = true }

--- a/components/provider/src/error.rs
+++ b/components/provider/src/error.rs
@@ -3,34 +3,40 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::prelude::*;
-use core::ops::Deref;
 use std::any::TypeId;
-use std::fmt;
+use thiserror::Error;
 
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
     /// The data provider does not support the requested category.
+    #[error("Unsupported category: {0}")]
     UnsupportedCategory(ResourceCategory),
 
     /// The data provider supports the category, but not the key (sub-category or version).
+    #[error("Unsupported resource key: {0}")]
     UnsupportedResourceKey(ResourceKey),
 
     /// The data provider supports the key, but does not have data for the specific entry.
+    #[error("Unavailable resource options: {0}")]
     UnavailableResourceOptions(DataRequest),
 
     /// The data provider supports the key, but it requires a language identifier, which was
     /// missing from the request.
+    #[error("Requested key needs language identifier in request: {0}")]
     NeedsLanguageIdentifier(DataRequest),
 
     /// The operation cannot be completed without more type information. For example, data
     /// cannot be deserialized without the concrete type.
+    #[error("Complete type information is required")]
     NeedsTypeInfo,
 
     /// The payload is missing. This error is usually unexpected.
+    #[error("Payload is missing")]
     MissingPayload,
 
     /// The TypeID of the payload does not match the expected TypeID.
+    #[error("Mismatched type: payload is {actual:?} (expected from generic type paramenter: {generic:?})")]
     MismatchedType {
         /// The actual TypeID of the payload, if available.
         actual: Option<TypeId>,
@@ -41,10 +47,21 @@ pub enum Error {
 
     /// An error occured during serialization or deserialization.
     #[cfg(feature = "erased-serde")]
-    Serde(erased_serde::Error),
+    #[error("Serde error: {0}")]
+    Serde(#[from] erased_serde::Error),
 
     /// The data provider encountered some other error when loading the resource, such as I/O.
-    Resource(Box<dyn std::error::Error>),
+    #[error("Failed to load resource: {0}")]
+    Resource(#[from] Box<dyn std::error::Error>),
+}
+
+impl Error {
+    pub fn new_resc_error<T>(err: T) -> Self
+    where
+        T: 'static + std::error::Error,
+    {
+        Self::Resource(Box::new(err))
+    }
 }
 
 impl From<&ResourceKey> for Error {
@@ -62,67 +79,5 @@ impl From<&ResourceCategory> for Error {
 impl From<DataRequest> for Error {
     fn from(req: DataRequest) -> Self {
         Self::UnavailableResourceOptions(req)
-    }
-}
-
-#[cfg(feature = "erased-serde")]
-impl From<erased_serde::Error> for Error {
-    fn from(err: erased_serde::Error) -> Self {
-        Self::Serde(err)
-    }
-}
-
-impl From<Box<dyn std::error::Error>> for Error {
-    fn from(err: Box<dyn std::error::Error>) -> Self {
-        Self::Resource(err)
-    }
-}
-
-impl Error {
-    pub fn new_resc_error<T>(err: T) -> Self
-    where
-        T: 'static + std::error::Error,
-    {
-        Self::Resource(Box::new(err))
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::UnsupportedCategory(category) => write!(f, "Unsupported category: {}", category),
-            Self::UnsupportedResourceKey(resc_key) => {
-                write!(f, "Unsupported resource key: {}", resc_key)
-            }
-            Self::UnavailableResourceOptions(request) => {
-                write!(f, "Unavailable resource options: {}", request)
-            }
-            Self::NeedsLanguageIdentifier(request) => write!(
-                f,
-                "Requested key needs language identifier in request: {}",
-                request
-            ),
-            Self::NeedsTypeInfo => write!(f, "Complete type information is required"),
-            Self::MissingPayload => write!(f, "Payload is missing"),
-            Self::MismatchedType { actual, generic } => {
-                write!(f, "Mismatched type: payload is {:?}", actual)?;
-                if let Some(type_id) = generic {
-                    write!(f, " (expected from generic type parameter: {:?})", type_id)?;
-                }
-                Ok(())
-            }
-            #[cfg(feature = "erased-serde")]
-            Self::Serde(err) => write!(f, "Serde error: {}", err),
-            Self::Resource(err) => write!(f, "Failed to load resource: {}", err),
-        }
-    }
-}
-
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Resource(error) => Some(error.deref()),
-            _ => None,
-        }
     }
 }

--- a/components/provider_cldr/Cargo.toml
+++ b/components/provider_cldr/Cargo.toml
@@ -46,6 +46,7 @@ serde-tuple-vec-map = "1.0"
 smallstr = { version = "0.2", features = ["serde"] }
 smallvec = "1.6"
 tinystr = { version = "0.4.5", features = ["serde"] }
+thiserror = "1.0"
 
 # Dependencies for the download feature
 urlencoding = { version = "1.1", optional = true }

--- a/components/provider_cldr/src/download/error.rs
+++ b/components/provider_cldr/src/download/error.rs
@@ -2,16 +2,19 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use std::error;
-use std::fmt;
 use std::io;
 use std::path::{Path, PathBuf};
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
-    Io(io::Error, Option<PathBuf>),
-    Reqwest(reqwest::Error),
+    #[error("{0}: {1:?}")]
+    Io(#[source] io::Error, Option<PathBuf>),
+    #[error(transparent)]
+    Reqwest(#[from] reqwest::Error),
+    #[error("HTTP request failed: {0}: {1}")]
     HttpStatus(reqwest::StatusCode, String),
+    #[error("dirs::cache_dir() returned None")]
     NoCacheDir,
 }
 
@@ -20,33 +23,5 @@ pub enum Error {
 impl<P: AsRef<Path>> From<(std::io::Error, P)> for Error {
     fn from(pieces: (std::io::Error, P)) -> Self {
         Self::Io(pieces.0, Some(pieces.1.as_ref().to_path_buf()))
-    }
-}
-
-impl From<reqwest::Error> for Error {
-    fn from(err: reqwest::Error) -> Self {
-        Self::Reqwest(err)
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Io(err, Some(path)) => write!(f, "{}: {:?}", err, path),
-            Self::Io(err, None) => err.fmt(f),
-            Self::Reqwest(err) => err.fmt(f),
-            Self::HttpStatus(status, url) => write!(f, "HTTP request failed: {}: {}", status, url),
-            Self::NoCacheDir => write!(f, "dirs::cache_dir() returned None"),
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Io(err, _) => Some(err),
-            Self::Reqwest(err) => Some(err),
-            _ => None,
-        }
     }
 }

--- a/components/provider_cldr/src/transform/numbers/decimal_pattern.rs
+++ b/components/provider_cldr/src/transform/numbers/decimal_pattern.rs
@@ -10,20 +10,14 @@ use std::str::FromStr;
 type SmallString8 = smallstr::SmallString<[u8; 8]>;
 use icu_decimal::provider::AffixesV1;
 use itertools::Itertools;
+use thiserror::Error;
 
-#[derive(Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq)]
 pub enum Error {
+    #[error("No body in decimal subpattern")]
     NoBodyInSubpattern,
+    #[error("Unknown decimal body: {0}")]
     UnknownPatternBody(String),
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Self::NoBodyInSubpattern => write!(f, "No body in decimal subpattern"),
-            Self::UnknownPatternBody(s) => write!(f, "Unknown decimal body: {}", s),
-        }
-    }
 }
 
 /// Representation of a UTS-35 number subpattern (part of a number pattern between ';'s).

--- a/components/provider_fs/Cargo.toml
+++ b/components/provider_fs/Cargo.toml
@@ -34,6 +34,7 @@ icu_provider = { version = "0.2", path = "../provider", features = ["provider_se
 icu_locid = { version = "0.2", path = "../locid", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 erased-serde = { version = "0.3" }
+thiserror = "1.0"
 
 # Serializers
 # Note: serde_json is always included because it is used for parsing manifest.json

--- a/components/provider_fs/src/deserializer.rs
+++ b/components/provider_fs/src/deserializer.rs
@@ -7,34 +7,21 @@ use icu_provider::prelude::*;
 use icu_provider::serde::SerdeDeDataReceiver;
 use std::io::Read;
 use std::path::Path;
+use thiserror::Error;
 
 /// An Error type specifically for the [`Deserializer`](serde::Deserializer) that doesn't carry filenames
+#[derive(Error, Debug)]
 pub enum Error {
-    Json(serde_json::error::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::error::Error),
     #[cfg(feature = "bincode")]
-    Bincode(bincode::Error),
-    DataProvider(DataError),
+    #[error(transparent)]
+    Bincode(#[from] bincode::Error),
+    #[error(transparent)]
+    DataProvider(#[from] DataError),
     #[allow(dead_code)]
+    #[error("Unknown syntax: {0:?}")]
     UnknownSyntax(SyntaxOption),
-}
-
-impl From<serde_json::Error> for Error {
-    fn from(err: serde_json::Error) -> Self {
-        Self::Json(err)
-    }
-}
-
-#[cfg(feature = "bincode")]
-impl From<bincode::Error> for Error {
-    fn from(err: bincode::Error) -> Self {
-        Self::Bincode(err)
-    }
-}
-
-impl From<DataError> for Error {
-    fn from(err: DataError) -> Self {
-        Self::DataProvider(err)
-    }
 }
 
 impl Error {

--- a/components/provider_fs/src/error.rs
+++ b/components/provider_fs/src/error.rs
@@ -3,16 +3,21 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::manifest::SyntaxOption;
-use std::fmt;
 use std::path::{Path, PathBuf};
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
-    Io(std::io::Error, Option<PathBuf>),
-    DataProvider(icu_provider::DataError),
-    Deserializer(Box<dyn std::error::Error>, Option<PathBuf>),
+    #[error("{0}: {1:?}")]
+    Io(#[source] std::io::Error, Option<PathBuf>),
+    #[error(transparent)]
+    DataProvider(#[from] icu_provider::DataError),
+    #[error("Deserializer error: {0}: {1:?}")]
+    Deserializer(#[source] Box<dyn std::error::Error>, Option<PathBuf>),
     #[cfg(feature = "export")]
-    Serializer(erased_serde::Error, Option<PathBuf>),
+    #[error("Serializer error: {0}: {1:?}")]
+    Serializer(#[source] erased_serde::Error, Option<PathBuf>),
+    #[error("Unknown syntax {0:?}. Do you need to enable a feature?")]
     UnknownSyntax(SyntaxOption),
 }
 
@@ -29,12 +34,6 @@ impl<P: AsRef<Path>> From<(std::io::Error, P)> for Error {
 impl<P: AsRef<Path>> From<(serde_json::error::Error, P)> for Error {
     fn from(pieces: (serde_json::error::Error, P)) -> Self {
         Self::Deserializer(Box::new(pieces.0), Some(pieces.1.as_ref().to_path_buf()))
-    }
-}
-
-impl From<icu_provider::DataError> for Error {
-    fn from(err: icu_provider::DataError) -> Self {
-        Self::DataProvider(err)
     }
 }
 
@@ -58,44 +57,6 @@ impl Error {
         match err {
             Error::Io(err) => Self::Io(err, None),
             Error::Serializer(err) => Self::Serializer(err, None),
-        }
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Io(err, Some(path)) => write!(f, "{}: {:?}", err, path),
-            Self::Io(err, None) => err.fmt(f),
-            Self::DataProvider(err) => err.fmt(f),
-            Self::Deserializer(err, Some(filename)) => {
-                write!(f, "Deserializer error: {}: {:?}", err, filename)
-            }
-            Self::Deserializer(err, None) => write!(f, "Deserializer error: {}", err),
-            #[cfg(feature = "export")]
-            Self::Serializer(err, Some(filename)) => {
-                write!(f, "Serializer error: {}: {:?}", err, filename)
-            }
-            #[cfg(feature = "export")]
-            Self::Serializer(err, None) => write!(f, "Serializer error: {}", err),
-            Self::UnknownSyntax(syntax_option) => write!(
-                f,
-                "Unknown syntax {:?}. Do you need to enable a feature?",
-                syntax_option
-            ),
-        }
-    }
-}
-
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Io(err, _) => Some(err),
-            Self::DataProvider(err) => Some(err),
-            Self::Deserializer(err, _) => Some(err.as_ref()),
-            #[cfg(feature = "export")]
-            Self::Serializer(err, _) => Some(err),
-            _ => None,
         }
     }
 }

--- a/components/provider_fs/src/export/serializers/mod.rs
+++ b/components/provider_fs/src/export/serializers/mod.rs
@@ -10,23 +10,15 @@ pub mod bincode;
 use crate::manifest::SyntaxOption;
 use std::io;
 use std::ops::Deref;
+use thiserror::Error;
 
 /// An Error type specifically for the [`Serializer`](serde::Serializer) that doesn't carry filenames
+#[derive(Error, Debug)]
 pub enum Error {
-    Io(io::Error),
-    Serializer(erased_serde::Error),
-}
-
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Self {
-        Self::Io(err)
-    }
-}
-
-impl From<erased_serde::Error> for Error {
-    fn from(err: erased_serde::Error) -> Self {
-        Self::Serializer(err)
-    }
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    Serializer(#[from] erased_serde::Error),
 }
 
 /// A simple serializer trait that works on whole objects.

--- a/components/uniset/Cargo.toml
+++ b/components/uniset/Cargo.toml
@@ -30,6 +30,7 @@ icu_provider = { version = "0.2", path = "../provider" }
 litemap = { version = "0.2", path = "../../utils/litemap" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 tinystr = "0.4.5"
+thiserror = "1.0"
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/components/uniset/src/lib.rs
+++ b/components/uniset/src/lib.rs
@@ -61,28 +61,19 @@ mod utils;
 pub use builder::UnicodeSetBuilder;
 pub use conversions::*;
 use icu_provider::DataError;
-pub use std::fmt;
+use thiserror::Error;
 pub use uniset::UnicodeSet;
 pub use utils::*;
 
 /// Custom Errors for [`UnicodeSet`].
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum UnicodeSetError {
+    #[error("Invalid set: {0:?}")]
     InvalidSet(Vec<u32>),
+    #[error("Invalid range: {0}..{1}")]
     InvalidRange(u32, u32),
-    PropDataLoad(DataError),
-}
-
-impl fmt::Display for UnicodeSetError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-impl From<DataError> for UnicodeSetError {
-    fn from(err: DataError) -> Self {
-        Self::PropDataLoad(err)
-    }
+    #[error(transparent)]
+    PropDataLoad(#[from] DataError),
 }
 
 #[derive(PartialEq)]

--- a/experimental/provider_ppucd/Cargo.toml
+++ b/experimental/provider_ppucd/Cargo.toml
@@ -30,3 +30,4 @@ icu_provider = { version = "0.2", path = "../../components/provider", features =
 icu_locid_macros = { version = "0.2", path = "../../components/locid/macros" }
 icu_uniset = { version = "0.2", path = "../../components/uniset" }
 tinystr = "0.4"
+thiserror = "1.0"

--- a/experimental/provider_ppucd/src/error.rs
+++ b/experimental/provider_ppucd/src/error.rs
@@ -2,34 +2,16 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use std::fmt;
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
-    PpucdParse(PpucdParseError),
+    #[error(transparent)]
+    PpucdParse(#[from] PpucdParseError),
 }
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Error, Debug, PartialEq, Copy, Clone)]
+#[error("Could not parse PPUCD file: {src}")]
 pub struct PpucdParseError {
     pub src: &'static str,
-}
-
-impl From<PpucdParseError> for Error {
-    fn from(err: PpucdParseError) -> Self {
-        Self::PpucdParse(err)
-    }
-}
-
-impl fmt::Display for PpucdParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Could not parse PPUCD file: {}", self.src)
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::PpucdParse(err) => err.fmt(f),
-        }
-    }
 }

--- a/resources/testdata/Cargo.toml
+++ b/resources/testdata/Cargo.toml
@@ -143,6 +143,7 @@ globwalk = { version = "0.8", optional = true }
 walkdir = { version = "2", optional = true }
 itertools = { version = "0.10", optional = true }
 writeable = { version = "0.2", path = "../../utils/writeable", optional = true }
+thiserror = "1.0"
 
 [dev-dependencies]
 icu_locid_macros = { version = "0.2", path = "../../components/locid/macros" }

--- a/resources/testdata/src/metadata.rs
+++ b/resources/testdata/src/metadata.rs
@@ -6,42 +6,18 @@ use camino::Utf8PathBuf;
 use cargo_metadata::{self, MetadataCommand};
 use icu_locid::LanguageIdentifier;
 use serde::Deserialize;
-use std::fmt;
+use thiserror::Error;
 
+#[derive(Error, Debug)]
 pub enum Error {
-    Cargo(cargo_metadata::Error),
-    SerdeJson(serde_json::Error),
+    #[error("Cargo Error: {0}")]
+    Cargo(#[from] cargo_metadata::Error),
+    #[error("Serde Error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("{0}: package not found", env!("CARGO_PKG_NAME"))]
     PackageNotFound,
+    #[error("package.metadata.icu4x_testdata not found")]
     MetadataNotFound,
-}
-
-impl From<cargo_metadata::Error> for Error {
-    fn from(err: cargo_metadata::Error) -> Error {
-        Error::Cargo(err)
-    }
-}
-
-impl From<serde_json::Error> for Error {
-    fn from(err: serde_json::Error) -> Error {
-        Error::SerdeJson(err)
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Error::Cargo(error) => write!(f, "Cargo Error: {}", error),
-            Error::SerdeJson(error) => write!(f, "Serde Error: {}", error),
-            Error::PackageNotFound => write!(f, "{}: package not found", env!("CARGO_PKG_NAME")),
-            Error::MetadataNotFound => write!(f, "package.metadata.icu4x_testdata not found"),
-        }
-    }
-}
-
-impl fmt::Debug for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        (self as &dyn fmt::Display).fmt(f)
-    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -26,6 +26,7 @@ include = [
 smallvec = "1.6"
 static_assertions = "1.1"
 writeable = { version = "0.2", path = "../../utils/writeable" }
+thiserror = "1.0"
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/utils/fixed_decimal/src/lib.rs
+++ b/utils/fixed_decimal/src/lib.rs
@@ -44,8 +44,9 @@ mod uint_iterator;
 
 pub use decimal::FixedDecimal;
 pub use signum::Signum;
+use thiserror::Error;
 
-#[derive(Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq)]
 pub enum Error {
     /// The magnitude or number of digits exceeds the limit of the FixedDecimal. The highest
     /// magnitude of the most significant digit is std::i16::MAX, and the lowest magnitude of the
@@ -60,6 +61,7 @@ pub enum Error {
     /// let mut dec1 = FixedDecimal::from(123);
     /// assert_eq!(Error::Limit, dec1.multiply_pow10(std::i16::MAX).unwrap_err());
     /// ```
+    #[error("Magnitude or number of digits exceeded")]
     Limit,
     /// The input of a string that is supposed to be converted to FixedDecimal is not accepted.
     ///
@@ -68,5 +70,6 @@ pub enum Error {
     /// Strings of form "12_345_678" are not accepted, the accepted format is "12345678".
     /// Also '.' shouldn't be first or the last characters, i. e. .123 and 123. are not accepted, and instead 0.123 and
     /// 123 (or 123.0) must be used.
+    #[error("Failed to parse the input string")]
     Syntax,
 }


### PR DESCRIPTION
Fixes #298.

This moves vast majority of our tests to use `thiserror`.

I skipped `zerovec` since its generic errors are particularly complicated to handle via Display/Debug and I believe that it deserves a separate PR (maybe together with `cargo clippy`)

I also quite arbitrarily populated error values for errors that did not have display, and retained inconsistent capitalization (some errors start with capital letter, others don't).

Finally, `thiserror` does not have a good answer to conditional display like:

```rust
fn fmt() -> {
    match self {
          SomeError(err, None) => write!(f, "This is an error: {}", err),
          SomeError(err, Some(ctx)) => write!(f, "This is an error: {} (ctx: {})", err, ctx), 
    }
}
```

I had a choice to keep those errors with custom display (and forgo `thiserror`), or plaster the conditional part unconditionally. I chose the latter, and my hope is that as people work with those errors down the road they'll fine tune the errors as they see fit in context.