### PR TITLE
Quick fix for permissions issue

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -20,41 +20,21 @@ jobs:
     - uses: actions/checkout@v2
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
-    - name: "⭐⭐⭐ Check Credentials ⭐⭐⭐"
-      env:
-        HAS_KEY: ${{ secrets.ICU4X_GCP_SA_KEY }}
-      if: env.HAS_KEY == null
-      run: |
-        echo "::group::🔒 Credentials Not Found"
-        echo "If you are a regular contributor, please request the key so that you can view docs previews in PRs."
-        echo "::endgroup::"
     - name: Authenticate to Google Cloud
-      env:
-        HAS_KEY: ${{ secrets.ICU4X_GCP_SA_KEY }}
-      if: env.HAS_KEY != null
       uses: google-github-actions/setup-gcloud@v0.2
       with:
         project_id: ${{ env.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.ICU4X_GCP_SA_KEY }}
         export_default_credentials: true
     - name: Build docs
-      env:
-        HAS_KEY: ${{ secrets.ICU4X_GCP_SA_KEY }}
-      if: env.HAS_KEY != null
       uses: actions-rs/cargo@v1
       with:
         command: doc
         args: --workspace --release --all-features --no-deps
     - name: Upload docs to Google Cloud Storage
-      env:
-        HAS_KEY: ${{ secrets.ICU4X_GCP_SA_KEY }}
-      if: env.HAS_KEY != null
       run: |
         gsutil -m cp -r target/doc gs://${{ env.GCP_BUCKET_ID }}/gha/${{ github.run_number }}/docs
     - name: "⭐⭐⭐ Links to Uploaded Artifacts ⭐⭐⭐"
-      env:
-        HAS_KEY: ${{ secrets.ICU4X_GCP_SA_KEY }}
-      if: env.HAS_KEY != null
       run: |
         echo "::group::📖 Docs Preview"
         echo "http://${{ env.GCP_BUCKET_ID }}.storage.googleapis.com/gha/${{ github.run_number }}/docs/icu/index.html"

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -16,9 +16,6 @@ jobs:
       GCP_PROJECT_ID: "dev-infra-273822"
       GCP_BUCKET_ID: "icu4x-pr-artifacts"
     steps:
-    - uses: actions/checkout@v2
-    - name: Load the default Rust toolchain via the rust-toolchain file.
-      run: rustup show
     - name: "⭐⭐⭐ Check Credentials ⭐⭐⭐"
       env:
         HAS_KEY: ${{ secrets.ICU4X_GCP_SA_KEY }}
@@ -27,6 +24,15 @@ jobs:
         echo "::group::🔒 Credentials Not Found"
         echo "If you are a regular contributor, please request the key so that you can view docs previews in PRs."
         echo "::endgroup::"
+    - uses: actions/checkout@v2
+      env:
+        HAS_KEY: ${{ secrets.ICU4X_GCP_SA_KEY }}
+      if: env.HAS_KEY != null
+    - name: Load the default Rust toolchain via the rust-toolchain file.
+      env:
+        HAS_KEY: ${{ secrets.ICU4X_GCP_SA_KEY }}
+      if: env.HAS_KEY != null
+      run: rustup show
     - name: Authenticate to Google Cloud
       env:
         HAS_KEY: ${{ secrets.ICU4X_GCP_SA_KEY }}

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       GCP_PROJECT_ID: "dev-infra-273822"
       GCP_BUCKET_ID: "icu4x-pr-artifacts"
+    # To generate docs previews, you must add the GCP key to your fork. If you are a regular contributor, please ask icu4x-core@unicode.org for the key.
     if: secrets.ICU4X_GCP_SA_KEY != null
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -17,6 +17,9 @@ jobs:
       GCP_BUCKET_ID: "icu4x-pr-artifacts"
     if: secrets.ICU4X_GCP_SA_KEY != null
     steps:
+    - uses: actions/checkout@v2
+    - name: Load the default Rust toolchain via the rust-toolchain file.
+      run: rustup show
     - name: "⭐⭐⭐ Check Credentials ⭐⭐⭐"
       env:
         HAS_KEY: ${{ secrets.ICU4X_GCP_SA_KEY }}
@@ -25,15 +28,6 @@ jobs:
         echo "::group::🔒 Credentials Not Found"
         echo "If you are a regular contributor, please request the key so that you can view docs previews in PRs."
         echo "::endgroup::"
-    - uses: actions/checkout@v2
-      env:
-        HAS_KEY: ${{ secrets.ICU4X_GCP_SA_KEY }}
-      if: env.HAS_KEY != null
-    - name: Load the default Rust toolchain via the rust-toolchain file.
-      env:
-        HAS_KEY: ${{ secrets.ICU4X_GCP_SA_KEY }}
-      if: env.HAS_KEY != null
-      run: rustup show
     - name: Authenticate to Google Cloud
       env:
         HAS_KEY: ${{ secrets.ICU4X_GCP_SA_KEY }}

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       GCP_PROJECT_ID: "dev-infra-273822"
       GCP_BUCKET_ID: "icu4x-pr-artifacts"
+    if: secrets.ICU4X_GCP_SA_KEY != null
     steps:
     - name: "⭐⭐⭐ Check Credentials ⭐⭐⭐"
       env:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -19,21 +19,41 @@ jobs:
     - uses: actions/checkout@v2
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
+    - name: "⭐⭐⭐ Check Credentials ⭐⭐⭐"
+      env:
+        HAS_KEY: ${{ secrets.ICU4X_GCP_SA_KEY }}
+      if: env.HAS_KEY == null
+      run: |
+        echo "::group::🔒 Credentials Not Found"
+        echo "If you are a regular contributor, please request the key so that you can view docs previews in PRs."
+        echo "::endgroup::"
     - name: Authenticate to Google Cloud
+      env:
+        HAS_KEY: ${{ secrets.ICU4X_GCP_SA_KEY }}
+      if: env.HAS_KEY != null
       uses: google-github-actions/setup-gcloud@v0.2
       with:
         project_id: ${{ env.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.ICU4X_GCP_SA_KEY }}
         export_default_credentials: true
     - name: Build docs
+      env:
+        HAS_KEY: ${{ secrets.ICU4X_GCP_SA_KEY }}
+      if: env.HAS_KEY != null
       uses: actions-rs/cargo@v1
       with:
         command: doc
         args: --workspace --release --all-features --no-deps
     - name: Upload docs to Google Cloud Storage
+      env:
+        HAS_KEY: ${{ secrets.ICU4X_GCP_SA_KEY }}
+      if: env.HAS_KEY != null
       run: |
         gsutil -m cp -r target/doc gs://${{ env.GCP_BUCKET_ID }}/gha/${{ github.run_number }}/docs
     - name: "⭐⭐⭐ Links to Uploaded Artifacts ⭐⭐⭐"
+      env:
+        HAS_KEY: ${{ secrets.ICU4X_GCP_SA_KEY }}
+      if: env.HAS_KEY != null
       run: |
         echo "::group::📖 Docs Preview"
         echo "http://${{ env.GCP_BUCKET_ID }}.storage.googleapis.com/gha/${{ github.run_number }}/docs/icu/index.html"


### PR DESCRIPTION
For now, check that the key is present before running the job.  I think contributors can add the key to their own fork's secrets to enable the behavior.  If this sounds okay, I can share the secret with the team.