### PR TITLE
Yoke derive tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,6 +791,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "h2"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,6 +2420,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2606,6 +2621,20 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "trybuild"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bdaf2a1d317f3d58b44b31c7f6436b9b9acafe7bddfeace50897c2b804d7792"
+dependencies = [
+ "glob",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "termcolor",
+ "toml",
+]
 
 [[package]]
 name = "ucd-trie"
@@ -2903,6 +2932,7 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+ "trybuild",
  "yoke",
  "zerovec",
 ]

--- a/utils/yoke/derive/Cargo.toml
+++ b/utils/yoke/derive/Cargo.toml
@@ -26,5 +26,6 @@ syn = { version = "1.0.73", features = ["derive"] }
 synstructure = "0.12.4"
 
 [dev-dependencies]
+trybuild = "1.0.45"
 yoke = { path = "..", version = "0.2.0" }
 zerovec = { path = "../../zerovec", version = "0.3", features = ["yoke"] }

--- a/utils/yoke/derive/examples/derive.rs
+++ b/utils/yoke/derive/examples/derive.rs
@@ -8,25 +8,33 @@ use std::borrow::Cow;
 use yoke_derive::{Yokeable, ZeroCopyFrom};
 use zerovec::{VarZeroVec, ZeroMap, ZeroVec};
 
+// #[derive(Yokeable)]
+// pub struct StringExample {
+//     x: String,
+//}
+
+// #[derive(Yokeable, ZeroCopyFrom)]
+// pub struct CowExample<'a> {
+//     x: u8,
+//     y: &'a str,
+//     z: Cow<'a, str>,
+//     w: Cow<'a, [u8]>,
+// }
+
+// #[derive(Yokeable, ZeroCopyFrom)]
+// #[yoke(prove_covariance_manually)]
+// pub struct ZeroVecExample<'a> {
+//     // https://github.com/unicode-org/icu4x/issues/844
+//     // map: ZeroMap<'a, String, String>,
+//     var: VarZeroVec<'a, String>,
+//     vec: ZeroVec<'a, u16>,
+// }
+
 #[derive(Yokeable)]
-pub struct Foo {
-    x: String,
-}
-
-#[derive(Yokeable, ZeroCopyFrom)]
-pub struct Bar<'a> {
-    x: u8,
-    y: &'a str,
-    z: Cow<'a, str>,
-    w: Cow<'a, [u8]>,
-}
-
-#[derive(Yokeable, ZeroCopyFrom)]
-pub struct Baz<'a> {
+#[yoke(prove_covariance_manually)]
+pub struct ZeroMapExample<'a> {
     // https://github.com/unicode-org/icu4x/issues/844
-    // map: ZeroMap<'a, String, String>,
-    var: VarZeroVec<'a, String>,
-    vec: ZeroVec<'a, u16>,
+    map: ZeroMap<'a, String, u16>,
 }
 
 fn main() {}

--- a/utils/yoke/derive/examples/derive.rs
+++ b/utils/yoke/derive/examples/derive.rs
@@ -34,7 +34,6 @@ pub struct ZeroVecExample<'a> {
 #[derive(Yokeable)]
 #[yoke(prove_covariance_manually)]
 pub struct ZeroMapExample<'a> {
-    // https://github.com/unicode-org/icu4x/issues/844
     map: ZeroMap<'a, String, u16>,
 }
 

--- a/utils/yoke/derive/examples/derive.rs
+++ b/utils/yoke/derive/examples/derive.rs
@@ -8,28 +8,29 @@ use std::borrow::Cow;
 use yoke_derive::{Yokeable, ZeroCopyFrom};
 use zerovec::{VarZeroVec, ZeroMap, ZeroVec};
 
-// #[derive(Yokeable)]
-// pub struct StringExample {
-//     x: String,
-//}
+#[derive(Yokeable)]
+pub struct StringExample {
+    x: String,
+}
 
