### PR TITLE
Add missing Serde/Yoke impls to ZeroVec crate

### DIFF
--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -24,7 +24,7 @@ include = [
 all-features = true
 
 [dependencies]
-serde = { version = "1.0", optional = true , default-features = false, features = ["alloc"] }
+serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
 yoke = { version = "0.3.1", path = "../yoke", optional = true }
 
 [dev-dependencies]
@@ -39,6 +39,7 @@ rand = "0.8"
 rand_pcg = "0.3"
 rand_distr = "0.4"
 getrandom = { version = "0.2", features = ["js"] }
+yoke = { version = "0.3.1", path = "../yoke", features = ["derive"] }
 
 [features]
 bench = []
@@ -64,6 +65,7 @@ harness = false
 [[bench]]
 name = "zeromap"
 harness = false
+required-features = ["serde"]
 
 [[example]]
 name = "zv_serde"

--- a/utils/zerovec/src/map/kv.rs
+++ b/utils/zerovec/src/map/kv.rs
@@ -40,7 +40,7 @@ pub trait ZeroMapKV<'a> {
     /// also used during deserialization. If `Self` is human readable serialized,
     /// deserializing to `Self::OwnedType` should produce the same value once
     /// passed through `Self::owned_as_self()`
-    type OwnedType;
+    type OwnedType: 'static;
     /// Convert to a needle for searching
     fn as_needle(&self) -> &Self::NeedleType;
     /// Compare this type with a `Self::GetType`. This must produce the same result as

--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -114,15 +114,16 @@ where
 }
 
 /// This impl can be made available by enabling the optional `serde` feature of the `zerovec` crate
-impl<'de, K: ?Sized, V: ?Sized> Deserialize<'de> for ZeroMap<'de, K, V>
+impl<'de, 'a, K: ?Sized, V: ?Sized> Deserialize<'de> for ZeroMap<'a, K, V>
 where
     K: Ord,
-    K::Container: Deserialize<'de>,
-    V::Container: Deserialize<'de>,
-    K: ZeroMapKV<'de>,
-    V: ZeroMapKV<'de>,
-    K::OwnedType: Deserialize<'de>,
-    V::OwnedType: Deserialize<'de>,
+    K::Container: Deserialize<'a>,
+    V::Container: Deserialize<'a>,
+    K: ZeroMapKV<'a>,
+    V: ZeroMapKV<'a>,
+    K::OwnedType: Deserialize<'a>,
+    V::OwnedType: Deserialize<'a>,
+    'de: 'a,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -147,15 +148,16 @@ where
 }
 
 // /// This impl can be made available by enabling the optional `serde` feature of the `zerovec` crate
-impl<'de, K: ?Sized, V: ?Sized> Deserialize<'de> for ZeroMapBorrowed<'de, K, V>
+impl<'de, 'a, K: ?Sized, V: ?Sized> Deserialize<'de> for ZeroMapBorrowed<'a, K, V>
 where
     K: Ord,
