### PR TITLE
Replacing `IterableProvider` by `IterableDynProvider` and `IterableResourceProvider`

### DIFF
--- a/docs/tutorials/writing_a_new_data_struct.md
+++ b/docs/tutorials/writing_a_new_data_struct.md
@@ -65,9 +65,9 @@ Examples of source data providers include:
 
 Source data providers must implement the following traits:
 
-- `DataProvider<M>` for one or more data markers `M`; this impl is the main step where data transformation takes place
-- `DataProvider<SerdeSeDataStructMarker>`, usually implemented with the macro [`impl_dyn_provider!`](https://unicode-org.github.io/icu4x-docs/doc/icu_provider/macro.impl_dyn_provider.html)
-- [`IterableProvider`](https://unicode-org.github.io/icu4x-docs/doc/icu_provider/iter/trait.IterableProvider.html), required for the data exporter (see below)
+- `ResourceProvider<M>` or `DynProvider<M>` for one or more data markers `M`; this impl is the main step where data transformation takes place
+- `IterableDynProvider<M>`. or `IterableResourceProvider<M>`, required for the data exporter (see below)
+- `DynProvider<SerializeMarker>` and `IterableDynProvider<SerializeMarker>`, usually implemented with the macro [`impl_dyn_provider!`](https://unicode-org.github.io/icu4x-docs/doc/icu_provider/macro.impl_dyn_provider.html) after the above traits have been implemented
 
 Source data providers are often complex to write. Rules of thumb:
 
@@ -216,10 +216,9 @@ impl ResourceProvider<FooV1Marker> for FooProvider {
     }
 }
 
-impl IterableProvider for FooProvider {
-    fn supported_options_for_key(
+impl IterableResourceProvider<FooV1Marker> for FooProvider {
+    fn supported_options(
         &self,
-        _resc_key: &ResourceKey,
     ) -> Result<Box<dyn Iterator<Item = ResourceOptions>>, DataError> {
         // This should list all supported locales, for example.
     }
@@ -231,7 +230,7 @@ impl KeyedDataProvider for FooProvider {
     }
 }
 
-// Once we have ResourceProvider, IterableProvider, and KeyedDataProvider, we can
+// Once we have ResourceProvider, IterableResourceProvider, and KeyedDataProvider, we can
 // implement DynProvider<SerializeMarker>.
 icu_provider::impl_dyn_provider!(FooProvider, [
     FooV1Marker,

--- a/provider/cldr/src/support.rs
+++ b/provider/cldr/src/support.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::CldrPaths;
-use icu_provider::iter::IterableProvider;
+use icu_provider::iter::IterableDynProvider;
 use icu_provider::prelude::*;
 use icu_provider::serde::SerializeMarker;
 use std::convert::TryFrom;
@@ -36,8 +36,7 @@ impl<T> Default for LazyCldrProvider<T> {
 /// A lazy-initialized CLDR JSON data provider.
 impl<'b, T> LazyCldrProvider<T>
 where
-    T: DynProvider<SerializeMarker>
-        + IterableProvider
+    T: IterableDynProvider<SerializeMarker>
         + KeyedDataProvider
         + TryFrom<&'b dyn CldrPaths, Error = crate::error::Error>,
 {
@@ -68,7 +67,7 @@ where
         .map(Some)
     }
 
-    /// Call [`IterableProvider::supported_options_for_key()`], initializing `T` if necessary.
+    /// Call [`IterableDynProvider::supported_options_for_key()`], initializing `T` if necessary.
     pub fn try_supported_options(
         &self,
         key: &ResourceKey,

--- a/provider/cldr/src/transform/calendar/japanese.rs
+++ b/provider/cldr/src/transform/calendar/japanese.rs
@@ -9,7 +9,7 @@ use crate::support::KeyedDataProvider;
 use crate::CldrPaths;
 use icu_calendar::provider::*;
 use icu_locid_macros::langid;
-use icu_provider::iter::IterableProvider;
+use icu_provider::iter::IterableResourceProvider;
 use icu_provider::prelude::*;
 use litemap::LiteMap;
 use std::convert::TryFrom;
@@ -224,11 +224,8 @@ impl ResourceProvider<JapaneseErasV1Marker> for JapaneseErasProvider {
 
 icu_provider::impl_dyn_provider!(JapaneseErasProvider, [JapaneseErasV1Marker,], SERDE_SE);
 
-impl IterableProvider for JapaneseErasProvider {
-    fn supported_options_for_key(
-        &self,
-        _resc_key: &ResourceKey,
-    ) -> Result<Box<dyn Iterator<Item = ResourceOptions>>, DataError> {
+impl IterableResourceProvider<JapaneseErasV1Marker> for JapaneseErasProvider {
+    fn supported_options(&self) -> Result<Box<dyn Iterator<Item = ResourceOptions>>, DataError> {
         Ok(Box::new(core::iter::once(ResourceOptions::default())))
     }
 }

--- a/provider/cldr/src/transform/datetime/common.rs
+++ b/provider/cldr/src/transform/datetime/common.rs
@@ -81,9 +81,8 @@ impl CommonDateProvider {
 }
 
 impl CommonDateProvider {
-    pub fn supported_options_for_key(
+    pub fn supported_options(
         &self,
-        _resc_key: &ResourceKey,
     ) -> Result<Box<dyn Iterator<Item = ResourceOptions> + '_>, DataError> {
         Ok(Box::new(self.data.iter().flat_map(|(cal, map)| {
             let cal = Some((*cal).into());

--- a/provider/cldr/src/transform/datetime/patterns.rs
+++ b/provider/cldr/src/transform/datetime/patterns.rs
@@ -13,7 +13,7 @@ use icu_datetime::pattern::CoarseHourCycle;
 use icu_datetime::provider::calendar::*;
 
 use crate::support::KeyedDataProvider;
-use icu_provider::iter::IterableProvider;
+use icu_provider::iter::IterableResourceProvider;
 use icu_provider::prelude::*;
 use std::convert::TryFrom;
 
@@ -51,12 +51,11 @@ impl ResourceProvider<DatePatternsV1Marker> for DatePatternsProvider {
 
 icu_provider::impl_dyn_provider!(DatePatternsProvider, [DatePatternsV1Marker,], SERDE_SE);
 
-impl IterableProvider for DatePatternsProvider {
-    fn supported_options_for_key(
+impl IterableResourceProvider<DatePatternsV1Marker> for DatePatternsProvider {
+    fn supported_options(
         &self,
-        resc_key: &ResourceKey,
     ) -> Result<Box<dyn Iterator<Item = ResourceOptions> + '_>, DataError> {
-        self.0.supported_options_for_key(resc_key)
+        self.0.supported_options()
     }
 }
 

--- a/provider/cldr/src/transform/datetime/skeletons.rs
+++ b/provider/cldr/src/transform/datetime/skeletons.rs
@@ -12,7 +12,7 @@ use icu_datetime::skeleton::SkeletonError;
 
 use crate::support::KeyedDataProvider;
 use icu_plurals::PluralCategory;
-use icu_provider::iter::IterableProvider;
+use icu_provider::iter::IterableResourceProvider;
 use icu_provider::prelude::*;
 use std::convert::TryFrom;
 
@@ -56,12 +56,11 @@ icu_provider::impl_dyn_provider!(
     SERDE_SE
 );
 
-impl IterableProvider for DateSkeletonPatternsProvider {
-    fn supported_options_for_key(
+impl IterableResourceProvider<DateSkeletonPatternsV1Marker> for DateSkeletonPatternsProvider {
+    fn supported_options(
         &self,
-        resc_key: &ResourceKey,
     ) -> Result<Box<dyn Iterator<Item = ResourceOptions> + '_>, DataError> {
-        self.0.supported_options_for_key(resc_key)
+        self.0.supported_options()
     }
 }
 

--- a/provider/cldr/src/transform/datetime/symbols.rs
+++ b/provider/cldr/src/transform/datetime/symbols.rs
@@ -11,7 +11,7 @@ use crate::CldrPaths;
 use icu_datetime::provider::calendar::*;
 
 use crate::support::KeyedDataProvider;
-use icu_provider::iter::IterableProvider;
+use icu_provider::iter::IterableResourceProvider;
 use icu_provider::prelude::*;
 use std::borrow::Cow;
 use std::convert::TryFrom;
@@ -55,12 +55,11 @@ impl ResourceProvider<DateSymbolsV1Marker> for DateSymbolsProvider {
 
 icu_provider::impl_dyn_provider!(DateSymbolsProvider, [DateSymbolsV1Marker,], SERDE_SE);
 
-impl IterableProvider for DateSymbolsProvider {
-    fn supported_options_for_key(
+impl IterableResourceProvider<DateSymbolsV1Marker> for DateSymbolsProvider {
+    fn supported_options(
         &self,
-        resc_key: &ResourceKey,
     ) -> Result<Box<dyn Iterator<Item = ResourceOptions> + '_>, DataError> {
-        self.0.supported_options_for_key(resc_key)
+        self.0.supported_options()
     }
 }
 

--- a/provider/cldr/src/transform/decimal/mod.rs
+++ b/provider/cldr/src/transform/decimal/mod.rs
@@ -9,7 +9,7 @@ use crate::support::KeyedDataProvider;
 use crate::CldrPaths;
 use icu_decimal::provider::*;
 use icu_locid::LanguageIdentifier;
-use icu_provider::iter::IterableProvider;
+use icu_provider::iter::IterableResourceProvider;
 use icu_provider::prelude::*;
 use litemap::LiteMap;
 use std::borrow::Cow;
@@ -132,10 +132,9 @@ impl ResourceProvider<DecimalSymbolsV1Marker> for NumbersProvider {
 
 icu_provider::impl_dyn_provider!(NumbersProvider, [DecimalSymbolsV1Marker,], SERDE_SE);
 
-impl IterableProvider for NumbersProvider {
-    fn supported_options_for_key(
+impl IterableResourceProvider<DecimalSymbolsV1Marker> for NumbersProvider {
+    fn supported_options(
         &self,
-        _resc_key: &ResourceKey,
     ) -> Result<Box<dyn Iterator<Item = ResourceOptions> + '_>, DataError> {
         Ok(Box::new(
             self.cldr_numbers_data

--- a/provider/cldr/src/transform/list/mod.rs
+++ b/provider/cldr/src/transform/list/mod.rs
@@ -9,7 +9,7 @@ use crate::CldrPaths;
 use icu_list::provider::*;
 use icu_locid::LanguageIdentifier;
 use icu_locid_macros::langid;
-use icu_provider::iter::IterableProvider;
+use icu_provider::iter::IterableResourceProvider;
 use icu_provider::prelude::*;
 use litemap::LiteMap;
 use std::convert::TryFrom;
@@ -160,10 +160,11 @@ impl KeyedDataProvider for ListProvider {
     }
 }
 
-impl IterableProvider for ListProvider {
-    fn supported_options_for_key(
+impl<M: ResourceMarker<Yokeable = ListFormatterPatternsV1<'static>>> IterableResourceProvider<M>
+    for ListProvider
+{
+    fn supported_options(
         &self,
-        _resc_key: &ResourceKey,
     ) -> Result<Box<dyn Iterator<Item = ResourceOptions> + '_>, DataError> {
         Ok(Box::new(
             self.data

--- a/provider/cldr/src/transform/locale_canonicalizer/aliases.rs
+++ b/provider/cldr/src/transform/locale_canonicalizer/aliases.rs
@@ -9,7 +9,7 @@ use crate::support::KeyedDataProvider;
 use crate::CldrPaths;
 use icu_locale_canonicalizer::provider::*;
 use icu_locid::{subtags, LanguageIdentifier};
-use icu_provider::iter::IterableProvider;
+use icu_provider::iter::IterableResourceProvider;
 use icu_provider::prelude::*;
 use std::convert::TryFrom;
 use tinystr::{TinyStr4, TinyStr8};
@@ -70,11 +70,8 @@ impl ResourceProvider<AliasesV1Marker> for AliasesProvider {
 
 icu_provider::impl_dyn_provider!(AliasesProvider, [AliasesV1Marker,], SERDE_SE);
 
-impl IterableProvider for AliasesProvider {
-    fn supported_options_for_key(
-        &self,
-        _resc_key: &ResourceKey,
-    ) -> Result<Box<dyn Iterator<Item = ResourceOptions>>, DataError> {
+impl IterableResourceProvider<AliasesV1Marker> for AliasesProvider {
+    fn supported_options(&self) -> Result<Box<dyn Iterator<Item = ResourceOptions>>, DataError> {
         Ok(Box::new(core::iter::once(ResourceOptions::default())))
     }
 }

--- a/provider/cldr/src/transform/locale_canonicalizer/likely_subtags.rs
+++ b/provider/cldr/src/transform/locale_canonicalizer/likely_subtags.rs
@@ -8,7 +8,7 @@ use crate::reader::open_reader;
 use crate::support::KeyedDataProvider;
 use crate::CldrPaths;
 use icu_locale_canonicalizer::provider::*;
-use icu_provider::iter::IterableProvider;
+use icu_provider::iter::IterableResourceProvider;
 use icu_provider::prelude::*;
 use litemap::LiteMap;
 
@@ -65,11 +65,8 @@ impl ResourceProvider<LikelySubtagsV1Marker> for LikelySubtagsProvider {
 
 icu_provider::impl_dyn_provider!(LikelySubtagsProvider, [LikelySubtagsV1Marker,], SERDE_SE);
 
-impl IterableProvider for LikelySubtagsProvider {
-    fn supported_options_for_key(
-        &self,
-        _resc_key: &ResourceKey,
-    ) -> Result<Box<dyn Iterator<Item = ResourceOptions>>, DataError> {
+impl IterableResourceProvider<LikelySubtagsV1Marker> for LikelySubtagsProvider {
+    fn supported_options(&self) -> Result<Box<dyn Iterator<Item = ResourceOptions>>, DataError> {
         Ok(Box::new(core::iter::once(ResourceOptions::default())))
     }
 }

--- a/provider/cldr/src/transform/mod.rs
+++ b/provider/cldr/src/transform/mod.rs
@@ -18,7 +18,7 @@ mod time_zones;
 use crate::support::KeyedDataProvider;
 use crate::support::LazyCldrProvider;
 use crate::CldrPaths;
-use icu_provider::iter::IterableProvider;
+use icu_provider::iter::IterableDynProvider;
 use icu_provider::prelude::*;
 use icu_provider::serde::SerializeMarker;
 
@@ -58,7 +58,7 @@ macro_rules! cldr_json_data_provider {
             }
         }
 
-        impl<'a> IterableProvider for CldrJsonDataProvider<'a> {
+        impl<'a> IterableDynProvider<SerializeMarker> for CldrJsonDataProvider<'a> {
             fn supported_options_for_key(
                 &self,
                 resc_key: &ResourceKey,

--- a/provider/cldr/src/transform/plurals/mod.rs
+++ b/provider/cldr/src/transform/plurals/mod.rs
@@ -137,14 +137,11 @@ fn test_basic() {
     let provider = PluralsProvider::try_from(&cldr_paths as &dyn CldrPaths).unwrap();
 
     // Spot-check locale 'cs' since it has some interesting entries
-    let cs_rules: DataPayload<PluralRulesV1Marker> = provider
-        .load_payload(
-            CardinalV1Marker::KEY,
-            &DataRequest {
-                options: langid!("cs").into(),
-                metadata: Default::default(),
-            },
-        )
+    let cs_rules: DataPayload<CardinalV1Marker> = provider
+        .load_resource(&DataRequest {
+            options: langid!("cs").into(),
+            metadata: Default::default(),
+        })
         .unwrap()
         .take_payload()
         .unwrap();

--- a/provider/core/README.md
+++ b/provider/core/README.md
@@ -83,8 +83,8 @@ structs to borrow zero-copy data.
 
 #### `IterableDataProvider`
 
-Data providers can implement [`IterableProvider`], allowing iteration over all
-[`ResourceOptions`] instances supported for a certain key in the data provider.
+Data providers can implement [`IterableDynProvider`]/[`IterableResourceProvider`], allowing
+iteration over all [`ResourceOptions`] instances supported for a certain key in the data provider.
 
 For more information, see the [`iter`] module.
 
@@ -101,7 +101,8 @@ This trait is normally implemented using the [`impl_dyn_provider!`] macro.
 [`DataProvider`]: data_provider::DataProvider
 [`ResourceKey`]: resource::ResourceKey
 [`ResourceOptions`]: resource::ResourceOptions
-[`IterableProvider`]: iter::IterableProvider
+[`IterableDynProvider`]: iter::IterableDynProvider
+[`IterableResourceProvider`]: iter::IterableResourceProvider
 [`InvariantDataProvider`]: inv::InvariantDataProvider
 [`AnyPayloadProvider`]: struct_provider::AnyPayloadProvider
 [`HelloWorldProvider`]: hello_world::HelloWorldProvider

--- a/provider/core/src/data_provider/test.rs
+++ b/provider/core/src/data_provider/test.rs
@@ -63,6 +63,12 @@ impl ResourceProvider<HelloWorldV1Marker> for DataWarehouse {
     }
 }
 
+impl IterableResourceProvider<HelloWorldV1Marker> for DataWarehouse {
+    fn supported_options(&self) -> Result<Box<dyn Iterator<Item = ResourceOptions>>, DataError> {
+        Ok(Box::new(core::iter::once(ResourceOptions::default())))
+    }
+}
+
 crate::impl_dyn_provider!(DataWarehouse, [HelloWorldV1Marker,], ANY);
 
 /// A DataProvider that supports both key::HELLO_WORLD_V1 and HELLO_ALT.
@@ -89,12 +95,24 @@ impl ResourceProvider<HelloWorldV1Marker> for DataProvider2 {
     }
 }
 
+impl IterableResourceProvider<HelloWorldV1Marker> for DataProvider2 {
+    fn supported_options(&self) -> Result<Box<dyn Iterator<Item = ResourceOptions>>, DataError> {
+        Ok(Box::new(core::iter::once(ResourceOptions::default())))
+    }
+}
+
 impl ResourceProvider<HelloAltMarker> for DataProvider2 {
     fn load_resource(&self, _: &DataRequest) -> Result<DataResponse<HelloAltMarker>, DataError> {
         Ok(DataResponse {
             metadata: DataResponseMetadata::default(),
             payload: Some(DataPayload::from_owned(self.data.hello_alt.clone())),
         })
+    }
+}
+
+impl IterableResourceProvider<HelloAltMarker> for DataProvider2 {
+    fn supported_options(&self) -> Result<Box<dyn Iterator<Item = ResourceOptions>>, DataError> {
+        Ok(Box::new(core::iter::once(ResourceOptions::default())))
     }
 }
 

--- a/provider/core/src/data_provider/test.rs
+++ b/provider/core/src/data_provider/test.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use super::*;
 use crate::hello_world::*;
+use crate::iter::*;
 use crate::prelude::*;
 use crate::yoke;
 

--- a/provider/core/src/dynutil.rs
+++ b/provider/core/src/dynutil.rs
@@ -57,6 +57,7 @@ where
 ///
 /// ```
 /// use icu_provider::prelude::*;
+/// use icu_provider::iter::*;
 /// use icu_provider::hello_world::*;
 /// use icu_provider::inv::InvariantDataProvider;
 ///
@@ -67,6 +68,13 @@ where
 ///             -> Result<DataResponse<HelloWorldV1Marker>, DataError> {
 ///         let provider = InvariantDataProvider;
 ///         provider.load_resource(req)
+///     }
+/// }
+///
+/// impl IterableResourceProvider<HelloWorldV1Marker> for MyProvider {
+///     fn supported_options(&self)
+///         -> Result<Box<dyn Iterator<Item = ResourceOptions> + '_>, DataError> {
+///         Ok(Box::new(core::iter::once(Default::default())))
 ///     }
 /// }
 ///
@@ -98,6 +106,7 @@ where
 ///
 /// ```
 /// use icu_provider::prelude::*;
+/// use icu_provider::iter::*;
 /// use icu_provider::hello_world::*;
 /// use icu_provider::inv::InvariantDataProvider;
 ///
@@ -108,6 +117,13 @@ where
 ///             -> Result<DataResponse<HelloWorldV1Marker>, DataError> {
 ///         let provider = InvariantDataProvider;
 ///         provider.load_resource(req)
+///     }
+/// }
+///
+/// impl IterableDynProvider<HelloWorldV1Marker> for MyProvider {
+///     fn supported_options_for_key(&self, _key: &ResourceKey)
+///         -> Result<Box<dyn Iterator<Item = ResourceOptions> + '_>, DataError> {
+///         Ok(Box::new(core::iter::once(Default::default())))
 ///     }
 /// }
 ///

--- a/provider/core/src/either.rs
+++ b/provider/core/src/either.rs
@@ -4,7 +4,7 @@
 
 //! Helpers for switching between multiple providers.
 
-use crate::iter::IterableProvider;
+use crate::iter::*;
 use crate::prelude::*;
 use alloc::boxed::Box;
 
@@ -73,7 +73,9 @@ impl<M: ResourceMarker, P0: ResourceProvider<M>, P1: ResourceProvider<M>> Resour
     }
 }
 
-impl<P0: IterableProvider, P1: IterableProvider> IterableProvider for EitherProvider<P0, P1> {
+impl<M: DataMarker, P0: IterableDynProvider<M>, P1: IterableDynProvider<M>> IterableDynProvider<M>
+    for EitherProvider<P0, P1>
+{
     #[inline]
     fn supported_options_for_key(
         &self,
@@ -83,6 +85,21 @@ impl<P0: IterableProvider, P1: IterableProvider> IterableProvider for EitherProv
         match self {
             A(p) => p.supported_options_for_key(resc_key),
             B(p) => p.supported_options_for_key(resc_key),
+        }
+    }
+}
+
+impl<M: ResourceMarker, P0: IterableResourceProvider<M>, P1: IterableResourceProvider<M>>
+    IterableResourceProvider<M> for EitherProvider<P0, P1>
+{
+    #[inline]
+    fn supported_options(
+        &self,
+    ) -> Result<Box<dyn Iterator<Item = ResourceOptions> + '_>, DataError> {
+        use EitherProvider::*;
+        match self {
+            A(p) => p.supported_options(),
+            B(p) => p.supported_options(),
         }
     }
 }

--- a/provider/core/src/export.rs
+++ b/provider/core/src/export.rs
@@ -4,7 +4,7 @@
 
 //! Types having to do with the exporting of data.
 
-use crate::iter::IterableProvider;
+use crate::iter::IterableDynProvider;
 use crate::prelude::*;
 
 /// An object capable of serializing data payloads to be read by a data provider.
@@ -33,11 +33,11 @@ where
     }
 }
 
-/// Convenience function to drive a [`DataExporter`] from an [`IterableProvider`].
+/// Convenience function to drive a [`DataExporter`] from an [`IterableDynProvider`].
 ///
 /// # Example
 ///
-/// [`HelloWorldProvider`] implements both [`DataExporter`] and [`IterableProvider`]. The
+/// [`HelloWorldProvider`] implements both [`DataExporter`] and [`IterableDynProvider`]. The
 /// following example copies the data from one instance to another instance.
 ///
 /// ```
@@ -65,7 +65,7 @@ pub fn export_from_iterable<P, E, M>(
 ) -> Result<(), DataError>
 where
     M: DataMarker,
-    P: DynProvider<M> + IterableProvider + ?Sized,
+    P: IterableDynProvider<M> + ?Sized,
     E: DataExporter<M> + ?Sized,
 {
     let it = provider.supported_options_for_key(resc_key)?;

--- a/provider/core/src/filter/impls.rs
+++ b/provider/core/src/filter/impls.rs
@@ -24,7 +24,7 @@ where
     /// use icu_provider::prelude::*;
     /// use icu_provider::hello_world::*;
     /// use icu_provider::filter::Filterable;
-    /// use icu_provider::iter::IterableDynProvider;
+    /// use icu_provider::iter::*;
     /// use icu_locid::LanguageIdentifier;
     /// use icu_locid_macros::{language, langid};
     ///
@@ -54,7 +54,7 @@ where
     /// ));
     ///
     /// // English should not appear in the iterator result:
-    /// let supported_langids = provider.supported_options_for_key(&HelloWorldV1Marker::KEY)
+    /// let supported_langids = provider.supported_options()
     ///     .expect("Should successfully make an iterator of supported locales")
     ///     .filter_map(|options| options.langid)
     ///     .collect::<Vec<LanguageIdentifier>>();

--- a/provider/core/src/filter/impls.rs
+++ b/provider/core/src/filter/impls.rs
@@ -24,7 +24,7 @@ where
     /// use icu_provider::prelude::*;
     /// use icu_provider::hello_world::*;
     /// use icu_provider::filter::Filterable;
-    /// use icu_provider::iter::IterableProvider;
+    /// use icu_provider::iter::IterableDynProvider;
     /// use icu_locid::LanguageIdentifier;
     /// use icu_locid_macros::{language, langid};
     ///

--- a/provider/core/src/filter/mod.rs
+++ b/provider/core/src/filter/mod.rs
@@ -5,7 +5,7 @@
 //! Providers that filter resource requests.
 //!
 //! Requests that fail a filter test will return [`DataError`] of kind [`FilteredResource`](
-//! DataErrorKind::FilteredResource) and will not appear in [`IterableProvider`] iterators.
+//! DataErrorKind::FilteredResource) and will not appear in [`IterableDynProvider`] iterators.
 //!
 //! The main struct is [`RequestFilterDataProvider`]. Although that struct can be created
 //! directly, the traits in this module provide helper functions for common filtering patterns.
@@ -32,13 +32,13 @@
 //!     .filter_by_langid(|langid| langid.language == language!("de"));
 //! ```
 //!
-//! [`IterableProvider`]: crate::iter::IterableProvider
+//! [`IterableDynProvider`]: crate::iter::IterableDynProvider
 
 mod impls;
 
 pub use impls::*;
 
-use crate::iter::IterableProvider;
+use crate::iter::IterableDynProvider;
 use crate::prelude::*;
 use alloc::boxed::Box;
 
@@ -46,7 +46,7 @@ use alloc::boxed::Box;
 ///
 /// Data requests that are rejected by the filter will return a [`DataError`] with kind
 /// [`FilteredResource`](DataErrorKind::FilteredResource), and they will not be returned
-/// by [`IterableProvider::supported_options_for_key`].
+/// by [`IterableDynProvider::supported_options_for_key`].
 ///
 /// Although this struct can be created directly, the traits in this module provide helper
 /// functions for common filtering patterns.
@@ -139,10 +139,11 @@ where
     }
 }
 
-impl<D, F> IterableProvider for RequestFilterDataProvider<D, F>
+impl<M, D, F> IterableDynProvider<M> for RequestFilterDataProvider<D, F>
 where
+    M: DataMarker,
     F: Fn(&DataRequest) -> bool,
-    D: IterableProvider,
+    D: IterableDynProvider<M>,
 {
     fn supported_options_for_key(
         &self,

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -6,7 +6,7 @@
 
 use crate::buf::BufferFormat;
 use crate::helpers;
-use crate::iter::IterableProvider;
+use crate::iter::IterableResourceProvider;
 use crate::prelude::*;
 use crate::yoke::{self, *};
 use alloc::borrow::Cow;
@@ -170,12 +170,10 @@ impl BufferProvider for HelloWorldJsonProvider {
     }
 }
 
-impl IterableProvider for HelloWorldProvider {
-    fn supported_options_for_key(
+impl IterableResourceProvider<HelloWorldV1Marker> for HelloWorldProvider {
+    fn supported_options(
         &self,
-        resc_key: &ResourceKey,
     ) -> Result<Box<dyn Iterator<Item = ResourceOptions> + '_>, DataError> {
-        resc_key.match_key(HelloWorldV1Marker::KEY)?;
         Ok(Box::new(
             self.map
                 .iter_keys()

--- a/provider/core/src/inv.rs
+++ b/provider/core/src/inv.rs
@@ -4,7 +4,7 @@
 
 //! Locale-invariant data provider that requires no I/O.
 
-use crate::iter::IterableProvider;
+use crate::iter::IterableDynProvider;
 use crate::prelude::*;
 use alloc::boxed::Box;
 
@@ -59,7 +59,11 @@ where
     }
 }
 
-impl IterableProvider for InvariantDataProvider {
+impl<M> IterableDynProvider<M> for InvariantDataProvider
+where
+    M: DataMarker,
+    M::Yokeable: Default,
+{
     fn supported_options_for_key(
         &self,
         _resc_key: &ResourceKey,

--- a/provider/core/src/iter.rs
+++ b/provider/core/src/iter.rs
@@ -7,14 +7,25 @@
 use crate::prelude::*;
 use alloc::boxed::Box;
 
-/// A provider that can iterate over all supported [`ResourceOptions`] for a certain key.
+/// A [`DynProvider`] that can iterate over all supported [`ResourceOptions`] for a certain key.
 ///
 /// Implementing this trait means that a data provider knows all of the data it can successfully
 /// return from a load request.
-pub trait IterableProvider {
+pub trait IterableDynProvider<M: DataMarker>: DynProvider<M> {
     /// Given a [`ResourceKey`], returns a boxed iterator over [`ResourceOptions`].
     fn supported_options_for_key(
         &self,
         resc_key: &ResourceKey,
+    ) -> Result<Box<dyn Iterator<Item = ResourceOptions> + '_>, DataError>;
+}
+
+/// A [`ResourceProvider`] that can iterate over all supported [`ResourceOptions`] for a certain key.
+///
+/// Implementing this trait means that a data provider knows all of the data it can successfully
+/// return from a load request.
+pub trait IterableResourceProvider<M: ResourceMarker>: ResourceProvider<M> {
+    /// Returns a boxed iterator over [`ResourceOptions`].
+    fn supported_options(
+        &self,
     ) -> Result<Box<dyn Iterator<Item = ResourceOptions> + '_>, DataError>;
 }

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -85,8 +85,8 @@
 //!
 //! ### `IterableDataProvider`
 //!
-//! Data providers can implement [`IterableProvider`], allowing iteration over all
-//! [`ResourceOptions`] instances supported for a certain key in the data provider.
+//! Data providers can implement [`IterableDynProvider`]/[`IterableResourceProvider`], allowing
+//! iteration over all [`ResourceOptions`] instances supported for a certain key in the data provider.
 //!
 //! For more information, see the [`iter`] module.
 //!
@@ -103,7 +103,8 @@
 //! [`DataProvider`]: data_provider::DataProvider
 //! [`ResourceKey`]: resource::ResourceKey
 //! [`ResourceOptions`]: resource::ResourceOptions
-//! [`IterableProvider`]: iter::IterableProvider
+//! [`IterableDynProvider`]: iter::IterableDynProvider
+//! [`IterableResourceProvider`]: iter::IterableResourceProvider
 //! [`InvariantDataProvider`]: inv::InvariantDataProvider
 //! [`AnyPayloadProvider`]: struct_provider::AnyPayloadProvider
 //! [`HelloWorldProvider`]: hello_world::HelloWorldProvider

--- a/provider/core/tests/iteration.rs
+++ b/provider/core/tests/iteration.rs
@@ -5,14 +5,14 @@
 use icu_locid::LanguageIdentifier;
 use icu_locid_macros::langid;
 use icu_provider::hello_world::*;
-use icu_provider::iter::IterableDynProvider;
+use icu_provider::iter::IterableResourceProvider;
 use icu_provider::prelude::*;
 
 #[test]
 fn test_supported_langids() {
     let provider = HelloWorldProvider::new_with_placeholder_data();
     let mut supported_langids: Vec<LanguageIdentifier> = provider
-        .supported_options_for_key(&HelloWorldV1Marker::KEY)
+        .supported_options()
         .unwrap()
         .map(|resc_options| resc_options.langid.unwrap())
         .collect();

--- a/provider/core/tests/iteration.rs
+++ b/provider/core/tests/iteration.rs
@@ -5,7 +5,7 @@
 use icu_locid::LanguageIdentifier;
 use icu_locid_macros::langid;
 use icu_provider::hello_world::*;
-use icu_provider::iter::IterableProvider;
+use icu_provider::iter::IterableDynProvider;
 use icu_provider::prelude::*;
 
 #[test]

--- a/provider/uprops/src/bin_uniset.rs
+++ b/provider/uprops/src/bin_uniset.rs
@@ -6,7 +6,7 @@ use crate::uprops_helpers::{self, get_last_component_no_version, TomlBinary};
 
 use icu_properties::provider::UnicodePropertyV1;
 use icu_properties::provider::UnicodePropertyV1Marker;
-use icu_provider::iter::IterableProvider;
+use icu_provider::iter::IterableDynProvider;
 use icu_provider::prelude::*;
 use icu_uniset::UnicodeSetBuilder;
 use std::path::Path;
@@ -53,7 +53,7 @@ icu_provider::impl_dyn_provider!(BinaryPropertyUnicodeSetDataProvider, {
     _ => UnicodePropertyV1Marker,
 }, SERDE_SE);
 
-impl IterableProvider for BinaryPropertyUnicodeSetDataProvider {
+impl IterableDynProvider<UnicodePropertyV1Marker> for BinaryPropertyUnicodeSetDataProvider {
     fn supported_options_for_key(
         &self,
         _resc_key: &ResourceKey,

--- a/provider/uprops/src/enum_codepointtrie.rs
+++ b/provider/uprops/src/enum_codepointtrie.rs
@@ -12,7 +12,7 @@ use icu_properties::{
     CanonicalCombiningClass, EastAsianWidth, GeneralCategory, GraphemeClusterBreak, LineBreak,
     Script, SentenceBreak, WordBreak,
 };
-use icu_provider::iter::IterableProvider;
+use icu_provider::iter::IterableDynProvider;
 use icu_provider::prelude::*;
 use std::convert::TryFrom;
 use std::path::Path;
@@ -130,7 +130,9 @@ icu_provider::impl_dyn_provider!(EnumeratedPropertyCodePointTrieProvider, {
     key::SENTENCE_BREAK_V1 => UnicodePropertyMapV1Marker<SentenceBreak>,
 }, SERDE_SE);
 
-impl IterableProvider for EnumeratedPropertyCodePointTrieProvider {
+impl<T: TrieValue> IterableDynProvider<UnicodePropertyMapV1Marker<T>>
+    for EnumeratedPropertyCodePointTrieProvider
+{
     fn supported_options_for_key(
         &self,
         _resc_key: &ResourceKey,

--- a/provider/uprops/src/enum_uniset.rs
+++ b/provider/uprops/src/enum_uniset.rs
@@ -6,7 +6,7 @@ use crate::uprops_helpers::{self, get_last_component_no_version, TomlEnumerated}
 
 use icu_properties::provider::UnicodePropertyV1;
 use icu_properties::provider::UnicodePropertyV1Marker;
-use icu_provider::iter::IterableProvider;
+use icu_provider::iter::IterableDynProvider;
 use icu_provider::prelude::*;
 use icu_uniset::UnicodeSetBuilder;
 use std::path::Path;
@@ -102,7 +102,7 @@ icu_provider::impl_dyn_provider!(EnumeratedPropertyUnicodeSetDataProvider, {
     _ => UnicodePropertyV1Marker,
 }, SERDE_SE);
 
-impl IterableProvider for EnumeratedPropertyUnicodeSetDataProvider {
+impl IterableDynProvider<UnicodePropertyV1Marker> for EnumeratedPropertyUnicodeSetDataProvider {
     fn supported_options_for_key(
         &self,
         _resc_key: &ResourceKey,

--- a/provider/uprops/src/provider.rs
+++ b/provider/uprops/src/provider.rs
@@ -6,7 +6,7 @@ use crate::bin_uniset::BinaryPropertyUnicodeSetDataProvider;
 use crate::enum_uniset::EnumeratedPropertyUnicodeSetDataProvider;
 use crate::uprops_helpers::get_last_component_no_version;
 use icu_properties::provider::UnicodePropertyV1Marker;
-use icu_provider::iter::IterableProvider;
+use icu_provider::iter::IterableDynProvider;
 use icu_provider::prelude::*;
 
 use std::path::Path;
@@ -48,7 +48,7 @@ icu_provider::impl_dyn_provider!(PropertiesDataProvider, {
     _ => UnicodePropertyV1Marker,
 }, SERDE_SE);
 
-impl IterableProvider for PropertiesDataProvider {
+impl IterableDynProvider<UnicodePropertyV1Marker> for PropertiesDataProvider {
     fn supported_options_for_key(
         &self,
         _resc_key: &ResourceKey,

--- a/provider/uprops/src/script.rs
+++ b/provider/uprops/src/script.rs
@@ -8,7 +8,7 @@ use icu_codepointtrie::CodePointTrie;
 use icu_properties::provider::{key, ScriptExtensionsPropertyV1, ScriptExtensionsPropertyV1Marker};
 use icu_properties::script::{ScriptExtensions, ScriptWithExt};
 use icu_properties::Script;
-use icu_provider::iter::IterableProvider;
+use icu_provider::iter::IterableDynProvider;
 use icu_provider::prelude::*;
 use std::convert::TryFrom;
 use std::path::Path;
@@ -101,7 +101,7 @@ icu_provider::impl_dyn_provider!(ScriptExtensionsPropertyProvider, {
     key::SCRIPT_EXTENSIONS_V1 => ScriptExtensionsPropertyV1Marker,
 }, SERDE_SE);
 
-impl IterableProvider for ScriptExtensionsPropertyProvider {
+impl IterableDynProvider<ScriptExtensionsPropertyV1Marker> for ScriptExtensionsPropertyProvider {
     fn supported_options_for_key(
         &self,
         _resc_key: &ResourceKey,


### PR DESCRIPTION
Also adding `DataMarker` bounds to those traits, and making them require `DynProvider` and `ResourceProvider`.

Ignore the first four commits