### PR TITLE
Add ZeroCopyClone for Yoke backed by borrowed data

### DIFF
--- a/utils/yoke/src/borrowing.rs
+++ b/utils/yoke/src/borrowing.rs
@@ -3,43 +3,10 @@ use crate::Yokeable;
 use std::borrow::Borrow;
 use std::borrow::Cow;
 use std::mem;
+use std::rc::Rc;
 
-pub trait ZeroCopyCloneV2 {
-    type Yokeable: for<'a> Yokeable<'a>;
-
-    fn zero_copy_clone_v2<'b>(&'b self) -> <Self::Yokeable as Yokeable<'b>>::Output;
-
-    fn borrow_into_yoke<'b>(&'b self) -> Yoke<Self::Yokeable, &'b Self> {
-        Yoke::<Self::Yokeable, &'b Self>::attach_to_cart_badly(self, Self::zero_copy_clone_v2)
-    }
-}
-
-pub trait ZeroCopyCloneV4: for<'a> Yokeable<'a> {
-    fn zero_copy_clone_v4<'b>(
-        this: &'b <Self as Yokeable<'b>>::Output,
-    ) -> <Self as Yokeable<'b>>::Output;
-}
-
-// pub trait ZeroCopyCloneV5<'d> {
-//     type Yokeable: for<'a> Yokeable<'a> + Yokeable<'d, Output = Self>;
-
-//     fn zero_copy_clone_v5<'b>(&self) -> <Self::Yokeable as Yokeable<'b>>::Output;
-// }
-
-pub trait ZeroCopyCloneV6<'d>: 'd {
-    type Yokeable: for<'a> Yokeable<'a>;
-
-    fn zero_copy_clone_v6<'b>(&'b self) -> <Self::Yokeable as Yokeable<'b>>::Output;
-}
-
-pub trait ZeroCopyCloneV7<'s> {
-    fn zero_copy_clone_v7(&'s self) -> Self;
-}
-
-pub trait ZeroCopyCloneV8<'o, 'i: 'o>: 'i {
-    type Output: 'o;
-
-    fn zero_copy_clone_v8(&'o self) -> Self::Output;
+pub trait ZeroCopyClone: for<'a> Yokeable<'a> {
+    fn zcc<'b, 's>(this: &'b <Self as Yokeable<'s>>::Output) -> <Self as Yokeable<'b>>::Output;
 }
 
 struct DataStruct<'s> {
@@ -68,19 +35,8 @@ unsafe impl<'a> Yokeable<'a> for DataStruct<'static> {
     }
 }
 
