### PR TITLE
Add tinystr-neo to experimental/

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,6 +2644,7 @@ name = "tinystr-neo"
 version = "0.3.1"
 dependencies = [
  "displaydoc",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,6 +2640,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr-neo"
+version = "0.3.1"
+dependencies = [
+ "displaydoc",
+]
+
+[[package]]
 name = "tinystr-raw"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,8 +2643,11 @@ dependencies = [
 name = "tinystr-neo"
 version = "0.3.1"
 dependencies = [
+ "bincode",
  "displaydoc",
+ "postcard",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "experimental/list_formatter",
     "experimental/segmenter",
     "experimental/segmenter_lstm",
+    "experimental/tinystr_neo",
     "ffi/diplomat",
     "ffi/ecma402",
     "provider/blob",

--- a/experimental/tinystr_neo/Cargo.toml
+++ b/experimental/tinystr_neo/Cargo.toml
@@ -27,3 +27,8 @@ all-features = true
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
 serde = { version = "1.0.123", optional = true, default-features = false, features = ["alloc"] }
+
+[dev-dependencies]
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+bincode = "1.3"
+postcard = { version = "0.7", features = ["use-std"] }

--- a/experimental/tinystr_neo/Cargo.toml
+++ b/experimental/tinystr_neo/Cargo.toml
@@ -26,3 +26,4 @@ all-features = true
 
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
+serde = { version = "1.0.123", optional = true, default-features = false, features = ["alloc"] }

--- a/experimental/tinystr_neo/Cargo.toml
+++ b/experimental/tinystr_neo/Cargo.toml
@@ -1,0 +1,28 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+[package]
+name = "tinystr-neo"
+version = "0.3.1"
+description = "A small ASCII-only bounded length string representation."
+authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
+edition = "2021"
+repository = "https://github.com/unicode-org/icu4x"
+license-file = "LICENSE"
+keywords = ["string", "str", "small", "tiny", "no_std"]
+categories = ["data-structures"]
+include = [
+    "src/**/*",
+    "examples/**/*",
+    "benches/**/*",
+    "Cargo.toml",
+    "LICENSE",
+    "README.md"
+]
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+displaydoc = { version = "0.2.3", default-features = false }

--- a/experimental/tinystr_neo/LICENSE
+++ b/experimental/tinystr_neo/LICENSE
@@ -1,0 +1,331 @@
+Except as otherwise noted below, ICU4X is licensed under the Apache
+License, Version 2.0 (included below) or the MIT license (included
+below), at your option. Unless importing data or code in the manner
+stated below, any contribution intentionally submitted for inclusion
+in ICU4X by you, as defined in the Apache-2.0 license, shall be dual
+licensed in the foregoing manner, without any additional terms or
+conditions.
+
+As exceptions to the above:
+* Portions of ICU4X that have been adapted from ICU4C and/or ICU4J are
+under the Unicode license (included below) and/or the ICU license
+(included below) as indicated by source code comments.
+* Unicode data incorporated in ICU4X is under the Unicode license
+(included below).
+* Your contributions may import code from ICU4C and/or ICU4J and
+Unicode data under these licenses. Indicate the license and the ICU4C
+or ICU4J origin in source code comments.
+
+- - - -
+
+Apache License, version 2.0
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+- - - -
+
+MIT License
+
+Copyright The ICU4X Authors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+- - - -
+
+Unicode License
+
+COPYRIGHT AND PERMISSION NOTICE (ICU 58 and later)
+
+Copyright © 1991-2020 Unicode, Inc. All rights reserved.
+Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Unicode data files and any associated documentation
+(the "Data Files") or Unicode software and any associated documentation
+(the "Software") to deal in the Data Files or Software
+without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, and/or sell copies of
+the Data Files or Software, and to permit persons to whom the Data Files
+or Software are furnished to do so, provided that either
+(a) this copyright and permission notice appear with all copies
+of the Data Files or Software, or
+(b) this copyright and permission notice appear in associated
+Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in these Data Files or Software without prior
+written authorization of the copyright holder.
+
+- - - -
+
+ICU License - ICU 1.8.1 to ICU 57.1
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright (c) 1995-2016 International Business Machines Corporation and others
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, and/or sell copies of the Software, and to permit persons
+to whom the Software is furnished to do so, provided that the above
+copyright notice(s) and this permission notice appear in all copies of
+the Software and that both the above copyright notice(s) and this
+permission notice appear in supporting documentation.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
+SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
+RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale, use
+or other dealings in this Software without prior written authorization
+of the copyright holder.
+
+All trademarks and registered trademarks mentioned herein are the
+property of their respective owners.
+
+- - - -

--- a/experimental/tinystr_neo/README.md
+++ b/experimental/tinystr_neo/README.md
@@ -1,0 +1,7 @@
+# tinystr-neo [![crates.io](https://img.shields.io/crates/v/tinystr-neo)](https://crates.io/crates/tinystr-neo)
+
+
+
+## More Information
+
+For more information on development, authorship, contributing etc. please visit [`ICU4X home page`](https://github.com/unicode-org/icu4x).

--- a/experimental/tinystr_neo/src/ascii.rs
+++ b/experimental/tinystr_neo/src/ascii.rs
@@ -53,6 +53,10 @@ impl<const N: usize> TinyAsciiStr<N> {
         self.bytes.iter().position(|x| *x == 0).unwrap_or(N)
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.bytes[0] == 0
+    }
+
     pub fn as_bytes(&self) -> &[u8] {
         &self.bytes[0..self.len()]
     }
@@ -61,6 +65,9 @@ impl<const N: usize> TinyAsciiStr<N> {
         &self.bytes
     }
 
+    /// # Safety
+    /// Must be called with a bytes array made of valid ASCII bytes, with no null bytes
+    /// between ASCII characters
     pub const unsafe fn from_bytes_unchecked(bytes: [u8; N]) -> Self {
         Self { bytes }
     }
@@ -69,7 +76,7 @@ impl<const N: usize> TinyAsciiStr<N> {
 impl<const N: usize> Deref for TinyAsciiStr<N> {
     type Target = str;
     fn deref(&self) -> &str {
-        unsafe { str::from_utf8_unchecked(&self.as_bytes()) }
+        unsafe { str::from_utf8_unchecked(self.as_bytes()) }
     }
 }
 

--- a/experimental/tinystr_neo/src/ascii.rs
+++ b/experimental/tinystr_neo/src/ascii.rs
@@ -41,6 +41,14 @@ impl<const N: usize> TinyAsciiStr<N> {
         Self::from_bytes(s.as_bytes())
     }
 
+    pub const fn from_str_panicky(s: &str) -> Self {
+        match Self::from_bytes(s.as_bytes()) {
+            Ok(s) => s,
+            // Cannot format the error since formatting isn't const yet
+            Err(_) => panic!("Failed to construct tinystr"),
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.bytes.iter().position(|x| *x == 0).unwrap_or(N)
     }

--- a/experimental/tinystr_neo/src/ascii.rs
+++ b/experimental/tinystr_neo/src/ascii.rs
@@ -4,7 +4,7 @@
 
 use crate::TinyStrError;
 use core::ops::Deref;
-use core::str;
+use core::str::{self, FromStr};
 
 #[repr(transparent)]
 #[derive(PartialEq, Eq, Ord, PartialOrd, Copy, Clone, Debug, Hash)]
@@ -48,11 +48,26 @@ impl<const N: usize> TinyAsciiStr<N> {
     pub fn as_bytes(&self) -> &[u8] {
         &self.bytes[0..self.len()]
     }
+
+    pub fn all_bytes(&self) -> &[u8; N] {
+        &self.bytes
+    }
+
+    pub const unsafe fn from_bytes_unchecked(bytes: [u8; N]) -> Self {
+        Self { bytes }
+    }
 }
 
 impl<const N: usize> Deref for TinyAsciiStr<N> {
     type Target = str;
     fn deref(&self) -> &str {
         unsafe { str::from_utf8_unchecked(&self.as_bytes()) }
+    }
+}
+
+impl<const N: usize> FromStr for TinyAsciiStr<N> {
+    type Err = TinyStrError;
+    fn from_str(s: &str) -> Result<Self, TinyStrError> {
+        Self::from_str(s)
     }
 }

--- a/experimental/tinystr_neo/src/ascii.rs
+++ b/experimental/tinystr_neo/src/ascii.rs
@@ -41,14 +41,6 @@ impl<const N: usize> TinyAsciiStr<N> {
         Self::from_bytes(s.as_bytes())
     }
 
-    pub const fn from_str_panicky(s: &str) -> Self {
-        match Self::from_bytes(s.as_bytes()) {
-            Ok(s) => s,
-            // Cannot format the error since formatting isn't const yet
-            Err(_) => panic!("Failed to construct tinystr"),
-        }
-    }
-
     pub fn len(&self) -> usize {
         self.bytes.iter().position(|x| *x == 0).unwrap_or(N)
     }

--- a/experimental/tinystr_neo/src/ascii.rs
+++ b/experimental/tinystr_neo/src/ascii.rs
@@ -1,0 +1,58 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use crate::TinyStrError;
+use core::ops::Deref;
+use core::str;
+
+#[repr(transparent)]
+#[derive(PartialEq, Eq, Ord, PartialOrd, Copy, Clone, Debug, Hash)]
+pub struct TinyAsciiStr<const N: usize> {
+    bytes: [u8; N],
+}
+
+impl<const N: usize> TinyAsciiStr<N> {
+    pub const fn from_bytes(bytes: &[u8]) -> Result<Self, TinyStrError> {
+        if bytes.len() > N {
+            return Err(TinyStrError::TooLarge {
+                max: N,
+                found: bytes.len(),
+            });
+        }
+
+        let mut out = [0; N];
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == 0 {
+                return Err(TinyStrError::ContainsNull);
+            } else if bytes[i] >= 0x80 {
+                return Err(TinyStrError::NonAscii);
+            }
+            out[i] = bytes[i];
+
+            i += 1;
+        }
+
+        Ok(Self { bytes: out })
+    }
+
+    pub const fn from_str(s: &str) -> Result<Self, TinyStrError> {
+        Self::from_bytes(s.as_bytes())
+    }
+
+    pub fn len(&self) -> usize {
+        self.bytes.iter().position(|x| *x == 0).unwrap_or(N)
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes[0..self.len()]
+    }
+}
+
+impl<const N: usize> Deref for TinyAsciiStr<N> {
+    type Target = str;
+    fn deref(&self) -> &str {
+        unsafe { str::from_utf8_unchecked(&self.as_bytes()) }
+    }
+}

--- a/experimental/tinystr_neo/src/error.rs
+++ b/experimental/tinystr_neo/src/error.rs
@@ -1,0 +1,15 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use displaydoc::Display;
+
+#[derive(Display, Debug)]
+pub enum TinyStrError {
+    #[displaydoc("found string of larger length {found} when constructing string of length {max}")]
+    TooLarge { max: usize, found: usize },
+    #[displaydoc("tinystr types do not support strings with null bytes")]
+    ContainsNull,
+    #[displaydoc("attempted to construct TinyStrAuto from a non-ascii string")]
+    NonAscii,
+}

--- a/experimental/tinystr_neo/src/lib.rs
+++ b/experimental/tinystr_neo/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+}

--- a/experimental/tinystr_neo/src/lib.rs
+++ b/experimental/tinystr_neo/src/lib.rs
@@ -9,6 +9,12 @@ mod macros;
 mod ascii;
 mod error;
 
+#[cfg(feature = "serde")]
+mod serde;
+
+#[cfg(feature = "serde")]
+extern crate alloc;
+
 pub use ascii::TinyAsciiStr;
 pub use error::TinyStrError;
 

--- a/experimental/tinystr_neo/src/lib.rs
+++ b/experimental/tinystr_neo/src/lib.rs
@@ -1,8 +1,19 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
-}
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+#![cfg_attr(not(test), no_std)]
+
+mod macros;
+
+mod ascii;
+mod error;
+
+pub use ascii::TinyAsciiStr;
+pub use error::TinyStrError;
+
+// /// Allows unit tests to use the macro
+// #[cfg(test)]
+// mod tinystr {
+//     pub use super::{TinyAsciiStr, TinyStrError};
+// }

--- a/experimental/tinystr_neo/src/macros.rs
+++ b/experimental/tinystr_neo/src/macros.rs
@@ -1,0 +1,25 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+#[macro_export]
+macro_rules! tinystr {
+    ($n:literal, $s:literal) => {
+        ({
+            const TINYSTR_MACRO_CONST: Result<$crate::TinyAsciiStr<$n>, $crate::TinyStrError> = $crate::TinyAsciiStr::from_str($s);
+            TINYSTR_MACRO_CONST
+        }).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_macro_construction() {
+        let s1 = tinystr!(8, "foobar");
+        assert_eq!(&*s1, "foobar");
+
+        let s1 = tinystr!(12, "foobarbaz");
+        assert_eq!(&*s1, "foobarbaz");
+    }
+}

--- a/experimental/tinystr_neo/src/macros.rs
+++ b/experimental/tinystr_neo/src/macros.rs
@@ -6,8 +6,13 @@
 macro_rules! tinystr {
     ($n:literal, $s:literal) => {{
         // Force it into a const context; otherwise it may get evaluated at runtime instead.
-        const TINYSTR_MACRO_CONST: $crate::TinyAsciiStr<$n> =
-            $crate::TinyAsciiStr::from_str_panicky($s);
+        const TINYSTR_MACRO_CONST: $crate::TinyAsciiStr<$n> = {
+            match $crate::TinyAsciiStr::from_bytes($s.as_bytes()) {
+                Ok(s) => s,
+                // Cannot format the error since formatting isn't const yet
+                Err(_) => panic!(concat!("Failed to construct tinystr from ", $s)),
+            }
+        };
         TINYSTR_MACRO_CONST
     }};
 }

--- a/experimental/tinystr_neo/src/macros.rs
+++ b/experimental/tinystr_neo/src/macros.rs
@@ -6,8 +6,10 @@
 macro_rules! tinystr {
     ($n:literal, $s:literal) => {
         ({
+            // Force it into a const context; otherwise it may get evaluated at runtime instead.
             const TINYSTR_MACRO_CONST: Result<$crate::TinyAsciiStr<$n>, $crate::TinyStrError> = $crate::TinyAsciiStr::from_str($s);
             TINYSTR_MACRO_CONST
+        // Note: Rust 1.57 allows panics in consts, until we update to that version we have to panic outside of the const and hope it optimizes away
         }).unwrap()
     }
 }

--- a/experimental/tinystr_neo/src/macros.rs
+++ b/experimental/tinystr_neo/src/macros.rs
@@ -4,14 +4,12 @@
 
 #[macro_export]
 macro_rules! tinystr {
-    ($n:literal, $s:literal) => {
-        ({
-            // Force it into a const context; otherwise it may get evaluated at runtime instead.
-            const TINYSTR_MACRO_CONST: Result<$crate::TinyAsciiStr<$n>, $crate::TinyStrError> = $crate::TinyAsciiStr::from_str($s);
-            TINYSTR_MACRO_CONST
-        // Note: Rust 1.57 allows panics in consts, until we update to that version we have to panic outside of the const and hope it optimizes away
-        }).unwrap()
-    }
+    ($n:literal, $s:literal) => {{
+        // Force it into a const context; otherwise it may get evaluated at runtime instead.
+        const TINYSTR_MACRO_CONST: $crate::TinyAsciiStr<$n> =
+            $crate::TinyAsciiStr::from_str_panicky($s);
+        TINYSTR_MACRO_CONST
+    }};
 }
 
 #[cfg(test)]

--- a/experimental/tinystr_neo/src/serde.rs
+++ b/experimental/tinystr_neo/src/serde.rs
@@ -56,7 +56,7 @@ impl<'de, const N: usize> Visitor<'de> for TinyAsciiStrVisitor<N> {
     {
         let mut bytes = [0u8; N];
         let mut zeroes = false;
-        for i in 0..N {
+        for out in &mut bytes.iter_mut().take(N) {
             let byte = seq
                 .next_element()?
                 .ok_or_else(|| Error::invalid_length(N, &self))?;
@@ -69,7 +69,7 @@ impl<'de, const N: usize> Visitor<'de> for TinyAsciiStrVisitor<N> {
             if byte >= 0x80 {
                 return Err(Error::custom("TinyAsciiStr cannot contain non-ascii bytes"));
             }
-            bytes[i] = byte;
+            *out = byte;
         }
 
         Ok(unsafe { TinyAsciiStr::from_bytes_unchecked(bytes) })

--- a/experimental/tinystr_neo/src/serde.rs
+++ b/experimental/tinystr_neo/src/serde.rs
@@ -1,0 +1,91 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use crate::TinyAsciiStr;
+use alloc::borrow::Cow;
+use alloc::string::ToString;
+use core::fmt;
+use core::marker::PhantomData;
+use core::ops::Deref;
+use serde::de::{Error, SeqAccess, Visitor};
+use serde::ser::SerializeTuple;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+impl<const N: usize> Serialize for TinyAsciiStr<N> {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            self.deref().serialize(serializer)
+        } else {
+            let mut seq = serializer.serialize_tuple(N)?;
+            for byte in self.all_bytes() {
+                seq.serialize_element(byte)?;
+            }
+            seq.end()
+        }
+    }
+}
+
+struct TinyAsciiStrVisitor<const N: usize> {
+    marker: PhantomData<TinyAsciiStr<N>>,
+}
+
+impl<const N: usize> TinyAsciiStrVisitor<N> {
+    fn new() -> Self {
+        TinyAsciiStrVisitor {
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'de, const N: usize> Visitor<'de> for TinyAsciiStrVisitor<N> {
+    type Value = TinyAsciiStr<N>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "a TinyAsciiStr<{}>", N)
+    }
+
+    #[inline]
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut bytes = [0u8; N];
+        let mut zeroes = false;
+        for i in 0..N {
+            let byte = seq
+                .next_element()?
+                .ok_or_else(|| Error::invalid_length(N, &self))?;
+            if byte == 0 {
+                zeroes = true;
+            } else if zeroes {
+                return Err(Error::custom("TinyAsciiStr cannot contain null bytes"));
+            }
+
+            if byte >= 0x80 {
+                return Err(Error::custom("TinyAsciiStr cannot contain non-ascii bytes"));
+            }
+            bytes[i] = byte;
+        }
+
+        Ok(unsafe { TinyAsciiStr::from_bytes_unchecked(bytes) })
+    }
+}
+
+impl<'de, const N: usize> Deserialize<'de> for TinyAsciiStr<N> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            let x: Cow<'de, str> = Deserialize::deserialize(deserializer)?;
+            TinyAsciiStr::from_str(&x).map_err(|e| Error::custom(e.to_string()))
+        } else {
+            deserializer.deserialize_tuple(N, TinyAsciiStrVisitor::<N>::new())
+        }
+    }
+}

--- a/experimental/tinystr_neo/tests/serde.rs
+++ b/experimental/tinystr_neo/tests/serde.rs
@@ -21,8 +21,8 @@ macro_rules! test_roundtrip {
 
             let post = postcard::to_stdvec(&tiny).unwrap();
             assert_eq!(post, &tiny.all_bytes()[..]);
-            let debin: TinyAsciiStr<$n> = postcard::from_bytes(&post).unwrap();
-            assert_eq!(&*tiny, &*debin);
+            let unpost: TinyAsciiStr<$n> = postcard::from_bytes(&post).unwrap();
+            assert_eq!(&*tiny, &*unpost);
         }
     };
 }

--- a/experimental/tinystr_neo/tests/serde.rs
+++ b/experimental/tinystr_neo/tests/serde.rs
@@ -1,0 +1,58 @@
+use tinystr_neo::*;
+
+// Tests largely adapted from `tinystr` crate
+// https://github.com/zbraniecki/tinystr/blob/4e4eab55dd6bded7f29a18b41452c506c461716c/tests/serde.rs
+
+macro_rules! test_roundtrip {
+    ($f:ident, $n:literal, $val:expr, $bytes:expr) => {
+        #[test]
+        fn $f() {
+            let tiny: TinyAsciiStr<$n> = $val.parse().unwrap();
+            let json_string = serde_json::to_string(&tiny).unwrap();
+            let expected_json = concat!("\"", $val, "\"");
+            assert_eq!(json_string, expected_json);
+            let recover: TinyAsciiStr<$n> = serde_json::from_str(&json_string).unwrap();
+            assert_eq!(&*tiny, &*recover);
+
+            let bin = bincode::serialize(&tiny).unwrap();
+            assert_eq!(bin, &tiny.all_bytes()[..]);
+            let debin: TinyAsciiStr<$n> = bincode::deserialize(&bin).unwrap();
+            assert_eq!(&*tiny, &*debin);
+
+            let post = postcard::to_stdvec(&tiny).unwrap();
+            assert_eq!(post, &tiny.all_bytes()[..]);
+            let debin: TinyAsciiStr<$n> = postcard::from_bytes(&post).unwrap();
+            assert_eq!(&*tiny, &*debin);
+        }
+    };
+}
+
+test_roundtrip!(test_roundtrip4_1, 4, "en", [101, 110, 0, 0]);
+test_roundtrip!(test_roundtrip4_2, 4, "Latn", [76, 97, 116, 110]);
+test_roundtrip!(
+    test_roundtrip8,
+    8,
+    "calendar",
+    [99, 97, 108, 101, 110, 100, 97, 114]
+);
+test_roundtrip!(
+    test_roundtrip16,
+    16,
+    "verylongstring",
+    [118, 101, 114, 121, 108, 111, 110, 103, 115, 116, 114, 105, 110, 103, 0, 0]
+);
+test_roundtrip!(
+    test_roundtrip10,
+    11,
+    "shortstring",
+    [115, 104, 111, 114, 116, 115, 116, 114, 105, 110, 103]
+);
+test_roundtrip!(
+    test_roundtrip30,
+    24,
+    "veryveryverylongstring",
+    [
+        118, 101, 114, 121, 118, 101, 114, 121, 118, 101, 114, 121, 108, 111, 110, 103, 115, 116,
+        114, 105, 110, 103, 0, 0
+    ]
+);

--- a/experimental/tinystr_neo/tests/serde.rs
+++ b/experimental/tinystr_neo/tests/serde.rs
@@ -4,7 +4,7 @@ use tinystr_neo::*;
 // https://github.com/zbraniecki/tinystr/blob/4e4eab55dd6bded7f29a18b41452c506c461716c/tests/serde.rs
 
 macro_rules! test_roundtrip {
-    ($f:ident, $n:literal, $val:expr, $bytes:expr) => {
+    ($f:ident, $n:literal, $val:expr) => {
         #[test]
         fn $f() {
             let tiny: TinyAsciiStr<$n> = $val.parse().unwrap();
@@ -27,32 +27,25 @@ macro_rules! test_roundtrip {
     };
 }
 
-test_roundtrip!(test_roundtrip4_1, 4, "en", [101, 110, 0, 0]);
-test_roundtrip!(test_roundtrip4_2, 4, "Latn", [76, 97, 116, 110]);
+test_roundtrip!(test_roundtrip4_1, 4, "en");
+test_roundtrip!(test_roundtrip4_2, 4, "Latn");
 test_roundtrip!(
     test_roundtrip8,
     8,
-    "calendar",
-    [99, 97, 108, 101, 110, 100, 97, 114]
+    "calendar"
 );
 test_roundtrip!(
     test_roundtrip16,
     16,
-    "verylongstring",
-    [118, 101, 114, 121, 108, 111, 110, 103, 115, 116, 114, 105, 110, 103, 0, 0]
+    "verylongstring"
 );
 test_roundtrip!(
     test_roundtrip10,
     11,
-    "shortstring",
-    [115, 104, 111, 114, 116, 115, 116, 114, 105, 110, 103]
+    "shortstring"
 );
 test_roundtrip!(
     test_roundtrip30,
     24,
-    "veryveryverylongstring",
-    [
-        118, 101, 114, 121, 118, 101, 114, 121, 118, 101, 114, 121, 108, 111, 110, 103, 115, 116,
-        114, 105, 110, 103, 0, 0
-    ]
+    "veryveryverylongstring"
 );

--- a/experimental/tinystr_neo/tests/serde.rs
+++ b/experimental/tinystr_neo/tests/serde.rs
@@ -29,23 +29,7 @@ macro_rules! test_roundtrip {
 
 test_roundtrip!(test_roundtrip4_1, 4, "en");
 test_roundtrip!(test_roundtrip4_2, 4, "Latn");
-test_roundtrip!(
-    test_roundtrip8,
-    8,
-    "calendar"
-);
-test_roundtrip!(
-    test_roundtrip16,
-    16,
-    "verylongstring"
-);
-test_roundtrip!(
-    test_roundtrip10,
-    11,
-    "shortstring"
-);
-test_roundtrip!(
-    test_roundtrip30,
-    24,
-    "veryveryverylongstring"
-);
+test_roundtrip!(test_roundtrip8, 8, "calendar");
+test_roundtrip!(test_roundtrip16, 16, "verylongstring");
+test_roundtrip!(test_roundtrip10, 11, "shortstring");
+test_roundtrip!(test_roundtrip30, 24, "veryveryverylongstring");

--- a/experimental/tinystr_neo/tests/serde.rs
+++ b/experimental/tinystr_neo/tests/serde.rs
@@ -1,3 +1,7 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
 use tinystr_neo::*;
 
 // Tests largely adapted from `tinystr` crate


### PR DESCRIPTION
This is a clean attempt at `tinystr`, using `const fn` and fixed size arrays.

This should address https://github.com/zbraniecki/tinystr/issues/45 / https://github.com/unicode-org/icu4x/issues/881

The general idea is, instead of encoding strings as digits, we encode them as byte arrays. This has many advantages:

 - No mucking about with endianness
 - We can support things like `TinyAsciiStr<5>` or `TinyAsciiStr<100>`, no restrictions on N
 - ULE gets cleaner


A potential downside is that these are less aligned (we can write TinyStr4/etc wrappers that are better aligned), and `.deref()`/`deserialize()` may not be as efficient (we might need to benchmark this).


This is still kinda WIP, but I'm not sure how much time I'll have to work on this so I'm landing what I have so far so that others can help out. In particular I'd love help with tests, benches, and docs.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->