### PR TITLE
Make `cargo quick` quicker

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -11,14 +11,14 @@ default_to_workspace = false
 
 
 [tasks.quick]
-description = "Run quick version of all lints and tests"
+description = "Run quick version of all lints and builds (useful before pushing to GitHub)"
 category = "ICU4X Development"
 dependencies = [
-    "test-all-features",
-    "tidy",
+    "ci-job-check",
+    "check-no-features",
+    "fmt-check",
     "clippy-all",
-    "test-ffi",
-    "test-cppdoc",
+    "ci-job-tidy",
 ]
 
 [tasks.tidy]
@@ -28,6 +28,12 @@ dependencies = [
     "fmt-check",
     "ci-job-tidy",
 ]
+
+[tasks.check-no-features]
+description = "Check ICU4X build with no features (covered in CI via cargo build-all-features)"
+category = "ICU4X Development"
+command = "cargo"
+args = ["check", "--all-targets", "--no-default-features"]
 
 [tasks.ci-job-check]
 description = "Run all tests for the CI 'check' job"


### PR DESCRIPTION
Fixes #896

The intent behind `cargo quick` is to run it before you open a PR.  If everything builds, that's sufficient to unblock most of CI; test failures are more rare and will be found by CI without having to run them locally.