### PR TITLE
Get rid of the lifetime on DataPayload/DataProvider/DataExporter

### DIFF
--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -61,14 +61,14 @@ use crate::{
 ///
 /// This model replicates that of `ICU` and `ECMA402`. In the future this will become even more pronounced
 /// when we introduce asynchronous [`DataProvider`] and corresponding asynchronous constructor.
-pub struct DateTimeFormat<'data> {
+pub struct DateTimeFormat {
     pub(super) locale: Locale,
-    pub(super) patterns: DataPayload<'data, PatternPluralsFromPatternsV1Marker>,
-    pub(super) symbols: Option<DataPayload<'data, DateSymbolsV1Marker>>,
-    pub(super) ordinal_rules: Option<PluralRules<'data>>,
+    pub(super) patterns: DataPayload<PatternPluralsFromPatternsV1Marker>,
+    pub(super) symbols: Option<DataPayload<DateSymbolsV1Marker>>,
+    pub(super) ordinal_rules: Option<PluralRules>,
 }
 
-impl<'data> DateTimeFormat<'data> {
+impl DateTimeFormat {
     /// Constructor that takes a selected [`Locale`], reference to a [`DataProvider`] and
     /// a list of options, then collects all data necessary to format date and time values into the given locale.
     ///
@@ -96,10 +96,10 @@ impl<'data> DateTimeFormat<'data> {
         options: &DateTimeFormatOptions,
     ) -> Result<Self, DateTimeFormatError>
     where
-        D: DataProvider<'data, DateSymbolsV1Marker>
-            + DataProvider<'data, DatePatternsV1Marker>
-            + DataProvider<'data, DateSkeletonPatternsV1Marker>
-            + DataProvider<'data, PluralRulesV1Marker>,
+        D: DataProvider<DateSymbolsV1Marker>
+            + DataProvider<DatePatternsV1Marker>
+            + DataProvider<DateSkeletonPatternsV1Marker>
+            + DataProvider<PluralRulesV1Marker>,
     {
         let locale = locale.into();
 
@@ -157,9 +157,9 @@ impl<'data> DateTimeFormat<'data> {
     /// [`ZonedDateTimeFormat`]: crate::zoned_datetime::ZonedDateTimeFormat
     pub(super) fn new<T: Into<Locale>>(
         locale: T,
-        patterns: DataPayload<'data, PatternPluralsFromPatternsV1Marker>,
-        symbols: Option<DataPayload<'data, DateSymbolsV1Marker>>,
-        ordinal_rules: Option<PluralRules<'data>>,
+        patterns: DataPayload<PatternPluralsFromPatternsV1Marker>,
+        symbols: Option<DataPayload<DateSymbolsV1Marker>>,
+        ordinal_rules: Option<PluralRules>,
     ) -> Self {
         let locale = locale.into();
 
@@ -199,7 +199,7 @@ impl<'data> DateTimeFormat<'data> {
     /// At the moment, there's little value in using that over one of the other `format` methods,
     /// but [`FormattedDateTime`] will grow with methods for iterating over fields, extracting information
     /// about formatted date and so on.
-    pub fn format<'l, T>(&'l self, value: &'l T) -> FormattedDateTime<'l, 'data, T>
+    pub fn format<'l, T>(&'l self, value: &'l T) -> FormattedDateTime<'l, T>
     where
         T: DateTimeInput,
     {

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -48,18 +48,18 @@ use writeable::Writeable;
 ///
 /// let _ = format!("Date: {}", formatted_date);
 /// ```
-pub struct FormattedDateTime<'l, 'data, T>
+pub struct FormattedDateTime<'l, T>
 where
     T: DateTimeInput,
 {
-    pub(crate) patterns: &'l DataPayload<'data, PatternPluralsFromPatternsV1Marker>,
+    pub(crate) patterns: &'l DataPayload<PatternPluralsFromPatternsV1Marker>,
     pub(crate) symbols: Option<&'l provider::gregory::DateSymbolsV1>,
     pub(crate) datetime: &'l T,
     pub(crate) locale: &'l Locale,
     pub(crate) ordinal_rules: Option<&'l PluralRules<'data>>,
 }
 
-impl<'l, 'data, T> Writeable for FormattedDateTime<'l, 'data, T>
+impl<'l, T> Writeable for FormattedDateTime<'l, T>
 where
     T: DateTimeInput,
 {
@@ -78,7 +78,7 @@ where
     // TODO(#489): Implement write_len
 }
 
-impl<'l, 'data, T> fmt::Display for FormattedDateTime<'l, 'data, T>
+impl<'l, T> fmt::Display for FormattedDateTime<'l, T>
 where
     T: DateTimeInput,
 {

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -56,7 +56,7 @@ where
     pub(crate) symbols: Option<&'l provider::gregory::DateSymbolsV1>,
     pub(crate) datetime: &'l T,
     pub(crate) locale: &'l Locale,
-    pub(crate) ordinal_rules: Option<&'l PluralRules<'data>>,
+    pub(crate) ordinal_rules: Option<&'l PluralRules>,
 }
 
 impl<'l, T> Writeable for FormattedDateTime<'l, T>

--- a/components/datetime/src/format/time_zone.rs
+++ b/components/datetime/src/format/time_zone.rs
@@ -17,7 +17,7 @@ pub struct FormattedTimeZone<'l, T>
 where
     T: TimeZoneInput,
 {
-    pub(crate) time_zone_format: &'l TimeZoneFormat<'l>,
+    pub(crate) time_zone_format: &'l TimeZoneFormat,
     pub(crate) time_zone: &'l T,
 }
 

--- a/components/datetime/src/format/zoned_datetime.rs
+++ b/components/datetime/src/format/zoned_datetime.rs
@@ -16,15 +16,15 @@ use super::datetime;
 use super::time_zone;
 
 #[allow(missing_docs)] // TODO(#686) - Add missing docs.
-pub struct FormattedZonedDateTime<'l, 'data, T>
+pub struct FormattedZonedDateTime<'l, T>
 where
     T: ZonedDateTimeInput,
 {
-    pub(crate) zoned_datetime_format: &'l ZonedDateTimeFormat<'data>,
+    pub(crate) zoned_datetime_format: &'l ZonedDateTimeFormat,
     pub(crate) zoned_datetime: &'l T,
 }
 
-impl<'l, 'd, T> Writeable for FormattedZonedDateTime<'l, 'd, T>
+impl<'l, T> Writeable for FormattedZonedDateTime<'l, T>
 where
     T: ZonedDateTimeInput,
 {
@@ -36,7 +36,7 @@ where
     // TODO(#489): Implement write_len
 }
 
-impl<'l, 'd, T> fmt::Display for FormattedZonedDateTime<'l, 'd, T>
+impl<'l, T> fmt::Display for FormattedZonedDateTime<'l, T>
 where
     T: ZonedDateTimeInput,
 {

--- a/components/datetime/src/provider/date_time.rs
+++ b/components/datetime/src/provider/date_time.rs
@@ -22,12 +22,12 @@ use icu_provider::prelude::*;
 
 type Result<T> = core::result::Result<T, DateTimeFormatError>;
 
-fn patterns_data_payload<'data, D>(
+fn patterns_data_payload<D>(
     data_provider: &D,
     locale: &Locale,
-) -> Result<DataPayload<'data, DatePatternsV1Marker>>
+) -> Result<DataPayload<DatePatternsV1Marker>>
 where
-    D: DataProvider<'data, DatePatternsV1Marker>,
+    D: DataProvider<DatePatternsV1Marker>,
 {
     let data = data_provider
         .load_payload(&DataRequest {
@@ -43,12 +43,12 @@ where
     Ok(data)
 }
 
-fn skeleton_data_payload<'data, D>(
+fn skeleton_data_payload<D>(
     data_provider: &D,
     locale: &Locale,
-) -> Result<DataPayload<'data, DateSkeletonPatternsV1Marker>>
+) -> Result<DataPayload<DateSkeletonPatternsV1Marker>>
 where
-    D: DataProvider<'data, DateSkeletonPatternsV1Marker>,
+    D: DataProvider<DateSkeletonPatternsV1Marker>,
 {
     let data = data_provider
         .load_payload(&DataRequest {
@@ -109,16 +109,15 @@ fn pattern_for_date_length_inner(data: DatePatternsV1, length: length::Date) -> 
 
 pub struct PatternSelector<D>(PhantomData<D>);
 
-impl<'data, D> PatternSelector<D>
+impl<D> PatternSelector<D>
 where
-    D: DataProvider<'data, DatePatternsV1Marker>
-        + DataProvider<'data, DateSkeletonPatternsV1Marker>,
+    D: DataProvider<DatePatternsV1Marker> + DataProvider<DateSkeletonPatternsV1Marker>,
 {
     pub(crate) fn for_options(
         data_provider: &D,
         locale: &Locale,
         options: &DateTimeFormatOptions,
-    ) -> Result<DataPayload<'data, PatternPluralsFromPatternsV1Marker>> {
+    ) -> Result<DataPayload<PatternPluralsFromPatternsV1Marker>> {
         match options {
             DateTimeFormatOptions::Length(bag) => {
                 Self::pattern_for_length_bag(data_provider, locale, bag)
@@ -134,7 +133,7 @@ where
         data_provider: &D,
         locale: &Locale,
         length: &length::Bag,
-    ) -> Result<DataPayload<'data, PatternPluralsFromPatternsV1Marker>> {
+    ) -> Result<DataPayload<PatternPluralsFromPatternsV1Marker>> {
         match (length.date, length.time) {
             (None, None) => Ok(DataPayload::from_owned(PatternPluralsV1(
                 PatternPlurals::default(),
@@ -163,7 +162,7 @@ where
         data_provider: &D,
         locale: &Locale,
         length: length::Date,
-    ) -> Result<DataPayload<'data, PatternPluralsFromPatternsV1Marker>> {
+    ) -> Result<DataPayload<PatternPluralsFromPatternsV1Marker>> {
         let patterns_data = patterns_data_payload(data_provider, locale)?;
         Ok(
             patterns_data.map_project_with_capture(length, |data, length, _| {
@@ -181,7 +180,7 @@ where
         locale: &Locale,
         length: length::Time,
         preferences: Option<preferences::Bag>,
-    ) -> Result<DataPayload<'data, PatternPluralsFromPatternsV1Marker>> {
+    ) -> Result<DataPayload<PatternPluralsFromPatternsV1Marker>> {
         let patterns_data = patterns_data_payload(data_provider, locale)?;
         Ok(patterns_data.map_project_with_capture(
             (length, preferences),
@@ -200,7 +199,7 @@ where
         date_length: length::Date,
         time_length: length::Time,
         preferences: Option<preferences::Bag>,
-    ) -> Result<DataPayload<'data, PatternPluralsFromPatternsV1Marker>> {
+    ) -> Result<DataPayload<PatternPluralsFromPatternsV1Marker>> {
         let patterns_data = patterns_data_payload(data_provider, locale)?;
         patterns_data.try_map_project_with_capture(
             (date_length, time_length, preferences),
@@ -227,7 +226,7 @@ where
         data_provider: &D,
         locale: &Locale,
         components: &components::Bag,
-    ) -> Result<DataPayload<'data, PatternPluralsFromPatternsV1Marker>> {
+    ) -> Result<DataPayload<PatternPluralsFromPatternsV1Marker>> {
         let skeletons_data = skeleton_data_payload(data_provider, locale)?;
         let patterns_data = patterns_data_payload(data_provider, locale)?;
         // Not all skeletons are currently supported.

--- a/components/datetime/src/skeleton/mod.rs
+++ b/components/datetime/src/skeleton/mod.rs
@@ -36,8 +36,8 @@ mod test {
     };
 
     fn get_data_payload() -> (
-        DataPayload<'static, DatePatternsV1Marker>,
-        DataPayload<'static, DateSkeletonPatternsV1Marker>,
+        DataPayload<DatePatternsV1Marker>,
+        DataPayload<DateSkeletonPatternsV1Marker>,
     ) {
         let provider = icu_testdata::get_provider();
         let langid = langid!("en");

--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -22,16 +22,16 @@ use icu_locid::{LanguageIdentifier, Locale};
 use icu_provider::prelude::*;
 
 /// Loads a resource into its destination if the destination has not already been filled.
-fn load_resource<'data, D, L, P>(
+fn load_resource<D, L, P>(
     locale: &L,
     resource_key: ResourceKey,
-    destination: &mut Option<DataPayload<'data, D>>,
+    destination: &mut Option<DataPayload<D>>,
     provider: &P,
 ) -> Result<(), DateTimeFormatError>
 where
     D: DataMarker,
     L: Clone + Into<LanguageIdentifier>,
-    P: DataProvider<'data, D> + ?Sized,
+    P: DataProvider<D> + ?Sized,
 {
     if destination.is_none() {
         *destination = Some(
@@ -90,29 +90,28 @@ where
 /// // let value = tzf.format_to_string(&time_zone);
 /// // ```
 // TODO(#622) Make TimeZoneFormat public once we have a clean way to provide it options.
-pub(super) struct TimeZoneFormat<'data> {
+pub(super) struct TimeZoneFormat {
     /// The pattern to format.
-    pub(super) patterns: DataPayload<'data, PatternPluralsFromPatternsV1Marker>,
+    pub(super) patterns: DataPayload<PatternPluralsFromPatternsV1Marker>,
     /// The data that contains meta information about how to display content.
-    pub(super) zone_formats: DataPayload<'data, provider::time_zones::TimeZoneFormatsV1Marker>,
+    pub(super) zone_formats: DataPayload<provider::time_zones::TimeZoneFormatsV1Marker>,
     /// The exemplar cities for time zones.
-    pub(super) exemplar_cities:
-        Option<DataPayload<'data, provider::time_zones::ExemplarCitiesV1Marker>>,
+    pub(super) exemplar_cities: Option<DataPayload<provider::time_zones::ExemplarCitiesV1Marker>>,
     /// The generic long metazone names, e.g. Pacific Time
     pub(super) mz_generic_long:
-        Option<DataPayload<'data, provider::time_zones::MetaZoneGenericNamesLongV1Marker>>,
+        Option<DataPayload<provider::time_zones::MetaZoneGenericNamesLongV1Marker>>,
     /// The generic short metazone names, e.g. PT
     pub(super) mz_generic_short:
-        Option<DataPayload<'data, provider::time_zones::MetaZoneGenericNamesShortV1Marker>>,
+        Option<DataPayload<provider::time_zones::MetaZoneGenericNamesShortV1Marker>>,
     /// The specific long metazone names, e.g. Pacific Daylight Time
     pub(super) mz_specific_long:
-        Option<DataPayload<'data, provider::time_zones::MetaZoneSpecificNamesLongV1Marker>>,
+        Option<DataPayload<provider::time_zones::MetaZoneSpecificNamesLongV1Marker>>,
     /// The specific short metazone names, e.g. Pacific Daylight Time
     pub(super) mz_specific_short:
-        Option<DataPayload<'data, provider::time_zones::MetaZoneSpecificNamesShortV1Marker>>,
+        Option<DataPayload<provider::time_zones::MetaZoneSpecificNamesShortV1Marker>>,
 }
 
-impl<'data> TimeZoneFormat<'data> {
+impl TimeZoneFormat {
     /// Constructor that selectively loads data based on what is required to
     /// format the given pattern into the given locale.
     ///
@@ -137,17 +136,17 @@ impl<'data> TimeZoneFormat<'data> {
     // TODO(#622) Make this public once TimeZoneFormat is public.
     pub(super) fn try_new<L, ZP>(
         locale: L,
-        patterns: DataPayload<'data, PatternPluralsFromPatternsV1Marker>,
+        patterns: DataPayload<PatternPluralsFromPatternsV1Marker>,
         zone_provider: &ZP,
     ) -> Result<Self, DateTimeFormatError>
     where
         L: Into<Locale>,
-        ZP: DataProvider<'data, provider::time_zones::TimeZoneFormatsV1Marker>
-            + DataProvider<'data, provider::time_zones::ExemplarCitiesV1Marker>
-            + DataProvider<'data, provider::time_zones::MetaZoneGenericNamesLongV1Marker>
-            + DataProvider<'data, provider::time_zones::MetaZoneGenericNamesShortV1Marker>
-            + DataProvider<'data, provider::time_zones::MetaZoneSpecificNamesLongV1Marker>
-            + DataProvider<'data, provider::time_zones::MetaZoneSpecificNamesShortV1Marker>
+        ZP: DataProvider<provider::time_zones::TimeZoneFormatsV1Marker>
+            + DataProvider<provider::time_zones::ExemplarCitiesV1Marker>
+            + DataProvider<provider::time_zones::MetaZoneGenericNamesLongV1Marker>
+            + DataProvider<provider::time_zones::MetaZoneGenericNamesShortV1Marker>
+            + DataProvider<provider::time_zones::MetaZoneSpecificNamesLongV1Marker>
+            + DataProvider<provider::time_zones::MetaZoneSpecificNamesShortV1Marker>
             + ?Sized,
     {
         let locale = locale.into();
@@ -302,7 +301,7 @@ impl<'data> TimeZoneFormat<'data> {
     // TODO(#622) Make this public once TimeZoneFormat is public.
     //           And remove #[allow(unused)]
     #[allow(unused)]
-    pub(super) fn format<'l: 'data, T>(&'l self, value: &'l T) -> FormattedTimeZone<'l, T>
+    pub(super) fn format<'l, T>(&'l self, value: &'l T) -> FormattedTimeZone<'l, T>
     where
         T: TimeZoneInput,
     {

--- a/components/datetime/src/zoned_datetime.rs
+++ b/components/datetime/src/zoned_datetime.rs
@@ -68,12 +68,12 @@ use crate::{
 ///
 /// let value = zdtf.format_to_string(&zoned_datetime);
 /// ```
-pub struct ZonedDateTimeFormat<'data> {
-    pub(super) datetime_format: DateTimeFormat<'data>,
-    pub(super) time_zone_format: TimeZoneFormat<'data>,
+pub struct ZonedDateTimeFormat {
+    pub(super) datetime_format: DateTimeFormat,
+    pub(super) time_zone_format: TimeZoneFormat,
 }
 
-impl<'data> ZonedDateTimeFormat<'data> {
+impl ZonedDateTimeFormat {
     /// Constructor that takes a selected [`Locale`], a reference to a [`DataProvider`] for
     /// dates, a [`DataProvider`] for time zones, and a list of [`DateTimeFormatOptions`].
     /// It collects all data necessary to format zoned datetime values into the given locale.
@@ -108,17 +108,17 @@ impl<'data> ZonedDateTimeFormat<'data> {
     ) -> Result<Self, DateTimeFormatError>
     where
         L: Into<Locale>,
-        DP: DataProvider<'data, DateSymbolsV1Marker>
-            + DataProvider<'data, DatePatternsV1Marker>
-            + DataProvider<'data, DateSkeletonPatternsV1Marker>,
-        ZP: DataProvider<'data, provider::time_zones::TimeZoneFormatsV1Marker>
-            + DataProvider<'data, provider::time_zones::ExemplarCitiesV1Marker>
-            + DataProvider<'data, provider::time_zones::MetaZoneGenericNamesLongV1Marker>
-            + DataProvider<'data, provider::time_zones::MetaZoneGenericNamesShortV1Marker>
-            + DataProvider<'data, provider::time_zones::MetaZoneSpecificNamesLongV1Marker>
-            + DataProvider<'data, provider::time_zones::MetaZoneSpecificNamesShortV1Marker>
+        DP: DataProvider<DateSymbolsV1Marker>
+            + DataProvider<DatePatternsV1Marker>
+            + DataProvider<DateSkeletonPatternsV1Marker>,
+        ZP: DataProvider<provider::time_zones::TimeZoneFormatsV1Marker>
+            + DataProvider<provider::time_zones::ExemplarCitiesV1Marker>
+            + DataProvider<provider::time_zones::MetaZoneGenericNamesLongV1Marker>
+            + DataProvider<provider::time_zones::MetaZoneGenericNamesShortV1Marker>
+            + DataProvider<provider::time_zones::MetaZoneSpecificNamesLongV1Marker>
+            + DataProvider<provider::time_zones::MetaZoneSpecificNamesShortV1Marker>
             + ?Sized,
-        PP: DataProvider<'data, PluralRulesV1Marker>,
+        PP: DataProvider<PluralRulesV1Marker>,
     {
         let locale = locale.into();
         let langid: LanguageIdentifier = locale.clone().into();
@@ -204,7 +204,7 @@ impl<'data> ZonedDateTimeFormat<'data> {
     /// At the moment, there's little value in using that over one of the other `format` methods,
     /// but [`FormattedZonedDateTime`] will grow with methods for iterating over fields, extracting information
     /// about formatted date and so on.
-    pub fn format<'l, T>(&'l self, value: &'l T) -> FormattedZonedDateTime<'l, 'data, T>
+    pub fn format<'l, T>(&'l self, value: &'l T) -> FormattedZonedDateTime<'l, T>
     where
         T: ZonedDateTimeInput,
     {

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -32,44 +32,44 @@ use patterns::{
 use std::fmt::Write;
 use tinystr::tinystr8;
 
-struct MultiKeyStructProvider<'data> {
-    pub symbols: StructProvider<'data, DateSymbolsV1Marker>,
-    pub skeletons: StructProvider<'data, DateSkeletonPatternsV1Marker>,
-    pub patterns: StructProvider<'data, DatePatternsV1Marker>,
+struct MultiKeyStructProvider {
+    pub symbols: StructProvider<DateSymbolsV1Marker>,
+    pub skeletons: StructProvider<DateSkeletonPatternsV1Marker>,
+    pub patterns: StructProvider<DatePatternsV1Marker>,
 }
 
-impl<'data> DataProvider<'data, DateSymbolsV1Marker> for MultiKeyStructProvider<'data> {
+impl DataProvider<DateSymbolsV1Marker> for MultiKeyStructProvider {
     fn load_payload(
         &self,
         req: &DataRequest,
-    ) -> Result<DataResponse<'data, DateSymbolsV1Marker>, icu_provider::DataError> {
+    ) -> Result<DataResponse<DateSymbolsV1Marker>, icu_provider::DataError> {
         self.symbols.load_payload(req)
     }
 }
 
-impl<'data> DataProvider<'data, DateSkeletonPatternsV1Marker> for MultiKeyStructProvider<'data> {
+impl DataProvider<DateSkeletonPatternsV1Marker> for MultiKeyStructProvider {
     fn load_payload(
         &self,
         req: &DataRequest,
-    ) -> Result<DataResponse<'data, DateSkeletonPatternsV1Marker>, icu_provider::DataError> {
+    ) -> Result<DataResponse<DateSkeletonPatternsV1Marker>, icu_provider::DataError> {
         self.skeletons.load_payload(req)
     }
 }
 
-impl<'data> DataProvider<'data, DatePatternsV1Marker> for MultiKeyStructProvider<'data> {
+impl DataProvider<DatePatternsV1Marker> for MultiKeyStructProvider {
     fn load_payload(
         &self,
         req: &DataRequest,
-    ) -> Result<DataResponse<'data, DatePatternsV1Marker>, icu_provider::DataError> {
+    ) -> Result<DataResponse<DatePatternsV1Marker>, icu_provider::DataError> {
         self.patterns.load_payload(req)
     }
 }
 
-impl<'data> DataProvider<'data, PluralRulesV1Marker> for MultiKeyStructProvider<'data> {
+impl DataProvider<PluralRulesV1Marker> for MultiKeyStructProvider {
     fn load_payload(
         &self,
         _req: &DataRequest,
-    ) -> Result<DataResponse<'data, PluralRulesV1Marker>, icu_provider::DataError> {
+    ) -> Result<DataResponse<PluralRulesV1Marker>, icu_provider::DataError> {
         Err(icu_provider::DataError::MissingPayload)
     }
 }

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -87,16 +87,16 @@ use icu_provider::prelude::*;
 /// Read more about the options in the [`options`] module.
 ///
 /// See the crate-level documentation for examples.
-pub struct FixedDecimalFormat<'data> {
+pub struct FixedDecimalFormat {
     options: options::FixedDecimalFormatOptions,
-    symbols: DataPayload<'data, provider::DecimalSymbolsV1Marker>,
+    symbols: DataPayload<provider::DecimalSymbolsV1Marker>,
 }
 
-impl<'data> FixedDecimalFormat<'data> {
+impl FixedDecimalFormat {
     /// Creates a new [`FixedDecimalFormat`] from locale data and an options bag.
     pub fn try_new<
         T: Into<Locale>,
-        D: DataProvider<'data, provider::DecimalSymbolsV1Marker> + ?Sized,
+        D: DataProvider<provider::DecimalSymbolsV1Marker> + ?Sized,
     >(
         locale: T,
         data_provider: &D,

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -94,10 +94,7 @@ pub struct FixedDecimalFormat {
 
 impl FixedDecimalFormat {
     /// Creates a new [`FixedDecimalFormat`] from locale data and an options bag.
-    pub fn try_new<
-        T: Into<Locale>,
-        D: DataProvider<provider::DecimalSymbolsV1Marker> + ?Sized,
-    >(
+    pub fn try_new<T: Into<Locale>, D: DataProvider<provider::DecimalSymbolsV1Marker> + ?Sized>(
         locale: T,
         data_provider: &D,
         options: options::FixedDecimalFormatOptions,

--- a/components/locale_canonicalizer/src/locale_canonicalizer.rs
+++ b/components/locale_canonicalizer/src/locale_canonicalizer.rs
@@ -101,11 +101,11 @@ pub enum CanonicalizationResult {
 /// [`CLDR`]: http://cldr.unicode.org/
 /// [`UTS #35: Unicode LDML 3. Likely Subtags`]: https://www.unicode.org/reports/tr35/#Likely_Subtags.
 /// [`UTS #35: Unicode LDML 3. LocaleId Canonicalization`]: http://unicode.org/reports/tr35/#LocaleId_Canonicalization,
-pub struct LocaleCanonicalizer<'data> {
+pub struct LocaleCanonicalizer {
     /// Data to support canonicalization.
-    aliases: DataPayload<'data, AliasesV1Marker>,
+    aliases: DataPayload<AliasesV1Marker>,
     /// Data to support likely subtags maximize and minimize.
-    likely_subtags: DataPayload<'data, LikelySubtagsV1Marker>,
+    likely_subtags: DataPayload<LikelySubtagsV1Marker>,
     /// Extension keys that require canonicalization.
     extension_keys: Vec<Key>,
 }
@@ -226,12 +226,12 @@ macro_rules! maximize_locale {
     }};
 }
 
-impl<'data> LocaleCanonicalizer<'data> {
+impl LocaleCanonicalizer {
     /// A constructor which takes a [`DataProvider`] and creates a [`LocaleCanonicalizer`].
-    pub fn new<P>(provider: &P) -> Result<LocaleCanonicalizer<'data>, DataError>
+    pub fn new<P>(provider: &P) -> Result<LocaleCanonicalizer, DataError>
     where
-        P: DataProvider<'data, AliasesV1Marker>
-            + DataProvider<'data, LikelySubtagsV1Marker>
+        P: DataProvider<AliasesV1Marker>
+            + DataProvider<LikelySubtagsV1Marker>
             + ?Sized,
     {
         // The `rg` region override and `sd` regional subdivision keys may contain

--- a/components/locale_canonicalizer/src/locale_canonicalizer.rs
+++ b/components/locale_canonicalizer/src/locale_canonicalizer.rs
@@ -230,9 +230,7 @@ impl LocaleCanonicalizer {
     /// A constructor which takes a [`DataProvider`] and creates a [`LocaleCanonicalizer`].
     pub fn new<P>(provider: &P) -> Result<LocaleCanonicalizer, DataError>
     where
-        P: DataProvider<AliasesV1Marker>
-            + DataProvider<LikelySubtagsV1Marker>
-            + ?Sized,
+        P: DataProvider<AliasesV1Marker> + DataProvider<LikelySubtagsV1Marker> + ?Sized,
     {
         // The `rg` region override and `sd` regional subdivision keys may contain
         // language codes that require canonicalization.

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -269,12 +269,12 @@ impl PluralCategory {
 /// [`ICU4X`]: ../icu/index.html
 /// [`Plural Type`]: PluralRuleType
 /// [`Plural Category`]: PluralCategory
-pub struct PluralRules<'data> {
+pub struct PluralRules {
     _locale: Locale,
-    rules: DataPayload<'data, PluralRulesV1Marker>,
+    rules: DataPayload<PluralRulesV1Marker>,
 }
 
-impl<'data> PluralRules<'data> {
+impl PluralRules {
     /// Constructs a new `PluralRules` for a given locale, [`type`] and [`data provider`].
     ///
     /// This constructor will fail if the [`Data Provider`] does not have the data.
@@ -301,7 +301,7 @@ impl<'data> PluralRules<'data> {
         rule_type: PluralRuleType,
     ) -> Result<Self, PluralRulesError>
     where
-        D: DataProvider<'data, PluralRulesV1Marker> + ?Sized,
+        D: DataProvider<PluralRulesV1Marker> + ?Sized,
     {
         let locale = locale.into();
         let key = match rule_type {
@@ -455,7 +455,7 @@ impl<'data> PluralRules<'data> {
     /// data obtained from a provider.
     pub fn new<T: Into<Locale>>(
         locale: T,
-        rules: DataPayload<'data, PluralRulesV1Marker>,
+        rules: DataPayload<PluralRulesV1Marker>,
     ) -> Result<Self, PluralRulesError> {
         let locale = locale.into();
         Ok(Self {

--- a/components/plurals/tests/plurals.rs
+++ b/components/plurals/tests/plurals.rs
@@ -70,26 +70,3 @@ fn test_plural_category_all() {
     assert_eq!(categories[4], PluralCategory::Two);
     assert_eq!(categories[5], PluralCategory::Zero);
 }
-
-#[test]
-fn test_plural_rules_non_static_lifetime() {
-    let local_string = "v = 0 and i % 10 = 1".to_string();
-    let local_data = PluralRulesV1 {
-        zero: None,
-        one: Some(local_string.parse().expect("Failed to parse plural rule")),
-        two: None,
-        few: None,
-        many: None,
-    };
-    let provider = StructProvider {
-        key: provider::key::CARDINAL_V1,
-        data: DataPayload::from_partial_owned(Rc::from(local_data)),
-    };
-
-    let lid = langid!("und");
-    let pr = PluralRules::try_new(lid, &provider, PluralRuleType::Cardinal).unwrap();
-
-    assert_eq!(pr.select(1_usize), PluralCategory::One);
-    assert_eq!(pr.select(5_usize), PluralCategory::Other);
-    assert_eq!(pr.select(11_usize), PluralCategory::One);
-}

--- a/components/plurals/tests/plurals.rs
+++ b/components/plurals/tests/plurals.rs
@@ -4,12 +4,11 @@
 
 use icu_locid_macros::langid;
 use icu_plurals::{
-    provider::{self, PluralRulesV1, PluralRulesV1Marker},
+    provider::{self, PluralRulesV1Marker},
     rules::runtime::ast::Rule,
     PluralCategory, PluralRuleType, PluralRules,
 };
-use icu_provider::{prelude::*, struct_provider::StructProvider};
-use std::rc::Rc;
+use icu_provider::prelude::*;
 use zerovec::VarZeroVec;
 
 #[test]
@@ -29,7 +28,7 @@ fn test_static_provider_borrowed_rules() {
 
     let lid = langid!("en");
 
-    let rules: DataPayload<'_, PluralRulesV1Marker> = provider
+    let rules: DataPayload<PluralRulesV1Marker> = provider
         .load_payload(&DataRequest {
             resource_path: ResourcePath {
                 key: provider::key::CARDINAL_V1,

--- a/components/properties/src/maps.rs
+++ b/components/properties/src/maps.rs
@@ -112,9 +112,9 @@ where
 /// ```
 ///
 /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
-pub fn get_east_asian_width<'data, D>(provider: &D) -> CodePointMapResult<'data, EastAsianWidth>
+pub fn get_east_asian_width<D>(provider: &D) -> CodePointMapResult<EastAsianWidth>
 where
-    D: DataProvider<'data, UnicodePropertyMapV1Marker<EastAsianWidth>> + ?Sized,
+    D: DataProvider<UnicodePropertyMapV1Marker<EastAsianWidth>> + ?Sized,
 {
     get_cp_map(provider, key::EAST_ASIAN_WIDTH_V1)
 }
@@ -136,9 +136,9 @@ where
 /// ```
 ///
 /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
-pub fn get_line_break<'data, D>(provider: &D) -> CodePointMapResult<'data, LineBreak>
+pub fn get_line_break<D>(provider: &D) -> CodePointMapResult<LineBreak>
 where
-    D: DataProvider<'data, UnicodePropertyMapV1Marker<LineBreak>> + ?Sized,
+    D: DataProvider<UnicodePropertyMapV1Marker<LineBreak>> + ?Sized,
 {
     get_cp_map(provider, key::LINE_BREAK_V1)
 }

--- a/components/properties/src/maps.rs
+++ b/components/properties/src/maps.rs
@@ -18,12 +18,11 @@ use crate::*;
 use icu_codepointtrie::TrieValue;
 use icu_provider::prelude::*;
 
-type CodePointMapResult<'data, T> =
-    Result<DataPayload<'data, UnicodePropertyMapV1Marker<T>>, PropertiesError>;
+type CodePointMapResult<T> = Result<DataPayload<UnicodePropertyMapV1Marker<T>>, PropertiesError>;
 
-fn get_cp_map<'data, D, T>(provider: &D, resc_key: ResourceKey) -> CodePointMapResult<'data, T>
+fn get_cp_map<D, T>(provider: &D, resc_key: ResourceKey) -> CodePointMapResult<T>
 where
-    D: DataProvider<'data, UnicodePropertyMapV1Marker<T>> + ?Sized,
+    D: DataProvider<UnicodePropertyMapV1Marker<T>> + ?Sized,
     T: TrieValue,
 {
     let data_req = DataRequest {
@@ -62,9 +61,9 @@ where
 /// ```
 ///
 /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
-pub fn get_general_category<'data, D>(provider: &D) -> CodePointMapResult<'data, GeneralSubcategory>
+pub fn get_general_category<D>(provider: &D) -> CodePointMapResult<GeneralSubcategory>
 where
-    D: DataProvider<'data, UnicodePropertyMapV1Marker<GeneralSubcategory>> + ?Sized,
+    D: DataProvider<UnicodePropertyMapV1Marker<GeneralSubcategory>> + ?Sized,
 {
     get_cp_map(provider, key::GENERAL_CATEGORY_V1)
 }
@@ -89,9 +88,9 @@ where
 /// ```
 ///
 /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
-pub fn get_script<'data, D>(provider: &D) -> CodePointMapResult<'data, Script>
+pub fn get_script<D>(provider: &D) -> CodePointMapResult<Script>
 where
-    D: DataProvider<'data, UnicodePropertyMapV1Marker<Script>> + ?Sized,
+    D: DataProvider<UnicodePropertyMapV1Marker<Script>> + ?Sized,
 {
     get_cp_map(provider, key::SCRIPT_V1)
 }
@@ -161,11 +160,9 @@ where
 /// ```
 ///
 /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
-pub fn get_grapheme_cluster_break<'data, D>(
-    provider: &D,
-) -> CodePointMapResult<'data, GraphemeClusterBreak>
+pub fn get_grapheme_cluster_break<D>(provider: &D) -> CodePointMapResult<GraphemeClusterBreak>
 where
-    D: DataProvider<'data, UnicodePropertyMapV1Marker<GraphemeClusterBreak>> + ?Sized,
+    D: DataProvider<UnicodePropertyMapV1Marker<GraphemeClusterBreak>> + ?Sized,
 {
     get_cp_map(provider, key::GRAPHEME_CLUSTER_BREAK_V1)
 }
@@ -187,9 +184,9 @@ where
 /// ```
 ///
 /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
-pub fn get_word_break<'data, D>(provider: &D) -> CodePointMapResult<'data, WordBreak>
+pub fn get_word_break<D>(provider: &D) -> CodePointMapResult<WordBreak>
 where
-    D: DataProvider<'data, UnicodePropertyMapV1Marker<WordBreak>> + ?Sized,
+    D: DataProvider<UnicodePropertyMapV1Marker<WordBreak>> + ?Sized,
 {
     get_cp_map(provider, key::WORD_BREAK_V1)
 }
@@ -211,9 +208,9 @@ where
 /// ```
 ///
 /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
-pub fn get_sentence_break<'data, D>(provider: &D) -> CodePointMapResult<'data, SentenceBreak>
+pub fn get_sentence_break<D>(provider: &D) -> CodePointMapResult<SentenceBreak>
 where
-    D: DataProvider<'data, UnicodePropertyMapV1Marker<SentenceBreak>> + ?Sized,
+    D: DataProvider<UnicodePropertyMapV1Marker<SentenceBreak>> + ?Sized,
 {
     get_cp_map(provider, key::SENTENCE_BREAK_V1)
 }

--- a/components/properties/src/sets.rs
+++ b/components/properties/src/sets.rs
@@ -19,12 +19,12 @@ use crate::provider::*;
 use crate::*;
 use icu_provider::prelude::*;
 
-type UnisetResult<'data> = Result<DataPayload<'data, UnicodePropertyV1Marker>, PropertiesError>;
+type UnisetResult = Result<DataPayload<UnicodePropertyV1Marker>, PropertiesError>;
 
 // helper fn
-fn get_uniset<'data, D>(provider: &D, resc_key: ResourceKey) -> UnisetResult<'data>
+fn get_uniset<D>(provider: &D, resc_key: ResourceKey) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     let data_req = DataRequest {
         resource_path: ResourcePath {
@@ -65,18 +65,18 @@ where
 /// assert!(ascii_hex_digit.contains('A'));
 /// assert!(!ascii_hex_digit.contains('Ä'));  // U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS
 /// ```
-pub fn get_ascii_hex_digit<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_ascii_hex_digit<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::ASCII_HEX_DIGIT_V1)
 }
 
 /// Characters with the Alphabetic or Decimal_Number property
 /// This is defined for POSIX compatibility.
-pub fn get_alnum<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_alnum<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::ALNUM_V1)
 }
@@ -100,9 +100,9 @@ where
 /// assert!(alphabetic.contains('A'));
 /// assert!(alphabetic.contains('Ä'));  // U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS
 /// ```
-pub fn get_alphabetic<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_alphabetic<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::ALPHABETIC_V1)
 }
@@ -125,9 +125,9 @@ where
 /// assert!(bidi_control.contains_u32(0x200F));  // RIGHT-TO-LEFT MARK
 /// assert!(!bidi_control.contains('ش'));  // U+0634 ARABIC LETTER SHEEN
 /// ```
-pub fn get_bidi_control<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_bidi_control<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::BIDI_CONTROL_V1)
 }
@@ -151,17 +151,17 @@ where
 /// assert!(bidi_mirrored.contains('∑'));  // U+2211 N-ARY SUMMATION
 /// assert!(!bidi_mirrored.contains('ཉ'));  // U+0F49 TIBETAN LETTER NYA
 /// ```
-pub fn get_bidi_mirrored<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_bidi_mirrored<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::BIDI_MIRRORED_V1)
 }
 
 /// Horizontal whitespace characters
-pub fn get_blank<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_blank<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::BLANK_V1)
 }
@@ -183,9 +183,9 @@ where
 /// assert!(cased.contains('Ꙡ'));  // U+A660 CYRILLIC CAPITAL LETTER REVERSED TSE
 /// assert!(!cased.contains('ދ'));  // U+078B THAANA LETTER DHAALU
 /// ```
-pub fn get_cased<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_cased<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::CASED_V1)
 }
@@ -207,18 +207,18 @@ where
 /// assert!(case_ignorable.contains(':'));
 /// assert!(!case_ignorable.contains('λ'));  // U+03BB GREEK SMALL LETTER LAMDA
 /// ```
-pub fn get_case_ignorable<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_case_ignorable<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::CASE_IGNORABLE_V1)
 }
 
 /// Characters that are excluded from composition
 /// See <https://unicode.org/Public/UNIDATA/CompositionExclusions.txt>
-pub fn get_full_composition_exclusion<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_full_composition_exclusion<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::FULL_COMPOSITION_EXCLUSION_V1)
 }
@@ -240,17 +240,17 @@ where
 /// assert!(changes_when_casefolded.contains('ß'));  // U+00DF LATIN SMALL LETTER SHARP S
 /// assert!(!changes_when_casefolded.contains('ᜉ'));  // U+1709 TAGALOG LETTER PA
 /// ```
-pub fn get_changes_when_casefolded<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_changes_when_casefolded<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::CHANGES_WHEN_CASEFOLDED_V1)
 }
 
 /// Characters which may change when they undergo case mapping
-pub fn get_changes_when_casemapped<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_changes_when_casemapped<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::CHANGES_WHEN_CASEMAPPED_V1)
 }
@@ -272,9 +272,9 @@ where
 /// assert!(changes_when_nfkc_casefolded.contains('🄵'));  // U+1F135 SQUARED LATIN CAPITAL LETTER F
 /// assert!(!changes_when_nfkc_casefolded.contains('f'));
 /// ```
-pub fn get_changes_when_nfkc_casefolded<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_changes_when_nfkc_casefolded<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::CHANGES_WHEN_NFKC_CASEFOLDED_V1)
 }
@@ -296,9 +296,9 @@ where
 /// assert!(changes_when_lowercased.contains('Ⴔ'));  // U+10B4 GEORGIAN CAPITAL LETTER PHAR
 /// assert!(!changes_when_lowercased.contains('ფ'));  // U+10E4 GEORGIAN LETTER PHAR
 /// ```
-pub fn get_changes_when_lowercased<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_changes_when_lowercased<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::CHANGES_WHEN_LOWERCASED_V1)
 }
@@ -320,9 +320,9 @@ where
 /// assert!(changes_when_titlecased.contains('æ'));  // U+00E6 LATIN SMALL LETTER AE
 /// assert!(!changes_when_titlecased.contains('Æ'));  // U+00E6 LATIN CAPITAL LETTER AE
 /// ```
-pub fn get_changes_when_titlecased<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_changes_when_titlecased<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::CHANGES_WHEN_TITLECASED_V1)
 }
@@ -344,9 +344,9 @@ where
 /// assert!(changes_when_uppercased.contains('ւ'));  // U+0582 ARMENIAN SMALL LETTER YIWN
 /// assert!(!changes_when_uppercased.contains('Ւ'));  // U+0552 ARMENIAN CAPITAL LETTER YIWN
 /// ```
-pub fn get_changes_when_uppercased<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_changes_when_uppercased<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::CHANGES_WHEN_UPPERCASED_V1)
 }
@@ -370,9 +370,9 @@ where
 /// assert!(dash.contains('-'));  // U+002D
 /// assert!(!dash.contains('='));  // U+003D
 /// ```
-pub fn get_dash<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_dash<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::DASH_V1)
 }
@@ -395,9 +395,9 @@ where
 /// assert!(deprecated.contains('ឣ'));  // U+17A3 KHMER INDEPENDENT VOWEL QAQ
 /// assert!(!deprecated.contains('A'));
 /// ```
-pub fn get_deprecated<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_deprecated<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::DEPRECATED_V1)
 }
@@ -422,9 +422,9 @@ where
 /// assert!(default_ignorable_code_point.contains_u32(0x180B));  // MONGOLIAN FREE VARIATION SELECTOR ONE
 /// assert!(!default_ignorable_code_point.contains('E'));
 /// ```
-pub fn get_default_ignorable_code_point<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_default_ignorable_code_point<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::DEFAULT_IGNORABLE_CODE_POINT_V1)
 }
@@ -446,9 +446,9 @@ where
 /// assert!(diacritic.contains('\u{05B3}'));  // HEBREW POINT HATAF QAMATS
 /// assert!(!diacritic.contains('א'));  // U+05D0 HEBREW LETTER ALEF
 /// ```
-pub fn get_diacritic<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_diacritic<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::DIACRITIC_V1)
 }
@@ -470,9 +470,9 @@ where
 /// assert!(emoji_modifier_base.contains('✊'));  // U+270A RAISED FIST
 /// assert!(!emoji_modifier_base.contains('⛰'));  // U+26F0 MOUNTAIN
 /// ```
-pub fn get_emoji_modifier_base<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_emoji_modifier_base<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::EMOJI_MODIFIER_BASE_V1)
 }
@@ -497,9 +497,9 @@ where
 /// assert!(emoji_component.contains('7'));
 /// assert!(!emoji_component.contains('T'));
 /// ```
-pub fn get_emoji_component<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_emoji_component<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::EMOJI_COMPONENT_V1)
 }
@@ -521,9 +521,9 @@ where
 /// assert!(emoji_modifier.contains_u32(0x1F3FD));  // EMOJI MODIFIER FITZPATRICK TYPE-4
 /// assert!(!emoji_modifier.contains_u32(0x200C));  // ZERO WIDTH NON-JOINER
 /// ```
-pub fn get_emoji_modifier<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_emoji_modifier<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::EMOJI_MODIFIER_V1)
 }
@@ -545,9 +545,9 @@ where
 /// assert!(emoji.contains('🔥'));  // U+1F525 FIRE
 /// assert!(!emoji.contains('V'));
 /// ```
-pub fn get_emoji<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_emoji<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::EMOJI_V1)
 }
@@ -569,9 +569,9 @@ where
 /// assert!(emoji_presentation.contains('🦬')); // U+1F9AC BISON
 /// assert!(!emoji_presentation.contains('♻'));  // U+267B BLACK UNIVERSAL RECYCLING SYMBOL
 /// ```
-pub fn get_emoji_presentation<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_emoji_presentation<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::EMOJI_PRESENTATION_V1)
 }
@@ -595,9 +595,9 @@ where
 /// assert!(extender.contains('ー'));  // U+30FC KATAKANA-HIRAGANA PROLONGED SOUND MARK
 /// assert!(!extender.contains('・'));  // U+30FB KATAKANA MIDDLE DOT
 /// ```
-pub fn get_extender<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_extender<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::EXTENDER_V1)
 }
@@ -620,18 +620,18 @@ where
 /// assert!(extended_pictographic.contains('🥳')); // U+1F973 FACE WITH PARTY HORN AND PARTY HAT
 /// assert!(!extended_pictographic.contains('🇪'));  // U+1F1EA REGIONAL INDICATOR SYMBOL LETTER E
 /// ```
-pub fn get_extended_pictographic<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_extended_pictographic<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::EXTENDED_PICTOGRAPHIC_V1)
 }
 
 /// Visible characters.
 /// This is defined for POSIX compatibility.
-pub fn get_graph<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_graph<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::GRAPH_V1)
 }
@@ -655,9 +655,9 @@ where
 /// assert!(grapheme_base.contains('\u{0D3F}'));  // U+0D3F MALAYALAM VOWEL SIGN I
 /// assert!(!grapheme_base.contains('\u{0D3E}'));  // U+0D3E MALAYALAM VOWEL SIGN AA
 /// ```
-pub fn get_grapheme_base<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_grapheme_base<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::GRAPHEME_BASE_V1)
 }
@@ -681,18 +681,18 @@ where
 /// assert!(!grapheme_extend.contains('\u{0D3F}'));  // U+0D3F MALAYALAM VOWEL SIGN I
 /// assert!(grapheme_extend.contains('\u{0D3E}'));  // U+0D3E MALAYALAM VOWEL SIGN AA
 /// ```
-pub fn get_grapheme_extend<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_grapheme_extend<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::GRAPHEME_EXTEND_V1)
 }
 
 /// Deprecated property. Formerly proposed for programmatic determination of grapheme
 /// cluster boundaries.
-pub fn get_grapheme_link<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_grapheme_link<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::GRAPHEME_LINK_V1)
 }
