### PR TITLE
Load Diplomat and twiggy from cache; update diplomat

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -41,7 +41,7 @@ jobs:
         path: |
           ~/.cargo/bin/cargo-make
           ~/.cargo/bin/cargo-make.exe
-        key: ${{ runner.os }}-${{ steps.cargo-make-version.outputs.hash }}
+        key: ${{ runner.os }}-make-${{ steps.cargo-make-version.outputs.hash }}
     - name: Install cargo-make
       if: steps.cargo-make-cache.outputs.cache-hit != 'true'
       uses: actions-rs/install@v0.1.2
@@ -80,7 +80,7 @@ jobs:
         path: |
           ~/.cargo/bin/cargo-make
           ~/.cargo/bin/cargo-make.exe
-        key: ${{ runner.os }}-${{ steps.cargo-make-version.outputs.hash }}
+        key: ${{ runner.os }}-make-${{ steps.cargo-make-version.outputs.hash }}
     - name: Install cargo-make
       if: steps.cargo-make-cache.outputs.cache-hit != 'true'
       uses: actions-rs/install@v0.1.2
@@ -129,7 +129,7 @@ jobs:
         path: |
           ~/.cargo/bin/cargo-make
           ~/.cargo/bin/cargo-make.exe
-        key: ${{ runner.os }}-${{ steps.cargo-make-version.outputs.hash }}
+        key: ${{ runner.os }}-make-${{ steps.cargo-make-version.outputs.hash }}
     - name: Install cargo-make
       if: steps.cargo-make-cache.outputs.cache-hit != 'true'
       uses: actions-rs/install@v0.1.2
@@ -157,7 +157,7 @@ jobs:
         path: |
           ~/.cargo/bin/diplomat-tool
           ~/.cargo/bin/diplomat-tool.exe
-        key: ${{ runner.os }}-${{ steps.diplomat-version.outputs.rev }}
+        key: ${{ runner.os }}-diplomat-${{ steps.diplomat-version.outputs.rev }}
 
     - name: Install Diplomat
       if: steps.diplomat-cache.outputs.cache-hit != 'true'
@@ -205,7 +205,7 @@ jobs:
         path: |
           ~/.cargo/bin/cargo-make
           ~/.cargo/bin/cargo-make.exe
-        key: ${{ runner.os }}-${{ steps.cargo-make-version.outputs.hash }}
+        key: ${{ runner.os }}-make-${{ steps.cargo-make-version.outputs.hash }}
     - name: Install cargo-make
       if: steps.cargo-make-cache.outputs.cache-hit != 'true'
       uses: actions-rs/install@v0.1.2
@@ -246,7 +246,7 @@ jobs:
           path: |
             ~/.cargo/bin/twiggy
             ~/.cargo/bin/twiggy.exe
-          key: ${{ runner.os }}-${{ steps.twiggy-version.outputs.hash }}
+          key: ${{ runner.os }}-twiggy-${{ steps.twiggy-version.outputs.hash }}
       - name: Install twiggy
         if: steps.twiggy-cache.outputs.cache-hit != 'true'
         uses: actions-rs/install@v0.1.2
@@ -266,7 +266,7 @@ jobs:
           path: |
             ~/.cargo/bin/cargo-make
             ~/.cargo/bin/cargo-make.exe
-          key: ${{ runner.os }}-${{ steps.cargo-make-version.outputs.hash }}
+          key: ${{ runner.os }}-make-${{ steps.cargo-make-version.outputs.hash }}
       - name: Install cargo-make
         if: steps.cargo-make-cache.outputs.cache-hit != 'true'
         uses: actions-rs/install@v0.1.2
@@ -286,7 +286,7 @@ jobs:
           path: |
             ~/.cargo/bin/diplomat-tool
             ~/.cargo/bin/diplomat-tool.exe
-          key: ${{ runner.os }}-${{ steps.diplomat-version.outputs.rev }}
+          key: ${{ runner.os }}-diplomat-${{ steps.diplomat-version.outputs.rev }}
 
       - name: Install Diplomat
         if: steps.diplomat-cache.outputs.cache-hit != 'true'
