### PR TITLE
Add zerovec::skip_kv and zerovec::skip_ord attributes, as well as generalized attribute handling framework

### DIFF
--- a/utils/zerovec/derive/examples/make.rs
+++ b/utils/zerovec/derive/examples/make.rs
@@ -30,6 +30,17 @@ enum Enum {
     F = 5,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd)]
+#[make_ule(NoKVULE)]
+#[zerovec::skip_kv]
+struct NoKV(u8, char);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[make_ule(NoOrdULE)]
+#[zerovec::skip_ord]
+#[zerovec::skip_kv]
+struct NoOrd(u8, char);
+
 fn test_zerovec<T: ule::AsULE + Debug + PartialEq>(slice: &[T]) {
     let zerovec: ZeroVec<T> = slice.iter().copied().collect();
 

--- a/utils/zerovec/derive/examples/make_var.rs
+++ b/utils/zerovec/derive/examples/make_var.rs
@@ -20,6 +20,17 @@ struct VarStruct<'a> {
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 struct VarTupleStruct<'a>(u32, char, VarZeroVec<'a, str>);
 
+#[make_varule(NoKVULE)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[zerovec::skip_kv]
+struct NoKV<'a>(u32, char, VarZeroVec<'a, str>);
+
+#[make_varule(NoOrdULE)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[zerovec::skip_kv]
+#[zerovec::skip_ord]
+struct NoOrd<'a>(u32, char, VarZeroVec<'a, str>);
+
 /// The `assert` function should have the body `|(stack, zero)| assert_eq!(stack, &U::zero_from(&zero))`
 ///
 /// We cannot do this internally because we technically need a different `U` with a shorter lifetime here

