### PR TITLE
Add double-to-decimal for FixedDecimal via ryū

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,7 @@ dependencies = [
  "rand",
  "rand_distr",
  "rand_pcg",
+ "ryu",
  "smallvec",
  "static_assertions",
  "writeable",

--- a/ffi/diplomat/cpp/examples/fixeddecimal/test.cpp
+++ b/ffi/diplomat/cpp/examples/fixeddecimal/test.cpp
@@ -39,5 +39,19 @@ int main() {
         std::cout << "Output does not match expected output" << std::endl;
         return 1;
     }
+
+    auto result = ICU4XFixedDecimal::create_from_f32(1234.5678);
+    if (!result.success) {
+        std::cout << "Constructing ICU4XFixedDecimal from float failed" << std::endl;
+        return 1;
+    }
+    // std::move necessary since ICU4XFixedDecimal doesn't have copy constructors
+    ICU4XFixedDecimal decimal2 = std::move(result.fd.value());
+    out = fdf.format(decimal2).ok().value();
+    std::cout << "Formatted value is " << out << std::endl;
+    if (out != "১,২৩৪.৫৬৭৭") {
+        std::cout << "Output does not match expected output" << std::endl;
+        return 1;
+    }
     return 0;
 }

--- a/ffi/diplomat/cpp/examples/fixeddecimal/test.cpp
+++ b/ffi/diplomat/cpp/examples/fixeddecimal/test.cpp
@@ -39,19 +39,5 @@ int main() {
         std::cout << "Output does not match expected output" << std::endl;
         return 1;
     }
