### PR TITLE
Add manual clone impl for VZV

### DIFF
--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -105,7 +105,6 @@ pub use ule::VarZeroVecULE;
 /// for more information.
 ///
 /// [`ule`]: crate::ule
-#[derive(Clone)]
 pub enum VarZeroVec<'a, T: ?Sized> {
     /// An allocated VarZeroVec, allowing for mutations.
     ///
@@ -138,6 +137,15 @@ pub enum VarZeroVec<'a, T: ?Sized> {
     /// assert!(matches!(vzv, VarZeroVec::Borrowed(_)));
     /// ```
     Borrowed(VarZeroVecBorrowed<'a, T>),
+}
+
+impl<'a, T: ?Sized> Clone for VarZeroVec<'a, T> {
+    fn clone(&self) -> Self {
+        match *self {
+            VarZeroVec::Owned(ref o) => o.clone().into(),
+            VarZeroVec::Borrowed(b) => b.into(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/utils/zerovec/src/varzerovec/owned.rs
+++ b/utils/zerovec/src/varzerovec/owned.rs
@@ -15,11 +15,19 @@ use core::slice;
 /// A fully-owned [`VarZeroVec`]. This type has no lifetime but has the same
 /// internal buffer representation of [`VarZeroVec`], making it cheaply convertible to
 /// [`VarZeroVec`] and [`VarZeroVecBorrowed`].
-#[derive(Clone)]
 pub struct VarZeroVecOwned<T: ?Sized> {
     marker: PhantomData<Box<T>>,
     // safety invariant: must parse into a valid VarZeroVecBorrowed
     entire_slice: Vec<u8>,
+}
+
+impl<T: ?Sized> Clone for VarZeroVecOwned<T> {
+    fn clone(&self) -> Self {
+        VarZeroVecOwned {
+            marker: self.marker,
+            entire_slice: self.entire_slice.clone(),
+        }
+    }
 }
 
 // The effect of a shift on the indices in the varzerovec.


### PR DESCRIPTION
This removes the `T: Clone` bound which is no longer necessary

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->