-    K::Container: Deserialize<'de>,
-    V::Container: Deserialize<'de>,
-    K: ZeroMapKV<'de>,
-    V: ZeroMapKV<'de>,
-    K::OwnedType: Deserialize<'de>,
-    V::OwnedType: Deserialize<'de>,
+    K::Container: Deserialize<'a>,
+    V::Container: Deserialize<'a>,
+    K: ZeroMapKV<'a>,
+    V: ZeroMapKV<'a>,
+    K::OwnedType: Deserialize<'a>,
+    V::OwnedType: Deserialize<'a>,
+    'de: 'a,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -166,7 +168,7 @@ where
                 "ZeroMapBorrowed cannot be deserialized from human-readable formats",
             ))
         } else {
-            let deserialized: ZeroMap<'de, K, V> = ZeroMap::deserialize(deserializer)?;
+            let deserialized: ZeroMap<'a, K, V> = ZeroMap::deserialize(deserializer)?;
             let keys = if let Some(keys) = deserialized.keys.as_borrowed_inner() {
                 keys
             } else {
@@ -187,8 +189,21 @@ where
 }
 
 #[cfg(test)]
+#[allow(non_camel_case_types)]
 mod test {
     use super::super::*;
+
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    struct DeriveTest_ZeroMap<'data> {
+        #[serde(borrow)]
+        _data: ZeroMap<'data, str, [u8]>
+    }
+
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    struct DeriveTest_ZeroMapBorrowed<'data> {
+        #[serde(borrow)]
+        _data: ZeroMapBorrowed<'data, str, [u8]>
+    }
 
     const JSON_STR: &str = "{\"1\":\"uno\",\"2\":\"dos\",\"3\":\"tres\"}";
     const BINCODE_BYTES: &[u8] = &[

--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -195,13 +195,13 @@ mod test {
     #[derive(::serde::Serialize, ::serde::Deserialize)]
     struct DeriveTest_ZeroMap<'data> {
         #[serde(borrow)]
-        _data: ZeroMap<'data, str, [u8]>
+        _data: ZeroMap<'data, str, [u8]>,
     }
 
     #[derive(::serde::Serialize, ::serde::Deserialize)]
     struct DeriveTest_ZeroMapBorrowed<'data> {
         #[serde(borrow)]
-        _data: ZeroMapBorrowed<'data, str, [u8]>
+        _data: ZeroMapBorrowed<'data, str, [u8]>,
     }
 
     const JSON_STR: &str = "{\"1\":\"uno\",\"2\":\"dos\",\"3\":\"tres\"}";

--- a/utils/zerovec/src/yoke_impls.rs
+++ b/utils/zerovec/src/yoke_impls.rs
@@ -91,6 +91,8 @@ unsafe impl<'a, K, V> Yokeable<'a> for ZeroMap<'static, K, V>
 where
     K: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
     V: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
