### PR TITLE
Migrate icu_locid to TinyAsciiStr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,11 +1218,11 @@ version = "0.4.0"
 dependencies = [
  "criterion",
  "displaydoc",
- "icu",
  "icu_benchmark_macros",
  "serde",
  "serde_json",
  "tinystr",
+ "tinystr-neo",
  "writeable",
 ]
 

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -35,13 +35,14 @@ all-features = true
 
 [dependencies]
 tinystr = { version = "0.4.10", features = ["alloc"], default-features = false }
+tinystr-neo = { path = "../../experimental/tinystr_neo" }
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
 writeable = { version = "0.2.1", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.3"
-icu = { path = "../icu", default-features = false }
+# icu = { path = "../icu", default-features = false }
 icu_benchmark_macros = { version = "0.4", path = "../../tools/benchmark/macros" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/components/locid/macros/src/token_stream.rs
+++ b/components/locid/macros/src/token_stream.rs
@@ -31,6 +31,12 @@ impl IntoTokenStream for u64 {
     }
 }
 
+impl IntoTokenStream for [u8; 3] {
+    fn into_token_stream_string(self) -> String {
+        format!("{:?}", self)
+    }
+}
+
 impl IntoTokenStream for subtags::Language {
     fn into_token_stream_string(self) -> String {
         format!(

--- a/components/locid/src/subtags/language.rs
+++ b/components/locid/src/subtags/language.rs
@@ -81,7 +81,6 @@ impl Language {
         }
     }
 
-    /*
     /// Deconstructs the [`Language`] into raw format to be consumed
     /// by [`from_raw_unchecked()`](Language::from_raw_unchecked()).
     ///
@@ -97,8 +96,8 @@ impl Language {
     /// let lang = unsafe { Language::from_raw_unchecked(raw) };
     /// assert_eq!(lang, "en");
     /// ```
-    pub fn into_raw(self) -> Option<u32> {
-        self.0.map(Into::<u32>::into)
+    pub fn into_raw(self) -> Option<[u8; 3]> {
+        self.0.map(|t| *t.all_bytes())
     }
 
     /// Constructor which takes a raw value returned by
@@ -119,15 +118,13 @@ impl Language {
     ///
     /// # Safety
     ///
-    /// This function accepts a [`u32`] that is expected to be a valid [`TinyStr4`]
-    /// representing a [`Language`] subtag in canonical syntax.
-    pub const unsafe fn from_raw_unchecked(v: Option<u32>) -> Self {
+    /// This function accepts a [`u32`] as returned by [`Self::into_raw()`].
+    pub const unsafe fn from_raw_unchecked(v: Option<[u8; 3]>) -> Self {
         Self(match v {
-            Some(v) => Some(TinyStr4::new_unchecked(v)),
+            Some(v) => Some(TinyAsciiStr::from_bytes_unchecked(v)),
             None => None,
         })
     }
-    */
 
     /// Returns the default undefined language "und". Same as [`default()`](Default::default()), but is `const`.
     ///
@@ -249,11 +246,3 @@ impl<'l> From<&'l Language> for &'l str {
         input.as_str()
     }
 }
-
-/*
-impl From<Language> for Option<TinyStr4> {
-    fn from(input: Language) -> Self {
-        input.0.map(Into::into)
-    }
-}
-*/

--- a/components/locid/src/subtags/language.rs
+++ b/components/locid/src/subtags/language.rs
@@ -7,6 +7,7 @@ use core::fmt;
 use core::ops::RangeInclusive;
 use core::str::FromStr;
 use tinystr::{tinystr4, TinyStr4};
+use tinystr_neo::{TinyAsciiStr, tinystr};
 
 /// A language subtag (examples: `"en"`, `"csb"`, `"zh"`, `"und"`, etc.)
 ///
@@ -39,10 +40,10 @@ use tinystr::{tinystr4, TinyStr4};
 ///
 /// [`unicode_language_id`]: https://unicode.org/reports/tr35/#unicode_language_id
 #[derive(Default, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord, Copy)]
-pub struct Language(Option<TinyStr4>);
+pub struct Language(Option<TinyAsciiStr<3>>);
 
 const LANGUAGE_LENGTH: RangeInclusive<usize> = 2..=3;
-const UND_VALUE: TinyStr4 = tinystr4!("und");
+const UND_VALUE: TinyAsciiStr<3> = tinystr!(3, "und");
 
 impl Language {
     /// A constructor which takes a utf8 slice, parses it and
@@ -65,7 +66,7 @@ impl Language {
             return Err(ParserError::InvalidLanguage);
         }
 
-        let s = TinyStr4::from_bytes(v).map_err(|_| ParserError::InvalidLanguage)?;
+        let s = TinyAsciiStr::from_bytes(v).map_err(|_| ParserError::InvalidLanguage)?;
 
         if !s.is_ascii_alphabetic() {
             return Err(ParserError::InvalidLanguage);
@@ -80,6 +81,7 @@ impl Language {
         }
     }
 
+    /*
     /// Deconstructs the [`Language`] into raw format to be consumed
     /// by [`from_raw_unchecked()`](Language::from_raw_unchecked()).
     ///
@@ -125,6 +127,7 @@ impl Language {
             None => None,
         })
     }
+    */
 
     /// Returns the default undefined language "und". Same as [`default()`](Default::default()), but is `const`.
     ///
@@ -247,8 +250,10 @@ impl<'l> From<&'l Language> for &'l str {
     }
 }
 
+/*
 impl From<Language> for Option<TinyStr4> {
     fn from(input: Language) -> Self {
         input.0.map(Into::into)
     }
 }
+*/


### PR DESCRIPTION
Depends on #1542

I migrated the `Language` field so I could run benches.  Most benches are a wash (defined by me as less than 10% in either direction, given criterion's variability), including the two "overview" benches.  The benches that are most impacted are:

1. Parsing benches, including "subtags/language/parse".  I do not know how much we care about the construction speed.  I would note that much of the time, this can (and should) be done at compile time.
2. Comparison benches, testing the `==` operator.  I do not know why this shows a change, since the bench in TinyAsciiStr testing that operator actually shows an improvement in TinyAsciiStr relative to TinyStr.

@zbraniecki Please let me know if this sounds okay to proceed.