### PR TITLE
Bump zerovec to 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3033,7 +3033,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bincode",
  "criterion",

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -39,7 +39,7 @@ icu_calendar = { version = "0.4", path = "../calendar" }
 writeable = { version = "0.2.1", path = "../../utils/writeable" }
 litemap = { version = "0.2", path = "../../utils/litemap" }
 tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
-zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["yoke"] }
+zerovec = { version = "0.5", path = "../../utils/zerovec", features = ["yoke"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 serde-tuple-vec-map = { version = "1.0", optional = true }
 smallvec = "1.6"

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -37,7 +37,7 @@ icu_provider = { version = "0.4", path = "../../provider/core", features = ["mac
 icu_locid = { version = "0.4", path = "../locid" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 displaydoc = { version = "0.2.3", default-features = false }
-zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["yoke"] }
+zerovec = { version = "0.5", path = "../../utils/zerovec", features = ["yoke"] }
 num_enum = { version = "0.5", default_features = false }
 
 [dev-dependencies]

--- a/components/properties/Cargo.toml
+++ b/components/properties/Cargo.toml
@@ -38,7 +38,7 @@ icu_provider = { version = "0.4", path = "../../provider/core", features = ["mac
 icu_uniset = { version = "0.4", path = "../../utils/uniset", features = ["serde"] }
 num_enum = { version = "0.5.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
-zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["serde"] }
+zerovec = { version = "0.5", path = "../../utils/zerovec", features = ["serde"] }
 
 [dev-dependencies]
 icu = { path = "../../components/icu", default-features = false }

--- a/experimental/list_formatter/Cargo.toml
+++ b/experimental/list_formatter/Cargo.toml
@@ -25,7 +25,7 @@ displaydoc = { version = "0.2.3", default-features = false }
 icu_locid = { version = "0.4", path = "../../components/locid" }
 icu_provider = { version = "0.4", path = "../../provider/core", features = ["macros"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
-zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["yoke"] }
+zerovec = { version = "0.5", path = "../../utils/zerovec", features = ["yoke"] }
 regex = "1.5"
 
 [dev-dependencies]

--- a/provider/uprops/Cargo.toml
+++ b/provider/uprops/Cargo.toml
@@ -34,7 +34,7 @@ icu_provider = { version = "0.4", path = "../../provider/core", features = ["pro
 icu_uniset = { version = "0.4", path = "../../utils/uniset", features = ["provider_serde"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = { version = "0.5" }
-zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["serde", "yoke"] }
+zerovec = { version = "0.5", path = "../../utils/zerovec", features = ["serde", "yoke"] }
 log = { version = "0.4", optional = true }
 eyre = "0.6.5"
 tinystr = "0.4"

--- a/utils/codepointtrie/Cargo.toml
+++ b/utils/codepointtrie/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 displaydoc = { version = "0.2.3", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 yoke = { version = "0.3.1", path = "../yoke", features = ["derive"] }
-zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["serde", "yoke"] }
+zerovec = { version = "0.5", path = "../../utils/zerovec", features = ["serde", "yoke"] }
 
 [dev-dependencies]
 postcard = { version = "0.7", features = ["alloc"] }

--- a/utils/uniset/Cargo.toml
+++ b/utils/uniset/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1.0", default-features = false, features = ["derive", "allo
 tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
 yoke = { version = "0.3.1", path = "../yoke", features = ["derive"] }
-zerovec = { version = "0.4", path = "../../utils/zerovec", features = ["serde"] }
+zerovec = { version = "0.5", path = "../../utils/zerovec", features = ["serde"] }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/utils/yoke/derive/Cargo.toml
+++ b/utils/yoke/derive/Cargo.toml
@@ -27,4 +27,4 @@ synstructure = "0.12.4"
 
 [dev-dependencies]
 yoke = { version = "0.3.1", path = "..", features = ["derive"]}
-zerovec = { version = "0.4", path = "../../zerovec", features = ["yoke"] }
+zerovec = { version = "0.5", path = "../../zerovec", features = ["yoke"] }

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "zerovec"
 description = "Zero-copy vector backed by a byte array"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"


### PR DESCRIPTION
https://github.com/unicode-org/icu4x/pull/1334 was a breaking change; though we don't use that code much yet.

I also plan to bump tinystr and give it a ZMKV impl, though I'll do that once this lands.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->