### PR TITLE
Add initial support for timezones in component::Bag

### DIFF
--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -378,28 +378,27 @@ pub enum TimeZoneName {
     // UTS-35 fields: z..zzz
     //
     /// Short localized form, without the location. (e.g.: PST, GMT-8)
-    #[cfg_attr(feature = "serde", serde(rename = "short"))]
-    Short,
+    #[cfg_attr(feature = "serde", serde(rename = "shortSpecific"))]
+    ShortSpecific,
 
     // UTS-35 fields: zzzz
     // Per UTS-35: [long form] specific non-location (falling back to long localized GMT)
     //
     /// Long localized form, without the location (e.g., Pacific Standard Time, Nordamerikanische Westküsten-Normalzeit)
-    #[cfg_attr(feature = "serde", serde(rename = "long"))]
-    Long,
+    #[cfg_attr(feature = "serde", serde(rename = "longSpecific"))]
+    LongSpecific,
 
-    // UTS-35 fields: O
-    //
-    /// Short localized GMT format (e.g., GMT-8)
-    #[cfg_attr(feature = "serde", serde(rename = "shortOffset"))]
-    ShortOffset,
-
-    // UTS-35 fields: OOOO
+    // UTS-35 fields: O, OOOO
     // Per UTS-35: The long localized GMT format. This is equivalent to the "OOOO" specifier
+    // Per UTS-35: Short localized GMT format (e.g., GMT-8)
+    // This enum variant is combining the two types of fields, as the CLDR specifices the preferred
+    // hour-format for the locale, and ICU4X uses the preferred one.
+    //   e.g.
+    //   https://github.com/unicode-org/cldr-json/blob/c23635f13946292e40077fd62aee6a8e122e7689/cldr-json/cldr-dates-full/main/es-MX/timeZoneNames.json#L13
     //
-    /// Long localized GMT format (e.g., GMT-0800),
-    #[cfg_attr(feature = "serde", serde(rename = "longOffset"))]
-    LongOffset,
+    /// Localized GMT format, in the locale's preferred hour format. (e.g., GMT-0800),
+    #[cfg_attr(feature = "serde", serde(rename = "gmtOffset"))]
+    GmtOffset,
 
     // UTS-35 fields: v
     //   * falling back to generic location (See UTS 35 for more specific rules)
@@ -419,19 +418,15 @@ pub enum TimeZoneName {
 impl From<TimeZoneName> for Field {
     fn from(time_zone_name: TimeZoneName) -> Self {
         match time_zone_name {
-            TimeZoneName::Short => Field {
+            TimeZoneName::ShortSpecific => Field {
                 symbol: FieldSymbol::TimeZone(fields::TimeZone::LowerZ),
                 length: FieldLength::One,
             },
-            TimeZoneName::Long => Field {
+            TimeZoneName::LongSpecific => Field {
                 symbol: FieldSymbol::TimeZone(fields::TimeZone::LowerZ),
                 length: FieldLength::Wide,
             },
-            TimeZoneName::ShortOffset => Field {
-                symbol: FieldSymbol::TimeZone(fields::TimeZone::UpperO),
-                length: FieldLength::One,
-            },
-            TimeZoneName::LongOffset => Field {
+            TimeZoneName::GmtOffset => Field {
                 symbol: FieldSymbol::TimeZone(fields::TimeZone::UpperO),
                 length: FieldLength::Wide,
             },

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -241,7 +241,7 @@ impl Bag {
                     // region-based (h12 for US, h23 for GB, etc). This is in CLDR, but we need
                     // to load it as well as think about the best architecture for where that
                     // data loading code should reside.
-                    _ => fields::Hour::H24,
+                    _ => fields::Hour::H23,
                 }),
                 length: match hour {
                     // Example for h: (note that this is the same for k, K, and H)
@@ -401,7 +401,7 @@ mod test {
                 (Symbol::Year(fields::Year::Calendar), Length::One).into(),
                 (Symbol::Month(fields::Month::Format), Length::Wide).into(),
                 (Symbol::Day(fields::Day::DayOfMonth), Length::One).into(),
-                (Symbol::Hour(fields::Hour::H24), Length::One).into(),
+                (Symbol::Hour(fields::Hour::H23), Length::One).into(),
                 (Symbol::Minute, Length::One).into(),
                 (Symbol::Second(fields::Second::Second), Length::One).into(),
             ]

--- a/components/datetime/src/pattern/transform_hour_cycle.rs
+++ b/components/datetime/src/pattern/transform_hour_cycle.rs
@@ -76,7 +76,7 @@ pub fn apply_coarse_hour_cycle(
         &datetime.skeletons,
         &datetime.length_patterns,
         skeleton.as_slice(),
-        &None,
+        &Default::default(),
         // Prefer using the matched pattern directly, rather than mutating it to match the
         // requested fields.
         true,

--- a/components/datetime/src/provider/helpers.rs
+++ b/components/datetime/src/provider/helpers.rs
@@ -75,7 +75,7 @@ impl DateTimePatterns for provider::gregory::DatePatternsV1 {
                 &self.datetime.skeletons,
                 &self.datetime.length_patterns,
                 &requested_fields,
-                &components.preferences,
+                components,
                 false, // Prefer the requested fields over the matched pattern.
             ) {
                 skeleton::BestSkeleton::AllFieldsMatch(pattern)

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -891,7 +891,7 @@ mod test {
             month: Some(components::Month::Long),
             day: Some(components::Numeric::Numeric),
             // This will be appended.
-            time_zone_name: Some(components::TimeZoneName::Long),
+            time_zone_name: Some(components::TimeZoneName::LongSpecific),
             ..Default::default()
         };
         let requested_fields = components.to_vec_fields();
@@ -937,7 +937,7 @@ mod test {
     #[test]
     fn test_skeleton_no_match() {
         let components = components::Bag {
-            time_zone_name: Some(components::TimeZoneName::Long),
+            time_zone_name: Some(components::TimeZoneName::LongSpecific),
             ..Default::default()
         };
         let requested_fields = components.to_vec_fields();

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -565,7 +565,10 @@ pub fn create_best_pattern_for_fields<'a>(
                 length::Date::Short => &length_patterns.short,
             };
 
-            Some(Pattern::from_bytes_combination(bytes, date_pattern, time_pattern).expect("TODO"))
+            Some(
+                Pattern::from_bytes_combination(bytes, date_pattern, time_pattern)
+                    .expect("Failed to create a Pattern from bytes"),
+            )
         }
         (None, Some(pattern)) => Some(pattern),
         (Some(pattern), None) => Some(pattern),

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -16,7 +16,7 @@ use smallvec::SmallVec;
 
 use crate::{
     fields::{self, Field, FieldLength, FieldSymbol},
-    options::{length, preferences},
+    options::{components, length, preferences},
     pattern::{Pattern, PatternItem},
     provider::gregory::patterns::{LengthPatternsV1, PatternV1, SkeletonV1, SkeletonsV1},
 };
@@ -442,6 +442,26 @@ fn naively_apply_hour_cycle_preferences(
     }
 }
 
+/// This function swaps out the the time zone name field for the appropriate one. Skeleton matching
+/// only needs to find a single "v" field, and then the time zone name can expand from there.
+fn naively_apply_time_zone_name(
+    pattern: &mut Pattern,
+    time_zone_name: &Option<components::TimeZoneName>,
+) {
+    // If there is a preference overiding the hour cycle, apply it now.
+    if let Some(time_zone_name) = time_zone_name {
+        for item in pattern.items_mut() {
+            if let PatternItem::Field(fields::Field {
+                symbol: fields::FieldSymbol::TimeZone(_),
+                length: _,
+            }) = item
+            {
+                *item = PatternItem::Field((*time_zone_name).into());
+            }
+        }
+    }
+}
+
 // TODO - This could return a Cow<'a, Pattern>, but it affects every other part of the API to
 // add a lifetime here. The pattern returned here could be one that we've already constructed in
 // the CLDR as an exotic type, or it could be one that was modified to meet the requirements of
@@ -461,7 +481,7 @@ pub fn create_best_pattern_for_fields<'a>(
     skeletons: &'a SkeletonsV1,
     length_patterns: &LengthPatternsV1,
     fields: &[Field],
-    preferences: &Option<preferences::Bag>,
+    components: &components::Bag,
     prefer_matched_pattern: bool,
 ) -> BestSkeleton<Pattern> {
     let first_pattern_match =
@@ -469,26 +489,12 @@ pub fn create_best_pattern_for_fields<'a>(
 
     // Try to match a skeleton to all of the fields.
     if let BestSkeleton::AllFieldsMatch(mut pattern) = first_pattern_match {
-        naively_apply_hour_cycle_preferences(&mut pattern, preferences);
+        naively_apply_hour_cycle_preferences(&mut pattern, &components.preferences);
+        naively_apply_time_zone_name(&mut pattern, &components.time_zone_name);
         return BestSkeleton::AllFieldsMatch(pattern);
     }
 
-    let FieldsByType { date, time, other } = group_fields_by_type(fields);
-
-    if !other.is_empty() {
-        // These require "append items" support, see #586.
-        // TODO(#583) - TimeZones
-        // TODO(#486) - Eras,
-        // ... etc.
-
-        // TODO(#583) - This is commented out because TimeZone support is required here in order to
-        // generate length::Bag patterns correctly. For now it's commented out so that everything
-        // works for length::Bag with a preference, although it may lack a time zone.
-
-        // unimplemented!(
-        //     "There are no \"other\" fields supported, these need to be appended to the pattern. {:?}", other
-        // );
-    }
+    let FieldsByType { date, time } = group_fields_by_type(fields);
 
     if date.is_empty() || time.is_empty() {
         return match first_pattern_match {
@@ -497,7 +503,8 @@ pub fn create_best_pattern_for_fields<'a>(
             }
             BestSkeleton::MissingOrExtraFields(mut pattern) => {
                 if date.is_empty() {
-                    naively_apply_hour_cycle_preferences(&mut pattern, preferences);
+                    naively_apply_hour_cycle_preferences(&mut pattern, &components.preferences);
+                    naively_apply_time_zone_name(&mut pattern, &components.time_zone_name);
                 }
                 BestSkeleton::MissingOrExtraFields(pattern)
             }
@@ -522,7 +529,8 @@ pub fn create_best_pattern_for_fields<'a>(
         };
 
     if let Some(ref mut pattern) = time_pattern {
-        naively_apply_hour_cycle_preferences(pattern, preferences)
+        naively_apply_hour_cycle_preferences(pattern, &components.preferences);
+        naively_apply_time_zone_name(pattern, &components.time_zone_name);
     }
 
     // Determine how to combine the date and time.
@@ -590,13 +598,11 @@ pub fn create_best_pattern_for_fields<'a>(
 struct FieldsByType {
     pub date: Vec<Field>,
     pub time: Vec<Field>,
-    pub other: Vec<Field>,
 }
 
 fn group_fields_by_type(fields: &[Field]) -> FieldsByType {
     let mut date = Vec::new();
     let mut time = Vec::new();
-    let mut other = Vec::new();
 
     for field in fields {
         match field.symbol {
@@ -614,17 +620,16 @@ fn group_fields_by_type(fields: &[Field]) -> FieldsByType {
             FieldSymbol::DayPeriod(_)
             | FieldSymbol::Hour(_)
             | FieldSymbol::Minute
-            | FieldSymbol::Second(_) => time.push(*field),
-
+            | FieldSymbol::Second(_)
+            | FieldSymbol::TimeZone(_) => time.push(*field),
             // Other components
-            FieldSymbol::TimeZone(_) => other.push(*field),
             // TODO(#486)
             // FieldSymbol::Era(_) => other.push(*field),
             // Plus others...
         };
     }
 
-    FieldsByType { date, time, other }
+    FieldsByType { date, time }
 }
 
 /// A partial implementation of the [UTS 35 skeleton matching algorithm](https://unicode.org/reports/tr35/tr35-dates.html#Matching_Skeletons).
@@ -879,6 +884,7 @@ mod test {
 
     // TODO(#586) - Append items support needs to be added.
     #[test]
+    #[should_panic]
     fn test_missing_append_items_support() {
         let components = components::Bag {
             year: Some(components::Numeric::Numeric),
@@ -895,15 +901,14 @@ mod test {
             &data_provider.get().datetime.skeletons,
             &data_provider.get().datetime.length_patterns,
             &requested_fields,
-            &None,
+            &Default::default(),
             false,
         ) {
             BestSkeleton::AllFieldsMatch(available_format_pattern) => {
-                // TODO - This needs to support the "Z" pattern. This test will begin to fail
-                // once support is added.
+                // TODO - Append items are needed here.
                 assert_eq!(
                     available_format_pattern.to_string(),
-                    String::from("MMMM d, y")
+                    String::from("MMMM d, y vvvv")
                 )
             }
             best => panic!("Unexpected {:?}", best),

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -341,6 +341,13 @@ fn test_components_hour_cycle() {
     test_fixture("components_hour_cycle");
 }
 
+/// Tests that time zones are included, which rely on the append items mechanism.
+#[test]
+fn test_components_with_zones() {
+    // components/datetime/tests/fixtures/tests/components_with_zones.json
+    test_fixture_with_time_zones("components_with_zones", TimeZoneConfig::default());
+}
+
 /// Tests that component::Bags can adjust for width differences in the final pattern.
 #[test]
 fn test_components_width_differences() {

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -69,26 +69,29 @@ fn test_fixture(fixture_name: &str) {
         let value: MockDateTime = fx.input.value.parse().unwrap();
 
         let result = dtf.format_to_string(&value);
-        match fx.description {
-            Some(description) => assert_eq!(
-                result, fx.output.value,
-                "expected {:?} to equal {:?} – {}",
-                result, fx.output.value, description
-            ),
-            None => assert_eq!(result, fx.output.value),
-        }
+        let description = match fx.description {
+            Some(description) => {
+                format!(
+                    "\n  test: {:?}\n  file: {}.json\n",
+                    description, fixture_name
+                )
+            }
+            None => format!("\n  file: {}.json\n", fixture_name),
+        };
+
+        assert_eq!(result, fx.output.value, "{}", description);
 
         let mut s = String::new();
         dtf.format_to_write(&mut s, &value).unwrap();
-        assert_eq!(s, fx.output.value, "\n file: {}.json\n", fixture_name);
+        assert_eq!(s, fx.output.value, "{}", description);
 
         let fdt = dtf.format(&value);
         let s = fdt.to_string();
-        assert_eq!(s, fx.output.value, "\n file: {}.json\n", fixture_name);
+        assert_eq!(s, fx.output.value, "{}", description);
 
         let mut s = String::new();
         write!(s, "{}", fdt).unwrap();
-        assert_eq!(s, fx.output.value, "\n file: {}.json\n", fixture_name);
+        assert_eq!(s, fx.output.value, "{}", description);
     }
 }
 
@@ -110,19 +113,29 @@ fn test_fixture_with_time_zones(fixture_name: &str, config: TimeZoneConfig) {
         value.time_zone.time_variant = config.time_variant;
 
         let result = dtf.format_to_string(&value);
-        assert_eq!(result, fx.output.value, "\n  file: {}.json\n", fixture_name);
+        let description = match fx.description {
+            Some(description) => {
+                format!(
+                    "\n  test: {:?}\n  file: {}.json\n",
+                    description, fixture_name
+                )
+            }
+            None => format!("\n  file: {}.json\n", fixture_name),
+        };
+
+        assert_eq!(result, fx.output.value, "{}", description);
 
         let mut s = String::new();
         dtf.format_to_write(&mut s, &value).unwrap();
-        assert_eq!(s, fx.output.value, "\n  file: {}.json\n", fixture_name);
+        assert_eq!(s, fx.output.value, "{}", description);
 
         let fdt = dtf.format(&value);
         let s = fdt.to_string();
-        assert_eq!(s, fx.output.value, "\n  file: {}.json\n", fixture_name);
+        assert_eq!(s, fx.output.value, "{}", description);
 
         let mut s = String::new();
         write!(s, "{}", fdt).unwrap();
-        assert_eq!(s, fx.output.value, "\n  file: {}.json\n", fixture_name);
+        assert_eq!(s, fx.output.value, "{}", description);
     }
 }
 

--- a/components/datetime/tests/fixtures/tests/components_with_zones.json
+++ b/components/datetime/tests/fixtures/tests/components_with_zones.json
@@ -57,7 +57,7 @@
                     "hour": "two-digit",
                     "minute": "two-digit",
                     "second": "two-digit",
-                    "time_zone_name": "short"
+                    "time_zone_name": "shortSpecific"
                 }
             }
         },
@@ -79,7 +79,7 @@
                     "hour": "two-digit",
                     "minute": "two-digit",
                     "second": "two-digit",
-                    "time_zone_name": "long"
+                    "time_zone_name": "longSpecific"
                 }
             }
         },
@@ -88,7 +88,7 @@
         }
     },
     {
-        "description": "Full date time example with short offset time zone",
+        "description": "Full date time example with GMT offset time zone",
         "input": {
             "locale": "en",
             "value": "2020-01-21T08:25:07.000+05:00",
@@ -101,29 +101,7 @@
                     "hour": "two-digit",
                     "minute": "two-digit",
                     "second": "two-digit",
-                    "time_zone_name": "shortOffset"
-                }
-            }
-        },
-        "output": {
-            "value": "Tuesday, January 21, 2020 at 08:25:07 GMT+05:00"
-        }
-    },
-    {
-        "description": "Full date time example with long offset time zone",
-        "input": {
-            "locale": "en",
-            "value": "2020-01-21T08:25:07.000+05:00",
-            "options": {
-                "components": {
-                    "weekday": "long",
-                    "month": "long",
-                    "day": "numeric",
-                    "year": "numeric",
-                    "hour": "two-digit",
-                    "minute": "two-digit",
-                    "second": "two-digit",
-                    "time_zone_name": "longOffset"
+                    "time_zone_name": "gmtOffset"
                 }
             }
         },

--- a/components/datetime/tests/fixtures/tests/components_with_zones.json
+++ b/components/datetime/tests/fixtures/tests/components_with_zones.json
@@ -1,23 +1,134 @@
 [
     {
+        "description": "Full date time example with long generic time zone",
         "input": {
             "locale": "en",
-            "value": "2020-01-21T08:25:07.000",
+            "value": "2020-01-21T08:25:07.000+05:00",
             "options": {
                 "components": {
                     "weekday": "long",
                     "month": "long",
-                    "day": "two-digit",
+                    "day": "numeric",
                     "year": "numeric",
-                    "hour": "numeric",
-                    "minute": "numeric",
-                    "second": "numeric",
+                    "hour": "two-digit",
+                    "minute": "two-digit",
+                    "second": "two-digit",
+                    "time_zone_name": "longGeneric"
+                }
+            }
+        },
+        "output": {
+            "value": "Tuesday, January 21, 2020 at 08:25:07 GMT+05:00"
+        }
+    },
+    {
+        "description": "Full date time example with short generic time zone",
+        "input": {
+            "locale": "en",
+            "value": "2020-01-21T08:25:07.000+05:00",
+            "options": {
+                "components": {
+                    "weekday": "long",
+                    "month": "long",
+                    "day": "numeric",
+                    "year": "numeric",
+                    "hour": "two-digit",
+                    "minute": "two-digit",
+                    "second": "two-digit",
+                    "time_zone_name": "shortGeneric"
+                }
+            }
+        },
+        "output": {
+            "value": "Tuesday, January 21, 2020 at 08:25:07 GMT+05:00"
+        }
+    },
+    {
+        "description": "Full date time example with short time zone",
+        "input": {
+            "locale": "en",
+            "value": "2020-01-21T08:25:07.000+05:00",
+            "options": {
+                "components": {
+                    "weekday": "long",
+                    "month": "long",
+                    "day": "numeric",
+                    "year": "numeric",
+                    "hour": "two-digit",
+                    "minute": "two-digit",
+                    "second": "two-digit",
+                    "time_zone_name": "short"
+                }
+            }
+        },
+        "output": {
+            "value": "Tuesday, January 21, 2020 at 08:25:07 GMT+05:00"
+        }
+    },
+    {
+        "description": "Full date time example with long time zone",
+        "input": {
+            "locale": "en",
+            "value": "2020-01-21T08:25:07.000+05:00",
+            "options": {
+                "components": {
+                    "weekday": "long",
+                    "month": "long",
+                    "day": "numeric",
+                    "year": "numeric",
+                    "hour": "two-digit",
+                    "minute": "two-digit",
+                    "second": "two-digit",
                     "time_zone_name": "long"
                 }
             }
         },
         "output": {
-            "value": "Tuesday, January 21, 2020 at 8:25:07 AM"
+            "value": "Tuesday, January 21, 2020 at 08:25:07 GMT+05:00"
+        }
+    },
+    {
+        "description": "Full date time example with short offset time zone",
+        "input": {
+            "locale": "en",
+            "value": "2020-01-21T08:25:07.000+05:00",
+            "options": {
+                "components": {
+                    "weekday": "long",
+                    "month": "long",
+                    "day": "numeric",
+                    "year": "numeric",
+                    "hour": "two-digit",
+                    "minute": "two-digit",
+                    "second": "two-digit",
+                    "time_zone_name": "shortOffset"
+                }
+            }
+        },
+        "output": {
+            "value": "Tuesday, January 21, 2020 at 08:25:07 GMT+05:00"
+        }
+    },
+    {
+        "description": "Full date time example with long offset time zone",
+        "input": {
+            "locale": "en",
+            "value": "2020-01-21T08:25:07.000+05:00",
+            "options": {
+                "components": {
+                    "weekday": "long",
+                    "month": "long",
+                    "day": "numeric",
+                    "year": "numeric",
+                    "hour": "two-digit",
+                    "minute": "two-digit",
+                    "second": "two-digit",
+                    "time_zone_name": "longOffset"
+                }
+            }
+        },
+        "output": {
+            "value": "Tuesday, January 21, 2020 at 08:25:07 GMT+05:00"
         }
     }
 ]


### PR DESCRIPTION
This PR allows for the initial pattern matching for time zones in the component::Bag, but is not fully featured as it doesn't use appendItems.

edit: This is ready for review, and is no longer draft.