### PR TITLE
Remove obsolete clippy arguments in CI scirpts

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,9 +9,7 @@ tidy = "make tidy"
 
 # Run Clippy on all code paths
 # Keep args in sync with `clippy` job in .github/workflows/build-test.yml
-# unknown-clippy-lints: to allow us to work with nightly clippy lints that we don't CI
-# field-reassign-with-default: https://github.com/rust-lang/rust-clippy/issues/6559 (fixed in nightly but not stable)
-clippy-all = "clippy --all-features --all-targets -- -D warnings -Aclippy::field-reassign-with-default"
+clippy-all = "clippy --all-features --all-targets -- -D warnings"
 
 # Build configurations for small binary size
 panic-abort-build = "build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -453,7 +453,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         # keep args in sync with `clippy-all` in .cargo/config.toml
-        args: --all-targets --all-features -- -D warnings -Aclippy::unknown-clippy-lints -Aclippy::field-reassign-with-default
+        args: --all-targets --all-features -- -D warnings
 
   # Benchmarking & dashboards job
 

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -136,8 +136,10 @@ impl DataProvider<HelloWorldV1Marker> for HelloWorldProvider {
             .get(langid)
             .map(|s| HelloWorldV1 { message: s.clone() })
             .ok_or_else(|| DataErrorKind::MissingLocale.with_req(req))?;
-        let mut metadata = DataResponseMetadata::default();
-        metadata.data_langid = Some(langid.clone());
+        let metadata = DataResponseMetadata {
+            data_langid: Some(langid.clone()),
+            ..Default::default()
+        };
         Ok(DataResponse {
             metadata,
             payload: Some(DataPayload::from_owned(data)),


### PR DESCRIPTION
The fix to false positive `clippy::field-reassign-with-default` should reach Rust stable now.

`clippy::unknown-clippy-lints` is already removed in `config.toml`, so I assume its not needed anymore.