### PR TITLE
Add borrowed-only version of ZeroMap

### DIFF
--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -6,7 +6,7 @@ use crate::ule::AsULE;
 use crate::ZeroVec;
 
 pub use super::kv::ZeroMapKV;
-pub use super::vecs::{BorrowedOnlyZeroVecLike, BorrowedZeroVecLike, ZeroVecLike};
+pub use super::vecs::{BorrowedOnlyZeroVecLike, BorrowedZeroVecLike, MutableZeroVecLike};
 
 /// A borrowed-only version of [`ZeroMap`](super::ZeroMap)
 ///
@@ -39,8 +39,8 @@ where
     K: ?Sized,
     V: ?Sized,
 {
-    pub(crate) keys: <<K as ZeroMapKV<'a>>::Container as ZeroVecLike<'a, K>>::BorrowedVersion,
-    pub(crate) values: <<V as ZeroMapKV<'a>>::Container as ZeroVecLike<'a, V>>::BorrowedVersion,
+    pub(crate) keys: <<K as ZeroMapKV<'a>>::Container as MutableZeroVecLike<'a, K>>::BorrowedVersion,
+    pub(crate) values: <<V as ZeroMapKV<'a>>::Container as MutableZeroVecLike<'a, V>>::BorrowedVersion,
 }
 
 impl<'a, K, V> Copy for ZeroMapBorrowed<'a, K, V>

--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -150,7 +150,7 @@ where
     /// For cases when `V` is fixed-size, obtain a direct copy of `V` instead of `V::ULE`
     pub fn get_copied(&self, key: &K::NeedleType) -> Option<V> {
         let index = self.keys.binary_search(key).ok()?;
-        <[V::ULE]>::get(&self.values, index)
+        <[V::ULE]>::get(self.values, index)
             .copied()
             .map(V::from_unaligned)
     }
@@ -163,7 +163,7 @@ where
         (0..self.keys.len()).map(move |idx| {
             (
                 self.keys.get(idx).unwrap(),
-                <[V::ULE]>::get(&self.values, idx)
+                <[V::ULE]>::get(self.values, idx)
                     .copied()
                     .map(V::from_unaligned)
                     .unwrap(),

--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -109,7 +109,7 @@ where
     /// ```
     pub fn get(&self, key: &K::NeedleType) -> Option<&'a V::GetType> {
         let index = self.keys.binary_search(key).ok()?;
-        self.values.get_lengthened(index)
+        self.values.get_borrowed(index)
     }
 
     /// Returns whether `key` is contained in this map
@@ -140,22 +140,22 @@ where
     > + 'b {
         (0..self.keys.len()).map(move |idx| {
             (
-                self.keys.get_lengthened(idx).unwrap(),
-                self.values.get_lengthened(idx).unwrap(),
+                self.keys.get_borrowed(idx).unwrap(),
+                self.values.get_borrowed(idx).unwrap(),
             )
         })
     }
 
     /// Produce an ordered iterator over keys
     pub fn iter_keys<'b>(&'b self) -> impl Iterator<Item = &'a <K as ZeroMapKV<'a>>::GetType> + 'b {
-        (0..self.keys.len()).map(move |idx| self.keys.get_lengthened(idx).unwrap())
+        (0..self.keys.len()).map(move |idx| self.keys.get_borrowed(idx).unwrap())
     }
 
     /// Produce an iterator over values, ordered by keys
     pub fn iter_values<'b>(
         &'b self,
     ) -> impl Iterator<Item = &'a <V as ZeroMapKV<'a>>::GetType> + 'b {
-        (0..self.values.len()).map(move |idx| self.values.get_lengthened(idx).unwrap())
+        (0..self.values.len()).map(move |idx| self.values.get_borrowed(idx).unwrap())
     }
 }
 

--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -132,22 +132,28 @@ where
         &'b self,
     ) -> impl Iterator<
         Item = (
-            &'b <K as ZeroMapKV<'a>>::GetType,
-            &'b <V as ZeroMapKV<'a>>::GetType,
+            &'a <K as ZeroMapKV<'a>>::GetType,
+            &'a <V as ZeroMapKV<'a>>::GetType,
         ),
-    > {
-        (0..self.keys.len())
-            .map(move |idx| (self.keys.get(idx).unwrap(), self.values.get(idx).unwrap()))
+    > + 'b {
+        (0..self.keys.len()).map(move |idx| {
+            (
+                self.keys.get_lengthened(idx).unwrap(),
+                self.values.get_lengthened(idx).unwrap(),
+            )
+        })
     }
 
     /// Produce an ordered iterator over keys
-    pub fn iter_keys<'b>(&'b self) -> impl Iterator<Item = &'b <K as ZeroMapKV<'a>>::GetType> {
-        (0..self.keys.len()).map(move |idx| self.keys.get(idx).unwrap())
+    pub fn iter_keys<'b>(&'b self) -> impl Iterator<Item = &'a <K as ZeroMapKV<'a>>::GetType> + 'b {
+        (0..self.keys.len()).map(move |idx| self.keys.get_lengthened(idx).unwrap())
     }
 
     /// Produce an iterator over values, ordered by keys
-    pub fn iter_values<'b>(&'b self) -> impl Iterator<Item = &'b <V as ZeroMapKV<'a>>::GetType> {
-        (0..self.values.len()).map(move |idx| self.values.get(idx).unwrap())
+    pub fn iter_values<'b>(
+        &'b self,
+    ) -> impl Iterator<Item = &'a <V as ZeroMapKV<'a>>::GetType> + 'b {
+        (0..self.values.len()).map(move |idx| self.values.get_lengthened(idx).unwrap())
     }
 }
 

--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -6,7 +6,7 @@ use crate::ule::AsULE;
 use crate::ZeroVec;
 
 pub use super::kv::ZeroMapKV;
-pub use super::vecs::{BorrowedZeroVecLike, ZeroVecLike, MutableZeroVecLike};
+pub use super::vecs::{BorrowedZeroVecLike, MutableZeroVecLike, ZeroVecLike};
 
 /// A borrowed-only version of [`ZeroMap`](super::ZeroMap)
 ///
@@ -39,8 +39,10 @@ where
     K: ?Sized,
     V: ?Sized,
 {
-    pub(crate) keys: <<K as ZeroMapKV<'a>>::Container as MutableZeroVecLike<'a, K>>::BorrowedVersion,
-    pub(crate) values: <<V as ZeroMapKV<'a>>::Container as MutableZeroVecLike<'a, V>>::BorrowedVersion,
+    pub(crate) keys:
+        <<K as ZeroMapKV<'a>>::Container as MutableZeroVecLike<'a, K>>::BorrowedVersion,
+    pub(crate) values:
+        <<V as ZeroMapKV<'a>>::Container as MutableZeroVecLike<'a, V>>::BorrowedVersion,
 }
 
 impl<'a, K, V> Copy for ZeroMapBorrowed<'a, K, V>