@@ -719,18 +719,18 @@ where
 /// assert!(hex_digit.contains('Ｆ'));  // U+FF26 FULLWIDTH LATIN CAPITAL LETTER F
 /// assert!(!hex_digit.contains('Ä'));  // U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS
 /// ```
-pub fn get_hex_digit<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_hex_digit<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::HEX_DIGIT_V1)
 }
 
 /// Deprecated property. Dashes which are used to mark connections between pieces of
 /// words, plus the Katakana middle dot.
-pub fn get_hyphen<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_hyphen<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::HYPHEN_V1)
 }
@@ -759,9 +759,9 @@ where
 /// assert!(!id_continue.contains('ⓧ'));  // U+24E7 CIRCLED LATIN SMALL LETTER X
 /// assert!(id_continue.contains_u32(0xFC5E));  // ARABIC LIGATURE SHADDA WITH DAMMATAN ISOLATED FORM
 /// ```
-pub fn get_id_continue<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_id_continue<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::ID_CONTINUE_V1)
 }
@@ -784,9 +784,9 @@ where
 /// assert!(ideographic.contains('川'));  // U+5DDD CJK UNIFIED IDEOGRAPH-5DDD
 /// assert!(!ideographic.contains('밥'));  // U+BC25 HANGUL SYLLABLE BAB
 /// ```
