### PR TITLE
Bump ZeroVec to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bincode",
  "criterion",

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -39,7 +39,7 @@ icu_calendar = { version = "0.3", path = "../calendar" }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 litemap = { version = "0.2", path = "../../utils/litemap" }
 tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
-zerovec = { version = "0.3", path = "../../utils/zerovec", features = ["yoke"] }
+zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["yoke"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 serde-tuple-vec-map = { version = "1.0", optional = true }
 smallvec = "1.6"

--- a/components/properties/Cargo.toml
+++ b/components/properties/Cargo.toml
@@ -36,7 +36,7 @@ icu_provider = { version = "0.3", path = "../../provider/core", features = ["mac
 icu_uniset = { version = "0.3", path = "../../utils/uniset", features = ["serde"] }
 num_enum = { version = "0.5.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
-zerovec = { version = "0.3", path = "../../utils/zerovec", features = ["serde"] }
+zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["serde"] }
 
 [dev-dependencies]
 icu = { path = "../../components/icu", default-features = false }

--- a/utils/codepointtrie/Cargo.toml
+++ b/utils/codepointtrie/Cargo.toml
@@ -35,13 +35,13 @@ all-features = true
 icu_provider = { version = "0.3", path = "../../provider/core", features = ["macros"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 thiserror = "1.0"
-zerovec = { version = "0.3", path = "../../utils/zerovec", features = ["serde", "yoke"] }
+zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["serde", "yoke"] }
 
 [dev-dependencies]
 postcard = { version = "0.7", features = ["alloc"] }
 toml = "0.5"
 serde = { version = "1.0", features = ["derive"] }
-zerovec = { version = "0.3", path = "../../utils/zerovec", features = ["serde"] }
+zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["serde"] }
 
 [lib]
 bench = false  # This option is required for Benchmark CI

--- a/utils/uniset/Cargo.toml
+++ b/utils/uniset/Cargo.toml
@@ -37,7 +37,7 @@ litemap = { version = "0.2", path = "../../utils/litemap" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
-zerovec = { version = "0.3", path = "../../utils/zerovec", features = ["serde"] }
+zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["serde"] }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/utils/yoke/derive/Cargo.toml
+++ b/utils/yoke/derive/Cargo.toml
@@ -27,4 +27,4 @@ synstructure = "0.12.4"
 
 [dev-dependencies]
 yoke = { path = "..", version = "0.2.0" , features = ["derive"]}
-zerovec = { path = "../../zerovec", version = "0.3", features = ["yoke"] }
+zerovec = { version = "0.4", path = "../../zerovec", features = ["yoke"] }

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "zerovec"
 description = "Zero-copy vector backed by a byte array"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"


### PR DESCRIPTION
We have a lot of new APIs, and we should cut a release so that they can be depended on by crates like tinystr.


https://github.com/unicode-org/icu4x/issues/1082 is not finished, but this should be the extent of the major breaking changes for a while.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->