### PR TITLE
Move locale_canonicalizer and StaticDataProvider to no_std, use SDP correctly in capi

### DIFF
--- a/components/locale_canonicalizer/src/lib.rs
+++ b/components/locale_canonicalizer/src/lib.rs
@@ -75,6 +75,10 @@
 //! [`CLDR`]: http://cldr.unicode.org/
 //! [`UTS #35: Unicode LDML 3. Likely Subtags`]: https://www.unicode.org/reports/tr35/#Likely_Subtags.
 
+#![no_std]
+
+extern crate alloc;
+
 pub mod locale_canonicalizer;
 pub mod provider;
 

--- a/components/locale_canonicalizer/src/locale_canonicalizer.rs
+++ b/components/locale_canonicalizer/src/locale_canonicalizer.rs
@@ -3,6 +3,9 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::provider::*;
+use alloc::string::ToString;
+use alloc::vec;
+use alloc::vec::Vec;
 use icu_locid::{
     extensions::unicode::{Key, Value},
     subtags, LanguageIdentifier, Locale,

--- a/components/locale_canonicalizer/src/provider.rs
+++ b/components/locale_canonicalizer/src/provider.rs
@@ -6,6 +6,7 @@
 //!
 //! Read more about data providers: [`icu_provider`]
 
+use alloc::vec::Vec;
 use icu_locid::LanguageIdentifier;
 use icu_provider::yoke::{self, *};
 use tinystr::{TinyStr4, TinyStr8};

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -44,7 +44,7 @@ writeable = { path = "../../utils/writeable/" }
 log = { version = "0.4" }
 
 [target.'cfg(any(target_arch = "wasm32", target_os = "none"))'.dependencies]
-icu_testdata = { version = "0.2", path = "../../provider/testdata" }
+icu_testdata = { version = "0.2", path = "../../provider/testdata", default-features = false, features = ["static"] }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "none")))'.dependencies]
 icu_provider_fs = { path = "../../provider/fs/" }

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -37,10 +37,14 @@ icu_locale_canonicalizer = { path = "../../components/locale_canonicalizer" }
 icu_locid = { path = "../../components/locid" }
 icu_plurals = { path = "../../components/plurals/" }
 icu_provider = { path = "../../provider/core" }
-icu_provider_fs = { path = "../../provider/fs/" }
 tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
 writeable = { path = "../../utils/writeable/" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 log = { version = "0.4" }
+
+[target.'cfg(any(target_arch = "wasm32", target_os = "none"))'.dependencies]
 icu_testdata = { version = "0.2", path = "../../provider/testdata" }
+
+[target.'cfg(not(any(target_arch = "wasm32", target_os = "none")))'.dependencies]
+icu_provider_fs = { path = "../../provider/fs/" }

--- a/ffi/capi/src/provider.rs
+++ b/ffi/capi/src/provider.rs
@@ -90,6 +90,8 @@ pub struct ICU4XCreateDataProviderResult {
     pub success: bool,
 }
 
+
+#[cfg(not(any(target_arch = "wasm32", target_os = "none")))]
 #[no_mangle]
 /// Constructs an [`FsDataProvider`] and retirns it as an [`ICU4XDataProvider`].
 /// See [`FsDataProvider::try_new()`] for more details.
@@ -120,7 +122,7 @@ pub unsafe extern "C" fn icu4x_fs_data_provider_create(
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(any(target_arch = "wasm32", target_os = "none"))]
 #[no_mangle]
 /// Constructs an [`StaticDataProvider`] and retirns it as an [`ICU4XDataProvider`].
 /// See [`StaticDataProvider::new()`] for more details.

--- a/ffi/capi/src/provider.rs
+++ b/ffi/capi/src/provider.rs
@@ -3,8 +3,9 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use icu_provider::serde::SerdeDeDataProvider;
+#[cfg(not(any(target_arch = "wasm32", target_os = "none")))]
 use icu_provider_fs::FsDataProvider;
-use std::{mem, ptr, slice, str};
+use std::{mem, ptr};
 
 #[repr(C)]
 /// FFI version of [`SerdeDeDataProvider`]. See its docs for more details.
@@ -105,6 +106,7 @@ pub unsafe extern "C" fn icu4x_fs_data_provider_create(
     path: *const u8,
     len: usize,
 ) -> ICU4XCreateDataProviderResult {
+    use std::{slice, str};
     let path = str::from_utf8_unchecked(slice::from_raw_parts(path, len));
     match FsDataProvider::try_new(path.to_string()) {
         Ok(fs) => {

--- a/ffi/capi/src/provider.rs
+++ b/ffi/capi/src/provider.rs
@@ -90,7 +90,6 @@ pub struct ICU4XCreateDataProviderResult {
     pub success: bool,
 }
 
-
 #[cfg(not(any(target_arch = "wasm32", target_os = "none")))]
 #[no_mangle]
 /// Constructs an [`FsDataProvider`] and retirns it as an [`ICU4XDataProvider`].

--- a/provider/blob/Cargo.toml
+++ b/provider/blob/Cargo.toml
@@ -38,7 +38,7 @@ log = { version = "0.4", optional = true }
 
 [dev-dependencies]
 icu = { version = "0.2", path = "../../components/icu" }
-icu_testdata = { version = "0.2", path = "../../provider/testdata" }
+icu_testdata = { version = "0.2", path = "../../provider/testdata", features = ["static"] }
 icu_locid_macros = { version = "0.2", path = "../../components/locid/macros" }
 
 [lib]

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -126,8 +126,8 @@ skip_optional_dependencies = true
 
 [dependencies]
 icu_provider = { version = "0.2", path = "../../provider/core" }
-icu_provider_blob = { version = "0.2", path = "../../provider/blob" }
-icu_provider_fs = { version = "0.2", path = "../../provider/fs" }
+icu_provider_blob = { version = "0.2", path = "../../provider/blob", optional = true }
+icu_provider_fs = { version = "0.2", path = "../../provider/fs", optional = true }
 icu_locid = { version = "0.2", path = "../../components/locid" }
 
 # Dependencies for the "metadata" feature
@@ -142,6 +142,7 @@ icu_locid_macros = { version = "0.2", path = "../../components/locid/macros" }
 icu_plurals = { version = "0.2", path = "../../components/plurals" }
 
 [features]
+default = ["fs", "std"]
 # Enables programmatic access to this Cargo.toml file
 metadata = [
     "cargo_metadata",
@@ -150,4 +151,9 @@ metadata = [
     "serde",
     "displaydoc",
     "writeable",
+    "std"
 ]
+
+fs = ["icu_provider_fs", "std"]
+static = ["icu_provider_blob"]
+std = []

--- a/provider/testdata/src/lib.rs
+++ b/provider/testdata/src/lib.rs
@@ -63,12 +63,21 @@
 //!
 //! [`ICU4X`]: ../icu/index.html
 
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
+
+extern crate alloc;
+
 #[cfg(feature = "metadata")]
 pub mod metadata;
+#[cfg(feature = "fs")]
 pub mod paths;
 
+#[cfg(feature = "static")]
 mod blob;
+#[cfg(feature = "fs")]
 mod fs;
 
+#[cfg(feature = "static")]
 pub use blob::get_static_provider;
+#[cfg(feature = "fs")]
 pub use fs::get_provider;


### PR DESCRIPTION
Progress towards #812

Also makes the capi crate pull in the Fs/Static data providers more strategically.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->