### PR TITLE
Add support for week-of-month.

### DIFF
--- a/components/calendar/src/arithmetic.rs
+++ b/components/calendar/src/arithmetic.rs
@@ -184,6 +184,31 @@ pub mod week_of {
         }
     }
 
+    /// Computes & returns the week of given month or year accoding to a calendar with min_week_days = 1.
+    ///
+    /// # Arguments
+    ///  - first_weekday: The first day of a week.
+    ///  - day: 1-based day of the month or year.
+    ///  - week_day: The weekday of `day`.
+    pub fn simple_week_of(first_weekday: IsoWeekday, day: u16, week_day: IsoWeekday) -> u16 {
+        let calendar = CalendarInfo {
+            first_weekday,
+            min_week_days: 1,
+        };
+
+        week_of(
+            &calendar,
+            // The duration of the current and previous unit does not influence the result if min_week_days = 1
+            // so we only need to use a valid value.
+            MIN_UNIT_DAYS,
+            MIN_UNIT_DAYS,
+            day,
+            week_day,
+        )
+        .expect("week_of should can't fail with MIN_UNIT_DAYS")
+        .week
+    }
+
     #[cfg(test)]
     mod tests {
         use super::{week_of, CalendarInfo, RelativeUnit, RelativeWeek, UnitInfo, WeekOf};
@@ -424,5 +449,30 @@ pub mod week_of {
 
             Ok(())
         }
+    }
+
+    #[test]
+    fn test_simple_week_of() {
+        // The 1st is a Monday and the week starts on Mondays.
+        assert_eq!(
+            simple_week_of(IsoWeekday::Monday, 2, IsoWeekday::Tuesday),
+            1
+        );
+        assert_eq!(simple_week_of(IsoWeekday::Monday, 7, IsoWeekday::Sunday), 1);
+        assert_eq!(simple_week_of(IsoWeekday::Monday, 8, IsoWeekday::Monday), 2);
+
+        // The 1st is a Wednesday and the week starts on Tuesdays.
+        assert_eq!(
+            simple_week_of(IsoWeekday::Tuesday, 1, IsoWeekday::Wednesday),
+            1
+        );
+        assert_eq!(
+            simple_week_of(IsoWeekday::Tuesday, 6, IsoWeekday::Monday),
+            1
+        );
+        assert_eq!(
+            simple_week_of(IsoWeekday::Tuesday, 7, IsoWeekday::Tuesday),
+            2
+        );
     }
 }

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -175,28 +175,18 @@ fn week_of_month<T: DateInput>(
     datetime: &T,
     first_weekday: IsoWeekday,
 ) -> Result<WeekOfMonth, DateTimeError> {
-    // This value isn't used by week_of() given that we use a calendar with min_week_days = 1.
-    const UNUSED_DAYS_IN_MONTH: u16 = 60;
-
-    let calendar = week_of::CalendarInfo {
-        first_weekday,
-        min_week_days: 1,
-    };
-
     let day_of_month = datetime
         .day_of_month()
         .ok_or(DateTimeError::MissingInput("DateTimeInput::day_of_month"))?;
 
-    let week = week_of::week_of(
-        &calendar,
-        UNUSED_DAYS_IN_MONTH,
-        UNUSED_DAYS_IN_MONTH,
+    let week = week_of::simple_week_of(
+        first_weekday,
         day_of_month.0 as u16,
         datetime
             .iso_weekday()
             .ok_or(DateTimeError::MissingInput("DateTimeInput::iso_weekday"))?,
-    )?;
-    Ok(WeekOfMonth(u32::from(week.week)))
+    );
+    Ok(WeekOfMonth(u32::from(week)))
 }
 
 impl<'data, T: DateTimeInput> DateTimeInputWithLocale<'data, T> {

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -167,10 +167,12 @@ fn week_of_year<T: DateInput>(
 
 /// Returns the week of month according to a calendar with min_week_days = 1.
 ///
-/// This is different from what the UTS35 spec describes but the latter is
+/// This is different from what the UTS35 spec describes [1] but the latter is
 /// missing a month of week-of-month field so following the spec would result
 /// in inconsistencies (e.g. in the ISO calendar 2021-01-01 is the last week
 /// of December but 'MMMMW' would have it formatted as 'week 5 of January').
+///
+/// 1: https://www.unicode.org/reports/tr35/tr35-55/tr35-dates.html#Date_Patterns_Week_Of_Year
 fn week_of_month<T: DateInput>(
     datetime: &T,
     first_weekday: IsoWeekday,

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -234,14 +234,7 @@ impl TryFrom<char> for FieldSymbol {
         })
         .or_else(|_| Year::try_from(ch).map(Self::Year))
         .or_else(|_| Month::try_from(ch).map(Self::Month))
-        .or_else(|_| {
-            if ch == 'w' {
-                Week::try_from(ch).map(Self::Week)
-            } else {
-                // TODO(#488): Add support for 'W'.
-                Err(SymbolError::Unknown(ch))
-            }
-        })
+        .or_else(|_| Week::try_from(ch).map(Self::Week))
         .or_else(|_| Day::try_from(ch).map(Self::Day))
         .or_else(|_| Weekday::try_from(ch).map(Self::Weekday))
         .or_else(|_| DayPeriod::try_from(ch).map(Self::DayPeriod))

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -215,10 +215,14 @@ where
                 w.write_str(symbol)?
             }
         },