-// #[derive(Yokeable, ZeroCopyFrom)]
-// pub struct CowExample<'a> {
-//     x: u8,
-//     y: &'a str,
-//     z: Cow<'a, str>,
-//     w: Cow<'a, [u8]>,
-// }
+#[derive(Yokeable, ZeroCopyFrom)]
+pub struct CowExample<'a> {
+    x: u8,
+    y: &'a str,
+    z: Cow<'a, str>,
+    w: Cow<'a, [u8]>,
+}
 
-// #[derive(Yokeable, ZeroCopyFrom)]
-// #[yoke(prove_covariance_manually)]
-// pub struct ZeroVecExample<'a> {
-//     // https://github.com/unicode-org/icu4x/issues/844
-//     // map: ZeroMap<'a, String, String>,
-//     var: VarZeroVec<'a, String>,
-//     vec: ZeroVec<'a, u16>,
-// }
+#[derive(Yokeable, ZeroCopyFrom)]
+pub struct ZeroVecExample<'a> {
+    var: VarZeroVec<'a, String>,
+    vec: ZeroVec<'a, u16>,
+}
 
+// Since ZeroMap has generic parameters, the Rust compiler cannot
+// prove the covariance of the lifetimes. To use derive(Yokeable)
+// with a type such as ZeroMap, you just add the attribute
+// yoke(prove_covariance_manually)
 #[derive(Yokeable)]
 #[yoke(prove_covariance_manually)]
 pub struct ZeroMapExample<'a> {

