### PR TITLE
Add UleError type; use for PlainOldULE and char conversions

### DIFF
--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -42,6 +42,7 @@ getrandom = { version = "0.2", features = ["js"] }
 
 [features]
 bench = []
+std = []
 
 [[bench]]
 name = "zerovec"

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -79,7 +79,7 @@
 //! # } // feature = "serde"
 //! ```
 
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 // this crate does a lot of nuanced lifetime manipulation, being explicit
 // is better here.
 #![allow(clippy::needless_lifetimes)]

--- a/utils/zerovec/src/ule/chars.rs
+++ b/utils/zerovec/src/ule/chars.rs
@@ -42,10 +42,16 @@ pub struct CharULE([u8; 4]);
 // This is safe to implement because from_byte_slice_unchecked returns
 // the same value as parse_byte_slice
 unsafe impl ULE for CharULE {
-    type Error = core::char::CharTryFromError;
+    type Error = ULEError<core::char::CharTryFromError>;
 
     #[inline]
     fn validate_byte_slice(bytes: &[u8]) -> Result<(), Self::Error> {
+        if bytes.len() % 4 != 0 {
+            return Err(ULEError::InvalidLength {
+                ty: "char",
+                len: bytes.len(),
+            });
+        }
         // Validate the bytes
         for chunk in bytes.chunks_exact(4) {
             // TODO: Use slice::as_chunks() when stabilized

--- a/utils/zerovec/src/ule/error.rs
+++ b/utils/zerovec/src/ule/error.rs
@@ -1,0 +1,29 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use core::fmt;
+
+/// A generic error type to be used for decoding slices of ULE types
+#[derive(Copy, Clone, Debug)]
+pub enum ULEError<E> {
+    InvalidLength { ty: &'static str, len: usize },
+    ParseError(E),
+}
+
+impl<E: fmt::Display> fmt::Display for ULEError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        match *self {
+            ULEError::InvalidLength { ty, len } => {
+                write!(f, "Invalid length {} for slice of type {}", len, ty)
+            }
+            ULEError::ParseError(ref e) => e.fmt(f),
+        }
+    }
+}
+
+impl<E> From<E> for ULEError<E> {
+    fn from(e: E) -> Self {
+        ULEError::ParseError(e)
+    }
+}

--- a/utils/zerovec/src/ule/error.rs
+++ b/utils/zerovec/src/ule/error.rs
@@ -27,3 +27,6 @@ impl<E> From<E> for ULEError<E> {
         ULEError::ParseError(e)
     }
 }
+
+#[cfg(feature = "std")]
+impl<E: fmt::Display + fmt::Debug> ::std::error::Error for ULEError<E> {}

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -6,11 +6,13 @@
 //! Traits over unaligned little-endian data (ULE, pronounced "yule").
 
 mod chars;
+mod error;
 mod plain;
 mod string;
 mod vec;
 
 pub use chars::CharULE;
+pub use error::ULEError;
 pub use plain::PlainOldULE;
 
 use alloc::alloc::Layout;

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -29,12 +29,19 @@ macro_rules! impl_byte_slice_size {
         // This is safe to implement because from_byte_slice_unchecked returns
         // the same value as parse_byte_slice
         unsafe impl ULE for PlainOldULE<$size> {
-            type Error = core::convert::Infallible;
+            type Error = ULEError<core::convert::Infallible>;
 
             #[inline]
-            fn validate_byte_slice(_bytes: &[u8]) -> Result<(), Self::Error> {
-                // Safe because Self is transparent over [u8; $size]
-                Ok(())
+            fn validate_byte_slice(bytes: &[u8]) -> Result<(), Self::Error> {
+                if bytes.len() % $size == 0 {
+                    // Safe because Self is transparent over [u8; $size]
+                    Ok(())
+                } else {
+                    Err(ULEError::InvalidLength {
+                        ty: concat!("PlainOldULE<", stringify!($size), ">"),
+                        len: bytes.len(),
+                    })
+                }
             }
         }
 

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -97,7 +97,7 @@ pub use ule::VarZeroVecULE;
 /// for (zv, v) in zerovec.iter().zip(numbers.iter()) {
 ///     assert_eq!(zv, v);   
 /// }
-/// # Ok::<(), VarZeroVecError<std::convert::Infallible>>(())
+/// # Ok::<(), VarZeroVecError<ULEError<_>>>(())
 /// ```
 ///
 ///


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/1144


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->