### PR TITLE
Add lifetime to patterns in DTF

### DIFF
--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -61,7 +61,7 @@ use crate::{
 /// when we introduce asynchronous [`DataProvider`] and corresponding asynchronous constructor.
 pub struct DateTimeFormat<'d> {
     pub(super) locale: Locale,
-    pub(super) pattern: Pattern,
+    pub(super) pattern: Pattern<'d>,
     pub(super) symbols: DataPayload<'d, 'd, DateSymbolsV1Marker>,
 }
 
@@ -163,7 +163,7 @@ impl<'d> DateTimeFormat<'d> {
     /// [`ZonedDateTimeFormat`]: crate::zoned_datetime::ZonedDateTimeFormat
     pub(super) fn new<T: Into<Locale>>(
         locale: T,
-        pattern: Pattern,
+        pattern: Pattern<'d>,
         symbols: DataPayload<'d, 'd, DateSymbolsV1Marker>,
     ) -> Self {
         let locale = locale.into();

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -45,7 +45,7 @@ pub struct FormattedDateTime<'l, T>
 where
     T: DateTimeInput,
 {
-    pub(crate) pattern: &'l Pattern,
+    pub(crate) pattern: &'l Pattern<'l>,
     pub(crate) symbols: &'l provider::gregory::DateSymbolsV1,
     pub(crate) datetime: &'l T,
     pub(crate) locale: &'l Locale,

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -201,10 +201,10 @@ impl TryFrom<&str> for Skeleton {
 pub struct AvailableFormatPattern<'a> {
     /// The skeleton that is used to match against.
     skeleton: &'a Skeleton,
-    pub pattern: &'a Pattern,
+    pub pattern: &'a Pattern<'a>,
 }
 
-impl<'a> From<(&'a SkeletonV1, &'a PatternV1)> for AvailableFormatPattern<'a> {
+impl<'a> From<(&'a SkeletonV1, &'a PatternV1<'a>)> for AvailableFormatPattern<'a> {
     fn from(tuple: (&'a SkeletonV1, &'a PatternV1)) -> Self {
         let (skeleton_v1, pattern_v1) = tuple;
 
@@ -349,7 +349,7 @@ pub fn create_best_pattern_for_fields<'a>(
     skeletons: &'a SkeletonsV1,
     length_patterns: &LengthPatternsV1,
     fields: &[Field],
-) -> BestSkeleton<Pattern> {
+) -> BestSkeleton<Pattern<'a>> {
     let first_pattern_match = get_best_available_format_pattern(skeletons, fields);
 
     // Try to match a skeleton to all of the fields.
@@ -520,7 +520,7 @@ fn group_fields_by_type(fields: &[Field]) -> FieldsByType {
 pub fn get_best_available_format_pattern<'a>(
     skeletons: &'a SkeletonsV1,
     fields: &[Field],
-) -> BestSkeleton<&'a Pattern> {
+) -> BestSkeleton<&'a Pattern<'a>> {
     let mut closest_format_pattern = None;
     let mut closest_distance: u32 = u32::MAX;
     let mut closest_missing_fields = 0;
@@ -618,7 +618,7 @@ pub fn get_best_available_format_pattern<'a>(
 
 pub fn get_available_format_patterns<'a>(
     skeletons: &'a SkeletonsV1,
-) -> impl Iterator<Item = AvailableFormatPattern> + 'a {
+) -> impl Iterator<Item = AvailableFormatPattern<'a>> + 'a {
     skeletons.0.iter().map(AvailableFormatPattern::from)
 }
 

--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -86,7 +86,7 @@ where
 // TODO(#622) Make TimeZoneFormat public once we have a clean way to provide it options.
 pub(super) struct TimeZoneFormat<'d> {
     /// The pattern to format.
-    pub(super) pattern: Pattern,
+    pub(super) pattern: Pattern<'d>,
     /// The data that contains meta information about how to display content.
     pub(super) zone_formats: DataPayload<'d, 'd, provider::time_zones::TimeZoneFormatsV1Marker>,
     /// The exemplar cities for time zones.
@@ -131,7 +131,7 @@ impl<'d> TimeZoneFormat<'d> {
     // TODO(#622) Make this public once TimeZoneFormat is public.
     pub(super) fn try_new<L, ZP>(
         locale: L,
-        pattern: Pattern,
+        pattern: Pattern<'d>,
         zone_provider: &ZP,
     ) -> Result<Self, DateTimeFormatError>
     where

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -34,7 +34,7 @@ use tinystr::tinystr8;
 
 struct MultiKeyStructProvider<'s> {
     pub symbols: StructProvider<'s, DateSymbolsV1>,
-    pub patterns: StructProvider<'s, DatePatternsV1>,
+    pub patterns: StructProvider<'s, DatePatternsV1<'s>>,
 }
 
 impl<'d, 's> DataProvider<'d, 's, DateSymbolsV1Marker> for MultiKeyStructProvider<'s> {


### PR DESCRIPTION
This is the first attempt. It's pretty quirky and I had to comment out (switch to `panic!()`) in two places that I had not had a chance to tackle.

I'm stuck on two things:

1) pulling pattern data from the provider:

```
error[E0597]: `patterns_data` does not live long enough
   --> components/datetime/src/datetime.rs:130:23
    |
68  |   impl<'d> DateTimeFormat<'d> {
    |        -- lifetime `'d` defined here
...
130 |           let pattern = patterns_data
    |                         -^^^^^^^^^^^^
    |                         |
    |  _______________________borrowed value does not live long enough
    | |
131 | |             .get()
    | |__________________- argument requires that `patterns_data` is borrowed for `'d`
...
149 |       }
    |       - `patterns_data` dropped here while still borrowed

error[E0597]: `pattern_data` does not live long enough
```

2) DeserializePatternUTS35String

```
error[E0277]: the trait bound `fn(PhantomData<&str>) -> DeserializePatternUTS35String<'_> {DeserializePatternUTS35String::<'_>}: Visitor<'de>` is not satisfied
   --> components/datetime/src/pattern/mod.rs:259:42
    |
259 |             deserializer.deserialize_str(DeserializePatternUTS35String)
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Visitor<'de>` is not implemented for `fn(PhantomData<&str>) -> DeserializePatternUTS35String<'_> {DeserializePatternUTS35String::<'_>}`
```

If anyone has a moment to take a look and unblock me, I'd appreciate. If not, I'll continue trying.