--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -102,7 +102,7 @@ where
     ///
     /// let borrow = borrowed.get(&1);
     /// drop(borrowed);
-    /// // still exists after the map has been dropped
+    /// // still exists after the ZeroMapBorrowed has been dropped
     /// assert_eq!(borrow, Some("one"));
     /// ```
     pub fn get(&self, key: &K::NeedleType) -> Option<&'a V::GetType> {

--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -1,0 +1,154 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use crate::ule::AsULE;
+use crate::ZeroVec;
+use core::cmp::Ordering;
+
+pub use super::kv::ZeroMapKV;
+pub use super::vecs::{BorrowedZeroVecLike, ZeroVecLike};
+
+/// A borrowed-only version of [`ZeroMapBorrowed`](super::ZeroMapBorrowed)
+pub struct ZeroMapBorrowed<'a, K, V>
+where
+    K: ZeroMapKV<'a>,
+    V: ZeroMapKV<'a>,
+    K: ?Sized,
+    V: ?Sized,
+{
+    pub(crate) keys: <<K as ZeroMapKV<'a>>::Container as ZeroVecLike<'a, K>>::BorrowedVersion,
+    pub(crate) values: <<V as ZeroMapKV<'a>>::Container as ZeroVecLike<'a, V>>::BorrowedVersion,
+}
+
+impl<'a, K, V> ZeroMapBorrowed<'a, K, V>
+where
+    K: ZeroMapKV<'a>,
+    V: ZeroMapKV<'a>,
+    K: ?Sized,
+    V: ?Sized,
+{
+    /// The number of elements in the [`ZeroMapBorrowed`]
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Whether the [`ZeroMapBorrowed`] is empty
+    pub fn is_empty(&self) -> bool {
+        self.values.len() == 0
+    }
+
+    /// Get the value associated with `key`, if it exists.
+    ///
+    /// ```rust
+    /// use zerovec::ZeroMapBorrowed;
+    ///
+    /// let mut map = ZeroMapBorrowed::new();
+    /// map.insert(&1, "one");
+    /// map.insert(&2, "two");
+    /// assert_eq!(map.get(&1), Some("one"));
+    /// assert_eq!(map.get(&3), None);
+    /// ```
+    pub fn get(&self, key: &K::NeedleType) -> Option<&V::GetType> {
+        let index = self.keys.binary_search(key).ok()?;
+        self.values.get(index)
+    }
+
+    /// Returns whether `key` is contained in this map
+    ///
+    /// ```rust
+    /// use zerovec::ZeroMapBorrowed;
+    ///
+    /// let mut map = ZeroMapBorrowed::new();
+    /// map.insert(&1, "one");
+    /// map.insert(&2, "two");
+    /// assert_eq!(map.contains_key(&1), true);
+    /// assert_eq!(map.contains_key(&3), false);
+    /// ```
+    pub fn contains_key(&self, key: &K::NeedleType) -> bool {
+        self.keys.binary_search(key).is_ok()
+    }
+
+    /// Produce an ordered iterator over key-value pairs
+    pub fn iter<'b>(
+        &'b self,
+    ) -> impl Iterator<
+        Item = (
+            &'b <K as ZeroMapKV<'a>>::GetType,
+            &'b <V as ZeroMapKV<'a>>::GetType,
+        ),
+    > {
+        (0..self.keys.len())
+            .map(move |idx| (self.keys.get(idx).unwrap(), self.values.get(idx).unwrap()))
+    }
+
+    /// Produce an ordered iterator over keys
+    pub fn iter_keys<'b>(&'b self) -> impl Iterator<Item = &'b <K as ZeroMapKV<'a>>::GetType> {
+        (0..self.keys.len()).map(move |idx| self.keys.get(idx).unwrap())
+    }
+
+    /// Produce an iterator over values, ordered by keys
+    pub fn iter_values<'b>(&'b self) -> impl Iterator<Item = &'b <V as ZeroMapKV<'a>>::GetType> {
+        (0..self.values.len()).map(move |idx| self.values.get(idx).unwrap())
+    }
+}
+
+impl<'a, K, V> ZeroMapBorrowed<'a, K, V>
+where
+    K: ZeroMapKV<'a>,
+    V: ZeroMapKV<'a, Container = ZeroVec<'a, V>>,
+    V: AsULE + Ord + Copy,
+{
+    /// For cases when `V` is fixed-size, obtain a direct copy of `V` instead of `V::ULE`
+    pub fn get_copied(&self, key: &K::NeedleType) -> Option<V> {
+        let index = self.keys.binary_search(key).ok()?;
+        <[V::ULE]>::get(&self.values, index)
+            .copied()
+            .map(V::from_unaligned)
+    }
+
+    /// Similar to [`Self::iter()`] except it returns a direct copy of the values instead of references
+    /// to `V::ULE`, in cases when `V` is fixed-size
+    pub fn iter_copied_values<'b>(
+        &'b self,
+    ) -> impl Iterator<Item = (&'b <K as ZeroMapKV<'a>>::GetType, V)> {
+        (0..self.keys.len()).map(move |idx| {
+            (
+                self.keys.get(idx).unwrap(),
+                <[V::ULE]>::get(&self.values, idx)
+                    .copied()
+                    .map(V::from_unaligned)
+                    .unwrap(),
+            )
+        })
+    }
+}
+
+impl<'a, K, V> ZeroMapBorrowed<'a, K, V>
+where
+    K: ZeroMapKV<'a, Container = ZeroVec<'a, K>>,
+    V: ZeroMapKV<'a, Container = ZeroVec<'a, V>>,
+    K: AsULE + Copy + Ord,
+    V: AsULE + Copy + Ord,
+{
+    /// Similar to [`Self::iter()`] except it returns a direct copy of the keys values instead of references
+    /// to `K::ULE` and `V::ULE`, in cases when `K` and `V` are fixed-size
+    #[allow(clippy::needless_lifetimes)] // Lifetime is necessary in impl Trait
+    pub fn iter_copied<'b>(&'b self) -> impl Iterator<Item = (K, V)> + 'b {
+        let keys = &self.keys;
+        let values = &self.values;
+        let len = <[K::ULE]>::len(keys);
+        (0..len).map(move |idx| {
+            (
+                <[K::ULE]>::get(keys, idx)
+                    .copied()
+                    .map(K::from_unaligned)
+                    .unwrap(),
+                <[V::ULE]>::get(values, idx)
+                    .copied()
+                    .map(V::from_unaligned)
+                    .unwrap(),
+            )
+        })
+    }
+}

