### PR TITLE
Add explicit aligned and unaligned read benches

### DIFF
--- a/utils/zerovec/benches/zerovec.rs
+++ b/utils/zerovec/benches/zerovec.rs
@@ -77,14 +77,28 @@ fn overview_bench(c: &mut Criterion) {
 
 #[cfg(feature = "bench")]
 fn sum_benches(c: &mut Criterion) {
+    let normal_slice = &TEST_SLICE[0..19];
+    let aligned_ule_slice = <u32 as AsULE>::ULE::parse_byte_slice(&TEST_BUFFER_LE[0..76]).unwrap();
+    let unalign_ule_slice = <u32 as AsULE>::ULE::parse_byte_slice(&TEST_BUFFER_LE[1..77]).unwrap();
+
+    assert_eq!(normal_slice.len(), aligned_ule_slice.len());
+    assert_eq!(normal_slice.len(), unalign_ule_slice.len());
+
     c.bench_function("zerovec/sum/sample/slice", |b| {
-        b.iter(|| black_box(&TEST_SLICE).iter().sum::<u32>());
+        b.iter(|| black_box(normal_slice).iter().sum::<u32>());
     });
 
-    c.bench_function("zerovec/sum/sample/zerovec", |b| {
+    c.bench_function("zerovec/sum/sample/zerovec_aligned", |b| {
         b.iter(|| {
-            ZeroVec::<u32>::parse_byte_slice(black_box(TEST_BUFFER_LE))
-                .unwrap()
+            ZeroVec::<u32>::Borrowed(black_box(aligned_ule_slice))
+                .iter()
+                .sum::<u32>()
+        });
+    });
+
+    c.bench_function("zerovec/sum/sample/zerovec_unaligned", |b| {
+        b.iter(|| {
+            ZeroVec::<u32>::Borrowed(black_box(unalign_ule_slice))
                 .iter()
                 .sum::<u32>()
         });

--- a/utils/zerovec/benches/zerovec.rs
+++ b/utils/zerovec/benches/zerovec.rs
@@ -85,14 +85,19 @@ fn sum_benches(c: &mut Criterion) {
     assert_eq!(normal_slice.len(), unalign_ule_slice.len());
 
     c.bench_function("zerovec/sum/sample/slice", |b| {
-        b.iter(|| black_box(normal_slice).iter().sum::<u32>());
+        b.iter(|| {
+            black_box(normal_slice)
+                .iter()
+                .copied()
+                .fold(0u32, |sum, val| sum.wrapping_add(val))
+        })
     });
 
     c.bench_function("zerovec/sum/sample/zerovec_aligned", |b| {
         b.iter(|| {
             ZeroVec::<u32>::Borrowed(black_box(aligned_ule_slice))
                 .iter()
-                .sum::<u32>()
+                .fold(0u32, |sum, val| sum.wrapping_add(val))
         });
     });
 
@@ -100,7 +105,7 @@ fn sum_benches(c: &mut Criterion) {
         b.iter(|| {
             ZeroVec::<u32>::Borrowed(black_box(unalign_ule_slice))
                 .iter()
-                .sum::<u32>()
+                .fold(0u32, |sum, val| sum.wrapping_add(val))
         });
     });
 }


### PR DESCRIPTION
I am adding another benchmark to illustrate the performance of aligned and unaligned reads.

I ran these benchmarks 5 times in a row on my x86_64 laptop.  Results:

<details>
Run 1:

```
zerovec/sum/sample/slice                                                                             
                        time:   [5.7847 ns 5.8072 ns 5.8329 ns]

zerovec/sum/sample/zerovec_aligned                                                                             
                        time:   [5.3018 ns 5.3197 ns 5.3393 ns]
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

zerovec/sum/sample/zerovec_unaligned                                                                             
                        time:   [5.1618 ns 5.1976 ns 5.2479 ns]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
```

Run 2:

```
zerovec/sum/sample/slice                                                                             
                        time:   [5.2745 ns 5.2897 ns 5.3091 ns]
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) low mild
  7 (7.00%) high mild
  3 (3.00%) high severe

zerovec/sum/sample/zerovec_aligned                                                                             
                        time:   [5.2183 ns 5.2403 ns 5.2657 ns]
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe

zerovec/sum/sample/zerovec_unaligned                                                                             
                        time:   [5.2843 ns 5.3101 ns 5.3400 ns]
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe
```

Run 3:

```
zerovec/sum/sample/slice                                                                             
                        time:   [5.3272 ns 5.3501 ns 5.3773 ns]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild

zerovec/sum/sample/zerovec_aligned                                                                             
                        time:   [5.3391 ns 5.3758 ns 5.4189 ns]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

zerovec/sum/sample/zerovec_unaligned                                                                             
                        time:   [5.3387 ns 5.3549 ns 5.3714 ns]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
```

Run 4:

```
zerovec/sum/sample/slice                                                                             
                        time:   [4.9303 ns 5.0362 ns 5.1684 ns]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe

zerovec/sum/sample/zerovec_aligned                                                                             
                        time:   [5.2726 ns 5.2883 ns 5.3053 ns]
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

zerovec/sum/sample/zerovec_unaligned                                                                             
                        time:   [5.4446 ns 5.4776 ns 5.5203 ns]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
```

Run 5:

```
zerovec/sum/sample/slice                                                                             
                        time:   [5.3702 ns 5.4031 ns 5.4386 ns]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

zerovec/sum/sample/zerovec_aligned                                                                             
                        time:   [5.2765 ns 5.3041 ns 5.3413 ns]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe

zerovec/sum/sample/zerovec_unaligned                                                                             
                        time:   [5.2893 ns 5.3111 ns 5.3399 ns]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high severe
```
</details>

In tabular form, if I take the median of the 5 runs:

| Read Type | Memory Type | 95% Confidence Interval |
|---|---|---|
| Aligned | Aligned | 5.3272 < 5.3501 < 5.3773 |
| Unaligned | Aligned | 5.2765 < 5.3041 < 5.3393 |
| Unaligned | Unaligned | 5.2893 < 5.3111 < 5.3400 |

In words: the confidence intervals for all 3 types are overlapping, and unaligned reads do not show any regression over aligned reads, especially if they come from aligned memory.