### PR TITLE
Simplify ZeroMapKV

### DIFF
--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -143,7 +143,7 @@ where
     /// // still exists after the ZeroMapBorrowed has been dropped
     /// assert_eq!(borrow, Some("one"));
     /// ```
-    pub fn get(&self, key: &K::NeedleType) -> Option<&'a V::GetType> {
+    pub fn get(&self, key: &K) -> Option<&'a V::GetType> {
         let index = self.keys.binary_search(key).ok()?;
         self.values.get_borrowed(index)
     }
@@ -161,7 +161,7 @@ where
     /// assert_eq!(borrowed.contains_key(&1), true);
     /// assert_eq!(borrowed.contains_key(&3), false);
     /// ```
-    pub fn contains_key(&self, key: &K::NeedleType) -> bool {
+    pub fn contains_key(&self, key: &K) -> bool {
         self.keys.binary_search(key).is_ok()
     }
 
@@ -202,7 +202,7 @@ where
     V: AsULE + Ord + Copy,
 {
     /// For cases when `V` is fixed-size, obtain a direct copy of `V` instead of `V::ULE`
-    pub fn get_copied(&self, key: &K::NeedleType) -> Option<V> {
+    pub fn get_copied(&self, key: &K) -> Option<V> {
         let index = self.keys.binary_search(key).ok()?;
         <[V::ULE]>::get(self.values, index)
             .copied()

--- a/utils/zerovec/src/map/kv.rs
+++ b/utils/zerovec/src/map/kv.rs
@@ -41,9 +41,6 @@ pub trait ZeroMapKV<'a> {
     /// deserializing to `Self::OwnedType` should produce the same value once
     /// passed through `Self::owned_as_self()`
     type OwnedType: 'static;
-
-    /// Convert an owned value to a borrowed Self
-    fn owned_as_self(o: &Self::OwnedType) -> &Self;
 }
 
 macro_rules! impl_sized_kv {
@@ -54,11 +51,6 @@ macro_rules! impl_sized_kv {
             type GetType = <$ty as AsULE>::ULE;
             type SerializeType = $ty;
             type OwnedType = $ty;
-
-            #[inline]
-            fn owned_as_self(o: &Self::OwnedType) -> &Self {
-                o
-            }
         }
     };
 }
@@ -79,11 +71,6 @@ impl<'a> ZeroMapKV<'a> for str {
     type GetType = str;
     type SerializeType = str;
     type OwnedType = Box<str>;
-
-    #[inline]
-    fn owned_as_self(o: &Self::OwnedType) -> &Self {
-        o
-    }
 }
 
 impl<'a> ZeroMapKV<'a> for [u8] {
@@ -92,9 +79,4 @@ impl<'a> ZeroMapKV<'a> for [u8] {
     type GetType = [u8];
     type SerializeType = [u8];
     type OwnedType = Box<[u8]>;
-
-    #[inline]
-    fn owned_as_self(o: &Self::OwnedType) -> &Self {
-        o
-    }
 }

--- a/utils/zerovec/src/map/kv.rs
+++ b/utils/zerovec/src/map/kv.rs
@@ -21,12 +21,16 @@ pub trait ZeroMapKV<'a> {
         + Sized;
     /// The type produced by `Container::get()`
     ///
-    /// This type will be predetermined by the choice of `Self::Container`
+    /// This type will be predetermined by the choice of `Self::Container`:
+    /// For sized types this must be `T::ULE`, and for unsized types this must be `T`
     type GetType: ?Sized + 'static;
     /// The type produced by `Container::replace()` and `Container::remove()`,
     /// also used during deserialization. If `Self` is human readable serialized,
     /// deserializing to `Self::OwnedType` should produce the same value once
     /// passed through `Self::owned_as_self()`
+    /// 
+    /// This type will be predetermined by the choice of `Self::Container`:
+    /// For sized types this must be `T` and for unsized types this must be `Box<T>`
     type OwnedType: 'static;
 }
 

--- a/utils/zerovec/src/map/kv.rs
+++ b/utils/zerovec/src/map/kv.rs
@@ -17,20 +17,12 @@ use alloc::boxed::Box;
 #[allow(clippy::upper_case_acronyms)] // KV is not an acronym
 pub trait ZeroMapKV<'a> {
     /// The container that can be used with this type: [`ZeroVec`] or [`VarZeroVec`].
-    type Container: MutableZeroVecLike<
-            'a,
-            Self,
-            GetType = Self::GetType,
-            OwnedType = Self::OwnedType,
-            SerializeType = Self::SerializeType,
-        > + Sized;
+    type Container: MutableZeroVecLike<'a, Self, GetType = Self::GetType, OwnedType = Self::OwnedType>
+        + Sized;
     /// The type produced by `Container::get()`
     ///
     /// This type will be predetermined by the choice of `Self::Container`
     type GetType: ?Sized + 'static;
-    /// The type to use whilst serializing. This may not necessarily be `Self`, however it
-    /// must serialize to the exact same thing as `Self`
-    type SerializeType: ?Sized;
     /// The type produced by `Container::replace()` and `Container::remove()`,
     /// also used during deserialization. If `Self` is human readable serialized,
     /// deserializing to `Self::OwnedType` should produce the same value once
@@ -43,7 +35,6 @@ macro_rules! impl_sized_kv {
         impl<'a> ZeroMapKV<'a> for $ty {
             type Container = ZeroVec<'a, $ty>;
             type GetType = <$ty as AsULE>::ULE;
-            type SerializeType = $ty;
             type OwnedType = $ty;
         }
     };
@@ -62,13 +53,11 @@ impl_sized_kv!(char);
 impl<'a> ZeroMapKV<'a> for str {
     type Container = VarZeroVec<'a, str>;
     type GetType = str;
-    type SerializeType = str;
     type OwnedType = Box<str>;
 }
 
 impl<'a> ZeroMapKV<'a> for [u8] {
     type Container = VarZeroVec<'a, [u8]>;
     type GetType = [u8];
-    type SerializeType = [u8];
     type OwnedType = Box<[u8]>;
 }

--- a/utils/zerovec/src/map/kv.rs
+++ b/utils/zerovec/src/map/kv.rs
@@ -41,8 +41,6 @@ pub trait ZeroMapKV<'a> {
     /// deserializing to `Self::OwnedType` should produce the same value once
     /// passed through `Self::owned_as_self()`
     type OwnedType: 'static;
-    /// Convert to a needle for searching
-    fn as_needle(&self) -> &Self::NeedleType;
     /// Compare this type with a `Self::GetType`. This must produce the same result as
     /// if `g` were converted to `Self`
     fn cmp_get(&self, g: &Self::GetType) -> Ordering;
@@ -64,11 +62,6 @@ macro_rules! impl_sized_kv {
             type GetType = <$ty as AsULE>::ULE;
             type SerializeType = $ty;
             type OwnedType = $ty;
-
-            #[inline]
-            fn as_needle(&self) -> &Self {
-                self
-            }
 
             #[inline]
             fn cmp_get(&self, g: &Self::GetType) -> Ordering {
@@ -106,11 +99,6 @@ impl<'a> ZeroMapKV<'a> for str {
     type OwnedType = Box<str>;
 
     #[inline]
-    fn as_needle(&self) -> &str {
-        self
-    }
-
-    #[inline]
     fn cmp_get(&self, g: &str) -> Ordering {
         (&*self).cmp(g)
     }
@@ -132,11 +120,6 @@ impl<'a> ZeroMapKV<'a> for [u8] {
     type GetType = [u8];
     type SerializeType = [u8];
     type OwnedType = Box<[u8]>;
-
-    #[inline]
-    fn as_needle(&self) -> &[u8] {
-        self
-    }
 
     #[inline]
     fn cmp_get(&self, g: &[u8]) -> Ordering {

--- a/utils/zerovec/src/map/kv.rs
+++ b/utils/zerovec/src/map/kv.rs
@@ -20,15 +20,10 @@ pub trait ZeroMapKV<'a> {
     type Container: MutableZeroVecLike<
             'a,
             Self,
-            NeedleType = Self::NeedleType,
             GetType = Self::GetType,
             OwnedType = Self::OwnedType,
             SerializeType = Self::SerializeType,
         > + Sized;
-    /// The type to use with `Container::binary_search()`
-    ///
-    /// This type will be predetermined by the choice of `Self::Container`
-    type NeedleType: ?Sized;
     /// The type produced by `Container::get()`
     ///
     /// This type will be predetermined by the choice of `Self::Container`
@@ -47,7 +42,6 @@ macro_rules! impl_sized_kv {
     ($ty:ident) => {
         impl<'a> ZeroMapKV<'a> for $ty {
             type Container = ZeroVec<'a, $ty>;
-            type NeedleType = $ty;
             type GetType = <$ty as AsULE>::ULE;
             type SerializeType = $ty;
             type OwnedType = $ty;
@@ -67,7 +61,6 @@ impl_sized_kv!(char);
 
 impl<'a> ZeroMapKV<'a> for str {
     type Container = VarZeroVec<'a, str>;
-    type NeedleType = str;
     type GetType = str;
     type SerializeType = str;
     type OwnedType = Box<str>;
@@ -75,7 +68,6 @@ impl<'a> ZeroMapKV<'a> for str {
 
 impl<'a> ZeroMapKV<'a> for [u8] {
     type Container = VarZeroVec<'a, [u8]>;
-    type NeedleType = [u8];
     type GetType = [u8];
     type SerializeType = [u8];
     type OwnedType = Box<[u8]>;

--- a/utils/zerovec/src/map/kv.rs
+++ b/utils/zerovec/src/map/kv.rs
@@ -28,7 +28,7 @@ pub trait ZeroMapKV<'a> {
     /// also used during deserialization. If `Self` is human readable serialized,
     /// deserializing to `Self::OwnedType` should produce the same value once
     /// passed through `Self::owned_as_self()`
-    /// 
+    ///
     /// This type will be predetermined by the choice of `Self::Container`:
     /// For sized types this must be `T` and for unsized types this must be `Box<T>`
     type OwnedType: 'static;

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -178,7 +178,7 @@ where
     /// assert_eq!(map.get(&3), None);
     /// ```
     pub fn insert(&mut self, key: &K, value: &V) -> Option<V::OwnedType> {
-        let key_needle = key.as_needle();
+        let key_needle = K::Container::t_as_needle(key);
         match self.keys.binary_search(key_needle) {
             Ok(index) => Some(self.values.replace(index, value)),
             Err(index) => {

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -178,8 +178,7 @@ where
     /// assert_eq!(map.get(&3), None);
     /// ```
     pub fn insert(&mut self, key: &K, value: &V) -> Option<V::OwnedType> {
-        let key_needle = K::Container::t_as_needle(key);
-        match self.keys.binary_search(key_needle) {
+        match self.keys.binary_search(key) {
             Ok(index) => Some(self.values.replace(index, value)),
             Err(index) => {
                 self.keys.insert(index, key);

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -146,7 +146,7 @@ where
     /// assert_eq!(map.get(&1), Some("one"));
     /// assert_eq!(map.get(&3), None);
     /// ```
-    pub fn get(&self, key: &K::NeedleType) -> Option<&V::GetType> {
+    pub fn get(&self, key: &K) -> Option<&V::GetType> {
         let index = self.keys.binary_search(key).ok()?;
         self.values.get(index)
     }
@@ -162,7 +162,7 @@ where
     /// assert_eq!(map.contains_key(&1), true);
     /// assert_eq!(map.contains_key(&3), false);
     /// ```
-    pub fn contains_key(&self, key: &K::NeedleType) -> bool {
+    pub fn contains_key(&self, key: &K) -> bool {
         self.keys.binary_search(key).is_ok()
     }
 
@@ -200,7 +200,7 @@ where
     /// assert_eq!(map.remove(&1), Some("one".to_owned().into_boxed_str()));
     /// assert_eq!(map.get(&1), None);
     /// ```
-    pub fn remove(&mut self, key: &K::NeedleType) -> Option<V::OwnedType> {
+    pub fn remove(&mut self, key: &K) -> Option<V::OwnedType> {
         let idx = self.keys.binary_search(key).ok()?;
         self.keys.remove(idx);
         Some(self.values.remove(idx))
@@ -276,7 +276,7 @@ where
     V: AsULE + Copy,
 {
     /// For cases when `V` is fixed-size, obtain a direct copy of `V` instead of `V::ULE`
-    pub fn get_copied(&self, key: &K::NeedleType) -> Option<V> {
+    pub fn get_copied(&self, key: &K) -> Option<V> {
         let index = self.keys.binary_search(key).ok()?;
         ZeroVec::get(&self.values, index)
     }

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -234,7 +234,7 @@ where
     pub fn try_append<'b>(&mut self, key: &'b K, value: &'b V) -> Option<(&'b K, &'b V)> {
         if self.keys.len() != 0 {
             if let Some(last) = self.keys.get(self.keys.len() - 1) {
-                if key.cmp_get(last) != Ordering::Greater {
+                if K::Container::t_cmp_get(key, last) != Ordering::Greater {
                     return Some((key, value));
                 }
             }

--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -99,7 +99,10 @@ where
             // If not sorted, return an error
             // a serialized map that came from another ZeroMap
             if map
-                .try_append(K::owned_as_self(&key), V::owned_as_self(&value))
+                .try_append(
+                    K::Container::owned_as_t(&key),
+                    V::Container::owned_as_t(&value),
+                )
                 .is_some()
             {
                 return Err(de::Error::custom(

--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -28,8 +28,8 @@ where
         if serializer.is_human_readable() {
             let mut map = serializer.serialize_map(Some(self.len()))?;
             for (k, v) in self.iter() {
-                K::with_ser(k, |k| map.serialize_key(k))?;
-                V::with_ser(v, |v| map.serialize_value(v))?;
+                K::Container::t_with_ser(k, |k| map.serialize_key(k))?;
+                V::Container::t_with_ser(v, |v| map.serialize_value(v))?;
             }
             map.end()
         } else {

--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -18,8 +18,8 @@ where
     V: ?Sized,
     K::Container: Serialize,
     V::Container: Serialize,
-    K::SerializeType: Serialize,
-    V::SerializeType: Serialize,
+    K: Serialize,
+    V: Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -47,8 +47,8 @@ where
     V: ?Sized,
     K::Container: Serialize,
     V::Container: Serialize,
-    K::SerializeType: Serialize,
-    V::SerializeType: Serialize,
+    K: Serialize,
+    V: Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -38,6 +38,10 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
 
     /// Convert T to a needle for searching
     fn t_as_needle(t: &T) -> &Self::NeedleType;
+
+    /// Compare this type with a `Self::GetType`. This must produce the same result as
+    /// if `g` were converted to `Self`
+    fn t_cmp_get(t: &T, g: &Self::GetType) -> Ordering;
 }
 
 /// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). You
@@ -129,6 +133,10 @@ where
     fn t_as_needle(t: &T) -> &T {
         t
     }
+
+    fn t_cmp_get(t: &T, g: &Self::GetType) -> Ordering {
+        t.cmp(&T::from_unaligned(*g))
+    }
 }
 
 impl<'a, T> ZeroVecLike<'a, T> for &'a [T::ULE]
@@ -158,6 +166,10 @@ where
 
     fn t_as_needle(t: &T) -> &T {
         t
+    }
+
+    fn t_cmp_get(t: &T, g: &Self::GetType) -> Ordering {
+        t.cmp(&T::from_unaligned(*g))
     }
 }
 
@@ -250,6 +262,10 @@ where
     fn t_as_needle(t: &T) -> &T {
         t
     }
+
+    fn t_cmp_get(t: &T, g: &Self::GetType) -> Ordering {
+        t.cmp(g)
+    }
 }
 
 impl<'a, T> ZeroVecLike<'a, T> for VarZeroVecBorrowed<'a, T>
@@ -288,6 +304,10 @@ where
 
     fn t_as_needle(t: &T) -> &T {
         t
+    }
+
+    fn t_cmp_get(t: &T, g: &Self::GetType) -> Ordering {
+        t.cmp(g)
     }
 }
 

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -35,6 +35,9 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Convert T to a needle for searching
+    fn t_as_needle(t: &T) -> &Self::NeedleType;
 }
 
 /// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). You
@@ -59,6 +62,7 @@ pub trait MutableZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
     type BorrowedVariant: ZeroVecLike<'a, T, NeedleType = Self::NeedleType, GetType = Self::GetType>
         + BorrowedZeroVecLike<'a, T>
         + Copy;
+
     /// Insert an element at `index`
     fn insert(&mut self, index: usize, value: &T);
     /// Remove the element at `index` (panicking if nonexistant)
@@ -121,6 +125,10 @@ where
             .windows(2)
             .all(|w| T::from_unaligned(w[1]).cmp(&T::from_unaligned(w[0])) == Ordering::Greater)
     }
+
+    fn t_as_needle(t: &T) -> &T {
+        t
+    }
 }
 
 impl<'a, T> ZeroVecLike<'a, T> for &'a [T::ULE]
@@ -146,6 +154,10 @@ where
             .as_slice()
             .windows(2)
             .all(|w| T::from_unaligned(w[1]).cmp(&T::from_unaligned(w[0])) == Ordering::Greater)
+    }
+
+    fn t_as_needle(t: &T) -> &T {
+        t
     }
 }
 
@@ -234,6 +246,10 @@ where
         }
         true
     }
+
+    fn t_as_needle(t: &T) -> &T {
+        t
+    }
 }
 
 impl<'a, T> ZeroVecLike<'a, T> for VarZeroVecBorrowed<'a, T>
@@ -268,6 +284,10 @@ where
             }
         }
         true
+    }
+
+    fn t_as_needle(t: &T) -> &T {
+        t
     }
 }
 

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -15,13 +15,11 @@ use core::mem;
 /// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). You
 /// should not be implementing or calling this trait directly.
 ///
-/// The T type is the type received by [`Self::binary_search()`]
+/// The T type is the type received by [`Self::binary_search()`], as well as the one used
+/// for human-readable serialization.
 pub trait ZeroVecLike<'a, T: ?Sized> {
     /// The type returned by `Self::get()`
     type GetType: ?Sized + 'static;
-    /// The type to use whilst serializing. This may not necessarily be `T`, however it
-    /// must serialize to the exact same thing as `T`
-    type SerializeType: ?Sized;
 
     /// Create a new, empty vector
     fn new() -> Self;
@@ -51,7 +49,7 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
     ///
     /// This uses a callback because it's not possible to return owned-or-borrowed
     /// types without GATs
-    fn t_with_ser<R>(g: &Self::GetType, f: impl FnOnce(&Self::SerializeType) -> R) -> R;
+    fn t_with_ser<R>(g: &Self::GetType, f: impl FnOnce(&T) -> R) -> R;
 }
 
 /// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). You
@@ -124,7 +122,6 @@ where
     T: AsULE + Ord + Copy,
 {
     type GetType = T::ULE;
-    type SerializeType = T;
     fn new() -> Self {
         Self::new()
     }
@@ -151,7 +148,7 @@ where
         t.cmp(&T::from_unaligned(*g))
     }
 
-    fn t_with_ser<R>(g: &Self::GetType, f: impl FnOnce(&Self::SerializeType) -> R) -> R {
+    fn t_with_ser<R>(g: &Self::GetType, f: impl FnOnce(&T) -> R) -> R {
         f(&T::from_unaligned(*g))
     }
 }
@@ -161,7 +158,6 @@ where
     T: AsULE + Ord + Copy,
 {
     type GetType = T::ULE;
-    type SerializeType = T;
     fn new() -> Self {
         &[]
     }
@@ -189,7 +185,7 @@ where
         t.cmp(&T::from_unaligned(*g))
     }
 
-    fn t_with_ser<R>(g: &Self::GetType, f: impl FnOnce(&Self::SerializeType) -> R) -> R {
+    fn t_with_ser<R>(g: &Self::GetType, f: impl FnOnce(&T) -> R) -> R {
         f(&T::from_unaligned(*g))
     }
 }
@@ -258,7 +254,6 @@ where
     T: ?Sized,
 {
     type GetType = T;
-    type SerializeType = T;
     fn new() -> Self {
         Self::new()
     }
@@ -293,7 +288,7 @@ where
     }
 
     #[inline]
-    fn t_with_ser<R>(g: &Self::GetType, f: impl FnOnce(&Self::SerializeType) -> R) -> R {
+    fn t_with_ser<R>(g: &Self::GetType, f: impl FnOnce(&T) -> R) -> R {
         f(g)
     }
 }
@@ -305,7 +300,6 @@ where
     T: ?Sized,
 {
     type GetType = T;
-    type SerializeType = T;
     fn new() -> Self {
         Self::new()
     }
@@ -341,7 +335,7 @@ where
     }
 
     #[inline]
-    fn t_with_ser<R>(g: &Self::GetType, f: impl FnOnce(&Self::SerializeType) -> R) -> R {
+    fn t_with_ser<R>(g: &Self::GetType, f: impl FnOnce(&T) -> R) -> R {
         f(g)
     }
 }

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -14,9 +14,9 @@ use core::mem;
 
 /// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). You
 /// should not be implementing or calling this trait directly.
+///
+/// The T type is the type received by [`Self::binary_search()`]
 pub trait ZeroVecLike<'a, T: ?Sized> {
-    /// The type received by `Self::binary_search()`
-    type NeedleType: ?Sized;
     /// The type returned by `Self::get()`
     type GetType: ?Sized + 'static;
     /// The type to use whilst serializing. This may not necessarily be `T`, however it
@@ -28,7 +28,7 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
     /// Search for a key in a sorted vector, returns `Ok(index)` if found,
     /// returns `Err(insert_index)` if not found, where `insert_index` is the
     /// index where it should be inserted to maintain sort order.
-    fn binary_search(&self, k: &Self::NeedleType) -> Result<usize, usize>;
+    fn binary_search(&self, k: &T) -> Result<usize, usize>;
     /// Get element at `index`
     fn get(&self, index: usize) -> Option<&Self::GetType>;
     /// The length of this vector
@@ -41,7 +41,7 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
     }
 
     /// Convert T to a needle for searching
-    fn t_as_needle(t: &T) -> &Self::NeedleType;
+    fn t_as_needle(t: &T) -> &T;
 
     /// Compare this type with a `Self::GetType`. This must produce the same result as
     /// if `g` were converted to `Self`
@@ -73,7 +73,7 @@ pub trait MutableZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
     /// The type returned by `Self::remove()` and `Self::replace()`
     type OwnedType;
     /// A fully borrowed version of this
-    type BorrowedVariant: ZeroVecLike<'a, T, NeedleType = Self::NeedleType, GetType = Self::GetType>
+    type BorrowedVariant: ZeroVecLike<'a, T, GetType = Self::GetType>
         + BorrowedZeroVecLike<'a, T>
         + Copy;
 
@@ -123,7 +123,6 @@ impl<'a, T> ZeroVecLike<'a, T> for ZeroVec<'a, T>
 where
     T: AsULE + Ord + Copy,
 {
-    type NeedleType = T;
     type GetType = T::ULE;
     type SerializeType = T;
     fn new() -> Self {
@@ -161,7 +160,6 @@ impl<'a, T> ZeroVecLike<'a, T> for &'a [T::ULE]
 where
     T: AsULE + Ord + Copy,
 {
-    type NeedleType = T;
     type GetType = T::ULE;
     type SerializeType = T;
     fn new() -> Self {
@@ -259,7 +257,6 @@ where
     T: Ord,
     T: ?Sized,
 {
-    type NeedleType = T;
     type GetType = T;
     type SerializeType = T;
     fn new() -> Self {
@@ -307,7 +304,6 @@ where
     T: Ord,
     T: ?Sized,
 {
-    type NeedleType = T;
     type GetType = T;
     type SerializeType = T;
     fn new() -> Self {

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -114,6 +114,9 @@ pub trait MutableZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
     ///
     /// These are useful to ensure serialization parity between borrowed and owned versions
     fn from_borrowed(b: Self::BorrowedVariant) -> Self;
+
+    /// Convert an owned value to a borrowed T
+    fn owned_as_t(o: &Self::OwnedType) -> &T;
 }
 
 impl<'a, T> ZeroVecLike<'a, T> for ZeroVec<'a, T>
@@ -243,6 +246,10 @@ where
     }
     fn from_borrowed(b: &'a [T::ULE]) -> Self {
         ZeroVec::Borrowed(b)
+    }
+
+    fn owned_as_t(o: &Self::OwnedType) -> &T {
+        o
     }
 }
 
@@ -403,5 +410,9 @@ where
     }
     fn from_borrowed(b: VarZeroVecBorrowed<'a, T>) -> Self {
         VarZeroVec::Borrowed(b)
+    }
+
+    fn owned_as_t(o: &Self::OwnedType) -> &T {
+        o
     }
 }

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -38,9 +38,6 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
         self.len() == 0
     }
 
-    /// Convert T to a needle for searching
-    fn t_as_needle(t: &T) -> &T;
-
     /// Compare this type with a `Self::GetType`. This must produce the same result as
     /// if `g` were converted to `Self`
     fn t_cmp_get(t: &T, g: &Self::GetType) -> Ordering;
@@ -140,10 +137,6 @@ where
             .all(|w| T::from_unaligned(w[1]).cmp(&T::from_unaligned(w[0])) == Ordering::Greater)
     }
 
-    fn t_as_needle(t: &T) -> &T {
-        t
-    }
-
     fn t_cmp_get(t: &T, g: &Self::GetType) -> Ordering {
         t.cmp(&T::from_unaligned(*g))
     }
@@ -175,10 +168,6 @@ where
             .as_slice()
             .windows(2)
             .all(|w| T::from_unaligned(w[1]).cmp(&T::from_unaligned(w[0])) == Ordering::Greater)
-    }
-
-    fn t_as_needle(t: &T) -> &T {
-        t
     }
 
     fn t_cmp_get(t: &T, g: &Self::GetType) -> Ordering {
@@ -279,10 +268,6 @@ where
         true
     }
 
-    fn t_as_needle(t: &T) -> &T {
-        t
-    }
-
     fn t_cmp_get(t: &T, g: &Self::GetType) -> Ordering {
         t.cmp(g)
     }
@@ -324,10 +309,6 @@ where
             }
         }
         true
-    }
-
-    fn t_as_needle(t: &T) -> &T {
-        t
     }
 
     fn t_cmp_get(t: &T, g: &Self::GetType) -> Ordering {


### PR DESCRIPTION
Fixes #1247

ZeroMapKV is supposed to be implemented by the end user, so the trait should be as simple as possible. Since all of its methods are predetermined by the choice of container, this PR moves most of the logic to `ZeroVecLike` instead, since that trait is not intended to be implemented by users.

A potential simplification is getting rid of the `OwnedType` and `GetType` associated types on `ZeroMapKV` and always using the one on the `Container` type, however this makes `ZeroMap`'s public API harder to understand since these types will show up as `<K::Container as ZeroVecLike<'a, K>>::GetType` etc and that's much harder to follow. Once we have associated type defaults we can clean this up for implementors, for now I've just documented it.

#1079 will also auto-implement this trait so ultimately it's not necessary to make this too easy.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->