### PR TITLE
Reject duplicate variants

### DIFF
--- a/components/locid/src/parser/langid.rs
+++ b/components/locid/src/parser/langid.rs
@@ -80,6 +80,8 @@ pub fn parse_language_identifier_from_iter<'a>(
         } else if let Ok(v) = subtags::Variant::from_bytes(subtag) {
             if let Err(idx) = variants.binary_search(&v) {
                 variants.insert(idx, v);
+            } else {
+                return Err(ParserError::InvalidSubtag);
             }
         } else if mode == ParserMode::Partial {
             break;

--- a/components/locid/tests/fixtures/invalid.json
+++ b/components/locid/tests/fixtures/invalid.json
@@ -71,5 +71,15 @@
       "error": "InvalidSubtag",
       "text": "Invalid subtag"
     }
+  },
+  {
+    "input": {
+      "type": "Locale",
+      "identifier": "en-variant-emodeng-emodeng"
+    },
+    "output": {
+      "error": "InvalidSubtag",
+      "text": "Invalid subtag"
+    }
   }
 ]

--- a/components/locid/tests/fixtures/langid.json
+++ b/components/locid/tests/fixtures/langid.json
@@ -141,7 +141,7 @@
     }
   },
   {
-    "input": "pl-macos-Windows-nedis-macos-nedis-aRabic",
+    "input": "pl-macos-Windows-nedis-aRabic",
     "output": {
       "type": "LanguageIdentifier",
       "language": "pl",


### PR DESCRIPTION
We currently silently drop duplicate variants, but according to BCP47,
this is not valid:

   5.  The same variant subtag MUST NOT be used more than once within a
       language tag.

       *  For example, the tag "de-DE-1901-1901" is not valid.

This changes the code to reject duplicate variants.