+    <K as ZeroMapKV<'static>>::Container: for<'b> Yokeable<'b>,
+    <V as ZeroMapKV<'static>>::Container: for<'b> Yokeable<'b>,
 {
     type Output = ZeroMap<'a, K, V>;
     fn transform(&'a self) -> &'a Self::Output {
@@ -132,6 +134,8 @@ unsafe impl<'a, K, V> Yokeable<'a> for ZeroMapBorrowed<'static, K, V>
 where
     K: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
     V: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
+    <K as ZeroMapKV<'static>>::Container: for<'b> Yokeable<'b>,
+    <V as ZeroMapKV<'static>>::Container: for<'b> Yokeable<'b>,
 {
     type Output = ZeroMapBorrowed<'a, K, V>;
     fn transform(&'a self) -> &'a Self::Output {

--- a/utils/zerovec/src/yoke_impls.rs
+++ b/utils/zerovec/src/yoke_impls.rs
@@ -2,9 +2,11 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::map::ZeroMapBorrowed;
 use crate::map::ZeroMapKV;
 use crate::ule::*;
 use crate::{VarZeroVec, ZeroMap, ZeroVec};
+use crate::varzerovec::VarZeroVecBorrowed;
 use core::{mem, ptr};
 use yoke::*;
 
@@ -12,14 +14,14 @@ use yoke::*;
 /// This impl can be made available by enabling the optional `yoke` feature of the `zerovec` crate
 unsafe impl<'a, T: 'static + AsULE + ?Sized> Yokeable<'a> for ZeroVec<'static, T> {
     type Output = ZeroVec<'a, T>;
-    fn transform(&'a self) -> &'a ZeroVec<'a, T> {
+    fn transform(&'a self) -> &'a Self::Output {
         self
     }
-    fn transform_owned(self) -> ZeroVec<'a, T> {
+    fn transform_owned(self) -> Self::Output {
         self
     }
-    unsafe fn make(from: ZeroVec<'a, T>) -> Self {
-        debug_assert!(mem::size_of::<ZeroVec<'a, T>>() == mem::size_of::<Self>());
+    unsafe fn make(from: Self::Output) -> Self {
+        debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
         let ptr: *const Self = (&from as *const Self::Output).cast();
         mem::forget(from);
         ptr::read(ptr)
@@ -37,14 +39,39 @@ unsafe impl<'a, T: 'static + AsULE + ?Sized> Yokeable<'a> for ZeroVec<'static, T
 /// This impl can be made available by enabling the optional `yoke` feature of the `zerovec` crate
 unsafe impl<'a, T: 'static + VarULE + ?Sized> Yokeable<'a> for VarZeroVec<'static, T> {
     type Output = VarZeroVec<'a, T>;
-    fn transform(&'a self) -> &'a VarZeroVec<'a, T> {
+    fn transform(&'a self) -> &'a Self::Output {
         self
     }
-    fn transform_owned(self) -> VarZeroVec<'a, T> {
+    fn transform_owned(self) -> Self::Output {
         self
     }
-    unsafe fn make(from: VarZeroVec<'a, T>) -> Self {
-        debug_assert!(mem::size_of::<VarZeroVec<'a, T>>() == mem::size_of::<Self>());
+    unsafe fn make(from: Self::Output) -> Self {
+        debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
+        let ptr: *const Self = (&from as *const Self::Output).cast();
+        mem::forget(from);
+        ptr::read(ptr)
+    }
+
+    fn transform_mut<F>(&'a mut self, f: F)
+    where
+        F: 'static + for<'b> FnOnce(&'b mut Self::Output),
+    {
+        unsafe { f(mem::transmute::<&mut Self, &mut Self::Output>(self)) }
+    }
+}
+
+// This impl is similar to the impl on Cow and is safe for the same reasons
+/// This impl can be made available by enabling the optional `yoke` feature of the `zerovec` crate
+unsafe impl<'a, T: 'static + VarULE + ?Sized> Yokeable<'a> for VarZeroVecBorrowed<'static, T> {
+    type Output = VarZeroVecBorrowed<'a, T>;
+    fn transform(&'a self) -> &'a Self::Output {
+        self
+    }
+    fn transform_owned(self) -> Self::Output {
+        self
+    }
+    unsafe fn make(from: Self::Output) -> Self {
+        debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
         let ptr: *const Self = (&from as *const Self::Output).cast();
         mem::forget(from);
         ptr::read(ptr)
@@ -66,7 +93,7 @@ where
     V: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
 {
     type Output = ZeroMap<'a, K, V>;
-    fn transform(&'a self) -> &'a ZeroMap<'a, K, V> {
+    fn transform(&'a self) -> &'a Self::Output {
         unsafe {
             // Unfortunately, because K and V are generic, rustc is
             // unaware that these are covariant types, and cannot perform this cast automatically.
@@ -74,7 +101,7 @@ where
             mem::transmute::<&Self, &Self::Output>(self)
         }
     }
-    fn transform_owned(self) -> ZeroMap<'a, K, V> {
+    fn transform_owned(self) -> Self::Output {
         debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
         unsafe {
             // Similar problem as transform(), but we need to use ptr::read since
@@ -84,8 +111,49 @@ where
             ptr::read(ptr)
         }
     }
-    unsafe fn make(from: ZeroMap<'a, K, V>) -> Self {
-        debug_assert!(mem::size_of::<ZeroMap<'a, K, V>>() == mem::size_of::<Self>());
+    unsafe fn make(from: Self::Output) -> Self {
+        debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
+        let ptr: *const Self = (&from as *const Self::Output).cast();
+        mem::forget(from);
+        ptr::read(ptr)
+    }
+
+    fn transform_mut<F>(&'a mut self, f: F)
+    where
+        F: 'static + for<'b> FnOnce(&'b mut Self::Output),
+    {
+        unsafe { f(mem::transmute::<&mut Self, &mut Self::Output>(self)) }
+    }
+}
+
+/// This impl can be made available by enabling the optional `yoke` feature of the `zerovec` crate
+#[allow(clippy::transmute_ptr_to_ptr)]
+unsafe impl<'a, K, V> Yokeable<'a> for ZeroMapBorrowed<'static, K, V>
+where
+    K: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
+    V: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
+{
+    type Output = ZeroMapBorrowed<'a, K, V>;
+    fn transform(&'a self) -> &'a Self::Output {
+        unsafe {
+            // Unfortunately, because K and V are generic, rustc is
+            // unaware that these are covariant types, and cannot perform this cast automatically.
+            // We transmute it instead, and enforce the lack of a lifetime with the `K, V: 'static` bound
+            mem::transmute::<&Self, &Self::Output>(self)
+        }
+    }
+    fn transform_owned(self) -> Self::Output {
+        debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
+        unsafe {
+            // Similar problem as transform(), but we need to use ptr::read since
+            // the compiler isn't sure of the sizes
+            let ptr: *const Self::Output = (&self as *const Self).cast();
+            mem::forget(self);
+            ptr::read(ptr)
+        }
+    }
+    unsafe fn make(from: Self::Output) -> Self {
+        debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
         let ptr: *const Self = (&from as *const Self::Output).cast();
         mem::forget(from);
         ptr::read(ptr)
@@ -131,5 +199,36 @@ where
                 &cart.values,
             ),
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(non_camel_case_types)]
+mod test {
+    use super::*;
+
+    #[derive(yoke::Yokeable)]
+    struct DeriveTest_ZeroVec<'data> {
+        _data: ZeroVec<'data, u16>,
+    }
+
+    #[derive(yoke::Yokeable)]
+    struct DeriveTest_VarZeroVec<'data> {
+        _data: VarZeroVec<'data, str>,
+    }
+
+    #[derive(yoke::Yokeable)]
+    struct DeriveTest_VarZeroVecBorrowed<'data> {
+        _data: VarZeroVecBorrowed<'data, str>,
+    }
+
+    #[derive(yoke::Yokeable)]
+    struct DeriveTest_ZeroMap<'data> {
+        _data: ZeroMap<'data, [u8], str>,
+    }
+
+    #[derive(yoke::Yokeable)]
+    struct DeriveTest_ZeroMapBorrowed<'data> {
+        _data: ZeroMapBorrowed<'data, [u8], str>,
     }
 }

--- a/utils/zerovec/src/yoke_impls.rs
+++ b/utils/zerovec/src/yoke_impls.rs
@@ -2,6 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+// This way we can copy-paste Yokeable impls
+#![allow(clippy::forget_copy)]
+
 use crate::map::ZeroMapBorrowed;
 use crate::map::ZeroMapKV;
 use crate::ule::*;

--- a/utils/zerovec/src/yoke_impls.rs
+++ b/utils/zerovec/src/yoke_impls.rs
@@ -5,8 +5,8 @@
 use crate::map::ZeroMapBorrowed;
 use crate::map::ZeroMapKV;
 use crate::ule::*;
-use crate::{VarZeroVec, ZeroMap, ZeroVec};
 use crate::varzerovec::VarZeroVecBorrowed;
+use crate::{VarZeroVec, ZeroMap, ZeroVec};
 use core::{mem, ptr};
 use yoke::*;
 

--- a/utils/zerovec/src/yoke_impls.rs
+++ b/utils/zerovec/src/yoke_impls.rs
@@ -223,11 +223,13 @@ mod test {
     }
 
     #[derive(yoke::Yokeable)]
+    #[yoke(prove_covariance_manually)]
     struct DeriveTest_ZeroMap<'data> {
         _data: ZeroMap<'data, [u8], str>,
     }
 
     #[derive(yoke::Yokeable)]
+    #[yoke(prove_covariance_manually)]
     struct DeriveTest_ZeroMapBorrowed<'data> {
         _data: ZeroMapBorrowed<'data, [u8], str>,
     }

--- a/utils/zerovec/src/zerovec/serde.rs
+++ b/utils/zerovec/src/zerovec/serde.rs
@@ -96,9 +96,16 @@ where
 }
 
 #[cfg(test)]
+#[allow(non_camel_case_types)]
 mod test {
     use super::super::*;
     use crate::samples::*;
+
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    struct DeriveTest_ZeroVec<'data> {
+        #[serde(borrow)]
+        _data: ZeroVec<'data, u16>,
+    }
 
     #[test]
     fn test_serde_json() {


### PR DESCRIPTION
DOES NOT BUILD!  ZeroVec and VarZeroVec behave, but not ZeroMap.

@Manishearth, can you clone this and take a look?