--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -6,7 +6,7 @@ use crate::ule::AsULE;
 use crate::ZeroVec;
 
 pub use super::kv::ZeroMapKV;
-pub use super::vecs::{BorrowedOnlyZeroVecLike, BorrowedZeroVecLike, MutableZeroVecLike};
+pub use super::vecs::{BorrowedOnlyZeroVecLike, ZeroVecLike, MutableZeroVecLike};
 
 /// A borrowed-only version of [`ZeroMap`](super::ZeroMap)
 ///

--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -40,9 +40,9 @@ where
     V: ?Sized,
 {
     pub(crate) keys:
-        <<K as ZeroMapKV<'a>>::Container as MutableZeroVecLike<'a, K>>::BorrowedVersion,
+        <<K as ZeroMapKV<'a>>::Container as MutableZeroVecLike<'a, K>>::BorrowedVariant,
     pub(crate) values:
-        <<V as ZeroMapKV<'a>>::Container as MutableZeroVecLike<'a, V>>::BorrowedVersion,
+        <<V as ZeroMapKV<'a>>::Container as MutableZeroVecLike<'a, V>>::BorrowedVariant,
 }
 
 impl<'a, K, V> Copy for ZeroMapBorrowed<'a, K, V>

--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -4,12 +4,16 @@
 
 use crate::ule::AsULE;
 use crate::ZeroVec;
-use core::cmp::Ordering;
 
 pub use super::kv::ZeroMapKV;
 pub use super::vecs::{BorrowedZeroVecLike, ZeroVecLike};
 
-/// A borrowed-only version of [`ZeroMapBorrowed`](super::ZeroMapBorrowed)
+/// A borrowed-only version of [`ZeroMap`](super::ZeroMap)
+///
+/// This is useful for fully-zero-copy deserialization from non-human-readable
+/// serialization formats.
+///
+/// This can be obtained from a [`ZeroMap`](super::ZeroMap) via [`ZeroMap::as_borrowed`](super::ZeroMap::as_borrowed)
 pub struct ZeroMapBorrowed<'a, K, V>
 where
     K: ZeroMapKV<'a>,
@@ -41,13 +45,15 @@ where
     /// Get the value associated with `key`, if it exists.
     ///
     /// ```rust
-    /// use zerovec::ZeroMapBorrowed;
+    /// use zerovec::ZeroMap;
+    /// use zerovec::map::ZeroMapBorrowed;
     ///
-    /// let mut map = ZeroMapBorrowed::new();
+    /// let mut map = ZeroMap::new();
     /// map.insert(&1, "one");
     /// map.insert(&2, "two");
-    /// assert_eq!(map.get(&1), Some("one"));
-    /// assert_eq!(map.get(&3), None);
+    /// let borrowed = map.as_borrowed();
+    /// assert_eq!(borrowed.get(&1), Some("one"));
+    /// assert_eq!(borrowed.get(&3), None);
     /// ```
     pub fn get(&self, key: &K::NeedleType) -> Option<&V::GetType> {
         let index = self.keys.binary_search(key).ok()?;
@@ -57,13 +63,15 @@ where
     /// Returns whether `key` is contained in this map
     ///
     /// ```rust
-    /// use zerovec::ZeroMapBorrowed;
+    /// use zerovec::ZeroMap;
+    /// use zerovec::map::ZeroMapBorrowed;
     ///
-    /// let mut map = ZeroMapBorrowed::new();
+    /// let mut map = ZeroMap::new();
     /// map.insert(&1, "one");
     /// map.insert(&2, "two");
-    /// assert_eq!(map.contains_key(&1), true);
-    /// assert_eq!(map.contains_key(&3), false);
+    /// let borrowed = map.as_borrowed();
+    /// assert_eq!(borrowed.contains_key(&1), true);
+    /// assert_eq!(borrowed.contains_key(&3), false);
     /// ```
     pub fn contains_key(&self, key: &K::NeedleType) -> bool {
         self.keys.binary_search(key).is_ok()

--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -6,7 +6,7 @@ use crate::ule::AsULE;
 use crate::ZeroVec;
 
 pub use super::kv::ZeroMapKV;
-pub use super::vecs::{BorrowedOnlyZeroVecLike, ZeroVecLike, MutableZeroVecLike};
+pub use super::vecs::{BorrowedZeroVecLike, ZeroVecLike, MutableZeroVecLike};
 
 /// A borrowed-only version of [`ZeroMap`](super::ZeroMap)
 ///

--- a/utils/zerovec/src/map/kv.rs
+++ b/utils/zerovec/src/map/kv.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use super::vecs::ZeroVecLike;
+use super::vecs::MutableZeroVecLike;
 use crate::ule::*;
 use crate::VarZeroVec;
 use crate::ZeroVec;
@@ -18,7 +18,7 @@ use core::cmp::Ordering;
 #[allow(clippy::upper_case_acronyms)] // KV is not an acronym
 pub trait ZeroMapKV<'a> {
     /// The container that can be used with this type: [`ZeroVec`] or [`VarZeroVec`].
-    type Container: ZeroVecLike<
+    type Container: MutableZeroVecLike<
             'a,
             Self,
             NeedleType = Self::NeedleType,

--- a/utils/zerovec/src/map/kv.rs
+++ b/utils/zerovec/src/map/kv.rs
@@ -32,7 +32,7 @@ pub trait ZeroMapKV<'a> {
     /// The type produced by `Container::get()`
     ///
     /// This type will be predetermined by the choice of `Self::Container`
-    type GetType: ?Sized;
+    type GetType: ?Sized + 'static;
     /// The type to use whilst serializing. This may not necessarily be `Self`, however it
     /// must serialize to the exact same thing as `Self`
     type SerializeType: ?Sized;

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -8,6 +8,7 @@ use crate::ule::AsULE;
 use crate::ZeroVec;
 use core::cmp::Ordering;
 
+mod borrowed;
 mod kv;
 #[cfg(feature = "serde")]
 mod serde;

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -16,7 +16,7 @@ mod vecs;
 
 pub use borrowed::ZeroMapBorrowed;
 pub use kv::ZeroMapKV;
-pub use vecs::{ZeroVecLike, MutableZeroVecLike};
+pub use vecs::{MutableZeroVecLike, ZeroVecLike};
 
 /// A zero-copy map datastructure, built on sorted binary-searchable [`ZeroVec`]
 /// and [`VarZeroVec`].

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -16,7 +16,7 @@ mod vecs;
 
 pub use borrowed::ZeroMapBorrowed;
 pub use kv::ZeroMapKV;
-pub use vecs::{BorrowedZeroVecLike, ZeroVecLike};
+pub use vecs::{BorrowedZeroVecLike, MutableZeroVecLike};
 
 /// A zero-copy map datastructure, built on sorted binary-searchable [`ZeroVec`]
 /// and [`VarZeroVec`].

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -307,3 +307,18 @@ where
         })
     }
 }
