### PR TITLE
Add EitherCart and rename Yoke ZCF constructors

### DIFF
--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -297,7 +297,7 @@ where
     /// let json_rc_buffer: Rc<[u8]> = json_text.as_bytes().into();
     ///
     /// let payload = DataPayload::<HelloWorldV1Marker>::try_from_yoked_buffer(
-    ///     Yoke::attach_to_rc_cart(json_rc_buffer),
+    ///     Yoke::attach_to_zero_copy_cart(json_rc_buffer),
     ///     (),
     ///     |bytes, _, _| {
     ///         serde_json::from_slice(bytes)
@@ -808,7 +808,7 @@ impl DataPayload<BufferMarker> {
     /// Converts a reference-counted byte buffer into a `DataPayload<BufferMarker>`.
     pub fn from_rc_buffer(buffer: Rc<[u8]>) -> Self {
         Self {
-            yoke: Yoke::attach_to_rc_cart(buffer).wrap_cart_in_option(),
+            yoke: Yoke::attach_to_zero_copy_cart(buffer).wrap_cart_in_option(),
         }
     }
 

--- a/utils/yoke/src/either.rs
+++ b/utils/yoke/src/either.rs
@@ -12,8 +12,14 @@ use stable_deref_trait::StableDeref;
 
 /// A cart that can be one type or the other. Enables ergonomic polymorphic carts.
 ///
+/// `EitherCart` enables yokes originating from different data sources and therefore
+/// having different cart types to be merged into the same yoke type, but still being
+/// able to recover the original cart type if necessary.
+///
 /// All relevant Cart traits are implemented for `EitherCart`, and carts can be
 /// safely wrapped in an `EitherCart`.
+///
+/// Also see [`Yoke::erase_box_cart()`].
 ///
 /// # Examples
 ///

--- a/utils/yoke/src/either.rs
+++ b/utils/yoke/src/either.rs
@@ -1,0 +1,122 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+//! Types to enable polymorphic carts.
+
+use crate::CloneableCart;
+use crate::Yoke;
+use crate::Yokeable;
+use core::ops::Deref;
+use stable_deref_trait::StableDeref;
+
+/// A cart that can be one type or the other. Enables ergonomic polymorphic carts.
+///
+/// All relevant Cart traits are implemented for `EitherCart`, and carts can be
+/// safely wrapped in an `EitherCart`.
+///
+/// # Examples
+///
+/// ```
+/// use yoke::Yoke;
+/// use yoke::either::EitherCart;
+/// use std::borrow::Cow;
+/// use std::rc::Rc;
+///
+/// let y1: Yoke<
+///     &'static str,
+///     Rc<str>
+/// > = Yoke::attach_to_zero_copy_cart(
+///     "reference counted hello world".into()
+/// );
+///
+/// let y2: Yoke<
+///     &'static str,
+///     &str
+/// > = Yoke::attach_to_zero_copy_cart(
+///     "borrowed hello world"
+/// );
+///
+/// type CombinedYoke<'a> = Yoke<
+///     &'static str,
+///     EitherCart<Rc<str>, &'a str>
+/// >;
+///
+/// // Both yokes can be combined into a single yoke type despite different carts
+/// let y3: CombinedYoke = y1.wrap_cart_in_either_a();
+/// let y4: CombinedYoke = y2.wrap_cart_in_either_b();
+///
+/// assert_eq!(*y3.get(), "reference counted hello world");
+/// assert_eq!(*y4.get(), "borrowed hello world");
+///
+/// // The resulting yoke is cloneable if both cart types implement CloneableCart
+/// let y5 = y4.clone();
+/// assert_eq!(*y5.get(), "borrowed hello world");
+/// ```
+#[derive(Clone, PartialEq, Eq)]
+pub enum EitherCart<C0, C1> {
+    A(C0),
+    B(C1),
+}
+
+impl<C0, C1, T> Deref for EitherCart<C0, C1>
+where
+    C0: Deref<Target = T>,
+    C1: Deref<Target = T>,
+{
+    type Target = T;
+    fn deref(&self) -> &T {
+        use EitherCart::*;
+        match self {
+            A(a) => a.deref(),
+            B(b) => b.deref(),
+        }
+    }
+}
+
+// Safe because both sub-types implement the trait.
+unsafe impl<C0, C1, T> StableDeref for EitherCart<C0, C1>
+where
+    C0: StableDeref,
+    C1: StableDeref,
+    C0: Deref<Target = T>,
+    C1: Deref<Target = T>,
+{
+}
+
+// Safe because both sub-types implement the trait.
+unsafe impl<C0, C1> CloneableCart for EitherCart<C0, C1>
+where
+    C0: CloneableCart,
+    C1: CloneableCart,
+{
+}
+
+impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
+    /// Helper function allowing one to wrap the cart type in an [`EitherCart`].
+    ///
+    /// This function wraps the cart into the `A` variant. To wrap it into the
+    /// `B` variant, use [`Self::wrap_cart_in_either_b()`].
+    ///
+    /// For an example, see [`EitherCart`].
+    #[inline]
+    pub fn wrap_cart_in_either_a<B>(self) -> Yoke<Y, EitherCart<C, B>> {
+        unsafe {
+            // safe because the cart is preserved, just wrapped
+            self.replace_cart(EitherCart::A)
+        }
+    }
+    /// Helper function allowing one to wrap the cart type in an [`EitherCart`].
+    ///
+    /// This function wraps the cart into the `B` variant. To wrap it into the
+    /// `A` variant, use [`Self::wrap_cart_in_either_a()`].
+    ///
+    /// For an example, see [`EitherCart`].
+    #[inline]
+    pub fn wrap_cart_in_either_b<A>(self) -> Yoke<Y, EitherCart<A, C>> {
+        unsafe {
+            // safe because the cart is preserved, just wrapped
+            self.replace_cart(EitherCart::B)
+        }
+    }
+}

