### PR TITLE
Using `VecDeque` in `FormattedString`

### DIFF
--- a/experimental/formatted_string/src/formatted_string.rs
+++ b/experimental/formatted_string/src/formatted_string.rs
@@ -4,8 +4,11 @@
 
 use crate::FormattedStringError;
 use alloc::borrow::ToOwned;
-use alloc::vec::Vec;
-use core::str;
+use alloc::collections::vec_deque::{self, VecDeque};
+use core::cell::RefCell;
+use core::iter::Copied;
+use core::ops::Range;
+use core::str::{self, Bytes};
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum LocationInPart {
@@ -15,27 +18,50 @@ pub enum LocationInPart {
 
 /// A string with L levels of annotations of type F. For N = 0, this is
 /// implemented for `&str`, for higher N see LayeredFormattedString.
-pub trait FormattedStringLike<F: Copy, const L: usize>: AsRef<str> {
+pub trait FormattedStringLike<'a, F: Copy, const L: usize> {
     fn fields_at(&self, pos: usize) -> [F; L] {
-        self.annotation_at(pos).map(|(_, field)| field)
+        self._annotation_at(pos).map(|(_, field)| field)
     }
 
     fn is_field_start(&self, pos: usize, level: usize) -> bool {
         debug_assert!(level < L);
-        let (location, _) = self.annotation_at(pos)[level];
+        let (location, _) = self._annotation_at(pos)[level];
         location == LocationInPart::Begin
     }
 
+    // These members are not part of the public API.
     #[doc(hidden)]
-    // This is used to make the inserts more efficient; clients should
-    // use fields_at and is_field_start.
-    fn annotation_at(&self, pos: usize) -> &[(LocationInPart, F); L];
+    fn _annotation_at(&self, pos: usize) -> &[(LocationInPart, F); L];
+    #[doc(hidden)]
+    type BytesIter: DoubleEndedIterator<Item = u8> + ExactSizeIterator + 'a;
+    #[doc(hidden)]
+    fn _bytes(&'a self) -> Self::BytesIter;
+    #[doc(hidden)]
+    fn _len(&self) -> usize;
 }
 
-impl<F: Copy> FormattedStringLike<F, 0> for &str {
-    fn annotation_at(&self, _pos: usize) -> &[(LocationInPart, F); 0] {
+impl<F: Copy, const L: usize> AsRef<str> for LayeredFormattedString<F, L> {
+    fn as_ref(&self) -> &str {
+        self.bytes.borrow_mut().make_contiguous();
+        // Any mutates to bytes other than make_continguous happen in mut
+        // contexts. As make_contiguous is idempotent, this is safe.
+        unsafe { str::from_utf8_unchecked((*self.bytes.as_ptr()).as_slices().0) }
+    }
+}
+
+impl<'a, F: Copy> FormattedStringLike<'a, F, 0> for &'a str {
+    fn _annotation_at(&self, _pos: usize) -> &[(LocationInPart, F); 0] {
         // Yay we can return dangling references for singleton types!
         &[]
+    }
+
+    type BytesIter = Bytes<'a>;
+    fn _bytes(&'a self) -> Self::BytesIter {
+        self.bytes()
+    }
+
+    fn _len(&self) -> usize {
+        self.len()
     }
 }
 
@@ -43,22 +69,28 @@ impl<F: Copy> FormattedStringLike<F, 0> for &str {
 #[derive(Debug, PartialEq)]
 pub struct LayeredFormattedString<F: Copy, const L: usize> {
     // bytes is always valid UTF-8, so from_utf8_unchecked is safe
-    bytes: Vec<u8>,
+    bytes: RefCell<VecDeque<u8>>,
     // The vector dimension corresponds to the bytes, the array dimension are the L levels of annotations
-    annotations: Vec<[(LocationInPart, F); L]>,
+    annotations: VecDeque<[(LocationInPart, F); L]>,
 }
 
 pub type FormattedString<F> = LayeredFormattedString<F, 1>;
 
-impl<F: Copy, const L: usize> AsRef<str> for LayeredFormattedString<F, L> {
-    fn as_ref(&self) -> &str {
-        unsafe { str::from_utf8_unchecked(&self.bytes) }
-    }
-}
-
-impl<F: Copy, const L: usize> FormattedStringLike<F, L> for LayeredFormattedString<F, L> {
-    fn annotation_at(&self, pos: usize) -> &[(LocationInPart, F); L] {
+impl<'a, F: Copy, const L: usize> FormattedStringLike<'a, F, L> for LayeredFormattedString<F, L> {
+    fn _annotation_at(&self, pos: usize) -> &[(LocationInPart, F); L] {
         &self.annotations[pos]
+    }
+
+    type BytesIter = Copied<vec_deque::Iter<'a, u8>>;
+    fn _bytes(&'a self) -> Self::BytesIter {
+        // We cannot return anything borrowed from bytes. However,
+        // as this result is immediately used by the single call
+        // site, this deref is safe.
+        unsafe { (*self.bytes.as_ptr()).iter().copied() }
+    }
+
+    fn _len(&self) -> usize {
+        self.annotations.len()
     }
 }
 
@@ -66,8 +98,8 @@ impl<F: Copy, const L: usize> LayeredFormattedString<F, L> {
     pub fn new() -> Self {
         debug_assert!(L > 0);
         Self {
-            bytes: Vec::new(),
-            annotations: Vec::new(),
+            bytes: RefCell::new(VecDeque::new()),
+            annotations: VecDeque::new(),
         }
     }
 
@@ -75,59 +107,58 @@ impl<F: Copy, const L: usize> LayeredFormattedString<F, L> {
         // A LayeredFormattedString with 0 annotations doesn't make sense.
         debug_assert!(L > 0);
         Self {
-            bytes: Vec::with_capacity(capacity),
-            annotations: Vec::with_capacity(capacity),
+            bytes: RefCell::new(VecDeque::with_capacity(capacity)),
+            annotations: VecDeque::with_capacity(capacity),
         }
     }
 
     pub fn capacity(&self) -> usize {
-        debug_assert_eq!(self.bytes.capacity(), self.annotations.capacity());
-        self.bytes.capacity()
+        debug_assert_eq!(self.bytes.borrow().capacity(), self.annotations.capacity());
+        self.annotations.capacity()
     }
 
     pub fn len(&self) -> usize {
-        debug_assert_eq!(self.bytes.len(), self.annotations.len());
-        self.bytes.len()
+        debug_assert_eq!(self.bytes.borrow().len(), self.annotations.len());
+        self.annotations.len()
     }
 
-    pub fn append<S, const L1: usize>(&mut self, string: &S, field: F) -> &mut Self
+    pub fn append<'a, S, const L1: usize>(&mut self, string: &'a S, field: F) -> &mut Self
     where
-        S: FormattedStringLike<F, L1>,
+        S: FormattedStringLike<'a, F, L1>,
     {
         debug_assert_eq!(L - 1, L1);
         // len() is always a char boundary
-        self.insert_internal(self.bytes.len(), string, field)
+        self.insert_internal(self.annotations.len(), string, field)
     }
 
-    pub fn prepend<S, const L1: usize>(&mut self, string: &S, field: F) -> &mut Self
+    pub fn prepend<'a, S, const L1: usize>(&mut self, string: &'a S, field: F) -> &mut Self
     where
-        S: FormattedStringLike<F, L1>,
+        S: FormattedStringLike<'a, F, L1>,
     {
         debug_assert_eq!(L - 1, L1);
         // 0 is always a char boundary
         self.insert_internal(0, string, field)
     }
 
-    pub fn insert<S, const L1: usize>(
+    pub fn insert<'a, S, const L1: usize>(
         &mut self,
         pos: usize,
-        string: &S,
+        string: &'a S,
         field: F,
     ) -> Result<&mut Self, FormattedStringError>
     where
-        S: FormattedStringLike<F, L1>,
+        S: FormattedStringLike<'a, F, L1>,
     {
         debug_assert_eq!(L - 1, L1);
-        if pos > self.bytes.len() {
+        if pos > self.annotations.len() {
             return Err(FormattedStringError::IndexOutOfBounds(pos));
         }
-        // bytes is valid UTF-8 precisely because we do this check before
-        // insertion (and string is valid UTF-8)
-        let current = unsafe { str::from_utf8_unchecked(&self.bytes) };
-        if !current.is_char_boundary(pos) {
+        // This is bit magic equivalent to: b >= 128 && b < 192, i.e. b is
+        // not a UTF-8 character boundary. Lifted from str::is_char_boundary
+        if pos < self.annotations.len() && (self.bytes.borrow()[pos] as i8) < -0x40 {
             Err(FormattedStringError::PositionNotCharBoundary(
                 pos,
-                current.to_owned(),
+                self.as_ref().to_owned(),
             ))
         } else {
             Ok(self.insert_internal(pos, string, field))
@@ -135,15 +166,20 @@ impl<F: Copy, const L: usize> LayeredFormattedString<F, L> {
     }
 
     // Precondition here is that pos is a char boundary and < bytes.len().
-    fn insert_internal<S, const L1: usize>(&mut self, pos: usize, string: &S, field: F) -> &mut Self
+    fn insert_internal<'a, S, const L1: usize>(
+        &mut self,
+        pos: usize,
+        string: &'a S,
+        field: F,
+    ) -> &mut Self
     where
-        S: FormattedStringLike<F, L1>,
+        S: FormattedStringLike<'a, F, L1>,
     {
         debug_assert_eq!(L - 1, L1);
-        self.bytes.splice(pos..pos, string.as_ref().bytes());
+        self.bytes.borrow_mut().splice(pos..pos, string._bytes());
         self.annotations.splice(
             pos..pos,
-            (0..string.as_ref().len()).map(|i| {
+            (0..string._len()).map(|i| {
                 let top_level = (
                     if i == 0 {
                         LocationInPart::Begin
@@ -153,7 +189,7 @@ impl<F: Copy, const L: usize> LayeredFormattedString<F, L> {
                     field,
                 );
                 let mut all_levels = [top_level; L];
-                all_levels[1..L].copy_from_slice(string.annotation_at(i));
+                all_levels[1..L].copy_from_slice(string._annotation_at(i));
                 all_levels
             }),
         );
@@ -168,6 +204,37 @@ impl<F: Copy, const L: usize> LayeredFormattedString<F, L> {
 impl<F: Copy, const L: usize> Default for LayeredFormattedString<F, L> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+// Very basic implementation of VecDeque::splice.
+// https://github.com/rust-lang/rust/issues/69939
+trait Splice<T> {
+    fn splice<I>(&mut self, range: Range<usize>, values: I)
+    where
+        I: DoubleEndedIterator<Item = T> + ExactSizeIterator;
+}
+
+impl<T> Splice<T> for VecDeque<T> {
+    fn splice<I>(&mut self, range: Range<usize>, values: I)
+    where
+        I: DoubleEndedIterator<Item = T> + ExactSizeIterator,
+    {
+        debug_assert_eq!(range.start, range.end);
+
+        self.reserve(values.len());
+
+        if range.start == self.len() {
+            self.extend(values)
+        } else if range.start == 0 {
+            for value in values.rev() {
+                self.push_front(value)
+            }
+        } else {
+            for (i, v) in values.enumerate() {
+                self.insert(range.start + i, v)
+            }
+        }
     }
 }
 
@@ -199,7 +266,13 @@ mod test {
         for i in 0.."world".len() {
             assert_eq!(x.field_at(6 + i), Field::Word);
         }
-        assert_panics(|| x.field_at(11));
+        assert_panics(|| {
+            let mut x = FormattedString::<Field>::new();
+            x.append(&"world", Field::Word)
+                .prepend(&" ", Field::Space)
+                .prepend(&"hello", Field::Word);
+            x.field_at(11);
+        });
     }
 
     #[test]
@@ -228,7 +301,11 @@ mod test {
         assert_eq!(x.as_ref(), "π");
         assert_eq!(x.field_at(0), Field::Word);
         assert_eq!(x.field_at(1), Field::Word);
-        assert_panics(|| x.field_at(2));
+        assert_panics(|| {
+            let mut x = FormattedString::<Field>::new();
+            x.append(&"π", Field::Word);
+            x.field_at(2);
+        });
     }
 
     #[test]

--- a/experimental/list_formatter/src/list_formatter.rs
+++ b/experimental/list_formatter/src/list_formatter.rs
@@ -215,7 +215,13 @@ mod tests {
         let string = formatter(Width::Short).format(VALUES);
         assert_eq!(string.capacity(), string.len());
 
+        // VecDeq only grows in powers of two, so this is not optimal anymore.
+        // It also always keeps one free slot, so lengths of 2^n are pretty
+        // inefficient.
         let labelled_string = formatter(Width::Short).format_to_parts(VALUES);
-        assert_eq!(labelled_string.capacity(), labelled_string.len());
+        assert_eq!(
+            labelled_string.capacity(),
+            labelled_string.len().next_power_of_two() - 1
+        );
     }
 }


### PR DESCRIPTION
Only really exploratory, I actually don't want to merge this as `VecDeque` has some shortcomings (no splice API, only power-of-2 sizes, slice only on `&mut`) and we currently don't need prepends or inserts.