### PR TITLE
ZeroCopyFrom simplification attempt

### DIFF
--- a/utils/yoke/src/macro_impls.rs
+++ b/utils/yoke/src/macro_impls.rs
@@ -61,11 +61,12 @@ unsafe impl<'a, T: Copy + 'static, const N: usize> Yokeable<'a> for [T; N] {
     type Output = Self;
     copy_yoke_impl!();
 }
-// impl<T: Copy + 'static, const N: usize> ZeroCopyFrom<[T; N]> for [T; N] {
-//     fn zero_copy_from(this: &Self) -> Self {
-//         *this
-//     }
-// }
+
+impl<'b, T: Copy + 'static, const N: usize> ZeroCopyFrom<'b, [T; N]> for [T; N] {
+    fn zero_copy_from(this: &'b Self) -> Self {
+        *this
+    }
+}
 
 // This is for when we're implementing Yoke on a complex type such that it's not
 // obvious to the compiler that the lifetime is covariant

--- a/utils/yoke/src/macro_impls.rs
+++ b/utils/yoke/src/macro_impls.rs
@@ -34,8 +34,8 @@ macro_rules! impl_copy_type {
             type Output = Self;
             copy_yoke_impl!();
         }
-        impl ZeroCopyFrom<$ty> for $ty {
-            fn zero_copy_from(this: &Self) -> Self {
+        impl<'b> ZeroCopyFrom<'b, $ty> for $ty {
+            fn zero_copy_from(this: &'b Self) -> Self {
                 // Essentially only works when the struct is fully Copy
                 *this
             }
@@ -61,11 +61,11 @@ unsafe impl<'a, T: Copy + 'static, const N: usize> Yokeable<'a> for [T; N] {
     type Output = Self;
     copy_yoke_impl!();
 }
-impl<T: Copy + 'static, const N: usize> ZeroCopyFrom<[T; N]> for [T; N] {
-    fn zero_copy_from(this: &Self) -> Self {
-        *this
-    }
-}
+// impl<T: Copy + 'static, const N: usize> ZeroCopyFrom<[T; N]> for [T; N] {
+//     fn zero_copy_from(this: &Self) -> Self {
+//         *this
+//     }
+// }
 
 // This is for when we're implementing Yoke on a complex type such that it's not
 // obvious to the compiler that the lifetime is covariant

--- a/utils/yoke/src/zero_copy_from.rs
+++ b/utils/yoke/src/zero_copy_from.rs
@@ -63,8 +63,8 @@ use alloc::string::String;
 /// }
 ///
 /// // Reference from a borrowed version of self
-/// impl<'data> ZeroCopyFrom<MyStruct<'data>> for MyStruct<'static> {
-///     fn zero_copy_from<'b>(cart: &'b MyStruct<'data>) -> MyStruct<'b> {
+/// impl<'data> ZeroCopyFrom<'data, MyStruct<'_>> for MyStruct<'data> {
+///     fn zero_copy_from(cart: &'data MyStruct<'_>) -> MyStruct<'data> {
 ///         MyStruct {
 ///             message: Cow::Borrowed(&cart.message)
 ///         }
@@ -72,8 +72,8 @@ use alloc::string::String;
 /// }
 ///
 /// // Reference from a string slice directly
-/// impl ZeroCopyFrom<str> for MyStruct<'static> {
-///     fn zero_copy_from<'b>(cart: &'b str) -> MyStruct<'b> {
+/// impl<'data> ZeroCopyFrom<'data, str> for MyStruct<'data> {
+///     fn zero_copy_from(cart: &'data str) -> MyStruct<'data> {
 ///         MyStruct {
 ///             message: Cow::Borrowed(cart)
 ///         }

--- a/utils/yoke/src/zero_copy_from.rs
+++ b/utils/yoke/src/zero_copy_from.rs
@@ -210,72 +210,72 @@ where
 // // to customize their `ZeroCopyFrom` impl. The blanket implementation may be safe once Rust has
 // // specialization.
 
-// #[cfg(feature = "alloc")]
-// impl ZeroCopyFrom<str> for Cow<'static, str> {
-//     fn zero_copy_from<'b>(cart: &'b str) -> Cow<'b, str> {
-//         Cow::Borrowed(cart)
-//     }
-// }
+#[cfg(feature = "alloc")]
+impl<'b> ZeroCopyFrom<'b, str> for Cow<'b, str> {
+    fn zero_copy_from(cart: &'b str) -> Cow<'b, str> {
+        Cow::Borrowed(cart)
+    }
+}
 
-// #[cfg(feature = "alloc")]
-// impl ZeroCopyFrom<String> for Cow<'static, str> {
-//     fn zero_copy_from<'b>(cart: &'b String) -> Cow<'b, str> {
-//         Cow::Borrowed(cart)
-//     }
-// }
+#[cfg(feature = "alloc")]
+impl<'b> ZeroCopyFrom<'b, String> for Cow<'b, str> {
+    fn zero_copy_from(cart: &'b String) -> Cow<'b, str> {
+        Cow::Borrowed(cart)
+    }
+}
 
-// impl ZeroCopyFrom<str> for &'static str {
-//     fn zero_copy_from<'b>(cart: &'b str) -> &'b str {
-//         cart
-//     }
-// }
+impl<'b> ZeroCopyFrom<'b, str> for &'b str {
+    fn zero_copy_from(cart: &'b str) -> &'b str {
+        cart
+    }
+}
 
-// #[cfg(feature = "alloc")]
-// impl ZeroCopyFrom<String> for &'static str {
-//     fn zero_copy_from<'b>(cart: &'b String) -> &'b str {
-//         cart
-//     }
-// }
+#[cfg(feature = "alloc")]
+impl<'b> ZeroCopyFrom<'b, String> for &'b str {
+    fn zero_copy_from(cart: &'b String) -> &'b str {
+        cart
+    }
+}
 
-// impl<C, T: ZeroCopyFrom<C>> ZeroCopyFrom<Option<C>> for Option<T> {
-//     fn zero_copy_from<'b>(cart: &'b Option<C>) -> Option<<T as Yokeable<'b>>::Output> {
-//         cart.as_ref()
-//             .map(|c| <T as ZeroCopyFrom<C>>::zero_copy_from(c))
-//     }
-// }
+impl<'b, C, T: ZeroCopyFrom<'b, C>> ZeroCopyFrom<'b, Option<C>> for Option<T> {
+    fn zero_copy_from(cart: &'b Option<C>) -> Option<T> {
+        cart.as_ref()
+            .map(|c| <T as ZeroCopyFrom<'b, C>>::zero_copy_from(c))
+    }
+}
 
-// impl<C1, T1: ZeroCopyFrom<C1>, C2, T2: ZeroCopyFrom<C2>> ZeroCopyFrom<(C1, C2)> for (T1, T2) {
-//     fn zero_copy_from<'b>(
-//         cart: &'b (C1, C2),
-//     ) -> (<T1 as Yokeable<'b>>::Output, <T2 as Yokeable<'b>>::Output) {
-//         (
-//             <T1 as ZeroCopyFrom<C1>>::zero_copy_from(&cart.0),
-//             <T2 as ZeroCopyFrom<C2>>::zero_copy_from(&cart.1),
-//         )
-//     }
-// }
+impl<'b, C1, T1: ZeroCopyFrom<'b, C1>, C2, T2: ZeroCopyFrom<'b, C2>> ZeroCopyFrom<'b, (C1, C2)>
+    for (T1, T2)
+{
+    fn zero_copy_from(cart: &'b (C1, C2)) -> (T1, T2) {
+        (
+            <T1 as ZeroCopyFrom<'b, C1>>::zero_copy_from(&cart.0),
+            <T2 as ZeroCopyFrom<'b, C2>>::zero_copy_from(&cart.1),
+        )
+    }
+}
 
-// // These duplicate the functionality from above and aren't quite necessary due
-// // to deref coercions, however for the custom derive to work, there always needs
-// // to be `impl ZCF<T> for T`, otherwise it may fail to perform the necessary
-// // type inference. Deref coercions do not typically work when sufficient generics
-// // or inference are involved, and the proc macro does not necessarily have
-// // enough type information to figure this out on its own.
-// #[cfg(feature = "alloc")]
-// impl<B: ToOwned + ?Sized + 'static> ZeroCopyFrom<Cow<'_, B>> for Cow<'static, B> {
-//     fn zero_copy_from<'b>(cart: &'b Cow<'_, B>) -> Cow<'b, B> {
-//         Cow::Borrowed(cart)
-//     }
-// }
+// These duplicate the functionality from above and aren't quite necessary due
+// to deref coercions, however for the custom derive to work, there always needs
+// to be `impl ZCF<T> for T`, otherwise it may fail to perform the necessary
+// type inference. Deref coercions do not typically work when sufficient generics
+// or inference are involved, and the proc macro does not necessarily have
+// enough type information to figure this out on its own.
+#[cfg(feature = "alloc")]
+impl<'b, B: ToOwned + ?Sized + 'static> ZeroCopyFrom<'b, Cow<'_, B>> for Cow<'b, B> {
+    fn zero_copy_from(cart: &'b Cow<'_, B>) -> Cow<'b, B> {
+        Cow::Borrowed(cart)
+    }
+}
 
