### PR TITLE
Expose PluralRules::categories() over capi FFI

### DIFF
--- a/ffi/capi/examples/pluralrules/test.c
+++ b/ffi/capi/examples/pluralrules/test.c
@@ -22,6 +22,14 @@ int main() {
     }
     ICU4XPluralRules* rules = plural_result.rules;
 
+    ICU4XPluralCategories categories = icu4x_plural_rules_categories(rules);
+    printf("Plural Category zero  (should be true): %s\n", categories.zero  ? "true" : "false");
+    printf("Plural Category one   (should be true): %s\n", categories.one   ? "true" : "false");
+    printf("Plural Category two   (should be true): %s\n", categories.two   ? "true" : "false");
+    printf("Plural Category few   (should be true): %s\n", categories.few   ? "true" : "false");
+    printf("Plural Category many  (should be true): %s\n", categories.many  ? "true" : "false");
+    printf("Plural Category other (should be true): %s\n", categories.other ? "true" : "false");
+
     ICU4XPluralOperands op1 = { .i = 3 };
 
     ICU4XPluralCategory cat1 = icu4x_plural_rules_select(rules, &op1);
@@ -43,11 +51,15 @@ int main() {
     icu4x_data_provider_destroy(provider);
     icu4x_locale_destroy(locale);
 
-    if (cat1 != ICU4XPluralCategory_Few) {
-        return 1;
-    }
-    if (cat2 != ICU4XPluralCategory_Many) {
-        return 1;
-    }
+    if (!categories.zero)  { return 1; }
+    if (!categories.one)   { return 1; }
+    if (!categories.two)   { return 1; }
+    if (!categories.few)   { return 1; }
+    if (!categories.many)  { return 1; }
+    if (!categories.other) { return 1; }
+
+    if (cat1 != ICU4XPluralCategory_Few)  { return 1; }
+    if (cat2 != ICU4XPluralCategory_Many) { return 1; }
+
     return 0;
 }

--- a/ffi/capi/include/pluralrules.h
+++ b/ffi/capi/include/pluralrules.h
@@ -38,6 +38,15 @@ typedef enum {
 } ICU4XPluralCategory;
 
 typedef struct {
+    bool zero;
+    bool one;
+    bool two;
+    bool few;
+    bool many;
+    bool other;
+} ICU4XPluralCategories;
+
+typedef struct {
     uint64_t i;
     size_t v;
     size_t w;
@@ -54,6 +63,7 @@ typedef struct {
 ICU4XCreatePluralRulesResult icu4x_plural_rules_create(const ICU4XLocale* locale, const ICU4XDataProvider* provider, ICU4XPluralRuleType ty);
 ICU4XCreatePluralOperandsResult icu4x_plural_operands_create(const char* number, size_t len);
 ICU4XPluralCategory icu4x_plural_rules_select(const ICU4XPluralRules* rules, const ICU4XPluralOperands* op);
+ICU4XPluralCategories icu4x_plural_rules_categories(const ICU4XPluralRules* rules);
 void icu4x_plural_rules_destroy(ICU4XPluralRules* rules);
 
 #ifdef __cplusplus

--- a/ffi/capi/src/pluralrules.rs
+++ b/ffi/capi/src/pluralrules.rs
@@ -6,7 +6,6 @@ use icu_locid::Locale as ICULocale;
 use icu_plurals::{PluralCategory, PluralOperands, PluralRuleType, PluralRules};
 
 use crate::provider::ICU4XDataProvider;
-use std::iter::FromIterator;
 use std::ptr;
 use std::slice;
 use std::str::{self, FromStr};
@@ -105,7 +104,20 @@ pub extern "C" fn icu4x_plural_rules_select(
 #[no_mangle]
 /// FFI version of [`PluralRules::categories()`]. See its docs for more details.
 pub extern "C" fn icu4x_plural_rules_categories(pr: &ICU4XPluralRules) -> ICU4XPluralCategories {
-    pr.categories().collect()
+    pr.categories().fold(
+        ICU4XPluralCategories::default(),
+        |mut categories, category| {
+            match category {
+                PluralCategory::Zero => categories.zero = true,
+                PluralCategory::One => categories.one = true,
+                PluralCategory::Two => categories.two = true,
+                PluralCategory::Few => categories.few = true,
+                PluralCategory::Many => categories.many = true,
+                PluralCategory::Other => categories.other = true,
+            };
+            categories
+        },
+    )
 }
 
 #[no_mangle]
@@ -161,25 +173,6 @@ pub struct ICU4XPluralCategories {
     few: bool,
     many: bool,
     other: bool,
-}
-
-impl FromIterator<&'static PluralCategory> for ICU4XPluralCategories {
-    fn from_iter<I: IntoIterator<Item = &'static PluralCategory>>(iter: I) -> Self {
-        iter.into_iter().fold(
-            ICU4XPluralCategories::default(),
-            |mut categories, category| {
-                match category {
-                    PluralCategory::Zero => categories.zero = true,
-                    PluralCategory::One => categories.one = true,
-                    PluralCategory::Two => categories.two = true,
-                    PluralCategory::Few => categories.few = true,
-                    PluralCategory::Many => categories.many = true,
-                    PluralCategory::Other => categories.other = true,
-                };
-                categories
-            },
-        )
-    }
 }
 
 impl From<PluralOperands> for ICU4XPluralOperands {


### PR DESCRIPTION
Fixes #779 

- Add new struct ICU4XPluralCategories to hold whether each category has
  rules or not for this PluralRules object.
- Add new function icu4x_plural_rules_categories()
