### PR TITLE
Disable code coverage comments on PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,3 +11,7 @@ ignore:
   - "**/benches/**/*"
   - "**/examples/**/*"
   - "provider/testdata/**/*"
+
+# Disable Codecov action from leaving comments on PRs
+# https://docs.codecov.com/docs/pull-request-comments#disable-comment
+comment: false


### PR DESCRIPTION
- [X] Coveralls comments was turned off globally for the repo via the settings in the [Coveralls UI for the repo](https://coveralls.io/github/unicode-org/icu4x) ([example](https://remarkablemark.org/blog/2020/12/02/coveralls-leave-comments-pull-request/))
- [X] Codecov comments need to be turned off via the `codecov.yml` file by [adding a line](https://docs.codecov.com/docs/pull-request-comments#disable-comment)

Closes #934 