-// impl ZeroCopyFrom<&'_ str> for &'static str {
-//     fn zero_copy_from<'b>(cart: &'b &'_ str) -> &'b str {
-//         cart
-//     }
-// }
+impl<'b> ZeroCopyFrom<'b, &'_ str> for &'b str {
+    fn zero_copy_from(cart: &'b &'_ str) -> &'b str {
+        cart
+    }
+}
 
-// impl<T> ZeroCopyFrom<[T]> for &'static [T] {
-//     fn zero_copy_from<'b>(cart: &'b [T]) -> &'b [T] {
-//         cart
-//     }
-// }
+impl<'b, T> ZeroCopyFrom<'b, [T]> for &'b [T] {
+    fn zero_copy_from(cart: &'b [T]) -> &'b [T] {
+        cart
+    }
+}

--- a/utils/yoke/src/zero_copy_from.rs
+++ b/utils/yoke/src/zero_copy_from.rs
@@ -85,164 +85,164 @@ pub trait ZeroCopyFrom<'b, C: ?Sized> {
     fn zero_copy_from(cart: &'b C) -> Self;
 }
 
-impl<'b, 's, Y: ZeroCopyFrom<C> + for<'a> Yokeable<'a>, C: ?Sized> Yoke<Y, &'b C> {
-    /// Construct a [`Yoke`]`<Y, &C>` from a borrowed cart by zero-copy cloning the cart to `Y` and
-    /// then yokeing that object to the cart.
-    ///
-    /// This results in a [`Yoke`] bound to the lifetime of the reference to the borrowed cart.
-    ///
-    /// The type `Y` must implement [`ZeroCopyFrom`]`<C>`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use yoke::Yoke;
-    /// use std::borrow::Cow;
-    ///  
-    /// let yoke = Yoke::<
-    ///     Cow<'static, str>,
-    ///     &str
-    /// >::attach_to_borrowed_cart("demo");
-    ///
-    /// assert_eq!("demo", yoke.get());
-    /// ```
-    pub fn attach_to_borrowed_cart(cart: &'b C) -> Self {
-        Yoke::<Y, &'b C>::attach_to_cart_badly(cart, Y::zero_copy_from)
-    }
-}
+// impl<'b, 's, Y: ZeroCopyFrom<C> + for<'a> Yokeable<'a>, C: ?Sized> Yoke<Y, &'b C> {
+//     /// Construct a [`Yoke`]`<Y, &C>` from a borrowed cart by zero-copy cloning the cart to `Y` and
+//     /// then yokeing that object to the cart.
+//     ///
+//     /// This results in a [`Yoke`] bound to the lifetime of the reference to the borrowed cart.
+//     ///
+//     /// The type `Y` must implement [`ZeroCopyFrom`]`<C>`.
+//     ///
+//     /// # Example
+//     ///
+//     /// ```
+//     /// use yoke::Yoke;
+//     /// use std::borrow::Cow;
+//     ///  
+//     /// let yoke = Yoke::<
+//     ///     Cow<'static, str>,
+//     ///     &str
+//     /// >::attach_to_borrowed_cart("demo");
+//     ///
+//     /// assert_eq!("demo", yoke.get());
+//     /// ```
+//     pub fn attach_to_borrowed_cart(cart: &'b C) -> Self {
+//         Yoke::<Y, &'b C>::attach_to_cart_badly(cart, Y::zero_copy_from)
+//     }
+// }
 
