### PR TITLE
Adding BlobDataProvider for dynamically loaded data blobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,7 @@ dependencies = [
  "postcard",
  "serde",
  "writeable",
+ "yoke",
 ]
 
 [[package]]

--- a/provider/blob/Cargo.toml
+++ b/provider/blob/Cargo.toml
@@ -34,6 +34,7 @@ postcard = { version = "0.7.0" }
 erased-serde = { version = "0.3", default-features = false, features = ["alloc"] }
 litemap = { version = "0.2.0", path = "../../utils/litemap/", features = ["serde"] }
 writeable = { path = "../../utils/writeable" }
+yoke = { path = "../../utils/yoke" }
 
 # For the export feature
 log = { version = "0.4", optional = true }

--- a/provider/blob/README.md
+++ b/provider/blob/README.md
@@ -3,8 +3,10 @@
 `icu_provider_blob` contains implementations of the [`ICU4X`] [`DataProvider`] interface
 that load data from a single blob.
 
-Currently, this crate supports only static blobs, but it will soon support blobs loaded
-dynamically at runtime (see [#848](https://github.com/unicode-org/icu4x/issues/848)).
+There are two exports:
+
+1. [`BlobDataProvider`] supports data blobs loaded dynamically at runtime.
+2. [`StaticDataProvider`] supports data blobs baked into the binary at compile time.
 
 To build blob data, use the `--format blob` option of [`icu4x-datagen`]. For example, to build
 "hello world" data, run:
@@ -25,6 +27,8 @@ Create a [`StaticDataProvider`] from pre-built test data:
 ```rust
 let _ = icu_testdata::get_static_provider();
 ```
+
+For more examples, see the specific data providers.
 
 [`ICU4X`]: ../icu/index.html
 [`DataProvider`]: icu_provider::prelude::DataProvider

--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -66,6 +66,7 @@ pub struct BlobDataProvider {
 }
 
 impl BlobDataProvider {
+    /// Create a [`BlobDataProvider`] from an `Rc` blob of ICU4X data.
     pub fn new_from_rc_blob(blob: Rc<[u8]>) -> Result<Self, DataError> {
         Ok(BlobDataProvider {
             blob: Yoke::try_attach_to_cart_badly(blob, |bytes| {

--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -12,6 +12,44 @@ use serde::de::Deserialize;
 use yoke::trait_hack::YokeTraitHack;
 use yoke::*;
 
+/// ```
+/// use icu_locid_macros::langid;
+/// use icu_provider::prelude::*;
+/// use icu_provider::hello_world::*;
+/// use icu_provider_blob::BlobDataProvider;
+/// use std::fs::File;
+/// use std::io::Read;
+/// use std::rc::Rc;
+///
+/// // Read an ICU4X data blob dynamically:
+/// let mut blob: Vec<u8> = Vec::new();
+/// let filename = concat!(
+///     env!("CARGO_MANIFEST_DIR"),
+///     "/tests/data/hello_world.postcard",
+/// );
+/// File::open(filename)
+///     .expect("File should exist")
+///     .read_to_end(&mut blob)
+///     .expect("Reading pre-computed postcard buffer");
+/// 
+/// // Create a DataProvider from it:
+/// let provider = BlobDataProvider::new_from_rc_blob(Rc::from(blob))
+///     .expect("Deserialization should succeed");
+/// 
+/// // Check that it works:
+/// let response: DataPayload<HelloWorldV1Marker> = provider.load_payload(
+///     &DataRequest {
+///         resource_path: ResourcePath {
+///             key: key::HELLO_WORLD_V1,
+///             options: langid!("la").into(),
+///         }
+///     })
+///     .expect("Data should be valid")
+///     .take_payload()
+///     .expect("Data should be present");
+///
+/// assert_eq!(response.get().message, "Ave, munde");
+/// ```
 pub struct BlobDataProvider {
     blob: Yoke<BlobSchema<'static>, Rc<[u8]>>,
 }

--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -5,6 +5,7 @@
 use crate::blob_schema::BlobSchema;
 use crate::path_util;
 use alloc::rc::Rc;
+use alloc::string::String;
 use icu_provider::prelude::*;
 use icu_provider::serde::{SerdeDeDataProvider, SerdeDeDataReceiver};
 use serde::de::Deserialize;
@@ -35,29 +36,40 @@ where
     for<'de> YokeTraitHack<<M::Yokeable as Yokeable<'de>>::Output>: serde::de::Deserialize<'de>,
 {
     fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<'data, M>, DataError> {
+        enum LocalError {
+            MissingResourceKey,
+            Postcard(postcard::Error),
+        }
         let path = path_util::resource_path_to_string(&req.resource_path);
-        let raw_payload: Result<Yoke<M::Yokeable, Rc<[u8]>>, DataError> =
-            self.blob.try_project_cloned_with_capture(
-                (path, req.resource_path.key),
-                move |blob, (path, key), _| {
+        let raw_payload = self
+            .blob
+            .try_project_cloned_with_capture::<M::Yokeable, String, LocalError>(
+                path,
+                move |blob, path, _| {
                     let BlobSchema::V001(blob) = blob;
                     let file = blob
                         .resources
                         .get(&*path)
-                        .ok_or(DataError::MissingResourceKey(key))
+                        .ok_or(LocalError::MissingResourceKey)
                         .map(|v| *v)?;
                     let mut d = postcard::Deserializer::from_bytes(file);
                     let data =
                         YokeTraitHack::<<M::Yokeable as Yokeable>::Output>::deserialize(&mut d)
-                            .map_err(DataError::new_resc_error)?;
+                            .map_err(LocalError::Postcard)?;
                     Ok(data.0)
                 },
-            );
+            )
+            .map_err(|local_error| match local_error {
+                LocalError::MissingResourceKey => {
+                    DataError::MissingResourceKey(req.resource_path.key)
+                }
+                LocalError::Postcard(err) => DataError::new_resc_error(err),
+            })?;
         Ok(DataResponse {
             metadata: DataResponseMetadata {
                 data_langid: req.resource_path.options.langid.clone(),
             },
-            payload: Some(DataPayload::from_rc_buffer_yoke(raw_payload?)),
+            payload: Some(DataPayload::from_rc_buffer_yoke(raw_payload)),
         })
     }
 }

--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -12,6 +12,15 @@ use serde::de::Deserialize;
 use yoke::trait_hack::YokeTraitHack;
 use yoke::*;
 
+/// A data provider loading data from blobs dynamically created at runtime.
+///
+/// This enables data blobs to be read from the filesystem or from an HTTP request dynamically
+/// at runtime, so that the code and data can be shipped separately.
+///
+/// If you prefer to bake the data into your binary, see [`StaticDataProvider`].
+///
+/// # Examples
+///
 /// ```
 /// use icu_locid_macros::langid;
 /// use icu_provider::prelude::*;
@@ -50,6 +59,8 @@ use yoke::*;
 ///
 /// assert_eq!(response.get().message, "Ave, munde");
 /// ```
+///
+/// [`StaticDataProvider`]: crate::StaticDataProvider
 pub struct BlobDataProvider {
     blob: Yoke<BlobSchema<'static>, Rc<[u8]>>,
 }

--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -1,0 +1,62 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use crate::blob_schema::BlobSchema;
+use crate::path_util;
+use alloc::rc::Rc;
+use icu_provider::prelude::*;
+use icu_provider::serde::{SerdeDeDataProvider, SerdeDeDataReceiver};
+use serde::de::Deserialize;
+use yoke::trait_hack::YokeTraitHack;
+use yoke::*;
+
+pub struct BlobDataProvider {
+    blob: Yoke<BlobSchema<'static>, Rc<[u8]>>,
+}
+
+impl BlobDataProvider {
+    pub fn new_from_rc_blob(blob: Rc<[u8]>) -> Result<Self, DataError> {
+        Ok(BlobDataProvider {
+            blob: Yoke::try_attach_to_cart_badly(blob, |bytes| {
+                BlobSchema::deserialize(&mut postcard::Deserializer::from_bytes(bytes))
+            })
+            .map_err(DataError::new_resc_error)?,
+        })
+    }
+}
+
+impl<'data, M> DataProvider<'data, M> for BlobDataProvider
+where
+    M: DataMarker<'data>,
+    // Actual bound:
+    //     for<'de> <M::Yokeable as Yokeable<'de>>::Output: serde::de::Deserialize<'de>,
+    // Necessary workaround bound (see `yoke::trait_hack` docs):
+    for<'de> YokeTraitHack<<M::Yokeable as Yokeable<'de>>::Output>: serde::de::Deserialize<'de>,
+{
+    fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<'data, M>, DataError> {
+        let path = path_util::resource_path_to_string(&req.resource_path);
+        let raw_payload: Yoke<M::Yokeable, Rc<[u8]>> = self.blob.project_cloned_with_capture(
+            (path, req.resource_path.key),
+            move |blob, (path, key), _| {
+                let BlobSchema::V001(blob) = blob;
+                let file = blob
+                    .resources
+                    .get(&*path)
+                    .ok_or(DataError::MissingResourceKey(key))
+                    .map(|v| *v)
+                    .unwrap();
+                let mut d = postcard::Deserializer::from_bytes(file);
+                let data = YokeTraitHack::<<M::Yokeable as Yokeable>::Output>::deserialize(&mut d)
+                    .unwrap();
+                data.0
+            },
+        );
+        Ok(DataResponse {
+            metadata: DataResponseMetadata {
+                data_langid: req.resource_path.options.langid.clone(),
+            },
+            payload: Some(DataPayload::from_rc_buffer_yoke(raw_payload)),
+        })
+    }
+}

--- a/provider/blob/src/blob_schema.rs
+++ b/provider/blob/src/blob_schema.rs
@@ -5,7 +5,7 @@
 use litemap::LiteMap;
 
 /// A versioned Serde schema for ICU4X data blobs.
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, yoke::Yokeable)]
 pub enum BlobSchema<'data> {
     #[serde(borrow)]
     V001(BlobSchemaV1<'data>),

--- a/provider/blob/src/lib.rs
+++ b/provider/blob/src/lib.rs
@@ -36,6 +36,7 @@
 
 extern crate alloc;
 
+mod blob_data_provider;
 mod blob_schema;
 mod path_util;
 mod static_data_provider;
@@ -43,4 +44,5 @@ mod static_data_provider;
 #[cfg(feature = "export")]
 pub mod export;
 
+pub use blob_data_provider::BlobDataProvider;
 pub use static_data_provider::StaticDataProvider;

--- a/provider/blob/src/lib.rs
+++ b/provider/blob/src/lib.rs
@@ -5,8 +5,10 @@
 //! `icu_provider_blob` contains implementations of the [`ICU4X`] [`DataProvider`] interface
 //! that load data from a single blob.
 //!
-//! Currently, this crate supports only static blobs, but it will soon support blobs loaded
-//! dynamically at runtime (see [#848](https://github.com/unicode-org/icu4x/issues/848)).
+//! There are two exports:
+//!
+//! 1. [`BlobDataProvider`] supports data blobs loaded dynamically at runtime.
+//! 2. [`StaticDataProvider`] supports data blobs baked into the binary at compile time.
 //!
 //! To build blob data, use the `--format blob` option of [`icu4x-datagen`]. For example, to build
 //! "hello world" data, run:
@@ -27,6 +29,8 @@
 //! ```
 //! let _ = icu_testdata::get_static_provider();
 //! ```
+//!
+//! For more examples, see the specific data providers.
 //!
 //! [`ICU4X`]: ../icu/index.html
 //! [`DataProvider`]: icu_provider::prelude::DataProvider

--- a/provider/blob/src/static_data_provider.rs
+++ b/provider/blob/src/static_data_provider.rs
@@ -10,7 +10,8 @@ use serde::de::Deserialize;
 
 /// A data provider loading data statically baked in to the binary.
 ///
-/// Although static data is convenient and highly portable, it also increases binary size.
+/// Although static data is convenient and highly portable, it also increases binary size. To
+/// load the data files dynamically at runtime, see [`BlobDataProvider`].
 ///
 /// To bake blob data into your binary, use [`include_bytes!`](std::include_bytes), as shown in
 /// the example below.
@@ -47,6 +48,8 @@ use serde::de::Deserialize;
 ///
 /// assert_eq!(response.get().message, "Ave, munde");
 /// ```
+///
+/// [`BlobDataProvider`]: crate::BlobDataProvider
 pub struct StaticDataProvider {
     blob: BlobSchema<'static>,
 }

--- a/provider/blob/src/static_data_provider.rs
+++ b/provider/blob/src/static_data_provider.rs
@@ -4,10 +4,8 @@
 
 use crate::blob_schema::BlobSchema;
 use crate::path_util;
-use icu_provider::{
-    prelude::*,
-    serde::{SerdeDeDataProvider, SerdeDeDataReceiver},
-};
+use icu_provider::prelude::*;
+use icu_provider::serde::{SerdeDeDataProvider, SerdeDeDataReceiver};
 use serde::de::Deserialize;
 
 /// A data provider loading data statically baked in to the binary.
@@ -76,7 +74,7 @@ impl<'data, M> DataProvider<'data, M> for StaticDataProvider
 where
     M: DataMarker<'data>,
     // 'static is what we want here, because we are deserializing from a static buffer.
-    M::Yokeable: serde::de::Deserialize<'static>,
+    M::Yokeable: Deserialize<'static>,
 {
     fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<'data, M>, DataError> {
         let file = self.get_file(req)?;

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -330,6 +330,17 @@ where
         }
     }
 
+    pub fn try_from_yoked_buffer<T, E>(
+        yoked_buffer: Yoke<&'static [u8], Rc<[u8]>>,
+        capture: T,
+        f: for<'de> fn(<&'static [u8] as yoke::Yokeable<'de>>::Output, T, PhantomData<&'de ()>) -> Result<<M::Yokeable as Yokeable<'de>>::Output, E>,
+    ) -> Result<Self, E> {
+        let yoke = yoked_buffer.try_project_with_capture(capture, f)?;
+        Ok(Self {
+            inner: DataPayloadInner::RcBuf(yoke),
+        })
+    }
+
     /// Convert a fully owned (`'static`) data struct into a DataPayload.
     ///
     /// This constructor creates `'static` payloads.

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -326,14 +326,19 @@ where
 
     pub fn from_rc_buffer_yoke(yoke: Yoke<M::Yokeable, Rc<[u8]>>) -> Self {
         Self {
-            inner: DataPayloadInner::RcBuf(yoke)
+            inner: DataPayloadInner::RcBuf(yoke),
         }
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn try_from_yoked_buffer<T, E>(
         yoked_buffer: Yoke<&'static [u8], Rc<[u8]>>,
         capture: T,
-        f: for<'de> fn(<&'static [u8] as yoke::Yokeable<'de>>::Output, T, PhantomData<&'de ()>) -> Result<<M::Yokeable as Yokeable<'de>>::Output, E>,
+        f: for<'de> fn(
+            <&'static [u8] as yoke::Yokeable<'de>>::Output,
+            T,
+            PhantomData<&'de ()>,
+        ) -> Result<<M::Yokeable as Yokeable<'de>>::Output, E>,
     ) -> Result<Self, E> {
         let yoke = yoked_buffer.try_project_with_capture(capture, f)?;
         Ok(Self {

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -297,7 +297,6 @@ where
     /// use icu_provider::prelude::*;
     /// use icu_provider::hello_world::*;
     /// use std::rc::Rc;
-    /// use icu_provider::yoke::Yokeable;
     ///
     /// let json_text = "{\"message\":\"Hello World\"}";
     /// let json_rc_buffer: Rc<[u8]> = json_text.as_bytes().into();
@@ -324,12 +323,36 @@ where
         })
     }
 
-    pub fn from_rc_buffer_yoke(yoke: Yoke<M::Yokeable, Rc<[u8]>>) -> Self {
-        Self {
-            inner: DataPayloadInner::RcBuf(yoke),
-        }
-    }
-
+    /// Convert a byte buffer into a [`DataPayload`]. A function must be provided to perform the
+    /// conversion. This can often be a Serde deserialization operation.
+    /// 
+    /// This function is similar to [`DataPayload::try_from_rc_buffer`], but it accepts a buffer
+    /// that is already yoked to an Rc buffer cart.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(feature = "provider_serde")] {
+    /// use icu_provider::prelude::*;
+    /// use icu_provider::hello_world::*;
+    /// use std::rc::Rc;
+    /// use icu_provider::yoke::Yoke;
+    ///
+    /// let json_text = "{\"message\":\"Hello World\"}";
+    /// let json_rc_buffer: Rc<[u8]> = json_text.as_bytes().into();
+    ///
+    /// let payload = DataPayload::<HelloWorldV1Marker>::try_from_yoked_buffer(
+    ///     Yoke::attach_to_rc_cart(json_rc_buffer),
+    ///     (),
+    ///     |bytes, _, _| {
+    ///         serde_json::from_slice(bytes)
+    ///     }
+    /// )
+    /// .expect("JSON is valid");
+    ///
+    /// assert_eq!("Hello World", payload.get().message);
+    /// # } // feature = "provider_serde"
+    /// ```
     #[allow(clippy::type_complexity)]
     pub fn try_from_yoked_buffer<T, E>(
         yoked_buffer: Yoke<&'static [u8], Rc<[u8]>>,

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -325,7 +325,7 @@ where
 
     /// Convert a byte buffer into a [`DataPayload`]. A function must be provided to perform the
     /// conversion. This can often be a Serde deserialization operation.
-    /// 
+    ///
     /// This function is similar to [`DataPayload::try_from_rc_buffer`], but it accepts a buffer
     /// that is already yoked to an Rc buffer cart.
     ///

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -324,6 +324,12 @@ where
         })
     }
 
+    pub fn from_rc_buffer_yoke(yoke: Yoke<M::Yokeable, Rc<[u8]>>) -> Self {
+        Self {
+            inner: DataPayloadInner::RcBuf(yoke)
+        }
+    }
+
     /// Convert a fully owned (`'static`) data struct into a DataPayload.
     ///
     /// This constructor creates `'static` payloads.

--- a/provider/core/src/serde.rs
+++ b/provider/core/src/serde.rs
@@ -69,6 +69,18 @@ pub trait SerdeDeDataReceiver {
         ),
     ) -> Result<(), Error>;
 