@@ -336,7 +336,7 @@ jobs:
         path: |
           ~/.cargo/bin/cargo-make
           ~/.cargo/bin/cargo-make.exe
-        key: ${{ runner.os }}-${{ steps.cargo-make-version.outputs.hash }}
+        key: ${{ runner.os }}-make-${{ steps.cargo-make-version.outputs.hash }}
     - name: Install cargo-make
       if: steps.cargo-make-cache.outputs.cache-hit != 'true'
       uses: actions-rs/install@v0.1.2
@@ -373,7 +373,7 @@ jobs:
         path: |
           ~/.cargo/bin/cargo-make
           ~/.cargo/bin/cargo-make.exe
-        key: ${{ runner.os }}-${{ steps.cargo-make-version.outputs.hash }}
+        key: ${{ runner.os }}-make-${{ steps.cargo-make-version.outputs.hash }}
     - name: Install cargo-make
       if: steps.cargo-make-cache.outputs.cache-hit != 'true'
       uses: actions-rs/install@v0.1.2
@@ -393,7 +393,7 @@ jobs:
         path: |
           ~/.cargo/bin/cargo-readme
           ~/.cargo/bin/cargo-readme.exe
-        key: ${{ runner.os }}-${{ steps.cargo-readme-version.outputs.hash }}
+        key: ${{ runner.os }}-readme-${{ steps.cargo-readme-version.outputs.hash }}
     - name: Install cargo-readme
       if: steps.cargo-readme-cache.outputs.cache-hit != 'true'
       uses: actions-rs/install@v0.1.2
@@ -694,7 +694,7 @@ jobs:
         path: |
           ~/.cargo/bin/cargo-make
           ~/.cargo/bin/cargo-make.exe
-        key: ${{ runner.os }}-${{ steps.cargo-make-version.outputs.hash }}
+        key: ${{ runner.os }}-make-${{ steps.cargo-make-version.outputs.hash }}
 
     - name: Install cargo-make
       if: steps.cargo-make-cache.outputs.cache-hit != 'true'
@@ -715,7 +715,7 @@ jobs:
         path: |
           ~/.cargo/bin/twiggy
           ~/.cargo/bin/twiggy.exe
-        key: ${{ runner.os }}-${{ steps.twiggy-version.outputs.hash }}
+        key: ${{ runner.os }}-twiggy-${{ steps.twiggy-version.outputs.hash }}
     - name: Install twiggy
       if: steps.twiggy-cache.outputs.cache-hit != 'true'
       uses: actions-rs/install@v0.1.2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -274,27 +274,27 @@ jobs:
           crate: cargo-make
           version: latest
 
-    - name: Get Diplomat version
-      id: diplomat-version
-      run: |
-        echo "::set-output name=rev::$(cargo make diplomat-get-rev --loglevel error |  tr -d '[:space:]')"
-      shell: bash
-    - name: Attempt to load cached Diplomat
-      uses: actions/cache@v2
-      id: diplomat-cache
-      with:
-        path: |
-          ~/.cargo/bin/diplomat-tool
-          ~/.cargo/bin/diplomat-tool.exe
-        key: ${{ runner.os }}-${{ steps.diplomat-version.outputs.rev }}
+      - name: Get Diplomat version
+        id: diplomat-version
+        run: |
+          echo "::set-output name=rev::$(cargo make diplomat-get-rev --loglevel error |  tr -d '[:space:]')"
+        shell: bash
+      - name: Attempt to load cached Diplomat
+        uses: actions/cache@v2
+        id: diplomat-cache
+        with:
+          path: |
+            ~/.cargo/bin/diplomat-tool
+            ~/.cargo/bin/diplomat-tool.exe
+          key: ${{ runner.os }}-${{ steps.diplomat-version.outputs.rev }}
 
