### PR TITLE
Add LineBreakSegmenter and rewire code to use it

### DIFF
--- a/experimental/segmenter/README.md
+++ b/experimental/segmenter/README.md
@@ -41,8 +41,6 @@ assert_eq!(&breakpoints, &[1, 2, 3, 4, 6, 7, 8, 9, 10, 11]);
 Segment a Latin1 byte string:
 
 ```rust
-use icu_segmenter::LineBreakIteratorLatin1;
-
 use icu_segmenter::LineBreakSegmenter;
 
 let segmenter = LineBreakSegmenter::try_new().expect("Data exists");

--- a/experimental/segmenter/README.md
+++ b/experimental/segmenter/README.md
@@ -8,42 +8,52 @@ A segmenter implementation for the following rules.
 [UAX14]: https://www.unicode.org/reports/tr14/
 [UAX29]: https://www.unicode.org/reports/tr29/
 
-## Line breaker
+## Examples
+
+### Line Break
+
+Segment a string with default options:
 
 ```rust
-use icu_segmenter::LineBreakIterator;
+use icu_segmenter::LineBreakSegmenter;
 
-let mut iter = LineBreakIterator::new("Hello World");
-let result: Vec<usize> = iter.collect();
-println!("{:?}", result);
+let segmenter = LineBreakSegmenter::try_new().expect("Data exists");
+
+let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
+assert_eq!(&breakpoints, &[6, 11]);
 ```
 
-With CSS property.
+Segment a string with CSS option overrides:
+
 ```rust
-use icu_segmenter::{LineBreakIterator, LineBreakRule, WordBreakRule};
+use icu_segmenter::{LineBreakSegmenter, LineBreakOptions, LineBreakRule, WordBreakRule};
 
-let iter = LineBreakIterator::new_with_break_rule(
-    "Hello World",
-    LineBreakRule::Strict,
-    WordBreakRule::BreakAll,
-    false,
-);
-let result: Vec<usize> = iter.collect();
-println!("{:?}", result);
+let mut options = LineBreakOptions::default();
+options.line_break_rule = LineBreakRule::Strict;
+options.word_break_rule = WordBreakRule::BreakAll;
+options.ja_zh = false;
+let segmenter = LineBreakSegmenter::try_new_with_options(options).expect("Data exists");
+
+let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
+assert_eq!(&breakpoints, &[1, 2, 3, 4, 6, 7, 8, 9, 10, 11]);
 ```
 
-Use Latin 1 string for C binding and etc.
+Segment a Latin1 byte string:
 
 ```rust
 use icu_segmenter::LineBreakIteratorLatin1;
 
-let s = "Hello World";
-let iter = LineBreakIteratorLatin1::new(s.as_bytes());
-let result: Vec<usize> = iter.collect();
-println!("{:?}", result);
+use icu_segmenter::LineBreakSegmenter;
+
+let segmenter = LineBreakSegmenter::try_new().expect("Data exists");
+
+let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
+assert_eq!(&breakpoints, &[6, 11]);
 ```
 
-## word breaker
+### Word Break
+
+Segment a string with default options:
 
 ```rust
 use icu_segmenter::WordBreakIterator;
@@ -53,7 +63,7 @@ let result: Vec<usize> = iter.collect();
 println!("{:?}", result);
 ```
 
-Use Latin 1 string for C binding and etc.
+Segment a Latin1 byte string:
 
 ```rust
 use icu_segmenter::WordBreakIteratorLatin1;

