### PR TITLE
Store DataPayload instead of Cow throughout ICU4X

### DIFF
--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -10,7 +10,7 @@ use crate::{
     provider::{gregory::DatesV1, helpers::DateTimePatterns},
 };
 use icu_locid::Locale;
-use icu_provider::{DataProvider, DataRequest, ResourceOptions, ResourcePath};
+use icu_provider::prelude::*;
 use std::borrow::Cow;
 
 use crate::{
@@ -60,7 +60,7 @@ use crate::{
 pub struct DateTimeFormat<'d> {
     pub(super) locale: Locale,
     pub(super) pattern: Pattern,
-    pub(super) symbols: Cow<'d, provider::gregory::DateSymbolsV1>,
+    pub(super) symbols: DataPayload<'d, provider::gregory::DateSymbolsV1>,
 }
 
 impl<'d> DateTimeFormat<'d> {
@@ -102,8 +102,7 @@ impl<'d> DateTimeFormat<'d> {
                     },
                 },
             })?
-            .payload
-            .take()?;
+            .take_payload()?;
 
         let pattern = data
             .patterns

--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -141,13 +141,17 @@ impl<'d> DateTimeFormat<'d> {
     pub(super) fn new<T: Into<Locale>>(
         locale: T,
         pattern: Pattern,
-        data: Cow<'d, DatesV1>,
+        data: DataPayload<'d, DatesV1>,
     ) -> Self {
         let locale = locale.into();
 
-        let symbols = match data {
-            Cow::Borrowed(data) => Cow::Borrowed(&data.symbols),
-            Cow::Owned(data) => Cow::Owned(data.symbols),
+        let symbols = match data.cow {
+            Cow::Borrowed(data) => DataPayload {
+                cow: Cow::Borrowed(&data.symbols),
+            },
+            Cow::Owned(data) => DataPayload {
+                cow: Cow::Owned(data.symbols),
+            },
         };
 
         Self {

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -248,7 +248,7 @@ mod tests {
         use crate::mock::datetime::MockDateTime;
         use crate::provider::gregory::DatesV1;
         use icu_provider::prelude::*;
-        use std::borrow::Cow;
+        
         let provider = icu_testdata::get_provider();
         let data: DataPayload<'_, DatesV1> = provider
             .load_payload(&DataRequest {

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -250,7 +250,7 @@ mod tests {
         use icu_provider::prelude::*;
         use std::borrow::Cow;
         let provider = icu_testdata::get_provider();
-        let data: Cow<'_, DatesV1> = provider
+        let data: DataPayload<'_, DatesV1> = provider
             .load_payload(&DataRequest {
                 resource_path: ResourcePath {
                     key: provider::key::GREGORY_V1,
@@ -261,8 +261,7 @@ mod tests {
                 },
             })
             .unwrap()
-            .payload
-            .take()
+            .take_payload()
             .unwrap();
         let pattern = crate::pattern::Pattern::from_bytes("MMM").unwrap();
         let datetime = MockDateTime::try_new(2020, 8, 1, 12, 34, 28).unwrap();

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -248,7 +248,7 @@ mod tests {
         use crate::mock::datetime::MockDateTime;
         use crate::provider::gregory::DatesV1;
         use icu_provider::prelude::*;
-        
+
         let provider = icu_testdata::get_provider();
         let data: DataPayload<'_, DatesV1> = provider
             .load_payload(&DataRequest {

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -627,7 +627,7 @@ mod test {
     use super::*;
 
     use icu_locid_macros::langid;
-    use icu_provider::{DataProvider, DataRequest, ResourceOptions, ResourcePath};
+    use icu_provider::prelude::*;
     use std::borrow::Cow;
 
     use crate::{
@@ -636,7 +636,7 @@ mod test {
         provider::{gregory::DatesV1, key::GREGORY_V1},
     };
 
-    fn get_data_provider() -> Cow<'static, DatesV1> {
+    fn get_data_provider() -> DataPayload<'static, DatesV1> {
         let provider = icu_testdata::get_provider();
         let langid = langid!("en");
         provider
@@ -650,8 +650,7 @@ mod test {
                 },
             })
             .unwrap()
-            .payload
-            .take()
+            .take_payload()
             .unwrap()
     }
 

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -628,7 +628,6 @@ mod test {
 
     use icu_locid_macros::langid;
     use icu_provider::prelude::*;
-    
 
     use crate::{
         fields::{Day, Field, FieldLength, Month, Weekday},

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -628,7 +628,7 @@ mod test {
 
     use icu_locid_macros::langid;
     use icu_provider::prelude::*;
-    use std::borrow::Cow;
+    
 
     use crate::{
         fields::{Day, Field, FieldLength, Month, Weekday},

--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use crate::{format::time_zone, provider::time_zones::TimeZoneFormatsV1};
 use icu_locid::{LanguageIdentifier, Locale};
-use icu_provider::{DataProvider, DataRequest, ResourceKey, ResourceOptions, ResourcePath};
+use icu_provider::prelude::*;
 
 use crate::fields::{FieldSymbol, TimeZone};
 use crate::pattern::{Pattern, PatternItem};
@@ -19,7 +19,7 @@ use crate::pattern::{Pattern, PatternItem};
 fn load_resource<'d, D, L, P>(
     locale: &L,
     resource_key: ResourceKey,
-    destination: &mut Option<Cow<'d, D>>,
+    destination: &mut Option<DataPayload<'d, D>>,
     provider: &P,
 ) -> Result<(), DateTimeFormatError>
 where
@@ -39,8 +39,7 @@ where
                         },
                     },
                 })?
-                .payload
-                .take()?,
+                .take_payload()?,
         );
     }
     Ok(())
@@ -89,21 +88,21 @@ pub(super) struct TimeZoneFormat<'d> {
     /// The pattern to format.
     pub(super) pattern: Pattern,
     /// The data that contains meta information about how to display content.
-    pub(super) zone_formats: Cow<'d, provider::time_zones::TimeZoneFormatsV1<'d>>,
+    pub(super) zone_formats: DataPayload<'d, provider::time_zones::TimeZoneFormatsV1<'d>>,
     /// The exemplar cities for time zones.
-    pub(super) exemplar_cities: Option<Cow<'d, provider::time_zones::ExemplarCitiesV1<'d>>>,
+    pub(super) exemplar_cities: Option<DataPayload<'d, provider::time_zones::ExemplarCitiesV1<'d>>>,
     /// The generic long metazone names, e.g. Pacific Time
     pub(super) mz_generic_long:
-        Option<Cow<'d, provider::time_zones::MetaZoneGenericNamesLongV1<'d>>>,
+        Option<DataPayload<'d, provider::time_zones::MetaZoneGenericNamesLongV1<'d>>>,
     /// The generic short metazone names, e.g. PT
     pub(super) mz_generic_short:
-        Option<Cow<'d, provider::time_zones::MetaZoneGenericNamesShortV1<'d>>>,
+        Option<DataPayload<'d, provider::time_zones::MetaZoneGenericNamesShortV1<'d>>>,
     /// The specific long metazone names, e.g. Pacific Daylight Time
     pub(super) mz_specific_long:
-        Option<Cow<'d, provider::time_zones::MetaZoneSpecificNamesLongV1<'d>>>,
+        Option<DataPayload<'d, provider::time_zones::MetaZoneSpecificNamesLongV1<'d>>>,
     /// The specific short metazone names, e.g. Pacific Daylight Time
     pub(super) mz_specific_short:
-        Option<Cow<'d, provider::time_zones::MetaZoneSpecificNamesShortV1<'d>>>,
+        Option<DataPayload<'d, provider::time_zones::MetaZoneSpecificNamesShortV1<'d>>>,
 }
 
 impl<'d> TimeZoneFormat<'d> {
@@ -146,7 +145,7 @@ impl<'d> TimeZoneFormat<'d> {
     {
         let locale = locale.into();
 
-        let zone_formats: Cow<TimeZoneFormatsV1> = zone_provider
+        let zone_formats: DataPayload<TimeZoneFormatsV1> = zone_provider
             .load_payload(&DataRequest {
                 resource_path: ResourcePath {
                     key: provider::key::TIMEZONE_FORMATS_V1,
@@ -156,8 +155,7 @@ impl<'d> TimeZoneFormat<'d> {
                     },
                 },
             })?
-            .payload
-            .take()?;
+            .take_payload()?;
 
         let mut time_zone_format = Self {
             pattern,

--- a/components/datetime/src/zoned_datetime.rs
+++ b/components/datetime/src/zoned_datetime.rs
@@ -116,8 +116,7 @@ impl<'d> ZonedDateTimeFormat<'d> {
                     },
                 },
             })?
-            .payload
-            .take()?;
+            .take_payload()?;
 
         let pattern = data
             .patterns

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -16,9 +16,8 @@ use icu_datetime::{
     DateTimeFormat,
 };
 use icu_locid::{LanguageIdentifier, Locale};
-use icu_provider::{
-    struct_provider::StructProvider, DataProvider, DataRequest, ResourceOptions, ResourcePath,
-};
+use icu_provider::prelude::*;
+use icu_provider::struct_provider::StructProvider;
 use patterns::{
     get_dayperiod_tests, get_time_zone_tests,
     structs::{
@@ -105,7 +104,7 @@ fn test_dayperiod_patterns() {
     let format_options = DateTimeFormatOptions::default();
     for test in get_dayperiod_tests("dayperiods").unwrap().0 {
         let langid: LanguageIdentifier = test.locale.parse().unwrap();
-        let mut data: Cow<DatesV1> = provider
+        let mut data: DataPayload<DatesV1> = provider
             .load_payload(&DataRequest {
                 resource_path: ResourcePath {
                     key: GREGORY_V1,
@@ -116,10 +115,10 @@ fn test_dayperiod_patterns() {
                 },
             })
             .unwrap()
-            .payload
-            .take()
+            .take_payload()
             .unwrap();
         *data
+            .cow
             .to_mut()
             .patterns
             .datetime
@@ -131,7 +130,8 @@ fn test_dayperiod_patterns() {
                 let datetime: MockDateTime = dt_input.parse().unwrap();
                 for DayPeriodExpectation { patterns, expected } in &test_case.expectations {
                     for pattern_input in patterns {
-                        *data.to_mut().patterns.time.long.to_mut() = String::from(pattern_input);
+                        *data.cow.to_mut().patterns.time.long.to_mut() =
+                            String::from(pattern_input);
                         let provider = StructProvider {
                             key: GREGORY_V1,
                             data: data.as_ref(),
@@ -171,7 +171,7 @@ fn test_time_zone_patterns() {
         datetime.time_zone.metazone_id = config.metazone_id.take();
         datetime.time_zone.time_variant = config.time_variant.take();
 
-        let mut data: Cow<DatesV1> = date_provider
+        let mut data: DataPayload<DatesV1> = date_provider
             .load_payload(&DataRequest {
                 resource_path: ResourcePath {
                     key: GREGORY_V1,
@@ -182,11 +182,11 @@ fn test_time_zone_patterns() {
                 },
             })
             .unwrap()
-            .payload
-            .take()
+            .take_payload()
             .unwrap();
 
         *data
+            .cow
             .to_mut()
             .patterns
             .datetime
@@ -196,7 +196,7 @@ fn test_time_zone_patterns() {
 
         for TimeZoneExpectation { patterns, expected } in &test.expectations {
             for pattern_input in patterns {
-                *data.to_mut().patterns.time.long.to_mut() = String::from(pattern_input);
+                *data.cow.to_mut().patterns.time.long.to_mut() = String::from(pattern_input);
                 let date_provider = StructProvider {
                     key: GREGORY_V1,
                     data: data.as_ref(),

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -25,7 +25,7 @@ use patterns::{
         time_zones::{TimeZoneConfig, TimeZoneExpectation},
     },
 };
-use std::{fmt::Write};
+use std::fmt::Write;
 
 fn test_fixture(fixture_name: &str) {
     let provider = icu_testdata::get_provider();

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -25,7 +25,7 @@ use patterns::{
         time_zones::{TimeZoneConfig, TimeZoneExpectation},
     },
 };
-use std::{borrow::Cow, fmt::Write};
+use std::{fmt::Write};
 
 fn test_fixture(fixture_name: &str) {
     let provider = icu_testdata::get_provider();

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -69,7 +69,6 @@ pub use format::FormattedFixedDecimal;
 use fixed_decimal::FixedDecimal;
 use icu_locid::Locale;
 use icu_provider::prelude::*;
-use std::borrow::Cow;
 
 /// A formatter for [`FixedDecimal`], rendering decimal digits in an i18n-friendly way.
 ///
@@ -84,7 +83,7 @@ use std::borrow::Cow;
 /// See the crate-level documentation for examples.
 pub struct FixedDecimalFormat<'d> {
     options: options::FixedDecimalFormatOptions,
-    symbols: Cow<'d, provider::DecimalSymbolsV1>,
+    symbols: DataPayload<'d, provider::DecimalSymbolsV1>,
 }
 
 impl<'d> FixedDecimalFormat<'d> {
@@ -104,8 +103,7 @@ impl<'d> FixedDecimalFormat<'d> {
                     },
                 },
             })?
-            .payload
-            .take()?;
+            .take_payload()?;
         Ok(Self { options, symbols })
     }
 

--- a/components/locale_canonicalizer/src/locale_canonicalizer.rs
+++ b/components/locale_canonicalizer/src/locale_canonicalizer.rs
@@ -5,7 +5,6 @@
 use crate::provider::*;
 use icu_locid::LanguageIdentifier;
 use icu_provider::prelude::*;
-use std::borrow::Cow;
 
 /// Used to track the result of a canonicalization operation that potentially modifies its argument in place.
 #[derive(Debug, PartialEq)]
@@ -15,7 +14,7 @@ pub enum CanonicalizationResult {
 }
 
 pub struct LocaleCanonicalizer<'a> {
-    likely_subtags: Cow<'a, LikelySubtagsV1>,
+    likely_subtags: DataPayload<'a, LikelySubtagsV1>,
 }
 
 #[inline]
@@ -51,10 +50,9 @@ impl LocaleCanonicalizer<'_> {
     pub fn new<'d>(
         provider: &(impl DataProvider<'d, LikelySubtagsV1> + ?Sized),
     ) -> Result<LocaleCanonicalizer<'d>, DataError> {
-        let payload: Cow<LikelySubtagsV1> = provider
+        let payload: DataPayload<LikelySubtagsV1> = provider
             .load_payload(&DataRequest::from(key::LIKELY_SUBTAGS_V1))?
-            .payload
-            .take()?;
+            .take_payload()?;
 
         Ok(LocaleCanonicalizer {
             likely_subtags: payload,

--- a/components/plurals/benches/parser.rs
+++ b/components/plurals/benches/parser.rs
@@ -20,7 +20,7 @@ fn parser(c: &mut Criterion) {
     let mut rules = vec![];
 
     for langid in &plurals_data.langs {
-        let plurals_data: Cow<icu_plurals::provider::PluralRuleStringsV1> = provider
+        let plurals_data: DataPayload<icu_plurals::provider::PluralRuleStringsV1> = provider
             .load_payload(&DataRequest {
                 resource_path: ResourcePath {
                     key: icu_plurals::provider::key::CARDINAL_V1,
@@ -31,8 +31,7 @@ fn parser(c: &mut Criterion) {
                 },
             })
             .unwrap()
-            .payload
-            .take()
+            .take_payload()
             .unwrap();
 
         let r = &[

--- a/components/plurals/benches/parser.rs
+++ b/components/plurals/benches/parser.rs
@@ -8,7 +8,7 @@ mod helpers;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use icu_provider::prelude::*;
-use std::borrow::Cow;
+
 
 fn parser(c: &mut Criterion) {
     use icu_plurals::rules::parse_condition;

--- a/components/plurals/benches/parser.rs
+++ b/components/plurals/benches/parser.rs
@@ -9,7 +9,6 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use icu_provider::prelude::*;
 
-
 fn parser(c: &mut Criterion) {
     use icu_plurals::rules::parse_condition;
 

--- a/components/plurals/src/provider/resolver.rs
+++ b/components/plurals/src/provider/resolver.rs
@@ -6,13 +6,12 @@ use super::PluralRuleStringsV1;
 use crate::{PluralRuleType, PluralRulesError};
 use icu_locid::LanguageIdentifier;
 use icu_provider::prelude::*;
-use std::borrow::Cow;
 
 pub fn resolve_plural_data<'s, D: DataProvider<'s, PluralRuleStringsV1<'s>> + ?Sized>(
     langid: LanguageIdentifier,
     data_provider: &D,
     type_: PluralRuleType,
-) -> Result<Cow<'s, PluralRuleStringsV1<'s>>, PluralRulesError> {
+) -> Result<DataPayload<'s, PluralRuleStringsV1<'s>>, PluralRulesError> {
     let key = match type_ {
         PluralRuleType::Cardinal => super::key::CARDINAL_V1,
         PluralRuleType::Ordinal => super::key::ORDINAL_V1,
@@ -27,6 +26,5 @@ pub fn resolve_plural_data<'s, D: DataProvider<'s, PluralRuleStringsV1<'s>> + ?S
                 },
             },
         })?
-        .payload
-        .take()?)
+        .take_payload()?)
 }

--- a/components/uniset/src/props.rs
+++ b/components/uniset/src/props.rs
@@ -11,7 +11,6 @@ use crate::enum_props::*;
 use crate::provider::*;
 use crate::{UnicodeSet, UnicodeSetError};
 use icu_provider::prelude::*;
-use std::borrow::Cow;
 use std::convert::TryInto;
 
 type UnisetResult = Result<UnicodeSet, UnicodeSetError>;
@@ -24,10 +23,10 @@ fn get_prop<'d, D: DataProvider<'d, UnicodeProperty<'d>> + ?Sized>(ppucd_provide
             options: ResourceOptions { variant: None, langid: None },
         },
     };
-    let mut resp: DataResponse<UnicodeProperty> = ppucd_provider.load_payload(&data_req)?;
+    let resp: DataResponse<UnicodeProperty> = ppucd_provider.load_payload(&data_req)?;
 
-    let ppucd_property_cow: Cow<UnicodeProperty> = resp.payload.take()?;
-    let ppucd_property: UnicodeProperty = ppucd_property_cow.into_owned();
+    let ppucd_property_payload: DataPayload<UnicodeProperty> = resp.take_payload()?;
+    let ppucd_property: UnicodeProperty = ppucd_property_payload.as_ref().clone();
     ppucd_property.try_into()
 }
 

--- a/experimental/provider_ppucd/src/support.rs
+++ b/experimental/provider_ppucd/src/support.rs
@@ -80,9 +80,9 @@ impl<'d, 's> DataProvider<'d, UnicodeProperty<'s>> for PpucdDataProvider<'s> {
         };
         Ok(DataResponse {
             metadata: DataResponseMetadata { data_langid: None },
-            payload: DataPayload {
-                cow: Some(Cow::Owned(prop)),
-            },
+            payload: Some(DataPayload {
+                cow: Cow::Owned(prop),
+            }),
         })
     }
 }
@@ -127,7 +127,7 @@ fn test_ppucd_provider_parse() {
     };
     let mut resp: DataResponse<UnicodeProperty> = ppucd_provider.load_payload(&data_req).unwrap();
 
-    let ppucd_property_cow: Cow<UnicodeProperty> = resp.payload.take().unwrap();
+    let ppucd_property_cow: DataPayload<UnicodeProperty> = resp.take_payload().unwrap();
     let exp_prop_uniset: UnicodeProperty = UnicodeProperty {
         name: Cow::Borrowed("WSpace"),
         inv_list: vec![
@@ -135,5 +135,5 @@ fn test_ppucd_provider_parse() {
             8287, 8288, 12288, 12289,
         ],
     };
-    assert_eq!(exp_prop_uniset, ppucd_property_cow.into_owned());
+    assert_eq!(exp_prop_uniset, ppucd_property_cow.as_ref().clone());
 }

--- a/experimental/provider_ppucd/src/support.rs
+++ b/experimental/provider_ppucd/src/support.rs
@@ -125,7 +125,7 @@ fn test_ppucd_provider_parse() {
             },
         },
     };
-    let mut resp: DataResponse<UnicodeProperty> = ppucd_provider.load_payload(&data_req).unwrap();
+    let resp: DataResponse<UnicodeProperty> = ppucd_provider.load_payload(&data_req).unwrap();
 
     let ppucd_property_cow: DataPayload<UnicodeProperty> = resp.take_payload().unwrap();
     let exp_prop_uniset: UnicodeProperty = UnicodeProperty {

--- a/provider/cldr/src/download/cldr_allinone.rs
+++ b/provider/cldr/src/download/cldr_allinone.rs
@@ -40,7 +40,7 @@ use std::path::PathBuf;
 ///     let data_provider = PluralsProvider::try_from(&paths as &dyn CldrPaths)
 ///         .expect("The data should be well-formed after downloading");
 ///
-///     let data: Cow<icu_plurals::provider::PluralRuleStringsV1> = data_provider
+///     let data: DataPayload<icu_plurals::provider::PluralRuleStringsV1> = data_provider
 ///         .load_payload(&DataRequest {
 ///             resource_path: ResourcePath {
 ///                 key: icu_plurals::provider::key::ORDINAL_V1,
@@ -51,7 +51,7 @@ use std::path::PathBuf;
 ///             },
 ///         })
 ///         .unwrap()
-///         .payload.take()
+///         .take_payload()
 ///         .unwrap();
 ///     assert_eq!(data.few, Some(Cow::Borrowed("n % 10 = 3 and n % 100 != 13")));
 /// }

--- a/provider/cldr/src/transform/dates.rs
+++ b/provider/cldr/src/transform/dates.rs
@@ -76,9 +76,9 @@ impl<'d> DataProvider<'d, gregory::DatesV1> for DatesProvider<'d> {
             metadata: DataResponseMetadata {
                 data_langid: req.resource_path.options.langid.clone(),
             },
-            payload: DataPayload {
-                cow: Some(Cow::Owned(gregory::DatesV1::from(dates))),
-            },
+            payload: Some(DataPayload {
+                cow: Cow::Owned(gregory::DatesV1::from(dates)),
+            }),
         })
     }
 }
@@ -501,12 +501,11 @@ pub(self) mod cldr_json {
 #[test]
 fn test_basic() {
     use icu_locid_macros::langid;
-    use std::borrow::Cow;
 
     let cldr_paths = crate::cldr_paths::for_test();
     let provider = DatesProvider::try_from(&cldr_paths as &dyn CldrPaths).unwrap();
 
-    let cs_dates: Cow<gregory::DatesV1> = provider
+    let cs_dates: DataPayload<gregory::DatesV1> = provider
         .load_payload(&DataRequest {
             resource_path: ResourcePath {
                 key: key::GREGORY_V1,
@@ -517,8 +516,7 @@ fn test_basic() {
             },
         })
         .unwrap()
-        .payload
-        .take()
+        .take_payload()
         .unwrap();
 
     assert_eq!("srpna", cs_dates.symbols.months.format.wide.0[7]);
@@ -534,12 +532,11 @@ fn test_basic() {
 #[test]
 fn test_with_numbering_system() {
     use icu_locid_macros::langid;
-    use std::borrow::Cow;
 
     let cldr_paths = crate::cldr_paths::for_test();
     let provider = DatesProvider::try_from(&cldr_paths as &dyn CldrPaths).unwrap();
 
-    let cs_dates: Cow<gregory::DatesV1> = provider
+    let cs_dates: DataPayload<gregory::DatesV1> = provider
         .load_payload(&DataRequest {
             resource_path: ResourcePath {
                 key: key::GREGORY_V1,
@@ -550,8 +547,7 @@ fn test_with_numbering_system() {
             },
         })
         .unwrap()
-        .payload
-        .take()
+        .take_payload()
         .unwrap();
 
     assert_eq!("d MMM y", cs_dates.patterns.date.medium);
@@ -562,12 +558,11 @@ fn test_with_numbering_system() {
 #[test]
 fn unalias_contexts() {
     use icu_locid_macros::langid;
-    use std::borrow::Cow;
 
     let cldr_paths = crate::cldr_paths::for_test();
     let provider = DatesProvider::try_from(&cldr_paths as &dyn CldrPaths).unwrap();
 
-    let cs_dates: Cow<gregory::DatesV1> = provider
+    let cs_dates: DataPayload<gregory::DatesV1> = provider
         .load_payload(&DataRequest {
             resource_path: ResourcePath {
                 key: key::GREGORY_V1,
@@ -578,8 +573,7 @@ fn unalias_contexts() {
             },
         })
         .unwrap()
-        .payload
-        .take()
+        .take_payload()
         .unwrap();
 
     // Czech months are not unaliased because `wide` differs.

--- a/provider/cldr/src/transform/likelysubtags.rs
+++ b/provider/cldr/src/transform/likelysubtags.rs
@@ -64,9 +64,9 @@ impl<'d> DataProvider<'d, LikelySubtagsV1> for LikelySubtagsProvider<'d> {
                 metadata: DataResponseMetadata {
                     data_langid: langid.clone(),
                 },
-                payload: DataPayload {
-                    cow: Some(Cow::Owned(LikelySubtagsV1::from(&self.data))),
-                },
+                payload: Some(DataPayload {
+                    cow: Cow::Owned(LikelySubtagsV1::from(&self.data)),
+                }),
             })
         } else {
             Err(DataError::UnavailableResourceOptions(req.clone()))
@@ -187,15 +187,13 @@ pub(self) mod cldr_json {
 #[test]
 fn test_basic() {
     use icu_locid_macros::langid;
-    use std::borrow::Cow;
 
     let cldr_paths = crate::cldr_paths::for_test();
     let provider = LikelySubtagsProvider::try_from(&cldr_paths as &dyn CldrPaths).unwrap();
-    let result: Cow<LikelySubtagsV1> = provider
+    let result: DataPayload<LikelySubtagsV1> = provider
         .load_payload(&DataRequest::from(key::LIKELY_SUBTAGS_V1))
         .unwrap()
-        .payload
-        .take()
+        .take_payload()
         .unwrap();
 
     let langid = langid!("cu-Glag");

--- a/provider/cldr/src/transform/numbers/mod.rs
+++ b/provider/cldr/src/transform/numbers/mod.rs
@@ -133,9 +133,9 @@ impl<'d> DataProvider<'d, DecimalSymbolsV1> for NumbersProvider {
             metadata: DataResponseMetadata {
                 data_langid: req.resource_path.options.langid.clone(),
             },
-            payload: DataPayload {
-                cow: Some(Cow::Owned(result)),
-            },
+            payload: Some(DataPayload {
+                cow: Cow::Owned(result),
+            }),
         })
     }
 }
@@ -200,12 +200,11 @@ impl TryFrom<&cldr_serde::numbers_json::Numbers> for DecimalSymbolsV1 {
 #[test]
 fn test_basic() {
     use icu_locid_macros::langid;
-    use std::borrow::Cow;
 
     let cldr_paths = crate::cldr_paths::for_test();
     let provider = NumbersProvider::try_from(&cldr_paths as &dyn CldrPaths).unwrap();
 
-    let ar_decimal: Cow<DecimalSymbolsV1> = provider
+    let ar_decimal: DataPayload<DecimalSymbolsV1> = provider
         .load_payload(&DataRequest {
             resource_path: ResourcePath {
                 key: key::SYMBOLS_V1,
@@ -216,8 +215,7 @@ fn test_basic() {
             },
         })
         .unwrap()
-        .payload
-        .take()
+        .take_payload()
         .unwrap();
 
     assert_eq!(ar_decimal.decimal_separator, "٫");

--- a/provider/cldr/src/transform/plurals.rs
+++ b/provider/cldr/src/transform/plurals.rs
@@ -93,9 +93,9 @@ impl<'d, 's> DataProvider<'d, PluralRuleStringsV1<'s>> for PluralsProvider<'d> {
             metadata: DataResponseMetadata {
                 data_langid: req.resource_path.options.langid.clone(),
             },
-            payload: DataPayload {
-                cow: Some(Cow::Owned(PluralRuleStringsV1::from(r))),
-            },
+            payload: Some(DataPayload {
+                cow: Cow::Owned(PluralRuleStringsV1::from(r)),
+            }),
         })
     }
 }
@@ -195,7 +195,7 @@ fn test_basic() {
     let provider = PluralsProvider::try_from(&cldr_paths as &dyn CldrPaths).unwrap();
 
     // Spot-check locale 'cs' since it has some interesting entries
-    let cs_rules: Cow<PluralRuleStringsV1> = provider
+    let cs_rules: DataPayload<PluralRuleStringsV1> = provider
         .load_payload(&DataRequest {
             resource_path: ResourcePath {
                 key: key::CARDINAL_V1,
@@ -206,8 +206,7 @@ fn test_basic() {
             },
         })
         .unwrap()
-        .payload
-        .take()
+        .take_payload()
         .unwrap();
 
     assert_eq!(None, cs_rules.zero);

--- a/provider/cldr/src/transform/time_zones/mod.rs
+++ b/provider/cldr/src/transform/time_zones/mod.rs
@@ -119,9 +119,9 @@ macro_rules! impl_data_provider {
                     metadata: DataResponseMetadata {
                         data_langid: req.resource_path.options.langid.clone(),
                     },
-                    payload: DataPayload {
-                        cow: Some(Cow::Owned($id::from(time_zones.clone()))),
-                    },
+                    payload: Some(DataPayload {
+                        cow: Cow::Owned($id::from(time_zones.clone())),
+                    }),
                 })
             }
         }
@@ -164,7 +164,7 @@ mod tests {
         let cldr_paths = crate::cldr_paths::for_test();
         let provider = TimeZonesProvider::try_from(&cldr_paths as &dyn CldrPaths).unwrap();
 
-        let time_zone_formats: Cow<TimeZoneFormatsV1> = provider
+        let time_zone_formats: DataPayload<TimeZoneFormatsV1> = provider
             .load_payload(&DataRequest {
                 resource_path: ResourcePath {
                     key: key::TIMEZONE_FORMATS_V1,
@@ -175,12 +175,11 @@ mod tests {
                 },
             })
             .unwrap()
-            .payload
-            .take()
+            .take_payload()
             .unwrap();
         assert_eq!("GMT", time_zone_formats.gmt_zero_format);
 
-        let exemplar_cities: Cow<ExemplarCitiesV1> = provider
+        let exemplar_cities: DataPayload<ExemplarCitiesV1> = provider
             .load_payload(&DataRequest {
                 resource_path: ResourcePath {
                     key: key::TIMEZONE_EXEMPLAR_CITIES_V1,
@@ -191,12 +190,11 @@ mod tests {
                 },
             })
             .unwrap()
-            .payload
-            .take()
+            .take_payload()
             .unwrap();
         assert_eq!("Pohnpei", exemplar_cities["Pacific/Ponape"]);
 
-        let generic_names_long: Cow<MetaZoneGenericNamesLongV1> = provider
+        let generic_names_long: DataPayload<MetaZoneGenericNamesLongV1> = provider
             .load_payload(&DataRequest {
                 resource_path: ResourcePath {
                     key: key::TIMEZONE_GENERIC_NAMES_LONG_V1,
@@ -207,15 +205,14 @@ mod tests {
                 },
             })
             .unwrap()
-            .payload
-            .take()
+            .take_payload()
             .unwrap();
         assert_eq!(
             "Australian Central Western Time",
             generic_names_long["Australia_CentralWestern"]
         );
 
-        let specific_names_long: Cow<MetaZoneSpecificNamesLongV1> = provider
+        let specific_names_long: DataPayload<MetaZoneSpecificNamesLongV1> = provider
             .load_payload(&DataRequest {
                 resource_path: ResourcePath {
                     key: key::TIMEZONE_SPECIFIC_NAMES_LONG_V1,
@@ -226,15 +223,14 @@ mod tests {
                 },
             })
             .unwrap()
-            .payload
-            .take()
+            .take_payload()
             .unwrap();
         assert_eq!(
             "Australian Central Western Standard Time",
             specific_names_long["Australia_CentralWestern"]["standard"]
         );
 
-        let generic_names_short: Cow<MetaZoneGenericNamesShortV1> = provider
+        let generic_names_short: DataPayload<MetaZoneGenericNamesShortV1> = provider
             .load_payload(&DataRequest {
                 resource_path: ResourcePath {
                     key: key::TIMEZONE_GENERIC_NAMES_SHORT_V1,
@@ -245,12 +241,11 @@ mod tests {
                 },
             })
             .unwrap()
-            .payload
-            .take()
+            .take_payload()
             .unwrap();
         assert_eq!("PT", generic_names_short["America_Pacific"]);
 
-        let specific_names_short: Cow<MetaZoneSpecificNamesShortV1> = provider
+        let specific_names_short: DataPayload<MetaZoneSpecificNamesShortV1> = provider
             .load_payload(&DataRequest {
                 resource_path: ResourcePath {
                     key: key::TIMEZONE_SPECIFIC_NAMES_SHORT_V1,
@@ -261,8 +256,7 @@ mod tests {
                 },
             })
             .unwrap()
-            .payload
-            .take()
+            .take_payload()
             .unwrap();
         assert_eq!("PDT", specific_names_short["America_Pacific"]["daylight"]);
     }

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -99,7 +99,7 @@ pub struct DataResponseMetadata {
 ///
 /// assert_eq!("Demo", &*payload);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DataPayload<'d, T>
 where
     T: ToOwned + ?Sized,

--- a/provider/core/src/erased.rs
+++ b/provider/core/src/erased.rs
@@ -91,11 +91,7 @@ impl<'d> DataPayload<'d, dyn ErasedDataStruct> {
     where
         T: Clone + Debug + Any,
     {
-        let old_cow = match self.cow {
-            Some(cow) => cow,
-            None => return Ok(DataPayload { cow: None }),
-        };
-        let new_cow = match old_cow {
+        let new_cow = match self.cow {
             Cow::Borrowed(erased) => {
                 let borrowed: &'d T =
                     erased
@@ -119,7 +115,7 @@ impl<'d> DataPayload<'d, dyn ErasedDataStruct> {
                 Cow::Owned(*boxed)
             }
         };
-        Ok(DataPayload { cow: Some(new_cow) })
+        Ok(DataPayload { cow: new_cow })
     }
 }
 
@@ -179,7 +175,7 @@ where
         let result = ErasedDataProvider::load_erased(self, req)?;
         Ok(DataResponse {
             metadata: result.metadata,
-            payload: result.payload.downcast()?,
+            payload: result.payload.map(|p| p.downcast()).transpose()?,
         })
     }
 }

--- a/provider/core/src/export.rs
+++ b/provider/core/src/export.rs
@@ -49,7 +49,7 @@ where
                     options: resc_options,
                 },
             };
-            let payload = provider.load_payload(&req)?.payload.take()?;
+            let payload = provider.load_payload(&req)?.take_payload()?;
             self.put_payload(&req, payload.borrow())?;
         }
         Ok(())

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -46,11 +46,10 @@ impl Default for HelloWorldV1<'_> {
 /// use icu_provider::hello_world::{key, HelloWorldProvider, HelloWorldV1};
 /// use icu_provider::prelude::*;
 /// use icu_locid_macros::langid;
-/// use std::borrow::Cow;
 ///
 /// let provider = HelloWorldProvider::new_with_placeholder_data();
 ///
-/// let german_hello_world: Cow<HelloWorldV1> = provider
+/// let german_hello_world: DataPayload<HelloWorldV1> = provider
 ///     .load_payload(&DataRequest {
 ///         resource_path: ResourcePath {
 ///             key: key::HELLO_WORLD_V1,
@@ -61,7 +60,7 @@ impl Default for HelloWorldV1<'_> {
 ///         }
 ///     })
 ///     .unwrap()
-///     .payload.take()
+///     .take_payload()
 ///     .unwrap();
 ///
 /// assert_eq!("Hallo Welt", german_hello_world.message);
@@ -125,9 +124,9 @@ where
             metadata: DataResponseMetadata {
                 data_langid: Some(langid.clone()),
             },
-            payload: DataPayload {
-                cow: Some(Cow::Owned(data)),
-            },
+            payload: Some(DataPayload {
+                cow: Cow::Owned(data),
+            }),
         })
     }
 }

--- a/provider/core/src/inv.rs
+++ b/provider/core/src/inv.rs
@@ -25,10 +25,10 @@ use std::fmt::Debug;
 /// use std::borrow::Cow;
 ///
 /// let provider = InvariantDataProvider;
-/// let result: Cow<HelloWorldV1> = provider
+/// let result: DataPayload<HelloWorldV1> = provider
 ///     .load_payload(&DataRequest::from(key::HELLO_WORLD_V1))
 ///     .unwrap()
-///     .payload.take()
+///     .take_payload()
 ///     .unwrap();
 ///
 /// assert_eq!("(und) Hello World", result.message);
@@ -42,9 +42,9 @@ where
     fn load_payload(&self, _req: &DataRequest) -> Result<DataResponse<'d, T>, Error> {
         Ok(DataResponse {
             metadata: DataResponseMetadata::default(),
-            payload: DataPayload {
-                cow: Some(Cow::Owned(T::default())),
-            },
+            payload: Some(DataPayload {
+                cow: Cow::Owned(T::default()),
+            }),
         })
     }
 }

--- a/provider/core/src/serde.rs
+++ b/provider/core/src/serde.rs
@@ -40,17 +40,16 @@ pub trait SerdeDeDataReceiver<'de> {
     /// ```
     /// use icu_provider::prelude::*;
     /// use icu_provider::serde::SerdeDeDataReceiver;
-    /// use std::borrow::Cow;
     ///
     /// const JSON: &'static str = "\"hello world\"";
     ///
-    /// let mut receiver = DataPayload::<String>::new();
+    /// let mut receiver: Option<&str> = None;
     /// let mut d = serde_json::Deserializer::from_str(JSON);
     /// receiver.receive_deserializer(&mut erased_serde::Deserializer::erase(&mut d))
     ///     .expect("Deserialization should be successful");
     ///
-    /// assert!(matches!(receiver.cow, Some(Cow::Owned(_))));
-    /// assert_eq!("hello world", *receiver.borrow().unwrap());
+    /// assert!(matches!(receiver, Some(_)));
+    /// assert_eq!(receiver, Some("hello world"));
     /// ```
     fn receive_deserializer(
         &mut self,

--- a/provider/core/src/struct_provider.rs
+++ b/provider/core/src/struct_provider.rs
@@ -36,13 +36,13 @@ use std::fmt::Debug;
 ///     data: &local_data,
 /// };
 ///
-/// let payload: Cow<SampleDataStruct> = provider.load_payload(&DataRequest::from(SAMPLE_KEY))
+/// let payload: DataPayload<SampleDataStruct> = provider.load_payload(&DataRequest::from(SAMPLE_KEY))
 ///     .expect("Load should succeed")
-///     .payload.take()
+///     .take_payload()
 ///     .expect("Data should be present");
 ///
 /// assert_eq!(*payload, local_data);
-/// assert!(matches!(payload, Cow::Borrowed(_)))
+/// assert!(matches!(payload.cow, Cow::Borrowed(_)))
 /// ```
 pub struct StructProvider<'d, T> {
     pub key: ResourceKey,
@@ -57,9 +57,9 @@ where
         req.resource_path.key.match_key(self.key)?;
         Ok(DataResponse {
             metadata: DataResponseMetadata::default(),
-            payload: DataPayload {
-                cow: Some(Cow::Borrowed(self.data)),
-            },
+            payload: Some(DataPayload {
+                cow: Cow::Borrowed(self.data),
+            }),
         })
     }
 }

--- a/provider/core/src/util.rs
+++ b/provider/core/src/util.rs
@@ -36,13 +36,13 @@ macro_rules! impl_dyn_from_payload {
             ) -> $crate::prelude::DataPayload<$d, dyn $trait + 's> {
                 use std::borrow::Cow;
                 Self {
-                    cow: other.cow.map(|p| match p {
+                    cow: match other.cow {
                         Cow::Borrowed(v) => Cow::Borrowed(v as &(dyn $trait + 's)),
                         Cow::Owned(v) => {
                             let boxed: Box<dyn $trait + 's> = Box::new(v);
                             Cow::Owned(boxed)
                         }
-                    }),
+                    },
                 }
             }
         }
@@ -85,9 +85,9 @@ macro_rules! impl_dyn_from_payload {
 ///         req.resource_path.key.match_key(DEMO_KEY)?;
 ///         Ok(DataResponse {
 ///             metadata: Default::default(),
-///             payload: DataPayload {
-///                 cow: Some(Cow::Owned(self.0.to_string()))
-///             }
+///             payload: Some(DataPayload {
+///                 cow: Cow::Owned(self.0.to_string())
+///             })
 ///         })
 ///     }
 /// }
@@ -114,9 +114,9 @@ macro_rules! impl_dyn_from_payload {
 /// #   fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<'d, String>, DataError> {
 /// #       Ok(DataResponse {
 /// #           metadata: Default::default(),
-/// #           payload: DataPayload {
-/// #               cow: Some(Cow::Owned(self.0.to_string()))
-/// #           }
+/// #           payload: Some(DataPayload {
+/// #               cow: Cow::Owned(self.0.to_string())
+/// #           })
 /// #       })
 /// #   }
 /// # }
@@ -165,7 +165,7 @@ macro_rules! impl_dyn_provider {
                                 $crate::prelude::DataProvider::load_payload(self, req)?;
                             Ok(DataResponse {
                                 metadata: result.metadata,
-                                payload: result.payload.into(),
+                                payload: result.payload.map(|p| p.into()),
                             })
                         }
                     )+,

--- a/provider/core/tests/data_receiver.rs
+++ b/provider/core/tests/data_receiver.rs
@@ -2,7 +2,6 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_provider::prelude::*;
 use icu_provider::serde::SerdeDeDataReceiver;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -22,16 +21,16 @@ const DATA_JSON: &'static str = r#"{
 fn test_deserializer_static() {
     // Deserialize from a string to create static references.
     let deserializer = &mut serde_json::Deserializer::from_str(DATA_JSON);
-    let mut receiver = DataPayload::<DataStruct>::new();
+    let mut receiver = None;
     receiver
         .receive_deserializer(&mut erased_serde::Deserializer::erase(deserializer))
         .expect("Well-formed data");
 
     assert!(matches!(
-        receiver.cow,
-        Some(Cow::Owned(DataStruct {
+        receiver,
+        Some(DataStruct {
             value: Cow::Borrowed(_)
-        }))
+        })
     ));
 }
 
@@ -40,16 +39,16 @@ fn test_deserializer_borrowed() {
     // Deserialize from a local string to create non-static references.
     let local_data = DATA_JSON.to_string();
     let deserializer = &mut serde_json::Deserializer::from_str(&local_data);
-    let mut receiver = DataPayload::<DataStruct>::new();
+    let mut receiver = None;
     receiver
         .receive_deserializer(&mut erased_serde::Deserializer::erase(deserializer))
         .expect("Well-formed data");
 
     assert!(matches!(
-        receiver.cow,
-        Some(Cow::Owned(DataStruct {
+        receiver,
+        Some(DataStruct {
             value: Cow::Borrowed(_)
-        }))
+        })
     ));
 }
 
@@ -57,15 +56,15 @@ fn test_deserializer_borrowed() {
 fn test_deserializer_owned() {
     // Deserialize from a reader to create owned data.
     let deserializer = &mut serde_json::Deserializer::from_reader(DATA_JSON.as_bytes());
-    let mut receiver = DataPayload::<DataStruct>::new();
+    let mut receiver = None;
     receiver
         .receive_deserializer(&mut erased_serde::Deserializer::erase(deserializer))
         .expect("Well-formed data");
 
     assert!(matches!(
-        receiver.cow,
-        Some(Cow::Owned(DataStruct {
+        receiver,
+        Some(DataStruct {
             value: Cow::Owned(_)
-        }))
+        })
     ));
 }

--- a/provider/fs/benches/provider_fs.rs
+++ b/provider/fs/benches/provider_fs.rs
@@ -10,7 +10,6 @@ use icu_provider::prelude::*;
 #[cfg(feature = "bench")]
 use icu_provider::serde::*;
 use icu_provider_fs::FsDataProvider;
-use std::borrow::Cow;
 
 fn overview_bench(c: &mut Criterion) {
     // End-to-end JSON test
@@ -18,7 +17,7 @@ fn overview_bench(c: &mut Criterion) {
         b.iter(|| {
             let provider = FsDataProvider::try_new("./tests/testdata/json")
                 .expect("Loading file from testdata directory");
-            let _: Cow<PluralRuleStringsV1> = black_box(&provider)
+            let _: DataPayload<PluralRuleStringsV1> = black_box(&provider)
                 .load_payload(&DataRequest {
                     resource_path: ResourcePath {
                         key: key::CARDINAL_V1,
@@ -29,8 +28,7 @@ fn overview_bench(c: &mut Criterion) {
                     },
                 })
                 .expect("The data should be valid")
-                .payload
-                .take()
+                .take_payload()
                 .expect("Loading was successful");
         });
     });
@@ -52,7 +50,7 @@ fn json_bench(c: &mut Criterion) {
 
     c.bench_function("json/generic", |b| {
         b.iter(|| {
-            let _: Cow<PluralRuleStringsV1> = black_box(&provider)
+            let _: DataPayload<PluralRuleStringsV1> = black_box(&provider)
                 .load_payload(&DataRequest {
                     resource_path: ResourcePath {
                         key: key::CARDINAL_V1,
@@ -63,28 +61,27 @@ fn json_bench(c: &mut Criterion) {
                     },
                 })
                 .expect("The data should be valid")
-                .payload
-                .take()
+                .take_payload()
                 .expect("Loading was successful");
         });
     });
 
     c.bench_function("json/erased_serde", |b| {
         b.iter(|| {
-            let _: Cow<PluralRuleStringsV1> = black_box(&provider as &dyn SerdeDeDataProvider)
-                .load_payload(&DataRequest {
-                    resource_path: ResourcePath {
-                        key: key::CARDINAL_V1,
-                        options: ResourceOptions {
-                            variant: None,
-                            langid: Some(langid!("ru")),
+            let _: DataPayload<PluralRuleStringsV1> =
+                black_box(&provider as &dyn SerdeDeDataProvider)
+                    .load_payload(&DataRequest {
+                        resource_path: ResourcePath {
+                            key: key::CARDINAL_V1,
+                            options: ResourceOptions {
+                                variant: None,
+                                langid: Some(langid!("ru")),
+                            },
                         },
-                    },
-                })
-                .expect("The data should be valid")
-                .payload
-                .take()
-                .expect("Loading was successful");
+                    })
+                    .expect("The data should be valid")
+                    .take_payload()
+                    .expect("Loading was successful");
         });
     });
 }
@@ -96,7 +93,7 @@ fn bincode_bench(c: &mut Criterion) {
 
     c.bench_function("bincode/generic", |b| {
         b.iter(|| {
-            let _: Cow<PluralRuleStringsV1> = black_box(&provider)
+            let _: DataPayload<PluralRuleStringsV1> = black_box(&provider)
                 .load_payload(&DataRequest {
                     resource_path: ResourcePath {
                         key: key::CARDINAL_V1,
@@ -107,28 +104,27 @@ fn bincode_bench(c: &mut Criterion) {
                     },
                 })
                 .expect("The data should be valid")
-                .payload
-                .take()
+                .take_payload()
                 .expect("Loading was successful");
         });
     });
 
     c.bench_function("bincode/erased_serde", |b| {
         b.iter(|| {
-            let _: Cow<PluralRuleStringsV1> = black_box(&provider as &dyn SerdeDeDataProvider)
-                .load_payload(&DataRequest {
-                    resource_path: ResourcePath {
-                        key: key::CARDINAL_V1,
-                        options: ResourceOptions {
-                            variant: None,
-                            langid: Some(langid!("sr")),
+            let _: DataPayload<PluralRuleStringsV1> =
+                black_box(&provider as &dyn SerdeDeDataProvider)
+                    .load_payload(&DataRequest {
+                        resource_path: ResourcePath {
+                            key: key::CARDINAL_V1,
+                            options: ResourceOptions {
+                                variant: None,
+                                langid: Some(langid!("sr")),
+                            },
                         },
-                    },
-                })
-                .expect("The data should be valid")
-                .payload
-                .take()
-                .expect("Loading was successful");
+                    })
+                    .expect("The data should be valid")
+                    .take_payload()
+                    .expect("Loading was successful");
         });
     });
 }

--- a/provider/fs/src/export/mod.rs
+++ b/provider/fs/src/export/mod.rs
@@ -57,8 +57,8 @@
 //!     fs_provider.load_payload(&req).unwrap();
 //!
 //! assert_eq!(
-//!     source_response.payload.cow,
-//!     fs_response.payload.cow,
+//!     source_response.payload,
+//!     fs_response.payload,
 //! );
 //!
 //! // Clean up from demo

--- a/provider/fs/src/fs_data_provider.rs
+++ b/provider/fs/src/fs_data_provider.rs
@@ -93,9 +93,9 @@ where
             metadata: DataResponseMetadata {
                 data_langid: req.resource_path.options.langid.clone(),
             },
-            payload: DataPayload {
-                cow: Some(Cow::Owned(data)),
-            },
+            payload: Some(DataPayload {
+                cow: Cow::Owned(data),
+            }),
         })
     }
 }

--- a/provider/fs/tests/test_file_io.rs
+++ b/provider/fs/tests/test_file_io.rs
@@ -52,11 +52,10 @@ fn test_json() {
     let provider = FsDataProvider::try_new("./tests/testdata/json")
         .expect("Loading file from testdata directory");
 
-    let plurals_data: Cow<PluralRuleStringsV1> = provider
+    let plurals_data: DataPayload<PluralRuleStringsV1> = provider
         .load_payload(&get_request(langid!("ru")))
         .expect("The data should be valid")
-        .payload
-        .take()
+        .take_payload()
         .expect("The data should be present");
     assert_eq!(*plurals_data, EXPECTED_RU_DATA);
 }
@@ -66,11 +65,10 @@ fn test_json_dyn_erased_serde() {
     let provider = FsDataProvider::try_new("./tests/testdata/json")
         .expect("Loading file from testdata directory");
 
-    let plurals_data: Cow<PluralRuleStringsV1> = (&provider as &dyn SerdeDeDataProvider)
+    let plurals_data: DataPayload<PluralRuleStringsV1> = (&provider as &dyn SerdeDeDataProvider)
         .load_payload(&get_request(langid!("ru")))
         .expect("The data should be valid")
-        .payload
-        .take()
+        .take_payload()
         .expect("The data should be present");
     assert_eq!(*plurals_data, EXPECTED_RU_DATA);
 }
@@ -159,11 +157,10 @@ fn test_bincode() {
     let provider = FsDataProvider::try_new("./tests/testdata/bincode")
         .expect("Loading file from testdata directory");
 
-    let plurals_data: Cow<PluralRuleStringsV1> = provider
+    let plurals_data: DataPayload<PluralRuleStringsV1> = provider
         .load_payload(&get_request(langid!("sr")))
         .expect("The data should be valid")
-        .payload
-        .take()
+        .take_payload()
         .expect("The data should be present");
     assert_eq!(*plurals_data, EXPECTED_SR_DATA);
 }
@@ -174,11 +171,10 @@ fn test_bincode_dyn_erased_serde() {
     let provider = FsDataProvider::try_new("./tests/testdata/bincode")
         .expect("Loading file from testdata directory");
 
-    let plurals_data: Cow<PluralRuleStringsV1> = (&provider as &dyn SerdeDeDataProvider)
+    let plurals_data: DataPayload<PluralRuleStringsV1> = (&provider as &dyn SerdeDeDataProvider)
         .load_payload(&get_request(langid!("sr")))
         .expect("The data should be valid")
-        .payload
-        .take()
+        .take_payload()
         .expect("The data should be present");
     assert_eq!(*plurals_data, EXPECTED_SR_DATA);
 }

--- a/provider/testdata/README.md
+++ b/provider/testdata/README.md
@@ -43,7 +43,7 @@ use icu_locid_macros::langid;
 
 let data_provider = icu_testdata::get_provider();
 
-let data: Cow<icu_plurals::provider::PluralRuleStringsV1> = data_provider
+let data: DataPayload<icu_plurals::provider::PluralRuleStringsV1> = data_provider
     .load_payload(&DataRequest {
         resource_path: ResourcePath {
             key: icu_plurals::provider::key::CARDINAL_V1,
@@ -54,7 +54,7 @@ let data: Cow<icu_plurals::provider::PluralRuleStringsV1> = data_provider
         },
     })
     .unwrap()
-    .payload.take()
+    .take_payload()
     .unwrap();
 assert_eq!(data.few, Some(Cow::Borrowed("v = 0 and i % 10 = 2..4 and i % 100 != 12..14")));
 ```

--- a/provider/testdata/src/lib.rs
+++ b/provider/testdata/src/lib.rs
@@ -45,7 +45,7 @@
 //!
 //! let data_provider = icu_testdata::get_provider();
 //!
-//! let data: Cow<icu_plurals::provider::PluralRuleStringsV1> = data_provider
+//! let data: DataPayload<icu_plurals::provider::PluralRuleStringsV1> = data_provider
 //!     .load_payload(&DataRequest {
 //!         resource_path: ResourcePath {
 //!             key: icu_plurals::provider::key::CARDINAL_V1,
@@ -56,7 +56,7 @@
 //!         },
 //!     })
 //!     .unwrap()
-//!     .payload.take()
+//!     .take_payload()
 //!     .unwrap();
 //! assert_eq!(data.few, Some(Cow::Borrowed("v = 0 and i % 10 = 2..4 and i % 100 != 12..14")));
 //! ```


### PR DESCRIPTION
First part of #667

I changed most of the places in ICU4X storing data structs in Cow to store them in DataPayload instead.  This involved the following additional changes:

- Moving the Option up a level from DataPayload to DataResponse (and associated changes)
- Implementing Borrow, AsRef, and Deref on DataPayload

There are still a few places in the ICU4X code base that depend on Cow-specific functionality.  I'll address those places next.