### PR TITLE
Cleanup line breaker data generation and rule table accessing APIs

### DIFF
--- a/experimental/segmenter/README.md
+++ b/experimental/segmenter/README.md
@@ -39,7 +39,7 @@ println!("{:?}", result);
 
 ## Generating property table
 
-Copy the following files to tools directory. Then run `python ./generate_properties.py` in `tools` directory. Machine generated files are moved to `src` directory.
+Copy the following files to `tools` directory. Then run `./generate_properties.py` in `tools` directory (requires Python 3.8+). Machine generated files are moved to `src` directory.
 - <https://www.unicode.org/Public/UCD/latest/ucd/LineBreak.txt>
 - <https://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt>
 

--- a/experimental/segmenter/src/lib.rs
+++ b/experimental/segmenter/src/lib.rs
@@ -41,7 +41,7 @@
 //!
 //! # Generating property table
 //!
-//! Copy the following files to tools directory. Then run `python ./generate_properties.py` in `tools` directory. Machine generated files are moved to `src` directory.
+//! Copy the following files to `tools` directory. Then run `./generate_properties.py` in `tools` directory (requires Python 3.8+). Machine generated files are moved to `src` directory.
 //! - <https://www.unicode.org/Public/UCD/latest/ucd/LineBreak.txt>
 //! - <https://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt>
 

