### PR TITLE
Add WriteableTrait to C++ bindings

### DIFF
--- a/ffi/cpp/examples/fixeddecimal/test.cpp
+++ b/ffi/cpp/examples/fixeddecimal/test.cpp
@@ -25,6 +25,19 @@ int main() {
         return 1;
     }
 
+    std::string out2;
+    bool success = fdf.FormatToWriteable(decimal, out2);
+    if (!success) {
+        std::cout << "FormatToWriteable failed" << std::endl;
+        return 1;
+    }
+    std::cout << "Formatted Writeable value is " << out2 << std::endl;
+
+    if (out2 != "১০,০০,০০৭") {
+        std::cout << "Output does not match expected output" << std::endl;
+        return 1;
+    }
+
     decimal.MultiplyPow10(2);
     decimal.Negate();
     out = fdf.Format(decimal).value();

--- a/ffi/cpp/include/decimal.hpp
+++ b/ffi/cpp/include/decimal.hpp
@@ -69,7 +69,7 @@ class FixedDecimalFormat {
   }
 
   template<typename T> bool FormatToWriteable(const FixedDecimal& dec, T& writeable) const {
-    ICU4XWriteable writer = icu4x::internal::WriteableTrait<T>::Construct(writeable);
+    ICU4XWriteable writer = icu4x::writeable::WriteableTrait<T>::Construct(writeable);
     bool success = icu4x_fixed_decimal_format_write(this->inner.get(),
                                                     dec.AsFFI(), &writer);
     return success;

--- a/ffi/cpp/include/decimal.hpp
+++ b/ffi/cpp/include/decimal.hpp
@@ -68,6 +68,12 @@ class FixedDecimalFormat {
     return out;
   }
 
+  template<typename T> bool FormatToWriteable(const FixedDecimal& dec, T& writeable) const {
+    ICU4XWriteable writer = icu4x::internal::WriteableTrait<T>::Construct(writeable);
+    bool success = icu4x_fixed_decimal_format_write(this->inner.get(),
+                                                    dec.AsFFI(), &writer);
+    return success;
+  }
  private:
   FixedDecimalFormat(ICU4XFixedDecimalFormat* i) : inner(i) {}
   std::unique_ptr<ICU4XFixedDecimalFormat, ICU4XFixedDecimalFormatDeleter>

--- a/ffi/cpp/include/locale.hpp
+++ b/ffi/cpp/include/locale.hpp
@@ -30,7 +30,7 @@ class Locale {
     return out;
   }
   template<typename T> bool ToWriteable(T& writeable) const {
-    ICU4XWriteable writer = icu4x::internal::WriteableTrait<T>::Construct(writeable);
+    ICU4XWriteable writer = icu4x::writeable::WriteableTrait<T>::Construct(writeable);
     ICU4XLocaleResult result = icu4x_locale_tostring(this->inner.get(), &writer);
     if (result != ICU4XLocaleResult_Ok) {
       return false;

--- a/ffi/cpp/include/locale.hpp
+++ b/ffi/cpp/include/locale.hpp
@@ -29,6 +29,14 @@ class Locale {
     }
     return out;
   }
+  template<typename T> bool ToWriteable(T& writeable) const {
+    ICU4XWriteable writer = icu4x::internal::WriteableTrait<T>::Construct(writeable);
+    ICU4XLocaleResult result = icu4x_locale_tostring(this->inner.get(), &writer);
+    if (result != ICU4XLocaleResult_Ok) {
+      return false;
+    }
+    return true;
+  }
   inline const ICU4XLocale* AsFFI() const { return this->inner.get(); }
 
  private:

--- a/ffi/cpp/include/writeable_utils.hpp
+++ b/ffi/cpp/include/writeable_utils.hpp
@@ -37,6 +37,18 @@ inline ICU4XWriteable WriteableFromString(std::string& string) {
   return w;
 };
 
+template<typename T> struct WriteableTrait {
+  // static inline ICU4XWriteable Construct(T& t);
+};
+
+
+template<> struct WriteableTrait<std::string> {
+  static inline ICU4XWriteable Construct(std::string& t) {
+    return WriteableFromString(t);
+  }
+};
+
+
 }  // namespace icu4x::internal
 
 #endif  // ICU4X_WRITEABLE_UTILS_HPP

--- a/ffi/cpp/include/writeable_utils.hpp
+++ b/ffi/cpp/include/writeable_utils.hpp
@@ -37,18 +37,19 @@ inline ICU4XWriteable WriteableFromString(std::string& string) {
   return w;
 };
 
-template<typename T> struct WriteableTrait {
-  // static inline ICU4XWriteable Construct(T& t);
-};
-
-
-template<> struct WriteableTrait<std::string> {
-  static inline ICU4XWriteable Construct(std::string& t) {
-    return WriteableFromString(t);
-  }
-};
-
-
 }  // namespace icu4x::internal
+
+namespace icu4x::writeable {
+  template<typename T> struct WriteableTrait {
+    // static inline ICU4XWriteable Construct(T& t);
+  };
+
+
+  template<> struct WriteableTrait<std::string> {
+    static inline ICU4XWriteable Construct(std::string& t) {
+      return icu4x::internal::WriteableFromString(t);
+    }
+  };
+} // namespace icu4x::writeable
 
 #endif  // ICU4X_WRITEABLE_UTILS_HPP


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/872


This adds a specializable WriteableTrait object that can be used to make any custom type a writeable, as well as methods on Locale and FDF that allow the passing in of arbitrary WriteableTrait implementors.


cc @dminor @shadaj

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->