### PR TITLE
Constrain zcf impl for `[T]` on T: 'static

### DIFF
--- a/utils/yoke/src/zero_copy_from.rs
+++ b/utils/yoke/src/zero_copy_from.rs
@@ -241,7 +241,7 @@ impl ZeroCopyFrom<&'_ str> for &'static str {
     }
 }
 
-impl<T> ZeroCopyFrom<[T]> for &'static [T] {
+impl<T: 'static> ZeroCopyFrom<[T]> for &'static [T] {
     fn zero_copy_from<'b>(cart: &'b [T]) -> &'b [T] {
         cart
     }


### PR DESCRIPTION
This used to work, but it was a bug in rustc that it did, because our `Yokeable` impl on `&T` requires `T: 'static`.

Regression filed at https://github.com/rust-lang/rust/issues/91899

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->