### PR TITLE
Fix get_best_available_format_pattern()'s skeleton matching logic.

### DIFF
--- a/components/datetime/src/skeleton/helpers.rs
+++ b/components/datetime/src/skeleton/helpers.rs
@@ -368,13 +368,13 @@ pub fn get_best_available_format_pattern<'data>(
                         .symbol
                         .discriminant_cmp(&requested_field.symbol)
                     {
-                        Ordering::Greater => {
+                        Ordering::Less => {
                             // Keep searching for a matching skeleton field.
                             skeleton_fields.next();
                             distance += SKELETON_EXTRA_SYMBOL;
                             continue;
                         }
-                        Ordering::Less => {
+                        Ordering::Greater => {
                             // The requested field symbol is missing from the skeleton.
                             distance += REQUESTED_SYMBOL_MISSING;
                             missing_fields += 1;

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -487,31 +487,6 @@ fn test_components_combine_datetime() {
 }
 
 #[test]
-fn constructing_datetime_format_with_missing_pattern_is_err() {
-    use icu_datetime::{
-        options::components::{Bag, Week},
-        DateTimeFormatError, DateTimeFormatOptions,
-    };
-    use icu_locid::Locale;
-    use icu_locid_macros::langid;
-
-    let options = DateTimeFormatOptions::Components(Bag {
-        // There's no pattern for just 'w'.
-        week: Some(Week::NumericWeekOfYear),
-        ..Default::default()
-    });
-
-    let locale: Locale = langid!("en").into();
-    let provider = icu_testdata::get_provider();
-    let result = DateTimeFormat::<Gregorian>::try_new(locale, &provider, &options);
-
-    assert!(matches!(
-        result.err(),
-        Some(DateTimeFormatError::UnsupportedOptions)
-    ));
-}
-
-#[test]
 fn constructing_datetime_format_with_time_zone_pattern_symbols_is_err() {
     use icu_datetime::{
         options::length::{Bag, Time},

--- a/components/datetime/tests/fixtures/tests/components-partial-matches.json
+++ b/components/datetime/tests/fixtures/tests/components-partial-matches.json
@@ -1,6 +1,6 @@
 [
     {
-        "description": "Partial match for m -> m:ss",
+        "description": "Partial match for m -> hm -> h:m a",
         "input": {
             "value": "2002-12-31T08:05:07.000",
             "options": {
@@ -11,13 +11,13 @@
         },
         "output": {
             "values": {
-                "en": "5:07",
-                "fr": "5:07"
+                "en": "8:5 AM",
+                "fr": "8:5 AM"
             }
         }
     },
     {
-        "description": "Partial match for Hs -> H",
+        "description": "Partial match for hs -> hms -> h:mm:s a",
         "input": {
             "value": "2002-12-31T08:05:07.000",
             "options": {
@@ -29,13 +29,13 @@
         },
         "output": {
             "values": {
-                "en": "8",
-                "fr": "8 h"
+                "en": "8:05:7",
+                "fr": "8:05:7"
             }
         }
     },
     {
-        "description": "Partial match for YEEEE -> y",
+        "description": "Partial match for YEEEE -> yMEd -> E, M/d/y",
         "input": {
             "value": "2002-12-31T08:25:07.000",
             "options": {
@@ -47,13 +47,13 @@
         },
         "output": {
             "values": {
-                "en": "2002",
-                "fr": "2002"
+                "en": "Tuesday, 12/31/2002",
+                "fr": "mardi 31/12/2002"
             }
         }
     },
     {
-        "description": "Partial match for YwEEEE -> 'week w of Y'",
+        "description": "Partial match for YwEEEE -> yw -> 'week w of Y'",
         "input": {
             "value": "2002-12-31T08:25:07.000",
             "options": {


### PR DESCRIPTION
The compare was inverted resulting in matching at best stopping at the first missing symbol rather than iterating through.

For example, with:

- `fields` = "hs"
- `skeletons` = ["h", "hms"]

Previously for "hms" we'd get a distance of 11000:

requested_fields.peek() | skeleton_fields.peek() | result
----------------------- | ---------------------- | -------
"h"                     | "h"                    | match
"s"                     | "m"                    | missing (+10000)
None                    | "s"                    | extra (+1000)

Whereas we now get 1000:

requested_fields.peek() | skeleton_fields.peek() | result
----------------------- | ---------------------- | ------
"h"                     | "h"                    | match
"s"                     | "m"                    | extra (+1000)
"s"                     | "s"                    | match

distance("hs", "h") = missing = 10000 both before & now resulting in the best match changing from "h" to "hms".

Worst case scenario was when a candidate pattern started with a symbol less than the first requested symbol. In such a case the pattern fails to match at all: e.g. `fields` = "s" won't match "hms".

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->