### PR TITLE
Remove RcStruct

### DIFF
--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -10,7 +10,6 @@ use crate::error::Error;
 use crate::marker::DataMarker;
 use crate::resource::ResourceKey;
 use crate::resource::ResourcePath;
-use crate::yoke::erased::ErasedRcCart;
 use crate::yoke::trait_hack::YokeTraitHack;
 use crate::yoke::*;
 
@@ -100,7 +99,6 @@ pub(crate) enum DataPayloadInner<M>
 where
     M: DataMarker,
 {
-    RcStruct(Yoke<M::Yokeable, ErasedRcCart>),
     Owned(Yoke<M::Yokeable, ()>),
     RcBuf(Yoke<M::Yokeable, Rc<[u8]>>),
 }
@@ -189,7 +187,6 @@ where
     fn clone(&self) -> Self {
         use DataPayloadInner::*;
         let new_inner = match &self.inner {
-            RcStruct(yoke) => RcStruct(yoke.clone()),
             Owned(yoke) => Owned(yoke.clone()),
             RcBuf(yoke) => RcBuf(yoke.clone()),
         };
@@ -397,7 +394,6 @@ where
     {
         use DataPayloadInner::*;
         match &mut self.inner {
-            RcStruct(yoke) => yoke.with_mut(f),
             Owned(yoke) => yoke.with_mut(f),
             RcBuf(yoke) => yoke.with_mut(f),
         }
@@ -422,7 +418,6 @@ where
     pub fn get<'a>(&'a self) -> &'a <M::Yokeable as Yokeable<'a>>::Output {
         use DataPayloadInner::*;
         match &self.inner {
-            RcStruct(yoke) => yoke.get(),
             Owned(yoke) => yoke.get(),
             RcBuf(yoke) => yoke.get(),
         }
@@ -487,9 +482,6 @@ where
     {
         use DataPayloadInner::*;
         match self.inner {
-            RcStruct(yoke) => DataPayload {
-                inner: RcStruct(yoke.project(f)),
-            },
             Owned(yoke) => DataPayload {
                 inner: Owned(yoke.project(f)),
             },
@@ -544,9 +536,6 @@ where
     {
         use DataPayloadInner::*;
         match &self.inner {
-            RcStruct(yoke) => DataPayload {
-                inner: RcStruct(yoke.project_cloned(f)),
-            },
             Owned(yoke) => DataPayload {
                 inner: Owned(yoke.project_cloned(f)),
             },
@@ -634,9 +623,6 @@ where
     {
         use DataPayloadInner::*;
         match self.inner {
-            RcStruct(yoke) => DataPayload {
-                inner: RcStruct(yoke.project_with_capture(capture, f)),
-            },
             Owned(yoke) => DataPayload {
                 inner: Owned(yoke.project_with_capture(capture, f)),
             },
@@ -699,9 +685,6 @@ where
     {
         use DataPayloadInner::*;
         match &self.inner {
-            RcStruct(yoke) => DataPayload {
-                inner: RcStruct(yoke.project_cloned_with_capture(capture, f)),
-            },
             Owned(yoke) => DataPayload {
                 inner: Owned(yoke.project_cloned_with_capture(capture, f)),
             },
@@ -797,9 +780,6 @@ where
     {
         use DataPayloadInner::*;
         Ok(match self.inner {
-            RcStruct(yoke) => DataPayload {
-                inner: RcStruct(yoke.try_project_with_capture(capture, f)?),
-            },
             Owned(yoke) => DataPayload {
                 inner: Owned(yoke.try_project_with_capture(capture, f)?),
             },
@@ -866,9 +846,6 @@ where
     {
         use DataPayloadInner::*;
         Ok(match &self.inner {
-            RcStruct(yoke) => DataPayload {
-                inner: RcStruct(yoke.try_project_cloned_with_capture(capture, f)?),
-            },
             Owned(yoke) => DataPayload {
                 inner: Owned(yoke.try_project_cloned_with_capture(capture, f)?),
             },

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -112,8 +112,7 @@ where
 /// several data stores ("carts"):
 ///
 /// 1. Fully-owned structured data ([`DataPayload::from_owned()`])
-/// 2. Partially-owned structured data in an [`Rc`] ([`DataPayload::from_partial_owned()`])
-/// 3. A reference-counted byte buffer ([`DataPayload::try_from_rc_buffer()`])
+/// 2. A reference-counted byte buffer ([`DataPayload::try_from_rc_buffer()`])
 ///
 /// The type of the data stored in [`DataPayload`], and the type of the structured data store
 /// (cart), is determined by the [`DataMarker`] type parameter.
@@ -221,48 +220,6 @@ fn test_clone_eq() {
     let p1 = DataPayload::<CowStrMarker>::from_static_str("Demo");
     let p2 = p1.clone();
     assert_eq!(p1, p2);
-}
-
-impl<M> DataPayload<M>
-where
-    M: DataMarker,
-{
-    /// Convert an [`Rc`]`<`[`Cart`]`>` into a [`DataPayload`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use icu_provider::prelude::*;
-    /// use icu_provider::hello_world::*;
-    /// use std::borrow::Cow;
-    /// use std::rc::Rc;
-    ///
-    /// let local_data = "example".to_string();
-    ///
-    /// let rc_struct = Rc::from(HelloWorldV1 {
-    ///     message: Cow::Owned(local_data),
-    /// });
-    ///
-    /// let payload = DataPayload::<HelloWorldV1Marker>::from_partial_owned(rc_struct.clone());
-    ///
-    /// assert_eq!(payload.get(), &*rc_struct);
-    /// ```
-    ///
-    /// [`Cart`]: crate::marker::DataMarker::Cart
-    #[inline]
-    pub fn from_partial_owned<T>(data: Rc<T>) -> Self
-    where
-        M::Yokeable: ZeroCopyFrom<T>,
-        T: 'static,
-    {
-        let yoke = unsafe {
-            // safe because we're not throwing away any actual data, simply type-erasing it
-            Yoke::attach_to_rc_cart(data).replace_cart(|c| c as ErasedRcCart)
-        };
-        Self {
-            inner: DataPayloadInner::RcStruct(yoke),
-        }
-    }
 }
 
 impl<M> DataPayload<M>

--- a/provider/core/src/erased.rs
+++ b/provider/core/src/erased.rs
@@ -4,9 +4,9 @@
 
 //! Collection of traits for providers that support type erasure of data structs.
 
-use crate::data_provider::ErasedCart;
 use crate::error::Error;
 use crate::prelude::*;
+use crate::yoke::erased::ErasedRcCart;
 use crate::yoke::*;
 use alloc::boxed::Box;
 use alloc::rc::Rc;
@@ -143,7 +143,7 @@ impl DataPayload<ErasedDataStructMarker> {
                 // `any_box` is the Yoke that was converted into the `dyn ErasedDataStruct`. It
                 // could have been either the RcStruct or the Owned variant of Yoke.
                 // Check first for Case 2: an RcStruct Yoke.
-                let y1 = any_box.downcast::<Yoke<M::Yokeable, ErasedCart>>();
+                let y1 = any_box.downcast::<Yoke<M::Yokeable, ErasedRcCart>>();
                 let any_box = match y1 {
                     Ok(yoke) => {
                         return Ok(DataPayload {

--- a/provider/core/src/erased.rs
+++ b/provider/core/src/erased.rs
@@ -6,7 +6,6 @@
 
 use crate::error::Error;
 use crate::prelude::*;
-use crate::yoke::erased::ErasedRcCart;
 use crate::yoke::*;
 use alloc::boxed::Box;
 use alloc::rc::Rc;
@@ -82,7 +81,6 @@ where
     fn upcast(other: DataPayload<M>) -> DataPayload<ErasedDataStructMarker> {
         use crate::data_provider::DataPayloadInner::*;
         let owned: Box<dyn ErasedDataStruct> = match other.inner {
-            RcStruct(yoke) => Box::new(yoke),
             Owned(yoke) => Box::new(yoke),
             RcBuf(yoke) => Box::new(yoke),
         };
@@ -141,18 +139,8 @@ impl DataPayload<ErasedDataStructMarker> {
             Owned(yoke) => {
                 let any_box: Box<dyn Any> = yoke.into_yokeable().0.into_any();
                 // `any_box` is the Yoke that was converted into the `dyn ErasedDataStruct`. It
-                // could have been either the RcStruct or the Owned variant of Yoke.
-                // Check first for Case 2: an RcStruct Yoke.
-                let y1 = any_box.downcast::<Yoke<M::Yokeable, ErasedRcCart>>();
-                let any_box = match y1 {
-                    Ok(yoke) => {
-                        return Ok(DataPayload {
-                            inner: RcStruct(*yoke),
-                        })
-                    }
-                    Err(any_box) => any_box,
-                };
-                // Check for Case 3: an Owned Yoke.
+                // could have been either the RcBuf or the Owned variant of Yoke.
+                // Check for an Owned Yoke.
                 let y2 = any_box.downcast::<Yoke<M::Yokeable, ()>>();
                 let any_box = match y2 {
                     Ok(yoke) => {
@@ -162,7 +150,7 @@ impl DataPayload<ErasedDataStructMarker> {
                     }
                     Err(any_box) => any_box,
                 };
-                // Check for Case 4: an RcBuf Yoke.
+                // Check for  an RcBuf Yoke.
                 let y2 = any_box.downcast::<Yoke<M::Yokeable, Rc<[u8]>>>();
                 let any_box = match y2 {
                     Ok(yoke) => {
@@ -181,7 +169,7 @@ impl DataPayload<ErasedDataStructMarker> {
             // This is unreachable because an ErasedDataStruct payload can only be constructed as fully owned
             // (It is impossible for clients to construct an ErasedDataStruct payload manually since ErasedDataStructBox
             // has a private field)
-            RcStruct(_) | RcBuf(_) => unreachable!(),
+            RcBuf(_) => unreachable!(),
         }
     }
 }

--- a/provider/core/src/erased.rs
+++ b/provider/core/src/erased.rs
@@ -255,17 +255,6 @@ mod test {
     use alloc::borrow::Cow;
 
     #[test]
-    fn test_erased_case_2() {
-        let data = Rc::new("foo".to_string());
-        let original = DataPayload::<CowStrMarker>::from_partial_owned(data);
-        let upcasted = ErasedDataStructMarker::upcast(original);
-        let downcasted = upcasted
-            .downcast::<CowStrMarker>()
-            .expect("Type conversion");
-        assert_eq!(downcasted.get(), "foo");
-    }
-
-    #[test]
     fn test_erased_case_3() {
         let data = "foo".to_string();
         let original = DataPayload::<CowStrMarker>::from_owned(Cow::Owned(data));

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -9,7 +9,6 @@ use crate::prelude::*;
 use crate::yoke::{self, *};
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
-use alloc::rc::Rc;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::fmt::Debug;
@@ -133,7 +132,7 @@ impl DataProvider<HelloWorldV1Marker> for HelloWorldProvider {
             metadata: DataResponseMetadata {
                 data_langid: Some(langid.clone()),
             },
-            payload: Some(DataPayload::from_partial_owned(Rc::from(data))),
+            payload: Some(DataPayload::from_owned(data)),
         })
     }
 }

--- a/provider/core/src/marker/mod.rs
+++ b/provider/core/src/marker/mod.rs
@@ -45,10 +45,10 @@ use crate::yoke::Yokeable;
 /// }
 ///
 /// // We can now use MyDataStruct with DataProvider:
-/// let s = Rc::from(MyDataStruct {
-///     message: Cow::Borrowed("Hello World")
-/// });
-/// let payload = DataPayload::<MyDataStructMarker>::from_partial_owned(s);
+/// let s = MyDataStruct {
+///     message: Cow::Owned("Hello World".into())
+/// };
+/// let payload = DataPayload::<MyDataStructMarker>::from_owned(s);
 /// assert_eq!(payload.get().message, "Hello World");
 /// ```
 pub trait DataMarker {

--- a/provider/core/src/serde.rs
+++ b/provider/core/src/serde.rs
@@ -258,6 +258,7 @@ where
 }
 
 /// A wrapper around `Box<`[`SerdeSeDataStruct`]`>` for integration with DataProvider.
+#[derive(yoke::Yokeable)]
 pub struct SerdeSeDataStructBox(Box<dyn SerdeSeDataStruct>);
 
 impl Deref for SerdeSeDataStructBox {
@@ -279,25 +280,6 @@ where
             DataPayloadInner::RcBuf(yoke) => Box::new(yoke) as Box<dyn SerdeSeDataStruct>,
         };
         DataPayload::from_owned(SerdeSeDataStructBox(b))
-    }
-}
-
-unsafe impl<'a> Yokeable<'a> for SerdeSeDataStructBox {
-    type Output = SerdeSeDataStructBox;
-    fn transform(&'a self) -> &'a Self::Output {
-        self
-    }
-    fn transform_owned(self) -> Self::Output {
-        self
-    }
-    unsafe fn make(from: Self::Output) -> Self {
-        from
-    }
-    fn transform_mut<F>(&'a mut self, f: F)
-    where
-        F: 'static + for<'b> FnOnce(&'b mut Self::Output),
-    {
-        f(self)
     }
 }
 

--- a/provider/core/src/serde.rs
+++ b/provider/core/src/serde.rs
@@ -275,7 +275,6 @@ where
     fn upcast(other: DataPayload<M>) -> DataPayload<SerdeSeDataStructMarker> {
         use crate::data_provider::DataPayloadInner;
         let b = match other.inner {
-            DataPayloadInner::RcStruct(yoke) => Box::new(yoke) as Box<dyn SerdeSeDataStruct>,
             DataPayloadInner::Owned(yoke) => Box::new(yoke) as Box<dyn SerdeSeDataStruct>,
             DataPayloadInner::RcBuf(yoke) => Box::new(yoke) as Box<dyn SerdeSeDataStruct>,
         };

--- a/provider/core/src/serde.rs
+++ b/provider/core/src/serde.rs
@@ -22,6 +22,7 @@
 use crate::error::Error;
 use crate::prelude::*;
 use crate::yoke::*;
+use alloc::boxed::Box;
 use alloc::rc::Rc;
 
 use core::ops::Deref;
@@ -274,15 +275,9 @@ where
     fn upcast(other: DataPayload<M>) -> DataPayload<SerdeSeDataStructMarker> {
         use crate::data_provider::DataPayloadInner;
         let b = match other.inner {
-            DataPayloadInner::RcStruct(yoke) => {
-                Box::new(yoke) as Box<dyn SerdeSeDataStruct>
-            }
-            DataPayloadInner::Owned(yoke) => {
-                Box::new(yoke) as Box<dyn SerdeSeDataStruct>
-            }
-            DataPayloadInner::RcBuf(yoke) => {
-                Box::new(yoke) as Box<dyn SerdeSeDataStruct>
-            }
+            DataPayloadInner::RcStruct(yoke) => Box::new(yoke) as Box<dyn SerdeSeDataStruct>,
+            DataPayloadInner::Owned(yoke) => Box::new(yoke) as Box<dyn SerdeSeDataStruct>,
+            DataPayloadInner::RcBuf(yoke) => Box::new(yoke) as Box<dyn SerdeSeDataStruct>,
         };
         DataPayload::from_owned(SerdeSeDataStructBox(b))
     }

--- a/utils/yoke/src/erased.rs
+++ b/utils/yoke/src/erased.rs
@@ -1,0 +1,34 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+//! This module contains helper types for erasing Cart types.
+//!
+//! See the docs of [`Yoke::erase_rc_cart()`](crate::Yoke::erase_rc_cart)
+//! and [`Yoke::erase_box_cart()`](crate::Yoke::erase_box_cart) for more info.
+//!
+//! Available with the `"alloc"` feature enabled.
+
+use alloc::boxed::Box;
+use alloc::rc::Rc;
+
+/// Dummy trait that lets us `dyn Drop`
+///
+/// `dyn Drop` isn't legal (and doesn't make sense since `Drop` is not
+/// implement on all destructible types). However, all trait objects come with
+/// a destructor, so we can just use an empty trait to get a destructor object.
+pub trait ErasedDestructor: 'static {}
+impl<T: 'static> ErasedDestructor for T {}
+
+/// A type-erased Cart that has `Rc` semantics
+///
+/// See the docs of [`Yoke::erase_rc_cart()`](crate::Yoke::erase_rc_cart) for more info.
+///
+/// Available with the `"alloc"` feature enabled.
+pub type ErasedRcCart = Rc<dyn ErasedDestructor>;
+/// A type-erased Cart that has `Box` semantics
+///
+/// See the docs of [`Yoke::erase_box_cart()`](crate::Yoke::erase_box_cart) for more info.
+///
+/// Available with the `"alloc"` feature enabled.
+pub type ErasedBoxCart = Box<dyn ErasedDestructor>;

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -17,6 +17,8 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+#[cfg(feature = "alloc")]
+pub mod erased;
 mod is_covariant;
 mod macro_impls;
 pub mod trait_hack;

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -883,7 +883,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     pub fn wrap_cart_in_box(self) -> Yoke<Y, Box<C>> {
         unsafe {
             // safe because the cart is preserved, just wrapped
-            self.replace_cart(|c| Box::new(c))
+            self.replace_cart(Box::new)
         }
     }
     /// Helper function allowing one to wrap the cart type in an `Rc<T>`,
@@ -894,7 +894,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     pub fn wrap_cart_in_rc(self) -> Yoke<Y, Rc<C>> {
         unsafe {
             // safe because the cart is preserved, just wrapped
-            self.replace_cart(|c| Rc::new(c))
+            self.replace_cart(Rc::new)
         }
     }
 }

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -1,7 +1,7 @@
-// This file is part of ICU4X. For terms of use, please see the file
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::erased::{ErasedBoxCart, ErasedRcCart};
 use crate::trait_hack::YokeTraitHack;
 use crate::IsCovariant;
 use crate::Yokeable;
@@ -9,6 +9,8 @@ use core::marker::PhantomData;
 use core::ops::Deref;
 use stable_deref_trait::StableDeref;
 
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
 use alloc::rc::Rc;
 #[cfg(feature = "alloc")]
@@ -779,6 +781,121 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
             yokeable: unsafe { P::make(p) },
             cart: self.cart.clone(),
         })
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<Y: for<'a> Yokeable<'a>, C: 'static + Sized> Yoke<Y, Rc<C>> {
+    /// Allows type-erasing the cart in a `Yoke<Y, Rc<C>>`.
+    ///
+    /// The yoke only carries around a cart type for its destructor,
+    /// since it needs to be able to guarantee that its internal references
+    /// are valid for the lifetime of the Yoke. As such, the actual type of the
+    /// Cart is not very useful unless you wish to extract data out of it
+    /// via [`Yoke::backing_cart()`]. Erasing the cart allows for one to mix
+    /// [`Yoke`]s obtained from different sources.
+    ///
+    /// In case the cart type is not already `Rc<T>`, you can use
+    /// [`Yoke::wrap_cart_in_rc()`] to wrap it.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use yoke::Yoke;
+    /// use yoke::erased::ErasedRcCart;
+    /// use std::rc::Rc;
+    ///
+    /// let buffer1: Rc<String> = Rc::new("   foo bar baz  ".into());
+    /// let buffer2: Box<String> = Box::new("  baz quux  ".into());
+    ///
+    /// let yoke1 = Yoke::<&'static str, _>::attach_to_cart_badly(buffer1, |rc| rc.trim());
+    /// let yoke2 = Yoke::<&'static str, _>::attach_to_cart_badly(buffer2, |b| b.trim());
+    ///
+    ///
+    /// let erased1: Yoke<_, ErasedRcCart> = yoke1.erase_rc_cart();
+    /// // Wrap the Box in an Rc to make it compatible
+    /// let erased2: Yoke<_, ErasedRcCart> = yoke2.wrap_cart_in_rc().erase_rc_cart();
+    ///
+    /// // Now erased1 and erased2 have the same type!
+    /// ```
+    ///
+    /// Available with the `"alloc"` feature enabled.
+    pub fn erase_rc_cart(self) -> Yoke<Y, ErasedRcCart> {
+        unsafe {
+            // safe because the cart is preserved, just
+            // type-erased
+            self.replace_cart(|c| c as ErasedRcCart)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<Y: for<'a> Yokeable<'a>, C: 'static + Sized> Yoke<Y, Box<C>> {
+    /// Allows type-erasing the cart in a `Yoke<Y, Box<C>>`.
+    ///
+    /// The yoke only carries around a cart type for its destructor,
+    /// since it needs to be able to guarantee that its internal references
+    /// are valid for the lifetime of the Yoke. As such, the actual type of the
+    /// Cart is not very useful unless you wish to extract data out of it
+    /// via [`Yoke::backing_cart()`]. Erasing the cart allows for one to mix
+    /// [`Yoke`]s obtained from different sources.
+    ///
+    /// In case the cart type is not already `Box<T>`, you can use
+    /// [`Yoke::wrap_cart_in_box()`] to wrap it.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use yoke::Yoke;
+    /// use yoke::erased::ErasedBoxCart;
+    /// use std::rc::Rc;
+    ///
+    /// let buffer1: Rc<String> = Rc::new("   foo bar baz  ".into());
+    /// let buffer2: Box<String> = Box::new("  baz quux  ".into());
+    ///
+    /// let yoke1 = Yoke::<&'static str, _>::attach_to_cart_badly(buffer1, |rc| rc.trim());
+    /// let yoke2 = Yoke::<&'static str, _>::attach_to_cart_badly(buffer2, |b| b.trim());
+    ///
+    ///
+    /// // Wrap the Rc in an Box to make it compatible
+    /// let erased1: Yoke<_, ErasedBoxCart> = yoke1.wrap_cart_in_box().erase_box_cart();
+    /// let erased2: Yoke<_, ErasedBoxCart> = yoke2.erase_box_cart();
+    ///
+    /// // Now erased1 and erased2 have the same type!
+    /// ```
+    ///
+    /// Available with the `"alloc"` feature enabled.
+    pub fn erase_box_cart(self) -> Yoke<Y, ErasedBoxCart> {
+        unsafe {
+            // safe because the cart is preserved, just
+            // type-erased
+            self.replace_cart(|c| c as ErasedBoxCart)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
+    /// Helper function allowing one to wrap the cart type in a `Box<T>`,
+    /// can be paired with [`Yoke::erase_box_cart()`]
+    ///
+    /// Available with the `"alloc"` feature enabled.
+    pub fn wrap_cart_in_box(self) -> Yoke<Y, Box<C>> {
+        unsafe {
+            // safe because the cart is preserved, just wrapped
+            self.replace_cart(|c| Box::new(c))
+        }
+    }
+    /// Helper function allowing one to wrap the cart type in an `Rc<T>`,
+    /// can be paired with [`Yoke::erase_rc_cart()`], or generally used
+    /// to make the [`Yoke`] cloneable.
+    ///
+    /// Available with the `"alloc"` feature enabled.
+    pub fn wrap_cart_in_rc(self) -> Yoke<Y, Rc<C>> {
+        unsafe {
+            // safe because the cart is preserved, just wrapped
+            self.replace_cart(|c| Rc::new(c))
+        }
     }
 }
 

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -1,6 +1,8 @@
+// This file is part of ICU4X. For terms of use, please see the file
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+#[cfg(feature = "alloc")]
 use crate::erased::{ErasedBoxCart, ErasedRcCart};
 use crate::trait_hack::YokeTraitHack;
 use crate::IsCovariant;


### PR DESCRIPTION
(finally)

Fixes https://github.com/unicode-org/icu4x/issues/1262, fixes https://github.com/unicode-org/icu4x/issues/1284

#1297 had all the churny parts of this change so this PR should be much more manageable (and can be reviewed at leisure).

This contains a bunch of related changes:

 - Moving all code over to `DataPayload::new_owned()` from `DataPayload::from_partial_owned()`
 - Moving `ErasedCart` into `yoke` (https://github.com/unicode-org/icu4x/issues/1284) and adding nice helper methods for working with it. We don't use it anymore, but it does seem generally useful.
 - Removing `DataPayloadInner::RcStruct` and `DataPayload::from_partial_owned()`

It should be easy to re-add an `ErasedCart` based `RcRef(Yoke<&'static Y, ErasedRcCart>)` later if needed. It's worth waiting to see what our needs are in this area before adding new variants or constructors; `Yoke` is pretty versatile so we should be able to use it as needed.



<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->