### PR TITLE
Add working Clone impl for Yoke

### DIFF
--- a/utils/yoke/src/trait_hack.rs
+++ b/utils/yoke/src/trait_hack.rs
@@ -203,6 +203,8 @@
 //! }
 //! ```
 
+use core::mem;
+
 /// A wrapper around a type `T`, forwarding trait calls down to the inner type.
 ///
 /// `YokeTraitHack` supports [`Clone`] and [`serde::Deserialize`] out of the box. Other traits can
@@ -212,6 +214,14 @@
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct YokeTraitHack<T>(pub T);
+
+impl<'a, T> YokeTraitHack<&'a T> {
+    pub fn to_ref(self) -> &'a YokeTraitHack<T> {
+        // YokeTraitHack is repr(transparent) so it's always safe
+        // to transmute YTH<&T> to &YTH<T>
+        unsafe { mem::transmute::<YokeTraitHack<&T>, &YokeTraitHack<T>>(self) }
+    }
+}
 
 // This is implemented manually to avoid the serde derive dependency.
 #[cfg(feature = "serde")]

--- a/utils/yoke/src/trait_hack.rs
+++ b/utils/yoke/src/trait_hack.rs
@@ -221,7 +221,7 @@ impl<'a, T> YokeTraitHack<&'a T> {
     /// This is safe because `YokeTraitHack` is `repr(transparent)`.
     ///
     /// This method is required to implement `Clone` on `Yoke`.
-    pub fn to_ref(self) -> &'a YokeTraitHack<T> {
+    pub fn into_ref(self) -> &'a YokeTraitHack<T> {
         // YokeTraitHack is repr(transparent) so it's always safe
         // to transmute YTH<&T> to &YTH<T>
         unsafe { mem::transmute::<YokeTraitHack<&T>, &YokeTraitHack<T>>(self) }

--- a/utils/yoke/src/trait_hack.rs
+++ b/utils/yoke/src/trait_hack.rs
@@ -216,6 +216,11 @@ use core::mem;
 pub struct YokeTraitHack<T>(pub T);
 
 impl<'a, T> YokeTraitHack<&'a T> {
+    /// Converts from `YokeTraitHack<&T>` to `&YokeTraitHack<T>`.
+    ///
+    /// This is safe because `YokeTraitHack` is `repr(transparent)`.
+    ///
+    /// This method is required to implement `Clone` on `Yoke`.
     pub fn to_ref(self) -> &'a YokeTraitHack<T> {
         // YokeTraitHack is repr(transparent) so it's always safe
         // to transmute YTH<&T> to &YTH<T>

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -481,7 +481,7 @@ where
     fn clone(&self) -> Self {
         let this: &Y::Output = self.get();
         // We have an &T not a T, and we can clone YokeTraitHack<T>
-        let this_hack = YokeTraitHack(this).to_ref();
+        let this_hack = YokeTraitHack(this).into_ref();
         Yoke {
             yokeable: unsafe { Y::make(this_hack.clone().0) },
             cart: self.cart.clone(),

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -482,6 +482,17 @@ where
     }
 }
 
+#[test]
+fn test_clone() {
+    let local_data = "foo".to_string();
+    let y1 = Yoke::<
+        alloc::borrow::Cow<'static, str>,
+        Rc<String>
+    >::attach_to_rc_cart(Rc::new(local_data));
+    let y2 = y1.clone();
+    assert_eq!(y1.get(), y2.get());
+}
+
 impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// Allows one to "project" a yoke to perform a transformation on the data, potentially
     /// looking at a subfield, and producing a new yoke. This will move cart, and the provided


### PR DESCRIPTION
@Manishearth Can you take a look and fix this so that the test builds?  I tried using YokeTraitHack but couldn't get it to behave property for Clone since it needs `T` to be an owned field, but I can only get a reference to `T`.

See #753