-#[cfg(feature = "alloc")]
-impl<'b, 's, Y: ZeroCopyFrom<C> + for<'a> Yokeable<'a>, C: ?Sized> Yoke<Y, Box<C>> {
-    /// Construct a [`Yoke`]`<Y, Box<C>>` from a boxed cart by zero-copy cloning the cart to `Y` and
-    /// then yokeing that object to the cart.
-    ///
-    /// This results in a [`Yoke`] bound to the lifetime of data within the cart. If the cart is
-    /// fully owned, then the resulting [`Yoke`] will be `'static`.
-    ///
-    /// The type `Y` must implement [`ZeroCopyFrom`]`<C>`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use yoke::Yoke;
-    /// use std::borrow::Cow;
-    ///
-    /// let box_cart = Box::new("demo".to_string());
-    ///  
-    /// let yoke = Yoke::<
-    ///     Cow<'static, str>,
-    ///     Box<String>
-    /// >::attach_to_box_cart(box_cart);
-    ///
-    /// assert_eq!("demo", yoke.get());
-    /// ```
-    pub fn attach_to_box_cart(cart: Box<C>) -> Self {
-        Yoke::<Y, Box<C>>::attach_to_cart_badly(cart, Y::zero_copy_from)
-    }
-}
+// #[cfg(feature = "alloc")]
+// impl<'b, 's, Y: ZeroCopyFrom<C> + for<'a> Yokeable<'a>, C: ?Sized> Yoke<Y, Box<C>> {
+//     /// Construct a [`Yoke`]`<Y, Box<C>>` from a boxed cart by zero-copy cloning the cart to `Y` and
+//     /// then yokeing that object to the cart.
+//     ///
+//     /// This results in a [`Yoke`] bound to the lifetime of data within the cart. If the cart is
+//     /// fully owned, then the resulting [`Yoke`] will be `'static`.
+//     ///
+//     /// The type `Y` must implement [`ZeroCopyFrom`]`<C>`.
+//     ///
+//     /// # Example
+//     ///
+//     /// ```
+//     /// use yoke::Yoke;
+//     /// use std::borrow::Cow;
+//     ///
+//     /// let box_cart = Box::new("demo".to_string());
+//     ///  
+//     /// let yoke = Yoke::<
+//     ///     Cow<'static, str>,
+//     ///     Box<String>
+//     /// >::attach_to_box_cart(box_cart);
+//     ///
+//     /// assert_eq!("demo", yoke.get());
+//     /// ```
+//     pub fn attach_to_box_cart(cart: Box<C>) -> Self {
+//         Yoke::<Y, Box<C>>::attach_to_cart_badly(cart, Y::zero_copy_from)
+//     }
+// }
 
