### PR TITLE
Improve EncodeAsVarULE

### DIFF
--- a/utils/zerovec/README.md
+++ b/utils/zerovec/README.md
@@ -73,7 +73,7 @@ pub struct DataStruct<'data> {
 
 let data = DataStruct {
     nums: ZeroVec::from_slice(&[211, 281, 421, 461]),
-    strs: VarZeroVec::from(&["hello", "world"] as &[_]),
+    strs: VarZeroVec::from(&["hello", "world"]),
 };
 let bincode_bytes = bincode::serialize(&data)
     .expect("Serialization should be successful");

--- a/utils/zerovec/benches/vzv.rs
+++ b/utils/zerovec/benches/vzv.rs
@@ -45,7 +45,7 @@ fn overview_bench(c: &mut Criterion) {
     // Same as vzv/char_count/vzv but with different inputs
     let seed = 42;
     let (string_vec, _) = random_alphanums(2..=10, 100, seed);
-    let bytes: Vec<u8> = VarZeroVec::<str>::get_serializable_bytes(string_vec.iter()).unwrap();
+    let bytes: Vec<u8> = VarZeroVec::<str>::get_serializable_bytes(&string_vec).unwrap();
     let vzv = VarZeroVec::<str>::parse_byte_slice(black_box(bytes.as_slice())).unwrap();
 
     c.bench_function("vzv/overview", |b| {
@@ -72,7 +72,7 @@ fn overview_bench(c: &mut Criterion) {
 fn char_count_benches(c: &mut Criterion) {
     let seed = 2021;
     let (string_vec, _) = random_alphanums(2..=20, 100, seed);
-    let bytes: Vec<u8> = VarZeroVec::<str>::get_serializable_bytes(string_vec.iter()).unwrap();
+    let bytes: Vec<u8> = VarZeroVec::<str>::get_serializable_bytes(&string_vec).unwrap();
     let vzv = VarZeroVec::<str>::parse_byte_slice(black_box(bytes.as_slice())).unwrap();
 
     // *** Count chars in vec of 100 strings ***
@@ -99,7 +99,7 @@ fn binary_search_benches(c: &mut Criterion) {
     let seed = 2021;
     let (string_vec, seed) = random_alphanums(2..=20, 500, seed);
     let (needles, _) = random_alphanums(2..=20, 10, seed);
-    let bytes: Vec<u8> = VarZeroVec::<str>::get_serializable_bytes(string_vec.iter()).unwrap();
+    let bytes: Vec<u8> = VarZeroVec::<str>::get_serializable_bytes(&string_vec).unwrap();
     let vzv = VarZeroVec::<str>::parse_byte_slice(black_box(bytes.as_slice())).unwrap();
     let single_needle = "lmnop".to_string();
 

--- a/utils/zerovec/benches/vzv.rs
+++ b/utils/zerovec/benches/vzv.rs
@@ -45,8 +45,7 @@ fn overview_bench(c: &mut Criterion) {
     // Same as vzv/char_count/vzv but with different inputs
     let seed = 42;
     let (string_vec, _) = random_alphanums(2..=10, 100, seed);
-    let bytes: Vec<u8> =
-        VarZeroVec::<str>::get_serializable_bytes::<String>(string_vec.as_slice()).unwrap();
+    let bytes: Vec<u8> = VarZeroVec::<str>::get_serializable_bytes(string_vec.iter()).unwrap();
     let vzv = VarZeroVec::<str>::parse_byte_slice(black_box(bytes.as_slice())).unwrap();
 
     c.bench_function("vzv/overview", |b| {
@@ -73,8 +72,7 @@ fn overview_bench(c: &mut Criterion) {
 fn char_count_benches(c: &mut Criterion) {
     let seed = 2021;
     let (string_vec, _) = random_alphanums(2..=20, 100, seed);
-    let bytes: Vec<u8> =
-        VarZeroVec::<str>::get_serializable_bytes::<String>(string_vec.as_slice()).unwrap();
+    let bytes: Vec<u8> = VarZeroVec::<str>::get_serializable_bytes(string_vec.iter()).unwrap();
     let vzv = VarZeroVec::<str>::parse_byte_slice(black_box(bytes.as_slice())).unwrap();
 
     // *** Count chars in vec of 100 strings ***
@@ -101,8 +99,7 @@ fn binary_search_benches(c: &mut Criterion) {
     let seed = 2021;
     let (string_vec, seed) = random_alphanums(2..=20, 500, seed);
     let (needles, _) = random_alphanums(2..=20, 10, seed);
-    let bytes: Vec<u8> =
-        VarZeroVec::<str>::get_serializable_bytes::<String>(string_vec.as_slice()).unwrap();
+    let bytes: Vec<u8> = VarZeroVec::<str>::get_serializable_bytes(string_vec.iter()).unwrap();
     let vzv = VarZeroVec::<str>::parse_byte_slice(black_box(bytes.as_slice())).unwrap();
     let single_needle = "lmnop".to_string();
 

--- a/utils/zerovec/src/error.rs
+++ b/utils/zerovec/src/error.rs
@@ -6,7 +6,7 @@ use core::any;
 use core::fmt;
 
 /// A generic error type to be used for decoding slices of ULE types
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ZeroVecError {
     /// Attempted to parse a buffer into a slice of the given ULE type but its
     /// length was not compatible

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -76,7 +76,7 @@
 //!
 //! let data = DataStruct {
 //!     nums: ZeroVec::from_slice(&[211, 281, 421, 461]),
-//!     strs: VarZeroVec::from(&["hello", "world"] as &[_]),
+//!     strs: VarZeroVec::from(["hello", "world"].iter()),
 //! };
 //! let bincode_bytes = bincode::serialize(&data)
 //!     .expect("Serialization should be successful");

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -76,7 +76,7 @@
 //!
 //! let data = DataStruct {
 //!     nums: ZeroVec::from_slice(&[211, 281, 421, 461]),
-//!     strs: VarZeroVec::from(["hello", "world"].iter()),
+//!     strs: VarZeroVec::from(&["hello", "world"]),
 //! };
 //! let bincode_bytes = bincode::serialize(&data)
 //!     .expect("Serialization should be successful");

--- a/utils/zerovec/src/ule/custom/encode.rs
+++ b/utils/zerovec/src/ule/custom/encode.rs
@@ -248,23 +248,23 @@ mod test {
 
     const U8_ARRAY: [u8; 8] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
 
-    const U8_NESTED_2D_ARRAY: [&[u8]; 2] = [&U8_ARRAY, &U8_ARRAY];
+    const U8_2D_ARRAY: [&[u8]; 2] = [&U8_ARRAY, &U8_ARRAY];
 
-    const U8_NESTED_2D_SLICE: &[&[u8]] = &[&U8_ARRAY, &U8_ARRAY];
+    const U8_2D_SLICE: &[&[u8]] = &[&U8_ARRAY, &U8_ARRAY];
 
-    const U8_NESTED_3D_ARRAY: [&[&[u8]]; 2] = [U8_NESTED_2D_SLICE, U8_NESTED_2D_SLICE];
+    const U8_3D_ARRAY: [&[&[u8]]; 2] = [U8_2D_SLICE, U8_2D_SLICE];
 
-    const U8_NESTED_3D_SLICE: &[&[&[u8]]] = &[U8_NESTED_2D_SLICE, U8_NESTED_2D_SLICE];
+    const U8_3D_SLICE: &[&[&[u8]]] = &[U8_2D_SLICE, U8_2D_SLICE];
 
     const U32_ARRAY: [u32; 4] = [0x00010203, 0x04050607, 0x08090A0B, 0x0C0D0E0F];
 
-    const U32_NESTED_2D_ARRAY: [&[u32]; 2] = [&U32_ARRAY, &U32_ARRAY];
+    const U32_2D_ARRAY: [&[u32]; 2] = [&U32_ARRAY, &U32_ARRAY];
 
-    const U32_NESTED_2D_SLICE: &[&[u32]] = &[&U32_ARRAY, &U32_ARRAY];
+    const U32_2D_SLICE: &[&[u32]] = &[&U32_ARRAY, &U32_ARRAY];
 
-    const U32_NESTED_3D_ARRAY: [&[&[u32]]; 2] = [U32_NESTED_2D_SLICE, U32_NESTED_2D_SLICE];
+    const U32_3D_ARRAY: [&[&[u32]]; 2] = [U32_2D_SLICE, U32_2D_SLICE];
 
-    const U32_NESTED_3D_SLICE: &[&[&[u32]]] = &[U32_NESTED_2D_SLICE, U32_NESTED_2D_SLICE];
+    const U32_3D_SLICE: &[&[&[u32]]] = &[U32_2D_SLICE, U32_2D_SLICE];
 
     #[test]
     fn test_vzv_from() {
@@ -272,40 +272,100 @@ mod test {
         type ZS<T> = ZeroSlice<T>;
         type VZS<T> = VarZeroSlice<T>;
 
-        let u8_nested_2d_vec: Vec<Vec<u8>> = vec![U8_ARRAY.into(), U8_ARRAY.into()];
-        let u8_nested_3d_vec: Vec<Vec<Vec<u8>>> =
-            vec![u8_nested_2d_vec.clone(), u8_nested_2d_vec.clone()];
+        let u8_zerovec: ZeroVec<u8> = ZeroVec::from_slice(&U8_ARRAY);
+        let u8_2d_zerovec: [ZeroVec<u8>; 2] = [u8_zerovec.clone(), u8_zerovec.clone()];
+        let u8_2d_vec: Vec<Vec<u8>> = vec![U8_ARRAY.into(), U8_ARRAY.into()];
+        let u8_3d_vec: Vec<Vec<Vec<u8>>> = vec![u8_2d_vec.clone(), u8_2d_vec.clone()];
 
-        let u32_nested_2d_vec: Vec<Vec<u32>> = vec![U32_ARRAY.into(), U32_ARRAY.into()];
-        let u32_nested_3d_vec: Vec<Vec<Vec<u32>>> =
-            vec![u32_nested_2d_vec.clone(), u32_nested_2d_vec.clone()];
+        let u32_zerovec: ZeroVec<u32> = ZeroVec::from_slice(&U32_ARRAY);
+        let u32_2d_zerovec: [ZeroVec<u32>; 2] = [u32_zerovec.clone(), u32_zerovec.clone()];
+        let u32_2d_vec: Vec<Vec<u32>> = vec![U32_ARRAY.into(), U32_ARRAY.into()];
+        let u32_3d_vec: Vec<Vec<Vec<u32>>> = vec![u32_2d_vec.clone(), u32_2d_vec.clone()];
 
-        let _: VZV<str> = VarZeroVec::from(&STRING_ARRAY);
-        let _: VZV<str> = VarZeroVec::from(STRING_SLICE);
-        let _: VZV<str> = VarZeroVec::from(&Vec::from(STRING_SLICE));
+        let a: VZV<str> = VarZeroVec::from(&STRING_ARRAY);
+        let b: VZV<str> = VarZeroVec::from(STRING_SLICE);
+        let c: VZV<str> = VarZeroVec::from(&Vec::from(STRING_SLICE));
+        assert_eq!(a, STRING_SLICE);
+        assert_eq!(a, b);
+        assert_eq!(a, c);
 
-        let _: VZV<[u8]> = VarZeroVec::from(&U8_NESTED_2D_ARRAY);
-        let _: VZV<[u8]> = VarZeroVec::from(U8_NESTED_2D_SLICE);
-        let _: VZV<[u8]> = VarZeroVec::from(&u8_nested_2d_vec);
+        let a: VZV<[u8]> = VarZeroVec::from(&U8_2D_ARRAY);
+        let b: VZV<[u8]> = VarZeroVec::from(U8_2D_SLICE);
+        let c: VZV<[u8]> = VarZeroVec::from(&u8_2d_vec);
+        assert_eq!(a, U8_2D_SLICE);
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+        let u8_3d_vzv_brackets = &[a.clone(), a.clone()];
 
-        let _: VZV<ZS<u8>> = VarZeroVec::from(&U8_NESTED_2D_ARRAY);
-        let _: VZV<ZS<u8>> = VarZeroVec::from(U8_NESTED_2D_SLICE);
-        let _: VZV<ZS<u8>> = VarZeroVec::from(&u8_nested_2d_vec);
+        let a: VZV<ZS<u8>> = VarZeroVec::from(&U8_2D_ARRAY);
+        let b: VZV<ZS<u8>> = VarZeroVec::from(U8_2D_SLICE);
+        let c: VZV<ZS<u8>> = VarZeroVec::from(&u8_2d_vec);
+        let d: VZV<ZS<u8>> = VarZeroVec::from(&u8_2d_zerovec);
+        assert_eq!(a, U8_2D_SLICE);
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+        assert_eq!(a, d);
+        let u8_3d_vzv_zeroslice = &[a.clone(), a.clone()];
 
-        let _: VZV<VZS<[u8]>> = VarZeroVec::from(&U8_NESTED_3D_ARRAY);
-        let _: VZV<VZS<[u8]>> = VarZeroVec::from(U8_NESTED_3D_SLICE);
-        let _: VZV<VZS<[u8]>> = VarZeroVec::from(&u8_nested_3d_vec);
+        let a: VZV<VZS<[u8]>> = VarZeroVec::from(&U8_3D_ARRAY);
+        let b: VZV<VZS<[u8]>> = VarZeroVec::from(U8_3D_SLICE);
+        let c: VZV<VZS<[u8]>> = VarZeroVec::from(&u8_3d_vec);
+        let d: VZV<VZS<[u8]>> = VarZeroVec::from(u8_3d_vzv_brackets);
+        assert_eq!(
+            a.iter()
+                .map(|x| x
+                    .iter()
+                    .map(|y| y.iter().copied().collect::<Vec<u8>>())
+                    .collect::<Vec<Vec<u8>>>())
+                .collect::<Vec<Vec<Vec<u8>>>>(),
+            u8_3d_vec
+        );
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+        assert_eq!(a, d);
 
-        let _: VZV<VZS<ZS<u8>>> = VarZeroVec::from(&U8_NESTED_3D_ARRAY);
-        let _: VZV<VZS<ZS<u8>>> = VarZeroVec::from(U8_NESTED_3D_SLICE);
-        let _: VZV<VZS<ZS<u8>>> = VarZeroVec::from(&u8_nested_3d_vec);
+        let a: VZV<VZS<ZS<u8>>> = VarZeroVec::from(&U8_3D_ARRAY);
+        let b: VZV<VZS<ZS<u8>>> = VarZeroVec::from(U8_3D_SLICE);
+        let c: VZV<VZS<ZS<u8>>> = VarZeroVec::from(&u8_3d_vec);
+        let d: VZV<VZS<ZS<u8>>> = VarZeroVec::from(u8_3d_vzv_zeroslice);
+        assert_eq!(
+            a.iter()
+                .map(|x| x
+                    .iter()
+                    .map(|y| y.iter().collect::<Vec<u8>>())
+                    .collect::<Vec<Vec<u8>>>())
+                .collect::<Vec<Vec<Vec<u8>>>>(),
+            u8_3d_vec
+        );
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+        assert_eq!(a, d);
 
-        let _: VZV<ZS<u32>> = VarZeroVec::from(&U32_NESTED_2D_ARRAY);
-        let _: VZV<ZS<u32>> = VarZeroVec::from(U32_NESTED_2D_SLICE);
-        let _: VZV<ZS<u32>> = VarZeroVec::from(&u32_nested_2d_vec);
+        let a: VZV<ZS<u32>> = VarZeroVec::from(&U32_2D_ARRAY);
+        let b: VZV<ZS<u32>> = VarZeroVec::from(U32_2D_SLICE);
+        let c: VZV<ZS<u32>> = VarZeroVec::from(&u32_2d_vec);
+        let d: VZV<ZS<u32>> = VarZeroVec::from(&u32_2d_zerovec);
+        assert_eq!(a, u32_2d_zerovec);
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+        assert_eq!(a, d);
+        let u32_3d_vzv = &[a.clone(), a.clone()];
 
-        let _: VZV<VZS<ZS<u32>>> = VarZeroVec::from(&U32_NESTED_3D_ARRAY);
-        let _: VZV<VZS<ZS<u32>>> = VarZeroVec::from(U32_NESTED_3D_SLICE);
-        let _: VZV<VZS<ZS<u32>>> = VarZeroVec::from(&u32_nested_3d_vec);
+        let a: VZV<VZS<ZS<u32>>> = VarZeroVec::from(&U32_3D_ARRAY);
+        let b: VZV<VZS<ZS<u32>>> = VarZeroVec::from(U32_3D_SLICE);
+        let c: VZV<VZS<ZS<u32>>> = VarZeroVec::from(&u32_3d_vec);
+        let d: VZV<VZS<ZS<u32>>> = VarZeroVec::from(u32_3d_vzv);
+        assert_eq!(
+            a.iter()
+                .map(|x| x
+                    .iter()
+                    .map(|y| y.iter().collect::<Vec<u32>>())
+                    .collect::<Vec<Vec<u32>>>())
+                .collect::<Vec<Vec<Vec<u32>>>>(),
+            u32_3d_vec
+        );
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+        assert_eq!(a, d);
     }
 }

--- a/utils/zerovec/src/ule/custom/encode.rs
+++ b/utils/zerovec/src/ule/custom/encode.rs
@@ -187,12 +187,12 @@ where
     }
 
     fn encode_var_ule_len(&self) -> usize {
-        // 4 for length + 4 for each offset + the body
-        4usize + (self.len() * 4) + self.iter().map(|v| v.encode_var_ule_len()).sum()
+        crate::varzerovec::borrowed::compute_serializable_len(self)
     }
 
     fn encode_var_ule_write(&self, dst: &mut [u8]) {
-        crate::varzerovec::borrowed::write_serializable_bytes(self.iter(), dst)
+        let len = crate::varzerovec::borrowed::write_serializable_bytes(self, dst);
+        debug_assert_eq!(len, Some(dst.len() as u32));
     }
 }
 

--- a/utils/zerovec/src/ule/custom/encode.rs
+++ b/utils/zerovec/src/ule/custom/encode.rs
@@ -188,7 +188,7 @@ where
 
     fn encode_var_ule_len(&self) -> usize {
         // 4 for length + 4 for each offset + the body
-        4 + self.len() * 4 + self.iter().map(|v| v.encode_var_ule_len()).sum()
+        4usize + (self.len() * 4) + self.iter().map(|v| v.encode_var_ule_len()).sum()
     }
 
     fn encode_var_ule_write(&self, dst: &mut [u8]) {

--- a/utils/zerovec/src/ule/custom/encode.rs
+++ b/utils/zerovec/src/ule/custom/encode.rs
@@ -187,12 +187,12 @@ where
     }
 
     fn encode_var_ule_len(&self) -> usize {
-        crate::varzerovec::borrowed::compute_serializable_len(self)
+        // TODO: Remove the unwrap somehow
+        crate::varzerovec::borrowed::compute_serializable_len(self).unwrap() as usize
     }
 
     fn encode_var_ule_write(&self, dst: &mut [u8]) {
-        let len = crate::varzerovec::borrowed::write_serializable_bytes(self, dst);
-        debug_assert_eq!(len, Some(dst.len() as u32));
+        crate::varzerovec::borrowed::write_serializable_bytes(self, dst)
     }
 }
 

--- a/utils/zerovec/src/ule/custom/encode.rs
+++ b/utils/zerovec/src/ule/custom/encode.rs
@@ -7,6 +7,7 @@ use crate::zerovec::{ZeroSlice, ZeroVec};
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
+use core::iter::ExactSizeIterator;
 
 /// Allows types to be encoded as VarULEs. This is highly useful for implementing VarULE on
 /// custom DSTs where the type cannot be obtained as a reference to some other type.
@@ -111,6 +112,35 @@ where
     }
 }
 
+pub struct ExactSizeIteratorEncoder<'l, T: 'l, I: ExactSizeIterator<Item = &'l T>>(pub I);
+
+unsafe impl<'l, T, I> EncodeAsVarULE<ZeroSlice<T>> for ExactSizeIteratorEncoder<'l, T, I>
+where
+    T: 'static + AsULE,
+    // Note: Should this be Copy? https://internals.rust-lang.org/t/should-core-iter-be-copy/15813
+    I: Clone + ExactSizeIterator<Item = &'l T>,
+{
+    fn encode_var_ule_as_slices<R>(&self, _: impl FnOnce(&[&[u8]]) -> R) -> R {
+        // unnecessary if the other two are implemented
+        unreachable!()
+    }
+
+    #[inline]
+    fn encode_var_ule_len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn encode_var_ule_write(&self, dst: &mut [u8]) {
+        #[allow(non_snake_case)]
+        let S = core::mem::size_of::<T::ULE>();
+        debug_assert_eq!(self.0.len() * S, dst.len());
+        for (item, ref mut chunk) in self.0.clone().zip(dst.chunks_mut(S)) {
+            let ule = item.as_unaligned();
+            chunk.copy_from_slice(ULE::as_byte_slice(core::slice::from_ref(&ule)));
+        }
+    }
+}
+
 unsafe impl<T> EncodeAsVarULE<ZeroSlice<T>> for &'_ [T]
 where
     T: AsULE + 'static,
@@ -150,6 +180,7 @@ where
         self.as_slice().encode_var_ule_len()
     }
 
+    #[inline]
     fn encode_var_ule_write(&self, dst: &mut [u8]) {
         self.as_slice().encode_var_ule_write(dst)
     }

--- a/utils/zerovec/src/ule/custom/encode.rs
+++ b/utils/zerovec/src/ule/custom/encode.rs
@@ -127,7 +127,7 @@ where
 
 unsafe impl<T> EncodeAsVarULE<[T]> for Vec<T>
 where
-    [T]: VarULE,
+    T: ULE,
 {
     fn encode_var_ule_as_slices<R>(&self, cb: impl FnOnce(&[&[u8]]) -> R) -> R {
         cb(&[<[T] as VarULE>::as_byte_slice(&*self)])

--- a/utils/zerovec/src/ule/custom/mod.rs
+++ b/utils/zerovec/src/ule/custom/mod.rs
@@ -90,7 +90,7 @@
 //!     let mut foos = vec![Foo {field1: 'u', field2: 983, field3: ZeroVec::alloc_from_slice(&[1212,2309,500,7000])},
 //!                         Foo {field1: 'l', field2: 1010, field3: ZeroVec::alloc_from_slice(&[1932, 0, 8888, 91237])}];
 //!
-//!     let vzv = VarZeroVec::from(&*foos);
+//!     let vzv = VarZeroVec::from(foos.iter());
 //!
 //!     assert_eq!(char::from_unaligned(vzv.get(0).unwrap().field1), 'u');
 //!     assert_eq!(u32::from_unaligned(vzv.get(0).unwrap().field2), 983);

--- a/utils/zerovec/src/ule/custom/mod.rs
+++ b/utils/zerovec/src/ule/custom/mod.rs
@@ -90,7 +90,7 @@
 //!     let mut foos = vec![Foo {field1: 'u', field2: 983, field3: ZeroVec::alloc_from_slice(&[1212,2309,500,7000])},
 //!                         Foo {field1: 'l', field2: 1010, field3: ZeroVec::alloc_from_slice(&[1932, 0, 8888, 91237])}];
 //!
-//!     let vzv = VarZeroVec::from(foos.iter());
+//!     let vzv = VarZeroVec::from(&foos);
 //!
 //!     assert_eq!(char::from_unaligned(vzv.get(0).unwrap().field1), 'u');
 //!     assert_eq!(u32::from_unaligned(vzv.get(0).unwrap().field2), 983);

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -146,14 +146,14 @@ pub trait AsULE: Copy {
     /// Types that are not well-defined for all bit values should implement a custom ULE.
     type ULE: ULE;
 
-    /// Converts from `&Self` to `Self::ULE`.
+    /// Converts from `Self` to `Self::ULE`.
     ///
     /// This function may involve byte order swapping (native-endian to little-endian).
     ///
     /// For best performance, mark your implementation of this function `#[inline]`.
     fn as_unaligned(self) -> Self::ULE;
 
-    /// Converts from `&Self::ULE` to `Self`.
+    /// Converts from `Self::ULE` to `Self`.
     ///
     /// This function may involve byte order swapping (little-endian to native-endian).
     ///

--- a/utils/zerovec/src/ule/slices.rs
+++ b/utils/zerovec/src/ule/slices.rs
@@ -33,16 +33,16 @@ unsafe impl VarULE for str {
 }
 
 // Safety (based on the safety checklist on the VarULE trait):
-//  1. [u8] does not include any uninitialized or padding bytes (achieved by being a slice of a ULE type)
-//  2. [u8] is aligned to 1 byte (achieved by being a slice of a ULE type)
+//  1. [T] does not include any uninitialized or padding bytes (achieved by being a slice of a ULE type)
+//  2. [T] is aligned to 1 byte (achieved by being a slice of a ULE type)
 //  3. The impl of `validate_byte_slice()` returns an error if any byte is not valid.
 //  4. The impl of `validate_byte_slice()` returns an error if the slice cannot be used in its entirety
 //  5. The impl of `from_byte_slice_unchecked()` returns a reference to the same data.
 //  6. All other methods are defaulted
-//  7. `[u8]` byte equality is semantic equality
+//  7. `[T]` byte equality is semantic equality (achieved by being a slice of a ULE type)
 unsafe impl<T> VarULE for [T]
 where
-    T: ULE + AsULE<ULE = T>,
+    T: ULE,
 {
     #[inline]
     fn validate_byte_slice(slice: &[u8]) -> Result<(), ZeroVecError> {

--- a/utils/zerovec/src/ule/slices.rs
+++ b/utils/zerovec/src/ule/slices.rs
@@ -32,6 +32,24 @@ unsafe impl VarULE for str {
     }
 }
 
+/// Note: VarULE is well-defined for all `[T]` where `T: ULE`, but [`ZeroSlice`] is more ergonomic
+/// when `T` is a low-level ULE type. For example:
+///
+/// ```no_run
+/// # use zerovec::ZeroSlice;
+/// # use zerovec::VarZeroVec;
+/// # use zerovec::ule::AsULE;
+/// // OK: [u8] is a useful type
+/// let _: VarZeroVec<[u8]> = unimplemented!();
+///
+/// // Technically works, but [u32::ULE] is not very useful
+/// let _: VarZeroVec<[<u32 as AsULE>::ULE]> = unimplemented!();
+///
+/// // Better: ZeroSlice<u32>
+/// let _: VarZeroVec<ZeroSlice<u32>> = unimplemented!();
+/// ```
+///
+/// [`ZeroSlice`]: crate::ZeroSlice
 // Safety (based on the safety checklist on the VarULE trait):
 //  1. [T] does not include any uninitialized or padding bytes (achieved by being a slice of a ULE type)
 //  2. [T] is aligned to 1 byte (achieved by being a slice of a ULE type)

--- a/utils/zerovec/src/varzerovec/borrowed.rs
+++ b/utils/zerovec/src/varzerovec/borrowed.rs
@@ -8,7 +8,6 @@ use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::convert::TryInto;
-use core::iter::ExactSizeIterator;
 use core::marker::PhantomData;
 use core::{iter, mem};
 
@@ -330,11 +329,10 @@ where
 }
 
 /// Collects the bytes for a VarZeroSlice into a Vec.
-pub fn get_serializable_bytes<'l, T, A, I>(elements: I) -> Option<Vec<u8>>
+pub fn get_serializable_bytes<T, A>(elements: &[A]) -> Option<Vec<u8>>
 where
     T: VarULE + ?Sized,
-    A: 'l + custom::EncodeAsVarULE<T>,
-    I: ExactSizeIterator<Item = &'l A>,
+    A: custom::EncodeAsVarULE<T>,
 {
     // Assume each element is probably around 4 bytes long when estimating the
     // initial size. Performance of this function does not matter *too* much since
@@ -345,7 +343,7 @@ where
     // Make space for indices
     vec.resize(4 + 4 * elements.len(), 0);
     let mut offset: u32 = 0;
-    for (idx, element) in elements.enumerate() {
+    for (idx, element) in elements.iter().enumerate() {
         let element_len = element.encode_var_ule_len();
         let indices = &mut vec[(4 + 4 * idx)..(4 + 4 * idx + 4)];
         indices.copy_from_slice(&offset.as_unaligned().0);

--- a/utils/zerovec/src/varzerovec/borrowed.rs
+++ b/utils/zerovec/src/varzerovec/borrowed.rs
@@ -329,11 +329,11 @@ where
     }
 }
 
-pub fn get_serializable_bytes<T, A, I>(elements: I) -> Option<Vec<u8>>
+pub fn get_serializable_bytes<'l, T, A, I>(elements: I) -> Option<Vec<u8>>
 where
     T: VarULE + ?Sized,
-    A: custom::EncodeAsVarULE<T>,
-    I: ExactSizeIterator<Item = A>,
+    A: 'l + custom::EncodeAsVarULE<T>,
+    I: ExactSizeIterator<Item = &'l A>,
 {
     // Assume each element is probably around 4 bytes long when estimating the
     // initial size. Performance of this function does not matter *too* much since

--- a/utils/zerovec/src/varzerovec/borrowed.rs
+++ b/utils/zerovec/src/varzerovec/borrowed.rs
@@ -329,6 +329,7 @@ where
     }
 }
 
+/// Collects the bytes for a VarZeroSlice into a Vec.
 pub fn get_serializable_bytes<'l, T, A, I>(elements: I) -> Option<Vec<u8>>
 where
     T: VarULE + ?Sized,
@@ -357,4 +358,18 @@ where
     }
 
     Some(vec)
+}
+
+/// Writes the bytes for a VarZeroSlice into an output buffer.
+///
+/// # Panics
+///
+/// Panics if `output` is not the correct length.
+pub fn write_serializable_bytes<'l, T, A, I>(elements: I, output: &mut [u8])
+where
+    T: VarULE + ?Sized,
+    A: 'l + custom::EncodeAsVarULE<T>,
+    I: ExactSizeIterator<Item = &'l A>,
+{
+    todo!()
 }

--- a/utils/zerovec/src/varzerovec/borrowed.rs
+++ b/utils/zerovec/src/varzerovec/borrowed.rs
@@ -336,7 +336,6 @@ where
 {
     let len = compute_serializable_len(elements)?;
     debug_assert!(len >= 4);
-    debug_assert!(len <= u32::MAX);
     let mut output = Vec::with_capacity(len as usize);
     // Safety: All bytes will be initialized after calling write_serializable_bytes
     unsafe {

--- a/utils/zerovec/src/varzerovec/borrowed.rs
+++ b/utils/zerovec/src/varzerovec/borrowed.rs
@@ -339,17 +339,19 @@ where
     debug_assert!(len <= u32::MAX);
     let mut output = Vec::with_capacity(len as usize);
     // Safety: All bytes will be initialized after calling write_serializable_bytes
-    unsafe { output.set_len(len as usize); }
+    unsafe {
+        output.set_len(len as usize);
+    }
     write_serializable_bytes(elements, &mut output);
     Some(output)
 }
 
 /// Writes the bytes for a VarZeroSlice into an output buffer.
-/// 
+///
 /// Every byte in the buffer will be initialized after calling this function.
-/// 
+///
 /// # Panics
-/// 
+///
 /// Panics if the buffer is not exactly the correct length.
 pub fn write_serializable_bytes<T, A>(elements: &[A], output: &mut [u8])
 where

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -462,10 +462,10 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # Ok::<(), ZeroVecError>(())
     /// ```
     ///
-    pub fn get_serializable_bytes<A, I>(elements: I) -> Option<Vec<u8>>
+    pub fn get_serializable_bytes<'l, A, I>(elements: I) -> Option<Vec<u8>>
     where
-        A: custom::EncodeAsVarULE<T>,
-        I: ExactSizeIterator<Item = A>,
+        A: 'l + custom::EncodeAsVarULE<T>,
+        I: ExactSizeIterator<Item = &'l A>,
     {
         borrowed::get_serializable_bytes(elements)
     }
@@ -521,11 +521,11 @@ impl<'a, T: VarULE + ?Sized> Index<usize> for VarZeroVec<'a, T> {
     }
 }
 
-impl<'a, T, A, I> From<I> for VarZeroVec<'a, T>
+impl<'a, 'l, T, A, I> From<I> for VarZeroVec<'a, T>
 where
     T: VarULE + ?Sized,
-    A: custom::EncodeAsVarULE<T>,
-    I: ExactSizeIterator<Item = A>,
+    A: 'l + custom::EncodeAsVarULE<T>,
+    I: ExactSizeIterator<Item = &'l A>,
 {
     fn from(elements: I) -> Self {
         VarZeroVecOwned::from_elements(elements).into()

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -101,12 +101,12 @@ pub use slice::VarZeroSlice;
 ///              0, 0, 42, 0, 0, 0, 3, 217, 0, 0, 57, 48, 0, 0, 49, 212, 0, 0,
 ///              9, 0, 0, 0];
 ///
-/// let zerovec: VarZeroVec<ZeroSlice<u32>> = VarZeroVec::parse_byte_slice(bytes)?;
+/// let zerovec1: VarZeroVec<ZeroSlice<u32>> = VarZeroVec::parse_byte_slice(bytes)?;
+/// assert_eq!(zerovec1.get(2).and_then(|v| v.get(1)), Some(55555));
 ///
-/// assert_eq!(zerovec.get(2).and_then(|v| v.get(1)), Some(55555));
-/// for (zv, v) in zerovec.iter().zip(numbers.iter()) {
-///     assert_eq!(zv, &**v);   
-/// }
+/// let zerovec2: VarZeroVec<ZeroSlice<u32>> = numbers.as_slice().into();
+/// assert_eq!(zerovec1, zerovec2);
+///
 /// # Ok::<(), ZeroVecError>(())
 /// ```
 ///

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -6,6 +6,7 @@ use crate::ule::*;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt;
+use core::iter::ExactSizeIterator;
 use core::ops::Index;
 
 pub(crate) mod borrowed;
@@ -461,7 +462,11 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # Ok::<(), ZeroVecError>(())
     /// ```
     ///
-    pub fn get_serializable_bytes<A: custom::EncodeAsVarULE<T>>(elements: &[A]) -> Option<Vec<u8>> {
+    pub fn get_serializable_bytes<A, I>(elements: I) -> Option<Vec<u8>>
+    where
+        A: custom::EncodeAsVarULE<T>,
+        I: ExactSizeIterator<Item = A>,
+    {
         borrowed::get_serializable_bytes(elements)
     }
 
@@ -516,14 +521,14 @@ impl<'a, T: VarULE + ?Sized> Index<usize> for VarZeroVec<'a, T> {
     }
 }
 
-impl<'a, A, T> From<&'_ [A]> for VarZeroVec<'a, T>
+impl<'a, T, A, I> From<I> for VarZeroVec<'a, T>
 where
-    T: VarULE,
-    T: ?Sized,
+    T: VarULE + ?Sized,
     A: custom::EncodeAsVarULE<T>,
+    I: ExactSizeIterator<Item = A>,
 {
-    fn from(other: &'_ [A]) -> Self {
-        VarZeroVecOwned::from_elements(other).into()
+    fn from(elements: I) -> Self {
+        VarZeroVecOwned::from_elements(elements).into()
     }
 }
 

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -295,6 +295,15 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
         Ok(VarZeroVec::Borrowed(borrowed))
     }
 
+    #[inline]
+    pub fn from_elements<'l, A, I>(elements: I) -> Self
+    where
+        A: 'l + custom::EncodeAsVarULE<T>,
+        I: ExactSizeIterator<Item = &'l A>,
+    {
+        VarZeroVecOwned::from_elements(elements).into()
+    }
+
     /// Obtain an iterator over VarZeroVec's elements
     ///
     /// # Example
@@ -514,14 +523,25 @@ impl<'a, T: VarULE + ?Sized> Index<usize> for VarZeroVec<'a, T> {
     }
 }
 
-impl<'a, 'l, T, A, I> From<I> for VarZeroVec<'a, T>
+impl<A, T> From<&Vec<A>> for VarZeroVec<'static, T>
 where
     T: VarULE + ?Sized,
-    A: 'l + custom::EncodeAsVarULE<T>,
-    I: ExactSizeIterator<Item = &'l A>,
+    A: custom::EncodeAsVarULE<T>,
 {
-    fn from(elements: I) -> Self {
-        VarZeroVecOwned::from_elements(elements).into()
+    #[inline]
+    fn from(elements: &Vec<A>) -> Self {
+        Self::from_elements(elements.iter())
+    }
+}
+
+impl<A, T> From<&[A]> for VarZeroVec<'static, T>
+where
+    T: VarULE + ?Sized,
+    A: custom::EncodeAsVarULE<T>,
+{
+    #[inline]
+    fn from(elements: &[A]) -> Self {
+        Self::from_elements(elements.iter())
     }
 }
 

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -67,7 +67,7 @@ pub use slice::VarZeroSlice;
 /// use zerovec::VarZeroVec;
 ///
 /// // The little-endian bytes correspond to the list of strings.
-/// let strings = vec!["w".to_owned(), "ω".to_owned(), "文".to_owned(), "𑄃".to_owned()];
+/// let strings = vec!["w", "ω", "文", "𑄃"];
 /// let bytes = &[
 ///     4, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,  3, 0, 0, 0,
 ///     6, 0, 0, 0, 119, 207, 137, 230, 150, 135, 240, 145, 132, 131,
@@ -105,7 +105,7 @@ pub use slice::VarZeroSlice;
 /// let zerovec1: VarZeroVec<ZeroSlice<u32>> = VarZeroVec::parse_byte_slice(bytes)?;
 /// assert_eq!(zerovec1.get(2).and_then(|v| v.get(1)), Some(55555));
 ///
-/// let zerovec2: VarZeroVec<ZeroSlice<u32>> = numbers.as_slice().into();
+/// let zerovec2: VarZeroVec<ZeroSlice<u32>> = numbers.iter().into();
 /// assert_eq!(zerovec1, zerovec2);
 ///
 /// # Ok::<(), ZeroVecError>(())
@@ -231,9 +231,8 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::ule::ZeroVecError;
     /// # use zerovec::VarZeroVec;
     ///
-    /// let strings = vec!["foo".to_owned(), "bar".to_owned(),
-    ///                    "baz".to_owned(), "quux".to_owned()];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
+    /// let strings = vec!["foo", "bar", "baz", "quux"];
+    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(strings.iter()).unwrap();
     ///
     /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     /// assert_eq!(vec.len(), 4);
@@ -253,7 +252,7 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::VarZeroVec;
     ///
     /// let strings: Vec<String> = vec![];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
+    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(strings.iter()).unwrap();
     ///
     /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     /// assert!(vec.is_empty());
@@ -275,9 +274,8 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::ule::ZeroVecError;
     /// # use zerovec::VarZeroVec;
     ///
-    /// let strings = vec!["foo".to_owned(), "bar".to_owned(),
-    ///                    "baz".to_owned(), "quux".to_owned()];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
+    /// let strings = vec!["foo", "bar", "baz", "quux"];
+    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(strings.iter()).unwrap();
     ///
     /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     /// assert_eq!(&vec[0], "foo");
@@ -306,9 +304,8 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::ule::ZeroVecError;
     /// # use zerovec::VarZeroVec;
     ///
-    /// let strings = vec!["foo".to_owned(), "bar".to_owned(),
-    ///                    "baz".to_owned(), "quux".to_owned()];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
+    /// let strings = vec!["foo", "bar", "baz", "quux"];
+    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(strings.iter()).unwrap();
     /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     ///
     /// let mut iter_results: Vec<&str> = vec.iter().collect();
@@ -331,9 +328,8 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::ule::ZeroVecError;
     /// # use zerovec::VarZeroVec;
     ///
-    /// let strings = vec!["foo".to_owned(), "bar".to_owned(),
-    ///                    "baz".to_owned(), "quux".to_owned()];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
+    /// let strings = vec!["foo", "bar", "baz", "quux"];
+    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(strings.iter()).unwrap();
     /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     ///
     /// let mut iter_results: Vec<&str> = vec.iter().collect();
@@ -358,9 +354,8 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::ule::ZeroVecError;
     /// # use zerovec::VarZeroVec;
     ///
-    /// let strings = vec!["foo".to_owned(), "bar".to_owned(),
-    ///                    "baz".to_owned(), "quux".to_owned()];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
+    /// let strings = vec!["foo", "bar", "baz", "quux"];
+    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(strings.iter()).unwrap();
     /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     ///
     /// assert_eq!(vec.len(), 4);
@@ -398,9 +393,8 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::ule::ZeroVecError;
     /// # use zerovec::VarZeroVec;
     ///
-    /// let strings = vec!["foo".to_owned(), "bar".to_owned(),
-    ///                    "baz".to_owned(), "quux".to_owned()];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
+    /// let strings = vec!["foo", "bar", "baz", "quux"];
+    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(strings.iter()).unwrap();
     /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     ///
     /// assert_eq!(vec.len(), 4);
@@ -453,8 +447,8 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::ule::ZeroVecError;
     /// # use zerovec::VarZeroVec;
     ///
-    /// let strings = vec!["foo".to_owned(), "bar".to_owned(), "baz".to_owned()];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
+    /// let strings = vec!["foo", "bar", "baz"];
+    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(strings.iter()).unwrap();
     ///
     /// let mut borrowed: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     /// assert_eq!(borrowed, &*strings);
@@ -497,9 +491,8 @@ where
     /// # use zerovec::ule::ZeroVecError;
     /// # use zerovec::VarZeroVec;
     ///
-    /// let strings = vec!["a".to_owned(), "b".to_owned(),
-    ///                    "f".to_owned(), "g".to_owned()];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
+    /// let strings = vec!["a", "b", "f", "g"];
+    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(strings.iter()).unwrap();
     /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     ///
     /// assert_eq!(vec.binary_search("f"), Ok(2));

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -105,7 +105,7 @@ pub use slice::VarZeroSlice;
 /// let zerovec1: VarZeroVec<ZeroSlice<u32>> = VarZeroVec::parse_byte_slice(bytes)?;
 /// assert_eq!(zerovec1.get(2).and_then(|v| v.get(1)), Some(55555));
 ///
-/// let zerovec2: VarZeroVec<ZeroSlice<u32>> = numbers.iter().into();
+/// let zerovec2: VarZeroVec<ZeroSlice<u32>> = numbers.into();
 /// assert_eq!(zerovec1, zerovec2);
 ///
 /// # Ok::<(), ZeroVecError>(())
@@ -541,6 +541,17 @@ where
 {
     #[inline]
     fn from(elements: &[A]) -> Self {
+        Self::from_elements(elements.iter())
+    }
+}
+
+impl<A, T, const N: usize> From<&[A; N]> for VarZeroVec<'static, T>
+where
+    T: VarULE + ?Sized,
+    A: custom::EncodeAsVarULE<T>,
+{
+    #[inline]
+    fn from(elements: &[A; N]) -> Self {
         Self::from_elements(elements.iter())
     }
 }

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -294,14 +294,6 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
         Ok(VarZeroVec::Borrowed(borrowed))
     }
 
-    #[inline]
-    pub fn from_elements<A>(elements: &[A]) -> Self
-    where
-        A: custom::EncodeAsVarULE<T>,
-    {
-        VarZeroVecOwned::from_elements(elements).into()
-    }
-
     /// Obtain an iterator over VarZeroVec's elements
     ///
     /// # Example
@@ -463,7 +455,7 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # Ok::<(), ZeroVecError>(())
     /// ```
     ///
-    pub fn get_serializable_bytes<'l, A>(elements: &[A]) -> Option<Vec<u8>>
+    pub fn get_serializable_bytes<A>(elements: &[A]) -> Option<Vec<u8>>
     where
         A: custom::EncodeAsVarULE<T>,
     {
@@ -527,7 +519,7 @@ where
 {
     #[inline]
     fn from(elements: &Vec<A>) -> Self {
-        Self::from_elements(elements)
+        VarZeroVecOwned::from_elements(elements).into()
     }
 }
 
@@ -538,7 +530,7 @@ where
 {
     #[inline]
     fn from(elements: &[A]) -> Self {
-        Self::from_elements(elements)
+        VarZeroVecOwned::from_elements(elements).into()
     }
 }
 
@@ -549,7 +541,7 @@ where
 {
     #[inline]
     fn from(elements: &[A; N]) -> Self {
-        Self::from_elements(elements)
+        VarZeroVecOwned::from_elements(elements).into()
     }
 }
 

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -6,7 +6,6 @@ use crate::ule::*;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt;
-use core::iter::ExactSizeIterator;
 use core::ops::Index;
 
 pub(crate) mod borrowed;
@@ -296,10 +295,9 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     }
 
     #[inline]
-    pub fn from_elements<'l, A, I>(elements: I) -> Self
+    pub fn from_elements<A>(elements: &[A]) -> Self
     where
-        A: 'l + custom::EncodeAsVarULE<T>,
-        I: ExactSizeIterator<Item = &'l A>,
+        A: custom::EncodeAsVarULE<T>,
     {
         VarZeroVecOwned::from_elements(elements).into()
     }
@@ -465,10 +463,9 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # Ok::<(), ZeroVecError>(())
     /// ```
     ///
-    pub fn get_serializable_bytes<'l, A, I>(elements: I) -> Option<Vec<u8>>
+    pub fn get_serializable_bytes<'l, A>(elements: &[A]) -> Option<Vec<u8>>
     where
-        A: 'l + custom::EncodeAsVarULE<T>,
-        I: ExactSizeIterator<Item = &'l A>,
+        A: custom::EncodeAsVarULE<T>,
     {
         borrowed::get_serializable_bytes(elements)
     }
@@ -530,7 +527,7 @@ where
 {
     #[inline]
     fn from(elements: &Vec<A>) -> Self {
-        Self::from_elements(elements.iter())
+        Self::from_elements(elements)
     }
 }
 
@@ -541,7 +538,7 @@ where
 {
     #[inline]
     fn from(elements: &[A]) -> Self {
-        Self::from_elements(elements.iter())
+        Self::from_elements(elements)
     }
 }
 
@@ -552,7 +549,7 @@ where
 {
     #[inline]
     fn from(elements: &[A; N]) -> Self {
-        Self::from_elements(elements.iter())
+        Self::from_elements(elements)
     }
 }
 

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -586,3 +586,15 @@ where
         self.iter().eq(other.iter().map(|t| t.as_ref()))
     }
 }
+
+impl<T, A, const N: usize> PartialEq<[A; N]> for VarZeroVec<'_, T>
+where
+    T: VarULE + ?Sized,
+    T: PartialEq,
+    A: AsRef<T>,
+{
+    #[inline]
+    fn eq(&self, other: &[A; N]) -> bool {
+        self.iter().eq(other.iter().map(|t| t.as_ref()))
+    }
+}

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -104,7 +104,7 @@ pub use slice::VarZeroSlice;
 /// let zerovec1: VarZeroVec<ZeroSlice<u32>> = VarZeroVec::parse_byte_slice(bytes)?;
 /// assert_eq!(zerovec1.get(2).and_then(|v| v.get(1)), Some(55555));
 ///
-/// let zerovec2: VarZeroVec<ZeroSlice<u32>> = numbers.into();
+/// let zerovec2: VarZeroVec<ZeroSlice<u32>> = (&numbers).into();
 /// assert_eq!(zerovec1, zerovec2);
 ///
 /// # Ok::<(), ZeroVecError>(())
@@ -231,7 +231,7 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::VarZeroVec;
     ///
     /// let strings = vec!["foo", "bar", "baz", "quux"];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(strings.iter()).unwrap();
+    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
     ///
     /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     /// assert_eq!(vec.len(), 4);
@@ -251,7 +251,7 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::VarZeroVec;
     ///
     /// let strings: Vec<String> = vec![];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(strings.iter()).unwrap();
+    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
     ///
     /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     /// assert!(vec.is_empty());
@@ -274,7 +274,7 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::VarZeroVec;
     ///
     /// let strings = vec!["foo", "bar", "baz", "quux"];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(strings.iter()).unwrap();
+    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
     ///
     /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     /// assert_eq!(&vec[0], "foo");
@@ -312,7 +312,7 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::VarZeroVec;
     ///
     /// let strings = vec!["foo", "bar", "baz", "quux"];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(strings.iter()).unwrap();
+    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
     /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     ///
     /// let mut iter_results: Vec<&str> = vec.iter().collect();
@@ -336,7 +336,7 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::VarZeroVec;
     ///
     /// let strings = vec!["foo", "bar", "baz", "quux"];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(strings.iter()).unwrap();
+    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
     /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     ///
     /// let mut iter_results: Vec<&str> = vec.iter().collect();
@@ -362,7 +362,7 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::VarZeroVec;
     ///
     /// let strings = vec!["foo", "bar", "baz", "quux"];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(strings.iter()).unwrap();
+    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
     /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     ///
     /// assert_eq!(vec.len(), 4);
@@ -401,7 +401,7 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::VarZeroVec;
     ///
     /// let strings = vec!["foo", "bar", "baz", "quux"];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(strings.iter()).unwrap();
+    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
     /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     ///
     /// assert_eq!(vec.len(), 4);
@@ -455,7 +455,7 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::VarZeroVec;
     ///
     /// let strings = vec!["foo", "bar", "baz"];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(strings.iter()).unwrap();
+    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
     ///
     /// let mut borrowed: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     /// assert_eq!(borrowed, &*strings);
@@ -498,7 +498,7 @@ where
     /// # use zerovec::VarZeroVec;
     ///
     /// let strings = vec!["a", "b", "f", "g"];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(strings.iter()).unwrap();
+    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
     /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     ///
     /// assert_eq!(vec.binary_search("f"), Ok(2));

--- a/utils/zerovec/src/varzerovec/owned.rs
+++ b/utils/zerovec/src/varzerovec/owned.rs
@@ -582,15 +582,7 @@ mod test {
 
     #[test]
     fn test_remove_integrity() {
-        let mut items: Vec<&str> = vec![
-            "apples",
-            "bananas",
-            "eeples",
-            "",
-            "baneenees",
-            "five",
-            "",
-        ];
+        let mut items: Vec<&str> = vec!["apples", "bananas", "eeples", "", "baneenees", "five", ""];
         let mut zerovec = VarZeroVecOwned::<str>::from_elements(items.iter());
 
         for index in [0, 2, 4, 0, 1, 1, 0] {
@@ -616,15 +608,7 @@ mod test {
 
     #[test]
     fn test_replace_integrity() {
-        let mut items: Vec<&str> = vec![
-            "apples",
-            "bananas",
-            "eeples",
-            "",
-            "baneenees",
-            "five",
-            "",
-        ];
+        let mut items: Vec<&str> = vec!["apples", "bananas", "eeples", "", "baneenees", "five", ""];
         let mut zerovec = VarZeroVecOwned::<str>::from_elements(items.iter());
 
         // Replace with an element of the same size (and the first element)

--- a/utils/zerovec/src/varzerovec/owned.rs
+++ b/utils/zerovec/src/varzerovec/owned.rs
@@ -610,27 +610,27 @@ mod test {
         let mut zerovec = VarZeroVecOwned::<str>::from_elements(&items);
 
         // Replace with an element of the same size (and the first element)
-        items[0] = "blablah".into();
+        items[0] = "blablah";
         zerovec.replace(0, "blablah");
         assert_eq!(zerovec, &*items);
 
         // Replace with a smaller element
-        items[1] = "twily".into();
+        items[1] = "twily";
         zerovec.replace(1, "twily");
         assert_eq!(zerovec, &*items);
 
         // Replace an empty element
-        items[3] = "aoeuidhtns".into();
+        items[3] = "aoeuidhtns";
         zerovec.replace(3, "aoeuidhtns");
         assert_eq!(zerovec, &*items);
 
         // Replace the last element
-        items[6] = "0123456789".into();
+        items[6] = "0123456789";
         zerovec.replace(6, "0123456789");
         assert_eq!(zerovec, &*items);
 
         // Replace with an empty element
-        items[2] = "".into();
+        items[2] = "";
         zerovec.replace(2, "");
         assert_eq!(zerovec, &*items);
     }

--- a/utils/zerovec/src/varzerovec/owned.rs
+++ b/utils/zerovec/src/varzerovec/owned.rs
@@ -57,10 +57,10 @@ impl<T: VarULE + ?Sized> VarZeroVecOwned<T> {
     }
 
     /// Construct a VarZeroVecOwned from a list of elements
-    pub fn from_elements<A, I>(elements: I) -> Self
+    pub fn from_elements<'l, A, I>(elements: I) -> Self
     where
-        A: custom::EncodeAsVarULE<T>,
-        I: ExactSizeIterator<Item = A>,
+        A: 'l + custom::EncodeAsVarULE<T>,
+        I: ExactSizeIterator<Item = &'l A>,
     {
         Self {
             marker: PhantomData,

--- a/utils/zerovec/src/varzerovec/owned.rs
+++ b/utils/zerovec/src/varzerovec/owned.rs
@@ -582,16 +582,16 @@ mod test {
 
     #[test]
     fn test_remove_integrity() {
-        let mut items: Vec<String> = vec![
-            "apples".into(),
-            "bananas".into(),
-            "eeples".into(),
-            "".into(),
-            "baneenees".into(),
-            "five".into(),
-            "".into(),
+        let mut items: Vec<&str> = vec![
+            "apples",
+            "bananas",
+            "eeples",
+            "",
+            "baneenees",
+            "five",
+            "",
         ];
-        let mut zerovec = VarZeroVecOwned::<str>::from_elements(&items);
+        let mut zerovec = VarZeroVecOwned::<str>::from_elements(items.iter());
 
         for index in [0, 2, 4, 0, 1, 1, 0] {
             items.remove(index);
@@ -602,7 +602,7 @@ mod test {
 
     #[test]
     fn test_removing_last_element_clears() {
-        let mut zerovec = VarZeroVecOwned::<str>::from_elements(&["buy some apples".to_string()]);
+        let mut zerovec = VarZeroVecOwned::<str>::from_elements(["buy some apples"].iter());
         assert!(!zerovec.as_borrowed().entire_slice().is_empty());
         zerovec.remove(0);
         assert!(zerovec.as_borrowed().entire_slice().is_empty());
@@ -616,16 +616,16 @@ mod test {
 
     #[test]
     fn test_replace_integrity() {
-        let mut items: Vec<String> = vec![
-            "apples".into(),
-            "bananas".into(),
-            "eeples".into(),
-            "".into(),
-            "baneenees".into(),
-            "five".into(),
-            "".into(),
+        let mut items: Vec<&str> = vec![
+            "apples",
+            "bananas",
+            "eeples",
+            "",
+            "baneenees",
+            "five",
+            "",
         ];
-        let mut zerovec = VarZeroVecOwned::<str>::from_elements(&items);
+        let mut zerovec = VarZeroVecOwned::<str>::from_elements(items.iter());
 
         // Replace with an element of the same size (and the first element)
         items[0] = "blablah".into();

--- a/utils/zerovec/src/varzerovec/owned.rs
+++ b/utils/zerovec/src/varzerovec/owned.rs
@@ -7,6 +7,7 @@ use alloc::vec::Vec;
 
 use super::*;
 use core::fmt;
+use core::iter::ExactSizeIterator;
 use core::marker::PhantomData;
 use core::ops::Range;
 use core::ptr;
@@ -56,7 +57,11 @@ impl<T: VarULE + ?Sized> VarZeroVecOwned<T> {
     }
 
     /// Construct a VarZeroVecOwned from a list of elements
-    pub fn from_elements<A: custom::EncodeAsVarULE<T>>(elements: &[A]) -> Self {
+    pub fn from_elements<A, I>(elements: I) -> Self
+    where
+        A: custom::EncodeAsVarULE<T>,
+        I: ExactSizeIterator<Item = A>,
+    {
         Self {
             marker: PhantomData,
             entire_slice: borrowed::get_serializable_bytes(elements).expect(

--- a/utils/zerovec/src/varzerovec/owned.rs
+++ b/utils/zerovec/src/varzerovec/owned.rs
@@ -7,7 +7,6 @@ use alloc::vec::Vec;
 
 use super::*;
 use core::fmt;
-use core::iter::ExactSizeIterator;
 use core::marker::PhantomData;
 use core::ops::Range;
 use core::ptr;
@@ -57,10 +56,9 @@ impl<T: VarULE + ?Sized> VarZeroVecOwned<T> {
     }
 
     /// Construct a VarZeroVecOwned from a list of elements
-    pub fn from_elements<'l, A, I>(elements: I) -> Self
+    pub fn from_elements<A>(elements: &[A]) -> Self
     where
-        A: 'l + custom::EncodeAsVarULE<T>,
-        I: ExactSizeIterator<Item = &'l A>,
+        A: custom::EncodeAsVarULE<T>,
     {
         Self {
             marker: PhantomData,
@@ -583,7 +581,7 @@ mod test {
     #[test]
     fn test_remove_integrity() {
         let mut items: Vec<&str> = vec!["apples", "bananas", "eeples", "", "baneenees", "five", ""];
-        let mut zerovec = VarZeroVecOwned::<str>::from_elements(items.iter());
+        let mut zerovec = VarZeroVecOwned::<str>::from_elements(&items);
 
         for index in [0, 2, 4, 0, 1, 1, 0] {
             items.remove(index);
@@ -594,7 +592,7 @@ mod test {
 
     #[test]
     fn test_removing_last_element_clears() {
-        let mut zerovec = VarZeroVecOwned::<str>::from_elements(["buy some apples"].iter());
+        let mut zerovec = VarZeroVecOwned::<str>::from_elements(&["buy some apples"]);
         assert!(!zerovec.as_borrowed().entire_slice().is_empty());
         zerovec.remove(0);
         assert!(zerovec.as_borrowed().entire_slice().is_empty());
@@ -609,7 +607,7 @@ mod test {
     #[test]
     fn test_replace_integrity() {
         let mut items: Vec<&str> = vec!["apples", "bananas", "eeples", "", "baneenees", "five", ""];
-        let mut zerovec = VarZeroVecOwned::<str>::from_elements(items.iter());
+        let mut zerovec = VarZeroVecOwned::<str>::from_elements(&items);
 
         // Replace with an element of the same size (and the first element)
         items[0] = "blablah".into();

--- a/utils/zerovec/src/varzerovec/serde.rs
+++ b/utils/zerovec/src/varzerovec/serde.rs
@@ -53,7 +53,7 @@ where
         while let Some(value) = seq.next_element::<Box<T>>()? {
             vec.push(value);
         }
-        Ok(vec.into_iter().into())
+        Ok(vec.iter().into())
     }
 }
 

--- a/utils/zerovec/src/varzerovec/serde.rs
+++ b/utils/zerovec/src/varzerovec/serde.rs
@@ -53,7 +53,7 @@ where
         while let Some(value) = seq.next_element::<Box<T>>()? {
             vec.push(value);
         }
-        Ok(vec.iter().into())
+        Ok(VarZeroVec::from(&vec))
     }
 }
 

--- a/utils/zerovec/src/varzerovec/serde.rs
+++ b/utils/zerovec/src/varzerovec/serde.rs
@@ -53,7 +53,7 @@ where
         while let Some(value) = seq.next_element::<Box<T>>()? {
             vec.push(value);
         }
-        Ok((&*vec).into())
+        Ok(vec.into_iter().into())
     }
 }
 

--- a/utils/zerovec/src/varzerovec/slice.rs
+++ b/utils/zerovec/src/varzerovec/slice.rs
@@ -30,13 +30,13 @@ use core::mem;
 /// let strings_34 = vec![strings_3.clone(), strings_4.clone()];
 /// let all_strings = vec![strings_12, strings_34];
 ///
-/// let vzv_1: VarZeroVec<str> = VarZeroVec::from(strings_1.iter());
-/// let vzv_2: VarZeroVec<str> = VarZeroVec::from(strings_2.iter());
-/// let vzv_3: VarZeroVec<str> = VarZeroVec::from(strings_3.iter());
-/// let vzv_4: VarZeroVec<str> = VarZeroVec::from(strings_4.iter());
-/// let vzv_12 = VarZeroVec::from([vzv_1.as_slice(), vzv_2.as_slice()].iter());
-/// let vzv_34 = VarZeroVec::from([vzv_3.as_slice(), vzv_4.as_slice()].iter());
-/// let vzv_all = VarZeroVec::from([vzv_12.as_slice(), vzv_34.as_slice()].iter());
+/// let vzv_1: VarZeroVec<str> = VarZeroVec::from(&strings_1);
+/// let vzv_2: VarZeroVec<str> = VarZeroVec::from(&strings_2);
+/// let vzv_3: VarZeroVec<str> = VarZeroVec::from(&strings_3);
+/// let vzv_4: VarZeroVec<str> = VarZeroVec::from(&strings_4);
+/// let vzv_12 = VarZeroVec::from(&[vzv_1.as_slice(), vzv_2.as_slice()]);
+/// let vzv_34 = VarZeroVec::from(&[vzv_3.as_slice(), vzv_4.as_slice()]);
+/// let vzv_all = VarZeroVec::from(&[vzv_12.as_slice(), vzv_34.as_slice()]);
 ///
 /// let reconstructed: Vec<Vec<Vec<String>>> = vzv_all.iter()
 ///        .map(|v: &VarZeroSlice<VarZeroSlice<str>>| {

--- a/utils/zerovec/src/varzerovec/slice.rs
+++ b/utils/zerovec/src/varzerovec/slice.rs
@@ -22,21 +22,21 @@ use core::mem;
 /// use zerovec::ZeroVec;
 /// use zerovec::varzerovec::VarZeroSlice;
 /// use zerovec::ule::*;
-/// let strings_1: Vec<String> = vec!["foo".into(), "bar".into(), "baz".into()];
-/// let strings_2: Vec<String> = vec!["twelve".into(), "seventeen".into(), "forty two".into()];
-/// let strings_3: Vec<String> = vec!["我".into(), "喜歡".into(), "烏龍茶".into()];
-/// let strings_4: Vec<String> = vec!["w".into(), "ω".into(), "文".into(), "𑄃".into()];
+/// let strings_1: Vec<&str> = vec!["foo", "bar", "baz"];
+/// let strings_2: Vec<&str> = vec!["twelve", "seventeen", "forty two"];
+/// let strings_3: Vec<&str> = vec!["我", "喜歡", "烏龍茶"];
+/// let strings_4: Vec<&str> = vec!["w", "ω", "文", "𑄃"];
 /// let strings_12 = vec![strings_1.clone(), strings_2.clone()];
 /// let strings_34 = vec![strings_3.clone(), strings_4.clone()];
 /// let all_strings = vec![strings_12, strings_34];
 ///
-/// let vzv_1: VarZeroVec<str> = VarZeroVec::from(&*strings_1);
-/// let vzv_2: VarZeroVec<str> = VarZeroVec::from(&*strings_2);
-/// let vzv_3: VarZeroVec<str> = VarZeroVec::from(&*strings_3);
-/// let vzv_4: VarZeroVec<str> = VarZeroVec::from(&*strings_4);
-/// let vzv_12 = VarZeroVec::from(&[vzv_1.as_slice(), vzv_2.as_slice()] as &[_]);
-/// let vzv_34 = VarZeroVec::from(&[vzv_3.as_slice(), vzv_4.as_slice()] as &[_]);
-/// let vzv_all = VarZeroVec::from(&[vzv_12.as_slice(), vzv_34.as_slice()] as &[_]);
+/// let vzv_1: VarZeroVec<str> = VarZeroVec::from(strings_1.iter());
+/// let vzv_2: VarZeroVec<str> = VarZeroVec::from(strings_2.iter());
+/// let vzv_3: VarZeroVec<str> = VarZeroVec::from(strings_3.iter());
+/// let vzv_4: VarZeroVec<str> = VarZeroVec::from(strings_4.iter());
+/// let vzv_12 = VarZeroVec::from([vzv_1.as_slice(), vzv_2.as_slice()].iter());
+/// let vzv_34 = VarZeroVec::from([vzv_3.as_slice(), vzv_4.as_slice()].iter());
+/// let vzv_all = VarZeroVec::from([vzv_12.as_slice(), vzv_34.as_slice()].iter());
 ///
 /// let reconstructed: Vec<Vec<Vec<String>>> = vzv_all.iter()
 ///        .map(|v: &VarZeroSlice<VarZeroSlice<str>>| {

--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -110,6 +110,12 @@ impl<'a, T: AsULE> Deref for ZeroVec<'a, T> {
     }
 }
 
+impl<'a, T: AsULE> AsRef<ZeroSlice<T>> for ZeroVec<'a, T> {
+    fn as_ref(&self) -> &ZeroSlice<T> {
+        self.deref()
+    }
+}
+
 impl<T> fmt::Debug for ZeroVec<'_, T>
 where
     T: AsULE + fmt::Debug,

--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -448,7 +448,7 @@ where
 
 impl<'a, T> ZeroVec<'a, T>
 where
-    T: AsULE + SliceAsULE,
+    T: EqULE,
 {
     /// Attempts to create a `ZeroVec<'a, T>` from a `&'a [T]` by borrowing the argument.
     ///

--- a/utils/zerovec/src/zerovec/slice.rs
+++ b/utils/zerovec/src/zerovec/slice.rs
@@ -322,6 +322,12 @@ impl<T: AsULE> AsRef<ZeroSlice<T>> for Vec<T::ULE> {
     }
 }
 
+impl<T: AsULE> AsRef<ZeroSlice<T>> for &[T::ULE] {
+    fn as_ref(&self) -> &ZeroSlice<T> {
+        ZeroSlice::<T>::from_ule_slice(&**self)
+    }
+}
+
 impl<T> Default for &ZeroSlice<T>
 where
     T: AsULE,


### PR DESCRIPTION
We can use `EqULE` to make it work for more types in a zero-copy way (on LE systems).