### PR TITLE
Swapping arguments of `assert_writeable_eq`

### DIFF
--- a/components/locid/src/helpers.rs
+++ b/components/locid/src/helpers.rs
@@ -22,7 +22,7 @@ macro_rules! impl_writeable_for_single_subtag {
 
         #[test]
         fn test_writeable() {
-            writeable::assert_writeable_eq!($sample, &$type::from_str($sample).unwrap());
+            writeable::assert_writeable_eq!(&$type::from_str($sample).unwrap(), $sample);
         }
     };
 }
@@ -64,17 +64,17 @@ macro_rules! impl_writeable_for_subtag_list {
 
         #[test]
         fn test_writeable() {
-            writeable::assert_writeable_eq!("", &$type::default());
+            writeable::assert_writeable_eq!(&$type::default(), "");
             writeable::assert_writeable_eq!(
+                &$type::from_vec_unchecked(alloc::vec![$sample1.parse().unwrap()]),
                 $sample1,
-                &$type::from_vec_unchecked(alloc::vec![$sample1.parse().unwrap()])
             );
             writeable::assert_writeable_eq!(
-                core::concat!($sample1, "-", $sample2),
                 &$type::from_vec_unchecked(alloc::vec![
                     $sample1.parse().unwrap(),
                     $sample2.parse().unwrap()
-                ])
+                ]),
+                core::concat!($sample1, "-", $sample2),
             );
         }
     };
@@ -122,15 +122,15 @@ macro_rules! impl_writeable_for_tinystr_list {
         #[test]
         fn test_writeable() {
             writeable::assert_writeable_eq!(
+                &$type::from_vec_unchecked(vec![$sample1.parse().unwrap()]),
                 $sample1,
-                &$type::from_vec_unchecked(vec![$sample1.parse().unwrap()])
             );
             writeable::assert_writeable_eq!(
-                core::concat!($sample1, "-", $sample2),
                 &$type::from_vec_unchecked(vec![
                     $sample1.parse().unwrap(),
                     $sample2.parse().unwrap()
-                ])
+                ]),
+                core::concat!($sample1, "-", $sample2),
             );
         }
     };
@@ -185,20 +185,20 @@ macro_rules! impl_writeable_for_key_value {
 
         #[test]
         fn test_writeable() {
-            writeable::assert_writeable_eq!("", &$type::default());
+            writeable::assert_writeable_eq!(&$type::default(), "");
             writeable::assert_writeable_eq!(
-                core::concat!($key1, "-", $value1),
                 &$type::from_vec_unchecked(vec![(
                     $key1.parse().unwrap(),
                     $value1.parse().unwrap()
-                )])
+                )]),
+                core::concat!($key1, "-", $value1),
             );
             writeable::assert_writeable_eq!(
-                core::concat!($key1, "-", $value1, "-", $expected2),
                 &$type::from_vec_unchecked(vec![
                     ($key1.parse().unwrap(), $value1.parse().unwrap()),
                     ($key2.parse().unwrap(), "true".parse().unwrap())
-                ])
+                ]),
+                core::concat!($key1, "-", $value1, "-", $expected2),
             );
         }
     };

