### PR TITLE
Fix clippy warning in yoke derive

### DIFF
--- a/utils/yoke/derive/src/lib.rs
+++ b/utils/yoke/derive/src/lib.rs
@@ -166,7 +166,7 @@ fn zcf_derive_impl(input: &DeriveInput) -> TokenStream2 {
             };
         }
 
-        let structure = Structure::new(&input);
+        let structure = Structure::new(input);
         let body = structure.each_variant(|vi| {
             vi.construct(|f, i| {
                 let binding = format!("__binding_{}", i);


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->