### PR TITLE
Remove Yokeable::Output from ZeroCopyFrom trait

### DIFF
--- a/experimental/segmenter/src/provider.rs
+++ b/experimental/segmenter/src/provider.rs
@@ -61,8 +61,8 @@ impl Deref for LineBreakPropertyTable<'_> {
     }
 }
 
-impl<'a> ZeroCopyFrom<'a, LineBreakPropertyTable<'_>> for LineBreakPropertyTable<'a> {
-    fn zero_copy_from(cart: &'a LineBreakPropertyTable<'_>) -> Self {
+impl<'zcf> ZeroCopyFrom<'zcf, LineBreakPropertyTable<'_>> for LineBreakPropertyTable<'zcf> {
+    fn zero_copy_from(cart: &'zcf LineBreakPropertyTable<'_>) -> Self {
         LineBreakPropertyTable::Borrowed(&*cart)
     }
 }

--- a/experimental/segmenter/src/provider.rs
+++ b/experimental/segmenter/src/provider.rs
@@ -61,8 +61,8 @@ impl Deref for LineBreakPropertyTable<'_> {
     }
 }
 
-impl<'a> ZeroCopyFrom<LineBreakPropertyTable<'a>> for LineBreakPropertyTable<'static> {
-    fn zero_copy_from<'b>(cart: &'b LineBreakPropertyTable<'a>) -> <Self as Yokeable<'b>>::Output {
+impl<'a> ZeroCopyFrom<'a, LineBreakPropertyTable<'_>> for LineBreakPropertyTable<'a> {
+    fn zero_copy_from(cart: &'a LineBreakPropertyTable<'_>) -> Self {
         LineBreakPropertyTable::Borrowed(&*cart)
     }
 }

--- a/provider/core/src/erased.rs
+++ b/provider/core/src/erased.rs
@@ -53,9 +53,8 @@ pub trait ErasedDataStruct: 'static {
     fn as_any(&self) -> &dyn Any;
 }
 
-impl ZeroCopyFrom<dyn ErasedDataStruct> for &'static dyn ErasedDataStruct {
-    #[allow(clippy::needless_lifetimes)]
-    fn zero_copy_from<'b>(this: &'b (dyn ErasedDataStruct)) -> &'b dyn ErasedDataStruct {
+impl<'zcf> ZeroCopyFrom<'zcf, dyn ErasedDataStruct> for &'zcf dyn ErasedDataStruct {
+    fn zero_copy_from(this: &'zcf (dyn ErasedDataStruct)) -> &'zcf dyn ErasedDataStruct {
         this
     }
 }

--- a/utils/yoke/derive/examples/derive.rs
+++ b/utils/yoke/derive/examples/derive.rs
@@ -51,12 +51,12 @@ pub struct HasTuples<'data> {
 }
 
 pub fn assert_zcf_tuples<'b, 'data>(x: &'b HasTuples<'data>) -> HasTuples<'b> {
-    HasTuples::<'static>::zero_copy_from(x)
+    HasTuples::<'b>::zero_copy_from(x)
 }
 pub fn assert_zcf_generics<'a, 'b>(
     x: &'b ZeroVecExampleWithGenerics<'a, u8>,
 ) -> ZeroVecExampleWithGenerics<'b, u8> {
-    ZeroVecExampleWithGenerics::<'static, u8>::zero_copy_from(x)
+    ZeroVecExampleWithGenerics::<'b, u8>::zero_copy_from(x)
 }
 
 // Since ZeroMap has generic parameters, the Rust compiler cannot
@@ -78,7 +78,7 @@ pub struct ZeroMapGenericExample<'a, T: for<'b> ZeroMapKV<'b> + ?Sized> {
 pub fn assert_zcf_map<'a, 'b>(
     x: &'b ZeroMapGenericExample<'a, str>,
 ) -> ZeroMapGenericExample<'b, str> {
-    ZeroMapGenericExample::<'static, str>::zero_copy_from(x)
+    ZeroMapGenericExample::<'b, str>::zero_copy_from(x)
 }
 
 #[derive(Yokeable, Clone, ZeroCopyFrom)]

