### PR TITLE
Make Bincode makefile commands equal to JSON and Blob ones

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -48,7 +48,7 @@ dependencies = [
     "test-all-features",
     "test-docs-default",
     "test-docs",
-    "bincode-gen-testdata",
+    "testdata-build-bincode",
     "testdata-check",
 ]
 

--- a/tools/scripts/data.toml
+++ b/tools/scripts/data.toml
@@ -96,17 +96,8 @@ if greater_than ${output_length} 0
 end
 '''
 
-[tasks.bincode-clean]
-description = "Clean out the bincode data."
-category = "ICU4X Data"
-script_runner = "@duckscript"
-script = '''
-# Use duckscript, rather than a unix command, so that this works on Windows.
-rm -r ./provider/testdata/data/bincode
-'''
-
-[tasks.bincode-gen-testdata-no-clean]
-description = "Generate bincode testdata without removing the old data"
+[tasks.testdata-build-bincode]
+description = "Build ICU4X Bincode filesystem structure from the downloaded CLDR JSON, overwriting the existing ICU4X Bincode if present."
 category = "ICU4X Data"
 command = "cargo"
 args = [
@@ -119,13 +110,5 @@ args = [
     "--all-keys",
     "--test-locales",
     "--syntax=bincode",
-]
-
-[tasks.bincode-gen-testdata]
-description = "Generate bincode for the testdata"
-category = "ICU4X Data"
-run_task = [
-    # Running "bincode-clean" first ensures that this command won't fail because the data
-    # already exists at that location.
-    { name = ["bincode-clean", "bincode-gen-testdata-no-clean"] },
+    "--overwrite",
 ]


### PR DESCRIPTION
Closes #524
Closes #869

I decided to keep the bincode plumbing, because it is our token non-JSON encoding for the filesystem layout.  I decided we don't need to put Postcard there since we already have Bincode.  We also have some unit tests that specifically use Bincode, which would be tedious and unnecessary to migrate to Postcard.  (Most ICU4X behavior tests are already on Postcard.)

Instead, I'm just sending a small change to unify the naming scheme between JSON and Bincode Makefile.toml.