+
+impl<'a, K, V> From<ZeroMapBorrowed<'a, K, V>> for ZeroMap<'a, K, V>
+where
+    K: ZeroMapKV<'a>,
+    V: ZeroMapKV<'a>,
+    K: ?Sized,
+    V: ?Sized,
+{
+    fn from(other: ZeroMapBorrowed<'a, K, V>) -> Self {
+        Self {
+            keys: K::Container::from_borrowed(other.keys),
+            values: V::Container::from_borrowed(other.values),
+        }
+    }
+}

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -14,6 +14,7 @@ mod kv;
 mod serde;
 mod vecs;
 
+pub use borrowed::ZeroMapBorrowed;
 pub use kv::ZeroMapKV;
 pub use vecs::{BorrowedZeroVecLike, ZeroVecLike};
 
@@ -89,6 +90,14 @@ where
         Self {
             keys: K::Container::with_capacity(capacity),
             values: V::Container::with_capacity(capacity),
+        }
+    }
+
+    /// Obtain a borrowed version of this map
+    pub fn as_borrowed(&'a self) -> ZeroMapBorrowed<'a, K, V> {
+        ZeroMapBorrowed {
+            keys: self.keys.as_borrowed(),
+            values: self.values.as_borrowed(),
         }
     }
 

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -14,7 +14,7 @@ mod serde;
 mod vecs;
 
 pub use kv::ZeroMapKV;
-pub use vecs::ZeroVecLike;
+pub use vecs::{BorrowedZeroVecLike, ZeroVecLike};
 
 /// A zero-copy map datastructure, built on sorted binary-searchable [`ZeroVec`]
 /// and [`VarZeroVec`].

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -16,7 +16,7 @@ mod vecs;
 
 pub use borrowed::ZeroMapBorrowed;
 pub use kv::ZeroMapKV;
-pub use vecs::{BorrowedZeroVecLike, MutableZeroVecLike};
+pub use vecs::{ZeroVecLike, MutableZeroVecLike};
 
 /// A zero-copy map datastructure, built on sorted binary-searchable [`ZeroVec`]
 /// and [`VarZeroVec`].

--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use super::{BorrowedZeroVecLike, ZeroMap, ZeroMapKV, ZeroVecLike};
+use super::{BorrowedZeroVecLike, ZeroMap, ZeroMapKV};
 use alloc::boxed::Box;
 use core::fmt;
 use core::marker::PhantomData;

--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use super::{BorrowedZeroVecLike, ZeroMap, ZeroMapBorrowed, ZeroMapKV, ZeroVecLike};
+use super::{BorrowedZeroVecLike, ZeroMap, ZeroMapBorrowed, ZeroMapKV, MutableZeroVecLike};
 use alloc::boxed::Box;
 use core::fmt;
 use core::marker::PhantomData;

--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -162,9 +162,9 @@ where
         D: Deserializer<'de>,
     {
         if deserializer.is_human_readable() {
-            return Err(de::Error::custom(
+            Err(de::Error::custom(
                 "ZeroMapBorrowed cannot be deserialized from human-readable formats",
-            ));
+            ))
         } else {
             let deserialized: ZeroMap<'de, K, V> = ZeroMap::deserialize(deserializer)?;
             let keys = if let Some(keys) = deserialized.keys.maybe_as_borrowed() {

--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use super::{BorrowedZeroVecLike, ZeroMap, ZeroMapKV};
+use super::{BorrowedZeroVecLike, ZeroMap, ZeroMapBorrowed, ZeroMapKV, ZeroVecLike};
 use alloc::boxed::Box;
 use core::fmt;
 use core::marker::PhantomData;
@@ -36,6 +36,26 @@ where
         } else {
             (&self.keys, &self.values).serialize(serializer)
         }
+    }
+}
+
+/// This impl can be made available by enabling the optional `serde` feature of the `zerovec` crate
+impl<'a, K, V> Serialize for ZeroMapBorrowed<'a, K, V>
+where
+    K: ZeroMapKV<'a>,
+    V: ZeroMapKV<'a>,
+    K: ?Sized,
+    V: ?Sized,
+    K::Container: Serialize,
+    V::Container: Serialize,
+    K::SerializeType: Serialize,
+    V::SerializeType: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        ZeroMap::<K, V>::from(*self).serialize(serializer)
     }
 }
 
@@ -126,6 +146,46 @@ where
     }
 }
 