-#[cfg(feature = "alloc")]
-impl<'b, 's, Y: ZeroCopyFrom<C> + for<'a> Yokeable<'a>, C: ?Sized> Yoke<Y, Rc<C>> {
-    /// Construct a [`Yoke`]`<Y, Rc<C>>` from a reference-counted cart by zero-copy cloning the
-    /// cart to `Y` and then yokeing that object to the cart.
-    ///
-    /// This results in a [`Yoke`] bound to the lifetime of data within the cart. If the cart is
-    /// fully owned, then the resulting [`Yoke`] will be `'static`.
-    ///
-    /// The type `Y` must implement [`ZeroCopyFrom`]`<C>`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use yoke::Yoke;
-    /// use std::borrow::Cow;
-    /// use std::rc::Rc;
-    ///
-    /// let rc_cart = Rc::from("demo".to_string());
-    ///  
-    /// let yoke = Yoke::<
-    ///     Cow<'static, str>,
-    ///     Rc<String>
-    /// >::attach_to_rc_cart(rc_cart);
-    ///
-    /// assert_eq!("demo", yoke.get());
-    /// ```
-    pub fn attach_to_rc_cart(cart: Rc<C>) -> Self {
-        Yoke::<Y, Rc<C>>::attach_to_cart_badly(cart, Y::zero_copy_from)
-    }
-}
+// #[cfg(feature = "alloc")]
+// impl<'b, 's, Y: ZeroCopyFrom<C> + for<'a> Yokeable<'a>, C: ?Sized> Yoke<Y, Rc<C>> {
+//     /// Construct a [`Yoke`]`<Y, Rc<C>>` from a reference-counted cart by zero-copy cloning the
+//     /// cart to `Y` and then yokeing that object to the cart.
+//     ///
+//     /// This results in a [`Yoke`] bound to the lifetime of data within the cart. If the cart is
+//     /// fully owned, then the resulting [`Yoke`] will be `'static`.
+//     ///
+//     /// The type `Y` must implement [`ZeroCopyFrom`]`<C>`.
+//     ///
+//     /// # Example
+//     ///
+//     /// ```
+//     /// use yoke::Yoke;
+//     /// use std::borrow::Cow;
+//     /// use std::rc::Rc;
+//     ///
+//     /// let rc_cart = Rc::from("demo".to_string());
+//     ///  
+//     /// let yoke = Yoke::<
+//     ///     Cow<'static, str>,
+//     ///     Rc<String>
+//     /// >::attach_to_rc_cart(rc_cart);
+//     ///
+//     /// assert_eq!("demo", yoke.get());
+//     /// ```
+//     pub fn attach_to_rc_cart(cart: Rc<C>) -> Self {
+//         Yoke::<Y, Rc<C>>::attach_to_cart_badly(cart, Y::zero_copy_from)
+//     }
+// }
 