--- a/utils/yoke/src/is_covariant.rs
+++ b/utils/yoke/src/is_covariant.rs
@@ -96,7 +96,7 @@ use alloc::{
 /// // Example usage: a Yoke of a trait object
 /// let s = "Hello World".to_string();
 /// let yoke: Yoke<ExampleTraitDynRef<'static>, Box<dyn ExampleTrait>> =
-///     Yoke::attach_to_box_cart(Box::new(MyStruct(&s)));
+///     Yoke::attach_to_zero_copy_cart(Box::new(MyStruct(&s)));
 ///
 /// assert_eq!(yoke.get().0.get_message(), "Hello World");
 /// ```

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -17,6 +17,7 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+pub mod either;
 #[cfg(feature = "alloc")]
 pub mod erased;
 mod is_covariant;

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -238,7 +238,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// let yoke = Yoke::<
     ///     &'static str,
     ///     Box<String>
-    /// >::attach_to_box_cart(Box::new(local_data));
+    /// >::attach_to_zero_copy_cart(Box::new(local_data));
     /// assert_eq!(*yoke.get(), "foo");
     ///
     /// // Get back the cart
@@ -256,7 +256,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// let mut yoke = Yoke::<
     ///     Cow<'static, str>,
     ///     Box<String>
-    /// >::attach_to_box_cart(Box::new(local_data));
+    /// >::attach_to_zero_copy_cart(Box::new(local_data));
     /// assert_eq!(yoke.get(), "foo");
     ///
     /// // Override data in the cart
@@ -529,7 +529,7 @@ unsafe impl<'b, Y: for<'a> Yokeable<'a>, C: IsCovariant<'b>> IsCovariant<'b> for
 #[test]
 fn test_clone() {
     let local_data = "foo".to_string();
-    let y1 = Yoke::<alloc::borrow::Cow<'static, str>, Rc<String>>::attach_to_rc_cart(Rc::new(
+    let y1 = Yoke::<alloc::borrow::Cow<'static, str>, Rc<String>>::attach_to_zero_copy_cart(Rc::new(
         local_data,
     ));
 

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -289,6 +289,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// `Yoke` only really cares about destructors for its carts so it's fine to erase other
     /// information about the cart, as long as the backing data will still be destroyed at the
     /// same time.
