### PR TITLE
Add quick-and-dirty static data provider for WASM testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,14 +1066,11 @@ dependencies = [
 name = "icu_provider_static"
 version = "0.2.0"
 dependencies = [
- "erased-serde",
  "icu",
  "icu_locid",
  "icu_provider",
- "icu_provider_fs",
  "serde",
  "serde_json",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,6 +1063,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_provider_static"
+version = "0.2.0"
+dependencies = [
+ "erased-serde",
+ "icu",
+ "icu_locid",
+ "icu_provider",
+ "icu_provider_fs",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "icu_segmenter"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "components/uniset",
     "experimental/bies",
     "experimental/provider_ppucd",
+    "experimental/provider_static",
     "experimental/segmenter",
     "experimental/segmenter_lstm",
     "ffi/capi",

--- a/experimental/provider_static/Cargo.toml
+++ b/experimental/provider_static/Cargo.toml
@@ -1,0 +1,51 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+[package]
+name = "icu_provider_static"
+description = "ICU4X data provider that reads from static memory"
+version = "0.2.0"
+authors = ["The ICU4X Project Developers"]
+edition = "2018"
+readme = "README.md"
+repository = "https://github.com/unicode-org/icu4x"
+license-file = "../../LICENSE"
+categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
+include = [
+    "src/**/*",
+    "examples/**/*",
+    "benches/**/*",
+    "tests/**/*",
+    "Cargo.toml",
+    "README.md"
+]
+
+[package.metadata.cargo-all-features]
+# Omit most optional dependency features from permutation testing
+skip_optional_dependencies = true
+extra_features = [
+    "log",
+]
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+icu = { version = "0.2", path = "../../components/icu" }
+icu_provider = { version = "0.2", path = "../../provider/core", features = ["provider_serde"] }
+icu_locid = { version = "0.2", path = "../../components/locid", features = ["serde"] }
+icu_provider_fs = { version = "0.2", path = "../../provider/fs" }
+serde = { version = "1.0", features = ["derive"] }
+erased-serde = { version = "0.3" }
+thiserror = "1.0"
+
+serde_json = { version = "1.0" }
+
+[build-dependencies]
+serde = { version = "1.0" }
+serde_json = { version = "1.0" }
+
+[lib]
+path = "src/lib.rs"

--- a/experimental/provider_static/Cargo.toml
+++ b/experimental/provider_static/Cargo.toml
@@ -22,13 +22,6 @@ include = [
     "README.md"
 ]
 
-[package.metadata.cargo-all-features]
-# Omit most optional dependency features from permutation testing
-skip_optional_dependencies = true
-extra_features = [
-    "log",
-]
-
 [package.metadata.docs.rs]
 all-features = true
 

--- a/experimental/provider_static/Cargo.toml
+++ b/experimental/provider_static/Cargo.toml
@@ -33,19 +33,16 @@ extra_features = [
 all-features = true
 
 [dependencies]
-icu = { version = "0.2", path = "../../components/icu" }
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["provider_serde"] }
 icu_locid = { version = "0.2", path = "../../components/locid", features = ["serde"] }
-icu_provider_fs = { version = "0.2", path = "../../provider/fs" }
 serde = { version = "1.0", features = ["derive"] }
-erased-serde = { version = "0.3" }
-thiserror = "1.0"
-
 serde_json = { version = "1.0" }
 
 [build-dependencies]
-serde = { version = "1.0" }
 serde_json = { version = "1.0" }
+
+[dev-dependencies]
+icu = { version = "0.2", path = "../../components/icu" }
 
 [lib]
 path = "src/lib.rs"

--- a/experimental/provider_static/build.rs
+++ b/experimental/provider_static/build.rs
@@ -1,3 +1,7 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
 use serde_json::{json, Map, Value};
 use std::env;
 use std::fs;

--- a/experimental/provider_static/build.rs
+++ b/experimental/provider_static/build.rs
@@ -1,0 +1,50 @@
+use serde_json::{json, Map, Value};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::str;
+
+const DATA_PATH: &str = "../../provider/testdata/data/json/";
+
+fn handle_path(map: &mut Map<String, Value>, path: &Path) {
+    let me = path.file_stem().unwrap().to_str().unwrap();
+    if path.is_dir() {
+        let mut children = Map::new();
+        for entry in fs::read_dir(path).unwrap() {
+            let entry = entry.unwrap();
+            handle_path(&mut children, &entry.path());
+        }
+        map.insert(
+            me.into(),
+            json!({
+                "ty": "Dir",
+                "contents": children,
+            }),
+        );
+    } else {
+        let bytes = fs::read(path).unwrap();
+        // This serializes each file as a string; it is also possible to serialize them
+        // as a normal json value if we'd like by converting to serde_json::Value first
+        let s = str::from_utf8(&bytes).unwrap();
+        map.insert(
+            me.into(),
+            json!({
+                "ty": "File",
+                "contents": s,
+            }),
+        );
+    }
+}
+
+fn main() {
+    let mut value: Map<String, Value> = Map::new();
+    let path = PathBuf::from(DATA_PATH);
+    for entry in fs::read_dir(path).unwrap() {
+        let entry = entry.unwrap();
+        handle_path(&mut value, &entry.path());
+    }
+    let output = serde_json::to_string_pretty(&value).unwrap();
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("static_data.json");
+    fs::write(&dest_path, output).unwrap();
+}

--- a/experimental/provider_static/examples/simple.rs
+++ b/experimental/provider_static/examples/simple.rs
@@ -1,0 +1,14 @@
+use icu::locid::macros::langid;
+use icu::plurals::{PluralCategory, PluralRuleType, PluralRules};
+use icu_provider_static::StaticDataProvider;
+
+fn main() {
+    let lid = langid!("en");
+
+    let dp = StaticDataProvider::new();
+
+    let pr = PluralRules::try_new(lid, &dp, PluralRuleType::Cardinal)
+        .expect("Failed to construct a PluralRules struct.");
+
+    assert_eq!(pr.select(5_usize), PluralCategory::Other);
+}

--- a/experimental/provider_static/examples/simple.rs
+++ b/experimental/provider_static/examples/simple.rs
@@ -1,3 +1,7 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
 use icu::locid::macros::langid;
 use icu::plurals::{PluralCategory, PluralRuleType, PluralRules};
 use icu_provider_static::StaticDataProvider;

--- a/experimental/provider_static/src/lib.rs
+++ b/experimental/provider_static/src/lib.rs
@@ -1,0 +1,74 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use icu_provider::prelude::*;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+const STATIC_STR_DATA: &str = include_str!(concat!(env!("OUT_DIR"), "/static_data.json"));
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "ty", content = "contents")]
+enum StaticFileOrDir {
+    File(String),
+    Dir(Directory),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Directory(Box<HashMap<String, StaticFileOrDir>>);
+
+pub struct StaticDataProvider {
+    json: Directory,
+}
+
+impl StaticDataProvider {
+    pub fn new() -> Self {
+        StaticDataProvider {
+            json: serde_json::from_str(&STATIC_STR_DATA).unwrap(),
+        }
+    }
+}
+
+impl Default for StaticDataProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'d, T> DataProvider<'d, T> for StaticDataProvider
+where
+    T: serde::Deserialize<'d> + serde::Serialize + Clone + Debug + 'd,
+{
+    fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<'d, T>, DataError> {
+        let components = req.resource_path.key.get_components();
+        let mut dir = &self.json;
+        let mut file: Option<&str> = None;
+        for component in components
+            .iter()
+            .chain(req.resource_path.options.get_components().iter())
+        {
+            if file.is_some() {
+                return Err(DataError::UnsupportedResourceKey(req.resource_path.key));
+            }
+            let fod = dir
+                .0
+                .get(component)
+                .ok_or(DataError::UnsupportedResourceKey(req.resource_path.key))?;
+            match fod {
+                StaticFileOrDir::Dir(ref d) => dir = d,
+                StaticFileOrDir::File(ref f) => file = Some(f),
+            }
+        }
+        let file = file.ok_or(DataError::UnsupportedResourceKey(req.resource_path.key))?;
+        let data: T = T::deserialize(&mut serde_json::Deserializer::from_reader(file.as_bytes()))
+            .map_err(|e| DataError::Resource(Box::new(e)))?;
+        Ok(DataResponse {
+            metadata: DataResponseMetadata {
+                data_langid: req.resource_path.options.langid.clone(),
+            },
+            payload: Some(DataPayload::from_owned(data)),
+        })
+    }
+}

--- a/experimental/provider_static/src/lib.rs
+++ b/experimental/provider_static/src/lib.rs
@@ -19,6 +19,10 @@ enum StaticFileOrDir {
 #[derive(Serialize, Deserialize, Debug)]
 struct Directory(Box<HashMap<String, StaticFileOrDir>>);
 
+/// A data provider loading data statically baked in to the binary. Useful for testing in situations
+/// where setting up a filesystem is tricky (e.g. WASM).
+///
+/// This should probably not be used in production code since it bloats the binary.
 pub struct StaticDataProvider {
     json: Directory,
 }

--- a/experimental/provider_static/src/lib.rs
+++ b/experimental/provider_static/src/lib.rs
@@ -54,6 +54,8 @@ where
             .chain(req.resource_path.options.get_components().iter())
         {
             if file.is_some() {
+                // We should eventually distinguish between UnsupportedResourceKey
+                // and UnsupportedResourceOptions here
                 return Err(DataError::UnsupportedResourceKey(req.resource_path.key));
             }
             let fod = dir


### PR DESCRIPTION
This seems to work, it's not pretty. We should eventually make this use DataExporter for the build step and make it possible to load the data as a single `.bin` file (ideally bincoded).

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->