--- a/components/locid/src/langid.rs
+++ b/components/locid/src/langid.rs
@@ -212,23 +212,23 @@ impl writeable::Writeable for LanguageIdentifier {
 #[test]
 fn test_writeable() {
     use writeable::assert_writeable_eq;
-    assert_writeable_eq!("und", LanguageIdentifier::und());
-    assert_writeable_eq!("und-001", LanguageIdentifier::from_str("und-001").unwrap());
+    assert_writeable_eq!(LanguageIdentifier::und(), "und");
+    assert_writeable_eq!(LanguageIdentifier::from_str("und-001").unwrap(), "und-001");
     assert_writeable_eq!(
+        LanguageIdentifier::from_str("und-Mymr").unwrap(),
         "und-Mymr",
-        LanguageIdentifier::from_str("und-Mymr").unwrap()
     );
     assert_writeable_eq!(
+        LanguageIdentifier::from_str("my-Mymr-MM").unwrap(),
         "my-Mymr-MM",
-        LanguageIdentifier::from_str("my-Mymr-MM").unwrap()
     );
     assert_writeable_eq!(
+        LanguageIdentifier::from_str("my-Mymr-MM-posix").unwrap(),
         "my-Mymr-MM-posix",
-        LanguageIdentifier::from_str("my-Mymr-MM-posix").unwrap()
     );
     assert_writeable_eq!(
+        LanguageIdentifier::from_str("zh-macos-posix").unwrap(),
         "zh-macos-posix",
-        LanguageIdentifier::from_str("zh-macos-posix").unwrap()
     );
 }
 

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -217,29 +217,29 @@ impl writeable::Writeable for Locale {
 #[test]
 fn test_writeable() {
     use writeable::assert_writeable_eq;
-    assert_writeable_eq!("und", Locale::und());
-    assert_writeable_eq!("und-001", Locale::from_str("und-001").unwrap());
-    assert_writeable_eq!("und-Mymr", Locale::from_str("und-Mymr").unwrap());
-    assert_writeable_eq!("my-Mymr-MM", Locale::from_str("my-Mymr-MM").unwrap());
+    assert_writeable_eq!(Locale::und(), "und");
+    assert_writeable_eq!(Locale::from_str("und-001").unwrap(), "und-001");
+    assert_writeable_eq!(Locale::from_str("und-Mymr").unwrap(), "und-Mymr");
+    assert_writeable_eq!(Locale::from_str("my-Mymr-MM").unwrap(), "my-Mymr-MM");
     assert_writeable_eq!(
+        Locale::from_str("my-Mymr-MM-posix").unwrap(),
         "my-Mymr-MM-posix",
-        Locale::from_str("my-Mymr-MM-posix").unwrap()
     );
     assert_writeable_eq!(
+        Locale::from_str("zh-macos-posix").unwrap(),
         "zh-macos-posix",
-        Locale::from_str("zh-macos-posix").unwrap()
     );
     assert_writeable_eq!(
+        Locale::from_str("my-t-my-d0-zawgyi").unwrap(),
         "my-t-my-d0-zawgyi",
-        Locale::from_str("my-t-my-d0-zawgyi").unwrap()
     );
     assert_writeable_eq!(
+        Locale::from_str("ar-SA-u-ca-islamic-civil").unwrap(),
         "ar-SA-u-ca-islamic-civil",
-        Locale::from_str("ar-SA-u-ca-islamic-civil").unwrap()
     );
     assert_writeable_eq!(
+        Locale::from_str("en-001-x-foo-bar").unwrap(),
         "en-001-x-foo-bar",
-        Locale::from_str("en-001-x-foo-bar").unwrap()
     );
 }
 

--- a/components/locid/src/subtags/language.rs
+++ b/components/locid/src/subtags/language.rs
@@ -230,9 +230,9 @@ impl writeable::Writeable for Language {
 
 #[test]
 fn test_writeable() {
-    writeable::assert_writeable_eq!("aa", &Language::from_str("aa").unwrap());
-    writeable::assert_writeable_eq!("xyz", &Language::from_str("xyz").unwrap());
-    writeable::assert_writeable_eq!("und", &Language::from_str("und").unwrap());
+    writeable::assert_writeable_eq!(&Language::from_str("aa").unwrap(), "aa");
+    writeable::assert_writeable_eq!(&Language::from_str("xyz").unwrap(), "xyz");
+    writeable::assert_writeable_eq!(&Language::from_str("und").unwrap(), "und");
 }
 
 impl PartialEq<&str> for Language {

--- a/provider/core/src/resource.rs
+++ b/provider/core/src/resource.rs
@@ -440,7 +440,7 @@ mod tests {
     fn test_options_to_string() {
         for cas in get_key_test_cases().iter() {
             assert_eq!(cas.expected, cas.resc_key.to_string());
-            writeable::assert_writeable_eq!(cas.expected, &cas.resc_key);
+            writeable::assert_writeable_eq!(&cas.resc_key, cas.expected);
             assert_eq!(
                 cas.expected,
                 cas.resc_key
@@ -488,7 +488,7 @@ mod tests {
     fn test_key_to_string() {
         for cas in get_options_test_cases().iter() {
             assert_eq!(cas.expected, cas.resc_options.to_string());
-            writeable::assert_writeable_eq!(cas.expected, &cas.resc_options);
+            writeable::assert_writeable_eq!(&cas.resc_options, cas.expected);
             assert_eq!(
                 cas.expected,
                 cas.resc_options
@@ -516,7 +516,7 @@ mod tests {
                     options: options_cas.resc_options.clone(),
                 };
                 assert_eq!(expected, resource_path.to_string());
-                writeable::assert_writeable_eq!(expected, &resource_path);
+                writeable::assert_writeable_eq!(&resource_path, expected);
             }
         }
     }

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -1013,7 +1013,7 @@ fn test_round() {
         let mut dec = FixedDecimal::new_from_f64_raw(case.input).unwrap();
         dec.round_trailing_digits(case.round, RoundingMode::HalfExpand)
             .unwrap();
-        writeable::assert_writeable_eq!(case.expected, dec, "{:?}", case);
+        writeable::assert_writeable_eq!(dec, case.expected, "{:?}", case);
     }
 }
 
@@ -1203,7 +1203,7 @@ fn test_float() {
 
     for case in &cases {
         let dec = FixedDecimal::new_from_f64(case.input, case.precision).unwrap();
-        writeable::assert_writeable_eq!(case.expected, dec, "{:?}", case);
+        writeable::assert_writeable_eq!(dec, case.expected, "{:?}", case);
     }
 }
 
@@ -1311,7 +1311,7 @@ fn test_basic() {
         let mut dec: FixedDecimal = cas.input.into();
         // println!("{}", cas.input + 0.01);
         dec.multiply_pow10(cas.delta).unwrap();
-        writeable::assert_writeable_eq!(cas.expected, dec, "{:?}", cas);
+        writeable::assert_writeable_eq!(dec, cas.expected, "{:?}", cas);
     }
 }
 
@@ -1417,7 +1417,7 @@ fn test_isize_limits() {
         let dec_str = dec.to_string();
         assert_eq!(num.to_string(), dec_str);
         assert_eq!(dec, FixedDecimal::from_str(&dec_str).unwrap());
-        writeable::assert_writeable_eq!(dec_str, dec);
+        writeable::assert_writeable_eq!(dec, dec_str);
     }
 }
 
@@ -1428,14 +1428,14 @@ fn test_ui128_limits() {
         let dec_str = dec.to_string();
         assert_eq!(num.to_string(), dec_str);
         assert_eq!(dec, FixedDecimal::from_str(&dec_str).unwrap());
-        writeable::assert_writeable_eq!(dec_str, dec);
+        writeable::assert_writeable_eq!(dec, dec_str);
     }
     for num in &[core::u128::MAX, core::u128::MIN] {
         let dec: FixedDecimal = (*num).into();
         let dec_str = dec.to_string();
         assert_eq!(num.to_string(), dec_str);
         assert_eq!(dec, FixedDecimal::from_str(&dec_str).unwrap());
-        writeable::assert_writeable_eq!(dec_str, dec);
+        writeable::assert_writeable_eq!(dec, dec_str);
     }
 }
 

--- a/utils/writeable/README.md
+++ b/utils/writeable/README.md
@@ -42,7 +42,7 @@ impl<'s> Writeable for WelcomeMessage<'s> {
 }
 
 let message = WelcomeMessage { name: "Alice" };
-assert_writeable_eq!("Hello, Alice!", &message);
+assert_writeable_eq!(&message, "Hello, Alice!");
 ```
 
 [`ICU4X`]: ../icu/index.html

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -73,19 +73,19 @@ impl Writeable for u16 {
 #[test]
 fn test_u8() {
     use crate::assert_writeable_eq;
-    assert_writeable_eq!("0", &0u8);
-    assert_writeable_eq!("1", &1u8);
-    assert_writeable_eq!("10", &10u8);
-    assert_writeable_eq!("99", &99u8);
-    assert_writeable_eq!("255", &255u8);
+    assert_writeable_eq!(&0u8, "0",);
+    assert_writeable_eq!(&1u8, "1",);
+    assert_writeable_eq!(&10u8, "10",);
+    assert_writeable_eq!(&99u8, "99",);
+    assert_writeable_eq!(&255u8, "255",);
 }
 
 #[test]
 fn test_u16() {
     use crate::assert_writeable_eq;
-    assert_writeable_eq!("0", &0u16);
-    assert_writeable_eq!("1", &1u16);
-    assert_writeable_eq!("10", &10u16);
-    assert_writeable_eq!("99", &99u16);
-    assert_writeable_eq!("65535", &65535u16);
+    assert_writeable_eq!(&0u16, "0",);
+    assert_writeable_eq!(&1u16, "1",);
+    assert_writeable_eq!(&10u16, "10",);
+    assert_writeable_eq!(&99u16, "99",);
+    assert_writeable_eq!(&65535u16, "65535",);
 }

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -46,7 +46,7 @@
 //! }
 //!
 //! let message = WelcomeMessage { name: "Alice" };
-//! assert_writeable_eq!("Hello, Alice!", &message);
+//! assert_writeable_eq!(&message, "Hello, Alice!");
 //! ```
 //!
 //! [`ICU4X`]: ../icu/index.html
@@ -149,12 +149,12 @@ pub trait Writeable {
 ///     }
 /// }
 ///
-/// assert_writeable_eq!("foo", &Demo);
-/// assert_writeable_eq!("foo", &Demo, "Message: {}", "Hello World");
+/// assert_writeable_eq!(&Demo, "foo");
+/// assert_writeable_eq!(&Demo, "foo", "Message: {}", "Hello World");
 /// ```
 #[macro_export]
 macro_rules! assert_writeable_eq {
-    ($expected_str:expr, $actual_writeable:expr $(,)?) => {
+    ($actual_writeable:expr, $expected_str:expr $(,)?) => {
         {
             use $crate::Writeable;
             let writeable = $actual_writeable;
@@ -165,7 +165,7 @@ macro_rules! assert_writeable_eq {
         }
     };
 
-    ($expected_str:expr, $actual_writeable:expr, $($arg:tt)+) => {
+    ($actual_writeable:expr, $expected_str:expr, $($arg:tt)+) => {
         {
             use $crate::Writeable;
             let writeable = $actual_writeable;

--- a/utils/writeable/tests/writeable.rs
+++ b/utils/writeable/tests/writeable.rs
@@ -28,5 +28,5 @@ fn test_basic() {
     let message = WriteableMessage {
         message: input_string,
     };
-    assert_writeable_eq!(input_string, &message);
+    assert_writeable_eq!(&message, input_string);
 }


### PR DESCRIPTION
The majority of uses of `assert_eq!` are `assert_eq!(actual, expected)`. This can also be read nicely as "assert that my computation equals this value". While `assert_eq` supports both styles, `assert_writeable_eq`'s arguments have different types, so currently only `assert_writeable_eq!(expected, actual)` is possible.