### PR TITLE
Create façades for ZeroVec types, hide internal code organization modules

### DIFF
--- a/components/datetime/src/provider/calendar/symbols.rs
+++ b/components/datetime/src/provider/calendar/symbols.rs
@@ -6,7 +6,7 @@
 
 use alloc::borrow::Cow;
 use icu_provider::{yoke, zerofrom};
-use zerovec::map::ZeroMap;
+use zerovec::ZeroMap;
 
 #[icu_provider::data_struct(DateSymbolsV1Marker = "datetime/symbols@1")]
 #[derive(Debug, PartialEq, Clone, Default)]

--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -10,7 +10,7 @@ use serde::de::Deserialize;
 use writeable::Writeable;
 use yoke::trait_hack::YokeTraitHack;
 use yoke::*;
-use zerovec::map2d::{KeyError, ZeroMap2dBorrowed};
+use zerovec::maps::{KeyError, ZeroMap2dBorrowed};
 
 /// A data provider loading data from blobs dynamically created at runtime.
 ///

--- a/provider/blob/src/blob_schema.rs
+++ b/provider/blob/src/blob_schema.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use icu_provider::prelude::*;
-use zerovec::map2d::ZeroMap2dBorrowed;
+use zerovec::maps::ZeroMap2dBorrowed;
 
 /// A versioned Serde schema for ICU4X data blobs.
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/provider/blob/src/export/blob_exporter.rs
+++ b/provider/blob/src/export/blob_exporter.rs
@@ -8,7 +8,7 @@ use icu_provider::prelude::*;
 use icu_provider::serde::SerializeMarker;
 use litemap::LiteMap;
 use writeable::Writeable;
-use zerovec::map2d::ZeroMap2d;
+use zerovec::ZeroMap2d;
 
 /// A data exporter that writes data to a single-file blob.
 /// See the module-level docs for an example.

--- a/provider/blob/src/static_data_provider.rs
+++ b/provider/blob/src/static_data_provider.rs
@@ -8,7 +8,7 @@ use icu_provider::prelude::*;
 use serde::de::Deserialize;
 use writeable::Writeable;
 use yoke::trait_hack::YokeTraitHack;
-use zerovec::map2d::{KeyError, ZeroMap2dBorrowed};
+use zerovec::maps::{KeyError, ZeroMap2dBorrowed};
 
 /// A data provider loading data statically baked in to the binary.
 ///

--- a/provider/core/src/resource.rs
+++ b/provider/core/src/resource.rs
@@ -59,7 +59,7 @@ impl ResourceKeyHash {
     }
 }
 
