### PR TITLE
Test fixture data should be easier to repeat with multiple locales

### DIFF
--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -62,13 +62,9 @@ fn test_fixture(fixture_name: &str) {
         .expect("Unable to get fixture.")
         .0
     {
-        let locale: Locale = fx.input.locale.parse().unwrap();
         let options = fixtures::get_options(&fx.input.options);
+        let input_value = parse_gregorian_from_str(&fx.input.value).unwrap();
 
-        let dtf = DateTimeFormat::try_new(locale, &provider, &options).unwrap();
-        let value = parse_gregorian_from_str(&fx.input.value).unwrap();
-
-        let result = dtf.format_to_string(&value);
         let description = match fx.description {
             Some(description) => {
                 format!(
@@ -78,20 +74,25 @@ fn test_fixture(fixture_name: &str) {
             }
             None => format!("\n  file: {}.json\n", fixture_name),
         };
+        for (locale, output_value) in fx.output.values.into_iter() {
+            let locale: Locale = locale.parse().unwrap();
+            let dtf = DateTimeFormat::try_new(locale, &provider, &options).unwrap();
+            let result = dtf.format_to_string(&input_value);
+            
+            assert_eq!(result, output_value, "{}", description);
 
-        assert_eq!(result, fx.output.value, "{}", description);
+            let mut s = String::new();
+            dtf.format_to_write(&mut s, &input_value).unwrap();
+            assert_eq!(s, output_value, "{}", description);
 
-        let mut s = String::new();
-        dtf.format_to_write(&mut s, &value).unwrap();
-        assert_eq!(s, fx.output.value, "{}", description);
+            let fdt = dtf.format(&input_value);
+            let s = fdt.to_string();
+            assert_eq!(s, output_value, "{}", description);
 
-        let fdt = dtf.format(&value);
-        let s = fdt.to_string();
-        assert_eq!(s, fx.output.value, "{}", description);
-
-        let mut s = String::new();
-        write!(s, "{}", fdt).unwrap();
-        assert_eq!(s, fx.output.value, "{}", description);
+            let mut s = String::new();
+            write!(s, "{}", fdt).unwrap();
+            assert_eq!(s, output_value, "{}", description);
+        }
     }
 }
 
@@ -102,17 +103,13 @@ fn test_fixture_with_time_zones(fixture_name: &str, config: TimeZoneConfig) {
         .expect("Unable to get fixture.")
         .0
     {
-        let locale: Locale = fx.input.locale.parse().unwrap();
         let options = fixtures::get_options(&fx.input.options);
 
-        let dtf = ZonedDateTimeFormat::try_new(locale, &provider, &provider, &options).unwrap();
-
-        let mut value: MockZonedDateTime = fx.input.value.parse().unwrap();
-        value.time_zone.time_zone_id = config.time_zone_id.clone();
-        value.time_zone.metazone_id = config.metazone_id.clone();
-        value.time_zone.time_variant = config.time_variant;
-
-        let result = dtf.format_to_string(&value);
+        let mut input_value: MockZonedDateTime = fx.input.value.parse().unwrap();
+        input_value.time_zone.time_zone_id = config.time_zone_id.clone();
+        input_value.time_zone.metazone_id = config.metazone_id.clone();
+        input_value.time_zone.time_variant = config.time_variant;
+            
         let description = match fx.description {
             Some(description) => {
                 format!(
@@ -122,20 +119,25 @@ fn test_fixture_with_time_zones(fixture_name: &str, config: TimeZoneConfig) {
             }
             None => format!("\n  file: {}.json\n", fixture_name),
         };
+        for (locale, output_value) in fx.output.values.into_iter() {
+            let locale: Locale = locale.parse().unwrap();
+            let dtf = ZonedDateTimeFormat::try_new(locale, &provider, &provider, &options).unwrap();
+            let result = dtf.format_to_string(&input_value);
+            
+            assert_eq!(result, output_value, "{}", description);
 
-        assert_eq!(result, fx.output.value, "{}", description);
+            let mut s = String::new();
+            dtf.format_to_write(&mut s, &input_value).unwrap();
+            assert_eq!(s, output_value, "{}", description);
 
-        let mut s = String::new();
-        dtf.format_to_write(&mut s, &value).unwrap();
-        assert_eq!(s, fx.output.value, "{}", description);
+            let fdt = dtf.format(&input_value);
+            let s = fdt.to_string();
+            assert_eq!(s, output_value, "{}", description);
 
-        let fdt = dtf.format(&value);
-        let s = fdt.to_string();
-        assert_eq!(s, fx.output.value, "{}", description);
-
-        let mut s = String::new();
-        write!(s, "{}", fdt).unwrap();
-        assert_eq!(s, fx.output.value, "{}", description);
+            let mut s = String::new();
+            write!(s, "{}", fdt).unwrap();
+            assert_eq!(s, output_value, "{}", description);
+        }        
     }
 }
 

--- a/components/datetime/tests/fixtures/structs.rs
+++ b/components/datetime/tests/fixtures/structs.rs
@@ -9,6 +9,7 @@
 
 use icu_datetime::options::{components, length};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Fixture(pub Vec<Test>);
@@ -22,7 +23,6 @@ pub struct Test {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TestInput {
-    pub locale: String,
     pub value: String,
     pub options: TestOptions,
 }
@@ -37,5 +37,5 @@ pub enum TestOptions {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TestOutput {
-    pub value: String,
+    pub values: HashMap<String, String>,
 }

--- a/components/datetime/tests/fixtures/tests/components-combine-datetime.json
+++ b/components/datetime/tests/fixtures/tests/components-combine-datetime.json
@@ -2,7 +2,6 @@
     {
         "description": "Combine date and time: yMMMd + Ehm",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -18,13 +17,14 @@
             }
         },
         "output": {
-            "value": "Tue, Jan 7, 2020, 8:25 AM"
+            "values": {
+                "en": "Tue, Jan 7, 2020, 8:25 AM"
+            }
         }
     },
     {
         "description": "Combine date and time with a \"full\" length glue pattern",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -40,7 +40,9 @@
             }
         },
         "output": {
-            "value": "Tuesday, January 7, 2020 at 8:25 AM"
+            "values": {
+                "en": "Tuesday, January 7, 2020 at 8:25 AM"
+            }
         }
     }
 ]

--- a/components/datetime/tests/fixtures/tests/components-exact-matches.json
+++ b/components/datetime/tests/fixtures/tests/components-exact-matches.json
@@ -2,7 +2,6 @@
     {
         "description": "Exact match for: y => y",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -11,13 +10,14 @@
             }
         },
         "output": {
-            "value": "2020"
+            "values": {
+                "en": "2020"
+            }
         }
     },
     {
         "description": "Exact match for: yM => M/y",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -27,13 +27,14 @@
             }
         },
         "output": {
-            "value": "1/2020"
+            "values": {
+                "en": "1/2020"
+            }
         }
     },
     {
         "description": "Exact match for: yMd => M/d/y",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -44,13 +45,14 @@
             }
         },
         "output": {
-            "value": "1/7/2020"
+            "values": {
+                "en": "1/7/2020"
+            }
         }
     },
     {
         "description": "Exact match for: yMdE => E, M/d/y",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -62,13 +64,14 @@
             }
         },
         "output": {
-            "value": "Tue, 1/7/2020"
+            "values": {
+                "en": "Tue, 1/7/2020"
+            }
         }
     },
     {
         "description": "Exact match for: yMMM => MMM y",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -78,13 +81,14 @@
             }
         },
         "output": {
-            "value": "Jan 2020"
+            "values": {
+                "en": "Jan 2020"
+            }
         }
     },
     {
         "description": "Exact match for: yMMMd => MMM d, y",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -95,13 +99,14 @@
             }
         },
         "output": {
-            "value": "Jan 7, 2020"
+            "values": {
+                "en": "Jan 7, 2020"
+            }
         }
     },
     {
         "description": "Exact match for: yMMMdE => E, MMM d, y",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -113,13 +118,14 @@
             }
         },
         "output": {
-            "value": "Tue, Jan 7, 2020"
+            "values": {
+                "en": "Tue, Jan 7, 2020"
+            }
         }
     },
     {
         "description": "Exact match for: yMMMM => MMMM y",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -129,13 +135,14 @@
             }
         },
         "output": {
-            "value": "January 2020"
+            "values": {
+                "en": "January 2020"
+            }
         }
     },
     {
         "description": "Exact match for: M => M",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -144,13 +151,14 @@
             }
         },
         "output": {
-            "value": "Jan"
+            "values": {
+                "en": "Jan"
+            }
         }
     },
     {
         "description": "Exact match for: Md => M/d",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -160,13 +168,14 @@
             }
         },
         "output": {
-            "value": "1/7"
+            "values": {
+                "en": "1/7"
+            }
         }
     },
     {
         "description": "Exact match for: MdE => E, M/d",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -177,13 +186,14 @@
             }
         },
         "output": {
-            "value": "Tue, 1/7"
+            "values": {
+                "en": "Tue, 1/7"
+            }
         }
     },
     {
         "description": "Exact match for: MMM => LLL",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -192,13 +202,14 @@
             }
         },
         "output": {
-            "value": "Jan"
+            "values": {
+                "en": "Jan"
+            }
         }
     },
     {
         "description": "Exact match for: MMMd => MMM d",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -208,13 +219,14 @@
             }
         },
         "output": {
-            "value": "Jan 7"
+            "values": {
+                "en": "Jan 7"
+            }
         }
     },
     {
         "description": "Exact match for: MMMdE => E, MMM d",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -225,13 +237,14 @@
             }
         },
         "output": {
-            "value": "Tue, Jan 7"
+            "values": {
+                "en": "Tue, Jan 7"
+            }
         }
     },
     {
         "description": "Exact match for: MMMMd => MMMM d",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -241,13 +254,14 @@
             }
         },
         "output": {
-            "value": "January 7"
+            "values": {
+                "en": "January 7"
+            }
         }
     },
     {
         "description": "Exact match for: d => d",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -256,13 +270,14 @@
             }
         },
         "output": {
-            "value": "7"
+            "values": {
+                "en": "7"
+            }
         }
     },
     {
         "description": "Exact match for: dE => d E",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -272,13 +287,14 @@
             }
         },
         "output": {
-            "value": "7 Tue"
+            "values": {
+                "en": "7 Tue"
+            }
         }
     },
     {
         "description": "Exact match for: E => ccc",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -287,13 +303,14 @@
             }
         },
         "output": {
-            "value": "Tue"
+            "values": {
+                "en": "Tue"
+            }
         }
     },
     {
         "description": "Exact match for: Ehm => E h:mm a",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -305,13 +322,14 @@
             }
         },
         "output": {
-            "value": "Tue 8:25 AM"
+            "values": {
+                "en": "Tue 8:25 AM"
+            }
         }
     },
     {
         "description": "Exact match for: Ehms => E h:mm:ss a",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -324,13 +342,14 @@
             }
         },
         "output": {
-            "value": "Tue 8:25:07 AM"
+            "values": {
+                "en": "Tue 8:25:07 AM"
+            }
         }
     },
     {
         "description": "Exact match for: EHm => E h:mm a",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -342,13 +361,14 @@
             }
         },
         "output": {
-            "value": "Tue 08:25"
+            "values": {
+                "en": "Tue 08:25"
+            }
         }
     },
     {
         "description": "Exact match for: EHms => E h:mm:ss a",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -361,13 +381,14 @@
             }
         },
         "output": {
-            "value": "Tue 08:25:07"
+            "values": {
+                "en": "Tue 08:25:07"
+            }
         }
     },
     {
         "description": "Exact match for: h => h a",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -377,13 +398,14 @@
             }
         },
         "output": {
-            "value": "8 AM"
+            "values": {
+                "en": "8 AM"
+            }
         }
     },
     {
         "description": "Exact match for: hm => h:mm a",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -394,13 +416,14 @@
             }
         },
         "output": {
-            "value": "8:25 AM"
+            "values": {
+                "en": "8:25 AM"
+            }
         }
     },
     {
         "description": "Exact match for: hms => h:mm:ss a",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -412,13 +435,14 @@
             }
         },
         "output": {
-            "value": "8:25:07 AM"
+            "values": {
+                "en": "8:25:07 AM"
+            }
         }
     },
     {
         "description": "Exact match for: H => HH",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -428,13 +452,14 @@
             }
         },
         "output": {
-            "value": "08"
+            "values": {
+                "en": "08"
+            }
         }
     },
     {
         "description": "Exact match for: Hm => HH:mm",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -445,13 +470,14 @@
             }
         },
         "output": {
-            "value": "08:25"
+            "values": {
+                "en": "08:25"
+            }
         }
     },
     {
         "description": "Exact match for: Hms => HH:mm:ss",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -463,13 +489,14 @@
             }
         },
         "output": {
-            "value": "08:25:07"
+            "values": {
+                "en": "08:25:07"
+            }
         }
     },
     {
         "description": "Exact match for: ms => mm:ss",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -479,7 +506,9 @@
             }
         },
         "output": {
-            "value": "25:07"
+            "values": {
+                "en": "25:07"
+            }
         }
     }
 ]

