### PR TITLE
Add custom derives for ULE and VarULE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3127,6 +3127,7 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+ "zerovec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3120,6 +3120,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerovec-derive"
+version = "0.6.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zip"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
     "utils/yoke",
     "utils/yoke/derive",
     "utils/zerovec",
+    "utils/zerovec/derive",
 ]
 
 # Enable lto for WASM.

--- a/utils/zerovec/derive/Cargo.toml
+++ b/utils/zerovec/derive/Cargo.toml
@@ -24,3 +24,6 @@ proc-macro2 = "1.0.27"
 quote = "1.0.9"
 syn = { version = "1.0.73", features = ["derive", "fold"] }
 synstructure = "0.12.4"
+
+[dev-dependencies]
+zerovec = { version = "0.6", path = ".." }

--- a/utils/zerovec/derive/Cargo.toml
+++ b/utils/zerovec/derive/Cargo.toml
@@ -1,0 +1,26 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+[package]
+name = "zerovec-derive"
+version = "0.6.0"
+description = "Custom derive for the zerovec crate"
+repository = "https://github.com/unicode-org/icu4x"
+license-file = "LICENSE"
+categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
+keywords = ["zerocopy", "serialization", "zero-copy", "serde"]
+authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc_macro = true
+path = "src/lib.rs"
+
+[dependencies]
+proc-macro2 = "1.0.27"
+quote = "1.0.9"
+syn = { version = "1.0.73", features = ["derive", "fold"] }
+synstructure = "0.12.4"

--- a/utils/zerovec/derive/LICENSE
+++ b/utils/zerovec/derive/LICENSE
@@ -1,0 +1,331 @@
+Except as otherwise noted below, ICU4X is licensed under the Apache
+License, Version 2.0 (included below) or the MIT license (included
+below), at your option. Unless importing data or code in the manner
+stated below, any contribution intentionally submitted for inclusion
+in ICU4X by you, as defined in the Apache-2.0 license, shall be dual
+licensed in the foregoing manner, without any additional terms or
+conditions.
+
+As exceptions to the above:
+* Portions of ICU4X that have been adapted from ICU4C and/or ICU4J are
+under the Unicode license (included below) and/or the ICU license
+(included below) as indicated by source code comments.
+* Unicode data incorporated in ICU4X is under the Unicode license
+(included below).
+* Your contributions may import code from ICU4C and/or ICU4J and
+Unicode data under these licenses. Indicate the license and the ICU4C
+or ICU4J origin in source code comments.
+
+- - - -
+
+Apache License, version 2.0
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+- - - -
+
+MIT License
+
+Copyright The ICU4X Authors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+- - - -
+
+Unicode License
+
+COPYRIGHT AND PERMISSION NOTICE (ICU 58 and later)
+
+Copyright © 1991-2020 Unicode, Inc. All rights reserved.
+Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Unicode data files and any associated documentation
+(the "Data Files") or Unicode software and any associated documentation
+(the "Software") to deal in the Data Files or Software
+without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, and/or sell copies of
+the Data Files or Software, and to permit persons to whom the Data Files
+or Software are furnished to do so, provided that either
+(a) this copyright and permission notice appear with all copies
+of the Data Files or Software, or
+(b) this copyright and permission notice appear in associated
+Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in these Data Files or Software without prior
+written authorization of the copyright holder.
+
+- - - -
+
+ICU License - ICU 1.8.1 to ICU 57.1
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright (c) 1995-2016 International Business Machines Corporation and others
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, and/or sell copies of the Software, and to permit persons
+to whom the Software is furnished to do so, provided that the above
+copyright notice(s) and this permission notice appear in all copies of
+the Software and that both the above copyright notice(s) and this
+permission notice appear in supporting documentation.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
+SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
+RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale, use
+or other dealings in this Software without prior written authorization
+of the copyright holder.
+
+All trademarks and registered trademarks mentioned herein are the
+property of their respective owners.
+
+- - - -

