### PR TITLE
Add namespace to ZeroCopyFrom in yoke derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 [dependencies]
 stable_deref_trait = { version = "1.2.0", features = ["alloc"], default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
-yoke-derive = { path = "./derive", version = "0.4.0", optional = true}
+yoke-derive = { path = "./derive", version = "0.4.1", optional = true}
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/utils/yoke/derive/Cargo.toml
+++ b/utils/yoke/derive/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "yoke-derive"
-version = "0.4.0"
+version = "0.4.1"
 description = "Custom derive for the yoke crate"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "LICENSE"

--- a/utils/yoke/derive/src/lib.rs
+++ b/utils/yoke/derive/src/lib.rs
@@ -253,7 +253,7 @@ fn zcf_derive_impl(input: &DeriveInput) -> TokenStream2 {
             .map(|ty| parse_quote!(#ty: #clone_trait + 'static))
             .collect();
         quote! {
-            impl<'zcf, #(#tybounds),*> ZeroCopyFrom<'zcf, #name<#(#typarams),*>> for #name<#(#typarams),*> where #(#bounds),* {
+            impl<'zcf, #(#tybounds),*> yoke::ZeroCopyFrom<'zcf, #name<#(#typarams),*>> for #name<#(#typarams),*> where #(#bounds),* {
                 fn zero_copy_from(this: &'zcf Self) -> Self {
                     #clone
                 }
@@ -269,7 +269,7 @@ fn zcf_derive_impl(input: &DeriveInput) -> TokenStream2 {
         }
         if has_clone {
             return quote! {
-                impl<'zcf> ZeroCopyFrom<'zcf, #name<'_>> for #name<'zcf> {
+                impl<'zcf> yoke::ZeroCopyFrom<'zcf, #name<'_>> for #name<'zcf> {
                     fn zero_copy_from(this: &'zcf #name<'_>) -> Self {
                         this.clone()
                     }


### PR DESCRIPTION
See #1557

This makes it such that you can `use icu_provider::yoke;` rather than need to `use icu_provider::yoke::{self, *}`.  One step in the right direction hopefully.