+    #[inline]
     pub unsafe fn replace_cart<C2>(self, f: impl FnOnce(C) -> C2) -> Yoke<Y, C2> {
         Yoke {
             yokeable: self.yokeable,
@@ -387,6 +388,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     }
 
     /// Helper function allowing one to wrap the cart type in an `Option<T>`.
+    #[inline]
     pub fn wrap_cart_in_option(self) -> Yoke<Y, Option<C>> {
         unsafe {
             // safe because the cart is preserved, just wrapped
@@ -529,9 +531,9 @@ unsafe impl<'b, Y: for<'a> Yokeable<'a>, C: IsCovariant<'b>> IsCovariant<'b> for
 #[test]
 fn test_clone() {
     let local_data = "foo".to_string();
-    let y1 = Yoke::<alloc::borrow::Cow<'static, str>, Rc<String>>::attach_to_zero_copy_cart(Rc::new(
-        local_data,
-    ));
+    let y1 = Yoke::<alloc::borrow::Cow<'static, str>, Rc<String>>::attach_to_zero_copy_cart(
+        Rc::new(local_data),
+    );
 
     // Test basic clone
     let y2 = y1.clone();
@@ -864,21 +866,23 @@ impl<Y: for<'a> Yokeable<'a>, C: 'static + Sized> Yoke<Y, Box<C>> {
 
 #[cfg(feature = "alloc")]
 impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
-    /// Helper function allowing one to wrap the cart type in a `Box<T>`,
-    /// can be paired with [`Yoke::erase_box_cart()`]
+    /// Helper function allowing one to wrap the cart type in a `Box<T>`.
+    /// Can be paired with [`Yoke::erase_box_cart()`]
     ///
     /// Available with the `"alloc"` feature enabled.
+    #[inline]
     pub fn wrap_cart_in_box(self) -> Yoke<Y, Box<C>> {
         unsafe {
             // safe because the cart is preserved, just wrapped
             self.replace_cart(Box::new)
         }
     }
-    /// Helper function allowing one to wrap the cart type in an `Rc<T>`,
-    /// can be paired with [`Yoke::erase_rc_cart()`], or generally used
+    /// Helper function allowing one to wrap the cart type in an `Rc<T>`.
+    /// Can be paired with [`Yoke::erase_rc_cart()`], or generally used
     /// to make the [`Yoke`] cloneable.
     ///
     /// Available with the `"alloc"` feature enabled.
+    #[inline]
     pub fn wrap_cart_in_rc(self) -> Yoke<Y, Rc<C>> {
         unsafe {
             // safe because the cart is preserved, just wrapped

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -30,7 +30,7 @@ use alloc::sync::Arc;
 ///
 /// `C` is the "cart", which `Y` may contain references to. After the yoke is constructed,
 /// the cart serves little purpose except to guarantee that `Y`'s references remain valid
-/// for as long as the yoke remains in memory.
+/// for as long as the yoke remains in memory (by calling the destructor at the appropriate moment).
 ///
 /// The primary constructor for [`Yoke`] is [`Yoke::attach_to_cart()`]. Several variants of that
 /// constructor are provided to serve numerous types of call sites and `Yoke` signatures.

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -28,7 +28,9 @@ use alloc::sync::Arc;
 /// not the actual lifetime of the data, rather it is a convenient way to erase
 /// the lifetime and make it dynamic.
 ///
-/// `C` is the "cart", which `Y` may contain references to.
+/// `C` is the "cart", which `Y` may contain references to. After the yoke is constructed,
+/// the cart serves little purpose except to guarantee that `Y`'s references remain valid
+/// for as long as the yoke remains in memory.
 ///
 /// The primary constructor for [`Yoke`] is [`Yoke::attach_to_cart()`]. Several variants of that
 /// constructor are provided to serve numerous types of call sites and `Yoke` signatures.


### PR DESCRIPTION
I put two changes in this PR.  Let me know if you want me to separate them.

1. New type `EitherCart` that allows for ergonomic polymorphic carts
2. Renamed `Yoke::attach_to_borrowed_cart`, etc., to a more general `Yoke::attach_to_zero_copy_cart`

I was also thinking of renaming `Yoke::attach_to_cart` to be `Yoke::attach_to_cart_with` but I stopped here.