--- a/utils/zerovec/derive/src/lib.rs
+++ b/utils/zerovec/derive/src/lib.rs
@@ -34,7 +34,13 @@ pub fn varule_derive(input: TokenStream) -> TokenStream {
 /// This can be attached to structs containing only AsULE types, or C-like enums that have `#[repr(u8)]`
 /// and all explicit discriminants.
 ///
-/// The type must be `Copy`, `PartialEq`, and `Ord`.
+/// The type must be `Copy`, `PartialEq`, and `Eq`.
+///
+/// By default this attribute will also autogenerate a `ZeroMapKV` implementation, which requires
+/// `Ord` and `PartialOrd` on `Self`. You can opt out of this with `#[zerovec::skip_kv]`.
+///
+/// This implementation will also by default autogenerate `Ord` and `PartialOrd` on the ULE type based on
+/// the implementation on `Self`. You can opt out of this with `#[zerovec::skip_ord]`
 #[proc_macro_attribute]
 pub fn make_ule(attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);
@@ -42,12 +48,18 @@ pub fn make_ule(attr: TokenStream, item: TokenStream) -> TokenStream {
     TokenStream::from(ule::make_ule_impl(attr, input))
 }
 
-/// Generate a corresponding VarULE type and the relevant EncodeAsVarULE implementations for this type
+/// Generate a corresponding VarULE type and the relevant EncodeAsVarULE/ZeroFrom implementations for this type
 ///
 /// This can be attached to structs containing only AsULE types with the last field being `Cow<'a, str>`,
-/// `Cow<'a, [u8]>`, ZeroSlice, or VarZeroSlice
+/// `Cow<'a, [u8]>`, ZeroSlice, or VarZeroSlice.
 ///
-/// The type must be `PartialEq` `Ord`.
+/// The type must be `PartialEq` and `Eq`.
+///
+/// By default this attribute will also autogenerate a `ZeroMapKV` implementation, which requires
+/// `Ord` and `PartialOrd` on the `VarULE` type. You can opt out of this with `#[zerovec::skip_kv]`.
+///
+/// This implementation will also by default autogenerate `Ord` and `PartialOrd` on the VarULE type based on
+/// the implementation on `Self`. You can opt out of this with `#[zerovec::skip_ord]`
 #[proc_macro_attribute]
 pub fn make_varule(attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -98,7 +98,7 @@ pub fn make_ule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStream
     let arg = &attr[0];
     let ule_name: Ident = parse_quote!(#arg);
 
-    let skip_kv = match utils::extract_attributes_common(&mut input.attrs, "make_ule") {
+    let (skip_kv, skip_ord) = match utils::extract_attributes_common(&mut input.attrs, "make_ule") {
         Ok(val) => val,
         Err(e) => return e.to_compile_error(),
     };
@@ -106,8 +106,8 @@ pub fn make_ule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStream
     let name = &input.ident;
 
     let ule_stuff = match input.data {
-        Data::Struct(ref s) => make_ule_struct_impl(name, &ule_name, &input, s),
-        Data::Enum(ref e) => make_ule_enum_impl(name, &ule_name, &input, e),
+        Data::Struct(ref s) => make_ule_struct_impl(name, &ule_name, &input, s, skip_ord),
+        Data::Enum(ref e) => make_ule_enum_impl(name, &ule_name, &input, e, skip_ord),
         _ => {
             return Error::new(input.span(), "#[make_ule] must be applied to a struct")
                 .to_compile_error();
@@ -140,6 +140,7 @@ fn make_ule_enum_impl(
     ule_name: &Ident,
     input: &DeriveInput,
     enu: &DataEnum,
+    skip_ord: bool,
 ) -> TokenStream2 {
     // We could support more int reprs in the future if needed
     if !utils::has_valid_repr(&input.attrs, |r| r == "u8") {
@@ -190,6 +191,12 @@ fn make_ule_enum_impl(
 
     let max = enu.variants.len() as u8;
 
+    let maybe_ord_derives = if skip_ord {
+        quote!()
+    } else {
+        quote!(#[derive(Ord, PartialOrd)])
+    };
+
     // Safety (based on the safety checklist on the ULE trait):
     //  1. ULE type does not include any uninitialized or padding bytes.
     //     (achieved by `#[repr(transparent)]` on a type that satisfies this invariant
@@ -203,7 +210,8 @@ fn make_ule_enum_impl(
     //  6. ULE type byte equality is semantic equality
     quote!(
         #[repr(transparent)]
-        #[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, PartialEq, Eq)]
+        #maybe_ord_derives
         struct #ule_name(u8);
 
         unsafe impl zerovec::ule::ULE for #ule_name {
@@ -273,6 +281,7 @@ fn make_ule_struct_impl(
     ule_name: &Ident,
     input: &DeriveInput,
     struc: &DataStruct,
+    skip_ord: bool,
 ) -> TokenStream2 {
     if struc.fields.iter().next().is_none() {
         return Error::new(
@@ -287,9 +296,16 @@ fn make_ule_struct_impl(
     let semi = utils::semi_for(&struc.fields);
     let repr_attr = utils::repr_for(&struc.fields);
 
+    let maybe_ord_derives = if skip_ord {
+        quote!()
+    } else {
+        quote!(#[derive(Ord, PartialOrd)])
+    };
+
     let ule_struct: DeriveInput = parse_quote!(
         #[repr(#repr_attr)]
-        #[derive(Copy, Clone, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, PartialEq, Eq)]
+        #maybe_ord_derives
         struct #ule_name #field_inits #semi
 
     );

--- a/utils/zerovec/derive/src/utils.rs
+++ b/utils/zerovec/derive/src/utils.rs
@@ -117,3 +117,37 @@ pub fn field_setter(f: &Field) -> TokenStream2 {
         quote!()
     }
 }
+
+/// Extracts a single `zerovec::name` attribute
+pub fn extract_zerovec_attribute_named<'a>(attrs: &mut Vec<Attribute>, name: &str) -> Option<Attribute> {
+    let mut ret = None;
+    attrs.retain(|a| {
+        // skip the "zerovec" part
+        let second_segment = a.path.segments.iter().skip(1).next();
+
+        if let Some(second) = second_segment {
+            if second.ident == name {
+                if ret.is_none() {
+                    ret = Some(a.clone());
+                    return false;
+                }
+            }
+        }
+
+        true
+    });
+    ret
+}
+
+/// Removes all attributes with `zerovec` in the name and places them in a separate vector
+pub fn extract_zerovec_attributes(attrs: &mut Vec<Attribute>) -> Vec<Attribute> {
+    let mut ret = vec![];
+    attrs.retain(|a| {
+        if a.path.segments.len() == 2 && a.path.segments[0].ident == "zerovec" {
+            ret.push(a.clone());
+            return false;
+        }
+        return true;
+    });
+    ret
+}

--- a/utils/zerovec/derive/src/utils.rs
+++ b/utils/zerovec/derive/src/utils.rs
@@ -119,21 +119,19 @@ pub fn field_setter(f: &Field) -> TokenStream2 {
 }
 
 /// Extracts a single `zerovec::name` attribute
-pub fn extract_zerovec_attribute_named<'a>(
+pub fn extract_zerovec_attribute_named(
     attrs: &mut Vec<Attribute>,
     name: &str,
 ) -> Option<Attribute> {
     let mut ret = None;
     attrs.retain(|a| {
         // skip the "zerovec" part
-        let second_segment = a.path.segments.iter().skip(1).next();
+        let second_segment = a.path.segments.iter().nth(1);
 
         if let Some(second) = second_segment {
-            if second.ident == name {
-                if ret.is_none() {
-                    ret = Some(a.clone());
-                    return false;
-                }
+            if second.ident == name && ret.is_none() {
+                ret = Some(a.clone());
+                return false;
             }
         }
 
@@ -150,7 +148,7 @@ pub fn extract_zerovec_attributes(attrs: &mut Vec<Attribute>) -> Vec<Attribute> 
             ret.push(a.clone());
             return false;
         }
-        return true;
+        true
     });
     ret
 }

--- a/utils/zerovec/derive/src/utils.rs
+++ b/utils/zerovec/derive/src/utils.rs
@@ -168,11 +168,12 @@ pub fn check_attr_empty(attr: &Option<Attribute>, name: &str) -> Result<()> {
 }
 
 /// Removes all known zerovec:: attributes from attrs and validates them
-/// Returns true if it found a skip_kv attribute. More will be added.
-pub fn extract_attributes_common(attrs: &mut Vec<Attribute>, name: &str) -> Result<bool> {
+/// Returns (skip_kv, skip_ord)
+pub fn extract_attributes_common(attrs: &mut Vec<Attribute>, name: &str) -> Result<(bool, bool)> {
     let mut zerovec_attrs = extract_zerovec_attributes(attrs);
 
     let skip_kv = extract_zerovec_attribute_named(&mut zerovec_attrs, "skip_kv");
+    let skip_ord = extract_zerovec_attribute_named(&mut zerovec_attrs, "skip_ord");
 
     if let Some(attr) = zerovec_attrs.get(0) {
         return Err(Error::new(
@@ -182,8 +183,10 @@ pub fn extract_attributes_common(attrs: &mut Vec<Attribute>, name: &str) -> Resu
     }
 
     check_attr_empty(&skip_kv, "skip_kv")?;
+    check_attr_empty(&skip_ord, "skip_ord")?;
 
     let skip_kv = skip_kv.is_some();
+    let skip_ord = skip_ord.is_some();
 
-    Ok(skip_kv)
+    Ok((skip_kv, skip_ord))
 }

--- a/utils/zerovec/derive/src/varule.rs
+++ b/utils/zerovec/derive/src/varule.rs
@@ -191,7 +191,7 @@ pub fn make_varule_impl(attr: AttributeArgs, input: DeriveInput) -> TokenStream2
 
     let varule_struct: DeriveInput = parse_quote!(
         #[repr(#repr_attr)]
-        #[derive(PartialEq)]
+        #[derive(PartialEq, Eq, PartialOrd, Ord)]
         struct #ule_name #field_inits #semi
     );
 
@@ -229,6 +229,13 @@ pub fn make_varule_impl(attr: AttributeArgs, input: DeriveInput) -> TokenStream2
         #zf_impl
 
         #derived
+
+
+        impl<'a> zerovec::map::ZeroMapKV<'a> for #ule_name {
+            type Container = zerovec::VarZeroVec<'a, #ule_name>;
+            type GetType = #ule_name;
+            type OwnedType = Box<#ule_name>;
+        }
     )
 }
 

--- a/utils/zerovec/derive/src/varule.rs
+++ b/utils/zerovec/derive/src/varule.rs
@@ -127,7 +127,7 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
         .to_compile_error();
     }
 
-    let skip_kv = match utils::extract_attributes_common(&mut input.attrs, "make_ule") {
+    let (skip_kv, skip_ord) = match utils::extract_attributes_common(&mut input.attrs, "make_ule") {
         Ok(val) => val,
         Err(e) => return e.to_compile_error(),
     };
@@ -194,9 +194,16 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
     let repr_attr = utils::repr_for(fields);
     let field_inits = utils::wrap_field_inits(&field_inits, fields);
 
+    let maybe_ord_derives = if skip_ord {
+        quote!()
+    } else {
+        quote!(#[derive(Ord, PartialOrd)])
+    };
+
     let varule_struct: DeriveInput = parse_quote!(
         #[repr(#repr_attr)]
-        #[derive(PartialEq, Eq, PartialOrd, Ord)]
+        #[derive(PartialEq, Eq)]
+        #maybe_ord_derives
         struct #ule_name #field_inits #semi
     );
 

--- a/utils/zerovec/src/ule/chars.rs
+++ b/utils/zerovec/src/ule/chars.rs
@@ -7,6 +7,7 @@
 
 use super::*;
 use core::convert::TryFrom;
+use core::cmp::Ordering;
 
 /// A u8 array of little-endian data corresponding to a Unicode code point.
 ///
@@ -85,6 +86,18 @@ impl AsULE for char {
 // EqULE is true because `char` is transmutable to `u32`, which in turn has the same byte sequence
 // as CharULE on little-endian platforms.
 unsafe impl EqULE for char {}
+
+impl PartialOrd for CharULE {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        char::from_unaligned(*self).partial_cmp(&char::from_unaligned(*other))
+    }
+}
+
+impl Ord for CharULE {
+    fn cmp(&self, other: &Self) -> Ordering {
+        char::from_unaligned(*self).cmp(&char::from_unaligned(*other))
+    }
+}
 
 #[cfg(test)]
 mod test {

--- a/utils/zerovec/src/ule/chars.rs
+++ b/utils/zerovec/src/ule/chars.rs
@@ -6,8 +6,8 @@
 //! ULE implementation for the `char` type.
 
 use super::*;
-use core::convert::TryFrom;
 use core::cmp::Ordering;
+use core::convert::TryFrom;
 
 /// A u8 array of little-endian data corresponding to a Unicode code point.
 ///

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -9,7 +9,7 @@ use super::*;
 
 /// A u8 array of little-endian data with infallible conversions to and from &[u8].
 #[repr(transparent)]
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
 pub struct RawBytesULE<const N: usize>(pub [u8; N]);
 
 macro_rules! impl_byte_slice_size {


### PR DESCRIPTION
Part of #1079

Once #1612 lands I'll use this to implement `zerovec::serde_impls`.

ZeroMapKV requires Ord, which isn't always easy to require. We've basically decided that Eq is more or less expected of ULE types given the equality invariant, however I'd rather not make Ord a requirement. However, we *can* make it a "default" requirement, where you have the option to opt out of both the ZMKV implementation and the Ord implementation on the ULE type. These are separate attribute since the user may want to supply their own implementation.



<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->