### PR TITLE
Add precompute benches for VZV, prefix all ZeroVecLike methods with `zvl_`

### DIFF
--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -146,7 +146,7 @@ where
     /// assert_eq!(borrow, Some("one"));
     /// ```
     pub fn get(&self, key: &K) -> Option<&'a V::GetType> {
-        let index = self.keys.binary_search(key).ok()?;
+        let index = self.keys.zvl_binary_search(key).ok()?;
         self.values.get_borrowed(index)
     }
 
@@ -164,7 +164,7 @@ where
     /// assert_eq!(borrowed.contains_key(&3), false);
     /// ```
     pub fn contains_key(&self, key: &K) -> bool {
-        self.keys.binary_search(key).is_ok()
+        self.keys.zvl_binary_search(key).is_ok()
     }
 
     /// Produce an ordered iterator over key-value pairs
@@ -205,7 +205,7 @@ where
 {
     /// For cases when `V` is fixed-size, obtain a direct copy of `V` instead of `V::ULE`
     pub fn get_copied(&self, key: &K) -> Option<V> {
-        let index = self.keys.binary_search(key).ok()?;
+        let index = self.keys.zvl_binary_search(key).ok()?;
         self.values.get(index)
     }
 

--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -30,7 +30,7 @@ pub use super::vecs::{BorrowedZeroVecLike, MutableZeroVecLike, ZeroVecLike};
 /// // Deserializing to ZeroMap requires no heap allocations.
 /// let zero_map: ZeroMapBorrowed<u32, str> = bincode::deserialize(BINCODE_BYTES)
 ///     .expect("Should deserialize successfully");
-/// assert_eq!(zero_map.get(&1), Some("one"));
+/// assert_eq!(zero_map.zvl_get(&1), Some("one"));
 /// ```
 ///
 /// This can be obtained from a [`ZeroMap`](super::ZeroMap) via [`ZeroMap::as_borrowed`](super::ZeroMap::as_borrowed)
@@ -137,17 +137,17 @@ where
     /// map.insert(&1, "one");
     /// map.insert(&2, "two");
     /// let borrowed = map.as_borrowed();
-    /// assert_eq!(borrowed.get(&1), Some("one"));
-    /// assert_eq!(borrowed.get(&3), None);
+    /// assert_eq!(borrowed.zvl_get(&1), Some("one"));
+    /// assert_eq!(borrowed.zvl_get(&3), None);
     ///
-    /// let borrow = borrowed.get(&1);
+    /// let borrow = borrowed.zvl_get(&1);
     /// drop(borrowed);
     /// // still exists after the ZeroMapBorrowed has been dropped
     /// assert_eq!(borrow, Some("one"));
     /// ```
     pub fn get(&self, key: &K) -> Option<&'a V::GetType> {
         let index = self.keys.zvl_binary_search(key).ok()?;
-        self.values.get_borrowed(index)
+        self.values.zvl_get_borrowed(index)
     }
 
     /// Returns whether `key` is contained in this map
@@ -178,22 +178,22 @@ where
     > + 'b {
         (0..self.keys.len()).map(move |idx| {
             (
-                self.keys.get_borrowed(idx).unwrap(),
-                self.values.get_borrowed(idx).unwrap(),
+                self.keys.zvl_get_borrowed(idx).unwrap(),
+                self.values.zvl_get_borrowed(idx).unwrap(),
             )
         })
     }
 
     /// Produce an ordered iterator over keys
     pub fn iter_keys<'b>(&'b self) -> impl Iterator<Item = &'a <K as ZeroMapKV<'a>>::GetType> + 'b {
-        (0..self.keys.len()).map(move |idx| self.keys.get_borrowed(idx).unwrap())
+        (0..self.keys.len()).map(move |idx| self.keys.zvl_get_borrowed(idx).unwrap())
     }
 
     /// Produce an iterator over values, ordered by keys
     pub fn iter_values<'b>(
         &'b self,
     ) -> impl Iterator<Item = &'a <V as ZeroMapKV<'a>>::GetType> + 'b {
-        (0..self.values.len()).map(move |idx| self.values.get_borrowed(idx).unwrap())
+        (0..self.values.len()).map(move |idx| self.values.zvl_get_borrowed(idx).unwrap())
     }
 }
 
@@ -215,7 +215,7 @@ where
         &'b self,
     ) -> impl Iterator<Item = (&'b <K as ZeroMapKV<'a>>::GetType, V)> {
         (0..self.keys.len())
-            .map(move |idx| (self.keys.get(idx).unwrap(), self.values.get(idx).unwrap()))
+            .map(move |idx| (self.keys.zvl_get(idx).unwrap(), self.values.get(idx).unwrap()))
     }
 }
 

--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -30,7 +30,7 @@ pub use super::vecs::{BorrowedZeroVecLike, MutableZeroVecLike, ZeroVecLike};
 /// // Deserializing to ZeroMap requires no heap allocations.
 /// let zero_map: ZeroMapBorrowed<u32, str> = bincode::deserialize(BINCODE_BYTES)
 ///     .expect("Should deserialize successfully");
-/// assert_eq!(zero_map.zvl_get(&1), Some("one"));
+/// assert_eq!(zero_map.get(&1), Some("one"));
 /// ```
 ///
 /// This can be obtained from a [`ZeroMap`](super::ZeroMap) via [`ZeroMap::as_borrowed`](super::ZeroMap::as_borrowed)
@@ -137,10 +137,10 @@ where
     /// map.insert(&1, "one");
     /// map.insert(&2, "two");
     /// let borrowed = map.as_borrowed();
