### PR TITLE
Add new_from_data for FixedDecimalFormat

### DIFF
--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -114,6 +114,16 @@ impl<'data> FixedDecimalFormat<'data> {
         Ok(Self { options, symbols })
     }
 
+    pub fn new_from_data(
+        data: DataPayload<'data, provider::DecimalSymbolsV1Marker>,
+        options: options::FixedDecimalFormatOptions,
+    ) -> Self {
+        Self {
+            options,
+            symbols: data,
+        }
+    }
+
     /// Formats a [`FixedDecimal`], returning a [`FormattedFixedDecimal`].
     pub fn format<'l>(&'l self, value: &'l FixedDecimal) -> FormattedFixedDecimal<'l> {
         FormattedFixedDecimal {


### PR DESCRIPTION
Progress on https://github.com/unicode-org/icu4x/issues/560

@sffc the constructor for DateTimeFormat is a bit more complicated, what would you like its constructor to look like?

Also, you've mentioned in the past that we should make PluralRulesList the data format for PluralRules. Anything I should know to start doing this?

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->