### PR TITLE
Bump yoke-derive in preparation for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bincode",
  "serde",
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/experimental/segmenter_lstm/Cargo.toml
+++ b/experimental/segmenter_lstm/Cargo.toml
@@ -29,7 +29,7 @@ litemap = { version = "0.2", path = "../../utils/litemap", features = ["serde"] 
 serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
 ndarray = { version = "0.15", features = ["serde"] }
 unicode-segmentation = "1.3.0"
-yoke = { version = "0.3", path = "../../utils/yoke", features = ["serde", "derive"] }
+yoke = { version = "0.3.1", path = "../../utils/yoke", features = ["serde", "derive"] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/provider/blob/Cargo.toml
+++ b/provider/blob/Cargo.toml
@@ -34,7 +34,7 @@ postcard = { version = "0.7.0", default-features = false }
 erased-serde = { version = "0.3", default-features = false, features = ["alloc"] }
 litemap = { version = "0.2.0", path = "../../utils/litemap/", features = ["serde"] }
 writeable = { path = "../../utils/writeable" }
-yoke = { version = "0.3", path = "../../utils/yoke" }
+yoke = { version = "0.3.1", path = "../../utils/yoke" }
 
 # For the export feature
 log = { version = "0.4", optional = true }

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -41,7 +41,7 @@ icu_locid = { version = "0.3", path = "../../components/locid" }
 tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
 writeable = { version = "0.2.1", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
-yoke = { version = "0.3", path = "../../utils/yoke", features = ["serde", "derive"] }
+yoke = { version = "0.3.1", path = "../../utils/yoke", features = ["serde", "derive"] }
 litemap = { path = "../../utils/litemap", version = "0.2.1" }
 icu_provider_macros = { version = "0.3", path = "../macros", optional = true }
 

--- a/utils/codepointtrie/Cargo.toml
+++ b/utils/codepointtrie/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
-yoke = { version = "0.3", path = "../yoke", features = ["derive"] }
+yoke = { version = "0.3.1", path = "../yoke", features = ["derive"] }
 zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["serde", "yoke"] }
 
 [dev-dependencies]

--- a/utils/uniset/Cargo.toml
+++ b/utils/uniset/Cargo.toml
@@ -36,7 +36,7 @@ litemap = { version = "0.2", path = "../../utils/litemap" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
-yoke = { version = "0.3", path = "../yoke", features = ["derive"] }
+yoke = { version = "0.3.1", path = "../yoke", features = ["derive"] }
 zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["serde"] }
 
 [dev-dependencies]

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "yoke"
-version = "0.3.0"
+version = "0.3.1"
 description = "Abstraction allowing borrowed data to be carried along with the backing data it borrows from"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2018"
@@ -32,7 +32,7 @@ all-features = true
 [dependencies]
 stable_deref_trait = { version = "1.2.0", features = ["alloc"], default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
-yoke-derive = { path = "./derive", version = "0.1.1", optional = true}
+yoke-derive = { path = "./derive", version = "0.1.2", optional = true}
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/utils/yoke/derive/Cargo.toml
+++ b/utils/yoke/derive/Cargo.toml
@@ -26,5 +26,5 @@ syn = { version = "1.0.73", features = ["derive", "fold"] }
 synstructure = "0.12.4"
 
 [dev-dependencies]
-yoke = { version = "0.3", path = "..", features = ["derive"]}
+yoke = { version = "0.3.1", path = "..", features = ["derive"]}
 zerovec = { version = "0.4", path = "../../zerovec", features = ["yoke"] }

--- a/utils/yoke/derive/Cargo.toml
+++ b/utils/yoke/derive/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "yoke-derive"
-version = "0.1.1"
+version = "0.1.2"
 description = "Custom derive for the yoke crate"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "LICENSE"

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -25,7 +25,7 @@ all-features = true
 
 [dependencies]
 serde = { version = "1.0", optional = true , default-features = false, features = ["alloc"] }
-yoke = { version = "0.3", path = "../yoke", optional = true }
+yoke = { version = "0.3.1", path = "../yoke", optional = true }
 
 [dev-dependencies]
 icu_benchmark_macros = { version = "0.3", path = "../../tools/benchmark/macros" }


### PR DESCRIPTION
I thought we had a release including this feature, i thought wrong.

(This prevents CPT from building since CPT uses the generics support)

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->