### PR TITLE
Add bincode example to icu4x-datagen readme

### DIFF
--- a/tools/datagen/README.md
+++ b/tools/datagen/README.md
@@ -16,11 +16,11 @@ Generate ICU4X JSON:
 ```bash
 # Run from the icu4x project folder
 $ cargo run --bin icu4x-datagen -- \
-    --cldr-tag 39.0.0              \
-    --all-keys                     \
-    --all-locales                  \
-    --out /tmp/icu4x_data/json     \
-    -v
+   --cldr-tag 39.0.0 \
+   --all-keys \
+   --all-locales \
+   --out /tmp/icu4x_data/json \
+   -v
 ```
 
 Generate ICU4X Bincode:
@@ -28,12 +28,12 @@ Generate ICU4X Bincode:
 ```bash
 # Run from the icu4x project folder
 $ cargo run --bin icu4x-datagen -- \
-    --cldr-tag 39.0.0              \
-    --all-keys                     \
-    --all-locales                  \
-    --out /tmp/icu4x_data/bincode  \
-    --syntax bincode               \
-    -v
+   --cldr-tag 39.0.0 \
+   --all-keys \
+   --all-locales \
+   --out /tmp/icu4x_data/bincode \
+   --syntax bincode \
+   -v
 ```
 
 ## More Information

--- a/tools/datagen/README.md
+++ b/tools/datagen/README.md
@@ -31,8 +31,8 @@ $ cargo run --bin icu4x-datagen -- \
    --cldr-tag 39.0.0 \
    --all-keys \
    --all-locales \
-   --out /tmp/icu4x_data/bincode \
    --syntax bincode \
+   --out /tmp/icu4x_data/bincode \
    -v
 ```
 

--- a/tools/datagen/README.md
+++ b/tools/datagen/README.md
@@ -16,10 +16,23 @@ Generate ICU4X JSON:
 ```bash
 # Run from the icu4x project folder
 $ cargo run --bin icu4x-datagen -- \
-    --cldr-tag 39.0.0 \
-    --all-keys \
-    --all-locales \
-    --out /tmp/icu4x_data \
+    --cldr-tag 39.0.0              \
+    --all-keys                     \
+    --all-locales                  \
+    --out /tmp/icu4x_data/json     \
+    -v
+```
+
+Generate ICU4X Bincode:
+
+```bash
+# Run from the icu4x project folder
+$ cargo run --bin icu4x-datagen -- \
+    --cldr-tag 39.0.0              \
+    --all-keys                     \
+    --all-locales                  \
+    --out /tmp/icu4x_data/bincode  \
+    --syntax bincode               \
     -v
 ```
 

--- a/tools/datagen/src/main.rs
+++ b/tools/datagen/src/main.rs
@@ -33,8 +33,8 @@
 //!    --cldr-tag 39.0.0 \
 //!    --all-keys \
 //!    --all-locales \
-//!    --out /tmp/icu4x_data/bincode \
 //!    --syntax bincode \
+//!    --out /tmp/icu4x_data/bincode \
 //!    -v
 //!```
 

--- a/tools/datagen/src/main.rs
+++ b/tools/datagen/src/main.rs
@@ -15,15 +15,28 @@
 //!
 //! Generate ICU4X JSON:
 //!
-//! ```bash
-//! # Run from the icu4x project folder
-//! $ cargo run --bin icu4x-datagen -- \
-//!     --cldr-tag 39.0.0 \
-//!     --all-keys \
-//!     --all-locales \
-//!     --out /tmp/icu4x_data \
-//!     -v
-//! ```
+//!```bash
+//!# Run from the icu4x project folder
+//!$ cargo run --bin icu4x-datagen -- \
+//!    --cldr-tag 39.0.0 \
+//!    --all-keys \
+//!    --all-locales \
+//!    --out /tmp/icu4x_data/json \
+//!    -v
+//!```
+//!
+//!Generate ICU4X Bincode:
+//!
+//!```bash
+//!# Run from the icu4x project folder
+//!$ cargo run --bin icu4x-datagen -- \
+//!    --cldr-tag 39.0.0 \
+//!    --all-keys \
+//!    --all-locales \
+//!    --out /tmp/icu4x_data/bincode \
+//!    --syntax bincode \
+//!    -v
+//!```
 
 fn main() {
     panic!("Please run a more specific binary")


### PR DESCRIPTION
Adds an example to the `icu4x-datagen` README to make it clear how to generate bincode data. The flag is shown in the `--help` menu for the tool, but I think this is a common enough use case that it could warrant being in the README.