### PR TITLE
Add segmenter factories to generate UAX29 iterators

### DIFF
--- a/experimental/segmenter/README.md
+++ b/experimental/segmenter/README.md
@@ -61,18 +61,23 @@ assert_eq!(&breakpoints, &[6, 11]);
 Segment a string:
 
 ```rust
-use icu_segmenter::GraphemeClusterBreakIterator;
+use icu_segmenter::GraphemeClusterBreakSegmenter;
+let segmenter = GraphemeClusterBreakSegmenter::try_new()
+    .expect("Data exists");
 
-let breakpoints: Vec<usize> = GraphemeClusterBreakIterator::new("Hello 🗺").collect();
-assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 10]); // World Map (U+1F5FA) is encoded in four bytes in UTF-8.
+let breakpoints: Vec<usize> = segmenter.segment_str("Hello 🗺").collect();
+// World Map (U+1F5FA) is encoded in four bytes in UTF-8.
+assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 10]);
 ```
 
 Segment a Latin1 byte string:
 
 ```rust
-use icu_segmenter::GraphemeClusterBreakIteratorLatin1;
+use icu_segmenter::GraphemeClusterBreakSegmenter;
+let segmenter = GraphemeClusterBreakSegmenter::try_new()
+    .expect("Data exists");
 
-let breakpoints: Vec<usize> = GraphemeClusterBreakIteratorLatin1::new(b"Hello World").collect();
+let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
 assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 ```
 
@@ -81,18 +86,22 @@ assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 Segment a string:
 
 ```rust
-use icu_segmenter::WordBreakIterator;
+use icu_segmenter::WordBreakSegmenter;
+let segmenter = WordBreakSegmenter::try_new()
+    .expect("Data exists");
 
-let breakpoints: Vec<usize> = WordBreakIterator::new("Hello World").collect();
+let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
 assert_eq!(&breakpoints, &[0, 5, 6, 11]);
 ```
 
 Segment a Latin1 byte string:
 
 ```rust
-use icu_segmenter::WordBreakIteratorLatin1;
+use icu_segmenter::WordBreakSegmenter;
+let segmenter = WordBreakSegmenter::try_new()
+    .expect("Data exists");
 
-let breakpoints: Vec<usize> = WordBreakIteratorLatin1::new(b"Hello World").collect();
+let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
 assert_eq!(&breakpoints, &[0, 5, 6, 11]);
 ```
 
@@ -101,18 +110,22 @@ assert_eq!(&breakpoints, &[0, 5, 6, 11]);
 Segment a string:
 
 ```rust
-use icu_segmenter::SentenceBreakIterator;
+use icu_segmenter::SentenceBreakSegmenter;
+let segmenter = SentenceBreakSegmenter::try_new()
+    .expect("Data exists");
 
-let breakpoints: Vec<usize> = SentenceBreakIterator::new("Hello World").collect();
+let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
 assert_eq!(&breakpoints, &[0, 11]);
 ```
 
 Segment a Latin1 byte string:
 
 ```rust
-use icu_segmenter::SentenceBreakIteratorLatin1;
+use icu_segmenter::SentenceBreakSegmenter;
+let segmenter = SentenceBreakSegmenter::try_new()
+    .expect("Data exists");
 
-let breakpoints: Vec<usize> = SentenceBreakIteratorLatin1::new(b"Hello World").collect();
+let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
 assert_eq!(&breakpoints, &[0, 11]);
 ```
 

--- a/experimental/segmenter/src/lib.rs
+++ b/experimental/segmenter/src/lib.rs
@@ -66,18 +66,23 @@
 //! Segment a string:
 //!
 //!```rust
-//! use icu_segmenter::GraphemeClusterBreakIterator;
+//! use icu_segmenter::GraphemeClusterBreakSegmenter;
+//! let segmenter = GraphemeClusterBreakSegmenter::try_new()
+//!     .expect("Data exists");
 //!
-//! let breakpoints: Vec<usize> = GraphemeClusterBreakIterator::new("Hello 🗺").collect();
-//! assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 10]); // World Map (U+1F5FA) is encoded in four bytes in UTF-8.
+//! let breakpoints: Vec<usize> = segmenter.segment_str("Hello 🗺").collect();
+//! // World Map (U+1F5FA) is encoded in four bytes in UTF-8.
+//! assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 10]);
 //! ```
 //!
 //! Segment a Latin1 byte string:
 //!
 //! ```rust
