### PR TITLE
Remove missing docs config flag from ICU crate.

### DIFF
--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -83,7 +83,6 @@
 //! [`Locale`]: crate::locid::Locale
 //! [`SymbolsV1`]: crate::decimal::provider::DecimalSymbolsV1
 
-#![warn(missing_docs)]
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 
 pub mod calendar {
@@ -295,7 +294,6 @@ pub mod locid {
     //! [`Unicode Extensions`]: extensions
     pub use icu_locid::*;
 
-    #[allow(missing_docs)] // TODO(#1026) - Add missing docs.
     pub mod macros {
         pub use icu_locid_macros::*;
     }


### PR DESCRIPTION
Fixes #1026.