--- a/experimental/segmenter/benches/bench.rs
+++ b/experimental/segmenter/benches/bench.rs
@@ -2,12 +2,12 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use criterion::{criterion_group, criterion_main, black_box, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-use icu_segmenter::LineBreakSegmenter;
-use icu_segmenter::LineBreakRule;
-use icu_segmenter::WordBreakRule;
 use icu_segmenter::LineBreakOptions;
+use icu_segmenter::LineBreakRule;
+use icu_segmenter::LineBreakSegmenter;
+use icu_segmenter::WordBreakRule;
 
 // Example is MIT license.
 const TEST_STR_EN: &str = "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.";
@@ -25,11 +25,19 @@ fn line_break_iter_latin1(c: &mut Criterion) {
     let segmenter_css = LineBreakSegmenter::try_new_with_options(options).expect("Data exists");
 
     group.bench_function("En", |b| {
-        b.iter(|| black_box(&segmenter).segment_latin1(black_box(TEST_STR_EN).as_bytes()).count())
+        b.iter(|| {
+            black_box(&segmenter)
+                .segment_latin1(black_box(TEST_STR_EN).as_bytes())
+                .count()
+        })
     });
 
     group.bench_function("En CSS", |b| {
-        b.iter(|| black_box(&segmenter_css).segment_latin1(black_box(TEST_STR_EN).as_bytes()).count())
+        b.iter(|| {
+            black_box(&segmenter_css)
+                .segment_latin1(black_box(TEST_STR_EN).as_bytes())
+                .count()
+        })
     });
 }
 
@@ -39,11 +47,19 @@ fn line_break_iter_utf8(c: &mut Criterion) {
     let segmenter = LineBreakSegmenter::try_new().expect("Data exists");
 
     group.bench_function("En", |b| {
-        b.iter(|| black_box(&segmenter).segment_str(black_box(TEST_STR_EN)).count())
+        b.iter(|| {
+            black_box(&segmenter)
+                .segment_str(black_box(TEST_STR_EN))
+                .count()
+        })
     });
 
     group.bench_function("Th", |b| {
-        b.iter(|| black_box(&segmenter).segment_str(black_box(TEST_STR_TH)).count())
+        b.iter(|| {
+            black_box(&segmenter)
+                .segment_str(black_box(TEST_STR_TH))
+                .count()
+        })
     });
 }
 
@@ -61,15 +77,27 @@ fn line_break_iter_utf16(c: &mut Criterion) {
     let segmenter_css = LineBreakSegmenter::try_new_with_options(options).expect("Data exists");
 
     group.bench_function("En", |b| {
-        b.iter(|| black_box(&segmenter).segment_utf16(black_box(&utf16_en)).count())
+        b.iter(|| {
+            black_box(&segmenter)
+                .segment_utf16(black_box(&utf16_en))
+                .count()
+        })
     });
 
     group.bench_function("En CSS", |b| {
-        b.iter(|| black_box(&segmenter_css).segment_utf16(black_box(&utf16_en)).count())
+        b.iter(|| {
+            black_box(&segmenter_css)
+                .segment_utf16(black_box(&utf16_en))
+                .count()
+        })
     });
 
     group.bench_function("Th", |b| {
-        b.iter(|| black_box(&segmenter).segment_utf16(black_box(&utf16_th)).count())
+        b.iter(|| {
+            black_box(&segmenter)
+                .segment_utf16(black_box(&utf16_th))
+                .count()
+        })
     });
 }
 

--- a/experimental/segmenter/benches/bench.rs
+++ b/experimental/segmenter/benches/bench.rs
@@ -2,81 +2,74 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, black_box, Criterion};
 
-use icu_segmenter::LineBreakIterator;
-use icu_segmenter::LineBreakIteratorLatin1;
-use icu_segmenter::LineBreakIteratorUtf16;
+use icu_segmenter::LineBreakSegmenter;
 use icu_segmenter::LineBreakRule;
 use icu_segmenter::WordBreakRule;
+use icu_segmenter::LineBreakOptions;
 
 // Example is MIT license.
-const TEST_STR: &str = "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.";
-const TEST_STR2: &str =
+const TEST_STR_EN: &str = "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.";
+const TEST_STR_TH: &str =
     "ภาษาไทยภาษาไทย ภาษาไทยภาษาไทย ภาษาไทยภาษาไทย ภาษาไทยภาษาไทย ภาษาไทยภาษาไทย ภาษาไทยภาษาไทย";
 
 fn line_break_iter_latin1(c: &mut Criterion) {
     let mut group = c.benchmark_group("Line Break/Latin1");
 
+    let segmenter = LineBreakSegmenter::try_new().expect("Data exists");
+
+    let mut options = LineBreakOptions::default();
+    options.line_break_rule = LineBreakRule::Anywhere;
+    options.word_break_rule = WordBreakRule::BreakAll;
+    let segmenter_css = LineBreakSegmenter::try_new_with_options(options).expect("Data exists");
+
     group.bench_function("En", |b| {
-        b.iter(|| LineBreakIteratorLatin1::new(TEST_STR.as_bytes()).count())
+        b.iter(|| black_box(&segmenter).segment_latin1(black_box(TEST_STR_EN).as_bytes()).count())
     });
 
     group.bench_function("En CSS", |b| {
-        b.iter(|| {
-            LineBreakIteratorLatin1::new_with_break_rule(
-                TEST_STR.as_bytes(),
-                LineBreakRule::Anywhere,
-                WordBreakRule::BreakAll,
-            )
-            .count()
-        })
+        b.iter(|| black_box(&segmenter_css).segment_latin1(black_box(TEST_STR_EN).as_bytes()).count())
     });
 }
 
 fn line_break_iter_utf8(c: &mut Criterion) {
     let mut group = c.benchmark_group("Line Break/UTF8");
 
+    let segmenter = LineBreakSegmenter::try_new().expect("Data exists");
+
     group.bench_function("En", |b| {
-        b.iter(|| LineBreakIterator::new(TEST_STR).count())
+        b.iter(|| black_box(&segmenter).segment_str(black_box(TEST_STR_EN)).count())
     });
 
     group.bench_function("Th", |b| {
-        b.iter(|| LineBreakIterator::new(TEST_STR2).count())
+        b.iter(|| black_box(&segmenter).segment_str(black_box(TEST_STR_TH)).count())
     });
 }
 
 fn line_break_iter_utf16(c: &mut Criterion) {
     let mut group = c.benchmark_group("Line Break/UTF16");
 
-    let utf16: Vec<u16> = TEST_STR.encode_utf16().collect();
+    let utf16_en: Vec<u16> = TEST_STR_EN.encode_utf16().collect();
+    let utf16_th: Vec<u16> = TEST_STR_TH.encode_utf16().collect();
+
+    let segmenter = LineBreakSegmenter::try_new().expect("Data exists");
+
+    let mut options = LineBreakOptions::default();
+    options.line_break_rule = LineBreakRule::Anywhere;
+    options.word_break_rule = WordBreakRule::BreakAll;
+    let segmenter_css = LineBreakSegmenter::try_new_with_options(options).expect("Data exists");
+
     group.bench_function("En", |b| {
-        b.iter(|| LineBreakIteratorUtf16::new(&utf16).count())
+        b.iter(|| black_box(&segmenter).segment_utf16(black_box(&utf16_en)).count())
     });
 
     group.bench_function("En CSS", |b| {
-        b.iter(|| {
-            LineBreakIteratorUtf16::new_with_break_rule(
-                &utf16,
-                LineBreakRule::Anywhere,
-                WordBreakRule::BreakAll,
-                true,
-            )
-            .count()
-        })
+        b.iter(|| black_box(&segmenter_css).segment_utf16(black_box(&utf16_en)).count())
     });
 
-    let utf16: Vec<u16> = TEST_STR.encode_utf16().collect();
     group.bench_function("Th", |b| {
-        b.iter(|| {
-            LineBreakIteratorUtf16::new_with_break_rule(
-                &utf16,
-                LineBreakRule::Anywhere,
-                WordBreakRule::BreakAll,
-                true,
-            )
-            .count()
-        })
+        b.iter(|| black_box(&segmenter).segment_utf16(black_box(&utf16_th)).count())
     });
 }
 