-//! use icu_segmenter::GraphemeClusterBreakIteratorLatin1;
+//! use icu_segmenter::GraphemeClusterBreakSegmenter;
+//! let segmenter = GraphemeClusterBreakSegmenter::try_new()
+//!     .expect("Data exists");
 //!
-//! let breakpoints: Vec<usize> = GraphemeClusterBreakIteratorLatin1::new(b"Hello World").collect();
+//! let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
 //! assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 //! ```
 //!
@@ -86,18 +91,22 @@
 //! Segment a string:
 //!
 //!```rust
-//! use icu_segmenter::WordBreakIterator;
+//! use icu_segmenter::WordBreakSegmenter;
+//! let segmenter = WordBreakSegmenter::try_new()
+//!     .expect("Data exists");
 //!
-//! let breakpoints: Vec<usize> = WordBreakIterator::new("Hello World").collect();
+//! let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
 //! assert_eq!(&breakpoints, &[0, 5, 6, 11]);
 //! ```
 //!
 //! Segment a Latin1 byte string:
 //!
 //! ```rust
-//! use icu_segmenter::WordBreakIteratorLatin1;
+//! use icu_segmenter::WordBreakSegmenter;
+//! let segmenter = WordBreakSegmenter::try_new()
+//!     .expect("Data exists");
 //!
-//! let breakpoints: Vec<usize> = WordBreakIteratorLatin1::new(b"Hello World").collect();
+//! let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
 //! assert_eq!(&breakpoints, &[0, 5, 6, 11]);
 //! ```
 //!
@@ -106,18 +115,22 @@
 //! Segment a string:
 //!
 //!```rust
-//! use icu_segmenter::SentenceBreakIterator;
+//! use icu_segmenter::SentenceBreakSegmenter;
+//! let segmenter = SentenceBreakSegmenter::try_new()
+//!     .expect("Data exists");
 //!
-//! let breakpoints: Vec<usize> = SentenceBreakIterator::new("Hello World").collect();
+//! let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
 //! assert_eq!(&breakpoints, &[0, 11]);
 //! ```
 //!
 //! Segment a Latin1 byte string:
 //!
 //! ```rust
-//! use icu_segmenter::SentenceBreakIteratorLatin1;
+//! use icu_segmenter::SentenceBreakSegmenter;
+//! let segmenter = SentenceBreakSegmenter::try_new()
+//!     .expect("Data exists");
 //!
-//! let breakpoints: Vec<usize> = SentenceBreakIteratorLatin1::new(b"Hello World").collect();
+//! let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
 //! assert_eq!(&breakpoints, &[0, 11]);
 //! ```
 //!
@@ -170,10 +183,13 @@ mod lstm {
 
 pub use crate::grapheme::{
     GraphemeClusterBreakIterator, GraphemeClusterBreakIteratorLatin1,
-    GraphemeClusterBreakIteratorUtf16,
+    GraphemeClusterBreakIteratorUtf16, GraphemeClusterBreakSegmenter,
 };
 pub use crate::line_breaker::*;
 pub use crate::sentence::{
     SentenceBreakIterator, SentenceBreakIteratorLatin1, SentenceBreakIteratorUtf16,
+    SentenceBreakSegmenter,
 };
-pub use crate::word::{WordBreakIterator, WordBreakIteratorLatin1, WordBreakIteratorUtf16};
+pub use crate::word::{
+    WordBreakIterator, WordBreakIteratorLatin1, WordBreakIteratorUtf16, WordBreakSegmenter,
+};

--- a/experimental/segmenter/src/line_breaker.rs
+++ b/experimental/segmenter/src/line_breaker.rs
@@ -104,6 +104,10 @@ impl Default for LineBreakOptions {
     }
 }
 
+/// Supports loading line break data, and creating line break iterators for different string
+/// encodings. Please see the [module-level documentation] for its usages.
+///
+/// [module-level documentation]: index.html
 pub struct LineBreakSegmenter {
     options: LineBreakOptions,
     payload: DataPayload<LineBreakDataV1Marker>,
@@ -400,9 +404,8 @@ pub trait LineBreakType<'l, 's> {
     ) -> Vec<usize>;
 }
 