--- a/components/datetime/tests/fixtures/tests/components-width-differences.json
+++ b/components/datetime/tests/fixtures/tests/components-width-differences.json
@@ -2,7 +2,6 @@
     {
         "description": "Width difference: y vs yy",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -11,13 +10,14 @@
             }
         },
         "output": {
-            "value": "20"
+            "values": {
+                "en": "20"
+            }
         }
     },
     {
         "description": "Enumerate month lengths which may need expansion: yMd => M/d/y",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -28,13 +28,14 @@
             }
         },
         "output": {
-            "value": "1/7/2020"
+            "values": {
+                "en": "1/7/2020"
+            }
         }
     },
     {
         "description": "Enumerate month lengths which may need expansion: yMMd => MM/d/y",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -45,13 +46,14 @@
             }
         },
         "output": {
-            "value": "01/7/2020"
+            "values": {
+                "en": "01/7/2020"
+            }
         }
     },
     {
         "description": "Enumerate month lengths which may need expansion: yMMMd => MMM d, y",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -62,13 +64,14 @@
             }
         },
         "output": {
-            "value": "Jan 7, 2020"
+            "values": {
+                "en": "Jan 7, 2020"
+            }
         }
     },
     {
         "description": "Enumerate month lengths which may need expansion: yMMMMd => MMMM d, y",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -79,13 +82,14 @@
             }
         },
         "output": {
-            "value": "January 7, 2020"
+            "values": {
+                "en": "January 7, 2020"
+            }
         }
     },
     {
         "description": "Enumerate month lengths which may need expansion: yMMMMMd => MMMMM d, y",
         "input": {
-            "locale": "en",
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
@@ -96,7 +100,9 @@
             }
         },
         "output": {
-            "value": "J 7, 2020"
+            "values": {
+                "en": "J 7, 2020"
+            }
         }
     }
 ]

