### PR TITLE
Move ZeroCopyFrom to its own crate, rename to ZeroFrom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3105,6 +3105,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.0"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+ "zerofrom",
+]
+
+[[package]]
 name = "zerovec"
 version = "0.6.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,6 +1299,7 @@ dependencies = [
  "tinystr 0.5.0",
  "writeable",
  "yoke",
+ "zerofrom",
  "zerovec",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,6 +1104,7 @@ dependencies = [
  "serde",
  "toml",
  "yoke",
+ "zerofrom",
  "zerovec",
 ]
 
@@ -1471,6 +1472,7 @@ dependencies = [
  "serde_json",
  "tinystr 0.5.0",
  "yoke",
+ "zerofrom",
  "zerovec",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3140,6 +3140,7 @@ dependencies = [
  "serde",
  "serde_json",
  "yoke",
+ "zerofrom",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3121,6 +3121,7 @@ dependencies = [
  "syn",
  "synstructure",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3090,6 +3090,7 @@ dependencies = [
  "serde",
  "stable_deref_trait",
  "yoke-derive",
+ "zerofrom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ members = [
     "utils/writeable",
     "utils/yoke",
     "utils/yoke/derive",
+    "utils/zerofrom",
+    "utils/zerofrom/derive",
     "utils/zerovec",
     "utils/zerovec/derive",
 ]

--- a/components/calendar/src/provider.rs
+++ b/components/calendar/src/provider.rs
@@ -33,7 +33,7 @@ pub struct EraStartDate {
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[yoke(cloning_zcf)]
+#[yoke(cloning_zf)]
 // TODO (#1393) Make this zero-copy
 pub struct JapaneseErasV1 {
     pub dates_to_historical_eras: LiteMap<EraStartDate, TinyStr16>,

--- a/components/calendar/src/provider.rs
+++ b/components/calendar/src/provider.rs
@@ -7,14 +7,14 @@
 //! Read more about data providers: [`icu_provider`]
 
 use core::str::FromStr;
-use icu_provider::yoke::{self, *};
+use icu_provider::{yoke, zerofrom};
 use litemap::LiteMap;
 use tinystr::TinyStr16;
 
 /// The date at which an era started
 ///
 /// The order of fields in this struct is important!
-#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Debug, Yokeable, ZeroCopyFrom)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Debug, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[cfg_attr(
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)

--- a/components/calendar/src/provider.rs
+++ b/components/calendar/src/provider.rs
@@ -14,7 +14,9 @@ use tinystr::TinyStr16;
 /// The date at which an era started
 ///
 /// The order of fields in this struct is important!
-#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Debug, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(
+    Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Debug, yoke::Yokeable, zerofrom::ZeroFrom,
+)]
 #[cfg_attr(
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)

--- a/components/calendar/src/provider.rs
+++ b/components/calendar/src/provider.rs
@@ -33,7 +33,7 @@ pub struct EraStartDate {
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[yoke(cloning_zf)]
+#[zerofrom(cloning_zf)]
 // TODO (#1393) Make this zero-copy
 pub struct JapaneseErasV1 {
     pub dates_to_historical_eras: LiteMap<EraStartDate, TinyStr16>,

--- a/components/datetime/src/fields/macros.rs
+++ b/components/datetime/src/fields/macros.rs
@@ -46,7 +46,7 @@ macro_rules! field_type {
         }
     );
     ($i:ident; { $($key:expr => $val:ident),* }) => (
-        #[derive(Debug, Eq, PartialEq, Clone, Copy, Yokeable, ZeroCopyFrom)]
+        #[derive(Debug, Eq, PartialEq, Clone, Copy, yoke::Yokeable, zerofrom::ZeroFrom)]
         // FIXME: This should be replaced with a custom derive.
         // See: https://github.com/unicode-org/icu4x/issues/1044
         #[derive(num_enum::IntoPrimitive, num_enum::TryFromPrimitive)]

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -5,7 +5,7 @@
 use crate::fields::FieldLength;
 use core::{cmp::Ordering, convert::TryFrom};
 use displaydoc::Display;
-use icu_provider::yoke::{self, Yokeable, ZeroCopyFrom};
+use icu_provider::{yoke, zerofrom};
 
 #[derive(Display, Debug, PartialEq)]
 pub enum SymbolError {

--- a/components/datetime/src/pattern/hour_cycle.rs
+++ b/components/datetime/src/pattern/hour_cycle.rs
@@ -7,11 +7,11 @@ use crate::pattern::{reference, runtime};
 use crate::{fields, options::preferences};
 #[cfg(feature = "provider_transform_internals")]
 use crate::{provider, skeleton};
-use icu_provider::yoke::{self, Yokeable, ZeroCopyFrom};
+use icu_provider::{yoke, zerofrom};
 
 /// Used to represent either H11/H12, or H23/H24. Skeletons only store these
 /// hour cycles as H12 or H23.
-#[derive(Debug, PartialEq, Clone, Copy, Yokeable, ZeroCopyFrom)]
+#[derive(Debug, PartialEq, Clone, Copy, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[cfg_attr(
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)

--- a/components/datetime/src/pattern/mod.rs
+++ b/components/datetime/src/pattern/mod.rs
@@ -12,12 +12,12 @@ pub mod runtime;
 use crate::fields;
 pub use error::PatternError;
 pub use hour_cycle::CoarseHourCycle;
-use icu_provider::yoke::{self, Yokeable, ZeroCopyFrom};
+use icu_provider::{yoke, zerofrom};
 pub use item::{GenericPatternItem, PatternItem};
 
 /// The granularity of time represented in a pattern item.
 /// Ordered from least granular to most granular for comparsion.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Yokeable, ZeroCopyFrom)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[cfg_attr(
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)

--- a/components/datetime/src/pattern/mod.rs
+++ b/components/datetime/src/pattern/mod.rs
@@ -17,7 +17,9 @@ pub use item::{GenericPatternItem, PatternItem};
 
 /// The granularity of time represented in a pattern item.
 /// Ordered from least granular to most granular for comparsion.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, yoke::Yokeable, zerofrom::ZeroFrom,
+)]
 #[cfg_attr(
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)

--- a/components/datetime/src/pattern/runtime/generic.rs
+++ b/components/datetime/src/pattern/runtime/generic.rs
@@ -9,10 +9,10 @@ use super::{
 };
 use alloc::vec::Vec;
 use core::{fmt, str::FromStr};
-use icu_provider::yoke::{self, Yokeable, ZeroCopyFrom};
+use icu_provider::{yoke, zerofrom};
 use zerovec::ZeroVec;
 
-#[derive(Debug, PartialEq, Clone, Yokeable, ZeroCopyFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
 pub struct GenericPattern<'data> {
     pub items: ZeroVec<'data, GenericPatternItem>,
 }

--- a/components/datetime/src/pattern/runtime/pattern.rs
+++ b/components/datetime/src/pattern/runtime/pattern.rs
@@ -5,10 +5,10 @@
 use super::super::{reference, PatternError, PatternItem, TimeGranularity};
 use alloc::{fmt, vec::Vec};
 use core::str::FromStr;
-use icu_provider::yoke::{self, Yokeable, ZeroCopyFrom};
+use icu_provider::{yoke, zerofrom};
 use zerovec::ZeroVec;
 
-#[derive(Debug, PartialEq, Clone, Yokeable, ZeroCopyFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
 pub struct Pattern<'data> {
     pub items: ZeroVec<'data, PatternItem>,
     pub(crate) time_granularity: TimeGranularity,

--- a/components/datetime/src/pattern/runtime/plural.rs
+++ b/components/datetime/src/pattern/runtime/plural.rs
@@ -10,10 +10,10 @@ use crate::{
 };
 use either::Either;
 use icu_plurals::{PluralCategory, PluralRules};
-use icu_provider::yoke::{self, Yokeable, ZeroCopyFrom};
+use icu_provider::{yoke, zerofrom};
 
 /// A collection of plural variants of a pattern.
-#[derive(Debug, PartialEq, Clone, Yokeable, ZeroCopyFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[cfg_attr(
     feature = "provider_serde",
     derive(::serde::Serialize, ::serde::Deserialize)
@@ -129,7 +129,7 @@ impl<'data> PluralPattern<'data> {
 }
 
 /// Either a single Pattern or a collection of pattern when there are plural variants.
-#[derive(Debug, PartialEq, Clone, Yokeable, ZeroCopyFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[allow(clippy::large_enum_variant)]
 pub enum PatternPlurals<'data> {
     /// A collection of pattern variants for when plurals differ.

--- a/components/datetime/src/provider/calendar/mod.rs
+++ b/components/datetime/src/provider/calendar/mod.rs
@@ -9,7 +9,7 @@ mod symbols;
 
 use crate::pattern;
 use icu_provider::prelude::*;
-use icu_provider::yoke;
+use icu_provider::{yoke, zerofrom};
 pub use skeletons::*;
 pub use symbols::*;
 
@@ -46,9 +46,9 @@ pub struct DatePatternsV1<'data> {
 pub mod patterns {
     use super::*;
     use crate::pattern::runtime::{GenericPattern, Pattern, PatternPlurals};
-    use icu_provider::yoke::{self, Yokeable, ZeroCopyFrom};
+    use icu_provider::{yoke, zerofrom};
 
-    #[derive(Debug, PartialEq, Clone, Default, Yokeable, ZeroCopyFrom)]
+    #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
     #[cfg_attr(
         feature = "provider_serde",
         derive(serde::Serialize, serde::Deserialize)
@@ -64,7 +64,7 @@ pub mod patterns {
         pub short: Pattern<'data>,
     }
 
-    #[derive(Debug, PartialEq, Clone, Default, Yokeable, ZeroCopyFrom)]
+    #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
     #[cfg_attr(
         feature = "provider_serde",
         derive(serde::Serialize, serde::Deserialize)
@@ -80,7 +80,7 @@ pub mod patterns {
         pub short: PatternPlurals<'data>,
     }
 
-    #[derive(Debug, PartialEq, Clone, Default, Yokeable, ZeroCopyFrom)]
+    #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
     #[cfg_attr(
         feature = "provider_serde",
         derive(serde::Serialize, serde::Deserialize)

--- a/components/datetime/src/provider/calendar/skeletons.rs
+++ b/components/datetime/src/provider/calendar/skeletons.rs
@@ -18,7 +18,7 @@ use litemap::LiteMap;
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[yoke(cloning_zcf)]
+#[yoke(cloning_zf)]
 pub struct DateSkeletonPatternsV1<'data>(
     #[cfg_attr(feature = "provider_serde", serde(borrow))]
     pub  LiteMap<SkeletonV1, PatternPlurals<'data>>,

--- a/components/datetime/src/provider/calendar/skeletons.rs
+++ b/components/datetime/src/provider/calendar/skeletons.rs
@@ -9,7 +9,7 @@ use crate::{
     skeleton::{reference::Skeleton, SkeletonError},
 };
 use core::convert::TryFrom;
-use icu_provider::yoke;
+use icu_provider::{yoke, zerofrom};
 use litemap::LiteMap;
 
 #[icu_provider::data_struct(DateSkeletonPatternsV1Marker = "datetime/skeletons@1")]

--- a/components/datetime/src/provider/calendar/skeletons.rs
+++ b/components/datetime/src/provider/calendar/skeletons.rs
@@ -18,7 +18,7 @@ use litemap::LiteMap;
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[yoke(cloning_zf)]
+#[zerofrom(cloning_zf)]
 pub struct DateSkeletonPatternsV1<'data>(
     #[cfg_attr(feature = "provider_serde", serde(borrow))]
     pub  LiteMap<SkeletonV1, PatternPlurals<'data>>,

--- a/components/datetime/src/provider/calendar/symbols.rs
+++ b/components/datetime/src/provider/calendar/symbols.rs
@@ -5,7 +5,7 @@
 #![allow(missing_docs)] // TODO(#686) - Add missing docs.
 
 use alloc::borrow::Cow;
-use icu_provider::yoke::{self, *};
+use icu_provider::{yoke, zerofrom};
 use zerovec::map::ZeroMap;
 
 #[icu_provider::data_struct(DateSymbolsV1Marker = "datetime/symbols@1")]
@@ -26,7 +26,7 @@ pub struct DateSymbolsV1<'data> {
     pub eras: Eras<'data>,
 }
 
-#[derive(Debug, PartialEq, Clone, Default, Yokeable, ZeroCopyFrom)]
+#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[cfg_attr(
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)
@@ -46,13 +46,13 @@ macro_rules! symbols {
         pub mod $name {
             use super::*;
 
-            #[derive(Debug, PartialEq, Clone, Default, ZeroCopyFrom, Yokeable)]
+            #[derive(Debug, PartialEq, Clone, Default, zerofrom::ZeroFrom, yoke::Yokeable)]
             #[cfg_attr(feature="provider_serde", derive(serde::Serialize, serde::Deserialize))]
             $symbols
 
             // UTS 35 specifies that `format` widths are mandatory
             // except of `short`.
-            #[derive(Debug, PartialEq, Clone, Default, Yokeable, ZeroCopyFrom)]
+            #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
             #[cfg_attr(feature="provider_serde", derive(serde::Serialize, serde::Deserialize))]
             pub struct FormatWidthsV1<'data> {
                 #[cfg_attr(feature = "provider_serde", serde(borrow))]
@@ -66,7 +66,7 @@ macro_rules! symbols {
             }
 
             // UTS 35 specifies that `stand_alone` widths are optional
-            #[derive(Debug, PartialEq, Clone, Default, Yokeable, ZeroCopyFrom)]
+            #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
             #[cfg_attr(feature="provider_serde", derive(serde::Serialize, serde::Deserialize))]
             pub struct StandAloneWidthsV1<'data> {
                 #[cfg_attr(feature = "provider_serde", serde(borrow))]
@@ -79,7 +79,7 @@ macro_rules! symbols {
                 pub wide: Option<SymbolsV1<'data>>,
             }
 
-            #[derive(Debug, PartialEq, Clone, Default, Yokeable, ZeroCopyFrom)]
+            #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
             #[cfg_attr(feature="provider_serde", derive(serde::Serialize, serde::Deserialize))]
             pub struct ContextsV1<'data> {
                 #[cfg_attr(feature = "provider_serde", serde(borrow))]

--- a/components/datetime/src/provider/time_zones.rs
+++ b/components/datetime/src/provider/time_zones.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use alloc::borrow::Cow;
-use icu_provider::yoke;
+use icu_provider::{yoke, zerofrom};
 use tinystr::TinyStr8;
 use zerovec::{ZeroMap, ZeroMap2d};
 

--- a/components/decimal/src/provider.rs
+++ b/components/decimal/src/provider.rs
@@ -7,10 +7,10 @@
 //! Read more about data providers: [`icu_provider`]
 
 use alloc::borrow::Cow;
-use icu_provider::yoke::{self, *};
+use icu_provider::{yoke, zerofrom};
 
 /// A collection of strings to affix to a decimal number.
-#[derive(Debug, PartialEq, Clone, Yokeable, ZeroCopyFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[cfg_attr(
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)
@@ -27,7 +27,7 @@ pub struct AffixesV1<'data> {
 
 /// A collection of settings expressing where to put grouping separators in a decimal number.
 /// For example, `1,000,000` has two grouping separators, positioned along every 3 digits.
-#[derive(Debug, PartialEq, Clone, Yokeable, Copy, ZeroCopyFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable, Copy, zerofrom::ZeroFrom)]
 #[cfg_attr(
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)

--- a/components/locale_canonicalizer/src/provider.rs
+++ b/components/locale_canonicalizer/src/provider.rs
@@ -18,7 +18,7 @@ use tinystr::{TinyStr4, TinyStr8};
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[yoke(cloning_zf)]
+#[zerofrom(cloning_zf)]
 /// This alias data is used for locale canonicalization. Each field defines a
 /// mapping from an old identifier to a new identifier, based upon the rules in
 /// from <http://unicode.org/reports/tr35/#LocaleId_Canonicalization>. The data
@@ -62,7 +62,7 @@ pub struct AliasesV1 {
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[yoke(cloning_zf)]
+#[zerofrom(cloning_zf)]
 /// This likely subtags data is used for the minimize and maximize operations.
 /// Each field defines a mapping from an old identifier to a new identifier,
 /// based upon the rules in

--- a/components/locale_canonicalizer/src/provider.rs
+++ b/components/locale_canonicalizer/src/provider.rs
@@ -8,7 +8,7 @@
 
 use alloc::vec::Vec;
 use icu_locid::LanguageIdentifier;
-use icu_provider::yoke;
+use icu_provider::prelude::*;
 use litemap::LiteMap;
 use tinystr::{TinyStr4, TinyStr8};
 

--- a/components/locale_canonicalizer/src/provider.rs
+++ b/components/locale_canonicalizer/src/provider.rs
@@ -18,7 +18,7 @@ use tinystr::{TinyStr4, TinyStr8};
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[yoke(cloning_zcf)]
+#[yoke(cloning_zf)]
 /// This alias data is used for locale canonicalization. Each field defines a
 /// mapping from an old identifier to a new identifier, based upon the rules in
 /// from <http://unicode.org/reports/tr35/#LocaleId_Canonicalization>. The data
@@ -62,7 +62,7 @@ pub struct AliasesV1 {
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)
 )]
-#[yoke(cloning_zcf)]
+#[yoke(cloning_zf)]
 /// This likely subtags data is used for the minimize and maximize operations.
 /// Each field defines a mapping from an old identifier to a new identifier,
 /// based upon the rules in

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -7,8 +7,8 @@
 //! Read more about data providers: [`icu_provider`]
 
 use crate::rules::runtime::ast::Rule;
-use icu_provider::{yoke, zerofrom};
 use icu_provider::DataMarker;
+use icu_provider::{yoke, zerofrom};
 
 /// Plural rule strings conforming to UTS 35 syntax. Includes separate fields for five of the six
 /// standard plural forms. If none of the rules match, the "other" category is assumed.

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -7,7 +7,7 @@
 //! Read more about data providers: [`icu_provider`]
 
 use crate::rules::runtime::ast::Rule;
-use icu_provider::yoke;
+use icu_provider::{yoke, zerofrom};
 use icu_provider::DataMarker;
 
 /// Plural rule strings conforming to UTS 35 syntax. Includes separate fields for five of the six

--- a/components/plurals/src/rules/runtime/ast.rs
+++ b/components/plurals/src/rules/runtime/ast.rs
@@ -10,14 +10,14 @@ use core::{
     fmt,
     str::FromStr,
 };
-use icu_provider::yoke::{self, *};
+use icu_provider::{yoke, zerofrom};
 use num_enum::{IntoPrimitive, TryFromPrimitive, UnsafeFromPrimitive};
 use zerovec::{
     ule::{custom::EncodeAsVarULE, AsULE, PairULE, RawBytesULE, VarULE, ZeroVecError, ULE},
     {VarZeroVec, ZeroVec},
 };
 
-#[derive(Yokeable, ZeroCopyFrom, Clone, PartialEq, Debug)]
+#[derive(yoke::Yokeable, zerofrom::ZeroFrom, Clone, PartialEq, Debug)]
 pub struct Rule<'data>(pub VarZeroVec<'data, RelationULE>);
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]

--- a/components/properties/src/provider.rs
+++ b/components/properties/src/provider.rs
@@ -8,7 +8,7 @@
 
 use crate::script::ScriptWithExtensions;
 use icu_codepointtrie::{CodePointTrie, TrieValue};
-use icu_provider::yoke::{self, *};
+use icu_provider::{yoke, zerofrom};
 use icu_uniset::UnicodeSet;
 use icu_uniset::UnicodeSetBuilder;
 
@@ -388,7 +388,7 @@ impl<'data> From<UnicodePropertyV1<'data>> for UnicodeSet<'data> {
 //
 
 /// A map efficiently storing data about individual characters.
-#[derive(Debug, Eq, PartialEq, Yokeable, ZeroCopyFrom)]
+#[derive(Debug, Eq, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[cfg_attr(
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)

--- a/components/properties/src/script.rs
+++ b/components/properties/src/script.rs
@@ -165,7 +165,7 @@ impl From<ScriptWithExt> for Script {
 /// the data and data structures that are stored in the corresponding ICU data
 /// file for these properties.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Eq, PartialEq, Yokeable, ZeroCopyFrom)]
+#[derive(Debug, Eq, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
 pub struct ScriptWithExtensions<'data> {
     /// Note: The `ScriptWithExt` values in this array will assume a 12-bit layout. The 2
     /// higher order bits 11..10 will indicate how to deduce the Script value and

--- a/components/properties/src/script.rs
+++ b/components/properties/src/script.rs
@@ -13,7 +13,6 @@ use core::iter::FromIterator;
 use core::ops::RangeInclusive;
 use icu_codepointtrie::{CodePointTrie, TrieValue};
 use icu_provider::prelude::*;
-use icu_provider::yoke::{self, *};
 use icu_uniset::UnicodeSet;
 use zerovec::{ule::AsULE, VarZeroVec, ZeroSlice};
 

--- a/experimental/list_formatter/src/provider.rs
+++ b/experimental/list_formatter/src/provider.rs
@@ -9,8 +9,8 @@
 use crate::string_matcher::StringMatcher;
 use crate::ListStyle;
 use alloc::borrow::Cow;
-use icu_provider::{yoke, zerofrom};
 use icu_provider::DataMarker;
+use icu_provider::{yoke, zerofrom};
 use writeable::{LengthHint, Writeable};
 
 /// Symbols and metadata required for [`ListFormatter`](crate::ListFormatter).

--- a/experimental/list_formatter/src/provider.rs
+++ b/experimental/list_formatter/src/provider.rs
@@ -9,7 +9,7 @@
 use crate::string_matcher::StringMatcher;
 use crate::ListStyle;
 use alloc::borrow::Cow;
-use icu_provider::yoke::{self, *};
+use icu_provider::{yoke, zerofrom};
 use icu_provider::DataMarker;
 use writeable::{LengthHint, Writeable};
 
@@ -73,7 +73,7 @@ impl<'data> ListFormatterPatternsV1<'data> {
 }
 
 /// A pattern that can behave conditionally on the next element.
-#[derive(Clone, Debug, PartialEq, Yokeable, ZeroCopyFrom)]
+#[derive(Clone, Debug, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[cfg_attr(
     feature = "provider_serde",
     derive(serde::Deserialize, serde::Serialize)
@@ -85,7 +85,7 @@ pub(crate) struct ConditionalListJoinerPattern<'data> {
     special_case: Option<SpecialCasePattern<'data>>,
 }
 
