### PR TITLE
Add runtime GenericPattern to DTF.

### DIFF
--- a/components/datetime/src/pattern/item/ule.rs
+++ b/components/datetime/src/pattern/item/ule.rs
@@ -55,6 +55,7 @@ use zerovec::ule::{AsULE, ULE};
 ///
 /// [`Unicode Code Point`]: http://www.unicode.org/versions/latest/
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(transparent)]
 pub struct PatternItemULE([u8; 3]);
 
 impl PatternItemULE {
@@ -185,6 +186,7 @@ impl AsULE for PatternItem {
 ///
 /// [`Unicode Code Point`]: http://www.unicode.org/versions/latest/
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(transparent)]
 pub struct GenericPatternItemULE([u8; 3]);
 
 impl GenericPatternItemULE {

--- a/components/datetime/src/pattern/item/ule.rs
+++ b/components/datetime/src/pattern/item/ule.rs
@@ -209,6 +209,8 @@ impl GenericPatternItemULE {
     }
 }
 
+// This impl is safe because (1) validate_byte_slice rejects all invalid byte slices, including
+// those that are the wrong length, and (2) byte equality is semantic equality.
 unsafe impl ULE for GenericPatternItemULE {
     type Error = &'static str;
 

--- a/components/datetime/src/pattern/item/ule.rs
+++ b/components/datetime/src/pattern/item/ule.rs
@@ -82,8 +82,11 @@ impl PatternItemULE {
     }
 }
 
-// This impl is safe because (1) validate_byte_slice rejects all invalid byte slices, including
-// those that are the wrong length, and (2) byte equality is semantic equality.
+// Safety (based on the safety checklist on the ULE trait):
+//  1. PatternItemULE does not include any uninitialized or padding bytes.
+//  2. The impl of validate_byte_slice() returns an error if any byte is not valid.
+//  3. The other ULE methods use the default impl.
+//  4. PatternItemULE byte equality is semantic equality.
 unsafe impl ULE for PatternItemULE {
     type Error = &'static str;
 
@@ -209,8 +212,11 @@ impl GenericPatternItemULE {
     }
 }
 
-// This impl is safe because (1) validate_byte_slice rejects all invalid byte slices, including
-// those that are the wrong length, and (2) byte equality is semantic equality.
+// Safety (based on the safety checklist on the ULE trait):
+//  1. GenericPatternItemULE does not include any uninitialized or padding bytes.
+//  2. The impl of validate_byte_slice() returns an error if any byte is not valid.
+//  3. The other ULE methods use the default impl.
+//  4. GenericPatternItemULE byte equality is semantic equality.
 unsafe impl ULE for GenericPatternItemULE {
     type Error = &'static str;
 

--- a/components/datetime/src/pattern/item/ule.rs
+++ b/components/datetime/src/pattern/item/ule.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use super::PatternItem;
+use super::{GenericPatternItem, PatternItem};
 use crate::fields;
 use core::convert::TryFrom;
 use zerovec::ule::{AsULE, ULE};
@@ -133,9 +133,126 @@ impl AsULE for PatternItem {
     }
 }
 
+/// `GenericPatternItemULE` is a type optimized for efficent storing and
+/// deserialization of `DateTimeFormat` `GenericPatternItem` elements using
+/// `ZeroVec` model.
+///
+/// The serialization model packages the pattern item in three bytes.
+///
+/// The first bit is used to disriminate the item variant. If the bit is
+/// set, then the value is the `GenericPatternItem::Placeholder` variant. Otherwise,
+/// the `GenericPatternItem::Literal` is used.
+///
+/// In case the discriminant is set:
+///
+/// 1) The rest of the first byte remains unused.
+/// 2) The second byte is unused.
+/// 3) The third byte encodes the placeholder index.
+///
+/// If the discriminant is not set, the bottom three bits of the first byte,
+/// together with the next two bytes, contain all 21 bits required to encode
+/// any [`Unicode Code Point`].
+///
+/// # Diagram
+///
+/// ```text
+/// ┌───────────────┬───────────────┬───────────────┐
+/// │       u8      │       u8      │       u8      │
+/// ├─┬─┬─┬─┬─┬─┬─┬─┼─┬─┬─┬─┬─┬─┬─┬─┼─┬─┬─┬─┬─┬─┬─┬─┤
+/// ├─┴─┴─┼─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┤
+/// │     │          Unicode Code Point             │ Literal
+/// ├─┬───┴─────────────────────────┬───────────────┤
+/// │X│                             │  Placeholder  │ Placeholder
+/// └─┴─────────────────────────────┴───────────────┘
+///  ▲
+///  │
+///  Variant Discriminant
+/// ```
+///
+/// # Optimization
+///
+/// This model is optimized for efficient packaging of the `GenericPatternItem` elements
+/// and performant deserialization from the `GernericPatternItemULE` to `GenericPatternItem` type.
+///
+/// # Constraints
+///
+/// The model leaves at most 8 `PatternItem` variants, and limits the placeholder
+/// to a single u8.
+///
+/// [`Unicode Code Point`]: http://www.unicode.org/versions/latest/
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct GenericPatternItemULE([u8; 3]);
+
+impl GenericPatternItemULE {
+    /// Given the first byte of the three-byte array that `GenericPatternItemULE` encodes,
+    /// the method determins whether the discriminant in
+    /// the byte indicates that the array encodes the `GenericPatternItem::Field`
+    /// or `GenericPatternItem::Literal` variant of the `GenericPatternItem`.
+    ///
+    /// Returns true when it is a `GenericPatternItem::Field`.
+    #[inline]
+    fn determine_field_from_u8(byte: u8) -> bool {
+        byte & 0b1000_0000 != 0
+    }
+
+    #[inline]
+    fn bytes_in_range(value: (&u8, &u8, &u8)) -> bool {
+        match Self::determine_field_from_u8(*value.0) {
+            true => true,
+            false => {
+                let u = u32::from_be_bytes([0x00, *value.0, *value.1, *value.2]);
+                char::try_from(u).is_ok()
+            }
+        }
+    }
+}
+
+unsafe impl ULE for GenericPatternItemULE {
+    type Error = &'static str;
+
+    fn validate_byte_slice(bytes: &[u8]) -> Result<(), Self::Error> {
+        let mut chunks = bytes.chunks_exact(3);
+
+        if !chunks.all(|c| Self::bytes_in_range((&c[0], &c[1], &c[2])))
+            || !chunks.remainder().is_empty()
+        {
+            return Err("Invalid byte sequence");
+        }
+        Ok(())
+    }
+}
+
+impl AsULE for GenericPatternItem {
+    type ULE = GenericPatternItemULE;
+
+    #[inline]
+    fn as_unaligned(&self) -> Self::ULE {
+        match self {
+            Self::Placeholder(idx) => GenericPatternItemULE([0b1000_0000, 0x00, *idx]),
+            Self::Literal(ch) => {
+                let u = *ch as u32;
+                let bytes = u.to_be_bytes();
+                GenericPatternItemULE([bytes[1], bytes[2], bytes[3]])
+            }
+        }
+    }
+
+    #[inline]
+    fn from_unaligned(unaligned: &Self::ULE) -> Self {
+        let value = unaligned.0;
+        match GenericPatternItemULE::determine_field_from_u8(value[0]) {
+            false => {
+                let u = u32::from_be_bytes([0x00, value[0], value[1], value[2]]);
+                Self::Literal(char::try_from(u).unwrap())
+            }
+            true => Self::Placeholder(value[2]),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use super::{PatternItem, PatternItemULE};
+    use super::*;
     use crate::fields::{FieldLength, FieldSymbol, Second, Year};
     use zerovec::ule::{AsULE, ULE};
 
@@ -218,6 +335,22 @@ mod test {
 
             assert!(PatternItemULE::validate_byte_slice(&bytes).is_ok());
             assert_eq!(bytes, bytes2);
+        }
+    }
+
+    #[test]
+    fn test_generic_pattern_item_as_ule() {
+        let samples = &[
+            (GenericPatternItem::Placeholder(4), &[0x80, 0x00, 4]),
+            (GenericPatternItem::Placeholder(0), &[0x80, 0x00, 0]),
+            (GenericPatternItem::from('z'), &[0x00, 0x00, 0x7a]),
+        ];
+
+        for (ref_pattern, ref_bytes) in samples {
+            let ule = ref_pattern.as_unaligned();
+            assert_eq!(ULE::as_byte_slice(&[ule]), *ref_bytes);
+            let pattern = GenericPatternItem::from_unaligned(&ule);
+            assert_eq!(pattern, *ref_pattern);
         }
     }
 }

--- a/components/datetime/src/pattern/item/ule.rs
+++ b/components/datetime/src/pattern/item/ule.rs
@@ -72,7 +72,8 @@ impl PatternItemULE {
     #[inline]
     fn bytes_in_range(value: (&u8, &u8, &u8)) -> bool {
         match Self::determine_field_from_u8(*value.0) {
-            true => fields::Field::bytes_in_range(value.1, value.2),
+            // ensure that unused bytes are all zero
+            true => fields::Field::bytes_in_range(value.1, value.2) && *value.0 == 0b1000_0000,
             false => {
                 let u = u32::from_be_bytes([0x00, *value.0, *value.1, *value.2]);
                 char::try_from(u).is_ok()
@@ -135,7 +136,7 @@ impl AsULE for PatternItem {
 
 /// `GenericPatternItemULE` is a type optimized for efficent storing and
 /// deserialization of `DateTimeFormat` `GenericPatternItem` elements using
-/// `ZeroVec` model.
+/// the `ZeroVec` model.
 ///
 /// The serialization model packages the pattern item in three bytes.
 ///
@@ -198,7 +199,8 @@ impl GenericPatternItemULE {
     #[inline]
     fn bytes_in_range(value: (&u8, &u8, &u8)) -> bool {
         match Self::determine_field_from_u8(*value.0) {
-            true => true,
+            // ensure that unused bytes are all zero
+            true => *value.0 == 0b1000_0000 && *value.1 == 0,
             false => {
                 let u = u32::from_be_bytes([0x00, *value.0, *value.1, *value.2]);
                 char::try_from(u).is_ok()

--- a/components/datetime/src/pattern/reference/mod.rs
+++ b/components/datetime/src/pattern/reference/mod.rs
@@ -4,7 +4,7 @@
 
 mod generic;
 mod parser;
-mod pattern;
+pub(crate) mod pattern;
 
 pub use generic::GenericPattern;
 pub use parser::Parser;

--- a/components/datetime/src/pattern/reference/pattern.rs
+++ b/components/datetime/src/pattern/reference/pattern.rs
@@ -70,7 +70,10 @@ impl From<&str> for Pattern {
     }
 }
 
-fn dump_buffer_into_formatter(literal: &str, formatter: &mut fmt::Formatter) -> fmt::Result {
+pub(crate) fn dump_buffer_into_formatter(
+    literal: &str,
+    formatter: &mut fmt::Formatter,
+) -> fmt::Result {
     if literal.is_empty() {
         return Ok(());
     }

--- a/components/datetime/src/pattern/runtime/generic.rs
+++ b/components/datetime/src/pattern/runtime/generic.rs
@@ -15,6 +15,34 @@ pub struct GenericPattern<'data> {
 }
 
 impl<'data> GenericPattern<'data> {
+    /// The function allows for creation of new DTF pattern from a generic pattern
+    /// and replacement patterns.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu_datetime::pattern::{runtime, reference};
+    ///
+    /// let date: runtime::Pattern =
+    ///     reference::Pattern::from_bytes("Y-m-d")
+    ///         .expect("Failed to parse pattern")
+    ///         .into();
+    /// let time: runtime::Pattern =
+    ///     reference::Pattern::from_bytes("HH:mm")
+    ///         .expect("Failed to parse pattern")
+    ///         .into();
+    ///
+    /// let glue: runtime::GenericPattern =
+    ///     reference::GenericPattern::from_bytes("{0} 'at' {1}")
+    ///         .expect("Failed to parse generic pattern")
+    ///         .into();
+    /// assert_eq!(
+    ///     glue.combined(vec![date, time])
+    ///         .expect("Failed to combine patterns")
+    ///         .to_string(),
+    ///     "Y-m-d 'at' HH:mm"
+    /// );
+    /// ```
     pub fn combined(self, replacements: Vec<Pattern>) -> Result<Pattern, PatternError> {
         let size = replacements.iter().fold(0, |acc, r| acc + r.items.len());
         let mut result = Vec::with_capacity(self.items.len() + size);

--- a/components/datetime/src/pattern/runtime/mod.rs
+++ b/components/datetime/src/pattern/runtime/mod.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+mod generic;
 mod pattern;
 
+pub use generic::GenericPattern;
 pub use pattern::Pattern;

--- a/components/datetime/src/pattern/runtime/pattern.rs
+++ b/components/datetime/src/pattern/runtime/pattern.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use super::super::{reference, PatternItem, TimeGranularity};
-use alloc::vec;
+use alloc::{vec, vec::Vec};
 use zerovec::ZeroVec;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -15,6 +15,15 @@ pub struct Pattern<'data> {
     #[cfg_attr(feature = "provider_serde", serde(borrow))]
     pub items: ZeroVec<'data, PatternItem>,
     pub(crate) time_granularity: TimeGranularity,
+}
+
+impl From<Vec<PatternItem>> for Pattern<'_> {
+    fn from(items: Vec<PatternItem>) -> Self {
+        Self {
+            time_granularity: items.iter().map(Into::into).max().unwrap_or_default(),
+            items: ZeroVec::clone_from_slice(&items),
+        }
+    }
 }
 
 impl From<reference::Pattern> for Pattern<'_> {


### PR DESCRIPTION
This PR builds on top of #1112 adding `GenericPattern` and `GenericPatternItem` to runtime pattern in DTF.

This is a temporary structure necessary to store parsed generic patterns until we move DTF to use icu_pattern. It follows closely what has been done so far in #1112.