### PR TITLE
Add benches to tinystr-neo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2660,10 +2660,12 @@ name = "tinystr-neo"
 version = "0.3.1"
 dependencies = [
  "bincode",
+ "criterion",
  "displaydoc",
  "postcard",
  "serde",
  "serde_json",
+ "tinystr",
  "zerovec",
 ]
 

--- a/experimental/tinystr_neo/Cargo.toml
+++ b/experimental/tinystr_neo/Cargo.toml
@@ -33,6 +33,7 @@ zerovec = { version = "0.5.0", path = "../../utils/zerovec", optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 bincode = "1.3"
 postcard = { version = "0.7", features = ["use-std"] }
+tinystr_old = { version = "0.4", package = "tinystr" }
 
 [[test]]
 name = "serde"

--- a/experimental/tinystr_neo/Cargo.toml
+++ b/experimental/tinystr_neo/Cargo.toml
@@ -34,7 +34,12 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 bincode = "1.3"
 postcard = { version = "0.7", features = ["use-std"] }
 tinystr_old = { version = "0.4", package = "tinystr" }
+criterion = "0.3"
 
 [[test]]
 name = "serde"
 required-features = ["serde"]
+
+[[bench]]
+name = "construct"
+harness = false

--- a/experimental/tinystr_neo/Cargo.toml
+++ b/experimental/tinystr_neo/Cargo.toml
@@ -43,3 +43,7 @@ required-features = ["serde"]
 [[bench]]
 name = "construct"
 harness = false
+
+[[bench]]
+name = "read"
+harness = false

--- a/experimental/tinystr_neo/Cargo.toml
+++ b/experimental/tinystr_neo/Cargo.toml
@@ -33,7 +33,7 @@ zerovec = { version = "0.5.0", path = "../../utils/zerovec", optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 bincode = "1.3"
 postcard = { version = "0.7", features = ["use-std"] }
-tinystr_old = { version = "0.4", package = "tinystr" }
+tinystr_old = { version = "0.4", package = "tinystr", features = ["serde"] }
 criterion = "0.3"
 
 [[test]]
@@ -47,3 +47,8 @@ harness = false
 [[bench]]
 name = "read"
 harness = false
+
+[[bench]]
+name = "serde"
+harness = false
+required-features = ["serde"]

--- a/experimental/tinystr_neo/benches/common/mod.rs
+++ b/experimental/tinystr_neo/benches/common/mod.rs
@@ -1,0 +1,79 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+// This file was adapted from parts of https://github.com/zbraniecki/tinystr
+
+pub static STRINGS_4: &[&str] = &[
+    "US", "GB", "AR", "Hans", "CN", "AT", "PL", "FR", "AT", "Cyrl", "SR", "NO", "FR", "MK", "UK",
+];
+
+pub static STRINGS_8: &[&str] = &[
+    "Latn", "windows", "AR", "Hans", "macos", "AT", "pl", "FR", "en", "Cyrl", "SR", "NO", "419",
+    "und", "UK",
+];
+
+pub static STRINGS_16: &[&str] = &[
+    "Latn",
+    "windows",
+    "AR",
+    "Hans",
+    "macos",
+    "AT",
+    "infiniband",
+    "FR",
+    "en",
+    "Cyrl",
+    "FromIntegral",
+    "NO",
+    "419",
+    "MacintoshOSX2019",
+    "UK",
+];
+
+#[macro_export]
+macro_rules! bench_block {
+    ($c:expr, $name:expr, $action:ident) => {
+        let mut group4 = $c.benchmark_group(&format!("{}/4", $name));
+        group4.bench_function("String", $action!(String, STRINGS_4));
+        group4.bench_function("TinyAsciiStr<4>", $action!(TinyAsciiStr<4>, STRINGS_4));
+        group4.bench_function(
+            "tinystr_old::TinyStr4",
+            $action!(tinystr_old::TinyStr4, STRINGS_4),
+        );
+        group4.bench_function("TinyAsciiStr<8>", $action!(TinyAsciiStr<8>, STRINGS_4));
+        group4.bench_function(
+            "tinystr_old::TinyStr8",
+            $action!(tinystr_old::TinyStr8, STRINGS_4),
+        );
+        group4.bench_function("TinyAsciiStr<16>", $action!(TinyAsciiStr<16>, STRINGS_4));
+        group4.bench_function(
+            "tinystr_old::TinyStr16",
+            $action!(tinystr_old::TinyStr16, STRINGS_4),
+        );
+        group4.finish();
+
+        let mut group8 = $c.benchmark_group(&format!("{}/8", $name));
+        group8.bench_function("String", $action!(String, STRINGS_8));
+        group8.bench_function("TinyAsciiStr<8>", $action!(TinyAsciiStr<8>, STRINGS_8));
+        group8.bench_function("TinyAsciiStr<16>", $action!(TinyAsciiStr<16>, STRINGS_8));
+        group8.bench_function(
+            "tinystr_old::TinyStr8",
+            $action!(tinystr_old::TinyStr8, STRINGS_8),
+        );
+        group8.bench_function(
+            "tinystr_old::TinyStr16",
+            $action!(tinystr_old::TinyStr16, STRINGS_8),
+        );
+        group8.finish();
+
+        let mut group16 = $c.benchmark_group(&format!("{}/16", $name));
+        group16.bench_function("String", $action!(String, STRINGS_16));
+        group16.bench_function("TinyAsciiStr<16>", $action!(TinyAsciiStr<16>, STRINGS_16));
+        group16.bench_function(
+            "tinystr_old::TinyStr16",
+            $action!(tinystr_old::TinyStr16, STRINGS_16),
+        );
+        group16.finish();
+    };
+}

--- a/experimental/tinystr_neo/benches/construct.rs
+++ b/experimental/tinystr_neo/benches/construct.rs
@@ -4,6 +4,9 @@
 
 // This file was adapted from https://github.com/zbraniecki/tinystr
 
+mod common;
+use common::*;
+
 use criterion::black_box;
 use criterion::criterion_group;
 use criterion::criterion_main;
@@ -11,61 +14,6 @@ use criterion::Bencher;
 use criterion::Criterion;
 
 use tinystr_neo::TinyAsciiStr;
-
-static STRINGS_4: &[&str] = &[
-    "US", "GB", "AR", "Hans", "CN", "AT", "PL", "FR", "AT", "Cyrl", "SR", "NO", "FR", "MK", "UK",
-];
-
-static STRINGS_8: &[&str] = &[
-    "Latn", "windows", "AR", "Hans", "macos", "AT", "pl", "FR", "en", "Cyrl", "SR", "NO", "419",
-    "und", "UK",
-];
-
-static STRINGS_16: &[&str] = &[
-    "Latn",
-    "windows",
-    "AR",
-    "Hans",
-    "macos",
-    "AT",
-    "infiniband",
-    "FR",
-    "en",
-    "Cyrl",
-    "FromIntegral",
-    "NO",
-    "419",
-    "MacintoshOSX2019",
-    "UK",
-];
-
-macro_rules! bench_block {
-    ($c:expr, $name:expr, $action:ident) => {
-        let mut group4 = $c.benchmark_group(&format!("{}/4", $name));
-        group4.bench_function("String", $action!(String, STRINGS_4));
-        group4.bench_function("TinyAsciiStr<4>", $action!(TinyAsciiStr<4>, STRINGS_4));
-        group4.bench_function("tinystr_old::TinyStr4", $action!(tinystr_old::TinyStr4, STRINGS_4));
-        group4.bench_function("TinyAsciiStr<8>", $action!(TinyAsciiStr<8>, STRINGS_4));
-        group4.bench_function("tinystr_old::TinyStr8", $action!(tinystr_old::TinyStr8, STRINGS_4));
-        group4.bench_function("TinyAsciiStr<16>", $action!(TinyAsciiStr<16>, STRINGS_4));
-        group4.bench_function("tinystr_old::TinyStr16", $action!(tinystr_old::TinyStr16, STRINGS_4));
-        group4.finish();
-
-        let mut group8 = $c.benchmark_group(&format!("{}/8", $name));
-        group8.bench_function("String", $action!(String, STRINGS_8));
-        group8.bench_function("TinyAsciiStr<8>", $action!(TinyAsciiStr<8>, STRINGS_8));
-        group8.bench_function("TinyAsciiStr<16>", $action!(TinyAsciiStr<16>, STRINGS_8));
-        group8.bench_function("tinystr_old::TinyStr8", $action!(tinystr_old::TinyStr8, STRINGS_8));
-        group8.bench_function("tinystr_old::TinyStr16", $action!(tinystr_old::TinyStr16, STRINGS_8));
-        group8.finish();
-
-        let mut group16 = $c.benchmark_group(&format!("{}/16", $name));
-        group16.bench_function("String", $action!(String, STRINGS_16));
-        group16.bench_function("TinyAsciiStr<16>", $action!(TinyAsciiStr<16>, STRINGS_16));
-        group16.bench_function("tinystr_old::TinyStr16", $action!(tinystr_old::TinyStr16, STRINGS_16));
-        group16.finish();
-    };
-}
 
 fn construct_from_str(c: &mut Criterion) {
     macro_rules! cfs {
@@ -99,29 +47,43 @@ fn construct_from_bytes(c: &mut Criterion) {
 
     let mut group4 = c.benchmark_group("construct_from_bytes/4");
     group4.bench_function("TinyAsciiStr<4>", cfu!(TinyAsciiStr<4>, STRINGS_4));
-    group4.bench_function("tinystr_old::TinyStr4", cfu!(tinystr_old::TinyStr4, STRINGS_4));
+    group4.bench_function(
+        "tinystr_old::TinyStr4",
+        cfu!(tinystr_old::TinyStr4, STRINGS_4),
+    );
     group4.bench_function("TinyAsciiStr<8>", cfu!(TinyAsciiStr<8>, STRINGS_4));
-    group4.bench_function("tinystr_old::TinyStr8", cfu!(tinystr_old::TinyStr8, STRINGS_4));
+    group4.bench_function(
+        "tinystr_old::TinyStr8",
+        cfu!(tinystr_old::TinyStr8, STRINGS_4),
+    );
     group4.bench_function("TinyAsciiStr<16>", cfu!(TinyAsciiStr<16>, STRINGS_4));
-    group4.bench_function("tinystr_old::TinyStr16", cfu!(tinystr_old::TinyStr16, STRINGS_4));
+    group4.bench_function(
+        "tinystr_old::TinyStr16",
+        cfu!(tinystr_old::TinyStr16, STRINGS_4),
+    );
     group4.finish();
 
     let mut group8 = c.benchmark_group("construct_from_bytes/8");
     group8.bench_function("TinyAsciiStr<8>", cfu!(TinyAsciiStr<8>, STRINGS_8));
-    group8.bench_function("tinystr_old::TinyStr8", cfu!(tinystr_old::TinyStr8, STRINGS_8));
+    group8.bench_function(
+        "tinystr_old::TinyStr8",
+        cfu!(tinystr_old::TinyStr8, STRINGS_8),
+    );
     group8.bench_function("TinyAsciiStr<16>", cfu!(TinyAsciiStr<16>, STRINGS_8));
-    group8.bench_function("tinystr_old::TinyStr16", cfu!(tinystr_old::TinyStr16, STRINGS_8));
+    group8.bench_function(
+        "tinystr_old::TinyStr16",
+        cfu!(tinystr_old::TinyStr16, STRINGS_8),
+    );
     group8.finish();
 
     let mut group16 = c.benchmark_group("construct_from_bytes/16");
     group16.bench_function("TinyAsciiStr<16>", cfu!(TinyAsciiStr<16>, STRINGS_16));
-    group16.bench_function("tinystr_old::TinyStr16", cfu!(tinystr_old::TinyStr16, STRINGS_16));
+    group16.bench_function(
+        "tinystr_old::TinyStr16",
+        cfu!(tinystr_old::TinyStr16, STRINGS_16),
+    );
     group16.finish();
 }
 
-criterion_group!(
-    benches,
-    construct_from_str,
-    construct_from_bytes,
-);
+criterion_group!(benches, construct_from_str, construct_from_bytes,);
 criterion_main!(benches);

--- a/experimental/tinystr_neo/benches/construct.rs
+++ b/experimental/tinystr_neo/benches/construct.rs
@@ -1,0 +1,127 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+// This file was adapted from https://github.com/zbraniecki/tinystr
+
+use criterion::black_box;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Bencher;
+use criterion::Criterion;
+
+use tinystr_neo::TinyAsciiStr;
+
+static STRINGS_4: &[&str] = &[
+    "US", "GB", "AR", "Hans", "CN", "AT", "PL", "FR", "AT", "Cyrl", "SR", "NO", "FR", "MK", "UK",
+];
+
+static STRINGS_8: &[&str] = &[
+    "Latn", "windows", "AR", "Hans", "macos", "AT", "pl", "FR", "en", "Cyrl", "SR", "NO", "419",
+    "und", "UK",
+];
+
+static STRINGS_16: &[&str] = &[
+    "Latn",
+    "windows",
+    "AR",
+    "Hans",
+    "macos",
+    "AT",
+    "infiniband",
+    "FR",
+    "en",
+    "Cyrl",
+    "FromIntegral",
+    "NO",
+    "419",
+    "MacintoshOSX2019",
+    "UK",
+];
+
+macro_rules! bench_block {
+    ($c:expr, $name:expr, $action:ident) => {
+        let mut group4 = $c.benchmark_group(&format!("{}/4", $name));
+        group4.bench_function("String", $action!(String, STRINGS_4));
+        group4.bench_function("TinyAsciiStr<4>", $action!(TinyAsciiStr<4>, STRINGS_4));
+        group4.bench_function("tinystr_old::TinyStr4", $action!(tinystr_old::TinyStr4, STRINGS_4));
+        group4.bench_function("TinyAsciiStr<8>", $action!(TinyAsciiStr<8>, STRINGS_4));
+        group4.bench_function("tinystr_old::TinyStr8", $action!(tinystr_old::TinyStr8, STRINGS_4));
+        group4.bench_function("TinyAsciiStr<16>", $action!(TinyAsciiStr<16>, STRINGS_4));
+        group4.bench_function("tinystr_old::TinyStr16", $action!(tinystr_old::TinyStr16, STRINGS_4));
+        group4.finish();
+
+        let mut group8 = $c.benchmark_group(&format!("{}/8", $name));
+        group8.bench_function("String", $action!(String, STRINGS_8));
+        group8.bench_function("TinyAsciiStr<8>", $action!(TinyAsciiStr<8>, STRINGS_8));
+        group8.bench_function("TinyAsciiStr<16>", $action!(TinyAsciiStr<16>, STRINGS_8));
+        group8.bench_function("tinystr_old::TinyStr8", $action!(tinystr_old::TinyStr8, STRINGS_8));
+        group8.bench_function("tinystr_old::TinyStr16", $action!(tinystr_old::TinyStr16, STRINGS_8));
+        group8.finish();
+
+        let mut group16 = $c.benchmark_group(&format!("{}/16", $name));
+        group16.bench_function("String", $action!(String, STRINGS_16));
+        group16.bench_function("TinyAsciiStr<16>", $action!(TinyAsciiStr<16>, STRINGS_16));
+        group16.bench_function("tinystr_old::TinyStr16", $action!(tinystr_old::TinyStr16, STRINGS_16));
+        group16.finish();
+    };
+}
+
+fn construct_from_str(c: &mut Criterion) {
+    macro_rules! cfs {
+        ($r:ty, $inputs:expr) => {
+            |b: &mut Bencher| {
+                b.iter(|| {
+                    for s in $inputs {
+                        let _: $r = black_box(s.parse().unwrap());
+                    }
+                })
+            }
+        };
+    }
+
+    bench_block!(c, "construct_from_str", cfs);
+}
+
+fn construct_from_bytes(c: &mut Criterion) {
+    macro_rules! cfu {
+        ($r:ty, $inputs:expr) => {
+            |b| {
+                let raw: Vec<&[u8]> = $inputs.iter().map(|s| s.as_bytes()).collect();
+                b.iter(move || {
+                    for u in &raw {
+                        let _ = black_box(<$r>::from_bytes(*u).unwrap());
+                    }
+                })
+            }
+        };
+    }
+
+    let mut group4 = c.benchmark_group("construct_from_bytes/4");
+    group4.bench_function("TinyAsciiStr<4>", cfu!(TinyAsciiStr<4>, STRINGS_4));
+    group4.bench_function("tinystr_old::TinyStr4", cfu!(tinystr_old::TinyStr4, STRINGS_4));
+    group4.bench_function("TinyAsciiStr<8>", cfu!(TinyAsciiStr<8>, STRINGS_4));
+    group4.bench_function("tinystr_old::TinyStr8", cfu!(tinystr_old::TinyStr8, STRINGS_4));
+    group4.bench_function("TinyAsciiStr<16>", cfu!(TinyAsciiStr<16>, STRINGS_4));
+    group4.bench_function("tinystr_old::TinyStr16", cfu!(tinystr_old::TinyStr16, STRINGS_4));
+    group4.finish();
+
+    let mut group8 = c.benchmark_group("construct_from_bytes/8");
+    group8.bench_function("TinyAsciiStr<8>", cfu!(TinyAsciiStr<8>, STRINGS_8));
+    group8.bench_function("tinystr_old::TinyStr8", cfu!(tinystr_old::TinyStr8, STRINGS_8));
+    group8.bench_function("TinyAsciiStr<16>", cfu!(TinyAsciiStr<16>, STRINGS_8));
+    group8.bench_function("tinystr_old::TinyStr16", cfu!(tinystr_old::TinyStr16, STRINGS_8));
+    group8.finish();
+
+    let mut group16 = c.benchmark_group("construct_from_bytes/16");
+    group16.bench_function("TinyAsciiStr<16>", cfu!(TinyAsciiStr<16>, STRINGS_16));
+    group16.bench_function("tinystr_old::TinyStr16", cfu!(tinystr_old::TinyStr16, STRINGS_16));
+    group16.finish();
+}
+
+criterion_group!(
+    benches,
+    construct_from_str,
+    construct_from_bytes,
+);
+criterion_main!(benches);

--- a/experimental/tinystr_neo/benches/read.rs
+++ b/experimental/tinystr_neo/benches/read.rs
@@ -1,0 +1,34 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+mod common;
+use common::*;
+
+use criterion::black_box;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Bencher;
+use criterion::Criterion;
+
+use tinystr_neo::TinyAsciiStr;
+
+fn read(c: &mut Criterion) {
+    macro_rules! cfs {
+        ($r:ty, $inputs:expr) => {
+            |b: &mut Bencher| {
+                let parsed: Vec<$r> = $inputs.iter().map(|s| s.parse().unwrap()).collect();
+                b.iter(|| {
+                    for s in &parsed {
+                        let _: &str = black_box(&**s);
+                    }
+                })
+            }
+        };
+    }
+
+    bench_block!(c, "read", cfs);
+}
+
+criterion_group!(benches, read,);
+criterion_main!(benches);

--- a/experimental/tinystr_neo/benches/serde.rs
+++ b/experimental/tinystr_neo/benches/serde.rs
@@ -1,0 +1,37 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+mod common;
+use common::*;
+
+use criterion::black_box;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Bencher;
+use criterion::Criterion;
+
+use tinystr_neo::TinyAsciiStr;
+
+fn deserialize(c: &mut Criterion) {
+    macro_rules! cfs {
+        ($r:ty, $inputs:expr) => {
+            |b: &mut Bencher| {
+                let serialized: Vec<Vec<u8>> = $inputs
+                    .iter()
+                    .map(|s| postcard::to_stdvec(&s.parse::<$r>().unwrap()).unwrap())
+                    .collect();
+                b.iter(|| {
+                    for bytes in &serialized {
+                        let _: Result<$r, _> = black_box(postcard::from_bytes(bytes));
+                    }
+                })
+            }
+        };
+    }
+
+    bench_block!(c, "deserialize", cfs);
+}
+
+criterion_group!(benches, deserialize,);
+criterion_main!(benches);


### PR DESCRIPTION
Cargo does support having the same crate as a dev-dep, so for now I think we should just do that. We can remove the old benches later if we'd like.

I'll post numbers later, overall they don't seem too bad. We're at most 2x slower on these operations, but these operations are overall very very fast (nanosecond scale) so it doesn't matter that much.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->