### PR TITLE
Progress towards no_std

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,6 +13,8 @@ tidy = "make tidy"
 # field-reassign-with-default: https://github.com/rust-lang/rust-clippy/issues/6559 (fixed in nightly but not stable)
 clippy-all = "clippy --all-features --all-targets -- -D warnings -Aclippy::field-reassign-with-default"
 
+check-thumb = "check --target thumbv7m-none-eabi"
+build-thumb = "build --target thumbv7m-none-eabi"
 ### WASM TASKS ###
 
 # Re-build standard library with panic=abort.

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,8 +13,6 @@ tidy = "make tidy"
 # field-reassign-with-default: https://github.com/rust-lang/rust-clippy/issues/6559 (fixed in nightly but not stable)
 clippy-all = "clippy --all-features --all-targets -- -D warnings -Aclippy::field-reassign-with-default"
 
-check-thumb = "check --target thumbv7m-none-eabi"
-build-thumb = "build --target thumbv7m-none-eabi"
 ### WASM TASKS ###
 
 # Re-build standard library with panic=abort.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,9 +2170,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "274c8ef43098dbaf4eb9cef570b1779a60ed3f0ea00fe745f7a95322d0a234e3"
+checksum = "01e8700bce17d12d9653596139d85039dd63b8728839a9f2e0c540d5301ea0cd"
 dependencies = [
  "serde",
  "tinystr-macros",
@@ -2190,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr-raw"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4dbdb0ea4eb91bce69f87d488ec7954f1aec64907fc4bc7dacbd787a398ed8"
+checksum = "10f87ef8b0485e4efff5cac95608adc3251e412fef6039ecd56c5618c8003895"
 
 [[package]]
 name = "tinytemplate"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,9 +2170,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.4.5"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0bc8f45dc08e13992f1596a7cbd410e3cdcac1d165ca909ab6ae5568566cbb"
+checksum = "dd713fb7e7bfdf9a373054abff0f85636af648e820edf5f2a42d68e812a55c0c"
 dependencies = [
  "serde",
  "tinystr-macros",
@@ -2190,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr-raw"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b975dd2af5824896acaeebf7336471fcafebfa417da0a290ded5509f297ccedb"
+checksum = "4c4dbdb0ea4eb91bce69f87d488ec7954f1aec64907fc4bc7dacbd787a398ed8"
 
 [[package]]
 name = "tinytemplate"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,9 +2170,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd713fb7e7bfdf9a373054abff0f85636af648e820edf5f2a42d68e812a55c0c"
+checksum = "274c8ef43098dbaf4eb9cef570b1779a60ed3f0ea00fe745f7a95322d0a234e3"
 dependencies = [
  "serde",
  "tinystr-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 [workspace]
-
+resolver = "2"
 members = [
     "components/datetime",
     "components/decimal",

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -34,7 +34,7 @@ icu_provider = { version = "0.2", path = "../../provider/core", features = ["mac
 writeable = { version = "0.2", path = "../../utils/writeable" }
 litemap = { version = "0.2", path = "../../utils/litemap", features = ["serde"] }
 tinystr = { version = "0.4.8", features = ["alloc"], default-features = false }
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 smallvec = "1.6"
 displaydoc = { version = "0.2.3", default-features = false }
 

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -33,7 +33,7 @@ icu_locid = { version = "0.2", path = "../locid" }
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["macros"] }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 litemap = { version = "0.2", path = "../../utils/litemap", features = ["serde"] }
-tinystr = { version = "0.4.8", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.9", features = ["alloc"], default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 smallvec = "1.6"
 displaydoc = { version = "0.2.3", default-features = false }

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -33,7 +33,7 @@ icu_locid = { version = "0.2", path = "../locid" }
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["macros"] }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 litemap = { version = "0.2", path = "../../utils/litemap", features = ["serde"] }
-tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.10", features = ["alloc", "serde"], default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 smallvec = "1.6"
 displaydoc = { version = "0.2.3", default-features = false }

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -33,7 +33,7 @@ icu_locid = { version = "0.2", path = "../locid" }
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["macros"] }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 litemap = { version = "0.2", path = "../../utils/litemap", features = ["serde"] }
-tinystr = { version = "0.4.5", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.8", features = ["alloc"], default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
 smallvec = "1.6"
 displaydoc = { version = "0.2.3", default-features = false }

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -33,7 +33,7 @@ icu_locid = { version = "0.2", path = "../locid" }
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["macros"] }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 litemap = { version = "0.2", path = "../../utils/litemap", features = ["serde"] }
-tinystr = { version = "0.4.5" }
+tinystr = { version = "0.4.5", features = ["alloc"], default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
 smallvec = "1.6"
 displaydoc = { version = "0.2.3", default-features = false }

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -33,7 +33,7 @@ icu_locid = { version = "0.2", path = "../locid" }
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["macros"] }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 litemap = { version = "0.2", path = "../../utils/litemap", features = ["serde"] }
-tinystr = { version = "0.4.9", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 smallvec = "1.6"
 displaydoc = { version = "0.2.3", default-features = false }

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -32,7 +32,7 @@ icu_locid = { version = "0.2", path = "../locid" }
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["macros"] }
 fixed_decimal = { version = "0.2", path = "../../utils/fixed_decimal" }
 writeable = { version = "0.2", path = "../../utils/writeable" }
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 displaydoc = { version = "0.2.3", default-features = false }
 
 [dev-dependencies]

--- a/components/locale_canonicalizer/Cargo.toml
+++ b/components/locale_canonicalizer/Cargo.toml
@@ -31,7 +31,7 @@ all-features = true
 icu_locid = { version = "0.2", path = "../locid" }
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["macros"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
-tinystr = { version = "0.4.5", features = ["serde"] }
+tinystr = { version = "0.4.5", features = ["alloc", "serde"], default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/components/locale_canonicalizer/Cargo.toml
+++ b/components/locale_canonicalizer/Cargo.toml
@@ -30,8 +30,8 @@ all-features = true
 [dependencies]
 icu_locid = { version = "0.2", path = "../locid" }
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["macros"] }
-serde = { version = "1.0", features = ["derive"], optional = true }
-tinystr = { version = "0.4.8", features = ["alloc", "serde"], default-features = false }
+serde = { version = "1.0", features = ["derive", "alloc"], optional = true, default-features = false }
+tinystr = { version = "0.4.8", default-features = false, features = ["alloc", "serde"] }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/components/locale_canonicalizer/Cargo.toml
+++ b/components/locale_canonicalizer/Cargo.toml
@@ -31,7 +31,7 @@ all-features = true
 icu_locid = { version = "0.2", path = "../locid" }
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["macros"] }
 serde = { version = "1.0", features = ["derive", "alloc"], optional = true, default-features = false }
-tinystr = { version = "0.4.9", default-features = false, features = ["alloc", "serde"] }
+tinystr = { version = "0.4.10", default-features = false, features = ["alloc", "serde"] }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/components/locale_canonicalizer/Cargo.toml
+++ b/components/locale_canonicalizer/Cargo.toml
@@ -31,7 +31,7 @@ all-features = true
 icu_locid = { version = "0.2", path = "../locid" }
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["macros"] }
 serde = { version = "1.0", features = ["derive", "alloc"], optional = true, default-features = false }
-tinystr = { version = "0.4.8", default-features = false, features = ["alloc", "serde"] }
+tinystr = { version = "0.4.9", default-features = false, features = ["alloc", "serde"] }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/components/locale_canonicalizer/Cargo.toml
+++ b/components/locale_canonicalizer/Cargo.toml
@@ -31,7 +31,7 @@ all-features = true
 icu_locid = { version = "0.2", path = "../locid" }
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["macros"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
-tinystr = { version = "0.4.5", features = ["alloc", "serde"], default-features = false }
+tinystr = { version = "0.4.8", features = ["alloc", "serde"], default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -31,7 +31,7 @@ extra_features = ["serde"]
 all-features = true
 
 [dependencies]
-tinystr = { version = "0.4.5", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.8", features = ["alloc"], default-features = false }
 serde = { version = "1.0", optional = true }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -31,7 +31,7 @@ extra_features = ["serde"]
 all-features = true
 
 [dependencies]
-tinystr = { version = "0.4.8", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.9", features = ["alloc"], default-features = false }
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -31,7 +31,7 @@ extra_features = ["serde"]
 all-features = true
 
 [dependencies]
-tinystr = "0.4.5"
+tinystr = { version = "0.4.5", features = ["alloc"], default-features = false }
 serde = { version = "1.0", optional = true }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -31,7 +31,7 @@ extra_features = ["serde"]
 all-features = true
 
 [dependencies]
-tinystr = { version = "0.4.9", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 tinystr = { version = "0.4.8", features = ["alloc"], default-features = false }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
 

--- a/components/locid/macros/Cargo.toml
+++ b/components/locid/macros/Cargo.toml
@@ -32,7 +32,7 @@ proc_macro = true
 [dependencies]
 proc-macro-crate = "1.0"
 icu_locid = { version = "0.2", path = "../" }
-tinystr = { version = "0.4.5", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.8", features = ["alloc"], default-features = false }
 
 [dev-dependencies]
 icu = { path = "../../icu", default-features = false }

--- a/components/locid/macros/Cargo.toml
+++ b/components/locid/macros/Cargo.toml
@@ -32,7 +32,7 @@ proc_macro = true
 [dependencies]
 proc-macro-crate = "1.0"
 icu_locid = { version = "0.2", path = "../" }
-tinystr = { version = "0.4.9", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
 
 [dev-dependencies]
 icu = { path = "../../icu", default-features = false }

--- a/components/locid/macros/Cargo.toml
+++ b/components/locid/macros/Cargo.toml
@@ -32,7 +32,7 @@ proc_macro = true
 [dependencies]
 proc-macro-crate = "1.0"
 icu_locid = { version = "0.2", path = "../" }
-tinystr = "0.4"
+tinystr = { version = "0.4.5", features = ["alloc"], default-features = false }
 
 [dev-dependencies]
 icu = { path = "../../icu", default-features = false }

--- a/components/locid/macros/Cargo.toml
+++ b/components/locid/macros/Cargo.toml
@@ -32,7 +32,7 @@ proc_macro = true
 [dependencies]
 proc-macro-crate = "1.0"
 icu_locid = { version = "0.2", path = "../" }
-tinystr = { version = "0.4.8", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.9", features = ["alloc"], default-features = false }
 
 [dev-dependencies]
 icu = { path = "../../icu", default-features = false }

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 fixed_decimal = { version = "0.2", path = "../../utils/fixed_decimal" }
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["macros"] }
 icu_locid = { version = "0.2", path = "../locid" }
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 displaydoc = { version = "0.2.3", default-features = false }
 
 [dev-dependencies]

--- a/components/uniset/Cargo.toml
+++ b/components/uniset/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["macros"] }
 litemap = { version = "0.2", path = "../../utils/litemap" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
-tinystr = { version = "0.4.9", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
 
 [dev-dependencies]

--- a/components/uniset/Cargo.toml
+++ b/components/uniset/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["macros"] }
 litemap = { version = "0.2", path = "../../utils/litemap" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
-tinystr = { version = "0.4.8", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.9", features = ["alloc"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
 
 [dev-dependencies]

--- a/components/uniset/Cargo.toml
+++ b/components/uniset/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["macros"] }
 litemap = { version = "0.2", path = "../../utils/litemap" }
 serde = { version = "1.0", features = ["derive"], optional = true }
-tinystr = { version = "0.4.5", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.8", features = ["alloc"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
 
 [dev-dependencies]

--- a/components/uniset/Cargo.toml
+++ b/components/uniset/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["macros"] }
 litemap = { version = "0.2", path = "../../utils/litemap" }
 serde = { version = "1.0", features = ["derive"], optional = true }
-tinystr = "0.4.5"
+tinystr = { version = "0.4.5", features = ["alloc"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
 
 [dev-dependencies]

--- a/components/uniset/Cargo.toml
+++ b/components/uniset/Cargo.toml
@@ -31,7 +31,7 @@ all-features = true
 [dependencies]
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["macros"] }
 litemap = { version = "0.2", path = "../../utils/litemap" }
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 tinystr = { version = "0.4.8", features = ["alloc"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
 

--- a/experimental/provider_ppucd/Cargo.toml
+++ b/experimental/provider_ppucd/Cargo.toml
@@ -29,5 +29,5 @@ icu_locid = { version = "0.2", path = "../../components/locid" }
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["provider_serde"] }
 icu_locid_macros = { version = "0.2", path = "../../components/locid/macros" }
 icu_uniset = { version = "0.2", path = "../../components/uniset" }
-tinystr = "0.4"
+tinystr = { version = "0.4.5", features = ["alloc"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }

--- a/experimental/provider_ppucd/Cargo.toml
+++ b/experimental/provider_ppucd/Cargo.toml
@@ -29,5 +29,5 @@ icu_locid = { version = "0.2", path = "../../components/locid" }
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["provider_serde"] }
 icu_locid_macros = { version = "0.2", path = "../../components/locid/macros" }
 icu_uniset = { version = "0.2", path = "../../components/uniset" }
-tinystr = { version = "0.4.5", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.8", features = ["alloc"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }

--- a/experimental/provider_ppucd/Cargo.toml
+++ b/experimental/provider_ppucd/Cargo.toml
@@ -29,5 +29,5 @@ icu_locid = { version = "0.2", path = "../../components/locid" }
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["provider_serde"] }
 icu_locid_macros = { version = "0.2", path = "../../components/locid/macros" }
 icu_uniset = { version = "0.2", path = "../../components/uniset" }
-tinystr = { version = "0.4.8", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.9", features = ["alloc"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }

--- a/experimental/provider_ppucd/Cargo.toml
+++ b/experimental/provider_ppucd/Cargo.toml
@@ -29,5 +29,5 @@ icu_locid = { version = "0.2", path = "../../components/locid" }
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["provider_serde"] }
 icu_locid_macros = { version = "0.2", path = "../../components/locid/macros" }
 icu_uniset = { version = "0.2", path = "../../components/uniset" }
-tinystr = { version = "0.4.9", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }

--- a/experimental/segmenter/Cargo.toml
+++ b/experimental/segmenter/Cargo.toml
@@ -26,7 +26,7 @@ include = [
 unicode-width = "0.1.7"
 icu_segmenter_lstm = { version = "0.1", path = "../segmenter_lstm" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 lazy_static = "1.0"
 
 [dev-dependencies]

--- a/experimental/segmenter/Cargo.toml
+++ b/experimental/segmenter/Cargo.toml
@@ -25,7 +25,7 @@ include = [
 [dependencies]
 unicode-width = "0.1.7"
 icu_segmenter_lstm = { version = "0.1", path = "../segmenter_lstm" }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 serde_json = "1.0"
 lazy_static = "1.0"
 

--- a/experimental/segmenter_lstm/Cargo.toml
+++ b/experimental/segmenter_lstm/Cargo.toml
@@ -23,7 +23,7 @@ include = [
 ]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 ndarray = { version = "0.15", features = ["serde"] }
 unicode-segmentation = "1.3.0"
 

--- a/experimental/segmenter_lstm/Cargo.toml
+++ b/experimental/segmenter_lstm/Cargo.toml
@@ -23,7 +23,7 @@ include = [
 ]
 
 [dependencies]
-serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
+serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
 ndarray = { version = "0.15", features = ["serde"] }
 unicode-segmentation = "1.3.0"
 

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -37,7 +37,7 @@ icu_locid = { path = "../../components/locid" }
 icu_plurals = { path = "../../components/plurals/" }
 icu_provider = { path = "../../provider/core" }
 icu_provider_fs = { path = "../../provider/fs/" }
-tinystr = { version = "0.4.5", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.8", features = ["alloc"], default-features = false }
 writeable = { path = "../../utils/writeable/" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -37,7 +37,7 @@ icu_locid = { path = "../../components/locid" }
 icu_plurals = { path = "../../components/plurals/" }
 icu_provider = { path = "../../provider/core" }
 icu_provider_fs = { path = "../../provider/fs/" }
-tinystr = "0.4.5"
+tinystr = { version = "0.4.5", features = ["alloc"], default-features = false }
 writeable = { path = "../../utils/writeable/" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -38,7 +38,7 @@ icu_locid = { path = "../../components/locid" }
 icu_plurals = { path = "../../components/plurals/" }
 icu_provider = { path = "../../provider/core" }
 icu_provider_fs = { path = "../../provider/fs/" }
-tinystr = { version = "0.4.9", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
 writeable = { path = "../../utils/writeable/" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -8,6 +8,7 @@ description = "C interface to ICU4X"
 version = "0.1.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
+resolver = "2"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "../../LICENSE"
 categories = ["internationalization"]
@@ -37,7 +38,7 @@ icu_locid = { path = "../../components/locid" }
 icu_plurals = { path = "../../components/plurals/" }
 icu_provider = { path = "../../provider/core" }
 icu_provider_fs = { path = "../../provider/fs/" }
-tinystr = { version = "0.4.8", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.9", features = ["alloc"], default-features = false }
 writeable = { path = "../../utils/writeable/" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/ffi/ecma402/Cargo.toml
+++ b/ffi/ecma402/Cargo.toml
@@ -33,7 +33,7 @@ icu_provider = { version = "0.2", path = "../../provider/core" }
 
 [dev-dependencies]
 criterion = "0.3"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 serde_json = {version = "1.0" }
 icu_locid = { version = "0.2", path = "../../components/locid" }
 icu_provider = { version = "0.2", path = "../../provider/core" }

--- a/provider/blob/Cargo.toml
+++ b/provider/blob/Cargo.toml
@@ -28,9 +28,9 @@ all-features = true
 [dependencies]
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["provider_serde"] }
 icu_locid = { version = "0.2", path = "../../components/locid", features = ["serde"] }
-serde = { version = "1.0" }
+serde = { version = "1.0", default-features = false, features = ["alloc"] }
 bincode = { version = "1.3.3" }
-erased-serde = { version = "0.3" }
+erased-serde = { version = "0.3", default-features = false, features = ["alloc"] }
 litemap = { version = "0.2.0", path = "../../utils/litemap/", features = ["serde"] }
 
 # For the export feature

--- a/provider/cldr/Cargo.toml
+++ b/provider/cldr/Cargo.toml
@@ -42,9 +42,9 @@ icu_decimal = { version = "0.2", path = "../../components/decimal" }
 itertools = "0.10"
 json = "0.12"
 litemap = { version = "0.2", path = "../../utils/litemap" }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 serde-aux = "2.1.1"
-serde_json = "1.0"
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde-tuple-vec-map = "1.0"
 smallstr = { version = "0.2", features = ["serde"] }
 smallvec = "1.6"

--- a/provider/cldr/Cargo.toml
+++ b/provider/cldr/Cargo.toml
@@ -48,7 +48,7 @@ serde_json = "1.0"
 serde-tuple-vec-map = "1.0"
 smallstr = { version = "0.2", features = ["serde"] }
 smallvec = "1.6"
-tinystr = { version = "0.4.5", features = ["serde"] }
+tinystr = { version = "0.4.5", features = ["alloc", "serde"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
 
 # Dependencies for the download feature

--- a/provider/cldr/Cargo.toml
+++ b/provider/cldr/Cargo.toml
@@ -48,7 +48,7 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde-tuple-vec-map = "1.0"
 smallstr = { version = "0.2", features = ["serde"] }
 smallvec = "1.6"
-tinystr = { version = "0.4.9", features = ["alloc", "serde"], default-features = false }
+tinystr = { version = "0.4.10", features = ["alloc", "serde"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
 
 # Dependencies for the download feature

--- a/provider/cldr/Cargo.toml
+++ b/provider/cldr/Cargo.toml
@@ -48,7 +48,7 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde-tuple-vec-map = "1.0"
 smallstr = { version = "0.2", features = ["serde"] }
 smallvec = "1.6"
-tinystr = { version = "0.4.8", features = ["alloc", "serde"], default-features = false }
+tinystr = { version = "0.4.9", features = ["alloc", "serde"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
 
 # Dependencies for the download feature

--- a/provider/cldr/Cargo.toml
+++ b/provider/cldr/Cargo.toml
@@ -48,7 +48,7 @@ serde_json = "1.0"
 serde-tuple-vec-map = "1.0"
 smallstr = { version = "0.2", features = ["serde"] }
 smallvec = "1.6"
-tinystr = { version = "0.4.5", features = ["alloc", "serde"], default-features = false }
+tinystr = { version = "0.4.8", features = ["alloc", "serde"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
 
 # Dependencies for the download feature

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -41,8 +41,8 @@ yoke = { version = "0.2", path = "../../utils/yoke", features = ["serde", "deriv
 icu_provider_macros = { version = "0.2", path = "../macros", optional = true }
 
 # For "provider_serde" feature
-erased-serde = { version = "0.3", optional = true }
-serde = { version = "1.0", features = ["derive"], optional = true }
+erased-serde = { version = "0.3", optional = true, default-features = false, features = ["alloc"] }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -34,7 +34,7 @@ macros = ["icu_provider_macros"]
 
 [dependencies]
 icu_locid = { version = "0.2", path = "../../components/locid" }
-tinystr = "0.4.5"
+tinystr = { version = "0.4.5", features = ["alloc"], default-features = false }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
 yoke = { version = "0.2", path = "../../utils/yoke", features = ["serde", "derive"] }

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -34,7 +34,7 @@ macros = ["icu_provider_macros"]
 
 [dependencies]
 icu_locid = { version = "0.2", path = "../../components/locid" }
-tinystr = { version = "0.4.9", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
 yoke = { version = "0.2", path = "../../utils/yoke", features = ["serde", "derive"] }

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -34,7 +34,7 @@ macros = ["icu_provider_macros"]
 
 [dependencies]
 icu_locid = { version = "0.2", path = "../../components/locid" }
-tinystr = { version = "0.4.5", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.8", features = ["alloc"], default-features = false }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
 yoke = { version = "0.2", path = "../../utils/yoke", features = ["serde", "derive"] }

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -34,7 +34,7 @@ macros = ["icu_provider_macros"]
 
 [dependencies]
 icu_locid = { version = "0.2", path = "../../components/locid" }
-tinystr = { version = "0.4.8", features = ["alloc"], default-features = false }
+tinystr = { version = "0.4.9", features = ["alloc"], default-features = false }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
 yoke = { version = "0.2", path = "../../utils/yoke", features = ["serde", "derive"] }

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -35,8 +35,8 @@ all-features = true
 [dependencies]
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["provider_serde"] }
 icu_locid = { version = "0.2", path = "../../components/locid", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
-erased-serde = { version = "0.3" }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
+erased-serde = { version = "0.3", default-features = false, features = ["alloc"] }
 displaydoc = { version = "0.2.3", default-features = false }
 
 # Serializers

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -41,7 +41,7 @@ displaydoc = { version = "0.2.3", default-features = false }
 
 # Serializers
 # Note: serde_json is always included because it is used for parsing manifest.json
-serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+serde_json = { version = "1.0", default-features = false, features = ["alloc", "std"] }
 bincode = { version = "1.3", optional = true }
 
 # Dependencies for the export module

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -41,7 +41,7 @@ displaydoc = { version = "0.2.3", default-features = false }
 
 # Serializers
 # Note: serde_json is always included because it is used for parsing manifest.json
-serde_json = { version = "1.0" }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 bincode = { version = "1.3", optional = true }
 
 # Dependencies for the export module

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 [dependencies]
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["provider_serde"] }
 icu_locid = { version = "0.2", path = "../../components/locid", features = ["serde"] }
-serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
+serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
 erased-serde = { version = "0.3", default-features = false, features = ["alloc"] }
 displaydoc = { version = "0.2.3", default-features = false }
 

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -134,7 +134,7 @@ icu_locid = { version = "0.2", path = "../../components/locid" }
 cargo_metadata = { version = "0.13", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 serde_json = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
-displaydoc = { version = "0.2.3", default-features = false }
+displaydoc = { version = "0.2.3", default-features = false, optional = true }
 writeable = { version = "0.2", path = "../../utils/writeable", optional = true }
 
 [dev-dependencies]

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -132,9 +132,9 @@ icu_locid = { version = "0.2", path = "../../components/locid" }
 
 # Dependencies for the "metadata" feature
 cargo_metadata = { version = "0.13", optional = true }
-serde = { version = "1.0", features = ["derive"], optional = true }
-serde_json = { version = "1.0", optional = true }
-displaydoc = { version = "0.2.3", default-features = false, optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
+serde_json = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
+displaydoc = { version = "0.2.3", default-features = false }
 writeable = { version = "0.2", path = "../../utils/writeable", optional = true }
 
 [dev-dependencies]

--- a/tools/benchmark/memory/Cargo.toml
+++ b/tools/benchmark/memory/Cargo.toml
@@ -18,6 +18,6 @@ include = [
 ]
 
 [dependencies]
-serde_json = "1.0"
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 clap = "2.33"
 cargo_metadata = "0.13"

--- a/tools/datagen/Cargo.toml
+++ b/tools/datagen/Cargo.toml
@@ -37,7 +37,7 @@ icu_provider_fs = { version = "0.2", path = "../../provider/fs", features = ["ex
 icu_testdata = { version = "0.2", path = "../../provider/testdata", features = ["metadata"] }
 log = "0.4"
 reqwest = { version = "0.11", features = ["json", "stream", "gzip"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 simple_logger = "1.11"
 tokio = { version = "1.5", features = ["rt-multi-thread", "macros", "fs"] }
 

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -27,7 +27,7 @@ include = [
 all-features = true
 
 [dependencies]
-serde = {version = "1", optional = true}
+serde = {version = "1", optional = true, default-features = false, features = ["alloc"]}
 
 [dev-dependencies]
 serde = "1"

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+#![cfg_attr(not(test), no_std)]
+
 //! `writeable` is a utility crate of the [`ICU4X`] project.
 //!
 //! It includes [`Writeable`], a core trait representing an object that can be written to a
@@ -49,9 +51,12 @@
 //!
 //! [`ICU4X`]: ../icu/index.html
 
+extern crate alloc;
+
 mod ops;
 
-use std::fmt;
+use core::fmt;
+use alloc::string::String;
 
 /// A hint to help consumers of Writeable pre-allocate bytes before they call write_to.
 ///

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -55,8 +55,8 @@ extern crate alloc;
 
 mod ops;
 
-use core::fmt;
 use alloc::string::String;
+use core::fmt;
 
 /// A hint to help consumers of Writeable pre-allocate bytes before they call write_to.
 ///

--- a/utils/writeable/src/ops.rs
+++ b/utils/writeable/src/ops.rs
@@ -4,7 +4,7 @@
 
 use crate::LengthHint;
 
-impl std::ops::Add<LengthHint> for LengthHint {
+impl core::ops::Add<LengthHint> for LengthHint {
     type Output = Self;
 
     fn add(self, other: LengthHint) -> Self {
@@ -18,22 +18,22 @@ impl std::ops::Add<LengthHint> for LengthHint {
     }
 }
 
-impl std::ops::AddAssign<LengthHint> for LengthHint {
+impl core::ops::AddAssign<LengthHint> for LengthHint {
     fn add_assign(&mut self, other: Self) {
         *self = *self + other;
     }
 }
 
-impl std::iter::Sum<LengthHint> for LengthHint {
+impl core::iter::Sum<LengthHint> for LengthHint {
     fn sum<I>(iter: I) -> Self
     where
         I: Iterator<Item = LengthHint>,
     {
-        iter.fold(LengthHint::Exact(0), std::ops::Add::add)
+        iter.fold(LengthHint::Exact(0), core::ops::Add::add)
     }
 }
 
-impl std::ops::Add<usize> for LengthHint {
+impl core::ops::Add<usize> for LengthHint {
     type Output = Self;
 
     fn add(self, other: usize) -> Self {
@@ -44,13 +44,13 @@ impl std::ops::Add<usize> for LengthHint {
     }
 }
 
-impl std::ops::AddAssign<usize> for LengthHint {
+impl core::ops::AddAssign<usize> for LengthHint {
     fn add_assign(&mut self, other: usize) {
         *self = *self + other;
     }
 }
 
-impl std::iter::Sum<usize> for LengthHint {
+impl core::iter::Sum<usize> for LengthHint {
     fn sum<I>(iter: I) -> Self
     where
         I: Iterator<Item = usize>,

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -28,7 +28,7 @@ all-features = true
 
 [dependencies]
 stable_deref_trait = { version = "1.2.0", features = ["alloc"], default-features = false }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"]}
 yoke-derive = { path = "./derive", version = "0.1.0", optional = true}
 
 [dev-dependencies]

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -27,7 +27,7 @@ derive = ["yoke-derive"]
 all-features = true
 
 [dependencies]
-stable_deref_trait = "1.2.0"
+stable_deref_trait = { version = "1.2.0", features = ["alloc"], default-features = false }
 serde = { version = "1.0", optional = true }
 yoke-derive = { path = "./derive", version = "0.1.0", optional = true}
 

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -22,13 +22,15 @@ include = [
 
 [features]
 derive = ["yoke-derive"]
+alloc = ["stable_deref_trait/alloc", "serde/alloc"]
+default = ["alloc"]
 
 [package.metadata.docs.rs]
 all-features = true
 
 [dependencies]
 stable_deref_trait = { version = "1.2.0", features = ["alloc"], default-features = false }
-serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"]}
+serde = { version = "1.0", optional = true, default-features = false }
 yoke-derive = { path = "./derive", version = "0.1.0", optional = true}
 
 [dev-dependencies]

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! See the documentation of [`Yoke`] for more details.
 
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 // The lifetimes here are important for safety and explicitly writing
 // them out is good even when redundant
 #![allow(clippy::needless_lifetimes)]

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -9,9 +9,14 @@
 //!
 //! See the documentation of [`Yoke`] for more details.
 
+#![no_std]
+
 // The lifetimes here are important for safety and explicitly writing
 // them out is good even when redundant
 #![allow(clippy::needless_lifetimes)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 mod macro_impls;
 pub mod trait_hack;

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -10,7 +10,6 @@
 //! See the documentation of [`Yoke`] for more details.
 
 #![no_std]
-
 // The lifetimes here are important for safety and explicitly writing
 // them out is good even when redundant
 #![allow(clippy::needless_lifetimes)]

--- a/utils/yoke/src/macro_impls.rs
+++ b/utils/yoke/src/macro_impls.rs
@@ -7,7 +7,7 @@
 #![allow(clippy::transmute_ptr_to_ptr)]
 
 use crate::{Yokeable, ZeroCopyFrom};
-use std::{mem, ptr};
+use core::{mem, ptr};
 
 macro_rules! copy_yoke_impl {
     () => {

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -460,7 +460,9 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, Option<C>> {
 /// handle to the same data".
 pub unsafe trait CloneableCart: Clone {}
 
+#[cfg(feature = "alloc")]
 unsafe impl<T: ?Sized> CloneableCart for Rc<T> {}
+#[cfg(feature = "alloc")]
 unsafe impl<T: ?Sized> CloneableCart for Arc<T> {}
 unsafe impl<T: CloneableCart> CloneableCart for Option<T> {}
 unsafe impl<'a, T: ?Sized> CloneableCart for &'a T {}

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -3,9 +3,9 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::Yokeable;
-use stable_deref_trait::StableDeref;
 use core::marker::PhantomData;
 use core::ops::Deref;
+use stable_deref_trait::StableDeref;
 
 #[cfg(feature = "alloc")]
 use alloc::rc::Rc;

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -4,10 +4,13 @@
 
 use crate::Yokeable;
 use stable_deref_trait::StableDeref;
-use std::marker::PhantomData;
-use std::ops::Deref;
-use std::rc::Rc;
-use std::sync::Arc;
+use core::marker::PhantomData;
+use core::ops::Deref;
+
+#[cfg(feature = "alloc")]
+use alloc::rc::Rc;
+#[cfg(feature = "alloc")]
+use alloc::sync::Arc;
 
 /// A Cow-like borrowed object "yoked" to its backing data.
 ///

--- a/utils/yoke/src/yokeable.rs
+++ b/utils/yoke/src/yokeable.rs
@@ -2,8 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use std::borrow::{Cow, ToOwned};
-use std::{mem, ptr};
+#[cfg(feature = "alloc")]
+use alloc::borrow::{Cow, ToOwned};
+use core::{mem, ptr};
 
 /// A [`Yokeable`] type is essentially one with a covariant lifetime parameter,
 /// matched to the parameter in the trait definition. The trait allows one to cast
@@ -227,6 +228,7 @@ pub unsafe trait Yokeable<'a>: 'static {
         F: 'static + for<'b> FnOnce(&'b mut Self::Output);
 }
 
+#[cfg(feature = "alloc")]
 unsafe impl<'a, T: 'static + ToOwned + ?Sized> Yokeable<'a> for Cow<'static, T>
 where
     <T as ToOwned>::Owned: Sized,

--- a/utils/yoke/src/zero_copy_from.rs
+++ b/utils/yoke/src/zero_copy_from.rs
@@ -4,8 +4,14 @@
 
 use crate::Yoke;
 use crate::Yokeable;
-use std::borrow::{Cow, ToOwned};
-use std::rc::Rc;
+#[cfg(feature = "alloc")]
+use alloc::borrow::{Cow, ToOwned};
+#[cfg(feature = "alloc")]
+use alloc::rc::Rc;
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+#[cfg(feature = "alloc")]
+use alloc::string::String;
 
 /// Trait for types that can be crated from a reference to a cart type `C` with no allocations.
 ///
@@ -105,6 +111,7 @@ impl<'b, 's, Y: ZeroCopyFrom<C> + for<'a> Yokeable<'a>, C: ?Sized> Yoke<Y, &'b C
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'b, 's, Y: ZeroCopyFrom<C> + for<'a> Yokeable<'a>, C: ?Sized> Yoke<Y, Box<C>> {
     /// Construct a [`Yoke`]`<Y, Box<C>>` from a boxed cart by zero-copy cloning the cart to `Y` and
     /// then yokeing that object to the cart.
@@ -134,6 +141,7 @@ impl<'b, 's, Y: ZeroCopyFrom<C> + for<'a> Yokeable<'a>, C: ?Sized> Yoke<Y, Box<C
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'b, 's, Y: ZeroCopyFrom<C> + for<'a> Yokeable<'a>, C: ?Sized> Yoke<Y, Rc<C>> {
     /// Construct a [`Yoke`]`<Y, Rc<C>>` from a reference-counted cart by zero-copy cloning the
     /// cart to `Y` and then yokeing that object to the cart.
@@ -169,12 +177,14 @@ impl<'b, 's, Y: ZeroCopyFrom<C> + for<'a> Yokeable<'a>, C: ?Sized> Yoke<Y, Rc<C>
 // to customize their `ZeroCopyFrom` impl. The blanket implementation may be safe once Rust has
 // specialization.
 
+#[cfg(feature = "alloc")]
 impl ZeroCopyFrom<str> for Cow<'static, str> {
     fn zero_copy_from<'b>(cart: &'b str) -> Cow<'b, str> {
         Cow::Borrowed(cart)
     }
 }
 
+#[cfg(feature = "alloc")]
 impl ZeroCopyFrom<String> for Cow<'static, str> {
     fn zero_copy_from<'b>(cart: &'b String) -> Cow<'b, str> {
         Cow::Borrowed(cart)
@@ -217,6 +227,7 @@ impl<C1, T1: ZeroCopyFrom<C1>, C2, T2: ZeroCopyFrom<C2>> ZeroCopyFrom<(C1, C2)> 
 // type inference. Deref coercions do not typically work when sufficient generics
 // or inference are involved, and the proc macro does not necessarily have
 // enough type information to figure this out on its own.
+#[cfg(feature = "alloc")]
 impl<B: ToOwned + ?Sized + 'static> ZeroCopyFrom<Cow<'_, B>> for Cow<'static, B> {
     fn zero_copy_from<'b>(cart: &'b Cow<'_, B>) -> Cow<'b, B> {
         Cow::Borrowed(cart)

--- a/utils/yoke/src/zero_copy_from.rs
+++ b/utils/yoke/src/zero_copy_from.rs
@@ -7,9 +7,9 @@ use crate::Yokeable;
 #[cfg(feature = "alloc")]
 use alloc::borrow::{Cow, ToOwned};
 #[cfg(feature = "alloc")]
-use alloc::rc::Rc;
-#[cfg(feature = "alloc")]
 use alloc::boxed::Box;
+#[cfg(feature = "alloc")]
+use alloc::rc::Rc;
 #[cfg(feature = "alloc")]
 use alloc::string::String;
 

--- a/utils/yoke/src/zero_copy_from.rs
+++ b/utils/yoke/src/zero_copy_from.rs
@@ -197,6 +197,7 @@ impl ZeroCopyFrom<str> for &'static str {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl ZeroCopyFrom<String> for &'static str {
     fn zero_copy_from<'b>(cart: &'b String) -> &'b str {
         cart

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -24,7 +24,7 @@ all-features = true
 
 [dependencies]
 either = "1.6.1"
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true , default-features = false, features = ["alloc"] }
 yoke = { path = "../yoke", version = "0.2.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Progress towards https://github.com/unicode-org/icu4x/issues/812

This contains some progress towards `no_std` support. The main accomplishments of this PR are:

 - Most of the utils are `no_std` compatible now
 - `serde` is built with `no_std` unless otherwise necessary.

This should not regress any behavior, and should generally be desirable for these crates anyway. We do not use any of serde's std features, so we do not need to pull it in with std. Rust unifies features so if icu4x is used by a crate that _does_ need serde-with-std, it will pull in the appropriate dependency as needed.

There is nothing to test as a result of this PR since we do not yet have a complete `icu_capi` `no_std` build.

Making a PR now because this work bitrots really easily.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->