### PR TITLE
Add icu4x_locale_tostring and example for locale

### DIFF
--- a/ffi/capi/examples/locale/Makefile
+++ b/ffi/capi/examples/locale/Makefile
@@ -1,0 +1,25 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+.DEFAULT_GOAL := test
+.PHONY: build test
+
+ALL_HEADERS := $(wildcard ../../include/*.h)
+ALL_RUST := $(wildcard ../../src/*.rs)
+
+$(ALL_RUST):
+
+$(ALL_HEADERS):
+
+
+../../../../target/debug/libicu_capi.a: $(ALL_RUST)
+	cargo build
+
+a.out: ../../../../target/debug/libicu_capi.a $(ALL_HEADERS) test.c
+	gcc test.c ../../../../target/debug/libicu_capi.a -ldl -lpthread -lm -g
+
+build: a.out
+
+test: build
+	./a.out

--- a/ffi/capi/examples/locale/test.c
+++ b/ffi/capi/examples/locale/test.c
@@ -1,0 +1,25 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+#include "../../include/locale.h"
+#include <string.h>
+#include <stdio.h>
+
+const char* path = "../../../../provider/testdata/data/json/";
+int main() {
+    char output[40];
+    ICU4XWriteable write = icu4x_simple_writeable(output, 40);
+
+    ICU4XLocale* locale = icu4x_locale_create("ar", 2);
+    bool success = icu4x_locale_tostring(locale, &write);
+    if (!success) {
+        return 1;
+    }
+
+    // expect "ar"
+    printf("Output is %s\n", output);
+
+    icu4x_locale_destroy(locale);
+    return 0;
+}

--- a/ffi/capi/include/decimal.h
+++ b/ffi/capi/include/decimal.h
@@ -14,7 +14,7 @@
 #include "custom_writeable.h"
 
 // opaque
-typedef struct ICU4XFixedDecimalFormat ICU4XFixedDecimalFormat; 
+typedef struct ICU4XFixedDecimalFormat ICU4XFixedDecimalFormat;
 
 typedef struct {
     ICU4XFixedDecimalFormat* fdf;

--- a/ffi/capi/include/fixed_decimal.h
+++ b/ffi/capi/include/fixed_decimal.h
@@ -6,7 +6,7 @@
 #define ICU4X_FIXED_DECIMAL_H
 
 // opaque
-typedef struct ICU4XFixedDecimal ICU4XFixedDecimal; 
+typedef struct ICU4XFixedDecimal ICU4XFixedDecimal;
 
 ICU4XFixedDecimal* icu4x_fixed_decimal_create(int64_t magnitude);
 bool icu4x_fixed_decimal_multiply_pow10(ICU4XFixedDecimal* fd, int16_t power);

--- a/ffi/capi/include/locale.h
+++ b/ffi/capi/include/locale.h
@@ -9,10 +9,13 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+#include "custom_writeable.h"
+
 // opaque
 typedef struct ICU4XLocale ICU4XLocale;
 
 ICU4XLocale* icu4x_locale_create(const char* value, size_t len);
+bool icu4x_locale_tostring(const ICU4XLocale* locale, ICU4XWriteable* write);
 void icu4x_locale_destroy(ICU4XLocale*);
 
 #endif // ICU4X_LOCALE_H

--- a/ffi/capi/include/pluralrules.h
+++ b/ffi/capi/include/pluralrules.h
@@ -12,7 +12,7 @@
 #include "locale.h"
 
 // opaque
-typedef struct ICU4XPluralRules ICU4XPluralRules; 
+typedef struct ICU4XPluralRules ICU4XPluralRules;
 
 typedef struct {
     ICU4XPluralRules* rules;

--- a/ffi/capi/src/locale.rs
+++ b/ffi/capi/src/locale.rs
@@ -2,9 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use std::slice;
-
+use crate::custom_writeable::ICU4XWriteable;
 use icu_locid::Locale;
+use std::slice;
 
 /// Opaque type for use behind a pointer, is [`Locale`]
 ///
@@ -24,6 +24,18 @@ pub unsafe extern "C" fn icu4x_locale_create(value: *const u8, len: usize) -> *m
     // todo: return errors
     let loc = ICU4XLocale::from_bytes(bytes).unwrap();
     Box::into_raw(Box::new(loc))
+}
+
+#[no_mangle]
+/// Write a string representation of [`ICU4XLocale`] to `write`
+///
+/// Returns `false` when there were errors writing to `write`
+pub extern "C" fn icu4x_locale_tostring(locale: &ICU4XLocale, write: &mut ICU4XWriteable) -> bool {
+    use writeable::Writeable;
+
+    let result = locale.write_to(write).is_ok();
+    write.flush();
+    result
 }
 
 #[no_mangle]


### PR DESCRIPTION
The example will be expanded to demonstrate locale canonicalization as well in a separate PR.

Partial fix for #757.