-    /// assert_eq!(borrowed.zvl_get(&1), Some("one"));
-    /// assert_eq!(borrowed.zvl_get(&3), None);
+    /// assert_eq!(borrowed.get(&1), Some("one"));
+    /// assert_eq!(borrowed.get(&3), None);
     ///
-    /// let borrow = borrowed.zvl_get(&1);
+    /// let borrow = borrowed.get(&1);
     /// drop(borrowed);
     /// // still exists after the ZeroMapBorrowed has been dropped
     /// assert_eq!(borrow, Some("one"));

--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -214,8 +214,12 @@ where
     pub fn iter_copied_values<'b>(
         &'b self,
     ) -> impl Iterator<Item = (&'b <K as ZeroMapKV<'a>>::GetType, V)> {
-        (0..self.keys.zvl_len())
-            .map(move |idx| (self.keys.zvl_get(idx).unwrap(), self.values.get(idx).unwrap()))
+        (0..self.keys.zvl_len()).map(move |idx| {
+            (
+                self.keys.zvl_get(idx).unwrap(),
+                self.values.get(idx).unwrap(),
+            )
+        })
     }
 }
 

--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -115,12 +115,12 @@ where
 
     /// The number of elements in the [`ZeroMapBorrowed`]
     pub fn len(&self) -> usize {
-        self.values.len()
+        self.values.zvl_len()
     }
 
     /// Whether the [`ZeroMapBorrowed`] is empty
     pub fn is_empty(&self) -> bool {
-        self.values.len() == 0
+        self.values.zvl_len() == 0
     }
 
     /// Get the value associated with `key`, if it exists.
@@ -176,7 +176,7 @@ where
             &'a <V as ZeroMapKV<'a>>::GetType,
         ),
     > + 'b {
-        (0..self.keys.len()).map(move |idx| {
+        (0..self.keys.zvl_len()).map(move |idx| {
             (
                 self.keys.zvl_get_borrowed(idx).unwrap(),
                 self.values.zvl_get_borrowed(idx).unwrap(),
@@ -186,14 +186,14 @@ where
 
     /// Produce an ordered iterator over keys
     pub fn iter_keys<'b>(&'b self) -> impl Iterator<Item = &'a <K as ZeroMapKV<'a>>::GetType> + 'b {
-        (0..self.keys.len()).map(move |idx| self.keys.zvl_get_borrowed(idx).unwrap())
+        (0..self.keys.zvl_len()).map(move |idx| self.keys.zvl_get_borrowed(idx).unwrap())
     }
 
     /// Produce an iterator over values, ordered by keys
     pub fn iter_values<'b>(
         &'b self,
     ) -> impl Iterator<Item = &'a <V as ZeroMapKV<'a>>::GetType> + 'b {
-        (0..self.values.len()).map(move |idx| self.values.zvl_get_borrowed(idx).unwrap())
+        (0..self.values.zvl_len()).map(move |idx| self.values.zvl_get_borrowed(idx).unwrap())
     }
 }
 
@@ -214,7 +214,7 @@ where
     pub fn iter_copied_values<'b>(
         &'b self,
     ) -> impl Iterator<Item = (&'b <K as ZeroMapKV<'a>>::GetType, V)> {
-        (0..self.keys.len())
+        (0..self.keys.zvl_len())
             .map(move |idx| (self.keys.zvl_get(idx).unwrap(), self.values.get(idx).unwrap()))
     }
 }
