### PR TITLE
Document ZeroVec's variants

### DIFF
--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -61,7 +61,7 @@ where
     T: AsULE + ?Sized,
 {
     /// An owned `ZeroVec<T>`. This will typically be constructed by [`ZeroVec::clone_from_slice()`]
-    /// or by calling [`ZeroVec::to_mut()`]/[`ZeroVec::for_each_mut()`]/etc on a `Borrowed` `ZeroVec`.
+    /// or by calling [`ZeroVec::to_mut()`]/[`ZeroVec::for_each_mut()`]/etc on [`ZeroVec::Borrowed`].
     Owned(Vec<T::ULE>),
 
     /// A borrowed `ZeroVec<T>`. This will typically be constructed by [`ZeroVec::parse_byte_slice()`],


### PR DESCRIPTION
Needed by Zibi for PR ULE.

<s>
It's possible to do this directly so this function isn't strictly necessary, but it's good to have as a convenience.

I'm not paying too much attention to the naming, i'd like us to come up with a holistic naming story in https://github.com/unicode-org/icu4x/issues/1181, and just land this separately so Zibi can use it.
</s>

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->