### PR TITLE
Likely subtags should minimize es-ES-preeuro to es-preeuro

### DIFF
--- a/components/locale_canonicalizer/tests/fixtures/minimize.json
+++ b/components/locale_canonicalizer/tests/fixtures/minimize.json
@@ -16,6 +16,10 @@
     "output": "en"
   },
   {
+    "input": "es-ES-preeuro",
+    "output": "es-preeuro"
+  },
+  {
     "input": "zh-Hant-TW-u-hc-h24-nu-chinese",
     "output": "zh-TW-u-hc-h24-nu-chinese"
   }


### PR DESCRIPTION
Fix https://github.com/unicode-org/icu4x/issues/823

https://github.com/unicode-org/icu4x/pull/1170 should be able to fix the issue and this PR passed all test cases.