### PR TITLE
Switch DTF to late resolve Hour Cycle

### DIFF
--- a/components/datetime/benches/datetime.rs
+++ b/components/datetime/benches/datetime.rs
@@ -34,7 +34,7 @@ fn datetime_benches(c: &mut Criterion) {
                     for setup in &fx.setups {
                         let locale: Locale = setup.locale.parse().expect("Failed to parse locale.");
                         let options = fixtures::get_options(&setup.options);
-                        let dtf = DateTimeFormat::try_new(locale, &provider, &options)
+                        let dtf = DateTimeFormat::try_new(locale, &provider, options)
                             .expect("Failed to create DateTimeFormat.");
 
                         let mut result = String::new();
@@ -67,7 +67,7 @@ fn datetime_benches(c: &mut Criterion) {
                     let locale: Locale = setup.locale.parse().unwrap();
                     let options = fixtures::get_options(&setup.options);
                     let dtf = ZonedDateTimeFormat::try_new(
-                        locale, &provider, &provider, &provider, &options,
+                        locale, &provider, &provider, &provider, options,
                     )
                     .unwrap();
 

--- a/components/datetime/examples/work_log.rs
+++ b/components/datetime/examples/work_log.rs
@@ -58,7 +58,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
         ..Default::default()
     };
 
-    let dtf = DateTimeFormat::try_new(locale, &provider, &options.into())
+    let dtf = DateTimeFormat::try_new(locale, &provider, options.into())
         .expect("Failed to create DateTimeFormat instance.");
     {
         print("\n====== Work Log (en) example ============", None);

--- a/components/datetime/src/format/zoned_datetime.rs
+++ b/components/datetime/src/format/zoned_datetime.rs
@@ -8,6 +8,7 @@ use crate::date::{LocalizedDateTimeInput, ZonedDateTimeInputWithLocale};
 use crate::error::DateTimeFormatError as Error;
 use crate::fields::{self, FieldSymbol};
 use crate::pattern::{runtime::Pattern, PatternItem};
+use crate::DateTimeFormatOptions;
 use crate::{date::ZonedDateTimeInput, zoned_datetime::ZonedDateTimeFormat};
 use core::fmt;
 use writeable::Writeable;
@@ -99,7 +100,14 @@ where
             loc_datetime.datetime(),
             w,
         )?,
-        _ => datetime::write_field(pattern, field, symbols, loc_datetime, w)?,
+        _ => datetime::write_field(
+            pattern,
+            field,
+            symbols,
+            loc_datetime,
+            &zoned_datetime_format.datetime_format.options,
+            w,
+        )?,
     }
     Ok(())
 }

--- a/components/datetime/src/options/mod.rs
+++ b/components/datetime/src/options/mod.rs
@@ -55,7 +55,7 @@ pub mod preferences;
 ///
 /// At the moment only the [`length::Bag`] works, and we plan to extend that to support
 /// `ECMA402` like components bag later.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum DateTimeFormatOptions {
     /// Bag of lengths for date and time.
     Length(length::Bag),

--- a/components/datetime/src/provider/date_time.rs
+++ b/components/datetime/src/provider/date_time.rs
@@ -93,7 +93,7 @@ fn pattern_for_time_length_inner<'data>(
         length::Time::Short => time.short,
     };
 
-    hour_cycle::naively_apply_preferences(&mut pattern, preferences);
+    // hour_cycle::naively_apply_preferences(&mut pattern, preferences);
     PatternPlurals::from(pattern)
 }
 

--- a/components/datetime/src/skeleton/helpers.rs
+++ b/components/datetime/src/skeleton/helpers.rs
@@ -135,7 +135,7 @@ pub fn create_best_pattern_for_fields<'data>(
     // Try to match a skeleton to all of the fields.
     if let BestSkeleton::AllFieldsMatch(mut pattern_plurals) = first_pattern_match {
         pattern_plurals.for_each_mut(|pattern| {
-            hour_cycle::naively_apply_preferences(pattern, &components.preferences);
+            // hour_cycle::naively_apply_preferences(pattern, &components.preferences);
             naively_apply_time_zone_name(pattern, &components.time_zone_name);
         });
         return BestSkeleton::AllFieldsMatch(pattern_plurals);
@@ -151,7 +151,7 @@ pub fn create_best_pattern_for_fields<'data>(
             BestSkeleton::MissingOrExtraFields(mut pattern_plurals) => {
                 if date.is_empty() {
                     pattern_plurals.for_each_mut(|pattern| {
-                        hour_cycle::naively_apply_preferences(pattern, &components.preferences);
+                        // hour_cycle::naively_apply_preferences(pattern, &components.preferences);
                         naively_apply_time_zone_name(pattern, &components.time_zone_name);
                     });
                 }
@@ -179,7 +179,7 @@ pub fn create_best_pattern_for_fields<'data>(
     let time_pattern: Option<Pattern<'data>> = time_patterns.map(|pattern_plurals| {
         let mut pattern =
             pattern_plurals.expect_pattern("Only date patterns can contain plural variants");
-        hour_cycle::naively_apply_preferences(&mut pattern, &components.preferences);
+        // hour_cycle::naively_apply_preferences(&mut pattern, &components.preferences);
         naively_apply_time_zone_name(&mut pattern, &components.time_zone_name);
         pattern
     });