-    - name: Install Diplomat
-      if: steps.diplomat-cache.outputs.cache-hit != 'true'
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: install
-        # Keep this in sync with ffi/capi/Cargo.toml
-        args: --git https://github.com/rust-diplomat/diplomat.git --rev ${{ steps.diplomat-version.outputs.rev }} diplomat-tool
+      - name: Install Diplomat
+        if: steps.diplomat-cache.outputs.cache-hit != 'true'
+        uses: actions-rs/cargo@v1.0.1
+        with:
+          command: install
+          # Keep this in sync with ffi/capi/Cargo.toml
+          args: --git https://github.com/rust-diplomat/diplomat.git --rev ${{ steps.diplomat-version.outputs.rev }} diplomat-tool
 
       - name: Build
         uses: actions-rs/cargo@v1.0.1

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -145,13 +145,27 @@ jobs:
         packages: |
           sphinx
           sphinx-rtd-theme
+    - name: Get Diplomat version
+      id: diplomat-version
+      run: |
+        echo "::set-output name=rev::$(cargo make diplomat-get-rev --loglevel error |  tr -d '[:space:]')"
+      shell: bash
+    - name: Attempt to load cached Diplomat
+      uses: actions/cache@v2
+      id: diplomat-cache
+      with:
+        path: |
+          ~/.cargo/bin/diplomat-tool
+          ~/.cargo/bin/diplomat-tool.exe
+        key: ${{ runner.os }}-${{ steps.diplomat-version.outputs.rev }}
 
     - name: Install Diplomat
+      if: steps.diplomat-cache.outputs.cache-hit != 'true'
       uses: actions-rs/cargo@v1.0.1
       with:
         command: install
         # Keep this in sync with ffi/capi/Cargo.toml
-        args: --git https://github.com/rust-diplomat/diplomat.git --rev 38cffa9bc2ef21d0aba89ed7d76236de4153248a diplomat-tool
+        args: --git https://github.com/rust-diplomat/diplomat.git --rev ${{ steps.diplomat-version.outputs.rev }} diplomat-tool
 
     - name: Build
       uses: actions-rs/cargo@v1.0.1
@@ -241,11 +255,27 @@ jobs:
           crate: cargo-make
           version: latest
 
-      - name: Install Diplomat
-        uses: actions-rs/cargo@v1.0.1
-        with:
-          command: install
-          args: --git https://github.com/rust-diplomat/diplomat.git --rev 3ac8c3e8e31353a2f3eb02d015eb23a1feb84b4d diplomat-tool
+    - name: Get Diplomat version
+      id: diplomat-version
+      run: |
+        echo "::set-output name=rev::$(cargo make diplomat-get-rev --loglevel error |  tr -d '[:space:]')"
+      shell: bash
+    - name: Attempt to load cached Diplomat
+      uses: actions/cache@v2
+      id: diplomat-cache
+      with:
+        path: |
+          ~/.cargo/bin/diplomat-tool
+          ~/.cargo/bin/diplomat-tool.exe
+        key: ${{ runner.os }}-${{ steps.diplomat-version.outputs.rev }}
+
+    - name: Install Diplomat
+      if: steps.diplomat-cache.outputs.cache-hit != 'true'
+      uses: actions-rs/cargo@v1.0.1
+      with:
+        command: install
+        # Keep this in sync with ffi/capi/Cargo.toml
+        args: --git https://github.com/rust-diplomat/diplomat.git --rev ${{ steps.diplomat-version.outputs.rev }} diplomat-tool
 
       - name: Build
         uses: actions-rs/cargo@v1.0.1

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -233,7 +233,26 @@ jobs:
       - name: Install WASM tools
         run: |
           sudo apt-get install wabt binaryen
