### PR TITLE
Run segmenter's build.rs only if data is changed

### DIFF
--- a/experimental/segmenter/build.rs
+++ b/experimental/segmenter/build.rs
@@ -545,6 +545,8 @@ fn generate_rule_segmenter_table(file_name: &str, toml_data: &[u8], provider: &F
 }
 
 fn main() {
+    println!("cargo:rerun-if-changed=data");
+
     const WORD_SEGMENTER_TOML: &[u8] = include_bytes!("data/word.toml");
     const GRAPHEME_SEGMENTER_TOML: &[u8] = include_bytes!("data/grapheme.toml");
     const SENTENCE_SEGMENTER_TOML: &[u8] = include_bytes!("data/sentence.toml");


### PR DESCRIPTION
Running `build.rs` takes at least 20 seconds on my machine. This patch reduces
the segmenter's build time when modifying files other than `data/*` or
`build.rs`.

Note that cargo automatically handles whether `build.rs` is changed.
https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed