### PR TITLE
Use/require byte equality in VarZeroVec

### DIFF
--- a/utils/zerovec/src/ule/chars.rs
+++ b/utils/zerovec/src/ule/chars.rs
@@ -62,14 +62,6 @@ unsafe impl ULE for CharULE {
         let len = bytes.len() / 4;
         core::slice::from_raw_parts(data as *const Self, len)
     }
-
-    #[inline]
-    fn as_byte_slice(slice: &[Self]) -> &[u8] {
-        let data = slice.as_ptr();
-        let len = slice.len() * 4;
-        // Safe because Self is transparent over [u8; 4]
-        unsafe { core::slice::from_raw_parts(data as *const u8, len) }
-    }
 }
 
 impl AsULE for char {

--- a/utils/zerovec/src/ule/chars.rs
+++ b/utils/zerovec/src/ule/chars.rs
@@ -55,13 +55,6 @@ unsafe impl ULE for CharULE {
         // Safe because Self is transparent over [u8; 4] and has been validated
         Ok(unsafe { Self::from_byte_slice_unchecked(bytes) })
     }
-
-    #[inline]
-    unsafe fn from_byte_slice_unchecked(bytes: &[u8]) -> &[Self] {
-        let data = bytes.as_ptr();
-        let len = bytes.len() / 4;
-        core::slice::from_raw_parts(data as *const Self, len)
-    }
 }
 
 impl AsULE for char {

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -19,10 +19,10 @@ pub use plain::PlainOldULE;
 ///
 /// # Safety
 ///
-/// There must be no padding bytes involved in this type: [`Self::as_byte_slice()`] MUST return
+/// There must be no padding bytes involved in this type: [`Self::as_byte_slice()`] *must* return
 /// a slice of initialized bytes provided that `Self` is initialized.
 ///
-/// This method _must_ be implemented to return the same result as [`ULE::parse_byte_slice()`].
+/// [`ULE::from_bytes_unchecked()`] *must* be implemented to return the same result as [`ULE::parse_byte_slice()`].
 ///
 /// [`ULE::as_byte_slice()`] should return a slice that is the in-memory representation of `Self`,
 /// i.e. it should be just a pointer cast, and `mem::size_of_val(self) == mem::size_of_val(self.as_byte_slice())`=
@@ -30,9 +30,11 @@ pub use plain::PlainOldULE;
 /// # Equality invariant
 ///
 /// A non-safety invariant is that if `Self` implements `PartialEq`, it *must* be logically equivalent to
-/// byte equality on `.as_byte_slice()`. Failure to follow this invariant will not cause undefined
-/// behavior, but may cause problems in the `PartialEq` implementations of `ZeroVec` and `VarZeroVec`,
-/// as well as the predictable operation of `ZeroMap`
+/// byte equality on `.as_byte_slice()`. If `PartialEq` does not imply byte-for-byte equality, then
+/// `.parse_byte_slice()` should return an error code for any values that are not in canonical form.
+///
+/// Failure to follow this invariant will cause surprising behavior in `PartialEq`, which may result in
+/// unpredictable operations on `ZeroVec`, `VarZeroVec`, and `ZeroMap`.
 pub unsafe trait ULE
 where
     Self: Sized,
@@ -205,7 +207,7 @@ pub trait AsVarULE {
 /// There must be no padding bytes involved in this type: [`Self::as_byte_slice()`] MUST return
 /// a slice of initialized bytes provided that `Self` is initialized.
 ///
-/// [`VarULE::from_byte_slice_unchecked()`] _must_ be implemented to return the same result
+/// [`VarULE::from_byte_slice_unchecked()`] *must* be implemented to return the same result
 /// as [`VarULE::parse_byte_slice()`] provided both are passed the same validly parsing byte slices.
 ///
 /// [`VarULE::as_byte_slice()`] should return a slice that is the in-memory representation of `Self`,
@@ -214,9 +216,11 @@ pub trait AsVarULE {
 /// # Equality invariant
 ///
 /// A non-safety invariant is that if `Self` implements `PartialEq`, it *must* be logically equivalent to
-/// byte equality on `.as_byte_slice()`. Failure to follow this invariant will not cause undefined
-/// behavior, but may cause problems in the `PartialEq` implementations of `ZeroVec` and `VarZeroVec`,
-/// as well as the predictable operation of `ZeroMap`.
+/// byte equality on `.as_byte_slice()`. If `PartialEq` does not imply byte-for-byte equality, then
+/// `.parse_byte_slice()` should return an error code for any values that are not in canonical form.
+///
+/// Failure to follow this invariant will cause surprising behavior in `PartialEq`, which may result in
+/// unpredictable operations on `ZeroVec`, `VarZeroVec`, and `ZeroMap`.
 pub unsafe trait VarULE: 'static {
     /// The error type to used by [`VarULE::parse_byte_slice()`]
     type Error;

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -35,13 +35,6 @@ macro_rules! impl_byte_slice_size {
                 // Safe because Self is transparent over [u8; $size]
                 Ok(unsafe { Self::from_byte_slice_unchecked(bytes) })
             }
-            #[inline]
-            unsafe fn from_byte_slice_unchecked(bytes: &[u8]) -> &[Self] {
-                let data = bytes.as_ptr();
-                let len = bytes.len() / $size;
-                // Safe because Self is transparent over [u8; $size]
-                core::slice::from_raw_parts(data as *const Self, len)
-            }
         }
 
         impl PlainOldULE<$size> {

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -42,13 +42,6 @@ macro_rules! impl_byte_slice_size {
                 // Safe because Self is transparent over [u8; $size]
                 core::slice::from_raw_parts(data as *const Self, len)
             }
-            #[inline]
-            fn as_byte_slice(slice: &[Self]) -> &[u8] {
-                let data = slice.as_ptr();
-                let len = slice.len() * $size;
-                // Safe because Self is transparent over [u8; $size]
-                unsafe { core::slice::from_raw_parts(data as *const u8, len) }
-            }
         }
 
         impl PlainOldULE<$size> {

--- a/utils/zerovec/src/varzerovec/components.rs
+++ b/utils/zerovec/src/varzerovec/components.rs
@@ -294,12 +294,10 @@ pub fn get_serializable_bytes<T: AsVarULE>(elements: &[T]) -> Option<Vec<u8>> {
     let mut offset: u32 = 0;
     for element in elements {
         vec.extend(&offset.as_unaligned().0);
-        let len_u32: u32 = element
-            .as_unaligned()
-            .as_byte_slice()
-            .len()
-            .try_into()
-            .ok()?;
+        let ule = element.as_unaligned();
+        let slice = ule.as_byte_slice();
+        debug_assert_eq!(mem::size_of_val(ule), mem::size_of_val(slice));
+        let len_u32: u32 = slice.len().try_into().ok()?;
         offset = offset.checked_add(len_u32)?;
     }
     vec.reserve(offset as usize);

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -501,8 +501,9 @@ where
 {
     #[inline]
     fn eq(&self, other: &VarZeroVec<'b, T>) -> bool {
-        // Note: T implements PartialEq but not T::ULE
-        self.iter().eq(other.iter())
+        // VarULE has an API guarantee that this is equivalent
+        // to `T::VarULE::eq()`
+        self.get_encoded_slice().eq(other.get_encoded_slice())
     }
 }
 

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -406,7 +406,10 @@ impl<'a, T: AsVarULE> VarZeroVec<'a, T> {
     ///
     /// This can be passed back to [`Self::parse_byte_slice()`]
     pub fn get_encoded_slice(&self) -> &[u8] {
-        self.get_components().entire_slice()
+        match self.0 {
+            VarZeroVecInner::Owned(ref vec) => vec.entire_slice(),
+            VarZeroVecInner::Borrowed(vec) => vec.entire_slice(),
+        }
     }
 
     /// For a slice of `T`, get a list of bytes that can be passed to

--- a/utils/zerovec/src/varzerovec/owned.rs
+++ b/utils/zerovec/src/varzerovec/owned.rs
@@ -110,6 +110,11 @@ impl<T: AsVarULE> VarZeroVecOwned<T> {
         self.get_components().to_vec()
     }
 
+    #[inline]
+    pub fn entire_slice(&self) -> &[u8] {
+        &self.entire_slice
+    }
+
     /// Insert an element at index `idx`
     pub fn insert(&mut self, index: usize, element: &T) {
         let len = self.len();

--- a/utils/zerovec/src/varzerovec/ule.rs
+++ b/utils/zerovec/src/varzerovec/ule.rs
@@ -147,8 +147,9 @@ where
 {
     #[inline]
     fn eq(&self, other: &VarZeroVecULE<T>) -> bool {
-        // Note: T implements PartialEq but not T::ULE
-        self.iter().eq(other.iter())
+        // VarULE has an API guarantee that this is equivalent
+        // to `T::VarULE::eq()`
+        self.entire_slice.eq(&other.entire_slice)
     }
 }
 


### PR DESCRIPTION
Part of #1082

Fixes #1083


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->