### PR TITLE
Bring back `cargo make wasm-examples`

### DIFF
--- a/tools/scripts/wasm.toml
+++ b/tools/scripts/wasm.toml
@@ -22,6 +22,16 @@ env = { "RUSTFLAGS" = "-C panic=abort -C opt-level=s" }
 command = "cargo"
 args = ["wasm-build-release", "--package", "icu_capi"]
 
+[tasks.wasm-build-examples]
+description = "Build WASM examples into the target directory"
+category = "ICU4X WASM"
+install_crate = { rustup_component_name = "rust-src" }
+toolchain = "nightly-2021-02-28"
+# We don't care about panics in release mode because most incorrect inputs are handled by result types.
+env = { "RUSTFLAGS" = "-C panic=abort -C opt-level=s" }
+command = "cargo"
+args = ["wasm-build-release", "--examples", "--workspace", "--exclude", "icu_datagen"]
+
 [tasks.wasm-dir]
 description = "Make the WASM package directory"
 category = "ICU4X WASM"
@@ -42,10 +52,17 @@ command = "cp"
 args = ["${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target/wasm32-unknown-unknown/release/icu_capi.wasm", "wasmpkg/"]
 dependencies = ["wasm-build-release", "wasm-dir"]
 
+[tasks.wasm-wasm-examples]
+description = "Copy the WASM files from examples into wasmpkg"
+category = "ICU4X WASM"
+command = "cp"
+args = ["-a", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target/wasm32-unknown-unknown/release/examples/.", "wasmpkg/"]
+dependencies = ["wasm-build-examples", "wasm-dir"]
+
 [tasks.wasm-wat]
 description = "Create WebAssembly Text files from the WASM files"
 category = "ICU4X WASM"
-dependencies = ["wasm-wasm-release"]
+dependencies = ["wasm-wasm-examples"]
 script_runner = "@duckscript"
 script = '''
 exit_on_error true
@@ -85,7 +102,7 @@ end
 [tasks.wasm-dcmp]
 description = "Create WebAssembly decompiled code files from the WASM files"
 category = "ICU4X WASM"
-dependencies = ["wasm-wasm-release"]
+dependencies = ["wasm-wasm-examples"]
 script_runner = "@duckscript"
 script = '''
 exit_on_error true
@@ -122,7 +139,7 @@ for src_path in ${handle}
 end
 '''
 
-[tasks.wasm-opt]
+[tasks.wasm-opt-release]
 description = "Create optimized WASM files from the WASM files"
 category = "ICU4X WASM"
 dependencies = ["wasm-wasm-release"]
@@ -162,7 +179,47 @@ for src_path in ${handle}
 end
 '''
 
-[tasks.wasm-twiggy-dominators]
+[tasks.wasm-opt-examples]
+description = "Create optimized WASM files from the WASM files"
+category = "ICU4X WASM"
+dependencies = ["wasm-wasm-examples"]
+script_runner = "@duckscript"
+script = '''
+exit_on_error true
+
+wasm-opt = which wasm-opt
+assert ${wasm-opt} "Could not find 'wasm-opt' in path.\n*** Please run 'npm install -g wasm-opt' ***"
+
+mkdir wasmpkg/wasm-opt
+
+handle = glob_array wasmpkg/*.wasm
+for src_path in ${handle}
+    path_no_extension = substring ${src_path} -5
+    basename = substring ${path_no_extension} 8
+    out_path = concat wasmpkg/wasm-opt/ ${basename} "+opt.wasm"
+
+    out_exists = is_path_exists ${out_path}
+    up_to_date = set false
+    if ${out_exists}
+        src_time = get_last_modified_time ${src_path}
+        out_time = get_last_modified_time ${out_path}
+        up_to_date = less_than ${src_time} ${out_time}
+    end
+
+    if not ${up_to_date}
+        echo Writing ${out_path}
+        output = exec ${wasm-opt} -Os ${src_path} -o ${out_path}
+        stdout = trim ${output.stdout}
+        stderr = trim ${output.stderr}
+        if ${stdout} or ${stderr} or ${output.code}
+            echo ${stdout}\n${stderr}\nexit code: ${output.code}
+            assert_fail "wasm-opt printed warnings (shown above)"
+        end
+    end
+end
+'''
+
+[tasks.wasm-twiggy-dominators-release]
 description = "Create Twiggy Dominator files from the WASM files"
 category = "ICU4X WASM"
 script_runner = "@duckscript"
@@ -196,6 +253,40 @@ end
 '''
 dependencies = ["wasm-wasm-release"]
 
+[tasks.wasm-twiggy-dominators-examples]
+description = "Create Twiggy Dominator files from the WASM files"
+category = "ICU4X WASM"
+script_runner = "@duckscript"
+script = '''
+exit_on_error true
+
+twiggy = which twiggy
+assert ${twiggy} "Could not find 'twiggy' in path.\n*** Please run 'cargo install twiggy' ***"
+
+mkdir wasmpkg/twiggy
+
+handle = glob_array wasmpkg/*.wasm
+for src_path in ${handle}
+    path_no_extension = substring ${src_path} -5
+    basename = substring ${path_no_extension} 8
+    out_path = concat wasmpkg/twiggy/ ${basename} "+twiggy.txt"
+
+    out_exists = is_path_exists ${out_path}
+    up_to_date = set false
+    if ${out_exists}
+        src_time = get_last_modified_time ${src_path}
+        out_time = get_last_modified_time ${out_path}
+        up_to_date = less_than ${src_time} ${out_time}
+    end
+
+    if not ${up_to_date}
+        echo Writing ${out_path}
+        exec --fail-on-error ${twiggy} dominators ${src_path} -o ${out_path}
+    end
+end
+'''
+dependencies = ["wasm-wasm-examples"]
+
 [tasks.wasm-dev]
 description = "All-in-one command to build dev-mode WASM FFI to wasmpkg"
 category = "ICU4X WASM"
@@ -208,10 +299,19 @@ description = "All-in-one command to build release-mode WASM FFI to wasmpkg"
 category = "ICU4X WASM"
 dependencies = [
     "wasm-wasm-release",
+    "wasm-opt-release",
+    "wasm-twiggy-dominators-release",
+]
+
+[tasks.wasm-examples]
+description = "All-in-one command to build release-mode WASM examples to wasmpkg"
+category = "ICU4X WASM"
+dependencies = [
+    "wasm-wasm-examples",
     "wasm-wat",
     "wasm-dcmp",
-    "wasm-opt",
-    "wasm-twiggy-dominators",
+    "wasm-opt-examples",
+    "wasm-twiggy-dominators-examples",
 ]
 
 [tasks.wasm-test-release]


### PR DESCRIPTION
Also disables WASM decompilation when building the FFI, instead decompiling the examples.