### PR TITLE
Move icu_plurals and icu_decimal to no_std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "ecma402_traits",
  "icu",
  "icu_locid",
+ "icu_plurals",
  "icu_provider",
  "icu_testdata",
  "serde",

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -47,6 +47,7 @@ rand_distr = "0.4"
 getrandom = { version = "0.2", features = ["js"] }
 
 [features]
+std = ["icu_locid/std", "icu_provider/std", "fixed_decimal/std"]
 default = ["provider_serde"]
 bench = []
 provider_serde = ["serde"]

--- a/components/decimal/src/error.rs
+++ b/components/decimal/src/error.rs
@@ -12,7 +12,8 @@ pub enum Error {
     Data(icu_provider::DataError),
 }
 
-impl core::error::Error for Error {}
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
 
 impl From<icu_provider::DataError> for Error {
     fn from(e: icu_provider::DataError) -> Self {

--- a/components/decimal/src/error.rs
+++ b/components/decimal/src/error.rs
@@ -12,7 +12,7 @@ pub enum Error {
     Data(icu_provider::DataError),
 }
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl From<icu_provider::DataError> for Error {
     fn from(e: icu_provider::DataError) -> Self {

--- a/components/decimal/src/format.rs
+++ b/components/decimal/src/format.rs
@@ -32,9 +32,9 @@ impl<'l> FormattedFixedDecimal<'l> {
 }
 
 impl<'l> Writeable for FormattedFixedDecimal<'l> {
-    fn write_to<W>(&self, sink: &mut W) -> std::result::Result<(), std::fmt::Error>
+    fn write_to<W>(&self, sink: &mut W) -> core::result::Result<(), core::fmt::Error>
     where
-        W: std::fmt::Write + ?Sized,
+        W: core::fmt::Write + ?Sized,
     {
         let affixes = self.get_affixes();
         if let Some(affixes) = affixes {

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -56,6 +56,10 @@
 //!
 //! [`FixedDecimalFormat`]: FixedDecimalFormat
 
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
+
+extern crate alloc;
+
 pub mod error;
 pub mod format;
 mod grouper;

--- a/components/decimal/src/provider.rs
+++ b/components/decimal/src/provider.rs
@@ -7,7 +7,7 @@
 //! Read more about data providers: [`icu_provider`]
 
 use icu_provider::yoke::{self, *};
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 
 pub mod key {
     //! Resource keys for [`icu_decimal`](crate).

--- a/components/decimal/src/provider.rs
+++ b/components/decimal/src/provider.rs
@@ -6,8 +6,8 @@
 //!
 //! Read more about data providers: [`icu_provider`]
 
-use icu_provider::yoke::{self, *};
 use alloc::borrow::Cow;
+use icu_provider::yoke::{self, *};
 
 pub mod key {
     //! Resource keys for [`icu_decimal`](crate).

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -74,6 +74,10 @@ required-features = ["provider_serde"]
 name = "plurals"
 required-features = ["provider_serde"]
 
+[[test]]
+name = "operands"
+required-features = ["provider_serde", "std"]
+
 [[example]]
 name = "unread_emails"
 required-features = ["provider_serde"]

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -51,6 +51,7 @@ path = "src/lib.rs"
 bench = false  # This option is required for Benchmark CI
 
 [features]
+std = ["icu_locid/std", "icu_provider/std"]
 default = ["provider_serde"]
 bench = []
 provider_serde = ["serde"]

--- a/components/plurals/src/data.rs
+++ b/components/plurals/src/data.rs
@@ -7,8 +7,8 @@ use crate::provider::PluralRuleStringsV1;
 use crate::rules;
 use crate::rules::ast;
 use crate::{PluralCategory, PluralRulesError};
-use std::borrow::Cow;
-use std::convert::TryInto;
+use alloc::borrow::Cow;
+use core::convert::TryInto;
 
 /// A raw function pointer to a `PluralRulesFn`
 // pub type PluralRulesFn = fn(&PluralOperands) -> PluralCategory;

--- a/components/plurals/src/error.rs
+++ b/components/plurals/src/error.rs
@@ -17,7 +17,7 @@ pub enum PluralRulesError {
     DataProvider(DataError),
 }
 
-impl std::error::Error for PluralRulesError {}
+impl core::error::Error for PluralRulesError {}
 
 impl From<ParserError> for PluralRulesError {
     fn from(e: ParserError) -> Self {

--- a/components/plurals/src/error.rs
+++ b/components/plurals/src/error.rs
@@ -17,7 +17,8 @@ pub enum PluralRulesError {
     DataProvider(DataError),
 }
 
-impl core::error::Error for PluralRulesError {}
+#[cfg(feature = "std")]
+impl std::error::Error for PluralRulesError {}
 
 impl From<ParserError> for PluralRulesError {
     fn from(e: ParserError) -> Self {

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -80,7 +80,7 @@ use icu_locid::LanguageIdentifier;
 use icu_provider::prelude::*;
 pub use operands::PluralOperands;
 use provider::{resolver, PluralRuleStringsV1, PluralRuleStringsV1Marker};
-use std::convert::TryInto;
+use core::convert::TryInto;
 
 /// A type of a plural rule which can be associated with the [`PluralRules`] struct.
 ///

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -64,6 +64,11 @@
 //! [`Plural Category`]: PluralCategory
 //! [`Language Plural Rules`]: https://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules
 //! [`CLDR`]: http://cldr.unicode.org/
+
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
+
+extern crate alloc;
+
 mod data;
 mod error;
 mod operands;

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -75,12 +75,12 @@ mod operands;
 pub mod provider;
 pub mod rules;
 
+use core::convert::TryInto;
 pub use error::PluralRulesError;
 use icu_locid::LanguageIdentifier;
 use icu_provider::prelude::*;
 pub use operands::PluralOperands;
 use provider::{resolver, PluralRuleStringsV1, PluralRuleStringsV1Marker};
-use core::convert::TryInto;
 
 /// A type of a plural rule which can be associated with the [`PluralRules`] struct.
 ///

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -5,7 +5,6 @@
 use displaydoc::Display;
 use fixed_decimal::FixedDecimal;
 use core::convert::TryFrom;
-use core::io::Error as IOError;
 use core::isize;
 use core::num::ParseIntError;
 use core::str::FromStr;
@@ -80,6 +79,9 @@ impl PluralOperands {
     /// Returns the number represented by this [`PluralOperands`] as floating point.
     /// The precision of the number returned is up to the representation accuracy
     /// of a double.
+    ///
+    /// This method requires the `"std"` feature be enabled
+    #[cfg(feature = "std")]
     pub fn n(&self) -> f64 {
         let fraction = self.t as f64 / 10_f64.powi(self.v as i32);
         self.i as f64 + fraction
@@ -105,8 +107,9 @@ impl From<ParseIntError> for OperandsError {
     }
 }
 
-impl From<IOError> for OperandsError {
-    fn from(_: IOError) -> Self {
+#[cfg(feature = "std")]
+impl From<std::io::Error> for OperandsError {
+    fn from(_: std::io::Error) -> Self {
         Self::Invalid
     }
 }

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -4,11 +4,11 @@
 
 use displaydoc::Display;
 use fixed_decimal::FixedDecimal;
-use std::convert::TryFrom;
-use std::io::Error as IOError;
-use std::isize;
-use std::num::ParseIntError;
-use std::str::FromStr;
+use core::convert::TryFrom;
+use core::io::Error as IOError;
+use core::isize;
+use core::num::ParseIntError;
+use core::str::FromStr;
 
 /// A full plural operands representation of a number. See [CLDR Plural Rules](http://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules) for complete operands description.
 /// Plural operands in compliance with [CLDR Plural Rules](http://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules).
@@ -96,7 +96,7 @@ pub enum OperandsError {
     Invalid,
 }
 
-impl std::error::Error for OperandsError {}
+impl core::error::Error for OperandsError {}
 
 impl From<ParseIntError> for OperandsError {
     fn from(_: ParseIntError) -> Self {
@@ -230,8 +230,8 @@ impl From<&FixedDecimal> for PluralOperands {
     /// digits each from the integer and fraction parts.
     fn from(dec: &FixedDecimal) -> Self {
         let mag_range = dec.magnitude_range();
-        let mag_high = std::cmp::min(17, *mag_range.end());
-        let mag_low = std::cmp::max(-18, *mag_range.start());
+        let mag_high = core::cmp::min(17, *mag_range.end());
+        let mag_low = core::cmp::max(-18, *mag_range.start());
 
         let mut i: u64 = 0;
         for magnitude in (0..=mag_high).rev() {

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -2,12 +2,12 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use displaydoc::Display;
-use fixed_decimal::FixedDecimal;
 use core::convert::TryFrom;
 use core::isize;
 use core::num::ParseIntError;
 use core::str::FromStr;
+use displaydoc::Display;
+use fixed_decimal::FixedDecimal;
 
 /// A full plural operands representation of a number. See [CLDR Plural Rules](http://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules) for complete operands description.
 /// Plural operands in compliance with [CLDR Plural Rules](http://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules).

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -96,7 +96,8 @@ pub enum OperandsError {
     Invalid,
 }
 
-impl core::error::Error for OperandsError {}
+#[cfg(feature = "std")]
+impl std::error::Error for OperandsError {}
 
 impl From<ParseIntError> for OperandsError {
     fn from(_: ParseIntError) -> Self {

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -7,7 +7,7 @@
 //! Read more about data providers: [`icu_provider`]
 
 use icu_provider::yoke::{self, *};
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 
 pub mod key {
     use icu_provider::{resource_key, ResourceKey};

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -6,8 +6,8 @@
 //!
 //! Read more about data providers: [`icu_provider`]
 
-use icu_provider::yoke::{self, *};
 use alloc::borrow::Cow;
+use icu_provider::yoke::{self, *};
 
 pub mod key {
     use icu_provider::{resource_key, ResourceKey};

--- a/components/plurals/src/rules/ast.rs
+++ b/components/plurals/src/rules/ast.rs
@@ -38,7 +38,9 @@
 //! [`PluralCategory`]: crate::PluralCategory
 //! [`parse`]: super::parse()
 //! [`test_condition`]: super::test_condition()
-use std::ops::RangeInclusive;
+use alloc::boxed::Box;
+use alloc::string::String;
+use core::ops::RangeInclusive;
 
 /// A complete AST representation of a plural rule.
 /// Comprises a vector of [`AndConditions`] and optionally a set of [`Samples`].

--- a/components/plurals/src/rules/lexer.rs
+++ b/components/plurals/src/rules/lexer.rs
@@ -34,7 +34,8 @@ pub enum LexerError {
     UnknownToken(u8),
 }
 
-impl core::error::Error for LexerError {}
+#[cfg(feature = "std")]
+impl std::error::Error for LexerError {}
 
 /// Unicode Plural Rule lexer is an iterator
 /// over tokens produced from an input string.

--- a/components/plurals/src/rules/lexer.rs
+++ b/components/plurals/src/rules/lexer.rs
@@ -34,7 +34,7 @@ pub enum LexerError {
     UnknownToken(u8),
 }
 
-impl std::error::Error for LexerError {}
+impl core::error::Error for LexerError {}
 
 /// Unicode Plural Rule lexer is an iterator
 /// over tokens produced from an input string.

--- a/components/plurals/src/rules/parser.rs
+++ b/components/plurals/src/rules/parser.rs
@@ -2,10 +2,14 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use alloc::vec;
 use super::ast;
 use super::lexer::{Lexer, Token};
 use displaydoc::Display;
-use std::iter::Peekable;
+use core::iter::Peekable;
 
 #[derive(Display, Debug, PartialEq, Eq)]
 pub enum ParserError {
@@ -23,7 +27,7 @@ pub enum ParserError {
     ExpectedSampleType,
 }
 
-impl std::error::Error for ParserError {}
+impl core::error::Error for ParserError {}
 
 /// Unicode Plural Rule parser converts an
 /// input string into a Rule [`AST`].

--- a/components/plurals/src/rules/parser.rs
+++ b/components/plurals/src/rules/parser.rs
@@ -2,14 +2,14 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use alloc::string::String;
-use alloc::string::ToString;
-use alloc::vec::Vec;
-use alloc::vec;
 use super::ast;
 use super::lexer::{Lexer, Token};
-use displaydoc::Display;
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec;
+use alloc::vec::Vec;
 use core::iter::Peekable;
+use displaydoc::Display;
 
 #[derive(Display, Debug, PartialEq, Eq)]
 pub enum ParserError {

--- a/components/plurals/src/rules/parser.rs
+++ b/components/plurals/src/rules/parser.rs
@@ -27,7 +27,8 @@ pub enum ParserError {
     ExpectedSampleType,
 }
 
-impl core::error::Error for ParserError {}
+#[cfg(feature = "std")]
+impl std::error::Error for ParserError {}
 
 /// Unicode Plural Rule parser converts an
 /// input string into a Rule [`AST`].

--- a/components/plurals/src/rules/serializer.rs
+++ b/components/plurals/src/rules/serializer.rs
@@ -3,8 +3,8 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::rules::ast;
-use std::fmt;
-use std::ops::RangeInclusive;
+use core::fmt;
+use core::ops::RangeInclusive;
 
 /// Unicode Plural Rule serializer converts an [`AST`] to a [`String`].
 ///

--- a/ffi/ecma402/Cargo.toml
+++ b/ffi/ecma402/Cargo.toml
@@ -29,6 +29,7 @@ all-features = true
 ecma402_traits = { version = "0.2.0" }
 icu = { path = "../../components/icu", default-features = false }
 icu_provider = { version = "0.2", path = "../../provider/core" }
+icu_plurals = { version = "0.2", path = "../../components/plurals", features = ["std"] }
 
 
 [dev-dependencies]


### PR DESCRIPTION
Progress towards #812


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->