### PR TITLE
Add [As]VarULE impls for Vec<T>/[T]

### DIFF
--- a/utils/zerovec/src/ule/chars.rs
+++ b/utils/zerovec/src/ule/chars.rs
@@ -50,10 +50,15 @@ impl ULE for CharULE {
             let u = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
             char::try_from(u)?;
         }
+        // Safe because Self is transparent over [u8; 4] and has been validated
+        Ok(unsafe { Self::from_byte_slice_unchecked(bytes) })
+    }
+
+    #[inline]
+    unsafe fn from_byte_slice_unchecked(bytes: &[u8]) -> &[Self] {
         let data = bytes.as_ptr();
         let len = bytes.len() / 4;
-        // Safe because Self is transparent over [u8; 4]
-        Ok(unsafe { std::slice::from_raw_parts(data as *const Self, len) })
+        std::slice::from_raw_parts(data as *const Self, len)
     }
 
     #[inline]

--- a/utils/zerovec/src/ule/chars.rs
+++ b/utils/zerovec/src/ule/chars.rs
@@ -39,7 +39,9 @@ use std::convert::TryFrom;
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct CharULE([u8; 4]);
 
-impl ULE for CharULE {
+// This is safe to implement because from_byte_slice_unchecked returns
+// the same value as parse_byte_slice
+unsafe impl ULE for CharULE {
     type Error = std::char::CharTryFromError;
 
     #[inline]

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -16,7 +16,11 @@ pub use plain::PlainOldULE;
 /// Fixed-width, byte-aligned data that can be cast to and from a little-endian byte slice.
 ///
 /// "ULE" stands for "Unaligned little-endian"
-pub trait ULE
+///
+/// # Safety
+///
+/// See the safety invariant documented on [`Self::from_byte_slice_unchecked()`] to implement this trait.
+pub unsafe trait ULE
 where
     Self: Sized,
     Self: 'static,
@@ -182,7 +186,11 @@ pub trait AsVarULE {
 ///
 /// This trait is mostly for unsized types like `str` and `[T]`. It can be implemented on sized types,
 /// however it is much more preferable to use [`ULE`] for that purpose.
-pub trait VarULE: 'static {
+///
+/// # Safety
+///
+/// See the safety invariant documented on [`Self::from_byte_slice_unchecked()`] to implement this trait.
+pub unsafe trait VarULE: 'static {
     /// The error type to used by [`VarULE::parse_byte_slice()`]
     type Error;
 

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -33,7 +33,29 @@ where
     /// Implementations of this method may involve `unsafe{}` blocks to cast the pointer to the
     /// correct type. It is up to the implementation to reason about the safety. Keep in mind that
     /// `&[Self]` and `&[u8]` may have different lengths.
+    ///
+    /// Ideally, implementations call [`ULE::from_byte_slice_unchecked()`] after validation.
     fn parse_byte_slice(bytes: &[u8]) -> Result<&[Self], Self::Error>;
+
+    /// Takes a byte slice, `&[u8]`, and return it as `&[Self]` with the same lifetime, assuming that
+    /// this byte slice has previously been run through [`ULE::parse_byte_slice()`] with success.
+    ///
+    /// There is no need to perform any validation here, this should almost always be a straight pointer
+    /// cast.
+    ///
+    /// # Safety
+    ///
+    /// ## Callers
+    /// Callers of this method must take care to ensure that `bytes` was previously passed through
+    /// [`ULE::parse_byte_slice()`] with success (and was not changed since then).
+    ///
+    /// ## Implementors
+    /// This method _must_ be implemented to return the same result as [`ULE::parse_byte_slice()`].
+    ///
+    /// Implementations of this method may involve `unsafe{}` blocks to cast the pointer to the
+    /// correct type. It is up to the implementation to reason about the safety, assuming the invariant
+    /// above.
+    unsafe fn from_byte_slice_unchecked(bytes: &[u8]) -> &[Self];
 
     /// Given `&[Self]`, returns a `&[u8]` with the same lifetime.
     ///
@@ -163,7 +185,7 @@ pub trait VarULE: 'static {
     /// The error type to used by [`VarULE::parse_byte_slice()`]
     type Error;
 
-    /// Parses a byte slice, `&[u8]`, and return it as `&self` with the same lifetime.
+    /// Parses a byte slice, `&[u8]`, and return it as `&Self` with the same lifetime.
     ///
     /// If `Self` is not well-defined for all possible bit values, the bytes should be validated,
     /// and `Self::Error` should be returned if they are not valid.

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -8,6 +8,7 @@
 mod chars;
 mod plain;
 mod string;
+mod vec;
 
 pub use chars::CharULE;
 pub use plain::PlainOldULE;

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -182,8 +182,12 @@ pub trait VarULE: 'static {
     ///
     /// # Safety
     ///
+    /// ## Callers
     /// Callers of this method must take care to ensure that `bytes` was previously passed through
     /// [`VarULE::parse_byte_slice()`] with success (and was not changed since then).
+    ///
+    /// ## Implementors
+    /// This method _must_ be implemented to return the same result as [`VarULE::parse_byte_slice()`].
     ///
     /// Implementations of this method may involve `unsafe{}` blocks to cast the pointer to the
     /// correct type. It is up to the implementation to reason about the safety, assuming the invariant

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -26,7 +26,9 @@ macro_rules! impl_byte_slice_size {
                 &self.0
             }
         }
-        impl ULE for PlainOldULE<$size> {
+        // This is safe to implement because from_byte_slice_unchecked returns
+        // the same value as parse_byte_slice
+        unsafe impl ULE for PlainOldULE<$size> {
             type Error = std::convert::Infallible;
             #[inline]
             fn parse_byte_slice(bytes: &[u8]) -> Result<&[Self], Self::Error> {

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -30,10 +30,15 @@ macro_rules! impl_byte_slice_size {
             type Error = std::convert::Infallible;
             #[inline]
             fn parse_byte_slice(bytes: &[u8]) -> Result<&[Self], Self::Error> {
+                // Safe because Self is transparent over [u8; $size]
+                Ok(unsafe { Self::from_byte_slice_unchecked(bytes) })
+            }
+            #[inline]
+            unsafe fn from_byte_slice_unchecked(bytes: &[u8]) -> &[Self] {
                 let data = bytes.as_ptr();
                 let len = bytes.len() / $size;
                 // Safe because Self is transparent over [u8; $size]
-                Ok(unsafe { std::slice::from_raw_parts(data as *const Self, len) })
+                std::slice::from_raw_parts(data as *const Self, len)
             }
             #[inline]
             fn as_byte_slice(slice: &[Self]) -> &[u8] {

--- a/utils/zerovec/src/ule/string.rs
+++ b/utils/zerovec/src/ule/string.rs
@@ -17,7 +17,9 @@ impl AsVarULE for String {
     }
 }
 
-impl VarULE for str {
+// This is safe to implement because from_byte_slice_unchecked returns
+// the same value as parse_byte_slice
+unsafe impl VarULE for str {
     type Error = str::Utf8Error;
 
     #[inline]

--- a/utils/zerovec/src/ule/vec.rs
+++ b/utils/zerovec/src/ule/vec.rs
@@ -4,7 +4,10 @@
 
 use crate::ule::*;
 
-impl<T> AsVarULE for Vec<T> where T: ULE + Clone {
+impl<T> AsVarULE for Vec<T>
+where
+    T: ULE + Clone,
+{
     type VarULE = [T];
     #[inline]
     fn as_unaligned(&self) -> &[T] {
@@ -26,8 +29,6 @@ where
     fn parse_byte_slice(bytes: &[u8]) -> Result<&Self, Self::Error> {
         T::parse_byte_slice(bytes)
     }
-    /// Invariant: must be safe to call when called on a slice that previously
-    /// succeeded with `parse_byte_slice`
     #[inline]
     unsafe fn from_byte_slice_unchecked(bytes: &[u8]) -> &Self {
         T::from_byte_slice_unchecked(bytes)

--- a/utils/zerovec/src/ule/vec.rs
+++ b/utils/zerovec/src/ule/vec.rs
@@ -1,0 +1,39 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use crate::ule::*;
+
+impl<T> AsVarULE for Vec<T> where T: ULE + Clone {
+    type VarULE = [T];
+    #[inline]
+    fn as_unaligned(&self) -> &[T] {
+        self
+    }
+    #[inline]
+    fn from_unaligned(unaligned: &[T]) -> Self {
+        unaligned.into()
+    }
+}
+
+impl<T> VarULE for [T]
+where
+    T: ULE,
+{
+    type Error = T::Error;
+
+    #[inline]
+    fn parse_byte_slice(bytes: &[u8]) -> Result<&Self, Self::Error> {
+        T::parse_byte_slice(bytes)
+    }
+    /// Invariant: must be safe to call when called on a slice that previously
+    /// succeeded with `parse_byte_slice`
+    #[inline]
+    unsafe fn from_byte_slice_unchecked(bytes: &[u8]) -> &Self {
+        T::from_byte_slice_unchecked(bytes)
+    }
+    #[inline]
+    fn as_byte_slice(&self) -> &[u8] {
+        T::as_byte_slice(self)
+    }
+}

--- a/utils/zerovec/src/ule/vec.rs
+++ b/utils/zerovec/src/ule/vec.rs
@@ -19,7 +19,9 @@ where
     }
 }
 
-impl<T> VarULE for [T]
+// This is safe to implement because from_byte_slice_unchecked returns
+// the same value as parse_byte_slice
+unsafe impl<T> VarULE for [T]
 where
     T: ULE,
 {

--- a/utils/zerovec/src/ule/vec.rs
+++ b/utils/zerovec/src/ule/vec.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::ule::*;
+use crate::ZeroVec;
 
 impl<T> AsVarULE for Vec<T>
 where
@@ -16,6 +17,22 @@ where
     #[inline]
     fn from_unaligned(unaligned: &[T]) -> Self {
         unaligned.into()
+    }
+}
+
+impl<T> AsVarULE for ZeroVec<'static, T>
+where
+    T: AsULE,
+    T::ULE: Clone,
+{
+    type VarULE = [T::ULE];
+    #[inline]
+    fn as_unaligned(&self) -> &[T::ULE] {
+        self.as_slice()
+    }
+    #[inline]
+    fn from_unaligned(unaligned: &[T::ULE]) -> Self {
+        ZeroVec::Owned(unaligned.into())
     }
 }
 

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -19,7 +19,8 @@ mod serde;
 /// where `T`'s data is variable-length (e.g. `String`)
 ///
 /// `T` must implement [`AsVarULE`], which is already implemented for [`String`] and `Vec<T>` where
-/// `T` implements [`ULE`]. References are obtained
+/// `T` implements [`ULE`]. It is also implemented on `VarZeroVec<'static, T>` if the inconvenience of
+/// converting to/from ULE is not desired. References are obtained
 /// as its [`AsVarULE::VarULE`] type, which in the case of [`String`] is [`str`].
 ///
 /// `VarZeroVec<T>` behaves much like [`std::borrow::Cow`], where it can be constructed from owned data
@@ -64,12 +65,13 @@ mod serde;
 /// # Ok::<(), VarZeroVecError<Utf8Error>>(())
 /// ```
 ///
-/// Here's another example with `Vec<T>`:
+/// Here's another example with `Vec<T>` and `ZeroVec<'static, T>`:
 ///
 /// ```rust
 /// # use std::str::Utf8Error;
 /// # use zerovec::VarZeroVecError;
 /// use zerovec::VarZeroVec;
+/// use zerovec::ZeroVec;
 /// use zerovec::ule::*;
 ///
 /// // The little-endian bytes correspond to the list of integers.
@@ -85,9 +87,14 @@ mod serde;
 ///              9, 0, 0, 0];
 ///
 /// let zerovec: VarZeroVec<Vec<PlainOldULE<4>>> = VarZeroVec::try_from_bytes(bytes)?;
+/// let zerovec2: VarZeroVec<ZeroVec<'static, u32>> = VarZeroVec::try_from_bytes(bytes)?;
 ///
 /// assert_eq!(zerovec.get(2).and_then(|v| v.get(1)), Some(&55555.into()));
+/// assert_eq!(zerovec2.get(2).and_then(|v| v.get(1)), Some(&55555.into()));
 /// assert_eq!(zerovec, &*numbers);
+/// for (zv, v) in zerovec.iter().zip(numbers.iter()) {
+///     assert_eq!(zv, v);   
+/// }
 /// # Ok::<(), VarZeroVecError<std::convert::Infallible>>(())
 /// ```
 ///

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -18,7 +18,8 @@ mod serde;
 /// desirable to borrow data from an unaligned byte slice, such as zero-copy deserialization, and
 /// where `T`'s data is variable-length (e.g. `String`)
 ///
-/// `T` must implement [`AsVarULE`], which is already implemented for [`String`]. References are obtained
+/// `T` must implement [`AsVarULE`], which is already implemented for [`String`] and `Vec<T>` where
+/// `T` implements [`ULE`]. References are obtained
 /// as its [`AsVarULE::VarULE`] type, which in the case of [`String`] is [`str`].
 ///
 /// `VarZeroVec<T>` behaves much like [`std::borrow::Cow`], where it can be constructed from owned data
@@ -44,7 +45,7 @@ mod serde;
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use std::str::Utf8Error;
 /// # use zerovec::VarZeroVecError;
 /// use zerovec::VarZeroVec;
@@ -61,6 +62,33 @@ mod serde;
 /// assert_eq!(zerovec.get(2), Some("文"));
 /// assert_eq!(zerovec, &*strings);
 /// # Ok::<(), VarZeroVecError<Utf8Error>>(())
+/// ```
+///
+/// Here's another example with `Vec<T>`:
+///
+/// ```rust
+/// # use std::str::Utf8Error;
+/// # use zerovec::VarZeroVecError;
+/// use zerovec::VarZeroVec;
+/// use zerovec::ule::*;
+///
+/// // The little-endian bytes correspond to the list of integers.
+/// let numbers: Vec<Vec<PlainOldULE<4>>> = vec![
+///     vec![12.into(), 25.into(), 38.into()],
+///     vec![39179.into(), 100.into()],
+///     vec![42.into(), 55555.into()],
+///     vec![12345.into(), 54321.into(), 9.into()],
+/// ];
+/// let bytes = &[4, 0, 0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 20, 0, 0, 0, 28, 0, 0, 0,
+///              12, 0, 0, 0, 25, 0, 0, 0, 38, 0, 0, 0, 11, 153, 0, 0, 100, 0,
+///              0, 0, 42, 0, 0, 0, 3, 217, 0, 0, 57, 48, 0, 0, 49, 212, 0, 0,
+///              9, 0, 0, 0];
+///
+/// let zerovec: VarZeroVec<Vec<PlainOldULE<4>>> = VarZeroVec::try_from_bytes(bytes)?;
+///
+/// assert_eq!(zerovec.get(2).and_then(|v| v.get(1)), Some(&55555.into()));
+/// assert_eq!(zerovec, &*numbers);
+/// # Ok::<(), VarZeroVecError<std::convert::Infallible>>(())
 /// ```
 ///
 /// [`ule`]: crate::ule


### PR DESCRIPTION
On request by @zbraniecki

This lets us nest vectors (one level deep only) in `VarZeroVec`, so we can have `VarZeroVec<Vec<T>>` as long as `T` is `ULE`. It behaves like a `Vec<Vec<T>>`

Note that the `T: ULE` bound means that most of the types you use here will be of the form `VarZeroVec<Vec<PlainOldULE<N>>`, i.e. the inner vector will expose `ULE` types in the API. This is kinda annoying but not a deal breaker.

This is not a hard constraint on the design, it would be possible to improve this by creating a `OwnedULEVec<T>` type (name suggestions welcome) that is basically just a `Vec<T::ULE>` that exposes native-endian getters. This could also be used as the `Owned` variant on `ZeroVec`. Happy to make these changes if folks want; overall I feel like having folks call `.into()` when needed is mostly _fine_.

We cannot support `VarZeroVec<ZeroVec<T>>` because `ZeroVec` has a lifetime (using the `'static` variant here would not be sound).



<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->