### PR TITLE
Remove name field from UnicodePropertyV1

### DIFF
--- a/components/uniset/src/provider.rs
+++ b/components/uniset/src/provider.rs
@@ -8,7 +8,6 @@
 
 use crate::builder::UnicodeSetBuilder;
 use crate::uniset::UnicodeSet;
-use alloc::borrow::Cow;
 use icu_provider::yoke::{self, *};
 
 //
@@ -320,16 +319,13 @@ pub mod key {
 )]
 pub struct UnicodePropertyV1<'data> {
     #[cfg_attr(feature = "provider_serde", serde(borrow))]
-    pub name: Cow<'data, str>,
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
     pub inv_list: UnicodeSet<'data>,
 }
 
 impl Default for UnicodePropertyV1<'static> {
-    /// Default empty nameless property
+    /// Default empty property
     fn default() -> UnicodePropertyV1<'static> {
         UnicodePropertyV1 {
-            name: Cow::Borrowed(""),
             inv_list: UnicodeSetBuilder::new().build(),
         }
     }
@@ -337,14 +333,8 @@ impl Default for UnicodePropertyV1<'static> {
 
 impl<'data> UnicodePropertyV1<'data> {
     #[allow(missing_docs)] // TODO(#1030) - Add missing docs.
-    pub fn from_owned_uniset(
-        set: UnicodeSet<'data>,
-        name: Cow<'data, str>,
-    ) -> UnicodePropertyV1<'data> {
-        UnicodePropertyV1 {
-            name,
-            inv_list: set,
-        }
+    pub fn from_owned_uniset(set: UnicodeSet<'data>) -> UnicodePropertyV1<'data> {
+        UnicodePropertyV1 { inv_list: set }
     }
 }
 

--- a/provider/uprops/src/binary.rs
+++ b/provider/uprops/src/binary.rs
@@ -8,7 +8,6 @@ use icu_provider::iter::IterableDataProviderCore;
 use icu_provider::prelude::*;
 use icu_uniset::provider::*;
 use icu_uniset::UnicodeSetBuilder;
-use std::borrow::Cow;
 use std::fs;
 use std::path::PathBuf;
 
@@ -44,13 +43,12 @@ impl<'data> DataProvider<'data, UnicodePropertyV1Marker> for BinaryPropertiesDat
         }
         let uniset = builder.build();
 
-        let name = Cow::from(toml_data.binary_property.data.short_name);
         Ok(DataResponse {
             metadata: DataResponseMetadata {
                 data_langid: req.resource_path.options.langid.clone(),
             },
             payload: Some(DataPayload::from_owned(
-                UnicodePropertyV1::from_owned_uniset(uniset, name),
+                UnicodePropertyV1::from_owned_uniset(uniset),
             )),
         })
     }

--- a/provider/uprops/src/enumerated.rs
+++ b/provider/uprops/src/enumerated.rs
@@ -8,7 +8,6 @@ use icu_provider::iter::IterableDataProviderCore;
 use icu_provider::prelude::*;
 use icu_uniset::provider::*;
 use icu_uniset::UnicodeSetBuilder;
-use std::borrow::Cow;
 use std::fs;
 use std::path::PathBuf;
 
@@ -94,13 +93,12 @@ impl<'data> DataProvider<'data, UnicodePropertyV1Marker> for EnumeratedPropertie
         }
         let uniset = builder.build();
 
-        let name = Cow::from(toml_data.enum_property.data.long_name);
         Ok(DataResponse {
             metadata: DataResponseMetadata {
                 data_langid: req.resource_path.options.langid.clone(),
             },
             payload: Some(DataPayload::from_owned(
-                UnicodePropertyV1::from_owned_uniset(uniset, name),
+                UnicodePropertyV1::from_owned_uniset(uniset),
             )),
         })
     }


### PR DESCRIPTION
This field is unused after the removal of the experimental PPUCD data provider.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->