### PR TITLE
Add "x86tiny" feature to icu_capi

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,11 +13,10 @@ tidy = "make tidy"
 # field-reassign-with-default: https://github.com/rust-lang/rust-clippy/issues/6559 (fixed in nightly but not stable)
 clippy-all = "clippy --all-features --all-targets -- -D warnings -Aclippy::field-reassign-with-default"
 
-### WASM TASKS ###
-
-# Re-build standard library with panic=abort.
-wasm-build-dev = "build -Z build-std=std,panic_abort --target wasm32-unknown-unknown"
-wasm-build-release = "build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target wasm32-unknown-unknown --release"
+# Build configurations for small binary size
+panic-abort-build = "build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort"
+wasm-build-dev = "panic-abort-build --target wasm32-unknown-unknown"
+wasm-build-release = "wasm-build-dev --release"
 
 [target.wasm32-unknown-unknown]
 rustflags = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,6 +976,7 @@ dependencies = [
  "cortex-m",
  "diplomat",
  "diplomat-runtime",
+ "dlmalloc",
  "fixed_decimal",
  "freertos-rust",
  "icu_decimal",

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -39,13 +39,16 @@ crate-type = ["staticlib", "rlib", "cdylib"]
 path = "src/lib.rs"
 
 [features]
-default = ["provider_fs", "provider_static"]
+default = ["provider_fs", "provider_static", "rust_global_allocator"]
 wearos = ["smaller_static", "freertos"]
 
 provider_fs = ["icu_provider_fs"]
 provider_static = ["icu_testdata"]
 smaller_static = ["provider_static"]
 freertos = ["freertos-rust", "cortex-m"]
+
+# Enables `dlmalloc` in example files to bypass the system allocator.
+rust_global_allocator = ["dlmalloc"]
 
 [dependencies]
 fixed_decimal = { path = "../../utils/fixed_decimal" }
@@ -61,6 +64,10 @@ writeable = { path = "../../utils/writeable/" }
 diplomat = { git = "https://github.com/rust-diplomat/diplomat", rev = "1307d215e1c8482bfa37082427389b240a81481d" }
 diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", rev = "1307d215e1c8482bfa37082427389b240a81481d" }
 icu_testdata = { version = "0.3", path = "../../provider/testdata", default-features = false, features = ["static"], optional = true }
+
+# This cfg originates in dlmalloc/lib.rs
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_arch = "wasm32"))'.dependencies]
+dlmalloc = { version = "0.2", optional = true, features = ["global"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 log = { version = "0.4" }

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -39,17 +39,22 @@ crate-type = ["staticlib", "rlib", "cdylib"]
 path = "src/lib.rs"
 
 [features]
-default = ["provider_fs", "provider_static", "std"]
+default = ["provider_fs", "provider_static"]
 wearos = ["smaller_static", "freertos"]
 
 provider_fs = ["icu_provider_fs"]
 provider_static = ["icu_testdata"]
 smaller_static = ["provider_static"]
-freertos = ["freertos-rust", "cortex-m"]
-std = []
+
+# Only 1 of the following features can be set. Doing so disables std and
+# replaces the global allocator and panic handler with something else.
+# If multiple of these features are set, it is as if none of them are set.
 
 # Enables size-optimized builds on x86_64
 x86tiny = ["dlmalloc"]
+
+# Enables no_std builds for freertos
+freertos = ["freertos-rust", "cortex-m"]
 
 [dependencies]
 fixed_decimal = { path = "../../utils/fixed_decimal" }

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -29,10 +29,10 @@ all-features = true
 [package.metadata.cargo-all-features]
 # Omit most optional dependency features from permutation testing
 skip_optional_dependencies = true
-# Bench feature gets tested separately and is only relevant for CI
-# wearos/freertos are not relevant on normal platforms,
+# Bench feature gets tested separately and is only relevant for CI.
+# wearos/freertos/x86tiny are not relevant in normal environments,
 # and smaller_static gets tested on the FFI job anyway
-denylist = ["bench", "wearos", "freertos", "smaller_static"]
+denylist = ["bench", "wearos", "freertos", "x86tiny", "smaller_static"]
 
 [lib]
 crate-type = ["staticlib", "rlib", "cdylib"]

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -39,16 +39,17 @@ crate-type = ["staticlib", "rlib", "cdylib"]
 path = "src/lib.rs"
 
 [features]
-default = ["provider_fs", "provider_static", "rust_global_allocator"]
+default = ["provider_fs", "provider_static", "std"]
 wearos = ["smaller_static", "freertos"]
 
 provider_fs = ["icu_provider_fs"]
 provider_static = ["icu_testdata"]
 smaller_static = ["provider_static"]
 freertos = ["freertos-rust", "cortex-m"]
+std = []
 
-# Enables `dlmalloc` in example files to bypass the system allocator.
-rust_global_allocator = ["dlmalloc"]
+# Enables size-optimized builds on x86_64
+x86tiny = ["dlmalloc"]
 
 [dependencies]
 fixed_decimal = { path = "../../utils/fixed_decimal" }

--- a/ffi/capi/examples/fixeddecimal/.gitignore
+++ b/ffi/capi/examples/fixeddecimal/.gitignore
@@ -1,1 +1,6 @@
 a.out
+optim*
+*.i64
+*.dot
+*.elf
+*.o

--- a/ffi/capi/examples/fixeddecimal/Makefile
+++ b/ffi/capi/examples/fixeddecimal/Makefile
@@ -16,6 +16,12 @@ $(ALL_HEADERS):
 ../../../../target/debug/libicu_capi.a: $(ALL_RUST)
 	cargo build
 
+../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a: $(ALL_RUST)
+	RUSTFLAGS="-Clinker-plugin-lto -Clinker=clang -Clink-arg=-flto -Cpanic=abort" cargo +nightly-2021-02-28 panic-abort-build --target x86_64-unknown-linux-gnu --no-default-features --features x86tiny
+
+../../../../target/x86_64-unknown-linux-gnu/release/libicu_capi.a: $(ALL_RUST)
+	RUSTFLAGS="-Clinker-plugin-lto -Clinker=clang -Clink-arg=-flto -Cpanic=abort" cargo +nightly-2021-02-28 panic-abort-build --target x86_64-unknown-linux-gnu --no-default-features --features x86tiny --features smaller_static --release
+
 a.out: ../../../../target/debug/libicu_capi.a $(ALL_HEADERS) test.c
 	gcc test.c ../../../../target/debug/libicu_capi.a -ldl -lpthread -lm -g
 
@@ -25,14 +31,17 @@ optim.elf: ../../../../target/debug/libicu_capi.a $(ALL_HEADERS) test.c
 optim2.elf: ../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a $(ALL_HEADERS) test.c
 	clang -flto -fdata-sections -ffunction-sections test.c ../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a -g -o optim2.elf -Wl,--gc-sections
 
-../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a: $(ALL_RUST)
-	RUSTFLAGS="-Clinker-plugin-lto -Clinker=clang -Clink-arg=-flto -Cpanic=abort" cargo +nightly-2021-02-28 panic-abort-build --target x86_64-unknown-linux-gnu --no-default-features --features x86tiny
-
 optim3.o: $(ALL_HEADERS)
-	clang -c -flto=thin --target=x86_64-unknown-linux-gnu test.c -g -o optim3.o
+	clang -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -g -o optim3.o
 
 optim3.elf: optim3.o ../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a
-	clang -flto=thin -fuse-ld=lld -L . -o optim3.elf optim3.o ../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a
+	clang -flto=thin -fuse-ld=lld -L . -o optim3.elf optim3.o ../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a -Wl,--gc-sections
+
+optim4.o: $(ALL_HEADERS)
+	clang -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -g -o optim4.o
+
+optim4.elf: optim4.o ../../../../target/x86_64-unknown-linux-gnu/release/libicu_capi.a
+	clang -flto=thin -fuse-ld=lld -L . -o optim4.elf optim4.o ../../../../target/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections
 
 build: a.out optim.elf optim2.elf
 

--- a/ffi/capi/examples/fixeddecimal/Makefile
+++ b/ffi/capi/examples/fixeddecimal/Makefile
@@ -15,7 +15,6 @@ $(ALL_HEADERS):
 
 ../../../../target/debug/libicu_capi.a: $(ALL_RUST)
 	cargo build
-	cargo +nightly-2021-02-28 build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu
 
 a.out: ../../../../target/debug/libicu_capi.a $(ALL_HEADERS) test.c
 	gcc test.c ../../../../target/debug/libicu_capi.a -ldl -lpthread -lm -g
@@ -24,7 +23,16 @@ optim.elf: ../../../../target/debug/libicu_capi.a $(ALL_HEADERS) test.c
 	gcc -fdata-sections -ffunction-sections test.c ../../../../target/debug/libicu_capi.a -ldl -lpthread -lm -g -o optim.elf -Wl,--gc-sections -Wl,--strip-all
 
 optim2.elf: ../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a $(ALL_HEADERS) test.c
-	gcc -fdata-sections -ffunction-sections test.c ../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a -g -o optim2.elf -Wl,--gc-sections
+	clang -flto -fdata-sections -ffunction-sections test.c ../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a -g -o optim2.elf -Wl,--gc-sections
+
+../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a: $(ALL_RUST)
+	RUSTFLAGS="-Clinker-plugin-lto -Clinker=clang -Clink-arg=-flto -Cpanic=abort" cargo +nightly-2021-02-28 panic-abort-build --target x86_64-unknown-linux-gnu --no-default-features --features x86tiny
+
+optim3.o: $(ALL_HEADERS)
+	clang -c -flto=thin --target=x86_64-unknown-linux-gnu test.c -g -o optim3.o
+
+optim3.elf: optim3.o ../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a
+	clang -flto=thin -fuse-ld=lld -L . -o optim3.elf optim3.o ../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a
 
 build: a.out optim.elf optim2.elf
 

--- a/ffi/capi/examples/fixeddecimal/Makefile
+++ b/ffi/capi/examples/fixeddecimal/Makefile
@@ -15,11 +15,18 @@ $(ALL_HEADERS):
 
 ../../../../target/debug/libicu_capi.a: $(ALL_RUST)
 	cargo build
+	cargo +nightly-2021-02-28 build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu
 
 a.out: ../../../../target/debug/libicu_capi.a $(ALL_HEADERS) test.c
 	gcc test.c ../../../../target/debug/libicu_capi.a -ldl -lpthread -lm -g
 
-build: a.out
+optim.elf: ../../../../target/debug/libicu_capi.a $(ALL_HEADERS) test.c
+	gcc -fdata-sections -ffunction-sections test.c ../../../../target/debug/libicu_capi.a -ldl -lpthread -lm -g -o optim.elf -Wl,--gc-sections -Wl,--strip-all
+
+optim2.elf: ../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a $(ALL_HEADERS) test.c
+	gcc -fdata-sections -ffunction-sections test.c ../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a -g -o optim2.elf -Wl,--gc-sections
+
+build: a.out optim.elf optim2.elf
 
 test: build
 	./a.out

--- a/ffi/capi/examples/fixeddecimal/Makefile
+++ b/ffi/capi/examples/fixeddecimal/Makefile
@@ -22,28 +22,44 @@ $(ALL_HEADERS):
 ../../../../target/x86_64-unknown-linux-gnu/release/libicu_capi.a: $(ALL_RUST)
 	RUSTFLAGS="-Clinker-plugin-lto -Clinker=clang -Clink-arg=-flto -Cpanic=abort" cargo +nightly-2021-02-28 panic-abort-build --target x86_64-unknown-linux-gnu --no-default-features --features x86tiny --features smaller_static --release
 
+# Naive target: no optimizations, full std
 a.out: ../../../../target/debug/libicu_capi.a $(ALL_HEADERS) test.c
 	gcc test.c ../../../../target/debug/libicu_capi.a -ldl -lpthread -lm -g
 
+# optim.elf: gcc with maximum link-time code stripping (gc-sections and strip-all)
 optim.elf: ../../../../target/debug/libicu_capi.a $(ALL_HEADERS) test.c
 	gcc -fdata-sections -ffunction-sections test.c ../../../../target/debug/libicu_capi.a -ldl -lpthread -lm -g -o optim.elf -Wl,--gc-sections -Wl,--strip-all
 
+# optim2.elf: clang single-step with gc-sections
 optim2.elf: ../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a $(ALL_HEADERS) test.c
 	clang -flto -fdata-sections -ffunction-sections test.c ../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a -g -o optim2.elf -Wl,--gc-sections
 
 optim3.o: $(ALL_HEADERS)
 	clang -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -g -o optim3.o
 
+# optim3.elf: clang two-step with lld, debug mode
 optim3.elf: optim3.o ../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a
 	clang -flto=thin -fuse-ld=lld -L . -o optim3.elf optim3.o ../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi.a -Wl,--gc-sections
 
 optim4.o: $(ALL_HEADERS)
 	clang -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -g -o optim4.o
 
+# optim4.elf: clang two-step with lld, release mode with debug symbols
 optim4.elf: optim4.o ../../../../target/x86_64-unknown-linux-gnu/release/libicu_capi.a
 	clang -flto=thin -fuse-ld=lld -L . -o optim4.elf optim4.o ../../../../target/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections
 
-build: a.out optim.elf optim2.elf
+optim5.o: $(ALL_HEADERS)
+	clang -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -o optim5.o
 
+# optim5.elf: clang two-step with lld, release mode stripped of debug symbols
+optim5.elf: optim5.o ../../../../target/x86_64-unknown-linux-gnu/release/libicu_capi.a
+	clang -flto=thin -fuse-ld=lld -L . -o optim5.elf optim5.o ../../../../target/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
+
+build: a.out optim.elf optim2.elf optim3.elf optim4.elf optim5.elf
+
+# note: optim2.elf and optim3.elf crash when run with error "Illegal instruction" (investigate?)
 test: build
 	./a.out
+	./optim.elf
+	./optim4.elf
+	./optim5.elf

--- a/ffi/capi/examples/fixeddecimal/Makefile
+++ b/ffi/capi/examples/fixeddecimal/Makefile
@@ -55,11 +55,15 @@ optim5.o: $(ALL_HEADERS)
 optim5.elf: optim5.o ../../../../target/x86_64-unknown-linux-gnu/release/libicu_capi.a
 	clang -flto=thin -fuse-ld=lld -L . -o optim5.elf optim5.o ../../../../target/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
 
-build: a.out optim.elf optim2.elf optim3.elf optim4.elf optim5.elf
+build: a.out
 
-# note: optim2.elf and optim3.elf crash when run with error "Illegal instruction" (investigate?)
 test: build
 	./a.out
+
+build-optim: optim.elf optim2.elf optim3.elf optim4.elf optim5.elf
+
+# note: optim2.elf and optim3.elf crash when run with error "Illegal instruction" (investigate?)
+test-optim: build-optim
 	./optim.elf
 	./optim4.elf
 	./optim5.elf

--- a/ffi/capi/examples/fixeddecimal/test.c
+++ b/ffi/capi/examples/fixeddecimal/test.c
@@ -6,10 +6,9 @@
 #include <string.h>
 #include <stdio.h>
 
-const char* path = "../../../../provider/testdata/data/json/";
 int main() {
     ICU4XLocale* locale = ICU4XLocale_create("bn", 2);
-    ICU4XCreateDataProviderResult result = ICU4XDataProvider_create_fs(path, strlen(path));
+    ICU4XCreateDataProviderResult result = ICU4XDataProvider_create_static();
     if (!result.success) {
         printf("Failed to create FsDataProvider\n");
         return 1;
@@ -29,7 +28,6 @@ int main() {
 
     DiplomatWriteable write = diplomat_simple_writeable(output, 40);
 
-    
     bool success = ICU4XFixedDecimalFormat_format(fdf, decimal, &write).is_ok;
     if (!success) {
         printf("Failed to write result of FixedDecimalFormat::format to string.\n");

--- a/ffi/capi/examples/fixeddecimal/test.c
+++ b/ffi/capi/examples/fixeddecimal/test.c
@@ -93,6 +93,7 @@ int main() {
     ICU4XFixedDecimal_destroy(decimal);
     ICU4XFixedDecimalFormat_destroy(fdf);
     ICU4XLocale_destroy(locale);
+    ICU4XDataProvider_destroy(provider);
 
     return 0;
 }

--- a/ffi/capi/src/lib.rs
+++ b/ffi/capi/src/lib.rs
@@ -9,6 +9,11 @@
 #![no_std]
 #![allow(clippy::upper_case_acronyms)]
 
+// Use Dlmalloc to remove the system allocator dependency
+#[cfg(feature = "rust_global_allocator")]
+#[global_allocator]
+static ALLOCATOR: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
+
 // Needed to be able to build cdylibs/etc
 //
 // Renamed so you can't accidentally use it

--- a/ffi/capi/src/lib.rs
+++ b/ffi/capi/src/lib.rs
@@ -3,21 +3,19 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 #![cfg_attr(
-    all(target_os = "none", feature = "freertos"),
+    any(
+        all(target_os = "none", feature = "freertos"),
+        feature = "x86tiny",
+    ),
     feature(alloc_error_handler)
 )]
 #![no_std]
 #![allow(clippy::upper_case_acronyms)]
 
-// Use Dlmalloc to remove the system allocator dependency
-#[cfg(feature = "rust_global_allocator")]
-#[global_allocator]
-static ALLOCATOR: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
-
 // Needed to be able to build cdylibs/etc
 //
 // Renamed so you can't accidentally use it
-#[cfg(not(target_os = "none"))]
+#[cfg(feature = "std")]
 extern crate std as rust_std;
 
 extern crate alloc;
@@ -37,3 +35,6 @@ mod wasm_glue;
 // https://github.com/unicode-org/icu4x/issues/891
 #[cfg(all(target_os = "none", feature = "freertos"))]
 mod freertos_glue;
+
+#[cfg(feature = "x86tiny")]
+mod x86tiny_glue;

--- a/ffi/capi/src/lib.rs
+++ b/ffi/capi/src/lib.rs
@@ -4,8 +4,8 @@
 
 #![cfg_attr(
     any(
-        all(target_os = "none", feature = "freertos"),
-        feature = "x86tiny",
+        all(feature = "freertos", not(feature = "x86tiny")),
+        all(feature = "x86tiny", not(feature = "freertos")),
     ),
     feature(alloc_error_handler)
 )]
@@ -15,7 +15,7 @@
 // Needed to be able to build cdylibs/etc
 //
 // Renamed so you can't accidentally use it
-#[cfg(feature = "std")]
+#[cfg(all(not(feature = "freertos"), not(feature = "x86tiny")))]
 extern crate std as rust_std;
 
 extern crate alloc;
@@ -31,10 +31,8 @@ pub mod provider;
 #[cfg(target_arch = "wasm32")]
 mod wasm_glue;
 
-// Assume "none" is FreeRTOS for now
-// https://github.com/unicode-org/icu4x/issues/891
-#[cfg(all(target_os = "none", feature = "freertos"))]
+#[cfg(all(feature = "freertos", not(feature = "x86tiny")))]
 mod freertos_glue;
 
-#[cfg(feature = "x86tiny")]
+#[cfg(all(feature = "x86tiny", not(feature = "freertos")))]
 mod x86tiny_glue;

--- a/ffi/capi/src/x86tiny_glue.rs
+++ b/ffi/capi/src/x86tiny_glue.rs
@@ -1,0 +1,20 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use dlmalloc::GlobalDlmalloc;
+use alloc::alloc::Layout;
+use core::panic::PanicInfo;
+
+#[global_allocator]
+static ALLOCATOR: GlobalDlmalloc = GlobalDlmalloc;
+
+#[alloc_error_handler]
+fn alloc_error(_layout: Layout) -> ! {
+    loop {}
+}
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    loop {}
+}

--- a/ffi/capi/src/x86tiny_glue.rs
+++ b/ffi/capi/src/x86tiny_glue.rs
@@ -2,9 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use dlmalloc::GlobalDlmalloc;
 use alloc::alloc::Layout;
 use core::panic::PanicInfo;
+use dlmalloc::GlobalDlmalloc;
 
 #[global_allocator]
 static ALLOCATOR: GlobalDlmalloc = GlobalDlmalloc;


### PR DESCRIPTION
Okay, here's where I'm at.  I feel I've done the extent of code size optimization that is possible through only the build system; further work will need to touch the code.

Quick start:

```
$ cd ffi/capi/examples/fixeddecimal
$ make
$ ls -l
```

You may need to install some apt-get packages for this to work, including `clang` and `ldd`.

See *ffi/capi/examples/fixeddecimal/Makefile* for a few comments.

By far, the largest chunk of the binary is `erased_serde`, including error handling and other functions we don't use.  However, the aggressive link-time optimization was unable to eliminate this from the code file.

It seems that building in release mode mostly takes care of the formatter machinery, except to the extent that `erased_serde` pulls it in.