### PR TITLE
Derive Yokeable for ZeroMap

### DIFF
--- a/utils/yoke/derive/examples/derive.rs
+++ b/utils/yoke/derive/examples/derive.rs
@@ -8,25 +8,33 @@ use std::borrow::Cow;
 use yoke_derive::{Yokeable, ZeroCopyFrom};
 use zerovec::{VarZeroVec, ZeroMap, ZeroVec};
 
+// #[derive(Yokeable)]
+// pub struct StringExample {
+//     x: String,
+//}
+
+// #[derive(Yokeable, ZeroCopyFrom)]
+// pub struct CowExample<'a> {
+//     x: u8,
+//     y: &'a str,
+//     z: Cow<'a, str>,
+//     w: Cow<'a, [u8]>,
+// }
+
+// #[derive(Yokeable, ZeroCopyFrom)]
+// #[yoke(prove_covariance_manually)]
+// pub struct ZeroVecExample<'a> {
+//     // https://github.com/unicode-org/icu4x/issues/844
+//     // map: ZeroMap<'a, String, String>,
+//     var: VarZeroVec<'a, String>,
+//     vec: ZeroVec<'a, u16>,
+// }
+
 #[derive(Yokeable)]
-pub struct Foo {
-    x: String,
-}
-
-#[derive(Yokeable, ZeroCopyFrom)]
-pub struct Bar<'a> {
-    x: u8,
-    y: &'a str,
-    z: Cow<'a, str>,
-    w: Cow<'a, [u8]>,
-}
-
-#[derive(Yokeable, ZeroCopyFrom)]
-pub struct Baz<'a> {
+#[yoke(prove_covariance_manually)]
+pub struct ZeroMapExample<'a> {
     // https://github.com/unicode-org/icu4x/issues/844
-    // map: ZeroMap<'a, String, String>,
-    var: VarZeroVec<'a, String>,
-    vec: ZeroVec<'a, u16>,
+    map: ZeroMap<'a, String, u16>,
 }
 
 fn main() {}

--- a/utils/yoke/derive/examples/derive.rs
+++ b/utils/yoke/derive/examples/derive.rs
@@ -34,7 +34,6 @@ pub struct ZeroVecExample<'a> {
 #[derive(Yokeable)]
 #[yoke(prove_covariance_manually)]
 pub struct ZeroMapExample<'a> {
-    // https://github.com/unicode-org/icu4x/issues/844
     map: ZeroMap<'a, String, u16>,
 }
 

--- a/utils/yoke/derive/examples/derive.rs
+++ b/utils/yoke/derive/examples/derive.rs
@@ -8,28 +8,29 @@ use std::borrow::Cow;
 use yoke_derive::{Yokeable, ZeroCopyFrom};
 use zerovec::{VarZeroVec, ZeroMap, ZeroVec};
 
-// #[derive(Yokeable)]
-// pub struct StringExample {
-//     x: String,
-//}
+#[derive(Yokeable)]
+pub struct StringExample {
+    x: String,
+}
 
-// #[derive(Yokeable, ZeroCopyFrom)]
-// pub struct CowExample<'a> {
-//     x: u8,
-//     y: &'a str,
-//     z: Cow<'a, str>,
-//     w: Cow<'a, [u8]>,
-// }
+#[derive(Yokeable, ZeroCopyFrom)]
+pub struct CowExample<'a> {
+    x: u8,
+    y: &'a str,
+    z: Cow<'a, str>,
+    w: Cow<'a, [u8]>,
+}
 
-// #[derive(Yokeable, ZeroCopyFrom)]
-// #[yoke(prove_covariance_manually)]
-// pub struct ZeroVecExample<'a> {
-//     // https://github.com/unicode-org/icu4x/issues/844
-//     // map: ZeroMap<'a, String, String>,
-//     var: VarZeroVec<'a, String>,
-//     vec: ZeroVec<'a, u16>,
-// }
+#[derive(Yokeable, ZeroCopyFrom)]
+pub struct ZeroVecExample<'a> {
+    var: VarZeroVec<'a, String>,
+    vec: ZeroVec<'a, u16>,
+}
 
+// Since ZeroMap has generic parameters, the Rust compiler cannot
+// prove the covariance of the lifetimes. To use derive(Yokeable)
+// with a type such as ZeroMap, you just add the attribute
+// yoke(prove_covariance_manually)
 #[derive(Yokeable)]
 #[yoke(prove_covariance_manually)]
 pub struct ZeroMapExample<'a> {

--- a/utils/yoke/derive/src/lib.rs
+++ b/utils/yoke/derive/src/lib.rs
@@ -13,13 +13,18 @@ use synstructure::Structure;
 
 /// Custom derive for `yoke::Yokeable`,
 ///
-/// If this fails to compile for lifetime issues, it means that
-/// the lifetime is not covariant and `Yokeable` is not safe to implement.
+/// If your struct contains `zerovec::ZeroMap`, then the compiler will not
+/// be able to guarantee the lifetime covariance due to the generic types on
+/// the `ZeroMap` itself. You must add the following attribute in order for
+/// the custom derive to work with `ZeroMap`.
 ///
-/// Note that right now this will fail to compile on structs involving
-/// `zerovec::ZeroMap`.
-/// Please comment on <https://github.com/unicode-org/icu4x/issues/844>
-/// if you need this
+/// ```rust,ignore
+/// #[derive(Yokeable)]
+/// #[yoke(manually_prove_covariance)]
+/// ```
+///
+/// Beyond this case, if the derive fails to compile due to lifetime issues, it
+/// means that the lifetime is not covariant and `Yokeable` is not safe to implement.
 #[proc_macro_derive(Yokeable, attributes(yoke))]
 pub fn yokeable_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/utils/yoke/derive/src/lib.rs
+++ b/utils/yoke/derive/src/lib.rs
@@ -85,8 +85,9 @@ fn yokeable_derive_impl(input: &DeriveInput) -> TokenStream2 {
                     let binding = format!("__binding_{}", i);
                     let field = Ident::new(&binding, Span::call_site());
                     let fty = replace_lifetime(&f.ty, static_lt());
-                    // By doing this we essentially require transform_owned to be implemented
-                    // on all fields
+                    // By calling transform_owned on all fields, we manually prove
+                    // that the lifetimes are covariant, since this requirement
+                    // must already be true for the type that implements transform_owned().
                     quote! {
                         <#fty as yoke::Yokeable<'a>>::transform_owned(#field)
                     }


### PR DESCRIPTION
Modifies the `Yokeable` custom derive to support types with generics like `ZeroMap` for which the compiler cannot prove the lifetime covariance on its own. 

Adding the attribute `yoke(prove_covariance_manually)` will invoke a different path in the macro in which each field is manually rebuilt using `Yokeable::transform_owned()`, which requires that the lifetimes must be covariant. 

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->