-impl<'a> zerovec::map::ZeroMapKV<'a> for ResourceKeyHash {
+impl<'a> zerovec::maps::ZeroMapKV<'a> for ResourceKeyHash {
     type Container = zerovec::ZeroVec<'a, ResourceKeyHash>;
     type GetType = <ResourceKeyHash as AsULE>::ULE;
     type OwnedType = ResourceKeyHash;

--- a/utils/tinystr/src/ule.rs
+++ b/utils/tinystr/src/ule.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::TinyAsciiStr;
-use zerovec::map::ZeroMapKV;
+use zerovec::maps::ZeroMapKV;
 use zerovec::ule::*;
 use zerovec::ZeroVec;
 

--- a/utils/yoke/derive/examples/derive.rs
+++ b/utils/yoke/derive/examples/derive.rs
@@ -6,7 +6,7 @@
 
 use std::borrow::Cow;
 use yoke::{Yoke, Yokeable};
-use zerovec::{map::ZeroMapKV, ule::AsULE, VarZeroVec, ZeroMap, ZeroVec};
+use zerovec::{maps::ZeroMapKV, ule::AsULE, VarZeroVec, ZeroMap, ZeroVec};
 
 #[derive(Yokeable)]
 pub struct StringExample {

--- a/utils/zerofrom/derive/examples/derive.rs
+++ b/utils/zerofrom/derive/examples/derive.rs
@@ -6,7 +6,7 @@
 
 use std::borrow::Cow;
 use zerofrom::ZeroFrom;
-use zerovec::{map::ZeroMapKV, ule::AsULE, VarZeroVec, ZeroMap, ZeroVec};
+use zerovec::{maps::ZeroMapKV, ule::AsULE, VarZeroVec, ZeroMap, ZeroVec};
 
 #[derive(ZeroFrom, Copy, Clone)]
 pub struct IntExample {

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -118,7 +118,7 @@ pub fn make_ule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStream
         quote!()
     } else {
         quote!(
-            impl<'a> zerovec::map::ZeroMapKV<'a> for #name {
+            impl<'a> zerovec::maps::ZeroMapKV<'a> for #name {
                 type Container = zerovec::ZeroVec<'a, #name>;
                 type GetType = #ule_name;
                 type OwnedType = #name;

--- a/utils/zerovec/derive/src/varule.rs
+++ b/utils/zerovec/derive/src/varule.rs
@@ -250,7 +250,7 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
         quote!()
     } else {
         quote!(
-            impl<'a> zerovec::map::ZeroMapKV<'a> for #ule_name {
+            impl<'a> zerovec::maps::ZeroMapKV<'a> for #ule_name {
                 type Container = zerovec::VarZeroVec<'a, #ule_name>;
                 type GetType = #ule_name;
                 type OwnedType = Box<#ule_name>;

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -101,8 +101,8 @@
 extern crate alloc;
 
 mod error;
-pub mod map;
-pub mod map2d;
+mod map;
+mod map2d;
 #[cfg(test)]
 pub mod samples;
 pub mod ule;
@@ -122,4 +122,28 @@ pub use crate::zerovec::{ZeroSlice, ZeroVec};
 #[doc(hidden)]
 pub mod __zerovec_internal_reexport {
     pub use zerofrom::ZeroFrom;
+}
+
+pub mod maps {
+    //! This module contains additional utility types and traits for working with
+    //! [`ZeroMap`] and [`ZeroMap2d`].
+    //!
+    //! [`ZeroMapBorrowed`] and [`ZeroMap2dBorrowed`] are versions of [`ZeroMap`] and [`ZeroMap2d`]
+    //! that can be used when you wish to guarantee that the map data is always borrowed, leading to
+    //! relaxed lifetime constraints.
+    //!
+    //! The [`ZeroMapKV`] trait is required to be implemented on any type that needs to be used
+    //! within a map type. [`ZeroVecLike`], [`BorrowedZeroVecLike`], and [`MutableZeroVecLike`] are
+    //! all traits used in the internal workings of the map types, and should typically not be used
+    //! or implemented by users of this crate.
+    #[doc(no_inline)]
+    pub use crate::map::ZeroMap;
+    pub use crate::map::ZeroMapBorrowed;
+
+    #[doc(no_inline)]
+    pub use crate::map2d::ZeroMap2d;
+    pub use crate::map2d::ZeroMap2dBorrowed;
+
+    pub use crate::map2d::KeyError;
+    pub use crate::map::{ZeroMapKV, ZeroVecLike, BorrowedZeroVecLike, MutableZeroVecLike};
 }

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -145,8 +145,8 @@ pub mod maps {
     pub use crate::map2d::ZeroMap2d;
     pub use crate::map2d::ZeroMap2dBorrowed;
 
+    pub use crate::map::{BorrowedZeroVecLike, MutableZeroVecLike, ZeroMapKV, ZeroVecLike};
     pub use crate::map2d::KeyError;
-    pub use crate::map::{ZeroMapKV, ZeroVecLike, BorrowedZeroVecLike, MutableZeroVecLike};
 }
 
 pub mod vecs {
@@ -161,10 +161,10 @@ pub mod vecs {
     //! direct manipulation of the backing buffer.
 
     #[doc(no_inline)]
-    pub use crate::zerovec::{ZeroVec, ZeroSlice};
+    pub use crate::zerovec::{ZeroSlice, ZeroVec};
 
     #[doc(no_inline)]
-    pub use crate::varzerovec::{VarZeroVec, VarZeroSlice};
+    pub use crate::varzerovec::{VarZeroSlice, VarZeroVec};
 
     pub use crate::varzerovec::VarZeroVecOwned;
 }

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -106,7 +106,7 @@ mod map2d;
 #[cfg(test)]
 pub mod samples;
 pub mod ule;
-pub mod varzerovec;
+mod varzerovec;
 mod zerovec;
 
 #[cfg(feature = "yoke")]
@@ -126,7 +126,8 @@ pub mod __zerovec_internal_reexport {
 
 pub mod maps {
     //! This module contains additional utility types and traits for working with
-    //! [`ZeroMap`] and [`ZeroMap2d`].
+    //! [`ZeroMap`] and [`ZeroMap2d`]. See their docs for more details on the general purpose
+    //! of these types.
     //!
     //! [`ZeroMapBorrowed`] and [`ZeroMap2dBorrowed`] are versions of [`ZeroMap`] and [`ZeroMap2d`]
     //! that can be used when you wish to guarantee that the map data is always borrowed, leading to
@@ -146,4 +147,24 @@ pub mod maps {
 
     pub use crate::map2d::KeyError;
     pub use crate::map::{ZeroMapKV, ZeroVecLike, BorrowedZeroVecLike, MutableZeroVecLike};
+}
+
+pub mod vecs {
+    //! This module contains additional utility types for working with
+    //! [`ZeroVec`] and  [`VarZeroVec`]. See their docs for more details on the general purpose
+    //! of these types.
+    //!
+    //! [`ZeroSlice`] and [`VarZeroSlice`] provide slice-like versions of the vector types
+    //! for use behind references and in custom ULE types.
+    //!
+    //! [`VarZeroVecOwned`] is a special owned/mutable version of [`VarZeroVec`], allowing
+    //! direct manipulation of the backing buffer.
+
+    #[doc(no_inline)]
+    pub use crate::zerovec::{ZeroVec, ZeroSlice};
+
+    #[doc(no_inline)]
+    pub use crate::varzerovec::{VarZeroVec, VarZeroSlice};
+
+    pub use crate::varzerovec::VarZeroVecOwned;
 }

--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -20,7 +20,7 @@ pub use super::vecs::{BorrowedZeroVecLike, MutableZeroVecLike, ZeroVecLike};
 /// # Examples
 ///
 /// ```
-/// use zerovec::map::ZeroMapBorrowed;
+/// use zerovec::maps::ZeroMapBorrowed;
 ///
 /// // Example byte buffer representing the map { 1: "one" }
 /// let BINCODE_BYTES: &[u8; 31] = &[
@@ -96,7 +96,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use zerovec::map::ZeroMapBorrowed;
+    /// use zerovec::maps::ZeroMapBorrowed;
     ///
     /// let zm: ZeroMapBorrowed<u16, str> = ZeroMapBorrowed::new();
     /// assert!(zm.is_empty());
@@ -128,7 +128,7 @@ where
     ///
     /// ```rust
     /// use zerovec::ZeroMap;
-    /// use zerovec::map::ZeroMapBorrowed;
+    /// use zerovec::maps::ZeroMapBorrowed;
     ///
     /// let mut map = ZeroMap::new();
     /// map.insert(&1, "one");
@@ -155,7 +155,7 @@ where
     ///
     /// ```rust
     /// use zerovec::ZeroMap;
-    /// use zerovec::map::ZeroMapBorrowed;
+    /// use zerovec::maps::ZeroMapBorrowed;
     ///
     /// let mut map = ZeroMap::new();
     /// map.insert(&1, "one");
@@ -178,7 +178,7 @@ where
     ///
     /// ```rust
     /// use zerovec::ZeroMap;
-    /// use zerovec::map::ZeroMapBorrowed;
+    /// use zerovec::maps::ZeroMapBorrowed;
     ///
     /// let mut map = ZeroMap::new();
     /// map.insert(&1, "one");

--- a/utils/zerovec/src/map/mod.rs
+++ b/utils/zerovec/src/map/mod.rs
@@ -12,7 +12,6 @@ pub(crate) mod map;
 mod serde;
 mod vecs;
 
-#[doc(no_inline)]
 pub use crate::ZeroMap;
 pub use borrowed::ZeroMapBorrowed;
 pub use kv::ZeroMapKV;

--- a/utils/zerovec/src/map2d/borrowed.rs
+++ b/utils/zerovec/src/map2d/borrowed.rs
@@ -21,7 +21,7 @@ use crate::map2d::KeyError;
 /// # Examples
 ///
 /// ```
-/// use zerovec::map2d::ZeroMap2dBorrowed;
+/// use zerovec::maps::ZeroMap2dBorrowed;
 ///
 /// // Example byte buffer representing the map { 1: {2: "three" } }
 /// let BINCODE_BYTES: &[u8; 53] = &[
@@ -112,7 +112,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use zerovec::map2d::ZeroMap2dBorrowed;
+    /// use zerovec::maps::ZeroMap2dBorrowed;
     ///
     /// let zm: ZeroMap2dBorrowed<u16, u16, str> = ZeroMap2dBorrowed::new();
     /// assert!(zm.is_empty());
@@ -149,7 +149,7 @@ where
     ///
     /// ```rust
     /// use zerovec::ZeroMap2d;
-    /// use zerovec::map2d::{KeyError, ZeroMap2dBorrowed};
+    /// use zerovec::maps::{KeyError, ZeroMap2dBorrowed};
     ///
     /// let mut map = ZeroMap2d::new();
     /// map.insert(&1, "one", "foo");
@@ -187,7 +187,7 @@ where
     ///
     /// ```rust
     /// use zerovec::ZeroMap2d;
-    /// use zerovec::map2d::ZeroMap2dBorrowed;
+    /// use zerovec::maps::ZeroMap2dBorrowed;
     ///
     /// let mut map = ZeroMap2d::new();
     /// map.insert(&1, "one", "foo");

--- a/utils/zerovec/src/map2d/map.rs
+++ b/utils/zerovec/src/map2d/map.rs
@@ -189,7 +189,7 @@ where
     ///
     /// ```rust
     /// use zerovec::ZeroMap2d;
-    /// use zerovec::map2d::KeyError;
+    /// use zerovec::maps::KeyError;
     ///
     /// let mut map = ZeroMap2d::new();
     /// map.insert(&1, "one", "foo");
@@ -257,7 +257,7 @@ where
     ///
     /// ```rust
     /// use zerovec::ZeroMap2d;
-    /// use zerovec::map2d::KeyError;
+    /// use zerovec::maps::KeyError;
     ///
     /// let mut map = ZeroMap2d::new();
     /// map.insert(&1, "one", "foo");
@@ -294,7 +294,7 @@ where
     /// sorted list.
     /// ```rust
     /// use zerovec::ZeroMap2d;
-    /// use zerovec::map2d::KeyError;
+    /// use zerovec::maps::KeyError;
     ///
     /// let mut map = ZeroMap2d::new();
     /// assert!(map.try_append(&1, "one", "uno").is_none());

--- a/utils/zerovec/src/map2d/mod.rs
+++ b/utils/zerovec/src/map2d/mod.rs
@@ -9,7 +9,6 @@ pub(crate) mod map;
 #[cfg(feature = "serde")]
 mod serde;
 
-#[doc(no_inline)]
 pub use crate::ZeroMap2d;
 pub use borrowed::ZeroMap2dBorrowed;
 pub use map::KeyError;

--- a/utils/zerovec/src/varzerovec/mod.rs
+++ b/utils/zerovec/src/varzerovec/mod.rs
@@ -12,7 +12,6 @@ pub(crate) mod vec;
 #[cfg(feature = "serde")]
 mod serde;
 
-#[doc(no_inline)]
 pub use crate::{VarZeroSlice, VarZeroVec};
 
 #[cfg(feature = "bench")]

--- a/utils/zerovec/src/varzerovec/slice.rs
+++ b/utils/zerovec/src/varzerovec/slice.rs
@@ -26,8 +26,7 @@ use core::ops::Range;
 /// example the following code constructs the conceptual zero-copy equivalent of `Vec<Vec<Vec<str>>>`
 ///
 /// ```rust
-/// use zerovec::VarZeroVec;
-/// use zerovec::{ZeroVec, VarZeroSlice};
+/// use zerovec::{ZeroVec, VarZeroSlice, VarZeroVec};
 /// use zerovec::ule::*;
 /// let strings_1: Vec<&str> = vec!["foo", "bar", "baz"];
 /// let strings_2: Vec<&str> = vec!["twelve", "seventeen", "forty two"];

--- a/utils/zerovec/src/varzerovec/slice.rs
+++ b/utils/zerovec/src/varzerovec/slice.rs
@@ -27,8 +27,7 @@ use core::ops::Range;
 ///
 /// ```rust
 /// use zerovec::VarZeroVec;
-/// use zerovec::ZeroVec;
-/// use zerovec::varzerovec::VarZeroSlice;
+/// use zerovec::{ZeroVec, VarZeroSlice};
 /// use zerovec::ule::*;
 /// let strings_1: Vec<&str> = vec!["foo", "bar", "baz"];
 /// let strings_2: Vec<&str> = vec!["twelve", "seventeen", "forty two"];


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/1190

After discussion with @sffc, we've opted for the zerovec module structure to have the vec/slice/map types at the top level, with `ule`, `maps`, and `vecs` modules containing the rest (and reexports as needed).

Currently we do have a `maps` _and_ `map` module, we could rename `map` to `map_impl` or something if we want later. Shane and I concur that the façade modules should ideally only contain reexports and be defined in lib.rs.



<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->