-impl<'s> ZeroCopyCloneV2 for DataStruct<'s> {
-    type Yokeable = DataStruct<'static>;
-
-    fn zero_copy_clone_v2<'b>(&'b self) -> <Self::Yokeable as Yokeable<'b>>::Output {
-        DataStruct {
-            f1: Cow::Borrowed(self.f1.borrow()),
-            f2: Cow::Borrowed(self.f2.borrow()),
-        }
-    }
-}
-
-impl<'s> ZeroCopyCloneV4 for DataStruct<'static> {
-    fn zero_copy_clone_v4<'b>(this: &'b DataStruct<'b>) -> DataStruct<'b> {
+impl ZeroCopyClone for DataStruct<'static> {
+    fn zcc<'b, 's>(this: &'b DataStruct<'s>) -> DataStruct<'b> {
         DataStruct {
             f1: Cow::Borrowed(this.f1.borrow()),
             f2: Cow::Borrowed(this.f2.borrow()),
@@ -88,75 +44,29 @@ impl<'s> ZeroCopyCloneV4 for DataStruct<'static> {
     }
 }
 
-impl<'s> ZeroCopyCloneV7<'s> for DataStruct<'s> {
-    fn zero_copy_clone_v7(&'s self) -> DataStruct<'s> {
-        DataStruct {
-            f1: Cow::Borrowed(self.f1.borrow()),
-            f2: Cow::Borrowed(self.f2.borrow()),
-        }
+impl ZeroCopyClone for &'static str {
+    fn zcc<'b, 's>(this: &'b &'s str) -> &'b str {
+        this
     }
-}
-
-impl ZeroCopyCloneV2 for str {
-    type Yokeable = &'static str;
-
-    fn zero_copy_clone_v2<'b>(&'b self) -> <Self::Yokeable as Yokeable<'b>>::Output {
-        self
-    }
-}
-
-impl<'b, B> Yoke<<B as ZeroCopyCloneV2>::Yokeable, &'b B>
-where
-    B: ZeroCopyCloneV2,
-{
-    fn from_borrowed_v2(b: &'b B) -> Self {
-        Self::attach_to_cart_badly(b, B::zero_copy_clone_v2)
-    }
-}
-
-/*
-fn zcc_v7_helper<'de, 'b, B>(v: &'de <B as Yokeable<'de>>::Output) -> <B as Yokeable<'de>>::Output
-where
-    B: for<'a> Yokeable<'a>,
-    for<'a> <B as Yokeable<'a>>::Output: ZeroCopyCloneV7<'a>,
-    'b: 'de,
-{
-    v.zero_copy_clone_v7()
 }
 
 impl<'b, B> Yoke<B, &'b <B as Yokeable<'b>>::Output>
 where
-    B: for<'a> Yokeable<'a>,
-    <B as Yokeable<'b>>::Output: ZeroCopyCloneV7<'b>,
+    B: ZeroCopyClone,
 {
-    fn from_borrowed_v7(b: &'b <B as Yokeable<'b>>::Output) -> Self {
-        Self::attach_to_cart_badly(
-            b,
-            ZeroCopyCloneV7::zero_copy_clone_v7,
-        )
+    fn from_borrowed(b: &'b <B as Yokeable<'b>>::Output) -> Self {
+        Self::attach_to_cart_badly(b, B::zcc)
     }
 }
 
-fn zcc_v8_helper<'de, 'b, B>(v: &'de <B as Yokeable<'b>>::Output) -> <B as Yokeable<'de>>::Output
+impl<'b, B> Yoke<B, Rc<<B as Yokeable<'b>>::Output>>
 where
-    B: for<'a> Yokeable<'a>,
-    <B as Yokeable<'b>>::Output: ZeroCopyCloneV8<'de, 'b, Output = <B as Yokeable<'de>>::Output>,
-    'b: 'de,
+    B: ZeroCopyClone,
 {
-    v.zero_copy_clone_v8()
-}
-
-impl<'b, B> Yoke<B, &'b <B as Yokeable<'b>>::Output>
-where
-    B: for<'a> Yokeable<'a>,
-    <B as Yokeable<'b>>::Output:
-        for<'de> ZeroCopyCloneV8<'de, 'b, Output = <B as Yokeable<'de>>::Output>,
-{
-    fn from_borrowed_v8(b: &'b <B as Yokeable<'b>>::Output) -> Self {
-        Self::attach_to_cart_badly(b, zcc_v8_helper)
+    fn from_rc(b: Rc<<B as Yokeable<'b>>::Output>) -> Self {
+        Self::attach_to_cart_badly(b, B::zcc)
     }
 }
-*/
 
 #[test]
 fn test_borrowing() {
@@ -165,12 +75,12 @@ fn test_borrowing() {
         f2: Cow::Owned("bar".to_string()),
     };
 
-    let yoke = data_struct.borrow_into_yoke();
+    let yoke = Yoke::<DataStruct<'static>, &DataStruct<'_>>::from_borrowed(&data_struct);
 
     assert_eq!(yoke.get().f1, "foo");
     assert!(matches!(yoke.get().f1, Cow::Borrowed(_)));
 
-    let yoke = Yoke::<DataStruct<'static>, &DataStruct<'_>>::from_borrowed_v2(&data_struct);
+    let yoke = Yoke::<DataStruct<'static>, Rc<DataStruct<'_>>>::from_rc(Rc::from(data_struct));
 
     assert_eq!(yoke.get().f1, "foo");
     assert!(matches!(yoke.get().f1, Cow::Borrowed(_)));

--- a/utils/yoke/src/borrowing.rs
+++ b/utils/yoke/src/borrowing.rs
@@ -1,0 +1,69 @@
+use crate::Yoke;
+use crate::Yokeable;
+use std::borrow::Borrow;
+use std::borrow::Cow;
+use std::mem;
+
+trait ZeroCopyCloneV2 {
+    type Yokeable: for<'a> Yokeable<'a>;
+
+    fn zero_copy_clone_v2<'b>(&'b self) -> <Self::Yokeable as Yokeable<'b>>::Output;
+}
+
+struct DataStruct<'s> {
+    f1: Cow<'s, str>,
+    f2: Cow<'s, str>,
+}
+
+unsafe impl<'a> Yokeable<'a> for DataStruct<'static> {
+    type Output = DataStruct<'a>;
+
+    fn transform(&'a self) -> &'a DataStruct<'a> {
+        unsafe { mem::transmute(self) }
+    }
+
+    unsafe fn make(from: DataStruct<'a>) -> Self {
+        mem::transmute(from)
+    }
+
+    fn with_mut<F>(&'a mut self, f: F)
+    where
+        F: 'static + for<'b> FnOnce(&'b mut Self::Output),
+    {
+        // Cast away the lifetime of Self
+        unsafe { f(mem::transmute::<&'a mut Self, &'a mut Self::Output>(self)) }
+    }
+}
+
+impl<'s> ZeroCopyCloneV2 for DataStruct<'s> {
+    type Yokeable = DataStruct<'static>;
+
+    fn zero_copy_clone_v2<'b>(&'b self) -> <Self::Yokeable as Yokeable<'b>>::Output {
+        DataStruct {
+            f1: Cow::Borrowed(self.f1.borrow()),
+            f2: Cow::Borrowed(self.f2.borrow()),
+        }
+    }
+}
+
+impl ZeroCopyCloneV2 for str {
+    type Yokeable = &'static str;
+
+    fn zero_copy_clone_v2<'b>(&'b self) -> <Self::Yokeable as Yokeable<'b>>::Output {
+        self
+    }
+}
+
+fn helper<'de, B>(b: &'de B) -> <<B as ZeroCopyCloneV2>::Yokeable as Yokeable<'de>>::Output
+where
+    B: ZeroCopyCloneV2
+{
+    todo!()
+}
+
+fn yoke_from_borrowed<'b, B>(b: &'b B) -> Yoke<<B as ZeroCopyCloneV2>::Yokeable, &'b B>
+where
+    B: ZeroCopyCloneV2
+{
+    Yoke::<<B as ZeroCopyCloneV2>::Yokeable, &'b B>::attach_to_cart_badly(b, helper)
+}