-
-    auto result = ICU4XFixedDecimal::create_from_f32(1234.5678);
-    if (!result.success) {
-        std::cout << "Constructing ICU4XFixedDecimal from float failed" << std::endl;
-        return 1;
-    }
-    // std::move necessary since ICU4XFixedDecimal doesn't have copy constructors
-    ICU4XFixedDecimal decimal2 = std::move(result.fd.value());
-    out = fdf.format(decimal2).ok().value();
-    std::cout << "Formatted value is " << out << std::endl;
-    if (out != "১,২৩৪.৫৬৭৭") {
-        std::cout << "Output does not match expected output" << std::endl;
-        return 1;
-    }
     return 0;
 }

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -31,6 +31,7 @@ smallvec = "1.6"
 static_assertions = "1.1"
 writeable = { version = "0.2.1", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
+ryu = { version = "1.0.5", optional = true, features = ["small"] }
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -768,7 +768,7 @@ impl FixedDecimal {
         let mut decimal = Self::new_from_f64_raw(float)?;
         match precision {
             DoublePrecision::Maximum => {
-                // ryu will usually tack on a `.0` to integers which gets included when parsing
+                // ryū will usually tack on a `.0` to integers which gets included when parsing
                 // the other precision modes will handle this anyway, so we handle it explicitly
                 // here
                 let n_digits = decimal.digits.len() as i16;
@@ -785,6 +785,8 @@ impl FixedDecimal {
                 if lowest_magnitude < 0 {
                     return Err(Error::Limit);
                 }
+                // ryū sometimes tacks on a `.0` to integer values which gets parsed
+                // as a lower precision
                 if decimal.lower_magnitude < 0 {
                     decimal.lower_magnitude = 0;
                 }
@@ -920,9 +922,10 @@ impl FixedDecimal {
 
             self.digits.clear();
             self.digits.push(1);
+            debug_assert!(self.upper_magnitude >= 0);
             self.magnitude += 1;
-            if self.magnitude != 0 && self.upper_magnitude <= self.magnitude {
-                self.upper_magnitude += 1;
+            if self.upper_magnitude < self.magnitude {
+                self.upper_magnitude = self.magnitude;
             }
         }
         Ok(())

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -886,7 +886,6 @@ impl FixedDecimal {
             dec.digits.truncate(first_nonzero + 1);
             if dec.digits.is_empty() {
                 dec.magnitude = 0;
-                dec.upper_magnitude = 0;
             }
         }
 
@@ -954,8 +953,9 @@ impl FixedDecimal {
             if self.upper_magnitude < self.magnitude {
                 self.upper_magnitude = self.magnitude;
             }
+        } else {
+            fixup_invariants(self);
         }
-        fixup_invariants(self);
         #[cfg(debug_assertions)]
         self.check_invariants();
         Ok(())

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -697,6 +697,32 @@ impl FromStr for FixedDecimal {
     }
 }
 
+/// Specifies the precision of a floating point value when constructing a FixedDecimal.
+///
+/// IEEE 754 is a representation of a point on the number line. On the other hand, FixedDecimal
+/// specifies not only the point on the number line but also the precision of the number to a
+/// specific power of 10. This enum augments a floating-point value with the additional
+/// information required by FixedDecimal.
+pub enum DoublePrecision {
+    // /// Specify that the floating point number is integer-valued.
+    // ///
+    // /// If the floating point is not actually integer-valued, an error will be returned.
+    // Integer,
+
+    // /// Specify that the floating point number is precise to a specific power of 10.
+    // /// The number may be rounded or trailing zeros may be added as necessary.
+    // Magnitude(i16),
+
+    // /// Specify that the floating point number is precise to a specific number of significant digits.
+    // /// The number may be rounded or trailing zeros may be added as necessary.
+    // SignificantDigits(u8),
+    /// Specify that the floating point number is precise to the maximum representable by IEEE.
+    ///
+    /// This results in a FixedDecimal having enough digits to recover the original floating point
+    /// value, with no trailing zeros.
+    Maximum,
+}
+
 #[cfg(feature = "ryu")]
 impl FixedDecimal {
     /// Construct a [`FixedDecimal`] from an f64. This uses `ryu` and
@@ -719,14 +745,18 @@ impl FixedDecimal {
     /// let decimal = FixedDecimal::new_from_f64(12345678000.).unwrap();
     /// assert_eq!(decimal.writeable_to_string(), "12345678000.0");
     /// ```
-    pub fn new_from_f64(float: f64) -> Result<Self, Error> {
+    pub fn new_from_f64(float: f64, precision: DoublePrecision) -> Result<Self, Error> {
         if !float.is_finite() {
             return Err(Error::Limit);
         }
         // note: this does not heap allocate
         let mut buf = ryu::Buffer::new();
         let formatted = buf.format_finite(float);
-        Self::from_str(formatted)
+        let mut decimal = Self::from_str(formatted);
+        match precision {
+            DoublePrecision::Maximum => (),
+        }
+        decimal
     }
 
     /// Internal function to round off `n` digits

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -769,9 +769,8 @@ impl FixedDecimal {
         let n_digits = decimal.digits.len();
         // magnitude of the lowest digit in self.digits
         let lowest_magnitude = decimal.magnitude - n_digits as i16 + 1;
-        // ryū will usually tack on a `.0` to integers which gets included when parsing
-        // the other precision modes will handle this anyway, so we handle it explicitly
-        // here
+        // ryū will usually tack on a `.0` to integers which gets included when parsing.
+        // Explicitly remove it before doing anything else
         if lowest_magnitude >= 0 && decimal.lower_magnitude < 0 {
             decimal.lower_magnitude = 0;
         }

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -862,12 +862,8 @@ impl FixedDecimal {
 
         match mode {
             RoundingMode::Unnecessary => {
-                for digit in &self.digits[cutoff..] {
-                    if *digit != 0 {
-                        return Err(Error::Limit);
-                    }
-                }
-                return Ok(());
+                // If we got to this point then rounding was not unnecessary
+                return Err(Error::Limit)
             }
             RoundingMode::Truncate => {
                 self.digits.truncate(cutoff);

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -729,14 +729,15 @@ pub enum DoublePrecision {
 /// Specifies how numbers should be rounded
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum RoundingMode {
-    /// Specify that the number should not need to be rounded, or else return an error.
+    /// Return an error if the number has trailing nonzero digits that need to be rounded.
     Unnecessary,
 
-    /// Specify that the number should be truncated.
+    /// Round toward zero (remove, or truncate, all trailing digits).
     Truncate,
 
-    /// Round up from zero after 0.5
+    /// Round ties away from zero.
     HalfExpand,
+
     // TODO(#1177): Add more rounding modes.
 }
 

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -697,6 +697,71 @@ impl FromStr for FixedDecimal {
     }
 }
 
+#[cfg(feature = "ryu")]
+impl FixedDecimal {
+    /// Construct a [`FixedDecimal`] from an f32. This uses `ryu` and
+    /// goes through an intermediate string representation, so is not
+    /// fully efficient. See https://github.com/unicode-org/icu4x/issues/166 for
+    /// more details.
+    ///
+    /// This function can be made available with the `"ryu"` feature.
+    ///
+    /// ```rust
+    /// use fixed_decimal::FixedDecimal;
+    /// use writeable::Writeable;
+    ///
+    /// let decimal = FixedDecimal::new_from_f32(0.012345678).unwrap();
+    /// assert_eq!(decimal.writeable_to_string(), "0.012345678");
+    ///
+    /// let decimal = FixedDecimal::new_from_f32(-123456.78).unwrap();
+    /// assert_eq!(decimal.writeable_to_string(), "-123456.78");
+    ///
+    /// let decimal = FixedDecimal::new_from_f32(12345678000.).unwrap();
+    /// assert_eq!(decimal.writeable_to_string(), "12345678000.0");
+    /// ```
+    pub fn new_from_f32(float: f32) -> Result<Self, Error> {
+        if !float.is_finite() {
+            return Err(Error::Limit)
+        }
+        // note: this does not heap allocate
+        let mut buf = ryu::Buffer::new();
+        let formatted = buf.format_finite(float);
+        Self::from_str(formatted)
+
+    }
+
+    /// Construct a [`FixedDecimal`] from an f64. This uses `ryu` and
+    /// goes through an intermediate string representation, so is not
+    /// fully efficient. See https://github.com/unicode-org/icu4x/issues/166 for
+    /// more details.
+    ///
+    /// This function can be made available with the `"ryu"` feature.
+    ///
+    /// ```rust
+    /// use fixed_decimal::FixedDecimal;
+    /// use writeable::Writeable;
+    ///
+    /// let decimal = FixedDecimal::new_from_f64(0.012345678).unwrap();
+    /// assert_eq!(decimal.writeable_to_string(), "0.012345678");
+    ///
+    /// let decimal = FixedDecimal::new_from_f64(-123456.78).unwrap();
+    /// assert_eq!(decimal.writeable_to_string(), "-123456.78");
+    ///
+    /// let decimal = FixedDecimal::new_from_f64(12345678000.).unwrap();
+    /// assert_eq!(decimal.writeable_to_string(), "12345678000.0");
+    /// ```
+    pub fn new_from_f64(float: f64) -> Result<Self, Error> {
+        if !float.is_finite() {
+            return Err(Error::Limit)
+        }
+        // note: this does not heap allocate
+        let mut buf = ryu::Buffer::new();
+        let formatted = buf.format_finite(float);
+        Self::from_str(formatted)
+
+    }
+}
+
 #[test]
 fn test_basic() {
     #[derive(Debug)]

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -734,21 +734,20 @@ impl FixedDecimal {
     /// This function can be made available with the `"ryu"` feature.
     ///
     /// ```rust
-    /// use fixed_decimal::FixedDecimal;
+    /// use fixed_decimal::{DoublePrecision, FixedDecimal};
     /// use writeable::Writeable;
     ///
-    /// let decimal = FixedDecimal::new_from_f64(0.012345678).unwrap();
+    /// let decimal = FixedDecimal::new_from_f64(0.012345678, DoublePrecision::Maximum).unwrap();
     /// assert_eq!(decimal.writeable_to_string(), "0.012345678");
     ///
-    /// let decimal = FixedDecimal::new_from_f64(-123456.78).unwrap();
+    /// let decimal = FixedDecimal::new_from_f64(-123456.78, DoublePrecision::Maximum).unwrap();
     /// assert_eq!(decimal.writeable_to_string(), "-123456.78");
     ///
-    /// let decimal = FixedDecimal::new_from_f64(12345678000.).unwrap();
+    /// let decimal = FixedDecimal::new_from_f64(12345678000., DoublePrecision::Maximum).unwrap();
     /// assert_eq!(decimal.writeable_to_string(), "12345678000.0");
     /// ```
     pub fn new_from_f64(float: f64, precision: DoublePrecision) -> Result<Self, Error> {
         extern crate std;
-        use writeable::Writeable;
         let mut decimal = Self::new_from_f64_raw(float)?;
         match precision {
             DoublePrecision::Maximum => (),

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -706,10 +706,11 @@ impl FromStr for FixedDecimal {
 #[cfg(feature = "ryu")]
 #[derive(Debug, Clone, Copy)]
 pub enum DoublePrecision {
-    // /// Specify that the floating point number is integer-valued.
-    // ///
-    // /// If the floating point is not actually integer-valued, an error will be returned.
+    /// Specify that the floating point number is integer-valued.
+    ///
+    /// If the floating point is not actually integer-valued, an error will be returned.
     Integer,
+    
     /// Specify that the floating point number is precise to a specific power of 10.
     /// The number may be rounded or trailing zeros may be added as necessary.
     Magnitude(i16, RoundingMode),
@@ -719,6 +720,7 @@ pub enum DoublePrecision {
     ///
     /// The number requested may not be zero
     SignificantDigits(u8, RoundingMode),
+    
     /// Specify that the floating point number is precise to the maximum representable by IEEE.
     ///
     /// This results in a FixedDecimal having enough digits to recover the original floating point

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -803,7 +803,7 @@ impl FixedDecimal {
         let cutoff = self.digits.len() - n as usize;
 
         // Do we need to round our significant digits?
-        let round = if self.digits[cutoff] >= 5;
+        let round = self.digits[cutoff] >= 5;
 
         self.digits.truncate(cutoff);
 

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -710,7 +710,7 @@ pub enum DoublePrecision {
     ///
     /// If the floating point is not actually integer-valued, an error will be returned.
     Integer,
-    
+
     /// Specify that the floating point number is precise to a specific power of 10.
     /// The number may be rounded or trailing zeros may be added as necessary.
     Magnitude(i16, RoundingMode),
@@ -720,7 +720,7 @@ pub enum DoublePrecision {
     ///
     /// The number requested may not be zero
     SignificantDigits(u8, RoundingMode),
-    
+
     /// Specify that the floating point number is precise to the maximum representable by IEEE.
     ///
     /// This results in a FixedDecimal having enough digits to recover the original floating point

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -814,7 +814,7 @@ impl FixedDecimal {
                     decimal.round_trailing_digits(round_by, mode)?;
                     // It may have rounded up by one
                     debug_assert!(
-                        decimal.digits.len() == sig as usize || decimal.digits.len() == 1
+                        decimal.digits.len() <= sig as usize
                     );
                 }
                 let target_lowest_magnitude = decimal.magnitude - sig as i16 + 1;
@@ -890,13 +890,16 @@ impl FixedDecimal {
         self.digits.truncate(cutoff);
 
         if round {
+            // how much to truncate by after rounding
+            let mut round_truncate = cutoff;
             for digit in self.digits[..cutoff].iter_mut().rev() {
                 if *digit == 9 {
-                    // We need to round the next digit
-                    *digit = 0;
+                    // Truncate this digit, the next digit can be rounded
+                    round_truncate -= 1;
                 } else {
                     // We need to update this digit, then we're done
                     *digit += 1;
+                    self.digits.truncate(round_truncate);
                     return Ok(());
                 }
             }

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -884,7 +884,7 @@ impl FixedDecimal {
         fn fixup_invariants(dec: &mut FixedDecimal) {
             let first_nonzero = dec.digits.iter().rposition(|d| *d != 0).unwrap_or(0);
             dec.digits.truncate(first_nonzero + 1);
-            if dec.digits.len() == 0 {
+            if dec.digits.is_empty() {
                 dec.magnitude = 0;
                 dec.upper_magnitude = 0;
             }

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -815,7 +815,7 @@ impl FixedDecimal {
                     let round_by = (n_digits - sig) as u16;
                     decimal.round_trailing_digits(round_by, mode)?;
                     // It may have rounded up by one
-                    debug_assert!(decimal.digits.len() >= sig as usize);
+                    debug_assert!(decimal.digits.len() == sig as usize || decimal.digits.len() == 1);
                 }
                 let target_lowest_magnitude = decimal.magnitude - sig as i16 + 1;
                 if target_lowest_magnitude <= 0 {
@@ -904,7 +904,8 @@ impl FixedDecimal {
             // If we reached this point then the last digit was 9 and we need to insert
             // another digit at the beginning
 
-            self.digits.insert(0, 1u8);
+            self.digits.clear();
+            self.digits.push(1);
             self.magnitude += 1;
             if self.magnitude != 0 && self.upper_magnitude <= self.magnitude {
                 self.upper_magnitude += 1;

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -721,13 +721,12 @@ impl FixedDecimal {
     /// ```
     pub fn new_from_f32(float: f32) -> Result<Self, Error> {
         if !float.is_finite() {
-            return Err(Error::Limit)
+            return Err(Error::Limit);
         }
         // note: this does not heap allocate
         let mut buf = ryu::Buffer::new();
         let formatted = buf.format_finite(float);
         Self::from_str(formatted)
-
     }
 
     /// Construct a [`FixedDecimal`] from an f64. This uses `ryu` and
@@ -752,13 +751,12 @@ impl FixedDecimal {
     /// ```
     pub fn new_from_f64(float: f64) -> Result<Self, Error> {
         if !float.is_finite() {
-            return Err(Error::Limit)
+            return Err(Error::Limit);
         }
         // note: this does not heap allocate
         let mut buf = ryu::Buffer::new();
         let formatted = buf.format_finite(float);
         Self::from_str(formatted)
-
     }
 }
 

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -737,7 +737,6 @@ pub enum RoundingMode {
 
     /// Round ties away from zero.
     HalfExpand,
-
     // TODO(#1177): Add more rounding modes.
 }
 
@@ -815,7 +814,9 @@ impl FixedDecimal {
                     let round_by = (n_digits - sig) as u16;
                     decimal.round_trailing_digits(round_by, mode)?;
                     // It may have rounded up by one
-                    debug_assert!(decimal.digits.len() == sig as usize || decimal.digits.len() == 1);
+                    debug_assert!(
+                        decimal.digits.len() == sig as usize || decimal.digits.len() == 1
+                    );
                 }
                 let target_lowest_magnitude = decimal.magnitude - sig as i16 + 1;
                 if target_lowest_magnitude <= 0 {
@@ -873,7 +874,7 @@ impl FixedDecimal {
         match mode {
             RoundingMode::Unnecessary => {
                 // If we got to this point then rounding was not unnecessary
-                return Err(Error::Limit)
+                return Err(Error::Limit);
             }
             RoundingMode::Truncate => {
                 self.digits.truncate(cutoff);

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -756,7 +756,7 @@ impl FixedDecimal {
                 let lowest_magnitude = decimal.magnitude - n_digits + 1;
 
                 if mag > lowest_magnitude {
-                    let mut round_by = (mag - lowest_magnitude) as i16;
+                    let round_by = (mag - lowest_magnitude) as i16;
 
                     if round_by <= n_digits {
                         decimal.round_digits(round_by as u16);
@@ -948,6 +948,21 @@ fn test_float() {
             input: 0.009,
             precision: DoublePrecision::Magnitude(0),
             expected: "0",
+        },
+        TestCase {
+            input: 0.0000009,
+            precision: DoublePrecision::Magnitude(0),
+            expected: "0",
+        },
+        TestCase {
+            input: 0.0000009,
+            precision: DoublePrecision::Magnitude(-7),
+            expected: "0.0000009",
+        },
+        TestCase {
+            input: 0.0000009,
+            precision: DoublePrecision::Magnitude(-6),
+            expected: "0.000001",
         },
     ];
 

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -709,7 +709,7 @@ pub enum DoublePrecision {
     // /// Specify that the floating point number is integer-valued.
     // ///
     // /// If the floating point is not actually integer-valued, an error will be returned.
-    // Integer,
+    Integer,
     /// Specify that the floating point number is precise to a specific power of 10.
     /// The number may be rounded or trailing zeros may be added as necessary.
     Magnitude(i16, RoundingMode),
@@ -767,6 +767,16 @@ impl FixedDecimal {
         let mut decimal = Self::new_from_f64_raw(float)?;
         match precision {
             DoublePrecision::Maximum => (),
+            DoublePrecision::Integer => {
+                let n_digits = decimal.digits.len() as i16;
+                let lowest_magnitude = decimal.magnitude - n_digits + 1;
+                if lowest_magnitude < 0 {
+                    return Err(Error::Limit);
+                }
+                if decimal.lower_magnitude < 0 {
+                    decimal.lower_magnitude = 0;
+                }
+            }
             DoublePrecision::Magnitude(mag, mode) => {
                 let n_digits = decimal.digits.len() as i16;
                 // magnitude of the lowest digit in self.digits
@@ -1130,6 +1140,11 @@ fn test_float() {
             input: 9.9888,
             precision: DoublePrecision::SignificantDigits(3, RoundingMode::Truncate),
             expected: "9.98",
+        },
+        TestCase {
+            input: 888999.,
+            precision: DoublePrecision::Integer,
+            expected: "888999",
         },
     ];
 

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -878,6 +878,7 @@ impl FixedDecimal {
         }
 
         // Do we need to round our significant digits?
+        // TODO(#1177): This heuristic is insufficient for most rounding modes.
         let round = self.digits[cutoff] >= 5;
 
         self.digits.truncate(cutoff);

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -761,7 +761,7 @@ impl FixedDecimal {
                     let round_by = (mag - lowest_magnitude) as i16;
 
                     if round_by <= n_digits {
-                        decimal.round_digits(round_by as u16);
+                        decimal.round_trailing_digits(round_by as u16);
                     } else {
                         // If we need to round by more digits than rounding can ever produce
                         // the number is zero
@@ -788,7 +788,7 @@ impl FixedDecimal {
 
                 if sig < n_digits {
                     let round_by = (n_digits - sig) as i16;
-                    decimal.round_digits(round_by as u16);
+                    decimal.round_trailing_digits(round_by as u16);
                     // It may have rounded up by one
                     debug_assert!(decimal.digits.len() >= sig as usize);
                 }
@@ -831,7 +831,7 @@ impl FixedDecimal {
     /// This function is responsible for fixing `digits`, `magnitude`, and `upper_magnitude`.
     /// It will only modify upper_magnitude when it is not large enough to fit the rounded number.
     /// The caller may fix up `lower_magnitude` by whatever scheme it desires
-    fn round_digits(&mut self, n: u16) {
+    fn round_trailing_digits(&mut self, n: u16) {
         debug_assert!(
             self.digits.len() >= n as usize,
             "Attempted to round off {} digits of number that has only {}",
@@ -922,7 +922,7 @@ fn test_round() {
 
     for case in &cases {
         let mut dec = FixedDecimal::new_from_f64_raw(case.input).unwrap();
-        dec.round_digits(case.round);
+        dec.round_trailing_digits(case.round);
         writeable::assert_writeable_eq!(case.expected, dec, "{:?}", case);
     }
 }

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -773,10 +773,10 @@ impl FixedDecimal {
                 let lowest_magnitude = decimal.magnitude - n_digits + 1;
 
                 if mag > lowest_magnitude {
-                    let round_by = (mag - lowest_magnitude) as i16;
+                    let round_by = (mag - lowest_magnitude) as u16;
 
-                    if round_by <= n_digits {
-                        decimal.round_trailing_digits(round_by as u16, mode)?;
+                    if round_by as i16 <= n_digits {
+                        decimal.round_trailing_digits(round_by, mode)?;
                     } else {
                         // If we need to round by more digits than rounding can ever produce
                         // the number is zero
@@ -802,8 +802,8 @@ impl FixedDecimal {
                 let n_digits = decimal.digits.len() as i16;
 
                 if sig < n_digits {
-                    let round_by = (n_digits - sig) as i16;
-                    decimal.round_trailing_digits(round_by as u16, mode)?;
+                    let round_by = (n_digits - sig) as u16;
+                    decimal.round_trailing_digits(round_by, mode)?;
                     // It may have rounded up by one
                     debug_assert!(decimal.digits.len() >= sig as usize);
                 }

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -782,8 +782,6 @@ impl FixedDecimal {
         // note: this does not heap allocate
         let mut buf = ryu::Buffer::new();
         let formatted = buf.format_finite(float);
-        extern crate std;
-        std::println!("{}", formatted);
         Self::from_str(formatted)
     }
 
@@ -805,7 +803,7 @@ impl FixedDecimal {
         let cutoff = self.digits.len() - n as usize;
 
         // Do we need to round our significant digits?
-        let round = if self.digits[cutoff] < 5 { false } else { true };
+        let round = if self.digits[cutoff] >= 5;
 
         self.digits.truncate(cutoff);
 

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -699,36 +699,6 @@ impl FromStr for FixedDecimal {
 
 #[cfg(feature = "ryu")]
 impl FixedDecimal {
-    /// Construct a [`FixedDecimal`] from an f32. This uses `ryu` and
-    /// goes through an intermediate string representation, so is not
-    /// fully efficient. See https://github.com/unicode-org/icu4x/issues/166 for
-    /// more details.
-    ///
-    /// This function can be made available with the `"ryu"` feature.
-    ///
-    /// ```rust
-    /// use fixed_decimal::FixedDecimal;
-    /// use writeable::Writeable;
-    ///
-    /// let decimal = FixedDecimal::new_from_f32(0.012345678).unwrap();
-    /// assert_eq!(decimal.writeable_to_string(), "0.012345678");
-    ///
-    /// let decimal = FixedDecimal::new_from_f32(-123456.78).unwrap();
-    /// assert_eq!(decimal.writeable_to_string(), "-123456.78");
-    ///
-    /// let decimal = FixedDecimal::new_from_f32(12345678000.).unwrap();
-    /// assert_eq!(decimal.writeable_to_string(), "12345678000.0");
-    /// ```
-    pub fn new_from_f32(float: f32) -> Result<Self, Error> {
-        if !float.is_finite() {
-            return Err(Error::Limit);
-        }
-        // note: this does not heap allocate
-        let mut buf = ryu::Buffer::new();
-        let formatted = buf.format_finite(float);
-        Self::from_str(formatted)
-    }
-
     /// Construct a [`FixedDecimal`] from an f64. This uses `ryu` and
     /// goes through an intermediate string representation, so is not
     /// fully efficient. See https://github.com/unicode-org/icu4x/issues/166 for

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -813,9 +813,7 @@ impl FixedDecimal {
                     let round_by = (n_digits - sig) as u16;
                     decimal.round_trailing_digits(round_by, mode)?;
                     // It may have rounded up by one
-                    debug_assert!(
-                        decimal.digits.len() <= sig as usize
-                    );
+                    debug_assert!(decimal.digits.len() <= sig as usize);
                 }
                 let target_lowest_magnitude = decimal.magnitude - sig as i16 + 1;
                 if target_lowest_magnitude <= 0 {

--- a/utils/fixed_decimal/src/lib.rs
+++ b/utils/fixed_decimal/src/lib.rs
@@ -44,7 +44,7 @@ pub mod decimal;
 pub mod signum;
 mod uint_iterator;
 
-pub use decimal::FixedDecimal;
+pub use decimal::{DoublePrecision, FixedDecimal};
 use displaydoc::Display;
 pub use signum::Signum;
 

--- a/utils/fixed_decimal/src/lib.rs
+++ b/utils/fixed_decimal/src/lib.rs
@@ -44,7 +44,10 @@ pub mod decimal;
 pub mod signum;
 mod uint_iterator;
 
-pub use decimal::{DoublePrecision, FixedDecimal};
+#[cfg(feature = "ryu")]
+pub use decimal::DoublePrecision;
+
+pub use decimal::FixedDecimal;
 use displaydoc::Display;
 pub use signum::Signum;
 


### PR DESCRIPTION
fixes https://github.com/unicode-org/icu4x/issues/166

This adds two functions instead of just one with a trait since it doesn't seem worth it to pull in the num_traits crate just for `.is_finite()`.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->