### PR TITLE
Move the `icu` crate to no_std

### DIFF
--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -54,6 +54,7 @@ path = "src/lib.rs"
 bench = false  # This option is required for Benchmark CI
 
 [features]
+std = ["icu_provider/std", "icu_locid/std"]
 default = ["provider_serde"]
 bench = []
 provider_serde = ["serde", "litemap/serde"]

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -21,7 +21,8 @@ pub enum DateTimeError {
     InvalidTimeZoneOffset,
 }
 
-impl core::error::Error for DateTimeError {}
+#[cfg(feature = "std")]
+impl std::error::Error for DateTimeError {}
 
 impl From<core::num::ParseIntError> for DateTimeError {
     fn from(e: core::num::ParseIntError) -> Self {

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -2,17 +2,17 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use core::convert::TryFrom;
+use core::ops::{Add, Sub};
+use core::str::FromStr;
 use displaydoc::Display;
 use icu_locid::Locale;
-use std::convert::TryFrom;
-use std::ops::{Add, Sub};
-use std::str::FromStr;
 use tinystr::TinyStr8;
 
 #[derive(Display, Debug)]
 pub enum DateTimeError {
     #[displaydoc("{0}")]
-    Parse(std::num::ParseIntError),
+    Parse(core::num::ParseIntError),
     #[displaydoc("{field} must be between 0-{max}")]
     Overflow { field: &'static str, max: usize },
     #[displaydoc("{field} must be between {min}-0")]
@@ -21,10 +21,10 @@ pub enum DateTimeError {
     InvalidTimeZoneOffset,
 }
 
-impl std::error::Error for DateTimeError {}
+impl core::error::Error for DateTimeError {}
 
-impl From<std::num::ParseIntError> for DateTimeError {
-    fn from(e: std::num::ParseIntError) -> Self {
+impl From<core::num::ParseIntError> for DateTimeError {
+    fn from(e: core::num::ParseIntError) -> Self {
         DateTimeError::Parse(e)
     }
 }
@@ -299,7 +299,7 @@ impl From<usize> for IsoWeekday {
         if ordinal == 0 {
             ordinal = 7;
         }
-        unsafe { std::mem::transmute(ordinal) }
+        unsafe { core::mem::transmute(ordinal) }
     }
 }
 

--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -10,6 +10,7 @@ use crate::{
         helpers::DateTimePatterns,
     },
 };
+use alloc::string::String;
 use icu_locid::Locale;
 use icu_provider::prelude::*;
 
@@ -235,9 +236,9 @@ impl<'data> DateTimeFormat<'data> {
     /// ```
     pub fn format_to_write(
         &self,
-        w: &mut impl std::fmt::Write,
+        w: &mut impl core::fmt::Write,
         value: &impl DateTimeInput,
-    ) -> std::fmt::Result {
+    ) -> core::fmt::Result {
         datetime::write_pattern(
             &self.pattern,
             self.symbols.as_ref().map(|s| s.get()),
@@ -245,7 +246,7 @@ impl<'data> DateTimeFormat<'data> {
             &self.locale,
             w,
         )
-        .map_err(|_| std::fmt::Error)
+        .map_err(|_| core::fmt::Error)
     }
 
     /// Takes a [`DateTimeInput`] implementer and returns it formatted as a string.

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -32,7 +32,8 @@ pub enum DateTimeFormatError {
     UnsupportedField(FieldSymbol),
 }
 
-impl core::error::Error for DateTimeFormatError {}
+#[cfg(feature = "std")]
+impl std::error::Error for DateTimeFormatError {}
 
 impl From<pattern::Error> for DateTimeFormatError {
     fn from(e: pattern::Error) -> Self {

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -16,7 +16,7 @@ pub enum DateTimeFormatError {
     Pattern(pattern::Error),
     /// An error originating from the [`Write`](std::fmt::Write) trait.
     #[displaydoc("{0}")]
-    Format(std::fmt::Error),
+    Format(core::fmt::Error),
     /// An error originating inside of the [`DataProvider`](icu_provider::DataProvider).
     #[displaydoc("{0}")]
     DataProvider(DataError),
@@ -32,7 +32,7 @@ pub enum DateTimeFormatError {
     UnsupportedField(FieldSymbol),
 }
 
-impl std::error::Error for DateTimeFormatError {}
+impl core::error::Error for DateTimeFormatError {}
 
 impl From<pattern::Error> for DateTimeFormatError {
     fn from(e: pattern::Error) -> Self {
@@ -46,8 +46,8 @@ impl From<DataError> for DateTimeFormatError {
     }
 }
 
-impl From<std::fmt::Error> for DateTimeFormatError {
-    fn from(e: std::fmt::Error) -> Self {
+impl From<core::fmt::Error> for DateTimeFormatError {
+    fn from(e: core::fmt::Error) -> Self {
         DateTimeFormatError::Format(e)
     }
 }

--- a/components/datetime/src/fields/length.rs
+++ b/components/datetime/src/fields/length.rs
@@ -14,7 +14,8 @@ pub enum LengthError {
     InvalidLength,
 }
 
-impl core::error::Error for LengthError {}
+#[cfg(feature = "std")]
+impl std::error::Error for LengthError {}
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]
 #[cfg_attr(

--- a/components/datetime/src/fields/length.rs
+++ b/components/datetime/src/fields/length.rs
@@ -2,11 +2,11 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use displaydoc::Display;
-use std::{
+use core::{
     cmp::{Ord, PartialOrd},
     convert::TryFrom,
 };
+use displaydoc::Display;
 
 #[derive(Display, Debug, PartialEq)]
 pub enum LengthError {
@@ -14,7 +14,7 @@ pub enum LengthError {
     InvalidLength,
 }
 
-impl std::error::Error for LengthError {}
+impl core::error::Error for LengthError {}
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]
 #[cfg_attr(

--- a/components/datetime/src/fields/mod.rs
+++ b/components/datetime/src/fields/mod.rs
@@ -20,7 +20,8 @@ pub enum Error {
     InvalidLength(FieldSymbol),
 }
 
-impl core::error::Error for Error {}
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]
 #[cfg_attr(

--- a/components/datetime/src/fields/mod.rs
+++ b/components/datetime/src/fields/mod.rs
@@ -9,7 +9,7 @@ use displaydoc::Display;
 pub use length::{FieldLength, LengthError};
 pub use symbols::*;
 
-use std::{
+use core::{
     cmp::{Ord, PartialOrd},
     convert::{TryFrom, TryInto},
 };
@@ -20,7 +20,7 @@ pub enum Error {
     InvalidLength(FieldSymbol),
 }
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]
 #[cfg_attr(

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -3,8 +3,8 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::fields::FieldLength;
+use core::{cmp::Ordering, convert::TryFrom};
 use displaydoc::Display;
-use std::{cmp::Ordering, convert::TryFrom};
 
 #[derive(Display, Debug, PartialEq)]
 pub enum SymbolError {
@@ -16,7 +16,7 @@ pub enum SymbolError {
     Invalid(char),
 }
 
-impl std::error::Error for SymbolError {}
+impl core::error::Error for SymbolError {}
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[cfg_attr(

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -16,7 +16,8 @@ pub enum SymbolError {
     Invalid(char),
 }
 
-impl core::error::Error for SymbolError {}
+#[cfg(feature = "std")]
+impl std::error::Error for SymbolError {}
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[cfg_attr(

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -9,7 +9,7 @@ use crate::fields::{self, Field, FieldLength, FieldSymbol};
 use crate::pattern::{Pattern, PatternItem};
 use crate::provider;
 use crate::provider::helpers::DateTimeSymbols;
-use alloc::string::String;
+
 use alloc::string::ToString;
 use core::fmt;
 use icu_locid::Locale;

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -9,8 +9,10 @@ use crate::fields::{self, Field, FieldLength, FieldSymbol};
 use crate::pattern::{Pattern, PatternItem};
 use crate::provider;
 use crate::provider::helpers::DateTimeSymbols;
+use alloc::string::String;
+use alloc::string::ToString;
+use core::fmt;
 use icu_locid::Locale;
-use std::fmt;
 use writeable::Writeable;
 
 /// [`FormattedDateTime`] is a intermediate structure which can be retrieved as
@@ -57,7 +59,7 @@ where
 {
     fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
         write_pattern(self.pattern, self.symbols, self.datetime, self.locale, sink)
-            .map_err(|_| std::fmt::Error)
+            .map_err(|_| core::fmt::Error)
     }
 
     // TODO(#489): Implement write_len
@@ -69,12 +71,12 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write_pattern(self.pattern, self.symbols, self.datetime, self.locale, f)
-            .map_err(|_| std::fmt::Error)
+            .map_err(|_| core::fmt::Error)
     }
 }
 
 // Temporary formatting number with length.
-fn format_number<W>(result: &mut W, num: isize, length: FieldLength) -> Result<(), std::fmt::Error>
+fn format_number<W>(result: &mut W, num: isize, length: FieldLength) -> Result<(), core::fmt::Error>
 where
     W: fmt::Write + ?Sized,
 {

--- a/components/datetime/src/format/time_zone.rs
+++ b/components/datetime/src/format/time_zone.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use std::fmt;
+use core::fmt;
 
 use crate::error::DateTimeFormatError as Error;
 use crate::fields::{self, FieldSymbol};
@@ -26,7 +26,7 @@ where
     T: TimeZoneInput,
 {
     fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
-        write_pattern(self.time_zone_format, self.time_zone, sink).map_err(|_| std::fmt::Error)
+        write_pattern(self.time_zone_format, self.time_zone, sink).map_err(|_| core::fmt::Error)
     }
 
     // TODO(#489): Implement write_len
@@ -37,7 +37,7 @@ where
     T: TimeZoneInput,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write_pattern(self.time_zone_format, self.time_zone, f).map_err(|_| std::fmt::Error)
+        write_pattern(self.time_zone_format, self.time_zone, f).map_err(|_| core::fmt::Error)
     }
 }
 

--- a/components/datetime/src/format/zoned_datetime.rs
+++ b/components/datetime/src/format/zoned_datetime.rs
@@ -7,7 +7,7 @@ use crate::error::DateTimeFormatError as Error;
 use crate::fields::{self, FieldSymbol};
 use crate::pattern::PatternItem;
 use crate::{date::ZonedDateTimeInput, zoned_datetime::ZonedDateTimeFormat};
-use std::fmt;
+use core::fmt;
 use writeable::Writeable;
 
 use super::datetime;
@@ -27,7 +27,7 @@ where
 {
     fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
         write_pattern(self.zoned_datetime_format, self.zoned_datetime, sink)
-            .map_err(|_| std::fmt::Error)
+            .map_err(|_| core::fmt::Error)
     }
 
     // TODO(#489): Implement write_len
@@ -39,7 +39,7 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write_pattern(self.zoned_datetime_format, self.zoned_datetime, f)
-            .map_err(|_| std::fmt::Error)
+            .map_err(|_| core::fmt::Error)
     }
 }
 

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -69,6 +69,11 @@
 //! [`ICU4X`]: ../icu/index.html
 //! [`Length`]: options::length
 //! [`MockDateTime`]: mock::datetime::MockDateTime
+
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
+
+extern crate alloc;
+
 mod arithmetic;
 pub mod date;
 pub mod datetime;

--- a/components/datetime/src/mock/datetime.rs
+++ b/components/datetime/src/mock/datetime.rs
@@ -4,8 +4,8 @@
 
 use crate::arithmetic;
 use crate::date::*;
-use std::convert::TryInto;
-use std::str::FromStr;
+use core::convert::TryInto;
+use core::str::FromStr;
 use tinystr::tinystr8;
 
 /// A temporary struct that implements [`DateTimeInput`]

--- a/components/datetime/src/mock/time_zone.rs
+++ b/components/datetime/src/mock/time_zone.rs
@@ -2,10 +2,11 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use alloc::string::String;
 use tinystr::TinyStr8;
 
 use crate::date::*;
-use std::str::FromStr;
+use core::str::FromStr;
 
 // TODO(#622) link [`TimeZoneFormat`] appropriately once it is public.
 /// A temporary struct that implements [`TimeZoneInput`]

--- a/components/datetime/src/mock/zoned_datetime.rs
+++ b/components/datetime/src/mock/zoned_datetime.rs
@@ -5,7 +5,7 @@
 use tinystr::TinyStr8;
 
 use crate::date::*;
-use std::str::FromStr;
+use core::str::FromStr;
 
 use super::{datetime::MockDateTime, time_zone::MockTimeZone};
 

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -73,7 +73,7 @@
 //! time. Formatted result should be treated as opaque and displayed to the user as-is,
 //! and it is strongly recommended to never write tests that expect a particular formatted output.
 use crate::fields::{self, Field, FieldLength, FieldSymbol};
-use alloc::vec;
+
 use alloc::vec::Vec;
 
 use super::preferences;

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -73,6 +73,8 @@
 //! time. Formatted result should be treated as opaque and displayed to the user as-is,
 //! and it is strongly recommended to never write tests that expect a particular formatted output.
 use crate::fields::{self, Field, FieldLength, FieldSymbol};
+use alloc::vec;
+use alloc::vec::Vec;
 
 use super::preferences;
 #[cfg(feature = "serde")]

--- a/components/datetime/src/pattern/error.rs
+++ b/components/datetime/src/pattern/error.rs
@@ -22,7 +22,7 @@ pub enum Error {
     UnclosedPlaceholder,
 }
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl From<fields::Error> for Error {
     fn from(input: fields::Error) -> Self {

--- a/components/datetime/src/pattern/error.rs
+++ b/components/datetime/src/pattern/error.rs
@@ -22,7 +22,8 @@ pub enum Error {
     UnclosedPlaceholder,
 }
 
-impl core::error::Error for Error {}
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
 
 impl From<fields::Error> for Error {
     fn from(input: fields::Error) -> Self {

--- a/components/datetime/src/pattern/mod.rs
+++ b/components/datetime/src/pattern/mod.rs
@@ -6,10 +6,15 @@ mod error;
 mod parser;
 
 use crate::fields::{self, Field, FieldLength, FieldSymbol};
+use alloc::format;
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::{convert::TryFrom, fmt};
+use core::{fmt::Write, iter::FromIterator};
 pub use error::Error;
 use parser::Parser;
-use std::{convert::TryFrom, fmt};
-use std::{fmt::Write, iter::FromIterator};
 
 #[cfg(feature = "provider_serde")]
 use serde::{

--- a/components/datetime/src/pattern/mod.rs
+++ b/components/datetime/src/pattern/mod.rs
@@ -6,8 +6,10 @@ mod error;
 mod parser;
 
 use crate::fields::{self, Field, FieldLength, FieldSymbol};
+#[cfg(feature = "provider_serde")]
 use alloc::format;
 use alloc::string::String;
+#[cfg(feature = "provider_serde")]
 use alloc::string::ToString;
 use alloc::vec;
 use alloc::vec::Vec;

--- a/components/datetime/src/pattern/parser.rs
+++ b/components/datetime/src/pattern/parser.rs
@@ -5,7 +5,10 @@
 use super::error::Error;
 use super::{Pattern, PatternItem};
 use crate::fields::FieldSymbol;
-use std::convert::{TryFrom, TryInto};
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::{TryFrom, TryInto};
 
 #[derive(Debug, PartialEq)]
 enum Segment {
@@ -32,7 +35,7 @@ impl<'p> Parser<'p> {
     fn handle_quoted_literal(
         &mut self,
         ch: char,
-        chars: &mut std::iter::Peekable<std::str::Chars>,
+        chars: &mut core::iter::Peekable<core::str::Chars>,
         result: &mut Vec<PatternItem>,
     ) -> Result<bool, Error> {
         if ch == '\'' {

--- a/components/datetime/src/provider/gregory.rs
+++ b/components/datetime/src/provider/gregory.rs
@@ -2,8 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use alloc::borrow::Cow;
 use icu_provider::yoke::{self, *};
-use std::borrow::Cow;
 
 #[icu_provider::data_struct]
 #[derive(Debug, PartialEq, Clone, Default)]
@@ -139,8 +139,8 @@ pub mod patterns {
         pattern::{self, Pattern},
         skeleton::{Skeleton, SkeletonError},
     };
+    use core::convert::TryFrom;
     use litemap::LiteMap;
-    use std::convert::TryFrom;
 
     #[derive(Debug, PartialEq, Clone, Default)]
     #[cfg_attr(

--- a/components/datetime/src/provider/helpers.rs
+++ b/components/datetime/src/provider/helpers.rs
@@ -9,9 +9,9 @@ use crate::options::{components, length, DateTimeFormatOptions};
 use crate::pattern::Pattern;
 use crate::provider;
 use crate::skeleton;
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 
-type Result<T> = std::result::Result<T, DateTimeFormatError>;
+type Result<T> = core::result::Result<T, DateTimeFormatError>;
 
 pub trait DateTimePatterns {
     fn get_pattern_for_options(&self, options: &DateTimeFormatOptions) -> Result<Option<Pattern>>;

--- a/components/datetime/src/provider/time_zones.rs
+++ b/components/datetime/src/provider/time_zones.rs
@@ -2,9 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use alloc::borrow::Cow;
 use icu_provider::yoke::{self, *};
 use litemap::LiteMap;
-use std::borrow::Cow;
 use tinystr::TinyStr8;
 
 /// Provides a few common map accessor methods to new-type structs that wrap a map type.
@@ -15,7 +15,7 @@ macro_rules! map_access {
             pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&$inner>
             where
                 Q: Ord,
-                Cow<'data, $key>: std::borrow::Borrow<Q>,
+                Cow<'data, $key>: core::borrow::Borrow<Q>,
             {
                 self.0.get(key)
             }
@@ -25,10 +25,10 @@ macro_rules! map_access {
             }
         }
 
-        impl<$lt, Q: ?Sized> std::ops::Index<&Q> for $outer
+        impl<$lt, Q: ?Sized> core::ops::Index<&Q> for $outer
         where
             Q: Ord,
-            Cow<'data, $key>: std::borrow::Borrow<Q>,
+            Cow<'data, $key>: core::borrow::Borrow<Q>,
         {
             type Output = $inner;
             fn index(&self, key: &Q) -> &Self::Output {

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -4,9 +4,14 @@
 
 //! Skeletons are used for pattern matching. See the [`Skeleton`] struct for more information.
 
+use alloc::format;
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use displaydoc::Display;
 use smallvec::SmallVec;
-use std::convert::TryFrom;
 
 use crate::{
     fields::{self, Field, FieldLength, FieldSymbol},
@@ -59,7 +64,7 @@ struct DeserializeSkeletonFieldsUTS35String;
 impl<'de> de::Visitor<'de> for DeserializeSkeletonFieldsUTS35String {
     type Value = Skeleton;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(formatter, "Expected to find a valid skeleton.")
     }
 
@@ -88,7 +93,7 @@ struct DeserializeSkeletonBincode;
 impl<'de> de::Visitor<'de> for DeserializeSkeletonBincode {
     type Value = Skeleton;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(formatter, "Unable to deserialize a bincode Pattern.")
     }
 
@@ -238,7 +243,7 @@ pub enum SkeletonError {
     Fields(fields::Error),
 }
 
-impl std::error::Error for SkeletonError {}
+impl core::error::Error for SkeletonError {}
 
 impl From<fields::Error> for SkeletonError {
     fn from(e: fields::Error) -> Self {
@@ -948,7 +953,7 @@ mod test {
             .collect();
 
         for (strings, fields) in skeletons_strings.windows(2).zip(skeleton_fields.windows(2)) {
-            if fields[0].cmp(&fields[1]) != std::cmp::Ordering::Less {
+            if fields[0].cmp(&fields[1]) != core::cmp::Ordering::Less {
                 panic!("Expected {:?} < {:?}", strings[0], strings[1]);
             }
         }

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -243,7 +243,8 @@ pub enum SkeletonError {
     Fields(fields::Error),
 }
 
-impl core::error::Error for SkeletonError {}
+#[cfg(feature = "std")]
+impl std::error::Error for SkeletonError {}
 
 impl From<fields::Error> for SkeletonError {
     fn from(e: fields::Error) -> Self {

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -7,7 +7,6 @@
 use alloc::format;
 use alloc::string::String;
 
-
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use displaydoc::Display;

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -6,8 +6,8 @@
 
 use alloc::format;
 use alloc::string::String;
-use alloc::string::ToString;
-use alloc::vec;
+
+
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use displaydoc::Display;

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -4,7 +4,9 @@
 
 //! Skeletons are used for pattern matching. See the [`Skeleton`] struct for more information.
 
+#[cfg(feature = "provider_serde")]
 use alloc::format;
+#[cfg(feature = "provider_serde")]
 use alloc::string::String;
 
 use alloc::vec::Vec;

--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -2,7 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use std::{borrow::Cow, fmt};
+use alloc::format;
+use alloc::string::String;
+use core::{borrow::Cow, fmt};
 
 use crate::{
     date::TimeZoneInput, format::time_zone::FormattedTimeZone, pattern::Error as PatternError,
@@ -342,10 +344,10 @@ impl<'data> TimeZoneFormat<'data> {
     #[allow(unused)]
     pub(super) fn format_to_write(
         &self,
-        w: &mut impl std::fmt::Write,
+        w: &mut impl core::fmt::Write,
         value: &impl TimeZoneInput,
     ) -> fmt::Result {
-        time_zone::write_pattern(self, value, w).map_err(|_| std::fmt::Error)
+        time_zone::write_pattern(self, value, w).map_err(|_| core::fmt::Error)
     }
 
     /// Takes a [`TimeZoneInput`] implementer and returns a string with the formatted value.

--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -2,9 +2,10 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use alloc::borrow::Cow;
 use alloc::format;
 use alloc::string::String;
-use core::{borrow::Cow, fmt};
+use core::fmt;
 
 use crate::{
     date::TimeZoneInput, format::time_zone::FormattedTimeZone, pattern::Error as PatternError,

--- a/components/datetime/src/zoned_datetime.rs
+++ b/components/datetime/src/zoned_datetime.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use alloc::string::String;
 use icu_locid::Locale;
 use icu_provider::{DataProvider, DataRequest, ResourceOptions, ResourcePath};
 
@@ -233,10 +234,10 @@ impl<'data> ZonedDateTimeFormat<'data> {
     /// ```
     pub fn format_to_write(
         &self,
-        w: &mut impl std::fmt::Write,
+        w: &mut impl core::fmt::Write,
         value: &impl ZonedDateTimeInput,
-    ) -> std::fmt::Result {
-        zoned_datetime::write_pattern(self, value, w).map_err(|_| std::fmt::Error)
+    ) -> core::fmt::Result {
+        zoned_datetime::write_pattern(self, value, w).map_err(|_| core::fmt::Error)
     }
 
     /// Takes a [`ZonedDateTimeInput`] implementer and returns it formatted as a string.

--- a/components/icu/Cargo.toml
+++ b/components/icu/Cargo.toml
@@ -74,6 +74,7 @@ icu_testdata = { version = "0.2", path = "../../provider/testdata" }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 
 [features]
+std = ["icu_datetime/std", "icu_locid/std", "icu_plurals/std", "icu_uniset/std", "fixed_decimal/std"]
 default = ["provider_serde"]
 serde = [
     "icu_locid/serde"

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -80,6 +80,8 @@
 //! [`Locale`]: crate::locid::Locale
 //! [`SymbolsV1`]: crate::decimal::provider::DecimalSymbolsV1
 
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
+
 pub mod datetime {
     //! Date and Time operations
     //!

--- a/components/uniset/Cargo.toml
+++ b/components/uniset/Cargo.toml
@@ -46,6 +46,7 @@ bench = false  # This option is required for Benchmark CI
 path = "src/lib.rs"
 
 [features]
+std = ["icu_provider/std"]
 default = ["provider_serde"]
 bench = []
 provider_serde = ["serde"]

--- a/components/uniset/src/builder.rs
+++ b/components/uniset/src/builder.rs
@@ -2,7 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use std::{char, cmp::Ordering, ops::RangeBounds};
+use alloc::vec;
+use alloc::vec::Vec;
+use core::{char, cmp::Ordering, ops::RangeBounds};
 
 use crate::{uniset::UnicodeSet, utils::deconstruct_range};
 
@@ -423,7 +425,7 @@ impl UnicodeSetBuilder {
 #[cfg(test)]
 mod tests {
     use super::{UnicodeSet, UnicodeSetBuilder};
-    use std::char;
+    use core::char;
 
     fn generate_tester(ex: Vec<u32>) -> UnicodeSetBuilder {
         let check = UnicodeSet::from_inversion_list(ex).unwrap();

--- a/components/uniset/src/conversions.rs
+++ b/components/uniset/src/conversions.rs
@@ -2,7 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use std::{
+use alloc::vec;
+use core::{
     convert::TryFrom,
     ops::{Range, RangeBounds, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive},
 };
@@ -73,7 +74,7 @@ impl TryFrom<&RangeToInclusive<char>> for UnicodeSet {
 mod tests {
     use super::UnicodeSetError;
     use crate::UnicodeSet;
-    use std::{char, convert::TryFrom};
+    use core::{char, convert::TryFrom};
 
     #[test]
     fn test_try_from_range() {

--- a/components/uniset/src/lib.rs
+++ b/components/uniset/src/lib.rs
@@ -49,6 +49,10 @@
 //!
 //! [`ICU4X`]: ../icu/index.html
 
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
+
+extern crate alloc;
+
 #[macro_use]
 mod builder;
 mod conversions;

--- a/components/uniset/src/lib.rs
+++ b/components/uniset/src/lib.rs
@@ -62,6 +62,7 @@ pub mod provider;
 mod uniset;
 mod utils;
 
+use alloc::vec::Vec;
 pub use builder::UnicodeSetBuilder;
 pub use conversions::*;
 use displaydoc::Display;
@@ -80,6 +81,7 @@ pub enum UnicodeSetError {
     PropDataLoad(DataError),
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for UnicodeSetError {}
 
 impl From<DataError> for UnicodeSetError {

--- a/components/uniset/src/props.rs
+++ b/components/uniset/src/props.rs
@@ -10,8 +10,8 @@
 use crate::enum_props::*;
 use crate::provider::*;
 use crate::{UnicodeSet, UnicodeSetError};
+use core::convert::TryInto;
 use icu_provider::prelude::*;
-use std::convert::TryInto;
 
 type UnisetResult = Result<UnicodeSet, UnicodeSetError>;
 

--- a/components/uniset/src/provider.rs
+++ b/components/uniset/src/provider.rs
@@ -8,9 +8,9 @@
 
 use crate::builder::UnicodeSetBuilder;
 use crate::uniset::UnicodeSet;
+use alloc::borrow::Cow;
+use core::convert::TryInto;
 use icu_provider::yoke::{self, *};
-use std::borrow::Cow;
-use std::convert::TryInto;
 //
 // resource key structs - the structs used directly by users of data provider
 //

--- a/components/uniset/src/uniset.rs
+++ b/components/uniset/src/uniset.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+#[cfg(feature = "serde")]
 use alloc::format;
 use alloc::vec;
 use alloc::vec::Vec;

--- a/components/uniset/src/uniset.rs
+++ b/components/uniset/src/uniset.rs
@@ -2,8 +2,11 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use alloc::format;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::{char, ops::RangeBounds, ops::RangeInclusive, slice::Chunks};
 use icu_provider::yoke::{self, *};
-use std::{char, ops::RangeBounds, ops::RangeInclusive, slice::Chunks};
 
 #[cfg(feature = "serde")]
 use serde::ser::SerializeSeq;
@@ -368,7 +371,7 @@ impl UnicodeSet {
 #[cfg(test)]
 mod tests {
     use super::{UnicodeSet, UnicodeSetError, BMP_MAX};
-    use std::{char, vec::Vec};
+    use core::{char, vec::Vec};
 
     #[test]
     fn test_unicodeset_try_from_vec() {

--- a/components/uniset/src/uniset.rs
+++ b/components/uniset/src/uniset.rs
@@ -371,7 +371,7 @@ impl UnicodeSet {
 #[cfg(test)]
 mod tests {
     use super::{UnicodeSet, UnicodeSetError, BMP_MAX};
-    use core::{char, vec::Vec};
+    use std::{char, vec::Vec};
 
     #[test]
     fn test_unicodeset_try_from_vec() {

--- a/components/uniset/src/utils.rs
+++ b/components/uniset/src/utils.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use std::{
+use core::{
     char,
     ops::{Bound::*, RangeBounds},
 };
@@ -31,7 +31,7 @@ pub fn deconstruct_range(range: &impl RangeBounds<char>) -> (u32, u32) {
 #[cfg(test)]
 mod tests {
     use super::{deconstruct_range, is_valid};
-    use std::char;
+    use core::char;
 
     #[test]
     fn test_is_valid() {

--- a/tools/scripts/ffi.toml
+++ b/tools/scripts/ffi.toml
@@ -10,7 +10,8 @@ category = "ICU4X Development"
 dependencies = [
     "test-capi",
     "test-cpp",
-    "test-cortex",
+    "test-cortex-ffi",
+    "test-nostd",
 ]
 
 [tasks.test-capi]
@@ -49,9 +50,16 @@ cd ffi/cpp/docs;
 exec make html
 '''
 
-[tasks.test-cortex]
+[tasks.test-cortex-ffi]
 description = "Build ICU4X CAPI for Cortex"
 category = "ICU4X FFI"
 toolchain = "nightly"
 command = "cargo"
 args = ["build", "--package", "icu_capi", "--target", "thumbv7m-none-eabi"]
+
+[tasks.test-nostd]
+description = "Ensure ICU4X core builds on no-std"
+category = "ICU4X FFI"
+toolchain = "nightly"
+command = "cargo"
+args = ["build", "--package", "icu", "--target", "thumbv7m-none-eabi"]


### PR DESCRIPTION
This fixes https://github.com/unicode-org/icu4x/issues/812 and gates CI on it building for no-std. Further dependencies being pulled into `icu` will have to support `no_std` (or be conditional on the `"std"` feature)



cc @nciric

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->