### PR TITLE
Install (and cache) grcov before loading overridden coverage toolchain

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,6 +23,26 @@ jobs:
 
       ## Coverage steps
 
+      - name: Get grcov version
+        id: grcov-version
+        run: |
+          echo "::set-output name=hash::$(cargo search grcov | grep '^grcov =' | md5sum)"
+        shell: bash
+      - name: Attempt to load cached grcov
+        uses: actions/cache@v2
+        id: grcov-cache
+        with:
+          path: |
+            ~/.cargo/bin/grcov
+            ~/.cargo/bin/grcov.exe
+          key: ${{ runner.os }}-make-${{ steps.grcov-version.outputs.hash }}
+      - name: Install grcov
+        if: steps.grcov-cache.outputs.cache-hit != 'true'
+        uses: actions-rs/install@v0.1.2
+        with:
+          crate: grcov
+          version: latest
+  
       - uses:                   actions-rs/toolchain@v1
         with:
           toolchain:            nightly-2021-09-22


### PR DESCRIPTION
grcov is currently broken on CI since this job sets up an older toolchain before grcov is installed. Explicitly installing it instead so that the grcov action does not attempt to install it on its own. This also lets us cache the binary.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->