--- a/utils/zerovec/derive/README.md
+++ b/utils/zerovec/derive/README.md
@@ -1,0 +1,7 @@
+# zerovec-derive [![crates.io](https://img.shields.io/crates/v/zerovec-derive)](https://crates.io/crates/zerovec-derive)
+
+Proc macros for generating `ULE`, `VarULE` impls and types for the `zerovec` crate
+
+## More Information
+
+For more information on development, authorship, contributing etc. please visit [`ICU4X home page`](https://github.com/unicode-org/icu4x).

--- a/utils/zerovec/derive/examples/derives.rs
+++ b/utils/zerovec/derive/examples/derives.rs
@@ -1,3 +1,7 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
 use zerovec::ule::custom::EncodeAsVarULE;
 use zerovec::ule::AsULE;
 use zerovec::*;

--- a/utils/zerovec/derive/examples/derives.rs
+++ b/utils/zerovec/derive/examples/derives.rs
@@ -1,0 +1,65 @@
+use zerovec::ule::AsULE;
+use zerovec::ZeroVec;
+use zerovec_derive::ULE;
+
+#[repr(packed)]
+#[derive(ULE, Copy, Clone)]
+pub struct FooULE {
+    a: u8,
+    b: <u32 as AsULE>::ULE,
+    c: <char as AsULE>::ULE,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Foo {
+    a: u8,
+    b: u32,
+    c: char,
+}
+
+impl AsULE for Foo {
+    type ULE = FooULE;
+    fn as_unaligned(self) -> FooULE {
+        FooULE {
+            a: self.a,
+            b: self.b.as_unaligned(),
+            c: self.c.as_unaligned(),
+        }
+    }
+
+    fn from_unaligned(other: FooULE) -> Self {
+        Self {
+            a: other.a,
+            b: AsULE::from_unaligned(other.b),
+            c: AsULE::from_unaligned(other.c),
+        }
+    }
+}
+
+fn main() {
+    let vec = vec![
+        Foo {
+            a: 101,
+            b: 924,
+            c: '⸘',
+        },
+        Foo {
+            a: 217,
+            b: 4228,
+            c: 'ə',
+        },
+        Foo {
+            a: 117,
+            b: 9090,
+            c: 'ø',
+        },
+    ];
+    let zerovec: ZeroVec<Foo> = vec.iter().copied().collect();
+
+    assert_eq!(zerovec, &*vec);
+
+    let bytes = zerovec.as_bytes();
+    let reparsed: ZeroVec<Foo> = ZeroVec::parse_byte_slice(bytes).unwrap();
+
+    assert_eq!(reparsed, &*vec);
+}

--- a/utils/zerovec/derive/src/lib.rs
+++ b/utils/zerovec/derive/src/lib.rs
@@ -7,7 +7,7 @@
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
-mod ule;
+pub(crate) mod ule;
 mod utils;
 
 /// Custom derive for `zerovec::ULE`,

--- a/utils/zerovec/derive/src/lib.rs
+++ b/utils/zerovec/derive/src/lib.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-//! Custom derives for `Yokeable` and `ZeroCopyFrom` from the `yoke` crate.
+//! Proc macros for generating `ULE`, `VarULE` impls and types for the `zerovec` crate
 
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};

--- a/utils/zerovec/derive/src/lib.rs
+++ b/utils/zerovec/derive/src/lib.rs
@@ -9,6 +9,7 @@ use syn::{parse_macro_input, DeriveInput};
 
 pub(crate) mod ule;
 mod utils;
+mod varule;
 
 /// Custom derive for `zerovec::ULE`,
 ///
@@ -17,4 +18,13 @@ mod utils;
 pub fn ule_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     TokenStream::from(ule::derive_impl(&input))
+}
+
+/// Custom derive for `zerovec::VarULE`,
+///
+/// This can be attached to structs containing only ULE types with one VarULE type at the end
+#[proc_macro_derive(VarULE)]
+pub fn varule_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    TokenStream::from(varule::derive_impl(&input))
 }