+// /// This impl can be made available by enabling the optional `serde` feature of the `zerovec` crate
+impl<'de, K: ?Sized, V: ?Sized> Deserialize<'de> for ZeroMapBorrowed<'de, K, V>
+where
+    K: Ord,
+    K::Container: Deserialize<'de>,
+    V::Container: Deserialize<'de>,
+    K: ZeroMapKV<'de>,
+    V: ZeroMapKV<'de>,
+    K::OwnedType: Deserialize<'de>,
+    V::OwnedType: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            return Err(de::Error::custom(
+                "ZeroMapBorrowed cannot be deserialized from human-readable formats",
+            ));
+        } else {
+            let deserialized: ZeroMap<'de, K, V> = ZeroMap::deserialize(deserializer)?;
+            let keys = if let Some(keys) = deserialized.keys.maybe_as_borrowed() {
+                keys
+            } else {
+                return Err(de::Error::custom(
+                    "ZeroMapBorrowed can only deserialize in zero-copy ways",
+                ));
+            };
+            let values = if let Some(values) = deserialized.values.maybe_as_borrowed() {
+                values
+            } else {
+                return Err(de::Error::custom(
+                    "ZeroMapBorrowed can only deserialize in zero-copy ways",
+                ));
+            };
+            Ok(Self { keys, values })
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::super::*;
@@ -161,6 +221,13 @@ mod test {
         let bincode_bytes = bincode::serialize(&map).expect("serialize");
         assert_eq!(BINCODE_BYTES, bincode_bytes);
         let new_map: ZeroMap<u32, str> = bincode::deserialize(&bincode_bytes).expect("deserialize");
+        assert_eq!(
+            new_map.iter().collect::<Vec<_>>(),
+            map.iter().collect::<Vec<_>>()
+        );
+
+        let new_map: ZeroMapBorrowed<u32, str> =
+            bincode::deserialize(&bincode_bytes).expect("deserialize");
         assert_eq!(
             new_map.iter().collect::<Vec<_>>(),
             map.iter().collect::<Vec<_>>()

--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use super::{ZeroVecLike, ZeroMap, ZeroMapBorrowed, ZeroMapKV, MutableZeroVecLike};
+use super::{MutableZeroVecLike, ZeroMap, ZeroMapBorrowed, ZeroMapKV, ZeroVecLike};
 use alloc::boxed::Box;
 use core::fmt;
 use core::marker::PhantomData;

--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use super::{BorrowedZeroVecLike, ZeroMap, ZeroMapBorrowed, ZeroMapKV, MutableZeroVecLike};
+use super::{ZeroVecLike, ZeroMap, ZeroMapBorrowed, ZeroMapKV, MutableZeroVecLike};
 use alloc::boxed::Box;
 use core::fmt;
 use core::marker::PhantomData;

--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use super::{ZeroMap, ZeroMapKV, ZeroVecLike};
+use super::{BorrowedZeroVecLike, ZeroMap, ZeroMapKV, ZeroVecLike};
 use alloc::boxed::Box;
 use core::fmt;
 use core::marker::PhantomData;

--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -167,14 +167,14 @@ where
             ))
         } else {
             let deserialized: ZeroMap<'de, K, V> = ZeroMap::deserialize(deserializer)?;
-            let keys = if let Some(keys) = deserialized.keys.maybe_as_borrowed() {
+            let keys = if let Some(keys) = deserialized.keys.as_borrowed_inner() {
                 keys
             } else {
                 return Err(de::Error::custom(
                     "ZeroMapBorrowed can only deserialize in zero-copy ways",
                 ));
             };
-            let values = if let Some(values) = deserialized.values.maybe_as_borrowed() {
+            let values = if let Some(values) = deserialized.values.as_borrowed_inner() {
                 values
             } else {
                 return Err(de::Error::custom(

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -50,7 +50,7 @@ pub trait BorrowedOnlyZeroVecLike<'a, T: ?Sized>: BorrowedZeroVecLike<'a, T> {
 ///
 /// This trait augments [`BorrowedZeroVecLike`] with methods allowing for mutation of the underlying
 /// vector for owned vector types.
-pub trait ZeroVecLike<'a, T: ?Sized>: BorrowedZeroVecLike<'a, T> {
+pub trait MutableZeroVecLike<'a, T: ?Sized>: BorrowedZeroVecLike<'a, T> {
     /// The type returned by `Self::remove()` and `Self::replace()`
     type OwnedType;
     /// A fully borrowed version of this
@@ -154,7 +154,7 @@ where
     }
 }
 
-impl<'a, T> ZeroVecLike<'a, T> for ZeroVec<'a, T>
+impl<'a, T> MutableZeroVecLike<'a, T> for ZeroVec<'a, T>
 where
     T: AsULE + Ord + Copy,
 {
@@ -276,7 +276,7 @@ where
     }
 }
 
-impl<'a, T> ZeroVecLike<'a, T> for VarZeroVec<'a, T>
+impl<'a, T> MutableZeroVecLike<'a, T> for VarZeroVec<'a, T>
 where
     T: VarULE,
     T: Ord,

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -14,7 +14,7 @@ use core::mem;
 
 /// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). You
 /// should not be implementing or calling this trait directly.
-pub trait BorrowedZeroVecLike<'a, T: ?Sized> {
+pub trait ZeroVecLike<'a, T: ?Sized> {
     /// The type received by `Self::binary_search()`
     type NeedleType: ?Sized;
     /// The type returned by `Self::get()`
@@ -38,9 +38,9 @@ pub trait BorrowedZeroVecLike<'a, T: ?Sized> {
 /// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). You
 /// should not be implementing or calling this trait directly.
 ///
-/// This trait augments [`BorrowedZeroVecLike`] with methods allowing for taking
+/// This trait augments [`ZeroVecLike`] with methods allowing for taking
 /// longer references to the underlying buffer, for borrowed-only vector types.
-pub trait BorrowedOnlyZeroVecLike<'a, T: ?Sized>: BorrowedZeroVecLike<'a, T> {
+pub trait BorrowedOnlyZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
     /// Get element at `index`, with a longer lifetime
     fn get_lengthened(&self, index: usize) -> Option<&'a Self::GetType>;
 }
@@ -48,13 +48,13 @@ pub trait BorrowedOnlyZeroVecLike<'a, T: ?Sized>: BorrowedZeroVecLike<'a, T> {
 /// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). You
 /// should not be implementing or calling this trait directly.
 ///
-/// This trait augments [`BorrowedZeroVecLike`] with methods allowing for mutation of the underlying
+/// This trait augments [`ZeroVecLike`] with methods allowing for mutation of the underlying
 /// vector for owned vector types.
-pub trait MutableZeroVecLike<'a, T: ?Sized>: BorrowedZeroVecLike<'a, T> {
+pub trait MutableZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
     /// The type returned by `Self::remove()` and `Self::replace()`
     type OwnedType;
     /// A fully borrowed version of this
-    type BorrowedVersion: BorrowedZeroVecLike<'a, T, NeedleType = Self::NeedleType, GetType = Self::GetType>
+    type BorrowedVersion: ZeroVecLike<'a, T, NeedleType = Self::NeedleType, GetType = Self::GetType>
         + BorrowedOnlyZeroVecLike<'a, T>
         + Copy;
     /// Insert an element at `index`
@@ -100,7 +100,7 @@ pub trait MutableZeroVecLike<'a, T: ?Sized>: BorrowedZeroVecLike<'a, T> {
     fn from_borrowed(b: Self::BorrowedVersion) -> Self;
 }
 
-impl<'a, T> BorrowedZeroVecLike<'a, T> for ZeroVec<'a, T>
+impl<'a, T> ZeroVecLike<'a, T> for ZeroVec<'a, T>
 where
     T: AsULE + Ord + Copy,
 {
@@ -122,7 +122,7 @@ where
     }
 }
 
-impl<'a, T> BorrowedZeroVecLike<'a, T> for &'a [T::ULE]
+impl<'a, T> ZeroVecLike<'a, T> for &'a [T::ULE]
 where
     T: AsULE + Ord + Copy,
 {
@@ -201,7 +201,7 @@ where
     }
 }
 
-impl<'a, T> BorrowedZeroVecLike<'a, T> for VarZeroVec<'a, T>
+impl<'a, T> ZeroVecLike<'a, T> for VarZeroVec<'a, T>
 where
     T: VarULE,
     T: Ord,
@@ -232,7 +232,7 @@ where
     }
 }
 
-impl<'a, T> BorrowedZeroVecLike<'a, T> for VarZeroVecBorrowed<'a, T>
+impl<'a, T> ZeroVecLike<'a, T> for VarZeroVecBorrowed<'a, T>
 where
     T: VarULE,
     T: Ord,

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -40,7 +40,7 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
 ///
 /// This trait augments [`ZeroVecLike`] with methods allowing for taking
 /// longer references to the underlying buffer, for borrowed-only vector types.
-pub trait BorrowedOnlyZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
+pub trait BorrowedZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
     /// Get element at `index`, with a longer lifetime
     fn get_lengthened(&self, index: usize) -> Option<&'a Self::GetType>;
 }
@@ -55,7 +55,7 @@ pub trait MutableZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
     type OwnedType;
     /// A fully borrowed version of this
     type BorrowedVersion: ZeroVecLike<'a, T, NeedleType = Self::NeedleType, GetType = Self::GetType>
-        + BorrowedOnlyZeroVecLike<'a, T>
+        + BorrowedZeroVecLike<'a, T>
         + Copy;
     /// Insert an element at `index`
     fn insert(&mut self, index: usize, value: &T);
@@ -145,7 +145,7 @@ where
     }
 }
 
-impl<'a, T> BorrowedOnlyZeroVecLike<'a, T> for &'a [T::ULE]
+impl<'a, T> BorrowedZeroVecLike<'a, T> for &'a [T::ULE]
 where
     T: AsULE + Ord + Copy,
 {
@@ -264,7 +264,7 @@ where
     }
 }
 
