### PR TITLE
Move Display bound on ULE::Error for Serde

### DIFF
--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -13,7 +13,7 @@ mod vec;
 pub use chars::CharULE;
 pub use plain::PlainOldULE;
 
-use core::{mem, slice};
+use core::{mem, slice, fmt};
 
 /// Fixed-width, byte-aligned data that can be cast to and from a little-endian byte slice.
 ///
@@ -47,7 +47,7 @@ where
     Self: 'static,
 {
     /// The error that occurs if a byte array is not valid for this ULE.
-    type Error;
+    type Error: fmt::Display;
 
     /// Validates a byte slice, `&[u8]`.
     ///
@@ -263,7 +263,7 @@ pub trait AsVarULE {
 /// unpredictable operations on `ZeroVec`, `VarZeroVec`, and `ZeroMap`.
 pub unsafe trait VarULE: 'static {
     /// The error type to used by [`VarULE::parse_byte_slice()`]
-    type Error;
+    type Error: fmt::Display;
 
     /// Validates a byte slice, `&[u8]`.
     ///

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -13,7 +13,7 @@ mod vec;
 pub use chars::CharULE;
 pub use plain::PlainOldULE;
 
-use core::{mem, slice, fmt};
+use core::{fmt, mem, slice};
 
 /// Fixed-width, byte-aligned data that can be cast to and from a little-endian byte slice.
 ///

--- a/utils/zerovec/src/varzerovec/serde.rs
+++ b/utils/zerovec/src/varzerovec/serde.rs
@@ -25,7 +25,6 @@ impl<T> Default for VarZeroVecVisitor<T> {
 impl<'de, T> Visitor<'de> for VarZeroVecVisitor<T>
 where
     T: 'de + Deserialize<'de> + AsVarULE,
-    <<T as AsVarULE>::VarULE as VarULE>::Error: fmt::Display,
 {
     type Value = VarZeroVec<'de, T>;
 
@@ -60,7 +59,6 @@ where
 impl<'de, 'a, T> Deserialize<'de> for VarZeroVec<'a, T>
 where
     T: 'de + Deserialize<'de> + AsVarULE,
-    <<T as AsVarULE>::VarULE as VarULE>::Error: fmt::Display,
     'de: 'a,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/utils/zerovec/src/zerovec/serde.rs
+++ b/utils/zerovec/src/zerovec/serde.rs
@@ -25,7 +25,6 @@ impl<T> Default for ZeroVecVisitor<T> {
 impl<'de, T> Visitor<'de> for ZeroVecVisitor<T>
 where
     T: 'de + Deserialize<'de> + AsULE,
-    <<T as AsULE>::ULE as ULE>::Error: fmt::Display,
 {
     type Value = ZeroVec<'de, T>;
 
@@ -60,7 +59,6 @@ where
 impl<'de, 'a, T> Deserialize<'de> for ZeroVec<'a, T>
 where
     T: 'de + Deserialize<'de> + AsULE,
-    <<T as AsULE>::ULE as ULE>::Error: fmt::Display,
     'de: 'a,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>


### PR DESCRIPTION
The fmt::Display bound on Serde requires complicated bounds when using `#[derive(Deserialize)]`.  These problems are not isolated; they will happen whenever `#[derive(Deserialize)]` is being used on custom ZeroVec types.  I believe it is cleaner, and low-impact, to put the bound directly on the ULE::Error associated type.