### PR TITLE
Minor fixes to from_bytes and must_use hygine

### DIFF
--- a/experimental/tinystr_neo/Cargo.toml
+++ b/experimental/tinystr_neo/Cargo.toml
@@ -6,7 +6,7 @@
 name = "tinystr-neo"
 version = "0.3.1"
 description = "A small ASCII-only bounded length string representation."
-authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
+authors = ["The ICU4X Project Developers"]
 edition = "2021"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "LICENSE"

--- a/experimental/tinystr_neo/src/ascii.rs
+++ b/experimental/tinystr_neo/src/ascii.rs
@@ -23,26 +23,26 @@ impl<const N: usize> TinyAsciiStr<N> {
         bytes: &[u8],
         allow_trailing_null: bool,
     ) -> Result<Self, TinyStrError> {
-        if bytes.len() > N {
-            return Err(TinyStrError::TooLarge {
-                max: N,
-                found: bytes.len(),
-            });
+        let len = bytes.len();
+        if len > N {
+            return Err(TinyStrError::TooLarge { max: N, len });
         }
 
         let mut out = [0; N];
         let mut i = 0;
         let mut found_null = false;
-        while i < bytes.len() {
-            if bytes[i] == 0 {
+        while i < len {
+            let b = bytes[i];
+
+            if b == 0 {
                 found_null = true;
-            } else if bytes[i] >= 0x80 {
+            } else if b >= 0x80 {
                 return Err(TinyStrError::NonAscii);
             } else if found_null {
                 // Error if there are contentful bytes after null
                 return Err(TinyStrError::ContainsNull);
             }
-            out[i] = bytes[i];
+            out[i] = b;
 
             i += 1;
         }
@@ -57,10 +57,11 @@ impl<const N: usize> TinyAsciiStr<N> {
 
     #[inline]
     pub const fn from_str(s: &str) -> Result<Self, TinyStrError> {
-        Self::from_bytes(s.as_bytes())
+        Self::from_bytes_inner(s.as_bytes(), false)
     }
 
     #[inline]
+    #[must_use]
     pub fn len(&self) -> usize {
         if N <= 4 {
             Aligned4::from_bytes(&self.bytes).len()
@@ -72,17 +73,20 @@ impl<const N: usize> TinyAsciiStr<N> {
     }
 
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
         self.bytes[0] == 0
     }
 
     #[inline]
+    #[must_use]
     pub fn as_bytes(&self) -> &[u8] {
         &self.bytes[0..self.len()]
     }
 
     #[inline]
-    pub fn all_bytes(&self) -> &[u8; N] {
+    #[must_use]
+    pub const fn all_bytes(&self) -> &[u8; N] {
         &self.bytes
     }
 
@@ -105,6 +109,7 @@ impl<const N: usize> TinyAsciiStr<N> {
     /// assert!(!s2.is_ascii_alphabetic());
     /// ```
     #[inline]
+    #[must_use]
     pub fn is_ascii_alphabetic(&self) -> bool {
         if N <= 4 {
             Aligned4::from_bytes(&self.bytes).is_ascii_alphabetic()
@@ -135,6 +140,7 @@ impl<const N: usize> TinyAsciiStr<N> {
     /// assert!(!s2.is_ascii_alphanumeric());
     /// ```
     #[inline]
+    #[must_use]
     pub fn is_ascii_alphanumeric(&self) -> bool {
         if N <= 4 {
             Aligned4::from_bytes(&self.bytes).is_ascii_alphanumeric()
@@ -163,6 +169,7 @@ impl<const N: usize> TinyAsciiStr<N> {
     /// assert!(!s2.is_ascii_numeric());
     /// ```
     #[inline]
+    #[must_use]
     pub fn is_ascii_numeric(&self) -> bool {
         if N <= 4 {
             Aligned4::from_bytes(&self.bytes).is_ascii_numeric()
@@ -188,6 +195,7 @@ impl<const N: usize> TinyAsciiStr<N> {
     /// assert_eq!(&*s1.to_ascii_lowercase(), "tes3");
     /// ```
     #[inline]
+    #[must_use]
     pub fn to_ascii_lowercase(mut self) -> Self {
         if N <= 4 {
             let aligned = Aligned4::from_bytes(&self.bytes).to_ascii_lowercase();
@@ -217,6 +225,7 @@ impl<const N: usize> TinyAsciiStr<N> {
     /// assert_eq!(&*s1.to_ascii_titlecase(), "Test");
     /// ```
     #[inline]
+    #[must_use]
     pub fn to_ascii_titlecase(mut self) -> Self {
         if N <= 4 {
             let aligned = Aligned4::from_bytes(&self.bytes).to_ascii_titlecase();
@@ -246,6 +255,7 @@ impl<const N: usize> TinyAsciiStr<N> {
     /// assert_eq!(&*s1.to_ascii_uppercase(), "TES3");
     /// ```
     #[inline]
+    #[must_use]
     pub fn to_ascii_uppercase(mut self) -> Self {
         if N <= 4 {
             let aligned = Aligned4::from_bytes(&self.bytes).to_ascii_uppercase();
@@ -270,6 +280,7 @@ impl<const N: usize> TinyAsciiStr<N> {
     /// # Safety
     /// Must be called with a bytes array made of valid ASCII bytes, with no null bytes
     /// between ASCII characters
+    #[must_use]
     pub const unsafe fn from_bytes_unchecked(bytes: [u8; N]) -> Self {
         Self { bytes }
     }

--- a/experimental/tinystr_neo/src/error.rs
+++ b/experimental/tinystr_neo/src/error.rs
@@ -6,8 +6,8 @@ use displaydoc::Display;
 
 #[derive(Display, Debug)]
 pub enum TinyStrError {
-    #[displaydoc("found string of larger length {found} when constructing string of length {max}")]
-    TooLarge { max: usize, found: usize },
+    #[displaydoc("found string of larger length {len} when constructing string of length {max}")]
+    TooLarge { max: usize, len: usize },
     #[displaydoc("tinystr types do not support strings with null bytes")]
     ContainsNull,
     #[displaydoc("attempted to construct TinyStrAuto from a non-ascii string")]


### PR DESCRIPTION
This is a first sprinkle of optimizations. On my MacOS 12 with Rust 1.58 I see the following changes:

```
construct_from_str/4/TinyAsciiStr<4>                                                                             
                        time:   [43.938 ns 44.053 ns 44.186 ns]
                        change: [-15.785% -15.422% -15.077%] (p = 0.00 < 0.05)
                        Performance has improved.

construct_from_str/4/TinyAsciiStr<8>                                                                            
                        time:   [55.559 ns 55.696 ns 55.901 ns]
                        change: [-29.884% -29.535% -29.170%] (p = 0.00 < 0.05)

construct_from_str/8/TinyAsciiStr<8>                                                                            
                        time:   [62.407 ns 62.594 ns 62.814 ns]
                        change: [-28.766% -28.438% -28.094%] (p = 0.00 < 0.05)
                        Performance has improved.
```

which gets us within a striking distance on `construct_from_str/4/4` and gives us a nice win on `construct_from_str/4/8` and `construct_from_str/8/8`.