--- a/components/datetime/tests/fixtures/tests/components.json
+++ b/components/datetime/tests/fixtures/tests/components.json
@@ -1,7 +1,6 @@
 [
     {
         "input": {
-            "locale": "en",
             "value": "2020-01-21T08:25:07.000",
             "options": {
                 "components": {
@@ -16,7 +15,9 @@
             }
         },
         "output": {
-            "value": "Tuesday, January 21, 2020 at 8:25:07 AM"
+            "values": {
+                "en": "Tuesday, January 21, 2020 at 8:25:07 AM"
+            }
         }
     }
 ]

--- a/components/datetime/tests/fixtures/tests/components_hour_cycle.json
+++ b/components/datetime/tests/fixtures/tests/components_hour_cycle.json
@@ -1,139 +1,147 @@
 [
-  {
-    "description": "h11 in the english locale",
-    "input": {
-        "locale": "en",
-        "value": "2020-01-07T00:25:07.000",
-        "options": {
-            "components": {
-                "hour": "numeric",
-                "minute": "numeric",
-                "preferences": { "hourCycle": "h11" }
+    {
+        "description": "h11 in the english locale",
+        "input": {
+            "value": "2020-01-07T00:25:07.000",
+            "options": {
+                "components": {
+                    "hour": "numeric",
+                    "minute": "numeric",
+                    "preferences": { "hourCycle": "h11" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "en": "0:25 AM"
             }
         }
     },
-    "output": {
-        "value": "0:25 AM"
-    }
-  },
-  {
-    "description": "h12 in the english locale",
-    "input": {
-        "locale": "en",
-        "value": "2020-01-07T00:25:07.000",
-        "options": {
-            "components": {
-                "hour": "numeric",
-                "minute": "numeric",
-                "preferences": { "hourCycle": "h12" }
+    {
+        "description": "h12 in the english locale",
+        "input": {
+            "value": "2020-01-07T00:25:07.000",
+            "options": {
+                "components": {
+                    "hour": "numeric",
+                    "minute": "numeric",
+                    "preferences": { "hourCycle": "h12" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "en": "12:25 AM"
             }
         }
     },
-    "output": {
-        "value": "12:25 AM"
-    }
-  },
-  {
-      "description": "h23 in the english locale",
-      "input": {
-          "locale": "en",
-          "value": "2020-01-07T00:25:07.000",
-          "options": {
-              "components": {
-                  "hour": "numeric",
-                  "minute": "numeric",
-                  "preferences": { "hourCycle": "h23" }
-              }
-          }
-      },
-      "output": {
-          "value": "00:25"
-      }
-  },
-  {
-      "description": "h24 in the english locale",
-      "input": {
-          "locale": "en",
-          "value": "2020-01-07T00:25:07.000",
-          "options": {
-              "components": {
-                  "hour": "numeric",
-                  "minute": "numeric",
-                  "preferences": { "hourCycle": "h24" }
-              }
-          }
-      },
-      "output": {
-          "value": "24:25"
-      }
-  },
+    {
+        "description": "h23 in the english locale",
+        "input": {
+            "value": "2020-01-07T00:25:07.000",
+            "options": {
+                "components": {
+                    "hour": "numeric",
+                    "minute": "numeric",
+                    "preferences": { "hourCycle": "h23" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "en": "00:25"
+            }
+        }
+    },
+    {
+        "description": "h24 in the english locale",
+        "input": {
+            "value": "2020-01-07T00:25:07.000",
+            "options": {
+                "components": {
+                    "hour": "numeric",
+                    "minute": "numeric",
+                    "preferences": { "hourCycle": "h24" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "en": "24:25"
+            }
+        }
+    },
 
-  {
-    "description": "h11 in the arabic locale",
-    "input": {
-        "locale": "ar",
-        "value": "2020-01-07T00:25:07.000",
-        "options": {
-            "components": {
-                "hour": "numeric",
-                "minute": "numeric",
-                "preferences": { "hourCycle": "h11" }
+    {
+        "description": "h11 in the arabic locale",
+        "input": {
+            "value": "2020-01-07T00:25:07.000",
+            "options": {
+                "components": {
+                    "hour": "numeric",
+                    "minute": "numeric",
+                    "preferences": { "hourCycle": "h11" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "ar": "0:25 ص"
             }
         }
     },
-    "output": {
-        "value": "0:25 ص"
-    }
-  },
-  {
-    "description": "h12 in the arabic locale",
-    "input": {
-        "locale": "ar",
-        "value": "2020-01-07T00:25:07.000",
-        "options": {
-            "components": {
-                "hour": "numeric",
-                "minute": "numeric",
-                "preferences": { "hourCycle": "h12" }
+    {
+        "description": "h12 in the arabic locale",
+        "input": {
+            "value": "2020-01-07T00:25:07.000",
+            "options": {
+                "components": {
+                    "hour": "numeric",
+                    "minute": "numeric",
+                    "preferences": { "hourCycle": "h12" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "ar": "12:25 ص"
             }
         }
     },
-    "output": {
-        "value": "12:25 ص"
+    {
+        "description": "h23 in the arabic locale",
+        "input": {
+            "value": "2020-01-07T00:25:07.000",
+            "options": {
+                "components": {
+                    "hour": "numeric",
+                    "minute": "numeric",
+                    "preferences": { "hourCycle": "h23" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "ar": "00:25"
+            }
+        }
+    },
+    {
+        "description": "h24 in the arabic locale",
+        "input": {
+            "value": "2020-01-07T00:25:07.000",
+            "options": {
+                "components": {
+                    "hour": "numeric",
+                    "minute": "numeric",
+                    "preferences": { "hourCycle": "h24" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "ar": "24:25"
+            }
+        }
     }
-  },
-  {
-      "description": "h23 in the arabic locale",
-      "input": {
-          "locale": "ar",
-          "value": "2020-01-07T00:25:07.000",
-          "options": {
-              "components": {
-                  "hour": "numeric",
-                  "minute": "numeric",
-                  "preferences": { "hourCycle": "h23" }
-              }
-          }
-      },
-      "output": {
-          "value": "00:25"
-      }
-  },
-  {
-      "description": "h24 in the arabic locale",
-      "input": {
-          "locale": "ar",
-          "value": "2020-01-07T00:25:07.000",
-          "options": {
-              "components": {
-                  "hour": "numeric",
-                  "minute": "numeric",
-                  "preferences": { "hourCycle": "h24" }
-              }
-          }
-      },
-      "output": {
-          "value": "24:25"
-      }
-  }
 ]

--- a/components/datetime/tests/fixtures/tests/components_with_zones.json
+++ b/components/datetime/tests/fixtures/tests/components_with_zones.json
@@ -2,7 +2,6 @@
     {
         "description": "Full date time example with long generic time zone",
         "input": {
-            "locale": "en",
             "value": "2020-01-21T08:25:07.000+05:00",
             "options": {
                 "components": {
@@ -18,13 +17,14 @@
             }
         },
         "output": {
-            "value": "Tuesday, January 21, 2020 at 08:25:07 GMT+05:00"
+            "values": {
+                "en": "Tuesday, January 21, 2020 at 08:25:07 GMT+05:00"
+            }
         }
     },
     {
         "description": "Full date time example with short generic time zone",
         "input": {
-            "locale": "en",
             "value": "2020-01-21T08:25:07.000+05:00",
             "options": {
                 "components": {
@@ -40,13 +40,14 @@
             }
         },
         "output": {
-            "value": "Tuesday, January 21, 2020 at 08:25:07 GMT+05:00"
+            "values": {
+                "en": "Tuesday, January 21, 2020 at 08:25:07 GMT+05:00"
+            }
         }
     },
     {
         "description": "Full date time example with short time zone",
         "input": {
-            "locale": "en",
             "value": "2020-01-21T08:25:07.000+05:00",
             "options": {
                 "components": {
@@ -62,13 +63,14 @@
             }
         },
         "output": {
-            "value": "Tuesday, January 21, 2020 at 08:25:07 GMT+05:00"
+            "values": {
+                "en": "Tuesday, January 21, 2020 at 08:25:07 GMT+05:00"
+            }
         }
     },
     {
         "description": "Full date time example with long time zone",
         "input": {
-            "locale": "en",
             "value": "2020-01-21T08:25:07.000+05:00",
             "options": {
                 "components": {
@@ -84,13 +86,14 @@
             }
         },
         "output": {
-            "value": "Tuesday, January 21, 2020 at 08:25:07 GMT+05:00"
+            "values": {
+                "en": "Tuesday, January 21, 2020 at 08:25:07 GMT+05:00"
+            }
         }
     },
     {
         "description": "Full date time example with GMT offset time zone",
         "input": {
-            "locale": "en",
             "value": "2020-01-21T08:25:07.000+05:00",
             "options": {
                 "components": {
@@ -106,7 +109,9 @@
             }
         },
         "output": {
-            "value": "Tuesday, January 21, 2020 at 08:25:07 GMT+05:00"
+            "values": {
+                "en": "Tuesday, January 21, 2020 at 08:25:07 GMT+05:00"
+            }
         }
     }
 ]

--- a/components/datetime/tests/fixtures/tests/lengths.json
+++ b/components/datetime/tests/fixtures/tests/lengths.json
@@ -1,7 +1,6 @@
 [
     {
         "input": {
-            "locale": "en",
             "value": "2020-02-20T00:12:00.000",
             "options": {
                 "length": {
@@ -11,12 +10,13 @@
             }
         },
         "output": {
-            "value": "Feb 20, 2020, 12:12:00 AM"
+            "values": {
+                "en" : "Feb 20, 2020, 12:12:00 AM"
+            }
         }
     },
     {
         "input": {
-            "locale": "en",
             "value": "2000-01-30T22:15:11.000",
             "options": {
                 "length": {
@@ -26,12 +26,13 @@
             }
         },
         "output": {
-            "value": "1/30/00, 10:15 PM"
+            "values": {
+                "en": "1/30/00, 10:15 PM"
+            }
         }
     },
     {
         "input": {
-            "locale": "en",
             "value": "2045-02-01T18:45:10.000",
             "options": {
                 "length": {
@@ -41,12 +42,13 @@
             }
         },
         "output": {
-            "value": "February 1, 2045"
+            "values": {
+                "en": "February 1, 2045"
+            }
         }
     },
     {
         "input": {
-            "locale": "en",
             "value": "2045-02-01T18:45:10.000",
             "options": {
                 "length": {
@@ -56,12 +58,14 @@
             }
         },
         "output": {
-            "value": "6:45:10 PM"
+            "values": {
+                "en": "6:45:10 PM"
+            }
         }
     },
     {
         "input": {
-            "locale": "ru",
+
             "value": "2020-03-21T08:25:07.000",
             "options": {
                 "length": {
@@ -71,7 +75,9 @@
             }
         },
         "output": {
-            "value": "21 мар. 2020 г., 08:25"
+            "values": {
+                "ru": "21 мар. 2020 г., 08:25"
+            }
         }
     }
 ]

--- a/components/datetime/tests/fixtures/tests/lengths_with_preferences.json
+++ b/components/datetime/tests/fixtures/tests/lengths_with_preferences.json
@@ -1,138 +1,146 @@
 [
-  {
-      "description": "Hour cycle preference h12",
-      "input": {
-          "locale": "en",
-          "value": "2020-02-20T00:12:00.000",
-          "options": {
-              "length": {
-                  "time": "medium",
-                  "date": "medium",
-                  "preferences": { "hourCycle": "h12" }
-              }
-          }
-      },
-      "output": {
-          "value": "Feb 20, 2020, 12:12:00 AM"
-      }
-  },
-  {
-      "description": "Hour cycle preference h24",
-      "input": {
-          "locale": "en",
-          "value": "2020-02-20T00:12:00.000",
-          "options": {
-              "length": {
-                  "time": "medium",
-                  "date": "medium",
-                  "preferences": { "hourCycle": "h24" }
-              }
-          }
-      },
-      "output": {
-          "value": "Feb 20, 2020, 24:12:00"
-      }
-  },
-  {
-      "description": "Hour cycle preference h11",
-      "input": {
-          "locale": "en",
-          "value": "2020-02-20T00:12:00.000",
-          "options": {
-              "length": {
-                  "time": "medium",
-                  "date": "medium",
-                  "preferences": { "hourCycle": "h11" }
-              }
-          }
-      },
-      "output": {
-          "value": "Feb 20, 2020, 0:12:00 AM"
-      }
-  },
-  {
-      "description": "Hour cycle preference h23",
-      "input": {
-          "locale": "en",
-          "value": "2020-02-20T00:12:00.000",
-          "options": {
-              "length": {
-                  "time": "medium",
-                  "date": "medium",
-                  "preferences": { "hourCycle": "h23" }
-              }
-          }
-      },
-      "output": {
-          "value": "Feb 20, 2020, 00:12:00"
-      }
-  },
-  {
-    "description": "Japan hour cycles use h11",
-    "input": {
-        "locale": "ja",
-        "value": "2020-02-20T00:12:00.000",
-        "options": {
-            "length": {
-                "time": "medium",
-                "date": "full",
-                "preferences": { "hourCycle": "h11" }
+    {
+        "description": "Hour cycle preference h12",
+        "input": {
+            "value": "2020-02-20T00:12:00.000",
+            "options": {
+                "length": {
+                    "time": "medium",
+                    "date": "medium",
+                    "preferences": { "hourCycle": "h12" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "en": "Feb 20, 2020, 12:12:00 AM"
             }
         }
     },
-    "output": {
-        "value": "2020年2月20日木曜日 午前0:12:00"
-    }
-  },
-  {
-    "description": "Japan hour cycles use h12",
-    "input": {
-        "locale": "ja",
-        "value": "2020-02-20T00:12:00.000",
-        "options": {
-            "length": {
-                "time": "medium",
-                "date": "full",
-                "preferences": { "hourCycle": "h12" }
+    {
+        "description": "Hour cycle preference h24",
+        "input": {
+            "value": "2020-02-20T00:12:00.000",
+            "options": {
+                "length": {
+                    "time": "medium",
+                    "date": "medium",
+                    "preferences": { "hourCycle": "h24" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "en": "Feb 20, 2020, 24:12:00"
             }
         }
     },
-    "output": {
-        "value": "2020年2月20日木曜日 午前12:12:00"
-    }
-  },
-  {
-    "description": "Japan hour cycles can use h24",
-    "input": {
-        "locale": "ja",
-        "value": "2020-02-20T00:12:00.000",
-        "options": {
-            "length": {
-                "time": "medium",
-                "date": "full",
-                "preferences": { "hourCycle": "h24" }
+    {
+        "description": "Hour cycle preference h11",
+        "input": {
+            "value": "2020-02-20T00:12:00.000",
+            "options": {
+                "length": {
+                    "time": "medium",
+                    "date": "medium",
+                    "preferences": { "hourCycle": "h11" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "en": "Feb 20, 2020, 0:12:00 AM"
             }
         }
     },
-    "output": {
-        "value": "2020年2月20日木曜日 24:12:00"
-    }
- },
- {
-    "description": "Japan hour cycles prefer h23",
-    "input": {
-        "locale": "ja",
-        "value": "2020-02-20T00:12:00.000",
-        "options": {
-            "length": {
-                "time": "medium",
-                "date": "full",
-                "preferences": { "hourCycle": "h23" }
+    {
+        "description": "Hour cycle preference h23",
+        "input": {
+            "value": "2020-02-20T00:12:00.000",
+            "options": {
+                "length": {
+                    "time": "medium",
+                    "date": "medium",
+                    "preferences": { "hourCycle": "h23" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "en": "Feb 20, 2020, 00:12:00"
             }
         }
     },
-    "output": {
-        "value": "2020年2月20日木曜日 0:12:00"
+    {
+        "description": "Japan hour cycles use h11",
+        "input": {
+            "value": "2020-02-20T00:12:00.000",
+            "options": {
+                "length": {
+                    "time": "medium",
+                    "date": "full",
+                    "preferences": { "hourCycle": "h11" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "ja": "2020年2月20日木曜日 午前0:12:00"
+            }
+        }
+    },
+    {
+        "description": "Japan hour cycles use h12",
+        "input": {
+            "value": "2020-02-20T00:12:00.000",
+            "options": {
+                "length": {
+                    "time": "medium",
+                    "date": "full",
+                    "preferences": { "hourCycle": "h12" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "ja": "2020年2月20日木曜日 午前12:12:00"
+            }
+        }
+    },
+    {
+        "description": "Japan hour cycles can use h24",
+        "input": {
+            "value": "2020-02-20T00:12:00.000",
+            "options": {
+                "length": {
+                    "time": "medium",
+                    "date": "full",
+                    "preferences": { "hourCycle": "h24" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "ja": "2020年2月20日木曜日 24:12:00"
+            }
+        }
+    },
+    {
+        "description": "Japan hour cycles prefer h23",
+        "input": {
+            "value": "2020-02-20T00:12:00.000",
+            "options": {
+                "length": {
+                    "time": "medium",
+                    "date": "full",
+                    "preferences": { "hourCycle": "h23" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "ja": "2020年2月20日木曜日 0:12:00"
+            }
+        }
     }
-  }
 ]

--- a/components/datetime/tests/fixtures/tests/lengths_with_zones.json
+++ b/components/datetime/tests/fixtures/tests/lengths_with_zones.json
@@ -1,7 +1,6 @@
 [
     {
         "input": {
-            "locale": "en",
             "value": "2020-01-21T08:25:07.000+05:30",
             "options": {
                 "length": {
@@ -11,12 +10,13 @@
             }
         },
         "output": {
-            "value": "Tuesday, January 21, 2020 at 8:25:07 AM GMT+05:30"
+            "values": {
+                "en": "Tuesday, January 21, 2020 at 8:25:07 AM GMT+05:30"
+            }
         }
     },
     {
         "input": {
-            "locale": "en",
             "value": "2020-09-10T13:34:59.000-08:15",
             "options": {
                 "length": {
@@ -26,12 +26,13 @@
             }
         },
         "output": {
-            "value": "September 10, 2020 at 1:34:59 PM GMT-08:15"
+            "values": {
+                "en": "September 10, 2020 at 1:34:59 PM GMT-08:15"
+            }
         }
     },
     {
         "input": {
-            "locale": "en",
             "value": "2020-02-20T00:12:00.000+05:00",
             "options": {
                 "length": {
@@ -41,12 +42,13 @@
             }
         },
         "output": {
-            "value": "Feb 20, 2020, 12:12:00 AM"
+            "values": {
+                "en": "Feb 20, 2020, 12:12:00 AM"
+            }
         }
     },
     {
         "input": {
-            "locale": "en",
             "value": "2000-01-30T22:15:11.000-10:05",
             "options": {
                 "length": {
@@ -56,12 +58,13 @@
             }
         },
         "output": {
-            "value": "1/30/00, 10:15 PM"
+            "values": {
+                "en": "1/30/00, 10:15 PM"
+            }
         }
     },
     {
         "input": {
-            "locale": "en",
             "value": "2045-02-01T18:45:10.000+11:00",
             "options": {
                 "length": {
@@ -71,12 +74,13 @@
             }
         },
         "output": {
-            "value": "February 1, 2045"
+            "values": {
+                "en": "February 1, 2045"
+            }
         }
     },
     {
         "input": {
-            "locale": "en",
             "value": "2045-02-01T18:45:10.000+08:08",
             "options": {
                 "length": {
@@ -86,12 +90,13 @@
             }
         },
         "output": {
-            "value": "6:45:10 PM GMT+08:08"
+            "values": {
+                "en": "6:45:10 PM GMT+08:08"
+            }
         }
     },
     {
         "input": {
-            "locale": "ru",
             "value": "2020-03-21T08:25:07.000Z",
             "options": {
                 "length": {
@@ -101,7 +106,9 @@
             }
         },
         "output": {
-            "value": "суббота, 21 марта 2020 г., 08:25:07 GMT"
+            "values": {
+                "ru": "суббота, 21 марта 2020 г., 08:25:07 GMT"
+            }
         }
     }
 ]

--- a/components/datetime/tests/fixtures/tests/lengths_with_zones_from_pdt.json
+++ b/components/datetime/tests/fixtures/tests/lengths_with_zones_from_pdt.json
@@ -1,7 +1,6 @@
 [
     {
         "input": {
-            "locale": "en",
             "value": "2020-01-21T08:25:07.000-07:00",
             "options": {
                 "length": {
@@ -11,12 +10,13 @@
             }
         },
         "output": {
-            "value": "Tuesday, January 21, 2020 at 8:25:07 AM Pacific Daylight Time"
+            "values": {
+                "en": "Tuesday, January 21, 2020 at 8:25:07 AM Pacific Daylight Time"
+            }
         }
     },
     {
         "input": {
-            "locale": "ru",
             "value": "2020-09-10T13:34:59.000-07:00",
             "options": {
                 "length": {
@@ -26,12 +26,13 @@
             }
         },
         "output": {
-            "value": "10 сентября 2020 г., 13:34:59 Тихоокеанское летнее время"
+            "values": {
+                "ru": "10 сентября 2020 г., 13:34:59 Тихоокеанское летнее время"
+            }
         }
     },
     {
         "input": {
-            "locale": "fr",
             "value": "2020-02-20T00:12:00.000-07:00",
             "options": {
                 "length": {
@@ -41,12 +42,13 @@
             }
         },
         "output": {
-            "value": "20 févr. 2020, 00:12:00 heure d’été du Pacifique"
+            "values": {
+                "fr": "20 févr. 2020, 00:12:00 heure d’été du Pacifique"
+            }
         }
     },
     {
         "input": {
-            "locale": "es",
             "value": "2000-01-30T22:15:11.000-07:00",
             "options": {
                 "length": {
@@ -56,12 +58,13 @@
             }
         },
         "output": {
-            "value": "30/1/00 22:15:11 (hora de verano del Pacífico)"
+            "values": {
+                "es": "30/1/00 22:15:11 (hora de verano del Pacífico)"
+            }
         }
     },
     {
         "input": {
-            "locale": "sr",
             "value": "2045-02-01T18:45:10.000-07:00",
             "options": {
                 "length": {
@@ -71,12 +74,13 @@
             }
         },
         "output": {
-            "value": "01. фебруар 2045. 18:45:10 Северноамеричко пацифичко летње време"
+            "values": {
+                "sr": "01. фебруар 2045. 18:45:10 Северноамеричко пацифичко летње време"
+            }
         }
     },
     {
         "input": {
-            "locale": "ar",
             "value": "2045-02-01T18:45:10.000-07:00",
             "options": {
                 "length": {
@@ -86,12 +90,13 @@
             }
         },
         "output": {
-            "value": "6:45:10 م توقيت المحيط الهادي الصيفي"
+            "values": {
+                "ar": "6:45:10 م توقيت المحيط الهادي الصيفي"
+            }
         }
     },
     {
         "input": {
-            "locale": "ja",
             "value": "2020-03-21T08:25:07.000-07:00",
             "options": {
                 "length": {
@@ -101,7 +106,9 @@
             }
         },
         "output": {
-            "value": "2020年3月21日土曜日 8時25分07秒 アメリカ太平洋夏時間"
+            "values": {
+                "ja": "2020年3月21日土曜日 8時25分07秒 アメリカ太平洋夏時間"
+            }
         }
     }
 ]


### PR DESCRIPTION
This PR fixes https://github.com/unicode-org/icu4x/issues/1032

It removes `locale` from `TestInput` and creates a map in `TestOutput`. The map's key is `locale` and value is the expected result.

Also, this PR updates JSON fixtures and test lib.