--- a/utils/yoke/derive/examples/derive.rs
+++ b/utils/yoke/derive/examples/derive.rs
@@ -51,7 +51,7 @@ pub struct HasTuples<'data> {
 }
 
 pub fn assert_zcf_tuples<'b, 'data>(x: &'b HasTuples<'data>) -> HasTuples<'b> {
-    HasTuples::<'b>::zero_copy_from(x)
+    HasTuples::zero_copy_from(x)
 }
 pub fn assert_zcf_generics<'a, 'b>(
     x: &'b ZeroVecExampleWithGenerics<'a, u8>,
@@ -78,7 +78,7 @@ pub struct ZeroMapGenericExample<'a, T: for<'b> ZeroMapKV<'b> + ?Sized> {
 pub fn assert_zcf_map<'a, 'b>(
     x: &'b ZeroMapGenericExample<'a, str>,
 ) -> ZeroMapGenericExample<'b, str> {
-    ZeroMapGenericExample::<'b, str>::zero_copy_from(x)
+    ZeroMapGenericExample::zero_copy_from(x)
 }
 
 #[derive(Yokeable, Clone, ZeroCopyFrom)]

--- a/utils/yoke/src/is_covariant.rs
+++ b/utils/yoke/src/is_covariant.rs
@@ -77,8 +77,8 @@ use alloc::{
 ///     }
 /// }
 ///
-/// impl<'a> ZeroCopyFrom<dyn ExampleTrait<'a> + 'a> for ExampleTraitDynRef<'static> {
-///     fn zero_copy_from<'b>(this: &'b (dyn ExampleTrait<'a> + 'a)) -> ExampleTraitDynRef<'b> {
+/// impl<'zcf, 'a> ZeroCopyFrom<'zcf, dyn ExampleTrait<'a> + 'a> for ExampleTraitDynRef<'zcf> {
+///     fn zero_copy_from(this: &'zcf (dyn ExampleTrait<'a> + 'a)) -> ExampleTraitDynRef<'zcf> {
 ///         // This is safe because the trait object requires IsCovariant.
 ///         ExampleTraitDynRef(unsafe { core::mem::transmute(this) })
 ///     }

--- a/utils/yoke/src/macro_impls.rs
+++ b/utils/yoke/src/macro_impls.rs
@@ -38,9 +38,9 @@ macro_rules! impl_copy_type {
             type Output = Self;
             copy_yoke_impl!();
         }
-        impl ZeroCopyFrom<$ty> for $ty {
+        impl<'a> ZeroCopyFrom<'a, $ty> for $ty {
             #[inline]
-            fn zero_copy_from(this: &Self) -> Self {
+            fn zero_copy_from(this: &'a Self) -> Self {
                 // Essentially only works when the struct is fully Copy
                 *this
             }
@@ -117,8 +117,8 @@ unsafe impl<'a, T: Yokeable<'a>, const N: usize> Yokeable<'a> for [T; N] {
 // https://github.com/rust-lang/rust/issues/76118
 macro_rules! array_zcf_impl {
     ($n:expr; $($i:expr),+) => {
-        impl<C, T: ZeroCopyFrom<C>> ZeroCopyFrom<[C; $n]> for [T; $n] {
-            fn zero_copy_from<'b>(this: &'b [C; $n]) -> [<T as Yokeable<'b>>::Output; $n] {
+        impl<'a, C, T: ZeroCopyFrom<'a, C>> ZeroCopyFrom<'a, [C; $n]> for [T; $n] {
+            fn zero_copy_from(this: &'a [C; $n]) -> Self {
                 [
                     $(
                         <T as ZeroCopyFrom<C>>::zero_copy_from(&this[$i])

--- a/utils/yoke/src/zero_copy_from.rs
+++ b/utils/yoke/src/zero_copy_from.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::trait_hack::YokeTraitHack;
 use crate::Yoke;
 use crate::Yokeable;
 #[cfg(feature = "alloc")]
@@ -10,7 +11,6 @@ use alloc::borrow::{Cow, ToOwned};
 use alloc::string::String;
 use core::ops::Deref;
 use stable_deref_trait::StableDeref;
-use crate::trait_hack::YokeTraitHack;
 
 /// Trait for types that can be crated from a reference to a cart type `C` with no allocations.
 ///
@@ -86,7 +86,7 @@ pub trait ZeroCopyFrom<'a, C: ?Sized>: 'a {
 
 impl<'a, C: ?Sized, T> ZeroCopyFrom<'a, C> for YokeTraitHack<T>
 where
-    T: ZeroCopyFrom<'a, C>
+    T: ZeroCopyFrom<'a, C>,
 {
     #[inline]
     fn zero_copy_from(cart: &'a C) -> Self {
@@ -172,10 +172,10 @@ impl<'a, C, T: ZeroCopyFrom<'a, C>> ZeroCopyFrom<'a, Option<C>> for Option<T> {
     }
 }
 
-impl<'a, C1, T1: ZeroCopyFrom<'a, C1>, C2, T2: ZeroCopyFrom<'a, C2>> ZeroCopyFrom<'a, (C1, C2)> for (T1, T2) {
-    fn zero_copy_from(
-        cart: &'a (C1, C2),
-    ) -> Self {
+impl<'a, C1, T1: ZeroCopyFrom<'a, C1>, C2, T2: ZeroCopyFrom<'a, C2>> ZeroCopyFrom<'a, (C1, C2)>
+    for (T1, T2)
+{
+    fn zero_copy_from(cart: &'a (C1, C2)) -> Self {
         (
             <T1 as ZeroCopyFrom<C1>>::zero_copy_from(&cart.0),
             <T2 as ZeroCopyFrom<C2>>::zero_copy_from(&cart.1),

--- a/utils/yoke/src/zero_copy_from.rs
+++ b/utils/yoke/src/zero_copy_from.rs
@@ -36,31 +36,6 @@ use stable_deref_trait::StableDeref;
 ///     message: Cow<'data, str>,
 /// }
 ///
-/// unsafe impl<'a> Yokeable<'a> for MyStruct<'static> {
-///     // (not shown; see `Yokeable` for examples)
-/// #    type Output = MyStruct<'a>;
-/// #    fn transform(&'a self) -> &'a Self::Output {
-/// #        self
-/// #    }
-/// #    fn transform_owned(self) -> MyStruct<'a> {
-/// #        // covariant lifetime cast, can be done safely
-/// #        self
-/// #    }
-/// #    unsafe fn make(from: Self::Output) -> Self {
-/// #        std::mem::transmute(from)
-/// #    }
-/// #    fn transform_mut<F>(&'a mut self, f: F)
-/// #    where
-/// #        F: 'static + for<'b> FnOnce(&'b mut Self::Output),
-/// #    {
-/// #        unsafe {
-/// #            f(std::mem::transmute::<&'a mut Self, &'a mut Self::Output>(
-/// #                self,
-/// #            ))
-/// #        }
-/// #    }
-/// }
-///
 /// // Reference from a borrowed version of self
 /// impl<'zcf> ZeroCopyFrom<'zcf, MyStruct<'_>> for MyStruct<'zcf> {
 ///     fn zero_copy_from(cart: &'zcf MyStruct<'_>) -> Self {

--- a/utils/zerovec/src/yoke_impls.rs
+++ b/utils/zerovec/src/yoke_impls.rs
@@ -263,43 +263,40 @@ where
     }
 }
 
-impl<'a, T: 'static + AsULE + ?Sized> ZeroCopyFrom<ZeroVec<'a, T>> for ZeroVec<'static, T> {
+impl<'a, T: 'static + AsULE + ?Sized> ZeroCopyFrom<'a, ZeroVec<'_, T>> for ZeroVec<'a, T> {
     #[inline]
-    fn zero_copy_from<'b>(cart: &'b ZeroVec<'a, T>) -> ZeroVec<'b, T> {
+    fn zero_copy_from(cart: &'a ZeroVec<'_, T>) -> Self {
         ZeroVec::Borrowed(cart.as_ule_slice())
     }
 }
 
-impl<'a, T: 'static + VarULE + ?Sized> ZeroCopyFrom<VarZeroVec<'a, T>> for VarZeroVec<'static, T> {
+impl<'a, T: 'static + VarULE + ?Sized> ZeroCopyFrom<'a, VarZeroVec<'_, T>> for VarZeroVec<'a, T> {
     #[inline]
-    fn zero_copy_from<'b>(cart: &'b VarZeroVec<'a, T>) -> VarZeroVec<'b, T> {
+    fn zero_copy_from(cart: &'a VarZeroVec<'_, T>) -> Self {
         cart.as_slice().into()
     }
 }
 
-impl<'a, K, V> ZeroCopyFrom<ZeroMap<'a, K, V>> for ZeroMap<'static, K, V>
+impl<'a, 's, K, V> ZeroCopyFrom<'a, ZeroMap<'s, K, V>> for ZeroMap<'a, K, V>
 where
     K: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
     V: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
-    <K as ZeroMapKV<'static>>::Container: for<'b> ZeroCopyFrom<<K as ZeroMapKV<'b>>::Container>,
-    <V as ZeroMapKV<'static>>::Container: for<'b> ZeroCopyFrom<<V as ZeroMapKV<'b>>::Container>,
-    <K as ZeroMapKV<'static>>::Container:
-        for<'b> Yokeable<'b, Output = <K as ZeroMapKV<'b>>::Container>,
-    <V as ZeroMapKV<'static>>::Container:
-        for<'b> Yokeable<'b, Output = <V as ZeroMapKV<'b>>::Container>,
+    <K as ZeroMapKV<'a>>::Container: ZeroCopyFrom<'a, <K as ZeroMapKV<'s>>::Container>,
+    <V as ZeroMapKV<'a>>::Container: ZeroCopyFrom<'a, <V as ZeroMapKV<'s>>::Container>,
 {
-    fn zero_copy_from<'b>(cart: &'b ZeroMap<'a, K, V>) -> ZeroMap<'b, K, V> {
+    fn zero_copy_from(cart: &'a ZeroMap<'s, K, V>) -> Self {
         ZeroMap {
-            keys: <<K as ZeroMapKV<'static>>::Container as ZeroCopyFrom<_>>::zero_copy_from(
+            keys: <<K as ZeroMapKV<'a>>::Container as ZeroCopyFrom<_>>::zero_copy_from(
                 &cart.keys,
             ),
-            values: <<V as ZeroMapKV<'static>>::Container as ZeroCopyFrom<_>>::zero_copy_from(
+            values: <<V as ZeroMapKV<'a>>::Container as ZeroCopyFrom<_>>::zero_copy_from(
                 &cart.values,
             ),
         }
     }
 }
 
+/*
 impl<'a, K0, K1, V> ZeroCopyFrom<ZeroMap2d<'a, K0, K1, V>> for ZeroMap2d<'static, K0, K1, V>
 where
     K0: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
@@ -330,6 +327,7 @@ where
         }
     }
 }
+*/
 
 #[cfg(test)]
 #[allow(non_camel_case_types)]

--- a/utils/zerovec/src/yoke_impls.rs
+++ b/utils/zerovec/src/yoke_impls.rs
@@ -286,9 +286,7 @@ where
 {
     fn zero_copy_from(cart: &'a ZeroMap<'s, K, V>) -> Self {
         ZeroMap {
-            keys: <<K as ZeroMapKV<'a>>::Container as ZeroCopyFrom<_>>::zero_copy_from(
-                &cart.keys,
-            ),
+            keys: <<K as ZeroMapKV<'a>>::Container as ZeroCopyFrom<_>>::zero_copy_from(&cart.keys),
             values: <<V as ZeroMapKV<'a>>::Container as ZeroCopyFrom<_>>::zero_copy_from(
                 &cart.values,
             ),
@@ -296,38 +294,30 @@ where
     }
 }
 
-/*
-impl<'a, K0, K1, V> ZeroCopyFrom<ZeroMap2d<'a, K0, K1, V>> for ZeroMap2d<'static, K0, K1, V>
+impl<'a, 's, K0, K1, V> ZeroCopyFrom<'a, ZeroMap2d<'s, K0, K1, V>> for ZeroMap2d<'a, K0, K1, V>
 where
     K0: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
     K1: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
     V: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
-    <K0 as ZeroMapKV<'static>>::Container: for<'b> ZeroCopyFrom<<K0 as ZeroMapKV<'b>>::Container>,
-    <K1 as ZeroMapKV<'static>>::Container: for<'b> ZeroCopyFrom<<K1 as ZeroMapKV<'b>>::Container>,
-    <V as ZeroMapKV<'static>>::Container: for<'b> ZeroCopyFrom<<V as ZeroMapKV<'b>>::Container>,
-    <K0 as ZeroMapKV<'static>>::Container:
-        for<'b> Yokeable<'b, Output = <K0 as ZeroMapKV<'b>>::Container>,
-    <K1 as ZeroMapKV<'static>>::Container:
-        for<'b> Yokeable<'b, Output = <K1 as ZeroMapKV<'b>>::Container>,
-    <V as ZeroMapKV<'static>>::Container:
-        for<'b> Yokeable<'b, Output = <V as ZeroMapKV<'b>>::Container>,
+    <K0 as ZeroMapKV<'a>>::Container: ZeroCopyFrom<'a, <K0 as ZeroMapKV<'s>>::Container>,
+    <K1 as ZeroMapKV<'a>>::Container: ZeroCopyFrom<'a, <K1 as ZeroMapKV<'s>>::Container>,
+    <V as ZeroMapKV<'a>>::Container: ZeroCopyFrom<'a, <V as ZeroMapKV<'s>>::Container>,
 {
-    fn zero_copy_from<'b>(cart: &'b ZeroMap2d<'a, K0, K1, V>) -> ZeroMap2d<'b, K0, K1, V> {
+    fn zero_copy_from(cart: &'a ZeroMap2d<'s, K0, K1, V>) -> Self {
         ZeroMap2d {
-            keys0: <<K0 as ZeroMapKV<'static>>::Container as ZeroCopyFrom<_>>::zero_copy_from(
+            keys0: <<K0 as ZeroMapKV<'a>>::Container as ZeroCopyFrom<_>>::zero_copy_from(
                 &cart.keys0,
             ),
             joiner: ZeroVec::zero_copy_from(&cart.joiner),
-            keys1: <<K1 as ZeroMapKV<'static>>::Container as ZeroCopyFrom<_>>::zero_copy_from(
+            keys1: <<K1 as ZeroMapKV<'a>>::Container as ZeroCopyFrom<_>>::zero_copy_from(
                 &cart.keys1,
             ),
-            values: <<V as ZeroMapKV<'static>>::Container as ZeroCopyFrom<_>>::zero_copy_from(
+            values: <<V as ZeroMapKV<'a>>::Container as ZeroCopyFrom<_>>::zero_copy_from(
                 &cart.values,
             ),
         }
     }
 }
-*/
 
 #[cfg(test)]
 #[allow(non_camel_case_types)]

--- a/utils/zerovec/src/yoke_impls.rs
+++ b/utils/zerovec/src/yoke_impls.rs
@@ -265,7 +265,7 @@ where
 
 impl<'zcf, T> ZeroCopyFrom<'zcf, ZeroVec<'_, T>> for ZeroVec<'zcf, T>
 where
-    T: 'zcf + AsULE + ?Sized,
+    T: 'static + AsULE + ?Sized,
 {
     #[inline]
     fn zero_copy_from(cart: &'zcf ZeroVec<'_, T>) -> Self {
@@ -285,8 +285,8 @@ where
 
 impl<'zcf, 's, K, V> ZeroCopyFrom<'zcf, ZeroMap<'s, K, V>> for ZeroMap<'zcf, K, V>
 where
-    K: 'zcf + for<'b> ZeroMapKV<'b> + ?Sized,
-    V: 'zcf + for<'b> ZeroMapKV<'b> + ?Sized,
+    K: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
+    V: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
     <K as ZeroMapKV<'zcf>>::Container: ZeroCopyFrom<'zcf, <K as ZeroMapKV<'s>>::Container>,
     <V as ZeroMapKV<'zcf>>::Container: ZeroCopyFrom<'zcf, <V as ZeroMapKV<'s>>::Container>,
 {
@@ -301,9 +301,9 @@ where
 impl<'zcf, 's, K0, K1, V> ZeroCopyFrom<'zcf, ZeroMap2d<'s, K0, K1, V>>
     for ZeroMap2d<'zcf, K0, K1, V>
 where
-    K0: 'zcf + for<'b> ZeroMapKV<'b> + ?Sized,
-    K1: 'zcf + for<'b> ZeroMapKV<'b> + ?Sized,
-    V: 'zcf + for<'b> ZeroMapKV<'b> + ?Sized,
+    K0: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
+    K1: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
+    V: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
     <K0 as ZeroMapKV<'zcf>>::Container: ZeroCopyFrom<'zcf, <K0 as ZeroMapKV<'s>>::Container>,
     <K1 as ZeroMapKV<'zcf>>::Container: ZeroCopyFrom<'zcf, <K1 as ZeroMapKV<'s>>::Container>,
     <V as ZeroMapKV<'zcf>>::Container: ZeroCopyFrom<'zcf, <V as ZeroMapKV<'s>>::Container>,

--- a/utils/zerovec/src/yoke_impls.rs
+++ b/utils/zerovec/src/yoke_impls.rs
@@ -263,58 +263,57 @@ where
     }
 }
 
-impl<'a, T: 'static + AsULE + ?Sized> ZeroCopyFrom<'a, ZeroVec<'_, T>> for ZeroVec<'a, T> {
+impl<'zcf, T> ZeroCopyFrom<'zcf, ZeroVec<'_, T>> for ZeroVec<'zcf, T>
+where
+    T: 'zcf + AsULE + ?Sized,
+{
     #[inline]
-    fn zero_copy_from(cart: &'a ZeroVec<'_, T>) -> Self {
+    fn zero_copy_from(cart: &'zcf ZeroVec<'_, T>) -> Self {
         ZeroVec::Borrowed(cart.as_ule_slice())
     }
 }
 
-impl<'a, T: 'static + VarULE + ?Sized> ZeroCopyFrom<'a, VarZeroVec<'_, T>> for VarZeroVec<'a, T> {
+impl<'zcf, T> ZeroCopyFrom<'zcf, VarZeroVec<'_, T>> for VarZeroVec<'zcf, T>
+where
+    T: 'static + VarULE + ?Sized,
+{
     #[inline]
-    fn zero_copy_from(cart: &'a VarZeroVec<'_, T>) -> Self {
+    fn zero_copy_from(cart: &'zcf VarZeroVec<'_, T>) -> Self {
         cart.as_slice().into()
     }
 }
 
-impl<'a, 's, K, V> ZeroCopyFrom<'a, ZeroMap<'s, K, V>> for ZeroMap<'a, K, V>
+impl<'zcf, 's, K, V> ZeroCopyFrom<'zcf, ZeroMap<'s, K, V>> for ZeroMap<'zcf, K, V>
 where
-    K: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
-    V: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
-    <K as ZeroMapKV<'a>>::Container: ZeroCopyFrom<'a, <K as ZeroMapKV<'s>>::Container>,
-    <V as ZeroMapKV<'a>>::Container: ZeroCopyFrom<'a, <V as ZeroMapKV<'s>>::Container>,
+    K: 'zcf + for<'b> ZeroMapKV<'b> + ?Sized,
+    V: 'zcf + for<'b> ZeroMapKV<'b> + ?Sized,
+    <K as ZeroMapKV<'zcf>>::Container: ZeroCopyFrom<'zcf, <K as ZeroMapKV<'s>>::Container>,
+    <V as ZeroMapKV<'zcf>>::Container: ZeroCopyFrom<'zcf, <V as ZeroMapKV<'s>>::Container>,
 {
-    fn zero_copy_from(cart: &'a ZeroMap<'s, K, V>) -> Self {
+    fn zero_copy_from(cart: &'zcf ZeroMap<'s, K, V>) -> Self {
         ZeroMap {
-            keys: <<K as ZeroMapKV<'a>>::Container as ZeroCopyFrom<_>>::zero_copy_from(&cart.keys),
-            values: <<V as ZeroMapKV<'a>>::Container as ZeroCopyFrom<_>>::zero_copy_from(
-                &cart.values,
-            ),
+            keys: K::Container::zero_copy_from(&cart.keys),
+            values: V::Container::zero_copy_from(&cart.values),
         }
     }
 }
 
-impl<'a, 's, K0, K1, V> ZeroCopyFrom<'a, ZeroMap2d<'s, K0, K1, V>> for ZeroMap2d<'a, K0, K1, V>
+impl<'zcf, 's, K0, K1, V> ZeroCopyFrom<'zcf, ZeroMap2d<'s, K0, K1, V>>
+    for ZeroMap2d<'zcf, K0, K1, V>
 where
-    K0: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
-    K1: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
-    V: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
-    <K0 as ZeroMapKV<'a>>::Container: ZeroCopyFrom<'a, <K0 as ZeroMapKV<'s>>::Container>,
-    <K1 as ZeroMapKV<'a>>::Container: ZeroCopyFrom<'a, <K1 as ZeroMapKV<'s>>::Container>,
-    <V as ZeroMapKV<'a>>::Container: ZeroCopyFrom<'a, <V as ZeroMapKV<'s>>::Container>,
+    K0: 'zcf + for<'b> ZeroMapKV<'b> + ?Sized,
+    K1: 'zcf + for<'b> ZeroMapKV<'b> + ?Sized,
+    V: 'zcf + for<'b> ZeroMapKV<'b> + ?Sized,
+    <K0 as ZeroMapKV<'zcf>>::Container: ZeroCopyFrom<'zcf, <K0 as ZeroMapKV<'s>>::Container>,
+    <K1 as ZeroMapKV<'zcf>>::Container: ZeroCopyFrom<'zcf, <K1 as ZeroMapKV<'s>>::Container>,
+    <V as ZeroMapKV<'zcf>>::Container: ZeroCopyFrom<'zcf, <V as ZeroMapKV<'s>>::Container>,
 {
-    fn zero_copy_from(cart: &'a ZeroMap2d<'s, K0, K1, V>) -> Self {
+    fn zero_copy_from(cart: &'zcf ZeroMap2d<'s, K0, K1, V>) -> Self {
         ZeroMap2d {
-            keys0: <<K0 as ZeroMapKV<'a>>::Container as ZeroCopyFrom<_>>::zero_copy_from(
-                &cart.keys0,
-            ),
+            keys0: K0::Container::zero_copy_from(&cart.keys0),
             joiner: ZeroVec::zero_copy_from(&cart.joiner),
-            keys1: <<K1 as ZeroMapKV<'a>>::Container as ZeroCopyFrom<_>>::zero_copy_from(
-                &cart.keys1,
-            ),
-            values: <<V as ZeroMapKV<'a>>::Container as ZeroCopyFrom<_>>::zero_copy_from(
-                &cart.values,
-            ),
+            keys1: K1::Container::zero_copy_from(&cart.keys1),
+            values: V::Container::zero_copy_from(&cart.values),
         }
     }
 }


### PR DESCRIPTION
Fixes #1255
Replaces #1257

Using this trait:

```rust
pub trait ZeroCopyFromV2<'a, C: ?Sized>: 'a {
    fn zero_copy_from_v2(cart: &'a C) -> Self;
}
```

And this function signature:

```rust
impl<Y, C> Yoke<Y, C>
where
    Y: for<'a> Yokeable<'a>,
    for<'a> YokeTraitHack<<Y as Yokeable<'a>>::Output>: ZeroCopyFromV2<'a, <C as Deref>::Target>,
    C: StableDeref + Deref,
{
    pub fn attach_to_zero_copy_v2_cart(cart: C) -> Self {
        Yoke::<Y, C>::attach_to_cart(cart, |c| {
            YokeTraitHack::<<Y as Yokeable>::Output>::zero_copy_from_v2(c).0
        })
    }
}
```

I managed to get this to compile:

```rust
    let yoke = Yoke::<
        Cow<'static, str>,
        String
    >::attach_to_zero_copy_v2_cart("demo".to_string());
```