-// Note: The following could be blanket implementations, but that would require constraining the
-// blanket `T` on `T: 'static`, which may not be desirable for all downstream users who may wish
-// to customize their `ZeroCopyFrom` impl. The blanket implementation may be safe once Rust has
-// specialization.
+// // Note: The following could be blanket implementations, but that would require constraining the
+// // blanket `T` on `T: 'static`, which may not be desirable for all downstream users who may wish
+// // to customize their `ZeroCopyFrom` impl. The blanket implementation may be safe once Rust has
+// // specialization.
 
-#[cfg(feature = "alloc")]
-impl ZeroCopyFrom<str> for Cow<'static, str> {
-    fn zero_copy_from<'b>(cart: &'b str) -> Cow<'b, str> {
-        Cow::Borrowed(cart)
-    }
-}
+// #[cfg(feature = "alloc")]
+// impl ZeroCopyFrom<str> for Cow<'static, str> {
+//     fn zero_copy_from<'b>(cart: &'b str) -> Cow<'b, str> {
+//         Cow::Borrowed(cart)
+//     }
+// }
 
-#[cfg(feature = "alloc")]
-impl ZeroCopyFrom<String> for Cow<'static, str> {
-    fn zero_copy_from<'b>(cart: &'b String) -> Cow<'b, str> {
-        Cow::Borrowed(cart)
-    }
-}
+// #[cfg(feature = "alloc")]
+// impl ZeroCopyFrom<String> for Cow<'static, str> {
+//     fn zero_copy_from<'b>(cart: &'b String) -> Cow<'b, str> {
+//         Cow::Borrowed(cart)
+//     }
+// }
 
-impl ZeroCopyFrom<str> for &'static str {
-    fn zero_copy_from<'b>(cart: &'b str) -> &'b str {
-        cart
-    }
-}
+// impl ZeroCopyFrom<str> for &'static str {
+//     fn zero_copy_from<'b>(cart: &'b str) -> &'b str {
+//         cart
+//     }
+// }
 
-#[cfg(feature = "alloc")]
-impl ZeroCopyFrom<String> for &'static str {
-    fn zero_copy_from<'b>(cart: &'b String) -> &'b str {
-        cart
-    }
-}
+// #[cfg(feature = "alloc")]
+// impl ZeroCopyFrom<String> for &'static str {
+//     fn zero_copy_from<'b>(cart: &'b String) -> &'b str {
+//         cart
+//     }
+// }
 
-impl<C, T: ZeroCopyFrom<C>> ZeroCopyFrom<Option<C>> for Option<T> {
-    fn zero_copy_from<'b>(cart: &'b Option<C>) -> Option<<T as Yokeable<'b>>::Output> {
-        cart.as_ref()
-            .map(|c| <T as ZeroCopyFrom<C>>::zero_copy_from(c))
-    }
-}
+// impl<C, T: ZeroCopyFrom<C>> ZeroCopyFrom<Option<C>> for Option<T> {
+//     fn zero_copy_from<'b>(cart: &'b Option<C>) -> Option<<T as Yokeable<'b>>::Output> {
+//         cart.as_ref()
+//             .map(|c| <T as ZeroCopyFrom<C>>::zero_copy_from(c))
+//     }
+// }
 
