### PR TITLE
Correctly apply the hour cycle in the components::Bag

### DIFF
--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -212,14 +212,18 @@ impl Bag {
                     Some(preferences::Bag {
                         hour_cycle: Some(hour_cycle),
                     }) => match hour_cycle {
-                        // k - symbol
-                        preferences::HourCycle::H24 => fields::Hour::H24,
-                        // H - symbol
-                        preferences::HourCycle::H23 => fields::Hour::H23,
-                        // h - symbol
-                        preferences::HourCycle::H12 => fields::Hour::H12,
-                        // K - symbol
-                        preferences::HourCycle::H11 => fields::Hour::H11,
+                        // Skeletons only contain the h12, not h11. The pattern that is matched
+                        // is free to use h11 or h12.
+                        preferences::HourCycle::H11 | preferences::HourCycle::H12 => {
+                            // h - symbol
+                            fields::Hour::H12
+                        }
+                        // Skeletons only contain the h23, not h24. The pattern that is matched
+                        // is free to use h23 or h24.
+                        preferences::HourCycle::H24 | preferences::HourCycle::H23 => {
+                            // H - symbol
+                            fields::Hour::H23
+                        }
                     },
                     // TODO(#594) - This should default should be the locale default, which is
                     // region-based (h12 for US, h23 for GB, etc). This is in CLDR, but we need

--- a/components/datetime/src/pattern/mod.rs
+++ b/components/datetime/src/pattern/mod.rs
@@ -99,6 +99,10 @@ impl Pattern {
         &self.items
     }
 
+    pub fn items_mut(&mut self) -> &mut [PatternItem] {
+        &mut self.items
+    }
+
     pub fn from_bytes(input: &str) -> Result<Self, Error> {
         Parser::new(input).parse().map(Self::from)
     }

--- a/components/datetime/src/provider/helpers.rs
+++ b/components/datetime/src/provider/helpers.rs
@@ -71,6 +71,7 @@ impl DateTimePatterns for provider::gregory::DatePatternsV1 {
                 &self.datetime.skeletons,
                 &self.datetime.length_patterns,
                 &requested_fields,
+                &components.preferences,
             ) {
                 skeleton::BestSkeleton::AllFieldsMatch(pattern)
                 | skeleton::BestSkeleton::MissingOrExtraFields(pattern) => Some(pattern),

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -10,7 +10,7 @@ use std::convert::TryFrom;
 
 use crate::{
     fields::{self, Field, FieldLength, FieldSymbol},
-    options::length,
+    options::{length, preferences},
     pattern::{Pattern, PatternItem},
     provider::gregory::patterns::{LengthPatternsV1, PatternV1, SkeletonV1, SkeletonsV1},
 };
@@ -349,6 +349,28 @@ pub enum BestSkeleton<T> {
     NoMatch,
 }
 
+/// The hour cycle can be set by preferences. This function switches between h11 and h12,
+/// and between h23 and h24. This function is naive as it is assumed that this application of
+/// the hour cycle will not change between h1x to h2x.
+fn naively_apply_hour_cycle_preferences(
+    pattern: &mut Pattern,
+    preferences: &Option<preferences::Bag>,
+) {
+    // If there is a preference overiding the hour cycle, apply it now.
+    if let Some(preferences::Bag {
+        hour_cycle: Some(hour_cycle),
+    }) = preferences
+    {
+        for item in pattern.items_mut() {
+            if let PatternItem::Field(fields::Field { symbol, length: _ }) = item {
+                if let fields::FieldSymbol::Hour(_) = symbol {
+                    *symbol = fields::FieldSymbol::Hour(hour_cycle.field());
+                }
+            }
+        }
+    }
+}
+
 // TODO - This could return a Cow<'a, Pattern>, but it affects every other part of the API to
 // add a lifetime here. The pattern returned here could be one that we've already constructed in
 // the CLDR as an exotic type, or it could be one that was modified to meet the requirements of
@@ -357,11 +379,13 @@ pub fn create_best_pattern_for_fields<'a>(
     skeletons: &'a SkeletonsV1,
     length_patterns: &LengthPatternsV1,
     fields: &[Field],
+    preferences: &Option<preferences::Bag>,
 ) -> BestSkeleton<Pattern> {
     let first_pattern_match = get_best_available_format_pattern(skeletons, fields);
 
     // Try to match a skeleton to all of the fields.
-    if let BestSkeleton::AllFieldsMatch(pattern) = first_pattern_match {
+    if let BestSkeleton::AllFieldsMatch(mut pattern) = first_pattern_match {
+        naively_apply_hour_cycle_preferences(&mut pattern, &preferences);
         return BestSkeleton::AllFieldsMatch(pattern);
     }
 
@@ -382,7 +406,10 @@ pub fn create_best_pattern_for_fields<'a>(
             BestSkeleton::AllFieldsMatch(_) => {
                 unreachable!("Logic error in implementation. AllFieldsMatch handled above.")
             }
-            BestSkeleton::MissingOrExtraFields(pattern) => {
+            BestSkeleton::MissingOrExtraFields(mut pattern) => {
+                if date.is_empty() {
+                    naively_apply_hour_cycle_preferences(&mut pattern, &preferences);
+                }
                 BestSkeleton::MissingOrExtraFields(pattern)
             }
             BestSkeleton::NoMatch => BestSkeleton::NoMatch,
@@ -398,12 +425,16 @@ pub fn create_best_pattern_for_fields<'a>(
             BestSkeleton::NoMatch => (None, true),
         };
 
-    let (time_pattern, time_missing_or_extra) =
+    let (mut time_pattern, time_missing_or_extra) =
         match get_best_available_format_pattern(skeletons, &time) {
             BestSkeleton::MissingOrExtraFields(fields) => (Some(fields), true),
             BestSkeleton::AllFieldsMatch(fields) => (Some(fields), false),
             BestSkeleton::NoMatch => (None, true),
         };
+
+    if let Some(ref mut pattern) = time_pattern {
+        naively_apply_hour_cycle_preferences(pattern, &preferences)
+    }
 
     // Determine how to combine the date and time.
     let pattern: Option<Pattern> = match (date_pattern, time_pattern) {
@@ -760,6 +791,7 @@ mod test {
             &data_provider.get().datetime.skeletons,
             &data_provider.get().datetime.length_patterns,
             &requested_fields,
+            &None,
         ) {
             BestSkeleton::AllFieldsMatch(available_format_pattern) => {
                 // TODO - This needs to support the "Z" pattern. This test will begin to fail

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -309,6 +309,12 @@ fn test_components_exact_matches() {
     test_fixture("components-exact-matches");
 }
 
+#[test]
+fn test_components_hour_cycle() {
+    // components/datetime/tests/fixtures/tests/components_hour_cycle.json
+    test_fixture("components_hour_cycle");
+}
+
 /// Tests that component::Bags can adjust for width differences in the final pattern.
 #[test]
 fn test_components_width_differences() {

--- a/components/datetime/tests/fixtures/tests/components_hour_cycle.json
+++ b/components/datetime/tests/fixtures/tests/components_hour_cycle.json
@@ -1,0 +1,139 @@
+[
+  {
+    "description": "h11 in the english locale",
+    "input": {
+        "locale": "en",
+        "value": "2020-01-07T00:25:07.000",
+        "options": {
+            "components": {
+                "hour": "numeric",
+                "minute": "numeric",
+                "preferences": { "hourCycle": "h11" }
+            }
+        }
+    },
+    "output": {
+        "value": "0:25 AM"
+    }
+  },
+  {
+    "description": "h12 in the english locale",
+    "input": {
+        "locale": "en",
+        "value": "2020-01-07T00:25:07.000",
+        "options": {
+            "components": {
+                "hour": "numeric",
+                "minute": "numeric",
+                "preferences": { "hourCycle": "h12" }
+            }
+        }
+    },
+    "output": {
+        "value": "12:25 AM"
+    }
+  },
+  {
+      "description": "h23 in the english locale",
+      "input": {
+          "locale": "en",
+          "value": "2020-01-07T00:25:07.000",
+          "options": {
+              "components": {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "preferences": { "hourCycle": "h23" }
+              }
+          }
+      },
+      "output": {
+          "value": "00:25"
+      }
+  },
+  {
+      "description": "h24 in the english locale",
+      "input": {
+          "locale": "en",
+          "value": "2020-01-07T00:25:07.000",
+          "options": {
+              "components": {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "preferences": { "hourCycle": "h24" }
+              }
+          }
+      },
+      "output": {
+          "value": "24:25"
+      }
+  },
+
+  {
+    "description": "h11 in the arabic locale",
+    "input": {
+        "locale": "ar",
+        "value": "2020-01-07T00:25:07.000",
+        "options": {
+            "components": {
+                "hour": "numeric",
+                "minute": "numeric",
+                "preferences": { "hourCycle": "h11" }
+            }
+        }
+    },
+    "output": {
+        "value": "0:25 ص"
+    }
+  },
+  {
+    "description": "h12 in the arabic locale",
+    "input": {
+        "locale": "ar",
+        "value": "2020-01-07T00:25:07.000",
+        "options": {
+            "components": {
+                "hour": "numeric",
+                "minute": "numeric",
+                "preferences": { "hourCycle": "h12" }
+            }
+        }
+    },
+    "output": {
+        "value": "12:25 ص"
+    }
+  },
+  {
+      "description": "h23 in the arabic locale",
+      "input": {
+          "locale": "ar",
+          "value": "2020-01-07T00:25:07.000",
+          "options": {
+              "components": {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "preferences": { "hourCycle": "h23" }
+              }
+          }
+      },
+      "output": {
+          "value": "00:25"
+      }
+  },
+  {
+      "description": "h24 in the arabic locale",
+      "input": {
+          "locale": "ar",
+          "value": "2020-01-07T00:25:07.000",
+          "options": {
+              "components": {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "preferences": { "hourCycle": "h24" }
+              }
+          }
+      },
+      "output": {
+          "value": "24:25"
+      }
+  }
+]


### PR DESCRIPTION
This resolves #843.

Please note the first commit is #832, but squashed into one commit. I can rebase this after #832 lands. You can only review 
91e101e.

This PR uses a similar mechanism as the length bag in #840, but for the components bag.