-impl<'a, T> BorrowedOnlyZeroVecLike<'a, T> for VarZeroVecBorrowed<'a, T>
+impl<'a, T> BorrowedZeroVecLike<'a, T> for VarZeroVecBorrowed<'a, T>
 where
     T: VarULE,
     T: Ord,

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -40,6 +40,8 @@ pub trait BorrowedZeroVecLike<'a, T: ?Sized> {
 pub trait ZeroVecLike<'a, T: ?Sized>: BorrowedZeroVecLike<'a, T> {
     /// The type returned by `Self::remove()` and `Self::replace()`
     type OwnedType;
+    /// A fully borrowed version of this
+    type BorrowedVersion: BorrowedZeroVecLike<'a, T>;
     /// Insert an element at `index`
     fn insert(&mut self, index: usize, value: &T);
     /// Remove the element at `index` (panicking if nonexistant)
@@ -108,6 +110,7 @@ where
     T: AsULE + Ord + Copy,
 {
     type OwnedType = T;
+    type BorrowedVersion = &'a [T::ULE];
     fn insert(&mut self, index: usize, value: &T) {
         self.to_mut().insert(index, value.as_unaligned())
     }
@@ -205,6 +208,7 @@ where
     T: ?Sized,
 {
     type OwnedType = Box<T>;
+    type BorrowedVersion = VarZeroVecBorrowed<'a, T>;
     fn insert(&mut self, index: usize, value: &T) {
         self.make_mut().insert(index, value)
     }

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -63,6 +63,13 @@ pub trait ZeroVecLike<'a, T: ?Sized>: BorrowedZeroVecLike<'a, T> {
     fn clear(&mut self);
     /// Reserve space for `addl` additional elements
     fn reserve(&mut self, addl: usize);
+    /// Construct a borrowed version from this
+    ///
+    /// Note: This really should be `&'b self -> Self::BorrowedVersion<'b>`
+    /// but doing that requires complicated `for<'b>` code that will likely trigger
+    /// compiler bugs. Instead, we hope that `self` is covariant so this cast will
+    /// just work in the implementation.
+    fn as_borrowed(&'a self) -> Self::BorrowedVersion;
 }
 
 impl<'a, T> BorrowedZeroVecLike<'a, T> for ZeroVec<'a, T>
@@ -140,6 +147,10 @@ where
     }
     fn reserve(&mut self, addl: usize) {
         self.to_mut().reserve(addl)
+    }
+
+    fn as_borrowed(&'a self) -> &'a [T::ULE] {
+        self.as_slice()
     }
 }
 
@@ -244,5 +255,8 @@ where
     }
     fn reserve(&mut self, addl: usize) {
         self.make_mut().reserve(addl)
+    }
+    fn as_borrowed(&'a self) -> VarZeroVecBorrowed<'a, T> {
+        self.as_borrowed()
     }
 }

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -41,7 +41,12 @@ pub trait ZeroVecLike<'a, T: ?Sized>: BorrowedZeroVecLike<'a, T> {
     /// The type returned by `Self::remove()` and `Self::replace()`
     type OwnedType;
     /// A fully borrowed version of this
-    type BorrowedVersion: BorrowedZeroVecLike<'a, T>;
+    type BorrowedVersion: BorrowedZeroVecLike<
+        'a,
+        T,
+        NeedleType = Self::NeedleType,
+        GetType = Self::GetType,
+    >;
     /// Insert an element at `index`
     fn insert(&mut self, index: usize, value: &T);
     /// Remove the element at `index` (panicking if nonexistant)

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -13,7 +13,7 @@ use core::mem;
 
 /// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). You
 /// should not be implementing or calling this trait directly.
-pub trait ZeroVecLike<'a, T: ?Sized> {
+pub trait BorrowedZeroVecLike<'a, T: ?Sized> {
     /// The type received by `Self::binary_search()`
     type NeedleType: ?Sized;
     /// The type returned by `Self::get()`
@@ -52,7 +52,11 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
     }
 }
 
-impl<'a, T> ZeroVecLike<'a, T> for ZeroVec<'a, T>
+/// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). You
+/// should not be implementing or calling this trait directly.
+pub trait ZeroVecLike<'a, T: ?Sized>: BorrowedZeroVecLike<'a, T> {}
+
+impl<'a, T> BorrowedZeroVecLike<'a, T> for ZeroVec<'a, T>
 where
     T: AsULE + Ord + Copy,
 {
@@ -100,7 +104,9 @@ where
     }
 }
 
-impl<'a, T> ZeroVecLike<'a, T> for VarZeroVec<'a, T>
+impl<'a, T> ZeroVecLike<'a, T> for ZeroVec<'a, T> where T: AsULE + Ord + Copy {}
+
+impl<'a, T> BorrowedZeroVecLike<'a, T> for VarZeroVec<'a, T>
 where
     T: VarULE,
     T: Ord,
@@ -161,4 +167,12 @@ where
         }
         true
     }
