### PR TITLE
Ignore duplicate keywords and attributes

### DIFF
--- a/components/locid/src/extensions/unicode/mod.rs
+++ b/components/locid/src/extensions/unicode/mod.rs
@@ -124,7 +124,9 @@ impl Unicode {
 
         while let Some(subtag) = iter.peek() {
             if let Ok(attr) = Attribute::from_bytes(subtag) {
-                attributes.push(attr);
+                if let Err(idx) = attributes.binary_search(&attr) {
+                    attributes.insert(idx, attr);
+                }
             } else {
                 break;
             }
@@ -135,7 +137,9 @@ impl Unicode {
             let slen = subtag.len();
             if slen == 2 {
                 if let Some(kw) = current_keyword.take() {
-                    keywords.push((kw, Value::from_vec_unchecked(current_type)));
+                    if let Err(idx) = keywords.binary_search_by_key(&kw, |(k, _)| *k) {
+                        keywords.insert(idx, (kw, Value::from_vec_unchecked(current_type)));
+                    }
                     current_type = vec![];
                 }
                 current_keyword = Some(Key::from_bytes(subtag)?);
@@ -152,10 +156,10 @@ impl Unicode {
         }
 
         if let Some(kw) = current_keyword.take() {
-            keywords.push((kw, Value::from_vec_unchecked(current_type)));
+            if let Err(idx) = keywords.binary_search_by_key(&kw, |(k, _)| *k) {
+                keywords.insert(idx, (kw, Value::from_vec_unchecked(current_type)));
+            }
         }
-
-        keywords.sort_by_key(|i| i.0);
 
         Ok(Self {
             keywords: Keywords::from_vec_unchecked(keywords),

--- a/components/locid/tests/fixtures/locale.json
+++ b/components/locid/tests/fixtures/locale.json
@@ -244,5 +244,35 @@
       "type": "Locale",
       "identifier": "und-t-c0-mixed-m0-true"
     }
+  },
+  {
+    "input": {
+      "type": "Locale",
+      "identifier": "da-u-ca-gregory-ca-buddhist"
+    },
+    "output": {
+      "type": "Locale",
+      "identifier": "da-u-ca-gregory"
+    }
+  },
+  {
+    "input": {
+      "type": "Locale",
+      "identifier": "pt-u-attr2-attr1-ca-gregory"
+    },
+    "output": {
+      "type": "Locale",
+      "identifier": "pt-u-attr1-attr2-ca-gregory"
+    }
+  },
+  {
+    "input": {
+      "type": "Locale",
+      "identifier": "pt-u-attr1-attr2-attr1-ca-gregory"
+    },
+    "output": {
+      "type": "Locale",
+      "identifier": "pt-u-attr1-attr2-ca-gregory"
+    }
   }
 ]


### PR DESCRIPTION
From https://tc39.es/ecma402/#sec-canonicalizeunicodelocaleid, we should
only keep the first keyword for a given key and the first instance of any
attribute defined in the input.