### PR TITLE
Add Default impls for all zerovec types

### DIFF
--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -68,6 +68,18 @@ where
     }
 }
 
+impl<'a, K, V> Default for ZeroMapBorrowed<'a, K, V>
+where
+    K: ZeroMapKV<'a>,
+    V: ZeroMapKV<'a>,
+    K: ?Sized,
+    V: ?Sized,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a, K, V> ZeroMapBorrowed<'a, K, V>
 where
     K: ZeroMapKV<'a>,
@@ -75,6 +87,30 @@ where
     K: ?Sized,
     V: ?Sized,
 {
+    /// Creates a new, empty `ZeroMapBorrowed<K, V>`.
+    ///
+    /// Note: Since [`ZeroMapBorrowed`] is not mutable, the return value will be a stub unless
+    /// converted into a [`ZeroMap`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zerovec::map::ZeroMapBorrowed;
+    ///
+    /// let zm: ZeroMapBorrowed<u16, str> = ZeroMapBorrowed::new();
+    /// assert!(zm.is_empty());
+    /// ```
+    pub fn new() -> Self {
+        Self {
+            keys:
+                <<K as ZeroMapKV<'a>>::Container as MutableZeroVecLike<'a, K>>::BorrowedVariant::new(
+                ),
+            values:
+                <<V as ZeroMapKV<'a>>::Container as MutableZeroVecLike<'a, V>>::BorrowedVariant::new(
+                ),
+        }
+    }
+
     /// The number of elements in the [`ZeroMapBorrowed`]
     pub fn len(&self) -> usize {
         self.values.len()

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -66,10 +66,7 @@ where
     V: ?Sized,
 {
     fn default() -> Self {
-        Self {
-            keys: K::Container::new(),
-            values: V::Container::new(),
-        }
+        Self::new()
     }
 }
 
@@ -80,9 +77,21 @@ where
     K: ?Sized,
     V: ?Sized,
 {
-    /// Construct a new [`ZeroMap`]
+    /// Creates a new, empty `ZeroMap<K, V>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zerovec::ZeroMap;
+    ///
+    /// let zm: ZeroMap<u16, str> = ZeroMap::new();
+    /// assert!(zm.is_empty());
+    /// ```
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            keys: K::Container::new(),
+            values: V::Container::new(),
+        }
     }
 
     /// Construct a new [`ZeroMap`] with a given capacity

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -19,6 +19,8 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
     type NeedleType: ?Sized;
     /// The type returned by `Self::get()`
     type GetType: ?Sized + 'static;
+    /// Create a new, empty vector
+    fn new() -> Self;
     /// Search for a key in a sorted vector, returns `Ok(index)` if found,
     /// returns `Err(insert_index)` if not found, where `insert_index` is the
     /// index where it should be inserted to maintain sort order.
@@ -65,8 +67,6 @@ pub trait MutableZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
     fn replace(&mut self, index: usize, value: &T) -> Self::OwnedType;
     /// Push an element to the end of this vector
     fn push(&mut self, value: &T);
-    /// Create a new, empty vector
-    fn new() -> Self;
     /// Create a new, empty vector, with given capacity
     fn with_capacity(cap: usize) -> Self;
     /// Remove all elements from the vector
@@ -104,6 +104,9 @@ where
 {
     type NeedleType = T;
     type GetType = T::ULE;
+    fn new() -> Self {
+        Self::new()
+    }
     fn binary_search(&self, k: &T) -> Result<usize, usize> {
         self.binary_search(k)
     }
@@ -126,6 +129,9 @@ where
 {
     type NeedleType = T;
     type GetType = T::ULE;
+    fn new() -> Self {
+        &[]
+    }
     fn binary_search(&self, k: &T) -> Result<usize, usize> {
         ZeroVec::<T>::Borrowed(self).binary_search(k)
     }
@@ -171,9 +177,6 @@ where
     fn push(&mut self, value: &T) {
         self.to_mut().push(value.as_unaligned())
     }
-    fn new() -> Self {
-        ZeroVec::Owned(Vec::new())
-    }
     fn with_capacity(cap: usize) -> Self {
         ZeroVec::Owned(Vec::with_capacity(cap))
     }
@@ -207,6 +210,9 @@ where
 {
     type NeedleType = T;
     type GetType = T;
+    fn new() -> Self {
+        Self::new()
+    }
     fn binary_search(&self, k: &T) -> Result<usize, usize> {
         self.binary_search(k)
     }
@@ -238,6 +244,9 @@ where
 {
     type NeedleType = T;
     type GetType = T;
+    fn new() -> Self {
+        Self::new()
+    }
     fn binary_search(&self, k: &T) -> Result<usize, usize> {
         Self::binary_search(self, k)
     }
@@ -300,9 +309,6 @@ where
     fn push(&mut self, value: &T) {
         let len = self.len();
         self.make_mut().insert(len, value)
-    }
-    fn new() -> Self {
-        VarZeroVecOwned::new().into()
     }
     fn with_capacity(cap: usize) -> Self {
         VarZeroVecOwned::with_capacity(cap).into()

--- a/utils/zerovec/src/varzerovec/borrowed.rs
+++ b/utils/zerovec/src/varzerovec/borrowed.rs
@@ -49,7 +49,28 @@ impl<'a, T: ?Sized> Clone for VarZeroVecBorrowed<'a, T> {
     }
 }
 
+impl<'a, T: VarULE + ?Sized> Default for VarZeroVecBorrowed<'a, T> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a, T: VarULE + ?Sized> VarZeroVecBorrowed<'a, T> {
+    /// Creates a new, empty `VarZeroVecBorrowed<T>`.
+    ///
+    /// Note: Since [`VarZeroVecBorrowed`] is not mutable, the return value will be a stub unless
+    /// wrapped in [`VarZeroVec::Borrowed`].
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            indices: &[],
+            things: &[],
+            entire_slice: &[],
+            marker: PhantomData,
+        }
+    }
+
     /// Construct a new VarZeroVecBorrowed, checking invariants about the overall buffer size:
     ///
     /// - There must be either zero or at least four bytes (if four, this is the "length" parsed as a usize)

--- a/utils/zerovec/src/varzerovec/borrowed.rs
+++ b/utils/zerovec/src/varzerovec/borrowed.rs
@@ -61,6 +61,15 @@ impl<'a, T: VarULE + ?Sized> VarZeroVecBorrowed<'a, T> {
     ///
     /// Note: Since [`VarZeroVecBorrowed`] is not mutable, the return value will be a stub unless
     /// wrapped in [`VarZeroVec::Borrowed`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zerovec::varzerovec::VarZeroVecBorrowed;
+    ///
+    /// let vzv: VarZeroVecBorrowed<str> = VarZeroVecBorrowed::new();
+    /// assert!(vzv.is_empty());
+    /// ```
     #[inline]
     pub fn new() -> Self {
         Self {

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -204,16 +204,26 @@ impl<'a, T: ?Sized + VarULE> From<VarZeroVec<'a, T>> for VarZeroVecOwned<T> {
 }
 
 impl<T: VarULE + ?Sized> Default for VarZeroVec<'_, T> {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }
 }
 
 impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
-    /// Construct a new empty [`VarZeroVec`]
+    /// Creates a new, empty `VarZeroVec<T>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zerovec::VarZeroVec;
+    ///
+    /// let vzv: VarZeroVec<str> = VarZeroVec::new();
+    /// assert!(vzv.is_empty());
+    /// ```
     #[inline]
     pub fn new() -> Self {
-        VarZeroVecOwned::new().into()
+        Self::Borrowed(VarZeroVecBorrowed::default())
     }
 
     /// Obtain a [`VarZeroVecBorrowed`] borrowing from the internal buffer

--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -123,10 +123,32 @@ where
     }
 }
 
+impl<'a, T: AsULE> Default for ZeroVec<'a, T> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a, T> ZeroVec<'a, T>
 where
     T: AsULE + ?Sized,
 {
+    #[inline]
+    /// Creates a new, empty `ZeroVec<T>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zerovec::ZeroVec;
+    ///
+    /// let zv: ZeroVec<u16> = ZeroVec::new();
+    /// assert!(zv.is_empty());
+    /// ```
+    pub fn new() -> Self {
+        Self::Borrowed(&[])
+    }
+
     /// Parses a `&[u8]` buffer into a `ZeroVec<T>`.
     ///
     /// This function is infallible for built-in integer types, but fallible for other types,
@@ -752,23 +774,6 @@ impl<T: AsULE> FromIterator<T> for ZeroVec<'_, T> {
         I: IntoIterator<Item = T>,
     {
         ZeroVec::Owned(iter.into_iter().map(|t| t.as_unaligned()).collect())
-    }
-}
-
-impl<'a, T: AsULE> Default for ZeroVec<'a, T> {
-    /// Creates a new, empty `ZeroVec<T>`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use zerovec::ZeroVec;
-    ///
-    /// let zv: ZeroVec<u16> = Default::default();
-    /// assert!(zv.is_empty());
-    /// ```
-    #[inline]
-    fn default() -> Self {
-        Self::Borrowed(&[])
     }
 }
 


### PR DESCRIPTION
Changes:

1. I moved `new()` from `MutableZeroVecLike` to `ZeroVecLike`
2. I implemented that function on all types that still needed it, and made the impls consistent across the crate
3. I was then able to add `Default` for `ZeroMapBorrowed`