--- a/utils/zerovec/derive/src/lib.rs
+++ b/utils/zerovec/derive/src/lib.rs
@@ -1,0 +1,19 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+//! Custom derives for `Yokeable` and `ZeroCopyFrom` from the `yoke` crate.
+
+use proc_macro::TokenStream;
+use syn::{parse_macro_input, DeriveInput};
+
+mod ule;
+
+/// Custom derive for `zerovec::ULE`,
+///
+/// This can be attached to structs containing only ULE types
+#[proc_macro_derive(ULE)]
+pub fn ule_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    TokenStream::from(ule::derive_impl(&input))
+}

--- a/utils/zerovec/derive/src/lib.rs
+++ b/utils/zerovec/derive/src/lib.rs
@@ -8,6 +8,7 @@ use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
 mod ule;
+mod utils;
 
 /// Custom derive for `zerovec::ULE`,
 ///

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -17,7 +17,7 @@ pub fn derive_impl(input: &DeriveInput) -> TokenStream2 {
     if !crate::utils::has_valid_repr(&input.attrs) {
         return Error::new(
             input.span(),
-            "derive(ULE) must be applied to a #[repr(C)] or #[repr(transparent)] type",
+            "derive(ULE) must be applied to a #[repr(packed)] or #[repr(transparent)] type",
         )
         .to_compile_error();
     }
@@ -52,12 +52,12 @@ pub fn derive_impl(input: &DeriveInput) -> TokenStream2 {
     // Safety (based on the safety checklist on the ULE trait):
     //  1. #name does not include any uninitialized or padding bytes.
     //     (achieved by enforcing #[repr(transparent)] or #[repr(packed)] on a struct of only ULE types)
-    //  2. CharULE is aligned to 1 byte.
+    //  2. #name is aligned to 1 byte.
     //     (achieved by enforcing #[repr(transparent)] or #[repr(packed)] on a struct of only ULE types)
     //  3. The impl of validate_byte_slice() returns an error if any byte is not valid.
     //  4. The impl of validate_byte_slice() returns an error if there are extra bytes.
     //  5. The other ULE methods use the default impl.
-    //  6. [This impl does not enforce the equality constraint, it is up to the user to do so, ideally via a custom derive]
+    //  6. [This impl does not enforce the non-safety equality constraint, it is up to the user to do so, ideally via a custom derive]
     quote! {
         unsafe impl zerovec::ule::ULE for #name {
             #[inline]

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -1,7 +1,113 @@
+use proc_macro2::Span;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::DeriveInput;
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
+use syn::{parenthesized, parse2, Attribute, Data, DeriveInput, Error, Ident, Result, Token};
 
-pub fn derive_impl(_input: &DeriveInput) -> TokenStream2 {
-    quote! {}
+fn suffixed_ident(name: &str, suffix: usize, s: Span) -> Ident {
+    Ident::new(&format!("{name}_{suffix}"), s)
+}
+
+pub fn derive_impl(input: &DeriveInput) -> TokenStream2 {
+    if !has_valid_repr(&input.attrs) {
+        return Error::new(
+            input.span(),
+            "derive(ULE) must be applied to a #[repr(C)] or #[repr(transparent)] type",
+        )
+        .to_compile_error();
+    }
+    if input.generics.type_params().next().is_some()
+        || input.generics.lifetimes().next().is_some()
+        || input.generics.const_params().next().is_some()
+    {
+        return Error::new(
+            input.generics.span(),
+            "derive(ULE) must be applied to a struct without any generics",
+        )
+        .to_compile_error();
+    }
+    let struc = if let Data::Struct(ref s) = input.data {
+        if s.fields.iter().next().is_none() {
+            return Error::new(
+                input.span(),
+                "derive(ULE) must be applied to a non-empty struct",
+            )
+            .to_compile_error();
+        }
+        s
+    } else {
+        return Error::new(input.span(), "derive(ULE) must be applied to a struct")
+            .to_compile_error();
+    };
+
+    let mut prev_offset_ident = Ident::new("ZERO", Span::call_site());
+    let mut validators = quote!(const ZERO: usize = 0);
+
+    for (i, field) in struc.fields.iter().enumerate() {
+        let ty = &field.ty;
+        let new_offset_ident = suffixed_ident("OFFSET", i, field.span());
+        let size_ident = suffixed_ident("SIZE", i, field.span());
+        validators = quote! {
+            #validators;
+            const #size_ident: usize = ::core::mem::size_of::<#ty>();
+            const #new_offset_ident: usize = #prev_offset_ident + #size_ident;
+            <#ty as zerovec::ule::ULE>::validate_byte_slice(&bytes[#new_offset_ident .. #new_offset_ident + #size_ident])?;
+        };
+
+        prev_offset_ident = new_offset_ident;
+    }
+
+    let name = &input.ident;
+
+    quote! {
+        unsafe impl zerovec::ule::ULE for #name {
+            #[inline]
+            fn validate_byte_slice(bytes: &[u8]) -> Result<(), zerovec::ZeroVecError> {
+                const SIZE: usize = ::core::mem::size_of::<#name>();
+                if bytes.len() % SIZE != 0 {
+                    return Err(zerovec::ZeroVecError::length::<Self>(bytes.len()));
+                }
+                // Validate the bytes
+                for chunk in bytes.chunks_exact(SIZE) {
+                    #validators
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+// Check attributes contain repr(transparent) or repr(packed)
+pub fn has_valid_repr(attrs: &[Attribute]) -> bool {
+    attrs
+        .iter()
+        .filter(|a| a.path.get_ident().map(|a| a == "repr").unwrap_or(false))
+        .find(|a| {
+            parse2::<ReprAttribute>(a.tokens.clone())
+                .ok()
+                .and_then(|s| {
+                    s.reprs
+                        .iter()
+                        .find(|r| *r == "packed" || *r == "transparent")
+                        .map(|_| ())
+                })
+                .is_some()
+        })
+        .is_some()
+}
+
+struct ReprAttribute {
+    reprs: Punctuated<Ident, Token![,]>,
+}
+
+impl Parse for ReprAttribute {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let content;
+        let _paren = parenthesized!(content in input);
+        Ok(ReprAttribute {
+            reprs: content.parse_terminated(Ident::parse)?,
+        })
+    }
 }

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -95,7 +95,7 @@ pub(crate) fn generate_ule_validators<'a>(
             #validators;
             const #size_ident: usize = ::core::mem::size_of::<#ty>();
             const #new_offset_ident: usize = #prev_offset_ident + #size_ident;
-            <#ty as zerovec::ule::ULE>::validate_byte_slice(&bytes[#new_offset_ident .. #new_offset_ident + #size_ident])?;
+            <#ty as zerovec::ule::ULE>::validate_byte_slice(&bytes[#prev_offset_ident .. #prev_offset_ident + #size_ident])?;
         };
 
         prev_offset_ident = new_offset_ident;

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -1,7 +1,10 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
 use proc_macro2::Span;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-
 
 use syn::spanned::Spanned;
 use syn::{Data, DeriveInput, Error, Ident};
@@ -61,6 +64,15 @@ pub fn derive_impl(input: &DeriveInput) -> TokenStream2 {
 
     let name = &input.ident;
 
+    // Safety (based on the safety checklist on the ULE trait):
+    //  1. #name does not include any uninitialized or padding bytes.
+    //     (achieved by enforcing #[repr(transparent)] or #[repr(packed)] on a struct of only ULE types)
+    //  2. CharULE is aligned to 1 byte.
+    //     (achieved by enforcing #[repr(transparent)] or #[repr(packed)] on a struct of only ULE types)
+    //  3. The impl of validate_byte_slice() returns an error if any byte is not valid.
+    //  4. The impl of validate_byte_slice() returns an error if there are extra bytes.
+    //  5. The other ULE methods use the default impl.
+    //  6. [This impl does not enforce the equality constraint, it is up to the user to do so, ideally via a custom derive]
     quote! {
         unsafe impl zerovec::ule::ULE for #name {
             #[inline]

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -1,0 +1,7 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::DeriveInput;
+
+pub fn derive_impl(_input: &DeriveInput) -> TokenStream2 {
+    quote! {}
+}

--- a/utils/zerovec/derive/src/utils.rs
+++ b/utils/zerovec/derive/src/utils.rs
@@ -11,7 +11,7 @@ pub fn has_valid_repr(attrs: &[Attribute]) -> bool {
     attrs
         .iter()
         .filter(|a| a.path.get_ident().map(|a| a == "repr").unwrap_or(false))
-        .find(|a| {
+        .any(|a| {
             parse2::<ReprAttribute>(a.tokens.clone())
                 .ok()
                 .and_then(|s| {
@@ -22,7 +22,6 @@ pub fn has_valid_repr(attrs: &[Attribute]) -> bool {
                 })
                 .is_some()
         })
-        .is_some()
 }
 
 struct ReprAttribute {

--- a/utils/zerovec/derive/src/utils.rs
+++ b/utils/zerovec/derive/src/utils.rs
@@ -1,0 +1,40 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::{parenthesized, parse2, Attribute, Ident, Result, Token};
+
+// Check attributes contain repr(transparent) or repr(packed)
+pub fn has_valid_repr(attrs: &[Attribute]) -> bool {
+    attrs
+        .iter()
+        .filter(|a| a.path.get_ident().map(|a| a == "repr").unwrap_or(false))
+        .find(|a| {
+            parse2::<ReprAttribute>(a.tokens.clone())
+                .ok()
+                .and_then(|s| {
+                    s.reprs
+                        .iter()
+                        .find(|r| *r == "packed" || *r == "transparent")
+                        .map(|_| ())
+                })
+                .is_some()
+        })
+        .is_some()
+}
+
+struct ReprAttribute {
+    reprs: Punctuated<Ident, Token![,]>,
+}
+
+impl Parse for ReprAttribute {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let content;
+        let _paren = parenthesized!(content in input);
+        Ok(ReprAttribute {
+            reprs: content.parse_terminated(Ident::parse)?,
+        })
+    }
+}

--- a/utils/zerovec/derive/src/varule.rs
+++ b/utils/zerovec/derive/src/varule.rs
@@ -1,0 +1,111 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use proc_macro2::Span;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::spanned::Spanned;
+use syn::{Data, DeriveInput, Error, Ident};
+
+pub fn derive_impl(input: &DeriveInput) -> TokenStream2 {
+    if !crate::utils::has_valid_repr(&input.attrs) {
+        return Error::new(
+            input.span(),
+            "derive(VarULE) must be applied to a #[repr(C)] or #[repr(transparent)] type",
+        )
+        .to_compile_error();
+    }
+    if input.generics.type_params().next().is_some()
+        || input.generics.lifetimes().next().is_some()
+        || input.generics.const_params().next().is_some()
+    {
+        return Error::new(
+            input.generics.span(),
+            "derive(ULE) must be applied to a struct without any generics",
+        )
+        .to_compile_error();
+    }
+    let struc = if let Data::Struct(ref s) = input.data {
+        if s.fields.iter().next().is_none() {
+            return Error::new(
+                input.span(),
+                "derive(ULE) must be applied to a non-empty struct",
+            )
+            .to_compile_error();
+        }
+        s
+    } else {
+        return Error::new(input.span(), "derive(ULE) must be applied to a struct")
+            .to_compile_error();
+    };
+
+    let n_fields = struc.fields.len();
+
+    let sizes = struc.fields.iter().take(n_fields - 1).map(|f| {
+        let ty = &f.ty;
+        quote!(::core::mem::size_of::<#ty>())
+    });
+
+    let (validators, remaining_offset) = if n_fields > 1 {
+        // generate ULE validators
+        crate::ule::generate_ule_validators(struc.fields.iter().take(n_fields - 1))
+    } else {
+        // no ULE subfields
+        (
+            quote!(const ZERO: usize = 0),
+            Ident::new("ZERO", Span::call_site()),
+        )
+    };
+
+    let unsized_field = &struc
+        .fields
+        .iter()
+        .next_back()
+        .expect("Already verified that struct is not empty")
+        .ty;
+
+    let name = &input.ident;
+    let ule_size = Ident::new(
+        &format!("__IMPL_VarULE_FOR_{name}_ULE_SIZE"),
+        Span::call_site(),
+    );
+
+    // Safety (based on the safety checklist on the ULE trait):
+    //  1. #name does not include any uninitialized or padding bytes.
+    //     (achieved by enforcing #[repr(transparent)] or #[repr(packed)] on a struct of only ULE types)
+    //  2. CharULE is aligned to 1 byte.
+    //     (achieved by enforcing #[repr(transparent)] or #[repr(packed)] on a struct of only ULE types)
+    //  3. The impl of validate_byte_slice() returns an error if any byte is not valid.
+    //  4. The impl of validate_byte_slice() returns an error if there are extra bytes.
+    //  5. The other ULE methods use the default impl.
+    //  6. [This impl does not enforce the equality constraint, it is up to the user to do so, ideally via a custom derive]
+    quote! {
+        // The size of the ULE section of this type
+        const #ule_size: usize = 0 #(+ #sizes)*;
+        unsafe impl zerovec::ule::VarULE for #name {
+            #[inline]
+            fn validate_byte_slice(bytes: &[u8]) -> Result<(), zerovec::ZeroVecError> {
+
+                if bytes.len() < #ule_size {
+                    return Err(zerovec::ZeroVecError::parse::<Self>());
+                }
+                #validators
+                debug_assert_eq!(#remaining_offset, #ule_size);
+                <#unsized_field as zerovec::ule::VarULE>::validate_byte_slice(&bytes[#remaining_offset..])?;
+                Ok(())
+            }
+            #[inline]
+            unsafe fn from_byte_slice_unchecked(bytes: &[u8]) -> &Self {
+                // just the unsized part
+                let unsized_bytes = &bytes[#ule_size..];
+                let unsized_ref = <#unsized_field as zerovec::ule::VarULE>::from_byte_slice_unchecked(unsized_bytes);
+                // We should use the pointer metadata APIs here when they are stable: https://github.com/rust-lang/rust/issues/81513
+                // For now we rely on all DST metadata being a usize to extract it via a fake slice pointer
+                let (_ptr, metadata): (usize, usize) = ::core::mem::transmute(unsized_ref);
+                let entire_struct_as_slice: *const [u8] = ::core::slice::from_raw_parts(bytes.as_ptr(), metadata);
+                &*(entire_struct_as_slice as *const Self)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a step towards https://github.com/unicode-org/icu4x/issues/1079, implementing [the first part of the design doc](https://github.com/unicode-org/icu4x/blob/main/utils/zerovec/design_doc.md#deriveule-and-derivevarule)

Note that this is _not_ the final form of this feature: `#[derive(ULE)]` and `#[derive(VarULE)]` are building blocks that most users will not directly use. Rather, these custom derives are for the specialized use case where you wish to implement your own AsULE/EncodeAsVarULE conversions.

I have not started using this in the codebase, but this could be already be used to simplify the RelationULE code if so desired (I'd rather just make that change when the final attribute is ready).

I've also not set up the reexports from the zerovec crate, we can do that at the end (and perhaps reorganize the ULE/VarULE types to be reexported?)

A thought I'm having is that it's worth writing fuzzers for these things because it's easy to write tests that ensure that parsing correct data works, but harder to ensure that incorrect data is rejected.


cc @robertbastian, @echeran, @nordzilla in case you are interested in looking at this to follow along.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->