### PR TITLE
Fix bug evaluating NotEq on RangeList

### DIFF
--- a/components/plurals/src/rules/resolver.rs
+++ b/components/plurals/src/rules/resolver.rs
@@ -74,10 +74,13 @@ fn calculate_expression(expression: &ast::Expression, operands: &PluralOperands)
 }
 
 fn test_range(range: &ast::RangeList, value: u64, operator: ast::Operator) -> bool {
-    range
-        .0
-        .iter()
-        .any(|item| test_range_item(item, value, operator))
+    let connect = match operator {
+        ast::Operator::Eq => Iterator::any,
+        ast::Operator::NotEq => Iterator::all,
+    };
+    connect(&mut range.0.iter(), |item| {
+        test_range_item(item, value, operator)
+    })
 }
 
 fn test_range_item(item: &ast::RangeListItem, value: u64, operator: ast::Operator) -> bool {

--- a/components/plurals/tests/fixtures/rules.json
+++ b/components/plurals/tests/fixtures/rules.json
@@ -113,6 +113,16 @@
     "output": true
   },
   {
+    "rule": "n % 10 = 1 and n % 100 != 11, 71, 91",
+    "input": 11,
+    "output": false
+  },
+  {
+    "rule": "n % 10 = 1 and n % 100 != 11, 71, 91",
+    "input": 91,
+    "output": false
+  },
+  {
     "rule": "n % 0 = 1",
     "input": 1,
     "output": false

--- a/components/plurals/tests/rules.rs
+++ b/components/plurals/tests/rules.rs
@@ -26,9 +26,23 @@ fn test_parsing_operands() {
                 let operands: PluralOperands = test.input.into();
 
                 if val {
-                    assert!(test_condition(&ast, &operands));
+                    assert!(
+                        test_condition(&ast, &operands),
+                        "\nExpected true\n\
+                            AST: {:#?}\n\
+                            Operands: {:#?}\n",
+                        ast,
+                        operands
+                    );
                 } else {
-                    assert!(!test_condition(&ast, &operands));
+                    assert!(
+                        !test_condition(&ast, &operands),
+                        "\nExpected false\n\
+                            AST: {:#?}\n\
+                            Operands: {:#?}\n",
+                        ast,
+                        operands
+                    );
                 }
 
                 // Test that parse/serialize roundtrip completes.


### PR DESCRIPTION
Fixes #807

Previously the `test_range` function would always default to connecting expressions with `Iterator::any`.

This works fine if you are testing a `RangeList` for equality, e.g. `n % 100 = 11, 71, 91`

But this fails if you are testing a `RangeList` for inequality, e.g. `n % 100 != 11, 71, 91`

The default usage of `Iterator::any` will allow 11, 71, and 91 to evaluate to `true`. 

Instead, we need to use `Iterator::any` if the operator is `Eq`, and use `Iterator::all` if the operator is `NotEq`.

This PR fixes the bug and adds test cases that test `NotEq` with a `RangeList` in the AST. 