### PR TITLE
Fix all doc warnings and update CI to not allow any

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -50,6 +50,7 @@ jobs:
     env:
       GCP_PROJECT_ID: "dev-infra-273822"
       GCP_BUCKET_ID: "icu4x-pr-artifacts"
+      RUSTDOCFLAGS: "-Dwarnings"
     steps:
     - uses: actions/checkout@v2
     - name: Load the default Rust toolchain via the rust-toolchain file.
@@ -63,8 +64,6 @@ jobs:
     - name: Build docs
       uses: actions-rs/cargo@v1
       with:
-        env:
-          RUSTDOCFLAGS: "-Dwarnings"
         command: doc
         args: --workspace --release --all-features --no-deps
     - name: Upload docs to Google Cloud Storage

--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -63,6 +63,8 @@ jobs:
     - name: Build docs
       uses: actions-rs/cargo@v1
       with:
+        env:
+          RUSTDOCFLAGS: "-Dwarnings"
         command: doc
         args: --workspace --release --all-features --no-deps
     - name: Upload docs to Google Cloud Storage

--- a/components/calendar/src/provider.rs
+++ b/components/calendar/src/provider.rs
@@ -15,7 +15,7 @@ pub mod key {
     //! Resource keys for [`icu_decimal`](crate).
     use icu_provider::{resource_key, ResourceKey};
 
-    /// Resource key: Japanese era data ([`JapaneseErasV1`])
+    /// Resource key: Japanese era data ([`JapaneseErasV1`](super::JapaneseErasV1))
     pub const JAPANESE_ERAS_V1: ResourceKey = resource_key!(Calendar, "japanese", 1);
 }
 

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -36,10 +36,10 @@ pub enum DateTimeFormatError {
     /// An error due to there being no patterns for the given options.
     #[displaydoc("Unsupported options")]
     UnsupportedOptions,
-    /// An error originating from [`PluralRules`][icu_plural::PluralRules].
+    /// An error originating from [`PluralRules`][icu_plurals::PluralRules].
     #[displaydoc("{0}")]
     PluralRules(PluralRulesError),
-    /// An error originating from [`DateTimeInput`][icu_datetime::date::DateTimeInput].
+    /// An error originating from [`DateTimeInput`][crate::date::DateTimeInput].
     #[displaydoc("{0}")]
     DateTimeInput(DateTimeError),
     /// An error originating from a missing weekday symbol in the data.

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -83,6 +83,7 @@ pub mod date;
 pub mod datetime;
 mod error;
 mod fields;
+#[allow(missing_docs)] // TODO(#686) - Add missing docs.
 mod format;
 pub mod mock;
 pub mod options;
@@ -101,6 +102,7 @@ pub use calendar::CldrCalendar;
 pub use datetime::DateTimeFormat;
 pub use error::DateTimeFormatError;
 pub use format::datetime::FormattedDateTime;
+pub use format::time_zone::FormattedTimeZone;
 pub use format::zoned_datetime::FormattedZonedDateTime;
 pub use options::DateTimeFormatOptions;
 pub use time_zone::TimeZoneFormat;

--- a/components/datetime/src/mock/time_zone.rs
+++ b/components/datetime/src/mock/time_zone.rs
@@ -12,9 +12,10 @@ use core::str::FromStr;
 /// and is used in tests, benchmarks and examples of this component.
 ///
 /// *Notice:* Rust at the moment does not have a canonical way to represent time zones. We are introducing
-/// [`MockTimeZone`] as an example of the data necessary for ICU [`TimeZoneFormat`] to work, and
-/// [we hope to work with the community](https://github.com/unicode-org/icu4x/blob/main/docs/research/datetime.md)
-/// to develop core date and time APIs that will work as an input for this component.
+/// [`MockTimeZone`](crate::mock::time_zone::MockTimeZone) as an example of the data necessary for
+/// ICU [`TimeZoneFormat`](crate::TimeZoneFormat) to work, and [we hope to work with the community](
+/// https://github.com/unicode-org/icu4x/blob/main/docs/research/datetime.md) to develop core date and time
+/// APIs that will work as an input for this component.
 ///
 /// # Examples
 ///

--- a/components/datetime/src/provider/mod.rs
+++ b/components/datetime/src/provider/mod.rs
@@ -15,7 +15,7 @@ pub mod calendar;
 /// Data providers for time zones.
 pub mod time_zones;
 
-/// Traits for managing data needed by [`DateTimeFormat`].
+/// Traits for managing data needed by [`DateTimeFormat`](crate::DateTimeFormat).
 pub(crate) mod date_time;
 
 /// A collection of [`ResourceKey`] structs for DateTime providers.

--- a/components/datetime/src/skeleton/mod.rs
+++ b/components/datetime/src/skeleton/mod.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-//! Skeletons are used for pattern matching. See the [`Skeleton`] struct for more information.
+//! Skeletons are used for pattern matching. See the [`Skeleton`](reference::Skeleton) struct for more information.
 
 mod error;
 mod helpers;

--- a/components/datetime/src/zoned_datetime.rs
+++ b/components/datetime/src/zoned_datetime.rs
@@ -19,7 +19,7 @@ use crate::{
     raw, CldrCalendar, DateTimeFormatError,
 };
 
-/// The composition of [`DateTimeFormat`] and [`TimeZoneFormat`].
+/// The composition of [`DateTimeFormat`](crate::DateTimeFormat) and [`TimeZoneFormat`](crate::TimeZoneFormat).
 ///
 /// [`ZonedDateTimeFormat`] uses data from the [`DataProvider`]s, the selected [`Locale`], and the
 /// provided pattern to collect all data necessary to format a datetime with time zones into that locale.

--- a/components/decimal/README.md
+++ b/components/decimal/README.md
@@ -6,9 +6,7 @@ Currently, [`icu_decimal`](crate) provides [`FixedDecimalFormat`], which renders
 in a locale-sensitive way.
 
 Support for currencies, measurement units, and compact notation is planned. To track progress,
-follow this issue:
-
-https://github.com/unicode-org/icu4x/issues/275
+follow [icu4x#275](https://github.com/unicode-org/icu4x/issues/275).
 
 ## Examples
 

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -10,9 +10,7 @@
 //! in a locale-sensitive way.
 //!
 //! Support for currencies, measurement units, and compact notation is planned. To track progress,
-//! follow this issue:
-//!
-//! https://github.com/unicode-org/icu4x/issues/275
+//! follow [icu4x#275](https://github.com/unicode-org/icu4x/issues/275).
 //!
 //! # Examples
 //!

--- a/components/locale_canonicalizer/src/locale_canonicalizer.rs
+++ b/components/locale_canonicalizer/src/locale_canonicalizer.rs
@@ -253,7 +253,7 @@ impl LocaleCanonicalizer {
 
     /// The canonicalize method potentially updates a passed in locale in place
     /// depending up the results of running the canonicalization algorithm
-    /// from http://unicode.org/reports/tr35/#LocaleId_Canonicalization
+    /// from <http://unicode.org/reports/tr35/#LocaleId_Canonicalization>.
     ///
     /// Some BCP47 canonicalization data is not part of the CLDR json package. Because
     /// of this, some canonicalizations are not performed, e.g. the canonicalization of
@@ -502,7 +502,7 @@ impl LocaleCanonicalizer {
 
     /// The maximize method potentially updates a passed in locale in place
     /// depending up the results of running the 'Add Likely Subtags' algorithm
-    /// from https://www.unicode.org/reports/tr35/#Likely_Subtags.
+    /// from <https://www.unicode.org/reports/tr35/#Likely_Subtags>.
     ///
     /// If the result of running the algorithm would result in a new locale, the
     /// locale argument is updated in place to match the result, and the method
@@ -561,7 +561,7 @@ impl LocaleCanonicalizer {
 
     /// This returns a new Locale that is the result of running the
     /// 'Remove Likely Subtags' algorithm from
-    /// https://www.unicode.org/reports/tr35/#Likely_Subtags.
+    /// <https://www.unicode.org/reports/tr35/#Likely_Subtags>.
     ///
     /// If the result of running the algorithm would result in a new locale, the
     /// locale argument is updated in place to match the result, and the method

--- a/components/locale_canonicalizer/src/provider.rs
+++ b/components/locale_canonicalizer/src/provider.rs
@@ -12,7 +12,8 @@ use icu_provider::yoke::{self, *};
 use litemap::LiteMap;
 use tinystr::{TinyStr4, TinyStr8};
 
-/// A collection of [`ResourceKey`] structs for LocaleCanonicalizer providers.
+/// A collection of [`ResourceKey`](icu_provider::ResourceKey) structs for 
+/// LocaleCanonicalizer providers.
 pub mod key {
     use icu_provider::{resource_key, ResourceKey};
     /// Key for aliases data.
@@ -31,7 +32,7 @@ pub mod key {
 #[yoke(cloning_zcf)]
 /// This alias data is used for locale canonicalization. Each field defines a
 /// mapping from an old identifier to a new identifier, based upon the rules in
-/// from http://unicode.org/reports/tr35/#LocaleId_Canonicalization. The data
+/// from <http://unicode.org/reports/tr35/#LocaleId_Canonicalization>. The data
 /// is stored in sorted order, allowing for binary search to identify rules to
 /// apply. It is broken down into smaller vectors based upon some characteristic
 /// of the data, to help avoid unnecessary searches. For example, the `sgn_region`
@@ -76,7 +77,7 @@ pub struct AliasesV1 {
 /// This likely subtags data is used for the minimize and maximize operations.
 /// Each field defines a mapping from an old identifier to a new identifier,
 /// based upon the rules in
-/// https://www.unicode.org/reports/tr35/#Likely_Subtags.
+/// <https://www.unicode.org/reports/tr35/#Likely_Subtags>.
 ///
 /// The data is stored in sorted order, allowing for binary search to identify
 /// rules to apply. It is broken down into smaller vectors based upon the rules

--- a/components/locale_canonicalizer/src/provider.rs
+++ b/components/locale_canonicalizer/src/provider.rs
@@ -12,7 +12,7 @@ use icu_provider::yoke::{self, *};
 use litemap::LiteMap;
 use tinystr::{TinyStr4, TinyStr8};
 
-/// A collection of [`ResourceKey`](icu_provider::ResourceKey) structs for 
+/// A collection of [`ResourceKey`](icu_provider::ResourceKey) structs for
 /// LocaleCanonicalizer providers.
 pub mod key {
     use icu_provider::{resource_key, ResourceKey};

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -402,7 +402,7 @@ impl PluralRules {
     }
 
     /// Returns all [`Plural Categories`] appropriate for a [`PluralRules`] object
-    /// based on the [`LanguageIdentifier`] and [`PluralRuleType`].
+    /// based on the [`LanguageIdentifier`](icu_locid::LanguageIdentifier) and [`PluralRuleType`].
     ///
     /// The [`Plural Categories`] are returned in UTS 35 sorted order.
     ///

--- a/components/plurals/src/rules/mod.rs
+++ b/components/plurals/src/rules/mod.rs
@@ -150,11 +150,11 @@
 //! [`PluralOperands::i`]: super::PluralOperands::i
 //! [`PluralOperands::v`]: super::PluralOperands::v
 //! [`PluralRuleType::Cardinal`]: super::PluralRuleType::Cardinal
-//! [`Rule`]: super::rules::ast::Rule
-//! [`Rules`]: super::rules::ast::Rule
-//! [`Condition`]: super::rules::ast::Condition
-//! [`Sample`]: super::rules::ast::Samples
-//! [`AST`]: super::rules::ast
+//! [`Rule`]: super::rules::reference::ast::Rule
+//! [`Rules`]: super::rules::reference::ast::Rule
+//! [`Condition`]: super::rules::reference::ast::Condition
+//! [`Sample`]: super::rules::reference::ast::Samples
+//! [`AST`]: super::rules::reference::ast
 pub mod reference;
 
 // Need to expose it for `icu::provider_cldr` use, but we don't

--- a/components/plurals/src/rules/reference/ast.rs
+++ b/components/plurals/src/rules/reference/ast.rs
@@ -134,7 +134,7 @@ pub struct Condition(pub Vec<AndCondition>);
 /// # Examples
 ///
 /// All AST nodes can be built explicitly, as seen in the example. However, due to its complexity, it is preferred to build the
-/// AST using the [`parse()`](crate::rules::parser::parse()) function.
+/// AST using the [`parse()`](crate::rules::reference::parser::parse()) function.
 ///
 /// ```text
 /// "i = 3 and v = 0"
@@ -175,7 +175,7 @@ pub struct AndCondition(pub Vec<Relation>);
 /// # Examples
 ///
 /// All AST nodes can be built explicitly, as seen in the example. However, due to its complexity, it is preferred to build the
-/// AST using the [`parse()`](crate::rules::parser::parse()) function.
+/// AST using the [`parse()`](crate::rules::reference::parser::parse()) function.
 ///
 /// ```text
 /// "i = 3"
@@ -225,7 +225,7 @@ pub enum Operator {
 /// # Examples
 ///
 /// All AST nodes can be built explicitly, as seen in the example. However, due to its complexity, it is preferred to build the
-/// AST using the [`parse()`](crate::rules::parser::parse()) function.
+/// AST using the [`parse()`](crate::rules::reference::parser::parse()) function.
 ///
 /// ```text
 /// "i % 100"
@@ -254,7 +254,7 @@ pub struct Expression {
 /// # Examples
 ///
 /// All AST nodes can be built explicitly, as seen in the example. However, due to its complexity, it is preferred to build the
-/// AST using the [`parse()`](crate::rules::parser::parse()) function.
+/// AST using the [`parse()`](crate::rules::reference::parser::parse()) function.
 ///
 /// ```text
 /// "i"
@@ -294,7 +294,7 @@ pub enum Operand {
 /// # Examples
 ///
 /// All AST nodes can be built explicitly, as seen in the example. However, due to its complexity, it is preferred to build the
-/// AST using the [`parse()`](crate::rules::parser::parse()) function.
+/// AST using the [`parse()`](crate::rules::reference::parser::parse()) function.
 ///
 /// ```text
 /// "5, 7, 9"
@@ -348,7 +348,7 @@ pub enum RangeListItem {
 /// # Examples
 ///
 /// All AST nodes can be built explicitly, as seen in the example. However, due to its complexity, it is preferred to build the
-/// AST using the [`parse()`](crate::rules::parser::parse()) function.
+/// AST using the [`parse()`](crate::rules::reference::parser::parse()) function.
 ///
 /// ```text
 /// "99"

--- a/experimental/char16trie/src/char16trie.rs
+++ b/experimental/char16trie/src/char16trie.rs
@@ -91,7 +91,7 @@ impl<'data> Char16Trie<'data> {
         Self { data }
     }
 
-    /// Returns a new [`Char16Iterator`] backed by borrowed data from the `trie` data
+    /// Returns a new [`Char16TrieIterator`] backed by borrowed data from the `trie` data
     pub fn iter(&self) -> Char16TrieIterator {
         Char16TrieIterator::new(self.data.as_ule_slice())
     }
@@ -144,7 +144,7 @@ fn u16_tail(supplementary: i32) -> u16 {
 }
 
 impl<'a> Char16TrieIterator<'a> {
-    /// Returns a new [`Char16Iterator`] backed by borrowed data for the `trie` array
+    /// Returns a new [`Char16TrieIterator`] backed by borrowed data for the `trie` array
     pub fn new(trie: &'a [<u16 as zerovec::ule::AsULE>::ULE]) -> Self {
         Self {
             trie,

--- a/provider/cldr/src/cldr_serde/aliases.rs
+++ b/provider/cldr/src/cldr_serde/aliases.rs
@@ -5,7 +5,7 @@
 //! Serde structs representing CLDR JSON aliases.json files.
 //!
 //! Sample file:
-//! https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-core/supplemental/aliases.json
+//! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-core/supplemental/aliases.json>
 
 use serde::Deserialize;
 use tinystr::{TinyStr4, TinyStr8};

--- a/provider/cldr/src/cldr_serde/ca.rs
+++ b/provider/cldr/src/cldr_serde/ca.rs
@@ -7,7 +7,7 @@
 //! CLDR JSON files having this structure include "ca-gregorian.json", "ca-buddhist.json", etc.
 //!
 //! Sample file:
-//! https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-dates-full/main/en/ca-gregorian.json
+//! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-dates-full/main/en/ca-gregorian.json>
 
 use icu_locid::LanguageIdentifier;
 use litemap::LiteMap;

--- a/provider/cldr/src/cldr_serde/likely_subtags.rs
+++ b/provider/cldr/src/cldr_serde/likely_subtags.rs
@@ -5,7 +5,7 @@
 //! Serde structs representing CLDR JSON likelySubtags.json files.
 //!
 //! Sample file:
-//! https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-core/supplemental/likelySubtags.json
+//! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-core/supplemental/likelySubtags.json>
 
 use icu_locid::LanguageIdentifier;
 use serde::Deserialize;

--- a/provider/cldr/src/cldr_serde/list_patterns.rs
+++ b/provider/cldr/src/cldr_serde/list_patterns.rs
@@ -5,7 +5,7 @@
 //! Serde structs representing CLDR JSON numbers.json files.
 //!
 //! Sample file:
-//! https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-misc-full/main/en/listPatterns.json
+//! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-misc-full/main/en/listPatterns.json>
 
 use icu_locid::LanguageIdentifier;
 use litemap::LiteMap;

--- a/provider/cldr/src/cldr_serde/numbering_systems.rs
+++ b/provider/cldr/src/cldr_serde/numbering_systems.rs
@@ -5,7 +5,7 @@
 //! Serde structs representing CLDR JSON numberingSystem.json files.
 //!
 //! Sample file:
-//! https://github.com/unicode-org/cldr-json/blob/master/cldr-json/cldr-core/supplemental/numberingSystems.json
+//! <https://github.com/unicode-org/cldr-json/blob/master/cldr-json/cldr-core/supplemental/numberingSystems.json>
 
 use litemap::LiteMap;
 use serde::Deserialize;

--- a/provider/cldr/src/cldr_serde/numbers.rs
+++ b/provider/cldr/src/cldr_serde/numbers.rs
@@ -5,7 +5,7 @@
 //! Serde structs representing CLDR JSON numbers.json files.
 //!
 //! Sample file:
-//! https://github.com/unicode-org/cldr-json/blob/master/cldr-json/cldr-numbers-full/main/en/numbers.json
+//! <https://github.com/unicode-org/cldr-json/blob/master/cldr-json/cldr-numbers-full/main/en/numbers.json>
 
 use icu_locid::LanguageIdentifier;
 use itertools::Itertools;

--- a/provider/cldr/src/cldr_serde/plurals.rs
+++ b/provider/cldr/src/cldr_serde/plurals.rs
@@ -5,7 +5,7 @@
 //! Serde structs representing CLDR JSON aliases.json files.
 //!
 //! Sample file:
-//! https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-core/supplemental/plurals.json
+//! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-core/supplemental/plurals.json>
 
 use icu_locid::LanguageIdentifier;
 use litemap::LiteMap;

--- a/provider/cldr/src/cldr_serde/time_zone_names.rs
+++ b/provider/cldr/src/cldr_serde/time_zone_names.rs
@@ -5,7 +5,7 @@
 //! Serde structs representing CLDR JSON timeZoneNames.json files.
 //!
 //! Sample file:
-//! https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-dates-full/main/en/timeZoneNames.json
+//! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-dates-full/main/en/timeZoneNames.json>
 
 use icu_locid::LanguageIdentifier;
 use litemap::LiteMap;

--- a/provider/cldr/src/download/cldr_allinone.rs
+++ b/provider/cldr/src/download/cldr_allinone.rs
@@ -11,8 +11,8 @@ use crate::CldrPathsAllInOne;
 use std::path::PathBuf;
 
 /// Implementation of CldrPaths that downloads CLDR data directories on demand.
-/// The download artifacts are saved in the user's cache directory; see
-/// https://docs.rs/dirs/3.0.0/dirs/fn.cache_dir.html
+/// The download artifacts are saved in the user's [cache directory](
+/// https://docs.rs/dirs/3.0.0/dirs/fn.cache_dir.html).
 ///
 /// Downloads a single zip file for all components, as used in CLDR 38 and later.
 ///
@@ -79,8 +79,8 @@ impl CldrAllInOneDownloader {
     ///
     /// Arguments:
     ///
-    /// - `github_tag`: a tag in the CLDR JSON repositories, such as "38.1.0":
-    ///   https://github.com/unicode-cldr/cldr-json/tags
+    /// - `github_tag`: a [tag in the CLDR JSON repositories](https://github.com/unicode-cldr/cldr-json/tags),
+    ///    such as "38.1.0"
     /// - `locale_subset`: either "modern" (fewer locales, smaller download) or "full" (more
     ///   locales, larger download)
     pub fn try_new_from_github(github_tag: &str, locale_subset: &str) -> Result<Self, Error> {

--- a/provider/cldr/src/transform/decimal/decimal_pattern.rs
+++ b/provider/cldr/src/transform/decimal/decimal_pattern.rs
@@ -4,7 +4,7 @@
 
 //! Functions for dealing with UTS-35 number patterns.
 //!
-//! Spec reference: https://unicode.org/reports/tr35/tr35-numbers.html#Number_Format_Patterns
+//! Spec reference: <https://unicode.org/reports/tr35/tr35-numbers.html#Number_Format_Patterns>
 
 use displaydoc::Display;
 use icu_decimal::provider::AffixesV1;

--- a/provider/core/README.md
+++ b/provider/core/README.md
@@ -10,9 +10,9 @@ a [`Response`]:
 fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<'data>, DataError>
 ```
 
-A [`Request`] contains a [`ResourceKey`] (a composition of a [`Category`] and sub-category, e.g.,
-"plurals/cardinal@1") and [`ResourceOptions`] (a language identifier and optional variant, e.g.,
-"fr") being requested. The Response contains the data payload corresponding to the Request.
+A [`Request`] contains a [`ResourceKey`] (a fixed identifier such as "plurals/cardinal@1") and
+[`ResourceOptions`] (a language identifier and optional variant, e.g. "fr") being requested.
+The Response contains the data payload corresponding to the Request.
 
 A [`Response`] contains a [`DataPayload`] along with other metadata.
 
@@ -35,7 +35,7 @@ with some pre-built data providers:
 This crate also contains some concrete implementations for testing purposes:
 
 - [`InvariantDataProvider`] returns fixed data that does not vary by locale.
-- [`StructProvider`] wraps a particular instance of a struct and returns it.
+- [`AnyPayloadProvider`] wraps a particular instance of a struct and returns it.
 - [`HelloWorldProvider`] returns "hello world" strings in several languages.
 
 ### Types and Lifetimes
@@ -52,7 +52,7 @@ see [`yoke`].
 
 #### `IterableDataProvider`
 
-Data providers can implement [`IterableDataProvider`], allowing iteration over all [`ResourceOptions`]
+Data providers can implement [`IterableProvider`], allowing iteration over all [`ResourceOptions`]
 instances supported for a certain key in the data provider.
 
 For more information, see the [`iter`] module.
@@ -88,11 +88,10 @@ This trait is normally implemented using the [`impl_dyn_provider!`] macro.
 [`Request`]: data_provider::DataRequest
 [`Response`]: data_provider::DataResponse
 [`ResourceKey`]: resource::ResourceKey
-[`Category`]: resource::ResourceCategory
 [`ResourceOptions`]: resource::ResourceOptions
-[`IterableDataProvider`]: iter::IterableDataProvider
+[`IterableProvider`]: iter::IterableProvider
 [`InvariantDataProvider`]: inv::InvariantDataProvider
-[`StructProvider`]: struct_provider::StructProvider
+[`AnyPayloadProvider`]: struct_provider::AnyPayloadProvider
 [`HelloWorldProvider`]: hello_world::HelloWorldProvider
 [`AnyProvider`]: any::AnyProvider
 [`Yokeable`]: yoke::Yokeable

--- a/provider/core/src/any.rs
+++ b/provider/core/src/any.rs
@@ -284,7 +284,7 @@ impl AnyResponse {
 /// assert_eq!(payload.get().message, "Custom Hello World");
 /// ```
 ///
-/// [`StructProviderStatic`]: crate::struct_provider::StructProviderStatic
+/// [`AnyPayloadProvider`]: crate::struct_provider::AnyPayloadProvider
 pub trait AnyProvider {
     fn load_any(&self, req: &DataRequest) -> Result<AnyResponse, DataError>;
 }

--- a/provider/core/src/buf.rs
+++ b/provider/core/src/buf.rs
@@ -51,7 +51,7 @@ impl DataMarker for BufferMarker {
 /// # }
 /// ```
 ///
-/// [`as_deserializing()`]: crate::serde::de::AsDeserializingBufferProvider::as_deserializing
+/// [`as_deserializing()`]: AsDeserializingBufferProvider::as_deserializing
 pub trait BufferProvider {
     fn load_buffer(&self, req: &DataRequest) -> Result<DataResponse<BufferMarker>, DataError>;
 }

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -944,7 +944,7 @@ fn test_debug() {
 /// See examples on some of the concrete implementations:
 ///
 /// - [`HelloWorldProvider`](crate::hello_world::HelloWorldProvider)
-/// - [`StructProvider`](crate::struct_provider::StructProvider)
+/// - [`AnyPayloadProvider`](crate::struct_provider::AnyPayloadProvider)
 /// - [`InvariantDataProvider`](crate::inv::InvariantDataProvider)
 pub trait DataProvider<M>
 where

--- a/provider/core/src/export.rs
+++ b/provider/core/src/export.rs
@@ -28,11 +28,11 @@ where
     }
 }
 
-/// Convenience function to drive a [`DataExporter`] from an [`IterableDataProvider`].
+/// Convenience function to drive a [`DataExporter`] from an [`IterableProvider`].
 ///
 /// # Example
 ///
-/// [`HelloWorldProvider`] implements both [`DataExporter`] and [`IterableDataProvider`]. The
+/// [`HelloWorldProvider`] implements both [`DataExporter`] and [`IterableProvider`]. The
 /// following example copies the data from one instance to another instance.
 ///
 /// ```

--- a/provider/core/src/filter/mod.rs
+++ b/provider/core/src/filter/mod.rs
@@ -4,8 +4,8 @@
 
 //! Providers that filter resource requests.
 //!
-//! Requests that fail a filter test will return [`DataError::FilteredResource`] and will not
-//! appear in [`IterableDataProvider`] iterators.
+//! Requests that fail a filter test will return [`DataError`] of kind [`FilteredResource`](
+//! DataErrorKind::FilteredResource) and will not appear in [`IterableProvider`] iterators.
 //!
 //! The main struct is [`RequestFilterDataProvider`]. Although that struct can be created
 //! directly, the traits in this module provide helper functions for common filtering patterns.
@@ -32,7 +32,7 @@
 //!     .filter_by_langid(|langid| langid.language == language!("de"));
 //! ```
 //!
-//! [`IterableDataProvider`]: crate::iter::IterableDataProvider
+//! [`IterableProvider`]: crate::iter::IterableProvider
 
 mod impls;
 
@@ -44,8 +44,9 @@ use alloc::boxed::Box;
 
 /// A data provider that selectively filters out data requests.
 ///
-/// Data requests that are rejected by the filter will return [`DataError::FilteredResource`], and
-/// they will not be returned by [`IterableProvider::supported_options_for_key`].
+/// Data requests that are rejected by the filter will return a [`DataError`] with kind
+/// [`FilteredResource`](DataErrorKind::FilteredResource), and they will not be returned
+/// by [`IterableProvider::supported_options_for_key`].
 ///
 /// Although this struct can be created directly, the traits in this module provide helper
 /// functions for common filtering patterns.
@@ -132,7 +133,7 @@ where
 pub trait Filterable: Sized {
     /// Creates a filterable data provider with the given name for debugging.
     ///
-    /// For more details, see [`icu_provider::filter`].
+    /// For more details, see [`icu_provider::filter`](crate::filter).
     fn filterable(
         self,
         filter_name: &'static str,

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -194,7 +194,7 @@ impl IterableProvider for HelloWorldProvider {
     }
 }
 
-/// Adds entries to a [`HelloWorldProvider`] from [`AnyMarker`](crate::erased::AnyMarker)
+/// Adds entries to a [`HelloWorldProvider`] from [`AnyMarker`](crate::any::AnyMarker)
 impl crate::export::DataExporter<crate::any::AnyMarker> for HelloWorldProvider {
     fn put_payload(
         &mut self,

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -12,7 +12,7 @@
 //! fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<'data>, DataError>
 //! ```
 //!
-//! A [`Request`] contains a [`ResourceKey`] (a fixed identifier such as "plurals/cardinal@1") and 
+//! A [`Request`] contains a [`ResourceKey`] (a fixed identifier such as "plurals/cardinal@1") and
 //! [`ResourceOptions`] (a language identifier and optional variant, e.g. "fr") being requested.
 //! The Response contains the data payload corresponding to the Request.
 //!

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -12,9 +12,9 @@
 //! fn load_payload(&self, req: &DataRequest) -> Result<DataResponse<'data>, DataError>
 //! ```
 //!
-//! A [`Request`] contains a [`ResourceKey`] (a composition of a [`Category`] and sub-category, e.g.,
-//! "plurals/cardinal@1") and [`ResourceOptions`] (a language identifier and optional variant, e.g.,
-//! "fr") being requested. The Response contains the data payload corresponding to the Request.
+//! A [`Request`] contains a [`ResourceKey`] (a fixed identifier such as "plurals/cardinal@1") and 
+//! [`ResourceOptions`] (a language identifier and optional variant, e.g. "fr") being requested.
+//! The Response contains the data payload corresponding to the Request.
 //!
 //! A [`Response`] contains a [`DataPayload`] along with other metadata.
 //!
@@ -37,7 +37,7 @@
 //! This crate also contains some concrete implementations for testing purposes:
 //!
 //! - [`InvariantDataProvider`] returns fixed data that does not vary by locale.
-//! - [`StructProvider`] wraps a particular instance of a struct and returns it.
+//! - [`AnyPayloadProvider`] wraps a particular instance of a struct and returns it.
 //! - [`HelloWorldProvider`] returns "hello world" strings in several languages.
 //!
 //! ## Types and Lifetimes
@@ -54,7 +54,7 @@
 //!
 //! ### `IterableDataProvider`
 //!
-//! Data providers can implement [`IterableDataProvider`], allowing iteration over all [`ResourceOptions`]
+//! Data providers can implement [`IterableProvider`], allowing iteration over all [`ResourceOptions`]
 //! instances supported for a certain key in the data provider.
 //!
 //! For more information, see the [`iter`] module.
@@ -90,11 +90,10 @@
 //! [`Request`]: data_provider::DataRequest
 //! [`Response`]: data_provider::DataResponse
 //! [`ResourceKey`]: resource::ResourceKey
-//! [`Category`]: resource::ResourceCategory
 //! [`ResourceOptions`]: resource::ResourceOptions
-//! [`IterableDataProvider`]: iter::IterableDataProvider
+//! [`IterableProvider`]: iter::IterableProvider
 //! [`InvariantDataProvider`]: inv::InvariantDataProvider
-//! [`StructProvider`]: struct_provider::StructProvider
+//! [`AnyPayloadProvider`]: struct_provider::AnyPayloadProvider
 //! [`HelloWorldProvider`]: hello_world::HelloWorldProvider
 //! [`AnyProvider`]: any::AnyProvider
 //! [`Yokeable`]: yoke::Yokeable

--- a/provider/uprops/src/script.rs
+++ b/provider/uprops/src/script.rs
@@ -13,7 +13,7 @@ use std::convert::TryFrom;
 use std::path::Path;
 use zerovec::{VarZeroVec, ZeroSlice, ZeroVec};
 
-/// This data provider returns a [`crate::script::ScriptExtensions`] instance,
+/// This data provider returns a [`ScriptExtensions`] instance,
 /// which efficiently represents data for the Script and Script_Extensions
 /// properties. The source data is the same as that of
 /// [crate::provider::PropertiesDataProvider], which is a TOML file of data

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -903,7 +903,7 @@ pub enum RoundingMode {
 impl FixedDecimal {
     /// Construct a [`FixedDecimal`] from an f64. This uses `ryu` and
     /// goes through an intermediate string representation, so is not
-    /// fully efficient. See https://github.com/unicode-org/icu4x/issues/166 for
+    /// fully efficient. See [icu4x#166](https://github.com/unicode-org/icu4x/issues/166) for
     /// more details.
     ///
     /// This function can be made available with the `"ryu"` feature.

--- a/utils/litemap/src/map.rs
+++ b/utils/litemap/src/map.rs
@@ -340,7 +340,7 @@ impl<K: Ord, V> LiteMap<K, V> {
     /// Obtain the index for a given key, or if the key is not found, the index
     /// at which it would be inserted.
     ///
-    /// (The return value works equivalently to [`Vec::binary_search_by()`])
+    /// (The return value works equivalently to [`slice::binary_search_by()`])
     ///
     /// The indices returned can be used with [`Self::get_indexed()`]. Prefer using
     /// [`Self::get()`] directly where possible.

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -443,6 +443,9 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, Option<C>> {
     /// this is good for e.g. constructing fully owned
     /// [`Yoke`]s with no internal borrowing.
     ///
+    /// This can be paired with [`Yoke:: wrap_cart_in_option()`] to mix owned
+    /// and borrowed data.
+    ///
     /// If you do not wish to pair this with borrowed data, [`Yoke::new_always_owned()`] can
     /// be used to get a [`Yoke`] API on always-owned data.
     ///

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -443,9 +443,6 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, Option<C>> {
     /// this is good for e.g. constructing fully owned
     /// [`Yoke`]s with no internal borrowing.
     ///
-    /// This can be paired with [`Yoke::attach_to_option_cart()`] to mix owned
-    /// and borrowed data.
-    ///
     /// If you do not wish to pair this with borrowed data, [`Yoke::new_always_owned()`] can
     /// be used to get a [`Yoke`] API on always-owned data.
     ///


### PR DESCRIPTION
Should we make doc warnings fail CI? Most of these are types that have been deleted or broken references.