### PR TITLE
Add SignedPlainOldULE, add serialize impls for ULE types (also missing Eq impl for VZV)

### DIFF
--- a/utils/zerovec/src/ule/chars.rs
+++ b/utils/zerovec/src/ule/chars.rs
@@ -91,6 +91,25 @@ impl AsULE for char {
 // as CharULE on little-endian platforms.
 unsafe impl EqULE for char {}
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for CharULE {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        char::from_unaligned(*self).serialize(serializer)
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for CharULE {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(char::as_unaligned(char::deserialize(deserializer)?))
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/utils/zerovec/src/ule/custom/mod.rs
+++ b/utils/zerovec/src/ule/custom/mod.rs
@@ -88,18 +88,18 @@
 //! }
 //!
 //! fn main() {
-//!     let mut foos = vec![Foo {field1: 'u', field2: 983, field3: ZeroVec::alloc_from_slice(&[1212,2309,500,7000])},
-//!                         Foo {field1: 'l', field2: 1010, field3: ZeroVec::alloc_from_slice(&[1932, 0, 8888, 91237])}];
+//!     let mut foos = vec![Foo {field1: 'u', field2: 983, field3: ZeroVec::<u32>::alloc_from_slice(&[1212,2309,500,7000])},
+//!                         Foo {field1: 'l', field2: 1010, field3: ZeroVec::<u32>::alloc_from_slice(&[1932, 0, 8888, 91237])}];
 //!
 //!     let vzv = VarZeroVec::from(&*foos);
 //!
 //!     assert_eq!(char::from_unaligned(vzv.get(0).unwrap().field1), 'u');
 //!     assert_eq!(u32::from_unaligned(vzv.get(0).unwrap().field2), 983);
-//!     assert_eq!(&vzv.get(0).unwrap().field3, ZeroVec::alloc_from_slice(&[1212,2309,500,7000]).as_slice());
+//!     assert_eq!(&vzv.get(0).unwrap().field3, ZeroVec::<u32>::alloc_from_slice(&[1212,2309,500,7000]).as_slice());
 //!
 //!     assert_eq!(char::from_unaligned(vzv.get(1).unwrap().field1), 'l');
 //!     assert_eq!(u32::from_unaligned(vzv.get(1).unwrap().field2), 1010);
-//!     assert_eq!(&vzv.get(1).unwrap().field3, ZeroVec::alloc_from_slice(&[1932, 0, 8888, 91237]).as_slice());
+//!     assert_eq!(&vzv.get(1).unwrap().field3, ZeroVec::<u32>::alloc_from_slice(&[1932, 0, 8888, 91237]).as_slice());
 //! }
 //! ```
 

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -150,8 +150,9 @@ pub trait AsULE: Copy {
     ///
     /// Types that are not well-defined for all bit values should implement a custom ULE.
     ///
-    /// If this ULE type is being used in `VarZeroVec<[ULE]>` and you want serialization to work
-    /// appropriately, make sure that the serializer impls on the `ULE` type are the same as those
+    /// If this ULE type is being used in `VarZeroVec<[ULE]>` and you want human readable
+    /// serialization to work identically to that of the `Self`,
+    /// make sure that the serializer impls on the `ULE` type are the same as those
     /// on `Self`. If not, it might be worth using a wrapped type for the `ULE` type.
     type ULE: ULE;
 

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -149,6 +149,10 @@ pub trait AsULE: Copy {
     /// `PlainOldULE` with the desired width; for example, `u32` uses `PlainOldULE<4>`.
     ///
     /// Types that are not well-defined for all bit values should implement a custom ULE.
+    ///
+    /// If this ULE type is being used in `VarZeroVec<[ULE]>` and you want serialization to work
+    /// appropriately, make sure that the serializer impls on the `ULE` type are the same as those
+    /// on `Self`. If not, it might be worth using a wrapped type for the `ULE` type.
     type ULE: ULE;
 
     /// Converts from `&Self` to `Self::ULE`.

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -16,7 +16,7 @@ mod vec;
 pub use chars::CharULE;
 pub use error::ULEError;
 pub use pair::{PairULE, PairULEError};
-pub use plain::PlainOldULE;
+pub use plain::{PlainOldULE, SignedPlainOldULE};
 
 use alloc::alloc::Layout;
 use alloc::borrow::ToOwned;

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -134,6 +134,7 @@ macro_rules! impl_byte_slice_type {
                 <$type>::from_unaligned(*self).serialize(serializer)
             }
         }
+
         #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for $ule_type {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -124,6 +124,25 @@ macro_rules! impl_byte_slice_type {
         // EqULE is true because $type and PlainOldULE<$size>
         // have the same byte sequence on little-endian
         unsafe impl EqULE for $type {}
+
+        #[cfg(feature = "serde")]
+        impl serde::Serialize for $ule_type {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                <$type>::from_unaligned(*self).serialize(serializer)
+            }
+        }
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for $ule_type {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                Ok(<$type>::as_unaligned(<$type>::deserialize(deserializer)?))
+            }
+        }
     };
 }
 

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -554,6 +554,14 @@ where
     }
 }
 
+impl<'a, T> Eq for VarZeroVec<'a, T>
+where
+    T: VarULE,
+    T: ?Sized,
+    T: PartialEq,
+{
+}
+
 impl<T, A> PartialEq<&'_ [A]> for VarZeroVec<'_, T>
 where
     T: VarULE + ?Sized,


### PR DESCRIPTION
in ZeroVec the "non ULE" version is always available so we can always convert to/from it for ser/de. However, VZV deals with unsized types and as such does not know anything about the "non ULE" version (EncodeAsVarULE helps but only in specific contexts). We could use FromVarULE (https://github.com/unicode-org/icu4x/issues/1180) here but `FromVarULE` will likely allow for multiple impls and there wouldn't be a way to select a particular one.

The current ser/de impls for VarZeroVec will serialize the byte buffer on machine formats, but for human readable formats will instead convert each element to `Box<T>` and serialize that instead.

For human readable serialization to do the "right thing", the serialization of the VarULE type should "look like the serialization of a normal type". This works out fine for regular `VarULE` types, however we have a complication when it comes to types like `[T: ULE]` because there can be more than one AsULE type that it matches. We would like `VarZeroVec<[i32::ULE]>` and `VarZeroVec<[u32::ULE]>` to have human readable serializations that show the actual integer (as opposed to a byte buffer).

This means that `u32` and `i32` cannot map to the _same_ ULE type since the ULE type must have different ser/de impls. This PR adds a `SignedPlainOldULE` type whose only difference is in how it ser/des.

Needed by @echeran for #1353, though in his PR he probably should have a wrapper type that serializes as a Script.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->