### PR TITLE
Change Writeable::writeable_to_string to return a Cow

### DIFF
--- a/components/decimal/benches/fixed_decimal_format.rs
+++ b/components/decimal/benches/fixed_decimal_format.rs
@@ -37,7 +37,7 @@ fn overview_bench(c: &mut Criterion) {
             nums.iter()
                 .map(|v| black_box(*v))
                 .map(FixedDecimal::from)
-                .map(|n| fdf.format(&n).writeable_to_string())
+                .map(|n| fdf.format(&n).writeable_to_string().into_owned())
                 .count();
         });
     });

--- a/components/decimal/src/grouper.rs
+++ b/components/decimal/src/grouper.rs
@@ -125,8 +125,8 @@ fn test_grouper() {
             };
             let fdf =
                 FixedDecimalFormat::try_new(LanguageIdentifier::und(), &provider, options).unwrap();
-            let actual = fdf.format(&dec).writeable_to_string();
-            assert_eq!(cas.expected[i], actual, "{:?}", cas);
+            let actual = fdf.format(&dec);
+            assert_eq!(cas.expected[i], actual.writeable_to_string(), "{:?}", cas);
         }
     }
 }

--- a/experimental/bies/tests/from_bies_matrix.rs
+++ b/experimental/bies/tests/from_bies_matrix.rs
@@ -57,7 +57,9 @@ impl<R: Rng> TestDataGenerator<R> {
         } else {
             true_breakpoints
         };
