### PR TITLE
Expose PluralOperands::from_str() over capi FFI

### DIFF
--- a/ffi/capi/examples/pluralrules/test.c
+++ b/ffi/capi/examples/pluralrules/test.c
@@ -22,17 +22,28 @@ int main() {
     }
     ICU4XPluralRules* rules = plural_result.rules;
 
-    ICU4XPluralOperands op = { .i = 3 };
+    ICU4XPluralOperands op1 = { .i = 3 };
 
-    ICU4XPluralCategory cat = icu4x_plural_rules_select(rules, &op);
+    ICU4XPluralCategory cat1 = icu4x_plural_rules_select(rules, &op1);
 
-    printf("Plural Category %d (should be %d)\n", (int)cat, (int)ICU4XPluralCategory_Few);
+    printf("Plural Category %d (should be %d)\n", (int)cat1, (int)ICU4XPluralCategory_Few);
+
+    ICU4XCreatePluralOperandsResult op_result = icu4x_plural_operands_create("1011.0", 6);
+
+    if (!op_result.success) {
+        printf("Failed to create PluralOperands from string\n");
+        return 1;
+    }
+
+    ICU4XPluralCategory cat2 = icu4x_plural_rules_select(rules, &op_result.operands);
+
+    printf("Plural Category %d (should be %d)\n", (int)cat2, (int)ICU4XPluralCategory_Many);
 
     icu4x_plural_rules_destroy(rules);
     icu4x_data_provider_destroy(provider);
     icu4x_locale_destroy(locale);
 
-    if (cat != ICU4XPluralCategory_Few) {
+    if (cat2 != ICU4XPluralCategory_Many) {
         return 1;
     }
     return 0;

--- a/ffi/capi/examples/pluralrules/test.c
+++ b/ffi/capi/examples/pluralrules/test.c
@@ -43,6 +43,9 @@ int main() {
     icu4x_data_provider_destroy(provider);
     icu4x_locale_destroy(locale);
 
+    if (cat1 != ICU4XPluralCategory_Few) {
+        return 1;
+    }
     if (cat2 != ICU4XPluralCategory_Many) {
         return 1;
     }

--- a/ffi/capi/include/pluralrules.h
+++ b/ffi/capi/include/pluralrules.h
@@ -46,8 +46,13 @@ typedef struct {
     size_t c;
 } ICU4XPluralOperands;
 
+typedef struct {
+    ICU4XPluralOperands operands;
+    bool success;
+} ICU4XCreatePluralOperandsResult;
 
 ICU4XCreatePluralRulesResult icu4x_plural_rules_create(const ICU4XLocale* locale, const ICU4XDataProvider* provider, ICU4XPluralRuleType ty);
+ICU4XCreatePluralOperandsResult icu4x_plural_operands_create(const char* number, size_t len);
 ICU4XPluralCategory icu4x_plural_rules_select(const ICU4XPluralRules* rules, const ICU4XPluralOperands* op);
 void icu4x_plural_rules_destroy(ICU4XPluralRules* rules);
 

--- a/ffi/capi/src/pluralrules.rs
+++ b/ffi/capi/src/pluralrules.rs
@@ -55,7 +55,6 @@ pub extern "C" fn icu4x_plural_rules_create(
 }
 
 #[repr(C)]
-#[derive(Default)]
 /// This is the result returned by [`icu4x_plural_operands_create()`]
 pub struct ICU4XCreatePluralOperandsResult {
     /// Will default initialized if `success` is [`false`]
@@ -87,7 +86,10 @@ pub unsafe extern "C" fn icu4x_plural_operands_create(
                     success: true,
                 })
         })
-        .unwrap_or_default()
+        .unwrap_or(ICU4XCreatePluralOperandsResult {
+            operands: ICU4XPluralOperands::default(),
+            success: false,
+        })
 }
 
 #[no_mangle]

--- a/ffi/capi/src/pluralrules.rs
+++ b/ffi/capi/src/pluralrules.rs
@@ -77,11 +77,7 @@ pub unsafe extern "C" fn icu4x_plural_operands_create(
     number: *const u8,
     len: usize,
 ) -> ICU4XCreatePluralOperandsResult {
-    // cheap as long as there are no variants
-    let bytes = slice::from_raw_parts(number, len);
-
-    // todo: return errors
-    str::from_utf8(bytes)
+    str::from_utf8(slice::from_raw_parts(number, len))
         .ok()
         .and_then(|s| {
             PluralOperands::from_str(s)

--- a/ffi/capi/src/pluralrules.rs
+++ b/ffi/capi/src/pluralrules.rs
@@ -82,7 +82,10 @@ pub unsafe extern "C" fn icu4x_plural_operands_create(
         .and_then(|s| {
             PluralOperands::from_str(s)
                 .ok()
-                .map(ICU4XCreatePluralOperandsResult::from)
+                .map(|ops| ICU4XCreatePluralOperandsResult {
+                    operands: ops.into(),
+                    success: true,
+                })
         })
         .unwrap_or_default()
 }
@@ -161,15 +164,6 @@ impl From<ICU4XPluralOperands> for PluralOperands {
             f: other.f,
             t: other.t,
             c: other.c,
-        }
-    }
-}
-
-impl From<PluralOperands> for ICU4XCreatePluralOperandsResult {
-    fn from(operands: PluralOperands) -> Self {
-        Self {
-            operands: operands.into(),
-            success: true,
         }
     }
 }

--- a/ffi/capi/src/pluralrules.rs
+++ b/ffi/capi/src/pluralrules.rs
@@ -86,7 +86,6 @@ pub unsafe extern "C" fn icu4x_plural_operands_create(
         .and_then(|s| {
             PluralOperands::from_str(s)
                 .ok()
-                .map(ICU4XPluralOperands::from)
                 .map(ICU4XCreatePluralOperandsResult::from)
         })
         .unwrap_or_default()
@@ -170,10 +169,10 @@ impl From<ICU4XPluralOperands> for PluralOperands {
     }
 }
 
-impl From<ICU4XPluralOperands> for ICU4XCreatePluralOperandsResult {
-    fn from(operands: ICU4XPluralOperands) -> Self {
+impl From<PluralOperands> for ICU4XCreatePluralOperandsResult {
+    fn from(operands: PluralOperands) -> Self {
         Self {
-            operands,
+            operands: operands.into(),
             success: true,
         }
     }


### PR DESCRIPTION
Fixes #794 

- Add new struct for ICU4XCreatePluralOperandsResult
- Add new function for icu4x_plural_operands_create()