--- a/utils/yoke/src/borrowing.rs
+++ b/utils/yoke/src/borrowing.rs
@@ -14,6 +14,10 @@ trait ZeroCopyCloneV2 {
     }
 }
 
+trait ZeroCopyCloneV4: for<'a> Yokeable<'a> {
+    fn zero_copy_clone_v4<'b>(this: &'b <Self as Yokeable<'b>>::Output) -> <Self as Yokeable<'b>>::Output;
+}
+
 struct DataStruct<'s> {
     f1: Cow<'s, str>,
     f2: Cow<'s, str>,
@@ -47,6 +51,15 @@ impl<'s> ZeroCopyCloneV2 for DataStruct<'s> {
         DataStruct {
             f1: Cow::Borrowed(self.f1.borrow()),
             f2: Cow::Borrowed(self.f2.borrow()),
+        }
+    }
+}
+
+impl<'s> ZeroCopyCloneV4 for DataStruct<'static> {
+    fn zero_copy_clone_v4<'b>(this: &'b DataStruct<'b>) -> DataStruct<'b> {
+        DataStruct {
+            f1: Cow::Borrowed(this.f1.borrow()),
+            f2: Cow::Borrowed(this.f2.borrow()),
         }
     }
 }

--- a/utils/yoke/src/borrowing.rs
+++ b/utils/yoke/src/borrowing.rs
@@ -4,7 +4,7 @@ use std::borrow::Borrow;
 use std::borrow::Cow;
 use std::mem;
 
