### PR TITLE
Document certain DataProvider impls that return `'static`

### DIFF
--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -188,8 +188,9 @@ where
     M: DataMarker<'data>,
     M::Yokeable: ZeroCopyFrom<M::Cart>,
 {
-    /// Convert an [`Rc`]`<`[`Cart`]`>` into a [`DataPayload`]. The data need not be fully owned;
-    /// it may be constrained by the `'data` lifetime.
+    /// Convert an [`Rc`]`<`[`Cart`]`>` into a [`DataPayload`].
+    ///
+    /// The data need not be fully owned; this constructor creates payloads bounded by `'data`.
     ///
     /// # Examples
     ///
@@ -226,6 +227,8 @@ where
     /// Convert a byte buffer into a [`DataPayload`]. A function must be provided to perform the
     /// conversion. This can often be a Serde deserialization operation.
     ///
+    /// This constructor creates `'static` payloads; borrowing is handled by [`Yoke`].
+    ///
     /// Due to [compiler bug #84937](https://github.com/rust-lang/rust/issues/84937), call sites
     /// for this function may not compile; if this happens, use
     /// [`try_from_rc_buffer_badly()`](Self::try_from_rc_buffer_badly) instead.
@@ -242,6 +245,8 @@ where
 
     /// Convert a byte buffer into a [`DataPayload`]. A function must be provided to perform the
     /// conversion. This can often be a Serde deserialization operation.
+    ///
+    /// This constructor creates `'static` payloads; borrowing is handled by [`Yoke`].
     ///
     /// For a version of this function that takes a `FnOnce` instead of a raw function pointer,
     /// see [`try_from_rc_buffer()`](Self::try_from_rc_buffer).
@@ -279,13 +284,10 @@ where
             inner: DataPayloadInner::RcBuf(yoke),
         })
     }
-}
 
-impl<'data, M> DataPayload<'data, M>
-where
-    M: DataMarker<'data>,
-{
     /// Convert a fully owned (`'static`) data struct into a DataPayload.
+    ///
+    /// This constructor creates `'static` payloads.
     ///
     /// # Examples
     ///

--- a/provider/core/src/serde.rs
+++ b/provider/core/src/serde.rs
@@ -159,7 +159,8 @@ pub trait SerdeDeDataProvider {
     ) -> Result<DataResponseMetadata, Error>;
 }
 
-impl<'data, M> DataProvider<'data, M> for dyn SerdeDeDataProvider + 'data
+/// Note: This impl returns `'static` payloads because borrowing is handled by [`Yoke`].
+impl<'data, M> DataProvider<'data, M> for dyn SerdeDeDataProvider + 'static
 where
     M: DataMarker<'data>,
     M::Yokeable: serde::de::Deserialize<'static>,
@@ -168,7 +169,7 @@ where
     // Necessary workaround bound (see `yoke::trait_hack` docs):
     for<'de> YokeTraitHack<<M::Yokeable as Yokeable<'de>>::Output>: serde::de::Deserialize<'de>,
 {
-    /// Serve objects implementing [`serde::Deserialize<'data>`] from a [`SerdeDeDataProvider`].
+    /// Serve objects implementing [`serde::Deserialize<'de>`] from a [`SerdeDeDataProvider`].
     fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<'data, M>, Error> {
         let mut payload = None;
         let metadata = self.load_to_receiver(req, &mut payload)?;


### PR DESCRIPTION
Reverts 4b48cf79996c997658606e30503ad46f4c586003 (#902)

Rather than changing these impls to be `'static` in code, @Manishearth recommended to leave them as `'data`.  So I am simply adding documentation instead.