-impl<C1, T1: ZeroCopyFrom<C1>, C2, T2: ZeroCopyFrom<C2>> ZeroCopyFrom<(C1, C2)> for (T1, T2) {
-    fn zero_copy_from<'b>(
-        cart: &'b (C1, C2),
-    ) -> (<T1 as Yokeable<'b>>::Output, <T2 as Yokeable<'b>>::Output) {
-        (
-            <T1 as ZeroCopyFrom<C1>>::zero_copy_from(&cart.0),
-            <T2 as ZeroCopyFrom<C2>>::zero_copy_from(&cart.1),
-        )
-    }
-}
+// impl<C1, T1: ZeroCopyFrom<C1>, C2, T2: ZeroCopyFrom<C2>> ZeroCopyFrom<(C1, C2)> for (T1, T2) {
+//     fn zero_copy_from<'b>(
+//         cart: &'b (C1, C2),
+//     ) -> (<T1 as Yokeable<'b>>::Output, <T2 as Yokeable<'b>>::Output) {
+//         (
+//             <T1 as ZeroCopyFrom<C1>>::zero_copy_from(&cart.0),
+//             <T2 as ZeroCopyFrom<C2>>::zero_copy_from(&cart.1),
+//         )
+//     }
+// }
 
-// These duplicate the functionality from above and aren't quite necessary due
-// to deref coercions, however for the custom derive to work, there always needs
-// to be `impl ZCF<T> for T`, otherwise it may fail to perform the necessary
-// type inference. Deref coercions do not typically work when sufficient generics
-// or inference are involved, and the proc macro does not necessarily have
-// enough type information to figure this out on its own.
-#[cfg(feature = "alloc")]
-impl<B: ToOwned + ?Sized + 'static> ZeroCopyFrom<Cow<'_, B>> for Cow<'static, B> {
-    fn zero_copy_from<'b>(cart: &'b Cow<'_, B>) -> Cow<'b, B> {
-        Cow::Borrowed(cart)
-    }
-}
+// // These duplicate the functionality from above and aren't quite necessary due
+// // to deref coercions, however for the custom derive to work, there always needs
+// // to be `impl ZCF<T> for T`, otherwise it may fail to perform the necessary
+// // type inference. Deref coercions do not typically work when sufficient generics
+// // or inference are involved, and the proc macro does not necessarily have
+// // enough type information to figure this out on its own.
+// #[cfg(feature = "alloc")]
+// impl<B: ToOwned + ?Sized + 'static> ZeroCopyFrom<Cow<'_, B>> for Cow<'static, B> {
+//     fn zero_copy_from<'b>(cart: &'b Cow<'_, B>) -> Cow<'b, B> {
+//         Cow::Borrowed(cart)
+//     }
+// }
 
-impl ZeroCopyFrom<&'_ str> for &'static str {
-    fn zero_copy_from<'b>(cart: &'b &'_ str) -> &'b str {
-        cart
-    }
-}
+// impl ZeroCopyFrom<&'_ str> for &'static str {
+//     fn zero_copy_from<'b>(cart: &'b &'_ str) -> &'b str {
+//         cart
+//     }
+// }
 
-impl<T> ZeroCopyFrom<[T]> for &'static [T] {
-    fn zero_copy_from<'b>(cart: &'b [T]) -> &'b [T] {
-        cart
-    }
-}
+// impl<T> ZeroCopyFrom<[T]> for &'static [T] {
+//     fn zero_copy_from<'b>(cart: &'b [T]) -> &'b [T] {
+//         cart
+//     }
+// }

--- a/utils/yoke/src/zero_copy_from.rs
+++ b/utils/yoke/src/zero_copy_from.rs
@@ -80,9 +80,9 @@ use alloc::string::String;
 ///     }
 /// }
 /// ```
-pub trait ZeroCopyFrom<C: ?Sized>: for<'a> Yokeable<'a> {
+pub trait ZeroCopyFrom<'b, C: ?Sized> {
     /// Clone the cart `C` into a [`Yokeable`] struct, which may retain references into `C`.
-    fn zero_copy_from<'b>(cart: &'b C) -> <Self as Yokeable<'b>>::Output;
+    fn zero_copy_from(cart: &'b C) -> Self;
 }
 
 impl<'b, 's, Y: ZeroCopyFrom<C> + for<'a> Yokeable<'a>, C: ?Sized> Yoke<Y, &'b C> {


### PR DESCRIPTION
fixes https://github.com/unicode-org/icu4x/issues/1255

This currently doesn't work because rustc is unable to satisfy the bound  `for<'a> <Cow<'static, str> as Yokeable<'a>>::Output: ZeroCopyFrom<'a, std::string::String>`.

Leaving the PR open as a draft in case someone wants to poke at it further.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->