### PR TITLE
Replace thiserror with displaydoc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dlmalloc"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +501,7 @@ name = "fixed_decimal"
 version = "0.2.0"
 dependencies = [
  "criterion",
+ "displaydoc",
  "getrandom 0.2.2",
  "icu_benchmark_macros",
  "rand",
@@ -497,7 +509,6 @@ dependencies = [
  "rand_pcg",
  "smallvec",
  "static_assertions",
- "thiserror",
  "writeable",
 ]
 
@@ -891,6 +902,7 @@ version = "0.2.0"
 dependencies = [
  "bincode",
  "criterion",
+ "displaydoc",
  "icu",
  "icu_benchmark_macros",
  "icu_locid",
@@ -901,7 +913,6 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror",
  "tinystr",
  "writeable",
 ]
@@ -911,6 +922,7 @@ name = "icu_decimal"
 version = "0.2.0"
 dependencies = [
  "criterion",
+ "displaydoc",
  "fixed_decimal",
  "getrandom 0.2.2",
  "icu",
@@ -923,7 +935,6 @@ dependencies = [
  "rand_distr",
  "rand_pcg",
  "serde",
- "thiserror",
  "writeable",
 ]
 
@@ -946,11 +957,11 @@ name = "icu_locid"
 version = "0.2.0"
 dependencies = [
  "criterion",
+ "displaydoc",
  "icu",
  "icu_benchmark_macros",
  "serde",
  "serde_json",
- "thiserror",
  "tinystr",
  "writeable",
 ]
@@ -969,8 +980,8 @@ dependencies = [
 name = "icu_pattern"
 version = "0.1.0"
 dependencies = [
+ "displaydoc",
  "iai",
- "thiserror",
  "writeable",
 ]
 
@@ -979,6 +990,7 @@ name = "icu_plurals"
 version = "0.2.0"
 dependencies = [
  "criterion",
+ "displaydoc",
  "fixed_decimal",
  "icu",
  "icu_benchmark_macros",
@@ -988,13 +1000,13 @@ dependencies = [
  "icu_testdata",
  "serde",
  "serde_json",
- "thiserror",
 ]
 
 [[package]]
 name = "icu_provider"
 version = "0.2.0"
 dependencies = [
+ "displaydoc",
  "erased-serde",
  "icu_locid",
  "icu_locid_macros",
@@ -1003,7 +1015,6 @@ dependencies = [
  "serde",
  "serde_json",
  "static_assertions",
- "thiserror",
  "tinystr",
  "writeable",
  "yoke",
@@ -1030,6 +1041,7 @@ name = "icu_provider_cldr"
 version = "0.2.0"
 dependencies = [
  "dirs",
+ "displaydoc",
  "icu_datetime",
  "icu_decimal",
  "icu_locale_canonicalizer",
@@ -1050,7 +1062,6 @@ dependencies = [
  "serde_json",
  "smallstr",
  "smallvec",
- "thiserror",
  "tinystr",
  "unzip",
  "urlencoding",
@@ -1062,6 +1073,7 @@ version = "0.2.0"
 dependencies = [
  "bincode",
  "criterion",
+ "displaydoc",
  "erased-serde",
  "icu_benchmark_macros",
  "icu_locid",
@@ -1072,7 +1084,6 @@ dependencies = [
  "serde",
  "serde_json",
  "static_assertions",
- "thiserror",
 ]
 
 [[package]]
@@ -1088,11 +1099,11 @@ dependencies = [
 name = "icu_provider_ppucd"
 version = "0.1.0"
 dependencies = [
+ "displaydoc",
  "icu_locid",
  "icu_locid_macros",
  "icu_provider",
  "icu_uniset",
- "thiserror",
  "tinystr",
 ]
 
@@ -1123,6 +1134,7 @@ name = "icu_testdata"
 version = "0.2.0"
 dependencies = [
  "cargo_metadata",
+ "displaydoc",
  "icu_locid",
  "icu_locid_macros",
  "icu_plurals",
@@ -1131,7 +1143,6 @@ dependencies = [
  "icu_provider_fs",
  "serde",
  "serde_json",
- "thiserror",
  "writeable",
 ]
 
@@ -1140,13 +1151,13 @@ name = "icu_uniset"
 version = "0.2.0"
 dependencies = [
  "criterion",
+ "displaydoc",
  "icu",
  "icu_benchmark_macros",
  "icu_provider",
  "litemap",
  "serde",
  "serde_json",
- "thiserror",
  "tinystr",
 ]
 

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -36,7 +36,7 @@ litemap = { version = "0.2", path = "../../utils/litemap", features = ["serde"] 
 tinystr = { version = "0.4.5" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 smallvec = "1.6"
-thiserror = "1.0"
+displaydoc = { version = "0.2.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -12,13 +12,19 @@ use tinystr::TinyStr8;
 #[derive(Display, Debug)]
 pub enum DateTimeError {
     #[displaydoc(transparent)]
-    Parse(#[from] std::num::ParseIntError),
+    Parse(std::num::ParseIntError),
     #[displaydoc("{field} must be between 0-{max}")]
     Overflow { field: &'static str, max: usize },
     #[displaydoc("{field} must be between {min}-0")]
     Underflow { field: &'static str, min: isize },
     #[displaydoc("Failed to parse time-zone offset")]
     InvalidTimeZoneOffset,
+}
+
+impl From<std::num::ParseIntError> for Error {
+    fn from(e: std::num::ParseIntError) -> Self {
+        Error::Parse(e)
+    }
 }
 
 /// Representation of a formattable calendar date. Supports dates in any calendar system that uses

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -2,11 +2,11 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use displaydoc::Display;
 use icu_locid::Locale;
 use std::convert::TryFrom;
 use std::ops::{Add, Sub};
 use std::str::FromStr;
-use displaydoc::Display;
 use tinystr::TinyStr8;
 
 #[derive(Display, Debug)]
@@ -22,7 +22,6 @@ pub enum DateTimeError {
 }
 
 impl std::error::Error for DateTimeError {}
-
 
 impl From<std::num::ParseIntError> for DateTimeError {
     fn from(e: std::num::ParseIntError) -> Self {

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use displaydoc::Display;
 use tinystr::TinyStr8;
 
-#[derive(Error, Debug)]
+#[derive(Display, Debug)]
 pub enum DateTimeError {
     #[displaydoc(transparent)]
     Parse(#[from] std::num::ParseIntError),

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -11,7 +11,7 @@ use tinystr::TinyStr8;
 
 #[derive(Display, Debug)]
 pub enum DateTimeError {
-    #[displaydoc(transparent)]
+    #[displaydoc("{0}")]
     Parse(std::num::ParseIntError),
     #[displaydoc("{field} must be between 0-{max}")]
     Overflow { field: &'static str, max: usize },

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -21,6 +21,9 @@ pub enum DateTimeError {
     InvalidTimeZoneOffset,
 }
 
+impl std::error::Error for DateTimeError {}
+
+
 impl From<std::num::ParseIntError> for Error {
     fn from(e: std::num::ParseIntError) -> Self {
         Error::Parse(e)

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -24,9 +24,9 @@ pub enum DateTimeError {
 impl std::error::Error for DateTimeError {}
 
 
-impl From<std::num::ParseIntError> for Error {
+impl From<std::num::ParseIntError> for DateTimeError {
     fn from(e: std::num::ParseIntError) -> Self {
-        Error::Parse(e)
+        DateTimeError::Parse(e)
     }
 }
 

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -11,13 +11,13 @@ use tinystr::TinyStr8;
 
 #[derive(Error, Debug)]
 pub enum DateTimeError {
-    #[error(transparent)]
+    #[displaydoc(transparent)]
     Parse(#[from] std::num::ParseIntError),
-    #[error("{field} must be between 0-{max}")]
+    #[displaydoc("{field} must be between 0-{max}")]
     Overflow { field: &'static str, max: usize },
-    #[error("{field} must be between {min}-0")]
+    #[displaydoc("{field} must be between {min}-0")]
     Underflow { field: &'static str, min: isize },
-    #[error("Failed to parse time-zone offset")]
+    #[displaydoc("Failed to parse time-zone offset")]
     InvalidTimeZoneOffset,
 }
 

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -6,7 +6,7 @@ use icu_locid::Locale;
 use std::convert::TryFrom;
 use std::ops::{Add, Sub};
 use std::str::FromStr;
-use thiserror::Error;
+use displaydoc::Display;
 use tinystr::TinyStr8;
 
 #[derive(Error, Debug)]

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -12,20 +12,20 @@ use displaydoc::Display;
 #[derive(Display, Debug)]
 pub enum DateTimeFormatError {
     /// An error originating from parsing a pattern.
-    #[displaydoc(transparent)]
+    #[displaydoc("{0}")]
     Pattern(pattern::Error),
     /// An error originating from the [`Write`](std::fmt::Write) trait.
-    #[displaydoc(transparent)]
+    #[displaydoc("{0}")]
     Format(std::fmt::Error),
     /// An error originating inside of the [`DataProvider`](icu_provider::DataProvider).
-    #[displaydoc(transparent)]
+    #[displaydoc("{0}")]
     DataProvider(DataError),
     /// An error originating from a missing field in datetime input.
     /// TODO: How can we return which field was missing?
     #[displaydoc("Missing input field")]
     MissingInputField,
     /// An error originating from skeleton matching.
-    #[displaydoc(transparent)]
+    #[displaydoc("{0}")]
     Skeleton(SkeletonError),
     /// An error originating from an unsupported field in a datetime format.
     #[displaydoc("Unsupported field: {0:?}")]

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -32,6 +32,9 @@ pub enum DateTimeFormatError {
     UnsupportedField(FieldSymbol),
 }
 
+impl std::error::Error for DateTimeFormatError {}
+
+
 impl From<pattern::Error> for DateTimeFormatError {
     fn from(e: pattern::Error) -> Self {
         DateTimeFormatError::Pattern(e)

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -9,7 +9,7 @@ use icu_provider::prelude::DataError;
 use displaydoc::Display;
 
 /// A list of possible error outcomes for the [`DateTimeFormat`](crate::DateTimeFormat) struct.
-#[derive(Error, Debug)]
+#[derive(Display, Debug)]
 pub enum DateTimeFormatError {
     /// An error originating from parsing a pattern.
     #[displaydoc(transparent)]

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -13,21 +13,45 @@ use displaydoc::Display;
 pub enum DateTimeFormatError {
     /// An error originating from parsing a pattern.
     #[displaydoc(transparent)]
-    Pattern(#[from] pattern::Error),
+    Pattern(pattern::Error),
     /// An error originating from the [`Write`](std::fmt::Write) trait.
     #[displaydoc(transparent)]
-    Format(#[from] std::fmt::Error),
+    Format(std::fmt::Error),
     /// An error originating inside of the [`DataProvider`](icu_provider::DataProvider).
     #[displaydoc(transparent)]
-    DataProvider(#[from] DataError),
+    DataProvider(DataError),
     /// An error originating from a missing field in datetime input.
     /// TODO: How can we return which field was missing?
     #[displaydoc("Missing input field")]
     MissingInputField,
     /// An error originating from skeleton matching.
     #[displaydoc(transparent)]
-    Skeleton(#[from] SkeletonError),
+    Skeleton(SkeletonError),
     /// An error originating from an unsupported field in a datetime format.
     #[displaydoc("Unsupported field: {0:?}")]
     UnsupportedField(FieldSymbol),
+}
+
+impl From<pattern::Error> for DateTimeFormatError {
+    fn from(e: pattern::Error) -> Self {
+        DateTimeFormatError::Pattern(e)
+    }
+}
+
+impl From<DataError> for DateTimeFormatError {
+    fn from(e: DataError) -> Self {
+        DateTimeFormatError::DataProvider(e)
+    }
+}
+
+impl From<std::fmt::Error> for DateTimeFormatError {
+    fn from(e: std::fmt::Error) -> Self {
+        DateTimeFormatError::Format(e)
+    }
+}
+
+impl From<SkeletonError> for DateTimeFormatError {
+    fn from(e: SkeletonError) -> Self {
+        DateTimeFormatError::Skeleton(e)
+    }
 }

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -5,8 +5,8 @@
 use crate::fields::FieldSymbol;
 use crate::pattern;
 use crate::skeleton::SkeletonError;
-use icu_provider::prelude::DataError;
 use displaydoc::Display;
+use icu_provider::prelude::DataError;
 
 /// A list of possible error outcomes for the [`DateTimeFormat`](crate::DateTimeFormat) struct.
 #[derive(Display, Debug)]
@@ -33,7 +33,6 @@ pub enum DateTimeFormatError {
 }
 
 impl std::error::Error for DateTimeFormatError {}
-
 
 impl From<pattern::Error> for DateTimeFormatError {
     fn from(e: pattern::Error) -> Self {

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -12,22 +12,22 @@ use displaydoc::Display;
 #[derive(Error, Debug)]
 pub enum DateTimeFormatError {
     /// An error originating from parsing a pattern.
-    #[error(transparent)]
+    #[displaydoc(transparent)]
     Pattern(#[from] pattern::Error),
     /// An error originating from the [`Write`](std::fmt::Write) trait.
-    #[error(transparent)]
+    #[displaydoc(transparent)]
     Format(#[from] std::fmt::Error),
     /// An error originating inside of the [`DataProvider`](icu_provider::DataProvider).
-    #[error(transparent)]
+    #[displaydoc(transparent)]
     DataProvider(#[from] DataError),
     /// An error originating from a missing field in datetime input.
     /// TODO: How can we return which field was missing?
-    #[error("Missing input field")]
+    #[displaydoc("Missing input field")]
     MissingInputField,
     /// An error originating from skeleton matching.
-    #[error(transparent)]
+    #[displaydoc(transparent)]
     Skeleton(#[from] SkeletonError),
     /// An error originating from an unsupported field in a datetime format.
-    #[error("Unsupported field: {0:?}")]
+    #[displaydoc("Unsupported field: {0:?}")]
     UnsupportedField(FieldSymbol),
 }

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -6,7 +6,7 @@ use crate::fields::FieldSymbol;
 use crate::pattern;
 use crate::skeleton::SkeletonError;
 use icu_provider::prelude::DataError;
-use thiserror::Error;
+use displaydoc::Display;
 
 /// A list of possible error outcomes for the [`DateTimeFormat`](crate::DateTimeFormat) struct.
 #[derive(Error, Debug)]

--- a/components/datetime/src/fields/length.rs
+++ b/components/datetime/src/fields/length.rs
@@ -14,6 +14,9 @@ pub enum LengthError {
     InvalidLength,
 }
 
+impl std::error::Error for LengthError {}
+
+
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]
 #[cfg_attr(
     feature = "provider_serde",

--- a/components/datetime/src/fields/length.rs
+++ b/components/datetime/src/fields/length.rs
@@ -8,7 +8,7 @@ use std::{
 };
 use displaydoc::Display;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Display, Debug, PartialEq)]
 pub enum LengthError {
     #[displaydoc("Invalid length")]
     InvalidLength,

--- a/components/datetime/src/fields/length.rs
+++ b/components/datetime/src/fields/length.rs
@@ -10,7 +10,7 @@ use displaydoc::Display;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum LengthError {
-    #[error("Invalid length")]
+    #[displaydoc("Invalid length")]
     InvalidLength,
 }
 

--- a/components/datetime/src/fields/length.rs
+++ b/components/datetime/src/fields/length.rs
@@ -2,11 +2,11 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use displaydoc::Display;
 use std::{
     cmp::{Ord, PartialOrd},
     convert::TryFrom,
 };
-use displaydoc::Display;
 
 #[derive(Display, Debug, PartialEq)]
 pub enum LengthError {
@@ -15,7 +15,6 @@ pub enum LengthError {
 }
 
 impl std::error::Error for LengthError {}
-
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]
 #[cfg_attr(

--- a/components/datetime/src/fields/length.rs
+++ b/components/datetime/src/fields/length.rs
@@ -6,7 +6,7 @@ use std::{
     cmp::{Ord, PartialOrd},
     convert::TryFrom,
 };
-use thiserror::Error;
+use displaydoc::Display;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum LengthError {

--- a/components/datetime/src/fields/mod.rs
+++ b/components/datetime/src/fields/mod.rs
@@ -16,7 +16,7 @@ use std::{
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Field {0:?} is not a valid length")]
+    #[displaydoc("Field {0:?} is not a valid length")]
     InvalidLength(FieldSymbol),
 }
 

--- a/components/datetime/src/fields/mod.rs
+++ b/components/datetime/src/fields/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod symbols;
 
 pub use length::{FieldLength, LengthError};
 pub use symbols::*;
-use thiserror::Error;
+use displaydoc::Display;
 
 use std::{
     cmp::{Ord, PartialOrd},

--- a/components/datetime/src/fields/mod.rs
+++ b/components/datetime/src/fields/mod.rs
@@ -20,6 +20,9 @@ pub enum Error {
     InvalidLength(FieldSymbol),
 }
 
+impl std::error::Error for Error {}
+
+
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]
 #[cfg_attr(
     feature = "provider_serde",

--- a/components/datetime/src/fields/mod.rs
+++ b/components/datetime/src/fields/mod.rs
@@ -14,7 +14,7 @@ use std::{
     convert::{TryFrom, TryInto},
 };
 
-#[derive(Error, Debug)]
+#[derive(Display, Debug)]
 pub enum Error {
     #[displaydoc("Field {0:?} is not a valid length")]
     InvalidLength(FieldSymbol),

--- a/components/datetime/src/fields/mod.rs
+++ b/components/datetime/src/fields/mod.rs
@@ -5,9 +5,9 @@
 mod length;
 pub(crate) mod symbols;
 
+use displaydoc::Display;
 pub use length::{FieldLength, LengthError};
 pub use symbols::*;
-use displaydoc::Display;
 
 use std::{
     cmp::{Ord, PartialOrd},
@@ -21,7 +21,6 @@ pub enum Error {
 }
 
 impl std::error::Error for Error {}
-
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]
 #[cfg_attr(

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -3,8 +3,8 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::fields::FieldLength;
-use std::{cmp::Ordering, convert::TryFrom};
 use displaydoc::Display;
+use std::{cmp::Ordering, convert::TryFrom};
 
 #[derive(Display, Debug, PartialEq)]
 pub enum SymbolError {
@@ -17,7 +17,6 @@ pub enum SymbolError {
 }
 
 impl std::error::Error for SymbolError {}
-
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[cfg_attr(

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -6,7 +6,7 @@ use crate::fields::FieldLength;
 use std::{cmp::Ordering, convert::TryFrom};
 use displaydoc::Display;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Display, Debug, PartialEq)]
 pub enum SymbolError {
     /// Unknown field symbol.
     #[displaydoc("Unknown field symbol: {0}")]

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -4,7 +4,7 @@
 
 use crate::fields::FieldLength;
 use std::{cmp::Ordering, convert::TryFrom};
-use thiserror::Error;
+use displaydoc::Display;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum SymbolError {

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -16,6 +16,9 @@ pub enum SymbolError {
     Invalid(char),
 }
 
+impl std::error::Error for SymbolError {}
+
+
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[cfg_attr(
     feature = "provider_serde",

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -9,10 +9,10 @@ use displaydoc::Display;
 #[derive(Error, Debug, PartialEq)]
 pub enum SymbolError {
     /// Unknown field symbol.
-    #[error("Unknown field symbol: {0}")]
+    #[displaydoc("Unknown field symbol: {0}")]
     Unknown(u8),
     /// Invalid character for a field symbol.
-    #[error("Invalid character for a field symbol: {0}")]
+    #[displaydoc("Invalid character for a field symbol: {0}")]
     Invalid(char),
 }
 

--- a/components/datetime/src/pattern/error.rs
+++ b/components/datetime/src/pattern/error.rs
@@ -24,7 +24,6 @@ pub enum Error {
 
 impl std::error::Error for Error {}
 
-
 impl From<fields::Error> for Error {
     fn from(input: fields::Error) -> Self {
         match input {

--- a/components/datetime/src/pattern/error.rs
+++ b/components/datetime/src/pattern/error.rs
@@ -22,6 +22,9 @@ pub enum Error {
     UnclosedPlaceholder,
 }
 
+impl std::error::Error for Error {}
+
+
 impl From<fields::Error> for Error {
     fn from(input: fields::Error) -> Self {
         match input {

--- a/components/datetime/src/pattern/error.rs
+++ b/components/datetime/src/pattern/error.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::fields;
-use thiserror::Error;
+use displaydoc::Display;
 
 /// These strings follow the recommendations for the serde::de::Unexpected::Other type.
 /// https://docs.serde.rs/serde/de/enum.Unexpected.html#variant.Other

--- a/components/datetime/src/pattern/error.rs
+++ b/components/datetime/src/pattern/error.rs
@@ -10,7 +10,7 @@ use displaydoc::Display;
 ///
 /// Serde will generate an error such as:
 /// "invalid value: unclosed literal in pattern, expected a valid UTS 35 pattern string at line 1 column 12"
-#[derive(Error, Debug, PartialEq)]
+#[derive(Display, Debug, PartialEq)]
 pub enum Error {
     #[displaydoc("{0:?} invalid field length in pattern")]
     FieldLengthInvalid(fields::FieldSymbol),

--- a/components/datetime/src/pattern/error.rs
+++ b/components/datetime/src/pattern/error.rs
@@ -12,13 +12,13 @@ use displaydoc::Display;
 /// "invalid value: unclosed literal in pattern, expected a valid UTS 35 pattern string at line 1 column 12"
 #[derive(Error, Debug, PartialEq)]
 pub enum Error {
-    #[error("{0:?} invalid field length in pattern")]
+    #[displaydoc("{0:?} invalid field length in pattern")]
     FieldLengthInvalid(fields::FieldSymbol),
-    #[error("unknown substitution {0} in pattern")]
+    #[displaydoc("unknown substitution {0} in pattern")]
     UnknownSubstitution(char),
-    #[error("unclosed literal in pattern")]
+    #[displaydoc("unclosed literal in pattern")]
     UnclosedLiteral,
-    #[error("unclosed placeholder in pattern")]
+    #[displaydoc("unclosed placeholder in pattern")]
     UnclosedPlaceholder,
 }
 

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -220,7 +220,7 @@ impl<'a> From<(&'a SkeletonV1, &'a PatternV1)> for AvailableFormatPattern<'a> {
 ///
 /// Serde will generate an error such as:
 /// "invalid value: unclosed literal in pattern, expected a valid UTS 35 pattern string at line 1 column 12"
-#[derive(Error, Debug)]
+#[derive(Display, Debug)]
 pub enum SkeletonError {
     #[displaydoc("field too long in skeleton")]
     InvalidFieldLength,

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -222,19 +222,19 @@ impl<'a> From<(&'a SkeletonV1, &'a PatternV1)> for AvailableFormatPattern<'a> {
 /// "invalid value: unclosed literal in pattern, expected a valid UTS 35 pattern string at line 1 column 12"
 #[derive(Error, Debug)]
 pub enum SkeletonError {
-    #[error("field too long in skeleton")]
+    #[displaydoc("field too long in skeleton")]
     InvalidFieldLength,
-    #[error("duplicate field in skeleton")]
+    #[displaydoc("duplicate field in skeleton")]
     DuplicateField,
-    #[error("symbol unknown {0} in skeleton")]
+    #[displaydoc("symbol unknown {0} in skeleton")]
     SymbolUnknown(char),
-    #[error("symbol invalid {0} in skeleton")]
+    #[displaydoc("symbol invalid {0} in skeleton")]
     SymbolInvalid(char),
-    #[error("symbol unimplemented {0} in skeleton")]
+    #[displaydoc("symbol unimplemented {0} in skeleton")]
     SymbolUnimplemented(char),
-    #[error("unimplemented field {0} in skeleton")]
+    #[displaydoc("unimplemented field {0} in skeleton")]
     UnimplementedField(char),
-    #[error(transparent)]
+    #[displaydoc(transparent)]
     Fields(#[from] fields::Error),
 }
 

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -4,9 +4,9 @@
 
 //! Skeletons are used for pattern matching. See the [`Skeleton`] struct for more information.
 
+use displaydoc::Display;
 use smallvec::SmallVec;
 use std::convert::TryFrom;
-use displaydoc::Display;
 
 use crate::{
     fields::{self, Field, FieldLength, FieldSymbol},
@@ -239,7 +239,6 @@ pub enum SkeletonError {
 }
 
 impl std::error::Error for SkeletonError {}
-
 
 impl From<fields::Error> for SkeletonError {
     fn from(e: fields::Error) -> Self {

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -238,6 +238,9 @@ pub enum SkeletonError {
     Fields(fields::Error),
 }
 
+impl std::error::Error for SkeletonError {}
+
+
 impl From<fields::Error> for SkeletonError {
     fn from(e: fields::Error) -> Self {
         SkeletonError::Fields(e)

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -6,7 +6,7 @@
 
 use smallvec::SmallVec;
 use std::convert::TryFrom;
-use thiserror::Error;
+use displaydoc::Display;
 
 use crate::{
     fields::{self, Field, FieldLength, FieldSymbol},

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -234,7 +234,7 @@ pub enum SkeletonError {
     SymbolUnimplemented(char),
     #[displaydoc("unimplemented field {0} in skeleton")]
     UnimplementedField(char),
-    #[displaydoc(transparent)]
+    #[displaydoc("{0}")]
     Fields(fields::Error),
 }
 

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -235,7 +235,13 @@ pub enum SkeletonError {
     #[displaydoc("unimplemented field {0} in skeleton")]
     UnimplementedField(char),
     #[displaydoc(transparent)]
-    Fields(#[from] fields::Error),
+    Fields(fields::Error),
+}
+
+impl From<fields::Error> for SkeletonError {
+    fn from(e: fields::Error) -> Self {
+        SkeletonError::Fields(e)
+    }
 }
 
 impl From<fields::LengthError> for SkeletonError {

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -33,7 +33,7 @@ icu_provider = { version = "0.2", path = "../../provider/core", features = ["mac
 fixed_decimal = { version = "0.2", path = "../../utils/fixed_decimal" }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 serde = { version = "1.0", features = ["derive"], optional = true }
-thiserror = "1.0"
+displaydoc = { version = "0.2.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/components/decimal/src/error.rs
+++ b/components/decimal/src/error.rs
@@ -12,6 +12,9 @@ pub enum Error {
     Data(icu_provider::DataError),
 }
 
+impl std::error::Error for Error {}
+
+
 impl From<icu_provider::DataError> for Error {
     fn from(e: icu_provider::DataError) -> Self {
         Error::Data(e)

--- a/components/decimal/src/error.rs
+++ b/components/decimal/src/error.rs
@@ -4,7 +4,7 @@
 
 //! Error types for decimal formatting.
 
-use thiserror::Error;
+use displaydoc::Display;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/components/decimal/src/error.rs
+++ b/components/decimal/src/error.rs
@@ -8,6 +8,6 @@ use displaydoc::Display;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("error loading data: {0}")]
+    #[displaydoc("error loading data: {0}")]
     Data(#[from] icu_provider::DataError),
 }

--- a/components/decimal/src/error.rs
+++ b/components/decimal/src/error.rs
@@ -6,7 +6,7 @@
 
 use displaydoc::Display;
 
-#[derive(Error, Debug)]
+#[derive(Display, Debug)]
 pub enum Error {
     #[displaydoc("error loading data: {0}")]
     Data(#[from] icu_provider::DataError),

--- a/components/decimal/src/error.rs
+++ b/components/decimal/src/error.rs
@@ -14,7 +14,6 @@ pub enum Error {
 
 impl std::error::Error for Error {}
 
-
 impl From<icu_provider::DataError> for Error {
     fn from(e: icu_provider::DataError) -> Self {
         Error::Data(e)

--- a/components/decimal/src/error.rs
+++ b/components/decimal/src/error.rs
@@ -9,5 +9,11 @@ use displaydoc::Display;
 #[derive(Display, Debug)]
 pub enum Error {
     #[displaydoc("error loading data: {0}")]
-    Data(#[from] icu_provider::DataError),
+    Data(icu_provider::DataError),
+}
+
+impl From<icu_provider::DataError> for Error {
+    fn from(e: icu_provider::DataError) -> Self {
+        Error::Data(e)
+    }
 }

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 tinystr = "0.4.5"
 serde = { version = "1.0", optional = true }
 writeable = { version = "0.2", path = "../../utils/writeable" }
-thiserror = "1.0"
+displaydoc = { version = "0.2.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/components/locid/src/parser/errors.rs
+++ b/components/locid/src/parser/errors.rs
@@ -54,3 +54,6 @@ pub enum ParserError {
     #[displaydoc("Invalid extension")]
     InvalidExtension,
 }
+
+impl std::error::Error for ParserError {}
+

--- a/components/locid/src/parser/errors.rs
+++ b/components/locid/src/parser/errors.rs
@@ -56,4 +56,3 @@ pub enum ParserError {
 }
 
 impl std::error::Error for ParserError {}
-

--- a/components/locid/src/parser/errors.rs
+++ b/components/locid/src/parser/errors.rs
@@ -21,7 +21,7 @@ pub enum ParserError {
     ///
     /// assert_eq!(Language::from_str("x2"), Err(ParserError::InvalidLanguage));
     /// ```
-    #[error("The given language subtag is invalid")]
+    #[displaydoc("The given language subtag is invalid")]
     InvalidLanguage,
 
     /// Invalid script, region or variant subtag.
@@ -36,7 +36,7 @@ pub enum ParserError {
     ///
     /// assert_eq!(Region::from_str("#@2X"), Err(ParserError::InvalidSubtag));
     /// ```
-    #[error("Invalid subtag")]
+    #[displaydoc("Invalid subtag")]
     InvalidSubtag,
 
     /// Invalid extension subtag.
@@ -51,6 +51,6 @@ pub enum ParserError {
     ///
     /// assert_eq!(Key::from_str("#@2X"), Err(ParserError::InvalidExtension));
     /// ```
-    #[error("Invalid extension")]
+    #[displaydoc("Invalid extension")]
     InvalidExtension,
 }

--- a/components/locid/src/parser/errors.rs
+++ b/components/locid/src/parser/errors.rs
@@ -7,7 +7,7 @@ use displaydoc::Display;
 /// List of parser errors that can be generated
 /// while parsing [`LanguageIdentifier`](crate::LanguageIdentifier), [`Locale`](crate::Locale),
 /// [`subtags`](crate::subtags) or [`extensions`](crate::extensions).
-#[derive(Error, Debug, PartialEq)]
+#[derive(Display, Debug, PartialEq)]
 pub enum ParserError {
     /// Invalid language subtag.
     ///

--- a/components/locid/src/parser/errors.rs
+++ b/components/locid/src/parser/errors.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use thiserror::Error;
+use displaydoc::Display;
 
 /// List of parser errors that can be generated
 /// while parsing [`LanguageIdentifier`](crate::LanguageIdentifier), [`Locale`](crate::Locale),

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -33,7 +33,7 @@ fixed_decimal = { version = "0.2", path = "../../utils/fixed_decimal" }
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["macros"] }
 icu_locid = { version = "0.2", path = "../locid" }
 serde = { version = "1.0", features = ["derive"], optional = true }
-thiserror = "1.0"
+displaydoc = { version = "0.2.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/components/plurals/src/error.rs
+++ b/components/plurals/src/error.rs
@@ -17,6 +17,9 @@ pub enum PluralRulesError {
     DataProvider(DataError),
 }
 
+impl std::error::Error for PluralRulesError {}
+
+
 impl From<ParserError> for PluralRulesError {
     fn from(e: ParserError) -> Self {
         PluralRulesError::Parser(e)

--- a/components/plurals/src/error.rs
+++ b/components/plurals/src/error.rs
@@ -4,7 +4,7 @@
 
 use crate::rules::parser::ParserError;
 use icu_provider::prelude::DataError;
-use thiserror::Error;
+use displaydoc::Display;
 
 /// A list of possible error outcomes for the [`PluralRules`](crate::PluralRules) struct.
 ///

--- a/components/plurals/src/error.rs
+++ b/components/plurals/src/error.rs
@@ -11,8 +11,20 @@ use displaydoc::Display;
 #[derive(Display, Debug)]
 pub enum PluralRulesError {
     #[displaydoc("Parser error: {0}")]
-    Parser(#[from] ParserError),
+    Parser(ParserError),
     /// An error originating inside of the [`DataProvider`](icu_provider::DataProvider)
     #[displaydoc("Data provider error: {0}")]
-    DataProvider(#[from] DataError),
+    DataProvider(DataError),
+}
+
+impl From<ParserError> for PluralRulesError {
+    fn from(e: ParserError) -> Self {
+        PluralRulesError::Parser(e)
+    }
+}
+
+impl From<DataError> for PluralRulesError {
+    fn from(e: DataError) -> Self {
+        PluralRulesError::DataProvider(e)
+    }
 }

--- a/components/plurals/src/error.rs
+++ b/components/plurals/src/error.rs
@@ -10,9 +10,9 @@ use displaydoc::Display;
 ///
 #[derive(Error, Debug)]
 pub enum PluralRulesError {
-    #[error("Parser error: {0}")]
+    #[displaydoc("Parser error: {0}")]
     Parser(#[from] ParserError),
     /// An error originating inside of the [`DataProvider`](icu_provider::DataProvider)
-    #[error("Data provider error: {0}")]
+    #[displaydoc("Data provider error: {0}")]
     DataProvider(#[from] DataError),
 }

--- a/components/plurals/src/error.rs
+++ b/components/plurals/src/error.rs
@@ -8,7 +8,7 @@ use displaydoc::Display;
 
 /// A list of possible error outcomes for the [`PluralRules`](crate::PluralRules) struct.
 ///
-#[derive(Error, Debug)]
+#[derive(Display, Debug)]
 pub enum PluralRulesError {
     #[displaydoc("Parser error: {0}")]
     Parser(#[from] ParserError),

--- a/components/plurals/src/error.rs
+++ b/components/plurals/src/error.rs
@@ -3,8 +3,8 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::rules::parser::ParserError;
-use icu_provider::prelude::DataError;
 use displaydoc::Display;
+use icu_provider::prelude::DataError;
 
 /// A list of possible error outcomes for the [`PluralRules`](crate::PluralRules) struct.
 ///
@@ -18,7 +18,6 @@ pub enum PluralRulesError {
 }
 
 impl std::error::Error for PluralRulesError {}
-
 
 impl From<ParserError> for PluralRulesError {
     fn from(e: ParserError) -> Self {

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -89,10 +89,10 @@ impl PluralOperands {
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum OperandsError {
     /// Input to the Operands parsing was empty.
-    #[error("Input to the Operands parsing was empty")]
+    #[displaydoc("Input to the Operands parsing was empty")]
     Empty,
     /// Input to the Operands parsing was invalid.
-    #[error("Input to the Operands parsing was invalid")]
+    #[displaydoc("Input to the Operands parsing was invalid")]
     Invalid,
 }
 

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -96,6 +96,9 @@ pub enum OperandsError {
     Invalid,
 }
 
+impl std::error::Error for OperandsError {}
+
+
 impl From<ParseIntError> for OperandsError {
     fn from(_: ParseIntError) -> Self {
         Self::Invalid

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -8,7 +8,7 @@ use std::io::Error as IOError;
 use std::isize;
 use std::num::ParseIntError;
 use std::str::FromStr;
-use thiserror::Error;
+use displaydoc::Display;
 
 /// A full plural operands representation of a number. See [CLDR Plural Rules](http://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules) for complete operands description.
 /// Plural operands in compliance with [CLDR Plural Rules](http://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules).

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -86,7 +86,7 @@ impl PluralOperands {
     }
 }
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Display, Debug, PartialEq, Eq)]
 pub enum OperandsError {
     /// Input to the Operands parsing was empty.
     #[displaydoc("Input to the Operands parsing was empty")]

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -2,13 +2,13 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use displaydoc::Display;
 use fixed_decimal::FixedDecimal;
 use std::convert::TryFrom;
 use std::io::Error as IOError;
 use std::isize;
 use std::num::ParseIntError;
 use std::str::FromStr;
-use displaydoc::Display;
 
 /// A full plural operands representation of a number. See [CLDR Plural Rules](http://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules) for complete operands description.
 /// Plural operands in compliance with [CLDR Plural Rules](http://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules).
@@ -97,7 +97,6 @@ pub enum OperandsError {
 }
 
 impl std::error::Error for OperandsError {}
-
 
 impl From<ParseIntError> for OperandsError {
     fn from(_: ParseIntError) -> Self {

--- a/components/plurals/src/rules/lexer.rs
+++ b/components/plurals/src/rules/lexer.rs
@@ -34,6 +34,9 @@ pub enum LexerError {
     UnknownToken(u8),
 }
 
+impl std::error::Error for LexerError {}
+
+
 /// Unicode Plural Rule lexer is an iterator
 /// over tokens produced from an input string.
 ///

--- a/components/plurals/src/rules/lexer.rs
+++ b/components/plurals/src/rules/lexer.rs
@@ -28,9 +28,9 @@ pub enum Token {
 
 #[derive(Error, Debug)]
 pub enum LexerError {
-    #[error("Expected byte: {0}")]
+    #[displaydoc("Expected byte: {0}")]
     ExpectedByte(u8),
-    #[error("Unknown token: {0}")]
+    #[displaydoc("Unknown token: {0}")]
     UnknownToken(u8),
 }
 

--- a/components/plurals/src/rules/lexer.rs
+++ b/components/plurals/src/rules/lexer.rs
@@ -26,7 +26,7 @@ pub enum Token {
     E,
 }
 
-#[derive(Error, Debug)]
+#[derive(Display, Debug)]
 pub enum LexerError {
     #[displaydoc("Expected byte: {0}")]
     ExpectedByte(u8),

--- a/components/plurals/src/rules/lexer.rs
+++ b/components/plurals/src/rules/lexer.rs
@@ -36,7 +36,6 @@ pub enum LexerError {
 
 impl std::error::Error for LexerError {}
 
-
 /// Unicode Plural Rule lexer is an iterator
 /// over tokens produced from an input string.
 ///

--- a/components/plurals/src/rules/lexer.rs
+++ b/components/plurals/src/rules/lexer.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use super::ast;
-use thiserror::Error;
+use displaydoc::Display;
 
 #[derive(Debug, PartialEq)]
 pub enum Token {

--- a/components/plurals/src/rules/parser.rs
+++ b/components/plurals/src/rules/parser.rs
@@ -5,7 +5,7 @@
 use super::ast;
 use super::lexer::{Lexer, Token};
 use std::iter::Peekable;
-use thiserror::Error;
+use displaydoc::Display;
 
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum ParserError {

--- a/components/plurals/src/rules/parser.rs
+++ b/components/plurals/src/rules/parser.rs
@@ -7,7 +7,7 @@ use super::lexer::{Lexer, Token};
 use std::iter::Peekable;
 use displaydoc::Display;
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Display, Debug, PartialEq, Eq)]
 pub enum ParserError {
     #[displaydoc("expected 'AND' condition")]
     ExpectedAndCondition,

--- a/components/plurals/src/rules/parser.rs
+++ b/components/plurals/src/rules/parser.rs
@@ -23,6 +23,9 @@ pub enum ParserError {
     ExpectedSampleType,
 }
 
+impl std::error::Error for ParserError {}
+
+
 /// Unicode Plural Rule parser converts an
 /// input string into a Rule [`AST`].
 ///

--- a/components/plurals/src/rules/parser.rs
+++ b/components/plurals/src/rules/parser.rs
@@ -4,8 +4,8 @@
 
 use super::ast;
 use super::lexer::{Lexer, Token};
-use std::iter::Peekable;
 use displaydoc::Display;
+use std::iter::Peekable;
 
 #[derive(Display, Debug, PartialEq, Eq)]
 pub enum ParserError {
@@ -24,7 +24,6 @@ pub enum ParserError {
 }
 
 impl std::error::Error for ParserError {}
-
 
 /// Unicode Plural Rule parser converts an
 /// input string into a Rule [`AST`].

--- a/components/plurals/src/rules/parser.rs
+++ b/components/plurals/src/rules/parser.rs
@@ -9,17 +9,17 @@ use displaydoc::Display;
 
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum ParserError {
-    #[error("expected 'AND' condition")]
+    #[displaydoc("expected 'AND' condition")]
     ExpectedAndCondition,
-    #[error("expected relation")]
+    #[displaydoc("expected relation")]
     ExpectedRelation,
-    #[error("expected operator")]
+    #[displaydoc("expected operator")]
     ExpectedOperator,
-    #[error("expected operand")]
+    #[displaydoc("expected operand")]
     ExpectedOperand,
-    #[error("expected value")]
+    #[displaydoc("expected value")]
     ExpectedValue,
-    #[error("expected sample type")]
+    #[displaydoc("expected sample type")]
     ExpectedSampleType,
 }
 

--- a/components/uniset/Cargo.toml
+++ b/components/uniset/Cargo.toml
@@ -33,7 +33,7 @@ icu_provider = { version = "0.2", path = "../../provider/core", features = ["mac
 litemap = { version = "0.2", path = "../../utils/litemap" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 tinystr = "0.4.5"
-thiserror = "1.0"
+displaydoc = { version = "0.2.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/components/uniset/src/lib.rs
+++ b/components/uniset/src/lib.rs
@@ -66,7 +66,7 @@ pub use uniset::UnicodeSet;
 pub use utils::*;
 
 /// Custom Errors for [`UnicodeSet`].
-#[derive(Error, Debug)]
+#[derive(Display, Debug)]
 pub enum UnicodeSetError {
     #[displaydoc("Invalid set: {0:?}")]
     InvalidSet(Vec<u32>),

--- a/components/uniset/src/lib.rs
+++ b/components/uniset/src/lib.rs
@@ -68,11 +68,11 @@ pub use utils::*;
 /// Custom Errors for [`UnicodeSet`].
 #[derive(Error, Debug)]
 pub enum UnicodeSetError {
-    #[error("Invalid set: {0:?}")]
+    #[displaydoc("Invalid set: {0:?}")]
     InvalidSet(Vec<u32>),
-    #[error("Invalid range: {0}..{1}")]
+    #[displaydoc("Invalid range: {0}..{1}")]
     InvalidRange(u32, u32),
-    #[error(transparent)]
+    #[displaydoc(transparent)]
     PropDataLoad(#[from] DataError),
 }
 

--- a/components/uniset/src/lib.rs
+++ b/components/uniset/src/lib.rs
@@ -73,7 +73,13 @@ pub enum UnicodeSetError {
     #[displaydoc("Invalid range: {0}..{1}")]
     InvalidRange(u32, u32),
     #[displaydoc(transparent)]
-    PropDataLoad(#[from] DataError),
+    PropDataLoad(DataError),
+}
+
+impl From<DataError> for UnicodeSetError {
+    fn from(e: DataError) -> Self {
+        UnicodeSetError::PropDataLoad(e)
+    }
 }
 
 #[derive(PartialEq)]

--- a/components/uniset/src/lib.rs
+++ b/components/uniset/src/lib.rs
@@ -72,7 +72,7 @@ pub enum UnicodeSetError {
     InvalidSet(Vec<u32>),
     #[displaydoc("Invalid range: {0}..{1}")]
     InvalidRange(u32, u32),
-    #[displaydoc(transparent)]
+    #[displaydoc("{0}")]
     PropDataLoad(DataError),
 }
 

--- a/components/uniset/src/lib.rs
+++ b/components/uniset/src/lib.rs
@@ -60,8 +60,8 @@ mod utils;
 
 pub use builder::UnicodeSetBuilder;
 pub use conversions::*;
-use icu_provider::DataError;
 use displaydoc::Display;
+use icu_provider::DataError;
 pub use uniset::UnicodeSet;
 pub use utils::*;
 
@@ -77,7 +77,6 @@ pub enum UnicodeSetError {
 }
 
 impl std::error::Error for UnicodeSetError {}
-
 
 impl From<DataError> for UnicodeSetError {
     fn from(e: DataError) -> Self {

--- a/components/uniset/src/lib.rs
+++ b/components/uniset/src/lib.rs
@@ -76,6 +76,9 @@ pub enum UnicodeSetError {
     PropDataLoad(DataError),
 }
 
+impl std::error::Error for UnicodeSetError {}
+
+
 impl From<DataError> for UnicodeSetError {
     fn from(e: DataError) -> Self {
         UnicodeSetError::PropDataLoad(e)

--- a/components/uniset/src/lib.rs
+++ b/components/uniset/src/lib.rs
@@ -61,7 +61,7 @@ mod utils;
 pub use builder::UnicodeSetBuilder;
 pub use conversions::*;
 use icu_provider::DataError;
-use thiserror::Error;
+use displaydoc::Display;
 pub use uniset::UnicodeSet;
 pub use utils::*;
 

--- a/experimental/provider_ppucd/Cargo.toml
+++ b/experimental/provider_ppucd/Cargo.toml
@@ -30,4 +30,4 @@ icu_provider = { version = "0.2", path = "../../provider/core", features = ["pro
 icu_locid_macros = { version = "0.2", path = "../../components/locid/macros" }
 icu_uniset = { version = "0.2", path = "../../components/uniset" }
 tinystr = "0.4"
-thiserror = "1.0"
+displaydoc = { version = "0.2.3", default-features = false }

--- a/experimental/provider_ppucd/src/error.rs
+++ b/experimental/provider_ppucd/src/error.rs
@@ -7,11 +7,17 @@ use displaydoc::Display;
 #[derive(Display, Debug)]
 pub enum Error {
     #[displaydoc(transparent)]
-    PpucdParse(#[from] PpucdParseError),
+    PpucdParse(PpucdParseError),
 }
 
 #[derive(Display, Debug, PartialEq, Copy, Clone)]
 #[displaydoc("Could not parse PPUCD file: {src}")]
 pub struct PpucdParseError {
     pub src: &'static str,
+}
+
+impl From<PpucdParseError> for Error {
+    fn from(e: PpucdParseError) -> Self {
+        Error::PpucdParse(e)
+    }
 }

--- a/experimental/provider_ppucd/src/error.rs
+++ b/experimental/provider_ppucd/src/error.rs
@@ -6,7 +6,7 @@ use displaydoc::Display;
 
 #[derive(Display, Debug)]
 pub enum Error {
-    #[displaydoc(transparent)]
+    #[displaydoc("{0}")]
     PpucdParse(PpucdParseError),
 }
 

--- a/experimental/provider_ppucd/src/error.rs
+++ b/experimental/provider_ppucd/src/error.rs
@@ -6,12 +6,12 @@ use displaydoc::Display;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error(transparent)]
+    #[displaydoc(transparent)]
     PpucdParse(#[from] PpucdParseError),
 }
 
 #[derive(Error, Debug, PartialEq, Copy, Clone)]
-#[error("Could not parse PPUCD file: {src}")]
+#[displaydoc("Could not parse PPUCD file: {src}")]
 pub struct PpucdParseError {
     pub src: &'static str,
 }

--- a/experimental/provider_ppucd/src/error.rs
+++ b/experimental/provider_ppucd/src/error.rs
@@ -10,11 +10,17 @@ pub enum Error {
     PpucdParse(PpucdParseError),
 }
 
+impl std::error::Error for Error {}
+
+
 #[derive(Display, Debug, PartialEq, Copy, Clone)]
 #[displaydoc("Could not parse PPUCD file: {src}")]
 pub struct PpucdParseError {
     pub src: &'static str,
 }
+
+impl std::error::Error for Error {}
+
 
 impl From<PpucdParseError> for Error {
     fn from(e: PpucdParseError) -> Self {

--- a/experimental/provider_ppucd/src/error.rs
+++ b/experimental/provider_ppucd/src/error.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use thiserror::Error;
+use displaydoc::Display;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/experimental/provider_ppucd/src/error.rs
+++ b/experimental/provider_ppucd/src/error.rs
@@ -4,13 +4,13 @@
 
 use displaydoc::Display;
 
-#[derive(Error, Debug)]
+#[derive(Display, Debug)]
 pub enum Error {
     #[displaydoc(transparent)]
     PpucdParse(#[from] PpucdParseError),
 }
 
-#[derive(Error, Debug, PartialEq, Copy, Clone)]
+#[derive(Display, Debug, PartialEq, Copy, Clone)]
 #[displaydoc("Could not parse PPUCD file: {src}")]
 pub struct PpucdParseError {
     pub src: &'static str,

--- a/experimental/provider_ppucd/src/error.rs
+++ b/experimental/provider_ppucd/src/error.rs
@@ -19,7 +19,7 @@ pub struct PpucdParseError {
     pub src: &'static str,
 }
 
-impl std::error::Error for Error {}
+impl std::error::Error for PpucdParseError {}
 
 
 impl From<PpucdParseError> for Error {

--- a/experimental/provider_ppucd/src/error.rs
+++ b/experimental/provider_ppucd/src/error.rs
@@ -12,7 +12,6 @@ pub enum Error {
 
 impl std::error::Error for Error {}
 
-
 #[derive(Display, Debug, PartialEq, Copy, Clone)]
 #[displaydoc("Could not parse PPUCD file: {src}")]
 pub struct PpucdParseError {
@@ -20,7 +19,6 @@ pub struct PpucdParseError {
 }
 
 impl std::error::Error for PpucdParseError {}
-
 
 impl From<PpucdParseError> for Error {
     fn from(e: PpucdParseError) -> Self {

--- a/provider/cldr/Cargo.toml
+++ b/provider/cldr/Cargo.toml
@@ -49,7 +49,7 @@ serde-tuple-vec-map = "1.0"
 smallstr = { version = "0.2", features = ["serde"] }
 smallvec = "1.6"
 tinystr = { version = "0.4.5", features = ["serde"] }
-thiserror = "1.0"
+displaydoc = { version = "0.2.3", default-features = false }
 
 # Dependencies for the download feature
 urlencoding = { version = "1.1", optional = true }

--- a/provider/cldr/src/download/error.rs
+++ b/provider/cldr/src/download/error.rs
@@ -6,7 +6,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use displaydoc::Display;
 
-#[derive(Error, Debug)]
+#[derive(Display, Debug)]
 pub enum Error {
     #[displaydoc("{0}: {1:?}")]
     Io(#[source] io::Error, Option<PathBuf>),

--- a/provider/cldr/src/download/error.rs
+++ b/provider/cldr/src/download/error.rs
@@ -2,9 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use displaydoc::Display;
 use std::io;
 use std::path::{Path, PathBuf};
-use displaydoc::Display;
 
 #[derive(Display, Debug)]
 pub enum Error {
@@ -19,7 +19,6 @@ pub enum Error {
 }
 
 impl std::error::Error for Error {}
-
 
 impl From<reqwest::Error> for Error {
     fn from(e: reqwest::Error) -> Self {

--- a/provider/cldr/src/download/error.rs
+++ b/provider/cldr/src/download/error.rs
@@ -18,6 +18,9 @@ pub enum Error {
     NoCacheDir,
 }
 
+impl std::error::Error for Error {}
+
+
 impl From<reqwest::Error> for Error {
     fn from(e: reqwest::Error) -> Self {
         Error::Reqwest(e)

--- a/provider/cldr/src/download/error.rs
+++ b/provider/cldr/src/download/error.rs
@@ -8,13 +8,13 @@ use displaydoc::Display;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("{0}: {1:?}")]
+    #[displaydoc("{0}: {1:?}")]
     Io(#[source] io::Error, Option<PathBuf>),
-    #[error(transparent)]
+    #[displaydoc(transparent)]
     Reqwest(#[from] reqwest::Error),
-    #[error("HTTP request failed: {0}: {1}")]
+    #[displaydoc("HTTP request failed: {0}: {1}")]
     HttpStatus(reqwest::StatusCode, String),
-    #[error("dirs::cache_dir() returned None")]
+    #[displaydoc("dirs::cache_dir() returned None")]
     NoCacheDir,
 }
 

--- a/provider/cldr/src/download/error.rs
+++ b/provider/cldr/src/download/error.rs
@@ -4,7 +4,7 @@
 
 use std::io;
 use std::path::{Path, PathBuf};
-use thiserror::Error;
+use displaydoc::Display;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/provider/cldr/src/download/error.rs
+++ b/provider/cldr/src/download/error.rs
@@ -9,7 +9,7 @@ use displaydoc::Display;
 #[derive(Display, Debug)]
 pub enum Error {
     #[displaydoc("{0}: {1:?}")]
-    Io(#[source] io::Error, Option<PathBuf>),
+    Io(io::Error, Option<PathBuf>),
     #[displaydoc("{0}")]
     Reqwest(reqwest::Error),
     #[displaydoc("HTTP request failed: {0}: {1}")]

--- a/provider/cldr/src/download/error.rs
+++ b/provider/cldr/src/download/error.rs
@@ -11,11 +11,17 @@ pub enum Error {
     #[displaydoc("{0}: {1:?}")]
     Io(#[source] io::Error, Option<PathBuf>),
     #[displaydoc(transparent)]
-    Reqwest(#[from] reqwest::Error),
+    Reqwest(reqwest::Error),
     #[displaydoc("HTTP request failed: {0}: {1}")]
     HttpStatus(reqwest::StatusCode, String),
     #[displaydoc("dirs::cache_dir() returned None")]
     NoCacheDir,
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(e: reqwest::Error) -> Self {
+        Error::Reqwest(e)
+    }
 }
 
 /// To help with debugging, I/O errors should be paired with a file path.

--- a/provider/cldr/src/download/error.rs
+++ b/provider/cldr/src/download/error.rs
@@ -10,7 +10,7 @@ use displaydoc::Display;
 pub enum Error {
     #[displaydoc("{0}: {1:?}")]
     Io(#[source] io::Error, Option<PathBuf>),
-    #[displaydoc(transparent)]
+    #[displaydoc("{0}")]
     Reqwest(reqwest::Error),
     #[displaydoc("HTTP request failed: {0}: {1}")]
     HttpStatus(reqwest::StatusCode, String),

--- a/provider/cldr/src/error.rs
+++ b/provider/cldr/src/error.rs
@@ -12,18 +12,18 @@ use crate::download;
 #[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("{0}: {1:?}")]
+    #[displaydoc("{0}: {1:?}")]
     Io(#[source] std::io::Error, Option<PathBuf>),
-    #[error("JSON error: {0}: {1:?}")]
+    #[displaydoc("JSON error: {0}: {1:?}")]
     Json(#[source] serde_json::error::Error, Option<PathBuf>),
-    #[error("{0}: {1:?}")]
+    #[displaydoc("{0}: {1:?}")]
     Custom(String, Option<LanguageIdentifier>),
-    #[error(transparent)]
+    #[displaydoc(transparent)]
     MissingSource(MissingSourceError),
     #[cfg(feature = "download")]
-    #[error(transparent)]
+    #[displaydoc(transparent)]
     Download(download::Error),
-    #[error("poisoned lock on CLDR provider")]
+    #[displaydoc("poisoned lock on CLDR provider")]
     Poison,
 }
 
@@ -38,7 +38,7 @@ impl From<download::Error> for Error {
 }
 
 #[derive(Error, Debug, PartialEq, Copy, Clone)]
-#[error("Missing CLDR data source: {src}")]
+#[displaydoc("Missing CLDR data source: {src}")]
 pub struct MissingSourceError {
     pub src: &'static str,
 }

--- a/provider/cldr/src/error.rs
+++ b/provider/cldr/src/error.rs
@@ -18,10 +18,10 @@ pub enum Error {
     Json(#[source] serde_json::error::Error, Option<PathBuf>),
     #[displaydoc("{0}: {1:?}")]
     Custom(String, Option<LanguageIdentifier>),
-    #[displaydoc(transparent)]
+    #[displaydoc("{0}")]
     MissingSource(MissingSourceError),
     #[cfg(feature = "download")]
-    #[displaydoc(transparent)]
+    #[displaydoc("{0}")]
     Download(download::Error),
     #[displaydoc("poisoned lock on CLDR provider")]
     Poison,

--- a/provider/cldr/src/error.rs
+++ b/provider/cldr/src/error.rs
@@ -2,9 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use displaydoc::Display;
 use icu_locid::LanguageIdentifier;
 use std::path::{Path, PathBuf};
-use displaydoc::Display;
 
 #[cfg(feature = "download")]
 use crate::download;
@@ -29,7 +29,6 @@ pub enum Error {
 
 impl std::error::Error for Error {}
 
-
 #[cfg(feature = "download")]
 impl From<download::Error> for Error {
     fn from(err: download::Error) -> Error {
@@ -47,7 +46,6 @@ pub struct MissingSourceError {
 }
 
 impl std::error::Error for MissingSourceError {}
-
 
 /// To help with debugging, I/O errors should be paired with a file path.
 /// If a path is unavailable, create the error directly: [`Error::Io`]`(err, `[`None`]`)`

--- a/provider/cldr/src/error.rs
+++ b/provider/cldr/src/error.rs
@@ -13,9 +13,9 @@ use crate::download;
 #[derive(Display, Debug)]
 pub enum Error {
     #[displaydoc("{0}: {1:?}")]
-    Io(#[source] std::io::Error, Option<PathBuf>),
+    Io(std::io::Error, Option<PathBuf>),
     #[displaydoc("JSON error: {0}: {1:?}")]
-    Json(#[source] serde_json::error::Error, Option<PathBuf>),
+    Json(serde_json::error::Error, Option<PathBuf>),
     #[displaydoc("{0}: {1:?}")]
     Custom(String, Option<LanguageIdentifier>),
     #[displaydoc("{0}")]

--- a/provider/cldr/src/error.rs
+++ b/provider/cldr/src/error.rs
@@ -46,7 +46,7 @@ pub struct MissingSourceError {
     pub src: &'static str,
 }
 
-impl std::error::Error for Error {}
+impl std::error::Error for MissingSourceError {}
 
 
 /// To help with debugging, I/O errors should be paired with a file path.

--- a/provider/cldr/src/error.rs
+++ b/provider/cldr/src/error.rs
@@ -27,6 +27,9 @@ pub enum Error {
     Poison,
 }
 
+impl std::error::Error for Error {}
+
+
 #[cfg(feature = "download")]
 impl From<download::Error> for Error {
     fn from(err: download::Error) -> Error {
@@ -42,6 +45,9 @@ impl From<download::Error> for Error {
 pub struct MissingSourceError {
     pub src: &'static str,
 }
+
+impl std::error::Error for Error {}
+
 
 /// To help with debugging, I/O errors should be paired with a file path.
 /// If a path is unavailable, create the error directly: [`Error::Io`]`(err, `[`None`]`)`

--- a/provider/cldr/src/error.rs
+++ b/provider/cldr/src/error.rs
@@ -10,7 +10,7 @@ use displaydoc::Display;
 use crate::download;
 
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Display, Debug)]
 pub enum Error {
     #[displaydoc("{0}: {1:?}")]
     Io(#[source] std::io::Error, Option<PathBuf>),
@@ -37,7 +37,7 @@ impl From<download::Error> for Error {
     }
 }
 
-#[derive(Error, Debug, PartialEq, Copy, Clone)]
+#[derive(Display, Debug, PartialEq, Copy, Clone)]
 #[displaydoc("Missing CLDR data source: {src}")]
 pub struct MissingSourceError {
     pub src: &'static str,

--- a/provider/cldr/src/error.rs
+++ b/provider/cldr/src/error.rs
@@ -4,7 +4,7 @@
 
 use icu_locid::LanguageIdentifier;
 use std::path::{Path, PathBuf};
-use thiserror::Error;
+use displaydoc::Display;
 
 #[cfg(feature = "download")]
 use crate::download;

--- a/provider/cldr/src/transform/numbers/decimal_pattern.rs
+++ b/provider/cldr/src/transform/numbers/decimal_pattern.rs
@@ -12,7 +12,7 @@ use std::borrow::Cow;
 use std::str::FromStr;
 use displaydoc::Display;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Display, Debug, PartialEq)]
 pub enum Error {
     #[displaydoc("No body in decimal subpattern")]
     NoBodyInSubpattern,

--- a/provider/cldr/src/transform/numbers/decimal_pattern.rs
+++ b/provider/cldr/src/transform/numbers/decimal_pattern.rs
@@ -6,11 +6,11 @@
 //!
 //! Spec reference: https://unicode.org/reports/tr35/tr35-numbers.html#Number_Format_Patterns
 
+use displaydoc::Display;
 use icu_decimal::provider::AffixesV1;
 use itertools::Itertools;
 use std::borrow::Cow;
 use std::str::FromStr;
-use displaydoc::Display;
 
 #[derive(Display, Debug, PartialEq)]
 pub enum Error {
@@ -21,7 +21,6 @@ pub enum Error {
 }
 
 impl std::error::Error for Error {}
-
 
 /// Representation of a UTS-35 number subpattern (part of a number pattern between ';'s).
 #[derive(Debug, PartialEq)]

--- a/provider/cldr/src/transform/numbers/decimal_pattern.rs
+++ b/provider/cldr/src/transform/numbers/decimal_pattern.rs
@@ -20,6 +20,9 @@ pub enum Error {
     UnknownPatternBody(String),
 }
 
+impl std::error::Error for Error {}
+
+
 /// Representation of a UTS-35 number subpattern (part of a number pattern between ';'s).
 #[derive(Debug, PartialEq)]
 pub struct DecimalSubPattern {

--- a/provider/cldr/src/transform/numbers/decimal_pattern.rs
+++ b/provider/cldr/src/transform/numbers/decimal_pattern.rs
@@ -10,7 +10,7 @@ use icu_decimal::provider::AffixesV1;
 use itertools::Itertools;
 use std::borrow::Cow;
 use std::str::FromStr;
-use thiserror::Error;
+use displaydoc::Display;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum Error {

--- a/provider/cldr/src/transform/numbers/decimal_pattern.rs
+++ b/provider/cldr/src/transform/numbers/decimal_pattern.rs
@@ -14,9 +14,9 @@ use displaydoc::Display;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum Error {
-    #[error("No body in decimal subpattern")]
+    #[displaydoc("No body in decimal subpattern")]
     NoBodyInSubpattern,
-    #[error("Unknown decimal body: {0}")]
+    #[displaydoc("Unknown decimal body: {0}")]
     UnknownPatternBody(String),
 }
 

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -36,7 +36,7 @@ macros = ["icu_provider_macros"]
 icu_locid = { version = "0.2", path = "../../components/locid" }
 tinystr = "0.4.5"
 writeable = { version = "0.2", path = "../../utils/writeable" }
-thiserror = "1.0"
+displaydoc = { version = "0.2.3", default-features = false }
 yoke = { version = "0.2", path = "../../utils/yoke", features = ["serde", "derive"] }
 icu_provider_macros = { version = "0.2", path = "../macros", optional = true }
 

--- a/provider/core/src/error.rs
+++ b/provider/core/src/error.rs
@@ -4,7 +4,7 @@
 
 use crate::prelude::*;
 use std::any::TypeId;
-use thiserror::Error;
+use displaydoc::Display;
 
 /// Error enumeration for DataProvider.
 #[non_exhaustive]

--- a/provider/core/src/error.rs
+++ b/provider/core/src/error.rs
@@ -3,8 +3,8 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::prelude::*;
-use std::any::TypeId;
 use displaydoc::Display;
+use std::any::TypeId;
 
 /// Error enumeration for DataProvider.
 #[non_exhaustive]
@@ -61,7 +61,6 @@ pub enum Error {
 }
 
 impl std::error::Error for Error {}
-
 
 impl From<erased_serde::Error> for Error {
     fn from(e: erased_serde::Error) -> Self {

--- a/provider/core/src/error.rs
+++ b/provider/core/src/error.rs
@@ -60,6 +60,9 @@ pub enum Error {
     Resource(Box<dyn std::error::Error + Send + Sync>),
 }
 
+impl std::error::Error for Error {}
+
+
 impl From<erased_serde::Error> for Error {
     fn from(e: erased_serde::Error) -> Self {
         Error::Serde(e)

--- a/provider/core/src/error.rs
+++ b/provider/core/src/error.rs
@@ -53,11 +53,23 @@ pub enum Error {
     /// An error occured during serialization or deserialization.
     #[cfg(feature = "erased-serde")]
     #[displaydoc("Serde error: {0}")]
-    Serde(#[from] erased_serde::Error),
+    Serde(erased_serde::Error),
 
     /// The data provider encountered some other error when loading the resource, such as I/O.
     #[displaydoc("Failed to load resource: {0}")]
-    Resource(#[from] Box<dyn std::error::Error + Send + Sync>),
+    Resource(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl From<erased_serde::Error> for Error {
+    fn from(e: erased_serde::Error) -> Self {
+        Error::Serde(e)
+    }
+}
+
+impl From<Box<dyn std::error::Error + Send + Sync>> for Error {
+    fn from(e: Box<dyn std::error::Error + Send + Sync>) -> Self {
+        Error::Resource(e)
+    }
 }
 
 impl Error {

--- a/provider/core/src/error.rs
+++ b/provider/core/src/error.rs
@@ -8,7 +8,7 @@ use displaydoc::Display;
 
 /// Error enumeration for DataProvider.
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Display, Debug)]
 pub enum Error {
     /// The data provider does not support the resource key.
     #[displaydoc("Unsupported resource key: {0}")]

--- a/provider/core/src/error.rs
+++ b/provider/core/src/error.rs
@@ -11,33 +11,33 @@ use displaydoc::Display;
 #[derive(Error, Debug)]
 pub enum Error {
     /// The data provider does not support the resource key.
-    #[error("Unsupported resource key: {0}")]
+    #[displaydoc("Unsupported resource key: {0}")]
     UnsupportedResourceKey(ResourceKey),
 
     /// The data provider supports the key, but does not have data for the specific entry.
-    #[error("Unavailable resource options: {0}")]
+    #[displaydoc("Unavailable resource options: {0}")]
     UnavailableResourceOptions(DataRequest),
 
     /// The resource was not returned due to a filter. The resource may or may not be available.
-    #[error("Resource was filtered: {1}: {0}")]
+    #[displaydoc("Resource was filtered: {1}: {0}")]
     FilteredResource(DataRequest, String),
 
     /// The data provider supports the key, but it requires a language identifier, which was
     /// missing from the request.
-    #[error("Requested key needs language identifier in request: {0}")]
+    #[displaydoc("Requested key needs language identifier in request: {0}")]
     NeedsLanguageIdentifier(DataRequest),
 
     /// The operation cannot be completed without more type information. For example, data
     /// cannot be deserialized without the concrete type.
-    #[error("Complete type information is required")]
+    #[displaydoc("Complete type information is required")]
     NeedsTypeInfo,
 
     /// The payload is missing. This error is usually unexpected.
-    #[error("Payload is missing")]
+    #[displaydoc("Payload is missing")]
     MissingPayload,
 
     /// The TypeID of the payload does not match the expected TypeID.
-    #[error("Mismatched type: payload is {actual:?} (expected from generic type paramenter: {generic:?})")]
+    #[displaydoc("Mismatched type: payload is {actual:?} (expected from generic type paramenter: {generic:?})")]
     MismatchedType {
         /// The actual TypeID of the payload, if available.
         actual: Option<TypeId>,
@@ -47,16 +47,16 @@ pub enum Error {
     },
 
     /// The requested operation failed to unwrap an Rc backing the data payload.
-    #[error("Could not unwrap Rc due to multiple references")]
+    #[displaydoc("Could not unwrap Rc due to multiple references")]
     MultipleReferences,
 
     /// An error occured during serialization or deserialization.
     #[cfg(feature = "erased-serde")]
-    #[error("Serde error: {0}")]
+    #[displaydoc("Serde error: {0}")]
     Serde(#[from] erased_serde::Error),
 
     /// The data provider encountered some other error when loading the resource, such as I/O.
-    #[error("Failed to load resource: {0}")]
+    #[displaydoc("Failed to load resource: {0}")]
     Resource(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 

--- a/provider/core/src/error.rs
+++ b/provider/core/src/error.rs
@@ -62,6 +62,7 @@ pub enum Error {
 
 impl std::error::Error for Error {}
 
+#[cfg(feature = "erased-serde")]
 impl From<erased_serde::Error> for Error {
     fn from(e: erased_serde::Error) -> Self {
         Error::Serde(e)

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -37,7 +37,7 @@ icu_provider = { version = "0.2", path = "../../provider/core", features = ["pro
 icu_locid = { version = "0.2", path = "../../components/locid", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 erased-serde = { version = "0.3" }
-thiserror = "1.0"
+displaydoc = { version = "0.2.3", default-features = false }
 
 # Serializers
 # Note: serde_json is always included because it is used for parsing manifest.json

--- a/provider/fs/src/deserializer.rs
+++ b/provider/fs/src/deserializer.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::manifest::SyntaxOption;
+use displaydoc::Display;
 use icu_provider::prelude::*;
 use icu_provider::serde::*;
 use icu_provider::yoke::trait_hack::YokeTraitHack;
@@ -10,7 +11,6 @@ use icu_provider::yoke::Yokeable;
 use serde::Deserialize;
 use std::path::Path;
 use std::rc::Rc;
-use displaydoc::Display;
 
 /// An Error type specifically for the [`Deserializer`](serde::Deserializer) that doesn't carry filenames
 #[derive(Display, Debug)]
@@ -28,7 +28,6 @@ pub enum Error {
 }
 
 impl std::error::Error for Error {}
-
 
 impl From<serde_json::error::Error> for Error {
     fn from(e: serde_json::error::Error) -> Self {

--- a/provider/fs/src/deserializer.rs
+++ b/provider/fs/src/deserializer.rs
@@ -13,7 +13,7 @@ use std::rc::Rc;
 use displaydoc::Display;
 
 /// An Error type specifically for the [`Deserializer`](serde::Deserializer) that doesn't carry filenames
-#[derive(Error, Debug)]
+#[derive(Display, Debug)]
 pub enum Error {
     #[displaydoc(transparent)]
     Json(#[from] serde_json::error::Error),

--- a/provider/fs/src/deserializer.rs
+++ b/provider/fs/src/deserializer.rs
@@ -27,6 +27,9 @@ pub enum Error {
     UnknownSyntax(SyntaxOption),
 }
 
+impl std::error::Error for Error {}
+
+
 impl From<serde_json::error::Error> for Error {
     fn from(e: serde_json::error::Error) -> Self {
         Error::Json(e)

--- a/provider/fs/src/deserializer.rs
+++ b/provider/fs/src/deserializer.rs
@@ -16,15 +16,33 @@ use displaydoc::Display;
 #[derive(Display, Debug)]
 pub enum Error {
     #[displaydoc(transparent)]
-    Json(#[from] serde_json::error::Error),
+    Json(serde_json::error::Error),
     #[cfg(feature = "bincode")]
     #[displaydoc(transparent)]
-    Bincode(#[from] bincode::Error),
+    Bincode(bincode::Error),
     #[displaydoc(transparent)]
-    DataProvider(#[from] DataError),
+    DataProvider(DataError),
     #[allow(dead_code)]
     #[displaydoc("Unknown syntax: {0:?}")]
     UnknownSyntax(SyntaxOption),
+}
+
+impl From<serde_json::error::Error> for Error {
+    fn from(e: serde_json::error::Error) -> Self {
+        Error::Json(e)
+    }
+}
+
+impl From<bincode::Error> for Error {
+    fn from(e: bincode::Error) -> Self {
+        Error::Bincode(e)
+    }
+}
+
+impl From<DataError> for Error {
+    fn from(e: DataError) -> Self {
+        Error::DataProvider(e)
+    }
 }
 
 impl Error {

--- a/provider/fs/src/deserializer.rs
+++ b/provider/fs/src/deserializer.rs
@@ -15,15 +15,15 @@ use displaydoc::Display;
 /// An Error type specifically for the [`Deserializer`](serde::Deserializer) that doesn't carry filenames
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error(transparent)]
+    #[displaydoc(transparent)]
     Json(#[from] serde_json::error::Error),
     #[cfg(feature = "bincode")]
-    #[error(transparent)]
+    #[displaydoc(transparent)]
     Bincode(#[from] bincode::Error),
-    #[error(transparent)]
+    #[displaydoc(transparent)]
     DataProvider(#[from] DataError),
     #[allow(dead_code)]
-    #[error("Unknown syntax: {0:?}")]
+    #[displaydoc("Unknown syntax: {0:?}")]
     UnknownSyntax(SyntaxOption),
 }
 

--- a/provider/fs/src/deserializer.rs
+++ b/provider/fs/src/deserializer.rs
@@ -10,7 +10,7 @@ use icu_provider::yoke::Yokeable;
 use serde::Deserialize;
 use std::path::Path;
 use std::rc::Rc;
-use thiserror::Error;
+use displaydoc::Display;
 
 /// An Error type specifically for the [`Deserializer`](serde::Deserializer) that doesn't carry filenames
 #[derive(Error, Debug)]

--- a/provider/fs/src/deserializer.rs
+++ b/provider/fs/src/deserializer.rs
@@ -35,6 +35,7 @@ impl From<serde_json::error::Error> for Error {
     }
 }
 
+#[cfg(feature = "bincode")]
 impl From<bincode::Error> for Error {
     fn from(e: bincode::Error) -> Self {
         Error::Bincode(e)

--- a/provider/fs/src/deserializer.rs
+++ b/provider/fs/src/deserializer.rs
@@ -15,12 +15,12 @@ use displaydoc::Display;
 /// An Error type specifically for the [`Deserializer`](serde::Deserializer) that doesn't carry filenames
 #[derive(Display, Debug)]
 pub enum Error {
-    #[displaydoc(transparent)]
+    #[displaydoc("{0}")]
     Json(serde_json::error::Error),
     #[cfg(feature = "bincode")]
-    #[displaydoc(transparent)]
+    #[displaydoc("{0}")]
     Bincode(bincode::Error),
-    #[displaydoc(transparent)]
+    #[displaydoc("{0}")]
     DataProvider(DataError),
     #[allow(dead_code)]
     #[displaydoc("Unknown syntax: {0:?}")]

--- a/provider/fs/src/error.rs
+++ b/provider/fs/src/error.rs
@@ -9,17 +9,17 @@ use displaydoc::Display;
 #[derive(Display, Debug)]
 pub enum Error {
     #[displaydoc("{0}: {1:?}")]
-    Io(#[source] std::io::Error, Option<PathBuf>),
+    Io(std::io::Error, Option<PathBuf>),
     #[displaydoc("{0}")]
     DataProvider(icu_provider::DataError),
     #[displaydoc("Deserializer error: {0}: {1:?}")]
     Deserializer(
-        #[source] Box<dyn std::error::Error + Send + Sync>,
+        Box<dyn std::error::Error + Send + Sync>,
         Option<PathBuf>,
     ),
     #[cfg(feature = "export")]
     #[displaydoc("Serializer error: {0}: {1:?}")]
-    Serializer(#[source] erased_serde::Error, Option<PathBuf>),
+    Serializer(erased_serde::Error, Option<PathBuf>),
     #[displaydoc("Unknown syntax {0:?}. Do you need to enable a feature?")]
     UnknownSyntax(SyntaxOption),
 }

--- a/provider/fs/src/error.rs
+++ b/provider/fs/src/error.rs
@@ -4,7 +4,7 @@
 
 use crate::manifest::SyntaxOption;
 use std::path::{Path, PathBuf};
-use thiserror::Error;
+use displaydoc::Display;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/provider/fs/src/error.rs
+++ b/provider/fs/src/error.rs
@@ -11,7 +11,7 @@ pub enum Error {
     #[displaydoc("{0}: {1:?}")]
     Io(#[source] std::io::Error, Option<PathBuf>),
     #[displaydoc(transparent)]
-    DataProvider(#[from] icu_provider::DataError),
+    DataProvider(icu_provider::DataError),
     #[displaydoc("Deserializer error: {0}: {1:?}")]
     Deserializer(
         #[source] Box<dyn std::error::Error + Send + Sync>,
@@ -22,6 +22,12 @@ pub enum Error {
     Serializer(#[source] erased_serde::Error, Option<PathBuf>),
     #[displaydoc("Unknown syntax {0:?}. Do you need to enable a feature?")]
     UnknownSyntax(SyntaxOption),
+}
+
+impl From<icu_provider::DataError> for Error {
+    fn from(e: icu_provider::DataError) -> Self {
+        Error::DataProvider(e)
+    }
 }
 
 /// To help with debugging, I/O errors should be paired with a file path.

--- a/provider/fs/src/error.rs
+++ b/provider/fs/src/error.rs
@@ -8,19 +8,19 @@ use displaydoc::Display;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("{0}: {1:?}")]
+    #[displaydoc("{0}: {1:?}")]
     Io(#[source] std::io::Error, Option<PathBuf>),
-    #[error(transparent)]
+    #[displaydoc(transparent)]
     DataProvider(#[from] icu_provider::DataError),
-    #[error("Deserializer error: {0}: {1:?}")]
+    #[displaydoc("Deserializer error: {0}: {1:?}")]
     Deserializer(
         #[source] Box<dyn std::error::Error + Send + Sync>,
         Option<PathBuf>,
     ),
     #[cfg(feature = "export")]
-    #[error("Serializer error: {0}: {1:?}")]
+    #[displaydoc("Serializer error: {0}: {1:?}")]
     Serializer(#[source] erased_serde::Error, Option<PathBuf>),
-    #[error("Unknown syntax {0:?}. Do you need to enable a feature?")]
+    #[displaydoc("Unknown syntax {0:?}. Do you need to enable a feature?")]
     UnknownSyntax(SyntaxOption),
 }
 

--- a/provider/fs/src/error.rs
+++ b/provider/fs/src/error.rs
@@ -24,6 +24,9 @@ pub enum Error {
     UnknownSyntax(SyntaxOption),
 }
 
+impl std::error::Error for Error {}
+
+
 impl From<icu_provider::DataError> for Error {
     fn from(e: icu_provider::DataError) -> Self {
         Error::DataProvider(e)

--- a/provider/fs/src/error.rs
+++ b/provider/fs/src/error.rs
@@ -3,8 +3,8 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::manifest::SyntaxOption;
-use std::path::{Path, PathBuf};
 use displaydoc::Display;
+use std::path::{Path, PathBuf};
 
 #[derive(Display, Debug)]
 pub enum Error {
@@ -13,10 +13,7 @@ pub enum Error {
     #[displaydoc("{0}")]
     DataProvider(icu_provider::DataError),
     #[displaydoc("Deserializer error: {0}: {1:?}")]
-    Deserializer(
-        Box<dyn std::error::Error + Send + Sync>,
-        Option<PathBuf>,
-    ),
+    Deserializer(Box<dyn std::error::Error + Send + Sync>, Option<PathBuf>),
     #[cfg(feature = "export")]
     #[displaydoc("Serializer error: {0}: {1:?}")]
     Serializer(erased_serde::Error, Option<PathBuf>),
@@ -25,7 +22,6 @@ pub enum Error {
 }
 
 impl std::error::Error for Error {}
-
 
 impl From<icu_provider::DataError> for Error {
     fn from(e: icu_provider::DataError) -> Self {

--- a/provider/fs/src/error.rs
+++ b/provider/fs/src/error.rs
@@ -6,7 +6,7 @@ use crate::manifest::SyntaxOption;
 use std::path::{Path, PathBuf};
 use displaydoc::Display;
 
-#[derive(Error, Debug)]
+#[derive(Display, Debug)]
 pub enum Error {
     #[displaydoc("{0}: {1:?}")]
     Io(#[source] std::io::Error, Option<PathBuf>),

--- a/provider/fs/src/error.rs
+++ b/provider/fs/src/error.rs
@@ -10,7 +10,7 @@ use displaydoc::Display;
 pub enum Error {
     #[displaydoc("{0}: {1:?}")]
     Io(#[source] std::io::Error, Option<PathBuf>),
-    #[displaydoc(transparent)]
+    #[displaydoc("{0}")]
     DataProvider(icu_provider::DataError),
     #[displaydoc("Deserializer error: {0}: {1:?}")]
     Deserializer(

--- a/provider/fs/src/export/serializers/mod.rs
+++ b/provider/fs/src/export/serializers/mod.rs
@@ -15,9 +15,9 @@ use displaydoc::Display;
 /// An Error type specifically for the [`Serializer`](serde::Serializer) that doesn't carry filenames
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error(transparent)]
+    #[displaydoc(transparent)]
     Io(#[from] io::Error),
-    #[error(transparent)]
+    #[displaydoc(transparent)]
     Serializer(#[from] erased_serde::Error),
 }
 

--- a/provider/fs/src/export/serializers/mod.rs
+++ b/provider/fs/src/export/serializers/mod.rs
@@ -16,11 +16,22 @@ use displaydoc::Display;
 #[derive(Display, Debug)]
 pub enum Error {
     #[displaydoc(transparent)]
-    Io(#[from] io::Error),
+    Io(io::Error),
     #[displaydoc(transparent)]
-    Serializer(#[from] erased_serde::Error),
+    Serializer(erased_serde::Error),
 }
 
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Error::Io(e)
+    }
+}
+
+impl From<erased_serde::Error> for Error {
+    fn from(e: erased_serde::Error) -> Self {
+        Error::Serializer(e)
+    }
+}
 /// A simple serializer trait that works on whole objects.
 pub trait AbstractSerializer: Deref<Target = SyntaxOption> {
     /// Serializes an object to a sink.

--- a/provider/fs/src/export/serializers/mod.rs
+++ b/provider/fs/src/export/serializers/mod.rs
@@ -15,9 +15,9 @@ use displaydoc::Display;
 /// An Error type specifically for the [`Serializer`](serde::Serializer) that doesn't carry filenames
 #[derive(Display, Debug)]
 pub enum Error {
-    #[displaydoc(transparent)]
+    #[displaydoc("{0}")]
     Io(io::Error),
-    #[displaydoc(transparent)]
+    #[displaydoc("{0}")]
     Serializer(erased_serde::Error),
 }
 

--- a/provider/fs/src/export/serializers/mod.rs
+++ b/provider/fs/src/export/serializers/mod.rs
@@ -13,7 +13,7 @@ use std::ops::Deref;
 use displaydoc::Display;
 
 /// An Error type specifically for the [`Serializer`](serde::Serializer) that doesn't carry filenames
-#[derive(Error, Debug)]
+#[derive(Display, Debug)]
 pub enum Error {
     #[displaydoc(transparent)]
     Io(#[from] io::Error),

--- a/provider/fs/src/export/serializers/mod.rs
+++ b/provider/fs/src/export/serializers/mod.rs
@@ -8,9 +8,9 @@ pub mod json;
 pub mod bincode;
 
 use crate::manifest::SyntaxOption;
+use displaydoc::Display;
 use std::io;
 use std::ops::Deref;
-use displaydoc::Display;
 
 /// An Error type specifically for the [`Serializer`](serde::Serializer) that doesn't carry filenames
 #[derive(Display, Debug)]
@@ -22,7 +22,6 @@ pub enum Error {
 }
 
 impl std::error::Error for Error {}
-
 
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self {

--- a/provider/fs/src/export/serializers/mod.rs
+++ b/provider/fs/src/export/serializers/mod.rs
@@ -21,6 +21,9 @@ pub enum Error {
     Serializer(erased_serde::Error),
 }
 
+impl std::error::Error for Error {}
+
+
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self {
         Error::Io(e)

--- a/provider/fs/src/export/serializers/mod.rs
+++ b/provider/fs/src/export/serializers/mod.rs
@@ -10,7 +10,7 @@ pub mod bincode;
 use crate::manifest::SyntaxOption;
 use std::io;
 use std::ops::Deref;
-use thiserror::Error;
+use displaydoc::Display;
 
 /// An Error type specifically for the [`Serializer`](serde::Serializer) that doesn't carry filenames
 #[derive(Error, Debug)]

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -134,7 +134,7 @@ icu_locid = { version = "0.2", path = "../../components/locid" }
 cargo_metadata = { version = "0.13", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
-thiserror = { version = "1.0", optional = true }
+displaydoc = { version = "0.2.3", default-features = false, optional = true }
 writeable = { version = "0.2", path = "../../utils/writeable", optional = true }
 
 [dev-dependencies]
@@ -148,6 +148,6 @@ metadata = [
     "icu_locid/serde",
     "serde_json",
     "serde",
-    "thiserror",
+    "displaydoc",
     "writeable",
 ]

--- a/provider/testdata/src/metadata.rs
+++ b/provider/testdata/src/metadata.rs
@@ -9,13 +9,13 @@ use displaydoc::Display;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Cargo Error: {0}")]
+    #[displaydoc("Cargo Error: {0}")]
     Cargo(#[from] cargo_metadata::Error),
-    #[error("Serde Error: {0}")]
+    #[displaydoc("Serde Error: {0}")]
     SerdeJson(#[from] serde_json::Error),
-    #[error("{0}: package not found", env!("CARGO_PKG_NAME"))]
+    #[displaydoc("{0}: package not found", env!("CARGO_PKG_NAME"))]
     PackageNotFound,
-    #[error("package.metadata.icu4x_testdata not found")]
+    #[displaydoc("package.metadata.icu4x_testdata not found")]
     MetadataNotFound,
 }
 

--- a/provider/testdata/src/metadata.rs
+++ b/provider/testdata/src/metadata.rs
@@ -7,7 +7,7 @@ use icu_locid::LanguageIdentifier;
 use serde::Deserialize;
 use displaydoc::Display;
 
-#[derive(Error, Debug)]
+#[derive(Display, Debug)]
 pub enum Error {
     #[displaydoc("Cargo Error: {0}")]
     Cargo(#[from] cargo_metadata::Error),

--- a/provider/testdata/src/metadata.rs
+++ b/provider/testdata/src/metadata.rs
@@ -13,7 +13,7 @@ pub enum Error {
     Cargo(cargo_metadata::Error),
     #[displaydoc("Serde Error: {0}")]
     SerdeJson(serde_json::Error),
-    #[displaydoc("{0}: package not found", env!("CARGO_PKG_NAME"))]
+    #[displaydoc("Package not found")]
     PackageNotFound,
     #[displaydoc("package.metadata.icu4x_testdata not found")]
     MetadataNotFound,

--- a/provider/testdata/src/metadata.rs
+++ b/provider/testdata/src/metadata.rs
@@ -5,7 +5,7 @@
 use cargo_metadata::{self, camino::Utf8PathBuf, MetadataCommand};
 use icu_locid::LanguageIdentifier;
 use serde::Deserialize;
-use thiserror::Error;
+use displaydoc::Display;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/provider/testdata/src/metadata.rs
+++ b/provider/testdata/src/metadata.rs
@@ -10,13 +10,25 @@ use displaydoc::Display;
 #[derive(Display, Debug)]
 pub enum Error {
     #[displaydoc("Cargo Error: {0}")]
-    Cargo(#[from] cargo_metadata::Error),
+    Cargo(cargo_metadata::Error),
     #[displaydoc("Serde Error: {0}")]
-    SerdeJson(#[from] serde_json::Error),
+    SerdeJson(serde_json::Error),
     #[displaydoc("{0}: package not found", env!("CARGO_PKG_NAME"))]
     PackageNotFound,
     #[displaydoc("package.metadata.icu4x_testdata not found")]
     MetadataNotFound,
+}
+
+impl From<cargo_metadata::Error> for Error {
+    fn from(e: cargo_metadata::Error) -> Self {
+        Error::Cargo(e)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(e: serde_json::Error) -> Self {
+        Error::SerdeJson(e)
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/provider/testdata/src/metadata.rs
+++ b/provider/testdata/src/metadata.rs
@@ -19,6 +19,9 @@ pub enum Error {
     MetadataNotFound,
 }
 
+impl std::error::Error for Error {}
+
+
 impl From<cargo_metadata::Error> for Error {
     fn from(e: cargo_metadata::Error) -> Self {
         Error::Cargo(e)

--- a/provider/testdata/src/metadata.rs
+++ b/provider/testdata/src/metadata.rs
@@ -3,9 +3,9 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use cargo_metadata::{self, camino::Utf8PathBuf, MetadataCommand};
+use displaydoc::Display;
 use icu_locid::LanguageIdentifier;
 use serde::Deserialize;
-use displaydoc::Display;
 
 #[derive(Display, Debug)]
 pub enum Error {
@@ -20,7 +20,6 @@ pub enum Error {
 }
 
 impl std::error::Error for Error {}
-
 
 impl From<cargo_metadata::Error> for Error {
     fn from(e: cargo_metadata::Error) -> Self {

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -29,7 +29,7 @@ all-features = true
 smallvec = "1.6"
 static_assertions = "1.1"
 writeable = { version = "0.2", path = "../../utils/writeable" }
-thiserror = "1.0"
+displaydoc = { version = "0.2.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/utils/fixed_decimal/src/lib.rs
+++ b/utils/fixed_decimal/src/lib.rs
@@ -44,7 +44,7 @@ mod uint_iterator;
 
 pub use decimal::FixedDecimal;
 pub use signum::Signum;
-use thiserror::Error;
+use displaydoc::Display;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum Error {

--- a/utils/fixed_decimal/src/lib.rs
+++ b/utils/fixed_decimal/src/lib.rs
@@ -46,7 +46,7 @@ pub use decimal::FixedDecimal;
 pub use signum::Signum;
 use displaydoc::Display;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Display, Debug, PartialEq)]
 pub enum Error {
     /// The magnitude or number of digits exceeds the limit of the FixedDecimal. The highest
     /// magnitude of the most significant digit is std::i16::MAX, and the lowest magnitude of the

--- a/utils/fixed_decimal/src/lib.rs
+++ b/utils/fixed_decimal/src/lib.rs
@@ -73,3 +73,6 @@ pub enum Error {
     #[displaydoc("Failed to parse the input string")]
     Syntax,
 }
+
+impl std::error::Error for Error {}
+

--- a/utils/fixed_decimal/src/lib.rs
+++ b/utils/fixed_decimal/src/lib.rs
@@ -43,8 +43,8 @@ pub mod signum;
 mod uint_iterator;
 
 pub use decimal::FixedDecimal;
-pub use signum::Signum;
 use displaydoc::Display;
+pub use signum::Signum;
 
 #[derive(Display, Debug, PartialEq)]
 pub enum Error {
@@ -75,4 +75,3 @@ pub enum Error {
 }
 
 impl std::error::Error for Error {}
-

--- a/utils/fixed_decimal/src/lib.rs
+++ b/utils/fixed_decimal/src/lib.rs
@@ -61,7 +61,7 @@ pub enum Error {
     /// let mut dec1 = FixedDecimal::from(123);
     /// assert_eq!(Error::Limit, dec1.multiply_pow10(std::i16::MAX).unwrap_err());
     /// ```
-    #[error("Magnitude or number of digits exceeded")]
+    #[displaydoc("Magnitude or number of digits exceeded")]
     Limit,
     /// The input of a string that is supposed to be converted to FixedDecimal is not accepted.
     ///
@@ -70,6 +70,6 @@ pub enum Error {
     /// Strings of form "12_345_678" are not accepted, the accepted format is "12345678".
     /// Also '.' shouldn't be first or the last characters, i. e. .123 and 123. are not accepted, and instead 0.123 and
     /// 123 (or 123.0) must be used.
-    #[error("Failed to parse the input string")]
+    #[displaydoc("Failed to parse the input string")]
     Syntax,
 }

--- a/utils/pattern/Cargo.toml
+++ b/utils/pattern/Cargo.toml
@@ -23,7 +23,7 @@ include = [
 all-features = true
 
 [dependencies]
-thiserror = "1"
+displaydoc = { version = "0.2.3", default-features = false }
 writeable = { version = "0.2", path = "../writeable" }
 
 [dev-dependencies]

--- a/utils/pattern/src/interpolator/error.rs
+++ b/utils/pattern/src/interpolator/error.rs
@@ -10,7 +10,7 @@ use displaydoc::Display;
 /// # Type parameters
 ///
 /// - `K`: A key for the replacement provider.
-#[derive(Error, Debug, PartialEq)]
+#[derive(Display, Debug, PartialEq)]
 pub enum InterpolatorError<K>
 where
     K: Debug + FromStr + PartialEq,

--- a/utils/pattern/src/interpolator/error.rs
+++ b/utils/pattern/src/interpolator/error.rs
@@ -25,3 +25,6 @@ where
     #[displaydoc("Unclosed quoted literal")]
     UnclosedQuotedLiteral,
 }
+
+impl std::error::Error for InterpolatorError {}
+

--- a/utils/pattern/src/interpolator/error.rs
+++ b/utils/pattern/src/interpolator/error.rs
@@ -16,12 +16,12 @@ where
     K: Debug + FromStr + PartialEq,
     K::Err: Debug + PartialEq,
 {
-    #[error("Invalid placeholder: {0:?}")]
+    #[displaydoc("Invalid placeholder: {0:?}")]
     InvalidPlaceholder(K::Err),
-    #[error("Missing placeholder: {0:?}")]
+    #[displaydoc("Missing placeholder: {0:?}")]
     MissingPlaceholder(K),
-    #[error("Unclosed placeholder")]
+    #[displaydoc("Unclosed placeholder")]
     UnclosedPlaceholder,
-    #[error("Unclosed quoted literal")]
+    #[displaydoc("Unclosed quoted literal")]
     UnclosedQuotedLiteral,
 }

--- a/utils/pattern/src/interpolator/error.rs
+++ b/utils/pattern/src/interpolator/error.rs
@@ -2,8 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use std::{fmt::Debug, str::FromStr};
 use displaydoc::Display;
+use std::{fmt::Debug, str::FromStr};
 
 /// An error returned when interpolating a pattern.
 ///
@@ -26,5 +26,9 @@ where
     UnclosedQuotedLiteral,
 }
 
-impl std::error::Error for InterpolatorError {}
-
+impl<K> std::error::Error for InterpolatorError<K>
+where
+    K: Debug + FromStr + PartialEq,
+    K::Err: Debug + PartialEq,
+{
+}

--- a/utils/pattern/src/interpolator/error.rs
+++ b/utils/pattern/src/interpolator/error.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use std::{fmt::Debug, str::FromStr};
-use thiserror::Error;
+use displaydoc::Display;
 
 /// An error returned when interpolating a pattern.
 ///

--- a/utils/pattern/src/parser/error.rs
+++ b/utils/pattern/src/parser/error.rs
@@ -28,18 +28,18 @@ where
     E: Debug,
 {
     /// Encountered an illegal character.
-    #[error("Illegal character: {0}.")]
+    #[displaydoc("Illegal character: {0}.")]
     IllegalCharacter(char),
 
     /// Placeholder hould not be parsed from the given string slice.
-    #[error("Invalid placeholder: {0:?}")]
+    #[displaydoc("Invalid placeholder: {0:?}")]
     InvalidPlaceholder(E),
 
     /// The pattern contains an unclosed placeholder.
-    #[error("Unclosed placeholder")]
+    #[displaydoc("Unclosed placeholder")]
     UnclosedPlaceholder,
 
     /// The pattern contains an unclosed quoted literal.
-    #[error("Unclosed quoted literal")]
+    #[displaydoc("Unclosed quoted literal")]
     UnclosedQuotedLiteral,
 }

--- a/utils/pattern/src/parser/error.rs
+++ b/utils/pattern/src/parser/error.rs
@@ -2,8 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use std::fmt::Debug;
 use displaydoc::Display;
+use std::fmt::Debug;
 
 /// An error returned when parsing a pattern.
 ///
@@ -44,5 +44,4 @@ where
     UnclosedQuotedLiteral,
 }
 
-impl std::error::Error for ParserError {}
-
+impl<E: Debug> std::error::Error for ParserError<E> {}

--- a/utils/pattern/src/parser/error.rs
+++ b/utils/pattern/src/parser/error.rs
@@ -43,3 +43,6 @@ where
     #[displaydoc("Unclosed quoted literal")]
     UnclosedQuotedLiteral,
 }
+
+impl std::error::Error for ParserError {}
+

--- a/utils/pattern/src/parser/error.rs
+++ b/utils/pattern/src/parser/error.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use std::fmt::Debug;
-use thiserror::Error;
+use displaydoc::Display;
 
 /// An error returned when parsing a pattern.
 ///

--- a/utils/pattern/src/parser/error.rs
+++ b/utils/pattern/src/parser/error.rs
@@ -22,7 +22,7 @@ use displaydoc::Display;
 /// - `E`: An error of the replacement type which implements [`FromStr`].
 ///
 /// [`FromStr`]: std::str::FromStr
-#[derive(Error, Debug, PartialEq)]
+#[derive(Display, Debug, PartialEq)]
 pub enum ParserError<E>
 where
     E: Debug,

--- a/utils/pattern/src/pattern/error.rs
+++ b/utils/pattern/src/pattern/error.rs
@@ -3,8 +3,8 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::interpolator::InterpolatorError;
-use std::{fmt::Debug, str::FromStr};
 use displaydoc::Display;
+use std::{fmt::Debug, str::FromStr};
 
 /// An error returned from a pattern.
 ///
@@ -23,8 +23,12 @@ where
     Format(std::fmt::Error),
 }
 
-impl std::error::Error for PatternError {}
-
+impl<K> std::error::Error for PatternError<K>
+where
+    K: Debug + FromStr + PartialEq,
+    K::Err: Debug + PartialEq,
+{
+}
 
 impl<K> From<InterpolatorError<K>> for PatternError<K>
 where

--- a/utils/pattern/src/pattern/error.rs
+++ b/utils/pattern/src/pattern/error.rs
@@ -11,7 +11,7 @@ use displaydoc::Display;
 /// # Type parameters
 ///
 /// - `K`: A key for the replacement provider.
-#[derive(Error, Debug, PartialEq)]
+#[derive(Display, Debug, PartialEq)]
 pub enum PatternError<K>
 where
     K: Debug + FromStr + PartialEq,

--- a/utils/pattern/src/pattern/error.rs
+++ b/utils/pattern/src/pattern/error.rs
@@ -4,7 +4,7 @@
 
 use crate::interpolator::InterpolatorError;
 use std::{fmt::Debug, str::FromStr};
-use thiserror::Error;
+use displaydoc::Display;
 
 /// An error returned from a pattern.
 ///

--- a/utils/pattern/src/pattern/error.rs
+++ b/utils/pattern/src/pattern/error.rs
@@ -17,9 +17,9 @@ where
     K: Debug + FromStr + PartialEq,
     K::Err: Debug + PartialEq,
 {
-    #[error("Interpolator error: {0:?}")]
+    #[displaydoc("Interpolator error: {0:?}")]
     Interpolator(InterpolatorError<K>),
-    #[error("Format error: {0:?}")]
+    #[displaydoc("Format error: {0:?}")]
     Format(std::fmt::Error),
 }
 

--- a/utils/pattern/src/pattern/error.rs
+++ b/utils/pattern/src/pattern/error.rs
@@ -23,6 +23,9 @@ where
     Format(std::fmt::Error),
 }
 
+impl std::error::Error for PatternError {}
+
+
 impl<K> From<InterpolatorError<K>> for PatternError<K>
 where
     K: Debug + FromStr + PartialEq,


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/860

I added [a displaydoc feature](https://github.com/yaahc/displaydoc/pull/31) that makes it more suited to our use case.


I've tried to include code transformation commands (fastmod, awk) in the commit message where I used them.

We have a couple downsides of this change:

 - `From` impls need to be manually written when required (not a huge deal)
 - An explicit `impl std::error::Error for FooError {}` is needed everywhere. We could follow this up with a custom derive but that seems like overkill to me

However, this change is required to sensibly support `no_std`.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->