-trait ZeroCopyCloneV2 {
+pub trait ZeroCopyCloneV2 {
     type Yokeable: for<'a> Yokeable<'a>;
 
     fn zero_copy_clone_v2<'b>(&'b self) -> <Self::Yokeable as Yokeable<'b>>::Output;
@@ -14,20 +14,32 @@ trait ZeroCopyCloneV2 {
     }
 }
 
-trait ZeroCopyCloneV4: for<'a> Yokeable<'a> {
-    fn zero_copy_clone_v4<'b>(this: &'b <Self as Yokeable<'b>>::Output) -> <Self as Yokeable<'b>>::Output;
+pub trait ZeroCopyCloneV4: for<'a> Yokeable<'a> {
+    fn zero_copy_clone_v4<'b>(
+        this: &'b <Self as Yokeable<'b>>::Output,
+    ) -> <Self as Yokeable<'b>>::Output;
 }
 
-// trait ZeroCopyCloneV5<'d> {
+// pub trait ZeroCopyCloneV5<'d> {
 //     type Yokeable: for<'a> Yokeable<'a> + Yokeable<'d, Output = Self>;
 
 //     fn zero_copy_clone_v5<'b>(&self) -> <Self::Yokeable as Yokeable<'b>>::Output;
 // }
 
-trait ZeroCopyCloneV6<'d>: 'd {
+pub trait ZeroCopyCloneV6<'d>: 'd {
     type Yokeable: for<'a> Yokeable<'a>;
 
     fn zero_copy_clone_v6<'b>(&'b self) -> <Self::Yokeable as Yokeable<'b>>::Output;
+}
+
+pub trait ZeroCopyCloneV7<'s> {
+    fn zero_copy_clone_v7(&'s self) -> Self;
+}
+
+pub trait ZeroCopyCloneV8<'o, 'i: 'o>: 'i {
+    type Output: 'o;
+
+    fn zero_copy_clone_v8(&'o self) -> Self::Output;
 }
 
 struct DataStruct<'s> {
@@ -76,6 +88,15 @@ impl<'s> ZeroCopyCloneV4 for DataStruct<'static> {
     }
 }
 
