### PR TITLE
Add benches for ZeroMap::get, also litemap/HashMap for comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,6 +1434,7 @@ version = "0.2.2"
 dependencies = [
  "bincode",
  "bytecheck",
+ "criterion",
  "icu_benchmark_macros",
  "icu_locid",
  "icu_locid_macros",

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -40,6 +40,7 @@ postcard = { version = "0.7", features = ["use-std"] }
 icu_locid = { version = "0.3", path = "../../components/locid" }
 icu_locid_macros = { version = "0.3", path = "../../components/locid/macros" }
 icu_benchmark_macros = { version = "0.3", path = "../../tools/benchmark/macros" }
+criterion = "0.3.4"
 
 [[test]]
 name = "serde"
@@ -54,3 +55,10 @@ required-features = ["serde"]
 name = "litemap_postcard"
 path = "benches/bin/litemap_postcard.rs"
 required-features = ["serde"]
+
+[features]
+bench = []
+
+[[bench]]
+name = "litemap"
+harness = false

--- a/utils/litemap/benches/litemap.rs
+++ b/utils/litemap/benches/litemap.rs
@@ -1,0 +1,55 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use litemap::LiteMap;
+
+const DATA: [(&str, &str); 16] = [
+    ("ar", "Arabic"),
+    ("bn", "Bangla"),
+    ("ccp", "Chakma"),
+    ("chr", "Cherokee"),
+    ("el", "Greek"),
+    ("en", "English"),
+    ("eo", "Esperanto"),
+    ("es", "Spanish"),
+    ("fr", "French"),
+    ("iu", "Inuktitut"),
+    ("ja", "Japanese"),
+    ("ru", "Russian"),
+    ("sr", "Serbian"),
+    ("th", "Thai"),
+    ("tr", "Turkish"),
+    ("zh", "Chinese"),
+];
+
+fn overview_bench(c: &mut Criterion) {
+    let mut map: LiteMap<String, String> = LiteMap::new();
+    for (key, value) in DATA.iter() {
+        map.insert(key.to_string(), value.to_string());
+    }
+    c.bench_function("litemap/read", |b| {
+        b.iter(|| {
+            assert_eq!(map.get("iu"), Some(&"Inuktitut".to_string()));
+            assert_eq!(map.get("zz"), None);
+        });
+    });
+
+    map.clear();
+    for (key, value) in DATA.iter() {
+        for n in 0..65536 {
+            map.insert(format!("{}{}", key, n), value.to_string());
+        }
+    }
+    c.bench_function("litemap/read/1m", |b| {
+        b.iter(|| {
+            assert_eq!(map.get("iu33333"), Some(&"Inuktitut".to_string()));
+            assert_eq!(map.get("zz"), None);
+        });
+    });
+}
+
+criterion_group!(benches, overview_bench);
+criterion_main!(benches);

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -61,6 +61,10 @@ harness = false
 name = "zerovec_iai"
 harness = false
 
+[[bench]]
+name = "zeromap"
+harness = false
+
 [[example]]
 name = "zv_serde"
 required-features = ["serde"]

--- a/utils/zerovec/benches/zeromap.rs
+++ b/utils/zerovec/benches/zeromap.rs
@@ -1,0 +1,90 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+// #[cfg(feature = "bench")]
+use std::collections::HashMap;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use zerovec::ZeroMap;
+
+const DATA: [(&str, &str); 16] = [
+    ("ar", "Arabic"),
+    ("bn", "Bangla"),
+    ("ccp", "Chakma"),
+    ("chr", "Cherokee"),
+    ("el", "Greek"),
+    ("en", "English"),
+    ("eo", "Esperanto"),
+    ("es", "Spanish"),
+    ("fr", "French"),
+    ("iu", "Inuktitut"),
+    ("ja", "Japanese"),
+    ("ru", "Russian"),
+    ("sr", "Serbian"),
+    ("th", "Thai"),
+    ("tr", "Turkish"),
+    ("zh", "Chinese"),
+];
+
+fn overview_bench(c: &mut Criterion) {
+    let mut map: ZeroMap<String, String> = ZeroMap::new();
+    for (key, value) in DATA.iter() {
+        map.insert(key.to_string(), value.to_string());
+    }
+    c.bench_function("zeromap/read", |b| {
+        b.iter(|| {
+            assert_eq!(map.get("iu"), Some("Inuktitut"));
+            assert_eq!(map.get("zz"), None);
+        });
+    });
+
+    map.clear();
+    for (key, value) in DATA.iter() {
+        for n in 0..65536 {
+            map.insert(format!("{}{}", key, n), value.to_string());
+        }
+    }
+    c.bench_function("zeromap/read/1m", |b| {
+        b.iter(|| {
+            assert_eq!(map.get("iu33333"), Some("Inuktitut"));
+            assert_eq!(map.get("zz"), None);
+        });
+    });
+
+    // #[cfg(feature = "bench")]
+    {
+        hashmap_benches(c);
+    }
+}
+
+// #[cfg(feature = "bench")]
+fn hashmap_benches(c: &mut Criterion) {
+    let mut map: HashMap<String, String> = HashMap::new();
+    for (key, value) in DATA.iter() {
+        map.insert(key.to_string(), value.to_string());
+    }
+    c.bench_function("zeromap/read/hashmap", |b| {
+        b.iter(|| {
+            assert_eq!(map.get("iu"), Some(&"Inuktitut".to_string()));
+            assert_eq!(map.get("zz"), None);
+        });
+    });
+
+    map.clear();
+    for (key, value) in DATA.iter() {
+        for n in 0..65536 {
+            map.insert(format!("{}{}", key, n), value.to_string());
+        }
+    }
+    c.bench_function("zeromap/read/1m/hashmap", |b| {
+        b.iter(|| {
+            assert_eq!(map.get("iu33333"), Some(&"Inuktitut".to_string()));
+            assert_eq!(map.get("zz"), None);
+        });
+    });
+}
+
+criterion_group!(benches, overview_bench);
+criterion_main!(benches);

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -40,6 +40,11 @@
 //!
 //! \* *This result is reported for `Vec<String>`. However, Serde also supports deserializing to `Vec<&str>`; this gives 1.8420 μs, much faster than `Vec<String>` but a bit slower than `zerovec`.*
 //!
+//! | Operation | `HashMap<K,V>`  | `LiteMap<K,V>` | `zeromap` |
+//! |---|---|---|---|
+//! | Look up a `&str` key from a 16-element map | 45 ns | 40 ns | 36 ns |
+//! | Look up a `&str` key from a 1,048,576-element map | 49 ns | 216 ns | 191 ns |
+//!
 //! The benches used to generate the above table can be found in the `benches` directory in the project repository.
 //!
 //! # Features


### PR DESCRIPTION
I've added benchmarks for `ZeroMap::get`, for small and large maps (16 and 1,048,576 entries, respectively).

I also added comparable benches for `LiteMap` and `HashMap`, for comparison. The `HashMap` benches are behind the feature `bench`.

Also updated the [comparison table](https://unicode-org.github.io/icu4x-docs/doc/zerovec/index.html#performance).

I thought I'd stop here and get some feedback before going hog wild -- for the use cases for which ZeroMap is designed, I think folks are mostly going to be interested in `get` performance. This might be good enough.