### PR TITLE
Polish up Yoke docs

### DIFF
--- a/utils/yoke/README.md
+++ b/utils/yoke/README.md
@@ -1,9 +1,24 @@
 # yoke [![crates.io](https://img.shields.io/crates/v/yoke)](https://crates.io/crates/yoke)
 
-This crate provides [`Yoke`], a data structure that allows one
-to "yoke" Cow-like borrowed data types to their backing storage,
-enabling one to use Cow (etc) in zero-copy deserialization
-with dynamic lifetimes for the borrowed data, for example caching it.
+This crate provides [`Yoke<Y, C>`][Yoke], which allows one to "yoke" a zero-copy deserialized
+object(say, a [`Cow<'a, str>`](alloc::borrow::Cow)) to the source it was deserialized from, (say, an [`Rc<[u8]>`](alloc::rc::Rc)),
+known as a "cart", producing a type that looks like `Yoke<Cow<'static, str>, Rc<[u8]>>`
+and can be moved around with impunity.
+
+Succinctly, this allows one to "erase" static lifetimes and turn them into dynamic ones, similarly
+to how `dyn` allows one to "erase" static types and turn them into dynamic ones.
+
+Most of the time the yokeable `Y` type will be some kind of zero-copy deserializable
+abstraction, potentially with an owned variant (like [`Cow`](alloc::borrow::Cow),
+[`ZeroVec`](https://docs.rs/zerovec), or an aggregate containing such types), and the cart `C` will be some smart pointer like
+  [`Box<T>`](alloc::boxed::Box), [`Rc<T>`](alloc::rc::Rc), or [`Arc<T>`](std::sync::Arc), potentially wrapped in an [`Option<T>`](Option).
+
+The key behind this crate is [`Yoke::get()`], where calling [`.get()`][Yoke::get] on a type like
+`Yoke<Cow<'static, str>, _>` will get you a short-lived `&'a Cow<'a, str>`, restricted to the
+lifetime of the borrow used during [`.get()`](Yoke::get). This is entirely safe since the `Cow` borrows from
+the cart type, which cannot be interfered with as long as the `Yoke` is borrowed by [`.get()`](Yoke::get).
+[`.get()`](Yoke::get) protects access by essentially reifying the erased lifetime to a safe local one
+when necessary.
 
 See the documentation of [`Yoke`] for more details.
 

--- a/utils/yoke/src/is_covariant.rs
+++ b/utils/yoke/src/is_covariant.rs
@@ -18,7 +18,7 @@ use alloc::{
 /// perform lifetime casting on trait objects (`dyn Trait`). This enables a type-erased [`Yoke`]
 /// consisting of only trait objects. See the examples.
 ///
-/// `IsCovariant` is auto-implemented in [`#[derive(Yokeable)]`](yoke_derive::Yokeable).
+/// `IsCovariant` is auto-implemented in [`#[derive(Yokeable)]`](macro@crate::Yokeable).
 ///
 /// # Safety
 ///

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -2,14 +2,29 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-//! This crate provides [`Yoke`], a data structure that allows one
-//! to "yoke" Cow-like borrowed data types to their backing storage,
-//! enabling one to use Cow (etc) in zero-copy deserialization
-//! with dynamic lifetimes for the borrowed data, for example caching it.
+//! This crate provides [`Yoke<Y, C>`][Yoke], which allows one to "yoke" a zero-copy deserialized
+//! object(say, a [`Cow<'a, str>`](alloc::borrow::Cow)) to the source it was deserialized from, (say, an [`Rc<[u8]>`](alloc::rc::Rc)),
+//! known as a "cart", producing a type that looks like `Yoke<Cow<'static, str>, Rc<[u8]>>`
+//! and can be moved around with impunity.
 //!
+//! Succinctly, this allows one to "erase" static lifetimes and turn them into dynamic ones, similarly
+//! to how `dyn` allows one to "erase" static types and turn them into dynamic ones.
+//!
+//! Most of the time the yokeable `Y` type will be some kind of zero-copy deserializable
+//! abstraction, potentially with an owned variant (like [`Cow`](alloc::borrow::Cow), 
+//! [`ZeroVec`](https://docs.rs/zerovec), or an aggregate containing such types), and the cart `C` will be some smart pointer like
+//!   [`Box<T>`](alloc::boxed::Box), [`Rc<T>`](alloc::rc::Rc), or [`Arc<T>`](std::sync::Arc), potentially wrapped in an [`Option<T>`](Option).
+//!
+//! The key behind this crate is [`Yoke::get()`], where calling [`.get()`][Yoke::get] on a type like
+//! `Yoke<Cow<'static, str>, _>` will get you a short-lived `&'a Cow<'a, str>`, restricted to the
+//! lifetime of the borrow used during [`.get()`](Yoke::get). This is entirely safe since the `Cow` borrows from
+//! the cart type, which cannot be interfered with as long as the `Yoke` is borrowed by [`.get()`](Yoke::get).
+//! [`.get()`](Yoke::get) protects access by essentially reifying the erased lifetime to a safe local one
+//! when necessary.
+//! 
 //! See the documentation of [`Yoke`] for more details.
 
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(all(not(test), not(doc)), no_std)]
 // The lifetimes here are important for safety and explicitly writing
 // them out is good even when redundant
 #![allow(clippy::needless_lifetimes)]

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -11,7 +11,7 @@
 //! to how `dyn` allows one to "erase" static types and turn them into dynamic ones.
 //!
 //! Most of the time the yokeable `Y` type will be some kind of zero-copy deserializable
-//! abstraction, potentially with an owned variant (like [`Cow`](alloc::borrow::Cow), 
+//! abstraction, potentially with an owned variant (like [`Cow`](alloc::borrow::Cow),
 //! [`ZeroVec`](https://docs.rs/zerovec), or an aggregate containing such types), and the cart `C` will be some smart pointer like
 //!   [`Box<T>`](alloc::boxed::Box), [`Rc<T>`](alloc::rc::Rc), or [`Arc<T>`](std::sync::Arc), potentially wrapped in an [`Option<T>`](Option).
 //!
@@ -21,7 +21,7 @@
 //! the cart type, which cannot be interfered with as long as the `Yoke` is borrowed by [`.get()`](Yoke::get).
 //! [`.get()`](Yoke::get) protects access by essentially reifying the erased lifetime to a safe local one
 //! when necessary.
-//! 
+//!
 //! See the documentation of [`Yoke`] for more details.
 
 #![cfg_attr(all(not(test), not(doc)), no_std)]

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -43,7 +43,7 @@ use alloc::sync::Arc;
 /// ()`. `.get()` protects access by essentially reifying the erased lifetime to a safe local one
 /// when necessary.
 ///
-/// Furthermore, There are various [`.project()`][Yoke::project] methods that allow turning a `Yoke`
+/// Furthermore, there are various [`.project()`][Yoke::project] methods that allow turning a `Yoke`
 /// into another `Yoke` containing a different type that may contain elements of the original yoked
 /// value. See the [`Yoke::project()`] docs for more details.
 ///

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -21,12 +21,13 @@ use alloc::sync::Arc;
 /// A Cow-like borrowed object "yoked" to its backing data.
 ///
 /// This allows things like zero copy deserialized data to carry around
-/// shared references to their backing buffer.
+/// shared references to their backing buffer, by "erasing" their static lifetime
+/// and turning it into a dynamically managed one.
 ///
 /// `Y` (the [`Yokeable`]) is the object containing the references,
 /// and will typically be of the form `Foo<'static>`. The `'static` is
-/// not the actual lifetime of the data, rather it is a convenient way to erase
-/// the lifetime and make it dynamic.
+/// not the actual lifetime of the data, rather it is a convenient way to mark the
+/// erased lifetime and make it dynamic.
 ///
 /// `C` is the "cart", which `Y` may contain references to. After the yoke is constructed,
 /// the cart serves little purpose except to guarantee that `Y`'s references remain valid
@@ -34,6 +35,17 @@ use alloc::sync::Arc;
 ///
 /// The primary constructor for [`Yoke`] is [`Yoke::attach_to_cart()`]. Several variants of that
 /// constructor are provided to serve numerous types of call sites and `Yoke` signatures.
+///
+/// The key behind this type is [`Yoke::get()`], where calling [`.get()`][Yoke::get] on a type like
+/// `Yoke<Cow<'static, str>, _>` will get you a short-lived `&'a Cow<'a, str>`, restricted to the
+/// lifetime of the borrow used during `.get()`. This is entirely safe since the `Cow` borrows from
+/// the cart type, which cannot be interfered with as long as the `Yoke` is borrowed by `.get
+/// ()`. `.get()` protects access by essentially reifying the erased lifetime to a safe local one
+/// when necessary.
+///
+/// Furthermore, There are various [`.project()`][Yoke::project] methods that allow turning a `Yoke`
+/// into another `Yoke` containing a different type that may contain elements of the original yoked
+/// value. See the [`Yoke::project()`] docs for more details.
 ///
 /// In general, `C` is a concrete type, but it is also possible for it to be a trait object;
 /// for more information, see [`IsCovariant`].

--- a/utils/yoke/src/yokeable.rs
+++ b/utils/yoke/src/yokeable.rs
@@ -6,15 +6,23 @@
 use alloc::borrow::{Cow, ToOwned};
 use core::mem;
 
+/// The `Yokeable<'a>` trait is implemented on the `'static` version of any zero-copy type; for
+/// example, `Cow<'static, T>` implements `Yokeable<'a>` (for all `'a`). One can use
+/// `Yokeable::Output` on this trait to obtain the "lifetime'd" value of the `Cow<'static, T>`,
+/// e.g. `<Cow<'static, T> as Yokeable<'a>'>::Output` is `Cow<'a, T>`.
+///
 /// A [`Yokeable`] type is essentially one with a covariant lifetime parameter,
 /// matched to the parameter in the trait definition. The trait allows one to cast
 /// the covariant lifetime to and from `'static`.
+///
+/// **Most of the time, if you need to implement [`Yokeable`], you should be able to use the safe
+/// [`#[derive(Yokeable)]`](yoke_derive::Yokeable) custom derive.**
 ///
 /// While Rust does not yet have GAT syntax, for the purpose of this documentation
 /// we shall refer to "`Self` with a lifetime `'a`" with the syntax `Self<'a>`.
 /// Self<'static> is a stand-in for the HKT Self<'_>: lifetime -> type.
 ///
-/// [`Yokeable`]  exposes ways to cast between `Self<'static>` and `Self<'a>` generically.
+/// With this terminology, [`Yokeable`]  exposes ways to cast between `Self<'static>` and `Self<'a>` generically.
 /// This is useful for turning covariant lifetimes to _dynamic_ lifetimes, where `'static` is
 /// used as a way to "erase" the lifetime.
 ///
@@ -38,10 +46,9 @@ use core::mem;
 ///
 /// # Implementation example
 ///
-/// This crate will eventually expose a custom derive that makes it possible to implement this
-/// trait safely without much ceremony. Such a custom derive will include static checks
-/// for the covariance of each field. In the meantime, this trait can typically be implemented as
-/// follows:
+/// Implementing this trait manually is unsafe. Where possible, you should use the safe
+/// [`#[derive(Yokeable)]`](yoke_derive::Yokeable) custom derive instead. We include an example
+/// in case you have your own zero-copy abstractions you wish to make yokeable.
 ///
 /// ```rust
 /// # use yoke::Yokeable;

--- a/utils/yoke/src/zero_copy_from.rs
+++ b/utils/yoke/src/zero_copy_from.rs
@@ -23,6 +23,9 @@ use stable_deref_trait::StableDeref;
 /// For example, `impl ZeroCopyFrom<C> for Cow<str>` should return a `Cow::Borrowed` pointing at
 /// data in the cart `C`, even if the cart is itself fully owned.
 ///
+/// One can use the [`#[derive(ZeroCopyFrom)]`](yoke_derive::ZeroCopyFrom) custom derive to automatically
+/// implement this trait.
+///
 /// # Examples
 ///
 /// Implementing `ZeroCopyFrom` on a custom data struct:

--- a/utils/yoke/src/zero_copy_from.rs
+++ b/utils/yoke/src/zero_copy_from.rs
@@ -12,7 +12,7 @@ use alloc::string::String;
 use core::ops::Deref;
 use stable_deref_trait::StableDeref;
 
-/// Trait for types that can be crated from a reference to a cart type `C` with no allocations.
+/// Trait for types that can be created from a reference to a cart type `C` with no allocations.
 ///
 /// A type can be the `ZeroCopyFrom` target of multiple cart types.
 ///


### PR DESCRIPTION
... mostly by copy pasting from the design doc.

fixes https://github.com/unicode-org/icu4x/issues/1474

Yoke already has good docs so there isn't much to do here. I suspect ZeroVec will be more.
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->