### PR TITLE
Add missing `#[serde(borrow)]`

### DIFF
--- a/components/decimal/src/provider.rs
+++ b/components/decimal/src/provider.rs
@@ -73,6 +73,7 @@ pub struct DecimalSymbolsV1<'data> {
     pub decimal_separator: Cow<'data, str>,
 
     /// Character used to separate groups in the integer part of the number.
+    #[cfg_attr(feature = "provider_serde", serde(borrow))]
     pub grouping_separator: Cow<'data, str>,
 
     /// Settings used to determine where to place groups in the integer part of the number.


### PR DESCRIPTION
I happened to notice this. Why was it not caught sooner?