### PR TITLE
Clean up zerovec::samples so that it is not available outside of tests

### DIFF
--- a/utils/zerovec/benches/zerovec.rs
+++ b/utils/zerovec/benches/zerovec.rs
@@ -8,7 +8,10 @@ use rand_distr::{Distribution, LogNormal};
 use rand_pcg::Lcg64Xsh32;
 use std::fmt;
 
-use zerovec::samples::*;
+#[path = "../src/samples.rs"]
+mod samples;
+use samples::*;
+
 use zerovec::ule::*;
 use zerovec::ZeroVec;
 

--- a/utils/zerovec/benches/zerovec_iai.rs
+++ b/utils/zerovec/benches/zerovec_iai.rs
@@ -4,7 +4,10 @@
 
 use iai::black_box;
 
-use zerovec::samples::*;
+#[path = "../src/samples.rs"]
+mod samples;
+use samples::*;
+
 use zerovec::ZeroVec;
 
 fn sum_slice() -> u32 {

--- a/utils/zerovec/benches/zerovec_serde.rs
+++ b/utils/zerovec/benches/zerovec_serde.rs
@@ -7,7 +7,10 @@ use rand::SeedableRng;
 use rand_distr::{Distribution, LogNormal};
 use rand_pcg::Lcg64Xsh32;
 
-use zerovec::samples::*;
+#[path = "../src/samples.rs"]
+mod samples;
+use samples::*;
+
 use zerovec::ZeroVec;
 
 /// Generate a large list of u32s for stress testing.

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -78,6 +78,7 @@
 //! ```
 
 pub mod map;
+#[cfg(test)]
 pub mod samples;
 pub mod ule;
 mod varzerovec;

--- a/utils/zerovec/src/samples.rs
+++ b/utils/zerovec/src/samples.rs
@@ -4,6 +4,10 @@
 
 //! Example data useful for testing ZeroVec.
 
+// This module is included directly in tests and can trigger the dead_code
+// warning since not all samples are used in each test
+#![allow(dead_code)]
+
 #[repr(align(8))]
 struct Aligned<T>(pub T);
 


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/657

The only other instance of testing utils in a crate is `icu_datetime::mock`. It is too far entrenched in that crate to usefully extract, however -- it depends on a lot of private stuff in ways that make the path-trick unworkable.




<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->