### PR TITLE
Add back the empty data provider hook in FFI

### DIFF
--- a/ffi/diplomat/c/include/ICU4XDataProvider.h
+++ b/ffi/diplomat/c/include/ICU4XDataProvider.h
@@ -18,6 +18,8 @@ ICU4XCreateDataProviderResult ICU4XDataProvider_create_fs(const char* path_data,
 ICU4XCreateDataProviderResult ICU4XDataProvider_create_static();
 
 ICU4XCreateDataProviderResult ICU4XDataProvider_create_from_byte_slice(const uint8_t* blob_data, size_t blob_len);
+
+ICU4XCreateDataProviderResult ICU4XDataProvider_create_empty();
 void ICU4XDataProvider_destroy(ICU4XDataProvider* self);
 
 #ifdef __cplusplus

--- a/ffi/diplomat/cpp/docs/source/provider_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/provider_ffi.rst
@@ -26,3 +26,7 @@
     .. cpp:function:: static ICU4XCreateDataProviderResult create_from_byte_slice(const diplomat::span<uint8_t> blob)
 
         Constructs a ``BlobDataProvider`` and returns it as an :cpp:class:`ICU4XDataProvider`. See `the Rust docs <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.BlobDataProvider.html>`__ for more details.
+
+    .. cpp:function:: static ICU4XCreateDataProviderResult create_empty()
+
+        Constructs an empty ``StaticDataProvider`` and returns it as an :cpp:class:`ICU4XDataProvider`. See `the Rust docs <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.StaticDataProvider.html>`__ for more details.

--- a/ffi/diplomat/cpp/include/ICU4XDataProvider.h
+++ b/ffi/diplomat/cpp/include/ICU4XDataProvider.h
@@ -18,6 +18,8 @@ ICU4XCreateDataProviderResult ICU4XDataProvider_create_fs(const char* path_data,
 ICU4XCreateDataProviderResult ICU4XDataProvider_create_static();
 
 ICU4XCreateDataProviderResult ICU4XDataProvider_create_from_byte_slice(const uint8_t* blob_data, size_t blob_len);
+
+ICU4XCreateDataProviderResult ICU4XDataProvider_create_empty();
 void ICU4XDataProvider_destroy(ICU4XDataProvider* self);
 
 #ifdef __cplusplus

--- a/ffi/diplomat/cpp/include/ICU4XDataProvider.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XDataProvider.hpp
@@ -43,6 +43,12 @@ class ICU4XDataProvider {
    * See [the Rust docs](https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.BlobDataProvider.html) for more details.
    */
   static ICU4XCreateDataProviderResult create_from_byte_slice(const diplomat::span<uint8_t> blob);
+
+  /**
+   * Constructs an empty `StaticDataProvider` and returns it as an [`ICU4XDataProvider`].
+   * See [the Rust docs](https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.StaticDataProvider.html) for more details.
+   */
+  static ICU4XCreateDataProviderResult create_empty();
   inline const capi::ICU4XDataProvider* AsFFI() const { return this->inner.get(); }
   inline capi::ICU4XDataProvider* AsFFIMut() { return this->inner.get(); }
   inline ICU4XDataProvider(capi::ICU4XDataProvider* i) : inner(i) {}
@@ -79,6 +85,17 @@ inline ICU4XCreateDataProviderResult ICU4XDataProvider::create_static() {
 }
 inline ICU4XCreateDataProviderResult ICU4XDataProvider::create_from_byte_slice(const diplomat::span<uint8_t> blob) {
   capi::ICU4XCreateDataProviderResult diplomat_raw_struct_out_value = capi::ICU4XDataProvider_create_from_byte_slice(blob.data(), blob.size());
+  auto diplomat_optional_raw_out_value_provider = diplomat_raw_struct_out_value.provider;
+  std::optional<ICU4XDataProvider> diplomat_optional_out_value_provider;
+  if (diplomat_optional_raw_out_value_provider != nullptr) {
+    diplomat_optional_out_value_provider = ICU4XDataProvider(diplomat_optional_raw_out_value_provider);
+  } else {
+    diplomat_optional_out_value_provider = std::nullopt;
+  }
+  return ICU4XCreateDataProviderResult{ .provider = std::move(diplomat_optional_out_value_provider), .success = std::move(diplomat_raw_struct_out_value.success) };
+}
+inline ICU4XCreateDataProviderResult ICU4XDataProvider::create_empty() {
+  capi::ICU4XCreateDataProviderResult diplomat_raw_struct_out_value = capi::ICU4XDataProvider_create_empty();
   auto diplomat_optional_raw_out_value_provider = diplomat_raw_struct_out_value.provider;
   std::optional<ICU4XDataProvider> diplomat_optional_out_value_provider;
   if (diplomat_optional_raw_out_value_provider != nullptr) {

--- a/ffi/diplomat/src/provider.rs
+++ b/ffi/diplomat/src/provider.rs
@@ -13,6 +13,7 @@ pub mod ffi {
 
     use icu_provider::prelude::BufferProvider;
     use icu_provider_blob::BlobDataProvider;
+    use icu_provider_blob::StaticDataProvider;
     #[cfg(all(
         feature = "provider_fs",
         not(any(target_arch = "wasm32", target_os = "none"))

--- a/ffi/diplomat/src/provider.rs
+++ b/ffi/diplomat/src/provider.rs
@@ -93,5 +93,15 @@ pub mod ffi {
                 },
             }
         }
+
+        /// Constructs an empty `StaticDataProvider` and returns it as an [`ICU4XDataProvider`].
+        /// See [the Rust docs](https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.StaticDataProvider.html) for more details.
+        pub fn create_empty() -> ICU4XCreateDataProviderResult {
+            let provider = StaticDataProvider::new_empty();
+            ICU4XCreateDataProviderResult {
+                provider: Some(Box::new(ICU4XDataProvider(Box::new(provider)))),
+                success: true,
+            }
+        }
     }
 }

--- a/ffi/diplomat/wasm/docs/provider_ffi.rst
+++ b/ffi/diplomat/wasm/docs/provider_ffi.rst
@@ -28,3 +28,7 @@
         Constructs a ``BlobDataProvider`` and returns it as an :js:class:`ICU4XDataProvider`. See `the Rust docs <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.BlobDataProvider.html>`__ for more details.
 
         - Note: ``blob`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
+
+    .. js:staticfunction:: create_empty()
+
+        Constructs an empty ``StaticDataProvider`` and returns it as an :js:class:`ICU4XDataProvider`. See `the Rust docs <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.StaticDataProvider.html>`__ for more details.

--- a/ffi/diplomat/wasm/lib/api.mjs
+++ b/ffi/diplomat/wasm/lib/api.mjs
@@ -283,6 +283,24 @@ export class ICU4XDataProvider {
     wasm.diplomat_free(blob_diplomat_ptr, blob_diplomat_bytes.length, 1);
     return diplomat_out;
   }
+
+  static create_empty() {
+    const diplomat_out = (() => {
+      const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
+      wasm.ICU4XDataProvider_create_empty(diplomat_receive_buffer);
+      const out = new ICU4XCreateDataProviderResult(diplomat_receive_buffer);
+      const out_provider_value = out.provider;
+      ICU4XDataProvider_box_destroy_registry.register(out_provider_value, out_provider_value.underlying);
+      Object.defineProperty(out, "provider", { value: out_provider_value });
+      diplomat_alloc_destroy_registry.register(out, {
+        ptr: out.underlying,
+        size: 5,
+        align: 4,
+      });
+      return out;
+    })();
+    return diplomat_out;
+  }
 }
 
 const ICU4XFixedDecimal_box_destroy_registry = new FinalizationRegistry(underlying => {


### PR DESCRIPTION
It was inadvertently deleted in https://github.com/unicode-org/icu4x/commit/0a9aea981ca6e85523600ff191562dc4576d7fb1