-          cargo install twiggy
+
+      - name: Get twiggy version
+        id: twiggy-version
+        run: |
+          echo "::set-output name=hash::$(cargo search twiggy | grep '^twiggy =' | md5sum)"
+        shell: bash
+      - name: Attempt to load cached twiggy
+        uses: actions/cache@v2
+        id: twiggy-cache
+        with:
+          path: |
+            ~/.cargo/bin/twiggy
+            ~/.cargo/bin/twiggy.exe
+          key: ${{ runner.os }}-${{ steps.twiggy-version.outputs.hash }}
+      - name: Install twiggy
+        if: steps.twiggy-cache.outputs.cache-hit != 'true'
+        uses: actions-rs/install@v0.1.2
+        with:
+          crate: twiggy
+          version: latest
 
       - name: Get cargo-make version
         id: cargo-make-version
@@ -684,6 +703,26 @@ jobs:
         crate: cargo-make
         version: latest
 
+    - name: Get twiggy version
+      id: twiggy-version
+      run: |
+        echo "::set-output name=hash::$(cargo search twiggy | grep '^twiggy =' | md5sum)"
+      shell: bash
+    - name: Attempt to load cached twiggy
+      uses: actions/cache@v2
+      id: twiggy-cache
+      with:
+        path: |
+          ~/.cargo/bin/twiggy
+          ~/.cargo/bin/twiggy.exe
+        key: ${{ runner.os }}-${{ steps.twiggy-version.outputs.hash }}
+    - name: Install twiggy
+      if: steps.twiggy-cache.outputs.cache-hit != 'true'
+      uses: actions-rs/install@v0.1.2
+      with:
+        crate: twiggy
+        version: latest
+
     - name: Install prerequisites for wasm build
       run: |
         rustup component add rust-src
@@ -691,7 +730,7 @@ jobs:
         rustup toolchain install nightly-2021-02-28
         sudo npm install -g wasm-opt --unsafe-perm
         sudo npm install -g wabt
-        cargo install twiggy
+
 
     - name: Setup output data directory
       run: mkdir -p benchmarks/binsize

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -151,7 +151,7 @@ jobs:
       with:
         command: install
         # Keep this in sync with ffi/capi/Cargo.toml
