### PR TITLE
Add VZS::binary_search_in_range and ZV::get_subslice

### DIFF
--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -56,53 +56,8 @@ macro_rules! impl_byte_slice_size {
                 unsafe { core::slice::from_raw_parts_mut(data as *mut Self, len) }
             }
 
-            /// Adds the given operand to this RawBytesULE, treating it as an unsigned int.
-            ///
-            /// # Example
-            ///
-            /// ```
-            /// # use zerovec::ZeroVec;
-            /// let mut zv: ZeroVec<u32> = ZeroVec::from_slice(&[0, 1, 2, 3]);
-            /// if let Some(ref mut x) = zv.to_mut().as_mut_slice().last_mut() {
-            ///     x.add_unsigned_int(1)?;
-            /// }
-            /// assert_eq!(zv, [0, 1, 2, 4]);
-            /// # Ok::<(), ()>(())
-            /// ```
-            pub fn add_unsigned_int(
-                &mut self,
-                operand: $unsigned,
-            ) -> Result<(), ()> {
-                let x: $unsigned = <$unsigned as $crate::ule::AsULE>::from_unaligned(*self);
-                let x: $unsigned = x.checked_add(operand).ok_or(())?;
-                *self = x.as_unaligned();
-                Ok(())
-            }
-
-            /// Subtracts the given operand from this RawBytesULE, treating it as an unsigned int.
-            ///
-            /// # Example
-            ///
-            /// ```
-            /// # use zerovec::ZeroVec;
-            /// let mut zv: ZeroVec<u32> = ZeroVec::from_slice(&[0, 1, 2, 3]);
-            /// if let Some(ref mut x) = zv.to_mut().as_mut_slice().last_mut() {
-            ///     x.sub_unsigned_int(1)?;
-            /// }
-            /// assert_eq!(zv, [0, 1, 2, 2]);
-            /// # Ok::<(), ()>(())
-            /// ```
-            pub fn sub_unsigned_int(
-                &mut self,
-                operand: $unsigned,
-            ) -> Result<(), ()> {
-                let x: $unsigned = <$unsigned as $crate::ule::AsULE>::from_unaligned(*self);
-                let x: $unsigned = x.checked_sub(operand).ok_or(())?;
-                *self = x.as_unaligned();
-                Ok(())
-            }
-
-            /// Gets this RawBytesULE as an unsigned int.
+            /// Gets this RawBytesULE as an unsigned int. This is equivalent to calling
+            /// [AsULE::from_unaligned()] on the appropriately sized type.
             pub fn as_unsigned_int(&self) -> $unsigned {
                 <$unsigned as $crate::ule::AsULE>::from_unaligned(*self)
             }

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -69,7 +69,7 @@ macro_rules! impl_byte_slice_size {
             /// assert_eq!(zv, [0, 1, 2, 4]);
             /// # Ok::<(), core::num::TryFromIntError>(())
             /// ```
-            pub fn add_unsigned(
+            pub fn add_unsigned_int(
                 &mut self,
                 operand: isize,
             ) -> Result<(), core::num::TryFromIntError> {
@@ -78,6 +78,11 @@ macro_rules! impl_byte_slice_size {
                 let x: $unsigned = ((x as isize) + operand).try_into()?;
                 *self = x.as_unaligned();
                 Ok(())
+            }
+
+            /// Gets this RawBytesULE as an unsigned int.
+            pub fn as_unsigned_int(&self) -> $unsigned {
+                <$unsigned as $crate::ule::AsULE>::from_unaligned(*self)
             }
         }
     };

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -58,6 +58,7 @@ macro_rules! impl_byte_slice_size {
 
             /// Gets this RawBytesULE as an unsigned int. This is equivalent to calling
             /// [AsULE::from_unaligned()] on the appropriately sized type.
+            #[inline]
             pub fn as_unsigned_int(&self) -> $unsigned {
                 <$unsigned as $crate::ule::AsULE>::from_unaligned(*self)
             }

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -64,18 +64,40 @@ macro_rules! impl_byte_slice_size {
             /// # use zerovec::ZeroVec;
             /// let mut zv: ZeroVec<u32> = ZeroVec::from_slice(&[0, 1, 2, 3]);
             /// if let Some(ref mut x) = zv.to_mut().as_mut_slice().last_mut() {
-            ///     x.add_unsigned(1)?;
+            ///     x.add_unsigned_int(1)?;
             /// }
             /// assert_eq!(zv, [0, 1, 2, 4]);
-            /// # Ok::<(), core::num::TryFromIntError>(())
+            /// # Ok::<(), ()>(())
             /// ```
             pub fn add_unsigned_int(
                 &mut self,
-                operand: isize,
-            ) -> Result<(), core::num::TryFromIntError> {
-                use core::convert::TryInto;
+                operand: $unsigned,
+            ) -> Result<(), ()> {
                 let x: $unsigned = <$unsigned as $crate::ule::AsULE>::from_unaligned(*self);
-                let x: $unsigned = ((x as isize) + operand).try_into()?;
+                let x: $unsigned = x.checked_add(operand).ok_or(())?;
+                *self = x.as_unaligned();
+                Ok(())
+            }
+
+            /// Subtracts the given operand from this RawBytesULE, treating it as an unsigned int.
+            ///
+            /// # Example
+            ///
+            /// ```
+            /// # use zerovec::ZeroVec;
+            /// let mut zv: ZeroVec<u32> = ZeroVec::from_slice(&[0, 1, 2, 3]);
+            /// if let Some(ref mut x) = zv.to_mut().as_mut_slice().last_mut() {
+            ///     x.sub_unsigned_int(1)?;
+            /// }
+            /// assert_eq!(zv, [0, 1, 2, 2]);
+            /// # Ok::<(), ()>(())
+            /// ```
+            pub fn sub_unsigned_int(
+                &mut self,
+                operand: $unsigned,
+            ) -> Result<(), ()> {
+                let x: $unsigned = <$unsigned as $crate::ule::AsULE>::from_unaligned(*self);
+                let x: $unsigned = x.checked_sub(operand).ok_or(())?;
                 *self = x.as_unaligned();
                 Ok(())
             }

--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -151,6 +151,16 @@ where
     }
 }
 
+impl<T, const N: usize> PartialEq<[T; N]> for ZeroVec<'_, T>
+where
+    T: AsULE + PartialEq + ?Sized,
+{
+    #[inline]
+    fn eq(&self, other: &[T; N]) -> bool {
+        self.iter().eq(other.iter().copied())
+    }
+}
+
 impl<'a, T: AsULE> Default for ZeroVec<'a, T> {
     #[inline]
     fn default() -> Self {

--- a/utils/zerovec/src/zerovec/slice.rs
+++ b/utils/zerovec/src/zerovec/slice.rs
@@ -4,6 +4,7 @@
 
 use super::*;
 use alloc::boxed::Box;
+use core::ops::Range;
 
 /// A zero-copy "slice", i.e. the zero-copy version of `[T]`. This behaves
 /// similarly to [`ZeroVec<T>`], however [`ZeroVec<T>`] is allowed to contain
@@ -138,6 +139,28 @@ where
             .get(index)
             .copied()
             .map(T::from_unaligned)
+    }
+
+    /// Gets a subslice of elements within a certain range. Returns None if the range
+    /// is out of bounds of this `ZeroSlice`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use zerovec::ZeroVec;
+    ///
+    /// let bytes: &[u8] = &[0xD3, 0x00, 0x19, 0x01, 0xA5, 0x01, 0xCD, 0x01];
+    /// let zerovec: ZeroVec<u16> = ZeroVec::parse_byte_slice(bytes).expect("infallible");
+    ///
+    /// assert_eq!(
+    ///     zerovec.get_subslice(1..3),
+    ///     Some(&*ZeroVec::from_slice(&[0x0119, 0x01A5]))
+    /// );
+    /// assert_eq!(zerovec.get_subslice(3..5), None);
+    /// ```
+    #[inline]
+    pub fn get_subslice(&self, range: Range<usize>) -> Option<&ZeroSlice<T>> {
+        self.0.get(range).map(ZeroSlice::from_ule_slice)
     }
 
     /// Get a borrowed reference to the underlying ULE type at a specified index.


### PR DESCRIPTION
Progress on #1107

At first I had intended to add `get_subslice()` to ZeroVecLike until I realized that we would need to add a new type such as `VarZeroSubSlice` in order to support that.  So, instead, I added a method `binary_search_in_range()`.

This sets the stage for the more efficient operations I need in order to make MultiBufferProvider performant.