+    /// Receives a yoked byte buffer.
+    ///
+    /// This function has behavior identical to that of [`SerdeDeDataReceiver::receive_rc_buffer`].
+    fn receive_yoked_buffer(
+        &mut self,
+        yoked_buffer: Yoke<&'static [u8], Rc<[u8]>>,
+        f1: for<'de> fn(
+            bytes: &'de [u8],
+            f2: &mut dyn FnMut(&mut dyn erased_serde::Deserializer<'de>),
+        ),
+    ) -> Result<(), Error>;
+
     /// Receives a `&'static` byte buffer via an [`erased_serde::Deserializer`].
     ///
     /// Note: Since the purpose of this function is to handle zero-copy deserialization of static
@@ -117,6 +129,31 @@ where
         ),
     ) -> Result<(), Error> {
         self.replace(DataPayload::try_from_rc_buffer(rc_buffer, move |bytes| {
+            let mut holder = None;
+            f1(bytes, &mut |deserializer| {
+                holder.replace(
+                    erased_serde::deserialize::<YokeTraitHack<<M::Yokeable as Yokeable>::Output>>(
+                        deserializer,
+                    )
+                    .map(|w| w.0),
+                );
+            });
+            // The holder is guaranteed to be populated so long as the lambda function was invoked,
+            // which is in the contract of `receive_rc_buffer`.
+            holder.unwrap()
+        })?);
+        Ok(())
+    }
+
+    fn receive_yoked_buffer(
+        &mut self,
+        yoked_buffer: Yoke<&'static [u8], Rc<[u8]>>,
+        f1: for<'de> fn(
+            bytes: &'de [u8],
+            f2: &mut dyn FnMut(&mut dyn erased_serde::Deserializer<'de>),
+        ),
+    ) -> Result<(), Error> {
+        self.replace(DataPayload::try_from_yoked_buffer(yoked_buffer, f1, move |bytes, f1, _| {
             let mut holder = None;
             f1(bytes, &mut |deserializer| {
                 holder.replace(

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -700,6 +700,29 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
         }
     }
 
+    /// A version of [`Yoke::project`] that takes a capture and bubbles up an error
+    /// from the callback function.
+    pub fn try_project_with_capture<P, T, E>(
+        self,
+        capture: T,
+        f: for<'a> fn(
+            <Y as Yokeable<'a>>::Output,
+            capture: T,
+            PhantomData<&'a ()>,
+        ) -> Result<<P as Yokeable<'a>>::Output, E>,
+    ) -> Result<Yoke<P, C>, E>
+    where
+        P: for<'a> Yokeable<'a>,
+    {
+        let p = f(self.yokeable.transform_owned(), capture, PhantomData)?;
+        Ok(Yoke {
+            yokeable: unsafe { P::make(p) },
+            cart: self.cart,
+        })
+    }
+
+    /// A version of [`Yoke::project_cloned`] that takes a capture and bubbles up an error
+    /// from the callback function.
     pub fn try_project_cloned_with_capture<'this, P, T, E>(
         &'this self,
         capture: T,

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -702,6 +702,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
 
     /// A version of [`Yoke::project`] that takes a capture and bubbles up an error
     /// from the callback function.
+    #[allow(clippy::type_complexity)]
     pub fn try_project_with_capture<P, T, E>(
         self,
         capture: T,
@@ -723,6 +724,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
 
     /// A version of [`Yoke::project_cloned`] that takes a capture and bubbles up an error
     /// from the callback function.
+    #[allow(clippy::type_complexity)]
     pub fn try_project_cloned_with_capture<'this, P, T, E>(
         &'this self,
         capture: T,

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -699,6 +699,26 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
             cart: self.cart.clone(),
         }
     }
+
+    pub fn try_project_cloned_with_capture<'this, P, T, E>(
+        &'this self,
+        capture: T,
+        f: for<'a> fn(
+            &'this <Y as Yokeable<'a>>::Output,
+            capture: T,
+            PhantomData<&'a ()>,
+        ) -> Result<<P as Yokeable<'a>>::Output, E>,
+    ) -> Result<Yoke<P, C>, E>
+    where
+        P: for<'a> Yokeable<'a>,
+        C: CloneableCart,
+    {
+        let p = f(self.get(), capture, PhantomData)?;
+        Ok(Yoke {
+            yokeable: unsafe { P::make(p) },
+            cart: self.cart.clone(),
+        })
+    }
 }
 
 /// Safety docs for project()

--- a/utils/yoke/src/zero_copy_from.rs
+++ b/utils/yoke/src/zero_copy_from.rs
@@ -240,3 +240,9 @@ impl ZeroCopyFrom<&'_ str> for &'static str {
         cart
     }
 }
+
+impl<T> ZeroCopyFrom<[T]> for &'static [T] {
+    fn zero_copy_from<'b>(cart: &'b [T]) -> &'b [T] {
+        cart
+    }
+}


### PR DESCRIPTION
This PR builds and runs against Rust 1.56 (October 21, 2021).  Unfortunately it's not just the docs tests that don't build; the code itself doesn't build.