### PR TITLE
Change DataRequest to be borrowed in BufferProvider

### DIFF
--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -109,8 +109,8 @@ where
 }
 
 impl BufferProvider for BlobDataProvider {
-    fn load_buffer(&self, req: DataRequest) -> Result<DataResponse<BufferMarker>, DataError> {
-        let yoked_buffer = self.get_file(&req)?;
+    fn load_buffer(&self, req: &DataRequest) -> Result<DataResponse<BufferMarker>, DataError> {
+        let yoked_buffer = self.get_file(req)?;
         let mut metadata = DataResponseMetadata::default();
         // TODO(#1109): Set metadata.data_langid correctly.
         metadata.buffer_format = Some(BufferFormat::Postcard07);

--- a/provider/blob/src/static_data_provider.rs
+++ b/provider/blob/src/static_data_provider.rs
@@ -123,8 +123,8 @@ where
 }
 
 impl BufferProvider for StaticDataProvider {
-    fn load_buffer(&self, req: DataRequest) -> Result<DataResponse<BufferMarker>, DataError> {
-        let static_buffer = self.get_file(&req)?;
+    fn load_buffer(&self, req: &DataRequest) -> Result<DataResponse<BufferMarker>, DataError> {
+        let static_buffer = self.get_file(req)?;
         let mut metadata = DataResponseMetadata::default();
         // TODO(#1109): Set metadata.data_langid correctly.
         metadata.buffer_format = Some(BufferFormat::Postcard07);

--- a/provider/core/src/buffer_provider.rs
+++ b/provider/core/src/buffer_provider.rs
@@ -14,7 +14,7 @@ impl DataMarker for BufferMarker {
 }
 
 pub trait BufferProvider {
-    fn load_buffer(&self, req: DataRequest) -> Result<DataResponse<BufferMarker>, Error>;
+    fn load_buffer(&self, req: &DataRequest) -> Result<DataResponse<BufferMarker>, Error>;
 }
 
 /// An enum expressing all Serde formats known to ICU4X.

--- a/provider/core/src/serde/de.rs
+++ b/provider/core/src/serde/de.rs
@@ -116,8 +116,7 @@ where
 {
     /// Converts a buffer into a concrete type by deserializing from a supported buffer format.
     fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
-        // TODO(#1077): Remove the `req.clone()` when we start taking `req` by value.
-        let old_response = BufferProvider::load_buffer(self.0, req.clone())?;
+        let old_response = BufferProvider::load_buffer(self.0, req)?;
         if let Some(old_payload) = old_response.payload {
             let buffer_format = old_response
                 .metadata

--- a/provider/fs/src/fs_data_provider.rs
+++ b/provider/fs/src/fs_data_provider.rs
@@ -96,8 +96,8 @@ impl FsDataProvider {
 }
 
 impl BufferProvider for FsDataProvider {
-    fn load_buffer(&self, req: DataRequest) -> Result<DataResponse<BufferMarker>, DataError> {
-        let (rc_buffer, _) = self.get_rc_buffer(&req)?;
+    fn load_buffer(&self, req: &DataRequest) -> Result<DataResponse<BufferMarker>, DataError> {
+        let (rc_buffer, _) = self.get_rc_buffer(req)?;
         let mut metadata = DataResponseMetadata::default();
         // TODO(#1109): Set metadata.data_langid correctly.
         metadata.buffer_format = Some(self.manifest.buffer_format);


### PR DESCRIPTION
Closes #1077

This is the opposite of what I proposed in #1077, because I found a use case for taking the request by reference: in a multi-provider, you may need to send the request to multiple sub-providers.  That said, there are still use cases for taking ownership, so I'm still a bit inconclusive.