-        args: --git https://github.com/rust-diplomat/diplomat.git --rev 3ac8c3e8e31353a2f3eb02d015eb23a1feb84b4d diplomat-tool
+        args: --git https://github.com/rust-diplomat/diplomat.git --rev 38cffa9bc2ef21d0aba89ed7d76236de4153248a diplomat-tool
 
     - name: Build
       uses: actions-rs/cargo@v1.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "diplomat"
 version = "0.2.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=3ac8c3e8e31353a2f3eb02d015eb23a1feb84b4d#3ac8c3e8e31353a2f3eb02d015eb23a1feb84b4d"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=38cffa9bc2ef21d0aba89ed7d76236de4153248a#38cffa9bc2ef21d0aba89ed7d76236de4153248a"
 dependencies = [
  "diplomat_core",
  "proc-macro2",
@@ -476,12 +476,12 @@ dependencies = [
 [[package]]
 name = "diplomat-runtime"
 version = "0.2.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=3ac8c3e8e31353a2f3eb02d015eb23a1feb84b4d#3ac8c3e8e31353a2f3eb02d015eb23a1feb84b4d"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=38cffa9bc2ef21d0aba89ed7d76236de4153248a#38cffa9bc2ef21d0aba89ed7d76236de4153248a"
 
 [[package]]
 name = "diplomat_core"
 version = "0.2.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=3ac8c3e8e31353a2f3eb02d015eb23a1feb84b4d#3ac8c3e8e31353a2f3eb02d015eb23a1feb84b4d"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=38cffa9bc2ef21d0aba89ed7d76236de4153248a#38cffa9bc2ef21d0aba89ed7d76236de4153248a"
 dependencies = [
  "impls",
  "lazy_static",

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -68,7 +68,7 @@ icu_provider_blob = { path = "../../provider/blob" }
 tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
 writeable = { path = "../../utils/writeable/" }
 
-# make sure to update GitHub actions to use the appropriate revision
+# Run `cargo make diplomat-install` to get the right diplomat binary installed
 diplomat = { git = "https://github.com/rust-diplomat/diplomat", rev = "38cffa9bc2ef21d0aba89ed7d76236de4153248a" }
 diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", rev = "38cffa9bc2ef21d0aba89ed7d76236de4153248a" }
 icu_testdata = { version = "0.3", path = "../../provider/testdata", default-features = false, features = ["static"], optional = true }

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -69,8 +69,8 @@ tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
 writeable = { path = "../../utils/writeable/" }
 
 # make sure to update GitHub actions to use the appropriate revision
-diplomat = { git = "https://github.com/rust-diplomat/diplomat", rev = "3ac8c3e8e31353a2f3eb02d015eb23a1feb84b4d" }
-diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", rev = "3ac8c3e8e31353a2f3eb02d015eb23a1feb84b4d" }
+diplomat = { git = "https://github.com/rust-diplomat/diplomat", rev = "38cffa9bc2ef21d0aba89ed7d76236de4153248a" }
+diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", rev = "38cffa9bc2ef21d0aba89ed7d76236de4153248a" }
 icu_testdata = { version = "0.3", path = "../../provider/testdata", default-features = false, features = ["static"], optional = true }
 
 # This cfg originates in dlmalloc/lib.rs

--- a/ffi/capi/include/result_void_ICU4XLocaleError.h
+++ b/ffi/capi/include/result_void_ICU4XLocaleError.h
@@ -12,7 +12,6 @@ extern "C" {
 #include "ICU4XLocaleError.h"
 typedef struct locale_ffi_result_void_ICU4XLocaleError {
     union {
-        uint8_t ok[0];
         ICU4XLocaleError err;
     };
     bool is_ok;

--- a/ffi/capi/include/result_void_void.h
+++ b/ffi/capi/include/result_void_void.h
@@ -10,10 +10,6 @@
 extern "C" {
 #endif
 typedef struct decimal_ffi_result_void_void {
-    union {
-        uint8_t ok[0];
-        uint8_t err[0];
-    };
     bool is_ok;
 } decimal_ffi_result_void_void;
 #ifdef __cplusplus

--- a/ffi/cpp/include/ICU4XFixedDecimalFormatOptions.hpp
+++ b/ffi/cpp/include/ICU4XFixedDecimalFormatOptions.hpp
@@ -32,6 +32,6 @@ struct ICU4XFixedDecimalFormatOptions {
 
 inline ICU4XFixedDecimalFormatOptions ICU4XFixedDecimalFormatOptions::default_() {
   capi::ICU4XFixedDecimalFormatOptions diplomat_raw_struct_out_value = capi::ICU4XFixedDecimalFormatOptions_default();
-  return ICU4XFixedDecimalFormatOptions{ .grouping_strategy = std::move(ICU4XFixedDecimalGroupingStrategy{ diplomat_raw_struct_out_value.grouping_strategy }), .sign_display = std::move(ICU4XFixedDecimalSignDisplay{ diplomat_raw_struct_out_value.sign_display }) };
+  return ICU4XFixedDecimalFormatOptions{ .grouping_strategy = std::move(static_cast<ICU4XFixedDecimalGroupingStrategy>(diplomat_raw_struct_out_value.grouping_strategy)), .sign_display = std::move(static_cast<ICU4XFixedDecimalSignDisplay>(diplomat_raw_struct_out_value.sign_display)) };
 }
 #endif

--- a/ffi/cpp/include/ICU4XLocale.hpp
+++ b/ffi/cpp/include/ICU4XLocale.hpp
@@ -72,7 +72,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XLocaleError> I
   diplomat::result<std::monostate, ICU4XLocaleError> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   } else {
-    diplomat_result_out_value.set_err((std::move(ICU4XLocaleError{ diplomat_result_raw_out_value.err })));
+    diplomat_result_out_value.set_err((std::move(static_cast<ICU4XLocaleError>(diplomat_result_raw_out_value.err))));
   }
   return diplomat_result_out_value;
 }
@@ -83,7 +83,7 @@ inline diplomat::result<std::string, ICU4XLocaleError> ICU4XLocale::basename() {
   diplomat::result<std::monostate, ICU4XLocaleError> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   } else {
-    diplomat_result_out_value.set_err((std::move(ICU4XLocaleError{ diplomat_result_raw_out_value.err })));
+    diplomat_result_out_value.set_err((std::move(static_cast<ICU4XLocaleError>(diplomat_result_raw_out_value.err))));
   }
   return diplomat_result_out_value.replace_ok(std::move(diplomat_writeable_string));
 }
@@ -93,7 +93,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XLocaleError> I
   diplomat::result<std::monostate, ICU4XLocaleError> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   } else {
-    diplomat_result_out_value.set_err((std::move(ICU4XLocaleError{ diplomat_result_raw_out_value.err })));
+    diplomat_result_out_value.set_err((std::move(static_cast<ICU4XLocaleError>(diplomat_result_raw_out_value.err))));
   }
   return diplomat_result_out_value;
 }
@@ -104,7 +104,7 @@ inline diplomat::result<std::string, ICU4XLocaleError> ICU4XLocale::get_unicode_
   diplomat::result<std::monostate, ICU4XLocaleError> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   } else {
-    diplomat_result_out_value.set_err((std::move(ICU4XLocaleError{ diplomat_result_raw_out_value.err })));
+    diplomat_result_out_value.set_err((std::move(static_cast<ICU4XLocaleError>(diplomat_result_raw_out_value.err))));
   }
   return diplomat_result_out_value.replace_ok(std::move(diplomat_writeable_string));
 }