--- a/experimental/segmenter/src/line_breaker.rs
+++ b/experimental/segmenter/src/line_breaker.rs
@@ -162,7 +162,7 @@ fn is_break_utf32_by_loose(
 
 #[inline]
 fn is_break_from_table(rule_table: &[i8], property_count: usize, left: u8, right: u8) -> bool {
-    let rule = rule_table[((left as usize) - 1) * property_count + (right as usize) - 1];
+    let rule = get_break_state_from_table(rule_table, property_count, left, right);
     if rule == KEEP_RULE {
         return false;
     }
@@ -171,6 +171,11 @@ fn is_break_from_table(rule_table: &[i8], property_count: usize, left: u8, right
         return false;
     }
     true
+}
+
+#[inline]
+fn is_break(left: u8, right: u8) -> bool {
+    is_break_from_table(&UAX14_RULE_TABLE, PROP_COUNT, left, right)
 }
 
 #[inline]
@@ -371,7 +376,7 @@ macro_rules! break_iterator_impl {
                         return Some(self.current_pos_data.unwrap().0);
                     }
 
-                    if is_break_from_table(&UAX14_RULE_TABLE, PROP_COUNT, left_prop, right_prop) {
+                    if is_break(left_prop, right_prop) {
                         return Some(self.current_pos_data.unwrap().0);
                     }
                 }
@@ -704,8 +709,7 @@ impl<'a> LineBreakIteratorUtf16<'a> {
 mod tests {
     use crate::lb_define::*;
     use crate::line_breaker::get_linebreak_property_with_rule;
-    use crate::line_breaker::is_break_from_table;
-    use crate::rule_table::*;
+    use crate::line_breaker::is_break;
     use crate::LineBreakRule;
     use crate::WordBreakRule;
 
@@ -729,10 +733,6 @@ mod tests {
         assert_eq!(get_linebreak_property('\u{50005}'), XX);
         assert_eq!(get_linebreak_property('\u{17D6}'), NS);
         assert_eq!(get_linebreak_property('\u{2014}'), B2);
-    }
-
-    fn is_break(left: u8, right: u8) -> bool {
-        is_break_from_table(&UAX14_RULE_TABLE, PROP_COUNT, left, right)
     }
 
     #[test]

--- a/experimental/segmenter/tools/generate_properties.py
+++ b/experimental/segmenter/tools/generate_properties.py
@@ -23,27 +23,25 @@ ea_props = ["N" for x in range(begin_plane2)]
 rule = []
 table = []
 
-with open('EastAsianWidth.txt', 'r') as file:
-    line = file.readline()
-    while line:
-        line = line.strip()
-        if not line.startswith('#'):
-            m = re.search("([0-9A-F]{1,6})\.\.([0-9A-F]{1,6})\;([A-Za-z]{1,})",
-                          line)
-            if m:
-                if int(m.group(2), 16) >= begin_plane2:
-                    break
-                length = int(m.group(2), 16) - int(m.group(1), 16) + 1
-                s = int(m.group(1), 16)
-                for x in range(length):
-                    ea_props[s + x] = m.group(3)
-            else:
-                m = re.search("([0-9A-F]{1,6})\;([A-Za-z]{1,})", line)
-                if m:
-                    if int(m.group(1), 16) >= begin_plane2:
-                        break
-                    ea_props[int(m.group(1), 16)] = m.group(2)
-        line = file.readline()
+with open('EastAsianWidth.txt', 'r') as eaw_file:
+    range_codepoint_pattern = r"([0-9A-F]{1,6})\.\.([0-9A-F]{1,6})\;([A-Za-z]{1,})"
+    single_codepoint_pattern = r"([0-9A-F]{1,6})\;([A-Za-z]{1,})"
+
+    for line in eaw_file.readlines():
+        start = end = prop = None
+        if m := re.match(range_codepoint_pattern, line):
+            start = int(m[1], 16)
+            end = int(m[2], 16)
+            prop = m[3]
+        elif m := re.match(single_codepoint_pattern, line):
+            start = end = int(m[1], 16)
+            prop = m[2]
+
+        # We have a success match, and the codepoints are in plane 0 & 1. Store
+        # their East Asian Width property.
+        if prop and start < begin_plane2:
+            for i in range(start, end + 1):
+                ea_props[i] = prop
 
 with open('LineBreak.txt', 'r') as file:
     line = file.readline()

--- a/experimental/segmenter/tools/generate_properties.py
+++ b/experimental/segmenter/tools/generate_properties.py
@@ -43,43 +43,39 @@ with open('EastAsianWidth.txt', 'r') as eaw_file:
             for i in range(start, end + 1):
                 ea_props[i] = prop
 
-with open('LineBreak.txt', 'r') as file:
-    line = file.readline()
-    while line:
-        line = line.strip()
-        if not line.startswith('#'):
-            m = re.search("([0-9A-F]{1,6})\.\.([0-9A-F]{1,6})\;([0-9A-Z]{2,})",
-                          line)
-            if m:
-                if int(m.group(2), 16) >= begin_plane2:
-                    break
-                length = int(m.group(2), 16) - int(m.group(1), 16) + 1
-                s = int(m.group(1), 16)
-                for x in range(length):
-                    if m.group(3) == "OP":
-                        if ea_props[s + x] in ("F", "W", "H"):
-                            lb_props[s + x] = "OP_EA"
-                        else:
-                            lb_props[s + x] = "OP_OP30"
+with open('LineBreak.txt', 'r') as lb_file:
+    range_codepoint_pattern = r"([0-9A-F]{1,6})\.\.([0-9A-F]{1,6})\;([0-9A-Z]{2,})"
+    single_codepoint_pattern = r"([0-9A-F]{1,6})\;([0-9A-Z]{2,})"
+
+    for line in lb_file.readlines():
+        start = end = prop = None
+        if m := re.match(range_codepoint_pattern, line):
+            start = int(m[1], 16)
+            end = int(m[2], 16)
+            prop = m[3]
+        elif m := re.match(single_codepoint_pattern, line):
+            start = end = int(m[1], 16)
+            prop = m[2]
+
+        # We have a success match, and the codepoints are in plane 0 & 1. Store
+        # their line break class.
+        if prop and start < begin_plane2:
+            for i in range(start, end + 1):
+                # for LB30
+                # https://www.unicode.org/reports/tr14/tr14-45.html
+                if prop == "OP":
+                    if ea_props[i] in ("F", "W", "H"):
+                        lb_props[i] = "OP_EA"
                     else:
-                        lb_props[s + x] = m.group(3)
-            else:
-                m = re.search("([0-9A-F]{1,6})\;([0-9A-Z]{2,})", line)
-                if m:
-                    if int(m.group(1), 16) >= begin_plane2:
-                        break
-                    # for LB30
-                    if m.group(2) == "OP":
-                        if ea_props[int(m.group(1), 16)] in ("F", "W", "H"):
-                            lb_props[int(m.group(1), 16)] = "OP_EA"
-                        else:
-                            lb_props[int(m.group(1), 16)] = "OP_OP30"
-                    elif m.group(2) == "CP" and ea_props[int(
-                            m.group(1), 16)] in ("F", "W", "H"):
-                        lb_props[int(m.group(1), 16)] = "CP_EA"
-                    else:
-                        lb_props[int(m.group(1), 16)] = m.group(2)
-        line = file.readline()
+                        lb_props[i] = "OP_OP30"
+                elif prop == "CP" and ea_props[i] in ("F", "W", "H"):
+                    # Note: This branch has no effect because the only two
+                    # codepoints 0x0029 and 0x005D with CP line break class both
+                    # have EA property "Na".
+                    lb_props[i] = "CP_EA"
+                else:
+                    lb_props[i] = prop
+
 
 prop_type = sorted([x for x in set(lb_props)])
 prop_type.append("B2_SP")


### PR DESCRIPTION
This PR simplifies some APIs accessing line break rule table, and clean up the logic parsing `EastAsianWidth.txt` and `LineBreak.txt`. This is a refactor and shouldn't change the behavior.