### PR TITLE
Move ErasedDataStruct to the owned variant of DataPayload

### DIFF
--- a/provider/core/src/erased.rs
+++ b/provider/core/src/erased.rs
@@ -82,12 +82,12 @@ where
     /// `Yoke` (i.e., `Box::new(yoke)`).
     fn upcast(other: DataPayload<'static, M>) -> DataPayload<'static, ErasedDataStructMarker> {
         use crate::data_provider::DataPayloadInner::*;
-        let cart: Box<dyn ErasedDataStruct> = match other.inner {
+        let owned: Box<dyn ErasedDataStruct> = match other.inner {
             RcStruct(yoke) => Box::new(yoke),
             Owned(yoke) => Box::new(yoke),
             RcBuf(yoke) => Box::new(yoke),
         };
-        DataPayload::from_owned(ErasedDataStructBox(cart))
+        DataPayload::from_owned(ErasedDataStructBox(owned))
     }
 }
 

--- a/provider/core/src/erased.rs
+++ b/provider/core/src/erased.rs
@@ -66,12 +66,12 @@ impl ZeroCopyFrom<dyn ErasedDataStruct> for &'static dyn ErasedDataStruct {
 pub struct ErasedDataStructMarker {}
 
 impl DataMarker<'static> for ErasedDataStructMarker {
-    type Yokeable = ErasedDataYokeable;
-    type Cart = ErasedDataYokeable;
+    type Yokeable = ErasedDataStructBox;
+    type Cart = ErasedDataStructBox;
 }
 
 #[derive(Yokeable)]
-pub struct ErasedDataYokeable(Box<dyn ErasedDataStruct>);
+pub struct ErasedDataStructBox(Box<dyn ErasedDataStruct>);
 
 impl<'data, M> crate::dynutil::UpcastDataPayload<'static, M> for ErasedDataStructMarker
 where
@@ -87,7 +87,7 @@ where
             Owned(yoke) => Box::new(yoke),
             RcBuf(yoke) => Box::new(yoke),
         };
-        DataPayload::from_owned(ErasedDataYokeable(cart))
+        DataPayload::from_owned(ErasedDataStructBox(cart))
     }
 }
 
@@ -182,7 +182,7 @@ impl<'data> DataPayload<'static, ErasedDataStructMarker> {
                 })
             }
             // This is unreachable because an ErasedDataStruct payload can only be constructed as fully owned
-            // (It is impossible for clients to construct an ErasedDataStruct payload manually since ErasedDataYokeable
+            // (It is impossible for clients to construct an ErasedDataStruct payload manually since ErasedDataStructBox
             // has a private field)
             RcStruct(_) | RcBuf(_) => unreachable!(),
         }

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -388,6 +388,15 @@ impl<Y: for<'a> Yokeable<'a>> Yoke<Y, ()> {
     pub fn new_always_owned(yokeable: Y) -> Self {
         Self { yokeable, cart: () }
     }
+
+    /// Obtain the yokeable out of a `Yoke<Y, ()>`
+    ///
+    /// For most `Yoke` types this would be unsafe but it's
+    /// fine for `Yoke<Y, ()>` since there are no actual internal
+    /// references
+    pub fn into_yokeable(self) -> Y {
+        self.yokeable
+    }
 }
 
 impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, Option<C>> {


### PR DESCRIPTION
Progress towards #1262

ErasedDataStruct is actually *reading from* the cart type which won't work once we get rid of RcStruct. Cleaning this up early so that future attempts to clean up RcStruct do not have to deal with this.

Ultimately, using an owned Yoke instead of an RcStruct shouldn't really change any performance characteristics or anything.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->