### PR TITLE
Remove DataPayload::from_borrowed

### DIFF
--- a/components/datetime/src/format/zoned_datetime.rs
+++ b/components/datetime/src/format/zoned_datetime.rs
@@ -13,15 +13,15 @@ use writeable::Writeable;
 use super::datetime;
 use super::time_zone;
 
-pub struct FormattedZonedDateTime<'l, T>
+pub struct FormattedZonedDateTime<'l, 'd, T>
 where
     T: ZonedDateTimeInput,
 {
-    pub(crate) zoned_datetime_format: &'l ZonedDateTimeFormat<'l>,
+    pub(crate) zoned_datetime_format: &'l ZonedDateTimeFormat<'d>,
     pub(crate) zoned_datetime: &'l T,
 }
 
-impl<'l, T> Writeable for FormattedZonedDateTime<'l, T>
+impl<'l, 'd, T> Writeable for FormattedZonedDateTime<'l, 'd, T>
 where
     T: ZonedDateTimeInput,
 {
@@ -33,7 +33,7 @@ where
     // TODO(#489): Implement write_len
 }
 
-impl<'l, T> fmt::Display for FormattedZonedDateTime<'l, T>
+impl<'l, 'd, T> fmt::Display for FormattedZonedDateTime<'l, 'd, T>
 where
     T: ZonedDateTimeInput,
 {

--- a/components/datetime/src/zoned_datetime.rs
+++ b/components/datetime/src/zoned_datetime.rs
@@ -196,7 +196,7 @@ impl<'d> ZonedDateTimeFormat<'d> {
     /// At the moment, there's little value in using that over one of the other `format` methods,
     /// but [`FormattedZonedDateTime`] will grow with methods for iterating over fields, extracting information
     /// about formatted date and so on.
-    pub fn format<'l: 'd, T>(&'l self, value: &'l T) -> FormattedZonedDateTime<'l, T>
+    pub fn format<'l, T>(&'l self, value: &'l T) -> FormattedZonedDateTime<'l, 'd, T>
     where
         T: ZonedDateTimeInput,
     {

--- a/components/decimal/src/grouper.rs
+++ b/components/decimal/src/grouper.rs
@@ -46,6 +46,8 @@ fn test_grouper() {
     use crate::FixedDecimalFormat;
     use fixed_decimal::FixedDecimal;
     use icu_locid::LanguageIdentifier;
+    use icu_provider::prelude::*;
+    use icu_provider::struct_provider::StructProvider;
     use writeable::Writeable;
 
     let western_sizes = GroupingSizesV1 {
@@ -111,9 +113,9 @@ fn test_grouper() {
                 .unwrap();
             let mut data_struct: crate::provider::DecimalSymbolsV1 = Default::default();
             data_struct.grouping_sizes = cas.sizes;
-            let provider = icu_provider::struct_provider::StructProvider {
+            let provider = StructProvider {
                 key: crate::provider::key::SYMBOLS_V1,
-                data: &data_struct,
+                data: DataPayload::from_owned(data_struct),
             };
             let options = options::FixedDecimalFormatOptions {
                 grouping_strategy: cas.strategy,

--- a/components/plurals/tests/plurals.rs
+++ b/components/plurals/tests/plurals.rs
@@ -5,8 +5,10 @@
 use icu_locid_macros::langid;
 use icu_plurals::provider::{self, PluralRuleStringsV1};
 use icu_plurals::{PluralCategory, PluralRuleType, PluralRules};
+use icu_provider::prelude::*;
 use icu_provider::struct_provider::StructProvider;
 use std::borrow::Cow;
+use std::rc::Rc;
 
 #[test]
 fn test_plural_rules() {
@@ -56,7 +58,7 @@ fn test_plural_rules_non_static_lifetime() {
     };
     let provider = StructProvider {
         key: provider::key::CARDINAL_V1,
-        data: &local_data,
+        data: DataPayload::from_partial_owned(Rc::from(local_data)),
     };
 
     let lid = langid!("und");

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -196,8 +196,8 @@ where
     /// ```
     /// use icu_provider::prelude::*;
     /// use icu_provider::hello_world::*;
-    /// use std::rc::Rc;
     /// use std::borrow::Cow;
+    /// use std::rc::Rc;
     ///
     /// let local_data = "example".to_string();
     ///
@@ -321,9 +321,8 @@ where
     /// ```
     /// use icu_provider::prelude::*;
     /// use icu_provider::marker::CowStrMarker;
-    /// use std::borrow::Cow;
     ///
-    /// let mut payload = DataPayload::<CowStrMarker>::from_owned(Cow::Borrowed("Hello"));
+    /// let mut payload = DataPayload::<CowStrMarker>::from_static_str("Hello");
     ///
     /// payload.with_mut(|s| s.to_mut().push_str(" World"));
     ///
@@ -335,9 +334,8 @@ where
     /// ```
     /// use icu_provider::prelude::*;
     /// use icu_provider::marker::CowStrMarker;
-    /// use std::borrow::Cow;
     ///
-    /// let mut payload = DataPayload::<CowStrMarker>::from_owned(Cow::Borrowed("Hello"));
+    /// let mut payload = DataPayload::<CowStrMarker>::from_static_str("Hello");
     ///
     /// let suffix = " World".to_string();
     /// payload.with_mut(move |s| s.to_mut().push_str(&suffix));
@@ -367,9 +365,8 @@ where
     /// ```
     /// use icu_provider::prelude::*;
     /// use icu_provider::marker::CowStrMarker;
-    /// use std::borrow::Cow;
     ///
-    /// let payload = DataPayload::<CowStrMarker>::from_owned(Cow::Borrowed("Demo"));
+    /// let payload = DataPayload::<CowStrMarker>::from_static_str("Demo");
     ///
     /// assert_eq!("Demo", payload.get());
     /// ```

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -98,6 +98,8 @@ pub(crate) enum DataPayloadInner<'d, 's: 'd, M>
 where
     M: DataMarker<'s>,
 {
+    // TODO(#752): Remove the Borrowed variant and rename the lifetime parameter
+    #[allow(dead_code)]
     Borrowed(Yoke<M::Yokeable, &'d M::Cart>),
     RcStruct(Yoke<M::Yokeable, Rc<M::Cart>>),
     Owned(Yoke<M::Yokeable, ()>),

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -118,8 +118,9 @@ where
 /// ```
 /// use icu_provider::prelude::*;
 /// use icu_provider::marker::CowStrMarker;
+/// use std::borrow::Cow;
 ///
-/// let payload = DataPayload::<CowStrMarker>::from_borrowed("Demo");
+/// let payload = DataPayload::<CowStrMarker>::from_owned(Cow::Borrowed("Demo"));
 ///
 /// assert_eq!("Demo", payload.get());
 /// ```
@@ -214,35 +215,6 @@ where
     pub fn from_partial_owned(data: Rc<M::Cart>) -> Self {
         Self {
             inner: DataPayloadInner::RcStruct(Yoke::attach_to_rc_cart(data)),
-        }
-    }
-
-    /// Convert an `&'d `[`Cart`] into a [`DataPayload`]. The data need not be fully owned;
-    /// it may be constrained by the `'s` lifetime.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use icu_provider::prelude::*;
-    /// use icu_provider::hello_world::*;
-    /// use std::borrow::Cow;
-    ///
-    /// let local_data = "example".to_string();
-    ///
-    /// let local_struct = HelloWorldV1 {
-    ///     message: Cow::Borrowed(&local_data),
-    /// };
-    ///
-    /// let payload = DataPayload::<HelloWorldV1Marker>::from_borrowed(&local_struct);
-    ///
-    /// assert_eq!(payload.get(), &local_struct);
-    /// ```
-    ///
-    /// [`Cart`]: crate::marker::DataMarker::Cart
-    #[inline]
-    pub fn from_borrowed(data: &'d M::Cart) -> Self {
-        Self {
-            inner: DataPayloadInner::Borrowed(Yoke::attach_to_borrowed_cart(data)),
         }
     }
 }
@@ -349,8 +321,9 @@ where
     /// ```
     /// use icu_provider::prelude::*;
     /// use icu_provider::marker::CowStrMarker;
+    /// use std::borrow::Cow;
     ///
-    /// let mut payload = DataPayload::<CowStrMarker>::from_borrowed("Hello");
+    /// let mut payload = DataPayload::<CowStrMarker>::from_owned(Cow::Borrowed("Hello"));
     ///
     /// payload.with_mut(|s| s.to_mut().push_str(" World"));
     ///
@@ -362,8 +335,9 @@ where
     /// ```
     /// use icu_provider::prelude::*;
     /// use icu_provider::marker::CowStrMarker;
+    /// use std::borrow::Cow;
     ///
-    /// let mut payload = DataPayload::<CowStrMarker>::from_borrowed("Hello");
+    /// let mut payload = DataPayload::<CowStrMarker>::from_owned(Cow::Borrowed("Hello"));
     ///
     /// let suffix = " World".to_string();
     /// payload.with_mut(move |s| s.to_mut().push_str(&suffix));
@@ -393,8 +367,9 @@ where
     /// ```
     /// use icu_provider::prelude::*;
     /// use icu_provider::marker::CowStrMarker;
+    /// use std::borrow::Cow;
     ///
-    /// let payload = DataPayload::<CowStrMarker>::from_borrowed("Demo");
+    /// let payload = DataPayload::<CowStrMarker>::from_owned(Cow::Borrowed("Demo"));
     ///
     /// assert_eq!("Demo", payload.get());
     /// ```
@@ -479,7 +454,7 @@ fn test_debug() {
     use alloc::borrow::Cow;
     let resp = DataResponse::<HelloWorldV1Marker> {
         metadata: Default::default(),
-        payload: Some(DataPayload::from_borrowed(&HelloWorldV1 {
+        payload: Some(DataPayload::from_owned(HelloWorldV1 {
             message: Cow::Borrowed("foo"),
         })),
     };

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -178,7 +178,7 @@ where
 #[test]
 fn test_clone_eq() {
     use crate::marker::CowStrMarker;
-    let p1 = DataPayload::<CowStrMarker>::from_borrowed("Demo");
+    let p1 = DataPayload::<CowStrMarker>::from_static_str("Demo");
     let p2 = p1.clone();
     assert_eq!(p1, p2);
 }

--- a/provider/core/src/marker/impls.rs
+++ b/provider/core/src/marker/impls.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use super::*;
+use crate::prelude::*;
 use alloc::borrow::Cow;
 use alloc::string::String;
 
@@ -12,6 +13,13 @@ pub struct CowStrMarker;
 impl<'s> DataMarker<'s> for CowStrMarker {
     type Yokeable = Cow<'static, str>;
     type Cart = str;
+}
+
+impl DataPayload<'static, 'static, CowStrMarker> {
+    /// Make a [`DataPayload`]`<`[`CowStrMarker`]`>` from a static string slice.
+    pub fn from_static_str(s: &'static str) -> DataPayload<'static, 'static, CowStrMarker> {
+        DataPayload::from_owned(Cow::Borrowed(s))
+    }
 }
 
 /// Marker type for [`Cow`]`<str>` where the backing cart is `String`. This is required if

--- a/provider/core/src/struct_provider.rs
+++ b/provider/core/src/struct_provider.rs
@@ -6,8 +6,8 @@
 
 use crate::error::Error;
 use crate::prelude::*;
-use crate::yoke::*;
 use crate::yoke::trait_hack::YokeTraitHack;
+use crate::yoke::*;
 
 /// A data provider that returns clones of a constant data payload.
 ///


### PR DESCRIPTION
Step toward #752

This PR removes the public function DataPayload::from_borrowed.  It does not actually remove the variant, because doing so will require performing the large refactor that removes the second lifetime argument; I would rather do that in its own PR (coming next after this one).