### PR TITLE
Homogenize yoke generic impls to always work with Yokeable, add OwnedYokeable

### DIFF
--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -33,7 +33,6 @@ mod serde;
 pub use yoke_derive::{Yokeable, ZeroCopyFrom};
 
 pub use crate::is_covariant::IsCovariant;
-pub use crate::macro_impls::OwnedYokeable;
 pub use crate::yoke::{CloneableCart, Yoke};
 pub use crate::yokeable::Yokeable;
 pub use crate::zero_copy_from::ZeroCopyFrom;

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -33,6 +33,7 @@ mod serde;
 pub use yoke_derive::{Yokeable, ZeroCopyFrom};
 
 pub use crate::is_covariant::IsCovariant;
+pub use crate::macro_impls::OwnedYokeable;
 pub use crate::yoke::{CloneableCart, Yoke};
 pub use crate::yokeable::Yokeable;
 pub use crate::zero_copy_from::ZeroCopyFrom;

--- a/utils/yoke/src/macro_impls.rs
+++ b/utils/yoke/src/macro_impls.rs
@@ -57,6 +57,27 @@ impl_copy_type!(i128);
 impl_copy_type!(char);
 impl_copy_type!(bool);
 
+/// [`OwnedYokeable`] is a convenience type that allows one to wrap fully-owned types and produce
+/// [`Yokeable`]s from them. Its primary purpose is to be able to quickly satisfy the
+/// requirements on fields in the [`Yokeable`] and [`ZeroCopyFrom`] custom derive without
+/// needing to do a manual impl.
+///
+/// The [`ZeroCopyFrom`] impl will call `.clone()` since there is no borrowed version of this type. This
+/// will be cheap for `Copy` types.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Ord, PartialOrd, Hash)]
+pub struct OwnedYokeable<T>(pub T);
+
+unsafe impl<'a, T: 'static> Yokeable<'a> for OwnedYokeable<T> {
+    type Output = Self;
+    copy_yoke_impl! {}
+}
+
+impl<T: Clone + 'static> ZeroCopyFrom<OwnedYokeable<T>> for OwnedYokeable<T> {
+    fn zero_copy_from(this: &Self) -> Self {
+        this.clone()
+    }
+}
+
 // This is for when we're implementing Yoke on a complex type such that it's not
 // obvious to the compiler that the lifetime is covariant
 macro_rules! unsafe_complex_yoke_impl {

--- a/utils/yoke/src/macro_impls.rs
+++ b/utils/yoke/src/macro_impls.rs
@@ -57,51 +57,6 @@ impl_copy_type!(i128);
 impl_copy_type!(char);
 impl_copy_type!(bool);
 
-/// [`OwnedYokeable`] is a convenience type that allows one to wrap fully-owned types and produce
-/// [`Yokeable`]s from them. Its primary purpose is to be able to quickly satisfy the
-/// requirements on fields in the [`Yokeable`] and [`ZeroCopyFrom`] custom derive without
-/// needing to do a manual impl.
-///
-/// The [`ZeroCopyFrom`] impl will call `.clone()` since there is no borrowed version of this type. This
-/// will be cheap for `Copy` types.
-///
-/// For example, the following custom derive would fail to compile:
-///
-/// ```rust,compile_fail
-/// use yoke::{Yokeable, ZeroCopyFrom};
-/// use std::borrow::Cow;
-///
-/// #[derive(Yokeable, ZeroCopyFrom)]
-/// struct Foo<'a> {
-///    arr: [String; 12],
-///    cow: Cow<'a, str>
-/// }
-/// ```
-///
-/// ```rust
-/// use yoke::{OwnedYokeable, Yokeable, ZeroCopyFrom};
-/// use std::borrow::Cow;
-///
-/// #[derive(Yokeable, ZeroCopyFrom)]
-/// struct Foo<'a> {
-///    arr: OwnedYokeable<[String; 12]>,
-///    cow: Cow<'a, str>
-/// }
-/// ```
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Ord, PartialOrd, Hash)]
-pub struct OwnedYokeable<T>(pub T);
-
-unsafe impl<'a, T: 'static> Yokeable<'a> for OwnedYokeable<T> {
-    type Output = Self;
-    copy_yoke_impl! {}
-}
-
-impl<T: Clone + 'static> ZeroCopyFrom<OwnedYokeable<T>> for OwnedYokeable<T> {
-    fn zero_copy_from(this: &Self) -> Self {
-        this.clone()
-    }
-}
-
 // This is for when we're implementing Yoke on a complex type such that it's not
 // obvious to the compiler that the lifetime is covariant
 macro_rules! unsafe_complex_yoke_impl {

--- a/utils/yoke/src/macro_impls.rs
+++ b/utils/yoke/src/macro_impls.rs
@@ -64,6 +64,30 @@ impl_copy_type!(bool);
 ///
 /// The [`ZeroCopyFrom`] impl will call `.clone()` since there is no borrowed version of this type. This
 /// will be cheap for `Copy` types.
+///
+/// For example, the following custom derive would fail to compile:
+///
+/// ```rust,compile_fail
+/// use yoke::{Yokeable, ZeroCopyFrom};
+/// use std::borrow::Cow;
+/// 
+/// #[derive(Yokeable, ZeroCopyFrom)]
+/// struct Foo<'a> {
+///    arr: [String; 12],
+///    cow: Cow<'a, str>
+/// }
+/// ```
+///
+/// ```rust
+/// use yoke::{OwnedYokeable, Yokeable, ZeroCopyFrom};
+/// use std::borrow::Cow;
+/// 
+/// #[derive(Yokeable, ZeroCopyFrom)]
+/// struct Foo<'a> {
+///    arr: OwnedYokeable<[String; 12]>,
+///    cow: Cow<'a, str>
+/// }
+/// ```
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Ord, PartialOrd, Hash)]
 pub struct OwnedYokeable<T>(pub T);
 

--- a/utils/yoke/src/macro_impls.rs
+++ b/utils/yoke/src/macro_impls.rs
@@ -70,7 +70,7 @@ impl_copy_type!(bool);
 /// ```rust,compile_fail
 /// use yoke::{Yokeable, ZeroCopyFrom};
 /// use std::borrow::Cow;
-/// 
+///
 /// #[derive(Yokeable, ZeroCopyFrom)]
 /// struct Foo<'a> {
 ///    arr: [String; 12],
@@ -81,7 +81,7 @@ impl_copy_type!(bool);
 /// ```rust
 /// use yoke::{OwnedYokeable, Yokeable, ZeroCopyFrom};
 /// use std::borrow::Cow;
-/// 
+///
 /// #[derive(Yokeable, ZeroCopyFrom)]
 /// struct Foo<'a> {
 ///    arr: OwnedYokeable<[String; 12]>,


### PR DESCRIPTION
This gives us a `[T; N] where T: Yokeable` impl. Unfortunately, we lose the `[T; N] where T: 'static + Copy` impl, however I've introduced `OwnedYokeable` which allows one to quickly wrap types to get a copying yokeable.

99% of the time this type won't be necessary since the Yoke derive is already pretty smart about this; however it's useful to just have.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->