### PR TITLE
Fix typo in Yokeable documentation

### DIFF
--- a/utils/yoke/derive/src/lib.rs
+++ b/utils/yoke/derive/src/lib.rs
@@ -22,7 +22,7 @@ mod visitor;
 ///
 /// ```rust,ignore
 /// #[derive(Yokeable)]
-/// #[yoke(manually_prove_covariance)]
+/// #[yoke(prove_covariance_manually)]
 /// ```
 ///
 /// Beyond this case, if the derive fails to compile due to lifetime issues, it


### PR DESCRIPTION
My goodness @Manishearth I'm incredibly embarrassed about this careless mistake. 

I just noticed it, so I want to fix it right away. 

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->