### PR TITLE
Switch examples to use static provider to better measure memory impact.

### DIFF
--- a/components/datetime/examples/work_log.rs
+++ b/components/datetime/examples/work_log.rs
@@ -43,7 +43,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
 
     let locale: Locale = langid!("en").into();
 
-    let provider = icu_testdata::get_provider();
+    let provider = icu_testdata::get_static_provider();
 
     let dates = DATES_ISO
         .iter()

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -43,7 +43,7 @@ criterion = "0.3"
 icu = { path = "../icu", default-features = false }
 icu_benchmark_macros = { version = "0.3", path = "../../tools/benchmark/macros" }
 icu_locid_macros = { version = "0.3", path = "../locid/macros" }
-icu_testdata = { version = "0.3", path = "../../provider/testdata" }
+icu_testdata = { version = "0.3", path = "../../provider/testdata", features = ["static"] }
 rand = "0.8"
 rand_pcg = "0.3"
 rand_distr = "0.4"

--- a/components/decimal/examples/code_line_diff.rs
+++ b/components/decimal/examples/code_line_diff.rs
@@ -29,7 +29,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
 
     let locale: Locale = langid!("bn").into();
 
-    let provider = icu_testdata::get_provider();
+    let provider = icu_testdata::get_static_provider();
 
     let mut options: options::FixedDecimalFormatOptions = Default::default();
     options.sign_display = options::SignDisplay::ExceptZero;

--- a/components/icu/Cargo.toml
+++ b/components/icu/Cargo.toml
@@ -78,7 +78,7 @@ default-features = false
 
 [dev-dependencies]
 icu_provider = { version = "0.3", path = "../../provider/core" }
-icu_testdata = { version = "0.3", path = "../../provider/testdata" }
+icu_testdata = { version = "0.3", path = "../../provider/testdata", features = ["static"] }
 icu_uniset = { version = "0.3", path = "../../utils/uniset" }
 writeable = { version = "0.2", path = "../../utils/writeable" }
 

--- a/components/icu/examples/tui.rs
+++ b/components/icu/examples/tui.rs
@@ -21,7 +21,7 @@ fn print<T: AsRef<str>>(_input: T) {
 
 #[no_mangle]
 fn main(_argc: isize, _argv: *const *const u8) -> isize {
-    let provider = icu_testdata::get_provider();
+    let provider = icu_testdata::get_static_provider();
 
     let args: Vec<String> = env::args().collect();
 

--- a/components/plurals/examples/elevator_floors.rs
+++ b/components/plurals/examples/elevator_floors.rs
@@ -28,7 +28,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
     icu_benchmark_macros::main_setup!();
     let lid = langid!("en");
 
-    let provider = icu_testdata::get_provider();
+    let provider = icu_testdata::get_static_provider();
 
     {
         print("\n====== Elevator Floor (en) example ============", None);

--- a/components/plurals/examples/unread_emails.rs
+++ b/components/plurals/examples/unread_emails.rs
@@ -27,7 +27,7 @@ fn print(_input: &str, _value: Option<usize>) {
 fn main(_argc: isize, _argv: *const *const u8) -> isize {
     icu_benchmark_macros::main_setup!();
     let lid = langid!("en");
-    let provider = icu_testdata::get_provider();
+    let provider = icu_testdata::get_static_provider();
 
     {
         print("\n====== Unread Emails (en) example ============", None);


### PR DESCRIPTION
This will allow us to monitor for changes to ZeroVec as those will not be reflected accurately in `icu_testdata::get_provider` scenario.