### PR TITLE
Add doc discussing enumerations versus identifiers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ List of documents describing design decisions for ICU4X.
 Document | Summary
 ---------|---------
 [data_pipeline.md](design/data_pipeline.md) | One of the key design principles of ICU4X is to make locale data small and portable, allowing it to be pulled from multiple sources depending on the needs of the application. This document explains how that goal can be achieved.
+[enums_or_ids.md](design/enums_or_ids.md) | When to use enums and when to use identifiers to represent entities in ICU4X
 [principles.md](design/principles.md) | These principles are not cast in stone, but are strong guidelines for developers.
 [string_representation.md](design/string_representation.md) | String representation on the library boundary.
 

--- a/docs/design/enums_or_ids.md
+++ b/docs/design/enums_or_ids.md
@@ -1,0 +1,92 @@
+Enums or Identifiers
+====================
+
+An *entity* is a discrete item in a set. For example, English is an entity: it is a specific instance of a language.
+
+There are two general ways to represent entities: *enumerations* and *identifiers*. An *enumeration* is a fixed list of entities; an *identifier* is a universally understood space of numbers or strings. For example, `"en"` is an identifier: it is a language code according to a standard published by ISO.
+
+This design doc helps explain how we think about entities in ICU4X and when to use enums versus identifiers to represent them.
+
+## Decision Tree
+
+If you need to decide whether to use an enum or an identifier for a certain set of entities in ICU4X, consider following this decision tree:
+
+**Question 1:** How are new entities added to the set?
+
+- *Spontaneously:* Use identifiers.
+- *By an authority, at least once every few years:* Use identifiers.
+- *Set is fixed or grows rarely:* Continue to Question 2.
+
+**Question 2:** How many entities are in the set?
+
+- *More than 20 or Infinite:* Use identifiers.
+- *20 or fewer:* Continue to Question 3.
+
+**Question 3:** Are the entities inclusive of all peoples and cultures? Is there a larger set out there which is not currently represented?
+
+- *No:* Use identifiers or an enum with a private-use variant.
+- *Yes or not applicable:* Use either enums or identifiers.
+
+## Enumerations
+
+An *enumeration* is a fixed list of entities. In Rust, an enumeration looks like this:
+
+```rust
+enum FooEnum {
+    Entity1,
+    Entity2,
+    Entity3,
+}
+```
+
+### Examples
+
+Examples of entities that are represented by enums:
+
+1. [`Signum`](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/signum/enum.Signum.html):
+    - Set of 4 values, determined by ECMA-402
+    - Unlikely to change over time
+    - Does not directly relate to peoples and cultures
+2. [`PluralCategory`](https://unicode-org.github.io/icu4x-docs/doc/icu_plurals/enum.PluralCategory.html):
+    - Set of 6 values, determined by Unicode/CLDR
+    - Could theoretically change, but has not grown for a long period of time
+    - Correctly represents all languages supported by CLDR
+
+### Non-exhaustive enums
+
+It is possible in Rust to mark enums as `#[non_exhaustive]`, which allows additional entries to be added over time.
+
+However, if there is a need to do this, then it means that the set of entities could grow over time. If this is the case, consider using identifiers instead.
+
+## Identifiers
+
+An *identifier* is a universally understood space of numbers or strings, where a particular number or string represents a particular entity.
+
+In ICU4X, identifiers are often represented as [new types](https://doc.rust-lang.org/rust-by-example/generics/new_types.html) wrapping the underlying representation:
+
+```rust
+struct FooId(u8);
+```
+
+### Examples
+
+Examples of entities that are represented by strings:
+
+1. [`Language`](https://unicode-org.github.io/icu4x-docs/doc/icu_locid/subtags/struct.Language.html):
+    - New languages are frequently added to CLDR
+    - Thousands of possible language codes
+2. [Time zones](https://unicode-org.github.io/icu4x-docs/doc/icu_datetime/date/trait.TimeZoneInput.html):
+    - New time zones are frequently created by governments
+    - No ceiling to the number of possible IANA time zones
+
+## Performance Considerations
+
+A common reason developers tend to gravitate toward enums are perceived performance benefits. However, from experience, and with tools in place in ICU4X, the performance of identifiers is often strongly competitive with the performance of enums, with differences in the noise.
+
+When choosing identifier schemes, keep the following in mind:
+
+1. Integer values are often the most efficient or compact, but they are not usually human-readable. If using integers, it is best to base them off an existing specification.
+2. An excellent alternative is [tinystr](https://docs.rs/tinystr/0.4.10/tinystr/index.html), which lets you represent short string values as integers. [`TinyStr4`](https://docs.rs/tinystr/0.4.10/tinystr/struct.TinyStr4.html), for instance, represents up to 4 ASCII characters as a `u32`.
+3. If you must use a variable-length string, consider using a Cow-like storage mechanism such that the identifier can be created zero-copy from data files.
+
+For example, time zones are often represented using the IANA names, such as "America/Chicago". However, in an effort to avoid variable-length strings in low-level functions, we instead opt for the BCP-47 time zone tags, like "uschi", which fit in a `TinyStr8`.

--- a/docs/design/enums_or_ids.md
+++ b/docs/design/enums_or_ids.md
@@ -82,7 +82,7 @@ If an enum is used for interchange between programs, including over FFI, discrim
 
 It is possible in Rust to mark enums as `#[non_exhaustive]`, which allows additional entries to be added over time.
 
-However, if there is a need to do this, then it means that the set of entities could grow over time. This is a signal that an enum might not be the right choice, which should be weighed with the other pros and cons of enums versus identifiers.
+Often, we do this in ICU4X out of an abundance of caution so that we can change APIs without breaking client code, such as option bag values. However, in other contexts, the need to mark an enum as `#[non_exhaustive]` could indicate that the enum is not fixed, which is a signal that an enum might not be the correct choice. As always, weigh this against the other pros and cons of enums versus identifiers.
 
 ## Identifiers
 

--- a/docs/design/enums_or_ids.md
+++ b/docs/design/enums_or_ids.md
@@ -82,7 +82,7 @@ If an enum is used for interchange between programs, including over FFI, discrim
 
 It is possible in Rust to mark enums as `#[non_exhaustive]`, which allows additional entries to be added over time.
 
-However, if there is a need to do this, then it means that the set of entities could grow over time. If this is the case, you should probably be using identifiers instead.
+However, if there is a need to do this, then it means that the set of entities could grow over time. This is a signal that an enum might not be the right choice, which should be weighed with the other pros and cons of enums versus identifiers.
 
 ## Identifiers
 

--- a/docs/design/enums_or_ids.md
+++ b/docs/design/enums_or_ids.md
@@ -9,26 +9,15 @@ This design doc helps explain how we think about entities in ICU4X and when to u
 
 ## Decision Tree
 
-If you need to decide whether to use an enum or an identifier for a certain set of entities in ICU4X, consider following this decision tree:
+If you need to decide whether to use an enum or an identifier for a certain set of entities in ICU4X, consider the following questions:
 
-**Question 1:** How many entities are in the set?
+1. Is the set **fixed**?
+2. Is the set **comprehensive**? Is it inclusive of all peoples and cultures? Are there no additional entities that are not currently represented?
+3. Are there **30 or fewer items** in the set?
+4. Are the entities used within the context of a single program, and **not normally interchanged** between different programs?
+5. Are entities in the set usually **compared** with one another, and rarely expressed in a standalone context?
 
-- *More than 20 or Infinite:* Use identifiers.
-- *20 or fewer:* Continue to Question 2.
-
-**Question 2:** How are new entities added to the set?
-
-- *Spontaneously:* Use identifiers.
-- *By an authority, at least once every few years:* Use identifiers.
-- *Set is fixed or grows rarely:* Continue to Question 3.
-
-**Question 3:** Consider the following statements:
-
-1. The set is *comprehensive*. It is inclusive of all peoples and cultures. There are no additional entities that are not currently represented.
-2. The entities are used within the context of a single program, and are *not normally interchanged* between different programs.
-3. Entities in the set are usually *compared* with one another. Entities are rarely expressed in a standalone context.
-
-If all three statements are *true*, then an enum is probably the right choice. If all three statements are *false*, then an identifier is probably the right choice. If there is a mix, you are in a gray area; continue reading this document for additional guidance.
+If you answered *yes* to the above questions, then an enum is probably the right choice. If you answered *no* to the above questions, then an identifier is probably the right choice. If there is a mix of *yes* and *no*, you are in a gray area; continue reading this document for additional guidance.
 
 ## Enumerations
 

--- a/docs/process/style_guide.md
+++ b/docs/process/style_guide.md
@@ -478,15 +478,19 @@ for n in 0 .. lang.len() {
 
 ## Enums
 
-### Strongly prefer enums to define states :: suggested
+### Strongly prefer enums to define bounded sets of states :: suggested
 
 Enums in Rust are cheap/free, and incredibly useful. They can be used (as in C++/Java) for providing named, bounded "choices", including avoiding bare boolean parameters, but they can also provide the basis for type-safe patterns such as [elegant finite state machines](https://bluejekyll.github.io/blog/fsm/rust/2015/08/13/rust-and-the-most-elegant-fsm.html) using generified enums with data.
 
 It's probably worth noting here that the [Result](https://doc.rust-lang.org/std/result/) type itself is just a normal enum in Rust with two values (`Ok` and `Err`).
 
+### Don't use enums to represent unbounded sets :: suggested
+
+If a set of entities is unbounded or grows over time, use an identifier instead of an enum. For more details, see [enums_or_ids.md](../design/enums_or_ids.md).
+
 ### Don't use explicit usize values :: suggested
 
-ICU4C has a convention of assigning stable integer values to enum entries. However, this is not common practice in Rust (main issue: [#115](https://github.com/unicode-org/icu4x/issues/115)). Instead, limit the definitions of stable values to the FFI layer, such as *cbindgen*.
+ICU4C has a convention of assigning stable integer values to enum entries. However, this is not common practice in Rust (main issue: [#115](https://github.com/unicode-org/icu4x/issues/115)). Instead, limit the definitions of stable values to the FFI layer.
 
 ## Matching
 


### PR DESCRIPTION
Fixes #596

This is relevant to our Unicode properties discussion.  I advocated to represent them with numerical IDs, on the basis that the set of IDs grows over time.  That type of decision-making is represented in this design principles doc, which is long overdue.