### PR TITLE
Remove use of `dyn Error` in library code in favor of Strings

### DIFF
--- a/provider/cldr/src/support.rs
+++ b/provider/cldr/src/support.rs
@@ -38,7 +38,7 @@ where
         + IterableDataProviderCore
         + KeyedDataProvider
         + TryFrom<&'b dyn CldrPaths>,
-    <T as TryFrom<&'b dyn CldrPaths>>::Error: 'static + std::error::Error + Send + Sync,
+    <T as TryFrom<&'b dyn CldrPaths>>::Error: std::fmt::Display,
 {
     /// Call [`DataProvider::load_payload()`], initializing `T` if necessary.
     pub fn try_load_serde(

--- a/provider/core/src/error.rs
+++ b/provider/core/src/error.rs
@@ -57,7 +57,7 @@ pub enum Error {
 
     /// The data provider encountered some other error when loading the resource, such as I/O.
     #[displaydoc("Failed to load resource: {0}")]
-    Resource(Box<dyn std::error::Error + Send + Sync>),
+    Resource(String),
 }
 
 impl std::error::Error for Error {}
@@ -69,8 +69,8 @@ impl From<erased_serde::Error> for Error {
     }
 }
 
-impl From<Box<dyn std::error::Error + Send + Sync>> for Error {
-    fn from(e: Box<dyn std::error::Error + Send + Sync>) -> Self {
+impl From<String> for Error {
+    fn from(e: String) -> Self {
         Error::Resource(e)
     }
 }
@@ -78,9 +78,9 @@ impl From<Box<dyn std::error::Error + Send + Sync>> for Error {
 impl Error {
     pub fn new_resc_error<T>(err: T) -> Self
     where
-        T: 'static + std::error::Error + Send + Sync,
+        T: std::fmt::Display,
     {
-        Self::Resource(Box::new(err))
+        Self::Resource(format!("{}", err))
     }
 }
 

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -35,13 +35,13 @@ all-features = true
 [dependencies]
 icu_provider = { version = "0.2", path = "../../provider/core", features = ["provider_serde"] }
 icu_locid = { version = "0.2", path = "../../components/locid", features = ["serde"] }
-serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 erased-serde = { version = "0.3", default-features = false, features = ["alloc"] }
 displaydoc = { version = "0.2.3", default-features = false }
 
 # Serializers
 # Note: serde_json is always included because it is used for parsing manifest.json
-serde_json = { version = "1.0", default-features = false, features = ["alloc", "std"] }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 bincode = { version = "1.3", optional = true }
 
 # Dependencies for the export module
@@ -56,7 +56,7 @@ criterion = "0.3.3"
 
 [features]
 # Enables the "export" module and FilesystemExporter
-export = ["static_assertions", "log"]
+export = ["static_assertions", "log", "serde_json/std"]
 bench = []
 
 [lib]

--- a/provider/fs/src/deserializer.rs
+++ b/provider/fs/src/deserializer.rs
@@ -64,7 +64,7 @@ impl Error {
             }
             Self::UnknownSyntax(v) => CrateError::UnknownSyntax(v),
         };
-        DataError::Resource(Box::new(crate_error))
+        DataError::new_resc_error(crate_error)
     }
 }
 

--- a/provider/fs/src/deserializer.rs
+++ b/provider/fs/src/deserializer.rs
@@ -53,14 +53,14 @@ impl Error {
         use crate::error::Error as CrateError;
         let crate_error = match self {
             Self::Json(err) => {
-                CrateError::Deserializer(Box::new(err), Some(path.as_ref().to_path_buf()))
+                CrateError::Deserializer(format!("{}", err), Some(path.as_ref().to_path_buf()))
             }
             #[cfg(feature = "bincode")]
             Self::Bincode(err) => {
-                CrateError::Deserializer(Box::new(err), Some(path.as_ref().to_path_buf()))
+                CrateError::Deserializer(format!("{}", err), Some(path.as_ref().to_path_buf()))
             }
             Self::DataProvider(err) => {
-                CrateError::Deserializer(Box::new(err), Some(path.as_ref().to_path_buf()))
+                CrateError::Deserializer(format!("{}", err), Some(path.as_ref().to_path_buf()))
             }
             Self::UnknownSyntax(v) => CrateError::UnknownSyntax(v),
         };

--- a/provider/fs/src/error.rs
+++ b/provider/fs/src/error.rs
@@ -41,7 +41,10 @@ impl<P: AsRef<Path>> From<(std::io::Error, P)> for Error {
 /// If a path is unavailable, create the error directly: [`Error::Deserializer`]`(err, `[`None`]`)`
 impl<P: AsRef<Path>> From<(serde_json::error::Error, P)> for Error {
     fn from(pieces: (serde_json::error::Error, P)) -> Self {
-        Self::Deserializer(format!("{}", pieces.0), Some(pieces.1.as_ref().to_path_buf()))
+        Self::Deserializer(
+            format!("{}", pieces.0),
+            Some(pieces.1.as_ref().to_path_buf()),
+        )
     }
 }
 

--- a/provider/fs/src/error.rs
+++ b/provider/fs/src/error.rs
@@ -13,7 +13,7 @@ pub enum Error {
     #[displaydoc("{0}")]
     DataProvider(icu_provider::DataError),
     #[displaydoc("Deserializer error: {0}: {1:?}")]
-    Deserializer(Box<dyn std::error::Error + Send + Sync>, Option<PathBuf>),
+    Deserializer(String, Option<PathBuf>),
     #[cfg(feature = "export")]
     #[displaydoc("Serializer error: {0}: {1:?}")]
     Serializer(erased_serde::Error, Option<PathBuf>),
@@ -41,7 +41,7 @@ impl<P: AsRef<Path>> From<(std::io::Error, P)> for Error {
 /// If a path is unavailable, create the error directly: [`Error::Deserializer`]`(err, `[`None`]`)`
 impl<P: AsRef<Path>> From<(serde_json::error::Error, P)> for Error {
     fn from(pieces: (serde_json::error::Error, P)) -> Self {
-        Self::Deserializer(Box::new(pieces.0), Some(pieces.1.as_ref().to_path_buf()))
+        Self::Deserializer(format!("{}", pieces.0), Some(pieces.1.as_ref().to_path_buf()))
     }
 }
 

--- a/provider/fs/src/error.rs
+++ b/provider/fs/src/error.rs
@@ -71,6 +71,6 @@ impl Error {
 
 impl From<Error> for icu_provider::DataError {
     fn from(err: Error) -> Self {
-        Self::Resource(Box::new(err))
+        Self::new_resc_error(&err)
     }
 }

--- a/provider/fs/src/fs_data_provider.rs
+++ b/provider/fs/src/fs_data_provider.rs
@@ -78,7 +78,7 @@ impl FsDataProvider {
         }
         let file = match File::open(&path_buf) {
             Ok(file) => file,
-            Err(err) => return Err(Error::Resource(Box::new(err))),
+            Err(err) => return Err(Error::new_resc_error(err)),
         };
         Ok((BufReader::new(file), path_buf))
     }
@@ -88,7 +88,7 @@ impl FsDataProvider {
         let mut buffer = Vec::<u8>::new();
         reader
             .read_to_end(&mut buffer)
-            .map_err(|e| DataError::Resource(Box::new(Error::Io(e, Some(path_buf.clone())))))?;
+            .map_err(|e| DataError::new_resc_error(Error::Io(e, Some(path_buf.clone()))))?;
         let rc_buffer: Rc<[u8]> = buffer.into();
         Ok((rc_buffer, path_buf))
     }


### PR DESCRIPTION
Progress on https://github.com/unicode-org/icu4x/issues/812

We're using `dyn Error` as `dyn Display + Debug`, and while we can get the same effect by defining a `trait ICU4XError: Debug + Display` that gets autoimplemented, for now it's better to just use a String and perhaps consider consolidating our error Debug impls to use Display over time.




<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->