### PR TITLE
Revert to Rust 1.57

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-# Version updated on 2022-01-14
-channel = "1.58"
+# Version updated on 2022-01-18
+channel = "1.57"


### PR DESCRIPTION
I am getting ICEs related to https://github.com/rust-lang/rust/issues/92163 when I build on 1.58, so I am reverting to 1.57, which has const panics but not the ICEs.