### PR TITLE
Add PluralRules::categories() function.

### DIFF
--- a/components/plurals/src/data.rs
+++ b/components/plurals/src/data.rs
@@ -92,6 +92,10 @@ impl RulesSelector {
         }
     }
 
+    /// Returns an iterator over each [`PluralCategory`] for which this [`RulesSelector`]
+    /// has rules for.
+    ///
+    /// The category [`PluralCategory::Other`] is always included.
     pub fn categories(&self) -> impl Iterator<Item = &'static PluralCategory> + '_ {
         match &self {
             Self::Conditions(conditions) => PluralCategory::all().filter(move |&category| {

--- a/components/plurals/src/data.rs
+++ b/components/plurals/src/data.rs
@@ -108,7 +108,7 @@ impl RulesSelector {
     ///
     /// The category [`PluralCategory::Other`] is always included.
     pub fn categories(&self) -> impl Iterator<Item = &'static PluralCategory> + '_ {
-        match &self {
+        match self {
             Self::Conditions(conditions) => {
                 PluralCategory::all().filter(move |&category| conditions.has_rules_for(*category))
             }

--- a/components/plurals/src/data.rs
+++ b/components/plurals/src/data.rs
@@ -91,6 +91,14 @@ impl RulesSelector {
                 .unwrap_or(PluralCategory::Other),
         }
     }
+
+    pub fn categories(&self) -> impl Iterator<Item = &'static PluralCategory> + '_ {
+        match &self {
+            Self::Conditions(conditions) => PluralCategory::all().filter(move |&category| {
+                category.eq(&PluralCategory::Other) || conditions.get(*category).is_some()
+            }),
+        }
+    }
 }
 
 impl From<PluralRuleList> for RulesSelector {

--- a/components/plurals/src/data.rs
+++ b/components/plurals/src/data.rs
@@ -27,6 +27,18 @@ pub struct PluralRuleList {
 }
 
 impl PluralRuleList {
+    fn has_rules_for(&self, category: PluralCategory) -> bool {
+        // There is implicitly always a rule for "Other" as the fallback.
+        match category {
+            PluralCategory::Zero => self.zero.is_some(),
+            PluralCategory::One => self.one.is_some(),
+            PluralCategory::Two => self.two.is_some(),
+            PluralCategory::Few => self.few.is_some(),
+            PluralCategory::Many => self.many.is_some(),
+            PluralCategory::Other => true,
+        }
+    }
+
     fn get(&self, category: PluralCategory) -> Option<&ast::Condition> {
         match category {
             PluralCategory::Zero => self.zero.as_ref(),
@@ -92,15 +104,14 @@ impl RulesSelector {
         }
     }
 
-    /// Returns an iterator over each [`PluralCategory`] for which this [`RulesSelector`]
-    /// has rules for.
+    /// Returns an iterator over each [`PluralCategory`] for which this [`RulesSelector`] has rules.
     ///
     /// The category [`PluralCategory::Other`] is always included.
     pub fn categories(&self) -> impl Iterator<Item = &'static PluralCategory> + '_ {
         match &self {
-            Self::Conditions(conditions) => PluralCategory::all().filter(move |&category| {
-                category.eq(&PluralCategory::Other) || conditions.get(*category).is_some()
-            }),
+            Self::Conditions(conditions) => {
+                PluralCategory::all().filter(move |&category| conditions.has_rules_for(*category))
+            }
         }
     }
 }

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -348,6 +348,8 @@ impl PluralRules {
     ///
     /// The [`Plural Categories`] are returned in alphabetically sorted order.
     ///
+    /// The category [`PluralCategory::Other`] is always included.
+    ///
     /// # Examples
     ///
     /// ```

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -357,17 +357,15 @@ impl PluralRules {
     /// use icu::plurals::{PluralRules, PluralRuleType, PluralCategory};
     /// use icu_provider::inv::InvariantDataProvider;
     ///
-    /// let lid = langid!("ja");
+    /// let lid = langid!("cy");
     ///
     /// let dp = InvariantDataProvider;
     ///
     /// let pr = PluralRules::try_new(lid, &dp, PluralRuleType::Ordinal)
     ///     .expect("Failed to construct a PluralRules struct.");
     ///
-    /// let mut categories = pr.categories();
-    ///
-    /// assert_eq!(categories.next(), Some(&PluralCategory::Other));
-    /// assert_eq!(categories.next(), None);
+    /// let categories = pr.categories().copied().collect::<Vec<PluralCategory>>();
+    /// assert!(categories.contains(&PluralCategory::Other));
     /// ```
     ///
     /// [`Plural Categories`]: PluralCategory

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -191,6 +191,8 @@ pub enum PluralCategory {
 impl PluralCategory {
     /// Returns an ordered iterator over variants of [`Plural Categories`].
     ///
+    /// Categories are returned in alphabetical order.
+    ///
     /// # Examples
     ///
     /// ```
@@ -198,24 +200,24 @@ impl PluralCategory {
     ///
     /// let mut categories = PluralCategory::all();
     ///
-    /// assert_eq!(categories.next(), Some(&PluralCategory::Zero));
-    /// assert_eq!(categories.next(), Some(&PluralCategory::One));
-    /// assert_eq!(categories.next(), Some(&PluralCategory::Two));
     /// assert_eq!(categories.next(), Some(&PluralCategory::Few));
     /// assert_eq!(categories.next(), Some(&PluralCategory::Many));
+    /// assert_eq!(categories.next(), Some(&PluralCategory::One));
     /// assert_eq!(categories.next(), Some(&PluralCategory::Other));
+    /// assert_eq!(categories.next(), Some(&PluralCategory::Two));
+    /// assert_eq!(categories.next(), Some(&PluralCategory::Zero));
     /// assert_eq!(categories.next(), None);
     /// ```
     ///
     /// [`Plural Categories`]: PluralCategory
     pub fn all() -> impl ExactSizeIterator<Item = &'static Self> {
         [
-            Self::Zero,
-            Self::One,
-            Self::Two,
             Self::Few,
             Self::Many,
+            Self::One,
             Self::Other,
+            Self::Two,
+            Self::Zero,
         ]
         .iter()
     }
@@ -339,6 +341,36 @@ impl PluralRules {
     /// [`Plural Operands`]: operands::PluralOperands
     pub fn select<I: Into<PluralOperands>>(&self, input: I) -> PluralCategory {
         self.selector.select(&input.into())
+    }
+
+    /// Returns all [`Plural Categories`] appropriate for a [`PluralRules`] object
+    /// based on the [`LanguageIdentifier`] and [`PluralRuleType`].
+    ///
+    /// The [`Plural Categories`] are returned in alphabetically sorted order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::locid::macros::langid;
+    /// use icu::plurals::{PluralRules, PluralRuleType, PluralCategory};
+    /// use icu_provider::inv::InvariantDataProvider;
+    ///
+    /// let lid = langid!("ja");
+    ///
+    /// let dp = InvariantDataProvider;
+    ///
+    /// let pr = PluralRules::try_new(lid, &dp, PluralRuleType::Ordinal)
+    ///     .expect("Failed to construct a PluralRules struct.");
+    ///
+    /// let mut categories = pr.categories();
+    ///
+    /// assert_eq!(categories.next(), Some(&PluralCategory::Other));
+    /// assert_eq!(categories.next(), None);
+    /// ```
+    ///
+    /// [`Plural Categories`]: PluralCategory
+    pub fn categories(&self) -> impl Iterator<Item = &'static PluralCategory> + '_ {
+        self.selector.categories()
     }
 
     /// Lower-level constructor that allows constructing a [`PluralRules`] directly from

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -357,15 +357,18 @@ impl PluralRules {
     /// use icu::plurals::{PluralRules, PluralRuleType, PluralCategory};
     /// use icu_provider::inv::InvariantDataProvider;
     ///
-    /// let lid = langid!("cy");
+    /// let lid = langid!("fr");
     ///
-    /// let dp = InvariantDataProvider;
+    /// let dp = icu_testdata::get_provider();
     ///
-    /// let pr = PluralRules::try_new(lid, &dp, PluralRuleType::Ordinal)
+    /// let pr = PluralRules::try_new(lid, &dp, PluralRuleType::Cardinal)
     ///     .expect("Failed to construct a PluralRules struct.");
     ///
-    /// let categories = pr.categories().copied().collect::<Vec<PluralCategory>>();
-    /// assert!(categories.contains(&PluralCategory::Other));
+    /// let mut categories = pr.categories();
+    /// assert_eq!(categories.next(), Some(&PluralCategory::Many));
+    /// assert_eq!(categories.next(), Some(&PluralCategory::One));
+    /// assert_eq!(categories.next(), Some(&PluralCategory::Other));
+    /// assert_eq!(categories.next(), None);
     /// ```
     ///
     /// [`Plural Categories`]: PluralCategory

--- a/components/plurals/tests/categories.rs
+++ b/components/plurals/tests/categories.rs
@@ -1,0 +1,58 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+mod fixtures;
+mod helpers;
+
+use icu_locid::LanguageIdentifier;
+use icu_plurals::{PluralCategory, PluralRules};
+use std::str::FromStr;
+
+#[test]
+fn test_categories() {
+    let provider = icu_testdata::get_provider();
+
+    let path = "./tests/fixtures/categories.json";
+    let test_set: Vec<fixtures::CategoriesTest> =
+        helpers::read_fixture(path).expect("Failed to read a fixture");
+
+    for test in test_set {
+        let pr = PluralRules::try_new(
+            LanguageIdentifier::from_str(&test.langid).unwrap(),
+            &provider,
+            test.plural_type.into(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            test.categories.len(),
+            pr.categories().count(),
+            "\n\
+	    {}({:?})\n\
+	    Expected: {:#?}\n\
+	    Actual: {:#?}\n\
+	    ",
+            test.langid,
+            test.plural_type,
+            test.categories,
+            pr.categories().collect::<Vec<&PluralCategory>>(),
+        );
+
+        for (expected, actual) in test.categories.iter().zip(pr.categories()) {
+            assert_eq!(
+                expected,
+                actual,
+                "\n\
+		{}({:?})\n\
+		Expected: {:#?}\n\
+		Actual: {:#?}\n\
+		",
+                test.langid,
+                test.plural_type,
+                test.categories,
+                pr.categories().collect::<Vec<&PluralCategory>>(),
+            );
+        }
+    }
+}

--- a/components/plurals/tests/fixtures/categories.json
+++ b/components/plurals/tests/fixtures/categories.json
@@ -1,0 +1,70 @@
+[
+  {
+    "langid": "ar",
+    "plural_type": "Cardinal",
+    "categories": [
+      "Few",
+      "Many",
+      "One",
+      "Other",
+      "Two",
+      "Zero"
+    ]
+  },
+  {
+    "langid": "ar",
+    "plural_type": "Ordinal",
+    "categories": [
+      "Other"
+    ]
+  },
+  {
+    "langid": "en",
+    "plural_type": "Cardinal",
+    "categories": [
+      "One",
+      "Other"
+    ]
+  },
+  {
+    "langid": "en",
+    "plural_type": "Ordinal",
+    "categories": [
+      "Few",
+      "One",
+      "Other",
+      "Two"
+    ]
+  },
+  {
+    "langid": "fr",
+    "plural_type": "Cardinal",
+    "categories": [
+      "Many",
+      "One",
+      "Other"
+    ]
+  },
+  {
+    "langid": "fr",
+    "plural_type": "Ordinal",
+    "categories": [
+      "One",
+      "Other"
+    ]
+  },
+  {
+    "langid": "ja",
+    "plural_type": "Cardinal",
+    "categories": [
+      "Other"
+    ]
+  },
+  {
+    "langid": "ja",
+    "plural_type": "Ordinal",
+    "categories": [
+      "Other"
+    ]
+  }
+]

--- a/components/plurals/tests/fixtures/categories.json
+++ b/components/plurals/tests/fixtures/categories.json
@@ -3,68 +3,68 @@
     "langid": "ar",
     "plural_type": "Cardinal",
     "categories": [
-      "Few",
-      "Many",
-      "One",
-      "Other",
-      "Two",
-      "Zero"
+      "few",
+      "many",
+      "one",
+      "other",
+      "two",
+      "zero"
     ]
   },
   {
     "langid": "ar",
     "plural_type": "Ordinal",
     "categories": [
-      "Other"
+      "other"
     ]
   },
   {
     "langid": "en",
     "plural_type": "Cardinal",
     "categories": [
-      "One",
-      "Other"
+      "one",
+      "other"
     ]
   },
   {
     "langid": "en",
     "plural_type": "Ordinal",
     "categories": [
-      "Few",
-      "One",
-      "Other",
-      "Two"
+      "few",
+      "one",
+      "other",
+      "two"
     ]
   },
   {
     "langid": "fr",
     "plural_type": "Cardinal",
     "categories": [
-      "Many",
-      "One",
-      "Other"
+      "many",
+      "one",
+      "other"
     ]
   },
   {
     "langid": "fr",
     "plural_type": "Ordinal",
     "categories": [
-      "One",
-      "Other"
+      "one",
+      "other"
     ]
   },
   {
     "langid": "ja",
     "plural_type": "Cardinal",
     "categories": [
-      "Other"
+      "other"
     ]
   },
   {
     "langid": "ja",
     "plural_type": "Ordinal",
     "categories": [
-      "Other"
+      "other"
     ]
   }
 ]

--- a/components/plurals/tests/fixtures/mod.rs
+++ b/components/plurals/tests/fixtures/mod.rs
@@ -149,15 +149,15 @@ pub enum PluralCategoryInput {
 
 impl PartialEq<PluralCategory> for PluralCategoryInput {
     fn eq(&self, other: &PluralCategory) -> bool {
-        match (self, other) {
-            (PluralCategoryInput::Zero, PluralCategory::Zero) => true,
-            (PluralCategoryInput::One, PluralCategory::One) => true,
-            (PluralCategoryInput::Two, PluralCategory::Two) => true,
-            (PluralCategoryInput::Few, PluralCategory::Few) => true,
-            (PluralCategoryInput::Many, PluralCategory::Many) => true,
-            (PluralCategoryInput::Other, PluralCategory::Other) => true,
-            _ => false,
-        }
+        matches!(
+            (self, other),
+            (PluralCategoryInput::Zero, PluralCategory::Zero)
+                | (PluralCategoryInput::One, PluralCategory::One)
+                | (PluralCategoryInput::Two, PluralCategory::Two)
+                | (PluralCategoryInput::Few, PluralCategory::Few)
+                | (PluralCategoryInput::Many, PluralCategory::Many)
+                | (PluralCategoryInput::Other, PluralCategory::Other)
+        )
     }
 }
 

--- a/components/plurals/tests/fixtures/mod.rs
+++ b/components/plurals/tests/fixtures/mod.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use fixed_decimal::FixedDecimal;
-use icu_plurals::PluralOperands;
+use icu_plurals::{PluralCategory, PluralOperands, PluralRuleType};
 use serde::Deserialize;
 use std::convert::TryInto;
 
@@ -121,3 +121,49 @@ pub enum RuleTestOutput {
 
 #[derive(Deserialize)]
 pub struct RuleTestSet(pub Vec<RuleTest>);
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+pub enum PluralRuleTypeInput {
+    Cardinal,
+    Ordinal,
+}
+
+impl From<PluralRuleTypeInput> for PluralRuleType {
+    fn from(other: PluralRuleTypeInput) -> Self {
+        match other {
+            PluralRuleTypeInput::Cardinal => PluralRuleType::Cardinal,
+            PluralRuleTypeInput::Ordinal => PluralRuleType::Ordinal,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub enum PluralCategoryInput {
+    Zero,
+    One,
+    Two,
+    Few,
+    Many,
+    Other,
+}
+
+impl PartialEq<PluralCategory> for PluralCategoryInput {
+    fn eq(&self, other: &PluralCategory) -> bool {
+        match (self, other) {
+            (PluralCategoryInput::Zero, PluralCategory::Zero) => true,
+            (PluralCategoryInput::One, PluralCategory::One) => true,
+            (PluralCategoryInput::Two, PluralCategory::Two) => true,
+            (PluralCategoryInput::Few, PluralCategory::Few) => true,
+            (PluralCategoryInput::Many, PluralCategory::Many) => true,
+            (PluralCategoryInput::Other, PluralCategory::Other) => true,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CategoriesTest {
+    pub langid: String,
+    pub plural_type: PluralRuleTypeInput,
+    pub categories: Vec<PluralCategoryInput>,
+}

--- a/components/plurals/tests/fixtures/mod.rs
+++ b/components/plurals/tests/fixtures/mod.rs
@@ -138,6 +138,7 @@ impl From<PluralRuleTypeInput> for PluralRuleType {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum PluralCategoryInput {
     Zero,
     One,

--- a/components/plurals/tests/plurals.rs
+++ b/components/plurals/tests/plurals.rs
@@ -34,7 +34,14 @@ fn test_plural_rules_missing() {
 fn test_plural_category_all() {
     let categories: Vec<&PluralCategory> = PluralCategory::all().collect();
 
-    assert_eq!(categories.get(0), Some(&&PluralCategory::Zero));
+    assert_eq!(categories.len(), 6);
+
+    assert_eq!(categories[0], &PluralCategory::Few);
+    assert_eq!(categories[1], &PluralCategory::Many);
+    assert_eq!(categories[2], &PluralCategory::One);
+    assert_eq!(categories[3], &PluralCategory::Other);
+    assert_eq!(categories[4], &PluralCategory::Two);
+    assert_eq!(categories[5], &PluralCategory::Zero);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #778 

The categories() function returns an iterator over each
PluralCategory supported by a PluralRules object that
has been created with a given LanguageIdentifier and
PluralRuleType.

The categories are returned in alphabetical order.
This is what is expected by browsers, and the same order
that ICU4C returns.

See https://github.com/tc39/ecma402/issues/578 for more info on the ordering.

@zbraniecki the above means I had to change the ordering in which the `PluralCategory::all()` function returns each category from numerical order to alphabetical order. This should have no impact on performance, since I doubt the numerical order is optimized for putting the most common category first (although that would be a really interesting and unlikely coincidence).

EDIT: Clearly I hadn't read the latest on the tc39 issue that I linked above. I'm happy to go back to numerical ordering based on that conversation. 

@Manishearth and @sffc I know we discussed returning a `struct` or `array` of `bool` for FFI reasons. I'm still happy to change it to this, but returning an iterator over `PluralCategory` seemed, to me, to be the most clean, idiomatic and natural Rust way to write this function. This approach should also be no-alloc, since it returns an iterator of `'static` references.

I am wondering if we can keep it this way, and put the iterator's contents into whatever structure is easiest for the FFI in the FFI layer. Please let me know either way. I'm happy to change it here if what I'm proposing won't work, but I think that returning an array of booleans is a pretty poor Rust-level API. That would make it entirely up to documentation to know which ordering the booleans represent (i.e. `Few` should always be first).  

Lastly, I was unsure of whether to call this `categories()` or `keywords()`. 

* We use the term `Category` frequently in ICU4X
* UTS-35 uses the term categories: https://www.unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules
* ICU4C uses the term keywords: https://unicode-org.github.io/icu-docs/apidoc/dev/icu4c/upluralrules_8h.html#a5f8a89ec2b58323e9f96ac0bf2c13ab5

I decided to go with `categories()` to match our usage in ICU4X.