### PR TITLE
Make ListFormatter data an optional feature of provider_cldr

### DIFF
--- a/provider/cldr/Cargo.toml
+++ b/provider/cldr/Cargo.toml
@@ -43,7 +43,7 @@ icu_datetime = { version = "0.5", path = "../../components/datetime", features =
 icu_locale_canonicalizer = { version = "0.5", path = "../../components/locale_canonicalizer" }
 icu_decimal = { version = "0.5", path = "../../components/decimal" }
 icu_calendar = { version = "0.5", path = "../../components/calendar", features = ["provider_serde"] }
-icu_list = { version = "0.1", path = "../../experimental/list_formatter", features = ["provider_transform_internals"]}
+icu_list = { version = "0.1", path = "../../experimental/list_formatter", features = ["provider_transform_internals"], optional = true}
 itertools = "0.10"
 json = "0.12"
 litemap = { version = "0.3.0", path = "../../utils/litemap/" }
@@ -75,3 +75,4 @@ writeable = { version = "0.3", path = "../../utils/writeable" }
 [features]
 # Automatically download CLDR data from a host
 download = ["urlencoding", "reqwest", "unzip", "dirs", "log"]
+experimental = ["icu_list"]

--- a/provider/cldr/src/transform/mod.rs
+++ b/provider/cldr/src/transform/mod.rs
@@ -9,6 +9,7 @@
 mod calendar;
 mod datetime;
 mod decimal;
+#[cfg(feature = "icu_list")]
 mod list;
 mod locale_canonicalizer;
 mod plurals;
@@ -20,6 +21,7 @@ pub use datetime::{
     symbols::DateSymbolsProvider,
 };
 pub use decimal::NumbersProvider;
+#[cfg(feature = "icu_list")]
 pub use list::ListProvider;
 pub use locale_canonicalizer::aliases::AliasesProvider;
 pub use locale_canonicalizer::likely_subtags::LikelySubtagsProvider;
@@ -46,6 +48,7 @@ pub fn get_all_cldr_keys() -> Vec<ResourceKey> {
     result.extend(&decimal::ALL_KEYS);
     result.extend(&plurals::ALL_KEYS);
     result.extend(&time_zones::ALL_KEYS);
+    #[cfg(feature = "icu_list")]
     result.extend(&list::ALL_KEYS);
     result
 }
@@ -62,6 +65,7 @@ pub struct CldrJsonDataProvider<'a> {
     numbers: LazyCldrProvider<NumbersProvider>,
     plurals: LazyCldrProvider<PluralsProvider>,
     time_zones: LazyCldrProvider<TimeZonesProvider>,
+    #[cfg(feature = "icu_list")]
     list: LazyCldrProvider<ListProvider>,
 }
 
@@ -78,6 +82,7 @@ impl<'a> CldrJsonDataProvider<'a> {
             numbers: Default::default(),
             plurals: Default::default(),
             time_zones: Default::default(),
+            #[cfg(feature = "icu_list")]
             list: Default::default(),
         }
     }
@@ -112,6 +117,7 @@ impl<'a> DataProvider<SerializeMarker> for CldrJsonDataProvider<'a> {
         if let Some(result) = self.time_zones.try_load_serde(req, self.cldr_paths)? {
             return Ok(result);
         }
+        #[cfg(feature = "icu_list")]
         if let Some(result) = self.list.try_load_serde(req, self.cldr_paths)? {
             return Ok(result);
         }
@@ -178,6 +184,7 @@ impl<'a> IterableProvider for CldrJsonDataProvider<'a> {
         {
             return Ok(Box::new(resp.into_iter()));
         }
+        #[cfg(feature = "icu_list")]
         if let Some(resp) = self.list.try_supported_options(resc_key, self.cldr_paths)? {
             return Ok(Box::new(resp.into_iter()));
         }

--- a/tools/datagen/Cargo.toml
+++ b/tools/datagen/Cargo.toml
@@ -45,6 +45,9 @@ simple_logger = "1.12"
 tokio = { version = "1.5", features = ["rt-multi-thread", "macros", "fs"] }
 writeable = { version = "0.3", path = "../../utils/writeable" }
 
+[features]
+experimental = ["icu_provider_cldr/experimental"]
+
 [[bin]]
 name = "icu4x-datagen"
 path = "src/bin/datagen.rs"

--- a/tools/scripts/data.toml
+++ b/tools/scripts/data.toml
@@ -28,6 +28,7 @@ command = "cargo"
 args = [
     "run",
     "--bin=icu4x-datagen",
+    "--features=experimental",
     "--",
     "--input-from-testdata",
     "--out-testdata",
@@ -45,6 +46,7 @@ command = "cargo"
 args = [
     "run",
     "--bin=icu4x-datagen",
+    "--features=experimental",
     "--",
     "--format=blob",
     "--input-from-testdata",
@@ -61,6 +63,7 @@ command = "cargo"
 args = [
     "run",
     "--bin=icu4x-datagen",
+    "--features=experimental",
     "--",
     "--format=blob",
     "--hello-world-key",
@@ -76,6 +79,7 @@ command = "cargo"
 args = [
     "run",
     "--bin=icu4x-datagen",
+    "--features=experimental",
     "--",
     "--format=blob",
     "--input-from-testdata",
@@ -124,6 +128,7 @@ command = "cargo"
 args = [
     "run",
     "--bin=icu4x-datagen",
+    "--features=experimental",
     "--",
     "--input-from-testdata",
     "--out-testdata",
@@ -140,6 +145,7 @@ command = "cargo"
 args = [
     "run",
     "--bin=icu4x-datagen",
+    "--features=experimental",
     "--",
     "--input-from-testdata",
     "--out-testdata",
@@ -156,6 +162,7 @@ command = "cargo"
 args = [
     "run",
     "--bin=icu4x-datagen",
+    "--features=experimental",
     "--",
     "--input-from-testdata",
     "--out=tools/datagen/tests/testdata/work_log_bincode",


### PR DESCRIPTION
This unblocks the release publish for datagen/cldr.


I believe @sffc is working on an alternate approach that pref-gates it at the list level, but this seems to work okayishly.

cc @robertbastian

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->