### PR TITLE
Rewriting ListFormatter to only use appends

### DIFF
--- a/experimental/list_formatter/src/list_formatter.rs
+++ b/experimental/list_formatter/src/list_formatter.rs
@@ -215,7 +215,7 @@ mod tests {
         let string = formatter(Width::Short).format(VALUES);
         assert_eq!(string.capacity(), string.len());
 
-        let labelled_string = formatter(Width::Short).format(VALUES);
+        let labelled_string = formatter(Width::Short).format_to_parts(VALUES);
         assert_eq!(labelled_string.capacity(), labelled_string.len());
     }
 }

--- a/experimental/list_formatter/src/list_formatter.rs
+++ b/experimental/list_formatter/src/list_formatter.rs
@@ -86,15 +86,17 @@ impl ListFormatter {
                     builder = append_value(builder, values[i]);
                     builder = append_literal(builder, between);
 
-                    if middle_after_count == 0 {
-                        middle_after = Some(after);
-                    } else {
-                        // We're assuming that all middle_afters are the same. If we ever
-                        // use conditional patterns for middle they could actually be
-                        // different, so we'd need to use a stack to track what to append.
-                        debug_assert_eq!(middle_after, Some(after));
+                    if !after.is_empty() {
+                        if middle_after_count == 0 {
+                            middle_after = Some(after);
+                        } else {
+                            // We're assuming that all middle_afters are the same. If we ever
+                            // use conditional patterns for middle they could actually be
+                            // different, so we'd need to use a stack to track what to append.
+                            debug_assert_eq!(middle_after, Some(after));
+                        }
+                        middle_after_count += 1;
                     }
-                    middle_after_count += 1;
                 }
 
                 let (end_before, end_between, end_after) =

--- a/experimental/list_formatter/src/list_formatter.rs
+++ b/experimental/list_formatter/src/list_formatter.rs
@@ -67,7 +67,7 @@ impl ListFormatter {
             }
             n => {
                 // Start(values[0], middle(..., middle(values[n-3], End(values[n-2], values[n-1]))...)) =
-                // start_before + values[0] + start_between + (middle_before + values[1..n-3] + middle_between)* + 
+                // start_before + values[0] + start_between + (middle_before + values[1..n-3] + middle_between)* +
                 // end_before + values[n-2] + end_between + values[n-1] + end_after + middle_after* + start_after
 
                 let (start_before, start_between, start_after) =

--- a/experimental/list_formatter/src/provider.rs
+++ b/experimental/list_formatter/src/provider.rs
@@ -277,11 +277,26 @@ pub(crate) mod test {
 
     #[test]
     fn produces_correct_parts_conditionally() {
-        assert_eq!(test_patterns().end(Width::Narrow).parts("A"), ("", " :o ", ""));
-        assert_eq!(test_patterns().end(Width::Narrow).parts("a"), ("", " :o ", ""));
-        assert_eq!(test_patterns().end(Width::Narrow).parts("ab"), ("", " :o ", ""));
-        assert_eq!(test_patterns().end(Width::Narrow).parts("B"), ("", ". ", ""));
-        assert_eq!(test_patterns().end(Width::Narrow).parts("BA"), ("", ". ", ""));
+        assert_eq!(
+            test_patterns().end(Width::Narrow).parts("A"),
+            ("", " :o ", "")
+        );
+        assert_eq!(
+            test_patterns().end(Width::Narrow).parts("a"),
+            ("", " :o ", "")
+        );
+        assert_eq!(
+            test_patterns().end(Width::Narrow).parts("ab"),
+            ("", " :o ", "")
+        );
+        assert_eq!(
+            test_patterns().end(Width::Narrow).parts("B"),
+            ("", ". ", "")
+        );
+        assert_eq!(
+            test_patterns().end(Width::Narrow).parts("BA"),
+            ("", ". ", "")
+        );
     }
 
     #[test]

--- a/experimental/list_formatter/src/provider.rs
+++ b/experimental/list_formatter/src/provider.rs
@@ -182,13 +182,10 @@ impl<'data> FromStr for ListJoinerPattern<'data> {
     type Err = Error;
     fn from_str(pattern: &str) -> Result<Self, Self::Err> {
         match (pattern.find("{0}"), pattern.find("{1}")) {
-            (Some(index_0), Some(index_1)) if index_1 - 3 < 256 => {
-                #[cfg(not(test))]
-                assert_eq!(
-                    index_0, 0,
-                    "Found valid pattern {:?} but the data struct cannot currently \
-                 store patterns where the 0 placeholder is not at the beginning.\
-                 To fix, unskip the serialization of ListJoinerPattern.index_0",
+            (Some(index_0), Some(index_1)) => {
+                assert!(
+                    (index_0 == 0 || cfg!(test)) && index_1 - 3 < 256,
+                    "Found valid pattern {:?} that cannot be stored in ListFormatterPatternsV1.",
                     pattern
                 );
                 Ok(ListJoinerPattern {

--- a/experimental/list_formatter/src/provider.rs
+++ b/experimental/list_formatter/src/provider.rs
@@ -157,7 +157,7 @@ struct ListJoinerPattern<'data> {
     /// The index of the first placeholder. Always 0 for CLDR
     /// data, so we don't need to serialize it. In-memory we
     /// have free space for it as index_1 doesn't fill a word.
-    #[serde(skip)]
+    #[cfg_attr(feature = "provider_serde", serde(skip))]
     index_0: u8,
     /// The index of the second placeholder
     index_1: u8,

--- a/experimental/list_formatter/src/provider.rs
+++ b/experimental/list_formatter/src/provider.rs
@@ -154,17 +154,25 @@ struct ListJoinerPattern<'data> {
     /// The pattern string without the placeholders
     #[cfg_attr(feature = "provider_serde", serde(borrow))]
     string: Cow<'data, str>,
+    /// The index of the first placeholder. Always 0 for CLDR
+    /// data, so we don't need to serialize it. In-memory we
+    /// have free space for it as index_1 doesn't fill a word.
+    #[serde(skip)]
+    index_0: u8,
     /// The index of the second placeholder
     index_1: u8,
 }
 
-pub type PatternParts<'a> = (&'a str, &'a str);
+pub type PatternParts<'a> = (&'a str, &'a str, &'a str);
 
 impl<'data> ListJoinerPattern<'data> {
     fn borrow_tuple(&'data self) -> PatternParts<'data> {
+        let index_0 = self.index_0 as usize;
+        let index_1 = self.index_1 as usize;
         (
-            &self.string[0..self.index_1 as usize],
-            &self.string[self.index_1 as usize..],
+            &self.string[0..index_0],
+            &self.string[index_0..index_1],
+            &self.string[index_1..],
         )
     }
 }
@@ -174,14 +182,26 @@ impl<'data> FromStr for ListJoinerPattern<'data> {
     type Err = Error;
     fn from_str(pattern: &str) -> Result<Self, Self::Err> {
         match (pattern.find("{0}"), pattern.find("{1}")) {
-            (Some(0), Some(index_1)) if index_1 - 3 < 256 => Ok(ListJoinerPattern {
-                string: Cow::Owned(alloc::format!(
-                    "{}{}",
-                    &pattern[3..index_1],
-                    &pattern[index_1 + 3..]
-                )),
-                index_1: (index_1 - 3) as u8,
-            }),
+            (Some(index_0), Some(index_1)) if index_1 - 3 < 256 => {
+                #[cfg(not(test))]
+                assert_eq!(
+                    index_0, 0,
+                    "Found valid pattern {:?} but the data struct cannot currently \
+                 store patterns where the 0 placeholder is not at the beginning.\
+                 To fix, unskip the serialization of ListJoinerPattern.index_0",
+                    pattern
+                );
+                Ok(ListJoinerPattern {
+                    string: Cow::Owned(alloc::format!(
+                        "{}{}{}",
+                        &pattern[0..index_0],
+                        &pattern[index_0 + 3..index_1],
+                        &pattern[index_1 + 3..]
+                    )),
+                    index_0: index_0 as u8,
+                    index_1: (index_1 - 3) as u8,
+                })
+            }
             _ => Err(Error::IllegalPattern(pattern.into())),
         }
     }
@@ -231,10 +251,10 @@ pub(crate) mod test {
     pub fn test_patterns() -> ListFormatterPatternsV1<'static> {
         let mut patterns = ListFormatterPatternsV1::try_new([
             // Wide: general
-            "{0}: {1}",
-            "{0}, {1}",
-            "{0}. {1}!",
-            "{0}; {1}",
+            "@{0}:{1}#",
+            "&{0},{1}?",
+            "*{0}.{1}!",
+            "${0};{1}+",
             // Short: different pattern lengths
             "{0}1{1}",
             "{0}12{1}",
@@ -255,16 +275,16 @@ pub(crate) mod test {
 
     #[test]
     fn produces_correct_parts() {
-        assert_eq!(test_patterns().end(Width::Wide).parts(""), (". ", "!"));
+        assert_eq!(test_patterns().end(Width::Wide).parts(""), ("*", ".", "!"));
     }
 
     #[test]
     fn produces_correct_parts_conditionally() {
-        assert_eq!(test_patterns().end(Width::Narrow).parts("A"), (" :o ", ""));
-        assert_eq!(test_patterns().end(Width::Narrow).parts("a"), (" :o ", ""));
-        assert_eq!(test_patterns().end(Width::Narrow).parts("ab"), (" :o ", ""));
-        assert_eq!(test_patterns().end(Width::Narrow).parts("B"), (". ", ""));
-        assert_eq!(test_patterns().end(Width::Narrow).parts("BA"), (". ", ""));
+        assert_eq!(test_patterns().end(Width::Narrow).parts("A"), ("", " :o ", ""));
+        assert_eq!(test_patterns().end(Width::Narrow).parts("a"), ("", " :o ", ""));
+        assert_eq!(test_patterns().end(Width::Narrow).parts("ab"), ("", " :o ", ""));
+        assert_eq!(test_patterns().end(Width::Narrow).parts("B"), ("", ". ", ""));
+        assert_eq!(test_patterns().end(Width::Narrow).parts("BA"), ("", ". ", ""));
     }
 
     #[test]

--- a/provider/cldr/src/transform/list/mod.rs
+++ b/provider/cldr/src/transform/list/mod.rs
@@ -262,10 +262,10 @@ mod tests {
 
     #[test]
     fn test_spanish() {
-        let y_parts = (" y ", "");
-        let e_parts = (" e ", "");
-        let o_parts = (" o ", "");
-        let u_parts = (" u ", "");
+        let y_parts = ("", " y ", "");
+        let e_parts = ("", " e ", "");
+        let o_parts = ("", " o ", "");
+        let u_parts = ("", " u ", "");
 
         let payload_and = provide(langid!("es"), key::LIST_FORMAT_AND_V1);
         let and = &payload_and.get().end(Width::Wide);
@@ -322,8 +322,8 @@ mod tests {
 
     #[test]
     fn test_hebrew() {
-        let vav_parts = (" ו", "");
-        let vav_dash_parts = (" ו-", "");
+        let vav_parts = ("", " ו", "");
+        let vav_dash_parts = ("", " ו-", "");
 
         assert_eq!(
             provide(langid!("he"), key::LIST_FORMAT_AND_V1)

--- a/provider/cldr/src/transform/list/mod.rs
+++ b/provider/cldr/src/transform/list/mod.rs
@@ -256,7 +256,7 @@ mod tests {
                 .get()
                 .end(Width::Wide)
                 .parts(""),
-            (" ou ", "")
+            ("", " ou ", "")
         );
     }
 


### PR DESCRIPTION
This improves performance and allows writing to arbitrary sinks.

Also reenabling full spec pattern support, including fragments before the `{0}` placeholder.