### PR TITLE
Add #[make_ule] proc macro

### DIFF
--- a/utils/zerovec/derive/Cargo.toml
+++ b/utils/zerovec/derive/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/lib.rs"
 [dependencies]
 proc-macro2 = "1.0.27"
 quote = "1.0.9"
-syn = { version = "1.0.73", features = ["derive", "fold"] }
+syn = { version = "1.0.73", features = ["derive", "parsing"] }
 synstructure = "0.12.4"
 
 [dev-dependencies]

--- a/utils/zerovec/derive/examples/make.rs
+++ b/utils/zerovec/derive/examples/make.rs
@@ -1,0 +1,84 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use std::fmt::Debug;
+use zerovec::*;
+use zerovec_derive::*;
+
+#[make_ule]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Struct {
+    a: u8,
+    b: u32,
+    c: char,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[make_ule]
+struct TupleStruct(u8, char);
+
+#[make_ule]
+#[repr(u8)]
+#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Debug)]
+enum Enum {
+    A = 0,
+    B = 1,
+    D = 2,
+    E = 3,
+    FooBar = 4,
+    F = 5,
+}
+
+fn test_zerovec<T: ule::AsULE + Debug + PartialEq>(slice: &[T]) {
+    let zerovec: ZeroVec<T> = slice.iter().copied().collect();
+
+    assert_eq!(zerovec, slice);
+
+    let bytes = zerovec.as_bytes();
+    let _name = std::any::type_name::<T>();
+    let reparsed: ZeroVec<T> = ZeroVec::parse_byte_slice(bytes)
+        .unwrap_or_else(|_| panic!("{}", "Parsing {name} should succeed"));
+
+    assert_eq!(reparsed, slice);
+}
+
+fn main() {
+    test_zerovec(TEST_SLICE_STRUCT);
+    test_zerovec(TEST_SLICE_TUPLESTRUCT);
+    test_zerovec(TEST_SLICE_ENUM);
+}
+
+const TEST_SLICE_STRUCT: &[Struct] = &[
+    Struct {
+        a: 101,
+        b: 924,
+        c: '⸘',
+    },
+    Struct {
+        a: 217,
+        b: 4228,
+        c: 'ə',
+    },
+    Struct {
+        a: 117,
+        b: 9090,
+        c: 'ø',
+    },
+];
+
+const TEST_SLICE_TUPLESTRUCT: &[TupleStruct] = &[
+    TupleStruct(101, 'ř'),
+    TupleStruct(76, '°'),
+    TupleStruct(15, 'a'),
+];
+
+const TEST_SLICE_ENUM: &[Enum] = &[
+    Enum::A,
+    Enum::FooBar,
+    Enum::F,
+    Enum::D,
+    Enum::B,
+    Enum::FooBar,
+    Enum::E,
+];

--- a/utils/zerovec/derive/examples/make.rs
+++ b/utils/zerovec/derive/examples/make.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 use zerovec::*;
 use zerovec_derive::*;
 
-#[make_ule]
+#[make_ule(StructULE)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct Struct {
     a: u8,
@@ -15,10 +15,10 @@ struct Struct {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-#[make_ule]
+#[make_ule(TupleStructULE)]
 struct TupleStruct(u8, char);
 
-#[make_ule]
+#[make_ule(EnumULE)]
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Debug)]
 enum Enum {

--- a/utils/zerovec/derive/src/lib.rs
+++ b/utils/zerovec/derive/src/lib.rs
@@ -5,7 +5,7 @@
 //! Proc macros for generating `ULE`, `VarULE` impls and types for the `zerovec` crate
 
 use proc_macro::TokenStream;
-use syn::{parse_macro_input, DeriveInput};
+use syn::{parse_macro_input, AttributeArgs, DeriveInput};
 
 pub(crate) mod ule;
 mod utils;
@@ -27,4 +27,14 @@ pub fn ule_derive(input: TokenStream) -> TokenStream {
 pub fn varule_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     TokenStream::from(varule::derive_impl(&input))
+}
+
+/// Custom derive for `zerovec::ULE`,
+///
+/// This can be attached to structs containing only ULE types
+#[proc_macro_attribute]
+pub fn make_ule(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as DeriveInput);
+    let attr = parse_macro_input!(attr as AttributeArgs);
+    TokenStream::from(ule::make_ule_impl(attr, input))
 }

