### PR TITLE
Rename as_unaligned to to_unaligned

### DIFF
--- a/components/datetime/src/fields/ule.rs
+++ b/components/datetime/src/fields/ule.rs
@@ -47,7 +47,7 @@ impl AsULE for fields::Field {
     type ULE = FieldULE;
 
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         FieldULE([self.symbol.idx(), self.length.idx()])
     }
 
@@ -121,7 +121,7 @@ mod test {
         ];
 
         for (ref_field, ref_bytes) in samples {
-            let ule = ref_field.as_unaligned();
+            let ule = ref_field.to_unaligned();
             assert_eq!(ULE::as_byte_slice(&[ule]), *ref_bytes);
             let field = Field::from_unaligned(ule);
             assert_eq!(field, *ref_field);
@@ -150,7 +150,7 @@ mod test {
         for (ref_field, ref_bytes) in samples {
             let mut bytes: Vec<u8> = vec![];
             for item in ref_field.iter() {
-                let ule = item.as_unaligned();
+                let ule = item.to_unaligned();
                 bytes.extend(ULE::as_byte_slice(&[ule]));
             }
 

--- a/components/datetime/src/pattern/item/ule.rs
+++ b/components/datetime/src/pattern/item/ule.rs
@@ -111,7 +111,7 @@ impl AsULE for PatternItem {
     type ULE = PatternItemULE;
 
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         match self {
             Self::Field(field) => {
                 PatternItemULE([0b1000_0000, field.symbol.idx(), field.length.idx()])
@@ -246,7 +246,7 @@ impl AsULE for GenericPatternItem {
     type ULE = GenericPatternItemULE;
 
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         match self {
             Self::Placeholder(idx) => GenericPatternItemULE([0b1000_0000, 0x00, idx]),
             Self::Literal(ch) => {
@@ -311,7 +311,7 @@ mod test {
         ];
 
         for (ref_pattern, ref_bytes) in samples {
-            let ule = ref_pattern.as_unaligned();
+            let ule = ref_pattern.to_unaligned();
             assert_eq!(ULE::as_byte_slice(&[ule]), *ref_bytes);
             let pattern = PatternItem::from_unaligned(ule);
             assert_eq!(pattern, *ref_pattern);
@@ -344,7 +344,7 @@ mod test {
         for (ref_pattern, ref_bytes) in samples {
             let mut bytes: Vec<u8> = vec![];
             for item in ref_pattern.iter() {
-                let ule = item.as_unaligned();
+                let ule = item.to_unaligned();
                 bytes.extend(ULE::as_byte_slice(&[ule]));
             }
 
@@ -367,7 +367,7 @@ mod test {
         ];
 
         for (ref_pattern, ref_bytes) in samples {
-            let ule = ref_pattern.as_unaligned();
+            let ule = ref_pattern.to_unaligned();
             assert_eq!(ULE::as_byte_slice(&[ule]), *ref_bytes);
             let pattern = GenericPatternItem::from_unaligned(ule);
             assert_eq!(pattern, *ref_pattern);

--- a/components/datetime/src/pattern/runtime/helpers.rs
+++ b/components/datetime/src/pattern/runtime/helpers.rs
@@ -26,7 +26,7 @@ pub fn maybe_replace_first(
         .enumerate()
         .find_map(|(i, item)| f(&item).map(|result| (i, result)));
     if let Some((i, result)) = result {
-        pattern.items.to_mut()[i] = result.as_unaligned();
+        pattern.items.to_mut()[i] = result.to_unaligned();
     }
 }
 
@@ -51,10 +51,10 @@ pub fn maybe_replace(
         .find_map(|(i, item)| f(&item).map(|result| (i, result)));
     if let Some((i, result)) = result {
         let owned = pattern.items.to_mut();
-        owned[i] = result.as_unaligned();
+        owned[i] = result.to_unaligned();
         owned.iter_mut().skip(i).for_each(|item| {
             if let Some(new_item) = f(&PatternItem::from_unaligned(*item)) {
-                *item = new_item.as_unaligned();
+                *item = new_item.to_unaligned();
             }
         });
     }

--- a/components/plurals/src/rules/runtime/ast.rs
+++ b/components/plurals/src/rules/runtime/ast.rs
@@ -407,7 +407,7 @@ unsafe impl EncodeAsVarULE<RelationULE> for Relation<'_> {
             RelationULE::encode_andor_polarity_operand(self.and_or, self.polarity, self.operand);
         cb(&[
             &[encoded],
-            RawBytesULE::<4>::as_byte_slice(&[self.modulo.as_unaligned()]),
+            RawBytesULE::<4>::as_byte_slice(&[self.modulo.to_unaligned()]),
             self.range_list.as_bytes(),
         ])
     }
@@ -419,10 +419,10 @@ impl AsULE for RangeOrValue {
     type ULE = RangeOrValueULE;
 
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         match self {
-            Self::Range(start, end) => PairULE(start.as_unaligned(), end.as_unaligned()),
-            Self::Value(idx) => PairULE(idx.as_unaligned(), idx.as_unaligned()),
+            Self::Range(start, end) => PairULE(start.to_unaligned(), end.to_unaligned()),
+            Self::Value(idx) => PairULE(idx.to_unaligned(), idx.to_unaligned()),
         }
     }
 
@@ -552,7 +552,7 @@ mod test {
                 polarity: Polarity::Positive,
                 operand: Operand::I,
                 modulo: 0,
-                range_list: ZeroVec::Borrowed(&[RangeOrValue::Value(1).as_unaligned()])
+                range_list: ZeroVec::Borrowed(&[RangeOrValue::Value(1).to_unaligned()])
             }
         );
 
@@ -611,12 +611,12 @@ mod test {
     #[test]
     fn range_or_value_ule_test() {
         let rov = RangeOrValue::Value(1);
-        let ule = rov.as_unaligned();
+        let ule = rov.to_unaligned();
         let ref_bytes = &[1, 0, 0, 0, 1, 0, 0, 0];
         assert_eq!(ULE::as_byte_slice(&[ule]), *ref_bytes);
 
         let rov = RangeOrValue::Range(2, 4);
-        let ule = rov.as_unaligned();
+        let ule = rov.to_unaligned();
         let ref_bytes = &[2, 0, 0, 0, 4, 0, 0, 0];
         assert_eq!(ULE::as_byte_slice(&[ule]), *ref_bytes);
     }

--- a/components/properties/src/script.rs
+++ b/components/properties/src/script.rs
@@ -458,7 +458,7 @@ impl<'data> ScriptWithExtensions<'data> {
             .filter(move |cpm_range| {
                 let sc_with_ext = ScriptWithExt(cpm_range.value.0);
                 if sc_with_ext.has_extensions() {
-                    self.get_scx_val_using_trie_val(&sc_with_ext.as_unaligned())
+                    self.get_scx_val_using_trie_val(&sc_with_ext.to_unaligned())
                         .iter()
                         .any(|sc| sc == script)
                 } else {

--- a/components/properties/src/ule.rs
+++ b/components/properties/src/ule.rs
@@ -15,7 +15,7 @@ impl AsULE for CanonicalCombiningClass {
     type ULE = u8;
 
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         self.0
     }
 
@@ -33,7 +33,7 @@ impl AsULE for GeneralCategory {
     type ULE = GeneralCategoryULE;
 
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         let u = self as u8;
         GeneralCategoryULE(u)
     }
@@ -69,7 +69,7 @@ impl AsULE for Script {
     type ULE = RawBytesULE<2>;
 
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         RawBytesULE(self.0.to_le_bytes())
     }
 
@@ -83,7 +83,7 @@ impl AsULE for ScriptWithExt {
     type ULE = RawBytesULE<2>;
 
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         RawBytesULE(self.0.to_le_bytes())
     }
 
@@ -97,7 +97,7 @@ impl AsULE for EastAsianWidth {
     type ULE = u8;
 
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         self.0
     }
 
@@ -111,7 +111,7 @@ impl AsULE for LineBreak {
     type ULE = u8;
 
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         self.0
     }
 
@@ -125,7 +125,7 @@ impl AsULE for GraphemeClusterBreak {
     type ULE = u8;
 
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         self.0
     }
 
@@ -139,7 +139,7 @@ impl AsULE for WordBreak {
     type ULE = u8;
 
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         self.0
     }
 
@@ -153,7 +153,7 @@ impl AsULE for SentenceBreak {
     type ULE = u8;
 
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         self.0
     }
 

--- a/provider/core/src/resource.rs
+++ b/provider/core/src/resource.rs
@@ -58,7 +58,7 @@ unsafe impl ULE for ResourceKeyHash {
 impl AsULE for ResourceKeyHash {
     type ULE = Self;
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         self
     }
     #[inline]

--- a/utils/tinystr/src/ule.rs
+++ b/utils/tinystr/src/ule.rs
@@ -35,7 +35,7 @@ impl<const N: usize> AsULE for TinyAsciiStr<N> {
     type ULE = Self;
 
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         self
     }
 

--- a/utils/zerovec/derive/examples/derives.rs
+++ b/utils/zerovec/derive/examples/derives.rs
@@ -24,11 +24,11 @@ struct Foo {
 
 impl AsULE for Foo {
     type ULE = FooULE;
-    fn as_unaligned(self) -> FooULE {
+    fn to_unaligned(self) -> FooULE {
         FooULE {
             a: self.a,
-            b: self.b.as_unaligned(),
-            c: self.c.as_unaligned(),
+            b: self.b.to_unaligned(),
+            c: self.c.to_unaligned(),
         }
     }
 
@@ -65,7 +65,7 @@ unsafe impl EncodeAsVarULE<RelationULE> for Relation<'_> {
     fn encode_var_ule_as_slices<R>(&self, cb: impl FnOnce(&[&[u8]]) -> R) -> R {
         cb(&[
             &[self.andor_polarity_operand],
-            ule::ULE::as_byte_slice(&[self.modulo.as_unaligned()]),
+            ule::ULE::as_byte_slice(&[self.modulo.to_unaligned()]),
             self.range_list.as_bytes(),
         ])
     }

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -210,7 +210,7 @@ fn make_ule_enum_impl(
         impl zerovec::ule::AsULE for #name {
             type ULE = #ule_name;
 
-            fn as_unaligned(self) -> Self::ULE {
+            fn to_unaligned(self) -> Self::ULE {
                 // safety: the enum is repr(u8) and can be cast to a u8
                 unsafe {
                     ::core::mem::transmute(self)
@@ -292,12 +292,12 @@ fn make_ule_struct_impl(
         let i = syn::Index::from(i);
         if let Some(ref ident) = field.ident {
             as_ule_conversions
-                .push(quote!(#ident: <#ty as zerovec::ule::AsULE>::as_unaligned(self.#ident)));
+                .push(quote!(#ident: <#ty as zerovec::ule::AsULE>::to_unaligned(self.#ident)));
             from_ule_conversions.push(
                 quote!(#ident: <#ty as zerovec::ule::AsULE>::from_unaligned(unaligned.#ident)),
             );
         } else {
-            as_ule_conversions.push(quote!(<#ty as zerovec::ule::AsULE>::as_unaligned(self.#i)));
+            as_ule_conversions.push(quote!(<#ty as zerovec::ule::AsULE>::to_unaligned(self.#i)));
             from_ule_conversions
                 .push(quote!(<#ty as zerovec::ule::AsULE>::from_unaligned(unaligned.#i)));
         };
@@ -308,7 +308,7 @@ fn make_ule_struct_impl(
     let asule_impl = quote!(
         impl zerovec::ule::AsULE for #name {
             type ULE = #ule_name;
-            fn as_unaligned(self) -> Self::ULE {
+            fn to_unaligned(self) -> Self::ULE {
                 #ule_name #as_ule_conversions
             }
             fn from_unaligned(unaligned: Self::ULE) -> Self {

--- a/utils/zerovec/derive/src/varule.rs
+++ b/utils/zerovec/derive/src/varule.rs
@@ -318,7 +318,7 @@ fn make_encode_impl(
             let accessor = utils::field_accessor(field, i);
             quote!(
                 let out = &mut dst[#prev_offset_ident .. #prev_offset_ident + #size_ident];
-                let unaligned = zerovec::ule::AsULE::as_unaligned(self.#accessor);
+                let unaligned = zerovec::ule::AsULE::to_unaligned(self.#accessor);
                 let unaligned_slice = &[unaligned];
                 let src = <#ty as zerovec::ule::ULE>::as_byte_slice(unaligned_slice);
                 out.copy_from_slice(src);

--- a/utils/zerovec/design_doc.md
+++ b/utils/zerovec/design_doc.md
@@ -152,7 +152,7 @@ The integer types use [`RawBytesULE<N>`][`RawBytesULE`], a type that is internal
 ```rust
 pub trait AsULE: Copy {
     type ULE: ULE;
-    fn as_unaligned(self) -> Self::ULE;
+    fn to_unaligned(self) -> Self::ULE;
     fn from_unaligned(unaligned: Self::ULE) -> Self;
 }
 ```

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -281,17 +281,17 @@ where
 {
     type OwnedType = T;
     fn zvl_insert(&mut self, index: usize, value: &T) {
-        self.to_mut().insert(index, value.as_unaligned())
+        self.to_mut().insert(index, value.to_unaligned())
     }
     fn zvl_remove(&mut self, index: usize) -> T {
         T::from_unaligned(self.to_mut().remove(index))
     }
     fn zvl_replace(&mut self, index: usize, value: &T) -> T {
         let vec = self.to_mut();
-        T::from_unaligned(mem::replace(&mut vec[index], value.as_unaligned()))
+        T::from_unaligned(mem::replace(&mut vec[index], value.to_unaligned()))
     }
     fn zvl_push(&mut self, value: &T) {
-        self.to_mut().push(value.as_unaligned())
+        self.to_mut().push(value.to_unaligned())
     }
     fn zvl_with_capacity(cap: usize) -> Self {
         ZeroVec::Owned(Vec::with_capacity(cap))

--- a/utils/zerovec/src/map2d/mod.rs
+++ b/utils/zerovec/src/map2d/mod.rs
@@ -329,7 +329,7 @@ where
     ) -> Option<(&'b K0, &'b K1, &'b V)> {
         if self.is_empty() {
             self.keys0.zvl_push(key0);
-            self.joiner.to_mut().push(1u32.as_unaligned());
+            self.joiner.to_mut().push(1u32.to_unaligned());
             self.keys1.zvl_push(key1);
             self.values.zvl_push(value);
             return None;
@@ -365,10 +365,10 @@ where
         // All OK to append
         if key0_cmp == Ordering::Greater {
             self.keys0.zvl_push(key0);
-            self.joiner.to_mut().push(joiner_value.as_unaligned());
+            self.joiner.to_mut().push(joiner_value.to_unaligned());
         } else {
             // This unwrap is protected because we are not empty
-            *self.joiner.to_mut().last_mut().unwrap() = joiner_value.as_unaligned();
+            *self.joiner.to_mut().last_mut().unwrap() = joiner_value.to_unaligned();
         }
         self.keys1.zvl_push(key1);
         self.values.zvl_push(value);
@@ -483,7 +483,7 @@ where
                 self.keys0.zvl_insert(key0_index, key0);
                 self.joiner
                     .to_mut()
-                    .insert(key0_index, joiner_value.as_unaligned());
+                    .insert(key0_index, joiner_value.to_unaligned());
                 (key0_index, (joiner_value as usize)..(joiner_value as usize))
             }
         }
@@ -507,7 +507,7 @@ where
                     .as_unsigned_int()
                     .checked_add(1)
                     .expect("Attempted to add more than 2^32 elements to a ZeroMap2d")
-                    .as_unaligned()
+                    .to_unaligned()
             });
     }
 
@@ -522,7 +522,7 @@ where
                     .as_unsigned_int()
                     .checked_sub(1)
                     .expect("Shrink should always succeed")
-                    .as_unaligned()
+                    .to_unaligned()
             });
     }
 

--- a/utils/zerovec/src/ule/chars.rs
+++ b/utils/zerovec/src/ule/chars.rs
@@ -21,7 +21,7 @@ use core::convert::TryFrom;
 /// use zerovec::ule::{ULE, AsULE, CharULE};
 ///
 /// let c1 = '𑄃';
-/// let ule = c1.as_unaligned();
+/// let ule = c1.to_unaligned();
 /// assert_eq!(CharULE::as_byte_slice(&[ule]), &[0x03, 0x11, 0x01, 0x00]);
 /// let c2 = char::from_unaligned(ule);
 /// assert_eq!(c1, c2);
@@ -68,7 +68,7 @@ impl AsULE for char {
     type ULE = CharULE;
 
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         let u = u32::from(self);
         CharULE(u.to_le_bytes())
     }
@@ -94,7 +94,7 @@ mod test {
     fn test_parse() {
         // 1-byte, 2-byte, 3-byte, and 4-byte character in UTF-8 (not as relevant in UTF-32)
         let chars = ['w', 'ω', '文', '𑄃'];
-        let char_ules: Vec<CharULE> = chars.iter().copied().map(char::as_unaligned).collect();
+        let char_ules: Vec<CharULE> = chars.iter().copied().map(char::to_unaligned).collect();
         let char_bytes: &[u8] = CharULE::as_byte_slice(&char_ules);
 
         // Check parsing
@@ -108,7 +108,7 @@ mod test {
         assert_eq!(&chars, parsed_chars.as_slice());
 
         // Check EqULE
-        let char_ule_slice = char::slice_as_unaligned(&chars);
+        let char_ule_slice = char::slice_to_unaligned(&chars);
         #[cfg(target_endian = "little")]
         assert_eq!(char_ule_slice, Some(char_ules.as_slice()));
         #[cfg(not(target_endian = "little"))]
@@ -119,7 +119,7 @@ mod test {
         let u32_ules: Vec<RawBytesULE<4>> = u32s
             .iter()
             .copied()
-            .map(<u32 as AsULE>::as_unaligned)
+            .map(<u32 as AsULE>::to_unaligned)
             .collect();
         let u32_bytes: &[u8] = RawBytesULE::<4>::as_byte_slice(&u32_ules);
         assert_eq!(char_bytes, u32_bytes);
@@ -138,7 +138,7 @@ mod test {
         let u32_ules: Vec<RawBytesULE<4>> = u32s
             .iter()
             .copied()
-            .map(<u32 as AsULE>::as_unaligned)
+            .map(<u32 as AsULE>::to_unaligned)
             .collect();
         let u32_bytes: &[u8] = RawBytesULE::<4>::as_byte_slice(&u32_ules);
         let parsed_ules_result = CharULE::parse_byte_slice(u32_bytes);
@@ -149,7 +149,7 @@ mod test {
         let u32_ules: Vec<RawBytesULE<4>> = u32s
             .iter()
             .copied()
-            .map(<u32 as AsULE>::as_unaligned)
+            .map(<u32 as AsULE>::to_unaligned)
             .collect();
         let u32_bytes: &[u8] = RawBytesULE::<4>::as_byte_slice(&u32_ules);
         let parsed_ules_result = CharULE::parse_byte_slice(u32_bytes);

--- a/utils/zerovec/src/ule/custom.rs
+++ b/utils/zerovec/src/ule/custom.rs
@@ -84,8 +84,8 @@
 //! unsafe impl EncodeAsVarULE<FooULE> for Foo<'_> {
 //!    fn encode_var_ule_as_slices<R>(&self, cb: impl FnOnce(&[&[u8]]) -> R) -> R {
 //!        // take each field, convert to ULE byte slices, and pass them through
-//!        cb(&[<char as AsULE>::ULE::as_byte_slice(&[self.field1.as_unaligned()]),
-//!             <u32 as AsULE>::ULE::as_byte_slice(&[self.field2.as_unaligned()]),
+//!        cb(&[<char as AsULE>::ULE::as_byte_slice(&[self.field1.to_unaligned()]),
+//!             <u32 as AsULE>::ULE::as_byte_slice(&[self.field2.to_unaligned()]),
 //!             // the ZeroVec is already in the correct slice format
 //!             self.field3.as_bytes()])
 //!    }

--- a/utils/zerovec/src/ule/encode.rs
+++ b/utils/zerovec/src/ule/encode.rs
@@ -151,7 +151,7 @@ where
         let S = core::mem::size_of::<T::ULE>();
         debug_assert_eq!(self.len() * S, dst.len());
         for (item, ref mut chunk) in self.iter().zip(dst.chunks_mut(S)) {
-            let ule = item.as_unaligned();
+            let ule = item.to_unaligned();
             chunk.copy_from_slice(ULE::as_byte_slice(core::slice::from_ref(&ule)));
         }
     }

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -156,7 +156,7 @@ pub trait AsULE: Copy {
     /// This function may involve byte order swapping (native-endian to little-endian).
     ///
     /// For best performance, mark your implementation of this function `#[inline]`.
-    fn as_unaligned(self) -> Self::ULE;
+    fn to_unaligned(self) -> Self::ULE;
 
     /// Converts from `Self::ULE` to `Self`.
     ///
@@ -193,7 +193,7 @@ where
     /// Converts from `&[Self]` to `&[Self::ULE]` if possible.
     ///
     /// In general, this function returns `Some` on little-endian and `None` on big-endian.
-    fn slice_as_unaligned(slice: &[Self]) -> Option<&[Self::ULE]>;
+    fn slice_to_unaligned(slice: &[Self]) -> Option<&[Self::ULE]>;
 }
 
 #[cfg(target_endian = "little")]
@@ -202,7 +202,7 @@ where
     T: EqULE,
 {
     #[inline]
-    fn slice_as_unaligned(slice: &[Self]) -> Option<&[Self::ULE]> {
+    fn slice_to_unaligned(slice: &[Self]) -> Option<&[Self::ULE]> {
         // This is safe because on little-endian platforms, the byte sequence of &[T]
         // is equivalent to the byte sequence of &[T::ULE] by the contract of EqULE,
         // and &[T::ULE] has equal or looser alignment than &[T].
@@ -218,7 +218,7 @@ where
     T: EqULE,
 {
     #[inline]
-    fn slice_as_unaligned(_: &[Self]) -> Option<&[Self::ULE]> {
+    fn slice_to_unaligned(_: &[Self]) -> Option<&[Self::ULE]> {
         None
     }
 }

--- a/utils/zerovec/src/ule/pair.rs
+++ b/utils/zerovec/src/ule/pair.rs
@@ -40,8 +40,8 @@ impl<A: AsULE, B: AsULE> AsULE for (A, B) {
     type ULE = PairULE<A::ULE, B::ULE>;
 
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
-        PairULE(self.0.as_unaligned(), self.1.as_unaligned())
+    fn to_unaligned(self) -> Self::ULE {
+        PairULE(self.0.to_unaligned(), self.1.to_unaligned())
     }
 
     #[inline]

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -77,7 +77,7 @@ macro_rules! impl_byte_slice_type {
         impl AsULE for $type {
             type ULE = RawBytesULE<$size>;
             #[inline]
-            fn as_unaligned(self) -> Self::ULE {
+            fn to_unaligned(self) -> Self::ULE {
                 RawBytesULE(self.to_le_bytes())
             }
             #[inline]
@@ -123,7 +123,7 @@ unsafe impl ULE for u8 {
 impl AsULE for u8 {
     type ULE = Self;
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         self
     }
     #[inline]
@@ -152,7 +152,7 @@ unsafe impl ULE for i8 {
 impl AsULE for i8 {
     type ULE = Self;
     #[inline]
-    fn as_unaligned(self) -> Self::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         self
     }
     #[inline]

--- a/utils/zerovec/src/varzerovec/components.rs
+++ b/utils/zerovec/src/varzerovec/components.rs
@@ -369,7 +369,7 @@ where
     A: EncodeAsVarULE<T>,
 {
     let num_elements = u32::try_from(elements.len()).ok().unwrap();
-    output[0..4].copy_from_slice(&num_elements.as_unaligned().0);
+    output[0..4].copy_from_slice(&num_elements.to_unaligned().0);
 
     // idx_offset = offset from the start of the buffer for the next index
     let mut idx_offset: usize = 4;
@@ -385,7 +385,7 @@ where
         let idx_slice = &mut output[idx_offset..idx_limit];
         // VZV expects data offsets to be stored relative to the first data block
         let offset = (dat_offset - first_dat_offset) as u32;
-        idx_slice.copy_from_slice(&offset.as_unaligned().0);
+        idx_slice.copy_from_slice(&offset.to_unaligned().0);
 
         let dat_limit = dat_offset + element_len;
         let dat_slice = &mut output[dat_offset..dat_limit];

--- a/utils/zerovec/src/varzerovec/owned.rs
+++ b/utils/zerovec/src/varzerovec/owned.rs
@@ -395,8 +395,8 @@ impl<T: VarULE + ?Sized> VarZeroVecOwned<T> {
             self.reserve(8 + value_len);
             let len_u32 = 1u32;
             let index_u32 = 0u32;
-            self.entire_slice.extend(&len_u32.as_unaligned().0);
-            self.entire_slice.extend(&index_u32.as_unaligned().0);
+            self.entire_slice.extend(&len_u32.to_unaligned().0);
+            self.entire_slice.extend(&index_u32.to_unaligned().0);
             element.encode_var_ule_as_slices(|slices| {
                 for slice in slices {
                     self.entire_slice.extend(*slice)

--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -87,8 +87,8 @@ where
     ///
     /// // The little-endian bytes correspond to the numbers on the following line.
     /// let bytes: &[u8] = &[0xD3, 0x00, 0x19, 0x01, 0xA5, 0x01, 0xCD, 0x01];
-    /// let nums: &[RawBytesULE<2>] = &[211_u16.as_unaligned(), 281_u16.as_unaligned(),
-    ///                                 421_u16.as_unaligned(), 461_u16.as_unaligned()];
+    /// let nums: &[RawBytesULE<2>] = &[211_u16.to_unaligned(), 281_u16.to_unaligned(),
+    ///                                 421_u16.to_unaligned(), 461_u16.to_unaligned()];
     ///
     /// let zerovec = ZeroVec::<u16>::Borrowed(nums);
     ///
@@ -445,7 +445,7 @@ where
     /// ```
     #[inline]
     pub fn alloc_from_slice(other: &[T]) -> Self {
-        Self::Owned(other.iter().copied().map(T::as_unaligned).collect())
+        Self::Owned(other.iter().copied().map(T::to_unaligned).collect())
     }
 
     /// Creates a `Vec<T>` from a `ZeroVec<T>`.
@@ -490,7 +490,7 @@ where
     /// ```
     #[inline]
     pub fn try_from_slice(slice: &'a [T]) -> Option<Self> {
-        T::slice_as_unaligned(slice).map(|ule_slice| Self::Borrowed(ule_slice))
+        T::slice_to_unaligned(slice).map(|ule_slice| Self::Borrowed(ule_slice))
     }
 
     /// Creates a `ZeroVec<'a, T>` from a `&'a [T]`, either by borrowing the argument or by
@@ -548,7 +548,7 @@ where
         self.to_mut().iter_mut().for_each(|item| {
             let mut aligned = T::from_unaligned(*item);
             f(&mut aligned);
-            *item = aligned.as_unaligned()
+            *item = aligned.to_unaligned()
         });
     }
 
@@ -580,7 +580,7 @@ where
         self.to_mut().iter_mut().try_for_each(|item| {
             let mut aligned = T::from_unaligned(*item);
             f(&mut aligned)?;
-            *item = aligned.as_unaligned();
+            *item = aligned.to_unaligned();
             Ok(())
         })
     }
@@ -603,7 +603,7 @@ where
         match self {
             Self::Owned(vec) => ZeroVec::Owned(vec),
             Self::Borrowed(_) => {
-                let vec: Vec<T::ULE> = self.iter().map(T::as_unaligned).collect();
+                let vec: Vec<T::ULE> = self.iter().map(T::to_unaligned).collect();
                 ZeroVec::Owned(vec)
             }
         }
@@ -622,14 +622,14 @@ where
     /// let mut zerovec: ZeroVec<u16> = ZeroVec::parse_byte_slice(bytes).expect("infallible");
     /// assert!(matches!(zerovec, ZeroVec::Borrowed(_)));
     ///
-    /// zerovec.to_mut().push(12_u16.as_unaligned());
+    /// zerovec.to_mut().push(12_u16.to_unaligned());
     /// assert!(matches!(zerovec, ZeroVec::Owned(_)));
     /// ```
     pub fn to_mut(&mut self) -> &mut Vec<T::ULE> {
         match self {
             ZeroVec::Owned(ref mut vec) => vec,
             ZeroVec::Borrowed(_) => {
-                let vec: Vec<T::ULE> = self.iter().map(T::as_unaligned).collect();
+                let vec: Vec<T::ULE> = self.iter().map(T::to_unaligned).collect();
                 let new_self = ZeroVec::Owned(vec);
                 *self = new_self;
                 // recursion is limited since we are guaranteed to hit the Owned branch
@@ -650,7 +650,7 @@ impl<T: AsULE> FromIterator<T> for ZeroVec<'_, T> {
     where
         I: IntoIterator<Item = T>,
     {
-        ZeroVec::Owned(iter.into_iter().map(|t| t.as_unaligned()).collect())
+        ZeroVec::Owned(iter.into_iter().map(|t| t.to_unaligned()).collect())
     }
 }
 

--- a/utils/zerovec/src/zerovec/serde.rs
+++ b/utils/zerovec/src/zerovec/serde.rs
@@ -51,7 +51,7 @@ where
             Vec::new()
         };
         while let Some(value) = seq.next_element::<T>()? {
-            vec.push(T::as_unaligned(value));
+            vec.push(T::to_unaligned(value));
         }
         Ok(ZeroVec::Owned(vec))
     }


### PR DESCRIPTION
Fixes #1260

Just one small leftover issue to knock out of the way. The Rust convention is to use to_ for by-copy functions. The as_ naming is from when this was by-ref.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->