--- a/experimental/segmenter/src/lib.rs
+++ b/experimental/segmenter/src/lib.rs
@@ -13,42 +13,52 @@
 //! [UAX14]: https://www.unicode.org/reports/tr14/
 //! [UAX29]: https://www.unicode.org/reports/tr29/
 //!
-//! # Line breaker
+//! # Examples
+//! 
+//! ## Line Break
+//!
+//! Segment a string with default options:
 //!
 //!```rust
-//! use icu_segmenter::LineBreakIterator;
+//! use icu_segmenter::LineBreakSegmenter;
 //!
-//! let mut iter = LineBreakIterator::new("Hello World");
-//! let result: Vec<usize> = iter.collect();
-//! println!("{:?}", result);
+//! let segmenter = LineBreakSegmenter::try_new().expect("Data exists");
+//!
+//! let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
+//! assert_eq!(&breakpoints, &[6, 11]);
 //! ```
 //!
-//! With CSS property.
+//! Segment a string with CSS option overrides:
+//!
 //! ```rust
-//! use icu_segmenter::{LineBreakIterator, LineBreakRule, WordBreakRule};
+//! use icu_segmenter::{LineBreakSegmenter, LineBreakOptions, LineBreakRule, WordBreakRule};
 //!
-//! let iter = LineBreakIterator::new_with_break_rule(
-//!     "Hello World",
-//!     LineBreakRule::Strict,
-//!     WordBreakRule::BreakAll,
-//!     false,
-//! );
-//! let result: Vec<usize> = iter.collect();
-//! println!("{:?}", result);
+//! let mut options = LineBreakOptions::default();
+//! options.line_break_rule = LineBreakRule::Strict;
+//! options.word_break_rule = WordBreakRule::BreakAll;
+//! options.ja_zh = false;
+//! let segmenter = LineBreakSegmenter::try_new_with_options(options).expect("Data exists");
+//!
+//! let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
+//! assert_eq!(&breakpoints, &[1, 2, 3, 4, 6, 7, 8, 9, 10, 11]);
 //! ```
 //!
-//! Use Latin 1 string for C binding and etc.
+//! Segment a Latin1 byte string:
 //!
 //! ```rust
 //! use icu_segmenter::LineBreakIteratorLatin1;
 //!
-//! let s = "Hello World";
-//! let iter = LineBreakIteratorLatin1::new(s.as_bytes());
-//! let result: Vec<usize> = iter.collect();
-//! println!("{:?}", result);
-//! ```
+//! use icu_segmenter::LineBreakSegmenter;
 //!
-//! # word breaker
+//! let segmenter = LineBreakSegmenter::try_new().expect("Data exists");
+//!
+//! let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
+//! assert_eq!(&breakpoints, &[6, 11]);
+//! ```
+//! 
+//! ## Word Break
+//!
+//! Segment a string with default options:
 //!
 //!```rust
 //! use icu_segmenter::WordBreakIterator;
@@ -58,7 +68,7 @@
 //! println!("{:?}", result);
 //! ```
 //!
-//! Use Latin 1 string for C binding and etc.
+//! Segment a Latin1 byte string:
 //!
 //! ```rust
 //! use icu_segmenter::WordBreakIteratorLatin1;

--- a/experimental/segmenter/src/lib.rs
+++ b/experimental/segmenter/src/lib.rs
@@ -14,7 +14,7 @@
 //! [UAX29]: https://www.unicode.org/reports/tr29/
 //!
 //! # Examples
-//! 
+//!
 //! ## Line Break
 //!
 //! Segment a string with default options:
@@ -55,7 +55,7 @@
 //! let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
 //! assert_eq!(&breakpoints, &[6, 11]);
 //! ```
-//! 
+//!
 //! ## Word Break
 //!
 //! Segment a string with default options:

--- a/experimental/segmenter/src/lib.rs
+++ b/experimental/segmenter/src/lib.rs
@@ -46,8 +46,6 @@
 //! Segment a Latin1 byte string:
 //!
 //! ```rust
