### PR TITLE
Removing uprops-specific code from ResourceKey

### DIFF
--- a/provider/uprops/src/bin_uniset.rs
+++ b/provider/uprops/src/bin_uniset.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::uprops_helpers::{self, TomlBinary};
+use crate::uprops_helpers::{self, get_last_component_no_version, TomlBinary};
 
 use icu_properties::provider::UnicodePropertyV1;
 use icu_properties::provider::UnicodePropertyV1Marker;
@@ -30,7 +30,7 @@ impl DataProvider<UnicodePropertyV1Marker> for BinaryPropertyUnicodeSetDataProvi
     ) -> Result<DataResponse<UnicodePropertyV1Marker>, DataError> {
         let data = &self
             .data
-            .get(req.resource_path.key.get_last_component_no_version())
+            .get(get_last_component_no_version(&req.resource_path.key))
             .ok_or_else(|| DataErrorKind::MissingResourceKey.with_req(req))?;
 
         let mut builder = UnicodeSetBuilder::new();

--- a/provider/uprops/src/enum_codepointtrie.rs
+++ b/provider/uprops/src/enum_codepointtrie.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::uprops_helpers::{self, TomlEnumerated};
+use crate::uprops_helpers::{self, get_last_component_no_version, TomlEnumerated};
 use crate::uprops_serde::enumerated::EnumeratedPropertyCodePointTrie;
 
 use icu_codepointtrie::{CodePointTrie, CodePointTrieHeader, TrieType, TrieValue};
@@ -102,7 +102,7 @@ impl<T: TrieValue> DataProvider<UnicodePropertyMapV1Marker<T>>
         // For data resource keys that represent the CodePointTrie data for an enumerated
         // property, the ResourceKey sub-category string will just be the short alias
         // for the property.
-        let prop_name = req.resource_path.key.get_last_component_no_version();
+        let prop_name = get_last_component_no_version(&req.resource_path.key);
         let source_cpt_data = &self
             .data
             .get(prop_name)

--- a/provider/uprops/src/enum_uniset.rs
+++ b/provider/uprops/src/enum_uniset.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::uprops_helpers::{self, TomlEnumerated};
+use crate::uprops_helpers::{self, get_last_component_no_version, TomlEnumerated};
 
 use icu_properties::provider::UnicodePropertyV1;
 use icu_properties::provider::UnicodePropertyV1Marker;
@@ -61,7 +61,7 @@ impl DataProvider<UnicodePropertyV1Marker> for EnumeratedPropertyUnicodeSetDataP
         &self,
         req: &DataRequest,
     ) -> Result<DataResponse<UnicodePropertyV1Marker>, DataError> {
-        let key = &req.resource_path.key.get_last_component_no_version();
+        let key = get_last_component_no_version(&req.resource_path.key);
 
         // ResourceKey subcategory strings for enumerated properties are
         // of the form "name=value", using the short name for both.

--- a/provider/uprops/src/provider.rs
+++ b/provider/uprops/src/provider.rs
@@ -4,6 +4,7 @@
 
 use crate::bin_uniset::BinaryPropertyUnicodeSetDataProvider;
 use crate::enum_uniset::EnumeratedPropertyUnicodeSetDataProvider;
+use crate::uprops_helpers::get_last_component_no_version;
 use icu_properties::provider::UnicodePropertyV1Marker;
 use icu_provider::iter::IterableProvider;
 use icu_provider::prelude::*;
@@ -34,12 +35,7 @@ impl DataProvider<UnicodePropertyV1Marker> for PropertiesDataProvider {
         &self,
         req: &DataRequest,
     ) -> Result<DataResponse<UnicodePropertyV1Marker>, DataError> {
-        if req
-            .resource_path
-            .key
-            .get_last_component_no_version()
-            .contains('=')
-        {
+        if get_last_component_no_version(&req.resource_path.key).contains('=') {
             self.enumerated.load_payload(req)
         } else {
             self.binary.load_payload(req)

--- a/provider/uprops/src/script.rs
+++ b/provider/uprops/src/script.rs
@@ -80,7 +80,7 @@ impl DataProvider<ScriptExtensionsPropertyV1Marker> for ScriptExtensionsProperty
         &self,
         req: &DataRequest,
     ) -> Result<DataResponse<ScriptExtensionsPropertyV1Marker>, DataError> {
-        if req.resource_path.key.get_last_component_no_version() != "scx" {
+        if uprops_helpers::get_last_component_no_version(&req.resource_path.key) != "scx" {
             return Err(DataErrorKind::MissingResourceKey.with_req(req));
         }
 

--- a/provider/uprops/src/uprops_helpers.rs
+++ b/provider/uprops/src/uprops_helpers.rs
@@ -68,3 +68,13 @@ pub fn load_script_extensions_from_dir(
             )
         })
 }
+
+pub fn get_last_component_no_version(key: &icu_provider::ResourceKey) -> &str {
+    key.get_path()
+        .split('/')
+        .last()
+        .expect("str::split doesn't return empty iterators")
+        .split('@')
+        .next()
+        .expect("str::split doesn't return empty iterators")
+}


### PR DESCRIPTION
This removes the constraint that the path has to contain at least one `/`. No other code seems to need this.