### PR TITLE
Add initial calendars crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,6 +845,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_calendar"
+version = "0.2.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "icu_capi"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,9 +847,6 @@ dependencies = [
 [[package]]
 name = "icu_calendar"
 version = "0.2.0"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "icu_capi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "components/plurals",
     "components/uniset",
     "experimental/bies",
+    "experimental/calendar",
     "experimental/provider_ppucd",
     "experimental/provider_static",
     "experimental/segmenter",

--- a/experimental/calendar/Cargo.toml
+++ b/experimental/calendar/Cargo.toml
@@ -24,3 +24,6 @@ include = [
 
 [package.metadata.docs.rs]
 all-features = true
+
+[package.metadata.cargo-all-features]
+skip_optional_dependencies = true

--- a/experimental/calendar/Cargo.toml
+++ b/experimental/calendar/Cargo.toml
@@ -1,0 +1,34 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+[package]
+name = "icu_calendar"
+description = "API for supporting various types of calendars"
+version = "0.2.0"
+authors = ["The ICU4X Project Developers"]
+edition = "2018"
+readme = "README.md"
+repository = "https://github.com/unicode-org/icu4x"
+license-file = "../../LICENSE"
+categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
+include = [
+    "src/**/*",
+    "examples/**/*",
+    "benches/**/*",
+    "tests/**/*",
+    "Cargo.toml",
+    "README.md"
+]
+
+[package.metadata.cargo-all-features]
+skip_optional_dependencies = true
+# "serde" is an intentional feature, enabling serialization of LanguageIdentifier and others:
+extra_features = ["serde"]
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+serde = { version = "1.0", optional = true }

--- a/experimental/calendar/Cargo.toml
+++ b/experimental/calendar/Cargo.toml
@@ -21,14 +21,3 @@ include = [
     "Cargo.toml",
     "README.md"
 ]
-
-[package.metadata.cargo-all-features]
-skip_optional_dependencies = true
-# "serde" is an intentional feature, enabling serialization of LanguageIdentifier and others:
-extra_features = ["serde"]
-
-[package.metadata.docs.rs]
-all-features = true
-
-[dependencies]
-serde = { version = "1.0", optional = true }

--- a/experimental/calendar/Cargo.toml
+++ b/experimental/calendar/Cargo.toml
@@ -21,3 +21,6 @@ include = [
     "Cargo.toml",
     "README.md"
 ]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/experimental/calendar/src/calendar.rs
+++ b/experimental/calendar/src/calendar.rs
@@ -3,7 +3,6 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::{Date, DateDuration, DurationUnit, Iso};
-use std::fmt::Debug;
 
 /// A calendar implementation
 ///
@@ -13,7 +12,7 @@ use std::fmt::Debug;
 /// Individual [`Calendar`] implementations may have inherent utility methods
 /// allowing for direct construction, etc.
 pub trait Calendar {
-    type DateInner: PartialEq + Eq + Debug + Clone;
+    type DateInner: PartialEq + Eq + Clone;
     /// Construct the date from an ISO date
     fn date_from_iso(&self, iso: Date<Iso>) -> Self::DateInner;
     fn date_to_iso(&self, date: &Self::DateInner) -> Date<Iso>;

--- a/experimental/calendar/src/calendar.rs
+++ b/experimental/calendar/src/calendar.rs
@@ -1,0 +1,47 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use crate::{Date, DateDuration, DurationUnit, Iso};
+use std::fmt::Debug;
+
+/// A calendar implementation
+///
+/// Only implementors of [`Calendar`] should care about these methods, in general users of
+/// these calendars should use the methods on [`Date`] instead.
+///
+/// Individual [`Calendar`] implementations may have inherent utility methods
+/// allowing for direct construction, etc.
+pub trait Calendar {
+    type DateInner: PartialEq + Eq + Debug + Clone;
+    /// Construct the date from an ISO date
+    fn date_from_iso(&self, iso: Date<Iso>) -> Self::DateInner;
+    fn date_to_iso(&self, date: &Self::DateInner) -> Date<Iso>;
+    // fn validate_date(&self, e: Era, y: Year, m: MonthCode, d: Day) -> bool;
+    // // similar validators for YearMonth, etc
+
+    // fn is_leap<A: AsCalendar<Calendar = Self>>(&self, date: &Date<A>) -> bool;
+    fn months_in_year(&self, date: &Self::DateInner) -> u8;
+    fn days_in_year(&self, date: &Self::DateInner) -> u32;
+    fn days_in_month(&self, date: &Self::DateInner) -> u8;
+    /// Monday is 1, Sunday is 7, according to ISO
+    fn day_of_week(&self, date: &Self::DateInner) -> u8 {
+        self.date_to_iso(date).day_of_week()
+    }
+    // fn week_of_year(&self, date: &Self::DateInner) -> u8;
+
+    /// Add `offset` to `date`
+    fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>);
+
+    /// Calculate `date2 - date` as a duration
+    fn until(
+        &self,
+        date1: &Self::DateInner,
+        date2: &Self::DateInner,
+        largest_unit: DurationUnit,
+        smallest_unit: DurationUnit,
+    ) -> DateDuration<Self>;
+
+    fn debug_name() -> &'static str;
+    // fn since(&self, from: &Date<Self>, to: &Date<Self>) -> Duration<Self>, Error;
+}

--- a/experimental/calendar/src/date.rs
+++ b/experimental/calendar/src/date.rs
@@ -120,7 +120,7 @@ where
 
 impl<A: AsCalendar> Eq for Date<A> {}
 
-impl<A: AsCalendar> fmt::Debug for Date<A> {
+impl<A: AsCalendar> fmt::Debug for Date<A> where <A::Calendar as Calendar>::DateInner: fmt::Debug {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,

--- a/experimental/calendar/src/date.rs
+++ b/experimental/calendar/src/date.rs
@@ -96,7 +96,7 @@ impl<A: AsCalendar> Date<A> {
     /// Calling this outside of calendar implementations is sound, but calendar implementations are not
     /// expected to do anything sensible with such invalid dates.
     #[inline]
-    pub fn construct_unchecked(inner: <A::Calendar as Calendar>::DateInner, calendar: A) -> Self {
+    pub fn from_raw(inner: <A::Calendar as Calendar>::DateInner, calendar: A) -> Self {
         Self { inner, calendar }
     }
 

--- a/experimental/calendar/src/date.rs
+++ b/experimental/calendar/src/date.rs
@@ -1,0 +1,123 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use crate::{Calendar, DateDuration, DurationUnit, Iso};
+use std::fmt;
+
+pub trait AsCalendar {
+    type Calendar: Calendar;
+    fn as_calendar(&self) -> &Self::Calendar;
+}
+
+impl<C: Calendar> AsCalendar for C {
+    type Calendar = C;
+    fn as_calendar(&self) -> &Self {
+        self
+    }
+}
+
+pub struct Date<A: AsCalendar> {
+    inner: <A::Calendar as Calendar>::DateInner,
+    calendar: A,
+}
+
+impl<A: AsCalendar> Date<A> {
+    /// Construct a date from an ISO date and some calendar representation
+    pub fn new_from_iso(iso: Date<Iso>, calendar: A) -> Self {
+        let inner = calendar.as_calendar().date_from_iso(iso);
+        Date { inner, calendar }
+    }
+
+    pub fn to_iso(&self) -> Date<Iso> {
+        self.calendar.as_calendar().date_to_iso(self.inner())
+    }
+
+    /// The number of months in the year of this date
+    pub fn months_in_year(&self) -> u8 {
+        self.calendar.as_calendar().months_in_year(&self.inner)
+    }
+
+    /// The number of days in the year of this date
+    pub fn days_in_year(&self) -> u32 {
+        self.calendar.as_calendar().days_in_year(&self.inner)
+    }
+
+    /// The number of days in the month of this date
+    pub fn days_in_month(&self) -> u8 {
+        self.calendar.as_calendar().days_in_month(&self.inner)
+    }
+
+    /// The day of the week for this date
+    ///
+    /// Monday is 1, Sunday is 7, according to ISO
+    pub fn day_of_week(&self) -> u8 {
+        self.calendar.as_calendar().day_of_week(&self.inner)
+    }
+
+    /// Add a `duration` to this date, mutating it
+    pub fn add(&mut self, duration: DateDuration<A::Calendar>) {
+        self.calendar
+            .as_calendar()
+            .offset_date(&mut self.inner, duration)
+    }
+
+    /// Calculating the duration between `other - self`
+    pub fn until<B: AsCalendar<Calendar = A::Calendar>>(
+        &self,
+        other: &Date<B>,
+        largest_unit: DurationUnit,
+        smallest_unit: DurationUnit,
+    ) -> DateDuration<A::Calendar> {
+        self.calendar
+            .as_calendar()
+            .until(self.inner(), other.inner(), largest_unit, smallest_unit)
+    }
+
+    /// Construct a date from raw values for a given calendar. This does not check any
+    /// invariants for the date and calendar, and should only be called by calendar implementations.
+    ///
+    /// Calling this outside of calendar implementations is sound, but calendar implementations are not
+    /// expected to do anything sensible with such invalid dates.
+    pub fn construct_unchecked(inner: <A::Calendar as Calendar>::DateInner, calendar: A) -> Self {
+        Self { inner, calendar }
+    }
+
+    /// Get the inner date implementation. Should not be called outside of calendar implementations
+    pub fn inner(&self) -> &<A::Calendar as Calendar>::DateInner {
+        &self.inner
+    }
+}
+
+impl<C, A, B> PartialEq<Date<B>> for Date<A>
+where
+    C: Calendar,
+    A: AsCalendar<Calendar = C>,
+    B: AsCalendar<Calendar = C>,
+{
+    fn eq(&self, other: &Date<B>) -> bool {
+        self.inner.eq(&other.inner)
+    }
+}
+
+impl<A: AsCalendar> Eq for Date<A> {}
+
+impl<A: AsCalendar> fmt::Debug for Date<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "Date({:?}, for calendar {})",
+            self.inner,
+            A::Calendar::debug_name()
+        )
+    }
+}
+
+impl<A: AsCalendar + Clone> Clone for Date<A> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            calendar: self.calendar.clone(),
+        }
+    }
+}

