### PR TITLE
Remove DataPayloadInner and migrate to a single Yoke type

### DIFF
--- a/provider/core/src/data_provider/test.rs
+++ b/provider/core/src/data_provider/test.rs
@@ -158,7 +158,6 @@ fn get_request_alt() -> DataRequest {
 fn test_warehouse_owned() {
     let warehouse = get_warehouse(DATA);
     let hello_data = get_payload_v1(&warehouse).unwrap();
-    assert!(matches!(hello_data.inner, DataPayloadInner::Owned(_)));
     assert!(matches!(
         hello_data.get(),
         HelloWorldV1 {
@@ -171,7 +170,6 @@ fn test_warehouse_owned() {
 fn test_warehouse_owned_dyn_erased() {
     let warehouse = get_warehouse(DATA);
     let hello_data = get_payload_v1(&warehouse as &dyn ErasedDataProvider).unwrap();
-    assert!(matches!(hello_data.inner, DataPayloadInner::Owned(_)));
     assert!(matches!(
         hello_data.get(),
         HelloWorldV1 {
@@ -184,7 +182,6 @@ fn test_warehouse_owned_dyn_erased() {
 fn test_warehouse_owned_dyn_generic() {
     let warehouse = get_warehouse(DATA);
     let hello_data = get_payload_v1(&warehouse as &dyn DataProvider<HelloWorldV1Marker>).unwrap();
-    assert!(matches!(hello_data.inner, DataPayloadInner::Owned(_)));
     assert!(matches!(
         hello_data.get(),
         HelloWorldV1 {
@@ -208,7 +205,6 @@ fn test_provider2() {
     let warehouse = get_warehouse(DATA);
     let provider = DataProvider2::from(warehouse);
     let hello_data = get_payload_v1(&provider).unwrap();
-    assert!(matches!(hello_data.inner, DataPayloadInner::Owned(_)));
     assert!(matches!(
         hello_data.get(),
         HelloWorldV1 {
@@ -222,7 +218,6 @@ fn test_provider2_dyn_erased() {
     let warehouse = get_warehouse(DATA);
     let provider = DataProvider2::from(warehouse);
     let hello_data = get_payload_v1(&provider as &dyn ErasedDataProvider).unwrap();
-    assert!(matches!(hello_data.inner, DataPayloadInner::Owned(_)));
     assert!(matches!(
         hello_data.get(),
         HelloWorldV1 {
@@ -236,7 +231,6 @@ fn test_provider2_dyn_erased_alt() {
     let warehouse = get_warehouse(DATA);
     let provider = DataProvider2::from(warehouse);
     let hello_data = get_payload_alt(&provider as &dyn ErasedDataProvider).unwrap();
-    assert!(matches!(hello_data.inner, DataPayloadInner::Owned(_)));
     assert!(matches!(hello_data.get(), HelloAlt { .. }));
 }
 
@@ -245,7 +239,6 @@ fn test_provider2_dyn_generic() {
     let warehouse = get_warehouse(DATA);
     let provider = DataProvider2::from(warehouse);
     let hello_data = get_payload_v1(&provider as &dyn DataProvider<HelloWorldV1Marker>).unwrap();
-    assert!(matches!(hello_data.inner, DataPayloadInner::Owned(_)));
     assert!(matches!(
         hello_data.get(),
         HelloWorldV1 {
@@ -259,7 +252,6 @@ fn test_provider2_dyn_generic_alt() {
     let warehouse = get_warehouse(DATA);
     let provider = DataProvider2::from(warehouse);
     let hello_data = get_payload_alt(&provider as &dyn DataProvider<HelloAltMarker>).unwrap();
-    assert!(matches!(hello_data.inner, DataPayloadInner::Owned(_)));
     assert!(matches!(hello_data.get(), HelloAlt { .. }));
 }
 

--- a/provider/core/src/serde.rs
+++ b/provider/core/src/serde.rs
@@ -274,12 +274,8 @@ where
     for<'a> &'a <M::Yokeable as Yokeable<'a>>::Output: serde::Serialize,
 {
     fn upcast(other: DataPayload<M>) -> DataPayload<SerdeSeDataStructMarker> {
-        use crate::data_provider::DataPayloadInner;
-        let b = match other.inner {
-            DataPayloadInner::Owned(yoke) => Box::new(yoke) as Box<dyn SerdeSeDataStruct>,
-            DataPayloadInner::RcBuf(yoke) => Box::new(yoke) as Box<dyn SerdeSeDataStruct>,
-        };
-        DataPayload::from_owned(SerdeSeDataStructBox(b))
+        let owned: Box<dyn SerdeSeDataStruct> = Box::new(other.yoke);
+        DataPayload::from_owned(SerdeSeDataStructBox(owned))
     }
 }
 

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -510,7 +510,7 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, Option<C>> {
     }
 
     /// Obtain the yokeable out of a `Yoke<Y, Option<C>>` if possible.
-    /// 
+    ///
     /// If the cart is `None`, this returns `Some`, but if the cart is `Some`,
     /// this returns `self` as an error.
     pub fn try_into_yokeable(self) -> Result<Y, Self> {

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -385,6 +385,14 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     {
         self.yokeable.transform_mut(f)
     }
+
+    /// Helper function allowing one to wrap the cart type in an `Option<T>`.
+    pub fn wrap_cart_in_option(self) -> Yoke<Y, Option<C>> {
+        unsafe {
+            // safe because the cart is preserved, just wrapped
+            self.replace_cart(Some)
+        }
+    }
 }
 
 impl<Y: for<'a> Yokeable<'a>> Yoke<Y, ()> {
@@ -486,6 +494,29 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, Option<C>> {
         Self {
             yokeable: unsafe { Y::make(deserialized) },
             cart: Some(cart),
+        }
+    }
+
+    /// Version of [`Yoke::attach_to_option_cart()`] that passes through an error.
+    pub fn try_attach_to_option_cart<E, F>(cart: C, f: F) -> Result<Self, E>
+    where
+        F: for<'de> FnOnce(&'de <C as Deref>::Target) -> Result<<Y as Yokeable<'de>>::Output, E>,
+    {
+        let deserialized = f(cart.deref())?;
+        Ok(Self {
+            yokeable: unsafe { Y::make(deserialized) },
+            cart: Some(cart),
+        })
+    }
+
+    /// Obtain the yokeable out of a `Yoke<Y, Option<C>>` if possible.
+    /// 
+    /// If the cart is `None`, this returns `Some`, but if the cart is `Some`,
+    /// this returns `self` as an error.
+    pub fn try_into_yokeable(self) -> Result<Y, Self> {
+        match self.cart {
+            Some(_) => Err(self),
+            None => Ok(self.yokeable),
         }
     }
 }


### PR DESCRIPTION
Progress on #1246

This is what @Manishearth originally had in mind when designing `Yoke<Y, Option<C>>`.  Since we now have only 2 variants of DataPayloadInner, I merged them into a single one that uses `Option<C>`.