### PR TITLE
Replace break_iterator_impl macro with a helper trait

### DIFF
--- a/experimental/segmenter/src/grapheme.rs
+++ b/experimental/segmenter/src/grapheme.rs
@@ -42,7 +42,10 @@ impl<'a> RuleBreakType<'a> for GraphemeClusterBreakType {
         iter.current_pos_data.unwrap().1.len_utf8()
     }
 
-    fn handle_complex_language(_: &mut RuleBreakIterator<Self>, _: Self::CharType) -> Option<usize> {
+    fn handle_complex_language(
+        _: &mut RuleBreakIterator<Self>,
+        _: Self::CharType,
+    ) -> Option<usize> {
         panic!("not reachable")
     }
 }
@@ -50,7 +53,8 @@ impl<'a> RuleBreakType<'a> for GraphemeClusterBreakType {
 pub struct GraphemeClusterBreakTypeLatin1;
 
 // Latin-1 version of grapheme break iterator using rule based segmenter.
-pub type GraphemeClusterBreakIteratorLatin1<'a> = RuleBreakIterator<'a, GraphemeClusterBreakTypeLatin1>;
+pub type GraphemeClusterBreakIteratorLatin1<'a> =
+    RuleBreakIterator<'a, GraphemeClusterBreakTypeLatin1>;
 
 impl<'a> GraphemeClusterBreakIteratorLatin1<'a> {
     /// Create grapheme break iterator using Latin-1/8-bit string.
@@ -79,7 +83,10 @@ impl<'a> RuleBreakType<'a> for GraphemeClusterBreakTypeLatin1 {
         panic!("not reachable")
     }
 
-    fn handle_complex_language(_: &mut RuleBreakIterator<Self>, _: Self::CharType) -> Option<usize> {
+    fn handle_complex_language(
+        _: &mut RuleBreakIterator<Self>,
+        _: Self::CharType,
+    ) -> Option<usize> {
         panic!("not reachable")
     }
 }
@@ -87,7 +94,8 @@ impl<'a> RuleBreakType<'a> for GraphemeClusterBreakTypeLatin1 {
 pub struct GraphemeClusterBreakTypeUtf16;
 
 // UTF-16 version of grapheme break iterator using rule based segmenter.
-pub type GraphemeClusterBreakIteratorUtf16<'a> = RuleBreakIterator<'a, GraphemeClusterBreakTypeUtf16>;
+pub type GraphemeClusterBreakIteratorUtf16<'a> =
+    RuleBreakIterator<'a, GraphemeClusterBreakTypeUtf16>;
 
 impl<'a> GraphemeClusterBreakIteratorUtf16<'a> {
     /// Create grapheme break iterator using UTF-16 string.
@@ -121,7 +129,10 @@ impl<'a> RuleBreakType<'a> for GraphemeClusterBreakTypeUtf16 {
         }
     }
 
-    fn handle_complex_language(_: &mut RuleBreakIterator<Self>, _: Self::CharType) -> Option<usize> {
+    fn handle_complex_language(
+        _: &mut RuleBreakIterator<Self>,
+        _: Self::CharType,
+    ) -> Option<usize> {
         panic!("not reachable")
     }
 }

--- a/experimental/segmenter/src/grapheme.rs
+++ b/experimental/segmenter/src/grapheme.rs
@@ -38,10 +38,6 @@ impl<'a> RuleBreakType<'a> for GraphemeClusterBreakType {
     type IterAttr = CharIndices<'a>;
     type CharType = char;
 
-    fn get_break_property(iter: &RuleBreakIterator<Self>) -> u8 {
-        get_break_property_utf8(iter.current_pos_data.unwrap().1, iter.property_table)
-    }
-
     fn get_current_position_character_len(iter: &RuleBreakIterator<Self>) -> usize {
         iter.current_pos_data.unwrap().1.len_utf8()
     }
@@ -79,11 +75,6 @@ impl<'a> RuleBreakType<'a> for GraphemeClusterBreakTypeLatin1 {
     type IterAttr = Latin1Indices<'a>;
     type CharType = u8; // TODO: Latin1Char
 
-    #[inline]
-    fn get_break_property(iter: &RuleBreakIterator<Self>) -> u8 {
-        get_break_property_latin1(iter.current_pos_data.unwrap().1, iter.property_table)
-    }
-
     fn get_current_position_character_len(_: &RuleBreakIterator<Self>) -> usize {
         panic!("not reachable")
     }
@@ -120,11 +111,6 @@ impl<'a> GraphemeClusterBreakIteratorUtf16<'a> {
 impl<'a> RuleBreakType<'a> for GraphemeClusterBreakTypeUtf16 {
     type IterAttr = Utf16Indices<'a>;
     type CharType = u32;
-
-    #[inline]
-    fn get_break_property(iter: &RuleBreakIterator<Self>) -> u8 {
-        get_break_property_utf32(iter.current_pos_data.unwrap().1, iter.property_table)
-    }
 
     fn get_current_position_character_len(iter: &RuleBreakIterator<Self>) -> usize {
         let ch = iter.current_pos_data.unwrap().1;

--- a/experimental/segmenter/src/grapheme.rs
+++ b/experimental/segmenter/src/grapheme.rs
@@ -5,14 +5,15 @@
 use alloc::vec::Vec;
 use core::str::CharIndices;
 
-use crate::break_iterator_impl;
 use crate::indices::{Latin1Indices, Utf16Indices};
 use crate::rule_segmenter::*;
 
 include!(concat!(env!("OUT_DIR"), "/generated_grapheme_table.rs"));
 
+pub struct GraphemeClusterBreakType;
+
 // UTF-8 version of grapheme break iterator using rule based segmenter.
-break_iterator_impl!(GraphemeClusterBreakIterator, CharIndices<'a>, char);
+pub type GraphemeClusterBreakIterator<'a> = RuleBreakIterator<'a, GraphemeClusterBreakType>;
 
 impl<'a> GraphemeClusterBreakIterator<'a> {
     /// Create grapheme break iterator
@@ -31,22 +32,29 @@ impl<'a> GraphemeClusterBreakIterator<'a> {
             complex_property: PROP_COMPLEX as u8,
         }
     }
+}
 
-    fn get_break_property(&mut self) -> u8 {
-        get_break_property_utf8(self.current_pos_data.unwrap().1, self.property_table)
+impl<'a> RuleBreakType<'a> for GraphemeClusterBreakType {
+    type IterAttr = CharIndices<'a>;
+    type CharType = char;
+
+    fn get_break_property(iter: &RuleBreakIterator<Self>) -> u8 {
+        get_break_property_utf8(iter.current_pos_data.unwrap().1, iter.property_table)
     }
 
-    fn get_current_position_character_len(&self) -> usize {
-        self.current_pos_data.unwrap().1.len_utf8()
+    fn get_current_position_character_len(iter: &RuleBreakIterator<Self>) -> usize {
+        iter.current_pos_data.unwrap().1.len_utf8()
     }
 
-    fn handle_complex_language(&mut self, _: char) -> Option<usize> {
+    fn handle_complex_language(_: &mut RuleBreakIterator<Self>, _: Self::CharType) -> Option<usize> {
         panic!("not reachable")
     }
 }
 
+pub struct GraphemeClusterBreakTypeLatin1;
+
 // Latin-1 version of grapheme break iterator using rule based segmenter.
-break_iterator_impl!(GraphemeClusterBreakIteratorLatin1, Latin1Indices<'a>, u8);
+pub type GraphemeClusterBreakIteratorLatin1<'a> = RuleBreakIterator<'a, GraphemeClusterBreakTypeLatin1>;
 
 impl<'a> GraphemeClusterBreakIteratorLatin1<'a> {
     /// Create grapheme break iterator using Latin-1/8-bit string.
@@ -65,23 +73,30 @@ impl<'a> GraphemeClusterBreakIteratorLatin1<'a> {
             complex_property: PROP_COMPLEX as u8,
         }
     }
+}
+
+impl<'a> RuleBreakType<'a> for GraphemeClusterBreakTypeLatin1 {
+    type IterAttr = Latin1Indices<'a>;
+    type CharType = u8; // TODO: Latin1Char
 
     #[inline]
-    fn get_break_property(&mut self) -> u8 {
-        get_break_property_latin1(self.current_pos_data.unwrap().1, self.property_table)
+    fn get_break_property(iter: &RuleBreakIterator<Self>) -> u8 {
+        get_break_property_latin1(iter.current_pos_data.unwrap().1, iter.property_table)
     }
 
-    fn get_current_position_character_len(&self) -> usize {
+    fn get_current_position_character_len(_: &RuleBreakIterator<Self>) -> usize {
         panic!("not reachable")
     }
 
-    fn handle_complex_language(&mut self, _: u8) -> Option<usize> {
+    fn handle_complex_language(_: &mut RuleBreakIterator<Self>, _: Self::CharType) -> Option<usize> {
         panic!("not reachable")
     }
 }
 
+pub struct GraphemeClusterBreakTypeUtf16;
+
 // UTF-16 version of grapheme break iterator using rule based segmenter.
-break_iterator_impl!(GraphemeClusterBreakIteratorUtf16, Utf16Indices<'a>, u32);
+pub type GraphemeClusterBreakIteratorUtf16<'a> = RuleBreakIterator<'a, GraphemeClusterBreakTypeUtf16>;
 
 impl<'a> GraphemeClusterBreakIteratorUtf16<'a> {
     /// Create grapheme break iterator using UTF-16 string.
@@ -100,14 +115,19 @@ impl<'a> GraphemeClusterBreakIteratorUtf16<'a> {
             complex_property: PROP_COMPLEX as u8,
         }
     }
+}
+
+impl<'a> RuleBreakType<'a> for GraphemeClusterBreakTypeUtf16 {
+    type IterAttr = Utf16Indices<'a>;
+    type CharType = u32;
 
     #[inline]
-    fn get_break_property(&mut self) -> u8 {
-        get_break_property_utf32(self.current_pos_data.unwrap().1, self.property_table)
+    fn get_break_property(iter: &RuleBreakIterator<Self>) -> u8 {
+        get_break_property_utf32(iter.current_pos_data.unwrap().1, iter.property_table)
     }
 
-    fn get_current_position_character_len(&self) -> usize {
-        let ch = self.current_pos_data.unwrap().1;
+    fn get_current_position_character_len(iter: &RuleBreakIterator<Self>) -> usize {
+        let ch = iter.current_pos_data.unwrap().1;
         if ch >= 0x10000 {
             2
         } else {
@@ -115,7 +135,7 @@ impl<'a> GraphemeClusterBreakIteratorUtf16<'a> {
         }
     }
 
-    fn handle_complex_language(&mut self, _: u32) -> Option<usize> {
+    fn handle_complex_language(_: &mut RuleBreakIterator<Self>, _: Self::CharType) -> Option<usize> {
         panic!("not reachable")
     }
 }

--- a/experimental/segmenter/src/rule_segmenter.rs
+++ b/experimental/segmenter/src/rule_segmenter.rs
@@ -104,7 +104,7 @@ impl<'a, Y: RuleBreakType<'a>> Iterator for RuleBreakIterator<'a, Y> {
             // If break_state is equals or grater than 0, it is alias of property.
             let mut break_state = self.get_break_state_from_table(left_prop, right_prop);
 
-            if break_state >= 0 as i8 {
+            if break_state >= 0 {
                 // This isn't simple rule set. We need marker to restore iterator to previous position.
                 let mut previous_iter = self.iter.clone();
                 let mut previous_pos_data = self.current_pos_data;

--- a/experimental/segmenter/src/rule_segmenter.rs
+++ b/experimental/segmenter/src/rule_segmenter.rs
@@ -2,6 +2,13 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+// Note: Keep these constants in sync with build.rs.
+const NOT_MATCH_RULE: i8 = -2;
+const KEEP_RULE: i8 = -1;
+// This is a mask bit chosen sufficiently large than all other concrete states.
+// If a break state contains this bit, we have to look ahead one more character.
+const INTERMEDIATE_MATCH_RULE: i8 = 64;
+
 pub fn get_break_property_utf32(codepoint: u32, property_table: &[&[u8; 1024]; 897]) -> u8 {
     let codepoint = codepoint as usize;
     if codepoint >= 897 * 1024 {
@@ -22,166 +29,175 @@ pub fn get_break_property_utf8(codepoint: char, property_table: &[&[u8; 1024]; 8
     get_break_property_utf32(codepoint as u32, property_table)
 }
 
-/// Base implementation of rule based segmenter
-#[macro_export]
-macro_rules! break_iterator_impl {
-    ($name:ident, $iter_attr:ty, $char_type:ty) => {
-        /// The struct implementing the [`Iterator`] trait over the segmenter break
-        /// opportunities of the given string. Please see the [module-level
-        /// documentation] for its usages.
-        ///
-        /// [`Iterator`]: core::iter::Iterator
-        /// [module-level documentation]: ../index.html
-        #[allow(dead_code)]
-        pub struct $name<'a> {
-            iter: $iter_attr,
-            len: usize,
-            current_pos_data: Option<(usize, $char_type)>,
-            result_cache: alloc::vec::Vec<usize>,
-            break_state_table: &'a [i8],
-            property_table: &'a [&'a [u8; 1024]; 897],
-            rule_property_count: usize,
-            last_codepoint_property: i8,
-            sot_property: u8,
-            eot_property: u8,
-            complex_property: u8,
+/// A trait allowing for RuleBreakIterator to be generalized to multiple string
+/// encoding methods and granularity such as grapheme cluster, word, etc.
+pub trait RuleBreakType<'a> {
+    /// The iterator over characters.
+    type IterAttr: Iterator<Item = (usize, Self::CharType)> + Clone;
+
+    /// The character type.
+    type CharType: Copy + Into<u32>;
+
+    fn get_break_property(iter: &RuleBreakIterator<'a, Self>) -> u8;
+
+    fn get_current_position_character_len(iter: &RuleBreakIterator<'a, Self>) -> usize;
+
+    fn handle_complex_language(iter: &mut RuleBreakIterator<'a, Self>, left_codepoint: Self::CharType) -> Option<usize>;
+}
+
+/// The struct implementing the [`Iterator`] trait over the segmenter break
+/// opportunities of the given string. Please see the [module-level
+/// documentation] for its usages.
+///
+/// [`Iterator`]: core::iter::Iterator
+/// [module-level documentation]: ../index.html
+pub struct RuleBreakIterator<'a, Y: RuleBreakType<'a> + ?Sized> {
+    pub(crate) iter: Y::IterAttr,
+    pub(crate) len: usize,
+    pub(crate) current_pos_data: Option<(usize, Y::CharType)>,
+    pub(crate) result_cache: alloc::vec::Vec<usize>,
+    pub(crate) break_state_table: &'a [i8],
+    pub(crate) property_table: &'a [&'a [u8; 1024]; 897],
+    pub(crate) rule_property_count: usize,
+    pub(crate) last_codepoint_property: i8,
+    pub(crate) sot_property: u8,
+    pub(crate) eot_property: u8,
+    pub(crate) complex_property: u8,
+}
+
+impl<'a, Y: RuleBreakType<'a>> Iterator for RuleBreakIterator<'a, Y> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // If we have break point cache by previous run, return this result
+        if !self.result_cache.is_empty() {
+            let mut i = 0;
+            loop {
+                if i == *self.result_cache.first().unwrap() {
+                    self.result_cache =
+                        self.result_cache.iter().skip(1).map(|r| r - i).collect();
+                    return Some(self.current_pos_data.unwrap().0);
+                }
+                i += Y::get_current_position_character_len(self);
+                self.current_pos_data = self.iter.next();
+                if self.current_pos_data.is_none() {
+                    // Reach EOF
+                    self.result_cache.clear();
+                    return Some(self.len);
+                }
+            }
         }
 
-        impl<'a> Iterator for $name<'a> {
-            type Item = usize;
+        if self.current_pos_data.is_none() {
+            let current_pos_data = self.iter.next()?;
+            self.current_pos_data = Some(current_pos_data);
+            // SOT x anything
+            let right_prop = Y::get_break_property(self);
+            if self.is_break_from_table(self.sot_property, right_prop) {
+                return Some(current_pos_data.0);
+            }
+        }
 
-            fn next(&mut self) -> Option<Self::Item> {
-                // If we have break point cache by previous run, return this result
-                if !self.result_cache.is_empty() {
-                    let mut i = 0;
-                    loop {
-                        if i == *self.result_cache.first().unwrap() {
-                            self.result_cache =
-                                self.result_cache.iter().skip(1).map(|r| r - i).collect();
-                            return Some(self.current_pos_data.unwrap().0);
-                        }
-                        i += self.get_current_position_character_len();
-                        self.current_pos_data = self.iter.next();
-                        if self.current_pos_data.is_none() {
-                            // Reach EOF
-                            self.result_cache.clear();
-                            return Some(self.len);
-                        }
-                    }
-                }
+        loop {
+            let left_prop = Y::get_break_property(self);
+            let left_codepoint = self.current_pos_data.unwrap().1;
+            self.current_pos_data = self.iter.next();
 
-                if self.current_pos_data.is_none() {
-                    let current_pos_data = self.iter.next()?;
-                    self.current_pos_data = Some(current_pos_data);
-                    // SOT x anything
-                    let right_prop = self.get_break_property();
-                    if self.is_break_from_table(self.sot_property, right_prop) {
-                        return Some(current_pos_data.0);
-                    }
+            if self.current_pos_data.is_none() {
+                return Some(self.len);
+            }
+            let right_prop = Y::get_break_property(self);
+
+            // Some segmenter rules doesn't have language-specific rules, we have to use LSTM (or dictionary) segmenter.
+            // If property is marked as SA, use it
+            if right_prop == self.complex_property {
+                if left_prop != self.complex_property {
+                    // break before SA
+                    return Some(self.current_pos_data.unwrap().0);
                 }
+                let break_offset = Y::handle_complex_language(self, left_codepoint);
+                if break_offset.is_some() {
+                    return break_offset;
+                }
+            }
+
+            // If break_state is equals or grater than 0, it is alias of property.
+            let mut break_state = self.get_break_state_from_table(left_prop, right_prop);
+
+            if break_state >= 0 as i8 {
+                // This isn't simple rule set. We need marker to restore iterator to previous position.
+                let mut previous_iter = self.iter.clone();
+                let mut previous_pos_data = self.current_pos_data;
 
                 loop {
-                    let left_prop = self.get_break_property();
-                    let left_codepoint = self.current_pos_data.unwrap().1;
                     self.current_pos_data = self.iter.next();
-
                     if self.current_pos_data.is_none() {
-                        return Some(self.len);
-                    }
-                    let right_prop = self.get_break_property();
-
-                    // Some segmenter rules doesn't have language-specific rules, we have to use LSTM (or dictionary) segmenter.
-                    // If property is marked as SA, use it
-                    if right_prop == self.complex_property {
-                        if left_prop != self.complex_property {
-                            // break before SA
-                            return Some(self.current_pos_data.unwrap().0);
-                        }
-                        let break_offset = self.handle_complex_language(left_codepoint);
-                        if break_offset.is_some() {
-                            return break_offset;
-                        }
-                    }
-
-                    // If break_state is equals or grater than 0, it is alias of property.
-                    let mut break_state = self.get_break_state_from_table(left_prop, right_prop);
-
-                    if break_state >= 0 as i8 {
-                        // This isn't simple rule set. We need marker to restore iterator to previous position.
-                        let mut previous_iter = self.iter.clone();
-                        let mut previous_pos_data = self.current_pos_data;
-
-                        loop {
-                            self.current_pos_data = self.iter.next();
-                            if self.current_pos_data.is_none() {
-                                // Reached EOF. But we are analyzing multiple characters now, so next break may be previous point.
-                                if self.get_break_state_from_table(
-                                    break_state as u8,
-                                    self.eot_property as u8,
-                                ) == NOT_MATCH_RULE
-                                {
-                                    self.iter = previous_iter;
-                                    self.current_pos_data = previous_pos_data;
-                                    return Some(previous_pos_data.unwrap().0);
-                                }
-                                // EOF
-                                return Some(self.len);
-                            }
-
-                            let previous_break_state = break_state;
-                            let prop = self.get_break_property();
-                            break_state = self.get_break_state_from_table(break_state as u8, prop);
-                            if break_state < 0 {
-                                break;
-                            }
-                            if previous_break_state >= 0
-                                && previous_break_state <= self.last_codepoint_property
-                            {
-                                // Move marker
-                                previous_iter = self.iter.clone();
-                                previous_pos_data = self.current_pos_data;
-                            }
-                            if (break_state & INTERMEDIATE_MATCH_RULE) != 0 {
-                                break_state -= INTERMEDIATE_MATCH_RULE;
-                                previous_iter = self.iter.clone();
-                                previous_pos_data = self.current_pos_data;
-                            }
-                        }
-                        if break_state == KEEP_RULE {
-                            continue;
-                        }
-                        if break_state == NOT_MATCH_RULE {
+                        // Reached EOF. But we are analyzing multiple characters now, so next break may be previous point.
+                        if self.get_break_state_from_table(
+                            break_state as u8,
+                            self.eot_property as u8,
+                        ) == NOT_MATCH_RULE
+                        {
                             self.iter = previous_iter;
                             self.current_pos_data = previous_pos_data;
                             return Some(previous_pos_data.unwrap().0);
                         }
-                        return Some(self.current_pos_data.unwrap().0);
+                        // EOF
+                        return Some(self.len);
                     }
 
-                    if self.is_break_from_table(left_prop, right_prop) {
-                        return Some(self.current_pos_data.unwrap().0);
+                    let previous_break_state = break_state;
+                    let prop = Y::get_break_property(self);
+                    break_state = self.get_break_state_from_table(break_state as u8, prop);
+                    if break_state < 0 {
+                        break;
+                    }
+                    if previous_break_state >= 0
+                        && previous_break_state <= self.last_codepoint_property
+                    {
+                        // Move marker
+                        previous_iter = self.iter.clone();
+                        previous_pos_data = self.current_pos_data;
+                    }
+                    if (break_state & INTERMEDIATE_MATCH_RULE) != 0 {
+                        break_state -= INTERMEDIATE_MATCH_RULE;
+                        previous_iter = self.iter.clone();
+                        previous_pos_data = self.current_pos_data;
                     }
                 }
+                if break_state == KEEP_RULE {
+                    continue;
+                }
+                if break_state == NOT_MATCH_RULE {
+                    self.iter = previous_iter;
+                    self.current_pos_data = previous_pos_data;
+                    return Some(previous_pos_data.unwrap().0);
+                }
+                return Some(self.current_pos_data.unwrap().0);
+            }
+
+            if self.is_break_from_table(left_prop, right_prop) {
+                return Some(self.current_pos_data.unwrap().0);
             }
         }
+    }
+}
 
-        impl<'a> $name<'a> {
-            fn get_break_state_from_table(&self, left: u8, right: u8) -> i8 {
-                self.break_state_table
-                    [(left as usize) * self.rule_property_count + (right as usize)]
-            }
+impl<'a, Y: RuleBreakType<'a>> RuleBreakIterator<'a, Y> {
+    fn get_break_state_from_table(&self, left: u8, right: u8) -> i8 {
+        self.break_state_table
+            [(left as usize) * self.rule_property_count + (right as usize)]
+    }
 
-            fn is_break_from_table(&self, left: u8, right: u8) -> bool {
-                let rule = self.get_break_state_from_table(left, right);
-                if rule == KEEP_RULE {
-                    return false;
-                }
-                if rule >= 0 {
-                    // need additional next characters to get break rule.
-                    return false;
-                }
-                true
-            }
+    fn is_break_from_table(&self, left: u8, right: u8) -> bool {
+        let rule = self.get_break_state_from_table(left, right);
+        if rule == KEEP_RULE {
+            return false;
         }
-    };
+        if rule >= 0 {
+            // need additional next characters to get break rule.
+            return false;
+        }
+        true
+    }
 }

--- a/experimental/segmenter/src/rule_segmenter.rs
+++ b/experimental/segmenter/src/rule_segmenter.rs
@@ -20,7 +20,10 @@ pub trait RuleBreakType<'a> {
 
     fn get_current_position_character_len(iter: &RuleBreakIterator<'a, Self>) -> usize;
 
-    fn handle_complex_language(iter: &mut RuleBreakIterator<'a, Self>, left_codepoint: Self::CharType) -> Option<usize>;
+    fn handle_complex_language(
+        iter: &mut RuleBreakIterator<'a, Self>,
+        left_codepoint: Self::CharType,
+    ) -> Option<usize>;
 }
 
 /// The struct implementing the [`Iterator`] trait over the segmenter break
@@ -52,8 +55,7 @@ impl<'a, Y: RuleBreakType<'a>> Iterator for RuleBreakIterator<'a, Y> {
             let mut i = 0;
             loop {
                 if i == *self.result_cache.first().unwrap() {
-                    self.result_cache =
-                        self.result_cache.iter().skip(1).map(|r| r - i).collect();
+                    self.result_cache = self.result_cache.iter().skip(1).map(|r| r - i).collect();
                     return Some(self.current_pos_data.unwrap().0);
                 }
                 i += Y::get_current_position_character_len(self);
@@ -111,10 +113,9 @@ impl<'a, Y: RuleBreakType<'a>> Iterator for RuleBreakIterator<'a, Y> {
                     self.current_pos_data = self.iter.next();
                     if self.current_pos_data.is_none() {
                         // Reached EOF. But we are analyzing multiple characters now, so next break may be previous point.
-                        if self.get_break_state_from_table(
-                            break_state as u8,
-                            self.eot_property as u8,
-                        ) == NOT_MATCH_RULE
+                        if self
+                            .get_break_state_from_table(break_state as u8, self.eot_property as u8)
+                            == NOT_MATCH_RULE
                         {
                             self.iter = previous_iter;
                             self.current_pos_data = previous_pos_data;
@@ -180,8 +181,7 @@ impl<'a, Y: RuleBreakType<'a>> RuleBreakIterator<'a, Y> {
     }
 
     fn get_break_state_from_table(&self, left: u8, right: u8) -> i8 {
-        self.break_state_table
-            [(left as usize) * self.rule_property_count + (right as usize)]
+        self.break_state_table[(left as usize) * self.rule_property_count + (right as usize)]
     }
 
     fn is_break_from_table(&self, left: u8, right: u8) -> bool {

--- a/experimental/segmenter/src/sentence.rs
+++ b/experimental/segmenter/src/sentence.rs
@@ -38,10 +38,6 @@ impl<'a> RuleBreakType<'a> for SentenceBreakType {
     type IterAttr = CharIndices<'a>;
     type CharType = char;
 
-    fn get_break_property(iter: &RuleBreakIterator<Self>) -> u8 {
-        get_break_property_utf8(iter.current_pos_data.unwrap().1, iter.property_table)
-    }
-
     fn get_current_position_character_len(iter: &RuleBreakIterator<Self>) -> usize {
         iter.current_pos_data.unwrap().1.len_utf8()
     }
@@ -79,11 +75,6 @@ impl<'a> RuleBreakType<'a> for SentenceBreakTypeLatin1 {
     type IterAttr = Latin1Indices<'a>;
     type CharType = u8; // TODO: Latin1Char
 
-    #[inline]
-    fn get_break_property(iter: &RuleBreakIterator<Self>) -> u8 {
-        get_break_property_latin1(iter.current_pos_data.unwrap().1, iter.property_table)
-    }
-
     fn get_current_position_character_len(_: &RuleBreakIterator<Self>) -> usize {
         panic!("not reachable")
     }
@@ -120,11 +111,6 @@ impl<'a> SentenceBreakIteratorUtf16<'a> {
 impl<'a> RuleBreakType<'a> for SentenceBreakTypeUtf16 {
     type IterAttr = Utf16Indices<'a>;
     type CharType = u32;
-
-    #[inline]
-    fn get_break_property(iter: &RuleBreakIterator<Self>) -> u8 {
-        get_break_property_utf32(iter.current_pos_data.unwrap().1, iter.property_table)
-    }
 
     fn get_current_position_character_len(iter: &RuleBreakIterator<Self>) -> usize {
         let ch = iter.current_pos_data.unwrap().1;

--- a/experimental/segmenter/src/sentence.rs
+++ b/experimental/segmenter/src/sentence.rs
@@ -42,7 +42,10 @@ impl<'a> RuleBreakType<'a> for SentenceBreakType {
         iter.current_pos_data.unwrap().1.len_utf8()
     }
 
-    fn handle_complex_language(_ : &mut RuleBreakIterator<Self>, _: Self::CharType) -> Option<usize> {
+    fn handle_complex_language(
+        _: &mut RuleBreakIterator<Self>,
+        _: Self::CharType,
+    ) -> Option<usize> {
         panic!("not reachable")
     }
 }
@@ -79,7 +82,10 @@ impl<'a> RuleBreakType<'a> for SentenceBreakTypeLatin1 {
         panic!("not reachable")
     }
 
-    fn handle_complex_language(_: &mut RuleBreakIterator<Self>, _: Self::CharType) -> Option<usize> {
+    fn handle_complex_language(
+        _: &mut RuleBreakIterator<Self>,
+        _: Self::CharType,
+    ) -> Option<usize> {
         panic!("not reachable")
     }
 }
@@ -121,7 +127,10 @@ impl<'a> RuleBreakType<'a> for SentenceBreakTypeUtf16 {
         }
     }
 
-    fn handle_complex_language(_: &mut RuleBreakIterator<Self>, _: Self::CharType) -> Option<usize> {
+    fn handle_complex_language(
+        _: &mut RuleBreakIterator<Self>,
+        _: Self::CharType,
+    ) -> Option<usize> {
         panic!("not reachable")
     }
 }

--- a/experimental/segmenter/src/word.rs
+++ b/experimental/segmenter/src/word.rs
@@ -58,10 +58,6 @@ impl<'a> RuleBreakType<'a> for WordBreakType {
     type IterAttr = CharIndices<'a>;
     type CharType = char;
 
-    fn get_break_property(iter: &RuleBreakIterator<Self>) -> u8 {
-        get_break_property_utf8(iter.current_pos_data.unwrap().1, iter.property_table)
-    }
-
     fn get_current_position_character_len(iter: &RuleBreakIterator<Self>) -> usize {
         iter.current_pos_data.unwrap().1.len_utf8()
     }
@@ -78,7 +74,7 @@ impl<'a> RuleBreakType<'a> for WordBreakType {
             if iter.current_pos_data.is_none() {
                 break;
             }
-            if Self::get_break_property(iter) != iter.complex_property {
+            if iter.get_current_break_property() != iter.complex_property {
                 break;
             }
         }
@@ -133,11 +129,6 @@ impl<'a> RuleBreakType<'a> for WordBreakTypeLatin1 {
     type IterAttr = Latin1Indices<'a>;
     type CharType = u8; // TODO: Latin1Char
 
-    #[inline]
-    fn get_break_property(iter: &RuleBreakIterator<Self>) -> u8 {
-        get_break_property_latin1(iter.current_pos_data.unwrap().1, iter.property_table)
-    }
-
     fn get_current_position_character_len(_: &RuleBreakIterator<Self>) -> usize {
         panic!("not reachable")
     }
@@ -175,11 +166,6 @@ impl<'a> RuleBreakType<'a> for WordBreakTypeUtf16 {
     type IterAttr = Utf16Indices<'a>;
     type CharType = u32;
 
-    #[inline]
-    fn get_break_property(iter: &RuleBreakIterator<Self>) -> u8 {
-        get_break_property_utf32(iter.current_pos_data.unwrap().1, iter.property_table)
-    }
-
     fn get_current_position_character_len(iter: &RuleBreakIterator<Self>) -> usize {
         let ch = iter.current_pos_data.unwrap().1;
         if ch >= 0x10000 {
@@ -200,7 +186,7 @@ impl<'a> RuleBreakType<'a> for WordBreakTypeUtf16 {
             if iter.current_pos_data.is_none() {
                 break;
             }
-            if Self::get_break_property(iter) != iter.complex_property {
+            if iter.get_current_break_property() != iter.complex_property {
                 break;
             }
         }

--- a/experimental/segmenter/src/word.rs
+++ b/experimental/segmenter/src/word.rs
@@ -62,7 +62,10 @@ impl<'a> RuleBreakType<'a> for WordBreakType {
         iter.current_pos_data.unwrap().1.len_utf8()
     }
 
-    fn handle_complex_language(iter: &mut RuleBreakIterator<'a, Self>, left_codepoint: Self::CharType) -> Option<usize> {
+    fn handle_complex_language(
+        iter: &mut RuleBreakIterator<'a, Self>,
+        left_codepoint: Self::CharType,
+    ) -> Option<usize> {
         // word segmenter doesn't define break rules for some languages such as Thai.
         let start_iter = iter.iter.clone();
         let start_point = iter.current_pos_data;
@@ -133,7 +136,10 @@ impl<'a> RuleBreakType<'a> for WordBreakTypeLatin1 {
         panic!("not reachable")
     }
 
-    fn handle_complex_language(_: &mut RuleBreakIterator<'a, Self>, _: Self::CharType) -> Option<usize> {
+    fn handle_complex_language(
+        _: &mut RuleBreakIterator<'a, Self>,
+        _: Self::CharType,
+    ) -> Option<usize> {
         panic!("not reachable")
     }
 }
@@ -175,7 +181,10 @@ impl<'a> RuleBreakType<'a> for WordBreakTypeUtf16 {
         }
     }
 
-    fn handle_complex_language(iter: &mut RuleBreakIterator<Self>, left_codepoint: Self::CharType) -> Option<usize> {
+    fn handle_complex_language(
+        iter: &mut RuleBreakIterator<Self>,
+        left_codepoint: Self::CharType,
+    ) -> Option<usize> {
         // word segmenter doesn't define break rules for some languages such as Thai.
         let start_iter = iter.iter.clone();
         let start_point = iter.current_pos_data;

--- a/experimental/segmenter/src/word.rs
+++ b/experimental/segmenter/src/word.rs
@@ -7,7 +7,6 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::str::CharIndices;
 
-use crate::break_iterator_impl;
 use crate::indices::{Latin1Indices, Utf16Indices};
 use crate::lstm::get_line_break_utf16;
 use crate::lstm::get_line_break_utf8;
@@ -31,8 +30,10 @@ fn get_complex_language_break_utf8(input: &str) -> Vec<usize> {
     [input.len()].to_vec()
 }
 
+pub struct WordBreakType;
+
 // UTF-8 version of word break iterator using rule based segmenter.
-break_iterator_impl!(WordBreakIterator, CharIndices<'a>, char);
+pub type WordBreakIterator<'a> = RuleBreakIterator<'a, WordBreakType>;
 
 impl<'a> WordBreakIterator<'a> {
     /// Create word break iterator
@@ -51,56 +52,63 @@ impl<'a> WordBreakIterator<'a> {
             complex_property: PROP_COMPLEX as u8,
         }
     }
+}
 
-    fn get_break_property(&mut self) -> u8 {
-        get_break_property_utf8(self.current_pos_data.unwrap().1, self.property_table)
+impl<'a> RuleBreakType<'a> for WordBreakType {
+    type IterAttr = CharIndices<'a>;
+    type CharType = char;
+
+    fn get_break_property(iter: &RuleBreakIterator<Self>) -> u8 {
+        get_break_property_utf8(iter.current_pos_data.unwrap().1, iter.property_table)
     }
 
-    fn get_current_position_character_len(&self) -> usize {
-        self.current_pos_data.unwrap().1.len_utf8()
+    fn get_current_position_character_len(iter: &RuleBreakIterator<Self>) -> usize {
+        iter.current_pos_data.unwrap().1.len_utf8()
     }
 
-    fn handle_complex_language(&mut self, left_codepoint: char) -> Option<usize> {
+    fn handle_complex_language(iter: &mut RuleBreakIterator<'a, Self>, left_codepoint: Self::CharType) -> Option<usize> {
         // word segmenter doesn't define break rules for some languages such as Thai.
-        let start_iter = self.iter.clone();
-        let start_point = self.current_pos_data;
+        let start_iter = iter.iter.clone();
+        let start_point = iter.current_pos_data;
         let mut s = String::new();
         s.push(left_codepoint);
         loop {
-            s.push(self.current_pos_data.unwrap().1);
-            self.current_pos_data = self.iter.next();
-            if self.current_pos_data.is_none() {
+            s.push(iter.current_pos_data.unwrap().1);
+            iter.current_pos_data = iter.iter.next();
+            if iter.current_pos_data.is_none() {
                 break;
             }
-            if self.get_break_property() != self.complex_property {
+            if Self::get_break_property(iter) != iter.complex_property {
                 break;
             }
         }
 
         // Restore iterator to move to head of complex string
-        self.iter = start_iter;
-        self.current_pos_data = start_point;
+        iter.iter = start_iter;
+        iter.current_pos_data = start_point;
         let breaks = get_complex_language_break_utf8(&s);
-        self.result_cache = breaks;
-        let mut i = self.current_pos_data.unwrap().1.len_utf8();
+        iter.result_cache = breaks;
+        let mut i = iter.current_pos_data.unwrap().1.len_utf8();
         loop {
-            if i == *self.result_cache.first().unwrap() {
+            if i == *iter.result_cache.first().unwrap() {
                 // Re-calculate breaking offset
-                self.result_cache = self.result_cache.iter().skip(1).map(|r| r - i).collect();
-                return Some(self.current_pos_data.unwrap().0);
+                iter.result_cache = iter.result_cache.iter().skip(1).map(|r| r - i).collect();
+                return Some(iter.current_pos_data.unwrap().0);
             }
-            self.current_pos_data = self.iter.next();
-            if self.current_pos_data.is_none() {
-                self.result_cache.clear();
-                return Some(self.len);
+            iter.current_pos_data = iter.iter.next();
+            if iter.current_pos_data.is_none() {
+                iter.result_cache.clear();
+                return Some(iter.len);
             }
-            i += self.get_current_position_character_len();
+            i += Self::get_current_position_character_len(iter);
         }
     }
 }
 
+pub struct WordBreakTypeLatin1;
+
 // Latin-1 version of word break iterator using rule based segmenter.
-break_iterator_impl!(WordBreakIteratorLatin1, Latin1Indices<'a>, u8);
+pub type WordBreakIteratorLatin1<'a> = RuleBreakIterator<'a, WordBreakTypeLatin1>;
 
 impl<'a> WordBreakIteratorLatin1<'a> {
     /// Create word break iterator using Latin-1/8-bit string.
@@ -119,23 +127,30 @@ impl<'a> WordBreakIteratorLatin1<'a> {
             complex_property: PROP_COMPLEX as u8,
         }
     }
+}
+
+impl<'a> RuleBreakType<'a> for WordBreakTypeLatin1 {
+    type IterAttr = Latin1Indices<'a>;
+    type CharType = u8; // TODO: Latin1Char
 
     #[inline]
-    fn get_break_property(&mut self) -> u8 {
-        get_break_property_latin1(self.current_pos_data.unwrap().1, self.property_table)
+    fn get_break_property(iter: &RuleBreakIterator<Self>) -> u8 {
+        get_break_property_latin1(iter.current_pos_data.unwrap().1, iter.property_table)
     }
 
-    fn get_current_position_character_len(&self) -> usize {
+    fn get_current_position_character_len(_: &RuleBreakIterator<Self>) -> usize {
         panic!("not reachable")
     }
 
-    fn handle_complex_language(&mut self, _: u8) -> Option<usize> {
+    fn handle_complex_language(_: &mut RuleBreakIterator<'a, Self>, _: Self::CharType) -> Option<usize> {
         panic!("not reachable")
     }
 }
 
+pub struct WordBreakTypeUtf16;
+
 // UTF-16 version of word break iterator using rule based segmenter.
-break_iterator_impl!(WordBreakIteratorUtf16, Utf16Indices<'a>, u32);
+pub type WordBreakIteratorUtf16<'a> = RuleBreakIterator<'a, WordBreakTypeUtf16>;
 
 impl<'a> WordBreakIteratorUtf16<'a> {
     /// Create word break iterator using UTF-16 string.
@@ -154,14 +169,19 @@ impl<'a> WordBreakIteratorUtf16<'a> {
             complex_property: PROP_COMPLEX as u8,
         }
     }
+}
+
+impl<'a> RuleBreakType<'a> for WordBreakTypeUtf16 {
+    type IterAttr = Utf16Indices<'a>;
+    type CharType = u32;
 
     #[inline]
-    fn get_break_property(&mut self) -> u8 {
-        get_break_property_utf32(self.current_pos_data.unwrap().1, self.property_table)
+    fn get_break_property(iter: &RuleBreakIterator<Self>) -> u8 {
+        get_break_property_utf32(iter.current_pos_data.unwrap().1, iter.property_table)
     }
 
-    fn get_current_position_character_len(&self) -> usize {
-        let ch = self.current_pos_data.unwrap().1;
+    fn get_current_position_character_len(iter: &RuleBreakIterator<Self>) -> usize {
+        let ch = iter.current_pos_data.unwrap().1;
         if ch >= 0x10000 {
             2
         } else {
@@ -169,39 +189,39 @@ impl<'a> WordBreakIteratorUtf16<'a> {
         }
     }
 
-    fn handle_complex_language(&mut self, left_codepoint: u32) -> Option<usize> {
+    fn handle_complex_language(iter: &mut RuleBreakIterator<Self>, left_codepoint: Self::CharType) -> Option<usize> {
         // word segmenter doesn't define break rules for some languages such as Thai.
-        let start_iter = self.iter.clone();
-        let start_point = self.current_pos_data;
+        let start_iter = iter.iter.clone();
+        let start_point = iter.current_pos_data;
         let mut s = vec![left_codepoint as u16];
         loop {
-            s.push(self.current_pos_data.unwrap().1 as u16);
-            self.current_pos_data = self.iter.next();
-            if self.current_pos_data.is_none() {
+            s.push(iter.current_pos_data.unwrap().1 as u16);
+            iter.current_pos_data = iter.iter.next();
+            if iter.current_pos_data.is_none() {
                 break;
             }
-            if self.get_break_property() != self.complex_property {
+            if Self::get_break_property(iter) != iter.complex_property {
                 break;
             }
         }
 
         // Restore iterator to move to head of complex string
-        self.iter = start_iter;
-        self.current_pos_data = start_point;
+        iter.iter = start_iter;
+        iter.current_pos_data = start_point;
         let breaks = get_complex_language_break(&s);
         let mut i = 1;
-        self.result_cache = breaks;
+        iter.result_cache = breaks;
         // result_cache vector is utf-16 index that is in BMP.
         loop {
-            if i == *self.result_cache.first().unwrap() {
+            if i == *iter.result_cache.first().unwrap() {
                 // Re-calculate breaking offset
-                self.result_cache = self.result_cache.iter().skip(1).map(|r| r - i).collect();
-                return Some(self.current_pos_data.unwrap().0);
+                iter.result_cache = iter.result_cache.iter().skip(1).map(|r| r - i).collect();
+                return Some(iter.current_pos_data.unwrap().0);
             }
-            self.current_pos_data = self.iter.next();
-            if self.current_pos_data.is_none() {
-                self.result_cache.clear();
-                return Some(self.len);
+            iter.current_pos_data = iter.iter.next();
+            if iter.current_pos_data.is_none() {
+                iter.result_cache.clear();
+                return Some(iter.len);
             }
             i += 1;
         }


### PR DESCRIPTION
This is a purely refactor and cleanup PR similar to #1380, and shouldn't change the behavior.

Tip: it would be easier to review when enabling "Hide Whitespace" or appending `?w=1` at the end of the URL. 