### PR TITLE
Get the WASM build running again

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -281,7 +281,7 @@ for src_path in ${handle}
 
     if not ${up_to_date}
         echo Writing ${out_path}
-        output = exec ${wasm-opt} ${src_path} -o ${out_path}
+        output = exec ${wasm-opt} -O ${src_path} -o ${out_path}
         stdout = trim ${output.stdout}
         stderr = trim ${output.stderr}
         if ${stdout} or ${stderr} or ${output.code}

--- a/provider/fs/src/export/aliasing.rs
+++ b/provider/fs/src/export/aliasing.rs
@@ -52,6 +52,7 @@ impl<T: fmt::Debug + Eq + Hash + Ord + AsRef<[u8]>> AliasCollection<T> {
             .push(path_buf);
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn flush(&mut self) -> Result<(), Error> {
         self.flushed = true;
         // TODO: Make sure the directory is empty
@@ -72,6 +73,11 @@ impl<T: fmt::Debug + Eq + Hash + Ord + AsRef<[u8]>> AliasCollection<T> {
             }
         }
         Ok(())
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn flush(&mut self) -> Result<(), Error> {
+        panic!("Flush is not supported on wasm32");
     }
 }
 


### PR DESCRIPTION
A change in the FS dataprovider introduced an API use that's not supported on WASM, so this replaces the call with a panic when targeting WASM. Also fixes a failure when running `cargo make wasm` due to `wasm-opt` being called without an optimization level.