### PR TITLE
Separate out validation function for ULE to be able to derive parse_byte_slice

### DIFF
--- a/utils/zerovec/src/ule/chars.rs
+++ b/utils/zerovec/src/ule/chars.rs
@@ -45,15 +45,14 @@ unsafe impl ULE for CharULE {
     type Error = core::char::CharTryFromError;
 
     #[inline]
-    fn parse_byte_slice(bytes: &[u8]) -> Result<&[Self], Self::Error> {
+    fn validate_byte_slice(bytes: &[u8]) -> Result<(), Self::Error> {
         // Validate the bytes
         for chunk in bytes.chunks_exact(4) {
             // TODO: Use slice::as_chunks() when stabilized
             let u = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
             char::try_from(u)?;
         }
-        // Safe because Self is transparent over [u8; 4] and has been validated
-        Ok(unsafe { Self::from_byte_slice_unchecked(bytes) })
+        Ok(())
     }
 }
 

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -24,6 +24,9 @@ use core::{mem, slice};
 /// There must be no padding bytes involved in this type: [`Self::as_byte_slice()`] *must* return
 /// a slice of initialized bytes provided that `Self` is initialized.
 ///
+/// [`ULE::validate_byte_slice()`] *must* be implemented to validate a byte slice and return error
+/// for the same slices as [`ULE::parse_byte_slice()`].
+///
 /// [`ULE::from_bytes_unchecked()`] *must* be implemented to return the same result as [`ULE::parse_byte_slice()`],
 /// and both should return slices to the same region of memory.
 ///
@@ -34,7 +37,7 @@ use core::{mem, slice};
 ///
 /// A non-safety invariant is that if `Self` implements `PartialEq`, it *must* be logically equivalent to
 /// byte equality on `.as_byte_slice()`. If `PartialEq` does not imply byte-for-byte equality, then
-/// `.parse_byte_slice()` should return an error code for any values that are not in canonical form.
+/// `.validate_byte_slice()` should return an error code for any values that are not in canonical form.
 ///
 /// Failure to follow this invariant will cause surprising behavior in `PartialEq`, which may result in
 /// unpredictable operations on `ZeroVec`, `VarZeroVec`, and `ZeroMap`.
@@ -84,7 +87,7 @@ where
     ///
     /// ## Callers
     /// Callers of this method must take care to ensure that `bytes` was previously passed through
-    /// [`ULE::parse_byte_slice()`] with success (and was not changed since then).
+    /// [`ULE::validate_byte_slice()`] with success (and was not changed since then).
     ///
     /// ## Implementors
     /// This method _must_ be implemented to return the same result as [`ULE::parse_byte_slice()`].
@@ -239,6 +242,9 @@ pub trait AsVarULE {
 /// There must be no padding bytes involved in this type: [`Self::as_byte_slice()`] MUST return
 /// a slice of initialized bytes provided that `Self` is initialized.
 ///
+/// [`ULE::validate_byte_slice()`] *must* be implemented to validate a byte slice and return error
+/// for the same slices as [`ULE::parse_byte_slice()`].
+///
 /// [`VarULE::from_byte_slice_unchecked()`] *must* be implemented to return the same result
 /// as [`VarULE::parse_byte_slice()`] provided both are passed the same validly parsing byte slices.
 /// Both should return a pointer to the same region of memory that was passed in, covering that region
@@ -251,7 +257,7 @@ pub trait AsVarULE {
 ///
 /// A non-safety invariant is that if `Self` implements `PartialEq`, it *must* be logically equivalent to
 /// byte equality on `.as_byte_slice()`. If `PartialEq` does not imply byte-for-byte equality, then
-/// `.parse_byte_slice()` should return an error code for any values that are not in canonical form.
+/// `.validate_byte_slice()` should return an error code for any values that are not in canonical form.
 ///
 /// Failure to follow this invariant will cause surprising behavior in `PartialEq`, which may result in
 /// unpredictable operations on `ZeroVec`, `VarZeroVec`, and `ZeroMap`.
@@ -294,7 +300,7 @@ pub unsafe trait VarULE: 'static {
     ///
     /// ## Callers
     /// Callers of this method must take care to ensure that `bytes` was previously passed through
-    /// [`VarULE::parse_byte_slice()`] with success (and was not changed since then).
+    /// [`VarULE::validate_byte_slice()`] with success (and was not changed since then).
     ///
     /// ## Implementors
     /// This method _must_ be implemented to return the same result as [`VarULE::parse_byte_slice()`].

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -49,12 +49,8 @@ where
     /// Validates a byte slice, `&[u8]`.
     ///
     /// If `Self` is not well-defined for all possible bit values, the bytes should be validated,
-    /// and `Self::Error` should be returned if they are not valid.
-    ///
-    /// The default implementation validates the slice for all possible bit values.
-    fn validate_byte_slice(_bytes: &[u8]) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    /// that they can be transumted to a `Self` and `Self::Error` should be returned otherwise.
+    fn validate_byte_slice(_bytes: &[u8]) -> Result<(), Self::Error>;
 
     /// Parses a byte slice, `&[u8]`, and return it as `&[Self]` with the same lifetime.
     ///

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -46,6 +46,16 @@ where
     /// The error that occurs if a byte array is not valid for this ULE.
     type Error;
 
+    /// Validates a byte slice, `&[u8]`.
+    ///
+    /// If `Self` is not well-defined for all possible bit values, the bytes should be validated,
+    /// and `Self::Error` should be returned if they are not valid.
+    ///
+    /// The default implementation validates the slice for all possible bit values.
+    fn validate_byte_slice(_bytes: &[u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     /// Parses a byte slice, `&[u8]`, and return it as `&[Self]` with the same lifetime.
     ///
     /// If `Self` is not well-defined for all possible bit values, the bytes should be validated,
@@ -60,7 +70,10 @@ where
     /// Implementors must return a slice to the same region of memory if parsing succeeds.
     ///
     /// Ideally, implementations call [`ULE::from_byte_slice_unchecked()`] after validation.
-    fn parse_byte_slice(bytes: &[u8]) -> Result<&[Self], Self::Error>;
+    fn parse_byte_slice(bytes: &[u8]) -> Result<&[Self], Self::Error> {
+        Self::validate_byte_slice(bytes)?;
+        Ok(unsafe { Self::from_byte_slice_unchecked(bytes) })
+    }
 
     /// Takes a byte slice, `&[u8]`, and return it as `&[Self]` with the same lifetime, assuming that
     /// this byte slice has previously been run through [`ULE::parse_byte_slice()`] with success.

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -30,6 +30,13 @@ macro_rules! impl_byte_slice_size {
         // the same value as parse_byte_slice
         unsafe impl ULE for PlainOldULE<$size> {
             type Error = core::convert::Infallible;
+
+            #[inline]
+            fn validate_byte_slice(_bytes: &[u8]) -> Result<(), Self::Error> {
+                // Safe because Self is transparent over [u8; $size]
+                Ok(())
+            }
+
         }
 
         impl PlainOldULE<$size> {
@@ -88,6 +95,10 @@ impl_byte_slice_type!(i128, 16);
 // the same value as parse_byte_slice
 unsafe impl ULE for u8 {
     type Error = core::convert::Infallible;
+    #[inline]
+    fn validate_byte_slice(_bytes: &[u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
     #[inline]
     fn parse_byte_slice(bytes: &[u8]) -> Result<&[Self], Self::Error> {
         Ok(bytes)

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -30,11 +30,6 @@ macro_rules! impl_byte_slice_size {
         // the same value as parse_byte_slice
         unsafe impl ULE for PlainOldULE<$size> {
             type Error = core::convert::Infallible;
-            #[inline]
-            fn parse_byte_slice(bytes: &[u8]) -> Result<&[Self], Self::Error> {
-                // Safe because Self is transparent over [u8; $size]
-                Ok(unsafe { Self::from_byte_slice_unchecked(bytes) })
-            }
         }
 
         impl PlainOldULE<$size> {

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -36,7 +36,6 @@ macro_rules! impl_byte_slice_size {
                 // Safe because Self is transparent over [u8; $size]
                 Ok(())
             }
-
         }
 
         impl PlainOldULE<$size> {

--- a/utils/zerovec/src/ule/string.rs
+++ b/utils/zerovec/src/ule/string.rs
@@ -24,6 +24,12 @@ unsafe impl VarULE for str {
     type Error = str::Utf8Error;
 
     #[inline]
+    fn validate_byte_slice(bytes: &[u8]) -> Result<(), Self::Error> {
+        str::from_utf8(bytes)?;
+        Ok(())
+    }
+
+    #[inline]
     fn parse_byte_slice(bytes: &[u8]) -> Result<&Self, Self::Error> {
         str::from_utf8(bytes)
     }

--- a/utils/zerovec/src/ule/vec.rs
+++ b/utils/zerovec/src/ule/vec.rs
@@ -46,6 +46,11 @@ where
     type Error = T::Error;
 
     #[inline]
+    fn validate_byte_slice(bytes: &[u8]) -> Result<(), Self::Error> {
+        T::validate_byte_slice(bytes)
+    }
+
+    #[inline]
     fn parse_byte_slice(bytes: &[u8]) -> Result<&Self, Self::Error> {
         T::parse_byte_slice(bytes)
     }

--- a/utils/zerovec/src/varzerovec/ule.rs
+++ b/utils/zerovec/src/varzerovec/ule.rs
@@ -105,9 +105,9 @@ where
 unsafe impl<T: AsVarULE + 'static> VarULE for VarZeroVecULE<T> {
     type Error = ParseErrorFor<T>;
 
-    fn parse_byte_slice(bytes: &[u8]) -> Result<&Self, Self::Error> {
+    fn validate_byte_slice(bytes: &[u8]) -> Result<(), Self::Error> {
         let _: SliceComponents<T> = SliceComponents::parse_byte_slice(bytes)?;
-        unsafe { Ok(Self::from_byte_slice_unchecked(bytes)) }
+        Ok(())
     }
 
     unsafe fn from_byte_slice_unchecked(bytes: &[u8]) -> &Self {


### PR DESCRIPTION
That would make it easier to avoid having to repeat the final part of `parse_byte_slice` in every call.