### PR TITLE
Remove attach_to_option_cart()

### DIFF
--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -225,7 +225,7 @@ where
         rc_buffer: Rc<[u8]>,
         f: impl for<'de> FnOnce(&'de [u8]) -> Result<<M::Yokeable as Yokeable<'de>>::Output, E>,
     ) -> Result<Self, E> {
-        let yoke = Yoke::try_attach_to_option_cart(rc_buffer, f)?;
+        let yoke = Yoke::try_attach_to_cart(rc_buffer, f)?.wrap_cart_in_option();
         Ok(Self { yoke })
     }
 
@@ -264,7 +264,7 @@ where
         rc_buffer: Rc<[u8]>,
         f: for<'de> fn(&'de [u8]) -> Result<<M::Yokeable as Yokeable<'de>>::Output, E>,
     ) -> Result<Self, E> {
-        let yoke = Yoke::try_attach_to_option_cart(rc_buffer, f)?;
+        let yoke = Yoke::try_attach_to_cart(rc_buffer, f)?.wrap_cart_in_option();
         Ok(Self { yoke })
     }
 

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -464,51 +464,6 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, Option<C>> {
         }
     }
 
-    /// Similar to [`Yoke::attach_to_cart()`], except it constructs a `Yoke<Y, Option<C>>`
-    /// instead, where the cart is `Some(..)`.
-    ///
-    /// This allows mixing [`Yoke`]s constructed from owned and borrowed data, when
-    /// paired with [`Yoke::new_owned()`].
-    ///
-    /// This method is currently unusable due to a [compiler bug](https://github.com/rust-lang/rust/issues/84937),
-    /// use [`Yoke::attach_to_option_cart_badly()`] instead
-    pub fn attach_to_option_cart<F>(cart: C, f: F) -> Self
-    where
-        F: for<'de> FnOnce(&'de <C as Deref>::Target) -> <Y as Yokeable<'de>>::Output,
-    {
-        let deserialized = f(cart.deref());
-        Self {
-            yokeable: unsafe { Y::make(deserialized) },
-            cart: Some(cart),
-        }
-    }
-    /// Temporary version of [`Yoke::attach_to_option_cart()`]
-    /// that doesn't hit <https://github.com/rust-lang/rust/issues/84937>
-    ///
-    /// See its docs for more details
-    pub fn attach_to_option_cart_badly(
-        cart: C,
-        f: for<'de> fn(&'de <C as Deref>::Target) -> <Y as Yokeable<'de>>::Output,
-    ) -> Self {
-        let deserialized = f(cart.deref());
-        Self {
-            yokeable: unsafe { Y::make(deserialized) },
-            cart: Some(cart),
-        }
-    }
-
-    /// Version of [`Yoke::attach_to_option_cart()`] that passes through an error.
-    pub fn try_attach_to_option_cart<E, F>(cart: C, f: F) -> Result<Self, E>
-    where
-        F: for<'de> FnOnce(&'de <C as Deref>::Target) -> Result<<Y as Yokeable<'de>>::Output, E>,
-    {
-        let deserialized = f(cart.deref())?;
-        Ok(Self {
-            yokeable: unsafe { Y::make(deserialized) },
-            cart: Some(cart),
-        })
-    }
-
     /// Obtain the yokeable out of a `Yoke<Y, Option<C>>` if possible.
     ///
     /// If the cart is `None`, this returns `Some`, but if the cart is `Some`,


### PR DESCRIPTION
We now have `.wrap_cart_in_option()` (and some other wrappers); we should rely on those instead of having another trifecta/quadrifecta of `attach_*` functions.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->