### PR TITLE
Add a resolve_components method to DateTimeFormat

### DIFF
--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -6,7 +6,7 @@
 //! Central to this is the [`DateTimeFormat`].
 
 use crate::{
-    options::DateTimeFormatOptions,
+    options::{components, DateTimeFormatOptions},
     provider::calendar::{DatePatternsV1Marker, DateSkeletonPatternsV1Marker, DateSymbolsV1Marker},
     raw,
 };
@@ -196,5 +196,46 @@ impl<C: CldrCalendar> DateTimeFormat<C> {
     #[inline]
     pub fn format_to_string(&self, value: &impl DateTimeInput<Calendar = C>) -> String {
         self.0.format_to_string(value)
+    }
+
+    /// Returns a [`components::Bag`] that represents the resolved components for the
+    /// options that were provided to the [`DateTimeFormat`]. The developer may request
+    /// a certain set of options for a [`DateTimeFormat`] but the locale and resolution
+    /// algorithm may change certain details of what actually gets resolved.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::Gregorian;
+    /// use icu::datetime::{
+    ///     options::{components, length},
+    ///     DateTimeFormat, DateTimeFormatOptions,
+    /// };
+    /// use icu::locid::macros::langid;
+    /// use icu::locid::Locale;
+    ///
+    /// let options = DateTimeFormatOptions::Length(length::Bag {
+    ///     date: Some(length::Date::Medium),
+    ///     time: None,
+    ///     preferences: None,
+    /// });
+    ///
+    /// let locale: Locale = langid!("en").into();
+    /// let provider = icu_testdata::get_provider();
+    /// let dtf = DateTimeFormat::<Gregorian>::try_new(locale, &provider, &options)
+    ///     .expect("Failed to create DateTimeFormat instance.");
+    ///
+    /// assert_eq!(
+    ///     dtf.resolve_components(),
+    ///     components::Bag {
+    ///         year: Some(components::Year::Numeric),
+    ///         month: Some(components::Month::Short),
+    ///         day: Some(components::Numeric::Numeric),
+    ///         ..Default::default()
+    ///     }
+    /// );
+    /// ```
+    pub fn resolve_components(&self) -> components::Bag {
+        self.0.resolve_components()
     }
 }

--- a/components/datetime/src/raw/datetime.rs
+++ b/components/datetime/src/raw/datetime.rs
@@ -7,6 +7,7 @@
 
 use crate::{
     format::datetime,
+    options::components,
     options::DateTimeFormatOptions,
     provider::calendar::patterns::PatternPluralsFromPatternsV1Marker,
     provider::calendar::{DatePatternsV1Marker, DateSkeletonPatternsV1Marker, DateSymbolsV1Marker},
@@ -152,5 +153,11 @@ impl DateTimeFormat {
         self.format_to_write(&mut s, value)
             .expect("Failed to write to a String.");
         s
+    }
+
+    /// Returns a [`components::Bag`] that represents the resolved components for the
+    /// options that were provided to the [`DateTimeFormat`].
+    pub fn resolve_components(&self) -> components::Bag {
+        components::Bag::from(&self.patterns.get().0)
     }
 }

--- a/components/datetime/tests/resolved_components.rs
+++ b/components/datetime/tests/resolved_components.rs
@@ -1,0 +1,111 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use icu_calendar::Gregorian;
+use icu_datetime::{
+    options::{components, length, preferences},
+    DateTimeFormat, DateTimeFormatOptions,
+};
+use icu_locid::Locale;
+use icu_locid_macros::langid;
+
+fn assert_resolved_components(options: &DateTimeFormatOptions, bag: &components::Bag) {
+    let locale: Locale = langid!("en").into();
+    let provider = icu_testdata::get_provider();
+    let dtf = DateTimeFormat::<Gregorian>::try_new(locale, &provider, options)
+        .expect("Failed to create a DateTimeFormat.");
+
+    assert_eq!(dtf.resolve_components(), *bag);
+}
+
+#[test]
+fn test_length_date() {
+    assert_resolved_components(
+        &DateTimeFormatOptions::Length(length::Bag {
+            date: Some(length::Date::Medium),
+            time: None,
+            preferences: None,
+        }),
+        &components::Bag {
+            year: Some(components::Year::Numeric),
+            month: Some(components::Month::Short),
+            day: Some(components::Numeric::Numeric),
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn test_length_time() {
+    assert_resolved_components(
+        &DateTimeFormatOptions::Length(length::Bag {
+            date: None,
+            time: Some(length::Time::Medium),
+            preferences: None,
+        }),
+        &components::Bag {
+            hour: Some(components::Numeric::Numeric),
+            minute: Some(components::Numeric::TwoDigit),
+            second: Some(components::Numeric::TwoDigit),
+            preferences: Some(preferences::Bag {
+                hour_cycle: Some(preferences::HourCycle::H12),
+            }),
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn test_length_time_preferences() {
+    assert_resolved_components(
+        &DateTimeFormatOptions::Length(length::Bag {
+            date: None,
+            time: Some(length::Time::Medium),
+            preferences: Some(preferences::Bag {
+                hour_cycle: Some(preferences::HourCycle::H24),
+            }),
+        }),
+        &components::Bag {
+            hour: Some(components::Numeric::TwoDigit),
+            minute: Some(components::Numeric::TwoDigit),
+            second: Some(components::Numeric::TwoDigit),
+            preferences: Some(preferences::Bag {
+                hour_cycle: Some(preferences::HourCycle::H24),
+            }),
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn test_components_bag() {
+    assert_resolved_components(
+        &DateTimeFormatOptions::Components(components::Bag {
+            era: Some(components::Text::Short),
+            year: Some(components::Year::Numeric),
+            month: Some(components::Month::Numeric),
+            day: Some(components::Numeric::TwoDigit),
+            weekday: Some(components::Text::Long),
+            hour: Some(components::Numeric::Numeric),
+            minute: Some(components::Numeric::TwoDigit),
+            second: Some(components::Numeric::TwoDigit),
+            preferences: None,
+            ..Default::default()
+        }),
+        &components::Bag {
+            era: Some(components::Text::Short),
+            year: Some(components::Year::Numeric),
+            month: Some(components::Month::Short),
+            day: Some(components::Numeric::TwoDigit),
+            weekday: Some(components::Text::Long),
+            hour: Some(components::Numeric::Numeric),
+            minute: Some(components::Numeric::TwoDigit),
+            second: Some(components::Numeric::TwoDigit),
+            preferences: Some(preferences::Bag {
+                hour_cycle: Some(preferences::HourCycle::H23),
+            }),
+            ..Default::default()
+        },
+    );
+}


### PR DESCRIPTION
This is required for feature compatibility with ECMA-402. The backing
DateTimeFormat implementation needs to be able to return the resolved
components from the given options. These resolved components can differ
based on locale or the resolution algorithm.

Resolves #1361