-pub fn get_ideographic<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_ideographic<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::IDEOGRAPHIC_V1)
 }
@@ -814,9 +814,9 @@ where
 /// assert!(!id_start.contains('ⓧ'));  // U+24E7 CIRCLED LATIN SMALL LETTER X
 /// assert!(id_start.contains_u32(0xFC5E));  // ARABIC LIGATURE SHADDA WITH DAMMATAN ISOLATED FORM
 /// ```
-pub fn get_id_start<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_id_start<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::ID_START_V1)
 }
@@ -838,9 +838,9 @@ where
 /// assert!(ids_binary_operator.contains_u32(0x2FF5));  // IDEOGRAPHIC DESCRIPTION CHARACTER SURROUND FROM ABOVE
 /// assert!(!ids_binary_operator.contains_u32(0x3006));  // IDEOGRAPHIC CLOSING MARK
 /// ```
-pub fn get_ids_binary_operator<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_ids_binary_operator<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::IDS_BINARY_OPERATOR_V1)
 }
@@ -865,9 +865,9 @@ where
 /// assert!(!ids_trinary_operator.contains_u32(0x2FF5));  // IDEOGRAPHIC DESCRIPTION CHARACTER SURROUND FROM ABOVE
 /// assert!(!ids_trinary_operator.contains_u32(0x3006));  // IDEOGRAPHIC CLOSING MARK
 /// ```
