### PR TITLE
Fix a typo in the destination directory path of binsize benchmark data.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -795,7 +795,7 @@ jobs:
       with:
         tool: 'ndjson'
         output-file-path: benchmarks/binsize/${{ matrix.type }}/output.txt
-        benchmark-data-dir-path: ./benchmarks/binsize${{ matrix.type }}
+        benchmark-data-dir-path: ./benchmarks/binsize/${{ matrix.type }}
         # Tentative setting, optimized value to be determined
         alert-threshold: '200%'
         fail-on-alert: true


### PR DESCRIPTION
Part of resolution of ticket #1019.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->