--- a/utils/zerovec/derive/src/lib.rs
+++ b/utils/zerovec/derive/src/lib.rs
@@ -13,7 +13,7 @@ mod varule;
 
 /// Custom derive for `zerovec::ULE`,
 ///
-/// This can be attached to structs containing only ULE types
+/// This can be attached to `Copy` structs containing only ULE types
 #[proc_macro_derive(ULE)]
 pub fn ule_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -29,9 +29,12 @@ pub fn varule_derive(input: TokenStream) -> TokenStream {
     TokenStream::from(varule::derive_impl(&input))
 }
 
-/// Custom derive for `zerovec::ULE`,
+/// Generate a corresponding ULE type and the relevant AsULE implementations for this type
 ///
-/// This can be attached to structs containing only ULE types
+/// This can be attached to structs containing only AsULE types, or C-like enums that have `#[repr(u8)]`
+/// and all explicit discriminants.
+///
+/// The type must be `Copy`, `PartialEq`, and `Ord`.
 #[proc_macro_attribute]
 pub fn make_ule(attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -88,7 +88,7 @@ pub fn make_ule_impl(attr: AttributeArgs, input: DeriveInput) -> TokenStream2 {
     {
         return Error::new(
             input.generics.span(),
-            "derive(ULE) must be applied to a struct without any generics",
+            "make_ule must be applied to a struct without any generics",
         )
         .to_compile_error();
     }

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -7,7 +7,10 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 
 use syn::spanned::Spanned;
-use syn::{parse_quote, AttributeArgs, Data, DataStruct, DeriveInput, Error, Field, Fields, Ident};
+use syn::{
+    parse_quote, AttributeArgs, Data, DataEnum, DataStruct, DeriveInput, Error, Expr, Field,
+    Fields, Ident, Lit,
+};
 
 fn suffixed_ident(name: &str, suffix: usize, s: Span) -> Ident {
     Ident::new(&format!("{name}_{suffix}"), s)
@@ -111,6 +114,7 @@ pub fn make_ule_impl(attr: AttributeArgs, input: DeriveInput) -> TokenStream2 {
 
     let ule_stuff = match input.data {
         Data::Struct(ref s) => make_ule_struct_impl(&name, &ule_name, &input, s),
+        Data::Enum(ref e) => make_ule_enum_impl(&name, &ule_name, &input, e),
         _ => {
             return Error::new(input.span(), "#[make_ule] must be applied to a struct")
                 .to_compile_error();
@@ -132,7 +136,135 @@ pub fn make_ule_impl(attr: AttributeArgs, input: DeriveInput) -> TokenStream2 {
     )
 }
 
-pub fn make_ule_struct_impl(
+fn make_ule_enum_impl(
+    name: &Ident,
+    ule_name: &Ident,
+    input: &DeriveInput,
+    enu: &DataEnum,
+) -> TokenStream2 {
+    // We could support more int reprs in the future if needed
+    if !crate::utils::has_valid_repr(&input.attrs, |r| r == "u8") {
+        return Error::new(
+            input.span(),
+            "#[make_ule] can only be applied to #[repr(u8)] enums",
+        )
+        .to_compile_error();
+    }
+
+    for (i, variant) in enu.variants.iter().enumerate() {
+        if variant.fields != Fields::Unit {
+            // This can be supported in the future, see zerovec/design_doc.md
+            return Error::new(
+                variant.span(),
+                "#[make_ule] can only be applied to enums with dataless variants",
+            )
+            .to_compile_error();
+        }
+
+        if let Some((_, ref discr)) = variant.discriminant {
+            if let Some(n) = get_expr_int(&discr) {
+                // We require explicit discriminants so that it is clear that reordering
+                // fields would be a breaking change. Furthermore, using explicit discriminants helps ensure that
+                // platform-specific C ABI choices do not matter.
+                // We could potentially add in explicit discriminants on the user's behalf in the future, or support
+                // more complicated sets of explicit discriminant values.
+                if n != i as u64 {
+                    return Error::new(discr.span(), &format!("#[make_ule] must be applied to enums with discriminants \
+                                                              increasing in order from 0, expected {i}, found {n}"))
+                        .to_compile_error();
+                }
+            } else {
+                return Error::new(
+                    discr.span(),
+                    "#[make_ule] must be applied to enums with explicit integer discriminants",
+                )
+                .to_compile_error();
+            }
+        } else {
+            return Error::new(
+                variant.span(),
+                "#[make_ule] must be applied to enums with explicit discriminants",
+            )
+            .to_compile_error();
+        }
+    }
+
+    let max = enu.variants.len() as u8;
+
+    // Safety (based on the safety checklist on the ULE trait):
+    //  1. ULE type does not include any uninitialized or padding bytes.
+    //     (achieved by `#[repr(transparent)]` on a type that satisfies this invariant
+    //  2. ULE type is aligned to 1 byte.
+    //     (achieved by `#[repr(transparent)]` on a type that satisfies this invariant)
+    //  3. The impl of validate_byte_slice() returns an error if any byte is not valid.
+    //  4. The impl of validate_byte_slice() returns an error if there are extra bytes (this never happens)
+    //  5. The other ULE methods use the default impl.
+    //  6. ULE type byte equality is semantic equality
+    quote!(
+        #[repr(transparent)]
+        #[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
+        struct #ule_name(u8);
+
+        unsafe impl zerovec::ule::ULE for #ule_name {
+            #[inline]
+            fn validate_byte_slice(bytes: &[u8]) -> Result<(), zerovec::ZeroVecError> {
+                for byte in bytes {
+                    if *byte >= #max {
+                        return Err(ZeroVecError::parse::<Self>())
+                    }
+                }
+                Ok(())
+            }
+        }
+
+        impl zerovec::ule::AsULE for #name {
+            type ULE = #ule_name;
+
+            fn as_unaligned(self) -> Self::ULE {
+                unsafe {
+                    ::core::mem::transmute(self)
+                }
+            }
+
+            fn from_unaligned(other: Self::ULE) -> Self {
+                unsafe {
+                    ::core::mem::transmute(other)
+                }
+            }
+        }
+
+        impl ::core::convert::TryFrom<u8> for #name {
+            type Error = ();
+            fn try_from(value: u8) -> Result<Self, Self::Error> {
+                if value <= #max {
+                    unsafe {
+                        Ok(::core::mem::transmute(value))
+                    }
+                } else {
+                    Err(())
+                }
+            }
+        }
+
+        impl From<#name> for u8 {
+            fn from(other: #name) -> Self {
+                other as u8
+            }
+        }
+    )
+}
+
+fn get_expr_int(e: &Expr) -> Option<u64> {
+    if let Expr::Lit(ref l) = *e {
+        if let Lit::Int(ref i) = l.lit {
+            return i.base10_parse().ok();
+        }
+    }
+
+    None
+}
+
+fn make_ule_struct_impl(
     name: &Ident,
     ule_name: &Ident,
     input: &DeriveInput,

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -93,17 +93,16 @@ pub fn make_ule_impl(attr: AttributeArgs, input: DeriveInput) -> TokenStream2 {
         .to_compile_error();
     }
 
-    if attr.len() > 1 {}
-
-    let ule_name: Ident = if let Some(arg) = attr.get(0) {
-        parse_quote!(#arg)
-    } else {
+    if attr.len() != 1 {
         return Error::new(
             input.span(),
             "#[make_ule] takes one argument for the name of the ULE type it produces",
         )
         .to_compile_error();
-    };
+    }
+    let arg = &attr[0];
+    let ule_name: Ident = parse_quote!(#arg);
+
     let name = &input.ident;
 
     let ule_stuff = match input.data {

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -223,8 +223,8 @@ fn make_ule_enum_impl(
             }
 
             fn from_unaligned(other: Self::ULE) -> Self {
-                // safety: the enum is repr(u8) and can be cast from a u8
-                // originally produced by as_unaligned
+                // safety: the enum is repr(u8) and can be cast from a u8,
+                // and `#ule_name` guarantees a valid value for this enum.
                 unsafe {
                     ::core::mem::transmute(other)
                 }

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -93,9 +93,7 @@ pub fn make_ule_impl(attr: AttributeArgs, input: DeriveInput) -> TokenStream2 {
         .to_compile_error();
     }
 
-    if attr.len() > 1 {
-
-    }
+    if attr.len() > 1 {}
 
     let ule_name: Ident = if let Some(arg) = attr.get(0) {
         parse_quote!(#arg)

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -212,12 +212,15 @@ fn make_ule_enum_impl(
             type ULE = #ule_name;
 
             fn as_unaligned(self) -> Self::ULE {
+                // safety: the enum is repr(u8) and can be cast to a u8
                 unsafe {
                     ::core::mem::transmute(self)
                 }
             }
 
             fn from_unaligned(other: Self::ULE) -> Self {
+                // safety: the enum is repr(u8) and can be cast from a u8
+                // originally produced by as_unaligned
                 unsafe {
                     ::core::mem::transmute(other)
                 }

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -190,7 +190,9 @@ fn make_ule_enum_impl(
     //  2. ULE type is aligned to 1 byte.
     //     (achieved by `#[repr(transparent)]` on a type that satisfies this invariant)
     //  3. The impl of validate_byte_slice() returns an error if any byte is not valid.
-    //  4. The impl of validate_byte_slice() returns an error if there are extra bytes (this never happens)
+    //     (Guarantees that the byte is in range of the corresponding enum.)
+    //  4. The impl of validate_byte_slice() returns an error if there are extra bytes.
+    //     (This does not happen since we are backed by 1 byte.)
     //  5. The other ULE methods use the default impl.
     //  6. ULE type byte equality is semantic equality
     quote!(

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -14,7 +14,7 @@ fn suffixed_ident(name: &str, suffix: usize, s: Span) -> Ident {
 }
 
 pub fn derive_impl(input: &DeriveInput) -> TokenStream2 {
-    if !crate::utils::has_valid_repr(&input.attrs) {
+    if !crate::utils::has_valid_repr(&input.attrs, |r| r == "packed" || r == "transparent") {
         return Error::new(
             input.span(),
             "derive(ULE) must be applied to a #[repr(packed)] or #[repr(transparent)] type",

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -93,15 +93,20 @@ pub fn make_ule_impl(attr: AttributeArgs, input: DeriveInput) -> TokenStream2 {
         .to_compile_error();
     }
 
-    if !attr.is_empty() {
+    if attr.len() > 1 {
+
+    }
+
+    let ule_name: Ident = if let Some(arg) = attr.get(0) {
+        parse_quote!(#arg)
+    } else {
         return Error::new(
             input.span(),
-            "#[make_ule] does not currently support any arguments",
+            "#[make_ule] takes one argument for the name of the ULE type it produces",
         )
         .to_compile_error();
-    }
+    };
     let name = &input.ident;
-    let ule_name = Ident::new(&format!("{}ULE", name), Span::call_site());
 
     let ule_stuff = match input.data {
         Data::Struct(ref s) => make_ule_struct_impl(name, &ule_name, &input, s),

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -113,8 +113,8 @@ pub fn make_ule_impl(attr: AttributeArgs, input: DeriveInput) -> TokenStream2 {
     let ule_name = Ident::new(&format!("{}ULE", name), Span::call_site());
 
     let ule_stuff = match input.data {
-        Data::Struct(ref s) => make_ule_struct_impl(&name, &ule_name, &input, s),
-        Data::Enum(ref e) => make_ule_enum_impl(&name, &ule_name, &input, e),
+        Data::Struct(ref s) => make_ule_struct_impl(name, &ule_name, &input, s),
+        Data::Enum(ref e) => make_ule_enum_impl(name, &ule_name, &input, e),
         _ => {
             return Error::new(input.span(), "#[make_ule] must be applied to a struct")
                 .to_compile_error();
@@ -162,7 +162,7 @@ fn make_ule_enum_impl(
         }
 
         if let Some((_, ref discr)) = variant.discriminant {
-            if let Some(n) = get_expr_int(&discr) {
+            if let Some(n) = get_expr_int(discr) {
                 // We require explicit discriminants so that it is clear that reordering
                 // fields would be a breaking change. Furthermore, using explicit discriminants helps ensure that
                 // platform-specific C ABI choices do not matter.

--- a/utils/zerovec/derive/src/utils.rs
+++ b/utils/zerovec/derive/src/utils.rs
@@ -2,9 +2,12 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use quote::quote;
+
+use proc_macro2::TokenStream as TokenStream2;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
-use syn::{parenthesized, parse2, Attribute, Ident, Result, Token};
+use syn::{parenthesized, parse2, Attribute, Fields, Ident, Result, Token};
 
 // Check that there are repr attributes satisfying the given predicate
 pub fn has_valid_repr(attrs: &[Attribute], predicate: impl Fn(&Ident) -> bool + Copy) -> bool {
@@ -30,5 +33,35 @@ impl Parse for ReprAttribute {
         Ok(ReprAttribute {
             reprs: content.parse_terminated(Ident::parse)?,
         })
+    }
+}
+
+/// Given a set of entries for struct field definitions to go inside a `struct {}` definition,
+/// wrap in a () or {} based on the type of field
+pub fn wrap_field_inits(streams: &[TokenStream2], fields: &Fields) -> TokenStream2 {
+    match *fields {
+        Fields::Named(_) => quote!( { #(#streams),* } ),
+        Fields::Unnamed(_) => quote!( ( #(#streams),* ) ),
+        Fields::Unit => {
+            unreachable!("#[make_(var)ule] should have already checked that there are fields")
+        }
+    }
+}
+
+/// Return a semicolon token if necessary after the struct definition
+pub fn semi_for(f: &Fields) -> TokenStream2 {
+    if let Fields::Unnamed(..) = *f {
+        quote!(;)
+    } else {
+        quote!()
+    }
+}
+
+/// Returns the repr attribute to be applied to the resultant ULE or VarULE type
+pub fn repr_for(f: &Fields) -> TokenStream2 {
+    if f.len() == 1 {
+        quote!(transparent)
+    } else {
+        quote!(packed)
     }
 }

--- a/utils/zerovec/derive/src/varule.rs
+++ b/utils/zerovec/derive/src/varule.rs
@@ -9,7 +9,7 @@ use syn::spanned::Spanned;
 use syn::{Data, DeriveInput, Error, Ident};
 
 pub fn derive_impl(input: &DeriveInput) -> TokenStream2 {
-    if !crate::utils::has_valid_repr(&input.attrs) {
+    if !crate::utils::has_valid_repr(&input.attrs, |r| r == "packed" || r == "transparent") {
         return Error::new(
             input.span(),
             "derive(VarULE) must be applied to a #[repr(packed)] or #[repr(transparent)] type",


### PR DESCRIPTION
Part of https://github.com/unicode-org/icu4x/issues/1079

`#[make_varule]` to come soon.

This proc macro handles structs and C-like enums.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->