### PR TITLE
Properly initialize ICU4XPluralOperands struct in the capi example

### DIFF
--- a/ffi/capi/examples/pluralrules/test.c
+++ b/ffi/capi/examples/pluralrules/test.c
@@ -22,8 +22,7 @@ int main() {
     }
     ICU4XPluralRules* rules = plural_result.rules;
 
-    ICU4XPluralOperands op;
-    op.i = 3;
+    ICU4XPluralOperands op = { .i = 3 };
 
     ICU4XPluralCategory cat = icu4x_plural_rules_select(rules, &op);
 


### PR DESCRIPTION
Other fields in ICU4XPluralOperands are meant to be zero.

Fixed #732.