--- a/utils/yoke/derive/src/lib.rs
+++ b/utils/yoke/derive/src/lib.rs
@@ -82,8 +82,9 @@ fn yokeable_derive_impl(input: &DeriveInput) -> TokenStream2 {
                     let binding = format!("__binding_{}", i);
                     let field = Ident::new(&binding, Span::call_site());
                     let fty = replace_lifetime(&f.ty, static_lt());
-                    // By doing this we essentially require transform_owned to be implemented
-                    // on all fields
+                    // By calling transform_owned on all fields, we manually prove
+                    // that the lifetimes are covariant, since this requirement
+                    // must already be true for the type that implements transform_owned().
                     quote! {
                         <#fty as yoke::Yokeable<'a>>::transform_owned(#field)
                     }

--- a/utils/yoke/derive/src/lib.rs
+++ b/utils/yoke/derive/src/lib.rs
@@ -5,7 +5,7 @@
 //! Custom derives for `Yokeable` and `ZeroCopyFrom` from the `yoke` crate.
 
 use proc_macro::TokenStream;
-use proc_macro2::{Span, TokenStream as TokenStream2, TokenTree};
+use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
 use syn::spanned::Spanned;
 use syn::{parse_macro_input, DeriveInput, Ident, Lifetime, Type};
@@ -75,17 +75,17 @@ fn yokeable_derive_impl(input: &DeriveInput) -> TokenStream2 {
             false
         });
         if manual_covariance {
-            let structure = Structure::new(input);
+            let mut structure = Structure::new(input);
+            structure.bind_with(|_| synstructure::BindStyle::Move);
             let body = structure.each_variant(|vi| {
                 vi.construct(|f, i| {
                     let binding = format!("__binding_{}", i);
                     let field = Ident::new(&binding, Span::call_site());
-                    //let fty = replace_lifetime(&f.ty, static_lt());
-                    let fty = &f.ty;
+                    let fty = replace_lifetime(&f.ty, static_lt());
                     // By doing this we essentially require transform_owned to be implemented
                     // on all fields
                     quote! {
-                        <#fty as yoke::Yokeable<_>>::transform_owned(#field)
+                        <#fty as yoke::Yokeable<'a>>::transform_owned(#field)
                     }
                 })
             });
@@ -93,7 +93,11 @@ fn yokeable_derive_impl(input: &DeriveInput) -> TokenStream2 {
                 unsafe impl<'a> yoke::Yokeable<'a> for #name<'static> {
                     type Output = #name<'a>;
                     fn transform(&'a self) -> &'a Self::Output {
-                        self
+                        unsafe {
+                            // safety: we have asserted covariance in
+                            // transform_owned
+                            ::core::mem::transmute(self)
+                        }
                     }
                     fn transform_owned(self) -> Self::Output {
                         match self { #body }

--- a/utils/yoke/derive/src/lib.rs
+++ b/utils/yoke/derive/src/lib.rs
@@ -13,13 +13,18 @@ use synstructure::Structure;
 
 /// Custom derive for `yoke::Yokeable`,
 ///
-/// If this fails to compile for lifetime issues, it means that
-/// the lifetime is not covariant and `Yokeable` is not safe to implement.
+/// If your struct contains `zerovec::ZeroMap`, then the compiler will not
+/// be able to guarantee the lifetime covariance due to the generic types on
+/// the `ZeroMap` itself. You must add the following attribute in order for
+/// the custom derive to work with `ZeroMap`.
 ///
-/// Note that right now this will fail to compile on structs involving
-/// `zerovec::ZeroMap`.
-/// Please comment on https://github.com/unicode-org/icu4x/issues/844
-/// if you need this
+/// ```text
+/// #[derive(Yokeable)]
+/// #[yoke(manually_prove_covariance)]
+/// ```
+///
+/// Beyond this case, if the derive fails to compile due to lifetime issues, it
+/// means that the lifetime is not covariant and `Yokeable` is not safe to implement.
 #[proc_macro_derive(Yokeable, attributes(yoke))]
 pub fn yokeable_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/utils/yoke/derive/src/lib.rs
+++ b/utils/yoke/derive/src/lib.rs
@@ -5,7 +5,7 @@
 //! Custom derives for `Yokeable` and `ZeroCopyFrom` from the `yoke` crate.
 
 use proc_macro::TokenStream;
-use proc_macro2::{Span, TokenStream as TokenStream2};
+use proc_macro2::{Span, TokenStream as TokenStream2, TokenTree};
 use quote::quote;
 use syn::spanned::Spanned;
 use syn::{parse_macro_input, DeriveInput, Ident, Lifetime, Type};
@@ -20,7 +20,7 @@ use synstructure::Structure;
 /// `zerovec::ZeroMap`.
 /// Please comment on https://github.com/unicode-org/icu4x/issues/844
 /// if you need this
-#[proc_macro_derive(Yokeable)]
+#[proc_macro_derive(Yokeable, attributes(yoke))]
 pub fn yokeable_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     TokenStream::from(yokeable_derive_impl(&input))
@@ -66,6 +66,55 @@ fn yokeable_derive_impl(input: &DeriveInput) -> TokenStream2 {
             .to_compile_error();
         }
         let name = &input.ident;
+        let manual_covariance = input.attrs.iter().any(|a| {
+            if let Ok(i) = a.parse_args::<Ident>() {
+                if i == "prove_covariance_manually" {
+                    return true;
+                }
+            }
+            false
+        });
+        if manual_covariance {
+            let structure = Structure::new(input);
+            let body = structure.each_variant(|vi| {
+                vi.construct(|f, i| {
+                    let binding = format!("__binding_{}", i);
+                    let field = Ident::new(&binding, Span::call_site());
+                    //let fty = replace_lifetime(&f.ty, static_lt());
+                    let fty = &f.ty;
+                    // By doing this we essentially require transform_owned to be implemented
+                    // on all fields
+                    quote! {
+                        <#fty as yoke::Yokeable<_>>::transform_owned(#field)
+                    }
+                })
+            });
+            return quote! {
+                unsafe impl<'a> yoke::Yokeable<'a> for #name<'static> {
+                    type Output = #name<'a>;
+                    fn transform(&'a self) -> &'a Self::Output {
+                        self
+                    }
+                    fn transform_owned(self) -> Self::Output {
+                        match self { #body }
+                    }
+                    unsafe fn make(this: Self::Output) -> Self {
+                        use core::{mem, ptr};
+                        // unfortunately Rust doesn't think `mem::transmute` is possible since it's not sure the sizes
+                        // are the same
+                        debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
+                        let ptr: *const Self = (&this as *const Self::Output).cast();
+                        mem::forget(this);
+                        ptr::read(ptr)
+                    }
+                    fn transform_mut<F>(&'a mut self, f: F)
+                    where
+                        F: 'static + for<'b> FnOnce(&'b mut Self::Output) {
+                        unsafe { f(core::mem::transmute::<&'a mut Self, &'a mut Self::Output>(self)) }
+                    }
+                }
+            };
+        }
         quote! {
             // This is safe because as long as `transform()` compiles,
             // we can be sure that `'a` is a covariant lifetime on `Self`

--- a/utils/yoke/derive/src/lib.rs
+++ b/utils/yoke/derive/src/lib.rs
@@ -18,7 +18,7 @@ use synstructure::Structure;
 /// the `ZeroMap` itself. You must add the following attribute in order for
 /// the custom derive to work with `ZeroMap`.
 ///
-/// ```text
+/// ```rust,ignore
 /// #[derive(Yokeable)]
 /// #[yoke(manually_prove_covariance)]
 /// ```

--- a/utils/yoke/derive/tests/mod.rs
+++ b/utils/yoke/derive/tests/mod.rs
@@ -1,0 +1,8 @@
+#[test]
+fn tests() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/with-string.rs");
+    t.pass("tests/with-cow.rs");
+    t.pass("tests/with-zerovec.rs");
+    t.pass("tests/with-zeromap.rs");
+}

--- a/utils/yoke/derive/tests/with-cow.rs
+++ b/utils/yoke/derive/tests/with-cow.rs
@@ -1,0 +1,17 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use std::borrow::Cow;
+use yoke_derive::{Yokeable, ZeroCopyFrom};
+
+#[derive(Yokeable, ZeroCopyFrom)]
+pub struct CowExample<'a> {
+    x: u8,
+    y: &'a str,
+    z: Cow<'a, str>,
+    w: Cow<'a, [u8]>,
+}
+
+fn main() {}
+

--- a/utils/yoke/derive/tests/with-string.rs
+++ b/utils/yoke/derive/tests/with-string.rs
@@ -1,0 +1,15 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+#![allow(unused)]
+
+use yoke_derive::Yokeable;
+
+#[derive(Yokeable)]
+pub struct StringExample {
+    x: String,
+}
+
+fn main() {}
+

--- a/utils/yoke/derive/tests/with-zeromap.rs
+++ b/utils/yoke/derive/tests/with-zeromap.rs
@@ -1,0 +1,15 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use yoke_derive::Yokeable;
+use zerovec::ZeroMap;
+
+#[derive(Yokeable)]
+#[yoke(prove_covariance_manually)]
+pub struct ZeroMapExample<'a> {
+    map: ZeroMap<'a, String, u16>,
+}
+
+fn main() {}
+

--- a/utils/yoke/derive/tests/with-zerovec.rs
+++ b/utils/yoke/derive/tests/with-zerovec.rs
@@ -1,0 +1,15 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use yoke_derive::{Yokeable, ZeroCopyFrom};
+use zerovec::{VarZeroVec, ZeroVec};
+
+#[derive(Yokeable, ZeroCopyFrom)]
+pub struct ZeroVecExample<'a> {
+    var: VarZeroVec<'a, String>,
+    vec: ZeroVec<'a, u16>,
+}
+
+fn main() {}
+


### PR DESCRIPTION
Depends on #1046 

Adds tests for deriving `Yokeable` and `ZeroCopyFrom`. 

It seemed like a good idea to have these as real tests in addition to just the example. 

Relevant changes are in this commit: https://github.com/unicode-org/icu4x/pull/1048/commits/8231288c348dd4781fa4810964e512599e1f3f22

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->