### PR TITLE
Construct VZVs and use as_encoded_bytes instead of the static function

### DIFF
--- a/components/plurals/src/rules/runtime/ast.rs
+++ b/components/plurals/src/rules/runtime/ast.rs
@@ -456,7 +456,7 @@ mod serde {
                 let string: String = self.to_string();
                 serializer.serialize_str(&string)
             } else {
-                serializer.serialize_bytes(self.0.get_encoded_slice())
+                serializer.serialize_bytes(self.0.as_encoded_bytes())
             }
         }
     }
@@ -634,7 +634,7 @@ mod test {
         let relations = alloc::vec![relation];
         let vzv = VarZeroVec::from(relations.as_slice());
         assert_eq!(
-            vzv.get_encoded_slice(),
+            vzv.as_encoded_bytes(),
             &[1, 0, 0, 0, 0, 0, 0, 0, 192, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0]
         );
     }

--- a/utils/zerovec/benches/vzv.rs
+++ b/utils/zerovec/benches/vzv.rs
@@ -45,7 +45,9 @@ fn overview_bench(c: &mut Criterion) {
     // Same as vzv/char_count/vzv but with different inputs
     let seed = 42;
     let (string_vec, _) = random_alphanums(2..=10, 100, seed);
-    let bytes: Vec<u8> = VarZeroVec::<str>::from(&string_vec).get_encoded_slice().to_vec();
+    let bytes: Vec<u8> = VarZeroVec::<str>::from(&string_vec)
+        .get_encoded_slice()
+        .to_vec();
     let vzv = VarZeroVec::<str>::parse_byte_slice(black_box(bytes.as_slice())).unwrap();
 
     c.bench_function("vzv/overview", |b| {
@@ -72,7 +74,9 @@ fn overview_bench(c: &mut Criterion) {
 fn char_count_benches(c: &mut Criterion) {
     let seed = 2021;
     let (string_vec, _) = random_alphanums(2..=20, 100, seed);
-    let bytes: Vec<u8> = VarZeroVec::<str>::from(&string_vec).get_encoded_slice().to_vec();
+    let bytes: Vec<u8> = VarZeroVec::<str>::from(&string_vec)
+        .get_encoded_slice()
+        .to_vec();
     let vzv = VarZeroVec::<str>::parse_byte_slice(black_box(bytes.as_slice())).unwrap();
 
     // *** Count chars in vec of 100 strings ***
@@ -99,7 +103,9 @@ fn binary_search_benches(c: &mut Criterion) {
     let seed = 2021;
     let (string_vec, seed) = random_alphanums(2..=20, 500, seed);
     let (needles, _) = random_alphanums(2..=20, 10, seed);
-    let bytes: Vec<u8> = VarZeroVec::<str>::from(&string_vec).get_encoded_slice().to_vec();
+    let bytes: Vec<u8> = VarZeroVec::<str>::from(&string_vec)
+        .get_encoded_slice()
+        .to_vec();
     let vzv = VarZeroVec::<str>::parse_byte_slice(black_box(bytes.as_slice())).unwrap();
     let single_needle = "lmnop".to_string();
 

--- a/utils/zerovec/benches/vzv.rs
+++ b/utils/zerovec/benches/vzv.rs
@@ -45,7 +45,7 @@ fn overview_bench(c: &mut Criterion) {
     // Same as vzv/char_count/vzv but with different inputs
     let seed = 42;
     let (string_vec, _) = random_alphanums(2..=10, 100, seed);
-    let bytes: Vec<u8> = VarZeroVec::<str>::get_serializable_bytes(&string_vec).unwrap();
+    let bytes: Vec<u8> = VarZeroVec::<str>::from(&string_vec).get_encoded_slice().to_vec();
     let vzv = VarZeroVec::<str>::parse_byte_slice(black_box(bytes.as_slice())).unwrap();
 
     c.bench_function("vzv/overview", |b| {
@@ -72,7 +72,7 @@ fn overview_bench(c: &mut Criterion) {
 fn char_count_benches(c: &mut Criterion) {
     let seed = 2021;
     let (string_vec, _) = random_alphanums(2..=20, 100, seed);
-    let bytes: Vec<u8> = VarZeroVec::<str>::get_serializable_bytes(&string_vec).unwrap();
+    let bytes: Vec<u8> = VarZeroVec::<str>::from(&string_vec).get_encoded_slice().to_vec();
     let vzv = VarZeroVec::<str>::parse_byte_slice(black_box(bytes.as_slice())).unwrap();
 
     // *** Count chars in vec of 100 strings ***
@@ -99,7 +99,7 @@ fn binary_search_benches(c: &mut Criterion) {
     let seed = 2021;
     let (string_vec, seed) = random_alphanums(2..=20, 500, seed);
     let (needles, _) = random_alphanums(2..=20, 10, seed);
-    let bytes: Vec<u8> = VarZeroVec::<str>::get_serializable_bytes(&string_vec).unwrap();
+    let bytes: Vec<u8> = VarZeroVec::<str>::from(&string_vec).get_encoded_slice().to_vec();
     let vzv = VarZeroVec::<str>::parse_byte_slice(black_box(bytes.as_slice())).unwrap();
     let single_needle = "lmnop".to_string();
 

--- a/utils/zerovec/benches/vzv.rs
+++ b/utils/zerovec/benches/vzv.rs
@@ -45,9 +45,7 @@ fn overview_bench(c: &mut Criterion) {
     // Same as vzv/char_count/vzv but with different inputs
     let seed = 42;
     let (string_vec, _) = random_alphanums(2..=10, 100, seed);
-    let bytes: Vec<u8> = VarZeroVec::<str>::from(&string_vec)
-        .get_encoded_slice()
-        .to_vec();
+    let bytes: Vec<u8> = VarZeroVec::<str>::from(&string_vec).into_encoded_bytes();
     let vzv = VarZeroVec::<str>::parse_byte_slice(black_box(bytes.as_slice())).unwrap();
 
     c.bench_function("vzv/overview", |b| {
@@ -74,9 +72,7 @@ fn overview_bench(c: &mut Criterion) {
 fn char_count_benches(c: &mut Criterion) {
     let seed = 2021;
     let (string_vec, _) = random_alphanums(2..=20, 100, seed);
-    let bytes: Vec<u8> = VarZeroVec::<str>::from(&string_vec)
-        .get_encoded_slice()
-        .to_vec();
+    let bytes: Vec<u8> = VarZeroVec::<str>::from(&string_vec).into_encoded_bytes();
     let vzv = VarZeroVec::<str>::parse_byte_slice(black_box(bytes.as_slice())).unwrap();
 
     // *** Count chars in vec of 100 strings ***
@@ -103,9 +99,7 @@ fn binary_search_benches(c: &mut Criterion) {
     let seed = 2021;
     let (string_vec, seed) = random_alphanums(2..=20, 500, seed);
     let (needles, _) = random_alphanums(2..=20, 10, seed);
-    let bytes: Vec<u8> = VarZeroVec::<str>::from(&string_vec)
-        .get_encoded_slice()
-        .to_vec();
+    let bytes: Vec<u8> = VarZeroVec::<str>::from(&string_vec).into_encoded_bytes();
     let vzv = VarZeroVec::<str>::parse_byte_slice(black_box(bytes.as_slice())).unwrap();
     let single_needle = "lmnop".to_string();
 

--- a/utils/zerovec/benches/vzv.rs
+++ b/utils/zerovec/benches/vzv.rs
@@ -165,7 +165,7 @@ fn vzv_precompute_bench(c: &mut Criterion) {
     let seed = 2021;
     let (string_vec, seed) = random_alphanums(2..=20, 500, seed);
     let (needles, _) = random_alphanums(2..=20, 10, seed);
-    let bytes: Vec<u8> = VarZeroVec::<str>::get_serializable_bytes(&string_vec).unwrap();
+    let bytes: Vec<u8> = VarZeroVec::<str>::from(&string_vec).into_encoded_bytes();
     let vzv = VarZeroVec::<str>::parse_byte_slice(black_box(bytes.as_slice())).unwrap();
     let borrowed = vzv.as_borrowed();
     let slice = vzv.as_slice();

--- a/utils/zerovec/src/ule/custom/encode.rs
+++ b/utils/zerovec/src/ule/custom/encode.rs
@@ -187,7 +187,7 @@ where
     }
 
     fn encode_var_ule_len(&self) -> usize {
-        // TODO: Remove the unwrap somehow
+        // TODO(#1410): Rethink length errors in VZV.
         crate::varzerovec::borrowed::compute_serializable_len(self).unwrap() as usize
     }
 

--- a/utils/zerovec/src/ule/custom/encode.rs
+++ b/utils/zerovec/src/ule/custom/encode.rs
@@ -228,13 +228,13 @@ where
 
     #[inline]
     fn encode_var_ule_len(&self) -> usize {
-        self.get_encoded_slice().len()
+        self.as_encoded_bytes().len()
     }
 
     #[inline]
     fn encode_var_ule_write(&self, dst: &mut [u8]) {
-        debug_assert_eq!(self.get_encoded_slice().len(), dst.len());
-        dst.copy_from_slice(self.get_encoded_slice());
+        debug_assert_eq!(self.as_encoded_bytes().len(), dst.len());
+        dst.copy_from_slice(self.as_encoded_bytes());
     }
 }
 

--- a/utils/zerovec/src/varzerovec/borrowed.rs
+++ b/utils/zerovec/src/varzerovec/borrowed.rs
@@ -174,7 +174,7 @@ impl<'a, T: VarULE + ?Sized> VarZeroVecBorrowed<'a, T> {
 
     /// Get a reference to the entire backing buffer of this vector
     #[inline]
-    pub fn entire_slice(self) -> &'a [u8] {
+    pub fn as_encoded_bytes(self) -> &'a [u8] {
         self.entire_slice
     }
 

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -519,7 +519,7 @@ where
 {
     #[inline]
     fn from(elements: &Vec<A>) -> Self {
-        VarZeroVecOwned::from_elements(elements).into()
+        VarZeroVecOwned::try_from_elements(elements).unwrap().into()
     }
 }
 
@@ -530,7 +530,7 @@ where
 {
     #[inline]
     fn from(elements: &[A]) -> Self {
-        VarZeroVecOwned::from_elements(elements).into()
+        VarZeroVecOwned::try_from_elements(elements).unwrap().into()
     }
 }
 
@@ -541,7 +541,7 @@ where
 {
     #[inline]
     fn from(elements: &[A; N]) -> Self {
-        VarZeroVecOwned::from_elements(elements).into()
+        VarZeroVecOwned::try_from_elements(elements).unwrap().into()
     }
 }
 

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -231,9 +231,8 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::VarZeroVec;
     ///
     /// let strings = vec!["foo", "bar", "baz", "quux"];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
+    /// let vec = VarZeroVec::<str>::from(&strings);
     ///
-    /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     /// assert_eq!(vec.len(), 4);
     /// # Ok::<(), ZeroVecError>(())
     /// ```
@@ -251,9 +250,8 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::VarZeroVec;
     ///
     /// let strings: Vec<String> = vec![];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
+    /// let vec = VarZeroVec::<str>::from(&strings);
     ///
-    /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     /// assert!(vec.is_empty());
     /// # Ok::<(), ZeroVecError>(())
     /// ```
@@ -263,8 +261,7 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
 
     /// Parse a VarZeroVec from a slice of the appropriate format
     ///
-    /// Slices of the right format can be obtained via [`VarZeroVec::<str>::get_serializable_bytes()`]
-    /// or [`VarZeroVec::as_encoded_bytes()`]
+    /// Slices of the right format can be obtained via [`VarZeroVec::as_encoded_bytes()`].
     ///
     /// # Example
     ///
@@ -274,9 +271,8 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::VarZeroVec;
     ///
     /// let strings = vec!["foo", "bar", "baz", "quux"];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
+    /// let vec = VarZeroVec::<str>::from(&strings);
     ///
-    /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
     /// assert_eq!(&vec[0], "foo");
     /// assert_eq!(&vec[1], "bar");
     /// assert_eq!(&vec[2], "baz");
@@ -304,10 +300,9 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::VarZeroVec;
     ///
     /// let strings = vec!["foo", "bar", "baz", "quux"];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
-    /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
+    /// let vec = VarZeroVec::<str>::from(&strings);
     ///
-    /// let mut iter_results: Vec<&str> = vec.iter().collect();
+    /// let iter_results: Vec<&str> = vec.iter().collect();
     /// assert_eq!(iter_results[0], "foo");
     /// assert_eq!(iter_results[1], "bar");
     /// assert_eq!(iter_results[2], "baz");
@@ -328,10 +323,8 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::VarZeroVec;
     ///
     /// let strings = vec!["foo", "bar", "baz", "quux"];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
-    /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
+    /// let vec = VarZeroVec::<str>::from(&strings);
     ///
-    /// let mut iter_results: Vec<&str> = vec.iter().collect();
     /// assert_eq!(vec.get(0), Some("foo"));
     /// assert_eq!(vec.get(1), Some("bar"));
     /// assert_eq!(vec.get(2), Some("baz"));
@@ -354,8 +347,7 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::VarZeroVec;
     ///
     /// let strings = vec!["foo", "bar", "baz", "quux"];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
-    /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
+    /// let mut vec = VarZeroVec::<str>::from(&strings);
     ///
     /// assert_eq!(vec.len(), 4);
     /// let mutvec = vec.make_mut();
@@ -393,8 +385,7 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
     /// # use zerovec::VarZeroVec;
     ///
     /// let strings = vec!["foo", "bar", "baz", "quux"];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
-    /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
+    /// let vec = VarZeroVec::<str>::from(&strings);
     ///
     /// assert_eq!(vec.len(), 4);
     /// // has 'static lifetime
@@ -423,9 +414,26 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
         self.as_borrowed().to_vec()
     }
 
-    /// Obtain the internal encoded slice
+    /// Gets a reference to the byte slice representing the encoded data of this VarZeroVec.
     ///
-    /// This can be passed back to [`Self::parse_byte_slice()`]
+    /// The bytes can be passed back to [`Self::parse_byte_slice()`].
+    ///
+    /// To take the bytes as a vector, see [`Self::into_encoded_bytes()`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use std::str::Utf8Error;
+    /// # use zerovec::ule::ZeroVecError;
+    /// # use zerovec::VarZeroVec;
+    ///
+    /// let strings = vec!["foo", "bar", "baz"];
+    /// let vzv = VarZeroVec::<str>::from(&strings);
+    ///
+    /// assert_eq!(vzv, VarZeroVec::parse_byte_slice(vzv.as_encoded_bytes()).unwrap());
+    ///
+    /// # Ok::<(), ZeroVecError>(())
+    /// ```
     pub fn as_encoded_bytes(&self) -> &[u8] {
         match self {
             VarZeroVec::Owned(ref vec) => vec.as_encoded_bytes(),
@@ -433,11 +441,12 @@ impl<'a, T: VarULE + ?Sized> VarZeroVec<'a, T> {
         }
     }
 
-    /// For a slice of `T`, get a list of bytes that can be passed to
-    /// `parse_byte_slice` to recoup the same data.
+    /// Takes the byte vector representing the encoded data of this VarZeroVec. If borrowed,
+    /// this function allocates a byte vector and copies the borrowed bytes into it.
     ///
-    /// Returns `None` if the slice is too large to be represented in a list of
-    /// bytes whose length fits in a `u32`.
+    /// The bytes can be passed back to [`Self::parse_byte_slice()`].
+    ///
+    /// To get a reference to the bytes without moving, see [`Self::as_encoded_bytes()`].
     ///
     /// # Example
     ///
@@ -490,8 +499,7 @@ where
     /// # use zerovec::VarZeroVec;
     ///
     /// let strings = vec!["a", "b", "f", "g"];
-    /// let bytes = VarZeroVec::<str>::get_serializable_bytes(&strings).unwrap();
-    /// let mut vec: VarZeroVec<str> = VarZeroVec::parse_byte_slice(&bytes)?;
+    /// let vec: VarZeroVec<str> = VarZeroVec::from(&strings);
     ///
     /// assert_eq!(vec.binary_search("f"), Ok(2));
     /// assert_eq!(vec.binary_search("e"), Err(2));

--- a/utils/zerovec/src/varzerovec/owned.rs
+++ b/utils/zerovec/src/varzerovec/owned.rs
@@ -51,7 +51,7 @@ impl<T: VarULE + ?Sized> VarZeroVecOwned<T> {
     pub fn from_borrowed(borrowed: VarZeroVecBorrowed<T>) -> Self {
         Self {
             marker: PhantomData,
-            entire_slice: borrowed.entire_slice().into(),
+            entire_slice: borrowed.as_encoded_bytes().to_vec(),
         }
     }
 
@@ -121,7 +121,7 @@ impl<T: VarULE + ?Sized> VarZeroVecOwned<T> {
     /// If `idx == self.len()`, it will return the size of the data segment (where a new element would go).
     ///
     /// ## Safety
-    /// `idx <= self.len()` and `self.entire_slice()` is well-formed.
+    /// `idx <= self.len()` and `self.as_encoded_bytes()` is well-formed.
     unsafe fn element_position_unchecked(&self, idx: usize) -> usize {
         let len = self.len();
         let out = if idx == len {
@@ -136,7 +136,7 @@ impl<T: VarULE + ?Sized> VarZeroVecOwned<T> {
     /// Get the range of a specific element in the data segment.
     ///
     /// ## Safety
-    /// `idx < self.len()` and `self.entire_slice()` is well-formed.
+    /// `idx < self.len()` and `self.as_encoded_bytes()` is well-formed.
     unsafe fn element_range_unchecked(&self, idx: usize) -> core::ops::Range<usize> {
         let start = self.element_position_unchecked(idx);
         let end = self.element_position_unchecked(idx + 1);
@@ -147,7 +147,7 @@ impl<T: VarULE + ?Sized> VarZeroVecOwned<T> {
     /// Set the number of elements in the list without any checks.
     ///
     /// ## Safety
-    /// No safe functions may be called until `self.entire_slice()` is well-formed.
+    /// No safe functions may be called until `self.as_encoded_bytes()` is well-formed.
     unsafe fn set_len(&mut self, len: u32) {
         PlainOldULE::<4>::from_byte_slice_unchecked_mut(&mut self.entire_slice[..4])[0] =
             len.into();
@@ -161,7 +161,7 @@ impl<T: VarULE + ?Sized> VarZeroVecOwned<T> {
     /// Return the slice representing the given `index`.
     ///
     /// ## Safety
-    /// The index must be valid, and self.entire_slice() must be well-formed
+    /// The index must be valid, and self.as_encoded_bytes() must be well-formed
     unsafe fn index_data(&self, index: usize) -> &PlainOldULE<4> {
         &PlainOldULE::<4>::from_byte_slice_unchecked(&self.entire_slice[Self::index_range(index)])
             [0]
@@ -170,7 +170,7 @@ impl<T: VarULE + ?Sized> VarZeroVecOwned<T> {
     /// Return the mutable slice representing the given `index`.
     ///
     /// ## Safety
-    /// The index must be valid. self.entire_slice() must have allocated space
+    /// The index must be valid. self.as_encoded_bytes() must have allocated space
     /// for this index, but need not have its length appropriately set.
     unsafe fn index_data_mut(&mut self, index: usize) -> &mut PlainOldULE<4> {
         let ptr = self.entire_slice.as_mut_ptr();
@@ -218,8 +218,14 @@ impl<T: VarULE + ?Sized> VarZeroVecOwned<T> {
 
     /// Get a reference to the entire backing buffer of this vector
     #[inline]
-    pub fn entire_slice(&self) -> &[u8] {
+    pub fn as_encoded_bytes(&self) -> &[u8] {
         &self.entire_slice
+    }
+
+    /// Consume this vector and return the backing buffer
+    #[inline]
+    pub fn into_encoded_bytes(self) -> Vec<u8> {
+        self.entire_slice
     }
 
     /// Invalidate and resize the data at an index, optionally inserting or removing the index.
@@ -594,9 +600,9 @@ mod test {
     #[test]
     fn test_removing_last_element_clears() {
         let mut zerovec = VarZeroVecOwned::<str>::try_from_elements(&["buy some apples"]).unwrap();
-        assert!(!zerovec.as_borrowed().entire_slice().is_empty());
+        assert!(!zerovec.as_borrowed().as_encoded_bytes().is_empty());
         zerovec.remove(0);
-        assert!(zerovec.as_borrowed().entire_slice().is_empty());
+        assert!(zerovec.as_borrowed().as_encoded_bytes().is_empty());
     }
 
     #[test]

--- a/utils/zerovec/src/varzerovec/serde.rs
+++ b/utils/zerovec/src/varzerovec/serde.rs
@@ -122,7 +122,7 @@ where
             }
             seq.end()
         } else {
-            serializer.serialize_bytes(self.get_encoded_slice())
+            serializer.serialize_bytes(self.as_encoded_bytes())
         }
     }
 }

--- a/utils/zerovec/src/varzerovec/slice.rs
+++ b/utils/zerovec/src/varzerovec/slice.rs
@@ -45,7 +45,7 @@ use core::mem;
 ///         }).collect::<Vec<_>>();
 /// assert_eq!(reconstructed, all_strings);
 ///
-/// let bytes = vzv_all.get_encoded_slice();
+/// let bytes = vzv_all.as_encoded_bytes();
 /// let vzv_from_bytes: VarZeroVec<VarZeroSlice<VarZeroSlice<str>>> = VarZeroVec::parse_byte_slice(bytes).unwrap();
 /// assert_eq!(vzv_from_bytes, vzv_all);
 /// ```


### PR DESCRIPTION
This is something that's annoyed me for a while.  We can now do this at zero cost, so let's do it.

Do note that this raises questions with regard to error handling, but these questions already existed before.  I filed #1410 and left TODOs linked to that issue.