### PR TITLE
Fix UnicodeSetBuilder::complement for empty sets

### DIFF
--- a/components/uniset/src/builder.rs
+++ b/components/uniset/src/builder.rs
@@ -364,6 +364,8 @@ impl UnicodeSetBuilder {
             } else {
                 self.intervals.push((char::MAX as u32) + 1);
             }
+        } else {
+            self.intervals.extend_from_slice(&[0, (char::MAX as u32 + 1)]);
         }
     }
 
@@ -809,6 +811,18 @@ mod tests {
         let mut builder = generate_tester(vec![0xA, 0x14, 0x28, 0x32]);
         builder.complement();
         let expected = vec![0x0, 0xA, 0x14, 0x28, 0x32, (char::MAX as u32) + 1];
+        assert_eq!(builder.intervals, expected);
+    }
+
+    #[test]
+    fn test_complement_empty() {
+        let mut builder = generate_tester(vec![]);
+        builder.complement();
+        let expected = vec![0x0, (char::MAX as u32) + 1];
+        assert_eq!(builder.intervals, expected);
+
+        builder.complement();
+        let expected: Vec<u32> = vec![];
         assert_eq!(builder.intervals, expected);
     }
 

--- a/components/uniset/src/builder.rs
+++ b/components/uniset/src/builder.rs
@@ -365,7 +365,8 @@ impl UnicodeSetBuilder {
                 self.intervals.push((char::MAX as u32) + 1);
             }
         } else {
-            self.intervals.extend_from_slice(&[0, (char::MAX as u32 + 1)]);
+            self.intervals
+                .extend_from_slice(&[0, (char::MAX as u32 + 1)]);
         }
     }
 


### PR DESCRIPTION
Fixes #960.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->