--- a/components/datetime/src/zoned_datetime.rs
+++ b/components/datetime/src/zoned_datetime.rs
@@ -104,7 +104,7 @@ impl ZonedDateTimeFormat {
         date_provider: &DP,
         zone_provider: &ZP,
         plural_provider: &PP,
-        options: &DateTimeFormatOptions,
+        options: DateTimeFormatOptions,
     ) -> Result<Self, DateTimeFormatError>
     where
         L: Into<Locale>,
@@ -124,7 +124,7 @@ impl ZonedDateTimeFormat {
         let langid: LanguageIdentifier = locale.clone().into();
 
         let patterns =
-            provider::date_time::PatternSelector::for_options(date_provider, &locale, options)?;
+            provider::date_time::PatternSelector::for_options(date_provider, &locale, &options)?;
 
         let requires_data = datetime::analyze_patterns(&patterns.get().0, true)
             .map_err(|field| DateTimeFormatError::UnsupportedField(field.symbol))?;
@@ -157,7 +157,8 @@ impl ZonedDateTimeFormat {
             None
         };
 
-        let datetime_format = DateTimeFormat::new(locale, patterns, symbols_data, ordinal_rules);
+        let datetime_format =
+            DateTimeFormat::new(locale, patterns, symbols_data, ordinal_rules, options);
         let time_zone_format = TimeZoneFormat::try_new(
             datetime_format.locale.clone(),
             datetime_format

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -93,7 +93,7 @@ fn test_fixture(fixture_name: &str) {
         };
         for (locale, output_value) in fx.output.values.into_iter() {
             let locale: Locale = locale.parse().unwrap();
-            let dtf = DateTimeFormat::try_new(locale, &provider, &options).unwrap();
+            let dtf = DateTimeFormat::try_new(locale, &provider, options).unwrap();
             let result = dtf.format_to_string(&input_value);
 
             assert_eq!(result, output_value, "{}", description);
@@ -139,7 +139,7 @@ fn test_fixture_with_time_zones(fixture_name: &str, config: TimeZoneConfig) {
         for (locale, output_value) in fx.output.values.into_iter() {
             let locale: Locale = locale.parse().unwrap();
             let dtf =
-                ZonedDateTimeFormat::try_new(locale, &provider, &provider, &provider, &options)
+                ZonedDateTimeFormat::try_new(locale, &provider, &provider, &provider, options)
                     .unwrap();
             let result = dtf.format_to_string(&input_value);
 
@@ -236,7 +236,7 @@ fn test_dayperiod_patterns() {
                         let dtf = DateTimeFormat::try_new(
                             langid.clone(),
                             &local_provider,
-                            &format_options,
+                            format_options,
                         )
                         .unwrap();
                         assert_eq!(
@@ -344,7 +344,7 @@ fn test_time_zone_patterns() {
                     &local_provider,
                     &zone_provider,
                     &plural_provider,
-                    &format_options,
+                    format_options,
                 )
                 .unwrap();
 
@@ -436,7 +436,7 @@ fn constructing_datetime_format_with_time_zone_pattern_symbols_is_err() {
 
     let locale: Locale = langid!("en").into();
     let provider = icu_testdata::get_provider();
-    let result = DateTimeFormat::try_new(locale, &provider, &options);
+    let result = DateTimeFormat::try_new(locale, &provider, options);
 
     assert!(result.is_err());
 }


### PR DESCRIPTION
Fixes #877.

This is an exploratory patch to try to remove the need to modify patterns at runtime shifting the weight of handling preferences overrides from pattern resolution to pattern formatting.

The patch should not have any significant impact on our tests because the common path is to not override any preference, in which case neither path should cost.

The main value proposition of the patchset is that it would simplify code by making patterns read-only/borrowed in all cases without the need to handle owned patterns.