### PR TITLE
Reject empty unicode extensions

### DIFF
--- a/components/locid/src/extensions/unicode/mod.rs
+++ b/components/locid/src/extensions/unicode/mod.rs
@@ -161,6 +161,11 @@ impl Unicode {
             }
         }
 
+        // Ensure we've defined at least one attribute or keyword
+        if attributes.is_empty() && keywords.is_empty() {
+            return Err(ParserError::InvalidExtension);
+        }
+
         Ok(Self {
             keywords: Keywords::from_vec_unchecked(keywords),
             attributes: Attributes::from_vec_unchecked(attributes),

--- a/components/locid/tests/fixtures/invalid-extensions.json
+++ b/components/locid/tests/fixtures/invalid-extensions.json
@@ -78,5 +78,45 @@
       "error": "InvalidExtension",
       "text": "Invalid subtag"
     }
+  },
+  {
+    "input": {
+      "type": "Locale",
+      "identifier": "da-u"
+    },
+    "output": {
+      "error": "InvalidExtension",
+      "text": "Invalid subtag"
+    }
+  },
+  {
+    "input": {
+      "type": "Locale",
+      "identifier": "da-u--"
+    },
+    "output": {
+      "error": "InvalidExtension",
+      "text": "Invalid subtag"
+    }
+  },
+  {
+    "input": {
+      "type": "Locale",
+      "identifier": "da-u-t-latn"
+    },
+    "output": {
+      "error": "InvalidExtension",
+      "text": "Invalid subtag"
+    }
+  },
+  {
+    "input": {
+      "type": "Locale",
+      "identifier": "cmn-hans-cn-u-u"
+    },
+    "output": {
+      "error": "InvalidExtension",
+      "text": "Invalid subtag"
+    }
   }
 ]


### PR DESCRIPTION
From https://www.unicode.org/reports/tr35/#Unicode_locale_identifier,
unicode extensions must include at least one attribute or at least one
keyword.