### PR TITLE
Add build scripts in segmenter's Cargo.toml for cargo vendor.

### DIFF
--- a/experimental/segmenter/Cargo.toml
+++ b/experimental/segmenter/Cargo.toml
@@ -14,10 +14,12 @@ license-file = "LICENSE"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions
 include = [
+    "data/*",
     "src/**/*",
     "examples/**/*",
     "benches/**/*",
     "tests/**/*",
+    "build.rs",
     "Cargo.toml",
     "LICENSE",
     "README.md"


### PR DESCRIPTION
When integrating rust modules in Gecko, it uses `cargo vendor` to have the copies. So `build.rs` etc has to be published for `cargo vendor`.