### PR TITLE
WIP: Attempting to add Yoke variant to DataPayload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,6 +997,7 @@ dependencies = [
  "thiserror",
  "tinystr",
  "writeable",
+ "yoke",
 ]
 
 [[package]]

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -36,6 +36,7 @@ icu_locid = { version = "0.2", path = "../../components/locid" }
 tinystr = "0.4.5"
 writeable = { version = "0.2", path = "../../utils/writeable" }
 thiserror = "1.0"
+yoke = { version = "0.1", path = "../../utils/yoke" }
 
 # For "provider_serde" feature
 erased-serde = { version = "0.3", optional = true }

--- a/provider/core/src/iter.rs
+++ b/provider/core/src/iter.rs
@@ -7,6 +7,8 @@
 use crate::error::Error;
 use crate::prelude::*;
 use std::fmt::Debug;
+use std::borrow::Borrow;
+use yoke::Yokeable;
 
 /// A provider that can iterate over all supported [`ResourceOptions`] for a certain key.
 ///
@@ -25,7 +27,9 @@ pub trait IterableDataProviderCore {
 pub trait IterableDataProvider<'d, T>: IterableDataProviderCore + DataProvider<'d, T>
 where
     T: ToOwned + ?Sized,
-    <T as ToOwned>::Owned: Debug,
+    <T as ToOwned>::Owned: for<'a> yoke::Yokeable<'a>,
+    for<'a> <<T as ToOwned>::Owned as Yokeable<'a>>::Output: Borrow<T>,
+    for<'a> <<T as ToOwned>::Owned as Yokeable<'a>>::Output: Clone,
 {
 }
 
@@ -33,7 +37,9 @@ impl<'d, S, T> IterableDataProvider<'d, T> for S
 where
     S: IterableDataProviderCore + DataProvider<'d, T>,
     T: ToOwned + ?Sized,
-    <T as ToOwned>::Owned: Debug,
+    <T as ToOwned>::Owned: for<'a> yoke::Yokeable<'a>,
+    for<'a> <<T as ToOwned>::Owned as Yokeable<'a>>::Output: Borrow<T>,
+    for<'a> <<T as ToOwned>::Owned as Yokeable<'a>>::Output: Clone,
 {
 }
 

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -112,13 +112,13 @@ mod data_provider;
 mod resource;
 #[macro_use]
 pub mod erased;
-pub mod export;
-pub mod hello_world;
-pub mod inv;
+// pub mod export;
+// pub mod hello_world;
+// pub mod inv;
 pub mod iter;
 #[cfg(feature = "provider_serde")]
 pub mod serde;
-pub mod struct_provider;
+// pub mod struct_provider;
 
 mod error;
 


### PR DESCRIPTION
Here's where I've gotten so far.

The tricky thing is figuring out the correct type bounds to put on DataPayload.  In my branch for this PR, I have:

```rust
enum DataPayloadInternal<'d, T>
where
    T: ToOwned + ?Sized,
    <T as ToOwned>::Owned: for<'a> yoke::Yokeable<'a>,
    for<'a> <<T as ToOwned>::Owned as Yokeable<'a>>::Output: Borrow<T>,
{
    Borrowed(&'d T),
    Yoked(yoke::Yoke<<T as ToOwned>::Owned, Option<std::rc::Rc<[u8]>>>),
}
```

The constraint on `Borrow<T>` enables `Deref` to work:

```rust
impl<'d, T> Deref for DataPayload<'d, T>
where
    T: ToOwned + ?Sized,
    <T as ToOwned>::Owned: for<'a> yoke::Yokeable<'a>,
    for<'a> <<T as ToOwned>::Owned as Yokeable<'a>>::Output: Borrow<T>,
{
    type Target = T;

    #[inline]
    fn deref<'a>(&'a self) -> &'a Self::Target {
        use DataPayloadInternal::*;
        match self.internal {
            Borrowed(borrowed) => borrowed,
            Yoked(ref yoke) => {
                yoke.get().borrow()
            },
        }
    }
}
```

However, then I get errors such as

> the trait `for<'a> Borrow<(dyn ErasedDataStruct + 'static)>` is not implemented for `<Box<dyn ErasedDataStruct> as Yokeable<'a>>::Output

Suggestions on how to make Yoke play nice with Deref?