@@ -232,7 +232,7 @@ where
     pub fn iter_copied<'b: 'a>(&'b self) -> impl Iterator<Item = (K, V)> + 'b {
         let keys = &*self.keys;
         let values = &*self.values;
-        let len = self.keys.len();
+        let len = self.keys.zvl_len();
         (0..len).map(move |idx| {
             (
                 ZeroSlice::get(keys, idx).unwrap(),

--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -105,10 +105,10 @@ where
     pub fn new() -> Self {
         Self {
             keys:
-                <<K as ZeroMapKV<'a>>::Container as MutableZeroVecLike<'a, K>>::BorrowedVariant::new(
+                <<K as ZeroMapKV<'a>>::Container as MutableZeroVecLike<'a, K>>::BorrowedVariant::zvl_new(
                 ),
             values:
-                <<V as ZeroMapKV<'a>>::Container as MutableZeroVecLike<'a, V>>::BorrowedVariant::new(
+                <<V as ZeroMapKV<'a>>::Container as MutableZeroVecLike<'a, V>>::BorrowedVariant::zvl_new(
                 ),
         }
     }

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -90,8 +90,8 @@ where
     /// ```
     pub fn new() -> Self {
         Self {
-            keys: K::Container::new(),
-            values: V::Container::new(),
+            keys: K::Container::zvl_new(),
+            values: V::Container::zvl_new(),
         }
     }
 

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -254,8 +254,12 @@ where
             &'b <V as ZeroMapKV<'a>>::GetType,
         ),
     > {
-        (0..self.keys.zvl_len())
-            .map(move |idx| (self.keys.zvl_get(idx).unwrap(), self.values.zvl_get(idx).unwrap()))
+        (0..self.keys.zvl_len()).map(move |idx| {
+            (
+                self.keys.zvl_get(idx).unwrap(),
+                self.values.zvl_get(idx).unwrap(),
+            )
+        })
     }
 
     /// Produce an ordered iterator over keys

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -98,8 +98,8 @@ where
     /// Construct a new [`ZeroMap`] with a given capacity
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            keys: K::Container::with_capacity(capacity),
-            values: V::Container::with_capacity(capacity),
+            keys: K::Container::zvl_with_capacity(capacity),
+            values: V::Container::zvl_with_capacity(capacity),
         }
     }
 
@@ -123,8 +123,8 @@ where
 
     /// Remove all elements from the [`ZeroMap`]
     pub fn clear(&mut self) {
-        self.keys.clear();
-        self.values.clear();
+        self.keys.zvl_clear();
+        self.values.zvl_clear();
     }
 
     /// Reserve capacity for `additional` more elements to be inserted into
@@ -132,8 +132,8 @@ where
     ///
     /// See [`Vec::reserve()`](alloc::vec::Vec::reserve) for more information.
     pub fn reserve(&mut self, additional: usize) {
-        self.keys.reserve(additional);
-        self.values.reserve(additional);
+        self.keys.zvl_reserve(additional);
+        self.values.zvl_reserve(additional);
     }
 
     /// Get the value associated with `key`, if it exists.
@@ -180,10 +180,10 @@ where
     /// ```
     pub fn insert(&mut self, key: &K, value: &V) -> Option<V::OwnedType> {
         match self.keys.zvl_binary_search(key) {
-            Ok(index) => Some(self.values.replace(index, value)),
+            Ok(index) => Some(self.values.zvl_replace(index, value)),
             Err(index) => {
-                self.keys.insert(index, key);
-                self.values.insert(index, value);
+                self.keys.zvl_insert(index, key);
+                self.values.zvl_insert(index, value);
                 None
             }
         }
@@ -202,8 +202,8 @@ where
     /// ```
     pub fn remove(&mut self, key: &K) -> Option<V::OwnedType> {
         let idx = self.keys.zvl_binary_search(key).ok()?;
-        self.keys.remove(idx);
-        Some(self.values.remove(idx))
+        self.keys.zvl_remove(idx);
+        Some(self.values.zvl_remove(idx))
     }
 
     /// Appends `value` with `key` to the end of the underlying vector, returning
@@ -240,8 +240,8 @@ where
             }
         }
 
-        self.keys.push(key);
-        self.values.push(value);
+        self.keys.zvl_push(key);
+        self.values.zvl_push(value);
         None
     }
 

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -148,7 +148,7 @@ where
     /// assert_eq!(map.get(&3), None);
     /// ```
     pub fn get(&self, key: &K) -> Option<&V::GetType> {
-        let index = self.keys.binary_search(key).ok()?;
+        let index = self.keys.zvl_binary_search(key).ok()?;
         self.values.get(index)
     }
 
@@ -164,7 +164,7 @@ where
     /// assert_eq!(map.contains_key(&3), false);
     /// ```
     pub fn contains_key(&self, key: &K) -> bool {
-        self.keys.binary_search(key).is_ok()
+        self.keys.zvl_binary_search(key).is_ok()
     }
 
     /// Insert `value` with `key`, returning the existing value if it exists.
@@ -179,7 +179,7 @@ where
     /// assert_eq!(map.get(&3), None);
     /// ```
     pub fn insert(&mut self, key: &K, value: &V) -> Option<V::OwnedType> {
-        match self.keys.binary_search(key) {
+        match self.keys.zvl_binary_search(key) {
             Ok(index) => Some(self.values.replace(index, value)),
             Err(index) => {
                 self.keys.insert(index, key);
@@ -201,7 +201,7 @@ where
     /// assert_eq!(map.get(&1), None);
     /// ```
     pub fn remove(&mut self, key: &K) -> Option<V::OwnedType> {
-        let idx = self.keys.binary_search(key).ok()?;
+        let idx = self.keys.zvl_binary_search(key).ok()?;
         self.keys.remove(idx);
         Some(self.values.remove(idx))
     }
@@ -277,7 +277,7 @@ where
 {
     /// For cases when `V` is fixed-size, obtain a direct copy of `V` instead of `V::ULE`
     pub fn get_copied(&self, key: &K) -> Option<V> {
-        let index = self.keys.binary_search(key).ok()?;
+        let index = self.keys.zvl_binary_search(key).ok()?;
         ZeroSlice::get(&*self.values, index)
     }
 

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -113,12 +113,12 @@ where
 
     /// The number of elements in the [`ZeroMap`]
     pub fn len(&self) -> usize {
-        self.values.len()
+        self.values.zvl_len()
     }
 
     /// Whether the [`ZeroMap`] is empty
     pub fn is_empty(&self) -> bool {
-        self.values.len() == 0
+        self.values.zvl_len() == 0
     }
 
     /// Remove all elements from the [`ZeroMap`]
@@ -232,8 +232,8 @@ where
     /// ```
     #[must_use]
     pub fn try_append<'b>(&mut self, key: &'b K, value: &'b V) -> Option<(&'b K, &'b V)> {
-        if self.keys.len() != 0 {
-            if let Some(last) = self.keys.zvl_get(self.keys.len() - 1) {
+        if self.keys.zvl_len() != 0 {
+            if let Some(last) = self.keys.zvl_get(self.keys.zvl_len() - 1) {
                 if K::Container::t_cmp_get(key, last) != Ordering::Greater {
                     return Some((key, value));
                 }
@@ -254,18 +254,18 @@ where
             &'b <V as ZeroMapKV<'a>>::GetType,
         ),
     > {
-        (0..self.keys.len())
+        (0..self.keys.zvl_len())
             .map(move |idx| (self.keys.zvl_get(idx).unwrap(), self.values.zvl_get(idx).unwrap()))
     }
 
     /// Produce an ordered iterator over keys
     pub fn iter_keys<'b>(&'b self) -> impl Iterator<Item = &'b <K as ZeroMapKV<'a>>::GetType> {
-        (0..self.keys.len()).map(move |idx| self.keys.zvl_get(idx).unwrap())
+        (0..self.keys.zvl_len()).map(move |idx| self.keys.zvl_get(idx).unwrap())
     }
 
     /// Produce an iterator over values, ordered by keys
     pub fn iter_values<'b>(&'b self) -> impl Iterator<Item = &'b <V as ZeroMapKV<'a>>::GetType> {
-        (0..self.values.len()).map(move |idx| self.values.zvl_get(idx).unwrap())
+        (0..self.values.zvl_len()).map(move |idx| self.values.zvl_get(idx).unwrap())
     }
 }
 
@@ -286,7 +286,7 @@ where
     pub fn iter_copied_values<'b>(
         &'b self,
     ) -> impl Iterator<Item = (&'b <K as ZeroMapKV<'a>>::GetType, V)> {
-        (0..self.keys.len()).map(move |idx| {
+        (0..self.keys.zvl_len()).map(move |idx| {
             (
                 self.keys.zvl_get(idx).unwrap(),
                 ZeroSlice::get(&*self.values, idx).unwrap(),

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -326,8 +326,8 @@ where
 {
     fn from(other: ZeroMapBorrowed<'a, K, V>) -> Self {
         Self {
-            keys: K::Container::from_borrowed(other.keys),
-            values: V::Container::from_borrowed(other.values),
+            keys: K::Container::zvl_from_borrowed(other.keys),
+            values: V::Container::zvl_from_borrowed(other.values),
         }
     }
 }

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -44,7 +44,7 @@ pub use vecs::{MutableZeroVecLike, ZeroVecLike};
 /// // Deserializing to ZeroMap requires no heap allocations.
 /// let zero_map: ZeroMap<u32, str> = bincode::deserialize(BINCODE_BYTES)
 ///     .expect("Should deserialize successfully");
-/// assert_eq!(zero_map.zvl_get(&1), Some("one"));
+/// assert_eq!(zero_map.get(&1), Some("one"));
 /// ```
 ///
 /// [`VarZeroVec`]: crate::VarZeroVec
@@ -144,8 +144,8 @@ where
     /// let mut map = ZeroMap::new();
     /// map.insert(&1, "one");
     /// map.insert(&2, "two");
-    /// assert_eq!(map.zvl_get(&1), Some("one"));
-    /// assert_eq!(map.zvl_get(&3), None);
+    /// assert_eq!(map.get(&1), Some("one"));
+    /// assert_eq!(map.get(&3), None);
     /// ```
     pub fn get(&self, key: &K) -> Option<&V::GetType> {
         let index = self.keys.zvl_binary_search(key).ok()?;
@@ -175,8 +175,8 @@ where
     /// let mut map = ZeroMap::new();
     /// map.insert(&1, "one");
     /// map.insert(&2, "two");
-    /// assert_eq!(map.zvl_get(&1), Some("one"));
-    /// assert_eq!(map.zvl_get(&3), None);
+    /// assert_eq!(map.get(&1), Some("one"));
+    /// assert_eq!(map.get(&3), None);
     /// ```
     pub fn insert(&mut self, key: &K, value: &V) -> Option<V::OwnedType> {
         match self.keys.zvl_binary_search(key) {
@@ -198,7 +198,7 @@ where
     /// map.insert(&1, "one");
     /// map.insert(&2, "two");
     /// assert_eq!(map.remove(&1), Some("one".to_owned().into_boxed_str()));
-    /// assert_eq!(map.zvl_get(&1), None);
+    /// assert_eq!(map.get(&1), None);
     /// ```
     pub fn remove(&mut self, key: &K) -> Option<V::OwnedType> {
         let idx = self.keys.zvl_binary_search(key).ok()?;
@@ -222,13 +222,13 @@ where
     /// let unsuccessful = map.try_append(&2, "dos");
     /// assert!(unsuccessful.is_some(), "append out of order");
     ///
-    /// assert_eq!(map.zvl_get(&1), Some("uno"));
+    /// assert_eq!(map.get(&1), Some("uno"));
     ///
     /// // contains the original value for the key: 3
-    /// assert_eq!(map.zvl_get(&3), Some("tres"));
+    /// assert_eq!(map.get(&3), Some("tres"));
     ///
     /// // not appended since it wasn't in order
-    /// assert_eq!(map.zvl_get(&2), None);
+    /// assert_eq!(map.get(&2), None);
     /// ```
     #[must_use]
     pub fn try_append<'b>(&mut self, key: &'b K, value: &'b V) -> Option<(&'b K, &'b V)> {

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -106,8 +106,8 @@ where
     /// Obtain a borrowed version of this map
     pub fn as_borrowed(&'a self) -> ZeroMapBorrowed<'a, K, V> {
         ZeroMapBorrowed {
-            keys: self.keys.as_borrowed(),
-            values: self.values.as_borrowed(),
+            keys: self.keys.zvl_as_borrowed(),
+            values: self.values.zvl_as_borrowed(),
         }
     }
 

--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -136,7 +136,7 @@ where
         } else {
             let (keys, values): (K::Container, V::Container) =
                 Deserialize::deserialize(deserializer)?;
-            if keys.len() != values.len() {
+            if keys.zvl_len() != values.zvl_len() {
                 return Err(de::Error::custom(
                     "Mismatched key and value sizes in ZeroMap",
                 ));

--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -171,14 +171,14 @@ where
             ))
         } else {
             let deserialized: ZeroMap<'a, K, V> = ZeroMap::deserialize(deserializer)?;
-            let keys = if let Some(keys) = deserialized.keys.as_borrowed_inner() {
+            let keys = if let Some(keys) = deserialized.keys.zvl_as_borrowed_inner() {
                 keys
             } else {
                 return Err(de::Error::custom(
                     "ZeroMapBorrowed can only deserialize in zero-copy ways",
                 ));
             };
-            let values = if let Some(values) = deserialized.values.as_borrowed_inner() {
+            let values = if let Some(values) = deserialized.values.zvl_as_borrowed_inner() {
                 values
             } else {
                 return Err(de::Error::custom(

--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -141,7 +141,7 @@ where
                     "Mismatched key and value sizes in ZeroMap",
                 ));
             }
-            if !keys.is_ascending() {
+            if !keys.zvl_is_ascending() {
                 return Err(de::Error::custom("ZeroMap deserializing keys out of order"));
             }
             Ok(Self { keys, values })

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -94,7 +94,7 @@ pub trait MutableZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
     /// Note: We rely on the compiler recognizing `'a` and `'b` as covariant and
     /// casting `&'b Self<'a>` to `&'b Self<'b>` when this gets called, which works
     /// out for `ZeroVec` and `VarZeroVec` containers just fine.
-    fn as_borrowed(&'a self) -> Self::BorrowedVariant;
+    fn zvl_as_borrowed(&'a self) -> Self::BorrowedVariant;
 
     /// Extract the inner borrowed variant if possible. Returns `None` if the data is owned.
     ///
@@ -103,7 +103,7 @@ pub trait MutableZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
     ///
     /// This function is similar to matching the `Borrowed` variant of `ZeroVec`
     /// or `VarZeroVec`, returning the inner borrowed type.
-    fn as_borrowed_inner(&self) -> Option<Self::BorrowedVariant>;
+    fn zvl_as_borrowed_inner(&self) -> Option<Self::BorrowedVariant>;
 
     /// Construct from the borrowed version of the type
     ///
@@ -216,10 +216,10 @@ where
         self.to_mut().reserve(addl)
     }
 
-    fn as_borrowed(&'a self) -> &'a ZeroSlice<T> {
+    fn zvl_as_borrowed(&'a self) -> &'a ZeroSlice<T> {
         &*self
     }
-    fn as_borrowed_inner(&self) -> Option<&'a ZeroSlice<T>> {
+    fn zvl_as_borrowed_inner(&self) -> Option<&'a ZeroSlice<T>> {
         if let ZeroVec::Borrowed(b) = *self {
             Some(ZeroSlice::from_ule_slice(b))
         } else {
@@ -368,10 +368,10 @@ where
     fn zvl_reserve(&mut self, addl: usize) {
         self.make_mut().reserve(addl)
     }
-    fn as_borrowed(&'a self) -> VarZeroVecBorrowed<'a, T> {
+    fn zvl_as_borrowed(&'a self) -> VarZeroVecBorrowed<'a, T> {
         self.as_borrowed()
     }
-    fn as_borrowed_inner(&self) -> Option<VarZeroVecBorrowed<'a, T>> {
+    fn zvl_as_borrowed_inner(&self) -> Option<VarZeroVecBorrowed<'a, T>> {
         if let VarZeroVec::Borrowed(b) = *self {
             Some(b)
         } else {

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -22,7 +22,7 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
     type GetType: ?Sized + 'static;
 
     /// Create a new, empty vector
-    fn new() -> Self;
+    fn zvl_new() -> Self;
     /// Search for a key in a sorted vector, returns `Ok(index)` if found,
     /// returns `Err(insert_index)` if not found, where `insert_index` is the
     /// index where it should be inserted to maintain sort order.
@@ -119,7 +119,7 @@ where
     T: AsULE + Ord + Copy,
 {
     type GetType = T::ULE;
-    fn new() -> Self {
+    fn zvl_new() -> Self {
         Self::new()
     }
     fn binary_search(&self, k: &T) -> Result<usize, usize> {
@@ -151,7 +151,7 @@ where
     T: AsULE + Ord + Copy,
 {
     type GetType = T::ULE;
-    fn new() -> Self {
+    fn zvl_new() -> Self {
         ZeroSlice::from_ule_slice(&[])
     }
     fn binary_search(&self, k: &T) -> Result<usize, usize> {
@@ -242,7 +242,7 @@ where
     T: ?Sized,
 {
     type GetType = T;
-    fn new() -> Self {
+    fn zvl_new() -> Self {
         Self::new()
     }
     fn binary_search(&self, k: &T) -> Result<usize, usize> {
@@ -284,7 +284,7 @@ where
     T: ?Sized,
 {
     type GetType = T;
-    fn new() -> Self {
+    fn zvl_new() -> Self {
         Self::new()
     }
     fn binary_search(&self, k: &T) -> Result<usize, usize> {

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -30,12 +30,12 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
     /// Get element at `index`
     fn zvl_get(&self, index: usize) -> Option<&Self::GetType>;
     /// The length of this vector
-    fn len(&self) -> usize;
+    fn zvl_len(&self) -> usize;
     /// Check if this vector is in ascending order according to `T`s `Ord` impl
     fn is_ascending(&self) -> bool;
     /// Check if this vector is empty
     fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.zvl_len() == 0
     }
 
     /// Compare this type with a `Self::GetType`. This must produce the same result as
@@ -128,7 +128,7 @@ where
     fn zvl_get(&self, index: usize) -> Option<&T::ULE> {
         self.get_ule_ref(index)
     }
-    fn len(&self) -> usize {
+    fn zvl_len(&self) -> usize {
         ZeroSlice::len(self)
     }
     fn is_ascending(&self) -> bool {
@@ -160,7 +160,7 @@ where
     fn zvl_get(&self, index: usize) -> Option<&T::ULE> {
         self.get_ule_ref(index)
     }
-    fn len(&self) -> usize {
+    fn zvl_len(&self) -> usize {
         ZeroSlice::len(*self)
     }
     fn is_ascending(&self) -> bool {
@@ -251,7 +251,7 @@ where
     fn zvl_get(&self, index: usize) -> Option<&T> {
         self.get(index)
     }
-    fn len(&self) -> usize {
+    fn zvl_len(&self) -> usize {
         self.len()
     }
     fn is_ascending(&self) -> bool {
@@ -294,7 +294,7 @@ where
         // using UFCS to avoid accidental recursion
         Self::get(*self, index)
     }
-    fn len(&self) -> usize {
+    fn zvl_len(&self) -> usize {
         Self::len(*self)
     }
     fn is_ascending(&self) -> bool {

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -28,7 +28,7 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
     /// index where it should be inserted to maintain sort order.
     fn zvl_binary_search(&self, k: &T) -> Result<usize, usize>;
     /// Get element at `index`
-    fn get(&self, index: usize) -> Option<&Self::GetType>;
+    fn zvl_get(&self, index: usize) -> Option<&Self::GetType>;
     /// The length of this vector
     fn len(&self) -> usize;
     /// Check if this vector is in ascending order according to `T`s `Ord` impl
@@ -56,7 +56,7 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
 /// longer references to the underlying buffer, for borrowed-only vector types.
 pub trait BorrowedZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
     /// Get element at `index`, with a longer lifetime
-    fn get_borrowed(&self, index: usize) -> Option<&'a Self::GetType>;
+    fn zvl_get_borrowed(&self, index: usize) -> Option<&'a Self::GetType>;
 }
 
 /// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). You
@@ -125,7 +125,7 @@ where
     fn zvl_binary_search(&self, k: &T) -> Result<usize, usize> {
         ZeroSlice::binary_search(self, k)
     }
-    fn get(&self, index: usize) -> Option<&T::ULE> {
+    fn zvl_get(&self, index: usize) -> Option<&T::ULE> {
         self.get_ule_ref(index)
     }
     fn len(&self) -> usize {
@@ -157,7 +157,7 @@ where
     fn zvl_binary_search(&self, k: &T) -> Result<usize, usize> {
         ZeroSlice::binary_search(*self, k)
     }
-    fn get(&self, index: usize) -> Option<&T::ULE> {
+    fn zvl_get(&self, index: usize) -> Option<&T::ULE> {
         self.get_ule_ref(index)
     }
     fn len(&self) -> usize {
@@ -182,7 +182,7 @@ impl<'a, T> BorrowedZeroVecLike<'a, T> for &'a ZeroSlice<T>
 where
     T: AsULE + Ord + Copy,
 {
-    fn get_borrowed(&self, index: usize) -> Option<&'a T::ULE> {
+    fn zvl_get_borrowed(&self, index: usize) -> Option<&'a T::ULE> {
         self.as_ule_slice().get(index)
     }
 }
@@ -248,7 +248,7 @@ where
     fn zvl_binary_search(&self, k: &T) -> Result<usize, usize> {
         self.binary_search(k)
     }
-    fn get(&self, index: usize) -> Option<&T> {
+    fn zvl_get(&self, index: usize) -> Option<&T> {
         self.get(index)
     }
     fn len(&self) -> usize {
@@ -290,7 +290,7 @@ where
     fn zvl_binary_search(&self, k: &T) -> Result<usize, usize> {
         Self::binary_search(self, k)
     }
-    fn get(&self, index: usize) -> Option<&T> {
+    fn zvl_get(&self, index: usize) -> Option<&T> {
         // using UFCS to avoid accidental recursion
         Self::get(*self, index)
     }
@@ -326,7 +326,7 @@ where
     T: Ord,
     T: ?Sized,
 {
-    fn get_borrowed(&self, index: usize) -> Option<&'a T> {
+    fn zvl_get_borrowed(&self, index: usize) -> Option<&'a T> {
         // using UFCS to avoid accidental recursion
         Self::get(*self, index)
     }

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -108,7 +108,7 @@ pub trait MutableZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
     /// Construct from the borrowed version of the type
     ///
     /// These are useful to ensure serialization parity between borrowed and owned versions
-    fn from_borrowed(b: Self::BorrowedVariant) -> Self;
+    fn zvl_from_borrowed(b: Self::BorrowedVariant) -> Self;
 
     /// Convert an owned value to a borrowed T
     fn owned_as_t(o: &Self::OwnedType) -> &T;
@@ -226,7 +226,7 @@ where
             None
         }
     }
-    fn from_borrowed(b: &'a ZeroSlice<T>) -> Self {
+    fn zvl_from_borrowed(b: &'a ZeroSlice<T>) -> Self {
         b.as_zerovec()
     }
 
@@ -378,7 +378,7 @@ where
             None
         }
     }
-    fn from_borrowed(b: VarZeroVecBorrowed<'a, T>) -> Self {
+    fn zvl_from_borrowed(b: VarZeroVecBorrowed<'a, T>) -> Self {
         VarZeroVec::Borrowed(b)
     }
 

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -26,7 +26,7 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
     /// Search for a key in a sorted vector, returns `Ok(index)` if found,
     /// returns `Err(insert_index)` if not found, where `insert_index` is the
     /// index where it should be inserted to maintain sort order.
-    fn binary_search(&self, k: &T) -> Result<usize, usize>;
+    fn zvl_binary_search(&self, k: &T) -> Result<usize, usize>;
     /// Get element at `index`
     fn get(&self, index: usize) -> Option<&Self::GetType>;
     /// The length of this vector
@@ -122,7 +122,7 @@ where
     fn zvl_new() -> Self {
         Self::new()
     }
-    fn binary_search(&self, k: &T) -> Result<usize, usize> {
+    fn zvl_binary_search(&self, k: &T) -> Result<usize, usize> {
         ZeroSlice::binary_search(self, k)
     }
     fn get(&self, index: usize) -> Option<&T::ULE> {
@@ -154,7 +154,7 @@ where
     fn zvl_new() -> Self {
         ZeroSlice::from_ule_slice(&[])
     }
-    fn binary_search(&self, k: &T) -> Result<usize, usize> {
+    fn zvl_binary_search(&self, k: &T) -> Result<usize, usize> {
         ZeroSlice::binary_search(*self, k)
     }
     fn get(&self, index: usize) -> Option<&T::ULE> {
@@ -245,7 +245,7 @@ where
     fn zvl_new() -> Self {
         Self::new()
     }
-    fn binary_search(&self, k: &T) -> Result<usize, usize> {
+    fn zvl_binary_search(&self, k: &T) -> Result<usize, usize> {
         self.binary_search(k)
     }
     fn get(&self, index: usize) -> Option<&T> {
@@ -287,7 +287,7 @@ where
     fn zvl_new() -> Self {
         Self::new()
     }
-    fn binary_search(&self, k: &T) -> Result<usize, usize> {
+    fn zvl_binary_search(&self, k: &T) -> Result<usize, usize> {
         Self::binary_search(self, k)
     }
     fn get(&self, index: usize) -> Option<&T> {

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -12,11 +12,13 @@ use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::mem;
 
-/// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). You
-/// should not be implementing or calling this trait directly.
+/// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). **You
+/// should not be implementing or calling this trait directly.**
 ///
 /// The T type is the type received by [`Self::binary_search()`], as well as the one used
 /// for human-readable serialization.
+///
+/// Methods are prefixed with `zvl_*` to avoid clashes with methods on the types themselves
 pub trait ZeroVecLike<'a, T: ?Sized> {
     /// The type returned by `Self::get()`
     type GetType: ?Sized + 'static;
@@ -49,21 +51,25 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
     fn t_with_ser<R>(g: &Self::GetType, f: impl FnOnce(&T) -> R) -> R;
 }
 
-/// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). You
-/// should not be implementing or calling this trait directly.
+/// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). **You
+/// should not be implementing or calling this trait directly.**
 ///
 /// This trait augments [`ZeroVecLike`] with methods allowing for taking
 /// longer references to the underlying buffer, for borrowed-only vector types.
+///
+/// Methods are prefixed with `zvl_*` to avoid clashes with methods on the types themselves
 pub trait BorrowedZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
     /// Get element at `index`, with a longer lifetime
     fn zvl_get_borrowed(&self, index: usize) -> Option<&'a Self::GetType>;
 }
 
-/// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). You
-/// should not be implementing or calling this trait directly.
+/// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). **You
+/// should not be implementing or calling this trait directly.**
 ///
 /// This trait augments [`ZeroVecLike`] with methods allowing for mutation of the underlying
 /// vector for owned vector types.
+///
+/// Methods are prefixed with `zvl_*` to avoid clashes with methods on the types themselves
 pub trait MutableZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
     /// The type returned by `Self::remove()` and `Self::replace()`
     type OwnedType;

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -73,19 +73,19 @@ pub trait MutableZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
         + Copy;
 
     /// Insert an element at `index`
-    fn insert(&mut self, index: usize, value: &T);
+    fn zvl_insert(&mut self, index: usize, value: &T);
     /// Remove the element at `index` (panicking if nonexistant)
-    fn remove(&mut self, index: usize) -> Self::OwnedType;
+    fn zvl_remove(&mut self, index: usize) -> Self::OwnedType;
     /// Replace the element at `index` with another one, returning the old element
-    fn replace(&mut self, index: usize, value: &T) -> Self::OwnedType;
+    fn zvl_replace(&mut self, index: usize, value: &T) -> Self::OwnedType;
     /// Push an element to the end of this vector
-    fn push(&mut self, value: &T);
+    fn zvl_push(&mut self, value: &T);
     /// Create a new, empty vector, with given capacity
-    fn with_capacity(cap: usize) -> Self;
+    fn zvl_with_capacity(cap: usize) -> Self;
     /// Remove all elements from the vector
-    fn clear(&mut self);
+    fn zvl_clear(&mut self);
     /// Reserve space for `addl` additional elements
-    fn reserve(&mut self, addl: usize);
+    fn zvl_reserve(&mut self, addl: usize);
     /// Construct a borrowed variant by borrowing from `&self`.
     ///
     /// This function behaves like `&'b self -> Self::BorrowedVariant<'b>`,
@@ -193,26 +193,26 @@ where
 {
     type OwnedType = T;
     type BorrowedVariant = &'a ZeroSlice<T>;
-    fn insert(&mut self, index: usize, value: &T) {
+    fn zvl_insert(&mut self, index: usize, value: &T) {
         self.to_mut().insert(index, value.as_unaligned())
     }
-    fn remove(&mut self, index: usize) -> T {
+    fn zvl_remove(&mut self, index: usize) -> T {
         T::from_unaligned(self.to_mut().remove(index))
     }
-    fn replace(&mut self, index: usize, value: &T) -> T {
+    fn zvl_replace(&mut self, index: usize, value: &T) -> T {
         let vec = self.to_mut();
         T::from_unaligned(mem::replace(&mut vec[index], value.as_unaligned()))
     }
-    fn push(&mut self, value: &T) {
+    fn zvl_push(&mut self, value: &T) {
         self.to_mut().push(value.as_unaligned())
     }
-    fn with_capacity(cap: usize) -> Self {
+    fn zvl_with_capacity(cap: usize) -> Self {
         ZeroVec::Owned(Vec::with_capacity(cap))
     }
-    fn clear(&mut self) {
+    fn zvl_clear(&mut self) {
         self.to_mut().clear()
     }
-    fn reserve(&mut self, addl: usize) {
+    fn zvl_reserve(&mut self, addl: usize) {
         self.to_mut().reserve(addl)
     }
 
@@ -340,32 +340,32 @@ where
 {
     type OwnedType = Box<T>;
     type BorrowedVariant = VarZeroVecBorrowed<'a, T>;
-    fn insert(&mut self, index: usize, value: &T) {
+    fn zvl_insert(&mut self, index: usize, value: &T) {
         self.make_mut().insert(index, value)
     }
-    fn remove(&mut self, index: usize) -> Box<T> {
+    fn zvl_remove(&mut self, index: usize) -> Box<T> {
         let vec = self.make_mut();
         let old = vec.get(index).expect("invalid index").to_boxed();
         vec.remove(index);
         old
     }
-    fn replace(&mut self, index: usize, value: &T) -> Box<T> {
+    fn zvl_replace(&mut self, index: usize, value: &T) -> Box<T> {
         let vec = self.make_mut();
         let old = vec.get(index).expect("invalid index").to_boxed();
         vec.replace(index, value);
         old
     }
-    fn push(&mut self, value: &T) {
+    fn zvl_push(&mut self, value: &T) {
         let len = self.len();
         self.make_mut().insert(len, value)
     }
-    fn with_capacity(cap: usize) -> Self {
+    fn zvl_with_capacity(cap: usize) -> Self {
         VarZeroVecOwned::with_capacity(cap).into()
     }
-    fn clear(&mut self) {
+    fn zvl_clear(&mut self) {
         self.make_mut().clear()
     }
-    fn reserve(&mut self, addl: usize) {
+    fn zvl_reserve(&mut self, addl: usize) {
         self.make_mut().reserve(addl)
     }
     fn as_borrowed(&'a self) -> VarZeroVecBorrowed<'a, T> {

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -32,9 +32,9 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
     /// The length of this vector
     fn zvl_len(&self) -> usize;
     /// Check if this vector is in ascending order according to `T`s `Ord` impl
-    fn is_ascending(&self) -> bool;
+    fn zvl_is_ascending(&self) -> bool;
     /// Check if this vector is empty
-    fn is_empty(&self) -> bool {
+    fn zvl_is_empty(&self) -> bool {
         self.zvl_len() == 0
     }
 
@@ -131,7 +131,7 @@ where
     fn zvl_len(&self) -> usize {
         ZeroSlice::len(self)
     }
-    fn is_ascending(&self) -> bool {
+    fn zvl_is_ascending(&self) -> bool {
         self.as_ule_slice()
             .windows(2)
             .all(|w| T::from_unaligned(w[1]).cmp(&T::from_unaligned(w[0])) == Ordering::Greater)
@@ -163,7 +163,7 @@ where
     fn zvl_len(&self) -> usize {
         ZeroSlice::len(*self)
     }
-    fn is_ascending(&self) -> bool {
+    fn zvl_is_ascending(&self) -> bool {
         self.as_ule_slice()
             .windows(2)
             .all(|w| T::from_unaligned(w[1]).cmp(&T::from_unaligned(w[0])) == Ordering::Greater)
@@ -254,7 +254,7 @@ where
     fn zvl_len(&self) -> usize {
         self.len()
     }
-    fn is_ascending(&self) -> bool {
+    fn zvl_is_ascending(&self) -> bool {
         if !self.is_empty() {
             let mut prev = self.get(0).unwrap();
             for element in self.iter().skip(1) {
@@ -297,7 +297,7 @@ where
     fn zvl_len(&self) -> usize {
         Self::len(*self)
     }
-    fn is_ascending(&self) -> bool {
+    fn zvl_is_ascending(&self) -> bool {
         if !self.is_empty() {
             let mut prev = self.get(0).unwrap();
             for element in self.iter().skip(1) {


### PR DESCRIPTION
Next step of https://github.com/unicode-org/icu4x/issues/1367, I decided
to make a PR early since this is itself a large change.

This does two things. Firstly, it adds a precompute bench for VZV to obtain the numbers found [here](https://github.com/unicode-org/icu4x/issues/1367#issuecomment-997338820).

Secondly, it prefixes all unprefixed methods on the ZeroVecLike traits with `zvl_`. The reason behind this is that a lot of these methods clash with existing method names, leading to ambiguity. This means that UFCS is required more often when dealing with ZV/VZV, but also it means that ZVL methods will be more likely to crop up in suggestions. We basically never want users to be calling these traits directly, so we rename the methods.

I'm doing this in preparation for #1367 because I otherwise forsee myself doing a lot of UFCS-ing as a part of that change :)


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->