@@ -114,7 +114,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XLocaleError> I
   diplomat::result<std::monostate, ICU4XLocaleError> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   } else {
-    diplomat_result_out_value.set_err((std::move(ICU4XLocaleError{ diplomat_result_raw_out_value.err })));
+    diplomat_result_out_value.set_err((std::move(static_cast<ICU4XLocaleError>(diplomat_result_raw_out_value.err))));
   }
   return diplomat_result_out_value;
 }
@@ -125,7 +125,7 @@ inline diplomat::result<std::string, ICU4XLocaleError> ICU4XLocale::language() {
   diplomat::result<std::monostate, ICU4XLocaleError> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   } else {
-    diplomat_result_out_value.set_err((std::move(ICU4XLocaleError{ diplomat_result_raw_out_value.err })));
+    diplomat_result_out_value.set_err((std::move(static_cast<ICU4XLocaleError>(diplomat_result_raw_out_value.err))));
   }
   return diplomat_result_out_value.replace_ok(std::move(diplomat_writeable_string));
 }
@@ -135,7 +135,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XLocaleError> I
   diplomat::result<std::monostate, ICU4XLocaleError> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   } else {
-    diplomat_result_out_value.set_err((std::move(ICU4XLocaleError{ diplomat_result_raw_out_value.err })));
+    diplomat_result_out_value.set_err((std::move(static_cast<ICU4XLocaleError>(diplomat_result_raw_out_value.err))));
   }
   return diplomat_result_out_value;
 }
@@ -146,7 +146,7 @@ inline diplomat::result<std::string, ICU4XLocaleError> ICU4XLocale::region() {
   diplomat::result<std::monostate, ICU4XLocaleError> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   } else {
-    diplomat_result_out_value.set_err((std::move(ICU4XLocaleError{ diplomat_result_raw_out_value.err })));
+    diplomat_result_out_value.set_err((std::move(static_cast<ICU4XLocaleError>(diplomat_result_raw_out_value.err))));
   }
   return diplomat_result_out_value.replace_ok(std::move(diplomat_writeable_string));
 }
@@ -156,7 +156,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XLocaleError> I
   diplomat::result<std::monostate, ICU4XLocaleError> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   } else {
-    diplomat_result_out_value.set_err((std::move(ICU4XLocaleError{ diplomat_result_raw_out_value.err })));
+    diplomat_result_out_value.set_err((std::move(static_cast<ICU4XLocaleError>(diplomat_result_raw_out_value.err))));
   }
   return diplomat_result_out_value;
 }
