### PR TITLE
Use TinyStr8 for time-zone variant identifiers

### DIFF
--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -85,7 +85,7 @@ pub trait TimeZoneInput {
 
     /// The time variant (e.g. "daylight", "standard")
     /// TODO(#619) use TinyStr for time variants.
-    fn time_variant(&self) -> Option<&str>;
+    fn time_variant(&self) -> Option<&TinyStr8>;
 }
 
 /// A combination of a formattable calendar date and ISO time.

--- a/components/datetime/src/mock/time_zone.rs
+++ b/components/datetime/src/mock/time_zone.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use tinystr::TinyStr8;
+
 use crate::date::*;
 use std::str::FromStr;
 
@@ -41,7 +43,7 @@ pub struct MockTimeZone {
     // TODO(#528) change this to <TBD> identifier
     pub metazone_id: Option<String>,
     /// The time variant e.g. "daylight" or "standard"
-    pub time_variant: Option<String>,
+    pub time_variant: Option<TinyStr8>,
 }
 
 impl MockTimeZone {
@@ -52,7 +54,7 @@ impl MockTimeZone {
         gmt_offset: GmtOffset,
         time_zone_id: Option<String>,
         metazone_id: Option<String>,
-        time_variant: Option<String>,
+        time_variant: Option<TinyStr8>,
     ) -> Self {
         Self {
             gmt_offset,
@@ -111,7 +113,7 @@ impl TimeZoneInput for MockTimeZone {
         self.metazone_id.as_ref().map(AsRef::as_ref)
     }
 
-    fn time_variant(&self) -> Option<&str> {
-        self.time_variant.as_ref().map(AsRef::as_ref)
+    fn time_variant(&self) -> Option<&TinyStr8> {
+        self.time_variant.as_ref()
     }
 }

--- a/components/datetime/src/mock/zoned_datetime.rs
+++ b/components/datetime/src/mock/zoned_datetime.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use tinystr::TinyStr8;
+
 use crate::date::*;
 use std::str::FromStr;
 
@@ -141,7 +143,7 @@ impl TimeZoneInput for MockZonedDateTime {
         self.time_zone.metazone_id()
     }
 
-    fn time_variant(&self) -> Option<&str> {
+    fn time_variant(&self) -> Option<&TinyStr8> {
         self.time_zone.time_variant()
     }
 }

--- a/components/datetime/src/provider/time_zones.rs
+++ b/components/datetime/src/provider/time_zones.rs
@@ -4,16 +4,17 @@
 
 use litemap::LiteMap;
 use std::borrow::Cow;
+use tinystr::TinyStr8;
 
 /// Provides a few common map accessor methods to new-type structs that wrap a map type.
 /// The methods are all pass-through calls to the internal methods of the same name.
 macro_rules! map_access {
-    ($outer: ty => $inner: ty: $lt: lifetime) => {
+    ($outer: ty[$key: ty] => $inner: ty: $lt: lifetime) => {
         impl<$lt> $outer {
             pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&$inner>
             where
                 Q: Ord,
-                Cow<'s, str>: std::borrow::Borrow<Q>,
+                Cow<'s, $key>: std::borrow::Borrow<Q>,
             {
                 self.0.get(key)
             }
@@ -26,7 +27,7 @@ macro_rules! map_access {
         impl<$lt, Q: ?Sized> std::ops::Index<&Q> for $outer
         where
             Q: Ord,
-            Cow<'s, str>: std::borrow::Borrow<Q>,
+            Cow<'s, $key>: std::borrow::Borrow<Q>,
         {
             type Output = $inner;
             fn index(&self, key: &Q) -> &Self::Output {
@@ -54,7 +55,7 @@ pub struct TimeZoneFormatsV1<'s> {
     pub region_format: Cow<'s, str>,
     /// The format strings for region format variants
     /// e.g. daylight, standard.
-    pub region_format_variants: LiteMap<Cow<'s, str>, Cow<'s, str>>,
+    pub region_format_variants: LiteMap<Cow<'s, TinyStr8>, Cow<'s, str>>,
     /// The format string to fall back to if data is unavailable.
     pub fallback_format: Cow<'s, str>,
 }
@@ -67,7 +68,7 @@ pub struct TimeZoneFormatsV1<'s> {
     derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct ExemplarCitiesV1<'s>(pub LiteMap<Cow<'s, str>, Cow<'s, str>>);
-map_access!(ExemplarCitiesV1<'s> => Cow<'s, str>: 's);
+map_access!(ExemplarCitiesV1<'s>[str] => Cow<'s, str>: 's);
 
 /// An ICU4X mapping to the long-form generic metazone names.
 /// See CLDR-JSON timeZoneNames.json for more context.
@@ -77,7 +78,7 @@ map_access!(ExemplarCitiesV1<'s> => Cow<'s, str>: 's);
     derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct MetaZoneGenericNamesLongV1<'s>(pub LiteMap<Cow<'s, str>, Cow<'s, str>>);
-map_access!(MetaZoneGenericNamesLongV1<'s> => Cow<'s, str>: 's);
+map_access!(MetaZoneGenericNamesLongV1<'s>[str] => Cow<'s, str>: 's);
 
 /// An ICU4X mapping to the short-form generic metazone names.
 /// See CLDR-JSON timeZoneNames.json for more context.
@@ -87,7 +88,7 @@ map_access!(MetaZoneGenericNamesLongV1<'s> => Cow<'s, str>: 's);
     derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct MetaZoneGenericNamesShortV1<'s>(pub LiteMap<Cow<'s, str>, Cow<'s, str>>);
-map_access!(MetaZoneGenericNamesShortV1<'s> => Cow<'s, str>: 's);
+map_access!(MetaZoneGenericNamesShortV1<'s>[str] => Cow<'s, str>: 's);
 
 /// An ICU4X mapping to the long-form specific metazone names.
 /// Specific names include time variants such as "daylight."
@@ -98,7 +99,7 @@ map_access!(MetaZoneGenericNamesShortV1<'s> => Cow<'s, str>: 's);
     derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct MetaZoneSpecificNamesLongV1<'s>(pub LiteMap<Cow<'s, str>, MetaZoneSpecificNamesV1<'s>>);
-map_access!(MetaZoneSpecificNamesLongV1<'s> => MetaZoneSpecificNamesV1<'s>: 's);
+map_access!(MetaZoneSpecificNamesLongV1<'s>[str] => MetaZoneSpecificNamesV1<'s>: 's);
 
 /// An ICU4X mapping to the short-form specific metazone names.
 /// Specific names include time variants such as "daylight."
@@ -109,7 +110,7 @@ map_access!(MetaZoneSpecificNamesLongV1<'s> => MetaZoneSpecificNamesV1<'s>: 's);
     derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct MetaZoneSpecificNamesShortV1<'s>(pub LiteMap<Cow<'s, str>, MetaZoneSpecificNamesV1<'s>>);
-map_access!(MetaZoneSpecificNamesShortV1<'s> => MetaZoneSpecificNamesV1<'s>: 's);
+map_access!(MetaZoneSpecificNamesShortV1<'s>[str] => MetaZoneSpecificNamesV1<'s>: 's);
 
 /// A general struct to hold metazone specific name variants.
 /// Specific names include time variants such as "daylight."
@@ -119,5 +120,5 @@ map_access!(MetaZoneSpecificNamesShortV1<'s> => MetaZoneSpecificNamesV1<'s>: 's)
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)
 )]
-pub struct MetaZoneSpecificNamesV1<'s>(pub LiteMap<Cow<'s, str>, Cow<'s, str>>);
-map_access!(MetaZoneSpecificNamesV1<'s> => Cow<'s, str>: 's);
+pub struct MetaZoneSpecificNamesV1<'s>(pub LiteMap<Cow<'s, TinyStr8>, Cow<'s, str>>);
+map_access!(MetaZoneSpecificNamesV1<'s>[TinyStr8] => Cow<'s, str>: 's);

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -81,7 +81,7 @@ fn test_fixture_with_time_zones(fixture_name: &str, config: TimeZoneConfig) {
         let mut value: MockZonedDateTime = fx.input.value.parse().unwrap();
         value.time_zone.time_zone_id = config.time_zone_id.clone();
         value.time_zone.metazone_id = config.metazone_id.clone();
-        value.time_zone.time_variant = config.time_variant.clone();
+        value.time_zone.time_variant = config.time_variant;
 
         let result = dtf.format_to_string(&value);
         assert_eq!(result, fx.output.value, "\n  file: {}.json\n", fixture_name);

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -27,6 +27,7 @@ use patterns::{
 };
 use std::borrow::Cow;
 use std::fmt::Write;
+use tinystr::TinyStr8;
 
 fn test_fixture(fixture_name: &str) {
     let provider = icu_testdata::get_provider();
@@ -231,7 +232,7 @@ fn test_length_fixtures() {
         "lengths_with_zones_from_pdt",
         TimeZoneConfig {
             metazone_id: Some(String::from("America_Pacific")),
-            time_variant: Some(String::from("daylight")),
+            time_variant: Some("daylight".parse::<TinyStr8>().unwrap()),
             ..TimeZoneConfig::default()
         },
     );

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -27,7 +27,7 @@ use patterns::{
 };
 use std::borrow::Cow;
 use std::fmt::Write;
-use tinystr::TinyStr8;
+use tinystr::tinystr8;
 
 fn test_fixture(fixture_name: &str) {
     let provider = icu_testdata::get_provider();
@@ -232,7 +232,7 @@ fn test_length_fixtures() {
         "lengths_with_zones_from_pdt",
         TimeZoneConfig {
             metazone_id: Some(String::from("America_Pacific")),
-            time_variant: Some("daylight".parse::<TinyStr8>().unwrap()),
+            time_variant: Some(tinystr8!("daylight")),
             ..TimeZoneConfig::default()
         },
     );

--- a/components/datetime/tests/patterns/structs/time_zones.rs
+++ b/components/datetime/tests/patterns/structs/time_zones.rs
@@ -3,11 +3,12 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use serde::{Deserialize, Serialize};
+use tinystr::TinyStr8;
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TimeZoneConfig {
     pub time_zone_id: Option<String>,
     pub metazone_id: Option<String>,
-    pub time_variant: Option<String>,
+    pub time_variant: Option<TinyStr8>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/provider/cldr/src/transform/time_zones/cldr_json/convert.rs
+++ b/provider/cldr/src/transform/time_zones/cldr_json/convert.rs
@@ -10,6 +10,7 @@ use icu_datetime::provider::time_zones::{
 };
 use litemap::LiteMap;
 use std::borrow::Cow;
+use tinystr::TinyStr8;
 
 fn parse_hour_format<'d>(hour_format: &str) -> (Cow<'d, str>, Cow<'d, str>) {
     // e.g. "+HH:mm;-HH:mm" -> ("+HH:mm", "-HH:mm")
@@ -29,7 +30,15 @@ impl<'d> From<TimeZoneNames> for TimeZoneFormatsV1<'d> {
             region_format_variants: other
                 .region_format_variants
                 .into_iter()
-                .map(|(key, value)| (key.into(), value.into()))
+                .map(|(key, value)| {
+                    (
+                        Cow::Owned(
+                            key.parse::<TinyStr8>()
+                                .expect("Time-zone variant was not compatible with TinyStr8"),
+                        ),
+                        value.into(),
+                    )
+                })
                 .collect(),
             fallback_format: other.fallback_format.into(),
         }
@@ -187,7 +196,15 @@ impl<'d> From<ZoneFormat> for MetaZoneSpecificNamesV1<'d> {
                 .0
                 .into_iter()
                 .filter(|(key, _)| len > 1 && !key.eq("generic"))
-                .map(|(key, value)| (key.into(), value.into()))
+                .map(|(key, value)| {
+                    (
+                        Cow::Owned(
+                            key.parse::<TinyStr8>()
+                                .expect("Time-zone variant was not compatible with TinyStr8"),
+                        ),
+                        value.into(),
+                    )
+                })
                 .collect(),
         )
     }

--- a/provider/cldr/src/transform/time_zones/mod.rs
+++ b/provider/cldr/src/transform/time_zones/mod.rs
@@ -153,7 +153,7 @@ impl_data_provider!(MetaZoneSpecificNamesShortV1: 'd);
 
 #[cfg(test)]
 mod tests {
-    use tinystr::TinyStr8;
+    use tinystr::tinystr8;
 
     use super::*;
 
@@ -227,8 +227,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             "Australian Central Western Standard Time",
-            specific_names_long.get()["Australia_CentralWestern"]
-                [&"standard".parse::<TinyStr8>().unwrap()]
+            specific_names_long.get()["Australia_CentralWestern"][&tinystr8!("standard")]
         );
 
         let generic_names_short: DataPayload<MetaZoneGenericNamesShortV1> = provider
@@ -261,7 +260,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             "PDT",
-            specific_names_short.get()["America_Pacific"][&"daylight".parse::<TinyStr8>().unwrap()]
+            specific_names_short.get()["America_Pacific"][&tinystr8!("daylight")]
         );
     }
 }

--- a/provider/cldr/src/transform/time_zones/mod.rs
+++ b/provider/cldr/src/transform/time_zones/mod.rs
@@ -153,6 +153,8 @@ impl_data_provider!(MetaZoneSpecificNamesShortV1: 'd);
 
 #[cfg(test)]
 mod tests {
+    use tinystr::TinyStr8;
+
     use super::*;
 
     #[test]
@@ -225,7 +227,8 @@ mod tests {
             .unwrap();
         assert_eq!(
             "Australian Central Western Standard Time",
-            specific_names_long.get()["Australia_CentralWestern"]["standard"]
+            specific_names_long.get()["Australia_CentralWestern"]
+                [&"standard".parse::<TinyStr8>().unwrap()]
         );
 
         let generic_names_short: DataPayload<MetaZoneGenericNamesShortV1> = provider
@@ -258,7 +261,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             "PDT",
-            specific_names_short.get()["America_Pacific"]["daylight"]
+            specific_names_short.get()["America_Pacific"][&"daylight".parse::<TinyStr8>().unwrap()]
         );
     }
 }


### PR DESCRIPTION
Fixes #619 

- Updates `TimeZoneFormatsV1.region_format_variants` from `str` to
  `TinyStr8`.
- Updates `MetaZoneSpecificNamesV1` key form `str` to `TinyStr8`.
- Updates `map_access` macro to take key types of `str` or `TinyStr8`.

The `TinyStr8` impl seems to serialize the same as the `str` impl (for
JSON), so no changes are expected in the test data.

I did run `cargo make testdata` to be certain.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->