+}
+
+impl<'a, T> ZeroVecLike<'a, T> for VarZeroVec<'a, T>
+where
+    T: VarULE,
+    T: Ord,
+    T: ?Sized,
+{
 }

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -92,7 +92,7 @@ pub trait MutableZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
     /// wider lifetime when we *know* for a fact that it is borrowed data.
     ///
     /// These are useful to ensure serialization parity between borrowed and owned versions
-    fn maybe_as_borrowed(&self) -> Option<Self::BorrowedVariant>;
+    fn as_borrowed_inner(&self) -> Option<Self::BorrowedVariant>;
 
     /// Construct from the borrowed version of the type
     ///
@@ -189,7 +189,7 @@ where
     fn as_borrowed(&'a self) -> &'a [T::ULE] {
         self.as_slice()
     }
-    fn maybe_as_borrowed(&self) -> Option<&'a [T::ULE]> {
+    fn as_borrowed_inner(&self) -> Option<&'a [T::ULE]> {
         if let ZeroVec::Borrowed(b) = *self {
             Some(b)
         } else {
@@ -318,7 +318,7 @@ where
     fn as_borrowed(&'a self) -> VarZeroVecBorrowed<'a, T> {
         self.as_borrowed()
     }
-    fn maybe_as_borrowed(&self) -> Option<VarZeroVecBorrowed<'a, T>> {
+    fn as_borrowed_inner(&self) -> Option<VarZeroVecBorrowed<'a, T>> {
         if let VarZeroVec::Borrowed(b) = *self {
             Some(b)
         } else {

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -42,7 +42,7 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
 /// longer references to the underlying buffer, for borrowed-only vector types.
 pub trait BorrowedZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
     /// Get element at `index`, with a longer lifetime
-    fn get_lengthened(&self, index: usize) -> Option<&'a Self::GetType>;
+    fn get_borrowed(&self, index: usize) -> Option<&'a Self::GetType>;
 }
 
 /// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). You
@@ -147,7 +147,7 @@ impl<'a, T> BorrowedZeroVecLike<'a, T> for &'a [T::ULE]
 where
     T: AsULE + Ord + Copy,
 {
-    fn get_lengthened(&self, index: usize) -> Option<&'a T::ULE> {
+    fn get_borrowed(&self, index: usize) -> Option<&'a T::ULE> {
         <[T::ULE]>::get(self, index)
     }
 }
@@ -268,7 +268,7 @@ where
     T: Ord,
     T: ?Sized,
 {
-    fn get_lengthened(&self, index: usize) -> Option<&'a T> {
+    fn get_borrowed(&self, index: usize) -> Option<&'a T> {
         // using UFCS to avoid accidental recursion
         Self::get(*self, index)
     }

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -18,7 +18,7 @@ pub trait BorrowedZeroVecLike<'a, T: ?Sized> {
     /// The type received by `Self::binary_search()`
     type NeedleType: ?Sized;
     /// The type returned by `Self::get()`
-    type GetType: ?Sized;
+    type GetType: ?Sized + 'static;
     /// Search for a key in a sorted vector, returns `Ok(index)` if found,
     /// returns `Err(insert_index)` if not found, where `insert_index` is the
     /// index where it should be inserted to maintain sort order.

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -18,32 +18,14 @@ pub trait BorrowedZeroVecLike<'a, T: ?Sized> {
     type NeedleType: ?Sized;
     /// The type returned by `Self::get()`
     type GetType: ?Sized;
-    /// The type returned by `Self::remove()` and `Self::replace()`
-    type OwnedType;
     /// Search for a key in a sorted vector, returns `Ok(index)` if found,
     /// returns `Err(insert_index)` if not found, where `insert_index` is the
     /// index where it should be inserted to maintain sort order.
     fn binary_search(&self, k: &Self::NeedleType) -> Result<usize, usize>;
     /// Get element at `index`
     fn get(&self, index: usize) -> Option<&Self::GetType>;
-    /// Insert an element at `index`
-    fn insert(&mut self, index: usize, value: &T);
-    /// Remove the element at `index` (panicking if nonexistant)
-    fn remove(&mut self, index: usize) -> Self::OwnedType;
-    /// Replace the element at `index` with another one, returning the old element
-    fn replace(&mut self, index: usize, value: &T) -> Self::OwnedType;
-    /// Push an element to the end of this vector
-    fn push(&mut self, value: &T);
     /// The length of this vector
     fn len(&self) -> usize;
-    /// Create a new, empty vector
-    fn new() -> Self;
-    /// Create a new, empty vector, with given capacity
-    fn with_capacity(cap: usize) -> Self;
-    /// Remove all elements from the vector
-    fn clear(&mut self);
-    /// Reserve space for `addl` additional elements
-    fn reserve(&mut self, addl: usize);
     /// Check if this vector is in ascending order according to `T`s `Ord` impl
     fn is_ascending(&self) -> bool;
     /// Check if this vector is empty
@@ -54,7 +36,26 @@ pub trait BorrowedZeroVecLike<'a, T: ?Sized> {
 
 /// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). You
 /// should not be implementing or calling this trait directly.
-pub trait ZeroVecLike<'a, T: ?Sized>: BorrowedZeroVecLike<'a, T> {}
+pub trait ZeroVecLike<'a, T: ?Sized>: BorrowedZeroVecLike<'a, T> {
+    /// The type returned by `Self::remove()` and `Self::replace()`
+    type OwnedType;
+    /// Insert an element at `index`
+    fn insert(&mut self, index: usize, value: &T);
+    /// Remove the element at `index` (panicking if nonexistant)
+    fn remove(&mut self, index: usize) -> Self::OwnedType;
+    /// Replace the element at `index` with another one, returning the old element
+    fn replace(&mut self, index: usize, value: &T) -> Self::OwnedType;
+    /// Push an element to the end of this vector
+    fn push(&mut self, value: &T);
+    /// Create a new, empty vector
+    fn new() -> Self;
+    /// Create a new, empty vector, with given capacity
+    fn with_capacity(cap: usize) -> Self;
+    /// Remove all elements from the vector
+    fn clear(&mut self);
+    /// Reserve space for `addl` additional elements
+    fn reserve(&mut self, addl: usize);
+}
 
 impl<'a, T> BorrowedZeroVecLike<'a, T> for ZeroVec<'a, T>
 where
@@ -62,13 +63,27 @@ where
 {
     type NeedleType = T;
     type GetType = T::ULE;
-    type OwnedType = T;
     fn binary_search(&self, k: &T) -> Result<usize, usize> {
         self.binary_search(k)
     }
     fn get(&self, index: usize) -> Option<&T::ULE> {
         self.get_ule_ref(index)
     }
+    fn len(&self) -> usize {
+        self.len()
+    }
+    fn is_ascending(&self) -> bool {
+        self.as_slice()
+            .windows(2)
+            .all(|w| T::from_unaligned(w[1]).cmp(&T::from_unaligned(w[0])) == Ordering::Greater)
+    }
+}
+
+impl<'a, T> ZeroVecLike<'a, T> for ZeroVec<'a, T>
+where
+    T: AsULE + Ord + Copy,
+{
+    type OwnedType = T;
     fn insert(&mut self, index: usize, value: &T) {
         self.to_mut().insert(index, value.as_unaligned())
     }
@@ -82,9 +97,6 @@ where
     fn push(&mut self, value: &T) {
         self.to_mut().push(value.as_unaligned())
     }
-    fn len(&self) -> usize {
-        self.len()
-    }
     fn new() -> Self {
         ZeroVec::Owned(Vec::new())
     }
@@ -97,14 +109,7 @@ where
     fn reserve(&mut self, addl: usize) {
         self.to_mut().reserve(addl)
     }
-    fn is_ascending(&self) -> bool {
-        self.as_slice()
-            .windows(2)
-            .all(|w| T::from_unaligned(w[1]).cmp(&T::from_unaligned(w[0])) == Ordering::Greater)
-    }
 }
-
-impl<'a, T> ZeroVecLike<'a, T> for ZeroVec<'a, T> where T: AsULE + Ord + Copy {}
 
 impl<'a, T> BorrowedZeroVecLike<'a, T> for VarZeroVec<'a, T>
 where
@@ -114,46 +119,14 @@ where
 {
     type NeedleType = T;
     type GetType = T;
-    type OwnedType = Box<T>;
     fn binary_search(&self, k: &T) -> Result<usize, usize> {
         self.binary_search(k)
     }
     fn get(&self, index: usize) -> Option<&T> {
         self.get(index)
     }
-    fn insert(&mut self, index: usize, value: &T) {
-        self.make_mut().insert(index, value)
-    }
-    fn remove(&mut self, index: usize) -> Box<T> {
-        let vec = self.make_mut();
-        let old = vec.get(index).expect("invalid index").to_boxed();
-        vec.remove(index);
-        old
-    }
-    fn replace(&mut self, index: usize, value: &T) -> Box<T> {
-        let vec = self.make_mut();
-        let old = vec.get(index).expect("invalid index").to_boxed();
-        vec.replace(index, value);
-        old
-    }
-    fn push(&mut self, value: &T) {
-        let len = self.len();
-        self.make_mut().insert(len, value)
-    }
     fn len(&self) -> usize {
         self.len()
-    }
-    fn new() -> Self {
-        VarZeroVecOwned::new().into()
-    }
-    fn with_capacity(cap: usize) -> Self {
-        VarZeroVecOwned::with_capacity(cap).into()
-    }
-    fn clear(&mut self) {
-        self.make_mut().clear()
-    }
-    fn reserve(&mut self, addl: usize) {
-        self.make_mut().reserve(addl)
     }
     fn is_ascending(&self) -> bool {
         if !self.is_empty() {
@@ -175,4 +148,36 @@ where
     T: Ord,
     T: ?Sized,
 {
+    type OwnedType = Box<T>;
+    fn insert(&mut self, index: usize, value: &T) {
+        self.make_mut().insert(index, value)
+    }
+    fn remove(&mut self, index: usize) -> Box<T> {
+        let vec = self.make_mut();
+        let old = vec.get(index).expect("invalid index").to_boxed();
+        vec.remove(index);
+        old
+    }
+    fn replace(&mut self, index: usize, value: &T) -> Box<T> {
+        let vec = self.make_mut();
+        let old = vec.get(index).expect("invalid index").to_boxed();
+        vec.replace(index, value);
+        old
+    }
+    fn push(&mut self, value: &T) {
+        let len = self.len();
+        self.make_mut().insert(len, value)
+    }
+    fn new() -> Self {
+        VarZeroVecOwned::new().into()
+    }
+    fn with_capacity(cap: usize) -> Self {
+        VarZeroVecOwned::with_capacity(cap).into()
+    }
+    fn clear(&mut self) {
+        self.make_mut().clear()
+    }
+    fn reserve(&mut self, addl: usize) {
+        self.make_mut().reserve(addl)
+    }
 }

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -73,25 +73,23 @@ pub trait MutableZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
     fn clear(&mut self);
     /// Reserve space for `addl` additional elements
     fn reserve(&mut self, addl: usize);
-    /// Construct a borrowed version from this
+    /// Construct a borrowed variant by borrowing from `&self`.
     ///
-    /// Note: This really should be `&'b self -> Self::BorrowedVariant<'b>`
-    /// but doing that requires complicated `for<'b>` code that will likely trigger
-    /// compiler bugs. Instead, we hope that `self` is covariant so this cast will
-    /// just work in the implementation. Basically, we rely on the compiler
+    /// This function behaves like `&'b self -> Self::BorrowedVariant<'b>`,
+    /// where `'b` is the lifetime of the reference to this object.
+    ///
+    /// Note: We rely on the compiler recognizing `'a` and `'b` as covariant and
     /// casting `&'b Self<'a>` to `&'b Self<'b>` when this gets called, which works
     /// out for `ZeroVec` and `VarZeroVec` containers just fine.
     fn as_borrowed(&'a self) -> Self::BorrowedVariant;
 
-    /// If this type *contains* its borrowed version, return that. Returns `None`
-    /// when this contains owned data.
+    /// Extract the inner borrowed variant if possible. Returns `None` if the data is owned.
     ///
-    /// This is subtly different from the [`Self::as_borrowed()`] since the returned type does
-    /// is not tied to the lifetime of the reference `&self`. The tradeoff here is that this
-    /// returns `None` when owned data is encountered, while we gain the ability to refer to the
-    /// wider lifetime when we *know* for a fact that it is borrowed data.
+    /// This function behaves like `&'_ self -> Self::BorrowedVariant<'a>`,
+    /// where `'a` is the lifetime of this object's borrowed data.
     ///
-    /// These are useful to ensure serialization parity between borrowed and owned versions
+    /// This function is similar to matching the `Borrowed` variant of `ZeroVec`
+    /// or `VarZeroVec`, returning the inner borrowed type.
     fn as_borrowed_inner(&self) -> Option<Self::BorrowedVariant>;
 
     /// Construct from the borrowed version of the type


### PR DESCRIPTION
Fixes #676

Part of #1082 

The ZeroMapBorrowed code is basically a straight copy-paste of the ZeroMap code (which in turn is extremely thin wrappers itself) tweaked to make it compile. The main work here was in the scaffolding so that the ZeroMap traits know about "borrowed only versions" and how to switch back and forth between them.



<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->