### PR TITLE
Burn DataMarker::Cart down with fire

### DIFF
--- a/components/datetime/src/provider/gregory/mod.rs
+++ b/components/datetime/src/provider/gregory/mod.rs
@@ -118,7 +118,7 @@ pub mod patterns {
     /// `DataPayload<PatternPluralsV1>`.
     pub(crate) struct PatternPluralsFromPatternsV1Marker;
 
-    impl<'data> DataMarker<'data> for PatternPluralsFromPatternsV1Marker {
+    impl DataMarker for PatternPluralsFromPatternsV1Marker {
         type Yokeable = PatternPluralsV1<'static>;
     }
 }

--- a/components/datetime/src/provider/gregory/mod.rs
+++ b/components/datetime/src/provider/gregory/mod.rs
@@ -120,6 +120,5 @@ pub mod patterns {
 
     impl<'data> DataMarker<'data> for PatternPluralsFromPatternsV1Marker {
         type Yokeable = PatternPluralsV1<'static>;
-        type Cart = DatePatternsV1<'data>;
     }
 }

--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -29,7 +29,7 @@ fn load_resource<'data, D, L, P>(
     provider: &P,
 ) -> Result<(), DateTimeFormatError>
 where
-    D: DataMarker<'data>,
+    D: DataMarker,
     L: Clone + Into<LanguageIdentifier>,
     P: DataProvider<'data, D> + ?Sized,
 {

--- a/components/properties/src/provider.rs
+++ b/components/properties/src/provider.rs
@@ -404,5 +404,4 @@ pub struct UnicodePropertyMapV1Marker<T: TrieValue> {
 
 impl<'data, T: TrieValue> icu_provider::DataMarker<'data> for UnicodePropertyMapV1Marker<T> {
     type Yokeable = UnicodePropertyMapV1<'static, T>;
-    type Cart = UnicodePropertyMapV1<'data, T>;
 }

--- a/components/properties/src/provider.rs
+++ b/components/properties/src/provider.rs
@@ -402,6 +402,6 @@ pub struct UnicodePropertyMapV1Marker<T: TrieValue> {
     _phantom: core::marker::PhantomData<T>,
 }
 
-impl<'data, T: TrieValue> icu_provider::DataMarker<'data> for UnicodePropertyMapV1Marker<T> {
+impl<T: TrieValue> icu_provider::DataMarker for UnicodePropertyMapV1Marker<T> {
     type Yokeable = UnicodePropertyMapV1<'static, T>;
 }

--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -94,7 +94,7 @@ impl BlobDataProvider {
 
 impl<'data, M> DataProvider<'data, M> for BlobDataProvider
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
     // Actual bound:
     //     for<'de> <M::Yokeable as Yokeable<'de>>::Output: serde::de::Deserialize<'de>,
     // Necessary workaround bound (see `yoke::trait_hack` docs):

--- a/provider/blob/src/static_data_provider.rs
+++ b/provider/blob/src/static_data_provider.rs
@@ -75,7 +75,7 @@ impl StaticDataProvider {
 
 impl<'data, M> DataProvider<'data, M> for StaticDataProvider
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
     // 'static is what we want here, because we are deserializing from a static buffer.
     M::Yokeable: Deserialize<'static>,
 {

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -105,13 +105,13 @@ impl<T> ErasedDestructor for T {}
 
 /// All that Yoke needs from the Cart type is the destructor. We can
 /// use a trait object to handle that.
-pub(crate) type ErasedCart<'a> = Rc<dyn ErasedDestructor + 'a>;
+pub(crate) type ErasedCart<'data> = Rc<dyn ErasedDestructor + 'data>;
 
 pub(crate) enum DataPayloadInner<'data, M>
 where
     M: DataMarker<'data>,
 {
-    RcStruct(Yoke<M::Yokeable, Rc<M::Cart>>),
+    RcStruct(Yoke<M::Yokeable, ErasedCart<'data>>),
     Owned(Yoke<M::Yokeable, ()>),
     RcBuf(Yoke<M::Yokeable, Rc<[u8]>>),
 }

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -513,7 +513,7 @@ where
     /// // target type, and the Cart should correspond to the type being transformed.
     ///
     /// struct HelloWorldV1MessageMarker;
-    /// impl<'data> DataMarker<'data> for HelloWorldV1MessageMarker {
+    /// impl DataMarker for HelloWorldV1MessageMarker {
     ///     type Yokeable = Cow<'static, str>;
     ///     type Cart = HelloWorldV1<'data>;
     /// }
@@ -571,7 +571,7 @@ where
     /// # use icu_provider::prelude::*;
     /// # use std::borrow::Cow;
     /// # struct HelloWorldV1MessageMarker;
-    /// # impl<'data> DataMarker<'data> for HelloWorldV1MessageMarker {
+    /// # impl DataMarker for HelloWorldV1MessageMarker {
     /// #     type Yokeable = Cow<'static, str>;
     /// #     type Cart = HelloWorldV1<'data>;
     /// # }
@@ -630,7 +630,7 @@ where
     /// # use icu_provider::prelude::*;
     /// # use std::borrow::Cow;
     /// # struct HelloWorldV1MessageMarker;
-    /// # impl<'data> DataMarker<'data> for HelloWorldV1MessageMarker {
+    /// # impl DataMarker for HelloWorldV1MessageMarker {
     /// #     type Yokeable = Cow<'static, str>;
     /// #     type Cart = HelloWorldV1<'data>;
     /// # }
@@ -659,7 +659,7 @@ where
     /// # use icu_provider::prelude::*;
     /// # use std::borrow::Cow;
     /// # struct HelloWorldV1MessageMarker;
-    /// # impl<'data> DataMarker<'data> for HelloWorldV1MessageMarker {
+    /// # impl DataMarker for HelloWorldV1MessageMarker {
     /// #     type Yokeable = Cow<'static, str>;
     /// #     type Cart = HelloWorldV1<'data>;
     /// # }
@@ -722,7 +722,7 @@ where
     /// # use icu_provider::prelude::*;
     /// # use std::borrow::Cow;
     /// # struct HelloWorldV1MessageMarker;
-    /// # impl<'data> DataMarker<'data> for HelloWorldV1MessageMarker {
+    /// # impl DataMarker for HelloWorldV1MessageMarker {
     /// #     type Yokeable = Cow<'static, str>;
     /// #     type Cart = HelloWorldV1<'data>;
     /// # }
@@ -788,7 +788,7 @@ where
     /// # use icu_provider::prelude::*;
     /// # use std::borrow::Cow;
     /// # struct HelloWorldV1MessageMarker;
-    /// # impl<'data> DataMarker<'data> for HelloWorldV1MessageMarker {
+    /// # impl DataMarker for HelloWorldV1MessageMarker {
     /// #     type Yokeable = Cow<'static, str>;
     /// #     type Cart = HelloWorldV1<'data>;
     /// # }
@@ -821,7 +821,7 @@ where
     /// # use icu_provider::prelude::*;
     /// # use std::borrow::Cow;
     /// # struct HelloWorldV1MessageMarker;
-    /// # impl<'data> DataMarker<'data> for HelloWorldV1MessageMarker {
+    /// # impl DataMarker for HelloWorldV1MessageMarker {
     /// #     type Yokeable = Cow<'static, str>;
     /// #     type Cart = HelloWorldV1<'data>;
     /// # }
@@ -888,7 +888,7 @@ where
     /// # use icu_provider::prelude::*;
     /// # use std::borrow::Cow;
     /// # struct HelloWorldV1MessageMarker;
-    /// # impl<'data> DataMarker<'data> for HelloWorldV1MessageMarker {
+    /// # impl DataMarker for HelloWorldV1MessageMarker {
     /// #     type Yokeable = Cow<'static, str>;
     /// #     type Cart = HelloWorldV1<'data>;
     /// # }

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -540,7 +540,7 @@ where
         ) -> <M2::Yokeable as Yokeable<'a>>::Output,
     ) -> DataPayload<'data, M2>
     where
-        M2: DataMarker<'data, Cart = M::Cart>,
+        M2: DataMarker<'data>,
     {
         use DataPayloadInner::*;
         match self.inner {
@@ -598,7 +598,7 @@ where
         ) -> <M2::Yokeable as Yokeable<'a>>::Output,
     ) -> DataPayload<'data, M2>
     where
-        M2: DataMarker<'data, Cart = M::Cart>,
+        M2: DataMarker<'data>,
     {
         use DataPayloadInner::*;
         match &self.inner {
@@ -690,7 +690,7 @@ where
         ) -> <M2::Yokeable as Yokeable<'a>>::Output,
     ) -> DataPayload<'data, M2>
     where
-        M2: DataMarker<'data, Cart = M::Cart>,
+        M2: DataMarker<'data>,
     {
         use DataPayloadInner::*;
         match self.inner {
@@ -756,7 +756,7 @@ where
         ) -> <M2::Yokeable as Yokeable<'a>>::Output,
     ) -> DataPayload<'data, M2>
     where
-        M2: DataMarker<'data, Cart = M::Cart>,
+        M2: DataMarker<'data>,
     {
         use DataPayloadInner::*;
         match &self.inner {
@@ -856,7 +856,7 @@ where
         ) -> Result<<M2::Yokeable as Yokeable<'a>>::Output, E>,
     ) -> Result<DataPayload<'data, M2>, E>
     where
-        M2: DataMarker<'data, Cart = M::Cart>,
+        M2: DataMarker<'data>,
     {
         use DataPayloadInner::*;
         Ok(match self.inner {
@@ -926,7 +926,7 @@ where
         ) -> Result<<M2::Yokeable as Yokeable<'a>>::Output, E>,
     ) -> Result<DataPayload<'data, M2>, E>
     where
-        M2: DataMarker<'data, Cart = M::Cart>,
+        M2: DataMarker<'data>,
     {
         use DataPayloadInner::*;
         Ok(match &self.inner {

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -100,6 +100,9 @@ pub struct DataResponseMetadata {
 /// `dyn Drop` isn't legal (and doesn't make sense since `Drop` is not
 /// implement on all destructible types). However, all trait objects come with
 /// a destructor, so we can just use an empty trait to get a destructor object.
+///
+/// This should eventually be moved into the yoke crate once it's cleaner
+/// https://github.com/unicode-org/icu4x/issues/1284
 pub(crate) trait ErasedDestructor<'data>: IsCovariant<'data> {}
 impl<'data, T: IsCovariant<'data>> ErasedDestructor<'data> for T {}
 

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -109,7 +109,7 @@ pub(crate) type ErasedCart<'data> = Rc<dyn ErasedDestructor<'data> + 'data>;
 
 pub(crate) enum DataPayloadInner<'data, M>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
 {
     RcStruct(Yoke<M::Yokeable, ErasedCart<'data>>),
     Owned(Yoke<M::Yokeable, ()>),
@@ -166,14 +166,14 @@ where
 /// [`ErasedDataStructMarker`]: crate::erased::ErasedDataStructMarker
 pub struct DataPayload<'data, M>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
 {
     pub(crate) inner: DataPayloadInner<'data, M>,
 }
 
 impl<'data, M> Debug for DataPayload<'data, M>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
     for<'a> &'a <M::Yokeable as Yokeable<'a>>::Output: Debug,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -195,7 +195,7 @@ where
 /// ```
 impl<'data, M> Clone for DataPayload<'data, M>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
     for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
 {
     fn clone(&self) -> Self {
@@ -211,7 +211,7 @@ where
 
 impl<'data, M> PartialEq for DataPayload<'data, M>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
     for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
@@ -221,7 +221,7 @@ where
 
 impl<'data, M> Eq for DataPayload<'data, M>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
     for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Eq,
 {
 }
@@ -236,7 +236,7 @@ fn test_clone_eq() {
 
 impl<'data, M> DataPayload<'data, M>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
 {
     /// Convert an [`Rc`]`<`[`Cart`]`>` into a [`DataPayload`].
     ///
@@ -280,7 +280,7 @@ where
 
 impl<'data, M> DataPayload<'data, M>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
 {
     /// Convert a byte buffer into a [`DataPayload`]. A function must be provided to perform the
     /// conversion. This can often be a Serde deserialization operation.
@@ -540,7 +540,7 @@ where
         ) -> <M2::Yokeable as Yokeable<'a>>::Output,
     ) -> DataPayload<'data, M2>
     where
-        M2: DataMarker<'data>,
+        M2: DataMarker,
     {
         use DataPayloadInner::*;
         match self.inner {
@@ -598,7 +598,7 @@ where
         ) -> <M2::Yokeable as Yokeable<'a>>::Output,
     ) -> DataPayload<'data, M2>
     where
-        M2: DataMarker<'data>,
+        M2: DataMarker,
     {
         use DataPayloadInner::*;
         match &self.inner {
@@ -690,7 +690,7 @@ where
         ) -> <M2::Yokeable as Yokeable<'a>>::Output,
     ) -> DataPayload<'data, M2>
     where
-        M2: DataMarker<'data>,
+        M2: DataMarker,
     {
         use DataPayloadInner::*;
         match self.inner {
@@ -756,7 +756,7 @@ where
         ) -> <M2::Yokeable as Yokeable<'a>>::Output,
     ) -> DataPayload<'data, M2>
     where
-        M2: DataMarker<'data>,
+        M2: DataMarker,
     {
         use DataPayloadInner::*;
         match &self.inner {
@@ -856,7 +856,7 @@ where
         ) -> Result<<M2::Yokeable as Yokeable<'a>>::Output, E>,
     ) -> Result<DataPayload<'data, M2>, E>
     where
-        M2: DataMarker<'data>,
+        M2: DataMarker,
     {
         use DataPayloadInner::*;
         Ok(match self.inner {
@@ -926,7 +926,7 @@ where
         ) -> Result<<M2::Yokeable as Yokeable<'a>>::Output, E>,
     ) -> Result<DataPayload<'data, M2>, E>
     where
-        M2: DataMarker<'data>,
+        M2: DataMarker,
     {
         use DataPayloadInner::*;
         Ok(match &self.inner {
@@ -946,7 +946,7 @@ where
 /// A response object containing an object as payload and metadata about it.
 pub struct DataResponse<'data, M>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
 {
     /// Metadata about the returned object.
     pub metadata: DataResponseMetadata,
@@ -957,7 +957,7 @@ where
 
 impl<'data, M> DataResponse<'data, M>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
 {
     /// Takes ownership of the underlying payload. Error if not present.
     #[inline]
@@ -968,7 +968,7 @@ where
 
 impl<'data, M> TryFrom<DataResponse<'data, M>> for DataPayload<'data, M>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
 {
     type Error = Error;
 
@@ -979,7 +979,7 @@ where
 
 impl<'data, M> Debug for DataResponse<'data, M>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
     for<'a> &'a <M::Yokeable as Yokeable<'a>>::Output: Debug,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -1005,7 +1005,7 @@ where
 /// ```
 impl<'data, M> Clone for DataResponse<'data, M>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
     for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
 {
     fn clone(&self) -> Self {
@@ -1038,7 +1038,7 @@ fn test_debug() {
 /// - [`InvariantDataProvider`](crate::inv::InvariantDataProvider)
 pub trait DataProvider<'data, M>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
 {
     /// Query the provider for data, returning the result.
     ///

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -95,6 +95,18 @@ pub struct DataResponseMetadata {
     pub data_langid: Option<LanguageIdentifier>,
 }
 
+/// Dummy trait that lets us `dyn Drop`
+///
+/// `dyn Drop` isn't legal (and doesn't make sense since `Drop` is not
+/// implement on all destructible types). However, all trait objects come with
+/// a destructor, so we can just use an empty trait to get a destructor object.
+pub(crate) trait ErasedDestructor {}
+impl<T> ErasedDestructor for T {}
+
+/// All that Yoke needs from the Cart type is the destructor. We can
+/// use a trait object to handle that.
+pub(crate) type ErasedCart<'a> = Rc<dyn ErasedDestructor + 'a>;
+
 pub(crate) enum DataPayloadInner<'data, M>
 where
     M: DataMarker<'data>,

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -515,7 +515,6 @@ where
     /// struct HelloWorldV1MessageMarker;
     /// impl DataMarker for HelloWorldV1MessageMarker {
     ///     type Yokeable = Cow<'static, str>;
-    ///     type Cart = HelloWorldV1<'data>;
     /// }
     ///
     /// let p1: DataPayload<HelloWorldV1Marker> = DataPayload::from_owned(HelloWorldV1 {
@@ -573,7 +572,6 @@ where
     /// # struct HelloWorldV1MessageMarker;
     /// # impl DataMarker for HelloWorldV1MessageMarker {
     /// #     type Yokeable = Cow<'static, str>;
-    /// #     type Cart = HelloWorldV1<'data>;
     /// # }
     ///
     /// let p1: DataPayload<HelloWorldV1Marker> = DataPayload::from_owned(HelloWorldV1 {
@@ -632,7 +630,6 @@ where
     /// # struct HelloWorldV1MessageMarker;
     /// # impl DataMarker for HelloWorldV1MessageMarker {
     /// #     type Yokeable = Cow<'static, str>;
-    /// #     type Cart = HelloWorldV1<'data>;
     /// # }
     ///
     /// let p1: DataPayload<HelloWorldV1Marker> = DataPayload::from_owned(HelloWorldV1 {
@@ -661,7 +658,6 @@ where
     /// # struct HelloWorldV1MessageMarker;
     /// # impl DataMarker for HelloWorldV1MessageMarker {
     /// #     type Yokeable = Cow<'static, str>;
-    /// #     type Cart = HelloWorldV1<'data>;
     /// # }
     ///
     /// let p1: DataPayload<HelloWorldV1Marker> = DataPayload::from_owned(HelloWorldV1 {
@@ -724,7 +720,6 @@ where
     /// # struct HelloWorldV1MessageMarker;
     /// # impl DataMarker for HelloWorldV1MessageMarker {
     /// #     type Yokeable = Cow<'static, str>;
-    /// #     type Cart = HelloWorldV1<'data>;
     /// # }
     ///
     /// let p1: DataPayload<HelloWorldV1Marker> = DataPayload::from_owned(HelloWorldV1 {
@@ -790,7 +785,6 @@ where
     /// # struct HelloWorldV1MessageMarker;
     /// # impl DataMarker for HelloWorldV1MessageMarker {
     /// #     type Yokeable = Cow<'static, str>;
-    /// #     type Cart = HelloWorldV1<'data>;
     /// # }
     ///
     /// let p1: DataPayload<HelloWorldV1Marker> = DataPayload::from_owned(HelloWorldV1 {
@@ -823,7 +817,6 @@ where
     /// # struct HelloWorldV1MessageMarker;
     /// # impl DataMarker for HelloWorldV1MessageMarker {
     /// #     type Yokeable = Cow<'static, str>;
-    /// #     type Cart = HelloWorldV1<'data>;
     /// # }
     ///
     /// let p1: DataPayload<HelloWorldV1Marker> = DataPayload::from_owned(HelloWorldV1 {
@@ -890,7 +883,6 @@ where
     /// # struct HelloWorldV1MessageMarker;
     /// # impl DataMarker for HelloWorldV1MessageMarker {
     /// #     type Yokeable = Cow<'static, str>;
-    /// #     type Cart = HelloWorldV1<'data>;
     /// # }
     ///
     /// let p1: DataPayload<HelloWorldV1Marker> = DataPayload::from_owned(HelloWorldV1 {

--- a/provider/core/src/data_provider/test.rs
+++ b/provider/core/src/data_provider/test.rs
@@ -33,7 +33,6 @@ struct HelloAltMarker {}
 
 impl<'data> DataMarker<'data> for HelloAltMarker {
     type Yokeable = HelloAlt;
-    type Cart = HelloAlt;
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]

--- a/provider/core/src/data_provider/test.rs
+++ b/provider/core/src/data_provider/test.rs
@@ -31,7 +31,7 @@ struct HelloAlt {
 /// Marker type for [`HelloAlt`].
 struct HelloAltMarker {}
 
-impl<'data> DataMarker<'data> for HelloAltMarker {
+impl DataMarker for HelloAltMarker {
     type Yokeable = HelloAlt;
 }
 

--- a/provider/core/src/dynutil.rs
+++ b/provider/core/src/dynutil.rs
@@ -12,8 +12,8 @@
 /// [`DataPayload::downcast`]: crate::DataPayload::downcast
 pub trait UpcastDataPayload<'data, M>
 where
-    M: crate::prelude::DataMarker<'data>,
-    Self: Sized + crate::prelude::DataMarker<'data>,
+    M: crate::prelude::DataMarker,
+    Self: Sized + crate::prelude::DataMarker,
 {
     /// Upcast a `DataPayload<T>` to a `DataPayload<S>` where `T` implements trait `S`.
     ///

--- a/provider/core/src/dynutil.rs
+++ b/provider/core/src/dynutil.rs
@@ -26,14 +26,14 @@ where
     /// use icu_provider::prelude::*;
     /// use icu_provider::erased::*;
     /// use icu_provider::dynutil::UpcastDataPayload;
-    /// use icu_provider::marker::CowStringMarker;
+    /// use icu_provider::marker::CowStrMarker;
     /// use std::borrow::Cow;
     ///
     /// let data = "foo".to_string();
-    /// let original = DataPayload::<CowStringMarker>::from_owned(Cow::Owned(data));
+    /// let original = DataPayload::<CowStrMarker>::from_owned(Cow::Owned(data));
     /// let upcasted = ErasedDataStructMarker::upcast(original);
     /// let downcasted = upcasted
-    ///     .downcast::<CowStringMarker>()
+    ///     .downcast::<CowStrMarker>()
     ///     .expect("Type conversion");
     /// assert_eq!(downcasted.get(), "foo");
     /// ```
@@ -67,15 +67,15 @@ where
 /// ```
 /// use icu_provider::prelude::*;
 /// use icu_provider::erased::ErasedDataStructMarker;
-/// use icu_provider::marker::CowStringMarker;
+/// use icu_provider::marker::CowStrMarker;
 /// use std::borrow::Cow;
 /// const DEMO_KEY: ResourceKey = icu_provider::resource_key!(x, "foo", "bar", 1);
 ///
 /// // A small DataProvider that returns owned strings
 /// struct MyProvider(pub String);
-/// impl<'data> DataProvider<'static, CowStringMarker> for MyProvider {
+/// impl<'data> DataProvider<'static, CowStrMarker> for MyProvider {
 ///     fn load_payload(&self, req: &DataRequest)
-///             -> Result<DataResponse<'static, CowStringMarker>, DataError> {
+///             -> Result<DataResponse<'static, CowStrMarker>, DataError> {
 ///         req.resource_path.key.match_key(DEMO_KEY)?;
 ///         Ok(DataResponse {
 ///             metadata: Default::default(),
@@ -86,7 +86,7 @@ where
 ///
 /// // Implement DataProvider<ErasedDataStructMarker>
 /// icu_provider::impl_dyn_provider!(MyProvider, {
-///     DEMO_KEY => CowStringMarker,
+///     DEMO_KEY => CowStrMarker,
 /// }, ERASED);
 ///
 /// // Usage example
@@ -94,7 +94,7 @@ where
 /// let resp: DataResponse<ErasedDataStructMarker> = provider
 ///     .load_payload(&DEMO_KEY.into())
 ///     .expect("Loading should succeed");
-/// let payload: DataPayload<CowStringMarker> = resp
+/// let payload: DataPayload<CowStrMarker> = resp
 ///     .take_payload()
 ///     .expect("Payload should be present")
 ///     .downcast()
@@ -106,21 +106,21 @@ where
 ///
 /// ```
 /// # use icu_provider::prelude::*;
-/// # use icu_provider::marker::CowStringMarker;
+/// # use icu_provider::marker::CowStrMarker;
 /// # use std::borrow::Cow;
 /// # struct MyProvider(pub String);
-/// # impl<'data> DataProvider<'static, CowStringMarker> for MyProvider {
+/// # impl<'data> DataProvider<'static, CowStrMarker> for MyProvider {
 /// #   fn load_payload(&self, req: &DataRequest)
-/// #           -> Result<DataResponse<'static, CowStringMarker>, DataError> {
+/// #           -> Result<DataResponse<'static, CowStrMarker>, DataError> {
 /// #       Ok(DataResponse {
 /// #           metadata: Default::default(),
 /// #           payload: Some(DataPayload::from_owned(self.0.to_string().into()))
 /// #       })
 /// #   }
 /// # }
-/// // Send all keys to the `CowStringMarker` provider.
+/// // Send all keys to the `CowStrMarker` provider.
 /// icu_provider::impl_dyn_provider!(MyProvider, {
-///     _ => CowStringMarker,
+///     _ => CowStrMarker,
 /// }, ERASED);
 /// ```
 ///

--- a/provider/core/src/erased.rs
+++ b/provider/core/src/erased.rs
@@ -4,6 +4,7 @@
 
 //! Collection of traits for providers that support type erasure of data structs.
 
+use crate::data_provider::ErasedCart;
 use crate::error::Error;
 use crate::prelude::*;
 use crate::yoke::*;
@@ -146,7 +147,7 @@ impl<'data> DataPayload<'static, ErasedDataStructMarker> {
                 // `any_box` is the Yoke that was converted into the `dyn ErasedDataStruct`. It
                 // could have been either the RcStruct or the Owned variant of Yoke.
                 // Check first for Case 2: an RcStruct Yoke.
-                let y1 = any_box.downcast::<Yoke<M::Yokeable, Rc<M::Cart>>>();
+                let y1 = any_box.downcast::<Yoke<M::Yokeable, ErasedCart>>();
                 let any_box = match y1 {
                     Ok(yoke) => {
                         return Ok(DataPayload {

--- a/provider/core/src/erased.rs
+++ b/provider/core/src/erased.rs
@@ -66,7 +66,7 @@ impl ZeroCopyFrom<dyn ErasedDataStruct> for &'static dyn ErasedDataStruct {
 /// Marker type for [`ErasedDataStruct`].
 pub struct ErasedDataStructMarker {}
 
-impl DataMarker<'static> for ErasedDataStructMarker {
+impl DataMarker for ErasedDataStructMarker {
     type Yokeable = ErasedDataStructBox;
 }
 
@@ -75,7 +75,7 @@ pub struct ErasedDataStructBox(Box<dyn ErasedDataStruct>);
 
 impl<'data, M> crate::dynutil::UpcastDataPayload<'static, M> for ErasedDataStructMarker
 where
-    M: DataMarker<'static>,
+    M: DataMarker,
 {
     /// Upcast for ErasedDataStruct creates a `Box<dyn ErasedDataStruct>` from the current inner
     /// `Yoke` (i.e., `Box::new(yoke)`).
@@ -134,7 +134,7 @@ impl<'data> DataPayload<'static, ErasedDataStructMarker> {
     /// ```
     pub fn downcast<M>(self) -> Result<DataPayload<'static, M>, Error>
     where
-        M: DataMarker<'static>,
+        M: DataMarker,
     {
         use crate::data_provider::DataPayloadInner::*;
         match self.inner {
@@ -236,7 +236,7 @@ where
 
 impl<'data, M> DataProvider<'static, M> for dyn ErasedDataProvider<'data> + 'data
 where
-    M: DataMarker<'static>,
+    M: DataMarker,
     <M::Yokeable as Yokeable<'static>>::Output: Clone + Any,
 {
     /// Serve [`Sized`] objects from an [`ErasedDataProvider`] via downcasting.

--- a/provider/core/src/erased.rs
+++ b/provider/core/src/erased.rs
@@ -253,16 +253,16 @@ where
 mod test {
     use super::*;
     use crate::dynutil::UpcastDataPayload;
-    use crate::marker::CowStringMarker;
+    use crate::marker::CowStrMarker;
     use alloc::borrow::Cow;
 
     #[test]
     fn test_erased_case_2() {
         let data = Rc::new("foo".to_string());
-        let original = DataPayload::<CowStringMarker>::from_partial_owned(data);
+        let original = DataPayload::<CowStrMarker>::from_partial_owned(data);
         let upcasted = ErasedDataStructMarker::upcast(original);
         let downcasted = upcasted
-            .downcast::<CowStringMarker>()
+            .downcast::<CowStrMarker>()
             .expect("Type conversion");
         assert_eq!(downcasted.get(), "foo");
     }
@@ -270,10 +270,10 @@ mod test {
     #[test]
     fn test_erased_case_3() {
         let data = "foo".to_string();
-        let original = DataPayload::<CowStringMarker>::from_owned(Cow::Owned(data));
+        let original = DataPayload::<CowStrMarker>::from_owned(Cow::Owned(data));
         let upcasted = ErasedDataStructMarker::upcast(original);
         let downcasted = upcasted
-            .downcast::<CowStringMarker>()
+            .downcast::<CowStrMarker>()
             .expect("Type conversion");
         assert_eq!(downcasted.get(), "foo");
     }
@@ -281,13 +281,13 @@ mod test {
     #[test]
     fn test_erased_case_4() {
         let data: Rc<[u8]> = "foo".as_bytes().into();
-        let original = DataPayload::<CowStringMarker>::try_from_rc_buffer_badly(data, |bytes| {
+        let original = DataPayload::<CowStrMarker>::try_from_rc_buffer_badly(data, |bytes| {
             core::str::from_utf8(bytes).map(|s| Cow::Borrowed(s))
         })
         .expect("String is valid UTF-8");
         let upcasted = ErasedDataStructMarker::upcast(original);
         let downcasted = upcasted
-            .downcast::<CowStringMarker>()
+            .downcast::<CowStrMarker>()
             .expect("Type conversion");
         assert_eq!(downcasted.get(), "foo");
     }

--- a/provider/core/src/erased.rs
+++ b/provider/core/src/erased.rs
@@ -68,7 +68,6 @@ pub struct ErasedDataStructMarker {}
 
 impl DataMarker<'static> for ErasedDataStructMarker {
     type Yokeable = ErasedDataStructBox;
-    type Cart = ErasedDataStructBox;
 }
 
 #[derive(Yokeable)]

--- a/provider/core/src/export.rs
+++ b/provider/core/src/export.rs
@@ -13,7 +13,7 @@ use crate::prelude::*;
 /// A [`DataProvider`] by itself is "read-only"; this trait enables it to be "read-write".
 pub trait DataExporter<'data, M>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
 {
     /// Save a `payload` corresponding to the given data request (resource path).
     fn put_payload(
@@ -63,7 +63,7 @@ pub fn export_from_iterable<'data, P, E, M>(
     exporter: &mut E,
 ) -> Result<(), Error>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
     P: IterableDataProvider<'data, M> + ?Sized,
     E: DataExporter<'data, M> + ?Sized,
 {

--- a/provider/core/src/filter/mod.rs
+++ b/provider/core/src/filter/mod.rs
@@ -68,7 +68,7 @@ where
 impl<'data, D, F, M> DataProvider<'data, M> for RequestFilterDataProvider<D, F>
 where
     F: Fn(&DataRequest) -> bool,
-    M: DataMarker<'data>,
+    M: DataMarker,
     D: DataProvider<'data, M>,
 {
     fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<'data, M>, DataError> {

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -46,7 +46,6 @@ pub struct HelloWorldV1Marker;
 
 impl<'data> DataMarker<'data> for HelloWorldV1Marker {
     type Yokeable = HelloWorldV1<'static>;
-    type Cart = HelloWorldV1<'data>;
 }
 
 /// A data provider returning Hello World strings in different languages.

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -44,7 +44,7 @@ impl Default for HelloWorldV1<'_> {
 /// Marker type for [`HelloWorldV1`].
 pub struct HelloWorldV1Marker;
 
-impl<'data> DataMarker<'data> for HelloWorldV1Marker {
+impl DataMarker for HelloWorldV1Marker {
     type Yokeable = HelloWorldV1<'static>;
 }
 

--- a/provider/core/src/inv.rs
+++ b/provider/core/src/inv.rs
@@ -38,7 +38,7 @@ pub struct InvariantDataProvider;
 
 impl<'data, M> DataProvider<'data, M> for InvariantDataProvider
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
     M::Yokeable: Default,
 {
     fn load_payload(&self, _req: &DataRequest) -> Result<DataResponse<'data, M>, Error> {

--- a/provider/core/src/inv.rs
+++ b/provider/core/src/inv.rs
@@ -7,11 +7,9 @@
 use crate::error::Error;
 use crate::iter::IterableDataProviderCore;
 use crate::prelude::*;
-use crate::yoke;
 use alloc::boxed::Box;
-use alloc::rc::Rc;
-use alloc::vec;
 use alloc::vec::Vec;
+use alloc::vec;
 
 /// A locale-invariant data provider. Sometimes useful for testing. Not intended to be used in
 /// production environments.
@@ -41,15 +39,12 @@ pub struct InvariantDataProvider;
 impl<'data, M> DataProvider<'data, M> for InvariantDataProvider
 where
     M: DataMarker<'data>,
-    M::Cart: Default,
-    M::Yokeable: yoke::ZeroCopyFrom<M::Cart>,
+    M::Yokeable: Default,
 {
     fn load_payload(&self, _req: &DataRequest) -> Result<DataResponse<'data, M>, Error> {
         Ok(DataResponse {
             metadata: DataResponseMetadata::default(),
-            payload: Some(DataPayload::from_partial_owned(
-                Rc::from(M::Cart::default()),
-            )),
+            payload: Some(DataPayload::from_owned(M::Yokeable::default())),
         })
     }
 }

--- a/provider/core/src/inv.rs
+++ b/provider/core/src/inv.rs
@@ -8,8 +8,8 @@ use crate::error::Error;
 use crate::iter::IterableDataProviderCore;
 use crate::prelude::*;
 use alloc::boxed::Box;
-use alloc::vec::Vec;
 use alloc::vec;
+use alloc::vec::Vec;
 
 /// A locale-invariant data provider. Sometimes useful for testing. Not intended to be used in
 /// production environments.

--- a/provider/core/src/iter.rs
+++ b/provider/core/src/iter.rs
@@ -25,14 +25,14 @@ pub trait IterableDataProviderCore {
 pub trait IterableDataProvider<'data, M>:
     IterableDataProviderCore + DataProvider<'data, M>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
 {
 }
 
 impl<'data, S, M> IterableDataProvider<'data, M> for S
 where
     S: IterableDataProviderCore + DataProvider<'data, M>,
-    M: DataMarker<'data>,
+    M: DataMarker,
 {
 }
 

--- a/provider/core/src/marker/impls.rs
+++ b/provider/core/src/marker/impls.rs
@@ -9,7 +9,7 @@ use alloc::borrow::Cow;
 /// Marker type for [`Cow`]`<str>` where the backing cart is `str`.
 pub struct CowStrMarker;
 
-impl<'data> DataMarker<'data> for CowStrMarker {
+impl DataMarker for CowStrMarker {
     type Yokeable = Cow<'static, str>;
 }
 
@@ -24,6 +24,6 @@ impl DataPayload<'static, CowStrMarker> {
 /// `ErasedDataStruct` is to be used.
 pub struct CowStringMarker;
 
-impl<'data> DataMarker<'data> for CowStringMarker {
+impl DataMarker for CowStringMarker {
     type Yokeable = Cow<'static, str>;
 }

--- a/provider/core/src/marker/impls.rs
+++ b/provider/core/src/marker/impls.rs
@@ -19,11 +19,3 @@ impl DataPayload<'static, CowStrMarker> {
         DataPayload::from_owned(Cow::Borrowed(s))
     }
 }
-
-/// Marker type for [`Cow`]`<str>` where the backing cart is `String`. This is required if
-/// `ErasedDataStruct` is to be used.
-pub struct CowStringMarker;
-
-impl DataMarker for CowStringMarker {
-    type Yokeable = Cow<'static, str>;
-}

--- a/provider/core/src/marker/impls.rs
+++ b/provider/core/src/marker/impls.rs
@@ -5,14 +5,12 @@
 use super::*;
 use crate::prelude::*;
 use alloc::borrow::Cow;
-use alloc::string::String;
 
 /// Marker type for [`Cow`]`<str>` where the backing cart is `str`.
 pub struct CowStrMarker;
 
 impl<'data> DataMarker<'data> for CowStrMarker {
     type Yokeable = Cow<'static, str>;
-    type Cart = str;
 }
 
 impl DataPayload<'static, CowStrMarker> {
@@ -28,5 +26,4 @@ pub struct CowStringMarker;
 
 impl<'data> DataMarker<'data> for CowStringMarker {
     type Yokeable = Cow<'static, str>;
-    type Cart = String;
 }

--- a/provider/core/src/marker/mod.rs
+++ b/provider/core/src/marker/mod.rs
@@ -19,6 +19,7 @@ use crate::yoke::Yokeable;
 /// for the data struct:
 ///
 /// - `impl<'a> Yokeable<'a>` (required)
+/// - `impl ZeroCopyFrom<Self>`
 ///
 /// See also some common pre-made DataMarker impls in this module.
 ///

--- a/provider/core/src/marker/mod.rs
+++ b/provider/core/src/marker/mod.rs
@@ -19,7 +19,6 @@ use crate::yoke::Yokeable;
 /// for the data struct:
 ///
 /// - `impl<'a> Yokeable<'a>` (required)
-/// - `impl ZeroCopyFrom<Cart>` (required for use with some `DataPayload` constructors)
 ///
 /// See also some common pre-made DataMarker impls in this module.
 ///
@@ -59,8 +58,4 @@ pub trait DataMarker<'data> {
     /// A type that implements [`Yokeable`]. This should typically be the `'static` version of a
     /// data struct.
     type Yokeable: for<'a> Yokeable<'a>;
-
-    /// A type that is capable of owning all data necessary for the Yokeable type. This can often
-    /// be the `'data` version of the data struct.
-    type Cart: 'data + ?Sized;
 }

--- a/provider/core/src/marker/mod.rs
+++ b/provider/core/src/marker/mod.rs
@@ -41,10 +41,6 @@ use crate::yoke::Yokeable;
 ///
 /// impl DataMarker for MyDataStructMarker {
 ///     type Yokeable = MyDataStruct<'static>;
-///
-///     // Note: the cart could also be just `str` since
-///     // MyDataStruct has only one field.
-///     type Cart = MyDataStruct<'data>;
 /// }
 ///
 /// // We can now use MyDataStruct with DataProvider:

--- a/provider/core/src/marker/mod.rs
+++ b/provider/core/src/marker/mod.rs
@@ -39,7 +39,7 @@ use crate::yoke::Yokeable;
 ///
 /// struct MyDataStructMarker;
 ///
-/// impl<'data> DataMarker<'data> for MyDataStructMarker {
+/// impl DataMarker for MyDataStructMarker {
 ///     type Yokeable = MyDataStruct<'static>;
 ///
 ///     // Note: the cart could also be just `str` since

--- a/provider/core/src/marker/mod.rs
+++ b/provider/core/src/marker/mod.rs
@@ -54,7 +54,7 @@ use crate::yoke::Yokeable;
 /// let payload = DataPayload::<MyDataStructMarker>::from_partial_owned(s);
 /// assert_eq!(payload.get().message, "Hello World");
 /// ```
-pub trait DataMarker<'data> {
+pub trait DataMarker {
     /// A type that implements [`Yokeable`]. This should typically be the `'static` version of a
     /// data struct.
     type Yokeable: for<'a> Yokeable<'a>;

--- a/provider/core/src/serde.rs
+++ b/provider/core/src/serde.rs
@@ -294,6 +294,9 @@ where
                     Yoke::attach_to_rc_cart(rc.clone() as Rc<dyn SerdeSeDataStruct<'data> + 'data>);
                 // Safe since we are replacing the cart with another that owns
                 // the same underlying data
+                //
+                // eventually the yoke crate will have a safe function for this
+                // https://github.com/unicode-org/icu4x/issues/1284
                 unsafe { yoke.replace_cart(move |_| rc as ErasedCart<'data>) }
             }
             DataPayloadInner::Owned(yoke) => {
@@ -302,6 +305,9 @@ where
                     Yoke::attach_to_rc_cart(rc.clone() as Rc<dyn SerdeSeDataStruct<'data> + 'data>);
                 // Safe since we are replacing the cart with another that owns
                 // the same underlying data
+                //
+                // eventually the yoke crate will have a safe function for this
+                // https://github.com/unicode-org/icu4x/issues/1284
                 unsafe { yoke.replace_cart(move |_| rc as ErasedCart<'data>) }
             }
             DataPayloadInner::RcBuf(yoke) => {
@@ -310,6 +316,9 @@ where
                     Yoke::attach_to_rc_cart(rc.clone() as Rc<dyn SerdeSeDataStruct<'data> + 'data>);
                 // Safe since we are replacing the cart with another that owns
                 // the same underlying data
+                //
+                // eventually the yoke crate will have a safe function for this
+                // https://github.com/unicode-org/icu4x/issues/1284
                 unsafe { yoke.replace_cart(move |_| rc as ErasedCart<'data>) }
             }
         };

--- a/provider/core/src/serde.rs
+++ b/provider/core/src/serde.rs
@@ -113,7 +113,7 @@ pub trait SerdeDeDataReceiver {
 
 impl<'data, M> SerdeDeDataReceiver for Option<DataPayload<'data, M>>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
     M::Yokeable: serde::de::Deserialize<'static>,
     // Actual bound:
     //     for<'de> <M::Yokeable as Yokeable<'de>>::Output: serde::de::Deserialize<'de>,
@@ -202,7 +202,7 @@ pub trait SerdeDeDataProvider {
 /// Note: This impl returns `'static` payloads because borrowing is handled by [`Yoke`].
 impl<'data, M> DataProvider<'data, M> for dyn SerdeDeDataProvider + 'static
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
     M::Yokeable: serde::de::Deserialize<'static>,
     // Actual bound:
     //     for<'de> <M::Yokeable as Yokeable<'de>>::Output: serde::de::Deserialize<'de>,
@@ -282,7 +282,7 @@ impl<'a> Deref for SerdeSeDataStructDynRef<'a> {
 
 impl<'data, M> crate::dynutil::UpcastDataPayload<'data, M> for SerdeSeDataStructMarker
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
     for<'a> &'a <M::Yokeable as Yokeable<'a>>::Output: serde::Serialize,
 {
     fn upcast(other: DataPayload<'data, M>) -> DataPayload<'data, SerdeSeDataStructMarker> {

--- a/provider/core/src/serde.rs
+++ b/provider/core/src/serde.rs
@@ -284,7 +284,6 @@ impl<'data, M> crate::dynutil::UpcastDataPayload<'data, M> for SerdeSeDataStruct
 where
     M: DataMarker<'data>,
     for<'a> &'a <M::Yokeable as Yokeable<'a>>::Output: serde::Serialize,
-    M::Cart: IsCovariant<'data>,
 {
     fn upcast(other: DataPayload<'data, M>) -> DataPayload<'data, SerdeSeDataStructMarker> {
         use crate::data_provider::{DataPayloadInner, ErasedCart};

--- a/provider/core/src/serde.rs
+++ b/provider/core/src/serde.rs
@@ -343,5 +343,4 @@ pub struct SerdeSeDataStructMarker {}
 
 impl<'data> DataMarker<'data> for SerdeSeDataStructMarker {
     type Yokeable = SerdeSeDataStructDynRef<'static>;
-    type Cart = dyn SerdeSeDataStruct<'data>;
 }

--- a/provider/core/src/serde.rs
+++ b/provider/core/src/serde.rs
@@ -341,6 +341,6 @@ unsafe impl<'a> Yokeable<'a> for SerdeSeDataStructDynRef<'static> {
 /// Marker type for [`SerdeSeDataStruct`].
 pub struct SerdeSeDataStructMarker {}
 
-impl<'data> DataMarker<'data> for SerdeSeDataStructMarker {
+impl DataMarker for SerdeSeDataStructMarker {
     type Yokeable = SerdeSeDataStructDynRef<'static>;
 }

--- a/provider/core/src/serde.rs
+++ b/provider/core/src/serde.rs
@@ -292,18 +292,24 @@ where
                 let rc: Rc<Yoke<_, _>> = Rc::from(yoke);
                 let yoke =
                     Yoke::attach_to_rc_cart(rc.clone() as Rc<dyn SerdeSeDataStruct<'data> + 'data>);
+                // Safe since we are replacing the cart with another that owns
+                // the same underlying data
                 unsafe { yoke.replace_cart(move |_| rc as ErasedCart<'data>) }
             }
             DataPayloadInner::Owned(yoke) => {
                 let rc: Rc<Yoke<_, _>> = Rc::from(yoke);
                 let yoke =
                     Yoke::attach_to_rc_cart(rc.clone() as Rc<dyn SerdeSeDataStruct<'data> + 'data>);
+                // Safe since we are replacing the cart with another that owns
+                // the same underlying data
                 unsafe { yoke.replace_cart(move |_| rc as ErasedCart<'data>) }
             }
             DataPayloadInner::RcBuf(yoke) => {
                 let rc: Rc<Yoke<_, _>> = Rc::from(yoke);
                 let yoke =
                     Yoke::attach_to_rc_cart(rc.clone() as Rc<dyn SerdeSeDataStruct<'data> + 'data>);
+                // Safe since we are replacing the cart with another that owns
+                // the same underlying data
                 unsafe { yoke.replace_cart(move |_| rc as ErasedCart<'data>) }
             }
         };

--- a/provider/core/src/struct_provider.rs
+++ b/provider/core/src/struct_provider.rs
@@ -40,7 +40,7 @@ use crate::yoke::*;
 /// ```
 pub struct StructProvider<'data, M>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
 {
     pub key: ResourceKey,
     pub data: DataPayload<'data, M>,
@@ -48,7 +48,7 @@ where
 
 impl<'data, M> DataProvider<'data, M> for StructProvider<'data, M>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
     for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
 {
     fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<'data, M>, Error> {

--- a/provider/fs/src/deserializer.rs
+++ b/provider/fs/src/deserializer.rs
@@ -116,7 +116,7 @@ pub fn deserialize_zero_copy<'data, M>(
     syntax_option: &SyntaxOption,
 ) -> for<'de> fn(bytes: &'de [u8]) -> Result<<M::Yokeable as Yokeable<'de>>::Output, Error>
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
     // Actual bound:
     //     for<'de> <M::Yokeable as Yokeable<'de>>::Output: serde::de::Deserialize<'de>,
     // Necessary workaround bound (see `yoke::trait_hack` docs):

--- a/provider/fs/src/fs_data_provider.rs
+++ b/provider/fs/src/fs_data_provider.rs
@@ -99,7 +99,7 @@ impl FsDataProvider {
 /// Note: This impl returns `'static` payloads because borrowing is handled by [`Yoke`].
 impl<'data, M> DataProvider<'data, M> for FsDataProvider
 where
-    M: DataMarker<'data>,
+    M: DataMarker,
     // Actual bound:
     //     for<'de> <M::Yokeable as Yokeable<'de>>::Output: serde::de::Deserialize<'de>,
     // Necessary workaround bound (see `yoke::trait_hack` docs):

--- a/provider/macros/src/lib.rs
+++ b/provider/macros/src/lib.rs
@@ -50,7 +50,6 @@ fn data_struct_impl(item: ItemStruct) -> TokenStream2 {
 
             impl<#lt> icu_provider::DataMarker<#lt> for #marker {
                 type Yokeable = #name<'static>;
-                type Cart = #name<#lt>;
             }
 
             #[derive(Yokeable, ZeroCopyFrom)]
@@ -63,7 +62,6 @@ fn data_struct_impl(item: ItemStruct) -> TokenStream2 {
 
             impl<'data> icu_provider::DataMarker<'data> for #marker {
                 type Yokeable = #name;
-                type Cart = #name;
             }
 
             #[derive(Yokeable, ZeroCopyFrom)]

--- a/provider/macros/src/lib.rs
+++ b/provider/macros/src/lib.rs
@@ -43,12 +43,12 @@ fn data_struct_impl(item: ItemStruct) -> TokenStream2 {
 
     let docs = format!("Marker type for [`{}`]", name);
 
-    if let Some(lt) = lifetimes.get(0) {
+    if lifetimes.get(0).is_some() {
         quote!(
             #[doc = #docs]
             pub struct #marker;
 
-            impl<#lt> icu_provider::DataMarker<#lt> for #marker {
+            impl icu_provider::DataMarker for #marker {
                 type Yokeable = #name<'static>;
             }
 
@@ -60,7 +60,7 @@ fn data_struct_impl(item: ItemStruct) -> TokenStream2 {
             #[doc = #docs]
             pub struct #marker;
 
-            impl<'data> icu_provider::DataMarker<'data> for #marker {
+            impl icu_provider::DataMarker for #marker {
                 type Yokeable = #name;
             }
 

--- a/utils/yoke/src/is_covariant.rs
+++ b/utils/yoke/src/is_covariant.rs
@@ -7,6 +7,7 @@ use alloc::{
     borrow::{Cow, ToOwned},
     boxed::Box,
     rc::Rc,
+    string::String,
 };
 
 /// A type implementing `IsCovariant<'a>` is covariant with respect to lifetime `'a`.
@@ -112,6 +113,7 @@ pub unsafe trait IsCovariant<'a>: 'a {}
 unsafe impl<'a> IsCovariant<'a> for () {}
 
 unsafe impl<'a> IsCovariant<'a> for str {}
+unsafe impl<'a> IsCovariant<'a> for String {}
 
 unsafe impl<'a, T: IsCovariant<'a>> IsCovariant<'a> for Option<T> {}
 

--- a/utils/yoke/src/is_covariant.rs
+++ b/utils/yoke/src/is_covariant.rs
@@ -113,6 +113,7 @@ pub unsafe trait IsCovariant<'a>: 'a {}
 unsafe impl<'a> IsCovariant<'a> for () {}
 
 unsafe impl<'a> IsCovariant<'a> for str {}
+#[cfg(feature = "alloc")]
 unsafe impl<'a> IsCovariant<'a> for String {}
 
 unsafe impl<'a, T: IsCovariant<'a>> IsCovariant<'a> for Option<T> {}

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -271,6 +271,27 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
         self.cart
     }
 
+    /// Unsafe function for replacing the cart with another
+    ///
+    /// This can be used for type-erasing the cart, for example.
+    ///
+    /// # Safety:
+    ///
+    /// - `f()` must not panic
+    /// - References from the yokeable `Y` should still be valid for the lifetime of the
+    ///   returned cart type.
+    ///
+    /// Typically, this means implementing `f` as something which _wraps_ the inner cart type.
+    /// `Yoke` only really cares about destructors for its carts so it's fine to erase other
+    /// information about the cart, as long as the backing data will still be destroyed at the
+    /// same time.
+    pub unsafe fn replace_cart<C2>(self, f: impl FnOnce(C) -> C2) -> Yoke<Y, C2> {
+        Yoke {
+            yokeable: self.yokeable,
+            cart: f(self.cart),
+        }
+    }
+
     /// Mutate the stored [`Yokeable`] data.
     ///
     /// See [`Yokeable::transform_mut()`] for why this operation is safe.

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -275,7 +275,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     ///
     /// This can be used for type-erasing the cart, for example.
     ///
-    /// # Safety:
+    /// # Safety
     ///
     /// - `f()` must not panic
     /// - References from the yokeable `Y` should still be valid for the lifetime of the


### PR DESCRIPTION
Progress towards #1262
Builds on #1278

Fixes https://github.com/unicode-org/icu4x/issues/1151

This does not completely get rid of RcStruct, however it gets rid of the need for the "cart" type and removes a lot of lifetimes. The biggest win we get here is that projections can be made freely between data payload types now.

It should be much easier to get rid of RcStruct after this.

Notes for reviewing:
 
 - It's probably better to review this commit-by-commit
 - This PR is split into four sets of changes that could be landed as separate consecutive PRs if desired. It's fine to review them as such as well, I'm happy to split this if reviewers prefer:
   - The first two commits are https://github.com/unicode-org/icu4x/pull/1278
   - Adding ErasedCart: This is 132bbb9 to 0bd4bb4
   - Removing Cart: 0069af4 to 3fbc642
   - Removing the lifetime: 3fbc642 to 26320fc


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->