### PR TITLE
Clean up DTF Skeleton.

### DIFF
--- a/components/datetime/src/pattern/hour_cycle.rs
+++ b/components/datetime/src/pattern/hour_cycle.rs
@@ -99,7 +99,9 @@ impl CoarseHourCycle {
             true,
         ) {
             skeleton::BestSkeleton::AllFieldsMatch(pattern)
-            | skeleton::BestSkeleton::MissingOrExtraFields(pattern) => Some(format!("{}", pattern.0)),
+            | skeleton::BestSkeleton::MissingOrExtraFields(pattern) => {
+                Some(format!("{}", pattern.0))
+            }
             skeleton::BestSkeleton::NoMatch => None,
         }
     }

--- a/components/datetime/src/pattern/mod.rs
+++ b/components/datetime/src/pattern/mod.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 mod error;
-mod hour_cycle;
+pub(crate) mod hour_cycle;
 mod item;
 pub mod reference;
 pub mod runtime;

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -705,13 +705,7 @@ pub fn get_best_available_format_pattern(
     }
 
     // Modify the resulting pattern to have fields of the same length.
-    let expanded_pattern = if prefer_matched_pattern {
-        #[cfg(not(feature = "provider_transform_internals"))]
-        panic!("This code branch should only be run when transforming provider code.");
-
-        #[cfg(feature = "provider_transform_internals")]
-        closest_format_pattern
-    } else {
+    if prefer_matched_pattern {
         closest_format_pattern.0.items.iter_mut().for_each(|item| {
             if let PatternItem::Field(pattern_field) = item {
                 if let Some(requested_field) = fields
@@ -726,14 +720,16 @@ pub fn get_best_available_format_pattern(
                 }
             }
         });
-        closest_format_pattern
-    };
-
-    if closest_distance >= SKELETON_EXTRA_SYMBOL {
-        return BestSkeleton::MissingOrExtraFields(expanded_pattern);
+    } else {
+        #[cfg(not(feature = "provider_transform_internals"))]
+        panic!("This code branch should only be run when transforming provider code.");
     }
 
-    BestSkeleton::AllFieldsMatch(expanded_pattern)
+    if closest_distance >= SKELETON_EXTRA_SYMBOL {
+        return BestSkeleton::MissingOrExtraFields(closest_format_pattern);
+    }
+
+    BestSkeleton::AllFieldsMatch(closest_format_pattern)
 }
 
 #[cfg(all(test, feature = "provider_serde"))]

--- a/components/datetime/src/skeleton.rs
+++ b/components/datetime/src/skeleton.rs
@@ -706,6 +706,9 @@ pub fn get_best_available_format_pattern(
 
     // Modify the resulting pattern to have fields of the same length.
     if prefer_matched_pattern {
+        #[cfg(not(feature = "provider_transform_internals"))]
+        panic!("This code branch should only be run when transforming provider code.");
+    } else {
         closest_format_pattern.0.items.iter_mut().for_each(|item| {
             if let PatternItem::Field(pattern_field) = item {
                 if let Some(requested_field) = fields
@@ -720,9 +723,6 @@ pub fn get_best_available_format_pattern(
                 }
             }
         });
-    } else {
-        #[cfg(not(feature = "provider_transform_internals"))]
-        panic!("This code branch should only be run when transforming provider code.");
     }
 
     if closest_distance >= SKELETON_EXTRA_SYMBOL {


### PR DESCRIPTION
This is a small patch which prepares skeleton for larger changes listed in #519.

I am:
* Moving `naively_apply_preferences` to `hour_cycle` to reuse in helper and skeleton
* Removing the `AvailableFormatPatterns`
* Removing `FieldIndex`