-pub fn get_ids_trinary_operator<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_ids_trinary_operator<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::IDS_TRINARY_OPERATOR_V1)
 }
@@ -891,9 +891,9 @@ where
 /// assert!(join_control.contains_u32(0x200D));  // ZERO WIDTH JOINER
 /// assert!(!join_control.contains_u32(0x200E));
 /// ```
-pub fn get_join_control<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_join_control<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::JOIN_CONTROL_V1)
 }
@@ -915,9 +915,9 @@ where
 /// assert!(logical_order_exception.contains('ແ'));  // U+0EC1 LAO VOWEL SIGN EI
 /// assert!(!logical_order_exception.contains('ະ'));  // U+0EB0 LAO VOWEL SIGN A
 /// ```
-pub fn get_logical_order_exception<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_logical_order_exception<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::LOGICAL_ORDER_EXCEPTION_V1)
 }
@@ -939,9 +939,9 @@ where
 /// assert!(lowercase.contains('a'));
 /// assert!(!lowercase.contains('A'));
 /// ```
-pub fn get_lowercase<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_lowercase<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::LOWERCASE_V1)
 }
@@ -967,9 +967,9 @@ where
 /// assert!(!math.contains('/'));
 /// assert!(math.contains('∕'));  // U+2215 DIVISION SLASH
 /// ```
-pub fn get_math<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_math<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::MATH_V1)
 }
@@ -992,41 +992,41 @@ where
 /// assert!(noncharacter_code_point.contains_u32(0xFFFF));
 /// assert!(!noncharacter_code_point.contains_u32(0x10000));
 /// ```
-pub fn get_noncharacter_code_point<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_noncharacter_code_point<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::NONCHARACTER_CODE_POINT_V1)
 }
 
 /// Characters that are inert under NFC, i.e., they do not interact with adjacent characters
-pub fn get_nfc_inert<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_nfc_inert<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::NFC_INERT_V1)
 }
 
 /// Characters that are inert under NFD, i.e., they do not interact with adjacent characters
-pub fn get_nfd_inert<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_nfd_inert<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::NFD_INERT_V1)
 }
 
 /// Characters that are inert under NFKC, i.e., they do not interact with adjacent characters
-pub fn get_nfkc_inert<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_nfkc_inert<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::NFKC_INERT_V1)
 }
 
 /// Characters that are inert under NFKD, i.e., they do not interact with adjacent characters
-pub fn get_nfkd_inert<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_nfkd_inert<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::NFKD_INERT_V1)
 }
@@ -1051,9 +1051,9 @@ where
 /// assert!(pattern_syntax.contains('⇒'));  // U+21D2 RIGHTWARDS DOUBLE ARROW
 /// assert!(!pattern_syntax.contains('0'));
 /// ```
-pub fn get_pattern_syntax<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_pattern_syntax<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::PATTERN_SYNTAX_V1)
 }
@@ -1079,27 +1079,27 @@ where
 /// assert!(pattern_white_space.contains_u32(0x000A));  // NEW LINE
 /// assert!(!pattern_white_space.contains_u32(0x00A0));  // NO-BREAK SPACE
 /// ```
-pub fn get_pattern_white_space<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_pattern_white_space<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::PATTERN_WHITE_SPACE_V1)
 }
 
 /// A small class of visible format controls, which precede and then span a sequence of
 /// other characters, usually digits.
-pub fn get_prepended_concatenation_mark<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_prepended_concatenation_mark<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::PREPENDED_CONCATENATION_MARK_V1)
 }
 
 /// Printable characters (visible characters and whitespace).
 /// This is defined for POSIX compatibility.
-pub fn get_print<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_print<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::PRINT_V1)
 }
@@ -1122,9 +1122,9 @@ where
 /// assert!(quotation_mark.contains('„'));  // U+201E DOUBLE LOW-9 QUOTATION MARK
 /// assert!(!quotation_mark.contains('<'));
 /// ```
-pub fn get_quotation_mark<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_quotation_mark<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::QUOTATION_MARK_V1)
 }
@@ -1146,9 +1146,9 @@ where
 /// assert!(radical.contains('⺆'));  // U+2E86 CJK RADICAL BOX
 /// assert!(!radical.contains('丹'));  // U+F95E CJK COMPATIBILITY IDEOGRAPH-F95E
 /// ```
-pub fn get_radical<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_radical<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::RADICAL_V1)
 }
@@ -1171,9 +1171,9 @@ where
 /// assert!(!regional_indicator.contains('Ⓣ'));  // U+24C9 CIRCLED LATIN CAPITAL LETTER T
 /// assert!(!regional_indicator.contains('T'));
 /// ```
-pub fn get_regional_indicator<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_regional_indicator<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::REGIONAL_INDICATOR_V1)
 }
@@ -1196,27 +1196,27 @@ where
 /// assert!(soft_dotted.contains('і'));  //U+0456 CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
 /// assert!(!soft_dotted.contains('ı'));  // U+0131 LATIN SMALL LETTER DOTLESS I
 /// ```
-pub fn get_soft_dotted<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_soft_dotted<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::SOFT_DOTTED_V1)
 }
 
 /// Characters that are starters in terms of Unicode normalization and combining character
 /// sequences
-pub fn get_segment_starter<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_segment_starter<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::SEGMENT_STARTER_V1)
 }
 
 /// Characters that are either the source of a case mapping or in the target of a case
 /// mapping
-pub fn get_case_sensitive<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_case_sensitive<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::CASE_SENSITIVE_V1)
 }
