### PR TITLE
Likely subtags minimization of und should be en.

### DIFF
--- a/components/locale_canonicalizer/src/locale_canonicalizer.rs
+++ b/components/locale_canonicalizer/src/locale_canonicalizer.rs
@@ -579,6 +579,7 @@ impl<'data> LocaleCanonicalizer<'data> {
 
         let mut max = langid.clone();
         self.maximize(&mut max);
+        let variants = max.variants.clone();
         max.variants.clear();
         let mut trial = max.clone();
 
@@ -586,9 +587,11 @@ impl<'data> LocaleCanonicalizer<'data> {
         trial.region = None;
         self.maximize(&mut trial);
         if trial == max {
-            if langid.script.is_some() || langid.script.is_some() {
+            if langid.language != max.language || langid.script.is_some() || langid.region.is_some() {
+                langid.language = max.language;
                 langid.script = None;
                 langid.region = None;
+                langid.variants = variants;
                 return CanonicalizationResult::Modified;
             } else {
                 return CanonicalizationResult::Unmodified;
@@ -599,9 +602,11 @@ impl<'data> LocaleCanonicalizer<'data> {
         trial.region = max.region;
         self.maximize(&mut trial);
         if trial == max {
-            if langid.script.is_some() || langid.region != max.region {
+            if langid.language != max.language || langid.script.is_some() || langid.region != max.region {
+                langid.language = max.language;
                 langid.script = None;
                 langid.region = max.region;
+                langid.variants = variants;
                 return CanonicalizationResult::Modified;
             } else {
                 return CanonicalizationResult::Unmodified;
@@ -612,16 +617,19 @@ impl<'data> LocaleCanonicalizer<'data> {
         trial.region = None;
         self.maximize(&mut trial);
         if trial == max {
-            if langid.script != max.script || langid.region.is_some() {
+            if langid.language != max.language || langid.script != max.script || langid.region.is_some() {
+                langid.language = max.language;
                 langid.script = max.script;
                 langid.region = None;
+                langid.variants = variants;
                 return CanonicalizationResult::Modified;
             } else {
                 return CanonicalizationResult::Unmodified;
             }
         }
 
-        if langid.script != max.script || langid.region != max.region {
+        if langid.language != max.language || langid.script != max.script || langid.region != max.region {
+            langid.language = max.language;
             langid.script = max.script;
             langid.region = max.region;
             CanonicalizationResult::Modified

--- a/components/locale_canonicalizer/tests/fixtures/minimize.json
+++ b/components/locale_canonicalizer/tests/fixtures/minimize.json
@@ -12,6 +12,10 @@
     "output": "en"
   },
   {
+    "input": "und",
+    "output": "en"
+  },
+  {
     "input": "zh-Hant-TW-u-hc-h24-nu-chinese",
     "output": "zh-TW-u-hc-h24-nu-chinese"
   }


### PR DESCRIPTION
This PR is to fix a bug in 'minimize' method, which returns wrong result if 'langid' is 'und' (https://github.com/unicode-org/icu4x/issues/818)

The root cause is that the method has an assumption that 'language' after 'maximize' does not change. So it does not check and overwrite 'language' field. For example, the 'maximize' result of 'und' is '"en-Latn-US"'.

Meanwhile, this PR also considers 'variants' field if 'AddLikelySubtags(trial)' is equal to 'max'. (algorithm is here: https://www.unicode.org/reports/tr35/#Likely_Subtags)