### PR TITLE
Disable default features for postcard

### DIFF
--- a/provider/blob/Cargo.toml
+++ b/provider/blob/Cargo.toml
@@ -30,7 +30,7 @@ all-features = true
 icu_provider = { version = "0.3", path = "../../provider/core", features = ["provider_serde"] }
 icu_locid = { version = "0.3", path = "../../components/locid", features = ["serde"] }
 serde = { version = "1.0", default-features = false, features = ["alloc"] }
-postcard = { version = "0.7.0" }
+postcard = { version = "0.7.0", default-features = false }
 erased-serde = { version = "0.3", default-features = false, features = ["alloc"] }
 litemap = { version = "0.2.0", path = "../../utils/litemap/", features = ["serde"] }
 writeable = { path = "../../utils/writeable" }


### PR DESCRIPTION
postcard/heapless-cas is enabled by default, which causes us to unconditionally pull in dependencies that aren't needed in non-no_std builds.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->