### PR TITLE
Make icu_capi always no_std

### DIFF
--- a/ffi/capi/src/lib.rs
+++ b/ffi/capi/src/lib.rs
@@ -6,8 +6,14 @@
     all(target_os = "none", feature = "freertos"),
     feature(alloc_error_handler)
 )]
+#![no_std]
 #![allow(clippy::upper_case_acronyms)]
-#![cfg_attr(target_os = "none", no_std)]
+
+// Needed to be able to build cdylibs/etc
+//
+// Renamed so you can't accidentally use it
+#[cfg(not(target_os = "none"))]
+extern crate std as rust_std;
 
 extern crate alloc;
 

--- a/ffi/capi/src/wasm_glue.rs
+++ b/ffi/capi/src/wasm_glue.rs
@@ -3,9 +3,9 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use alloc::format;
-use std::ffi::CString;
-use std::io;
-use std::os::raw::c_char;
+use rust_std::ffi::CString;
+use rust_std::io;
+use rust_std::os::raw::c_char;
 
 use log::{Level, LevelFilter, Metadata, Record};
 


### PR DESCRIPTION
With the current code it's easy to accidentally use `std` features that will only be caught in CI. Better to force people to use core stuff unconditionally.

The `extern crate std` is still needed for WASM and also so that we can build cstaticlibs/cdylibs.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->