@@ -167,7 +167,7 @@ inline diplomat::result<std::string, ICU4XLocaleError> ICU4XLocale::script() {
   diplomat::result<std::monostate, ICU4XLocaleError> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   } else {
-    diplomat_result_out_value.set_err((std::move(ICU4XLocaleError{ diplomat_result_raw_out_value.err })));
+    diplomat_result_out_value.set_err((std::move(static_cast<ICU4XLocaleError>(diplomat_result_raw_out_value.err))));
   }
   return diplomat_result_out_value.replace_ok(std::move(diplomat_writeable_string));
 }
@@ -177,7 +177,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XLocaleError> I
   diplomat::result<std::monostate, ICU4XLocaleError> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   } else {
-    diplomat_result_out_value.set_err((std::move(ICU4XLocaleError{ diplomat_result_raw_out_value.err })));
+    diplomat_result_out_value.set_err((std::move(static_cast<ICU4XLocaleError>(diplomat_result_raw_out_value.err))));
   }
   return diplomat_result_out_value;
 }
@@ -188,7 +188,7 @@ inline diplomat::result<std::string, ICU4XLocaleError> ICU4XLocale::tostring() {
   diplomat::result<std::monostate, ICU4XLocaleError> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   } else {
-    diplomat_result_out_value.set_err((std::move(ICU4XLocaleError{ diplomat_result_raw_out_value.err })));
+    diplomat_result_out_value.set_err((std::move(static_cast<ICU4XLocaleError>(diplomat_result_raw_out_value.err))));
   }
   return diplomat_result_out_value.replace_ok(std::move(diplomat_writeable_string));
 }

--- a/ffi/cpp/include/ICU4XLocaleCanonicalizer.hpp
+++ b/ffi/cpp/include/ICU4XLocaleCanonicalizer.hpp
@@ -50,12 +50,12 @@ inline std::optional<ICU4XLocaleCanonicalizer> ICU4XLocaleCanonicalizer::create(
   return diplomat_optional_out_value;
 }
 inline ICU4XCanonicalizationResult ICU4XLocaleCanonicalizer::canonicalize(ICU4XLocale& locale) {
-  return ICU4XCanonicalizationResult{ capi::ICU4XLocaleCanonicalizer_canonicalize(this->inner.get(), locale.AsFFIMut()) };
+  return static_cast<ICU4XCanonicalizationResult>(capi::ICU4XLocaleCanonicalizer_canonicalize(this->inner.get(), locale.AsFFIMut()));
 }
 inline ICU4XCanonicalizationResult ICU4XLocaleCanonicalizer::maximize(ICU4XLocale& locale) {
-  return ICU4XCanonicalizationResult{ capi::ICU4XLocaleCanonicalizer_maximize(this->inner.get(), locale.AsFFIMut()) };
+  return static_cast<ICU4XCanonicalizationResult>(capi::ICU4XLocaleCanonicalizer_maximize(this->inner.get(), locale.AsFFIMut()));
 }
 inline ICU4XCanonicalizationResult ICU4XLocaleCanonicalizer::minimize(ICU4XLocale& locale) {
-  return ICU4XCanonicalizationResult{ capi::ICU4XLocaleCanonicalizer_minimize(this->inner.get(), locale.AsFFIMut()) };
+  return static_cast<ICU4XCanonicalizationResult>(capi::ICU4XLocaleCanonicalizer_minimize(this->inner.get(), locale.AsFFIMut()));
 }
 #endif

