### PR TITLE
ListFormatter on `Iterator<W>` instead of `&[W]`

### DIFF
--- a/experimental/list_formatter/examples/and_list.rs
+++ b/experimental/list_formatter/examples/and_list.rs
@@ -25,7 +25,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
     println!(
         "{}",
         list_formatter
-            .format(["España", "Francia", "Suiza", "Italia"].iter())
+            .format(["España", "Francia", "Suiza", "Italia"])
             .writeable_to_string()
     );
 

--- a/experimental/list_formatter/examples/and_list.rs
+++ b/experimental/list_formatter/examples/and_list.rs
@@ -25,7 +25,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
     println!(
         "{}",
         list_formatter
-            .format::<&str, _, _>(&["España", "Francia", "Suiza", "Italia"])
+            .format(["España", "Francia", "Suiza", "Italia"].iter())
             .writeable_to_string()
     );
 

--- a/experimental/list_formatter/examples/and_list.rs
+++ b/experimental/list_formatter/examples/and_list.rs
@@ -25,7 +25,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
     println!(
         "{}",
         list_formatter
-            .format(&["España", "Francia", "Suiza", "Italia"])
+            .format::<&str, _, _>(&["España", "Francia", "Suiza", "Italia"])
             .writeable_to_string()
     );
 

--- a/experimental/list_formatter/examples/and_list.rs
+++ b/experimental/list_formatter/examples/and_list.rs
@@ -25,7 +25,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
     println!(
         "{}",
         list_formatter
-            .format(["España", "Francia", "Suiza", "Italia"])
+            .format(["España", "Francia", "Suiza", "Italia"].iter())
             .writeable_to_string()
     );
 

--- a/experimental/list_formatter/src/list_formatter.rs
+++ b/experimental/list_formatter/src/list_formatter.rs
@@ -43,8 +43,8 @@ impl ListFormatter {
     /// Returns a `Writeable` composed of the input `Writeable`s and the language-dependent
     /// formatting. The first layer of fields contains `ListFormatter::element()` for input
     /// elements, and `ListFormatter::literal()` for list literals.
-    pub fn format<'a, 'b: 'a, 'c: 'a, W: Writeable + 'b, I: IntoIterator<Item = W>>(
-        &'c self,
+    pub fn format<'a, W: Writeable + 'a, I: IntoIterator<Item = W>>(
+        &'a self,
         values: I,
     ) -> List<'a, W, I::IntoIter>
     where


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->