### PR TITLE
Improve the segmenter document

### DIFF
--- a/experimental/segmenter/README.md
+++ b/experimental/segmenter/README.md
@@ -63,8 +63,8 @@ Segment a string:
 ```rust
 use icu_segmenter::GraphemeClusterBreakIterator;
 
-let breakpoints: Vec<usize> = GraphemeClusterBreakIterator::new("Hello World").collect();
-assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+let breakpoints: Vec<usize> = GraphemeClusterBreakIterator::new("Hello 🗺").collect();
+assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 10]); // World Map (U+1F5FA) is encoded in four bytes in UTF-8.
 ```
 
 Segment a Latin1 byte string:

--- a/experimental/segmenter/README.md
+++ b/experimental/segmenter/README.md
@@ -3,7 +3,8 @@
 A segmenter implementation for the following rules.
 
 - Line breaker that is compatible with [Unicode Standard Annex #14][UAX14] and CSS properties.
-- Word breaker that is compatible with [Unicode Standard Annex #29][UAX29].
+- Grapheme cluster breaker, word breaker, and sentence breaker that are compatible with
+  [Unicode Standard Annex #29][UAX29].
 
 [UAX14]: https://www.unicode.org/reports/tr14/
 [UAX29]: https://www.unicode.org/reports/tr29/
@@ -55,16 +56,35 @@ let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect()
 assert_eq!(&breakpoints, &[6, 11]);
 ```
 
+### Grapheme Cluster Break
+
+Segment a string:
+
+```rust
+use icu_segmenter::GraphemeClusterBreakIterator;
+
+let breakpoints: Vec<usize> = GraphemeClusterBreakIterator::new("Hello World").collect();
+assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+```
+
+Segment a Latin1 byte string:
+
+```rust
+use icu_segmenter::GraphemeClusterBreakIteratorLatin1;
+
+let breakpoints: Vec<usize> = GraphemeClusterBreakIteratorLatin1::new(b"Hello World").collect();
+assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+```
+
 ### Word Break
 
-Segment a string with default options:
+Segment a string:
 
 ```rust
 use icu_segmenter::WordBreakIterator;
 
-let mut iter = WordBreakIterator::new("Hello World");
-let result: Vec<usize> = iter.collect();
-println!("{:?}", result);
+let breakpoints: Vec<usize> = WordBreakIterator::new("Hello World").collect();
+assert_eq!(&breakpoints, &[0, 5, 6, 11]);
 ```
 
 Segment a Latin1 byte string:
@@ -72,29 +92,28 @@ Segment a Latin1 byte string:
 ```rust
 use icu_segmenter::WordBreakIteratorLatin1;
 
-let s = "Hello World";
-let iter = WordBreakIteratorLatin1::new(s.as_bytes());
-let result: Vec<usize> = iter.collect();
-println!("{:?}", result);
+let breakpoints: Vec<usize> = WordBreakIteratorLatin1::new(b"Hello World").collect();
+assert_eq!(&breakpoints, &[0, 5, 6, 11]);
 ```
 
 ### Sentence Break
 
+Segment a string:
+
 ```rust
 use icu_segmenter::SentenceBreakIterator;
 
-let mut iter = SentenceBreakIterator::new("Hello World");
-let result: Vec<usize> = iter.collect();
-println!("{:?}", result);
+let breakpoints: Vec<usize> = SentenceBreakIterator::new("Hello World").collect();
+assert_eq!(&breakpoints, &[0, 11]);
 ```
 
 Segment a Latin1 byte string:
 
 ```rust
 use icu_segmenter::SentenceBreakIteratorLatin1;
-let iter = SentenceBreakIteratorLatin1::new(b"Hello World");
-let result: Vec<usize> = iter.collect();
-assert_eq!(&result, &[0, 11]);
+
+let breakpoints: Vec<usize> = SentenceBreakIteratorLatin1::new(b"Hello World").collect();
+assert_eq!(&breakpoints, &[0, 11]);
 ```
 
 ## Generating property table

--- a/experimental/segmenter/src/grapheme.rs
+++ b/experimental/segmenter/src/grapheme.rs
@@ -12,9 +12,9 @@ use crate::rule_segmenter::*;
 include!(concat!(env!("OUT_DIR"), "/generated_grapheme_table.rs"));
 
 // UTF-8 version of grapheme break iterator using rule based segmenter.
-break_iterator_impl!(GraphemeBreakIterator, CharIndices<'a>, char);
+break_iterator_impl!(GraphemeClusterBreakIterator, CharIndices<'a>, char);
 
-impl<'a> GraphemeBreakIterator<'a> {
+impl<'a> GraphemeClusterBreakIterator<'a> {
     /// Create grapheme break iterator
     pub fn new(input: &'a str) -> Self {
         Self {
@@ -46,9 +46,9 @@ impl<'a> GraphemeBreakIterator<'a> {
 }
 
 // Latin-1 version of grapheme break iterator using rule based segmenter.
-break_iterator_impl!(GraphemeBreakIteratorLatin1, Latin1Indices<'a>, u8);
+break_iterator_impl!(GraphemeClusterBreakIteratorLatin1, Latin1Indices<'a>, u8);
 
-impl<'a> GraphemeBreakIteratorLatin1<'a> {
+impl<'a> GraphemeClusterBreakIteratorLatin1<'a> {
     /// Create grapheme break iterator using Latin-1/8-bit string.
     pub fn new(input: &'a [u8]) -> Self {
         Self {
@@ -81,9 +81,9 @@ impl<'a> GraphemeBreakIteratorLatin1<'a> {
 }
 
 // UTF-16 version of grapheme break iterator using rule based segmenter.
-break_iterator_impl!(GraphemeBreakIteratorUtf16, Utf16Indices<'a>, u32);
+break_iterator_impl!(GraphemeClusterBreakIteratorUtf16, Utf16Indices<'a>, u32);
 
-impl<'a> GraphemeBreakIteratorUtf16<'a> {
+impl<'a> GraphemeClusterBreakIteratorUtf16<'a> {
     /// Create grapheme break iterator using UTF-16 string.
     pub fn new(input: &'a [u16]) -> Self {
         Self {

--- a/experimental/segmenter/src/lib.rs
+++ b/experimental/segmenter/src/lib.rs
@@ -150,7 +150,8 @@ mod lstm {
 }
 
 pub use crate::grapheme::{
-    GraphemeBreakIterator, GraphemeBreakIteratorLatin1, GraphemeBreakIteratorUtf16,
+    GraphemeClusterBreakIterator, GraphemeClusterBreakIteratorLatin1,
+    GraphemeClusterBreakIteratorUtf16,
 };
 pub use crate::line_breaker::*;
 pub use crate::sentence::{

--- a/experimental/segmenter/src/lib.rs
+++ b/experimental/segmenter/src/lib.rs
@@ -68,8 +68,8 @@
 //!```rust
 //! use icu_segmenter::GraphemeClusterBreakIterator;
 //!
-//! let breakpoints: Vec<usize> = GraphemeClusterBreakIterator::new("Hello World").collect();
-//! assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+//! let breakpoints: Vec<usize> = GraphemeClusterBreakIterator::new("Hello 🗺").collect();
+//! assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 10]); // World Map (U+1F5FA) is encoded in four bytes in UTF-8.
 //! ```
 //!
 //! Segment a Latin1 byte string:

--- a/experimental/segmenter/src/lib.rs
+++ b/experimental/segmenter/src/lib.rs
@@ -8,7 +8,8 @@
 //! A segmenter implementation for the following rules.
 //!
 //! - Line breaker that is compatible with [Unicode Standard Annex #14][UAX14] and CSS properties.
-//! - Word breaker that is compatible with [Unicode Standard Annex #29][UAX29].
+//! - Grapheme cluster breaker, word breaker, and sentence breaker that are compatible with
+//!   [Unicode Standard Annex #29][UAX29].
 //!
 //! [UAX14]: https://www.unicode.org/reports/tr14/
 //! [UAX29]: https://www.unicode.org/reports/tr29/
@@ -60,16 +61,35 @@
 //! assert_eq!(&breakpoints, &[6, 11]);
 //! ```
 //!
+//! ## Grapheme Cluster Break
+//!
+//! Segment a string:
+//!
+//!```rust
+//! use icu_segmenter::GraphemeClusterBreakIterator;
+//!
+//! let breakpoints: Vec<usize> = GraphemeClusterBreakIterator::new("Hello World").collect();
+//! assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+//! ```
+//!
+//! Segment a Latin1 byte string:
+//!
+//! ```rust
+//! use icu_segmenter::GraphemeClusterBreakIteratorLatin1;
+//!
+//! let breakpoints: Vec<usize> = GraphemeClusterBreakIteratorLatin1::new(b"Hello World").collect();
+//! assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+//! ```
+//!
 //! ## Word Break
 //!
-//! Segment a string with default options:
+//! Segment a string:
 //!
 //!```rust
 //! use icu_segmenter::WordBreakIterator;
 //!
-//! let mut iter = WordBreakIterator::new("Hello World");
-//! let result: Vec<usize> = iter.collect();
-//! println!("{:?}", result);
+//! let breakpoints: Vec<usize> = WordBreakIterator::new("Hello World").collect();
+//! assert_eq!(&breakpoints, &[0, 5, 6, 11]);
 //! ```
 //!
 //! Segment a Latin1 byte string:
@@ -77,29 +97,28 @@
 //! ```rust
 //! use icu_segmenter::WordBreakIteratorLatin1;
 //!
-//! let s = "Hello World";
-//! let iter = WordBreakIteratorLatin1::new(s.as_bytes());
-//! let result: Vec<usize> = iter.collect();
-//! println!("{:?}", result);
+//! let breakpoints: Vec<usize> = WordBreakIteratorLatin1::new(b"Hello World").collect();
+//! assert_eq!(&breakpoints, &[0, 5, 6, 11]);
 //! ```
 //!
 //! ## Sentence Break
 //!
+//! Segment a string:
+//!
 //!```rust
 //! use icu_segmenter::SentenceBreakIterator;
 //!
-//! let mut iter = SentenceBreakIterator::new("Hello World");
-//! let result: Vec<usize> = iter.collect();
-//! println!("{:?}", result);
+//! let breakpoints: Vec<usize> = SentenceBreakIterator::new("Hello World").collect();
+//! assert_eq!(&breakpoints, &[0, 11]);
 //! ```
 //!
 //! Segment a Latin1 byte string:
 //!
 //! ```rust
 //! use icu_segmenter::SentenceBreakIteratorLatin1;
-//! let iter = SentenceBreakIteratorLatin1::new(b"Hello World");
-//! let result: Vec<usize> = iter.collect();
-//! assert_eq!(&result, &[0, 11]);
+//!
+//! let breakpoints: Vec<usize> = SentenceBreakIteratorLatin1::new(b"Hello World").collect();
+//! assert_eq!(&breakpoints, &[0, 11]);
 //! ```
 //!
 //! # Generating property table

--- a/experimental/segmenter/tests/spec_test.rs
+++ b/experimental/segmenter/tests/spec_test.rs
@@ -2,9 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_segmenter::GraphemeBreakIterator;
-use icu_segmenter::GraphemeBreakIteratorLatin1;
-use icu_segmenter::GraphemeBreakIteratorUtf16;
+use icu_segmenter::GraphemeClusterBreakIterator;
+use icu_segmenter::GraphemeClusterBreakIteratorLatin1;
+use icu_segmenter::GraphemeClusterBreakIteratorUtf16;
 use icu_segmenter::LineBreakSegmenter;
 use icu_segmenter::SentenceBreakIterator;
 use icu_segmenter::SentenceBreakIteratorLatin1;
@@ -176,11 +176,11 @@ fn run_grapheme_break_test() {
     let test_iter = TestContentIterator::new("./tests/testdata/GraphemeBreakTest.txt");
     for test in test_iter {
         let s: String = test.utf8_vec.into_iter().collect();
-        let iter = GraphemeBreakIterator::new(&s);
+        let iter = GraphemeClusterBreakIterator::new(&s);
         let result: Vec<usize> = iter.collect();
         assert_eq!(result, test.break_result_utf8, "{}", test.original_line);
 
-        let iter = GraphemeBreakIteratorUtf16::new(&test.utf16_vec);
+        let iter = GraphemeClusterBreakIteratorUtf16::new(&test.utf16_vec);
         let result: Vec<usize> = iter.collect();
         assert_eq!(
             result, test.break_result_utf16,
@@ -190,7 +190,7 @@ fn run_grapheme_break_test() {
 
         // Test data is Latin-1 character only, it can run for Latin-1 segmenter test.
         if let Some(break_result_latin1) = test.break_result_latin1 {
-            let iter = GraphemeBreakIteratorLatin1::new(&test.latin1_vec);
+            let iter = GraphemeClusterBreakIteratorLatin1::new(&test.latin1_vec);
             let result: Vec<usize> = iter.collect();
             assert_eq!(
                 result, break_result_latin1,


### PR DESCRIPTION
This PR renames `GraphemeBreakIterator` to `GraphemeClusterBreakIterator` to match the term used in the spec, and adds the missing crate level doc for grapheme cluster breaker.