@@ -1241,9 +1241,9 @@ where
 /// assert!(!sentence_terminal.contains(','));
 /// assert!(!sentence_terminal.contains('¿'));  // U+00BF INVERTED QUESTION MARK
 /// ```
-pub fn get_sentence_terminal<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_sentence_terminal<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::SENTENCE_TERMINAL_V1)
 }
@@ -1268,9 +1268,9 @@ where
 /// assert!(terminal_punctuation.contains(','));
 /// assert!(!terminal_punctuation.contains('¿'));  // U+00BF INVERTED QUESTION MARK
 /// ```
-pub fn get_terminal_punctuation<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_terminal_punctuation<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::TERMINAL_PUNCTUATION_V1)
 }
@@ -1293,9 +1293,9 @@ where
 /// assert!(unified_ideograph.contains('木'));  // U+6728 CJK UNIFIED IDEOGRAPH-6728
 /// assert!(!unified_ideograph.contains('𛅸'));  // U+1B178 NUSHU CHARACTER-1B178
 /// ```
-pub fn get_unified_ideograph<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_unified_ideograph<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::UNIFIED_IDEOGRAPH_V1)
 }
@@ -1317,9 +1317,9 @@ where
 /// assert!(uppercase.contains('U'));
 /// assert!(!uppercase.contains('u'));
 /// ```
-pub fn get_uppercase<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_uppercase<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::UPPERCASE_V1)
 }
@@ -1344,9 +1344,9 @@ where
 /// assert!(!variation_selector.contains_u32(0xFE10));  // PRESENTATION FORM FOR VERTICAL COMMA
 /// assert!(variation_selector.contains_u32(0xE01EF));  // VARIATION SELECTOR-256
 /// ```
-pub fn get_variation_selector<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_variation_selector<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::VARIATION_SELECTOR_V1)
 }
@@ -1371,18 +1371,18 @@ where
 /// assert!(white_space.contains_u32(0x00A0));  // NO-BREAK SPACE
 /// assert!(!white_space.contains_u32(0x200B));  // ZERO WIDTH SPACE
 /// ```
-pub fn get_white_space<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_white_space<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::WHITE_SPACE_V1)
 }
 
 /// Hexadecimal digits
 /// This is defined for POSIX compatibility.
-pub fn get_xdigit<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_xdigit<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::XDIGIT_V1)
 }
@@ -1409,9 +1409,9 @@ where
 /// assert!(!xid_continue.contains('ⓧ'));  // U+24E7 CIRCLED LATIN SMALL LETTER X
 /// assert!(!xid_continue.contains_u32(0xFC5E));  // ARABIC LIGATURE SHADDA WITH DAMMATAN ISOLATED FORM
 /// ```
-pub fn get_xid_continue<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_xid_continue<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::XID_CONTINUE_V1)
 }
@@ -1439,9 +1439,9 @@ where
 /// assert!(!xid_start.contains('ⓧ'));  // U+24E7 CIRCLED LATIN SMALL LETTER X
 /// assert!(!xid_start.contains_u32(0xFC5E));  // ARABIC LIGATURE SHADDA WITH DAMMATAN ISOLATED FORM
 /// ```
-pub fn get_xid_start<'data, D>(provider: &D) -> UnisetResult<'data>
+pub fn get_xid_start<D>(provider: &D) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     get_uniset(provider, key::XID_START_V1)
 }
@@ -1453,12 +1453,9 @@ where
 /// Return a [`UnicodeSet`] for a particular value of the General_Category Unicode enumerated property. See [`GeneralCategory`].
 ///
 /// [`UnicodeSet`]: icu_uniset::UnicodeSet
-pub fn get_for_general_category<'data, D>(
-    provider: &'data D,
-    enum_val: GeneralCategory,
-) -> UnisetResult
+pub fn get_for_general_category<D>(provider: &D, enum_val: GeneralCategory) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     let key = match enum_val {
         GeneralCategory::Other => key::GENERAL_CATEGORY_OTHER_V1,
@@ -1507,9 +1504,9 @@ where
 /// Return a [`UnicodeSet`] for a particular value of the Script Unicode enumerated property. See [`Script`].
 ///
 /// [`UnicodeSet`]: icu_uniset::UnicodeSet
-pub fn get_for_script<'data, D>(provider: &'data D, enum_val: Script) -> UnisetResult
+pub fn get_for_script<D>(provider: &D, enum_val: Script) -> UnisetResult
 where
