### PR TITLE
Use cargo-all-features' new denylist feature to improve our CI time

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -176,7 +176,7 @@ jobs:
       uses: actions-rs/cargo@v1.0.1
       with:
         command: install
-        args: cargo-all-features --version "^1.4"
+        args: cargo-all-features --version "^1.6"
 
     - name: Get cargo-make version
       id: cargo-make-version

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -24,6 +24,8 @@ include = [
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true
+# Bench feature gets tested separately and is only relevant for CI
+denylist = ["bench"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -23,6 +23,8 @@ include = [
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true
+# Bench feature gets tested separately and is only relevant for CI
+denylist = ["bench"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/components/icu/Cargo.toml
+++ b/components/icu/Cargo.toml
@@ -24,6 +24,8 @@ include = [
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true
+# Bench feature gets tested separately and is only relevant for CI
+denylist = ["bench"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/components/locale_canonicalizer/Cargo.toml
+++ b/components/locale_canonicalizer/Cargo.toml
@@ -23,6 +23,8 @@ include = [
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true
+# Bench feature gets tested separately and is only relevant for CI
+denylist = ["bench"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -24,6 +24,8 @@ include = [
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true
+# Bench feature gets tested separately and is only relevant for CI
+denylist = ["bench"]
 # "serde" is an intentional feature, enabling serialization of LanguageIdentifier and others:
 extra_features = ["serde"]
 

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -24,6 +24,8 @@ include = [
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true
+# Bench feature gets tested separately and is only relevant for CI
+denylist = ["bench"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/components/uniset/Cargo.toml
+++ b/components/uniset/Cargo.toml
@@ -24,6 +24,8 @@ include = [
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true
+# Bench feature gets tested separately and is only relevant for CI
+denylist = ["bench"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/experimental/calendar/Cargo.toml
+++ b/experimental/calendar/Cargo.toml
@@ -27,3 +27,5 @@ all-features = true
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true
+# Bench feature gets tested separately and is only relevant for CI
+denylist = ["bench"]

--- a/experimental/provider_ppucd/Cargo.toml
+++ b/experimental/provider_ppucd/Cargo.toml
@@ -23,6 +23,8 @@ include = [
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true
+# Bench feature gets tested separately and is only relevant for CI
+denylist = ["bench"]
 
 [dependencies]
 icu_locid = { version = "0.3", path = "../../components/locid" }

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -30,7 +30,9 @@ all-features = true
 # Omit most optional dependency features from permutation testing
 skip_optional_dependencies = true
 # Bench feature gets tested separately and is only relevant for CI
-denylist = ["bench"]
+# wearos/freertos are not relevant on normal platforms,
+# and smaller_static gets tested on the FFI job anyway
+denylist = ["bench", "wearos", "freertos", "smaller_static"]
 
 [lib]
 crate-type = ["staticlib", "rlib", "cdylib"]

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -29,6 +29,8 @@ all-features = true
 [package.metadata.cargo-all-features]
 # Omit most optional dependency features from permutation testing
 skip_optional_dependencies = true
+# Bench feature gets tested separately and is only relevant for CI
+denylist = ["bench"]
 
 [lib]
 crate-type = ["staticlib", "rlib", "cdylib"]

--- a/provider/cldr/Cargo.toml
+++ b/provider/cldr/Cargo.toml
@@ -25,6 +25,8 @@ include = [
 [package.metadata.cargo-all-features]
 # Omit most optional dependency features from permutation testing
 skip_optional_dependencies = true
+# Bench feature gets tested separately and is only relevant for CI
+denylist = ["bench"]
 extra_features = [
     "log",
 ]

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -24,6 +24,8 @@ include = [
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true
+# Bench feature gets tested separately and is only relevant for CI
+denylist = ["bench"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -25,6 +25,8 @@ include = [
 [package.metadata.cargo-all-features]
 # Omit most optional dependency features from permutation testing
 skip_optional_dependencies = true
+# Bench feature gets tested separately and is only relevant for CI
+denylist = ["bench"]
 extra_features = [
     "log",
 ]

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -123,6 +123,8 @@ gitref = "39.0.0"
 [package.metadata.cargo-all-features]
 # Omit most optional dependency features from permutation testing
 skip_optional_dependencies = true
+# Bench feature gets tested separately and is only relevant for CI
+denylist = ["bench"]
 
 [dependencies]
 icu_provider = { version = "0.3", path = "../../provider/core" }


### PR DESCRIPTION
Currently the `features` job takes 10+ minutes. I added [support to cargo-all-features](https://github.com/frewsxcv/cargo-all-features/pull/14) for allowlists and denylists, and I'm using them to deny features that are:

 - Not relevant for users, only for CI (like our "bench" features)
 - Only relevant on certain platforms not being CId by the features job


This should improve the features CI job runtime by a bit.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->