### PR TITLE
Change anyhow to eyre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,12 +47,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
-
-[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,8 +1090,8 @@ dependencies = [
 name = "icu_datagen"
 version = "0.4.0"
 dependencies = [
- "anyhow",
  "clap",
+ "eyre",
  "futures",
  "icu_locid",
  "icu_properties",

--- a/docs/process/style_guide.md
+++ b/docs/process/style_guide.md
@@ -724,7 +724,7 @@ enum IcuError {
 A couple of crates by `@dtolnay` that are considered "new wave of good error APIs" and are complementary to each other:
 
 * https://github.com/dtolnay/thiserror
-* https://github.com/dtolnay/anyhow
+* https://docs.rs/eyre/0.6.5/eyre/
 
 Other links on error handling:
 

--- a/tools/datagen/Cargo.toml
+++ b/tools/datagen/Cargo.toml
@@ -27,7 +27,7 @@ include = [
 all-features = true
 
 [dependencies]
-anyhow = "1.0"
+eyre = "0.6"
 clap = "2.33"
 futures = "0.3"
 icu_locid = { version = "0.4", path = "../../components/locid", features = ["std"]}

--- a/tools/datagen/src/bin/testdata-download.rs
+++ b/tools/datagen/src/bin/testdata-download.rs
@@ -2,8 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use anyhow::Context;
 use clap::{value_t, App, Arg, ArgMatches};
+use eyre::WrapErr;
 use futures::stream::{self, StreamExt, TryStreamExt};
 use icu_testdata::metadata::{self, PackageInfo};
 use simple_logger::SimpleLogger;
@@ -23,7 +23,7 @@ struct CldrJsonDownloader<'a> {
 }
 
 impl CldrJsonDownloader<'_> {
-    async fn fetch(&self, cldr_path: &str) -> anyhow::Result<()> {
+    async fn fetch(&self, cldr_path: &str) -> eyre::Result<()> {
         let url = format!(
             "https://raw.githubusercontent.com/{}/{}/cldr-json/{}",
             self.repo_owner_and_name, self.tag, cldr_path
@@ -61,7 +61,7 @@ impl CldrJsonDownloader<'_> {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> eyre::Result<()> {
     let cldr_json_root = icu_testdata::paths::cldr_json_root();
 
     let args = App::new("ICU4X Test Data Downloader")
@@ -115,7 +115,7 @@ async fn main() -> anyhow::Result<()> {
             .with_level(log::LevelFilter::Trace)
             .init()
             .unwrap(),
-        _ => anyhow::bail!("Only -v, -vv, and -vvv are supported"),
+        _ => eyre::bail!("Only -v, -vv, and -vvv are supported"),
     }
 
     let metadata = metadata::load()?;
@@ -130,7 +130,7 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn download_cldr(args: &ArgMatches<'_>, metadata: &PackageInfo) -> anyhow::Result<()> {
+async fn download_cldr(args: &ArgMatches<'_>, metadata: &PackageInfo) -> eyre::Result<()> {
     let output_path = PathBuf::from(
         args.value_of_os("OUTPUT")
             .expect("Option has a default value"),


### PR DESCRIPTION
Part of #574

This PR just gets rid of the `anyhow` dependency and replaces all call sites with `eyre`.  I still need to go and migrate more existing errors to use `eyre` instead of panics or other homegrown solutions.