-        FieldSymbol::Week(Week::WeekOfYear) => {
-            format_number(w, datetime.week_of_year()?.0 as isize, field.length)?
-        }
-        field @ FieldSymbol::Week(_) => return Err(Error::UnsupportedField(field)),
+        FieldSymbol::Week(week) => match week {
+            Week::WeekOfYear => {
+                format_number(w, datetime.week_of_year()?.0 as isize, field.length)?
+            }
+            Week::WeekOfMonth => {
+                format_number(w, datetime.week_of_month()?.0 as isize, field.length)?
+            }
+        },
         FieldSymbol::Weekday(weekday) => {
             let dow = datetime
                 .datetime()

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -93,7 +93,7 @@ pub struct Bag {
     pub year: Option<Year>,
     /// Include the month, such as "April" or "Apr".
     pub month: Option<Month>,
-    /// Include the week, such as "1st" or "1".
+    /// Include the week number, such as "51st" or "51" for week 51.
     pub week: Option<Week>,
     /// Include the day, such as "07" or "7".
     pub day: Option<Numeric>,
@@ -398,8 +398,10 @@ pub enum Month {
 
 // Each enum variant is documented with the UTS 35 field information from:
 // https://unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
-//
-/// Options for displaying the current week for the `components::`[`Bag`].
+
+/// Options for displaying the current week number for the `components::`[`Bag`].
+///
+/// Week numbers are relative to either a month or year, e.g. 'week 3 of January' or 'week 40 of 2000'.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
     feature = "serde",
@@ -407,11 +409,11 @@ pub enum Month {
     serde(rename_all = "kebab-case")
 )]
 pub enum Week {
-    /// The week of the month, such as "3".
+    /// The week of the month, such as the "3" in "week 3 of January".
     WeekOfMonth,
-    /// The numeric value of the week of the year, such as "8".
+    /// The numeric value of the week of the year, such as the "8" in "week 8 of 2000".
     NumericWeekOfYear,
-    /// The two-digit value of the week of the year, such as "08".
+    /// The two-digit value of the week of the year, such as the "08" in "2000-W08".
     TwoDigitWeekOfYear,
 }
 

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -94,8 +94,6 @@ pub struct Bag {
     /// Include the month, such as "April" or "Apr".
     pub month: Option<Month>,
     /// Include the week, such as "1st" or "1".
-    #[doc(hidden)]
-    // TODO(#488): make visible once fully supported.
     pub week: Option<Week>,
     /// Include the day, such as "07" or "7".
     pub day: Option<Numeric>,
@@ -390,7 +388,7 @@ pub enum Month {
     Numeric,
     /// The two-digit value of the month, such as "04".
     TwoDigit,
-    /// The two-digit value of the month, such as "April".
+    /// The long value of the month, such as "April".
     Long,
     /// The short value of the month, such as "Apr".
     Short,
@@ -402,8 +400,6 @@ pub enum Month {
 // https://unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
 //
 /// Options for displaying the current week for the `components::`[`Bag`].
-#[doc(hidden)]
-// TODO(#488): make visible once fully supported.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
     feature = "serde",

--- a/components/datetime/src/pattern/runtime/plural.rs
+++ b/components/datetime/src/pattern/runtime/plural.rs
@@ -152,7 +152,7 @@ impl<'data> PatternPlurals<'data> {
             Self::SinglePattern(pattern) => Ok(pattern),
             Self::MultipleVariants(plural_pattern) => {
                 let week_number = match plural_pattern.pivot_field() {
-                    Week::WeekOfMonth => loc_datetime.week_of_month().0,
+                    Week::WeekOfMonth => loc_datetime.week_of_month()?.0,
                     Week::WeekOfYear => loc_datetime.week_of_year()?.0,
                 };
                 let category = ordinal_rules

--- a/components/datetime/src/skeleton/error.rs
+++ b/components/datetime/src/skeleton/error.rs
@@ -60,8 +60,6 @@ impl From<fields::SymbolError> for SkeletonError {
                 match ch {
                     // TODO(#487) - Flexible day periods
                     'B'
-                    // TODO(#502) - Week of month
-                    | 'W'
                     // TODO(#501) - Quarters
                     | 'Q'
                     => Self::SymbolUnimplemented(ch),

--- a/components/datetime/src/skeleton/mod.rs
+++ b/components/datetime/src/skeleton/mod.rs
@@ -204,7 +204,8 @@ mod test {
     #[rustfmt::skip]
     const SUPPORTED_STRING_SKELETONS: &[&str] = &[
         "E", "dEEEE", "EHm", "EHms", "dE", "Ehm", "Ehms", "H", "HHmm", "HHmmss", "Hm", "Hms", "M",
-        "MdEEEE", "MdE", "MMM", "MMMdEEEE", "MMMdE", "MMMM", "MMMMdEEEE", "MMMMdE", "MMMMd",
+        "MdEEEE", "MdE", "MMM", "MMMdEEEE", "MMMdE", "MMMM", "MMMMW",
+        "MMMMdEEEE", "MMMMdE", "MMMMd",
         "MMMMdd", "MMMd", "MMMdd", "MMd", "MMdd", "Md", "Mdd", "d", "h", "hm", "hms", "mmss", "ms",
         "y", "yM", "yMdEEEE", "yMdE", "yMM", "yMMM", "yMMMdEEEE", "yMMMdE", "yMMMM", "yMMMMdEEEE",
         "yMMMMdE", "yMMMMdcccc", "yMMMMd", "yMMMd", "yMMdd", "yMd", "yw",
@@ -221,8 +222,6 @@ mod test {
     const UNSUPPORTED_STRING_SKELETONS: &[&str] = &[
         // TODO(#487) - Flexible day periods
         "Bh", "Bhm", "Bhms", "EBhm", "EBhms",
-        // TODO(#502) - Week of month
-        "MMMMW",
         // TODO(#501) - Quarters
         "yQ", "yQQQ", "yQQQQ",
     ];

--- a/components/datetime/tests/fixtures/tests/components-exact-matches.json
+++ b/components/datetime/tests/fixtures/tests/components-exact-matches.json
@@ -512,7 +512,7 @@
         }
     },
     {
-        "description": "Exact match for: yw => week' w 'of' Y",
+        "description": "Exact match for: yw => 'week' w 'of' Y",
         "input": {
             "locale": "en",
             "value": "2016-04-17T08:25:07.000",
@@ -528,6 +528,24 @@
                 "en":  "week 16 of 2016",
                 "fil": "linggo 16 ng 2016",
                 "en-ZA":  "week 17 of 2016"
+            }
+        }
+    },
+    {
+        "description": "Exact match for: MMMMW -> 'week' W 'of' MMMM",
+        "input": {
+            "locale": "en",
+            "value": "2022-01-01T08:25:07.000",
+            "options": {
+                "components": {
+                    "month": "long",
+                    "week": "week-of-month"
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "en":  "week 1 of January"
             }
         }
     }

--- a/components/datetime/tests/fixtures/tests/components-partial-matches.json
+++ b/components/datetime/tests/fixtures/tests/components-partial-matches.json
@@ -69,5 +69,23 @@
                 "en": "week 53 of 2002"
             }
         }
+    },
+    {
+        "description": "Partial match for: MMMMWEEEE -> MMMMW -> 'week' W 'of' MMMM",
+        "input": {
+            "value": "2002-12-31T08:25:07.000",
+            "options": {
+                "components": {
+                    "month": "long",
+                    "week": "week-of-month",
+                    "weekday": "long"
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "en":  "week 1 of December"
+            }
+        }
     }
 ]

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/ar-EG.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/ar-EG.json
@@ -21,6 +21,7 @@
   "MMM": "LLL",
   "MMMd": "d MMM",
   "MMMdE": "E، d MMM",
+  "MMMMW": "الأسبوع W من MMMM",
   "MMMMd": "d MMMM",
   "MMMMdE": "E، d MMMM",
   "d": "d",

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/ar.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/ar.json
@@ -21,6 +21,7 @@
   "MMM": "LLL",
   "MMMd": "d MMM",
   "MMMdE": "E، d MMM",
+  "MMMMW": "الأسبوع W من MMMM",
   "MMMMd": "d MMMM",
   "MMMMdE": "E، d MMMM",
   "d": "d",

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/bn.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/bn.json
@@ -21,6 +21,7 @@
   "MMM": "LLL",
   "MMMd": "d MMM",
   "MMMdE": "E d MMM",
+  "MMMMW": "MMMM এর Wয় সপ্তাহ",
   "MMMMd": "d MMMM",
   "MMMMdE": "E d MMMM",
   "d": "d",

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/ccp.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/ccp.json
@@ -21,6 +21,7 @@
   "MMM": "LLL",
   "MMMd": "d MMM",
   "MMMdE": "E d MMM",
+  "MMMMW": "MMMM 𑄃𑄬𑄢𑄴 𑄠𑄴 𑄥𑄛𑄴𑄖 W",
   "MMMMd": "d MMMM",
   "MMMMdE": "E d MMMM",
   "d": "d",

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/en-001.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/en-001.json
@@ -20,6 +20,7 @@
   "MMM": "LLL",
   "MMMd": "d MMM",
   "MMMdE": "E, d MMM",
+  "MMMMW": "'week' W 'of' MMMM",
   "MMMMd": "d MMMM",
   "d": "d",
   "dE": "E d",

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/en-ZA.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/en-ZA.json
@@ -20,6 +20,7 @@
   "MMM": "LLL",
   "MMMd": "dd MMM",
   "MMMdE": "E, dd MMM",
+  "MMMMW": "'week' W 'of' MMMM",
   "MMMMd": "d MMMM",
   "d": "d",
   "dE": "E d",

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/en.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/en.json
@@ -19,6 +19,7 @@
   "MMM": "LLL",
   "MMMd": "MMM d",
   "MMMdE": "E, MMM d",
+  "MMMMW": "'week' W 'of' MMMM",
   "MMMMd": "MMMM d",
   "d": "d",
   "dE": "d E",

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/es-AR.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/es-AR.json
@@ -28,6 +28,7 @@
   "MMMd": "d MMM",
   "MMMdE": "E, d MMM",
   "MMMdd": "dd-MMM",
+  "MMMMW": "'semana' W 'de' MMMM",
   "MMMMd": "d 'de' MMMM",
   "MMMMdE": "E, d 'de' MMMM",
   "d": "d",

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/es.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/es.json
@@ -27,6 +27,7 @@
   "MMM": "LLL",
   "MMMd": "d MMM",
   "MMMdE": "E, d MMM",
+  "MMMMW": "'semana' W 'de' MMMM",
   "MMMMd": "d 'de' MMMM",
   "MMMMdE": "E, d 'de' MMMM",
   "d": "d",

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/fil.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/fil.json
@@ -28,6 +28,15 @@
   "MMM": "LLL",
   "MMMd": "MMM d",
   "MMMdE": "E, MMM d",
+  "MMMMW": {
+    "pivot_field": "WeekOfMonth",
+    "zero": null,
+    "one": "'ika-'W 'linggo ng' MMMM",
+    "two": null,
+    "few": null,
+    "many": null,
+    "other": "'linggo' W 'ng' MMMM"
+  },
   "MMMMd": "MMMM d",
   "MMMMdE": "E, MMMM d",
   "d": "d",

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/fr.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/fr.json
@@ -19,6 +19,7 @@
   "MMM": "LLL",
   "MMMd": "d MMM",
   "MMMdE": "E d MMM",
+  "MMMMW": "'semaine' W (MMMM)",
   "MMMMd": "d MMMM",
   "d": "d",
   "dE": "E d",

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/ja.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/ja.json
@@ -25,6 +25,7 @@
   "MMMd": "M月d日",
   "MMMdE": "M月d日(E)",
   "MMMdEEEE": "M月d日EEEE",
+  "MMMMW": "M月第W週",
   "MMMMd": "M月d日",
   "d": "d日",
   "dE": "d日(E)",

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/ru.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/ru.json
@@ -21,6 +21,7 @@
   "MMM": "LLL",
   "MMMd": "d MMM",
   "MMMdE": "ccc, d MMM",
+  "MMMMW": "W-я неделя MMMM",
   "MMMMd": "d MMMM",
   "d": "d",
   "dE": "ccc, d",

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/sr-Cyrl.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/sr-Cyrl.json
@@ -23,6 +23,7 @@
   "MMMd": "d. MMM",
   "MMMdE": "E d. MMM",
   "MMMdd": "dd.MMM",
+  "MMMMW": "W. седмица у MMMM.",
   "MMMMd": "d. MMMM",
   "MMMMdE": "E, d. MMMM",
   "d": "d",

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/sr-Latn.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/sr-Latn.json
@@ -23,6 +23,7 @@
   "MMMd": "d. MMM",
   "MMMdE": "E d. MMM",
   "MMMdd": "dd.MMM",
+  "MMMMW": "W'. sedmica u' MMMM.",
   "MMMMd": "d. MMMM",
   "MMMMdE": "E, d. MMMM",
   "d": "d",

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/sr.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/sr.json
@@ -23,6 +23,7 @@
   "MMMd": "d. MMM",
   "MMMdE": "E d. MMM",
   "MMMdd": "dd.MMM",
+  "MMMMW": "W. седмица у MMMM.",
   "MMMMd": "d. MMMM",
   "MMMMdE": "E, d. MMMM",
   "d": "d",

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/th.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/th.json
@@ -25,6 +25,7 @@
   "MMMd": "d MMM",
   "MMMdE": "E d MMM",
   "MMMdEEEE": "EEEEที่ d MMM",
+  "MMMMW": "สัปดาห์ที่ W ของเดือนMMMM",
   "MMMMd": "d MMMM",
   "MMMMdE": "E d MMMM",
   "MMMMdEEEE": "EEEEที่ d MMMM",

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/tr.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/tr.json
@@ -20,6 +20,7 @@
   "MMM": "LLL",
   "MMMd": "d MMM",
   "MMMdE": "d MMMM E",
+  "MMMMW": "MMMM 'ayının' W'. haftası'",
   "MMMMd": "d MMMM",
   "MMMMdE": "d MMMM E",
   "d": "d",

--- a/provider/testdata/data/json/datetime/skeletons@1/gregory/und.json
+++ b/provider/testdata/data/json/datetime/skeletons@1/gregory/und.json
@@ -19,6 +19,7 @@
   "MMM": "LLL",
   "MMMd": "MMM d",
   "MMMdE": "MMM d, E",
+  "MMMMW": "'week' W 'of' MMMM",
   "MMMMd": "MMMM d",
   "d": "d",
   "dE": "d, E",


### PR DESCRIPTION
Fixes #502
Fixes #488 

Contrary to UTS 35 this always uses min_days = 1 as there's no month of
week-of-month field so there would be inconsistencies otherwise (e.g. in
the ISO calendar 2021-01-01 is the last week of December but 'MMMMW' would
have it formatted as 'week 5 of January').



<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->