-#[derive(Clone, Debug, PartialEq, Yokeable, ZeroCopyFrom)]
+#[derive(Clone, Debug, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[cfg_attr(
     feature = "provider_serde",
     derive(serde::Deserialize, serde::Serialize)
@@ -98,7 +98,7 @@ struct SpecialCasePattern<'data> {
 }
 
 /// A pattern containing two numeric placeholders ("{0}, and {1}.")
-#[derive(Clone, Debug, PartialEq, Yokeable, ZeroCopyFrom)]
+#[derive(Clone, Debug, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[cfg_attr(
     feature = "provider_serde",
     derive(serde::Deserialize, serde::Serialize)

--- a/experimental/list_formatter/src/string_matcher.rs
+++ b/experimental/list_formatter/src/string_matcher.rs
@@ -8,11 +8,11 @@ use alloc::borrow::Cow;
     feature = "provider_transform_internals"
 ))]
 use alloc::string::ToString;
-use icu_provider::yoke::{self, *};
+use icu_provider::{yoke, zerofrom};
 use regex_automata::dfa::sparse::DFA;
 use regex_automata::dfa::Automaton;
 
-#[derive(Clone, Debug, Yokeable, ZeroCopyFrom)]
+#[derive(Clone, Debug, yoke::Yokeable, zerofrom::ZeroFrom)]
 pub struct StringMatcher<'data> {
     // Safety: These always represent a valid DFA (DFA::from_bytes(dfa_bytes).is_ok())
     dfa_bytes: Cow<'data, [u8]>,

--- a/experimental/segmenter/src/provider.rs
+++ b/experimental/segmenter/src/provider.rs
@@ -54,8 +54,8 @@ impl Deref for LineBreakPropertyTable<'_> {
     }
 }
 
-impl<'zcf> zerofrom::ZeroFrom<'zcf, LineBreakPropertyTable<'_>> for LineBreakPropertyTable<'zcf> {
-    fn zero_from(cart: &'zcf LineBreakPropertyTable<'_>) -> Self {
+impl<'zf> zerofrom::ZeroFrom<'zf, LineBreakPropertyTable<'_>> for LineBreakPropertyTable<'zf> {
+    fn zero_from(cart: &'zf LineBreakPropertyTable<'_>) -> Self {
         LineBreakPropertyTable::Borrowed(&*cart)
     }
 }

--- a/experimental/segmenter/src/provider.rs
+++ b/experimental/segmenter/src/provider.rs
@@ -11,7 +11,7 @@ use crate::line::PROPERTY_COUNT;
 use crate::line::PROPERTY_TABLE;
 use alloc::boxed::Box;
 use core::ops::Deref;
-use icu_provider::yoke::{self, *};
+use icu_provider::{yoke, zerofrom};
 use zerovec::ZeroSlice;
 use zerovec::ZeroVec;
 
@@ -33,7 +33,7 @@ pub struct LineBreakDataV1<'data> {
 }
 
 /// Property table for line breaking.
-#[derive(Debug, PartialEq, Clone, Yokeable)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)
@@ -54,7 +54,7 @@ impl Deref for LineBreakPropertyTable<'_> {
     }
 }
 
-impl<'zcf> ZeroCopyFrom<'zcf, LineBreakPropertyTable<'_>> for LineBreakPropertyTable<'zcf> {
+impl<'zcf> zerofrom::ZeroFrom<'zcf, LineBreakPropertyTable<'_>> for LineBreakPropertyTable<'zcf> {
     fn zero_copy_from(cart: &'zcf LineBreakPropertyTable<'_>) -> Self {
         LineBreakPropertyTable::Borrowed(&*cart)
     }
@@ -67,7 +67,7 @@ impl Default for LineBreakPropertyTable<'static> {
 }
 
 /// Rule table for line breaking.
-#[derive(Debug, PartialEq, Clone, Yokeable, ZeroCopyFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[cfg_attr(
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)