-    D: DataProvider<'data, UnicodePropertyV1Marker> + ?Sized,
+    D: DataProvider<UnicodePropertyV1Marker> + ?Sized,
 {
     let key = match enum_val {
         Script::Adlam => key::SCRIPT_ADLAM_V1,

--- a/experimental/list_formatter/src/list_formatter.rs
+++ b/experimental/list_formatter/src/list_formatter.rs
@@ -16,13 +16,13 @@ pub enum FieldType {
     Literal,
 }
 
-pub struct ListFormatter<'data> {
-    data: DataPayload<'data, ListFormatterPatternsV1Marker>,
+pub struct ListFormatter {
+    data: DataPayload<ListFormatterPatternsV1Marker>,
     width: Width,
 }
 
-impl<'a> ListFormatter<'a> {
-    pub fn try_new<T: Into<Locale>, D: DataProvider<'a, ListFormatterPatternsV1Marker> + ?Sized>(
+impl ListFormatter {
+    pub fn try_new<T: Into<Locale>, D: DataProvider<ListFormatterPatternsV1Marker> + ?Sized>(
         locale: T,
         data_provider: &D,
         type_: Type,
@@ -121,7 +121,7 @@ mod tests {
 
     const VALUES: &[&str] = &["one", "two", "three", "four", "five"];
 
-    fn formatter<'data>() -> ListFormatter<'data> {
+    fn formatter() -> ListFormatter {
         let pattern = ListFormatterPatternsV1::new(
             ConditionalListJoinerPattern::from_str("{0}: {1}").unwrap(),
             ConditionalListJoinerPattern::from_str("{0}, {1}").unwrap(),

--- a/experimental/segmenter/src/lstm.rs
+++ b/experimental/segmenter/src/lstm.rs
@@ -26,7 +26,7 @@ lazy_static! {
 }
 
 // LSTM model depends on language, So we have to switch models per language.
-fn get_best_lstm_model(codepoint: u32) -> Lstm<'static> {
+fn get_best_lstm_model(codepoint: u32) -> Lstm {
     // TODO:
     // DataPayLoad isn't thread safe. We need anything static version.
     let lang = get_language(codepoint);

--- a/experimental/segmenter_lstm/src/lstm.rs
+++ b/experimental/segmenter_lstm/src/lstm.rs
@@ -10,13 +10,13 @@ use ndarray::{Array1, Array2, ArrayBase, Dim, ViewRepr};
 use std::str;
 use unicode_segmentation::UnicodeSegmentation;
 
-pub struct Lstm<'data> {
-    data: DataPayload<'data, structs::LstmDataMarker>,
+pub struct Lstm {
+    data: DataPayload<structs::LstmDataMarker>,
 }
 
-impl<'data> Lstm<'data> {
+impl Lstm {
     /// `try_new` is the initiator of struct `Lstm`
-    pub fn try_new(data: DataPayload<'data, structs::LstmDataMarker>) -> Result<Self, Error> {
+    pub fn try_new(data: DataPayload<structs::LstmDataMarker>) -> Result<Self, Error> {
         if data.get().dic.len() > std::i16::MAX as usize {
             return Err(Error::Limit);
         }

--- a/ffi/diplomat/src/decimal.rs
+++ b/ffi/diplomat/src/decimal.rs
@@ -22,7 +22,7 @@ pub mod ffi {
     #[diplomat::opaque]
     /// An ICU4X Fixed Decimal Format object, capable of formatting a [`ICU4XFixedDecimal`] as a string.
     /// See [the Rust docs](https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormat.html) for more information.
-    pub struct ICU4XFixedDecimalFormat(pub FixedDecimalFormat<'static>);
+    pub struct ICU4XFixedDecimalFormat(pub FixedDecimalFormat);
 
     pub struct ICU4XFixedDecimalFormatResult {
         /// The [`ICU4XFixedDecimalFormat`], exists if creation was successful.
@@ -88,7 +88,7 @@ pub mod ffi {
             options: ICU4XFixedDecimalFormatOptions,
         ) -> ICU4XFixedDecimalFormatResult
         where
-            D: DataProvider<'static, DecimalSymbolsV1Marker> + ?Sized,
+            D: DataProvider<DecimalSymbolsV1Marker> + ?Sized,
         {
             let langid = locale.0.as_ref().clone();
 

--- a/ffi/diplomat/src/locale_canonicalizer.rs
+++ b/ffi/diplomat/src/locale_canonicalizer.rs
@@ -29,7 +29,7 @@ pub mod ffi {
     /// A locale canonicalizer.
     /// See [the Rust docs](https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html) for more details.
     #[diplomat::opaque]
-    pub struct ICU4XLocaleCanonicalizer(LocaleCanonicalizer<'static>);
+    pub struct ICU4XLocaleCanonicalizer(LocaleCanonicalizer);
 
     impl ICU4XLocaleCanonicalizer {
         /// Create a new [`ICU4XLocaleCanonicalizer`].

--- a/ffi/diplomat/src/pluralrules.rs
+++ b/ffi/diplomat/src/pluralrules.rs
@@ -44,7 +44,7 @@ pub mod ffi {
     /// FFI version of `PluralRules`.
     /// See [the Rust docs](https://unicode-org.github.io/icu4x-docs/doc/icu_plurals/struct.PluralRules.html) for more details.
     #[diplomat::opaque]
-    pub struct ICU4XPluralRules(PluralRules<'static>);
+    pub struct ICU4XPluralRules(PluralRules);
 
     impl ICU4XPluralRules {
         /// FFI version of `PluralRules::try_new()`.
@@ -74,7 +74,7 @@ pub mod ffi {
             ty: ICU4XPluralRuleType,
         ) -> ICU4XCreatePluralRulesResult
         where
-            D: DataProvider<'static, PluralRulesV1Marker> + ?Sized,
+            D: DataProvider<PluralRulesV1Marker> + ?Sized,
         {
             PluralRules::try_new(
                 locale.0.as_ref().clone(),

--- a/ffi/ecma402/src/pluralrules.rs
+++ b/ffi/ecma402/src/pluralrules.rs
@@ -225,12 +225,12 @@ pub(crate) mod internal {
     }
 }
 
-pub struct PluralRules<'data> {
+pub struct PluralRules {
     opts: ecma402_traits::pluralrules::Options,
-    rep: ipr::PluralRules<'data>,
+    rep: ipr::PluralRules,
 }
 
-impl<'data> ecma402_traits::pluralrules::PluralRules for PluralRules<'data> {
+impl ecma402_traits::pluralrules::PluralRules for PluralRules {
     type Error = PluralRulesError;
 
     fn try_new<L>(l: L, opts: ecma402_traits::pluralrules::Options) -> Result<Self, Self::Error>
@@ -253,7 +253,7 @@ impl<'data> ecma402_traits::pluralrules::PluralRules for PluralRules<'data> {
     }
 }
 
-impl<'data> PluralRules<'data> {
+impl PluralRules {
     /// Creates a new [`PluralRules`], using the specified data provider.
     pub fn try_new_with_provider<L, P>(
         l: L,
@@ -262,7 +262,7 @@ impl<'data> PluralRules<'data> {
     ) -> Result<Self, PluralRulesError>
     where
         L: ecma402_traits::Locale,
-        P: icu_provider::DataProvider<'data, ipr::provider::PluralRulesV1Marker>,
+        P: icu_provider::DataProvider<ipr::provider::PluralRulesV1Marker>,
         Self: Sized,
     {
         let locale: String = format!("{}", l);

--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -92,7 +92,7 @@ impl BlobDataProvider {
     }
 }
 
-impl<'data, M> DataProvider<'data, M> for BlobDataProvider
+impl<M> DataProvider<M> for BlobDataProvider
 where
     M: DataMarker,
     // Actual bound:
@@ -100,7 +100,7 @@ where
     // Necessary workaround bound (see `yoke::trait_hack` docs):
     for<'de> YokeTraitHack<<M::Yokeable as Yokeable<'de>>::Output>: serde::de::Deserialize<'de>,
 {
-    fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<'data, M>, DataError> {
+    fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
         let file = self.get_file(req)?;
         let payload =
             DataPayload::try_from_yoked_buffer::<(), DataError>(file, (), |bytes, _, _| {

--- a/provider/blob/src/export/blob_exporter.rs
+++ b/provider/blob/src/export/blob_exporter.rs
@@ -43,11 +43,11 @@ fn serialize(obj: &dyn erased_serde::Serialize) -> Result<Vec<u8>, DataError> {
     Ok(serializer.output.0)
 }
 
-impl<'data> DataExporter<'data, SerdeSeDataStructMarker> for BlobExporter<'_> {
+impl DataExporter<SerdeSeDataStructMarker> for BlobExporter<'_> {
     fn put_payload(
         &mut self,
         req: DataRequest,
-        obj: DataPayload<'data, SerdeSeDataStructMarker>,
+        obj: DataPayload<SerdeSeDataStructMarker>,
     ) -> Result<(), DataError> {
         let path = path_util::resource_path_to_string(&req.resource_path);
         log::trace!("Adding: {}", path);

--- a/provider/blob/src/static_data_provider.rs
+++ b/provider/blob/src/static_data_provider.rs
@@ -73,13 +73,13 @@ impl StaticDataProvider {
     }
 }
 
-impl<'data, M> DataProvider<'data, M> for StaticDataProvider
+impl<M> DataProvider<M> for StaticDataProvider
 where
     M: DataMarker,
     // 'static is what we want here, because we are deserializing from a static buffer.
     M::Yokeable: Deserialize<'static>,
 {
-    fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<'data, M>, DataError> {
+    fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
         let file = self.get_file(req)?;
         let data = M::Yokeable::deserialize(&mut postcard::Deserializer::from_bytes(file))
             .map_err(DataError::new_resc_error)?;

--- a/provider/cldr/src/support.rs
+++ b/provider/cldr/src/support.rs
@@ -32,9 +32,9 @@ fn map_poison<E>(_err: E) -> DataError {
 }
 
 /// A lazy-initialized CLDR JSON data provider.
-impl<'b, 'data, T> LazyCldrProvider<T>
+impl<'b, T> LazyCldrProvider<T>
 where
-    T: DataProvider<'data, SerdeSeDataStructMarker>
+    T: DataProvider<SerdeSeDataStructMarker>
         + IterableDataProviderCore
         + KeyedDataProvider
         + TryFrom<&'b dyn CldrPaths>,
@@ -45,7 +45,7 @@ where
         &self,
         req: &DataRequest,
         cldr_paths: &'b dyn CldrPaths,
-    ) -> Result<Option<DataResponse<'data, SerdeSeDataStructMarker>>, DataError> {
+    ) -> Result<Option<DataResponse<SerdeSeDataStructMarker>>, DataError> {
         if T::supports_key(&req.resource_path.key).is_err() {
             return Ok(None);
         }

--- a/provider/cldr/src/support.rs
+++ b/provider/cldr/src/support.rs
@@ -59,7 +59,7 @@ where
         let data_provider = src
             .as_ref()
             .expect("The RwLock must be populated at this point.");
-        return DataProvider::load_payload(data_provider, req).map(Some);
+        DataProvider::load_payload(data_provider, req).map(Some)
     }
 
     /// Call [`IterableDataProviderCore::supported_options_for_key()`], initializing `T` if necessary.

--- a/provider/cldr/src/transform/aliases.rs
+++ b/provider/cldr/src/transform/aliases.rs
@@ -10,7 +10,6 @@ use icu_locid::{subtags, LanguageIdentifier};
 use icu_provider::iter::{IterableDataProviderCore, KeyedDataProvider};
 use icu_provider::prelude::*;
 use std::convert::TryFrom;
-use std::marker::PhantomData;
 use tinystr::{TinyStr4, TinyStr8};
 
 /// All keys that this module is able to produce.
@@ -18,12 +17,11 @@ pub const ALL_KEYS: [ResourceKey; 1] = [key::ALIASES_V1];
 
 /// A data provider reading from CLDR JSON likely subtags rule files.
 #[derive(PartialEq, Debug)]
-pub struct AliasesProvider<'data> {
+pub struct AliasesProvider {
     data: cldr_json::Resource,
-    _phantom: PhantomData<&'data ()>, // placeholder for when we need the lifetime param
 }
 
-impl TryFrom<&dyn CldrPaths> for AliasesProvider<'_> {
+impl TryFrom<&dyn CldrPaths> for AliasesProvider {
     type Error = Error;
     fn try_from(cldr_paths: &dyn CldrPaths) -> Result<Self, Self::Error> {
         let data: cldr_json::Resource = {
@@ -33,36 +31,27 @@ impl TryFrom<&dyn CldrPaths> for AliasesProvider<'_> {
                 .join("aliases.json");
             serde_json::from_reader(open_reader(&path)?).map_err(|e| (e, path))?
         };
-        Ok(Self {
-            data,
-            _phantom: PhantomData,
-        })
+        Ok(Self { data })
     }
 }
 
-impl<'data> TryFrom<&'data str> for AliasesProvider<'data> {
+impl TryFrom<&'_ str> for AliasesProvider {
     type Error = serde_json::error::Error;
     /// Attempt to parse a JSON string.
-    fn try_from(s: &'data str) -> Result<Self, Self::Error> {
+    fn try_from(s: &'_ str) -> Result<Self, Self::Error> {
         let data: cldr_json::Resource = serde_json::from_str(s)?;
-        Ok(Self {
-            data,
-            _phantom: PhantomData,
-        })
+        Ok(Self { data })
     }
 }
 
-impl<'data> KeyedDataProvider for AliasesProvider<'data> {
+impl KeyedDataProvider for AliasesProvider {
     fn supports_key(resc_key: &ResourceKey) -> Result<(), DataError> {
         key::ALIASES_V1.match_key(*resc_key)
     }
 }
 
-impl<'data> DataProvider<'data, AliasesV1Marker> for AliasesProvider<'data> {
-    fn load_payload(
-        &self,
-        req: &DataRequest,
-    ) -> Result<DataResponse<'data, AliasesV1Marker>, DataError> {
+impl DataProvider<AliasesV1Marker> for AliasesProvider {
+    fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<AliasesV1Marker>, DataError> {
         AliasesProvider::supports_key(&req.resource_path.key)?;
         let langid = &req.resource_path.options.langid;
 
@@ -81,11 +70,11 @@ impl<'data> DataProvider<'data, AliasesV1Marker> for AliasesProvider<'data> {
     }
 }
 
-icu_provider::impl_dyn_provider!(AliasesProvider<'data>, {
+icu_provider::impl_dyn_provider!(AliasesProvider, {
     _ => AliasesV1Marker,
-}, SERDE_SE, 'data);
+}, SERDE_SE);
 
-impl<'data> IterableDataProviderCore for AliasesProvider<'data> {
+impl IterableDataProviderCore for AliasesProvider {
     fn supported_options_for_key(
         &self,
         _resc_key: &ResourceKey,

--- a/provider/cldr/src/transform/dates/skeletons.rs
+++ b/provider/cldr/src/transform/dates/skeletons.rs
@@ -12,7 +12,6 @@ use icu_plurals::PluralCategory;
 use icu_provider::iter::{IterableDataProviderCore, KeyedDataProvider};
 use icu_provider::prelude::*;
 use std::convert::TryFrom;
-use std::marker::PhantomData;
 
 /// All keys that this module is able to produce.
 pub const ALL_KEYS: [ResourceKey; 1] = [
@@ -21,12 +20,11 @@ pub const ALL_KEYS: [ResourceKey; 1] = [
 
 /// A data provider reading from CLDR JSON dates files.
 #[derive(PartialEq, Debug)]
-pub struct DateSkeletonPatternsProvider<'data> {
+pub struct DateSkeletonPatternsProvider {
     data: Vec<(LanguageIdentifier, cldr_json::LangDates)>,
-    _phantom: PhantomData<&'data ()>, // placeholder for when we need the lifetime param
 }
 
-impl TryFrom<&dyn CldrPaths> for DateSkeletonPatternsProvider<'_> {
+impl TryFrom<&dyn CldrPaths> for DateSkeletonPatternsProvider {
     type Error = Error;
     fn try_from(cldr_paths: &dyn CldrPaths) -> Result<Self, Self::Error> {
         let mut data = vec![];
@@ -43,26 +41,21 @@ impl TryFrom<&dyn CldrPaths> for DateSkeletonPatternsProvider<'_> {
             data.append(&mut resource.main.0);
         }
 
-        Ok(Self {
-            data,
-            _phantom: PhantomData,
-        })
+        Ok(Self { data })
     }
 }
 
-impl<'data> KeyedDataProvider for DateSkeletonPatternsProvider<'data> {
+impl KeyedDataProvider for DateSkeletonPatternsProvider {
     fn supports_key(resc_key: &ResourceKey) -> Result<(), DataError> {
         key::GREGORY_DATE_SKELETON_PATTERNS_V1.match_key(*resc_key)
     }
 }
 
-impl<'data> DataProvider<'data, gregory::DateSkeletonPatternsV1Marker>
-    for DateSkeletonPatternsProvider<'data>
-{
+impl DataProvider<gregory::DateSkeletonPatternsV1Marker> for DateSkeletonPatternsProvider {
     fn load_payload(
         &self,
         req: &DataRequest,
-    ) -> Result<DataResponse<'data, gregory::DateSkeletonPatternsV1Marker>, DataError> {
+    ) -> Result<DataResponse<gregory::DateSkeletonPatternsV1Marker>, DataError> {
         DateSkeletonPatternsProvider::supports_key(&req.resource_path.key)?;
         let langid = req.try_langid()?;
         let dates = match self.data.binary_search_by_key(&langid, |(lid, _)| lid) {
@@ -80,11 +73,11 @@ impl<'data> DataProvider<'data, gregory::DateSkeletonPatternsV1Marker>
     }
 }
 
-icu_provider::impl_dyn_provider!(DateSkeletonPatternsProvider<'data>, {
+icu_provider::impl_dyn_provider!(DateSkeletonPatternsProvider, {
     _ => gregory::DateSkeletonPatternsV1Marker,
-}, SERDE_SE, 'data);
+}, SERDE_SE);
 
-impl<'data> IterableDataProviderCore for DateSkeletonPatternsProvider<'data> {
+impl IterableDataProviderCore for DateSkeletonPatternsProvider {
     #[allow(clippy::needless_collect)] // https://github.com/rust-lang/rust-clippy/issues/7526
     fn supported_options_for_key(
         &self,

--- a/provider/cldr/src/transform/mod.rs
+++ b/provider/cldr/src/transform/mod.rs
@@ -44,20 +44,20 @@ pub fn get_all_cldr_keys() -> Vec<ResourceKey> {
 }
 
 #[derive(Debug)]
-pub struct CldrJsonDataProvider<'a, 'data> {
+pub struct CldrJsonDataProvider<'a> {
     pub cldr_paths: &'a dyn CldrPaths,
-    aliases: LazyCldrProvider<AliasesProvider<'data>>,
-    date_symbols: LazyCldrProvider<DateSymbolsProvider<'data>>,
-    date_skeletons: LazyCldrProvider<DateSkeletonPatternsProvider<'data>>,
-    date_patterns: LazyCldrProvider<DatePatternsProvider<'data>>,
-    likelysubtags: LazyCldrProvider<LikelySubtagsProvider<'data>>,
+    aliases: LazyCldrProvider<AliasesProvider>,
+    date_symbols: LazyCldrProvider<DateSymbolsProvider>,
+    date_skeletons: LazyCldrProvider<DateSkeletonPatternsProvider>,
+    date_patterns: LazyCldrProvider<DatePatternsProvider>,
+    likelysubtags: LazyCldrProvider<LikelySubtagsProvider>,
     numbers: LazyCldrProvider<NumbersProvider>,
-    plurals: LazyCldrProvider<PluralsProvider<'data>>,
-    time_zones: LazyCldrProvider<TimeZonesProvider<'data>>,
-    list: LazyCldrProvider<ListProvider<'data>>,
+    plurals: LazyCldrProvider<PluralsProvider>,
+    time_zones: LazyCldrProvider<TimeZonesProvider>,
+    list: LazyCldrProvider<ListProvider>,
 }
 
-impl<'a> CldrJsonDataProvider<'a, '_> {
+impl<'a> CldrJsonDataProvider<'a> {
     pub fn new(cldr_paths: &'a dyn CldrPaths) -> Self {
         CldrJsonDataProvider {
             cldr_paths,
@@ -74,11 +74,11 @@ impl<'a> CldrJsonDataProvider<'a, '_> {
     }
 }
 
-impl<'a, 'data> DataProvider<'data, SerdeSeDataStructMarker> for CldrJsonDataProvider<'a, 'data> {
+impl<'a> DataProvider<SerdeSeDataStructMarker> for CldrJsonDataProvider<'a> {
     fn load_payload(
         &self,
         req: &DataRequest,
-    ) -> Result<DataResponse<'data, SerdeSeDataStructMarker>, DataError> {
+    ) -> Result<DataResponse<SerdeSeDataStructMarker>, DataError> {
         if let Some(result) = self.aliases.try_load_serde(req, self.cldr_paths)? {
             return Ok(result);
         }
@@ -110,7 +110,7 @@ impl<'a, 'data> DataProvider<'data, SerdeSeDataStructMarker> for CldrJsonDataPro
     }
 }
 
-impl<'a> IterableDataProviderCore for CldrJsonDataProvider<'a, '_> {
+impl<'a> IterableDataProviderCore for CldrJsonDataProvider<'a> {
     fn supported_options_for_key(
         &self,
         resc_key: &ResourceKey,
@@ -170,7 +170,7 @@ impl<'a> IterableDataProviderCore for CldrJsonDataProvider<'a, '_> {
     }
 }
 
-impl<'a, 'd> KeyedDataProvider for CldrJsonDataProvider<'a, 'd> {
+impl<'a> KeyedDataProvider for CldrJsonDataProvider<'a> {
     fn supports_key(resc_key: &ResourceKey) -> Result<(), DataError> {
         PluralsProvider::supports_key(resc_key)
             .or_else(|err| DateSymbolsProvider::or_else_supports_key(err, resc_key))

--- a/provider/cldr/src/transform/numbers/mod.rs
+++ b/provider/cldr/src/transform/numbers/mod.rs
@@ -99,11 +99,11 @@ impl NumbersProvider {
     }
 }
 
-impl<'data> DataProvider<'data, DecimalSymbolsV1Marker> for NumbersProvider {
+impl DataProvider<DecimalSymbolsV1Marker> for NumbersProvider {
     fn load_payload(
         &self,
         req: &DataRequest,
-    ) -> Result<DataResponse<'data, DecimalSymbolsV1Marker>, DataError> {
+    ) -> Result<DataResponse<DecimalSymbolsV1Marker>, DataError> {
         Self::supports_key(&req.resource_path.key)?;
         let langid = req.try_langid()?;
         let numbers = match self
@@ -139,9 +139,9 @@ impl<'data> DataProvider<'data, DecimalSymbolsV1Marker> for NumbersProvider {
 
 icu_provider::impl_dyn_provider!(NumbersProvider, {
     _ => DecimalSymbolsV1Marker,
-}, SERDE_SE, 'data);
+}, SERDE_SE);
 
-impl<'data> IterableDataProviderCore for NumbersProvider {
+impl IterableDataProviderCore for NumbersProvider {
     #[allow(clippy::needless_collect)] // https://github.com/rust-lang/rust-clippy/issues/7526
     fn supported_options_for_key(
         &self,

--- a/provider/cldr/src/transform/time_zones/cldr_json/convert.rs
+++ b/provider/cldr/src/transform/time_zones/cldr_json/convert.rs
@@ -24,7 +24,7 @@ fn type_fallback(zone_format: &ZoneFormat) -> Option<&String> {
         .or_else(|| zone_format.0.get("standard"))
 }
 
-fn parse_hour_format<'data>(hour_format: &str) -> (Cow<'data, str>, Cow<'data, str>) {
+fn parse_hour_format(hour_format: &str) -> (Cow<'static, str>, Cow<'static, str>) {
     // e.g. "+HH:mm;-HH:mm" -> ("+HH:mm", "-HH:mm")
     let index = hour_format.rfind(';').unwrap();
     let positive = String::from(&hour_format[0..index]);
@@ -32,7 +32,7 @@ fn parse_hour_format<'data>(hour_format: &str) -> (Cow<'data, str>, Cow<'data, s
     (Cow::Owned(positive), Cow::Owned(negative))
 }
 
-impl<'data> From<TimeZoneNames> for TimeZoneFormatsV1<'data> {
+impl From<TimeZoneNames> for TimeZoneFormatsV1<'_> {
     fn from(other: TimeZoneNames) -> Self {
         Self {
             hour_format: parse_hour_format(&other.hour_format),
@@ -67,7 +67,7 @@ impl Location {
     }
 }
 
-impl<'data> From<TimeZoneNames> for ExemplarCitiesV1<'data> {
+impl From<TimeZoneNames> for ExemplarCitiesV1<'_> {
     fn from(other: TimeZoneNames) -> Self {
         Self(
             other
@@ -104,7 +104,7 @@ impl<'data> From<TimeZoneNames> for ExemplarCitiesV1<'data> {
     }
 }
 
-impl<'data> From<TimeZoneNames> for MetaZoneGenericNamesLongV1<'data> {
+impl From<TimeZoneNames> for MetaZoneGenericNamesLongV1<'_> {
     fn from(other: TimeZoneNames) -> Self {
         match other.metazone {
             None => Self(LiteMap::new()),
@@ -125,7 +125,7 @@ impl<'data> From<TimeZoneNames> for MetaZoneGenericNamesLongV1<'data> {
     }
 }
 
-impl<'data> From<TimeZoneNames> for MetaZoneGenericNamesShortV1<'data> {
+impl From<TimeZoneNames> for MetaZoneGenericNamesShortV1<'_> {
     fn from(other: TimeZoneNames) -> Self {
         match other.metazone {
             None => Self(LiteMap::new()),
@@ -146,7 +146,7 @@ impl<'data> From<TimeZoneNames> for MetaZoneGenericNamesShortV1<'data> {
     }
 }
 
-impl<'data> From<TimeZoneNames> for MetaZoneSpecificNamesLongV1<'data> {
+impl From<TimeZoneNames> for MetaZoneSpecificNamesLongV1<'_> {
     fn from(other: TimeZoneNames) -> Self {
         match other.metazone {
             None => Self(LiteMap::new()),
@@ -167,7 +167,7 @@ impl<'data> From<TimeZoneNames> for MetaZoneSpecificNamesLongV1<'data> {
     }
 }
 
-impl<'data> From<TimeZoneNames> for MetaZoneSpecificNamesShortV1<'data> {
+impl From<TimeZoneNames> for MetaZoneSpecificNamesShortV1<'_> {
     fn from(other: TimeZoneNames) -> Self {
         match other.metazone {
             None => Self(LiteMap::new()),
@@ -188,7 +188,7 @@ impl<'data> From<TimeZoneNames> for MetaZoneSpecificNamesShortV1<'data> {
     }
 }
 
-impl<'data> From<ZoneFormat> for MetaZoneSpecificNamesV1<'data> {
+impl From<ZoneFormat> for MetaZoneSpecificNamesV1<'_> {
     fn from(other: ZoneFormat) -> Self {
         let len = other.0.len();
         Self(

--- a/provider/core/src/export.rs
+++ b/provider/core/src/export.rs
@@ -11,16 +11,12 @@ use crate::prelude::*;
 /// An object capable of serializing data payloads to be read by a [`DataProvider`].
 ///
 /// A [`DataProvider`] by itself is "read-only"; this trait enables it to be "read-write".
-pub trait DataExporter<'data, M>
+pub trait DataExporter<M>
 where
     M: DataMarker,
 {
     /// Save a `payload` corresponding to the given data request (resource path).
-    fn put_payload(
-        &mut self,
-        req: DataRequest,
-        payload: DataPayload<'data, M>,
-    ) -> Result<(), Error>;
+    fn put_payload(&mut self, req: DataRequest, payload: DataPayload<M>) -> Result<(), Error>;
 
     /// Function called after a key has been fully dumped into the exporter.
     fn flush(&mut self) -> Result<(), Error> {
@@ -57,15 +53,15 @@ where
 /// ```
 ///
 /// [`HelloWorldProvider`]: crate::hello_world::HelloWorldProvider
-pub fn export_from_iterable<'data, P, E, M>(
+pub fn export_from_iterable<P, E, M>(
     resc_key: &ResourceKey,
     provider: &P,
     exporter: &mut E,
 ) -> Result<(), Error>
 where
     M: DataMarker,
-    P: IterableDataProvider<'data, M> + ?Sized,
-    E: DataExporter<'data, M> + ?Sized,
+    P: IterableDataProvider<M> + ?Sized,
+    E: DataExporter<M> + ?Sized,
 {
     let it = provider.supported_options_for_key(resc_key)?;
     let try_export = || -> Result<(), Error> {

--- a/provider/core/src/filter/mod.rs
+++ b/provider/core/src/filter/mod.rs
@@ -65,13 +65,13 @@ where
     pub description: String,
 }
 
-impl<'data, D, F, M> DataProvider<'data, M> for RequestFilterDataProvider<D, F>
+impl<D, F, M> DataProvider<M> for RequestFilterDataProvider<D, F>
 where
     F: Fn(&DataRequest) -> bool,
     M: DataMarker,
-    D: DataProvider<'data, M>,
+    D: DataProvider<M>,
 {
-    fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<'data, M>, DataError> {
+    fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
         if (self.predicate)(req) {
             self.inner.load_payload(req)
         } else {

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -78,13 +78,13 @@ impl DataMarker for HelloWorldV1Marker {
 /// assert_eq!("Hallo Welt", german_hello_world.get().message);
 /// ```
 #[derive(Debug, PartialEq, Default)]
-pub struct HelloWorldProvider<'data> {
-    map: LiteMap<LanguageIdentifier, Cow<'data, str>>,
+pub struct HelloWorldProvider {
+    map: LiteMap<LanguageIdentifier, Cow<'static, str>>,
 }
 
-impl<'data> HelloWorldProvider<'data> {
+impl HelloWorldProvider {
     /// Creates a [`HelloWorldProvider`] pre-populated with hardcoded data from Wiktionary.
-    pub fn new_with_placeholder_data() -> HelloWorldProvider<'static> {
+    pub fn new_with_placeholder_data() -> HelloWorldProvider {
         // Data from https://en.wiktionary.org/wiki/Hello_World#Translations
         // Note: we don't want to use langid!() because icu_langid_macros is heavy.
         HelloWorldProvider {
@@ -117,11 +117,11 @@ impl<'data> HelloWorldProvider<'data> {
     }
 }
 
-impl<'data, 't> DataProvider<'data, HelloWorldV1Marker> for HelloWorldProvider<'data> {
+impl DataProvider<HelloWorldV1Marker> for HelloWorldProvider {
     fn load_payload(
         &self,
         req: &DataRequest,
-    ) -> Result<DataResponse<'data, HelloWorldV1Marker>, DataError> {
+    ) -> Result<DataResponse<HelloWorldV1Marker>, DataError> {
         req.resource_path.key.match_key(key::HELLO_WORLD_V1)?;
         let langid = req.try_langid()?;
         let data = self
@@ -138,16 +138,16 @@ impl<'data, 't> DataProvider<'data, HelloWorldV1Marker> for HelloWorldProvider<'
     }
 }
 
-impl_dyn_provider!(HelloWorldProvider<'static>, {
+impl_dyn_provider!(HelloWorldProvider, {
     _ => HelloWorldV1Marker,
 }, ERASED);
 
 #[cfg(feature = "provider_serde")]
-impl_dyn_provider!(HelloWorldProvider<'data>, {
+impl_dyn_provider!(HelloWorldProvider, {
     _ => HelloWorldV1Marker,
-}, SERDE_SE, 'data);
+}, SERDE_SE);
 
-impl<'data> IterableDataProviderCore for HelloWorldProvider<'data> {
+impl IterableDataProviderCore for HelloWorldProvider {
     #[allow(clippy::needless_collect)] // https://github.com/rust-lang/rust-clippy/issues/7526
     fn supported_options_for_key(
         &self,
@@ -167,13 +167,11 @@ impl<'data> IterableDataProviderCore for HelloWorldProvider<'data> {
 }
 
 /// Adds entries to a [`HelloWorldProvider`] from [`ErasedDataStruct`](crate::erased::ErasedDataStruct)
-impl<'data> crate::export::DataExporter<'static, crate::erased::ErasedDataStructMarker>
-    for HelloWorldProvider<'static>
-{
+impl crate::export::DataExporter<crate::erased::ErasedDataStructMarker> for HelloWorldProvider {
     fn put_payload(
         &mut self,
         req: DataRequest,
-        payload: DataPayload<'static, crate::erased::ErasedDataStructMarker>,
+        payload: DataPayload<crate::erased::ErasedDataStructMarker>,
     ) -> Result<(), DataError> {
         req.resource_path.key.match_key(key::HELLO_WORLD_V1)?;
         let langid = req.try_langid()?;

--- a/provider/core/src/inv.rs
+++ b/provider/core/src/inv.rs
@@ -36,12 +36,12 @@ use alloc::vec::Vec;
 /// ```
 pub struct InvariantDataProvider;
 
-impl<'data, M> DataProvider<'data, M> for InvariantDataProvider
+impl<M> DataProvider<M> for InvariantDataProvider
 where
     M: DataMarker,
     M::Yokeable: Default,
 {
-    fn load_payload(&self, _req: &DataRequest) -> Result<DataResponse<'data, M>, Error> {
+    fn load_payload(&self, _req: &DataRequest) -> Result<DataResponse<M>, Error> {
         Ok(DataResponse {
             metadata: DataResponseMetadata::default(),
             payload: Some(DataPayload::from_owned(M::Yokeable::default())),

--- a/provider/core/src/iter.rs
+++ b/provider/core/src/iter.rs
@@ -22,16 +22,15 @@ pub trait IterableDataProviderCore {
 
 /// A super-trait combining [`DataProvider`] and [`IterableDataProviderCore`], auto-implemented
 /// for all types implementing both of those traits.
-pub trait IterableDataProvider<'data, M>:
-    IterableDataProviderCore + DataProvider<'data, M>
+pub trait IterableDataProvider<M>: IterableDataProviderCore + DataProvider<M>
 where
     M: DataMarker,
 {
 }
 
-impl<'data, S, M> IterableDataProvider<'data, M> for S
+impl<S, M> IterableDataProvider<M> for S
 where
-    S: IterableDataProviderCore + DataProvider<'data, M>,
+    S: IterableDataProviderCore + DataProvider<M>,
     M: DataMarker,
 {
 }

--- a/provider/core/src/marker/impls.rs
+++ b/provider/core/src/marker/impls.rs
@@ -13,9 +13,9 @@ impl DataMarker for CowStrMarker {
     type Yokeable = Cow<'static, str>;
 }
 
-impl DataPayload<'static, CowStrMarker> {
+impl DataPayload<CowStrMarker> {
     /// Make a [`DataPayload`]`<`[`CowStrMarker`]`>` from a static string slice.
-    pub fn from_static_str(s: &'static str) -> DataPayload<'static, CowStrMarker> {
+    pub fn from_static_str(s: &'static str) -> DataPayload<CowStrMarker> {
         DataPayload::from_owned(Cow::Borrowed(s))
     }
 }

--- a/provider/core/src/struct_provider.rs
+++ b/provider/core/src/struct_provider.rs
@@ -38,20 +38,20 @@ use crate::yoke::*;
 ///
 /// assert_eq!(payload.get().message, "hello world");
 /// ```
-pub struct StructProvider<'data, M>
+pub struct StructProvider<M>
 where
     M: DataMarker,
 {
     pub key: ResourceKey,
-    pub data: DataPayload<'data, M>,
+    pub data: DataPayload<M>,
 }
 
-impl<'data, M> DataProvider<'data, M> for StructProvider<'data, M>
+impl<M> DataProvider<M> for StructProvider<M>
 where
     M: DataMarker,
     for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
 {
-    fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<'data, M>, Error> {
+    fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<M>, Error> {
         req.resource_path.key.match_key(self.key)?;
         Ok(DataResponse {
             metadata: DataResponseMetadata::default(),

--- a/provider/fs/src/export/fs_exporter.rs
+++ b/provider/fs/src/export/fs_exporter.rs
@@ -65,11 +65,11 @@ impl Drop for FilesystemExporter {
     }
 }
 
-impl<'data> DataExporter<'data, SerdeSeDataStructMarker> for FilesystemExporter {
+impl DataExporter<SerdeSeDataStructMarker> for FilesystemExporter {
     fn put_payload(
         &mut self,
         req: DataRequest,
-        obj: DataPayload<'data, SerdeSeDataStructMarker>,
+        obj: DataPayload<SerdeSeDataStructMarker>,
     ) -> Result<(), DataError> {
         let mut path_buf = self.root.clone();
         path_buf.extend(req.resource_path.key.get_components().iter());

--- a/provider/fs/src/fs_data_provider.rs
+++ b/provider/fs/src/fs_data_provider.rs
@@ -97,7 +97,7 @@ impl FsDataProvider {
 }
 
 /// Note: This impl returns `'static` payloads because borrowing is handled by [`Yoke`].
-impl<'data, M> DataProvider<'data, M> for FsDataProvider
+impl<M> DataProvider<M> for FsDataProvider
 where
     M: DataMarker,
     // Actual bound:
@@ -105,7 +105,7 @@ where
     // Necessary workaround bound (see `yoke::trait_hack` docs):
     for<'de> YokeTraitHack<<M::Yokeable as Yokeable<'de>>::Output>: serde::de::Deserialize<'de>,
 {
-    fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<'data, M>, DataError> {
+    fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
         let (rc_buffer, path_buf) = self.get_rc_buffer(req)?;
         Ok(DataResponse {
             metadata: DataResponseMetadata {

--- a/provider/fs/tests/test_file_io.rs
+++ b/provider/fs/tests/test_file_io.rs
@@ -21,7 +21,7 @@ struct PluralRulesTestData {
     many: Option<&'static str>,
 }
 
-impl From<&PluralRulesTestData> for PluralRulesV1<'_> {
+impl From<&PluralRulesTestData> for PluralRulesV1 {
     fn from(i: &PluralRulesTestData) -> Self {
         fn parse(i: &'static str) -> Rule {
             i.parse().expect("Failed to parse rule")
@@ -109,7 +109,7 @@ fn test_json_errors() {
     let provider = FsDataProvider::try_new("./tests/testdata/json")
         .expect("Loading file from testdata directory");
 
-    type Provider<'data> = dyn DataProvider<'data, PluralRulesV1Marker>;
+    type Provider = dyn DataProvider<PluralRulesV1Marker>;
 
     assert!(matches!(
         Provider::load_payload(

--- a/provider/fs/tests/test_file_io.rs
+++ b/provider/fs/tests/test_file_io.rs
@@ -21,7 +21,7 @@ struct PluralRulesTestData {
     many: Option<&'static str>,
 }
 
-impl From<&PluralRulesTestData> for PluralRulesV1 {
+impl From<&PluralRulesTestData> for PluralRulesV1<'_> {
     fn from(i: &PluralRulesTestData) -> Self {
         fn parse(i: &'static str) -> Rule {
             i.parse().expect("Failed to parse rule")

--- a/provider/uprops/src/bin_uniset.rs
+++ b/provider/uprops/src/bin_uniset.rs
@@ -23,11 +23,11 @@ impl BinaryPropertyUnicodeSetDataProvider {
     }
 }
 
-impl<'data> DataProvider<'data, UnicodePropertyV1Marker> for BinaryPropertyUnicodeSetDataProvider {
+impl DataProvider<UnicodePropertyV1Marker> for BinaryPropertyUnicodeSetDataProvider {
     fn load_payload(
         &self,
         req: &DataRequest,
-    ) -> Result<DataResponse<'data, UnicodePropertyV1Marker>, DataError> {
+    ) -> Result<DataResponse<UnicodePropertyV1Marker>, DataError> {
         let data = &self
             .data
             .get(&req.resource_path.key.sub_category)
@@ -52,7 +52,7 @@ impl<'data> DataProvider<'data, UnicodePropertyV1Marker> for BinaryPropertyUnico
 
 icu_provider::impl_dyn_provider!(BinaryPropertyUnicodeSetDataProvider, {
     _ => UnicodePropertyV1Marker,
-}, SERDE_SE, 'data);
+}, SERDE_SE);
 
 impl IterableDataProviderCore for BinaryPropertyUnicodeSetDataProvider {
     fn supported_options_for_key(
@@ -74,7 +74,7 @@ fn test_basic() {
     let provider = BinaryPropertyUnicodeSetDataProvider::try_new(&root_dir)
         .expect("TOML should load successfully");
 
-    let payload: DataPayload<'_, UnicodePropertyV1Marker> = provider
+    let payload: DataPayload<UnicodePropertyV1Marker> = provider
         .load_payload(&DataRequest {
             resource_path: ResourcePath {
                 key: key::WHITE_SPACE_V1,

--- a/provider/uprops/src/enum_codepointtrie.rs
+++ b/provider/uprops/src/enum_codepointtrie.rs
@@ -73,13 +73,13 @@ impl<T: TrieValue> TryFrom<&EnumeratedPropertyCodePointTrie> for UnicodeProperty
     }
 }
 
-impl<'data, T: TrieValue> DataProvider<'data, UnicodePropertyMapV1Marker<T>>
+impl<T: TrieValue> DataProvider<UnicodePropertyMapV1Marker<T>>
     for EnumeratedPropertyCodePointTrieProvider
 {
     fn load_payload(
         &self,
         req: &DataRequest,
-    ) -> Result<DataResponse<'data, UnicodePropertyMapV1Marker<T>>, DataError> {
+    ) -> Result<DataResponse<UnicodePropertyMapV1Marker<T>>, DataError> {
         // For data resource keys that represent the CodePointTrie data for an enumerated
         // property, the ResourceKey sub-category string will just be the short alias
         // for the property.
@@ -109,7 +109,7 @@ icu_provider::impl_dyn_provider!(EnumeratedPropertyCodePointTrieProvider, {
     key::GRAPHEME_CLUSTER_BREAK_V1 => UnicodePropertyMapV1Marker<GraphemeClusterBreak>,
     key::WORD_BREAK_V1 => UnicodePropertyMapV1Marker<WordBreak>,
     key::SENTENCE_BREAK_V1 => UnicodePropertyMapV1Marker<SentenceBreak>,
-}, SERDE_SE, 'data);
+}, SERDE_SE);
 
 impl IterableDataProviderCore for EnumeratedPropertyCodePointTrieProvider {
     fn supported_options_for_key(
@@ -138,7 +138,7 @@ mod tests {
         let provider = EnumeratedPropertyCodePointTrieProvider::try_new(&root_dir)
             .expect("TOML should load successfully");
 
-        let payload: DataPayload<'_, UnicodePropertyMapV1Marker<GeneralSubcategory>> = provider
+        let payload: DataPayload<UnicodePropertyMapV1Marker<GeneralSubcategory>> = provider
             .load_payload(&DataRequest {
                 resource_path: ResourcePath {
                     key: key::GENERAL_CATEGORY_V1,
@@ -161,7 +161,7 @@ mod tests {
         let provider = EnumeratedPropertyCodePointTrieProvider::try_new(&root_dir)
             .expect("TOML should load successfully");
 
-        let payload: DataPayload<'_, UnicodePropertyMapV1Marker<Script>> = provider
+        let payload: DataPayload<UnicodePropertyMapV1Marker<Script>> = provider
             .load_payload(&DataRequest {
                 resource_path: ResourcePath {
                     key: key::SCRIPT_V1,

--- a/provider/uprops/src/enum_uniset.rs
+++ b/provider/uprops/src/enum_uniset.rs
@@ -56,13 +56,11 @@ fn expand_groupings<'a>(prop_name: &str, prop_val: &'a str) -> Vec<&'a str> {
     }
 }
 
-impl<'data> DataProvider<'data, UnicodePropertyV1Marker>
-    for EnumeratedPropertyUnicodeSetDataProvider
-{
+impl DataProvider<UnicodePropertyV1Marker> for EnumeratedPropertyUnicodeSetDataProvider {
     fn load_payload(
         &self,
         req: &DataRequest,
-    ) -> Result<DataResponse<'data, UnicodePropertyV1Marker>, DataError> {
+    ) -> Result<DataResponse<UnicodePropertyV1Marker>, DataError> {
         let key = &req.resource_path.key.sub_category;
 
         // ResourceKey subcategory strings for enumerated properties are
@@ -106,7 +104,7 @@ impl<'data> DataProvider<'data, UnicodePropertyV1Marker>
 
 icu_provider::impl_dyn_provider!(EnumeratedPropertyUnicodeSetDataProvider, {
     _ => UnicodePropertyV1Marker,
-}, SERDE_SE, 'data);
+}, SERDE_SE);
 
 impl IterableDataProviderCore for EnumeratedPropertyUnicodeSetDataProvider {
     fn supported_options_for_key(
@@ -132,7 +130,7 @@ mod tests {
         let provider = EnumeratedPropertyUnicodeSetDataProvider::try_new(&root_dir)
             .expect("TOML should load successfully");
 
-        let payload: DataPayload<'_, UnicodePropertyV1Marker> = provider
+        let payload: DataPayload<UnicodePropertyV1Marker> = provider
             .load_payload(&DataRequest {
                 resource_path: ResourcePath {
                     key: key::GENERAL_CATEGORY_NUMBER_V1,
@@ -161,7 +159,7 @@ mod tests {
         let provider = EnumeratedPropertyUnicodeSetDataProvider::try_new(&root_dir)
             .expect("TOML should load successfully");
 
-        let payload: DataPayload<'_, UnicodePropertyV1Marker> = provider
+        let payload: DataPayload<UnicodePropertyV1Marker> = provider
             .load_payload(&DataRequest {
                 resource_path: ResourcePath {
                     key: key::SCRIPT_THAI_V1,
@@ -186,13 +184,11 @@ mod tests {
         use icu_uniset::{UnicodeSet, UnicodeSetBuilder};
         use std::convert::TryInto;
 
-        fn get_uniset_payload<'data>(
-            key: ResourceKey,
-        ) -> DataPayload<'data, UnicodePropertyV1Marker> {
+        fn get_uniset_payload(key: ResourceKey) -> DataPayload<UnicodePropertyV1Marker> {
             let root_dir = icu_testdata::paths::data_root().join("uprops");
             let provider = EnumeratedPropertyUnicodeSetDataProvider::try_new(&root_dir)
                 .expect("TOML should load successfully");
-            let payload: DataPayload<'_, UnicodePropertyV1Marker> = provider
+            let payload: DataPayload<UnicodePropertyV1Marker> = provider
                 .load_payload(&DataRequest {
                     resource_path: ResourcePath {
                         key,
@@ -306,7 +302,7 @@ mod tests {
         let provider = EnumeratedPropertyUnicodeSetDataProvider::try_new(&root_dir)
             .expect("TOML should load successfully");
 
-        let payload: DataPayload<'_, UnicodePropertyV1Marker> = provider
+        let payload: DataPayload<UnicodePropertyV1Marker> = provider
             .load_payload(&DataRequest {
                 resource_path: ResourcePath {
                     key: key::GENERAL_CATEGORY_SURROGATE_V1,

--- a/provider/uprops/src/provider.rs
+++ b/provider/uprops/src/provider.rs
@@ -29,11 +29,11 @@ impl PropertiesDataProvider {
     }
 }
 
-impl<'data> DataProvider<'data, UnicodePropertyV1Marker> for PropertiesDataProvider {
+impl DataProvider<UnicodePropertyV1Marker> for PropertiesDataProvider {
     fn load_payload(
         &self,
         req: &DataRequest,
-    ) -> Result<DataResponse<'data, UnicodePropertyV1Marker>, DataError> {
+    ) -> Result<DataResponse<UnicodePropertyV1Marker>, DataError> {
         if req.resource_path.key.sub_category.contains('=') {
             self.enumerated.load_payload(req)
         } else {
@@ -44,7 +44,7 @@ impl<'data> DataProvider<'data, UnicodePropertyV1Marker> for PropertiesDataProvi
 
 icu_provider::impl_dyn_provider!(PropertiesDataProvider, {
     _ => UnicodePropertyV1Marker,
-}, SERDE_SE, 'data);
+}, SERDE_SE);
 
 impl IterableDataProviderCore for PropertiesDataProvider {
     fn supported_options_for_key(

--- a/tools/datagen/src/bin/datagen.rs
+++ b/tools/datagen/src/bin/datagen.rs
@@ -375,9 +375,9 @@ fn get_blob_exporter(matches: &ArgMatches) -> eyre::Result<BlobExporter<'static>
     Ok(BlobExporter::new_with_sink(sink))
 }
 
-fn export_cldr<'data>(
+fn export_cldr(
     matches: &ArgMatches,
-    exporter: &mut (impl DataExporter<'data, SerdeSeDataStructMarker> + ?Sized),
+    exporter: &mut (impl DataExporter<SerdeSeDataStructMarker> + ?Sized),
     allowed_locales: Option<&[LanguageIdentifier]>,
     allowed_keys: Option<&HashSet<&str>>,
 ) -> eyre::Result<()> {
@@ -429,9 +429,9 @@ fn export_cldr<'data>(
     Ok(())
 }
 
-fn export_set_props<'data>(
+fn export_set_props(
     matches: &ArgMatches,
-    exporter: &mut (impl DataExporter<'data, SerdeSeDataStructMarker> + ?Sized),
+    exporter: &mut (impl DataExporter<SerdeSeDataStructMarker> + ?Sized),
     allowed_keys: Option<&HashSet<&str>>,
 ) -> eyre::Result<()> {
     log::trace!("Loading data for binary properties...");
@@ -471,9 +471,9 @@ fn export_set_props<'data>(
     Ok(())
 }
 
-fn export_map_props<'data>(
+fn export_map_props(
     matches: &ArgMatches,
-    exporter: &mut (impl DataExporter<'data, SerdeSeDataStructMarker> + ?Sized),
+    exporter: &mut (impl DataExporter<SerdeSeDataStructMarker> + ?Sized),
     allowed_keys: Option<&HashSet<&str>>,
 ) -> eyre::Result<()> {
     log::trace!("Loading data for enumerated properties...");
@@ -513,9 +513,9 @@ fn export_map_props<'data>(
     Ok(())
 }
 
-fn export_hello_world<'data>(
+fn export_hello_world(
     _: &ArgMatches,
-    exporter: &mut (impl DataExporter<'data, SerdeSeDataStructMarker> + ?Sized),
+    exporter: &mut (impl DataExporter<SerdeSeDataStructMarker> + ?Sized),
     allowed_locales: Option<&[LanguageIdentifier]>,
 ) -> eyre::Result<()> {
     let raw_provider = HelloWorldProvider::new_with_placeholder_data();


### PR DESCRIPTION
Progress on https://github.com/unicode-org/icu4x/issues/1262

`RcStruct` is now pretty useless but this PR doesn't yet remove it to reduce the amount of actual changes.

The actual changes here are:

 - `DataPayload`, `DataProvider`, `DataExporter` no longer have lifetimes (and as a result all the formatters/etc don't either)
 - It is no longer possible to construct data payloads from locally borrowed data
 - Tests testing for construction of providers/formatters from local data have been removed

Everything else is mostly just updates to bring the uses of these types in line with the changes

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->