### PR TITLE
Skip node_modules in license header check

### DIFF
--- a/tools/scripts/tidy.toml
+++ b/tools/scripts/tidy.toml
@@ -28,7 +28,7 @@ exit_on_error true
 glob_pattern_array = array "./**/*.rs" "./**/*.yml" "./**/*.toml" "./**/*.rst" "./**/*.bat"
 
 # Skip the files matching these patterns.
-glob_skip_pattern_array = array "target/**/*.rs" "ffi/diplomat/cpp/docs/**/*" "ffi/diplomat/wasm/docs/**/*"
+glob_skip_pattern_array = array "target/**/*.rs" "ffi/diplomat/cpp/docs/**/*" "ffi/diplomat/wasm/docs/**/*" "**/node_modules/**/*"
 
 blank_line = set ""
 


### PR DESCRIPTION
I was getting errors like

```
[cargo-make] ERROR - Error while running duckscript: Source: Unknown Line: 70 - License header missing or misformatted in ffi/diplomat/wasm/node_modules/arrgv/.travis.yml.
```

This PR fixes it.