+impl<'s> ZeroCopyCloneV7<'s> for DataStruct<'s> {
+    fn zero_copy_clone_v7(&'s self) -> DataStruct<'s> {
+        DataStruct {
+            f1: Cow::Borrowed(self.f1.borrow()),
+            f2: Cow::Borrowed(self.f2.borrow()),
+        }
+    }
+}
+
 impl ZeroCopyCloneV2 for str {
     type Yokeable = &'static str;
 
@@ -86,12 +107,56 @@ impl ZeroCopyCloneV2 for str {
 
 impl<'b, B> Yoke<<B as ZeroCopyCloneV2>::Yokeable, &'b B>
 where
-    B: ZeroCopyCloneV2
+    B: ZeroCopyCloneV2,
 {
-    fn from_borrowed(b: &'b B) -> Self {
+    fn from_borrowed_v2(b: &'b B) -> Self {
         Self::attach_to_cart_badly(b, B::zero_copy_clone_v2)
     }
 }
+
+/*
+fn zcc_v7_helper<'de, 'b, B>(v: &'de <B as Yokeable<'de>>::Output) -> <B as Yokeable<'de>>::Output
+where
+    B: for<'a> Yokeable<'a>,
+    for<'a> <B as Yokeable<'a>>::Output: ZeroCopyCloneV7<'a>,
+    'b: 'de,
+{
+    v.zero_copy_clone_v7()
+}
+
+impl<'b, B> Yoke<B, &'b <B as Yokeable<'b>>::Output>
+where
+    B: for<'a> Yokeable<'a>,
+    <B as Yokeable<'b>>::Output: ZeroCopyCloneV7<'b>,
+{
+    fn from_borrowed_v7(b: &'b <B as Yokeable<'b>>::Output) -> Self {
+        Self::attach_to_cart_badly(
+            b,
+            ZeroCopyCloneV7::zero_copy_clone_v7,
+        )
+    }
+}
+
+fn zcc_v8_helper<'de, 'b, B>(v: &'de <B as Yokeable<'b>>::Output) -> <B as Yokeable<'de>>::Output
+where
+    B: for<'a> Yokeable<'a>,
+    <B as Yokeable<'b>>::Output: ZeroCopyCloneV8<'de, 'b, Output = <B as Yokeable<'de>>::Output>,
+    'b: 'de,
+{
+    v.zero_copy_clone_v8()
+}
+
+impl<'b, B> Yoke<B, &'b <B as Yokeable<'b>>::Output>
+where
+    B: for<'a> Yokeable<'a>,
+    <B as Yokeable<'b>>::Output:
+        for<'de> ZeroCopyCloneV8<'de, 'b, Output = <B as Yokeable<'de>>::Output>,
+{
+    fn from_borrowed_v8(b: &'b <B as Yokeable<'b>>::Output) -> Self {
+        Self::attach_to_cart_badly(b, zcc_v8_helper)
+    }
+}
+*/
 
 #[test]
 fn test_borrowing() {
@@ -105,7 +170,7 @@ fn test_borrowing() {
     assert_eq!(yoke.get().f1, "foo");
     assert!(matches!(yoke.get().f1, Cow::Borrowed(_)));
 
-    let yoke = Yoke::<DataStruct<'static>, &DataStruct<'_>>::from_borrowed(&data_struct);
+    let yoke = Yoke::<DataStruct<'static>, &DataStruct<'_>>::from_borrowed_v2(&data_struct);
 
     assert_eq!(yoke.get().f1, "foo");
     assert!(matches!(yoke.get().f1, Cow::Borrowed(_)));

--- a/utils/yoke/src/borrowing.rs
+++ b/utils/yoke/src/borrowing.rs
@@ -18,6 +18,18 @@ trait ZeroCopyCloneV4: for<'a> Yokeable<'a> {
     fn zero_copy_clone_v4<'b>(this: &'b <Self as Yokeable<'b>>::Output) -> <Self as Yokeable<'b>>::Output;
 }
 
+// trait ZeroCopyCloneV5<'d> {
+//     type Yokeable: for<'a> Yokeable<'a> + Yokeable<'d, Output = Self>;
+
+//     fn zero_copy_clone_v5<'b>(&self) -> <Self::Yokeable as Yokeable<'b>>::Output;
+// }
+
+trait ZeroCopyCloneV6<'d>: 'd {
+    type Yokeable: for<'a> Yokeable<'a>;
+
+    fn zero_copy_clone_v6<'b>(&'b self) -> <Self::Yokeable as Yokeable<'b>>::Output;
+}
+
 struct DataStruct<'s> {
     f1: Cow<'s, str>,
     f2: Cow<'s, str>,

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -13,6 +13,7 @@
 // them out is good even when redundant
 #![allow(clippy::needless_lifetimes)]
 
+mod borrowing;
 mod yoke;
 mod yokeable;
 


### PR DESCRIPTION
Fixes #737
See #667

The trait that ended up working for this use case was

```rust
trait ZeroCopyCloneV2 {
    type Yokeable: for<'a> Yokeable<'a>;

    fn zero_copy_clone_v2<'b>(&'b self) -> <Self::Yokeable as Yokeable<'b>>::Output;
}
```

It ends up being quite clean.  I like this as a viable alternative to the standalone Borrowed variant on DataPayload.

Let me know what you think of where to put the construction function (on `Yoke` or on the trait).  Then I'll polish it up and get it ready to submit.