### PR TITLE
Upgrade default rust-toolchain to 1.56-beta.3

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,5 @@
 [toolchain]
-# Version updated on 2021-07-29
-channel = "1.54.0"
+# Version updated on 2021-09-22
+# Note: This is 1.56.0-beta.3, but it can't be specified in that way;
+# see https://github.com/rust-lang/rustup/issues/1329
+channel = "beta-2021-09-18"

--- a/utils/yoke/src/trait_hack.rs
+++ b/utils/yoke/src/trait_hack.rs
@@ -31,7 +31,7 @@
 //! ***[#1061](https://github.com/unicode-org/icu4x/issues/1061): The following example
 //! compiles starting in Rust 1.56.
 //!
-//! ```
+//! ```ignore
 //! use yoke::Yoke;
 //! use yoke::Yokeable;
 //!

--- a/utils/yoke/src/trait_hack.rs
+++ b/utils/yoke/src/trait_hack.rs
@@ -28,7 +28,10 @@
 //!
 //! Code that does not compile:
 //!
-//! ```compile_fail
+//! ***[#1061](https://github.com/unicode-org/icu4x/issues/1061): The following example
+//! compiles starting in Rust 1.56.
+//!
+//! ```
 //! use yoke::Yoke;
 //! use yoke::Yokeable;
 //!


### PR DESCRIPTION
This unblocks various PRs that need to use `.map_project()` and related functions (such as #1084).  It also unblocks us to start updating the Yoke and DataPayload APIs to turn on examples and remove obsolete functions like `with_context` (#1061).

We will switch to 1.56 stable on October 21, and we will not push anything to crates.io unless the code builds on stable.