-        let expected_bies = BiesString::from(&expected_breakpoints).writeable_to_string();
+        let expected_bies = BiesString::from(&expected_breakpoints)
+            .writeable_to_string()
+            .into_owned();
         TestCase {
             sample_data: SampleData {
                 matrix,
@@ -132,8 +134,9 @@ impl<R: Rng> TestDataGenerator<R> {
 
     /// Returns a BIES matrix representing the given Breakpoints
     fn bies_matrix_for_breakpoints(&mut self, breakpoints: &Breakpoints, noise: f32) -> BiesMatrix {
-        let bies = BiesString::from(breakpoints).writeable_to_string();
+        let bies = BiesString::from(breakpoints);
         let matrix = bies
+            .writeable_to_string()
             .chars()
             .map(|ch| self.bies_vector_for_char(ch, noise))
             .collect();
@@ -365,8 +368,13 @@ fn get_test_cases() -> Vec<TestCase> {
 #[test]
 fn test_to_bies_string() {
     for test_case in get_test_cases().iter() {
-        let actual_bies = BiesString::from(&test_case.expected_breakpoints).writeable_to_string();
-        assert_eq!(test_case.expected_bies, actual_bies, "{:?}", test_case);
+        let actual_bies = BiesString::from(&test_case.expected_breakpoints);
+        assert_eq!(
+            test_case.expected_bies,
+            actual_bies.writeable_to_string(),
+            "{:?}",
+            test_case
+        );
     }
 }
 

--- a/utils/writeable/benches/writeable.rs
+++ b/utils/writeable/benches/writeable.rs
@@ -73,6 +73,7 @@ fn writeable_benches(c: &mut Criterion) {
                 message: black_box(SHORT_STR),
             }
             .writeable_to_string()
+            .into_owned()
         });
     });
     c.bench_function("writeable/to_string/medium", |b| {
@@ -81,6 +82,7 @@ fn writeable_benches(c: &mut Criterion) {
                 message: black_box(MEDIUM_STR),
             }
             .writeable_to_string()
+            .into_owned()
         });
     });
     c.bench_function("writeable/to_string/long", |b| {
@@ -89,6 +91,7 @@ fn writeable_benches(c: &mut Criterion) {
                 message: black_box(LONG_STR),
             }
             .writeable_to_string()
+            .into_owned()
         });
     });
 }

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -2,6 +2,10 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::*;
+use alloc::borrow::Cow;
+use core::fmt;
+
 macro_rules! impl_write_num {
     ($u:ty, $i:ty, $test:ident, $log10:ident) => {
         impl $crate::Writeable for $u {
@@ -117,4 +121,97 @@ fn assert_log10_approximation() {
     for i in 1..u128::BITS {
         assert_eq!(i * 59 / 196, 2f64.powf(i.into()).log10().floor() as u32);
     }
+}
+
+impl Writeable for str {
+    #[inline]
+    fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
+        sink.write_str(self)
+    }
+
+    #[inline]
+    fn write_len(&self) -> LengthHint {
+        LengthHint::exact(self.len())
+    }
+
+    /// Returns a borrowed `str`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use writeable::Writeable;
+    /// use std::borrow::Cow;
+    ///
+    /// let cow = "foo".writeable_to_string();
+    /// assert!(matches!(cow, Cow::Borrowed(_)));
+    /// ```
+    #[inline]
+    fn writeable_to_string(&self) -> Cow<str> {
+        Cow::Borrowed(self)
+    }
+}
+
+impl Writeable for String {
+    #[inline]
+    fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
+        sink.write_str(self)
+    }
+
+    #[inline]
+    fn write_len(&self) -> LengthHint {
+        LengthHint::exact(self.len())
+    }
+
+    /// Returns a borrowed `str`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use writeable::Writeable;
+    /// use std::borrow::Cow;
+    ///
+    /// let cow = "foo".writeable_to_string();
+    /// assert!(matches!(cow, Cow::Borrowed(_)));
+    /// ```
+    #[inline]
+    fn writeable_to_string(&self) -> Cow<str> {
+        Cow::Borrowed(self)
+    }
+}
+
+impl<'a, T: Writeable + ?Sized> Writeable for &T {
+    #[inline]
+    fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
+        (*self).write_to(sink)
+    }
+
+    #[inline]
+    fn write_len(&self) -> LengthHint {
+        (*self).write_len()
+    }
+
+    #[inline]
+    fn writeable_to_string(&self) -> Cow<str> {
+        (*self).writeable_to_string()
+    }
+}
+
+#[test]
+fn test_string_impls() {
+    fn check_writeable_slice<W: Writeable>(writeables: &[W]) {
+        assert_writeable_eq!(&writeables[0], "");
+        assert_writeable_eq!(&writeables[1], "abc");
+    }
+
+    // test str impl
+    let arr: &[&str] = &["", "abc"];
+    check_writeable_slice(&arr);
+
+    // test String impl
+    let arr: &[String] = &["".to_string(), "abc".to_string()];
+    check_writeable_slice(&arr);
+
+    // test &T impl
+    let arr: &[&String] = &[&"".to_string(), &"abc".to_string()];
+    check_writeable_slice(arr);
 }

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -194,11 +194,11 @@ fn test_string_impls() {
 
     // test str impl
     let arr: &[&str] = &["", "abc"];
-    check_writeable_slice(&arr);
+    check_writeable_slice(arr);
 
     // test String impl
     let arr: &[String] = &["".to_string(), "abc".to_string()];
-    check_writeable_slice(&arr);
+    check_writeable_slice(arr);
 
     // test &T impl
     let arr: &[&String] = &[&"".to_string(), &"abc".to_string()];

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -162,17 +162,6 @@ impl Writeable for String {
         LengthHint::exact(self.len())
     }
 
-    /// Returns a borrowed `str`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use writeable::Writeable;
-    /// use std::borrow::Cow;
-    ///
-    /// let cow = "foo".writeable_to_string();
-    /// assert!(matches!(cow, Cow::Borrowed(_)));
-    /// ```
     #[inline]
     fn writeable_to_string(&self) -> Cow<str> {
         Cow::Borrowed(self)


### PR DESCRIPTION
Also adds `impl Writeable for str`.

This enables `writeable_to_string` to be more efficient in certain cases.

Replaces part of #1438