### PR TITLE
Update utils in preparation for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "criterion",
  "icu_benchmark_macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "icu_uniset"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "displaydoc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "bincode",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "icu_codepointtrie"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "displaydoc",
  "postcard",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "icu_pattern"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "displaydoc",
  "iai",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "bincode",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bincode",
  "criterion",

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -36,7 +36,7 @@ icu_locid = { version = "0.3", path = "../locid" }
 icu_plurals = { version = "0.3", path = "../plurals" }
 icu_provider = { version = "0.3", path = "../../provider/core", features = ["macros"] }
 icu_calendar = { version = "0.3", path = "../calendar" }
-writeable = { version = "0.2", path = "../../utils/writeable" }
+writeable = { version = "0.2.1", path = "../../utils/writeable" }
 litemap = { version = "0.2", path = "../../utils/litemap" }
 tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
 zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["yoke"] }

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 icu_locid = { version = "0.3", path = "../locid" }
 icu_provider = { version = "0.3", path = "../../provider/core", features = ["macros"] }
 fixed_decimal = { version = "0.2", path = "../../utils/fixed_decimal" }
-writeable = { version = "0.2", path = "../../utils/writeable" }
+writeable = { version = "0.2.1", path = "../../utils/writeable" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 displaydoc = { version = "0.2.3", default-features = false }
 

--- a/components/icu/Cargo.toml
+++ b/components/icu/Cargo.toml
@@ -80,7 +80,7 @@ default-features = false
 icu_codepointtrie = { version = "0.3", path = "../../utils/codepointtrie" }
 icu_provider = { version = "0.3", path = "../../provider/core" }
 icu_testdata = { version = "0.3", path = "../../provider/testdata", features = ["static"] }
-icu_uniset = { version = "0.3", path = "../../utils/uniset" }
+icu_uniset = { version = "0.4", path = "../../utils/uniset" }
 writeable = { version = "0.2.1", path = "../../utils/writeable" }
 
 [features]

--- a/components/icu/Cargo.toml
+++ b/components/icu/Cargo.toml
@@ -81,7 +81,7 @@ icu_codepointtrie = { version = "0.2", path = "../../utils/codepointtrie" }
 icu_provider = { version = "0.3", path = "../../provider/core" }
 icu_testdata = { version = "0.3", path = "../../provider/testdata", features = ["static"] }
 icu_uniset = { version = "0.3", path = "../../utils/uniset" }
-writeable = { version = "0.2", path = "../../utils/writeable" }
+writeable = { version = "0.2.1", path = "../../utils/writeable" }
 
 [features]
 std = [

--- a/components/icu/Cargo.toml
+++ b/components/icu/Cargo.toml
@@ -77,7 +77,7 @@ path = "../../utils/fixed_decimal"
 default-features = false
 
 [dev-dependencies]
-icu_codepointtrie = { version = "0.2", path = "../../utils/codepointtrie" }
+icu_codepointtrie = { version = "0.3", path = "../../utils/codepointtrie" }
 icu_provider = { version = "0.3", path = "../../provider/core" }
 icu_testdata = { version = "0.3", path = "../../provider/testdata", features = ["static"] }
 icu_uniset = { version = "0.3", path = "../../utils/uniset" }

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -36,7 +36,7 @@ all-features = true
 [dependencies]
 tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
-writeable = { version = "0.2", path = "../../utils/writeable" }
+writeable = { version = "0.2.1", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
 
 [dev-dependencies]

--- a/components/properties/Cargo.toml
+++ b/components/properties/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 displaydoc = { version = "0.2.3", default-features = false }
 icu_codepointtrie = { version = "0.3", path = "../../utils/codepointtrie", features = ["serde"] }
 icu_provider = { version = "0.3", path = "../../provider/core", features = ["macros"] }
-icu_uniset = { version = "0.3", path = "../../utils/uniset", features = ["serde"] }
+icu_uniset = { version = "0.4", path = "../../utils/uniset", features = ["serde"] }
 num_enum = { version = "0.5.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["serde"] }

--- a/components/properties/Cargo.toml
+++ b/components/properties/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
-icu_codepointtrie = { version = "0.2", path = "../../utils/codepointtrie", features = ["serde"] }
+icu_codepointtrie = { version = "0.3", path = "../../utils/codepointtrie", features = ["serde"] }
 icu_provider = { version = "0.3", path = "../../provider/core", features = ["macros"] }
 icu_uniset = { version = "0.3", path = "../../utils/uniset", features = ["serde"] }
 num_enum = { version = "0.5.4", default-features = false }

--- a/experimental/bies/Cargo.toml
+++ b/experimental/bies/Cargo.toml
@@ -29,7 +29,7 @@ all-features = true
 itertools = "0.10"
 num-traits = "0.2"
 partial-min-max = "0.4"
-writeable = { version = "0.2", path = "../../utils/writeable" }
+writeable = { version = "0.2.1", path = "../../utils/writeable" }
 strum = { version = "0.20", features = ["derive"] }
 
 [dev-dependencies]

--- a/experimental/segmenter_lstm/Cargo.toml
+++ b/experimental/segmenter_lstm/Cargo.toml
@@ -29,7 +29,7 @@ litemap = { version = "0.2", path = "../../utils/litemap", features = ["serde"] 
 serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
 ndarray = { version = "0.15", features = ["serde"] }
 unicode-segmentation = "1.3.0"
-yoke = { path = "../../utils/yoke", features = ["serde", "derive"] }
+yoke = { version = "0.3", path = "../../utils/yoke", features = ["serde", "derive"] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/provider/blob/Cargo.toml
+++ b/provider/blob/Cargo.toml
@@ -34,7 +34,7 @@ postcard = { version = "0.7.0", default-features = false }
 erased-serde = { version = "0.3", default-features = false, features = ["alloc"] }
 litemap = { version = "0.2.0", path = "../../utils/litemap/", features = ["serde"] }
 writeable = { path = "../../utils/writeable" }
-yoke = { path = "../../utils/yoke" }
+yoke = { version = "0.3", path = "../../utils/yoke" }
 
 # For the export feature
 log = { version = "0.4", optional = true }

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -39,7 +39,7 @@ macros = ["icu_provider_macros"]
 [dependencies]
 icu_locid = { version = "0.3", path = "../../components/locid" }
 tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
-writeable = { version = "0.2", path = "../../utils/writeable" }
+writeable = { version = "0.2.1", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
 yoke = { version = "0.2.1", path = "../../utils/yoke", features = ["serde", "derive"] }
 litemap = { path = "../../utils/litemap", version = "0.2.1" }

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -41,7 +41,7 @@ icu_locid = { version = "0.3", path = "../../components/locid" }
 tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
 writeable = { version = "0.2.1", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
-yoke = { version = "0.2.1", path = "../../utils/yoke", features = ["serde", "derive"] }
+yoke = { version = "0.3", path = "../../utils/yoke", features = ["serde", "derive"] }
 litemap = { path = "../../utils/litemap", version = "0.2.1" }
 icu_provider_macros = { version = "0.3", path = "../macros", optional = true }
 

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -142,7 +142,7 @@ cargo_metadata = { version = "0.13", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 serde_json = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
 displaydoc = { version = "0.2.3", default-features = false, optional = true }
-writeable = { version = "0.2", path = "../../utils/writeable", optional = true }
+writeable = { version = "0.2.1", path = "../../utils/writeable", optional = true }
 
 [dev-dependencies]
 icu_locid_macros = { version = "0.3", path = "../../components/locid/macros" }

--- a/provider/uprops/Cargo.toml
+++ b/provider/uprops/Cargo.toml
@@ -28,7 +28,7 @@ all-features = true
 
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
-icu_codepointtrie = { version = "0.2", path = "../../utils/codepointtrie", features = ["provider_serde"] }
+icu_codepointtrie = { version = "0.3", path = "../../utils/codepointtrie", features = ["provider_serde"] }
 icu_properties = { version = "0.3", path = "../../components/properties", features = ["provider_serde"] }
 icu_provider = { version = "0.3", path = "../../provider/core", features = ["provider_serde"] }
 icu_uniset = { version = "0.3", path = "../../utils/uniset", features = ["provider_serde"] }

--- a/provider/uprops/Cargo.toml
+++ b/provider/uprops/Cargo.toml
@@ -31,7 +31,7 @@ displaydoc = { version = "0.2.3", default-features = false }
 icu_codepointtrie = { version = "0.3", path = "../../utils/codepointtrie", features = ["provider_serde"] }
 icu_properties = { version = "0.3", path = "../../components/properties", features = ["provider_serde"] }
 icu_provider = { version = "0.3", path = "../../provider/core", features = ["provider_serde"] }
-icu_uniset = { version = "0.3", path = "../../utils/uniset", features = ["provider_serde"] }
+icu_uniset = { version = "0.4", path = "../../utils/uniset", features = ["provider_serde"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = { version = "0.5" }
 zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["serde", "yoke"] }

--- a/tools/datagen/Cargo.toml
+++ b/tools/datagen/Cargo.toml
@@ -43,7 +43,7 @@ reqwest = { version = "0.11", features = ["json", "stream", "gzip"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 simple_logger = "1.12"
 tokio = { version = "1.5", features = ["rt-multi-thread", "macros", "fs"] }
-writeable = { version = "0.2", path = "../../utils/writeable" }
+writeable = { version = "0.2.1", path = "../../utils/writeable" }
 
 [[bin]]
 name = "icu4x-datagen"

--- a/utils/codepointtrie/Cargo.toml
+++ b/utils/codepointtrie/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_codepointtrie"
 description = "API for an efficient trie of data for Unicode code points"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"

--- a/utils/codepointtrie/Cargo.toml
+++ b/utils/codepointtrie/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
-yoke = { path = "../yoke", version = "0.2.0", features = ["derive"] }
+yoke = { version = "0.3", path = "../yoke", features = ["derive"] }
 zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["serde", "yoke"] }
 
 [dev-dependencies]

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -29,7 +29,7 @@ all-features = true
 [dependencies]
 smallvec = "1.6"
 static_assertions = "1.1"
-writeable = { version = "0.2", path = "../../utils/writeable" }
+writeable = { version = "0.2.1", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
 
 [dev-dependencies]

--- a/utils/pattern/Cargo.toml
+++ b/utils/pattern/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_pattern"
 description = "ICU pattern utilities"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"

--- a/utils/pattern/Cargo.toml
+++ b/utils/pattern/Cargo.toml
@@ -25,7 +25,7 @@ all-features = true
 
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
-writeable = { version = "0.2", path = "../writeable" }
+writeable = { version = "0.2.1", path = "../writeable" }
 
 [dev-dependencies]
 iai = "0.1"

--- a/utils/uniset/Cargo.toml
+++ b/utils/uniset/Cargo.toml
@@ -36,7 +36,7 @@ litemap = { version = "0.2", path = "../../utils/litemap" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
-yoke = { path = "../yoke", version = "0.2.0", features = ["derive"] }
+yoke = { version = "0.3", path = "../yoke", features = ["derive"] }
 zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["serde"] }
 
 [dev-dependencies]

--- a/utils/uniset/Cargo.toml
+++ b/utils/uniset/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_uniset"
 description = "API for highly efficient querying of sets of Unicode characters"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"

--- a/utils/writeable/Cargo.toml
+++ b/utils/writeable/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "writeable"
 description = "A more efficient alternative to fmt::Display"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "yoke"
-version = "0.2.3"
+version = "0.3.0"
 description = "Abstraction allowing borrowed data to be carried along with the backing data it borrows from"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2018"

--- a/utils/yoke/derive/Cargo.toml
+++ b/utils/yoke/derive/Cargo.toml
@@ -26,5 +26,5 @@ syn = { version = "1.0.73", features = ["derive", "fold"] }
 synstructure = "0.12.4"
 
 [dev-dependencies]
-yoke = { path = "..", version = "0.2.0" , features = ["derive"]}
+yoke = { version = "0.3", path = "..", features = ["derive"]}
 zerovec = { version = "0.4", path = "../../zerovec", features = ["yoke"] }

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -25,7 +25,7 @@ all-features = true
 
 [dependencies]
 serde = { version = "1.0", optional = true , default-features = false, features = ["alloc"] }
-yoke = { path = "../yoke", version = "0.2.0", optional = true }
+yoke = { version = "0.3", path = "../yoke", optional = true }
 
 [dev-dependencies]
 icu_benchmark_macros = { version = "0.3", path = "../../tools/benchmark/macros" }

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "zerovec"
 description = "Zero-copy vector backed by a byte array"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"


### PR DESCRIPTION
This PR should be merged shortly before the 0.4 release is cut -- crucially we should not land any changes to `utils` between this landing and the 0.4 release being made.

Released crates cannot depend on features from path dependencies, so every time we make a release we should be making sure the utils are appropriately updated.

I went through all of our utils and did the following:

 - Utils with breaking changes got a breaking version bump and all other crates updated their dependency on them
 - Utils with non breaking changes that introduced behavior that other parts of icu4x depend got a non-breaking bump and all other crates updated their dependency on them
 - Utils with non breaking changes that other crates are not relying on (e.g. "better error formatting") sill got a non breaking bump so that users can benefit from that, but other crates were not updated since the older version is also compatible
 - Utils with no code changes were left alone

`zerovec` technically had a breaking change but I treated it as if it didn't: the signature of `EncodeAsVarULE` was changed since the last major version (0.4). To be fully correct we should release a 0.5, but this is a new feature in a crate that is not widely used yet, so I'm not that worried about just bumping to 0.4.1. Furthermore, if we released 0.5, `tinystr` would also need to be updated. I'm happy to change this to a 0.5 instead if people want.