--- a/ffi/cpp/include/ICU4XPluralRules.hpp
+++ b/ffi/cpp/include/ICU4XPluralRules.hpp
@@ -56,7 +56,7 @@ inline ICU4XCreatePluralRulesResult ICU4XPluralRules::create(const ICU4XLocale& 
   return ICU4XCreatePluralRulesResult{ .rules = std::move(diplomat_optional_out_value_rules), .success = std::move(diplomat_raw_struct_out_value.success) };
 }
 inline ICU4XPluralCategory ICU4XPluralRules::select(const ICU4XPluralOperands& op) {
-  return ICU4XPluralCategory{ capi::ICU4XPluralRules_select(this->inner.get(), (capi::ICU4XPluralOperands*) &op) };
+  return static_cast<ICU4XPluralCategory>(capi::ICU4XPluralRules_select(this->inner.get(), (capi::ICU4XPluralOperands*) &op));
 }
 inline ICU4XPluralCategories ICU4XPluralRules::categories() {
   capi::ICU4XPluralCategories diplomat_raw_struct_out_value = capi::ICU4XPluralRules_categories(this->inner.get());

--- a/ffi/cpp/include/result_void_ICU4XLocaleError.h
+++ b/ffi/cpp/include/result_void_ICU4XLocaleError.h
@@ -12,7 +12,6 @@ extern "C" {
 #include "ICU4XLocaleError.h"
 typedef struct locale_ffi_result_void_ICU4XLocaleError {
     union {
-        uint8_t ok[0];
         ICU4XLocaleError err;
     };
     bool is_ok;

--- a/ffi/cpp/include/result_void_void.h
+++ b/ffi/cpp/include/result_void_void.h
@@ -10,10 +10,6 @@
 extern "C" {
 #endif
 typedef struct decimal_ffi_result_void_void {
-    union {
-        uint8_t ok[0];
-        uint8_t err[0];
-    };
     bool is_ok;
 } decimal_ffi_result_void_void;
 #ifdef __cplusplus

--- a/tools/scripts/ffi.toml
+++ b/tools/scripts/ffi.toml
@@ -141,3 +141,49 @@ category = "ICU4X FFI"
 toolchain = "nightly-2021-02-28"
 command = "cargo"
 args = ["build", "--package", "icu", "--target", "thumbv7m-none-eabi"]
+
+[tasks.diplomat-get-rev]
+description = "Get current Diplomat revision"
+category = "ICU4X Development"
+script_runner = "@duckscript"
+script = '''
+exit_on_error true
+metadata = exec --fail-on-error cargo metadata
+metadata = set ${metadata.stdout}
+# Parse output
+metadata = json_parse --collection ${metadata}
+# packages = metadata.packages
+packages = map_get ${metadata} packages
+for pkg in ${packages}
+    # find pkg.name
+    name = map_get ${pkg} name
+    # check if it is "diplomat"
+    e = eq ${name} "diplomat"
+    if ${e}
+        # get pkg.source
+        source = map_get ${pkg} source
+        # extract the bit between `rev=` and `#`
+        handle = split ${source} "rev="
+        hash = array_get ${handle} 1
+        release handle
+        handle = split ${hash} "#"
+        rev = array_get ${handle} 0
+        release handle
+        # print it
+        echo ${rev}
+    end
+end
+release --recursive ${metadata}
+'''
+
+[tasks.diplomat-install]
+description = "Install Diplomat at current Diplomat revision"
+category = "ICU4X Development"
+script_runner = "@duckscript"
+script = '''
+exit_on_error true
+rev = exec cargo make diplomat-get-rev --loglevel error
+rev = trim ${rev.stdout}
+echo "Installing Diplomat rev ${rev}"
+exec cargo install --git https://github.com/rust-diplomat/diplomat.git --rev ${rev} diplomat-tool -f
+'''


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/973

Pulls in diplomat update from https://github.com/unicode-org/icu4x/pull/968

This has the added benefit of no longer needing to sync Diplomat versions across two files; the single source of truth is `icu_capi`'s Cargo.toml. You can reinstall the correct version of Diplomat with `cargo make diplomat-install`, easy peasy :smile: 

Our builds are not bottlenecked on the FFI/WASM builds, but it's always good to have room to grow, and to get failing CI results earlier.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->