--- a/experimental/segmenter/src/provider.rs
+++ b/experimental/segmenter/src/provider.rs
@@ -55,7 +55,7 @@ impl Deref for LineBreakPropertyTable<'_> {
 }
 
 impl<'zcf> zerofrom::ZeroFrom<'zcf, LineBreakPropertyTable<'_>> for LineBreakPropertyTable<'zcf> {
-    fn zero_copy_from(cart: &'zcf LineBreakPropertyTable<'_>) -> Self {
+    fn zero_from(cart: &'zcf LineBreakPropertyTable<'_>) -> Self {
         LineBreakPropertyTable::Borrowed(&*cart)
     }
 }

--- a/experimental/segmenter_lstm/src/structs.rs
+++ b/experimental/segmenter_lstm/src/structs.rs
@@ -7,6 +7,7 @@ use ndarray::Array1;
 use ndarray::Array2;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
+use icu_provider::prelude::*;
 
 /// 'LstmData' is a struct that store a LSTM model. Its attributes are:
 /// `model`: name of the model

--- a/experimental/segmenter_lstm/src/structs.rs
+++ b/experimental/segmenter_lstm/src/structs.rs
@@ -2,12 +2,12 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use icu_provider::prelude::*;
 use litemap::LiteMap;
 use ndarray::Array1;
 use ndarray::Array2;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use icu_provider::prelude::*;
 
 /// 'LstmData' is a struct that store a LSTM model. Its attributes are:
 /// `model`: name of the model

--- a/experimental/segmenter_lstm/src/structs.rs
+++ b/experimental/segmenter_lstm/src/structs.rs
@@ -18,7 +18,7 @@ use std::borrow::Cow;
 /// `mat8` - `mat9`: the matrices associated with output layer (weight and bias term respectiely)
 #[icu_provider::data_struct(LstmDataMarker)]
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
-#[yoke(cloning_zf)]
+#[zerofrom(cloning_zf)]
 pub struct LstmData<'data> {
     #[serde(borrow)]
     pub model: Cow<'data, str>,

--- a/experimental/segmenter_lstm/src/structs.rs
+++ b/experimental/segmenter_lstm/src/structs.rs
@@ -18,7 +18,7 @@ use std::borrow::Cow;
 /// `mat8` - `mat9`: the matrices associated with output layer (weight and bias term respectiely)
 #[icu_provider::data_struct(LstmDataMarker)]
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
-#[yoke(cloning_zcf)]
+#[yoke(cloning_zf)]
 pub struct LstmData<'data> {
     #[serde(borrow)]
     pub model: Cow<'data, str>,

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -53,6 +53,7 @@ tinystr = { path = "../../utils/tinystr", version = "0.5.0", features = ["alloc"
 writeable = { version = "0.3", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
 yoke = { version = "0.4.0", path = "../../utils/yoke", features = ["serde", "derive"] }
+zerofrom = { version = "0.1.0", path = "../../utils/zerofrom", features = ["derive"] }
 zerovec = { version = "0.6.0", path = "../../utils/zerovec" }
 litemap = { version = "0.3.0", path = "../../utils/litemap" }
 log = { version = "0.4", optional = true }

--- a/provider/core/src/any.rs
+++ b/provider/core/src/any.rs
@@ -79,9 +79,7 @@ impl AnyPayload {
                 let down_ref: &'static M::Yokeable = any_ref
                     .downcast_ref()
                     .ok_or_else(|| DataError::for_type::<M>().with_str_context(type_name))?;
-                Ok(DataPayload::from_owned(M::Yokeable::zero_from(
-                    down_ref,
-                )))
+                Ok(DataPayload::from_owned(M::Yokeable::zero_from(down_ref)))
             }
             PayloadRc(any_rc) => {
                 let down_rc: Rc<DataPayload<M>> = any_rc

--- a/provider/core/src/any.rs
+++ b/provider/core/src/any.rs
@@ -11,7 +11,7 @@ use core::convert::TryFrom;
 use core::convert::TryInto;
 use yoke::trait_hack::YokeTraitHack;
 use yoke::Yokeable;
-use yoke::ZeroCopyFrom;
+use zerofrom::ZeroFrom;
 
 /// Representations of the `Any` trait object.
 ///
@@ -68,7 +68,7 @@ impl AnyPayload {
     where
         M: DataMarker + 'static,
         // For the StructRef case:
-        M::Yokeable: ZeroCopyFrom<'static, M::Yokeable>,
+        M::Yokeable: ZeroFrom<'static, M::Yokeable>,
         // For the PayloadRc case:
         for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
     {
@@ -196,7 +196,7 @@ impl DataPayload<AnyMarker> {
     where
         M: DataMarker + 'static,
         for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
-        M::Yokeable: ZeroCopyFrom<'static, M::Yokeable>,
+        M::Yokeable: ZeroFrom<'static, M::Yokeable>,
     {
         self.try_unwrap_owned()?.downcast()
     }
@@ -241,7 +241,7 @@ impl AnyResponse {
     where
         M: DataMarker + 'static,
         for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
-        M::Yokeable: ZeroCopyFrom<'static, M::Yokeable>,
+        M::Yokeable: ZeroFrom<'static, M::Yokeable>,
     {
         Ok(DataResponse {
             metadata: self.metadata,
@@ -341,7 +341,7 @@ where
     P: AnyProvider + ?Sized,
     M: ResourceMarker + 'static,
     for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
-    M::Yokeable: ZeroCopyFrom<'static, M::Yokeable>,
+    M::Yokeable: ZeroFrom<'static, M::Yokeable>,
 {
     #[inline]
     fn load_resource(&self, req: &DataRequest) -> Result<DataResponse<M>, DataError> {

--- a/provider/core/src/any.rs
+++ b/provider/core/src/any.rs
@@ -79,7 +79,7 @@ impl AnyPayload {
                 let down_ref: &'static M::Yokeable = any_ref
                     .downcast_ref()
                     .ok_or_else(|| DataError::for_type::<M>().with_str_context(type_name))?;
-                Ok(DataPayload::from_owned(M::Yokeable::zero_copy_from(
+                Ok(DataPayload::from_owned(M::Yokeable::zero_from(
                     down_ref,
                 )))
             }

--- a/provider/core/src/data_provider/test.rs
+++ b/provider/core/src/data_provider/test.rs
@@ -12,6 +12,7 @@ use crate::hello_world::*;
 use crate::iter::*;
 use crate::prelude::*;
 use crate::yoke;
+use crate::zerofrom;
 
 // This file tests DataProvider borrow semantics with a dummy data provider based on a
 // JSON string. It also exercises most of the data provider code paths.
@@ -20,7 +21,7 @@ use crate::yoke;
 const HELLO_ALT_KEY: ResourceKey = crate::resource_key!("core/helloalt@1");
 
 /// A data struct serialization-compatible with HelloWorldV1 used for testing mismatched types
-#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Yokeable, ZeroCopyFrom)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Yokeable, zerofrom::ZeroFrom)]
 #[yoke(cloning_zcf)]
 struct HelloAlt {
     message: String,

--- a/provider/core/src/data_provider/test.rs
+++ b/provider/core/src/data_provider/test.rs
@@ -24,7 +24,7 @@ const HELLO_ALT_KEY: ResourceKey = crate::resource_key!("core/helloalt@1");
 #[derive(
     Serialize, Deserialize, Debug, Clone, Default, PartialEq, Yokeable, zerofrom::ZeroFrom,
 )]
-#[yoke(cloning_zf)]
+#[zerofrom(cloning_zf)]
 struct HelloAlt {
     message: String,
 }

--- a/provider/core/src/data_provider/test.rs
+++ b/provider/core/src/data_provider/test.rs
@@ -21,7 +21,9 @@ use crate::zerofrom;
 const HELLO_ALT_KEY: ResourceKey = crate::resource_key!("core/helloalt@1");
 
 /// A data struct serialization-compatible with HelloWorldV1 used for testing mismatched types
-#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Yokeable, zerofrom::ZeroFrom)]
+#[derive(
+    Serialize, Deserialize, Debug, Clone, Default, PartialEq, Yokeable, zerofrom::ZeroFrom,
+)]
 #[yoke(cloning_zcf)]
 struct HelloAlt {
     message: String,

--- a/provider/core/src/data_provider/test.rs
+++ b/provider/core/src/data_provider/test.rs
@@ -24,7 +24,7 @@ const HELLO_ALT_KEY: ResourceKey = crate::resource_key!("core/helloalt@1");
 #[derive(
     Serialize, Deserialize, Debug, Clone, Default, PartialEq, Yokeable, zerofrom::ZeroFrom,
 )]
-#[yoke(cloning_zcf)]
+#[yoke(cloning_zf)]
 struct HelloAlt {
     message: String,
 }

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -9,6 +9,7 @@ use crate::helpers;
 use crate::iter::IterableResourceProvider;
 use crate::prelude::*;
 use crate::yoke::{self, *};
+use crate::zerofrom::{self, *};
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::rc::Rc;
@@ -20,7 +21,7 @@ use icu_locid::LanguageIdentifier;
 use litemap::LiteMap;
 
 /// A struct containing "Hello World" in the requested language.
-#[derive(Debug, PartialEq, Clone, Yokeable, ZeroCopyFrom)]
+#[derive(Debug, PartialEq, Clone, Yokeable, ZeroFrom)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HelloWorldV1<'data> {
     #[cfg_attr(feature = "serde", serde(borrow))]

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -175,8 +175,8 @@ pub mod prelude {
     #[cfg(feature = "serde")]
     pub use crate::serde::AsDeserializingBufferProvider;
 
-    pub use crate::yoke;
-    pub use crate::zerofrom;
+    pub use yoke;
+    pub use zerofrom;
 }
 
 /// Re-export of the yoke and zerofrom crates for convenience of downstream implementors.

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -174,6 +174,9 @@ pub mod prelude {
     pub use crate::any::AsDynProviderAnyMarkerWrap;
     #[cfg(feature = "serde")]
     pub use crate::serde::AsDeserializingBufferProvider;
+
+    pub use crate::yoke;
+    pub use crate::zerofrom;
 }
 
 /// Re-export of the yoke and zerofrom crates for convenience of downstream implementors.

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -176,8 +176,9 @@ pub mod prelude {
     pub use crate::serde::AsDeserializingBufferProvider;
 }
 
-/// Re-export of the yoke crate for convenience of downstream implementors.
+/// Re-export of the yoke and zerofrom crates for convenience of downstream implementors.
 pub use yoke;
+pub use zerofrom;
 
 // Also include the same symbols at the top level for selective inclusion
 pub use prelude::*;

--- a/provider/core/src/marker/mod.rs
+++ b/provider/core/src/marker/mod.rs
@@ -20,7 +20,7 @@ use crate::ResourceKey;
 /// for the data struct:
 ///
 /// - `impl<'a> Yokeable<'a>` (required)
-/// - `impl ZeroCopyFrom<Self>`
+/// - `impl ZeroFrom<Self>`
 ///
 /// See also some common pre-made DataMarker impls in this module.
 ///
@@ -31,10 +31,11 @@ use crate::ResourceKey;
 /// ```
 /// use icu_provider::prelude::*;
 /// use icu_provider::yoke::*;
+/// use icu_provider::zerofrom::*;
 /// use std::borrow::Cow;
 /// use std::rc::Rc;
 ///
-/// #[derive(Yokeable, ZeroCopyFrom)]
+/// #[derive(Yokeable, ZeroFrom)]
 /// struct MyDataStruct<'data> {
 ///     message: Cow<'data, str>,
 /// }

--- a/provider/macros/src/lib.rs
+++ b/provider/macros/src/lib.rs
@@ -21,7 +21,7 @@ mod tests;
 /// for use in a `DataStruct`. It does the following things:
 ///
 /// - `Apply #[derive(Yokeable, ZeroFrom)]`. The `ZeroFrom` derive can
-///    be customized with `#[yoke(cloning_zcf)]` as needed
+///    be customized with `#[yoke(cloning_zf)]` as needed
 ///
 /// In addition, the attribute can be used to implement `DataMarker` and/or `ResourceMarker`
 /// by adding symbols with optional key strings:

--- a/provider/macros/src/lib.rs
+++ b/provider/macros/src/lib.rs
@@ -21,7 +21,7 @@ mod tests;
 /// for use in a `DataStruct`. It does the following things:
 ///
 /// - `Apply #[derive(Yokeable, ZeroFrom)]`. The `ZeroFrom` derive can
-///    be customized with `#[yoke(cloning_zf)]` as needed
+///    be customized with `#[zerofrom(cloning_zf)]` as needed
 ///
 /// In addition, the attribute can be used to implement `DataMarker` and/or `ResourceMarker`
 /// by adding symbols with optional key strings:

--- a/provider/macros/src/lib.rs
+++ b/provider/macros/src/lib.rs
@@ -20,7 +20,7 @@ mod tests;
 /// The `#[data_struct]` attribute should be applied to all types intended
 /// for use in a `DataStruct`. It does the following things:
 ///
-/// - `Apply #[derive(Yokeable, ZeroCopyFrom)]`. The `ZeroCopyFrom` derive can
+/// - `Apply #[derive(Yokeable, ZeroFrom)]`. The `ZeroFrom` derive can
 ///    be customized with `#[yoke(cloning_zcf)]` as needed
 ///
 /// In addition, the attribute can be used to implement `DataMarker` and/or `ResourceMarker`
@@ -28,6 +28,7 @@ mod tests;
 ///
 /// ```
 /// use icu_provider::prelude::*;
+/// use icu_provider::zerofrom;
 /// use std::borrow::Cow;
 ///
 /// // We also need `yoke` in scope: [icu4x#1557](https://github.com/unicode-org/icu4x/issues/1557)
@@ -121,7 +122,7 @@ fn data_struct_impl(attr: AttributeArgs, item: ItemStruct) -> TokenStream2 {
     }
 
     result.extend(quote!(
-        #[derive(yoke::Yokeable, yoke::ZeroCopyFrom)]
+        #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
         #item
     ));
 

--- a/provider/macros/src/lib.rs
+++ b/provider/macros/src/lib.rs
@@ -28,11 +28,7 @@ mod tests;
 ///
 /// ```
 /// use icu_provider::prelude::*;
-/// use icu_provider::zerofrom;
 /// use std::borrow::Cow;
-///
-/// // We also need `yoke` in scope: [icu4x#1557](https://github.com/unicode-org/icu4x/issues/1557)
-/// use icu_provider::yoke;
 ///
 /// #[icu_provider::data_struct(
 ///     FooV1Marker,

--- a/provider/macros/src/tests.rs
+++ b/provider/macros/src/tests.rs
@@ -27,7 +27,7 @@ fn test_basic() {
             pub struct FooV1;
         ),
         quote!(
-            #[derive(yoke::Yokeable, yoke::ZeroCopyFrom)]
+            #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
             pub struct FooV1;
         ),
     );
@@ -47,7 +47,7 @@ fn test_data_marker() {
             impl icu_provider::DataMarker for FooV1Marker {
                 type Yokeable = FooV1;
             }
-            #[derive(yoke::Yokeable, yoke::ZeroCopyFrom)]
+            #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
             pub struct FooV1;
         ),
     );
@@ -70,7 +70,7 @@ fn test_resource_marker() {
             impl icu_provider::ResourceMarker for BarV1Marker {
                 const KEY: icu_provider::ResourceKey = icu_provider::resource_key!("demo/bar@1");
             }
-            #[derive(yoke::Yokeable, yoke::ZeroCopyFrom)]
+            #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
             pub struct FooV1;
         ),
     );
@@ -110,7 +110,7 @@ fn test_multi_named_resource_marker() {
             impl icu_provider::ResourceMarker for BazV1Marker {
                 const KEY: icu_provider::ResourceKey = icu_provider::resource_key!("demo/baz@1");
             }
-            #[derive(yoke::Yokeable, yoke::ZeroCopyFrom)]
+            #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
             pub struct FooV1<'data>;
         ),
     );

--- a/utils/codepointtrie/Cargo.toml
+++ b/utils/codepointtrie/Cargo.toml
@@ -35,6 +35,7 @@ all-features = true
 displaydoc = { version = "0.2.3", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 yoke = { version = "0.4.0", path = "../yoke", features = ["derive"] }
+zerofrom = { version = "0.1.0", path = "../zerofrom", features = ["derive"] }
 zerovec = { version = "0.6", path = "../../utils/zerovec", features = ["serde", "yoke"] }
 
 [dev-dependencies]

--- a/utils/codepointtrie/src/codepointtrie.rs
+++ b/utils/codepointtrie/src/codepointtrie.rs
@@ -11,7 +11,8 @@ use core::num::TryFromIntError;
 use core::ops::RangeInclusive;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use yoke::{Yokeable, ZeroCopyFrom};
+use yoke::Yokeable;
+use zerofrom::ZeroFrom;
 use zerovec::ZeroVec;
 use zerovec::ZeroVecError;
 
@@ -103,7 +104,7 @@ fn maybe_filter_value<T: TrieValue>(value: T, trie_null_value: T, null_value: T)
 /// - [ICU Site design doc](http://site.icu-project.org/design/struct/utrie)
 /// - [ICU User Guide section on Properties lookup](https://unicode-org.github.io/icu/userguide/strings/properties.html#lookup)
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Eq, PartialEq, Yokeable, ZeroCopyFrom)]
+#[derive(Debug, Eq, PartialEq, Yokeable, ZeroFrom)]
 pub struct CodePointTrie<'trie, T: TrieValue> {
     header: CodePointTrieHeader,
     #[cfg_attr(feature = "serde", serde(borrow))]
@@ -114,7 +115,7 @@ pub struct CodePointTrie<'trie, T: TrieValue> {
 
 /// This struct contains the fixed-length header fields of a [`CodePointTrie`].
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Yokeable, ZeroCopyFrom)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Yokeable, ZeroFrom)]
 pub struct CodePointTrieHeader {
     /// The code point of the start of the last range of the trie. A
     /// range is defined as a partition of the code point space such that the

--- a/utils/uniset/Cargo.toml
+++ b/utils/uniset/Cargo.toml
@@ -37,6 +37,7 @@ serde = { version = "1.0", default-features = false, features = ["derive", "allo
 tinystr = { path = "../../utils/tinystr", version = "0.5.0", features = ["alloc"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
 yoke = { version = "0.4.0", path = "../yoke", features = ["derive"] }
+zerofrom = { version = "0.1.0", path = "../zerofrom", features = ["derive"] }
 zerovec = { version = "0.6", path = "../../utils/zerovec", features = ["serde", "yoke"] }
 
 [dev-dependencies]

--- a/utils/uniset/src/uniset.rs
+++ b/utils/uniset/src/uniset.rs
@@ -6,7 +6,8 @@
 use alloc::format;
 use alloc::vec::Vec;
 use core::{char, ops::RangeBounds, ops::RangeInclusive};
-use yoke::{self, *};
+use yoke::Yokeable;
+use zerofrom::ZeroFrom;
 use zerovec::{ule::AsULE, ZeroVec};
 
 use super::UnicodeSetError;
@@ -25,7 +26,7 @@ const ALL_SLICE: &[u32] = &[0x0, (char::MAX as u32) + 1];
 ///
 /// Provides exposure to membership functions and constructors from serialized [`UnicodeSets`](UnicodeSet)
 /// and predefined ranges.
-#[derive(Debug, Eq, PartialEq, Clone, Yokeable, ZeroCopyFrom)]
+#[derive(Debug, Eq, PartialEq, Clone, Yokeable, ZeroFrom)]
 pub struct UnicodeSet<'data> {
     // If we wanted to use an array to keep the memory on the stack, there is an unsafe nightly feature
     // https://doc.rust-lang.org/nightly/core/array/trait.FixedSizeArray.html

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -22,9 +22,9 @@ include = [
 ]
 
 [features]
-derive = ["yoke-derive"]
-alloc = ["stable_deref_trait/alloc", "serde/alloc"]
-default = ["alloc"]
+derive = ["yoke-derive", "zerofrom/derive"]
+alloc = ["stable_deref_trait/alloc", "serde/alloc", "zerofrom/alloc"]
+default = ["alloc", "zerofrom"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -32,7 +32,8 @@ all-features = true
 [dependencies]
 stable_deref_trait = { version = "1.2.0", features = ["alloc"], default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
-yoke-derive = { path = "./derive", version = "0.4.1", optional = true}
+yoke-derive = { path = "./derive", version = "0.4.1", optional = true }
+zerofrom = { path = "../zerofrom", version = "0.1.0", default-features = false, optional = true} 
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/utils/yoke/derive/README.md
+++ b/utils/yoke/derive/README.md
@@ -1,6 +1,6 @@
 # yoke-derive [![crates.io](https://img.shields.io/crates/v/yoke-derive)](https://crates.io/crates/yoke-derive)
 
-Custom derives for `Yokeable` and `ZeroFrom` from the `yoke` crate.
+Custom derives for `Yokeable` from the `yoke` crate.
 
 ## More Information
 

--- a/utils/yoke/derive/README.md
+++ b/utils/yoke/derive/README.md
@@ -1,6 +1,6 @@
 # yoke-derive [![crates.io](https://img.shields.io/crates/v/yoke-derive)](https://crates.io/crates/yoke-derive)
 
-Custom derives for `Yokeable` and `ZeroCopyFrom` from the `yoke` crate.
+Custom derives for `Yokeable` and `ZeroFrom` from the `yoke` crate.
 
 ## More Information
 

--- a/utils/yoke/derive/examples/derive.rs
+++ b/utils/yoke/derive/examples/derive.rs
@@ -5,7 +5,7 @@
 #![allow(unused)]
 
 use std::borrow::Cow;
-use yoke::{Yoke, Yokeable, ZeroCopyFrom};
+use yoke::{Yoke, Yokeable};
 use zerovec::{map::ZeroMapKV, ule::AsULE, VarZeroVec, ZeroMap, ZeroVec};
 
 #[derive(Yokeable)]
@@ -13,18 +13,18 @@ pub struct StringExample {
     x: String,
 }
 
-#[derive(Yokeable, ZeroCopyFrom, Copy, Clone)]
+#[derive(Yokeable, Copy, Clone)]
 pub struct IntExample {
     x: u32,
 }
 
-#[derive(Yokeable, ZeroCopyFrom, Copy, Clone)]
+#[derive(Yokeable, Copy, Clone)]
 pub struct GenericsExample<T> {
     x: u32,
     y: T,
 }
 
-#[derive(Yokeable, ZeroCopyFrom)]
+#[derive(Yokeable)]
 pub struct CowExample<'a> {
     x: u8,
     y: &'a str,
@@ -32,31 +32,17 @@ pub struct CowExample<'a> {
     w: Cow<'a, [u8]>,
 }
 
-#[derive(Yokeable, ZeroCopyFrom)]
+#[derive(Yokeable)]
 pub struct ZeroVecExample<'a> {
     var: VarZeroVec<'a, str>,
     vec: ZeroVec<'a, u16>,
 }
 
-#[derive(Yokeable, ZeroCopyFrom)]
+#[derive(Yokeable)]
 pub struct ZeroVecExampleWithGenerics<'a, T: AsULE> {
     gen: ZeroVec<'a, T>,
     vec: ZeroVec<'a, u16>,
     bare: T,
-}
-
-#[derive(Yokeable, ZeroCopyFrom)]
-pub struct HasTuples<'data> {
-    pub bar: (&'data str, &'data str),
-}
-
-pub fn assert_zcf_tuples<'b, 'data>(x: &'b HasTuples<'data>) -> HasTuples<'b> {
-    HasTuples::zero_copy_from(x)
-}
-pub fn assert_zcf_generics<'a, 'b>(
-    x: &'b ZeroVecExampleWithGenerics<'a, u8>,
-) -> ZeroVecExampleWithGenerics<'b, u8> {
-    ZeroVecExampleWithGenerics::<'b, u8>::zero_copy_from(x)
 }
 
 // Since ZeroMap has generic parameters, the Rust compiler cannot
@@ -69,49 +55,10 @@ pub struct ZeroMapExample<'a> {
     map: ZeroMap<'a, str, u16>,
 }
 
-#[derive(Yokeable, ZeroCopyFrom)]
+#[derive(Yokeable)]
 #[yoke(prove_covariance_manually)]
 pub struct ZeroMapGenericExample<'a, T: for<'b> ZeroMapKV<'b> + ?Sized> {
     map: ZeroMap<'a, str, T>,
-}
-
-pub fn assert_zcf_map<'a, 'b>(
-    x: &'b ZeroMapGenericExample<'a, str>,
-) -> ZeroMapGenericExample<'b, str> {
-    ZeroMapGenericExample::zero_copy_from(x)
-}
-
-#[derive(Yokeable, Clone, ZeroCopyFrom)]
-#[yoke(cloning_zcf)]
-pub struct CloningZCF1 {
-    vec: Vec<u8>,
-}
-
-#[derive(Yokeable, Clone, ZeroCopyFrom)]
-#[yoke(cloning_zcf)] // this will clone `cow` instead of borrowing from it
-pub struct CloningZCF2<'data> {
-    cow: Cow<'data, str>,
-    vec: Vec<u8>,
-}
-
-#[derive(Yokeable, ZeroCopyFrom)]
-pub struct CloningZCF3<'data> {
-    cow: Cow<'data, str>,
-    #[yoke(cloning_zcf)]
-    vec: Vec<u8>,
-}
-
-#[derive(Yokeable, ZeroCopyFrom)]
-pub enum CloningZCF4<'data> {
-    Cow(Cow<'data, str>),
-    #[yoke(cloning_zcf)] // this will clone the first field instead of borrowing
-    CowVec(Cow<'data, str>, Vec<u8>),
-}
-
-#[derive(Yokeable, ZeroCopyFrom)]
-pub enum CloningZCF5<'data> {
-    Cow(Cow<'data, str>),
-    CowVec(Cow<'data, str>, #[yoke(cloning_zcf)] Vec<u8>),
 }
 
 pub struct AssertYokeable {

--- a/utils/yoke/derive/src/lib.rs
+++ b/utils/yoke/derive/src/lib.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-//! Custom derives for `Yokeable` and `ZeroCopyFrom` from the `yoke` crate.
+//! Custom derives for `Yokeable` from the `yoke` crate.
 
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
@@ -203,130 +203,6 @@ fn yokeable_derive_impl(input: &DeriveInput) -> TokenStream2 {
             // This is safe because it is in the same block as the above impl, which only compiles
             // if 'a is a covariant lifetime.
             unsafe impl<'a, #(#tybounds),*> yoke::IsCovariant<'a> for #name<'a, #(#typarams),*> where #(#static_bounds),* {}
-        }
-    }
-}
-
-/// Custom derive for `yoke::ZeroCopyFrom`,
-///
-/// This implements `ZeroCopyFrom<Ty> for Ty` for types
-/// without a lifetime parameter, and `ZeroCopyFrom<Ty<'data>> for Ty<'static>`
-/// for types with a lifetime parameter.
-///
-/// Apply the `#[yoke(cloning_zcf)]` attribute if you wish for this custom derive
-/// to use `.clone()` for its implementation. The attribute can be applied to
-/// fields as well.
-#[proc_macro_derive(ZeroCopyFrom, attributes(yoke))]
-pub fn zcf_derive(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
-    TokenStream::from(zcf_derive_impl(&input))
-}
-
-fn has_cloning_zcf_attr(attrs: &[syn::Attribute]) -> bool {
-    attrs.iter().any(|a| {
-        if let Ok(i) = a.parse_args::<Ident>() {
-            if i == "cloning_zcf" {
-                return true;
-            }
-        }
-        false
-    })
-}
-
-fn zcf_derive_impl(input: &DeriveInput) -> TokenStream2 {
-    let tybounds = input.generics.type_params().collect::<Vec<_>>();
-    let typarams = tybounds
-        .iter()
-        .map(|ty| ty.ident.clone())
-        .collect::<Vec<_>>();
-    let has_clone = has_cloning_zcf_attr(&input.attrs);
-    let lts = input.generics.lifetimes().count();
-    let name = &input.ident;
-    if lts == 0 {
-        let (clone, clone_trait) = if has_clone {
-            (quote!(this.clone()), quote!(Clone))
-        } else {
-            (quote!(*this), quote!(Copy))
-        };
-        let bounds: Vec<WherePredicate> = typarams
-            .iter()
-            .map(|ty| parse_quote!(#ty: #clone_trait + 'static))
-            .collect();
-        quote! {
-            impl<'zcf, #(#tybounds),*> yoke::ZeroCopyFrom<'zcf, #name<#(#typarams),*>> for #name<#(#typarams),*> where #(#bounds),* {
-                fn zero_copy_from(this: &'zcf Self) -> Self {
-                    #clone
-                }
-            }
-        }
-    } else {
-        if lts != 1 {
-            return syn::Error::new(
-                input.generics.span(),
-                "derive(ZeroCopyFrom) cannot have multiple lifetime parameters",
-            )
-            .to_compile_error();
-        }
-        if has_clone {
-            return quote! {
-                impl<'zcf> yoke::ZeroCopyFrom<'zcf, #name<'_>> for #name<'zcf> {
-                    fn zero_copy_from(this: &'zcf #name<'_>) -> Self {
-                        this.clone()
-                    }
-                }
-            };
-        }
-
-        let structure = Structure::new(input);
-        let generics_env = typarams.iter().cloned().collect();
-
-        let mut zcf_bounds: Vec<WherePredicate> = vec![];
-        let body = structure.each_variant(|vi| {
-            let variant_cloning = has_cloning_zcf_attr(vi.ast().attrs);
-            vi.construct(|f, i| {
-                let binding_cloning = variant_cloning || has_cloning_zcf_attr(&f.attrs);
-                let binding = format!("__binding_{}", i);
-                let field = Ident::new(&binding, Span::call_site());
-
-                if binding_cloning {
-                    quote! {
-                        #field.clone()
-                    }
-                } else {
-                    let fty = replace_lifetime(&f.ty, custom_lt("'zcf"));
-                    let lifetime_ty = replace_lifetime(&f.ty, custom_lt("'zcf_inner"));
-
-                    let (has_ty, has_lt) = visitor::check_type_for_parameters(&f.ty, &generics_env);
-                    if has_ty {
-                        // For types without type parameters, the compiler can figure out that the field implements
-                        // ZeroCopyFrom on its own. However, if there are type parameters, there may be complex preconditions
-                        // to `FieldTy: ZeroCopyFrom` that need to be satisfied. We get them to be satisfied by requiring
-                        // `FieldTy<'zcf>: ZeroCopyFrom<'zcf, FieldTy<'zcf_inner>>`
-                        if has_lt {
-                            zcf_bounds
-                                .push(parse_quote!(#fty: yoke::ZeroCopyFrom<'zcf, #lifetime_ty>));
-                        } else {
-                            zcf_bounds.push(parse_quote!(#fty: yoke::ZeroCopyFrom<'zcf, #fty>));
-                        }
-                    }
-
-                    // By doing this we essentially require ZCF to be implemented
-                    // on all fields
-                    quote! {
-                        <#fty as yoke::ZeroCopyFrom<'zcf, #lifetime_ty>>::zero_copy_from(#field)
-                    }
-                }
-            })
-        });
-
-        quote! {
-            impl<'zcf, 'zcf_inner, #(#tybounds),*> yoke::ZeroCopyFrom<'zcf, #name<'zcf_inner, #(#typarams),*>> for #name<'zcf, #(#typarams),*>
-                where
-                #(#zcf_bounds,)* {
-                fn zero_copy_from(this: &'zcf #name<'zcf_inner, #(#typarams),*>) -> Self {
-                    match *this { #body }
-                }
-            }
         }
     }
 }

--- a/utils/yoke/design_doc.md
+++ b/utils/yoke/design_doc.md
@@ -209,7 +209,7 @@ What this function does is take a closure that, for all `'a`, can convert `Y<'a>
 
 ### ZeroFrom
 
-The `yoke` crate comes with an additional trait, [`ZeroFrom`]. Implementing this trait allows one to define a canonical, infallible implementation of Yoke's `attach_to_cart` function, enabling various additional constructors on Yoke for convenience, including `Yoke::attach_to_borrowed_cart()`, `Yoke::attach_to_box_cart()`, and `Yoke::attach_to_rc_cart()`.
+The `zerofrom` crate comes with the [`ZeroFrom`] trait. Implementing this trait allows one to define a canonical, infallible implementation of Yoke's `attach_to_cart` function, enabling various additional constructors on Yoke for convenience, including `Yoke::attach_to_borrowed_cart()`, `Yoke::attach_to_box_cart()`, and `Yoke::attach_to_rc_cart()`.
 
 Using this trait, for example, one can generically talk about taking a `Cow<'a, T>` and borrowing it to produce a `Cow<'b, T>` that is `Cow::Borrowed`, borrowing from the original `Cow`, regardless of whether or not the original `Cow` was owned or borrowed.
 
@@ -226,7 +226,7 @@ pub trait ZeroFrom<C: ?Sized>: for<'a> Yokeable<'a> {
  [`Yoke`]: https://docs.rs/yoke/latest/yoke/struct.Yoke.html
  [`Yokeable`]: https://docs.rs/yoke/latest/yoke/trait.Yokeable.html
  [yokeable-derive]: https://docs.rs/yoke/latest/yoke/derive.Yokeable.html
- [`ZeroFrom`]: https://docs.rs/yoke/latest/yoke/trait.ZeroFrom.html
+ [`ZeroFrom`]: https://docs.rs/zerofrom/latest/zerofrom/trait.ZeroFrom.html
  [get]: https://docs.rs/yoke/latest/yoke/struct.Yoke.html#method.get
  [attach]: https://docs.rs/yoke/latest/yoke/struct.Yoke.html#method.attach
  [with_mut]: https://docs.rs/yoke/latest/yoke/struct.Yoke.html#method.with_mut

--- a/utils/yoke/design_doc.md
+++ b/utils/yoke/design_doc.md
@@ -207,16 +207,16 @@ This is a fair bit more complicated. First off the bat, the `PhantomData` can be
 What this function does is take a closure that, for all `'a`, can convert `Y<'a>` to `P<'a>`. The `for<'a>` here has the same effect as in `Yoke::attach_to_cart()`: it pins down a lifetime flow such that all borrowed data in `P<'a>` _must_ have come from `Y<'a>` and nowhere else, satisfying safety point 2. There's no chance for `f` to smuggle any borrowed out so safety point 1 is also satisfied. The `with_capture` variants of this are able to enforce that no data of the wrong lifetime is smuggled out by relying on the `for<'a>` again: any data being smuggled out would not have a statically known lifetime and cannot be stuffed into the capture since that would give the capture a statically unknown lifetime.
 
 
-### ZeroCopyFrom
+### ZeroFrom
 
-The `yoke` crate comes with an additional trait, [`ZeroCopyFrom`]. Implementing this trait allows one to define a canonical, infallible implementation of Yoke's `attach_to_cart` function, enabling various additional constructors on Yoke for convenience, including `Yoke::attach_to_borrowed_cart()`, `Yoke::attach_to_box_cart()`, and `Yoke::attach_to_rc_cart()`.
+The `yoke` crate comes with an additional trait, [`ZeroFrom`]. Implementing this trait allows one to define a canonical, infallible implementation of Yoke's `attach_to_cart` function, enabling various additional constructors on Yoke for convenience, including `Yoke::attach_to_borrowed_cart()`, `Yoke::attach_to_box_cart()`, and `Yoke::attach_to_rc_cart()`.
 
 Using this trait, for example, one can generically talk about taking a `Cow<'a, T>` and borrowing it to produce a `Cow<'b, T>` that is `Cow::Borrowed`, borrowing from the original `Cow`, regardless of whether or not the original `Cow` was owned or borrowed.
 
 It has the following signature and also has a custom derive:
 
 ```rust
-pub trait ZeroCopyFrom<C: ?Sized>: for<'a> Yokeable<'a> {
+pub trait ZeroFrom<C: ?Sized>: for<'a> Yokeable<'a> {
     fn zero_copy_from<'b>(cart: &'b C) -> <Self as Yokeable<'b>>::Output;
 }
 ```
@@ -226,7 +226,7 @@ pub trait ZeroCopyFrom<C: ?Sized>: for<'a> Yokeable<'a> {
  [`Yoke`]: https://docs.rs/yoke/latest/yoke/struct.Yoke.html
  [`Yokeable`]: https://docs.rs/yoke/latest/yoke/trait.Yokeable.html
  [yokeable-derive]: https://docs.rs/yoke/latest/yoke/derive.Yokeable.html
- [`ZeroCopyFrom`]: https://docs.rs/yoke/latest/yoke/trait.ZeroCopyFrom.html
+ [`ZeroFrom`]: https://docs.rs/yoke/latest/yoke/trait.ZeroFrom.html
  [get]: https://docs.rs/yoke/latest/yoke/struct.Yoke.html#method.get
  [attach]: https://docs.rs/yoke/latest/yoke/struct.Yoke.html#method.attach
  [with_mut]: https://docs.rs/yoke/latest/yoke/struct.Yoke.html#method.with_mut

--- a/utils/yoke/design_doc.md
+++ b/utils/yoke/design_doc.md
@@ -217,7 +217,7 @@ It has the following signature and also has a custom derive:
 
 ```rust
 pub trait ZeroFrom<C: ?Sized>: for<'a> Yokeable<'a> {
-    fn zero_copy_from<'b>(cart: &'b C) -> <Self as Yokeable<'b>>::Output;
+    fn zero_from<'b>(cart: &'b C) -> <Self as Yokeable<'b>>::Output;
 }
 ```
 

--- a/utils/yoke/src/is_covariant.rs
+++ b/utils/yoke/src/is_covariant.rs
@@ -78,8 +78,8 @@ use alloc::{
 ///     }
 /// }
 ///
-/// impl<'zcf, 'a> ZeroFrom<'zcf, dyn ExampleTrait<'a> + 'a> for ExampleTraitDynRef<'zcf> {
-///     fn zero_from(this: &'zcf (dyn ExampleTrait<'a> + 'a)) -> ExampleTraitDynRef<'zcf> {
+/// impl<'zf, 'a> ZeroFrom<'zf, dyn ExampleTrait<'a> + 'a> for ExampleTraitDynRef<'zf> {
+///     fn zero_from(this: &'zf (dyn ExampleTrait<'a> + 'a)) -> ExampleTraitDynRef<'zf> {
 ///         // This is safe because the trait object requires IsCovariant.
 ///         ExampleTraitDynRef(unsafe { core::mem::transmute(this) })
 ///     }

--- a/utils/yoke/src/is_covariant.rs
+++ b/utils/yoke/src/is_covariant.rs
@@ -42,7 +42,7 @@ use alloc::{
 /// ```
 ///
 /// By constraining the trait `ExampleTrait<'a>` on `IsCovariant<'a>`, we can safely implement
-/// [`Yokeable`] and [`ZeroCopyFrom`] on its trait object:
+/// [`Yokeable`] and [`ZeroFrom`] on its trait object:
 ///
 /// ```
 /// # use yoke::*;
@@ -77,7 +77,7 @@ use alloc::{
 ///     }
 /// }
 ///
-/// impl<'zcf, 'a> ZeroCopyFrom<'zcf, dyn ExampleTrait<'a> + 'a> for ExampleTraitDynRef<'zcf> {
+/// impl<'zcf, 'a> ZeroFrom<'zcf, dyn ExampleTrait<'a> + 'a> for ExampleTraitDynRef<'zcf> {
 ///     fn zero_copy_from(this: &'zcf (dyn ExampleTrait<'a> + 'a)) -> ExampleTraitDynRef<'zcf> {
 ///         // This is safe because the trait object requires IsCovariant.
 ///         ExampleTraitDynRef(unsafe { core::mem::transmute(this) })
@@ -103,7 +103,7 @@ use alloc::{
 ///
 /// [`Yoke`]: crate::Yoke
 /// [`Yokeable`]: crate::Yokeable
-/// [`ZeroCopyFrom`]: crate::ZeroCopyFrom
+/// [`ZeroFrom`]: crate::ZeroFrom
 pub unsafe trait IsCovariant<'a>: 'a {}
 
 // IsCovariant is implemented on the standard library Copy types in macro_impls.rs

--- a/utils/yoke/src/is_covariant.rs
+++ b/utils/yoke/src/is_covariant.rs
@@ -79,7 +79,7 @@ use alloc::{
 /// }
 ///
 /// impl<'zcf, 'a> ZeroFrom<'zcf, dyn ExampleTrait<'a> + 'a> for ExampleTraitDynRef<'zcf> {
-///     fn zero_copy_from(this: &'zcf (dyn ExampleTrait<'a> + 'a)) -> ExampleTraitDynRef<'zcf> {
+///     fn zero_from(this: &'zcf (dyn ExampleTrait<'a> + 'a)) -> ExampleTraitDynRef<'zcf> {
 ///         // This is safe because the trait object requires IsCovariant.
 ///         ExampleTraitDynRef(unsafe { core::mem::transmute(this) })
 ///     }

--- a/utils/yoke/src/is_covariant.rs
+++ b/utils/yoke/src/is_covariant.rs
@@ -46,6 +46,7 @@ use alloc::{
 ///
 /// ```
 /// # use yoke::*;
+/// # use zerofrom::*;
 /// # use core::mem;
 /// trait ExampleTrait<'a>: IsCovariant<'a> {
 ///     fn get_message(&self) -> &'a str;

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -47,7 +47,7 @@ mod zero_copy_from;
 mod serde;
 
 #[cfg(feature = "derive")]
-pub use yoke_derive::{Yokeable, ZeroCopyFrom};
+pub use yoke_derive::Yokeable;
 
 pub use crate::is_covariant::IsCovariant;
 pub use crate::yoke::{CloneableCart, Yoke};

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -40,6 +40,7 @@ mod macro_impls;
 pub mod trait_hack;
 mod yoke;
 mod yokeable;
+#[cfg(feature = "zerofrom")]
 mod zero_copy_from;
 
 #[cfg(feature = "serde")]
@@ -51,4 +52,6 @@ pub use yoke_derive::{Yokeable, ZeroCopyFrom};
 pub use crate::is_covariant::IsCovariant;
 pub use crate::yoke::{CloneableCart, Yoke};
 pub use crate::yokeable::Yokeable;
-pub use crate::zero_copy_from::ZeroCopyFrom;
+
+#[cfg(feature = "zerofrom")]
+pub use zerofrom::ZeroFrom as ZeroCopyFrom;

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -54,4 +54,4 @@ pub use crate::yoke::{CloneableCart, Yoke};
 pub use crate::yokeable::Yokeable;
 
 #[cfg(feature = "zerofrom")]
-pub use zerofrom::ZeroFrom;
+use zerofrom::ZeroFrom;

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -41,7 +41,7 @@ pub mod trait_hack;
 mod yoke;
 mod yokeable;
 #[cfg(feature = "zerofrom")]
-mod zero_copy_from;
+mod zero_from;
 
 #[cfg(feature = "serde")]
 mod serde;

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -54,4 +54,4 @@ pub use crate::yoke::{CloneableCart, Yoke};
 pub use crate::yokeable::Yokeable;
 
 #[cfg(feature = "zerofrom")]
-pub use zerofrom::ZeroFrom as ZeroCopyFrom;
+pub use zerofrom::ZeroFrom;

--- a/utils/yoke/src/macro_impls.rs
+++ b/utils/yoke/src/macro_impls.rs
@@ -6,7 +6,7 @@
 // than using pointer casts
 #![allow(clippy::transmute_ptr_to_ptr)]
 
-use crate::{IsCovariant, Yokeable, ZeroCopyFrom};
+use crate::{IsCovariant, Yokeable};
 use core::{mem, ptr};
 
 macro_rules! copy_yoke_impl {
@@ -37,13 +37,6 @@ macro_rules! impl_copy_type {
         unsafe impl<'a> Yokeable<'a> for $ty {
             type Output = Self;
             copy_yoke_impl!();
-        }
-        impl<'a> ZeroCopyFrom<'a, $ty> for $ty {
-            #[inline]
-            fn zero_copy_from(this: &'a Self) -> Self {
-                // Essentially only works when the struct is fully Copy
-                *this
-            }
         }
         unsafe impl<'a> IsCovariant<'a> for $ty {}
     };
@@ -114,37 +107,3 @@ unsafe impl<'a, T: Yokeable<'a>, const N: usize> Yokeable<'a> for [T; N] {
     type Output = [<T as Yokeable<'a>>::Output; N];
     unsafe_complex_yoke_impl!();
 }
-
-// This can be cleaned up once `[T; N]`::each_ref() is stabilized
-// https://github.com/rust-lang/rust/issues/76118
-macro_rules! array_zcf_impl {
-    ($n:expr; $($i:expr),+) => {
-        impl<'a, C, T: ZeroCopyFrom<'a, C>> ZeroCopyFrom<'a, [C; $n]> for [T; $n] {
-            fn zero_copy_from(this: &'a [C; $n]) -> Self {
-                [
-                    $(
-                        <T as ZeroCopyFrom<C>>::zero_copy_from(&this[$i])
-                    ),+
-
-                ]
-            }
-        }
-    }
-}
-
-array_zcf_impl!(1; 0);
-array_zcf_impl!(2; 0, 1);
-array_zcf_impl!(3; 0, 1, 2);
-array_zcf_impl!(4; 0, 1, 2, 3);
-array_zcf_impl!(5; 0, 1, 2, 3, 4);
-array_zcf_impl!(6; 0, 1, 2, 3, 4, 5);
-array_zcf_impl!(7; 0, 1, 2, 3, 4, 5, 6);
-array_zcf_impl!(8; 0, 1, 2, 3, 4, 5, 6, 7);
-array_zcf_impl!(9; 0, 1, 2, 3, 4, 5, 6, 7, 8);
-array_zcf_impl!(10; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
-array_zcf_impl!(11; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-array_zcf_impl!(12; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-array_zcf_impl!(13; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-array_zcf_impl!(14; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
-array_zcf_impl!(15; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
-array_zcf_impl!(16; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);

--- a/utils/yoke/src/zero_copy_from.rs
+++ b/utils/yoke/src/zero_copy_from.rs
@@ -5,62 +5,11 @@
 use crate::trait_hack::YokeTraitHack;
 use crate::Yoke;
 use crate::Yokeable;
-#[cfg(feature = "alloc")]
-use alloc::borrow::{Cow, ToOwned};
-#[cfg(feature = "alloc")]
-use alloc::string::String;
+
 use core::ops::Deref;
 use stable_deref_trait::StableDeref;
 
-/// Trait for types that can be created from a reference to a cart type `C` with no allocations.
-///
-/// A type can be the `ZeroCopyFrom` target of multiple cart types.
-///
-/// The intention is for `ZeroCopyFrom` to produce a struct from a cart with as little work as
-/// possible. Although it is technically possible to implement `ZeroCopyFrom` without being
-/// zero-copy (using heap allocations), doing so defeats the purpose of `ZeroCopyFrom`.
-///
-/// For example, `impl ZeroCopyFrom<C> for Cow<str>` should return a `Cow::Borrowed` pointing at
-/// data in the cart `C`, even if the cart is itself fully owned.
-///
-/// One can use the [`#[derive(ZeroCopyFrom)]`](yoke_derive::ZeroCopyFrom) custom derive to automatically
-/// implement this trait.
-///
-/// # Examples
-///
-/// Implementing `ZeroCopyFrom` on a custom data struct:
-///
-/// ```
-/// use yoke::Yokeable;
-/// use yoke::ZeroCopyFrom;
-/// use std::borrow::Cow;
-///
-/// struct MyStruct<'data> {
-///     message: Cow<'data, str>,
-/// }
-///
-/// // Reference from a borrowed version of self
-/// impl<'zcf> ZeroCopyFrom<'zcf, MyStruct<'_>> for MyStruct<'zcf> {
-///     fn zero_copy_from(cart: &'zcf MyStruct<'_>) -> Self {
-///         MyStruct {
-///             message: Cow::Borrowed(&cart.message)
-///         }
-///     }
-/// }
-///
-/// // Reference from a string slice directly
-/// impl<'zcf> ZeroCopyFrom<'zcf, str> for MyStruct<'zcf> {
-///     fn zero_copy_from(cart: &'zcf str) -> Self {
-///         MyStruct {
-///             message: Cow::Borrowed(cart)
-///         }
-///     }
-/// }
-/// ```
-pub trait ZeroCopyFrom<'zcf, C: ?Sized>: 'zcf {
-    /// Clone the cart `C` into a struct that may retain references into `C`.
-    fn zero_copy_from(cart: &'zcf C) -> Self;
-}
+use crate::ZeroCopyFrom;
 
 impl<'zcf, C: ?Sized, T> ZeroCopyFrom<'zcf, C> for YokeTraitHack<T>
 where
@@ -104,87 +53,5 @@ where
         Yoke::<Y, C>::attach_to_cart(cart, |c| {
             YokeTraitHack::<<Y as Yokeable>::Output>::zero_copy_from(c).0
         })
-    }
-}
-
-// Note: The following could be blanket implementations, but that would require constraining the
-// blanket `T` on `T: 'static`, which may not be desirable for all downstream users who may wish
-// to customize their `ZeroCopyFrom` impl. The blanket implementation may be safe once Rust has
-// specialization.
-
-#[cfg(feature = "alloc")]
-impl<'zcf> ZeroCopyFrom<'zcf, str> for Cow<'zcf, str> {
-    #[inline]
-    fn zero_copy_from(cart: &'zcf str) -> Self {
-        Cow::Borrowed(cart)
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<'zcf> ZeroCopyFrom<'zcf, String> for Cow<'zcf, str> {
-    #[inline]
-    fn zero_copy_from(cart: &'zcf String) -> Self {
-        Cow::Borrowed(cart)
-    }
-}
-
-impl<'zcf> ZeroCopyFrom<'zcf, str> for &'zcf str {
-    #[inline]
-    fn zero_copy_from(cart: &'zcf str) -> Self {
-        cart
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<'zcf> ZeroCopyFrom<'zcf, String> for &'zcf str {
-    #[inline]
-    fn zero_copy_from(cart: &'zcf String) -> Self {
-        cart
-    }
-}
-
-impl<'zcf, C, T: ZeroCopyFrom<'zcf, C>> ZeroCopyFrom<'zcf, Option<C>> for Option<T> {
-    fn zero_copy_from(cart: &'zcf Option<C>) -> Self {
-        cart.as_ref()
-            .map(|c| <T as ZeroCopyFrom<C>>::zero_copy_from(c))
-    }
-}
-
-impl<'zcf, C1, T1: ZeroCopyFrom<'zcf, C1>, C2, T2: ZeroCopyFrom<'zcf, C2>>
-    ZeroCopyFrom<'zcf, (C1, C2)> for (T1, T2)
-{
-    fn zero_copy_from(cart: &'zcf (C1, C2)) -> Self {
-        (
-            <T1 as ZeroCopyFrom<C1>>::zero_copy_from(&cart.0),
-            <T2 as ZeroCopyFrom<C2>>::zero_copy_from(&cart.1),
-        )
-    }
-}
-
-// These duplicate the functionality from above and aren't quite necessary due
-// to deref coercions, however for the custom derive to work, there always needs
-// to be `impl ZCF<T> for T`, otherwise it may fail to perform the necessary
-// type inference. Deref coercions do not typically work when sufficient generics
-// or inference are involved, and the proc macro does not necessarily have
-// enough type information to figure this out on its own.
-#[cfg(feature = "alloc")]
-impl<'zcf, B: ToOwned + ?Sized> ZeroCopyFrom<'zcf, Cow<'_, B>> for Cow<'zcf, B> {
-    #[inline]
-    fn zero_copy_from(cart: &'zcf Cow<'_, B>) -> Self {
-        Cow::Borrowed(cart)
-    }
-}
-
-impl<'zcf> ZeroCopyFrom<'zcf, &'_ str> for &'zcf str {
-    #[inline]
-    fn zero_copy_from(cart: &'zcf &'_ str) -> &'zcf str {
-        cart
-    }
-}
-
-impl<'zcf, T> ZeroCopyFrom<'zcf, [T]> for &'zcf [T] {
-    #[inline]
-    fn zero_copy_from(cart: &'zcf [T]) -> &'zcf [T] {
-        cart
     }
 }

--- a/utils/yoke/src/zero_copy_from.rs
+++ b/utils/yoke/src/zero_copy_from.rs
@@ -9,11 +9,11 @@ use crate::Yokeable;
 use core::ops::Deref;
 use stable_deref_trait::StableDeref;
 
-use crate::ZeroCopyFrom;
+use crate::ZeroFrom;
 
-impl<'zcf, C: ?Sized, T> ZeroCopyFrom<'zcf, C> for YokeTraitHack<T>
+impl<'zcf, C: ?Sized, T> ZeroFrom<'zcf, C> for YokeTraitHack<T>
 where
-    T: ZeroCopyFrom<'zcf, C>,
+    T: ZeroFrom<'zcf, C>,
 {
     #[inline]
     fn zero_copy_from(cart: &'zcf C) -> Self {
@@ -24,13 +24,13 @@ where
 impl<Y, C> Yoke<Y, C>
 where
     Y: for<'a> Yokeable<'a>,
-    for<'a> YokeTraitHack<<Y as Yokeable<'a>>::Output>: ZeroCopyFrom<'a, <C as Deref>::Target>,
+    for<'a> YokeTraitHack<<Y as Yokeable<'a>>::Output>: ZeroFrom<'a, <C as Deref>::Target>,
     C: StableDeref + Deref,
 {
     /// Construct a [`Yoke`]`<Y, C>` from a cart implementing `StableDeref` by zero-copy cloning
     /// the cart to `Y` and then yokeing that object to the cart.
     ///
-    /// The type `Y` must implement [`ZeroCopyFrom`]`<C::Target>`. This trait is auto-implemented
+    /// The type `Y` must implement [`ZeroFrom`]`<C::Target>`. This trait is auto-implemented
     /// on many common types and can be custom implemented or derived in order to make it easier
     /// to construct a `Yoke`.
     ///

--- a/utils/yoke/src/zero_from.rs
+++ b/utils/yoke/src/zero_from.rs
@@ -11,12 +11,12 @@ use stable_deref_trait::StableDeref;
 
 use crate::ZeroFrom;
 
-impl<'zcf, C: ?Sized, T> ZeroFrom<'zcf, C> for YokeTraitHack<T>
+impl<'zf, C: ?Sized, T> ZeroFrom<'zf, C> for YokeTraitHack<T>
 where
-    T: ZeroFrom<'zcf, C>,
+    T: ZeroFrom<'zf, C>,
 {
     #[inline]
-    fn zero_from(cart: &'zcf C) -> Self {
+    fn zero_from(cart: &'zf C) -> Self {
         YokeTraitHack(T::zero_from(cart))
     }
 }

--- a/utils/yoke/src/zero_from.rs
+++ b/utils/yoke/src/zero_from.rs
@@ -16,8 +16,8 @@ where
     T: ZeroFrom<'zcf, C>,
 {
     #[inline]
-    fn zero_copy_from(cart: &'zcf C) -> Self {
-        YokeTraitHack(T::zero_copy_from(cart))
+    fn zero_from(cart: &'zcf C) -> Self {
+        YokeTraitHack(T::zero_from(cart))
     }
 }
 
@@ -51,7 +51,7 @@ where
     /// ```
     pub fn attach_to_zero_copy_cart(cart: C) -> Self {
         Yoke::<Y, C>::attach_to_cart(cart, |c| {
-            YokeTraitHack::<<Y as Yokeable>::Output>::zero_copy_from(c).0
+            YokeTraitHack::<<Y as Yokeable>::Output>::zero_from(c).0
         })
     }
 }

--- a/utils/zerofrom/Cargo.toml
+++ b/utils/zerofrom/Cargo.toml
@@ -1,0 +1,33 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+[package]
+name = "zerofrom"
+version = "0.1.0"
+description = "ZeroFrom trait for constructing"
+authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
+edition = "2018"
+repository = "https://github.com/unicode-org/icu4x"
+license-file = "LICENSE"
+categories = ["data-structures", "caching", "no-std"]
+keywords = ["zerocopy", "serialization", "lifetime", "borrow"]
+include = [
+    "src/**/*",
+    "examples/**/*",
+    "benches/**/*",
+    "Cargo.toml",
+    "LICENSE",
+    "README.md"
+]
+
+[features]
+alloc = []
+derive = ["zerofrom-derive"]
+default = ["alloc"]
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+zerofrom-derive = { path = "./derive", version = "0.1.0", optional = true}

--- a/utils/zerofrom/LICENSE
+++ b/utils/zerofrom/LICENSE
@@ -1,0 +1,331 @@
+Except as otherwise noted below, ICU4X is licensed under the Apache
+License, Version 2.0 (included below) or the MIT license (included
+below), at your option. Unless importing data or code in the manner
+stated below, any contribution intentionally submitted for inclusion
+in ICU4X by you, as defined in the Apache-2.0 license, shall be dual
+licensed in the foregoing manner, without any additional terms or
+conditions.
+
+As exceptions to the above:
+* Portions of ICU4X that have been adapted from ICU4C and/or ICU4J are
+under the Unicode license (included below) and/or the ICU license
+(included below) as indicated by source code comments.
+* Unicode data incorporated in ICU4X is under the Unicode license
+(included below).
+* Your contributions may import code from ICU4C and/or ICU4J and
+Unicode data under these licenses. Indicate the license and the ICU4C
+or ICU4J origin in source code comments.
+
+- - - -
+
+Apache License, version 2.0
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+- - - -
+
+MIT License
+
+Copyright The ICU4X Authors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+- - - -
+
+Unicode License
+
+COPYRIGHT AND PERMISSION NOTICE (ICU 58 and later)
+
+Copyright © 1991-2020 Unicode, Inc. All rights reserved.
+Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Unicode data files and any associated documentation
+(the "Data Files") or Unicode software and any associated documentation
+(the "Software") to deal in the Data Files or Software
+without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, and/or sell copies of
+the Data Files or Software, and to permit persons to whom the Data Files
+or Software are furnished to do so, provided that either
+(a) this copyright and permission notice appear with all copies
+of the Data Files or Software, or
+(b) this copyright and permission notice appear in associated
+Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in these Data Files or Software without prior
+written authorization of the copyright holder.
+
+- - - -
+
+ICU License - ICU 1.8.1 to ICU 57.1
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright (c) 1995-2016 International Business Machines Corporation and others
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, and/or sell copies of the Software, and to permit persons
+to whom the Software is furnished to do so, provided that the above
+copyright notice(s) and this permission notice appear in all copies of
+the Software and that both the above copyright notice(s) and this
+permission notice appear in supporting documentation.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
+SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
+RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale, use
+or other dealings in this Software without prior written authorization
+of the copyright holder.
+
+All trademarks and registered trademarks mentioned herein are the
+property of their respective owners.
+
+- - - -

--- a/utils/zerofrom/README.md
+++ b/utils/zerofrom/README.md
@@ -1,26 +1,8 @@
 # zerofrom [![crates.io](https://img.shields.io/crates/v/zerofrom)](https://crates.io/crates/zerofrom)
 
-This crate provides [`Yoke<Y, C>`][Yoke], which allows one to "yoke" a zero-copy deserialized
-object(say, a [`Cow<'a, str>`](alloc::borrow::Cow)) to the source it was deserialized from, (say, an [`Rc<[u8]>`](alloc::rc::Rc)),
-known as a "cart", producing a type that looks like `Yoke<Cow<'static, str>, Rc<[u8]>>`
-and can be moved around with impunity.
+This crate provides [`ZeroFrom`], a trait for converting types in a zero-copy way.
 
-Succinctly, this allows one to "erase" static lifetimes and turn them into dynamic ones, similarly
-to how `dyn` allows one to "erase" static types and turn them into dynamic ones.
-
-Most of the time the yokeable `Y` type will be some kind of zero-copy deserializable
-abstraction, potentially with an owned variant (like [`Cow`](alloc::borrow::Cow),
-[`ZeroVec`](https://docs.rs/zerovec), or an aggregate containing such types), and the cart `C` will be some smart pointer like
-  [`Box<T>`](alloc::boxed::Box), [`Rc<T>`](alloc::rc::Rc), or [`Arc<T>`](std::sync::Arc), potentially wrapped in an [`Option<T>`](Option).
-
-The key behind this crate is [`Yoke::get()`], where calling [`.get()`][Yoke::get] on a type like
-`Yoke<Cow<'static, str>, _>` will get you a short-lived `&'a Cow<'a, str>`, restricted to the
-lifetime of the borrow used during [`.get()`](Yoke::get). This is entirely safe since the `Cow` borrows from
-the cart type, which cannot be interfered with as long as the `Yoke` is borrowed by [`.get()`](Yoke::get).
-[`.get()`](Yoke::get) protects access by essentially reifying the erased lifetime to a safe local one
-when necessary.
-
-See the documentation of [`Yoke`] for more details.
+See the documentation of [`ZeroFrom`] for more details.
 
 ## More Information
 

--- a/utils/zerofrom/README.md
+++ b/utils/zerofrom/README.md
@@ -1,4 +1,4 @@
-# yoke [![crates.io](https://img.shields.io/crates/v/yoke)](https://crates.io/crates/yoke)
+# zerofrom [![crates.io](https://img.shields.io/crates/v/zerofrom)](https://crates.io/crates/zerofrom)
 
 This crate provides [`Yoke<Y, C>`][Yoke], which allows one to "yoke" a zero-copy deserialized
 object(say, a [`Cow<'a, str>`](alloc::borrow::Cow)) to the source it was deserialized from, (say, an [`Rc<[u8]>`](alloc::rc::Rc)),

--- a/utils/zerofrom/README.md
+++ b/utils/zerofrom/README.md
@@ -1,0 +1,27 @@
+# yoke [![crates.io](https://img.shields.io/crates/v/yoke)](https://crates.io/crates/yoke)
+
+This crate provides [`Yoke<Y, C>`][Yoke], which allows one to "yoke" a zero-copy deserialized
+object(say, a [`Cow<'a, str>`](alloc::borrow::Cow)) to the source it was deserialized from, (say, an [`Rc<[u8]>`](alloc::rc::Rc)),
+known as a "cart", producing a type that looks like `Yoke<Cow<'static, str>, Rc<[u8]>>`
+and can be moved around with impunity.
+
+Succinctly, this allows one to "erase" static lifetimes and turn them into dynamic ones, similarly
+to how `dyn` allows one to "erase" static types and turn them into dynamic ones.
+
+Most of the time the yokeable `Y` type will be some kind of zero-copy deserializable
+abstraction, potentially with an owned variant (like [`Cow`](alloc::borrow::Cow),
+[`ZeroVec`](https://docs.rs/zerovec), or an aggregate containing such types), and the cart `C` will be some smart pointer like
+  [`Box<T>`](alloc::boxed::Box), [`Rc<T>`](alloc::rc::Rc), or [`Arc<T>`](std::sync::Arc), potentially wrapped in an [`Option<T>`](Option).
+
+The key behind this crate is [`Yoke::get()`], where calling [`.get()`][Yoke::get] on a type like
+`Yoke<Cow<'static, str>, _>` will get you a short-lived `&'a Cow<'a, str>`, restricted to the
+lifetime of the borrow used during [`.get()`](Yoke::get). This is entirely safe since the `Cow` borrows from
+the cart type, which cannot be interfered with as long as the `Yoke` is borrowed by [`.get()`](Yoke::get).
+[`.get()`](Yoke::get) protects access by essentially reifying the erased lifetime to a safe local one
+when necessary.
+
+See the documentation of [`Yoke`] for more details.
+
+## More Information
+
+For more information on development, authorship, contributing etc. please visit [`ICU4X home page`](https://github.com/unicode-org/icu4x).

--- a/utils/zerofrom/derive/Cargo.toml
+++ b/utils/zerofrom/derive/Cargo.toml
@@ -27,3 +27,5 @@ synstructure = "0.12.4"
 
 [dev-dependencies]
 zerofrom = { version = "0.1.0", path = "..", features = ["derive"]}
+zerovec = { version = "0.6", path = "../../zerovec", features = ["yoke"] }
+

--- a/utils/zerofrom/derive/Cargo.toml
+++ b/utils/zerofrom/derive/Cargo.toml
@@ -1,0 +1,29 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+[package]
+name = "zerofrom-derive"
+version = "0.1.0"
+description = "Custom derive for the zerofrom crate"
+repository = "https://github.com/unicode-org/icu4x"
+license-file = "LICENSE"
+categories = ["data-structures", "memory-management", "caching", "no-std"]
+keywords = ["zerocopy", "serialization", "lifetime", "borrow"]
+authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc_macro = true
+path = "src/lib.rs"
+
+[dependencies]
+proc-macro2 = "1.0.27"
+quote = "1.0.9"
+syn = { version = "1.0.73", features = ["derive", "fold"] }
+synstructure = "0.12.4"
+
+[dev-dependencies]
+zerofrom = { version = "0.1.0", path = "..", features = ["derive"]}

--- a/utils/zerofrom/derive/LICENSE
+++ b/utils/zerofrom/derive/LICENSE
@@ -1,0 +1,331 @@
+Except as otherwise noted below, ICU4X is licensed under the Apache
+License, Version 2.0 (included below) or the MIT license (included
+below), at your option. Unless importing data or code in the manner
+stated below, any contribution intentionally submitted for inclusion
+in ICU4X by you, as defined in the Apache-2.0 license, shall be dual
+licensed in the foregoing manner, without any additional terms or
+conditions.
+
+As exceptions to the above:
+* Portions of ICU4X that have been adapted from ICU4C and/or ICU4J are
+under the Unicode license (included below) and/or the ICU license
+(included below) as indicated by source code comments.
+* Unicode data incorporated in ICU4X is under the Unicode license
+(included below).
+* Your contributions may import code from ICU4C and/or ICU4J and
+Unicode data under these licenses. Indicate the license and the ICU4C
+or ICU4J origin in source code comments.
+
+- - - -
+
+Apache License, version 2.0
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+- - - -
+
+MIT License
+
+Copyright The ICU4X Authors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+- - - -
+
+Unicode License
+
+COPYRIGHT AND PERMISSION NOTICE (ICU 58 and later)
+
+Copyright © 1991-2020 Unicode, Inc. All rights reserved.
+Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Unicode data files and any associated documentation
+(the "Data Files") or Unicode software and any associated documentation
+(the "Software") to deal in the Data Files or Software
+without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, and/or sell copies of
+the Data Files or Software, and to permit persons to whom the Data Files
+or Software are furnished to do so, provided that either
+(a) this copyright and permission notice appear with all copies
+of the Data Files or Software, or
+(b) this copyright and permission notice appear in associated
+Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in these Data Files or Software without prior
+written authorization of the copyright holder.
+
+- - - -
+
+ICU License - ICU 1.8.1 to ICU 57.1
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright (c) 1995-2016 International Business Machines Corporation and others
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, and/or sell copies of the Software, and to permit persons
+to whom the Software is furnished to do so, provided that the above
+copyright notice(s) and this permission notice appear in all copies of
+the Software and that both the above copyright notice(s) and this
+permission notice appear in supporting documentation.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
+SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
+RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale, use
+or other dealings in this Software without prior written authorization
+of the copyright holder.
+
+All trademarks and registered trademarks mentioned herein are the
+property of their respective owners.
+
+- - - -

--- a/utils/zerofrom/derive/README.md
+++ b/utils/zerofrom/derive/README.md
@@ -1,6 +1,6 @@
 # yoke-derive [![crates.io](https://img.shields.io/crates/v/yoke-derive)](https://crates.io/crates/yoke-derive)
 
-Custom derives for `Yokeable` and `ZeroCopyFrom` from the `yoke` crate.
+Custom derives for `Yokeable` and `ZeroFrom` from the `yoke` crate.
 
 ## More Information
 

--- a/utils/zerofrom/derive/README.md
+++ b/utils/zerofrom/derive/README.md
@@ -1,0 +1,7 @@
+# yoke-derive [![crates.io](https://img.shields.io/crates/v/yoke-derive)](https://crates.io/crates/yoke-derive)
+
+Custom derives for `Yokeable` and `ZeroCopyFrom` from the `yoke` crate.
+
+## More Information
+
+For more information on development, authorship, contributing etc. please visit [`ICU4X home page`](https://github.com/unicode-org/icu4x).

--- a/utils/zerofrom/derive/README.md
+++ b/utils/zerofrom/derive/README.md
@@ -1,6 +1,6 @@
-# yoke-derive [![crates.io](https://img.shields.io/crates/v/yoke-derive)](https://crates.io/crates/yoke-derive)
+# zerofrom-derive [![crates.io](https://img.shields.io/crates/v/zerofrom-derive)](https://crates.io/crates/zerofrom-derive)
 
-Custom derives for `Yokeable` and `ZeroFrom` from the `yoke` crate.
+Custom derives for `ZeroFrom` from the `zerofrom` crate.
 
 ## More Information
 

--- a/utils/zerofrom/derive/examples/derive.rs
+++ b/utils/zerofrom/derive/examples/derive.rs
@@ -67,33 +67,33 @@ pub fn assert_zf_map<'a, 'b>(
 
 #[derive(Clone, ZeroFrom)]
 #[zerofrom(cloning_zf)]
-pub struct CloningZCF1 {
+pub struct CloningZF1 {
     vec: Vec<u8>,
 }
 
 #[derive(Clone, ZeroFrom)]
 #[zerofrom(cloning_zf)] // this will clone `cow` instead of borrowing from it
-pub struct CloningZCF2<'data> {
+pub struct CloningZF2<'data> {
     cow: Cow<'data, str>,
     vec: Vec<u8>,
 }
 
 #[derive(ZeroFrom)]
-pub struct CloningZCF3<'data> {
+pub struct CloningZF3<'data> {
     cow: Cow<'data, str>,
     #[zerofrom(cloning_zf)]
     vec: Vec<u8>,
 }
 
 #[derive(ZeroFrom)]
-pub enum CloningZCF4<'data> {
+pub enum CloningZF4<'data> {
     Cow(Cow<'data, str>),
     #[zerofrom(cloning_zf)] // this will clone the first field instead of borrowing
     CowVec(Cow<'data, str>, Vec<u8>),
 }
 
 #[derive(ZeroFrom)]
-pub enum CloningZCF5<'data> {
+pub enum CloningZF5<'data> {
     Cow(Cow<'data, str>),
     CowVec(Cow<'data, str>, #[zerofrom(cloning_zf)] Vec<u8>),
 }

--- a/utils/zerofrom/derive/examples/derive.rs
+++ b/utils/zerofrom/derive/examples/derive.rs
@@ -66,13 +66,13 @@ pub fn assert_zf_map<'a, 'b>(
 }
 
 #[derive(Clone, ZeroFrom)]
-#[yoke(cloning_zf)]
+#[zerofrom(cloning_zf)]
 pub struct CloningZCF1 {
     vec: Vec<u8>,
 }
 
 #[derive(Clone, ZeroFrom)]
-#[yoke(cloning_zf)] // this will clone `cow` instead of borrowing from it
+#[zerofrom(cloning_zf)] // this will clone `cow` instead of borrowing from it
 pub struct CloningZCF2<'data> {
     cow: Cow<'data, str>,
     vec: Vec<u8>,
@@ -81,21 +81,21 @@ pub struct CloningZCF2<'data> {
 #[derive(ZeroFrom)]
 pub struct CloningZCF3<'data> {
     cow: Cow<'data, str>,
-    #[yoke(cloning_zf)]
+    #[zerofrom(cloning_zf)]
     vec: Vec<u8>,
 }
 
 #[derive(ZeroFrom)]
 pub enum CloningZCF4<'data> {
     Cow(Cow<'data, str>),
-    #[yoke(cloning_zf)] // this will clone the first field instead of borrowing
+    #[zerofrom(cloning_zf)] // this will clone the first field instead of borrowing
     CowVec(Cow<'data, str>, Vec<u8>),
 }
 
 #[derive(ZeroFrom)]
 pub enum CloningZCF5<'data> {
     Cow(Cow<'data, str>),
-    CowVec(Cow<'data, str>, #[yoke(cloning_zf)] Vec<u8>),
+    CowVec(Cow<'data, str>, #[zerofrom(cloning_zf)] Vec<u8>),
 }
 
 fn main() {}

--- a/utils/zerofrom/derive/examples/derive.rs
+++ b/utils/zerofrom/derive/examples/derive.rs
@@ -45,10 +45,10 @@ pub struct HasTuples<'data> {
     pub bar: (&'data str, &'data str),
 }
 
-pub fn assert_zcf_tuples<'b, 'data>(x: &'b HasTuples<'data>) -> HasTuples<'b> {
+pub fn assert_zf_tuples<'b, 'data>(x: &'b HasTuples<'data>) -> HasTuples<'b> {
     HasTuples::zero_from(x)
 }
-pub fn assert_zcf_generics<'a, 'b>(
+pub fn assert_zf_generics<'a, 'b>(
     x: &'b ZeroVecExampleWithGenerics<'a, u8>,
 ) -> ZeroVecExampleWithGenerics<'b, u8> {
     ZeroVecExampleWithGenerics::<'b, u8>::zero_from(x)
@@ -59,20 +59,20 @@ pub struct ZeroMapGenericExample<'a, T: for<'b> ZeroMapKV<'b> + ?Sized> {
     map: ZeroMap<'a, str, T>,
 }
 
-pub fn assert_zcf_map<'a, 'b>(
+pub fn assert_zf_map<'a, 'b>(
     x: &'b ZeroMapGenericExample<'a, str>,
 ) -> ZeroMapGenericExample<'b, str> {
     ZeroMapGenericExample::zero_from(x)
 }
 
 #[derive(Clone, ZeroFrom)]
-#[yoke(cloning_zcf)]
+#[yoke(cloning_zf)]
 pub struct CloningZCF1 {
     vec: Vec<u8>,
 }
 
 #[derive(Clone, ZeroFrom)]
-#[yoke(cloning_zcf)] // this will clone `cow` instead of borrowing from it
+#[yoke(cloning_zf)] // this will clone `cow` instead of borrowing from it
 pub struct CloningZCF2<'data> {
     cow: Cow<'data, str>,
     vec: Vec<u8>,
@@ -81,21 +81,21 @@ pub struct CloningZCF2<'data> {
 #[derive(ZeroFrom)]
 pub struct CloningZCF3<'data> {
     cow: Cow<'data, str>,
-    #[yoke(cloning_zcf)]
+    #[yoke(cloning_zf)]
     vec: Vec<u8>,
 }
 
 #[derive(ZeroFrom)]
 pub enum CloningZCF4<'data> {
     Cow(Cow<'data, str>),
-    #[yoke(cloning_zcf)] // this will clone the first field instead of borrowing
+    #[yoke(cloning_zf)] // this will clone the first field instead of borrowing
     CowVec(Cow<'data, str>, Vec<u8>),
 }
 
 #[derive(ZeroFrom)]
 pub enum CloningZCF5<'data> {
     Cow(Cow<'data, str>),
-    CowVec(Cow<'data, str>, #[yoke(cloning_zcf)] Vec<u8>),
+    CowVec(Cow<'data, str>, #[yoke(cloning_zf)] Vec<u8>),
 }
 
 fn main() {}

--- a/utils/zerofrom/derive/examples/derive.rs
+++ b/utils/zerofrom/derive/examples/derive.rs
@@ -1,0 +1,103 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+#![allow(unused)]
+
+use std::borrow::Cow;
+use zerofrom::ZeroCopyFrom;
+use zerovec::{map::ZeroMapKV, ule::AsULE, VarZeroVec, ZeroMap, ZeroVec};
+
+#[derive(ZeroCopyFrom, Copy, Clone)]
+pub struct IntExample {
+    x: u32,
+}
+
+#[derive(ZeroCopyFrom, Copy, Clone)]
+pub struct GenericsExample<T> {
+    x: u32,
+    y: T,
+}
+
+#[derive(ZeroCopyFrom)]
+pub struct CowExample<'a> {
+    x: u8,
+    y: &'a str,
+    z: Cow<'a, str>,
+    w: Cow<'a, [u8]>,
+}
+
+#[derive(ZeroCopyFrom)]
+pub struct ZeroVecExample<'a> {
+    var: VarZeroVec<'a, str>,
+    vec: ZeroVec<'a, u16>,
+}
+
+#[derive(ZeroCopyFrom)]
+pub struct ZeroVecExampleWithGenerics<'a, T: AsULE> {
+    gen: ZeroVec<'a, T>,
+    vec: ZeroVec<'a, u16>,
+    bare: T,
+}
+
+#[derive(ZeroCopyFrom)]
+pub struct HasTuples<'data> {
+    pub bar: (&'data str, &'data str),
+}
+
+pub fn assert_zcf_tuples<'b, 'data>(x: &'b HasTuples<'data>) -> HasTuples<'b> {
+    HasTuples::zero_copy_from(x)
+}
+pub fn assert_zcf_generics<'a, 'b>(
+    x: &'b ZeroVecExampleWithGenerics<'a, u8>,
+) -> ZeroVecExampleWithGenerics<'b, u8> {
+    ZeroVecExampleWithGenerics::<'b, u8>::zero_copy_from(x)
+}
+
+
+#[derive(ZeroCopyFrom)]
+pub struct ZeroMapGenericExample<'a, T: for<'b> ZeroMapKV<'b> + ?Sized> {
+    map: ZeroMap<'a, str, T>,
+}
+
+pub fn assert_zcf_map<'a, 'b>(
+    x: &'b ZeroMapGenericExample<'a, str>,
+) -> ZeroMapGenericExample<'b, str> {
+    ZeroMapGenericExample::zero_copy_from(x)
+}
+
+#[derive(Clone, ZeroCopyFrom)]
+#[yoke(cloning_zcf)]
+pub struct CloningZCF1 {
+    vec: Vec<u8>,
+}
+
+#[derive(Clone, ZeroCopyFrom)]
+#[yoke(cloning_zcf)] // this will clone `cow` instead of borrowing from it
+pub struct CloningZCF2<'data> {
+    cow: Cow<'data, str>,
+    vec: Vec<u8>,
+}
+
+#[derive(ZeroCopyFrom)]
+pub struct CloningZCF3<'data> {
+    cow: Cow<'data, str>,
+    #[yoke(cloning_zcf)]
+    vec: Vec<u8>,
+}
+
+#[derive(ZeroCopyFrom)]
+pub enum CloningZCF4<'data> {
+    Cow(Cow<'data, str>),
+    #[yoke(cloning_zcf)] // this will clone the first field instead of borrowing
+    CowVec(Cow<'data, str>, Vec<u8>),
+}
+
+#[derive(ZeroCopyFrom)]
+pub enum CloningZCF5<'data> {
+    Cow(Cow<'data, str>),
+    CowVec(Cow<'data, str>, #[yoke(cloning_zcf)] Vec<u8>),
+}
+
+
+fn main() {}

--- a/utils/zerofrom/derive/examples/derive.rs
+++ b/utils/zerofrom/derive/examples/derive.rs
@@ -5,21 +5,21 @@
 #![allow(unused)]
 
 use std::borrow::Cow;
-use zerofrom::ZeroCopyFrom;
+use zerofrom::ZeroFrom;
 use zerovec::{map::ZeroMapKV, ule::AsULE, VarZeroVec, ZeroMap, ZeroVec};
 
-#[derive(ZeroCopyFrom, Copy, Clone)]
+#[derive(ZeroFrom, Copy, Clone)]
 pub struct IntExample {
     x: u32,
 }
 
-#[derive(ZeroCopyFrom, Copy, Clone)]
+#[derive(ZeroFrom, Copy, Clone)]
 pub struct GenericsExample<T> {
     x: u32,
     y: T,
 }
 
-#[derive(ZeroCopyFrom)]
+#[derive(ZeroFrom)]
 pub struct CowExample<'a> {
     x: u8,
     y: &'a str,
@@ -27,20 +27,20 @@ pub struct CowExample<'a> {
     w: Cow<'a, [u8]>,
 }
 
-#[derive(ZeroCopyFrom)]
+#[derive(ZeroFrom)]
 pub struct ZeroVecExample<'a> {
     var: VarZeroVec<'a, str>,
     vec: ZeroVec<'a, u16>,
 }
 
-#[derive(ZeroCopyFrom)]
+#[derive(ZeroFrom)]
 pub struct ZeroVecExampleWithGenerics<'a, T: AsULE> {
     gen: ZeroVec<'a, T>,
     vec: ZeroVec<'a, u16>,
     bare: T,
 }
 
-#[derive(ZeroCopyFrom)]
+#[derive(ZeroFrom)]
 pub struct HasTuples<'data> {
     pub bar: (&'data str, &'data str),
 }
@@ -54,8 +54,7 @@ pub fn assert_zcf_generics<'a, 'b>(
     ZeroVecExampleWithGenerics::<'b, u8>::zero_copy_from(x)
 }
 
-
-#[derive(ZeroCopyFrom)]
+#[derive(ZeroFrom)]
 pub struct ZeroMapGenericExample<'a, T: for<'b> ZeroMapKV<'b> + ?Sized> {
     map: ZeroMap<'a, str, T>,
 }
@@ -66,38 +65,37 @@ pub fn assert_zcf_map<'a, 'b>(
     ZeroMapGenericExample::zero_copy_from(x)
 }
 
-#[derive(Clone, ZeroCopyFrom)]
+#[derive(Clone, ZeroFrom)]
 #[yoke(cloning_zcf)]
 pub struct CloningZCF1 {
     vec: Vec<u8>,
 }
 
-#[derive(Clone, ZeroCopyFrom)]
+#[derive(Clone, ZeroFrom)]
 #[yoke(cloning_zcf)] // this will clone `cow` instead of borrowing from it
 pub struct CloningZCF2<'data> {
     cow: Cow<'data, str>,
     vec: Vec<u8>,
 }
 
-#[derive(ZeroCopyFrom)]
+#[derive(ZeroFrom)]
 pub struct CloningZCF3<'data> {
     cow: Cow<'data, str>,
     #[yoke(cloning_zcf)]
     vec: Vec<u8>,
 }
 
-#[derive(ZeroCopyFrom)]
+#[derive(ZeroFrom)]
 pub enum CloningZCF4<'data> {
     Cow(Cow<'data, str>),
     #[yoke(cloning_zcf)] // this will clone the first field instead of borrowing
     CowVec(Cow<'data, str>, Vec<u8>),
 }
 
-#[derive(ZeroCopyFrom)]
+#[derive(ZeroFrom)]
 pub enum CloningZCF5<'data> {
     Cow(Cow<'data, str>),
     CowVec(Cow<'data, str>, #[yoke(cloning_zcf)] Vec<u8>),
 }
-
 
 fn main() {}

--- a/utils/zerofrom/derive/examples/derive.rs
+++ b/utils/zerofrom/derive/examples/derive.rs
@@ -46,12 +46,12 @@ pub struct HasTuples<'data> {
 }
 
 pub fn assert_zcf_tuples<'b, 'data>(x: &'b HasTuples<'data>) -> HasTuples<'b> {
-    HasTuples::zero_copy_from(x)
+    HasTuples::zero_from(x)
 }
 pub fn assert_zcf_generics<'a, 'b>(
     x: &'b ZeroVecExampleWithGenerics<'a, u8>,
 ) -> ZeroVecExampleWithGenerics<'b, u8> {
-    ZeroVecExampleWithGenerics::<'b, u8>::zero_copy_from(x)
+    ZeroVecExampleWithGenerics::<'b, u8>::zero_from(x)
 }
 
 #[derive(ZeroFrom)]
@@ -62,7 +62,7 @@ pub struct ZeroMapGenericExample<'a, T: for<'b> ZeroMapKV<'b> + ?Sized> {
 pub fn assert_zcf_map<'a, 'b>(
     x: &'b ZeroMapGenericExample<'a, str>,
 ) -> ZeroMapGenericExample<'b, str> {
-    ZeroMapGenericExample::zero_copy_from(x)
+    ZeroMapGenericExample::zero_from(x)
 }
 
 #[derive(Clone, ZeroFrom)]

--- a/utils/zerofrom/derive/src/lib.rs
+++ b/utils/zerofrom/derive/src/lib.rs
@@ -19,10 +19,10 @@ mod visitor;
 /// without a lifetime parameter, and `ZeroFrom<Ty<'data>> for Ty<'static>`
 /// for types with a lifetime parameter.
 ///
-/// Apply the `#[yoke(cloning_zf)]` attribute if you wish for this custom derive
+/// Apply the `#[zerofrom(cloning_zf)]` attribute if you wish for this custom derive
 /// to use `.clone()` for its implementation. The attribute can be applied to
 /// fields as well.
-#[proc_macro_derive(ZeroFrom, attributes(yoke))]
+#[proc_macro_derive(ZeroFrom, attributes(zerofrom))]
 pub fn zf_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     TokenStream::from(zf_derive_impl(&input))

--- a/utils/zerofrom/derive/src/lib.rs
+++ b/utils/zerofrom/derive/src/lib.rs
@@ -1,0 +1,154 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+//! Custom derives for `ZeroCopyFrom` from the `zerofrom` crate.
+
+use proc_macro::TokenStream;
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::quote;
+use syn::spanned::Spanned;
+use syn::{parse_macro_input, parse_quote, DeriveInput, Ident, Lifetime, Type, WherePredicate};
+use synstructure::Structure;
+
+mod visitor;
+
+/// Custom derive for `zerofrom::ZeroCopyFrom`,
+///
+/// This implements `ZeroCopyFrom<Ty> for Ty` for types
+/// without a lifetime parameter, and `ZeroCopyFrom<Ty<'data>> for Ty<'static>`
+/// for types with a lifetime parameter.
+///
+/// Apply the `#[yoke(cloning_zcf)]` attribute if you wish for this custom derive
+/// to use `.clone()` for its implementation. The attribute can be applied to
+/// fields as well.
+#[proc_macro_derive(ZeroCopyFrom, attributes(yoke))]
+pub fn zcf_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    TokenStream::from(zcf_derive_impl(&input))
+}
+
+fn has_cloning_zcf_attr(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|a| {
+        if let Ok(i) = a.parse_args::<Ident>() {
+            if i == "cloning_zcf" {
+                return true;
+            }
+        }
+        false
+    })
+}
+
+fn zcf_derive_impl(input: &DeriveInput) -> TokenStream2 {
+    let tybounds = input.generics.type_params().collect::<Vec<_>>();
+    let typarams = tybounds
+        .iter()
+        .map(|ty| ty.ident.clone())
+        .collect::<Vec<_>>();
+    let has_clone = has_cloning_zcf_attr(&input.attrs);
+    let lts = input.generics.lifetimes().count();
+    let name = &input.ident;
+    if lts == 0 {
+        let (clone, clone_trait) = if has_clone {
+            (quote!(this.clone()), quote!(Clone))
+        } else {
+            (quote!(*this), quote!(Copy))
+        };
+        let bounds: Vec<WherePredicate> = typarams
+            .iter()
+            .map(|ty| parse_quote!(#ty: #clone_trait + 'static))
+            .collect();
+        quote! {
+            impl<'zcf, #(#tybounds),*> zerofrom::ZeroCopyFrom<'zcf, #name<#(#typarams),*>> for #name<#(#typarams),*> where #(#bounds),* {
+                fn zero_copy_from(this: &'zcf Self) -> Self {
+                    #clone
+                }
+            }
+        }
+    } else {
+        if lts != 1 {
+            return syn::Error::new(
+                input.generics.span(),
+                "derive(ZeroCopyFrom) cannot have multiple lifetime parameters",
+            )
+            .to_compile_error();
+        }
+        if has_clone {
+            return quote! {
+                impl<'zcf> zerofrom::ZeroCopyFrom<'zcf, #name<'_>> for #name<'zcf> {
+                    fn zero_copy_from(this: &'zcf #name<'_>) -> Self {
+                        this.clone()
+                    }
+                }
+            };
+        }
+
+        let structure = Structure::new(input);
+        let generics_env = typarams.iter().cloned().collect();
+
+        let mut zcf_bounds: Vec<WherePredicate> = vec![];
+        let body = structure.each_variant(|vi| {
+            let variant_cloning = has_cloning_zcf_attr(vi.ast().attrs);
+            vi.construct(|f, i| {
+                let binding_cloning = variant_cloning || has_cloning_zcf_attr(&f.attrs);
+                let binding = format!("__binding_{}", i);
+                let field = Ident::new(&binding, Span::call_site());
+
+                if binding_cloning {
+                    quote! {
+                        #field.clone()
+                    }
+                } else {
+                    let fty = replace_lifetime(&f.ty, custom_lt("'zcf"));
+                    let lifetime_ty = replace_lifetime(&f.ty, custom_lt("'zcf_inner"));
+
+                    let (has_ty, has_lt) = visitor::check_type_for_parameters(&f.ty, &generics_env);
+                    if has_ty {
+                        // For types without type parameters, the compiler can figure out that the field implements
+                        // ZeroCopyFrom on its own. However, if there are type parameters, there may be complex preconditions
+                        // to `FieldTy: ZeroCopyFrom` that need to be satisfied. We get them to be satisfied by requiring
+                        // `FieldTy<'zcf>: ZeroCopyFrom<'zcf, FieldTy<'zcf_inner>>`
+                        if has_lt {
+                            zcf_bounds
+                                .push(parse_quote!(#fty: zerofrom::ZeroCopyFrom<'zcf, #lifetime_ty>));
+                        } else {
+                            zcf_bounds.push(parse_quote!(#fty: zerofrom::ZeroCopyFrom<'zcf, #fty>));
+                        }
+                    }
+
+                    // By doing this we essentially require ZCF to be implemented
+                    // on all fields
+                    quote! {
+                        <#fty as zerofrom::ZeroCopyFrom<'zcf, #lifetime_ty>>::zero_copy_from(#field)
+                    }
+                }
+            })
+        });
+
+        quote! {
+            impl<'zcf, 'zcf_inner, #(#tybounds),*> zerofrom::ZeroCopyFrom<'zcf, #name<'zcf_inner, #(#typarams),*>> for #name<'zcf, #(#typarams),*>
+                where
+                #(#zcf_bounds,)* {
+                fn zero_copy_from(this: &'zcf #name<'zcf_inner, #(#typarams),*>) -> Self {
+                    match *this { #body }
+                }
+            }
+        }
+    }
+}
+
+fn custom_lt(s: &str) -> Lifetime {
+    Lifetime::new(s, Span::call_site())
+}
+
+fn replace_lifetime(x: &Type, lt: Lifetime) -> Type {
+    use syn::fold::Fold;
+    struct ReplaceLifetime(Lifetime);
+
+    impl Fold for ReplaceLifetime {
+        fn fold_lifetime(&mut self, _: Lifetime) -> Lifetime {
+            self.0.clone()
+        }
+    }
+    ReplaceLifetime(lt).fold_type(x.clone())
+}

--- a/utils/zerofrom/derive/src/lib.rs
+++ b/utils/zerofrom/derive/src/lib.rs
@@ -116,7 +116,7 @@ fn zf_derive_impl(input: &DeriveInput) -> TokenStream2 {
                         }
                     }
 
-                    // By doing this we essentially require ZCF to be implemented
+                    // By doing this we essentially require ZF to be implemented
                     // on all fields
                     quote! {
                         <#fty as zerofrom::ZeroFrom<'zf, #lifetime_ty>>::zero_from(#field)

--- a/utils/zerofrom/derive/src/lib.rs
+++ b/utils/zerofrom/derive/src/lib.rs
@@ -60,7 +60,7 @@ fn zcf_derive_impl(input: &DeriveInput) -> TokenStream2 {
             .collect();
         quote! {
             impl<'zcf, #(#tybounds),*> zerofrom::ZeroFrom<'zcf, #name<#(#typarams),*>> for #name<#(#typarams),*> where #(#bounds),* {
-                fn zero_copy_from(this: &'zcf Self) -> Self {
+                fn zero_from(this: &'zcf Self) -> Self {
                     #clone
                 }
             }
@@ -76,7 +76,7 @@ fn zcf_derive_impl(input: &DeriveInput) -> TokenStream2 {
         if has_clone {
             return quote! {
                 impl<'zcf> zerofrom::ZeroFrom<'zcf, #name<'_>> for #name<'zcf> {
-                    fn zero_copy_from(this: &'zcf #name<'_>) -> Self {
+                    fn zero_from(this: &'zcf #name<'_>) -> Self {
                         this.clone()
                     }
                 }
@@ -119,7 +119,7 @@ fn zcf_derive_impl(input: &DeriveInput) -> TokenStream2 {
                     // By doing this we essentially require ZCF to be implemented
                     // on all fields
                     quote! {
-                        <#fty as zerofrom::ZeroFrom<'zcf, #lifetime_ty>>::zero_copy_from(#field)
+                        <#fty as zerofrom::ZeroFrom<'zcf, #lifetime_ty>>::zero_from(#field)
                     }
                 }
             })
@@ -129,7 +129,7 @@ fn zcf_derive_impl(input: &DeriveInput) -> TokenStream2 {
             impl<'zcf, 'zcf_inner, #(#tybounds),*> zerofrom::ZeroFrom<'zcf, #name<'zcf_inner, #(#typarams),*>> for #name<'zcf, #(#typarams),*>
                 where
                 #(#zcf_bounds,)* {
-                fn zero_copy_from(this: &'zcf #name<'zcf_inner, #(#typarams),*>) -> Self {
+                fn zero_from(this: &'zcf #name<'zcf_inner, #(#typarams),*>) -> Self {
                     match *this { #body }
                 }
             }

--- a/utils/zerofrom/derive/src/visitor.rs
+++ b/utils/zerofrom/derive/src/visitor.rs
@@ -1,0 +1,114 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+//! Visitor for determining whether a type has type and non-static lifetime parameters
+//! (duplicated in yoke/derive/src/visitor.rs)
+
+use std::collections::HashSet;
+use syn::visit::{visit_lifetime, visit_type, visit_type_path, Visit};
+use syn::{Ident, Lifetime, Type, TypePath};
+
+struct TypeVisitor<'a> {
+    /// The type parameters in scope
+    typarams: &'a HashSet<Ident>,
+    /// Whether we found a type parameter
+    found_typarams: bool,
+    /// Whether we found a non-'static lifetime parameter
+    found_lifetimes: bool,
+}
+
+impl<'a, 'ast> Visit<'ast> for TypeVisitor<'a> {
+    fn visit_lifetime(&mut self, lt: &'ast Lifetime) {
+        if lt.ident != "static" {
+            self.found_lifetimes = true;
+        }
+        visit_lifetime(self, lt)
+    }
+    fn visit_type_path(&mut self, ty: &'ast TypePath) {
+        // We only need to check ty.path.get_ident() and not ty.qself or any
+        // generics in ty.path because the visitor will eventually visit those
+        // types on its own
+        if let Some(ident) = ty.path.get_ident() {
+            if self.typarams.contains(ident) {
+                self.found_typarams = true;
+            }
+        }
+
+        visit_type_path(self, ty)
+    }
+}
+
+/// Checks if a type has type or lifetime parameters, given the local context of
+/// named type parameters. Returns (has_type_params, has_lifetime_params)
+pub fn check_type_for_parameters(ty: &Type, typarams: &HashSet<Ident>) -> (bool, bool) {
+    let mut visit = TypeVisitor {
+        typarams,
+        found_typarams: false,
+        found_lifetimes: false,
+    };
+    visit_type(&mut visit, ty);
+
+    (visit.found_typarams, visit.found_lifetimes)
+}
+
+#[cfg(test)]
+mod tests {
+    use proc_macro2::Span;
+    use std::collections::HashSet;
+    use syn::{parse_quote, Ident};
+
+    use super::check_type_for_parameters;
+    fn make_typarams(params: &[&str]) -> HashSet<Ident> {
+        params
+            .iter()
+            .map(|x| Ident::new(x, Span::call_site()))
+            .collect()
+    }
+
+    #[test]
+    fn test_simple_type() {
+        let environment = make_typarams(&["T", "U", "V"]);
+
+        let ty = parse_quote!(Foo<'a, T>);
+        let check = check_type_for_parameters(&ty, &environment);
+        assert_eq!(check, (true, true));
+
+        let ty = parse_quote!(Foo<T>);
+        let check = check_type_for_parameters(&ty, &environment);
+        assert_eq!(check, (true, false));
+
+        let ty = parse_quote!(Foo<'static, T>);
+        let check = check_type_for_parameters(&ty, &environment);
+        assert_eq!(check, (true, false));
+
+        let ty = parse_quote!(Foo<'a>);
+        let check = check_type_for_parameters(&ty, &environment);
+        assert_eq!(check, (false, true));
+
+        let ty = parse_quote!(Foo<'a, Bar<U>, Baz<(V, u8)>>);
+        let check = check_type_for_parameters(&ty, &environment);
+        assert_eq!(check, (true, true));
+
+        let ty = parse_quote!(Foo<'a, W>);
+        let check = check_type_for_parameters(&ty, &environment);
+        assert_eq!(check, (false, true));
+    }
+
+    #[test]
+    fn test_assoc_types() {
+        let environment = make_typarams(&["T"]);
+
+        let ty = parse_quote!(<Foo as SomeTrait<'a, T>>::Output);
+        let check = check_type_for_parameters(&ty, &environment);
+        assert_eq!(check, (true, true));
+
+        let ty = parse_quote!(<Foo as SomeTrait<'static, T>>::Output);
+        let check = check_type_for_parameters(&ty, &environment);
+        assert_eq!(check, (true, false));
+
+        let ty = parse_quote!(<T as SomeTrait<'static, Foo>>::Output);
+        let check = check_type_for_parameters(&ty, &environment);
+        assert_eq!(check, (true, false));
+    }
+}

--- a/utils/zerofrom/src/lib.rs
+++ b/utils/zerofrom/src/lib.rs
@@ -2,27 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-//! This crate provides [`Yoke<Y, C>`][Yoke], which allows one to "yoke" a zero-copy deserialized
-//! object(say, a [`Cow<'a, str>`](alloc::borrow::Cow)) to the source it was deserialized from, (say, an [`Rc<[u8]>`](alloc::rc::Rc)),
-//! known as a "cart", producing a type that looks like `Yoke<Cow<'static, str>, Rc<[u8]>>`
-//! and can be moved around with impunity.
+//! This crate provides [`ZeroFrom`], a trait for converting types in a zero-copy way.
 //!
-//! Succinctly, this allows one to "erase" static lifetimes and turn them into dynamic ones, similarly
-//! to how `dyn` allows one to "erase" static types and turn them into dynamic ones.
-//!
-//! Most of the time the yokeable `Y` type will be some kind of zero-copy deserializable
-//! abstraction, potentially with an owned variant (like [`Cow`](alloc::borrow::Cow),
-//! [`ZeroVec`](https://docs.rs/zerovec), or an aggregate containing such types), and the cart `C` will be some smart pointer like
-//!   [`Box<T>`](alloc::boxed::Box), [`Rc<T>`](alloc::rc::Rc), or [`Arc<T>`](std::sync::Arc), potentially wrapped in an [`Option<T>`](Option).
-//!
-//! The key behind this crate is [`Yoke::get()`], where calling [`.get()`][Yoke::get] on a type like
-//! `Yoke<Cow<'static, str>, _>` will get you a short-lived `&'a Cow<'a, str>`, restricted to the
-//! lifetime of the borrow used during [`.get()`](Yoke::get). This is entirely safe since the `Cow` borrows from
-//! the cart type, which cannot be interfered with as long as the `Yoke` is borrowed by [`.get()`](Yoke::get).
-//! [`.get()`](Yoke::get) protects access by essentially reifying the erased lifetime to a safe local one
-//! when necessary.
-//!
-//! See the documentation of [`Yoke`] for more details.
+//! See the documentation of [`ZeroFrom`] for more details.
 
 #![cfg_attr(all(not(test), not(doc)), no_std)]
 // The lifetimes here are important for safety and explicitly writing

--- a/utils/zerofrom/src/lib.rs
+++ b/utils/zerofrom/src/lib.rs
@@ -32,6 +32,7 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+mod macro_impls;
 mod zero_copy_from;
 
 #[cfg(feature = "derive")]

--- a/utils/zerofrom/src/lib.rs
+++ b/utils/zerofrom/src/lib.rs
@@ -33,9 +33,9 @@
 extern crate alloc;
 
 mod macro_impls;
-mod zero_copy_from;
+mod zero_from;
 
 #[cfg(feature = "derive")]
 pub use zerofrom_derive::ZeroFrom;
 
-pub use crate::zero_copy_from::ZeroFrom;
+pub use crate::zero_from::ZeroFrom;

--- a/utils/zerofrom/src/lib.rs
+++ b/utils/zerofrom/src/lib.rs
@@ -35,6 +35,6 @@ extern crate alloc;
 mod zero_copy_from;
 
 #[cfg(feature = "derive")]
-pub use zerofrom_derive::ZeroCopyFrom;
+pub use zerofrom_derive::ZeroFrom;
 
-pub use crate::zero_copy_from::ZeroCopyFrom;
+pub use crate::zero_copy_from::ZeroFrom;

--- a/utils/zerofrom/src/macro_impls.rs
+++ b/utils/zerofrom/src/macro_impls.rs
@@ -1,0 +1,71 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+// In this case consistency between impls is more important
+// than using pointer casts
+#![allow(clippy::transmute_ptr_to_ptr)]
+
+use crate::ZeroCopyFrom;
+use core::{mem, ptr};
+
+macro_rules! impl_copy_type {
+    ($ty:ident) => {
+        impl<'a> ZeroCopyFrom<'a, $ty> for $ty {
+            #[inline]
+            fn zero_copy_from(this: &'a Self) -> Self {
+                // Essentially only works when the struct is fully Copy
+                *this
+            }
+        }
+    };
+}
+
+impl_copy_type!(u8);
+impl_copy_type!(u16);
+impl_copy_type!(u32);
+impl_copy_type!(u64);
+impl_copy_type!(u128);
+impl_copy_type!(usize);
+impl_copy_type!(i8);
+impl_copy_type!(i16);
+impl_copy_type!(i32);
+impl_copy_type!(i64);
+impl_copy_type!(i128);
+impl_copy_type!(isize);
+impl_copy_type!(char);
+impl_copy_type!(bool);
+
+// This can be cleaned up once `[T; N]`::each_ref() is stabilized
+// https://github.com/rust-lang/rust/issues/76118
+macro_rules! array_zcf_impl {
+    ($n:expr; $($i:expr),+) => {
+        impl<'a, C, T: ZeroCopyFrom<'a, C>> ZeroCopyFrom<'a, [C; $n]> for [T; $n] {
+            fn zero_copy_from(this: &'a [C; $n]) -> Self {
+                [
+                    $(
+                        <T as ZeroCopyFrom<C>>::zero_copy_from(&this[$i])
+                    ),+
+
+                ]
+            }
+        }
+    }
+}
+
+array_zcf_impl!(1; 0);
+array_zcf_impl!(2; 0, 1);
+array_zcf_impl!(3; 0, 1, 2);
+array_zcf_impl!(4; 0, 1, 2, 3);
+array_zcf_impl!(5; 0, 1, 2, 3, 4);
+array_zcf_impl!(6; 0, 1, 2, 3, 4, 5);
+array_zcf_impl!(7; 0, 1, 2, 3, 4, 5, 6);
+array_zcf_impl!(8; 0, 1, 2, 3, 4, 5, 6, 7);
+array_zcf_impl!(9; 0, 1, 2, 3, 4, 5, 6, 7, 8);
+array_zcf_impl!(10; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+array_zcf_impl!(11; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+array_zcf_impl!(12; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+array_zcf_impl!(13; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+array_zcf_impl!(14; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+array_zcf_impl!(15; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
+array_zcf_impl!(16; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);

--- a/utils/zerofrom/src/macro_impls.rs
+++ b/utils/zerofrom/src/macro_impls.rs
@@ -12,7 +12,7 @@ macro_rules! impl_copy_type {
     ($ty:ident) => {
         impl<'a> ZeroFrom<'a, $ty> for $ty {
             #[inline]
-            fn zero_copy_from(this: &'a Self) -> Self {
+            fn zero_from(this: &'a Self) -> Self {
                 // Essentially only works when the struct is fully Copy
                 *this
             }
@@ -40,10 +40,10 @@ impl_copy_type!(bool);
 macro_rules! array_zcf_impl {
     ($n:expr; $($i:expr),+) => {
         impl<'a, C, T: ZeroFrom<'a, C>> ZeroFrom<'a, [C; $n]> for [T; $n] {
-            fn zero_copy_from(this: &'a [C; $n]) -> Self {
+            fn zero_from(this: &'a [C; $n]) -> Self {
                 [
                     $(
-                        <T as ZeroFrom<C>>::zero_copy_from(&this[$i])
+                        <T as ZeroFrom<C>>::zero_from(&this[$i])
                     ),+
 
                 ]

--- a/utils/zerofrom/src/macro_impls.rs
+++ b/utils/zerofrom/src/macro_impls.rs
@@ -6,12 +6,12 @@
 // than using pointer casts
 #![allow(clippy::transmute_ptr_to_ptr)]
 
-use crate::ZeroCopyFrom;
+use crate::ZeroFrom;
 use core::{mem, ptr};
 
 macro_rules! impl_copy_type {
     ($ty:ident) => {
-        impl<'a> ZeroCopyFrom<'a, $ty> for $ty {
+        impl<'a> ZeroFrom<'a, $ty> for $ty {
             #[inline]
             fn zero_copy_from(this: &'a Self) -> Self {
                 // Essentially only works when the struct is fully Copy
@@ -40,11 +40,11 @@ impl_copy_type!(bool);
 // https://github.com/rust-lang/rust/issues/76118
 macro_rules! array_zcf_impl {
     ($n:expr; $($i:expr),+) => {
-        impl<'a, C, T: ZeroCopyFrom<'a, C>> ZeroCopyFrom<'a, [C; $n]> for [T; $n] {
+        impl<'a, C, T: ZeroFrom<'a, C>> ZeroFrom<'a, [C; $n]> for [T; $n] {
             fn zero_copy_from(this: &'a [C; $n]) -> Self {
                 [
                     $(
-                        <T as ZeroCopyFrom<C>>::zero_copy_from(&this[$i])
+                        <T as ZeroFrom<C>>::zero_copy_from(&this[$i])
                     ),+
 
                 ]

--- a/utils/zerofrom/src/macro_impls.rs
+++ b/utils/zerofrom/src/macro_impls.rs
@@ -7,7 +7,6 @@
 #![allow(clippy::transmute_ptr_to_ptr)]
 
 use crate::ZeroFrom;
-use core::{mem, ptr};
 
 macro_rules! impl_copy_type {
     ($ty:ident) => {

--- a/utils/zerofrom/src/macro_impls.rs
+++ b/utils/zerofrom/src/macro_impls.rs
@@ -37,7 +37,7 @@ impl_copy_type!(bool);
 
 // This can be cleaned up once `[T; N]`::each_ref() is stabilized
 // https://github.com/rust-lang/rust/issues/76118
-macro_rules! array_zcf_impl {
+macro_rules! array_zf_impl {
     ($n:expr; $($i:expr),+) => {
         impl<'a, C, T: ZeroFrom<'a, C>> ZeroFrom<'a, [C; $n]> for [T; $n] {
             fn zero_from(this: &'a [C; $n]) -> Self {
@@ -52,19 +52,19 @@ macro_rules! array_zcf_impl {
     }
 }
 
-array_zcf_impl!(1; 0);
-array_zcf_impl!(2; 0, 1);
-array_zcf_impl!(3; 0, 1, 2);
-array_zcf_impl!(4; 0, 1, 2, 3);
-array_zcf_impl!(5; 0, 1, 2, 3, 4);
-array_zcf_impl!(6; 0, 1, 2, 3, 4, 5);
-array_zcf_impl!(7; 0, 1, 2, 3, 4, 5, 6);
-array_zcf_impl!(8; 0, 1, 2, 3, 4, 5, 6, 7);
-array_zcf_impl!(9; 0, 1, 2, 3, 4, 5, 6, 7, 8);
-array_zcf_impl!(10; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
-array_zcf_impl!(11; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-array_zcf_impl!(12; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-array_zcf_impl!(13; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-array_zcf_impl!(14; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
-array_zcf_impl!(15; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
-array_zcf_impl!(16; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+array_zf_impl!(1; 0);
+array_zf_impl!(2; 0, 1);
+array_zf_impl!(3; 0, 1, 2);
+array_zf_impl!(4; 0, 1, 2, 3);
+array_zf_impl!(5; 0, 1, 2, 3, 4);
+array_zf_impl!(6; 0, 1, 2, 3, 4, 5);
+array_zf_impl!(7; 0, 1, 2, 3, 4, 5, 6);
+array_zf_impl!(8; 0, 1, 2, 3, 4, 5, 6, 7);
+array_zf_impl!(9; 0, 1, 2, 3, 4, 5, 6, 7, 8);
+array_zf_impl!(10; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+array_zf_impl!(11; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+array_zf_impl!(12; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+array_zf_impl!(13; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+array_zf_impl!(14; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+array_zf_impl!(15; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
+array_zf_impl!(16; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);

--- a/utils/zerofrom/src/zero_copy_from.rs
+++ b/utils/zerofrom/src/zero_copy_from.rs
@@ -26,8 +26,7 @@ use alloc::string::String;
 /// Implementing `ZeroFrom` on a custom data struct:
 ///
 /// ```
-/// use yoke::Yokeable;
-/// use yoke::ZeroFrom;
+/// use zerofrom::ZeroFrom;
 /// use std::borrow::Cow;
 ///
 /// struct MyStruct<'data> {

--- a/utils/zerofrom/src/zero_copy_from.rs
+++ b/utils/zerofrom/src/zero_copy_from.rs
@@ -1,0 +1,140 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+#[cfg(feature = "alloc")]
+use alloc::borrow::{Cow, ToOwned};
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+
+/// Trait for types that can be created from a reference to a cart type `C` with no allocations.
+///
+/// A type can be the `ZeroCopyFrom` target of multiple cart types.
+///
+/// The intention is for `ZeroCopyFrom` to produce a struct from a cart with as little work as
+/// possible. Although it is technically possible to implement `ZeroCopyFrom` without being
+/// zero-copy (using heap allocations), doing so defeats the purpose of `ZeroCopyFrom`.
+///
+/// For example, `impl ZeroCopyFrom<C> for Cow<str>` should return a `Cow::Borrowed` pointing at
+/// data in the cart `C`, even if the cart is itself fully owned.
+///
+/// One can use the [`#[derive(ZeroCopyFrom)]`](yoke_derive::ZeroCopyFrom) custom derive to automatically
+/// implement this trait.
+///
+/// # Examples
+///
+/// Implementing `ZeroCopyFrom` on a custom data struct:
+///
+/// ```
+/// use yoke::Yokeable;
+/// use yoke::ZeroCopyFrom;
+/// use std::borrow::Cow;
+///
+/// struct MyStruct<'data> {
+///     message: Cow<'data, str>,
+/// }
+///
+/// // Reference from a borrowed version of self
+/// impl<'zcf> ZeroCopyFrom<'zcf, MyStruct<'_>> for MyStruct<'zcf> {
+///     fn zero_copy_from(cart: &'zcf MyStruct<'_>) -> Self {
+///         MyStruct {
+///             message: Cow::Borrowed(&cart.message)
+///         }
+///     }
+/// }
+///
+/// // Reference from a string slice directly
+/// impl<'zcf> ZeroCopyFrom<'zcf, str> for MyStruct<'zcf> {
+///     fn zero_copy_from(cart: &'zcf str) -> Self {
+///         MyStruct {
+///             message: Cow::Borrowed(cart)
+///         }
+///     }
+/// }
+/// ```
+pub trait ZeroCopyFrom<'zcf, C: ?Sized>: 'zcf {
+    /// Clone the cart `C` into a struct that may retain references into `C`.
+    fn zero_copy_from(cart: &'zcf C) -> Self;
+}
+
+// Note: The following could be blanket implementations, but that would require constraining the
+// blanket `T` on `T: 'static`, which may not be desirable for all downstream users who may wish
+// to customize their `ZeroCopyFrom` impl. The blanket implementation may be safe once Rust has
+// specialization.
+
+#[cfg(feature = "alloc")]
+impl<'zcf> ZeroCopyFrom<'zcf, str> for Cow<'zcf, str> {
+    #[inline]
+    fn zero_copy_from(cart: &'zcf str) -> Self {
+        Cow::Borrowed(cart)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'zcf> ZeroCopyFrom<'zcf, String> for Cow<'zcf, str> {
+    #[inline]
+    fn zero_copy_from(cart: &'zcf String) -> Self {
+        Cow::Borrowed(cart)
+    }
+}
+
+impl<'zcf> ZeroCopyFrom<'zcf, str> for &'zcf str {
+    #[inline]
+    fn zero_copy_from(cart: &'zcf str) -> Self {
+        cart
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'zcf> ZeroCopyFrom<'zcf, String> for &'zcf str {
+    #[inline]
+    fn zero_copy_from(cart: &'zcf String) -> Self {
+        cart
+    }
+}
+
+impl<'zcf, C, T: ZeroCopyFrom<'zcf, C>> ZeroCopyFrom<'zcf, Option<C>> for Option<T> {
+    fn zero_copy_from(cart: &'zcf Option<C>) -> Self {
+        cart.as_ref()
+            .map(|c| <T as ZeroCopyFrom<C>>::zero_copy_from(c))
+    }
+}
+
+impl<'zcf, C1, T1: ZeroCopyFrom<'zcf, C1>, C2, T2: ZeroCopyFrom<'zcf, C2>>
+    ZeroCopyFrom<'zcf, (C1, C2)> for (T1, T2)
+{
+    fn zero_copy_from(cart: &'zcf (C1, C2)) -> Self {
+        (
+            <T1 as ZeroCopyFrom<C1>>::zero_copy_from(&cart.0),
+            <T2 as ZeroCopyFrom<C2>>::zero_copy_from(&cart.1),
+        )
+    }
+}
+
+// These duplicate the functionality from above and aren't quite necessary due
+// to deref coercions, however for the custom derive to work, there always needs
+// to be `impl ZCF<T> for T`, otherwise it may fail to perform the necessary
+// type inference. Deref coercions do not typically work when sufficient generics
+// or inference are involved, and the proc macro does not necessarily have
+// enough type information to figure this out on its own.
+#[cfg(feature = "alloc")]
+impl<'zcf, B: ToOwned + ?Sized> ZeroCopyFrom<'zcf, Cow<'_, B>> for Cow<'zcf, B> {
+    #[inline]
+    fn zero_copy_from(cart: &'zcf Cow<'_, B>) -> Self {
+        Cow::Borrowed(cart)
+    }
+}
+
+impl<'zcf> ZeroCopyFrom<'zcf, &'_ str> for &'zcf str {
+    #[inline]
+    fn zero_copy_from(cart: &'zcf &'_ str) -> &'zcf str {
+        cart
+    }
+}
+
+impl<'zcf, T> ZeroCopyFrom<'zcf, [T]> for &'zcf [T] {
+    #[inline]
+    fn zero_copy_from(cart: &'zcf [T]) -> &'zcf [T] {
+        cart
+    }
+}

--- a/utils/zerofrom/src/zero_from.rs
+++ b/utils/zerofrom/src/zero_from.rs
@@ -7,7 +7,8 @@ use alloc::borrow::{Cow, ToOwned};
 #[cfg(feature = "alloc")]
 use alloc::string::String;
 
-/// Trait for types that can be created from a reference to a cart type `C` with no allocations.
+/// Trait for types that can be created from a reference to a cart type `C` with no allocations,
+/// i.e. a zero-copy (zero-alloc) version of "From"
 ///
 /// A type can be the `ZeroFrom` target of multiple cart types.
 ///

--- a/utils/zerofrom/src/zero_from.rs
+++ b/utils/zerofrom/src/zero_from.rs
@@ -35,7 +35,7 @@ use alloc::string::String;
 ///
 /// // Reference from a borrowed version of self
 /// impl<'zcf> ZeroFrom<'zcf, MyStruct<'_>> for MyStruct<'zcf> {
-///     fn zero_copy_from(cart: &'zcf MyStruct<'_>) -> Self {
+///     fn zero_from(cart: &'zcf MyStruct<'_>) -> Self {
 ///         MyStruct {
 ///             message: Cow::Borrowed(&cart.message)
 ///         }
@@ -44,7 +44,7 @@ use alloc::string::String;
 ///
 /// // Reference from a string slice directly
 /// impl<'zcf> ZeroFrom<'zcf, str> for MyStruct<'zcf> {
-///     fn zero_copy_from(cart: &'zcf str) -> Self {
+///     fn zero_from(cart: &'zcf str) -> Self {
 ///         MyStruct {
 ///             message: Cow::Borrowed(cart)
 ///         }
@@ -53,7 +53,7 @@ use alloc::string::String;
 /// ```
 pub trait ZeroFrom<'zcf, C: ?Sized>: 'zcf {
     /// Clone the cart `C` into a struct that may retain references into `C`.
-    fn zero_copy_from(cart: &'zcf C) -> Self;
+    fn zero_from(cart: &'zcf C) -> Self;
 }
 
 // Note: The following could be blanket implementations, but that would require constraining the
@@ -64,7 +64,7 @@ pub trait ZeroFrom<'zcf, C: ?Sized>: 'zcf {
 #[cfg(feature = "alloc")]
 impl<'zcf> ZeroFrom<'zcf, str> for Cow<'zcf, str> {
     #[inline]
-    fn zero_copy_from(cart: &'zcf str) -> Self {
+    fn zero_from(cart: &'zcf str) -> Self {
         Cow::Borrowed(cart)
     }
 }
@@ -72,14 +72,14 @@ impl<'zcf> ZeroFrom<'zcf, str> for Cow<'zcf, str> {
 #[cfg(feature = "alloc")]
 impl<'zcf> ZeroFrom<'zcf, String> for Cow<'zcf, str> {
     #[inline]
-    fn zero_copy_from(cart: &'zcf String) -> Self {
+    fn zero_from(cart: &'zcf String) -> Self {
         Cow::Borrowed(cart)
     }
 }
 
 impl<'zcf> ZeroFrom<'zcf, str> for &'zcf str {
     #[inline]
-    fn zero_copy_from(cart: &'zcf str) -> Self {
+    fn zero_from(cart: &'zcf str) -> Self {
         cart
     }
 }
@@ -87,24 +87,24 @@ impl<'zcf> ZeroFrom<'zcf, str> for &'zcf str {
 #[cfg(feature = "alloc")]
 impl<'zcf> ZeroFrom<'zcf, String> for &'zcf str {
     #[inline]
-    fn zero_copy_from(cart: &'zcf String) -> Self {
+    fn zero_from(cart: &'zcf String) -> Self {
         cart
     }
 }
 
 impl<'zcf, C, T: ZeroFrom<'zcf, C>> ZeroFrom<'zcf, Option<C>> for Option<T> {
-    fn zero_copy_from(cart: &'zcf Option<C>) -> Self {
-        cart.as_ref().map(|c| <T as ZeroFrom<C>>::zero_copy_from(c))
+    fn zero_from(cart: &'zcf Option<C>) -> Self {
+        cart.as_ref().map(|c| <T as ZeroFrom<C>>::zero_from(c))
     }
 }
 
 impl<'zcf, C1, T1: ZeroFrom<'zcf, C1>, C2, T2: ZeroFrom<'zcf, C2>> ZeroFrom<'zcf, (C1, C2)>
     for (T1, T2)
 {
-    fn zero_copy_from(cart: &'zcf (C1, C2)) -> Self {
+    fn zero_from(cart: &'zcf (C1, C2)) -> Self {
         (
-            <T1 as ZeroFrom<C1>>::zero_copy_from(&cart.0),
-            <T2 as ZeroFrom<C2>>::zero_copy_from(&cart.1),
+            <T1 as ZeroFrom<C1>>::zero_from(&cart.0),
+            <T2 as ZeroFrom<C2>>::zero_from(&cart.1),
         )
     }
 }
@@ -118,21 +118,21 @@ impl<'zcf, C1, T1: ZeroFrom<'zcf, C1>, C2, T2: ZeroFrom<'zcf, C2>> ZeroFrom<'zcf
 #[cfg(feature = "alloc")]
 impl<'zcf, B: ToOwned + ?Sized> ZeroFrom<'zcf, Cow<'_, B>> for Cow<'zcf, B> {
     #[inline]
-    fn zero_copy_from(cart: &'zcf Cow<'_, B>) -> Self {
+    fn zero_from(cart: &'zcf Cow<'_, B>) -> Self {
         Cow::Borrowed(cart)
     }
 }
 
 impl<'zcf> ZeroFrom<'zcf, &'_ str> for &'zcf str {
     #[inline]
-    fn zero_copy_from(cart: &'zcf &'_ str) -> &'zcf str {
+    fn zero_from(cart: &'zcf &'_ str) -> &'zcf str {
         cart
     }
 }
 
 impl<'zcf, T> ZeroFrom<'zcf, [T]> for &'zcf [T] {
     #[inline]
-    fn zero_copy_from(cart: &'zcf [T]) -> &'zcf [T] {
+    fn zero_from(cart: &'zcf [T]) -> &'zcf [T] {
         cart
     }
 }

--- a/utils/zerofrom/src/zero_from.rs
+++ b/utils/zerofrom/src/zero_from.rs
@@ -112,7 +112,7 @@ impl<'zf, C1, T1: ZeroFrom<'zf, C1>, C2, T2: ZeroFrom<'zf, C2>> ZeroFrom<'zf, (C
 
 // These duplicate the functionality from above and aren't quite necessary due
 // to deref coercions, however for the custom derive to work, there always needs
-// to be `impl ZCF<T> for T`, otherwise it may fail to perform the necessary
+// to be `impl ZeroFrom<T> for T`, otherwise it may fail to perform the necessary
 // type inference. Deref coercions do not typically work when sufficient generics
 // or inference are involved, and the proc macro does not necessarily have
 // enough type information to figure this out on its own.

--- a/utils/zerofrom/src/zero_from.rs
+++ b/utils/zerofrom/src/zero_from.rs
@@ -19,7 +19,7 @@ use alloc::string::String;
 /// For example, `impl ZeroFrom<C> for Cow<str>` should return a `Cow::Borrowed` pointing at
 /// data in the cart `C`, even if the cart is itself fully owned.
 ///
-/// One can use the [`#[derive(ZeroFrom)]`](yoke_derive::ZeroFrom) custom derive to automatically
+/// One can use the [`#[derive(ZeroFrom)]`](zerofrom_derive::ZeroFrom) custom derive to automatically
 /// implement this trait.
 ///
 /// # Examples

--- a/utils/zerofrom/src/zero_from.rs
+++ b/utils/zerofrom/src/zero_from.rs
@@ -35,8 +35,8 @@ use alloc::string::String;
 /// }
 ///
 /// // Reference from a borrowed version of self
-/// impl<'zcf> ZeroFrom<'zcf, MyStruct<'_>> for MyStruct<'zcf> {
-///     fn zero_from(cart: &'zcf MyStruct<'_>) -> Self {
+/// impl<'zf> ZeroFrom<'zf, MyStruct<'_>> for MyStruct<'zf> {
+///     fn zero_from(cart: &'zf MyStruct<'_>) -> Self {
 ///         MyStruct {
 ///             message: Cow::Borrowed(&cart.message)
 ///         }
@@ -44,17 +44,17 @@ use alloc::string::String;
 /// }
 ///
 /// // Reference from a string slice directly
-/// impl<'zcf> ZeroFrom<'zcf, str> for MyStruct<'zcf> {
-///     fn zero_from(cart: &'zcf str) -> Self {
+/// impl<'zf> ZeroFrom<'zf, str> for MyStruct<'zf> {
+///     fn zero_from(cart: &'zf str) -> Self {
 ///         MyStruct {
 ///             message: Cow::Borrowed(cart)
 ///         }
 ///     }
 /// }
 /// ```
-pub trait ZeroFrom<'zcf, C: ?Sized>: 'zcf {
+pub trait ZeroFrom<'zf, C: ?Sized>: 'zf {
     /// Clone the cart `C` into a struct that may retain references into `C`.
-    fn zero_from(cart: &'zcf C) -> Self;
+    fn zero_from(cart: &'zf C) -> Self;
 }
 
 // Note: The following could be blanket implementations, but that would require constraining the
@@ -63,46 +63,46 @@ pub trait ZeroFrom<'zcf, C: ?Sized>: 'zcf {
 // specialization.
 
 #[cfg(feature = "alloc")]
-impl<'zcf> ZeroFrom<'zcf, str> for Cow<'zcf, str> {
+impl<'zf> ZeroFrom<'zf, str> for Cow<'zf, str> {
     #[inline]
-    fn zero_from(cart: &'zcf str) -> Self {
+    fn zero_from(cart: &'zf str) -> Self {
         Cow::Borrowed(cart)
     }
 }
 
 #[cfg(feature = "alloc")]
-impl<'zcf> ZeroFrom<'zcf, String> for Cow<'zcf, str> {
+impl<'zf> ZeroFrom<'zf, String> for Cow<'zf, str> {
     #[inline]
-    fn zero_from(cart: &'zcf String) -> Self {
+    fn zero_from(cart: &'zf String) -> Self {
         Cow::Borrowed(cart)
     }
 }
 
-impl<'zcf> ZeroFrom<'zcf, str> for &'zcf str {
+impl<'zf> ZeroFrom<'zf, str> for &'zf str {
     #[inline]
-    fn zero_from(cart: &'zcf str) -> Self {
+    fn zero_from(cart: &'zf str) -> Self {
         cart
     }
 }
 
 #[cfg(feature = "alloc")]
-impl<'zcf> ZeroFrom<'zcf, String> for &'zcf str {
+impl<'zf> ZeroFrom<'zf, String> for &'zf str {
     #[inline]
-    fn zero_from(cart: &'zcf String) -> Self {
+    fn zero_from(cart: &'zf String) -> Self {
         cart
     }
 }
 
-impl<'zcf, C, T: ZeroFrom<'zcf, C>> ZeroFrom<'zcf, Option<C>> for Option<T> {
-    fn zero_from(cart: &'zcf Option<C>) -> Self {
+impl<'zf, C, T: ZeroFrom<'zf, C>> ZeroFrom<'zf, Option<C>> for Option<T> {
+    fn zero_from(cart: &'zf Option<C>) -> Self {
         cart.as_ref().map(|c| <T as ZeroFrom<C>>::zero_from(c))
     }
 }
 
-impl<'zcf, C1, T1: ZeroFrom<'zcf, C1>, C2, T2: ZeroFrom<'zcf, C2>> ZeroFrom<'zcf, (C1, C2)>
+impl<'zf, C1, T1: ZeroFrom<'zf, C1>, C2, T2: ZeroFrom<'zf, C2>> ZeroFrom<'zf, (C1, C2)>
     for (T1, T2)
 {
-    fn zero_from(cart: &'zcf (C1, C2)) -> Self {
+    fn zero_from(cart: &'zf (C1, C2)) -> Self {
         (
             <T1 as ZeroFrom<C1>>::zero_from(&cart.0),
             <T2 as ZeroFrom<C2>>::zero_from(&cart.1),
@@ -117,23 +117,23 @@ impl<'zcf, C1, T1: ZeroFrom<'zcf, C1>, C2, T2: ZeroFrom<'zcf, C2>> ZeroFrom<'zcf
 // or inference are involved, and the proc macro does not necessarily have
 // enough type information to figure this out on its own.
 #[cfg(feature = "alloc")]
-impl<'zcf, B: ToOwned + ?Sized> ZeroFrom<'zcf, Cow<'_, B>> for Cow<'zcf, B> {
+impl<'zf, B: ToOwned + ?Sized> ZeroFrom<'zf, Cow<'_, B>> for Cow<'zf, B> {
     #[inline]
-    fn zero_from(cart: &'zcf Cow<'_, B>) -> Self {
+    fn zero_from(cart: &'zf Cow<'_, B>) -> Self {
         Cow::Borrowed(cart)
     }
 }
 
-impl<'zcf> ZeroFrom<'zcf, &'_ str> for &'zcf str {
+impl<'zf> ZeroFrom<'zf, &'_ str> for &'zf str {
     #[inline]
-    fn zero_from(cart: &'zcf &'_ str) -> &'zcf str {
+    fn zero_from(cart: &'zf &'_ str) -> &'zf str {
         cart
     }
 }
 
-impl<'zcf, T> ZeroFrom<'zcf, [T]> for &'zcf [T] {
+impl<'zf, T> ZeroFrom<'zf, [T]> for &'zf [T] {
     #[inline]
-    fn zero_from(cart: &'zcf [T]) -> &'zcf [T] {
+    fn zero_from(cart: &'zf [T]) -> &'zf [T] {
         cart
     }
 }

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -28,6 +28,7 @@ all-features = true
 [dependencies]
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
 yoke = { version = "0.4.0", path = "../yoke", optional = true }
+zerofrom = { version = "0.1.0", path = "../zerofrom" }
 
 [dev-dependencies]
 icu_benchmark_macros = { version = "0.5", path = "../../tools/benchmark/macros" }
@@ -42,6 +43,7 @@ rand_pcg = "0.3"
 rand_distr = "0.4"
 getrandom = { version = "0.2", features = ["js"] }
 yoke = { version = "0.4.0", path = "../yoke", features = ["derive"] }
+zerofrom = { version = "0.1.0", path = "../zerofrom", features = ["derive"] }
 
 [features]
 bench = []

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -111,6 +111,7 @@ mod zerovec;
 
 #[cfg(feature = "yoke")]
 mod yoke_impls;
+mod zerofrom_impls;
 
 pub use crate::error::ZeroVecError;
 pub use crate::map::ZeroMap;

--- a/utils/zerovec/src/yoke_impls.rs
+++ b/utils/zerovec/src/yoke_impls.rs
@@ -263,73 +263,18 @@ where
     }
 }
 
-impl<'zcf, T> ZeroCopyFrom<'zcf, ZeroVec<'_, T>> for ZeroVec<'zcf, T>
-where
-    T: 'static + AsULE + ?Sized,
-{
-    #[inline]
-    fn zero_copy_from(cart: &'zcf ZeroVec<'_, T>) -> Self {
-        ZeroVec::Borrowed(cart.as_ule_slice())
-    }
-}
-
-impl<'zcf, T> ZeroCopyFrom<'zcf, VarZeroVec<'_, T>> for VarZeroVec<'zcf, T>
-where
-    T: 'static + VarULE + ?Sized,
-{
-    #[inline]
-    fn zero_copy_from(cart: &'zcf VarZeroVec<'_, T>) -> Self {
-        cart.as_slice().into()
-    }
-}
-
-impl<'zcf, 's, K, V> ZeroCopyFrom<'zcf, ZeroMap<'s, K, V>> for ZeroMap<'zcf, K, V>
-where
-    K: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
-    V: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
-    <K as ZeroMapKV<'zcf>>::Container: ZeroCopyFrom<'zcf, <K as ZeroMapKV<'s>>::Container>,
-    <V as ZeroMapKV<'zcf>>::Container: ZeroCopyFrom<'zcf, <V as ZeroMapKV<'s>>::Container>,
-{
-    fn zero_copy_from(cart: &'zcf ZeroMap<'s, K, V>) -> Self {
-        ZeroMap {
-            keys: K::Container::zero_copy_from(&cart.keys),
-            values: V::Container::zero_copy_from(&cart.values),
-        }
-    }
-}
-
-impl<'zcf, 's, K0, K1, V> ZeroCopyFrom<'zcf, ZeroMap2d<'s, K0, K1, V>>
-    for ZeroMap2d<'zcf, K0, K1, V>
-where
-    K0: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
-    K1: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
-    V: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
-    <K0 as ZeroMapKV<'zcf>>::Container: ZeroCopyFrom<'zcf, <K0 as ZeroMapKV<'s>>::Container>,
-    <K1 as ZeroMapKV<'zcf>>::Container: ZeroCopyFrom<'zcf, <K1 as ZeroMapKV<'s>>::Container>,
-    <V as ZeroMapKV<'zcf>>::Container: ZeroCopyFrom<'zcf, <V as ZeroMapKV<'s>>::Container>,
-{
-    fn zero_copy_from(cart: &'zcf ZeroMap2d<'s, K0, K1, V>) -> Self {
-        ZeroMap2d {
-            keys0: K0::Container::zero_copy_from(&cart.keys0),
-            joiner: ZeroVec::zero_copy_from(&cart.joiner),
-            keys1: K1::Container::zero_copy_from(&cart.keys1),
-            values: V::Container::zero_copy_from(&cart.values),
-        }
-    }
-}
-
 #[cfg(test)]
 #[allow(non_camel_case_types)]
 mod test {
     use super::*;
     use crate::{VarZeroSlice, ZeroSlice};
 
-    #[derive(yoke::Yokeable, yoke::ZeroCopyFrom)]
+    #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
     struct DeriveTest_ZeroVec<'data> {
         _data: ZeroVec<'data, u16>,
     }
 
-    #[derive(yoke::Yokeable, yoke::ZeroCopyFrom)]
+    #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
     struct DeriveTest_VarZeroVec<'data> {
         _data: VarZeroVec<'data, str>,
     }
@@ -339,7 +284,7 @@ mod test {
         _data: &'data VarZeroSlice<str>,
     }
 
-    #[derive(yoke::Yokeable, yoke::ZeroCopyFrom)]
+    #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
     #[yoke(prove_covariance_manually)]
     struct DeriveTest_ZeroMap<'data> {
         _data: ZeroMap<'data, [u8], str>,
@@ -351,13 +296,13 @@ mod test {
         _data: ZeroMapBorrowed<'data, [u8], str>,
     }
 
-    #[derive(yoke::Yokeable, yoke::ZeroCopyFrom)]
+    #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
     #[yoke(prove_covariance_manually)]
     struct DeriveTest_ZeroMapWithULE<'data> {
         _data: ZeroMap<'data, ZeroSlice<u32>, str>,
     }
 
-    #[derive(yoke::Yokeable, yoke::ZeroCopyFrom)]
+    #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
     #[yoke(prove_covariance_manually)]
     struct DeriveTest_ZeroMap2d<'data> {
         _data: ZeroMap2d<'data, u16, u16, str>,

--- a/utils/zerovec/src/zerofrom_impls.rs
+++ b/utils/zerovec/src/zerofrom_impls.rs
@@ -1,7 +1,9 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
 use zerofrom::ZeroFrom;
-
 use crate::map::ZeroMapKV;
-
 use crate::ule::*;
 use crate::{VarZeroVec, ZeroMap, ZeroMap2d, ZeroVec};
 

--- a/utils/zerovec/src/zerofrom_impls.rs
+++ b/utils/zerovec/src/zerofrom_impls.rs
@@ -1,0 +1,60 @@
+use zerofrom::ZeroFrom;
+
+use crate::map::ZeroMapKV;
+
+use crate::ule::*;
+use crate::{VarZeroVec, ZeroMap, ZeroMap2d, ZeroVec};
+
+impl<'zcf, T> ZeroFrom<'zcf, ZeroVec<'_, T>> for ZeroVec<'zcf, T>
+where
+    T: 'static + AsULE + ?Sized,
+{
+    #[inline]
+    fn zero_copy_from(cart: &'zcf ZeroVec<'_, T>) -> Self {
+        ZeroVec::Borrowed(cart.as_ule_slice())
+    }
+}
+
+impl<'zcf, T> ZeroFrom<'zcf, VarZeroVec<'_, T>> for VarZeroVec<'zcf, T>
+where
+    T: 'static + VarULE + ?Sized,
+{
+    #[inline]
+    fn zero_copy_from(cart: &'zcf VarZeroVec<'_, T>) -> Self {
+        cart.as_slice().into()
+    }
+}
+
+impl<'zcf, 's, K, V> ZeroFrom<'zcf, ZeroMap<'s, K, V>> for ZeroMap<'zcf, K, V>
+where
+    K: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
+    V: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
+    <K as ZeroMapKV<'zcf>>::Container: ZeroFrom<'zcf, <K as ZeroMapKV<'s>>::Container>,
+    <V as ZeroMapKV<'zcf>>::Container: ZeroFrom<'zcf, <V as ZeroMapKV<'s>>::Container>,
+{
+    fn zero_copy_from(cart: &'zcf ZeroMap<'s, K, V>) -> Self {
+        ZeroMap {
+            keys: K::Container::zero_copy_from(&cart.keys),
+            values: V::Container::zero_copy_from(&cart.values),
+        }
+    }
+}
+
+impl<'zcf, 's, K0, K1, V> ZeroFrom<'zcf, ZeroMap2d<'s, K0, K1, V>> for ZeroMap2d<'zcf, K0, K1, V>
+where
+    K0: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
+    K1: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
+    V: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
+    <K0 as ZeroMapKV<'zcf>>::Container: ZeroFrom<'zcf, <K0 as ZeroMapKV<'s>>::Container>,
+    <K1 as ZeroMapKV<'zcf>>::Container: ZeroFrom<'zcf, <K1 as ZeroMapKV<'s>>::Container>,
+    <V as ZeroMapKV<'zcf>>::Container: ZeroFrom<'zcf, <V as ZeroMapKV<'s>>::Container>,
+{
+    fn zero_copy_from(cart: &'zcf ZeroMap2d<'s, K0, K1, V>) -> Self {
+        ZeroMap2d {
+            keys0: K0::Container::zero_copy_from(&cart.keys0),
+            joiner: ZeroVec::zero_copy_from(&cart.joiner),
+            keys1: K1::Container::zero_copy_from(&cart.keys1),
+            values: V::Container::zero_copy_from(&cart.values),
+        }
+    }
+}

--- a/utils/zerovec/src/zerofrom_impls.rs
+++ b/utils/zerovec/src/zerofrom_impls.rs
@@ -10,7 +10,7 @@ where
     T: 'static + AsULE + ?Sized,
 {
     #[inline]
-    fn zero_copy_from(cart: &'zcf ZeroVec<'_, T>) -> Self {
+    fn zero_from(cart: &'zcf ZeroVec<'_, T>) -> Self {
         ZeroVec::Borrowed(cart.as_ule_slice())
     }
 }
@@ -20,7 +20,7 @@ where
     T: 'static + VarULE + ?Sized,
 {
     #[inline]
-    fn zero_copy_from(cart: &'zcf VarZeroVec<'_, T>) -> Self {
+    fn zero_from(cart: &'zcf VarZeroVec<'_, T>) -> Self {
         cart.as_slice().into()
     }
 }
@@ -32,10 +32,10 @@ where
     <K as ZeroMapKV<'zcf>>::Container: ZeroFrom<'zcf, <K as ZeroMapKV<'s>>::Container>,
     <V as ZeroMapKV<'zcf>>::Container: ZeroFrom<'zcf, <V as ZeroMapKV<'s>>::Container>,
 {
-    fn zero_copy_from(cart: &'zcf ZeroMap<'s, K, V>) -> Self {
+    fn zero_from(cart: &'zcf ZeroMap<'s, K, V>) -> Self {
         ZeroMap {
-            keys: K::Container::zero_copy_from(&cart.keys),
-            values: V::Container::zero_copy_from(&cart.values),
+            keys: K::Container::zero_from(&cart.keys),
+            values: V::Container::zero_from(&cart.values),
         }
     }
 }
@@ -49,12 +49,12 @@ where
     <K1 as ZeroMapKV<'zcf>>::Container: ZeroFrom<'zcf, <K1 as ZeroMapKV<'s>>::Container>,
     <V as ZeroMapKV<'zcf>>::Container: ZeroFrom<'zcf, <V as ZeroMapKV<'s>>::Container>,
 {
-    fn zero_copy_from(cart: &'zcf ZeroMap2d<'s, K0, K1, V>) -> Self {
+    fn zero_from(cart: &'zcf ZeroMap2d<'s, K0, K1, V>) -> Self {
         ZeroMap2d {
-            keys0: K0::Container::zero_copy_from(&cart.keys0),
-            joiner: ZeroVec::zero_copy_from(&cart.joiner),
-            keys1: K1::Container::zero_copy_from(&cart.keys1),
-            values: V::Container::zero_copy_from(&cart.values),
+            keys0: K0::Container::zero_from(&cart.keys0),
+            joiner: ZeroVec::zero_from(&cart.joiner),
+            keys1: K1::Container::zero_from(&cart.keys1),
+            values: V::Container::zero_from(&cart.values),
         }
     }
 }

--- a/utils/zerovec/src/zerofrom_impls.rs
+++ b/utils/zerovec/src/zerofrom_impls.rs
@@ -12,8 +12,8 @@ where
     T: 'static + AsULE + ?Sized,
 {
     #[inline]
-    fn zero_from(cart: &'zf ZeroVec<'_, T>) -> Self {
-        ZeroVec::Borrowed(cart.as_ule_slice())
+    fn zero_from(other: &'zf ZeroVec<'_, T>) -> Self {
+        ZeroVec::Borrowed(other.as_ule_slice())
     }
 }
 
@@ -22,8 +22,8 @@ where
     T: 'static + VarULE + ?Sized,
 {
     #[inline]
-    fn zero_from(cart: &'zf VarZeroVec<'_, T>) -> Self {
-        cart.as_slice().into()
+    fn zero_from(other: &'zf VarZeroVec<'_, T>) -> Self {
+        other.as_slice().into()
     }
 }
 
@@ -34,10 +34,10 @@ where
     <K as ZeroMapKV<'zf>>::Container: ZeroFrom<'zf, <K as ZeroMapKV<'s>>::Container>,
     <V as ZeroMapKV<'zf>>::Container: ZeroFrom<'zf, <V as ZeroMapKV<'s>>::Container>,
 {
-    fn zero_from(cart: &'zf ZeroMap<'s, K, V>) -> Self {
+    fn zero_from(other: &'zf ZeroMap<'s, K, V>) -> Self {
         ZeroMap {
-            keys: K::Container::zero_from(&cart.keys),
-            values: V::Container::zero_from(&cart.values),
+            keys: K::Container::zero_from(&other.keys),
+            values: V::Container::zero_from(&other.values),
         }
     }
 }
@@ -51,12 +51,12 @@ where
     <K1 as ZeroMapKV<'zf>>::Container: ZeroFrom<'zf, <K1 as ZeroMapKV<'s>>::Container>,
     <V as ZeroMapKV<'zf>>::Container: ZeroFrom<'zf, <V as ZeroMapKV<'s>>::Container>,
 {
-    fn zero_from(cart: &'zf ZeroMap2d<'s, K0, K1, V>) -> Self {
+    fn zero_from(other: &'zf ZeroMap2d<'s, K0, K1, V>) -> Self {
         ZeroMap2d {
-            keys0: K0::Container::zero_from(&cart.keys0),
-            joiner: ZeroVec::zero_from(&cart.joiner),
-            keys1: K1::Container::zero_from(&cart.keys1),
-            values: V::Container::zero_from(&cart.values),
+            keys0: K0::Container::zero_from(&other.keys0),
+            joiner: ZeroVec::zero_from(&other.joiner),
+            keys1: K1::Container::zero_from(&other.keys1),
+            values: V::Container::zero_from(&other.values),
         }
     }
 }

--- a/utils/zerovec/src/zerofrom_impls.rs
+++ b/utils/zerovec/src/zerofrom_impls.rs
@@ -2,10 +2,10 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use zerofrom::ZeroFrom;
 use crate::map::ZeroMapKV;
 use crate::ule::*;
 use crate::{VarZeroVec, ZeroMap, ZeroMap2d, ZeroVec};
+use zerofrom::ZeroFrom;
 
 impl<'zf, T> ZeroFrom<'zf, ZeroVec<'_, T>> for ZeroVec<'zf, T>
 where

--- a/utils/zerovec/src/zerofrom_impls.rs
+++ b/utils/zerovec/src/zerofrom_impls.rs
@@ -5,34 +5,34 @@ use crate::map::ZeroMapKV;
 use crate::ule::*;
 use crate::{VarZeroVec, ZeroMap, ZeroMap2d, ZeroVec};
 
-impl<'zcf, T> ZeroFrom<'zcf, ZeroVec<'_, T>> for ZeroVec<'zcf, T>
+impl<'zf, T> ZeroFrom<'zf, ZeroVec<'_, T>> for ZeroVec<'zf, T>
 where
     T: 'static + AsULE + ?Sized,
 {
     #[inline]
-    fn zero_from(cart: &'zcf ZeroVec<'_, T>) -> Self {
+    fn zero_from(cart: &'zf ZeroVec<'_, T>) -> Self {
         ZeroVec::Borrowed(cart.as_ule_slice())
     }
 }
 
-impl<'zcf, T> ZeroFrom<'zcf, VarZeroVec<'_, T>> for VarZeroVec<'zcf, T>
+impl<'zf, T> ZeroFrom<'zf, VarZeroVec<'_, T>> for VarZeroVec<'zf, T>
 where
     T: 'static + VarULE + ?Sized,
 {
     #[inline]
-    fn zero_from(cart: &'zcf VarZeroVec<'_, T>) -> Self {
+    fn zero_from(cart: &'zf VarZeroVec<'_, T>) -> Self {
         cart.as_slice().into()
     }
 }
 
-impl<'zcf, 's, K, V> ZeroFrom<'zcf, ZeroMap<'s, K, V>> for ZeroMap<'zcf, K, V>
+impl<'zf, 's, K, V> ZeroFrom<'zf, ZeroMap<'s, K, V>> for ZeroMap<'zf, K, V>
 where
     K: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
     V: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
-    <K as ZeroMapKV<'zcf>>::Container: ZeroFrom<'zcf, <K as ZeroMapKV<'s>>::Container>,
-    <V as ZeroMapKV<'zcf>>::Container: ZeroFrom<'zcf, <V as ZeroMapKV<'s>>::Container>,
+    <K as ZeroMapKV<'zf>>::Container: ZeroFrom<'zf, <K as ZeroMapKV<'s>>::Container>,
+    <V as ZeroMapKV<'zf>>::Container: ZeroFrom<'zf, <V as ZeroMapKV<'s>>::Container>,
 {
-    fn zero_from(cart: &'zcf ZeroMap<'s, K, V>) -> Self {
+    fn zero_from(cart: &'zf ZeroMap<'s, K, V>) -> Self {
         ZeroMap {
             keys: K::Container::zero_from(&cart.keys),
             values: V::Container::zero_from(&cart.values),
@@ -40,16 +40,16 @@ where
     }
 }
 
-impl<'zcf, 's, K0, K1, V> ZeroFrom<'zcf, ZeroMap2d<'s, K0, K1, V>> for ZeroMap2d<'zcf, K0, K1, V>
+impl<'zf, 's, K0, K1, V> ZeroFrom<'zf, ZeroMap2d<'s, K0, K1, V>> for ZeroMap2d<'zf, K0, K1, V>
 where
     K0: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
     K1: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
     V: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
-    <K0 as ZeroMapKV<'zcf>>::Container: ZeroFrom<'zcf, <K0 as ZeroMapKV<'s>>::Container>,
-    <K1 as ZeroMapKV<'zcf>>::Container: ZeroFrom<'zcf, <K1 as ZeroMapKV<'s>>::Container>,
-    <V as ZeroMapKV<'zcf>>::Container: ZeroFrom<'zcf, <V as ZeroMapKV<'s>>::Container>,
+    <K0 as ZeroMapKV<'zf>>::Container: ZeroFrom<'zf, <K0 as ZeroMapKV<'s>>::Container>,
+    <K1 as ZeroMapKV<'zf>>::Container: ZeroFrom<'zf, <K1 as ZeroMapKV<'s>>::Container>,
+    <V as ZeroMapKV<'zf>>::Container: ZeroFrom<'zf, <V as ZeroMapKV<'s>>::Container>,
 {
-    fn zero_from(cart: &'zcf ZeroMap2d<'s, K0, K1, V>) -> Self {
+    fn zero_from(cart: &'zf ZeroMap2d<'s, K0, K1, V>) -> Self {
         ZeroMap2d {
             keys0: K0::Container::zero_from(&cart.keys0),
             joiner: ZeroVec::zero_from(&cart.joiner),


### PR DESCRIPTION
Fixes #1590

ZCF is no longer tightly tied to Yoke, and overall it serves a rather different purpose. Furthermore, we're reaching the point in the zerovec custom derives (tracked in #1079) where we'll need ZCF to be able to autogenerate code that recoups the stack type.

Overall zerovec and yoke use ZCF for different purposes. This PR splits ZCF into a separate pair of crates (lib and derive). It also renames it to `ZeroFrom` for brevity and consistency.

This is probably best reviewed commit by commit, there are many commits that are just doing one kind of change all over the place. The code starts out by making a new crate and making yoke reexport it, but that reexport will later be removed. It also takes the opportunity to improve the status quo for https://github.com/unicode-org/icu4x/issues/1557 where the data provider macro can now pull from the prelude. It does not update all the code to use the prelude where it wasn't already, however.

cc @zbraniecki @robertbastian


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->