-/// The struct implementing the [`Iterator`] trait over the line break
-/// opportunities of the given string. Please see the [module-level
-/// documentation] for its usages.
+/// Implements the [`Iterator`] trait over the line break opportunities of the given string. Please
+/// see the [module-level documentation] for its usages.
 ///
 /// Lifetimes:
 ///
@@ -410,7 +413,7 @@ pub trait LineBreakType<'l, 's> {
 /// - `'s` = lifetime of the string being segmented
 ///
 /// [`Iterator`]: core::iter::Iterator
-/// [module-level documentation]: ../index.html
+/// [module-level documentation]: index.html
 pub struct LineBreakIterator<'l, 's, Y: LineBreakType<'l, 's> + ?Sized> {
     iter: Y::IterAttr,
     len: usize,

--- a/experimental/segmenter/src/rule_segmenter.rs
+++ b/experimental/segmenter/src/rule_segmenter.rs
@@ -168,7 +168,9 @@ impl<'a, Y: RuleBreakType<'a>> RuleBreakIterator<'a, Y> {
     }
 
     fn get_current_codepoint(&self) -> Y::CharType {
-        self.current_pos_data.expect("Not at the of the string").1
+        self.current_pos_data
+            .expect("Not at the end of the string!")
+            .1
     }
 
     fn get_break_property(&self, codepoint: Y::CharType) -> u8 {

--- a/experimental/segmenter/src/rule_segmenter.rs
+++ b/experimental/segmenter/src/rule_segmenter.rs
@@ -11,34 +11,38 @@ const INTERMEDIATE_MATCH_RULE: i8 = 64;
 
 /// A trait allowing for RuleBreakIterator to be generalized to multiple string
 /// encoding methods and granularity such as grapheme cluster, word, etc.
-pub trait RuleBreakType<'a> {
+pub trait RuleBreakType<'l, 's> {
     /// The iterator over characters.
     type IterAttr: Iterator<Item = (usize, Self::CharType)> + Clone;
 
     /// The character type.
     type CharType: Copy + Into<u32>;
 
-    fn get_current_position_character_len(iter: &RuleBreakIterator<'a, Self>) -> usize;
+    fn get_current_position_character_len(iter: &RuleBreakIterator<'l, 's, Self>) -> usize;
 
     fn handle_complex_language(
-        iter: &mut RuleBreakIterator<'a, Self>,
+        iter: &mut RuleBreakIterator<'l, 's, Self>,
         left_codepoint: Self::CharType,
     ) -> Option<usize>;
 }
 
-/// The struct implementing the [`Iterator`] trait over the segmenter break
-/// opportunities of the given string. Please see the [module-level
-/// documentation] for its usages.
+/// Implements the [`Iterator`] trait over the segmenter break opportunities of the given string.
+/// Please see the [module-level documentation] for its usages.
+///
+/// Lifetimes:
+///
+/// - `'l` = lifetime of the segmenter object from which this iterator was created
+/// - `'s` = lifetime of the string being segmented
 ///
 /// [`Iterator`]: core::iter::Iterator
-/// [module-level documentation]: ../index.html
-pub struct RuleBreakIterator<'a, Y: RuleBreakType<'a> + ?Sized> {
+/// [module-level documentation]: index.html
+pub struct RuleBreakIterator<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> {
     pub(crate) iter: Y::IterAttr,
     pub(crate) len: usize,
     pub(crate) current_pos_data: Option<(usize, Y::CharType)>,
     pub(crate) result_cache: alloc::vec::Vec<usize>,
-    pub(crate) break_state_table: &'a [i8],
-    pub(crate) property_table: &'a [&'a [u8; 1024]; 897],
+    pub(crate) break_state_table: &'l [i8],
+    pub(crate) property_table: &'l [&'l [u8; 1024]; 897],
     pub(crate) rule_property_count: usize,
     pub(crate) last_codepoint_property: i8,
     pub(crate) sot_property: u8,
@@ -46,7 +50,7 @@ pub struct RuleBreakIterator<'a, Y: RuleBreakType<'a> + ?Sized> {
     pub(crate) complex_property: u8,
 }
 
-impl<'a, Y: RuleBreakType<'a>> Iterator for RuleBreakIterator<'a, Y> {
+impl<'l, 's, Y: RuleBreakType<'l, 's>> Iterator for RuleBreakIterator<'l, 's, Y> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -162,7 +166,7 @@ impl<'a, Y: RuleBreakType<'a>> Iterator for RuleBreakIterator<'a, Y> {
     }
 }
 
-impl<'a, Y: RuleBreakType<'a>> RuleBreakIterator<'a, Y> {
+impl<'l, 's, Y: RuleBreakType<'l, 's>> RuleBreakIterator<'l, 's, Y> {
     pub(crate) fn get_current_break_property(&self) -> u8 {
         self.get_break_property(self.get_current_codepoint())
     }

--- a/experimental/segmenter/tests/complex_word.rs
+++ b/experimental/segmenter/tests/complex_word.rs
@@ -2,23 +2,24 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_segmenter::WordBreakIterator;
-use icu_segmenter::WordBreakIteratorUtf16;
+use icu_segmenter::WordBreakSegmenter;
 
 // Additional word segmenter tests with complex string.
 
 #[test]
 fn word_break_th() {
+    let segmenter = WordBreakSegmenter::try_new().expect("Data exists");
+
     // http://wpt.live/css/css-text/word-break/word-break-normal-th-000.html
     let s = "ภาษาไทยภาษาไทย";
     let utf16: Vec<u16> = s.encode_utf16().collect();
-    let iter = WordBreakIteratorUtf16::new(&utf16);
+    let iter = segmenter.segment_utf16(&utf16);
     assert_eq!(
         iter.collect::<Vec<usize>>(),
         vec![0, 4, 7, 11, 14],
         "word segmenter with Thai"
     );
-    let iter = WordBreakIterator::new(s);
+    let iter = segmenter.segment_str(s);
     assert_eq!(
         iter.collect::<Vec<usize>>(),
         vec![0, 12, 21, 33, 42],
@@ -28,7 +29,7 @@ fn word_break_th() {
     // Combine non-Thai and Thai.
     let s = "aภาษาไทยภาษาไทยb";
     let utf16: Vec<u16> = s.encode_utf16().collect();
-    let iter = WordBreakIteratorUtf16::new(&utf16);
+    let iter = segmenter.segment_utf16(&utf16);
     assert_eq!(
         iter.collect::<Vec<usize>>(),
         vec![0, 1, 5, 8, 12, 15, 16],
@@ -38,9 +39,11 @@ fn word_break_th() {
 
 #[test]
 fn word_break_my() {
+    let segmenter = WordBreakSegmenter::try_new().expect("Data exists");
+
     let s = "မြန်မာစာမြန်မာစာမြန်မာစာ";
     let utf16: Vec<u16> = s.encode_utf16().collect();
-    let iter = WordBreakIteratorUtf16::new(&utf16);
+    let iter = segmenter.segment_utf16(&utf16);
     assert_eq!(
         iter.collect::<Vec<usize>>(),
         vec![0, 8, 16, 22, 24],

--- a/experimental/segmenter/tests/spec_test.rs
+++ b/experimental/segmenter/tests/spec_test.rs
@@ -2,16 +2,10 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_segmenter::GraphemeClusterBreakIterator;
-use icu_segmenter::GraphemeClusterBreakIteratorLatin1;
-use icu_segmenter::GraphemeClusterBreakIteratorUtf16;
+use icu_segmenter::GraphemeClusterBreakSegmenter;
 use icu_segmenter::LineBreakSegmenter;
-use icu_segmenter::SentenceBreakIterator;
-use icu_segmenter::SentenceBreakIteratorLatin1;
-use icu_segmenter::SentenceBreakIteratorUtf16;
-use icu_segmenter::WordBreakIterator;
-use icu_segmenter::WordBreakIteratorLatin1;
-use icu_segmenter::WordBreakIteratorUtf16;
+use icu_segmenter::SentenceBreakSegmenter;
+use icu_segmenter::WordBreakSegmenter;
 use std::char;
 use std::fs::File;
 use std::io::prelude::*;
@@ -144,13 +138,14 @@ fn run_line_break_test() {
 #[test]
 fn run_word_break_test() {
     let test_iter = TestContentIterator::new("./tests/testdata/WordBreakTest.txt");
+    let segmenter = WordBreakSegmenter::try_new().expect("Data exists");
     for test in test_iter {
         let s: String = test.utf8_vec.into_iter().collect();
-        let iter = WordBreakIterator::new(&s);
+        let iter = segmenter.segment_str(&s);
         let result: Vec<usize> = iter.collect();
         assert_eq!(result, test.break_result_utf8, "{}", test.original_line);
 
-        let iter = WordBreakIteratorUtf16::new(&test.utf16_vec);
+        let iter = segmenter.segment_utf16(&test.utf16_vec);
         let result: Vec<usize> = iter.collect();
         assert_eq!(
             result, test.break_result_utf16,
@@ -160,7 +155,7 @@ fn run_word_break_test() {
 
         // Test data is Latin-1 character only, it can run for Latin-1 segmenter test.
         if let Some(break_result_latin1) = test.break_result_latin1 {
-            let iter = WordBreakIteratorLatin1::new(&test.latin1_vec);
+            let iter = segmenter.segment_latin1(&test.latin1_vec);
             let result: Vec<usize> = iter.collect();
             assert_eq!(
                 result, break_result_latin1,
@@ -174,13 +169,14 @@ fn run_word_break_test() {
 #[test]
 fn run_grapheme_break_test() {
     let test_iter = TestContentIterator::new("./tests/testdata/GraphemeBreakTest.txt");
+    let segmenter = GraphemeClusterBreakSegmenter::try_new().expect("Data exists");
     for test in test_iter {
         let s: String = test.utf8_vec.into_iter().collect();
-        let iter = GraphemeClusterBreakIterator::new(&s);
+        let iter = segmenter.segment_str(&s);
         let result: Vec<usize> = iter.collect();
         assert_eq!(result, test.break_result_utf8, "{}", test.original_line);
 
-        let iter = GraphemeClusterBreakIteratorUtf16::new(&test.utf16_vec);
+        let iter = segmenter.segment_utf16(&test.utf16_vec);
         let result: Vec<usize> = iter.collect();
         assert_eq!(
             result, test.break_result_utf16,
@@ -190,7 +186,7 @@ fn run_grapheme_break_test() {
 
         // Test data is Latin-1 character only, it can run for Latin-1 segmenter test.
         if let Some(break_result_latin1) = test.break_result_latin1 {
-            let iter = GraphemeClusterBreakIteratorLatin1::new(&test.latin1_vec);
+            let iter = segmenter.segment_latin1(&test.latin1_vec);
             let result: Vec<usize> = iter.collect();
             assert_eq!(
                 result, break_result_latin1,
@@ -204,13 +200,14 @@ fn run_grapheme_break_test() {
 #[test]
 fn run_sentence_break_test() {
     let test_iter = TestContentIterator::new("./tests/testdata/SentenceBreakTest.txt");
+    let segmenter = SentenceBreakSegmenter::try_new().expect("Data exists");
     for test in test_iter {
         let s: String = test.utf8_vec.into_iter().collect();
-        let iter = SentenceBreakIterator::new(&s);
+        let iter = segmenter.segment_str(&s);
         let result: Vec<usize> = iter.collect();
         assert_eq!(result, test.break_result_utf8, "{}", test.original_line);
 
-        let iter = SentenceBreakIteratorUtf16::new(&test.utf16_vec);
+        let iter = segmenter.segment_utf16(&test.utf16_vec);
         let result: Vec<usize> = iter.collect();
         assert_eq!(
             result, test.break_result_utf16,
@@ -220,7 +217,7 @@ fn run_sentence_break_test() {
 
         // Test data is Latin-1 character only, it can run for Latin-1 segmenter test.
         if let Some(break_result_latin1) = test.break_result_latin1 {
-            let iter = SentenceBreakIteratorLatin1::new(&test.latin1_vec);
+            let iter = segmenter.segment_latin1(&test.latin1_vec);
             let result: Vec<usize> = iter.collect();
             assert_eq!(
                 result, break_result_latin1,


### PR DESCRIPTION
Working towards #1579.

This PR ports #1387 to rule based iterators by adding segmenter factories to generate them.

Previously, we can generate iterator via `::new()` like

```
let breakpoints: Vec<usize> = WordBreakIterator::new("Hello World").collect();
```

Now you can write:

```
let segmenter = WordBreakSegmenter::try_new().expect("Data exists");
let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
```
