### PR TITLE
Add projection utilities to Yoke

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "serde",

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -36,7 +36,7 @@ icu_locid = { version = "0.2", path = "../../components/locid" }
 tinystr = "0.4.5"
 writeable = { version = "0.2", path = "../../utils/writeable" }
 thiserror = "1.0"
-yoke = { version = "0.1", path = "../../utils/yoke", features = ["serde"] }
+yoke = { version = "0.2", path = "../../utils/yoke", features = ["serde"] }
 
 # For "provider_serde" feature
 erased-serde = { version = "0.3", optional = true }

--- a/provider/core/src/data_provider/test.rs
+++ b/provider/core/src/data_provider/test.rs
@@ -37,6 +37,9 @@ unsafe impl<'a> Yokeable<'a> for HelloAlt {
     fn transform(&'a self) -> &'a Self::Output {
         self
     }
+    fn transform_owned(self) -> Self::Output {
+        self
+    }
     unsafe fn make(from: Self::Output) -> Self {
         from
     }

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -45,6 +45,9 @@ unsafe impl<'a> Yokeable<'a> for HelloWorldV1<'static> {
     fn transform(&'a self) -> &'a Self::Output {
         self
     }
+    fn transform_owned(self) -> Self::Output {
+        self
+    }
     unsafe fn make(from: Self::Output) -> Self {
         std::mem::transmute(from)
     }

--- a/provider/core/src/marker/macros.rs
+++ b/provider/core/src/marker/macros.rs
@@ -33,6 +33,9 @@ macro_rules! unsafe_impl_data_marker_with_lifetime {
             fn transform(&'a self) -> &'a Self::Output {
                 self
             }
+            fn transform_owned(self) -> Self::Output {
+                self
+            }
             unsafe fn make(from: Self::Output) -> Self {
                 std::mem::transmute(from)
             }
@@ -65,6 +68,9 @@ macro_rules! impl_data_marker_no_lifetime {
         unsafe impl<'a> icu_provider::yoke::Yokeable<'a> for $struct {
             type Output = $struct;
             fn transform(&'a self) -> &'a Self::Output {
+                self
+            }
+            fn transform_owned(self) -> Self::Output {
                 self
             }
             unsafe fn make(from: Self::Output) -> Self {

--- a/provider/core/src/marker/mod.rs
+++ b/provider/core/src/marker/mod.rs
@@ -55,6 +55,9 @@ use yoke::Yokeable;
 /// #    fn transform(&'a self) -> &'a Self::Output {
 /// #        self
 /// #    }
+/// #    fn transform_owned(self) -> Self::Output {
+/// #        self
+/// #    }
 /// #    unsafe fn make(from: Self::Output) -> Self {
 /// #        std::mem::transmute(from)
 /// #    }

--- a/provider/core/src/serde.rs
+++ b/provider/core/src/serde.rs
@@ -272,6 +272,15 @@ where
 unsafe impl<'a> Yokeable<'a> for SerdeSeDataStructWrap<'static, 'static> {
     type Output = SerdeSeDataStructWrap<'a, 'a>;
     fn transform(&'a self) -> &'a Self::Output {
+        // The compiler isn't able to guess the variance of the trait object,
+        // so we must transmute
+        // Note (Manishearth): this is technically unsound since SerdeDeDataStruct
+        // has no variance requirements. This will become a non-issue
+        // once Borrowed is removed (https://github.com/unicode-org/icu4x/issues/752)
+        unsafe { std::mem::transmute(self) }
+    }
+    fn transform_owned(self) -> Self::Output {
+        // (needs a transmute for the same reason as above)
         unsafe { std::mem::transmute(self) }
     }
     unsafe fn make(from: Self::Output) -> Self {

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "yoke"
-version = "0.1.0"
+version = "0.2.0"
 description = "Abstraction allowing borrowed data to be carried along with the backing data it borrows from"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2018"

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -21,6 +21,6 @@ mod zero_copy_from;
 #[cfg(feature = "serde")]
 mod serde;
 
-pub use crate::yoke::Yoke;
+pub use crate::yoke::{CloneableCart, Yoke};
 pub use crate::yokeable::Yokeable;
 pub use crate::zero_copy_from::ZeroCopyFrom;

--- a/utils/yoke/src/trait_hack.rs
+++ b/utils/yoke/src/trait_hack.rs
@@ -42,6 +42,9 @@
 //! #    fn transform(&'a self) -> &'a Self::Output {
 //! #        self
 //! #    }
+//! #    fn transform_owned(self) -> Self::Output {
+//! #        self
+//! #    }
 //! #    unsafe fn make(from: Self::Output) -> Self {
 //! #        std::mem::transmute(from)
 //! #    }
@@ -90,6 +93,9 @@
 //!     // (not shown; see `Yokeable` for examples)
 //! #    type Output = MyStruct;
 //! #    fn transform(&'a self) -> &'a Self::Output {
+//! #        self
+//! #    }
+//! #    fn transform_owned(self) -> Self::Output {
 //! #        self
 //! #    }
 //! #    unsafe fn make(from: Self::Output) -> Self {
@@ -152,6 +158,9 @@
 //!     // (not shown; see `Yokeable` for examples)
 //! #    type Output = MyStruct;
 //! #    fn transform(&'a self) -> &'a Self::Output {
+//! #        self
+//! #    }
+//! #    fn transform_owned(self) -> Self::Output {
 //! #        self
 //! #    }
 //! #    unsafe fn make(from: Self::Output) -> Self {

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -551,10 +551,15 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
         P: for<'a> Yokeable<'a>,
     {
         let p = f(self.get(), PhantomData);
-        Yoke {
+        let ret = Yoke {
             yokeable: unsafe { P::make(p) },
             cart: self.cart,
-        }
+        };
+        // Writing an explicit drop to make the safety behavior clear:
+        // self.yokeable must be dropped before the moved cart has a chance
+        // to be dropped
+        drop(self.yokeable);
+        ret
     }
 
     /// This is similar to [`Yoke::project`], however it works around it not being able to
@@ -575,10 +580,15 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
         P: for<'a> Yokeable<'a>,
     {
         let p = f(self.get(), capture, PhantomData);
-        Yoke {
+        let ret = Yoke {
             yokeable: unsafe { P::make(p) },
             cart: self.cart,
-        }
+        };
+        // Writing an explicit drop to make the safety behavior clear:
+        // self.yokeable must be dropped before the moved cart has a chance
+        // to be dropped
+        drop(self.yokeable);
+        ret
     }
 }
 

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -443,7 +443,7 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, Option<C>> {
 }
 
 /// Clone requires that the cart derefs to the same address after it is cloned. This works for Rc, Arc, and &'a T.
-/// For all other cart types, clone `.baking_cart()` and re-use `attach_to_cart()`.
+/// For all other cart types, clone `.backing_cart()` and re-use `attach_to_cart()`.
 impl<Y: for<'a> Yokeable<'a>, T: ?Sized> Clone for Yoke<Y, Rc<T>>
 where
     for<'a> <Y as Yokeable<'a>>::Output: Clone,

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -655,5 +655,6 @@ impl<Y: for<'a> Yokeable<'a>, C: CloneableCart> Yoke<Y, C> {
 ///
 /// Essentially, safety is achieved by using `for<'a> fn(...)` with `'a` used in both `Yokeable`s to ensure that
 /// the output yokeable can _only_ have borrowed data flow in to it from the input, and the `'this` ensures separation
-/// between `'a` data that the input is borrowing vs data that the input owns.
+/// between `'a` data that the input is borrowing vs data that the input owns. All paths of unsoundness require the
+/// unification of an existential and universal lifetime, which isn't possible.
 const _: () = ();

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -447,7 +447,7 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, Option<C>> {
 ///
 /// This is conceptually similar to [`stable_deref_trait::CloneStableDeref`],
 /// however [`stable_deref_trait::CloneStableDeref`] is not (and should not) be
-/// implemented on [`Option`]. [`CloneableCart`] essentially is
+/// implemented on [`Option`] (since it's not [`Deref`]. [`CloneableCart`] essentially is
 /// "if there _is_ data to borrow from here, cloning the cart gives you an additional
 /// handle to the same data".
 pub unsafe trait CloneableCart: Clone {}
@@ -577,81 +577,83 @@ impl<Y: for<'a> Yokeable<'a>, C: CloneableCart> Yoke<Y, C> {
             cart: self.cart.clone(),
         }
     }
-
-    /// (Docs are on a private function to allow the use of compile_fail doctests)
-    ///
-    /// This is safe to perform because of the choice of lifetimes on `f`, that is,
-    /// `for<'a> fn(&'this <Y as Yokeable<'a>>::Output, &'a ()) -> <P as Yokeable<'a>>::Output`.
-    ///
-    /// What we want this function to do is take a Yokeable (`Y`) that is borrowing from the cart, and
-    /// produce another Yokeable (`P`) that also borrows from the same cart. There are a couple potential
-    /// hazards here:
-    ///
-    /// - `P` ends up borrowing data from `Y` (or elsewhere) that did _not_ come from the cart,
-    ///   for example `P` could borrow owned data from a `Cow`.
-    /// - Borrowed data from `Y` escapes with the wrong lifetime
-    ///
-    /// Let's walk through these and see how they're prevented.
-    ///
-    /// ```rust, compile_fail
-    /// # use std::rc::Rc;
-    /// # use yoke::Yoke;
-    /// # use std::borrow::Cow;
-    /// fn borrow_potentially_owned(y: Yoke<Cow<'static, str>, Rc<[u8]>>) -> Yoke<&'static str, Rc<[u8]>> {
-    ///    y.project(|cow, _| &*cow)   
-    /// }
-    /// ```
-    ///
-    /// In this case, the lifetime of `&*cow` is `&'this str`, however the function needs to be able to return
-    /// `&'a str` _for all `'a`_, which isn't possible.
-    ///
-    /// Similarly, trying to project an owned field of a struct will produce similar errors:
-    ///
-    /// ```rust,compile_fail
-    /// # use std::borrow::Cow;
-    /// # use yoke::{Yoke, Yokeable};
-    /// # use std::mem;
-    /// # use std::rc::Rc;
-    /// #
-    /// // also safely implements Yokeable<'a>
-    /// struct Bar<'a> {
-    ///     owned: String,
-    ///     string_2: &'a str,
-    /// }
-    ///
-    /// fn project_owned(bar: &Yoke<Bar<'static>, Rc<[u8]>>) -> Yoke<&'static str, Rc<[u8]>> {
-    ///     // ERROR (but works if you replace owned with string_2)
-    ///     bar.project(|bar, _| &*bar.owned)   
-    /// }
-    ///
-    /// #
-    /// # unsafe impl<'a> Yokeable<'a> for Bar<'static> {
-    /// #     type Output = Bar<'a>;
-    /// #     fn transform(&'a self) -> &'a Bar<'a> {
-    /// #         self
-    /// #     }
-    /// #
-    /// #     unsafe fn make(from: Bar<'a>) -> Self {
-    /// #         let ret = mem::transmute_copy(&from);
-    /// #         mem::forget(from);
-    /// #         ret
-    /// #     }
-    /// #
-    /// #     fn transform_mut<F>(&'a mut self, f: F)
-    /// #     where
-    /// #         F: 'static + FnOnce(&'a mut Self::Output),
-    /// #     {
-    /// #         unsafe { f(mem::transmute(self)) }
-    /// #     }
-    /// # }
-    /// ```
-    ///
-    /// Borrowed data from `Y` similarly cannot escape with the wrong lifetime because of the `for<'a>`, since
-    /// it will never be valid for the borrowed data to escape for all lifetimes of 'a. Internally, `.project()`
-    /// uses `.get()`, however the signature forces the callers to be able to handle every lifetime.
-    ///
-    /// Essentially, safety is achieved by using `for<'a> fn(...)` with `'a` used in both `Yokeable`s to ensure that
-    /// the output yokeable can _only_ have borrowed data flow in to it from the input, and the `'this` ensures separation
-    /// between `'a` data that the input is borrowing vs data that the input owns.
-    fn __project_safety_docs(&self) {}
 }
+
+/// Safety docs for project()
+///
+/// (Docs are on a private const to allow the use of compile_fail doctests)
+///
+/// This is safe to perform because of the choice of lifetimes on `f`, that is,
+/// `for<'a> fn(&'this <Y as Yokeable<'a>>::Output, &'a ()) -> <P as Yokeable<'a>>::Output`.
+///
+/// What we want this function to do is take a Yokeable (`Y`) that is borrowing from the cart, and
+/// produce another Yokeable (`P`) that also borrows from the same cart. There are a couple potential
+/// hazards here:
+///
+/// - `P` ends up borrowing data from `Y` (or elsewhere) that did _not_ come from the cart,
+///   for example `P` could borrow owned data from a `Cow`.
+/// - Borrowed data from `Y` escapes with the wrong lifetime
+///
+/// Let's walk through these and see how they're prevented.
+///
+/// ```rust, compile_fail
+/// # use std::rc::Rc;
+/// # use yoke::Yoke;
+/// # use std::borrow::Cow;
+/// fn borrow_potentially_owned(y: Yoke<Cow<'static, str>, Rc<[u8]>>) -> Yoke<&'static str, Rc<[u8]>> {
+///    y.project(|cow, _| &*cow)   
+/// }
+/// ```
+///
+/// In this case, the lifetime of `&*cow` is `&'this str`, however the function needs to be able to return
+/// `&'a str` _for all `'a`_, which isn't possible.
+///
+/// Similarly, trying to project an owned field of a struct will produce similar errors:
+///
+/// ```rust,compile_fail
+/// # use std::borrow::Cow;
+/// # use yoke::{Yoke, Yokeable};
+/// # use std::mem;
+/// # use std::rc::Rc;
+/// #
+/// // also safely implements Yokeable<'a>
+/// struct Bar<'a> {
+///     owned: String,
+///     string_2: &'a str,
+/// }
+///
+/// fn project_owned(bar: &Yoke<Bar<'static>, Rc<[u8]>>) -> Yoke<&'static str, Rc<[u8]>> {
+///     // ERROR (but works if you replace owned with string_2)
+///     bar.project(|bar, _| &*bar.owned)   
+/// }
+///
+/// #
+/// # unsafe impl<'a> Yokeable<'a> for Bar<'static> {
+/// #     type Output = Bar<'a>;
+/// #     fn transform(&'a self) -> &'a Bar<'a> {
+/// #         self
+/// #     }
+/// #
+/// #     unsafe fn make(from: Bar<'a>) -> Self {
+/// #         let ret = mem::transmute_copy(&from);
+/// #         mem::forget(from);
+/// #         ret
+/// #     }
+/// #
+/// #     fn transform_mut<F>(&'a mut self, f: F)
+/// #     where
+/// #         F: 'static + FnOnce(&'a mut Self::Output),
+/// #     {
+/// #         unsafe { f(mem::transmute(self)) }
+/// #     }
+/// # }
+/// ```
+///
+/// Borrowed data from `Y` similarly cannot escape with the wrong lifetime because of the `for<'a>`, since
+/// it will never be valid for the borrowed data to escape for all lifetimes of 'a. Internally, `.project()`
+/// uses `.get()`, however the signature forces the callers to be able to handle every lifetime.
+///
+/// Essentially, safety is achieved by using `for<'a> fn(...)` with `'a` used in both `Yokeable`s to ensure that
+/// the output yokeable can _only_ have borrowed data flow in to it from the input, and the `'this` ensures separation
+/// between `'a` data that the input is borrowing vs data that the input owns.
+const _: () = ();

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -494,7 +494,8 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     ///
     /// This can be used, for example, to transform data from one format to another:
     ///
-    /// ```rust
+    /// ```rust,ignore
+    /// # // This doctest is temporarily ignored because of https://github.com/rust-lang/rust/issues/86703
     /// # use std::rc::Rc;
     /// # use yoke::Yoke;
     /// #
@@ -506,7 +507,8 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     ///
     /// This can also be used to create a yoke for a subfield
     ///
-    /// ```rust
+    /// ```rust,ignore
+    /// # // This doctest is temporarily ignored because of https://github.com/rust-lang/rust/issues/86703
     /// # use std::borrow::Cow;
     /// # use yoke::{Yoke, Yokeable};
     /// # use std::mem;

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -447,7 +447,7 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, Option<C>> {
 ///
 /// This is conceptually similar to [`stable_deref_trait::CloneStableDeref`],
 /// however [`stable_deref_trait::CloneStableDeref`] is not (and should not) be
-/// implemented on [`Option`] (since it's not [`Deref`]. [`CloneableCart`] essentially is
+/// implemented on [`Option`] (since it's not [`Deref`]). [`CloneableCart`] essentially is
 /// "if there _is_ data to borrow from here, cloning the cart gives you an additional
 /// handle to the same data".
 pub unsafe trait CloneableCart: Clone {}

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -477,11 +477,14 @@ impl<Y: for<'a> Yokeable<'a>, C: CloneableCart> Yoke<Y, C> {
     /// looking at a subfield, and producing a new yoke. This will clone the cart, and the provided
     /// transformation is only allowed to use data known to be borrowed from the cart.
     ///
-    /// This currently takes an additional `PhantomData<&()>` parameter as a workaround to
-    /// [compiler bug #86702](https://github.com/rust-lang/rust/issues/86702). This parameter
-    /// should just be ignored in the function. Furthermore,
+    /// This takes an additional `PhantomData<&()>` parameter as a workaround to the issue
+    /// described in [#86702](https://github.com/rust-lang/rust/issues/86702). This parameter
+    /// should just be ignored in the function.
+    /// 
+    /// Furthermore,
     /// [compiler bug #84937](https://github.com/rust-lang/rust/issues/84937) prevents
-    /// this from taking a capturing closure.
+    /// this from taking a capturing closure, however [`Yoke::project_with_capture()`]
+    /// can be used for the same use cases.
     ///
     ///
     /// This can be used, for example, to transform data from one format to another:

--- a/utils/yoke/src/zero_copy_from.rs
+++ b/utils/yoke/src/zero_copy_from.rs
@@ -37,6 +37,10 @@ use std::rc::Rc;
 /// #    fn transform(&'a self) -> &'a Self::Output {
 /// #        self
 /// #    }
+/// #    fn transform_owned(self) -> MyStruct<'a> {
+/// #        // covariant lifetime cast, can be done safely
+/// #        self
+/// #    }
 /// #    unsafe fn make(from: Self::Output) -> Self {
 /// #        std::mem::transmute(from)
 /// #    }

--- a/utils/yoke/tests/bincode.rs
+++ b/utils/yoke/tests/bincode.rs
@@ -40,6 +40,10 @@ unsafe impl<'a> Yokeable<'a> for Bar<'static> {
         self
     }
 
+    fn transform_owned(self) -> Bar<'a> {
+        self
+    }
+
     unsafe fn make(from: Bar<'a>) -> Self {
         let ret = mem::transmute_copy(&from);
         mem::forget(from);

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -25,7 +25,7 @@ all-features = true
 [dependencies]
 either = "1.6.1"
 serde = { version = "1.0", optional = true }
-yoke = { path = "../yoke", version = "0.1.0", optional = true }
+yoke = { path = "../yoke", version = "0.2.0", optional = true }
 
 [dev-dependencies]
 icu_benchmark_macros = { version = "0.2", path = "../../tools/benchmark/macros" }

--- a/utils/zerovec/src/yoke_impls.rs
+++ b/utils/zerovec/src/yoke_impls.rs
@@ -79,9 +79,7 @@ where
         }
     }
     fn transform_owned(self) -> ZeroMap<'a, K::Output, V::Output> {
-        debug_assert!(
-            mem::size_of::<Self::Output>() == mem::size_of::<Self>()
-        );
+        debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
         unsafe {
             // Similar problem as transform(), but we need to use ptr::read since
             // the compiler isn't sure of the sizes


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/829

Discovered another compiler bug in the process :upside_down_face: (https://github.com/rust-lang/rust/issues/86702)

I also figured out a better workaround for https://github.com/rust-lang/rust/issues/84937 and used it here: there's a separate version of this function with explicit capturing that can be used until we can use closures here.

Fallible `try_` versions of this can be added if necessary.
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->