### PR TITLE
Build docs previews in forks with valid key

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -5,8 +5,23 @@
 ##### README #####
 #
 # The CI action in this file is used to build the artifacts on pushes to a repository containing
-# the ICU4X service account key. All steps are skipped unless the key is present. If you are a
-# frequent contributor, you may request the key from icu4x-core@unicode.org.
+# the ICU4X service account key. All steps are skipped unless the key is present.
+#
+# If you are a frequent contributor, you can add the key to your fork. The key is shared with
+# icu4x collaborators and can be viewed here:
+#
+# https://drive.google.com/file/d/17-oMqRfuHOHL9hYp64NYOh8vcJ03DQHm/view
+#
+# To add the key, follow these steps:
+#
+# 1. Go to the secrets on your fork:
+#     - https://github.com/{USER}/icu4x/settings/secrets/actions
+# 2. Click "New repository secret" and enter the following information:
+#     - Name: ICU4X_GCP_SA_KEY
+#     - Value: The contents of the file linked above
+# 3. Click "Add secret"
+# 4. Re-run the latest "Artifacts Build" action on your fork to make sure it works:
+#     - https://github.com/{USER}/icu4x/actions/workflows/artifacts-build.yml
 
 name: Artifacts Build
 
@@ -25,7 +40,7 @@ jobs:
       run: |
         if [ -z "$ICU4X_GCP_SA_KEY" ]
         then
-          echo "GCP key not found. Docs previews will not be uploaded. If you are a frequent contributor, you may request the key from icu4x-core@unicode.org."
+          echo "GCP key not found. Docs previews will not be uploaded. If you are a frequent contributor, you may add the key to your fork; for instructions, see 'artifacts-build.yml'"
           exit 1;
         fi
   docs:

--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -2,21 +2,39 @@
 # called LICENSE at the top level of the ICU4X source tree
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-name: PR Artifacts
+##### README #####
+#
+# The CI action in this file is used to build the artifacts on pushes to a repository containing
+# the ICU4X service account key. All steps are skipped unless the key is present. If you are a
+# frequent contributor, you may request the key from icu4x-core@unicode.org.
+
+name: Artifacts Build
 
 on:
-  pull_request:
-    branches: '*'
+  push:
+    branches-ignore: ["main"]
 
 jobs:
+  credentials:
+    name: "Check Credentials"
+    runs-on: "ubuntu-latest"
+    env:
+      ICU4X_GCP_SA_KEY: "${{ secrets.ICU4X_GCP_SA_KEY }}"
+    steps:
+    - name: "Check for credentials"
+      run: |
+        if [ -z "$ICU4X_GCP_SA_KEY" ]
+        then
+          echo "GCP key not found. Docs previews will not be uploaded. If you are a frequent contributor, you may request the key from icu4x-core@unicode.org."
+          exit 1;
+        fi
   docs:
     name: "Docs Preview"
+    needs: credentials
     runs-on: "ubuntu-latest"
     env:
       GCP_PROJECT_ID: "dev-infra-273822"
       GCP_BUCKET_ID: "icu4x-pr-artifacts"
-    # To generate docs previews, you must add the GCP key to your fork. If you are a regular contributor, please ask icu4x-core@unicode.org for the key.
-    if: secrets.ICU4X_GCP_SA_KEY != null
     steps:
     - uses: actions/checkout@v2
     - name: Load the default Rust toolchain via the rust-toolchain file.
@@ -34,9 +52,9 @@ jobs:
         args: --workspace --release --all-features --no-deps
     - name: Upload docs to Google Cloud Storage
       run: |
-        gsutil -m cp -r target/doc gs://${{ env.GCP_BUCKET_ID }}/gha/${{ github.run_number }}/docs
+        gsutil -m cp -r target/doc gs://${{ env.GCP_BUCKET_ID }}/gha/${{ github.sha }}/docs
     - name: "⭐⭐⭐ Links to Uploaded Artifacts ⭐⭐⭐"
       run: |
         echo "::group::📖 Docs Preview"
-        echo "http://${{ env.GCP_BUCKET_ID }}.storage.googleapis.com/gha/${{ github.run_number }}/docs/icu/index.html"
+        echo "http://${{ env.GCP_BUCKET_ID }}.storage.googleapis.com/gha/${{ github.sha }}/docs/icu/index.html"
         echo "::endgroup::"

--- a/.github/workflows/artifacts-info.yml
+++ b/.github/workflows/artifacts-info.yml
@@ -1,0 +1,31 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+##### README #####
+#
+# The CI action prints links to uploaded artifacts built via "artifacts-build.yml".
+
+name: Artifacts
+
+on:
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  docs:
+    name: "Docs Preview"
+    runs-on: "ubuntu-latest"
+    env:
+      GCP_PROJECT_ID: "dev-infra-273822"
+      GCP_BUCKET_ID: "icu4x-pr-artifacts"
+    steps:
+    - name: "⭐⭐⭐ Links to Uploaded Artifacts ⭐⭐⭐"
+      run: |
+        echo "::group::🔒 Credentials Info"
+        echo "The following artifacts are built and uploaded in forks containing the ICU4X service account key as \`secrets.ICU4X_GCP_SA_KEY\`. If you are a frequent contributor, you may request the key from icu4x-core@unicode.org."
+        echo "::endgroup::"
+        echo "::group::📖 Docs Preview"
+        echo "It may take a few minutes for the following link to be available."
+        echo "http://${{ env.GCP_BUCKET_ID }}.storage.googleapis.com/gha/${{ github.event.pull_request.head.sha }}/docs/icu/index.html"
+        echo "::endgroup::"

--- a/.github/workflows/artifacts-info.yml
+++ b/.github/workflows/artifacts-info.yml
@@ -23,9 +23,11 @@ jobs:
     - name: "⭐⭐⭐ Links to Uploaded Artifacts ⭐⭐⭐"
       run: |
         echo "::group::🔒 Credentials Info"
-        echo "The following artifacts are built and uploaded in forks containing the ICU4X service account key as \`secrets.ICU4X_GCP_SA_KEY\`. If you are a frequent contributor, you may request the key from icu4x-core@unicode.org."
+        echo "The following artifacts are built and uploaded in forks containing the ICU4X service account key. If you are a frequent contributor, see 'artifacts-build.yml' for instructions on setting up the key."
         echo "::endgroup::"
         echo "::group::📖 Docs Preview"
-        echo "It may take a few minutes for the following link to be available."
+        echo "View the docs preview at:"
         echo "http://${{ env.GCP_BUCKET_ID }}.storage.googleapis.com/gha/${{ github.event.pull_request.head.sha }}/docs/icu/index.html"
+        echo "The link will be available after the following job completes:"
+        echo "${{ github.event.pull_request.head.repo.html_url }}/actions/workflows/artifacts-build.yml"
         echo "::endgroup::"


### PR DESCRIPTION
Here's what I came up with.

- There are 2 separate jobs: one runs on `push` (in the fork), and the other on `pull_request` (in upstream).
- The job that runs on `push` checks for valid credentials. If present, it builds and uploads the docs. If not present, the job fails and prints a message.
- The job that runs on `pull_request` prints the link at which the docs will be available if the `push` job succeeds.
- I use the sha of the head branch as the stable link between the `push` and `pull_request` jobs.

I tested this in my fork.  If I add the GCP key, the docs build successfully.  If I remove it, the "Check Credentials" job fails.  If it fails, I get an email notification (don't know if this is desirable or not).