### PR TITLE
Initial build infrastructure and example for WASM FFI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -44,7 +44,8 @@ bincode-gen-testdata = "make bincode-gen-testdata"
 ### WASM TASKS ###
 
 # Re-build standard library with panic=abort.
-wasm-build = "build -Z build-std=std,panic_abort --target wasm32-unknown-unknown --release"
+wasm-build-dev = "build -Z build-std=std,panic_abort --target wasm32-unknown-unknown"
+wasm-build-release = "build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target wasm32-unknown-unknown --release"
 
 [target.wasm32-unknown-unknown]
 rustflags = [

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -44,7 +44,7 @@ bincode-gen-testdata = "make bincode-gen-testdata"
 ### WASM TASKS ###
 
 # Re-build standard library with panic=abort.
-wasm-build = "build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target wasm32-unknown-unknown --release"
+wasm-build = "build -Z build-std=std,panic_abort --target wasm32-unknown-unknown --release"
 
 [target.wasm32-unknown-unknown]
 rustflags = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,6 +854,7 @@ dependencies = [
  "icu_plurals",
  "icu_provider",
  "icu_provider_fs",
+ "log",
  "writeable",
 ]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -151,13 +151,21 @@ dependencies = [
 
 ### WASM TASKS ###
 
-[tasks.wasm-build]
-description = "Build all examples as WASM into the target directory"
+[tasks.wasm-build-dev]
+description = "Build WASM FFI into the target directory (dev mode)"
 category = "ICU4X WASM"
 install_crate = { rustup_component_name = "rust-src" }
 toolchain = "nightly-2021-02-28"
 command = "cargo"
-args = ["wasm-build", "--package", "icu_capi"]
+args = ["wasm-build-dev", "--package", "icu_capi"]
+
+[tasks.wasm-build-release]
+description = "Build WASM FFI into the target directory (release mode)"
+category = "ICU4X WASM"
+install_crate = { rustup_component_name = "rust-src" }
+toolchain = "nightly-2021-02-28"
+command = "cargo"
+args = ["wasm-build-release", "--package", "icu_capi"]
 
 [tasks.wasm-dir]
 description = "Make the WASM package directory"
@@ -165,17 +173,24 @@ category = "ICU4X WASM"
 command = "mkdir"
 args = ["-p", "wasmpkg"]
 
-[tasks.wasm-wasm]
-description = "Copy the WASM files from target into wasmpkg"
+[tasks.wasm-wasm-dev]
+description = "Copy the WASM files from dev into wasmpkg"
+category = "ICU4X WASM"
+command = "cp"
+args = ["${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target/wasm32-unknown-unknown/debug/icu_capi.wasm", "wasmpkg/"]
+dependencies = ["wasm-build-dev", "wasm-dir"]
+
+[tasks.wasm-wasm-release]
+description = "Copy the WASM files from release into wasmpkg"
 category = "ICU4X WASM"
 command = "cp"
 args = ["${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target/wasm32-unknown-unknown/release/icu_capi.wasm", "wasmpkg/"]
-dependencies = ["wasm-build", "wasm-dir"]
+dependencies = ["wasm-build-release", "wasm-dir"]
 
 [tasks.wasm-wat]
 description = "Create WebAssembly Text files from the WASM files"
 category = "ICU4X WASM"
-dependencies = ["wasm-wasm"]
+dependencies = ["wasm-wasm-release"]
 script_runner = "@duckscript"
 script = '''
 exit_on_error true
@@ -215,7 +230,7 @@ end
 [tasks.wasm-dcmp]
 description = "Create WebAssembly decompiled code files from the WASM files"
 category = "ICU4X WASM"
-dependencies = ["wasm-wasm"]
+dependencies = ["wasm-wasm-release"]
 script_runner = "@duckscript"
 script = '''
 exit_on_error true
@@ -255,7 +270,7 @@ end
 [tasks.wasm-opt]
 description = "Create optimized WASM files from the WASM files"
 category = "ICU4X WASM"
-dependencies = ["wasm-wasm"]
+dependencies = ["wasm-wasm-release"]
 script_runner = "@duckscript"
 script = '''
 exit_on_error true
@@ -324,13 +339,20 @@ for src_path in ${handle}
     end
 end
 '''
-dependencies = ["wasm-wasm"]
+dependencies = ["wasm-wasm-release"]
 
-[tasks.wasm]
-description = "All-in-one command to build examples and supplements to wasmpkg"
+[tasks.wasm-dev]
+description = "All-in-one command to build dev-mode WASM FFI to wasmpkg"
 category = "ICU4X WASM"
 dependencies = [
-    "wasm-wasm",
+    "wasm-wasm-dev",
+]
+
+[tasks.wasm-release]
+description = "All-in-one command to build release-mode WASM FFI to wasmpkg"
+category = "ICU4X WASM"
+dependencies = [
+    "wasm-wasm-release",
     "wasm-wat",
     "wasm-dcmp",
     "wasm-opt",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -157,7 +157,7 @@ category = "ICU4X WASM"
 install_crate = { rustup_component_name = "rust-src" }
 toolchain = "nightly-2021-02-28"
 command = "cargo"
-args = ["wasm-build", "--examples", "--workspace", "--exclude", "icu_datagen"]
+args = ["wasm-build", "--package", "icu_capi"]
 
 [tasks.wasm-dir]
 description = "Make the WASM package directory"
@@ -169,7 +169,7 @@ args = ["-p", "wasmpkg"]
 description = "Copy the WASM files from target into wasmpkg"
 category = "ICU4X WASM"
 command = "cp"
-args = ["-a", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target/wasm32-unknown-unknown/release/examples/.", "wasmpkg/"]
+args = ["${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target/wasm32-unknown-unknown/release/icu_capi.wasm", "wasmpkg/"]
 dependencies = ["wasm-build", "wasm-dir"]
 
 [tasks.wasm-wat]

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -25,7 +25,7 @@ include = [
 all-features = true
 
 [lib]
-crate-type = ["staticlib", "rlib"]
+crate-type = ["staticlib", "rlib", "cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
@@ -36,3 +36,6 @@ icu_plurals = { path = "../../components/plurals/" }
 icu_provider = { path = "../../provider/core" }
 icu_provider_fs = { path = "../../provider/fs/" }
 writeable = { path = "../../utils/writeable/" }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+log = { version = "0.4" }

--- a/ffi/capi/src/custom_writeable.rs
+++ b/ffi/capi/src/custom_writeable.rs
@@ -117,7 +117,6 @@ pub unsafe extern "C" fn icu4x_simple_writeable(buf: *mut u8, buf_size: usize) -
     }
 }
 
-
 #[no_mangle]
 /// Create an [`ICU4XWriteable`] that can write to a dynamically allocated buffer managed by Rust.
 ///
@@ -141,9 +140,9 @@ pub unsafe extern "C" fn icu4x_buffer_writeable_create(cap: usize) -> *mut ICU4X
         context: ptr::null_mut(),
         buf: vec.as_mut_ptr(),
         len: 0,
-        cap: cap,
-        flush: flush,
-        grow: grow
+        cap,
+        flush,
+        grow,
     };
 
     std::mem::forget(vec);

--- a/ffi/capi/src/custom_writeable.rs
+++ b/ffi/capi/src/custom_writeable.rs
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn icu4x_simple_writeable(buf: *mut u8, buf_size: usize) -
 /// Create an [`ICU4XWriteable`] that can write to a dynamically allocated buffer managed by Rust.
 ///
 /// Use [`icu4x_buffer_writeable_destroy()`] to free the writable and its underlying buffer.
-pub unsafe extern "C" fn icu4x_buffer_writeable_create(cap: usize) -> *mut ICU4XWriteable {
+pub extern "C" fn icu4x_buffer_writeable_create(cap: usize) -> *mut ICU4XWriteable {
     extern "C" fn grow(this: *mut ICU4XWriteable, cap: usize) -> bool {
         unsafe {
             let this = &*this;

--- a/ffi/capi/src/custom_writeable.rs
+++ b/ffi/capi/src/custom_writeable.rs
@@ -120,8 +120,7 @@ pub unsafe extern "C" fn icu4x_simple_writeable(buf: *mut u8, buf_size: usize) -
 #[no_mangle]
 /// Create an [`ICU4XWriteable`] that can write to a dynamically allocated buffer managed by Rust.
 ///
-/// # Safety
-/// - Use [`icu4x_buffer_writeable_destroy()`] to free the writable and its underlying buffer.
+/// Use [`icu4x_buffer_writeable_destroy()`] to free the writable and its underlying buffer.
 pub unsafe extern "C" fn icu4x_buffer_writeable_create(cap: usize) -> *mut ICU4XWriteable {
     extern "C" fn grow(this: *mut ICU4XWriteable, cap: usize) -> bool {
         unsafe {
@@ -154,13 +153,10 @@ pub unsafe extern "C" fn icu4x_buffer_writeable_create(cap: usize) -> *mut ICU4X
 ///
 /// # Safety
 /// - The returned pointer is valid until the passed writable is destroyed.
-/// `this` must be a pointer to a valid [`ICU4XWriteable`] constructed by
+/// - `this` must be a pointer to a valid [`ICU4XWriteable`] constructed by
 /// [`icu4x_buffer_writeable_create()`].
-pub unsafe extern "C" fn icu4x_buffer_writeable_get_bytes(this: *mut ICU4XWriteable) -> *mut u8 {
-    let this = Box::from_raw(this);
-    let ret = this.buf;
-    std::mem::forget(this);
-    ret
+pub extern "C" fn icu4x_buffer_writeable_get_bytes(this: &ICU4XWriteable) -> *mut u8 {
+    this.buf
 }
 
 #[no_mangle]
@@ -169,11 +165,8 @@ pub unsafe extern "C" fn icu4x_buffer_writeable_get_bytes(this: *mut ICU4XWritea
 /// # Safety
 /// - `this` must be a pointer to a valid [`ICU4XWriteable`] constructed by
 /// [`icu4x_buffer_writeable_create()`].
-pub unsafe extern "C" fn icu4x_buffer_writeable_len(this: *mut ICU4XWriteable) -> usize {
-    let this = Box::from_raw(this);
-    let ret = this.len;
-    std::mem::forget(this);
-    ret
+pub extern "C" fn icu4x_buffer_writeable_len(this: &ICU4XWriteable) -> usize {
+    this.len
 }
 
 #[no_mangle]

--- a/ffi/capi/src/custom_writeable.rs
+++ b/ffi/capi/src/custom_writeable.rs
@@ -119,7 +119,7 @@ pub unsafe extern "C" fn icu4x_simple_writeable(buf: *mut u8, buf_size: usize) -
 
 
 #[no_mangle]
-pub unsafe extern "C" fn icu4x_sbuffer_writeable(cap: usize) -> *mut ICU4XWriteable {
+pub unsafe extern "C" fn icu4x_buffer_writeable(cap: usize) -> *mut ICU4XWriteable {
     extern "C" fn grow(this: *mut ICU4XWriteable, cap: usize) -> bool {
         unsafe {
             let this = &*this;
@@ -147,7 +147,23 @@ pub unsafe extern "C" fn icu4x_sbuffer_writeable(cap: usize) -> *mut ICU4XWritea
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn icu4x_free_sbuffer_writeable(this: *mut ICU4XWriteable) {
+pub unsafe extern "C" fn icu4x_buffer_writeable_borrow(this: *mut ICU4XWriteable) -> *mut u8 {
+    let this = Box::from_raw(this);
+    let ret = this.buf;
+    std::mem::forget(this);
+    ret
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn icu4x_buffer_writeable_len(this: *mut ICU4XWriteable) -> usize {
+    let this = Box::from_raw(this);
+    let ret = this.len;
+    std::mem::forget(this);
+    ret
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn icu4x_buffer_writeable_free(this: *mut ICU4XWriteable) {
     let this = Box::from_raw(this);
     let vec = Vec::from_raw_parts(this.buf, 0, this.cap);
     drop(vec);

--- a/ffi/capi/src/fixed_decimal.rs
+++ b/ffi/capi/src/fixed_decimal.rs
@@ -23,7 +23,7 @@ pub extern "C" fn icu4x_fixed_decimal_create(magnitude: i64) -> *mut ICU4XFixedD
 }
 
 #[no_mangle]
-/// FFI version of [`FixedDecimal::multiply_pow10()`]. See its docs for more details.ICU4XFixedDecimal
+/// FFI version of [`FixedDecimal::multiply_pow10()`]. See its docs for more details.
 ///
 /// Returns `true` if the multiplication was successful.
 pub extern "C" fn icu4x_fixed_decimal_multiply_pow10(
@@ -34,7 +34,7 @@ pub extern "C" fn icu4x_fixed_decimal_multiply_pow10(
 }
 
 #[no_mangle]
-/// FFI version of [`FixedDecimal::negate()`]. See its docs for more details.ICU4XFixedDecimal
+/// FFI version of [`FixedDecimal::negate()`]. See its docs for more details.
 pub extern "C" fn icu4x_fixed_decimal_negate(fd: &mut ICU4XFixedDecimal) {
     fd.negate()
 }

--- a/ffi/capi/src/fixed_decimal.rs
+++ b/ffi/capi/src/fixed_decimal.rs
@@ -40,6 +40,7 @@ pub extern "C" fn icu4x_fixed_decimal_negate(fd: &mut ICU4XFixedDecimal) {
 }
 
 #[no_mangle]
+/// FFI version of [`FixedDecimal::write_to()`]. See its docs for more details.ICU4XFixedDecimal
 pub extern "C" fn icu4x_fixed_decimal_write_to(fd: &ICU4XFixedDecimal, to: &mut ICU4XWriteable) {
     fd.write_to(to).unwrap();
 }

--- a/ffi/capi/src/fixed_decimal.rs
+++ b/ffi/capi/src/fixed_decimal.rs
@@ -4,8 +4,8 @@
 
 use fixed_decimal::FixedDecimal;
 
-use writeable::Writeable;
 use crate::custom_writeable::ICU4XWriteable;
+use writeable::Writeable;
 
 /// Opaque type for use behind a pointer, is [`FixedDecimal`]
 ///

--- a/ffi/capi/src/fixed_decimal.rs
+++ b/ffi/capi/src/fixed_decimal.rs
@@ -4,6 +4,9 @@
 
 use fixed_decimal::FixedDecimal;
 
+use writeable::Writeable;
+use crate::custom_writeable::ICU4XWriteable;
+
 /// Opaque type for use behind a pointer, is [`FixedDecimal`]
 ///
 /// Can be obtained via [`icu4x_fixed_decimal_create()`] and destroyed via [`icu4x_fixed_decimal_destroy()`]
@@ -35,6 +38,12 @@ pub extern "C" fn icu4x_fixed_decimal_multiply_pow10(
 pub extern "C" fn icu4x_fixed_decimal_negate(fd: &mut ICU4XFixedDecimal) {
     fd.negate()
 }
+
+#[no_mangle]
+pub extern "C" fn icu4x_fixed_decimal_write_to(fd: &ICU4XFixedDecimal, to: &mut ICU4XWriteable) {
+    fd.write_to(to).unwrap();
+}
+
 #[no_mangle]
 /// Destructor for [`ICU4XFixedDecimal`]
 ///

--- a/ffi/capi/src/fixed_decimal.rs
+++ b/ffi/capi/src/fixed_decimal.rs
@@ -39,9 +39,19 @@ pub extern "C" fn icu4x_fixed_decimal_negate(fd: &mut ICU4XFixedDecimal) {
     fd.negate()
 }
 
+#[repr(C)]
+pub struct TempStruct {
+    abc: u64,
+    def: u64
+}
+
 #[no_mangle]
-pub extern "C" fn icu4x_fixed_decimal_write_to(fd: &ICU4XFixedDecimal, to: &mut ICU4XWriteable) {
+pub extern "C" fn icu4x_fixed_decimal_write_to(fd: &ICU4XFixedDecimal, to: &mut ICU4XWriteable) -> TempStruct {
     fd.write_to(to).unwrap();
+    TempStruct {
+        abc: 123,
+        def: 456
+    }
 }
 
 #[no_mangle]

--- a/ffi/capi/src/fixed_decimal.rs
+++ b/ffi/capi/src/fixed_decimal.rs
@@ -40,7 +40,7 @@ pub extern "C" fn icu4x_fixed_decimal_negate(fd: &mut ICU4XFixedDecimal) {
 }
 
 #[no_mangle]
-/// FFI version of [`FixedDecimal::write_to()`]. See its docs for more details.ICU4XFixedDecimal
+/// FFI version of [`FixedDecimal::write_to()`]. See its docs for more details.
 pub extern "C" fn icu4x_fixed_decimal_write_to(fd: &ICU4XFixedDecimal, to: &mut ICU4XWriteable) {
     fd.write_to(to).unwrap();
 }

--- a/ffi/capi/src/fixed_decimal.rs
+++ b/ffi/capi/src/fixed_decimal.rs
@@ -39,19 +39,9 @@ pub extern "C" fn icu4x_fixed_decimal_negate(fd: &mut ICU4XFixedDecimal) {
     fd.negate()
 }
 
-#[repr(C)]
-pub struct TempStruct {
-    abc: u64,
-    def: u64
-}
-
 #[no_mangle]
-pub extern "C" fn icu4x_fixed_decimal_write_to(fd: &ICU4XFixedDecimal, to: &mut ICU4XWriteable) -> TempStruct {
+pub extern "C" fn icu4x_fixed_decimal_write_to(fd: &ICU4XFixedDecimal, to: &mut ICU4XWriteable) {
     fd.write_to(to).unwrap();
-    TempStruct {
-        abc: 123,
-        def: 456
-    }
 }
 
 #[no_mangle]

--- a/ffi/capi/src/lib.rs
+++ b/ffi/capi/src/lib.rs
@@ -13,3 +13,6 @@ pub mod fixed_decimal;
 pub mod locale;
 pub mod pluralrules;
 pub mod provider;
+
+#[cfg(target_arch = "wasm32")]
+mod wasm_glue;

--- a/ffi/capi/src/wasm_glue.rs
+++ b/ffi/capi/src/wasm_glue.rs
@@ -94,6 +94,10 @@ pub unsafe extern "C" fn icu4x_init() {
 }
 
 #[no_mangle]
+/// Allocates a buffer of a given size in Rust's memory.
+///
+/// # Safety
+/// - The allocated buffer must be freed with [`icu4x_free()`].
 pub unsafe extern "C" fn icu4x_alloc(size: usize) -> *mut u8 {
   let mut vec = Vec::<u8>::with_capacity(size);
   let ret = vec.as_mut_ptr();
@@ -102,6 +106,9 @@ pub unsafe extern "C" fn icu4x_alloc(size: usize) -> *mut u8 {
 }
 
 #[no_mangle]
+/// Frees a buffer that was allocated in Rust's memory.
+/// # Safety
+/// - `ptr` must be a pointer to a valid buffer allocated by [`icu4x_alloc()`].
 pub unsafe extern "C" fn icu4x_free(ptr: *mut u8, size: usize) {
   let vec = Vec::from_raw_parts(ptr, size, size);
   drop(vec);

--- a/ffi/capi/src/wasm_glue.rs
+++ b/ffi/capi/src/wasm_glue.rs
@@ -1,0 +1,101 @@
+use std::ffi::CString;
+use std::os::raw::c_char;
+use std::panic;
+use std::io;
+
+use log::{Record, Metadata, LevelFilter, Level};
+
+// minimal WASM logger based on https://github.com/DeMille/wasm-glue
+extern {
+    fn log_js(ptr: *const c_char);
+    fn warn_js(ptr: *const c_char);
+    fn trace_js(ptr: *const c_char);
+}
+
+fn _log(buf: &str) -> io::Result<()> {
+    let cstring = CString::new(buf)?;
+
+    unsafe {
+        log_js(cstring.as_ptr());
+    }
+
+    Ok(())
+}
+
+fn _warn(buf: &str) -> io::Result<()> {
+    let cstring = CString::new(buf)?;
+
+    unsafe {
+        warn_js(cstring.as_ptr());
+    }
+
+    Ok(())
+}
+
+struct ConsoleLogger;
+
+impl log::Log for ConsoleLogger  {
+    fn enabled(&self, _: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        if record.level() <= Level::Warn {
+            _warn(format!("[{}] {}", record.level(), record.args()).as_str()).unwrap();
+        } else {
+            _log(format!("[{}] {}", record.level(), record.args()).as_str()).unwrap();
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+/// Sets a custom panic hook, uses your JavaScript `trace` function
+pub fn set_panic_hook() {
+    panic::set_hook(Box::new(|info| {
+        let file = info.location().unwrap().file();
+        let line = info.location().unwrap().line();
+        let col = info.location().unwrap().column();
+
+        let msg = match info.payload().downcast_ref::<&'static str>() {
+            Some(s) => *s,
+            None => {
+                match info.payload().downcast_ref::<String>() {
+                    Some(s) => &s[..],
+                    None => "Box<Any>",
+                }
+            }
+        };
+
+        let err_info = format!("Panicked at '{}', {}:{}:{}", msg, file, line, col);
+        let cstring = CString::new(err_info).unwrap();
+
+        unsafe {
+            trace_js(cstring.as_ptr());
+        }
+    }));
+}
+
+static LOGGER: ConsoleLogger = ConsoleLogger;
+
+#[no_mangle]
+pub unsafe extern "C" fn icu4x_init() {
+    set_panic_hook();
+    log::set_logger(&LOGGER)
+        .map(|()| log::set_max_level(LevelFilter::Debug))
+        .unwrap();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn icu4x_alloc(size: usize) -> *mut u8 {
+  let mut vec = Vec::<u8>::with_capacity(size);
+  let ret = vec.as_mut_ptr();
+  std::mem::forget(vec);
+  ret
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn icu4x_free(ptr: *mut u8, size: usize) {
+  let vec = Vec::from_raw_parts(ptr, size, size);
+  drop(vec);
+}

--- a/ffi/capi/src/wasm_glue.rs
+++ b/ffi/capi/src/wasm_glue.rs
@@ -1,3 +1,7 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
 use std::ffi::CString;
 use std::io;
 use std::os::raw::c_char;

--- a/wasm-example/icu4x.mjs
+++ b/wasm-example/icu4x.mjs
@@ -1,0 +1,32 @@
+let icu4x;
+
+function readString(ptr) {
+  const view = new Uint8Array(icu4x.memory.buffer);
+  let end = ptr;
+  while (view[end]) ++ end;
+  const buf = new Uint8Array(view.subarray(ptr, end));
+  return (new TextDecoder()).decode(buf);
+}
+
+const imports = {
+  env: {
+    log_js(ptr) {
+      console.log(readString(ptr));
+    },
+
+    warn_js(ptr) {
+      console.warn(readString(ptr));
+    },
+
+    trace_js(ptr) {
+      throw new Error(readString(ptr));
+    }
+  }
+}
+
+const ixu4xWasm = await WebAssembly.instantiateStreaming(fetch('../wasmpkg/icu_capi.wasm'), imports);
+icu4x = ixu4xWasm.instance.exports;
+
+icu4x.icu4x_init();
+
+export default icu4x;

--- a/wasm-example/icu4x.mjs
+++ b/wasm-example/icu4x.mjs
@@ -3,9 +3,8 @@ let icu4x;
 function readString(ptr) {
   const view = new Uint8Array(icu4x.memory.buffer);
   let end = ptr;
-  while (view[end]) ++ end;
-  const buf = new Uint8Array(view.subarray(ptr, end));
-  return (new TextDecoder()).decode(buf);
+  while (view[end]) end++;
+  return (new TextDecoder("utf-8")).decode(view.subarray(ptr, end));
 }
 
 const imports = {

--- a/wasm-example/index.html
+++ b/wasm-example/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <script type="module" src="main.mjs"></script>
+  </body>
+</html>

--- a/wasm-example/main.mjs
+++ b/wasm-example/main.mjs
@@ -1,0 +1,19 @@
+import icu4x from "./icu4x.mjs"
+
+function withEncodedString(str, fn) {
+  let bytes = (new TextEncoder()).encode(str);
+
+  let ptr = icu4x.icu4x_alloc(bytes.length);
+  const memory = new Uint8Array(icu4x.memory.buffer);
+  const buf = memory.subarray(ptr, ptr + bytes.length);
+  buf.set(bytes, 0);
+
+  try {
+    return fn(ptr, buf.length);
+  } finally {
+    icu4x.icu4x_free(ptr, buf.length);
+  }
+}
+
+const locale = withEncodedString("en-US", icu4x.icu4x_locale_create);
+console.log(locale);

--- a/wasm-example/main.mjs
+++ b/wasm-example/main.mjs
@@ -20,7 +20,6 @@ function readString(ptr, len) {
 }
 
 const fixedDecimalRegistry = new FinalizationRegistry(ptr => {
-  console.log("freeing decimal!");
   icu4x.icu4x_fixed_decimal_destroy(ptr);
 });
 
@@ -39,20 +38,11 @@ class FixedDecimal {
   }
 
   write_to(writable) {
-    let outPtr = icu4x.icu4x_alloc(16);
-    icu4x.icu4x_fixed_decimal_write_to(outPtr, this.underlying, writable.underlying);
-    const buf = new BigUint64Array(icu4x.memory.buffer, outPtr, 2);
-    const ret = {
-      abc: buf[0],
-      def: buf[1]
-    };
-    icu4x.icu4x_free(outPtr, 16);
-    return ret;
+    icu4x.icu4x_fixed_decimal_write_to(this.underlying, writable.underlying);
   }
 }
 
 const bufferWritableRegistry = new FinalizationRegistry(ptr => {
-  console.log("freeing writable!");
   icu4x.icu4x_buffer_writeable_free(ptr);
 });
 
@@ -74,5 +64,5 @@ decimal.multiply_pow10(-2);
 decimal.negate();
 
 const outWritable = new BufferWritable();
-console.log(decimal.write_to(outWritable));
+decimal.write_to(outWritable);
 console.log(outWritable.getString());

--- a/wasm-example/main.mjs
+++ b/wasm-example/main.mjs
@@ -15,5 +15,20 @@ function withEncodedString(str, fn) {
   }
 }
 
-const locale = withEncodedString("en-US", icu4x.icu4x_locale_create);
-console.log(locale);
+function getString(ptr, len) {
+  const memory = new Uint8Array(icu4x.memory.buffer);
+  const buf = memory.subarray(ptr, ptr + len);
+  return (new TextDecoder()).decode(buf)
+}
+
+const decimal = icu4x.icu4x_fixed_decimal_create(BigInt(1234));
+icu4x.icu4x_fixed_decimal_multiply_pow10(decimal, -2);
+icu4x.icu4x_fixed_decimal_negate(decimal);
+
+const outWritable = icu4x.icu4x_buffer_writeable(10);
+icu4x.icu4x_fixed_decimal_write_to(decimal, outWritable);
+const outStringPtr = icu4x.icu4x_buffer_writeable_borrow(outWritable);
+const outStringLen = icu4x.icu4x_buffer_writeable_len(outWritable);
+console.log(getString(outStringPtr, outStringLen));
+icu4x.icu4x_buffer_writeable_free(outWritable);
+icu4x.icu4x_fixed_decimal_destroy(decimal);

--- a/wasm-example/main.mjs
+++ b/wasm-example/main.mjs
@@ -43,17 +43,17 @@ class FixedDecimal {
 }
 
 const bufferWritableRegistry = new FinalizationRegistry(ptr => {
-  icu4x.icu4x_buffer_writeable_free(ptr);
+  icu4x.icu4x_buffer_writeable_destroy(ptr);
 });
 
 class BufferWritable {
   constructor() {
-    this.underlying = icu4x.icu4x_buffer_writeable(0);    
+    this.underlying = icu4x.icu4x_buffer_writeable_create(0);    
     bufferWritableRegistry.register(this, this.underlying);
   }
 
   getString() {
-    const outStringPtr = icu4x.icu4x_buffer_writeable_borrow(this.underlying);
+    const outStringPtr = icu4x.icu4x_buffer_writeable_get_bytes(this.underlying);
     const outStringLen = icu4x.icu4x_buffer_writeable_len(this.underlying);
     return readString(outStringPtr, outStringLen);
   }

--- a/wasm-example/main.mjs
+++ b/wasm-example/main.mjs
@@ -4,8 +4,7 @@ function withEncodedString(str, fn) {
   let bytes = (new TextEncoder()).encode(str);
 
   let ptr = icu4x.icu4x_alloc(bytes.length);
-  const memory = new Uint8Array(icu4x.memory.buffer);
-  const buf = memory.subarray(ptr, ptr + bytes.length);
+  const buf = new Uint8Array(icu4x.memory.buffer, ptr, bytes.length);
   buf.set(bytes, 0);
 
   try {
@@ -16,8 +15,7 @@ function withEncodedString(str, fn) {
 }
 
 function readString(ptr, len) {
-  const memory = new Uint8Array(icu4x.memory.buffer);
-  const buf = memory.subarray(ptr, ptr + len);
+  const buf = new Uint8Array(icu4x.memory.buffer, ptr, len);
   return (new TextDecoder("utf-8")).decode(buf)
 }
 
@@ -67,7 +65,6 @@ class BufferWritable {
   getString() {
     const outStringPtr = icu4x.icu4x_buffer_writeable_borrow(this.underlying);
     const outStringLen = icu4x.icu4x_buffer_writeable_len(this.underlying);
-    console.log("len is", outStringLen);
     return readString(outStringPtr, outStringLen);
   }
 }


### PR DESCRIPTION
Adjust the WASM build config to build the FFI package instead of examples, and bring in a simple example of using the FFI from JavaScript.