-//! use icu_segmenter::LineBreakIteratorLatin1;
-//!
 //! use icu_segmenter::LineBreakSegmenter;
 //!
 //! let segmenter = LineBreakSegmenter::try_new().expect("Data exists");

--- a/experimental/segmenter/src/line_breaker.rs
+++ b/experimental/segmenter/src/line_breaker.rs
@@ -597,21 +597,19 @@ impl<'s, Y: LineBreakType<'s>> LineBreakIteratorImpl<'s, Y> {
     }
 }
 
-pub type LineBreakIterator<'s> = LineBreakIteratorImpl<'s, char>;
-
 impl<'s> LineBreakType<'s> for char {
     type IterAttr = CharIndices<'s>;
     type CharType = char;
 
-    fn get_linebreak_property(iterator: &LineBreakIterator) -> u8 {
+    fn get_linebreak_property(iterator: &LineBreakIteratorImpl<char>) -> u8 {
         Self::get_linebreak_property_with_rule(iterator, iterator.current_pos_data.unwrap().1)
     }
 
-    fn get_linebreak_property_with_rule(iterator: &LineBreakIterator, c: char) -> u8 {
+    fn get_linebreak_property_with_rule(iterator: &LineBreakIteratorImpl<char>, c: char) -> u8 {
         get_linebreak_property_with_rule(c, iterator.line_break_rule, iterator.word_break_rule)
     }
 
-    fn is_break_by_normal(iterator: &LineBreakIterator) -> bool {
+    fn is_break_by_normal(iterator: &LineBreakIteratorImpl<char>) -> bool {
         is_break_utf32_by_normal(iterator.current_pos_data.unwrap().1 as u32, iterator.ja_zh)
     }
 
@@ -620,7 +618,7 @@ impl<'s> LineBreakType<'s> for char {
         use_complex_breaking_utf32(c as u32)
     }
 
-    fn get_line_break_by_platform_fallback(_: &LineBreakIterator, input: &[u16]) -> Vec<usize> {
+    fn get_line_break_by_platform_fallback(_: &LineBreakIteratorImpl<char>, input: &[u16]) -> Vec<usize> {
         if let Some(mut ret) = get_line_break_utf16(input) {
             ret.push(input.len());
             return ret;
@@ -629,7 +627,7 @@ impl<'s> LineBreakType<'s> for char {
     }
 
     /*
-        fn handle_complex_language(iterator: &LineBreakIterator, left_codepoint: char) -> Option<usize> {
+        fn handle_complex_language(iterator: &LineBreakIteratorImpl<char>, left_codepoint: char) -> Option<usize> {
             let start_iter = self.iter.clone();
             let start_point = self.current_pos_data;
             loop {
@@ -652,24 +650,21 @@ impl<'s> LineBreakType<'s> for char {
 
 pub struct Latin1Char(pub u8);
 
-/// Latin-1 version of line break iterator.
-pub type LineBreakIteratorLatin1<'s> = LineBreakIteratorImpl<'s, Latin1Char>;
-
 impl<'s> LineBreakType<'s> for Latin1Char {
     type IterAttr = Latin1Indices<'s>;
     type CharType = u8; // TODO: Latin1Char
 
-    fn get_linebreak_property(iterator: &LineBreakIteratorLatin1) -> u8 {
+    fn get_linebreak_property(iterator: &LineBreakIteratorImpl<Latin1Char>) -> u8 {
         // No CJ on Latin1
         Self::get_linebreak_property_with_rule(iterator, iterator.current_pos_data.unwrap().1)
     }
 
-    fn get_linebreak_property_with_rule(_: &LineBreakIteratorLatin1, c: u8) -> u8 {
+    fn get_linebreak_property_with_rule(_: &LineBreakIteratorImpl<Latin1Char>, c: u8) -> u8 {
         // No CJ on Latin1
         get_linebreak_property_latin1(c)
     }
 
-    fn is_break_by_normal(iterator: &LineBreakIteratorLatin1) -> bool {
+    fn is_break_by_normal(iterator: &LineBreakIteratorImpl<Latin1Char>) -> bool {
         is_break_utf32_by_normal(iterator.current_pos_data.unwrap().1 as u32, iterator.ja_zh)
     }
 
@@ -679,7 +674,7 @@ impl<'s> LineBreakType<'s> for Latin1Char {
     }
 
     fn get_line_break_by_platform_fallback(
-        _: &LineBreakIteratorLatin1,
+        _: &LineBreakIteratorImpl<Latin1Char>,
         _input: &[u16],
     ) -> Vec<usize> {
         panic!("not reachable");
@@ -689,18 +684,15 @@ impl<'s> LineBreakType<'s> for Latin1Char {
 // TODO: This should be u16
 pub struct Utf16Char(pub u32);
 
-/// UTF-16 version of line break iterator.
-pub type LineBreakIteratorUtf16<'s> = LineBreakIteratorImpl<'s, Utf16Char>;
-
 impl<'s> LineBreakType<'s> for Utf16Char {
     type IterAttr = Utf16Indices<'s>;
     type CharType = u32; // TODO: Utf16Char
 
-    fn get_linebreak_property(iterator: &LineBreakIteratorUtf16) -> u8 {
+    fn get_linebreak_property(iterator: &LineBreakIteratorImpl<Utf16Char>) -> u8 {
         Self::get_linebreak_property_with_rule(iterator, iterator.current_pos_data.unwrap().1)
     }
 
-    fn get_linebreak_property_with_rule(iterator: &LineBreakIteratorUtf16, c: u32) -> u8 {
+    fn get_linebreak_property_with_rule(iterator: &LineBreakIteratorImpl<Utf16Char>, c: u32) -> u8 {
         get_linebreak_property_utf32_with_rule(
             c,
             iterator.line_break_rule,
@@ -708,7 +700,7 @@ impl<'s> LineBreakType<'s> for Utf16Char {
         )
     }
 
-    fn is_break_by_normal(iterator: &LineBreakIteratorUtf16) -> bool {
+    fn is_break_by_normal(iterator: &LineBreakIteratorImpl<Utf16Char>) -> bool {
         is_break_utf32_by_normal(iterator.current_pos_data.unwrap().1 as u32, iterator.ja_zh)
     }
 
@@ -718,7 +710,7 @@ impl<'s> LineBreakType<'s> for Utf16Char {
     }
 
     fn get_line_break_by_platform_fallback(
-        _: &LineBreakIteratorUtf16,
+        _: &LineBreakIteratorImpl<Utf16Char>,
         input: &[u16],
     ) -> Vec<usize> {
         if let Some(mut ret) = get_line_break_utf16(input) {

--- a/experimental/segmenter/src/line_breaker.rs
+++ b/experimental/segmenter/src/line_breaker.rs
@@ -99,14 +99,14 @@ pub struct LineBreakSegmenter {
 }
 
 impl LineBreakSegmenter {
-    pub fn new() -> Result<Self, DataError> {
+    pub fn try_new() -> Result<Self, DataError> {
         // Note: This will be able to return an Error once DataProvider is added
         Ok(Self {
             options: Default::default()
         })
     }
 
-    pub fn new_with_options(options: LineBreakOptions) -> Result<Self, DataError> {
+    pub fn try_new_with_options(options: LineBreakOptions) -> Result<Self, DataError> {
         // Note: This will be able to return an Error once DataProvider is added
         Ok(Self {
             options
@@ -847,7 +847,7 @@ mod tests {
 
     #[test]
     fn linebreak() {
-        let segmenter = LineBreakSegmenter::new().expect("Segmenter data is present");
+        let segmenter = LineBreakSegmenter::try_new().expect("Segmenter data is present");
 
         let mut iter = segmenter.segment_str("hello world");
         assert_eq!(Some(6), iter.next());

--- a/experimental/segmenter/src/line_breaker.rs
+++ b/experimental/segmenter/src/line_breaker.rs
@@ -847,7 +847,7 @@ mod tests {
 
     #[test]
     fn linebreak() {
-        let segmenter = LineBreakSegmenter::try_new().expect("Segmenter data is present");
+        let segmenter = LineBreakSegmenter::try_new().expect("Data exists");
 
         let mut iter = segmenter.segment_str("hello world");
         assert_eq!(Some(6), iter.next());

--- a/experimental/segmenter/src/line_breaker.rs
+++ b/experimental/segmenter/src/line_breaker.rs
@@ -291,7 +291,6 @@ pub trait LineBreakType<'a> {
     ) -> Vec<usize>;
 }
 
-#[allow(dead_code)]
 /// The struct implementing the [`Iterator`] trait over the line break
 /// opportunities of the given string. Please see the [module-level
 /// documentation] for its usages.

--- a/experimental/segmenter/src/line_breaker.rs
+++ b/experimental/segmenter/src/line_breaker.rs
@@ -13,8 +13,8 @@ use crate::rule_table::*;
 
 use core::char;
 use core::str::CharIndices;
-use unicode_width::UnicodeWidthChar;
 use icu_provider::DataError;
+use unicode_width::UnicodeWidthChar;
 
 /// An enum specifies the strictness of line-breaking rules. It can be passed as
 /// an argument when creating a line breaker.
@@ -79,7 +79,7 @@ pub struct LineBreakOptions {
     /// system is Chinese or Japanese. This allows more break opportunities when
     /// `LineBreakRule` is `Normal` or `Loose`. See
     /// <https://drafts.csswg.org/css-text-3/#line-break-property> for details.
-    /// 
+    ///
     /// This option has no effect in Latin-1 mode.
     pub ja_zh: bool,
 }
@@ -95,22 +95,20 @@ impl Default for LineBreakOptions {
 }
 
 pub struct LineBreakSegmenter {
-    options: LineBreakOptions
+    options: LineBreakOptions,
 }
 
 impl LineBreakSegmenter {
     pub fn try_new() -> Result<Self, DataError> {
         // Note: This will be able to return an Error once DataProvider is added
         Ok(Self {
-            options: Default::default()
+            options: Default::default(),
         })
     }
 
     pub fn try_new_with_options(options: LineBreakOptions) -> Result<Self, DataError> {
         // Note: This will be able to return an Error once DataProvider is added
-        Ok(Self {
-            options
-        })
+        Ok(Self { options })
     }
 
     /// Create a line break iterator for an `str` (a UTF-8 string).
@@ -127,7 +125,10 @@ impl LineBreakSegmenter {
     }
 
     /// Create a line break iterator for a Latin-1 (8-bit) string.
-    pub fn segment_latin1<'l, 's>(&'l self, input: &'s [u8]) -> LineBreakIteratorImpl<'s, Latin1Char> {
+    pub fn segment_latin1<'l, 's>(
+        &'l self,
+        input: &'s [u8],
+    ) -> LineBreakIteratorImpl<'s, Latin1Char> {
         LineBreakIteratorImpl {
             iter: Latin1Indices::new(input),
             len: input.len(),
@@ -140,7 +141,10 @@ impl LineBreakSegmenter {
     }
 
     /// Create a line break iterator for a UTF-16 string.
-    pub fn segment_utf16<'l, 's>(&'l self, input: &'s [u16]) -> LineBreakIteratorImpl<'s, Utf16Char> {
+    pub fn segment_utf16<'l, 's>(
+        &'l self,
+        input: &'s [u16],
+    ) -> LineBreakIteratorImpl<'s, Utf16Char> {
         LineBreakIteratorImpl {
             iter: Utf16Indices::new(input),
             len: input.len(),
@@ -383,9 +387,9 @@ pub trait LineBreakType<'s> {
 /// The struct implementing the [`Iterator`] trait over the line break
 /// opportunities of the given string. Please see the [module-level
 /// documentation] for its usages.
-/// 
+///
 /// Lifetimes:
-/// 
+///
 /// - `'l` = lifetime of the [`LineBreakSegmenter`] object from which this iterator was created
 /// - `'s` = lifetime of the string being segmented
 ///

--- a/experimental/segmenter/src/line_breaker.rs
+++ b/experimental/segmenter/src/line_breaker.rs
@@ -118,7 +118,7 @@ impl LineBreakSegmenter {
             len: input.len(),
             current_pos_data: None,
             result_cache: Vec::new(),
-            segmenter: &self,
+            segmenter: self,
         }
     }
 
@@ -132,7 +132,7 @@ impl LineBreakSegmenter {
             len: input.len(),
             current_pos_data: None,
             result_cache: Vec::new(),
-            segmenter: &self,
+            segmenter: self,
         }
     }
 
@@ -146,7 +146,7 @@ impl LineBreakSegmenter {
             len: input.len(),
             current_pos_data: None,
             result_cache: Vec::new(),
-            segmenter: &self,
+            segmenter: self,
         }
     }
 }

--- a/experimental/segmenter/tests/css_line_break.rs
+++ b/experimental/segmenter/tests/css_line_break.rs
@@ -2,93 +2,54 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_segmenter::LineBreakIterator;
-use icu_segmenter::LineBreakIteratorUtf16;
 use icu_segmenter::LineBreakRule;
 use icu_segmenter::WordBreakRule;
+use icu_segmenter::LineBreakSegmenter;
+use icu_segmenter::LineBreakOptions;
 
-fn strict(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
-    let iter = LineBreakIterator::new_with_break_rule(
-        s,
-        LineBreakRule::Strict,
-        WordBreakRule::Normal,
-        ja_zh,
-    );
+fn check_with_options(s: &str, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>, options: LineBreakOptions) {
+    let segmenter = LineBreakSegmenter::try_new_with_options(options).expect("Data exists");
+
+    let iter = segmenter.segment_str(s);
     let result: Vec<usize> = iter.collect();
     assert_eq!(expect_utf8, result, "{}", s);
 
     let s_utf16: Vec<u16> = s.encode_utf16().collect();
-    let iter = LineBreakIteratorUtf16::new_with_break_rule(
-        &s_utf16,
-        LineBreakRule::Strict,
-        WordBreakRule::Normal,
-        ja_zh,
-    );
+    let iter = segmenter.segment_utf16(&s_utf16);
     let result: Vec<usize> = iter.collect();
     assert_eq!(expect_utf16, result, "{}", s);
+}
+
+fn strict(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
+    let mut options = LineBreakOptions::default();
+    options.line_break_rule = LineBreakRule::Strict;
+    options.word_break_rule = WordBreakRule::Normal;
+    options.ja_zh = ja_zh;
+    check_with_options(s, expect_utf8, expect_utf16, options);
 }
 
 fn normal(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
-    let iter = LineBreakIterator::new_with_break_rule(
-        s,
-        LineBreakRule::Normal,
-        WordBreakRule::Normal,
-        ja_zh,
-    );
-    let result: Vec<usize> = iter.collect();
-    assert_eq!(expect_utf8, result, "{}", s);
-
-    let s_utf16: Vec<u16> = s.encode_utf16().collect();
-    let iter = LineBreakIteratorUtf16::new_with_break_rule(
-        &s_utf16,
-        LineBreakRule::Normal,
-        WordBreakRule::Normal,
-        ja_zh,
-    );
-    let result: Vec<usize> = iter.collect();
-    assert_eq!(expect_utf16, result, "{}", s);
+    let mut options = LineBreakOptions::default();
+    options.line_break_rule = LineBreakRule::Normal;
+    options.word_break_rule = WordBreakRule::Normal;
+    options.ja_zh = ja_zh;
+    check_with_options(s, expect_utf8, expect_utf16, options);
 }
 
 fn loose(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
-    let iter = LineBreakIterator::new_with_break_rule(
-        s,
-        LineBreakRule::Loose,
-        WordBreakRule::Normal,
-        ja_zh,
-    );
-    let result: Vec<usize> = iter.collect();
-    assert_eq!(expect_utf8, result, "{}", s);
-
-    let s_utf16: Vec<u16> = s.encode_utf16().collect();
-    let iter = LineBreakIteratorUtf16::new_with_break_rule(
-        &s_utf16,
-        LineBreakRule::Loose,
-        WordBreakRule::Normal,
-        ja_zh,
-    );
-    let result: Vec<usize> = iter.collect();
-    assert_eq!(expect_utf16, result, "{}", s);
+    let mut options = LineBreakOptions::default();
+    options.line_break_rule = LineBreakRule::Loose;
+    options.word_break_rule = WordBreakRule::Normal;
+    options.ja_zh = ja_zh;
+    check_with_options(s, expect_utf8, expect_utf16, options);
 }
 
 fn anywhere(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
-    let iter = LineBreakIterator::new_with_break_rule(
-        s,
-        LineBreakRule::Anywhere,
-        WordBreakRule::Normal,
-        ja_zh,
-    );
-    let result: Vec<usize> = iter.collect();
-    assert_eq!(expect_utf8, result, "{}", s);
-
-    let s_utf16: Vec<u16> = s.encode_utf16().collect();
-    let iter = LineBreakIteratorUtf16::new_with_break_rule(
-        &s_utf16,
-        LineBreakRule::Anywhere,
-        WordBreakRule::Normal,
-        ja_zh,
-    );
-    let result: Vec<usize> = iter.collect();
-    assert_eq!(expect_utf16, result, "{}", s);
+    let mut options = LineBreakOptions::default();
+    options.line_break_rule = LineBreakRule::Anywhere;
+    options.word_break_rule = WordBreakRule::Normal;
+    options.ja_zh = ja_zh;
+    check_with_options(s, expect_utf8, expect_utf16, options);
 }
 
 #[test]

--- a/experimental/segmenter/tests/css_line_break.rs
+++ b/experimental/segmenter/tests/css_line_break.rs
@@ -2,12 +2,17 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_segmenter::LineBreakRule;
-use icu_segmenter::WordBreakRule;
-use icu_segmenter::LineBreakSegmenter;
 use icu_segmenter::LineBreakOptions;
+use icu_segmenter::LineBreakRule;
+use icu_segmenter::LineBreakSegmenter;
+use icu_segmenter::WordBreakRule;
 
-fn check_with_options(s: &str, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>, options: LineBreakOptions) {
+fn check_with_options(
+    s: &str,
+    expect_utf8: Vec<usize>,
+    expect_utf16: Vec<usize>,
+    options: LineBreakOptions,
+) {
     let segmenter = LineBreakSegmenter::try_new_with_options(options).expect("Data exists");
 
     let iter = segmenter.segment_str(s);

--- a/experimental/segmenter/tests/css_word_break.rs
+++ b/experimental/segmenter/tests/css_word_break.rs
@@ -2,72 +2,46 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_segmenter::LineBreakIterator;
-use icu_segmenter::LineBreakIteratorUtf16;
 use icu_segmenter::LineBreakRule;
 use icu_segmenter::WordBreakRule;
+use icu_segmenter::LineBreakSegmenter;
+use icu_segmenter::LineBreakOptions;
 
-fn break_all(s: &str, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
-    let iter = LineBreakIterator::new_with_break_rule(
-        s,
-        LineBreakRule::Strict,
-        WordBreakRule::BreakAll,
-        false,
-    );
+fn check_with_options(s: &str, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>, options: LineBreakOptions) {
+    let segmenter = LineBreakSegmenter::try_new_with_options(options).expect("Data exists");
+
+    let iter = segmenter.segment_str(s);
     let result: Vec<usize> = iter.collect();
     assert_eq!(expect_utf8, result, "{}", s);
 
     let s_utf16: Vec<u16> = s.encode_utf16().collect();
-    let iter = LineBreakIteratorUtf16::new_with_break_rule(
-        &s_utf16,
-        LineBreakRule::Strict,
-        WordBreakRule::BreakAll,
-        false,
-    );
+    let iter = segmenter.segment_utf16(&s_utf16);
     let result: Vec<usize> = iter.collect();
     assert_eq!(expect_utf16, result, "{}", s);
+}
+
+fn break_all(s: &str, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
+    let mut options = LineBreakOptions::default();
+    options.line_break_rule = LineBreakRule::Strict;
+    options.word_break_rule = WordBreakRule::BreakAll;
+    options.ja_zh = false;
+    check_with_options(s, expect_utf8, expect_utf16, options);
 }
 
 fn keep_all(s: &str, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
-    let iter = LineBreakIterator::new_with_break_rule(
-        s,
-        LineBreakRule::Strict,
-        WordBreakRule::KeepAll,
-        false,
-    );
-    let result: Vec<usize> = iter.collect();
-    assert_eq!(expect_utf8, result, "{}", s);
-
-    let s_utf16: Vec<u16> = s.encode_utf16().collect();
-    let iter = LineBreakIteratorUtf16::new_with_break_rule(
-        &s_utf16,
-        LineBreakRule::Strict,
-        WordBreakRule::KeepAll,
-        false,
-    );
-    let result: Vec<usize> = iter.collect();
-    assert_eq!(expect_utf16, result, "{}", s);
+    let mut options = LineBreakOptions::default();
+    options.line_break_rule = LineBreakRule::Strict;
+    options.word_break_rule = WordBreakRule::KeepAll;
+    options.ja_zh = false;
+    check_with_options(s, expect_utf8, expect_utf16, options);
 }
 
 fn normal(s: &str, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
-    let iter = LineBreakIterator::new_with_break_rule(
-        s,
-        LineBreakRule::Strict,
-        WordBreakRule::Normal,
-        false,
-    );
-    let result: Vec<usize> = iter.collect();
-    assert_eq!(expect_utf8, result, "{}", s);
-
-    let s_utf16: Vec<u16> = s.encode_utf16().collect();
-    let iter = LineBreakIteratorUtf16::new_with_break_rule(
-        &s_utf16,
-        LineBreakRule::Strict,
-        WordBreakRule::Normal,
-        false,
-    );
-    let result: Vec<usize> = iter.collect();
-    assert_eq!(expect_utf16, result, "{}", s);
+    let mut options = LineBreakOptions::default();
+    options.line_break_rule = LineBreakRule::Strict;
+    options.word_break_rule = WordBreakRule::Normal;
+    options.ja_zh = false;
+    check_with_options(s, expect_utf8, expect_utf16, options);
 }
 
 #[test]

--- a/experimental/segmenter/tests/css_word_break.rs
+++ b/experimental/segmenter/tests/css_word_break.rs
@@ -2,12 +2,17 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_segmenter::LineBreakRule;
-use icu_segmenter::WordBreakRule;
-use icu_segmenter::LineBreakSegmenter;
 use icu_segmenter::LineBreakOptions;
+use icu_segmenter::LineBreakRule;
+use icu_segmenter::LineBreakSegmenter;
+use icu_segmenter::WordBreakRule;
 
-fn check_with_options(s: &str, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>, options: LineBreakOptions) {
+fn check_with_options(
+    s: &str,
+    expect_utf8: Vec<usize>,
+    expect_utf16: Vec<usize>,
+    options: LineBreakOptions,
+) {
     let segmenter = LineBreakSegmenter::try_new_with_options(options).expect("Data exists");
 
     let iter = segmenter.segment_str(s);

--- a/experimental/segmenter/tests/spec_test.rs
+++ b/experimental/segmenter/tests/spec_test.rs
@@ -2,9 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_segmenter::LineBreakIterator;
-use icu_segmenter::LineBreakIteratorLatin1;
-use icu_segmenter::LineBreakIteratorUtf16;
+use icu_segmenter::LineBreakSegmenter;
 use icu_segmenter::WordBreakIterator;
 use icu_segmenter::WordBreakIteratorLatin1;
 use icu_segmenter::WordBreakIteratorUtf16;
@@ -108,13 +106,14 @@ impl Iterator for TestContentIterator {
 #[test]
 fn run_line_break_test() {
     let test_iter = TestContentIterator::new("./tests/testdata/LineBreakTest.txt");
+    let segmenter = LineBreakSegmenter::try_new().expect("Data exists");
     for test in test_iter {
         let s: String = test.utf8_vec.into_iter().collect();
-        let iter = LineBreakIterator::new(&s);
+        let iter = segmenter.segment_str(&s);
         let result: Vec<usize> = iter.collect();
         assert_eq!(result, test.break_result_utf8, "{}", test.original_line);
 
-        let iter = LineBreakIteratorUtf16::new(&test.utf16_vec);
+        let iter = segmenter.segment_utf16(&test.utf16_vec);
         let result: Vec<usize> = iter.collect();
         assert_eq!(
             result, test.break_result_utf16,
@@ -124,7 +123,7 @@ fn run_line_break_test() {
 
         // Test data is Latin-1 character only, it can run for Latin-1 segmenter test.
         if let Some(break_result_latin1) = test.break_result_latin1 {
-            let iter = LineBreakIteratorLatin1::new(&test.latin1_vec);
+            let iter = segmenter.segment_latin1(&test.latin1_vec);
             let result: Vec<usize> = iter.collect();
             assert_eq!(
                 result, break_result_latin1,


### PR DESCRIPTION
Part of #1379 

This PR adds `LineBreakSegmenter`.  This API is more consistent with the Intl.Segmenter proposal and also paves the way for adding in DataProvider.

Previously, if you would write:

```rust
use icu_segmenter::LineBreakIterator;

let mut iter = LineBreakIterator::new("Hello World");
let result: Vec<usize> = iter.collect();
```

Now you write:

```rust
use icu_segmenter::LineBreakSegmenter;

let segmenter = LineBreakSegmenter::try_new().expect("Data exists");

let mut iter = segmenter.segment_str("Hello World");
let result: Vec<usize> = iter.collect();
```

When the data provider is added, it will be:

```rust
use icu_segmenter::LineBreakSegmenter;

let provider = icu_testdata::get_provider();
let segmenter = LineBreakSegmenter::try_new(&provider).expect("Data exists");

let mut iter = segmenter.segment_str("Hello World");
let result: Vec<usize> = iter.collect();
```