### PR TITLE
Migrate the various map impls in the CLDR transformer to LiteMap

### DIFF
--- a/docs/tutorials/writing_a_new_data_struct.md
+++ b/docs/tutorials/writing_a_new_data_struct.md
@@ -177,7 +177,7 @@ pub mod numbers_json {
     }
 
     #[derive(PartialEq, Debug, Deserialize)]
-    pub struct LangData(#[serde(with = "tuple_vec_map")] pub(crate) Vec<(LanguageIdentifier, LangNumbers)>);
+    pub struct LangData(pub LiteMap<LanguageIdentifier, LangNumbers>);
 
     #[derive(PartialEq, Debug, Deserialize)]
     pub struct Resource {

--- a/provider/cldr/src/cldr_serde/ca.rs
+++ b/provider/cldr/src/cldr_serde/ca.rs
@@ -10,9 +10,9 @@
 //! https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-dates-full/main/en/ca-gregorian.json
 
 use icu_locid::LanguageIdentifier;
+use litemap::LiteMap;
 use serde::Deserialize;
 use std::borrow::Cow;
-use litemap::LiteMap;
 
 macro_rules! symbols {
     ($name: ident, $([$alias: expr, $element: ident, $ty: ty]),+ $(,)?) => {
@@ -146,9 +146,7 @@ pub struct DateTimeFormats {
 }
 
 #[derive(PartialEq, Clone, Debug, Deserialize)]
-pub struct AvailableFormats(
-    pub LiteMap<String, String>,
-);
+pub struct AvailableFormats(pub LiteMap<String, String>);
 
 /// This struct represents a 1:1 mapping of the CLDR ca-gregorian.json data at the key
 /// "main.LANGID.dates.calendars.gregorian" where "LANGID" is the identifier.
@@ -180,9 +178,7 @@ pub struct LangDates {
 }
 
 #[derive(PartialEq, Debug, Deserialize)]
-pub struct LangData(
-    pub LiteMap<LanguageIdentifier, LangDates>,
-);
+pub struct LangData(pub LiteMap<LanguageIdentifier, LangDates>);
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub struct Resource {

--- a/provider/cldr/src/cldr_serde/ca.rs
+++ b/provider/cldr/src/cldr_serde/ca.rs
@@ -12,7 +12,7 @@
 use icu_locid::LanguageIdentifier;
 use serde::Deserialize;
 use std::borrow::Cow;
-use std::collections::HashMap;
+use litemap::LiteMap;
 
 macro_rules! symbols {
     ($name: ident, $([$alias: expr, $element: ident, $ty: ty]),+ $(,)?) => {
@@ -147,7 +147,7 @@ pub struct DateTimeFormats {
 
 #[derive(PartialEq, Clone, Debug, Deserialize)]
 pub struct AvailableFormats(
-    #[serde(with = "tuple_vec_map")] pub(crate) Vec<(Cow<'static, str>, Cow<'static, str>)>,
+    pub LiteMap<String, String>,
 );
 
 /// This struct represents a 1:1 mapping of the CLDR ca-gregorian.json data at the key
@@ -171,7 +171,7 @@ pub struct Dates {
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub struct DatesCalendars {
-    pub calendars: HashMap<String, Dates>,
+    pub calendars: LiteMap<String, Dates>,
 }
 
 #[derive(PartialEq, Debug, Deserialize)]
@@ -181,7 +181,7 @@ pub struct LangDates {
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub struct LangData(
-    #[serde(with = "tuple_vec_map")] pub(crate) Vec<(LanguageIdentifier, LangDates)>,
+    pub LiteMap<LanguageIdentifier, LangDates>,
 );
 
 #[derive(PartialEq, Debug, Deserialize)]

--- a/provider/cldr/src/cldr_serde/list_patterns.rs
+++ b/provider/cldr/src/cldr_serde/list_patterns.rs
@@ -8,6 +8,7 @@
 //! https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-misc-full/main/en/listPatterns.json
 
 use icu_locid::LanguageIdentifier;
+use litemap::LiteMap;
 use serde::Deserialize;
 
 #[derive(PartialEq, Debug, Deserialize)]
@@ -48,9 +49,7 @@ pub struct LangListPatterns {
 }
 
 #[derive(PartialEq, Debug, Deserialize)]
-pub struct LangData(
-    #[serde(with = "tuple_vec_map")] pub(crate) Vec<(LanguageIdentifier, LangListPatterns)>,
-);
+pub struct LangData(pub LiteMap<LanguageIdentifier, LangListPatterns>);
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub struct Resource {

--- a/provider/cldr/src/cldr_serde/numbering_systems.rs
+++ b/provider/cldr/src/cldr_serde/numbering_systems.rs
@@ -7,9 +7,9 @@
 //! Sample file:
 //! https://github.com/unicode-org/cldr-json/blob/master/cldr-json/cldr-core/supplemental/numberingSystems.json
 
+use litemap::LiteMap;
 use serde::Deserialize;
 use tinystr::{TinyStr8, TinyStrAuto};
-use litemap::LiteMap;
 
 #[derive(PartialEq, Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]

--- a/provider/cldr/src/cldr_serde/numbering_systems.rs
+++ b/provider/cldr/src/cldr_serde/numbering_systems.rs
@@ -8,8 +8,8 @@
 //! https://github.com/unicode-org/cldr-json/blob/master/cldr-json/cldr-core/supplemental/numberingSystems.json
 
 use serde::Deserialize;
-use std::collections::HashMap;
 use tinystr::{TinyStr8, TinyStrAuto};
+use litemap::LiteMap;
 
 #[derive(PartialEq, Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -31,7 +31,7 @@ pub struct NumberingSystem {
 #[derive(PartialEq, Debug, Deserialize)]
 pub struct SupplementalData {
     #[serde(rename = "numberingSystems")]
-    pub numbering_systems: HashMap<TinyStr8, NumberingSystem>,
+    pub numbering_systems: LiteMap<TinyStr8, NumberingSystem>,
 }
 
 #[derive(PartialEq, Debug, Deserialize)]

--- a/provider/cldr/src/cldr_serde/numbers.rs
+++ b/provider/cldr/src/cldr_serde/numbers.rs
@@ -9,10 +9,10 @@
 
 use icu_locid::LanguageIdentifier;
 use itertools::Itertools;
+use litemap::LiteMap;
 use serde::de::{Deserializer, Error, MapAccess, Unexpected, Visitor};
 use serde::Deserialize;
 use serde_aux::prelude::*;
-use litemap::LiteMap;
 use tinystr::TinyStr8;
 
 #[derive(PartialEq, Debug, Deserialize)]
@@ -108,9 +108,7 @@ pub struct LangNumbers {
 }
 
 #[derive(PartialEq, Debug, Deserialize)]
-pub struct LangData(
-    pub LiteMap<LanguageIdentifier, LangNumbers>,
-);
+pub struct LangData(pub LiteMap<LanguageIdentifier, LangNumbers>);
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub struct Resource {

--- a/provider/cldr/src/cldr_serde/numbers.rs
+++ b/provider/cldr/src/cldr_serde/numbers.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use serde::de::{Deserializer, Error, MapAccess, Unexpected, Visitor};
 use serde::Deserialize;
 use serde_aux::prelude::*;
-use std::collections::HashMap;
+use litemap::LiteMap;
 use tinystr::TinyStr8;
 
 #[derive(PartialEq, Debug, Deserialize)]
@@ -34,9 +34,9 @@ pub struct DecimalFormats {
 #[derive(PartialEq, Debug, Default)]
 pub struct NumberingSystemData {
     /// Map from numbering system to symbols
-    pub symbols: HashMap<TinyStr8, Symbols>,
+    pub symbols: LiteMap<TinyStr8, Symbols>,
     /// Map from numbering system to decimal formats
-    pub formats: HashMap<TinyStr8, DecimalFormats>,
+    pub formats: LiteMap<TinyStr8, DecimalFormats>,
 }
 
 pub struct NumberingSystemDataVisitor;
@@ -109,7 +109,7 @@ pub struct LangNumbers {
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub struct LangData(
-    #[serde(with = "tuple_vec_map")] pub(crate) Vec<(LanguageIdentifier, LangNumbers)>,
+    pub LiteMap<LanguageIdentifier, LangNumbers>,
 );
 
 #[derive(PartialEq, Debug, Deserialize)]

--- a/provider/cldr/src/cldr_serde/plurals.rs
+++ b/provider/cldr/src/cldr_serde/plurals.rs
@@ -8,6 +8,7 @@
 //! https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-core/supplemental/plurals.json
 
 use icu_locid::LanguageIdentifier;
+use litemap::LiteMap;
 use serde::Deserialize;
 
 #[derive(PartialEq, PartialOrd, Ord, Eq, Debug, Deserialize)]
@@ -25,9 +26,7 @@ pub struct LocalePluralRules {
 }
 
 #[derive(PartialEq, Debug, Deserialize)]
-pub struct Rules(
-    #[serde(with = "tuple_vec_map")] pub(crate) Vec<(LanguageIdentifier, LocalePluralRules)>,
-);
+pub struct Rules(pub LiteMap<LanguageIdentifier, LocalePluralRules>);
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub struct Supplemental {

--- a/provider/cldr/src/cldr_serde/time_zone_names.rs
+++ b/provider/cldr/src/cldr_serde/time_zone_names.rs
@@ -5,17 +5,17 @@
 //! Serde structs representing CLDR JSON timeZoneNames.json files.
 //!
 //! Sample file:
-//! https://raw.githubusercontent.com/unicode-org/cldr-json/master/cldr-json/cldr-dates-full/main/en/timeZoneNames.json
+//! https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-dates-full/main/en/timeZoneNames.json
 
 use icu_locid::LanguageIdentifier;
 use serde::{
     de::{IgnoredAny, MapAccess, Visitor},
     Deserialize, Deserializer,
 };
-use std::collections::BTreeMap;
+use litemap::LiteMap;
 
 #[derive(PartialEq, Debug, Clone, Deserialize)]
-pub struct ZoneFormat(pub BTreeMap<String, String>);
+pub struct ZoneFormat(pub LiteMap<String, String>);
 
 #[derive(PartialEq, Debug, Clone, Deserialize)]
 pub struct MetaZone {
@@ -24,7 +24,7 @@ pub struct MetaZone {
 }
 
 #[derive(PartialEq, Debug, Clone, Deserialize)]
-pub struct MetaZones(pub BTreeMap<String, MetaZone>);
+pub struct MetaZones(pub LiteMap<String, MetaZone>);
 
 #[derive(PartialEq, Debug, Clone, Deserialize)]
 pub struct LocationWithExemplarCity {
@@ -63,14 +63,14 @@ pub enum Location {
 #[serde(untagged)]
 pub enum LocationOrSubRegion {
     Location(Location),
-    SubRegion(BTreeMap<String, Location>),
+    SubRegion(LiteMap<String, Location>),
 }
 
 #[derive(PartialEq, Debug, Clone, Default, Deserialize)]
-pub struct Region(pub BTreeMap<String, LocationOrSubRegion>);
+pub struct Region(pub LiteMap<String, LocationOrSubRegion>);
 
 #[derive(PartialEq, Debug, Clone, Default, Deserialize)]
-pub struct Zones(pub BTreeMap<String, Region>);
+pub struct Zones(pub LiteMap<String, Region>);
 
 #[derive(PartialEq, Debug, Default, Clone)]
 pub struct TimeZoneNames {
@@ -78,7 +78,7 @@ pub struct TimeZoneNames {
     pub gmt_format: String,
     pub gmt_zero_format: String,
     pub region_format: String,
-    pub region_format_variants: BTreeMap<String, String>,
+    pub region_format_variants: LiteMap<String, String>,
     pub fallback_format: String,
     pub zone: Zones,
     pub metazone: Option<MetaZones>,
@@ -160,7 +160,7 @@ pub struct LangTimeZones {
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub struct LangData(
-    #[serde(with = "tuple_vec_map")] pub(crate) Vec<(LanguageIdentifier, LangTimeZones)>,
+    pub LiteMap<LanguageIdentifier, LangTimeZones>,
 );
 
 #[derive(PartialEq, Debug, Deserialize)]

--- a/provider/cldr/src/cldr_serde/time_zone_names.rs
+++ b/provider/cldr/src/cldr_serde/time_zone_names.rs
@@ -8,11 +8,11 @@
 //! https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-dates-full/main/en/timeZoneNames.json
 
 use icu_locid::LanguageIdentifier;
+use litemap::LiteMap;
 use serde::{
     de::{IgnoredAny, MapAccess, Visitor},
     Deserialize, Deserializer,
 };
-use litemap::LiteMap;
 
 #[derive(PartialEq, Debug, Clone, Deserialize)]
 pub struct ZoneFormat(pub LiteMap<String, String>);
@@ -159,9 +159,7 @@ pub struct LangTimeZones {
 }
 
 #[derive(PartialEq, Debug, Deserialize)]
-pub struct LangData(
-    pub LiteMap<LanguageIdentifier, LangTimeZones>,
-);
+pub struct LangData(pub LiteMap<LanguageIdentifier, LangTimeZones>);
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub struct Resource {

--- a/provider/cldr/src/transform/datetime/common.rs
+++ b/provider/cldr/src/transform/datetime/common.rs
@@ -37,9 +37,9 @@ impl TryFrom<&dyn CldrPaths> for CommonDateProvider {
             for dir in locale_dirs {
                 let path = dir.join(&cal_file);
 
-                let mut resource: cldr_serde::ca::Resource =
+                let resource: cldr_serde::ca::Resource =
                     serde_json::from_reader(open_reader(&path)?).map_err(|e| (e, path))?;
-                for (k, mut v) in resource.main.0.drain(..) {
+                for (k, mut v) in resource.main.0.into_tuple_vec().drain(..) {
                     let v = v.dates.calendars.remove(cldr_cal).ok_or_else(|| {
                         Error::Custom(
                             format!("{} does not have {} field", cal_file, cldr_cal),

--- a/provider/cldr/src/transform/decimal/mod.rs
+++ b/provider/cldr/src/transform/decimal/mod.rs
@@ -107,7 +107,7 @@ impl DataProvider<DecimalSymbolsV1Marker> for NumbersProvider {
     ) -> Result<DataResponse<DecimalSymbolsV1Marker>, DataError> {
         Self::supports_key(&req.resource_path.key)?;
         let langid = req.try_langid()?;
-        let numbers = match self.cldr_numbers_data.get(&langid) {
+        let numbers = match self.cldr_numbers_data.get(langid) {
             Some(v) => &v.numbers,
             None => return Err(DataError::MissingResourceOptions(req.clone())),
         };

--- a/provider/cldr/src/transform/decimal/mod.rs
+++ b/provider/cldr/src/transform/decimal/mod.rs
@@ -10,10 +10,10 @@ use icu_decimal::provider::*;
 use icu_locid::LanguageIdentifier;
 use icu_provider::iter::{IterableDataProviderCore, KeyedDataProvider};
 use icu_provider::prelude::*;
+use litemap::LiteMap;
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use tinystr::TinyStr8;
-use litemap::LiteMap;
 
 mod decimal_pattern;
 
@@ -107,10 +107,7 @@ impl DataProvider<DecimalSymbolsV1Marker> for NumbersProvider {
     ) -> Result<DataResponse<DecimalSymbolsV1Marker>, DataError> {
         Self::supports_key(&req.resource_path.key)?;
         let langid = req.try_langid()?;
-        let numbers = match self
-            .cldr_numbers_data
-            .get(&langid)
-        {
+        let numbers = match self.cldr_numbers_data.get(&langid) {
             Some(v) => &v.numbers,
             None => return Err(DataError::MissingResourceOptions(req.clone())),
         };

--- a/provider/cldr/src/transform/decimal/mod.rs
+++ b/provider/cldr/src/transform/decimal/mod.rs
@@ -13,6 +13,7 @@ use icu_provider::prelude::*;
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use tinystr::TinyStr8;
+use litemap::LiteMap;
 
 mod decimal_pattern;
 
@@ -25,7 +26,7 @@ pub const ALL_KEYS: [ResourceKey; 1] = [
 #[derive(PartialEq, Debug)]
 pub struct NumbersProvider {
     cldr_numbering_systems_data: cldr_serde::numbering_systems::Resource,
-    cldr_numbers_data: Vec<(LanguageIdentifier, cldr_serde::numbers::LangNumbers)>,
+    cldr_numbers_data: LiteMap<LanguageIdentifier, cldr_serde::numbers::LangNumbers>,
 }
 
 impl TryFrom<&dyn CldrPaths> for NumbersProvider {
@@ -41,14 +42,14 @@ impl TryFrom<&dyn CldrPaths> for NumbersProvider {
         };
 
         // Load data for each locale:
-        let mut cldr_numbers_data = vec![];
+        let mut cldr_numbers_data = LiteMap::new();
         let path = cldr_paths.cldr_numbers()?.join("main");
         let locale_dirs = get_langid_subdirectories(&path)?;
         for dir in locale_dirs {
             let path = dir.join("numbers.json");
-            let mut resource: cldr_serde::numbers::Resource =
+            let resource: cldr_serde::numbers::Resource =
                 serde_json::from_reader(open_reader(&path)?).map_err(|e| (e, path))?;
-            cldr_numbers_data.append(&mut resource.main.0);
+            cldr_numbers_data.extend_from_litemap(resource.main.0);
         }
 
         Ok(Self {
@@ -108,10 +109,10 @@ impl DataProvider<DecimalSymbolsV1Marker> for NumbersProvider {
         let langid = req.try_langid()?;
         let numbers = match self
             .cldr_numbers_data
-            .binary_search_by_key(&langid, |(lid, _)| lid)
+            .get(&langid)
         {
-            Ok(idx) => &self.cldr_numbers_data[idx].1.numbers,
-            Err(_) => return Err(DataError::MissingResourceOptions(req.clone())),
+            Some(v) => &v.numbers,
+            None => return Err(DataError::MissingResourceOptions(req.clone())),
         };
         let nsname = numbers.default_numbering_system;
 

--- a/provider/cldr/src/transform/list/mod.rs
+++ b/provider/cldr/src/transform/list/mod.rs
@@ -56,7 +56,7 @@ impl DataProvider<ListFormatterPatternsV1Marker> for ListProvider {
     ) -> Result<DataResponse<ListFormatterPatternsV1Marker>, DataError> {
         Self::supports_key(&req.resource_path.key)?;
         let langid = req.try_langid()?;
-        let data = match self.data.get(&langid) {
+        let data = match self.data.get(langid) {
             Some(v) => &v.list_patterns,
             None => return Err(DataError::MissingResourceOptions(req.clone())),
         };

--- a/provider/cldr/src/transform/plurals/mod.rs
+++ b/provider/cldr/src/transform/plurals/mod.rs
@@ -85,7 +85,7 @@ impl DataProvider<PluralRulesV1Marker> for PluralsProvider {
         let cldr_rules = self.get_rules_for(&req.resource_path.key)?;
         // TODO: Implement language fallback?
         let langid = req.try_langid()?;
-        let r = match cldr_rules.0.get(&langid) {
+        let r = match cldr_rules.0.get(langid) {
             Some(v) => v,
             None => return Err(req.clone().into()),
         };

--- a/provider/cldr/src/transform/plurals/mod.rs
+++ b/provider/cldr/src/transform/plurals/mod.rs
@@ -35,11 +35,7 @@ impl TryFrom<&dyn CldrPaths> for PluralsProvider {
                 .join("plurals.json");
             let data: cldr_serde::plurals::Resource =
                 serde_json::from_reader(open_reader(&path)?).map_err(|e| (e, path))?;
-            let mut rules = data.supplemental.plurals_type_cardinal;
-            if let Some(v) = rules.as_mut() {
-                v.0.sort()
-            }
-            rules
+            data.supplemental.plurals_type_cardinal
         };
         let ordinal_rules = {
             let path = cldr_paths
@@ -48,11 +44,7 @@ impl TryFrom<&dyn CldrPaths> for PluralsProvider {
                 .join("ordinals.json");
             let data: cldr_serde::plurals::Resource =
                 serde_json::from_reader(open_reader(&path)?).map_err(|e| (e, path))?;
-            let mut rules = data.supplemental.plurals_type_ordinal;
-            if let Some(v) = rules.as_mut() {
-                v.0.sort()
-            }
-            rules
+            data.supplemental.plurals_type_ordinal
         };
         Ok(PluralsProvider {
             cardinal_rules,
@@ -93,9 +85,9 @@ impl DataProvider<PluralRulesV1Marker> for PluralsProvider {
         let cldr_rules = self.get_rules_for(&req.resource_path.key)?;
         // TODO: Implement language fallback?
         let langid = req.try_langid()?;
-        let (_, r) = match cldr_rules.0.binary_search_by_key(&langid, |(l, _)| l) {
-            Ok(idx) => &cldr_rules.0[idx],
-            Err(_) => return Err(req.clone().into()),
+        let r = match cldr_rules.0.get(&langid) {
+            Some(v) => v,
+            None => return Err(req.clone().into()),
         };
         Ok(DataResponse {
             metadata: DataResponseMetadata {

--- a/provider/cldr/src/transform/time_zones/convert.rs
+++ b/provider/cldr/src/transform/time_zones/convert.rs
@@ -42,6 +42,7 @@ impl From<TimeZoneNames> for TimeZoneFormatsV1<'_> {
             region_format: other.region_format.into(),
             region_format_variants: other
                 .region_format_variants
+                .into_tuple_vec()
                 .into_iter()
                 .map(|(key, value)| {
                     (
@@ -74,10 +75,12 @@ impl From<TimeZoneNames> for ExemplarCitiesV1<'_> {
             other
                 .zone
                 .0
+                .into_tuple_vec()
                 .into_iter()
                 .flat_map(|(key, region)| {
                     region
                         .0
+                        .into_tuple_vec()
                         .into_iter()
                         .flat_map(move |(inner_key, place_or_region)| {
                             let mut key = key.clone();
@@ -89,6 +92,7 @@ impl From<TimeZoneNames> for ExemplarCitiesV1<'_> {
                                     .map(|city| vec![(key.into(), city.into())])
                                     .unwrap_or_default(),
                                 LocationOrSubRegion::SubRegion(region) => region
+                                    .into_tuple_vec()
                                     .into_iter()
                                     .filter_map(|(inner_key, place)| {
                                         let mut key = key.clone();
@@ -154,6 +158,7 @@ impl From<TimeZoneNames> for MetaZoneSpecificNamesLongV1<'_> {
             Some(metazones) => Self(
                 metazones
                     .0
+                    .into_tuple_vec()
                     .into_iter()
                     .filter_map(|(key, metazone)| metazone.long.map(|value| (key, value)))
                     .map(|(key, zf)| (key.into(), zf.into()))
@@ -175,6 +180,7 @@ impl From<TimeZoneNames> for MetaZoneSpecificNamesShortV1<'_> {
             Some(metazones) => Self(
                 metazones
                     .0
+                    .into_tuple_vec()
                     .into_iter()
                     .filter_map(|(key, metazone)| metazone.short.map(|value| (key, value)))
                     .map(|(key, value)| (key.into(), value.into()))
@@ -195,6 +201,7 @@ impl From<ZoneFormat> for MetaZoneSpecificNamesV1<'_> {
         Self(
             other
                 .0
+                .into_tuple_vec()
                 .into_iter()
                 .filter(|(key, _)| len > 1 && !key.eq("generic"))
                 .map(|(key, value)| {

--- a/provider/cldr/src/transform/time_zones/convert.rs
+++ b/provider/cldr/src/transform/time_zones/convert.rs
@@ -78,11 +78,8 @@ impl From<TimeZoneNames> for ExemplarCitiesV1<'_> {
                 .into_tuple_vec()
                 .into_iter()
                 .flat_map(|(key, region)| {
-                    region
-                        .0
-                        .into_tuple_vec()
-                        .into_iter()
-                        .flat_map(move |(inner_key, place_or_region)| {
+                    region.0.into_tuple_vec().into_iter().flat_map(
+                        move |(inner_key, place_or_region)| {
                             let mut key = key.clone();
                             key.push('/');
                             key.push_str(&inner_key);
@@ -102,7 +99,8 @@ impl From<TimeZoneNames> for ExemplarCitiesV1<'_> {
                                     })
                                     .collect::<Vec<_>>(),
                             }
-                        })
+                        },
+                    )
                 })
                 .collect(),
         )

--- a/provider/cldr/src/transform/time_zones/mod.rs
+++ b/provider/cldr/src/transform/time_zones/mod.rs
@@ -31,10 +31,7 @@ pub const ALL_KEYS: [ResourceKey; 6] = [
 /// A data provider reading from CLDR JSON zones files.
 #[derive(PartialEq, Debug)]
 pub struct TimeZonesProvider {
-    data: LiteMap<
-        LanguageIdentifier,
-        cldr_serde::time_zone_names::LangTimeZones,
-    >,
+    data: LiteMap<LanguageIdentifier, cldr_serde::time_zone_names::LangTimeZones>,
 }
 
 impl TryFrom<&dyn CldrPaths> for TimeZonesProvider {


### PR DESCRIPTION
More progress on #568

Depends on #1340 

We had several different map implementations in different places, including:

- tuple_vec_map
- HashMap
- BTreeMap

I have replaced all of them with LiteMap.  I chose LiteMap because:

1. It is compatible with tuple_vec_map, which was the most common map
2. We can add methods to litemap, like #1340, to make it work better for our use case
3. This is a good use of LiteMap to prevent it from bitrotting

CC @samchen61661: The only remaining uses of `tuple_vec_map` are in the LocaleCanonicalizer transformer.  I hope you can remove those as part of your work to transition that class to LiteMap.  I could have done it here, but I didn't want to conflict with your work.