### PR TITLE
Support creating a FixedDecimal from a float value through Ryu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,7 @@ dependencies = [
  "rand",
  "rand_distr",
  "rand_pcg",
+ "ryu",
  "smallvec",
  "static_assertions",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,7 +495,7 @@ dependencies = [
  "rand",
  "rand_distr",
  "rand_pcg",
- "ryu",
+ "ryu_floating_decimal",
  "smallvec",
  "static_assertions",
  "thiserror",
@@ -1787,6 +1787,12 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "ryu_floating_decimal"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "700de91d5fd6091442d00fdd9ee790af6d4f0f480562b0f5a1e8f59e90aafe73"
 
 [[package]]
 name = "same-file"

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -22,6 +22,9 @@ include = [
     "README.md"
 ]
 
+[package.metadata.cargo-all-features]
+skip_optional_dependencies = true
+
 [package.metadata.docs.rs]
 all-features = true
 
@@ -30,6 +33,7 @@ smallvec = "1.6"
 static_assertions = "1.1"
 writeable = { version = "0.2", path = "../../utils/writeable" }
 thiserror = "1.0"
+ryu = { version = "1.0.5", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.4"
@@ -45,6 +49,8 @@ path = "src/lib.rs"
 
 [features]
 default = []
+
+ryu_decimal = ["ryu"]
 
 bench = []
 

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -33,7 +33,7 @@ smallvec = "1.6"
 static_assertions = "1.1"
 writeable = { version = "0.2", path = "../../utils/writeable" }
 thiserror = "1.0"
-ryu = { version = "1.0.5", optional = true }
+ryu_floating_decimal = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.4"
@@ -50,7 +50,7 @@ path = "src/lib.rs"
 [features]
 default = []
 
-ryu_decimal = ["ryu"]
+ryu_decimal = ["ryu_floating_decimal"]
 
 bench = []
 

--- a/utils/fixed_decimal/benches/fixed_decimal.rs
+++ b/utils/fixed_decimal/benches/fixed_decimal.rs
@@ -51,6 +51,8 @@ fn overview_bench(c: &mut Criterion) {
         larger_isize_benches(c);
         to_string_benches(c);
         from_string_benches(c);
+        from_float_ryu_benches(c);
+        from_double_ryu_benches(c);
     }
 }
 
@@ -157,6 +159,60 @@ fn from_string_benches(c: &mut Criterion) {
                 BenchmarkId::from_parameter(object.to_string()),
                 object,
                 |b, object| b.iter(|| FixedDecimal::from_str(object).unwrap()),
+            );
+        }
+        group.finish();
+    }
+}
+
+#[cfg(feature = "bench")]
+fn from_float_ryu_benches(c: &mut Criterion) {
+    use criterion::BenchmarkId;
+
+    let objects = [
+        12.34,
+        0.001221673434,
+        234256110.0,
+        -123400.0,
+        123.45,
+        0.000000001,
+        10001.0,
+    ];
+
+    {
+        let mut group = c.benchmark_group("from_float_ryu");
+        for object in objects.iter() {
+            group.bench_with_input(
+                BenchmarkId::from_parameter(object.to_string()),
+                object,
+                |b, object| b.iter(|| FixedDecimal::from_float_ryu(*object, 64).unwrap()),
+            );
+        }
+        group.finish();
+    }
+}
+
+#[cfg(feature = "bench")]
+fn from_double_ryu_benches(c: &mut Criterion) {
+    use criterion::BenchmarkId;
+
+    let objects = [
+        12.34,
+        0.001221673434,
+        2342561123400.0,
+        -123400.0,
+        1234.56789,
+        0.000000001,
+        1000000001.0,
+    ];
+
+    {
+        let mut group = c.benchmark_group("from_double_ryu");
+        for object in objects.iter() {
+            group.bench_with_input(
+                BenchmarkId::from_parameter(object.to_string()),
+                object,
+                |b, object| b.iter(|| FixedDecimal::from_double_ryu(*object, 64).unwrap()),
             );
         }
         group.finish();

--- a/utils/fixed_decimal/benches/fixed_decimal.rs
+++ b/utils/fixed_decimal/benches/fixed_decimal.rs
@@ -185,7 +185,7 @@ fn from_float_ryu_benches(c: &mut Criterion) {
             group.bench_with_input(
                 BenchmarkId::from_parameter(object.to_string()),
                 object,
-                |b, object| b.iter(|| FixedDecimal::from_float_ryu(*object, 64).unwrap()),
+                |b, object| b.iter(|| FixedDecimal::from_float_ryu(*object, 10).unwrap()),
             );
         }
         group.finish();
@@ -212,7 +212,7 @@ fn from_double_ryu_benches(c: &mut Criterion) {
             group.bench_with_input(
                 BenchmarkId::from_parameter(object.to_string()),
                 object,
-                |b, object| b.iter(|| FixedDecimal::from_double_ryu(*object, 64).unwrap()),
+                |b, object| b.iter(|| FixedDecimal::from_double_ryu(*object, 10).unwrap()),
             );
         }
         group.finish();

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -181,7 +181,8 @@ impl FixedDecimal {
 
     /// Initialize a `FixedDecimal` with a float value, using Ryu under the hood
     /// to get digits from the value. The `post_decimal_places` parameter fixes
-    /// the number of digits after the decimal point.
+    /// the number of digits after the decimal point. This API requires the
+    /// `ryu_decimal` feature.
     ///
     /// # Examples
     ///
@@ -211,12 +212,15 @@ impl FixedDecimal {
             i16_post_decimal.checked_add(limited_exponent).ok_or(Error::Limit)?
         ).ok_or(Error::Limit)?;
 
+        res.is_negative = value.is_sign_negative();
+
         Ok(res)
     }
 
     /// Initialize a `FixedDecimal` with a double value, using Ryu under the hood
     /// to get digits from the value. The `post_decimal_places` parameter fixes
-    /// the number of digits after the decimal point.
+    /// the number of digits after the decimal point. This API requires the
+    /// `ryu_decimal` feature.
     ///
     /// # Examples
     ///
@@ -245,6 +249,8 @@ impl FixedDecimal {
             // add because exponent is negative of post decimal
             i16_post_decimal.checked_add(limited_exponent).ok_or(Error::Limit)?
         ).ok_or(Error::Limit)?;
+
+        res.is_negative = value.is_sign_negative();
 
         Ok(res)
     }
@@ -1106,6 +1112,21 @@ fn test_from_float_ryu() {
             post_decimal_places: 100,
             expected_decimal: FixedDecimal::from_str(format!("12.34{}", "0".repeat(98)).as_str()).unwrap(),
         },
+        TestCase {
+            float: -12.34,
+            post_decimal_places: 2,
+            expected_decimal: FixedDecimal::from_str("-12.34").unwrap(),
+        },
+        TestCase {
+            float: -12.34,
+            post_decimal_places: 1,
+            expected_decimal: FixedDecimal::from_str("-12.3").unwrap(),
+        },
+        TestCase {
+            float: -12.34,
+            post_decimal_places: 3,
+            expected_decimal: FixedDecimal::from_str("-12.340").unwrap(),
+        },
     ];
     for cas in &cases {
         let to_decimal = FixedDecimal::from_float_ryu(cas.float, cas.post_decimal_places).unwrap();
@@ -1151,6 +1172,21 @@ fn test_from_double_ryu() {
             double: 12.34,
             post_decimal_places: 100,
             expected_decimal: FixedDecimal::from_str(format!("12.34{}", "0".repeat(98)).as_str()).unwrap(),
+        },
+        TestCase {
+            double: -12.34,
+            post_decimal_places: 2,
+            expected_decimal: FixedDecimal::from_str("-12.34").unwrap(),
+        },
+        TestCase {
+            double: -12.34,
+            post_decimal_places: 1,
+            expected_decimal: FixedDecimal::from_str("-12.3").unwrap(),
+        },
+        TestCase {
+            double: -12.34,
+            post_decimal_places: 3,
+            expected_decimal: FixedDecimal::from_str("-12.340").unwrap(),
         },
     ];
     for cas in &cases {

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -178,6 +178,26 @@ impl FixedDecimal {
         Ok(result)
     }
 
+    /// Initialize a `FixedDecimal` with a floating-point value, using Ryu under the hood
+    /// to get digits from the value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_decimal::FixedDecimal;
+    ///
+    /// let dec = FixedDecimal::from_float_ryu::<f32>(12.34).unwrap();
+    /// assert_eq!(4, dec.digit_at(-2));
+    /// assert_eq!(3, dec.digit_at(-1));
+    /// assert_eq!(2, dec.digit_at(0));
+    /// assert_eq!(1, dec.digit_at(1));
+    /// ```
+    #[cfg(feature = "ryu_decimal")]
+    pub fn from_float_ryu<F: ryu::Float>(value: f64) -> Result<Self, Error> {
+        let mut buffer = ryu::Buffer::new();
+        FixedDecimal::from_str(buffer.format(value))
+    }
+
     /// Gets the digit at the specified order of magnitude. Returns 0 if the magnitude is out of
     /// range of the currently visible digits.
     ///

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -199,7 +199,7 @@ impl FixedDecimal {
         
         while limited_exponent > 0 || (-limited_exponent as u16) < post_decimal_places {
             limited_exponent -= 1;
-            limited_mantissa *= 10;
+            limited_mantissa = limited_mantissa.checked_mul(10).ok_or(Error::Limit)?;
         }
 
         // at this point the limited exponent is at most 0
@@ -233,7 +233,7 @@ impl FixedDecimal {
 
         while limited_exponent > 0 || (-limited_exponent as u16) < post_decimal_places {
             limited_exponent -= 1;
-            limited_mantissa *= 10;
+            limited_mantissa = limited_mantissa.checked_mul(10).ok_or(Error::Limit)?;
         }
 
         // at this point the limited exponent is at most 0
@@ -1104,6 +1104,9 @@ fn test_from_float_ryu() {
         let to_decimal = FixedDecimal::from_float_ryu(cas.float, cas.post_decimal_places).unwrap();
         assert_eq!(cas.expected_decimal, to_decimal, "{:?}", cas);
     }
+
+    // bonus test: errors when a large post decimal request would cause overflow
+    assert_eq!(Error::Limit, FixedDecimal::from_float_ryu(12.34, 100).err().unwrap());
 }
 
 #[test]
@@ -1145,4 +1148,7 @@ fn test_from_double_ryu() {
         let to_decimal = FixedDecimal::from_double_ryu(cas.double, cas.post_decimal_places).unwrap();
         assert_eq!(cas.expected_decimal, to_decimal, "{:?}", cas);
     }
+
+    // bonus test: errors when a large post decimal request would cause overflow
+    assert_eq!(Error::Limit, FixedDecimal::from_double_ryu(12.34, 100).err().unwrap());
 }


### PR DESCRIPTION
This introduces the `FixedDecimal::from_float_ryu` and `FixedDecimal::from_double_ryu` APIs, which use Ryu to convert a floating value (`f32` or `f64`, respectively) into a `FixedDecimal` by using the Ryu algorithm.

To avoid introducing unnecessary dependencies, this API and its dependency on Ryu are hidden behind the `ryu_decimal` feature.

Fixes #166