--- a/experimental/calendar/src/date.rs
+++ b/experimental/calendar/src/date.rs
@@ -120,7 +120,7 @@ where
 
 impl<A: AsCalendar> Eq for Date<A> {}
 
-impl<A: AsCalendar> fmt::Debug for Date<A> {
+impl<A: AsCalendar> fmt::Debug for Date<A> where {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,

--- a/experimental/calendar/src/date.rs
+++ b/experimental/calendar/src/date.rs
@@ -120,7 +120,7 @@ where
 
 impl<A: AsCalendar> Eq for Date<A> {}
 
-impl<A: AsCalendar> fmt::Debug for Date<A> where {
+impl<A: AsCalendar> fmt::Debug for Date<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,

--- a/experimental/calendar/src/date.rs
+++ b/experimental/calendar/src/date.rs
@@ -120,7 +120,10 @@ where
 
 impl<A: AsCalendar> Eq for Date<A> {}
 
-impl<A: AsCalendar> fmt::Debug for Date<A> where <A::Calendar as Calendar>::DateInner: fmt::Debug {
+impl<A: AsCalendar> fmt::Debug for Date<A>
+where
+    <A::Calendar as Calendar>::DateInner: fmt::Debug,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,

--- a/experimental/calendar/src/date.rs
+++ b/experimental/calendar/src/date.rs
@@ -12,6 +12,7 @@ pub trait AsCalendar {
 
 impl<C: Calendar> AsCalendar for C {
     type Calendar = C;
+    #[inline]
     fn as_calendar(&self) -> &Self {
         self
     }
@@ -24,45 +25,60 @@ pub struct Date<A: AsCalendar> {
 
 impl<A: AsCalendar> Date<A> {
     /// Construct a date from an ISO date and some calendar representation
+    #[inline]
     pub fn new_from_iso(iso: Date<Iso>, calendar: A) -> Self {
         let inner = calendar.as_calendar().date_from_iso(iso);
         Date { inner, calendar }
     }
 
+    #[inline]
     pub fn to_iso(&self) -> Date<Iso> {
         self.calendar.as_calendar().date_to_iso(self.inner())
     }
 
     /// The number of months in the year of this date
+    #[inline]
     pub fn months_in_year(&self) -> u8 {
-        self.calendar.as_calendar().months_in_year(&self.inner)
+        self.calendar.as_calendar().months_in_year(self.inner())
     }
 
     /// The number of days in the year of this date
+    #[inline]
     pub fn days_in_year(&self) -> u32 {
-        self.calendar.as_calendar().days_in_year(&self.inner)
+        self.calendar.as_calendar().days_in_year(self.inner())
     }
 
     /// The number of days in the month of this date
+    #[inline]
     pub fn days_in_month(&self) -> u8 {
-        self.calendar.as_calendar().days_in_month(&self.inner)
+        self.calendar.as_calendar().days_in_month(self.inner())
     }
 
     /// The day of the week for this date
     ///
     /// Monday is 1, Sunday is 7, according to ISO
+    #[inline]
     pub fn day_of_week(&self) -> u8 {
-        self.calendar.as_calendar().day_of_week(&self.inner)
+        self.calendar.as_calendar().day_of_week(self.inner())
     }
 
     /// Add a `duration` to this date, mutating it
+    #[inline]
     pub fn add(&mut self, duration: DateDuration<A::Calendar>) {
         self.calendar
             .as_calendar()
             .offset_date(&mut self.inner, duration)
     }
 
+    /// Add a `duration` to this date, returning the new one
+    #[inline]
+    pub fn added(mut self, duration: DateDuration<A::Calendar>) -> Self {
+        self.add(duration);
+        self
+    }
+
     /// Calculating the duration between `other - self`
+    #[inline]
     pub fn until<B: AsCalendar<Calendar = A::Calendar>>(
         &self,
         other: &Date<B>,
@@ -79,11 +95,13 @@ impl<A: AsCalendar> Date<A> {
     ///
     /// Calling this outside of calendar implementations is sound, but calendar implementations are not
     /// expected to do anything sensible with such invalid dates.
+    #[inline]
     pub fn construct_unchecked(inner: <A::Calendar as Calendar>::DateInner, calendar: A) -> Self {
         Self { inner, calendar }
     }
 
     /// Get the inner date implementation. Should not be called outside of calendar implementations
+    #[inline]
     pub fn inner(&self) -> &<A::Calendar as Calendar>::DateInner {
         &self.inner
     }

--- a/experimental/calendar/src/duration.rs
+++ b/experimental/calendar/src/duration.rs
@@ -1,0 +1,60 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use crate::Calendar;
+use std::fmt;
+use std::marker::PhantomData;
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+/// A duration between two dates
+pub struct DateDuration<C: Calendar + ?Sized> {
+    pub years: i32,
+    pub months: i32,
+    pub weeks: i32,
+    pub days: i32,
+    pub marker: PhantomData<C>,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum DurationUnit {
+    Years,
+    Months,
+    Weeks,
+    Days,
+}
+
+impl<C: Calendar + ?Sized> Default for DateDuration<C> {
+    fn default() -> Self {
+        Self {
+            years: 0,
+            months: 0,
+            weeks: 0,
+            days: 0,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<C: Calendar + ?Sized> DateDuration<C> {
+    pub fn new(years: i32, months: i32, weeks: i32, days: i32) -> Self {
+        DateDuration {
+            years,
+            months,
+            weeks,
+            days,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<C: Calendar> fmt::Debug for DateDuration<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.debug_struct("DateDuration")
+            .field("years", &self.years)
+            .field("months", &self.months)
+            .field("weeks", &self.weeks)
+            .field("days", &self.days)
+            .finish()
+    }
+}

--- a/experimental/calendar/src/error.rs
+++ b/experimental/calendar/src/error.rs
@@ -1,0 +1,8 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Error {
+    OutOfRange,
+}

--- a/experimental/calendar/src/iso.rs
+++ b/experimental/calendar/src/iso.rs
@@ -95,7 +95,7 @@ impl Calendar for Iso {
     }
 
     fn date_to_iso(&self, date: &Self::DateInner) -> Date<Iso> {
-        Date::construct_unchecked(*date, Iso)
+        Date::from_raw(*date, Iso)
     }
 
     fn months_in_year(&self, _date: &Self::DateInner) -> u8 {
@@ -116,7 +116,7 @@ impl Calendar for Iso {
 
     fn day_of_week(&self, date: &Self::DateInner) -> u8 {
         // TODO (Manishearth) share code with icu_datetime
-        
+
         // For the purposes of the calculation here, Monday is 0, Sunday is 6
         // ISO has Monday=1, Sunday=7, which we transform in the last step
 
@@ -229,7 +229,7 @@ impl Date<Iso> {
             }
         }
 
-        Ok(Date::construct_unchecked(
+        Ok(Date::from_raw(
             IsoDateInner { day, month, year },
             Iso,
         ))

--- a/experimental/calendar/src/iso.rs
+++ b/experimental/calendar/src/iso.rs
@@ -1,0 +1,310 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use crate::{Calendar, Date, DateDuration, DurationUnit};
+use std::convert::{TryFrom, TryInto};
+
+#[derive(Copy, Clone, Debug)]
+/// The ISO Calendar
+pub struct Iso;
+
+/// A 1-indexed representation of an ISO day
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub struct IsoDay(u8);
+/// A 1-indexed representation of an ISO month
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub struct IsoMonth(u8);
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+/// An ISO year. Year 0 == 1 BCE
+pub struct IsoYear(pub i32);
+
+impl TryFrom<u8> for IsoDay {
+    type Error = ();
+    fn try_from(int: u8) -> Result<Self, ()> {
+        if int > 31 || int < 1 {
+            return Err(());
+        }
+        Ok(Self(int))
+    }
+}
+
+impl TryFrom<u8> for IsoMonth {
+    type Error = ();
+    fn try_from(int: u8) -> Result<Self, ()> {
+        if int > 12 || int < 1 {
+            return Err(());
+        }
+        Ok(Self(int))
+    }
+}
+
+impl From<i32> for IsoYear {
+    fn from(int: i32) -> Self {
+        Self(int)
+    }
+}
+
+impl From<IsoDay> for u8 {
+    fn from(day: IsoDay) -> Self {
+        day.0
+    }
+}
+
+impl From<IsoMonth> for u8 {
+    fn from(month: IsoMonth) -> Self {
+        month.0
+    }
+}
+
+impl From<IsoYear> for i32 {
+    fn from(year: IsoYear) -> Self {
+        year.0
+    }
+}
+
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub struct IsoDateInner {
+    day: IsoDay,
+    month: IsoMonth,
+    year: IsoYear,
+}
+
+impl IsoDateInner {
+    fn add_months(&mut self, months: i32) {
+        // Get a zero-indexed new month
+        let new_month = (self.month.0 as i32 - 1) + months;
+        if new_month >= 0 {
+            self.year.0 += new_month / 12;
+            self.month.0 = ((new_month % 12) + 1) as u8;
+        } else {
+            // subtract full years
+            self.year.0 -= (-new_month) / 12;
+            // subtract a partial year
+            self.year.0 -= 1;
+            // adding 13 since months are 1-indexed
+            self.month.0 = (13 + (new_month % 12)) as u8
+        }
+    }
+}
+
+impl Calendar for Iso {
+    type DateInner = IsoDateInner;
+    fn date_from_iso(&self, iso: Date<Iso>) -> IsoDateInner {
+        *iso.inner()
+    }
+
+    fn date_to_iso(&self, date: &Self::DateInner) -> Date<Iso> {
+        Date::construct_unchecked(*date, Iso)
+    }
+
+    fn months_in_year(&self, _date: &Self::DateInner) -> u8 {
+        12
+    }
+
+    fn days_in_year(&self, date: &Self::DateInner) -> u32 {
+        if Self::is_leap_year(date.year) {
+            366
+        } else {
+            365
+        }
+    }
+
+    fn days_in_month(&self, date: &Self::DateInner) -> u8 {
+        Self::days_in_month(date.year, date.month)
+    }
+
+    fn day_of_week(&self, date: &Self::DateInner) -> u8 {
+        // For the purposes of the calculation here, Monday is 0, Sunday is 6
+        // ISO has Monday=1, Sunday=7, which we transform in the last step
+
+        // The days of the week are the same every 400 years
+        // so we normalize to the nearest multiple of 400
+        let years_since_400 = date.year.0 % 400;
+        let leap_years_since_400 = years_since_400 / 4 - years_since_400 / 100;
+        // The number of days to the current year
+        let days_to_current_year = 365 * years_since_400 + leap_years_since_400;
+        // The weekday offset from January 1 this year and January 1 2000
+        let year_offset = days_to_current_year % 7;
+
+        // Corresponding months from
+        // https://en.wikipedia.org/wiki/Determination_of_the_day_of_the_week#Corresponding_months
+        let month_offset = if Self::is_leap_year(date.year) {
+            match date.month.0 {
+                1 | 4 | 7 => 0,
+                10 => 1,
+                5 => 2,
+                2 | 8 => 3,
+                3 | 11 => 4,
+                6 => 5,
+                9 | 12 => 6,
+                _ => unreachable!(),
+            }
+        } else {
+            match date.month.0 {
+                1 | 10 => 0,
+                5 => 1,
+                8 => 2,
+                2 | 3 | 11 => 3,
+                6 => 4,
+                9 | 12 => 5,
+                4 | 7 => 6,
+                _ => unreachable!(),
+            }
+        };
+
+        let january_1_2000 = 5; // Saturday
+        let day_offset = (january_1_2000 + year_offset + month_offset + date.day.0 as i32) % 7;
+
+        // We calculated in a zero-indexed fashion, but ISO specifies one-indexed
+        (day_offset + 1) as u8
+    }
+
+    fn offset_date(&self, date: &mut Self::DateInner, mut offset: DateDuration<Self>) {
+        date.year.0 += offset.years;
+        date.add_months(offset.months);
+        offset.months = 0;
+
+        offset.days = offset.days + offset.weeks * 7;
+
+        // Normalize date to beginning of month
+        offset.days += date.day.0 as i32 - 1;
+        date.day.0 = 1;
+
+        while offset.days != 0 {
+            if offset.days < 0 {
+                date.add_months(-1);
+                let month_days = self.days_in_month(date);
+                if (-offset.days) > month_days as i32 {
+                    offset.days += month_days as i32;
+                } else {
+                    // Add 1 since we are subtracting from the first day of the
+                    // *next* month
+                    date.day.0 = 1 + (month_days as i8 + offset.days as i8) as u8;
+                    offset.days = 0;
+                }
+            } else {
+                let month_days = self.days_in_month(date);
+                if offset.days > month_days as i32 {
+                    date.add_months(1);
+                    offset.days -= month_days as i32;
+                } else {
+                    date.day.0 += offset.days as u8;
+                    offset.days = 0;
+                }
+            }
+        }
+    }
+
+    fn until(
+        &self,
+        date1: &Self::DateInner,
+        date2: &Self::DateInner,
+        _largest_unit: DurationUnit,
+        _smallest_unit: DurationUnit,
+    ) -> DateDuration<Self> {
+        let mut difference = DateDuration::default();
+        // XXXManishearth handle the unit bounds and rounding behavior
+        difference.years = date1.year.0 - date2.year.0;
+        difference.months = date1.month.0 as i32 - date2.month.0 as i32;
+        difference.days = date1.day.0 as i32 - date2.day.0 as i32;
+
+        difference
+    }
+
+    fn debug_name() -> &'static str {
+        "ISO"
+    }
+}
+
+impl Iso {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn create_iso_date(day: IsoDay, month: IsoMonth, year: IsoYear) -> Result<Date<Iso>, ()> {
+        if day.0 > 28 {
+            let bound = Self::days_in_month(year, month);
+            if day.0 < bound {
+                return Err(());
+            }
+        }
+
+        Ok(Date::construct_unchecked(
+            IsoDateInner { day, month, year },
+            Iso,
+        ))
+    }
+
+    pub fn create_iso_date_from_integers(day: u8, month: u8, year: i32) -> Result<Date<Iso>, ()> {
+        Self::create_iso_date(day.try_into()?, month.try_into()?, year.into())
+    }
+
+    pub fn is_leap_year(year: IsoYear) -> bool {
+        year.0 % 4 == 0 && (year.0 % 400 == 0 || year.0 % 100 != 0)
+    }
+
+    fn days_in_month(year: IsoYear, month: IsoMonth) -> u8 {
+        match month.0 {
+            4 | 6 | 9 | 11 => 30,
+            2 if Self::is_leap_year(year) => 29,
+            2 => 28,
+            _ => 31,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_day_of_week() {
+        // June 23, 2021 is a Wednesday
+        assert_eq!(
+            Iso::create_iso_date_from_integers(23, 6, 2021)
+                .unwrap()
+                .day_of_week(),
+            3
+        );
+        // Feb 2, 1983 was a Wednesday
+        assert_eq!(
+            Iso::create_iso_date_from_integers(2, 2, 1983)
+                .unwrap()
+                .day_of_week(),
+            3
+        );
+    }
+
+    fn simple_subtract(a: &Date<Iso>, b: &Date<Iso>) -> DateDuration<Iso> {
+        let a = a.inner();
+        let b = b.inner();
+        DateDuration::new(
+            a.year.0 - b.year.0,
+            a.month.0 as i32 - b.month.0 as i32,
+            0,
+            a.day.0 as i32 - b.day.0 as i32,
+        )
+    }
+
+    #[test]
+    fn test_offset() {
+        let today = Iso::create_iso_date_from_integers(23, 6, 2021).unwrap();
+        let today_plus_5000 = Iso::create_iso_date_from_integers(2, 3, 2035).unwrap();
+        let mut offset = today.clone();
+        offset.add(DateDuration::new(0, 0, 0, 5000));
+        assert_eq!(offset, today_plus_5000);
+        let mut offset = today.clone();
+        offset.add(simple_subtract(&today_plus_5000, &today));
+        assert_eq!(offset, today_plus_5000);
+
+        let today = Iso::create_iso_date_from_integers(23, 6, 2021).unwrap();
+        let today_minus_5000 = Iso::create_iso_date_from_integers(15, 10, 2007).unwrap();
+        let mut offset = today.clone();
+        offset.add(DateDuration::new(0, 0, 0, -5000));
+        assert_eq!(offset, today_minus_5000);
+        let mut offset = today.clone();
+        offset.add(simple_subtract(&today_minus_5000, &today));
+        assert_eq!(offset, today_minus_5000);
+    }
+}

--- a/experimental/calendar/src/iso.rs
+++ b/experimental/calendar/src/iso.rs
@@ -5,7 +5,7 @@
 use crate::{Calendar, Date, DateDuration, DurationUnit};
 use std::convert::{TryFrom, TryInto};
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 /// The ISO Calendar
 pub struct Iso;
 

--- a/experimental/calendar/src/iso.rs
+++ b/experimental/calendar/src/iso.rs
@@ -229,10 +229,7 @@ impl Date<Iso> {
             }
         }
 
-        Ok(Date::from_raw(
-            IsoDateInner { day, month, year },
-            Iso,
-        ))
+        Ok(Date::from_raw(IsoDateInner { day, month, year }, Iso))
     }
     pub fn new_iso_date_from_integers(day: u8, month: u8, year: i32) -> Result<Date<Iso>, ()> {
         Self::new_iso_date(day.try_into()?, month.try_into()?, year.into())

--- a/experimental/calendar/src/iso.rs
+++ b/experimental/calendar/src/iso.rs
@@ -293,14 +293,18 @@ mod test {
         let today_plus_5000 = Iso::create_iso_date_from_integers(2, 3, 2035).unwrap();
         let offset = today.clone().added(DateDuration::new(0, 0, 0, 5000));
         assert_eq!(offset, today_plus_5000);
-        let offset = today.clone().added(simple_subtract(&today_plus_5000, &today));
+        let offset = today
+            .clone()
+            .added(simple_subtract(&today_plus_5000, &today));
         assert_eq!(offset, today_plus_5000);
 
         let today = Iso::create_iso_date_from_integers(23, 6, 2021).unwrap();
         let today_minus_5000 = Iso::create_iso_date_from_integers(15, 10, 2007).unwrap();
         let offset = today.clone().added(DateDuration::new(0, 0, 0, -5000));
         assert_eq!(offset, today_minus_5000);
-        let offset = today.clone().added(simple_subtract(&today_minus_5000, &today));
+        let offset = today
+            .clone()
+            .added(simple_subtract(&today_minus_5000, &today));
         assert_eq!(offset, today_minus_5000);
     }
 }

--- a/experimental/calendar/src/iso.rs
+++ b/experimental/calendar/src/iso.rs
@@ -115,6 +115,8 @@ impl Calendar for Iso {
     }
 
     fn day_of_week(&self, date: &Self::DateInner) -> u8 {
+        // TODO (Manishearth) share code with icu_datetime
+        
         // For the purposes of the calculation here, Monday is 0, Sunday is 6
         // ISO has Monday=1, Sunday=7, which we transform in the last step
 
@@ -204,7 +206,8 @@ impl Calendar for Iso {
         _smallest_unit: DurationUnit,
     ) -> DateDuration<Self> {
         let mut difference = DateDuration::default();
-        // XXXManishearth handle the unit bounds and rounding behavior
+        // TODO (Manishearth) handle the unit bounds and rounding behavior
+        // (perhaps share code with icu_datetime)
         difference.years = date1.year.0 - date2.year.0;
         difference.months = date1.month.0 as i32 - date2.month.0 as i32;
         difference.days = date1.day.0 as i32 - date2.day.0 as i32;

--- a/experimental/calendar/src/iso.rs
+++ b/experimental/calendar/src/iso.rs
@@ -217,14 +217,10 @@ impl Calendar for Iso {
     }
 }
 
-impl Iso {
-    pub fn new() -> Self {
-        Self
-    }
-
-    pub fn create_iso_date(day: IsoDay, month: IsoMonth, year: IsoYear) -> Result<Date<Iso>, ()> {
+impl Date<Iso> {
+    pub fn new_iso_date(day: IsoDay, month: IsoMonth, year: IsoYear) -> Result<Date<Iso>, ()> {
         if day.0 > 28 {
-            let bound = Self::days_in_month(year, month);
+            let bound = Iso::days_in_month(year, month);
             if day.0 < bound {
                 return Err(());
             }
@@ -235,9 +231,14 @@ impl Iso {
             Iso,
         ))
     }
+    pub fn new_iso_date_from_integers(day: u8, month: u8, year: i32) -> Result<Date<Iso>, ()> {
+        Self::new_iso_date(day.try_into()?, month.try_into()?, year.into())
+    }
+}
 
-    pub fn create_iso_date_from_integers(day: u8, month: u8, year: i32) -> Result<Date<Iso>, ()> {
-        Self::create_iso_date(day.try_into()?, month.try_into()?, year.into())
+impl Iso {
+    pub fn new() -> Self {
+        Self
     }
 
     pub fn is_leap_year(year: IsoYear) -> bool {
@@ -262,14 +263,14 @@ mod test {
     fn test_day_of_week() {
         // June 23, 2021 is a Wednesday
         assert_eq!(
-            Iso::create_iso_date_from_integers(23, 6, 2021)
+            Date::new_iso_date_from_integers(23, 6, 2021)
                 .unwrap()
                 .day_of_week(),
             3
         );
         // Feb 2, 1983 was a Wednesday
         assert_eq!(
-            Iso::create_iso_date_from_integers(2, 2, 1983)
+            Date::new_iso_date_from_integers(2, 2, 1983)
                 .unwrap()
                 .day_of_week(),
             3
@@ -289,8 +290,8 @@ mod test {
 
     #[test]
     fn test_offset() {
-        let today = Iso::create_iso_date_from_integers(23, 6, 2021).unwrap();
-        let today_plus_5000 = Iso::create_iso_date_from_integers(2, 3, 2035).unwrap();
+        let today = Date::new_iso_date_from_integers(23, 6, 2021).unwrap();
+        let today_plus_5000 = Date::new_iso_date_from_integers(2, 3, 2035).unwrap();
         let offset = today.clone().added(DateDuration::new(0, 0, 0, 5000));
         assert_eq!(offset, today_plus_5000);
         let offset = today
@@ -298,8 +299,8 @@ mod test {
             .added(simple_subtract(&today_plus_5000, &today));
         assert_eq!(offset, today_plus_5000);
 
-        let today = Iso::create_iso_date_from_integers(23, 6, 2021).unwrap();
-        let today_minus_5000 = Iso::create_iso_date_from_integers(15, 10, 2007).unwrap();
+        let today = Date::new_iso_date_from_integers(23, 6, 2021).unwrap();
+        let today_minus_5000 = Date::new_iso_date_from_integers(15, 10, 2007).unwrap();
         let offset = today.clone().added(DateDuration::new(0, 0, 0, -5000));
         assert_eq!(offset, today_minus_5000);
         let offset = today

--- a/experimental/calendar/src/iso.rs
+++ b/experimental/calendar/src/iso.rs
@@ -291,20 +291,16 @@ mod test {
     fn test_offset() {
         let today = Iso::create_iso_date_from_integers(23, 6, 2021).unwrap();
         let today_plus_5000 = Iso::create_iso_date_from_integers(2, 3, 2035).unwrap();
-        let mut offset = today.clone();
-        offset.add(DateDuration::new(0, 0, 0, 5000));
+        let offset = today.clone().added(DateDuration::new(0, 0, 0, 5000));
         assert_eq!(offset, today_plus_5000);
-        let mut offset = today.clone();
-        offset.add(simple_subtract(&today_plus_5000, &today));
+        let offset = today.clone().added(simple_subtract(&today_plus_5000, &today));
         assert_eq!(offset, today_plus_5000);
 
         let today = Iso::create_iso_date_from_integers(23, 6, 2021).unwrap();
         let today_minus_5000 = Iso::create_iso_date_from_integers(15, 10, 2007).unwrap();
-        let mut offset = today.clone();
-        offset.add(DateDuration::new(0, 0, 0, -5000));
+        let offset = today.clone().added(DateDuration::new(0, 0, 0, -5000));
         assert_eq!(offset, today_minus_5000);
-        let mut offset = today.clone();
-        offset.add(simple_subtract(&today_minus_5000, &today));
+        let offset = today.clone().added(simple_subtract(&today_minus_5000, &today));
         assert_eq!(offset, today_minus_5000);
     }
 }

--- a/experimental/calendar/src/lib.rs
+++ b/experimental/calendar/src/lib.rs
@@ -1,0 +1,13 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+mod calendar;
+mod date;
+mod duration;
+pub mod iso;
+
+pub use calendar::Calendar;
+pub use date::{AsCalendar, Date};
+pub use duration::{DateDuration, DurationUnit};
+pub use iso::Iso;

--- a/experimental/calendar/src/lib.rs
+++ b/experimental/calendar/src/lib.rs
@@ -5,9 +5,11 @@
 mod calendar;
 mod date;
 mod duration;
+mod error;
 pub mod iso;
 
 pub use calendar::Calendar;
 pub use date::{AsCalendar, Date};
 pub use duration::{DateDuration, DurationUnit};
+pub use error::Error;
 pub use iso::Iso;


### PR DESCRIPTION
Progress on https://github.com/unicode-org/icu4x/issues/534

This contains an initial implementation of the calendar types, including a reference ISO implementation.

It does not include:

 - Formatting logic (This may require some sharing with the existing date time format code)
 - Time/ZonedTime objects
 - A gregorian calendar
 - Proper date subtraction logic


I can work on these in parallel as this gets reviewed, I wanted to get the initial design landed.

cc @sffc
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->