### PR TITLE
Add boilerplate to new ListFormatter example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,6 +1170,7 @@ dependencies = [
  "deduplicating_array",
  "displaydoc",
  "formatted_string",
+ "icu_benchmark_macros",
  "icu_locid",
  "icu_locid_macros",
  "icu_provider",

--- a/experimental/list_formatter/Cargo.toml
+++ b/experimental/list_formatter/Cargo.toml
@@ -35,6 +35,7 @@ serde_json = "1"
 postcard = { version = "0.7", features = ["use-std"] }
 icu_testdata = { version = "0.4", path = "../../provider/testdata", features = ["static"] }
 icu_locid_macros = { version = "0.4", path = "../../components/locid/macros"}
+icu_benchmark_macros = { version = "0.4", path = "../../tools/benchmark/macros" }
 
 [lib]
 path = "src/lib.rs"

--- a/experimental/list_formatter/examples/and_list.rs
+++ b/experimental/list_formatter/examples/and_list.rs
@@ -2,13 +2,20 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+#![no_main] // https://github.com/unicode-org/icu4x/issues/395
+
+icu_benchmark_macros::static_setup!();
+
 use icu_list::{
     options::{Type, Width},
     ListFormatter,
 };
 use icu_locid_macros::langid;
 
-fn main() {
+#[no_mangle]
+fn main(_argc: isize, _argv: *const *const u8) -> isize {
+    icu_benchmark_macros::main_setup!();
+
     let provider = icu_testdata::get_static_provider();
 
     let list_formatter =
@@ -18,4 +25,6 @@ fn main() {
         "{}",
         list_formatter.format(&["España", "Francia", "Suiza", "Italia"])
     );
+
+    0
 }


### PR DESCRIPTION
All examples should have this boilerplate in order to enable dhat and valgrind to work correctly.