### PR TITLE
Add serde support to the zerovec proc macro; reexport from the zerovec crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3144,6 +3144,7 @@ dependencies = [
  "serde_json",
  "yoke",
  "zerofrom",
+ "zerovec-derive",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,8 +3150,11 @@ dependencies = [
 name = "zerovec-derive"
 version = "0.6.0"
 dependencies = [
+ "postcard",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_json",
  "syn",
  "synstructure",
  "zerofrom",

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -29,6 +29,7 @@ all-features = true
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
 yoke = { version = "0.4.0", path = "../yoke", optional = true }
 zerofrom = { version = "0.1.0", path = "../zerofrom" }
+zerovec-derive = {version = "0.6.0", path = "./derive", optional = true}
 
 [dev-dependencies]
 icu_benchmark_macros = { version = "0.5", path = "../../tools/benchmark/macros" }
@@ -48,6 +49,7 @@ zerofrom = { version = "0.1.0", path = "../zerofrom", features = ["derive"] }
 [features]
 bench = []
 std = []
+derive = ["zerovec-derive"]
 
 [[bench]]
 name = "zerovec"

--- a/utils/zerovec/README.md
+++ b/utils/zerovec/README.md
@@ -19,9 +19,13 @@ intended as a replacement for `HashMap` or `LiteMap`.
 Clients upgrading to `zerovec` benefit from zero heap allocations when deserializing
 read-only data.
 
-This crate has two optional features: `serde` and `yoke`. `serde` allows serializing and deserializing
+This crate has three optional features: `serde`, `yoke`, and `derive`. `serde` allows serializing and deserializing
 `zerovec`'s abstractions via [`serde`](https://docs.rs/serde), and `yoke` enables implementations of `Yokeable`
 from the [`yoke`](https://docs.rs/yoke/) crate.
+
+`derive` makes it easier to use custom types in these collections by providing the [`#[make_ule]`](crate::make_ule) and
+[`#[make_varule]`](crate::make_varule) proc macros, which generate appropriate [`ULE`](crate::ule::ULE) and
+[`VarULE`](crate::ule::VarULE)-conformant types for a given "normal" type.
 
 ## Performance
 

--- a/utils/zerovec/derive/Cargo.toml
+++ b/utils/zerovec/derive/Cargo.toml
@@ -26,7 +26,7 @@ syn = { version = "1.0.73", features = ["derive", "parsing"] }
 synstructure = "0.12.4"
 
 [dev-dependencies]
-zerovec = { version = "0.6", path = "..", features = ["serde"] }
+zerovec = { version = "0.6", path = "..", features = ["serde", "derive"] }
 serde = { version = "1.0", features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../../zerofrom" }
 postcard = { version = "0.7", features = ["use-std"] }

--- a/utils/zerovec/derive/Cargo.toml
+++ b/utils/zerovec/derive/Cargo.toml
@@ -26,5 +26,8 @@ syn = { version = "1.0.73", features = ["derive", "parsing"] }
 synstructure = "0.12.4"
 
 [dev-dependencies]
-zerovec = { version = "0.6", path = ".." }
+zerovec = { version = "0.6", path = "..", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../../zerofrom" }
+postcard = { version = "0.7", features = ["use-std"] }
+serde_json = "1.0"

--- a/utils/zerovec/derive/examples/derives.rs
+++ b/utils/zerovec/derive/examples/derives.rs
@@ -5,10 +5,9 @@
 use zerovec::ule::AsULE;
 use zerovec::ule::EncodeAsVarULE;
 use zerovec::*;
-use zerovec_derive::*;
 
 #[repr(packed)]
-#[derive(ULE, Copy, Clone)]
+#[derive(ule::ULE, Copy, Clone)]
 pub struct FooULE {
     a: u8,
     b: <u32 as AsULE>::ULE,
@@ -42,7 +41,7 @@ impl AsULE for Foo {
 }
 
 #[repr(packed)]
-#[derive(VarULE)]
+#[derive(ule::VarULE)]
 pub struct RelationULE {
     /// This maps to (AndOr, Polarity, Operand),
     /// with the first bit mapping to AndOr (1 == And), the second bit

--- a/utils/zerovec/derive/examples/make.rs
+++ b/utils/zerovec/derive/examples/make.rs
@@ -4,7 +4,6 @@
 
 use std::fmt::Debug;
 use zerovec::*;
-use zerovec_derive::*;
 
 #[make_ule(StructULE)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/utils/zerovec/derive/examples/make_var.rs
+++ b/utils/zerovec/derive/examples/make_var.rs
@@ -9,37 +9,45 @@ use zerovec::*;
 use zerovec_derive::*;
 
 #[make_varule(VarStructULE)]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
+#[zerovec::serde]
 struct VarStruct<'a> {
     a: u32,
     b: char,
+    #[serde(borrow)]
     c: Cow<'a, str>,
 }
 
 #[make_varule(VarTupleStructULE)]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
-struct VarTupleStruct<'a>(u32, char, VarZeroVec<'a, str>);
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
+#[zerovec::serde]
+struct VarTupleStruct<'a>(u32, char, #[serde(borrow)] VarZeroVec<'a, str>);
 
 #[make_varule(NoKVULE)]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
 #[zerovec::skip_kv]
-struct NoKV<'a>(u32, char, VarZeroVec<'a, str>);
+#[zerovec::serde]
+struct NoKV<'a>(u32, char, #[serde(borrow)] VarZeroVec<'a, str>);
 
 #[make_varule(NoOrdULE)]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
 #[zerovec::skip_kv]
 #[zerovec::skip_ord]
-struct NoOrd<'a>(u32, char, VarZeroVec<'a, str>);
+#[zerovec::serde]
+struct NoOrd<'a>(u32, char, #[serde(borrow)] VarZeroVec<'a, str>);
 
 /// The `assert` function should have the body `|(stack, zero)| assert_eq!(stack, &U::zero_from(&zero))`
 ///
 /// We cannot do this internally because we technically need a different `U` with a shorter lifetime here
 /// which would require some gnarly lifetime bounds and perhaps a Yoke dependency. This is just a test, so it's
 /// not important to get this 100% perfect
-fn assert_zerovec<T: ule::VarULE + ?Sized, U: ule::EncodeAsVarULE<T>, F: Fn(&U, &T)>(
-    slice: &[U],
-    assert: F,
-) {
+fn assert_zerovec<T, U, F>(slice: &[U], assert: F)
+where
+    T: ule::VarULE + ?Sized + serde::Serialize,
+    U: ule::EncodeAsVarULE<T> + serde::Serialize,
+    F: Fn(&U, &T),
+    for<'a> Box<T>: serde::Deserialize<'a>,
+{
     let varzerovec: VarZeroVec<T> = slice.into();
 
     assert_eq!(varzerovec.len(), slice.len());
@@ -56,6 +64,24 @@ fn assert_zerovec<T: ule::VarULE + ?Sized, U: ule::EncodeAsVarULE<T>, F: Fn(&U, 
     assert_eq!(reparsed.len(), slice.len());
 
     for (stack, zero) in slice.iter().zip(reparsed.iter()) {
+        assert(stack, zero)
+    }
+
+    let postcard = postcard::to_stdvec(&varzerovec).unwrap();
+    let deserialized: VarZeroVec<T> = postcard::from_bytes(&postcard).unwrap();
+
+    for (stack, zero) in slice.iter().zip(deserialized.iter()) {
+        assert(stack, zero)
+    }
+
+    let json_slice = serde_json::to_string(&slice).unwrap();
+    let json_vzv = serde_json::to_string(&varzerovec).unwrap();
+
+    assert_eq!(json_slice, json_vzv);
+
+    let deserialized: VarZeroVec<T> = serde_json::from_str(&json_vzv).unwrap();
+
+    for (stack, zero) in slice.iter().zip(deserialized.iter()) {
         assert(stack, zero)
     }
 }

--- a/utils/zerovec/derive/examples/make_var.rs
+++ b/utils/zerovec/derive/examples/make_var.rs
@@ -6,7 +6,6 @@ use std::borrow::Cow;
 
 use zerofrom::ZeroFrom;
 use zerovec::*;
-use zerovec_derive::*;
 
 #[make_varule(VarStructULE)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]

--- a/utils/zerovec/derive/src/lib.rs
+++ b/utils/zerovec/derive/src/lib.rs
@@ -55,6 +55,10 @@ pub fn make_ule(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// The type must be `PartialEq` and `Eq`.
 ///
+/// Provided the type implements `serde::Serialize` and `serde::Deserialize`, this attribute can also generate
+/// the relevant serialize/deserialize implementations for the `VarULE` type if you apply the `#[zerovec::serde]`
+/// attribute. This needs the `serde` feature to be enabled on the `zerovec` crate to work.
+///
 /// By default this attribute will also autogenerate a `ZeroMapKV` implementation, which requires
 /// `Ord` and `PartialOrd` on the `VarULE` type. You can opt out of this with `#[zerovec::skip_kv]`.
 ///

--- a/utils/zerovec/derive/src/lib.rs
+++ b/utils/zerovec/derive/src/lib.rs
@@ -57,7 +57,8 @@ pub fn make_ule(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// Provided the type implements `serde::Serialize` and `serde::Deserialize`, this attribute can also generate
 /// the relevant serialize/deserialize implementations for the `VarULE` type if you apply the `#[zerovec::serde]`
-/// attribute. This needs the `serde` feature to be enabled on the `zerovec` crate to work.
+/// attribute. Those impls are required to support human-readable serialization of the VarZeroVec.
+/// This needs the `serde` feature to be enabled on the `zerovec` crate to work.
 ///
 /// By default this attribute will also autogenerate a `ZeroMapKV` implementation, which requires
 /// `Ord` and `PartialOrd` on the `VarULE` type. You can opt out of this with `#[zerovec::skip_kv]`.

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -206,6 +206,8 @@ fn make_ule_enum_impl(
         quote!(#[derive(Ord, PartialOrd)])
     };
 
+    let vis = &input.vis;
+
     // Safety (based on the safety checklist on the ULE trait):
     //  1. ULE type does not include any uninitialized or padding bytes.
     //     (achieved by `#[repr(transparent)]` on a type that satisfies this invariant
@@ -221,7 +223,7 @@ fn make_ule_enum_impl(
         #[repr(transparent)]
         #[derive(Copy, Clone, PartialEq, Eq)]
         #maybe_ord_derives
-        struct #ule_name(u8);
+        #vis struct #ule_name(u8);
 
         unsafe impl zerovec::ule::ULE for #ule_name {
             #[inline]
@@ -304,11 +306,12 @@ fn make_ule_struct_impl(
 
     let semi = utils::semi_for(&struc.fields);
     let repr_attr = utils::repr_for(&struc.fields);
+    let vis = &input.vis;
 
     let ule_struct: DeriveInput = parse_quote!(
         #[repr(#repr_attr)]
         #[derive(Copy, Clone, PartialEq, Eq)]
-        struct #ule_name #field_inits #semi
+        #vis struct #ule_name #field_inits #semi
     );
     let derived = derive_impl(&ule_struct);
 

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -98,10 +98,19 @@ pub fn make_ule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStream
     let arg = &attr[0];
     let ule_name: Ident = parse_quote!(#arg);
 
-    let (skip_kv, skip_ord) = match utils::extract_attributes_common(&mut input.attrs, "make_ule") {
-        Ok(val) => val,
-        Err(e) => return e.to_compile_error(),
-    };
+    let (skip_kv, skip_ord, serde) =
+        match utils::extract_attributes_common(&mut input.attrs, "make_ule") {
+            Ok(val) => val,
+            Err(e) => return e.to_compile_error(),
+        };
+
+    if serde {
+        return Error::new(
+            input.span(),
+            "#[make_ule] does not support #[zerovec::serde]",
+        )
+        .to_compile_error();
+    }
 
     let name = &input.ident;
 

--- a/utils/zerovec/derive/src/utils.rs
+++ b/utils/zerovec/derive/src/utils.rs
@@ -166,12 +166,16 @@ pub fn check_attr_empty(attr: &Option<Attribute>, name: &str) -> Result<()> {
 }
 
 /// Removes all known zerovec:: attributes from attrs and validates them
-/// Returns (skip_kv, skip_ord)
-pub fn extract_attributes_common(attrs: &mut Vec<Attribute>, name: &str) -> Result<(bool, bool)> {
+/// Returns (skip_kv, skip_ord, serde)
+pub fn extract_attributes_common(
+    attrs: &mut Vec<Attribute>,
+    name: &str,
+) -> Result<(bool, bool, bool)> {
     let mut zerovec_attrs = extract_zerovec_attributes(attrs);
 
     let skip_kv = extract_zerovec_attribute_named(&mut zerovec_attrs, "skip_kv");
     let skip_ord = extract_zerovec_attribute_named(&mut zerovec_attrs, "skip_ord");
+    let serde = extract_zerovec_attribute_named(&mut zerovec_attrs, "serde");
 
     if let Some(attr) = zerovec_attrs.get(0) {
         return Err(Error::new(
@@ -182,9 +186,11 @@ pub fn extract_attributes_common(attrs: &mut Vec<Attribute>, name: &str) -> Resu
 
     check_attr_empty(&skip_kv, "skip_kv")?;
     check_attr_empty(&skip_ord, "skip_ord")?;
+    check_attr_empty(&serde, "serde")?;
 
     let skip_kv = skip_kv.is_some();
     let skip_ord = skip_ord.is_some();
+    let serde = serde.is_some();
 
-    Ok((skip_kv, skip_ord))
+    Ok((skip_kv, skip_ord, serde))
 }

--- a/utils/zerovec/derive/src/varule.rs
+++ b/utils/zerovec/derive/src/varule.rs
@@ -127,10 +127,11 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
         .to_compile_error();
     }
 
-    let (skip_kv, skip_ord) = match utils::extract_attributes_common(&mut input.attrs, "make_ule") {
-        Ok(val) => val,
-        Err(e) => return e.to_compile_error(),
-    };
+    let (skip_kv, skip_ord, serde) =
+        match utils::extract_attributes_common(&mut input.attrs, "make_ule") {
+            Ok(val) => val,
+            Err(e) => return e.to_compile_error(),
+        };
 
     let lt = input.generics.lifetimes().next();
 
@@ -224,22 +225,25 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
         input.span(),
     );
 
+    let zerofrom_fq_path =
+        quote!(<#name as zerovec::__zerovec_internal_reexport::ZeroFrom<#ule_name>>);
+
     let maybe_ord_impls = if skip_ord {
         quote!()
     } else {
         quote!(
             impl core::cmp::PartialOrd for #ule_name {
                 fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-                    let this = <#name as zerovec::__zerovec_internal_reexport::ZeroFrom<#ule_name>>::zero_from(self);
-                    let other = <#name as zerovec::__zerovec_internal_reexport::ZeroFrom<#ule_name>>::zero_from(other);
+                    let this = #zerofrom_fq_path::zero_from(self);
+                    let other = #zerofrom_fq_path::zero_from(other);
                     <#name as core::cmp::PartialOrd>::partial_cmp(&this, &other)
                 }
             }
 
             impl core::cmp::Ord for #ule_name {
                 fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-                    let this = <#name as zerovec::__zerovec_internal_reexport::ZeroFrom<#ule_name>>::zero_from(self);
-                    let other = <#name as zerovec::__zerovec_internal_reexport::ZeroFrom<#ule_name>>::zero_from(other);
+                    let this = #zerofrom_fq_path::zero_from(self);
+                    let other = #zerofrom_fq_path::zero_from(other);
                     <#name as core::cmp::Ord>::cmp(&this, &other)
                 }
             }
@@ -258,6 +262,26 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
         )
     };
 
+    let maybe_serde_impl = if serde {
+        let serde_path = quote!(zerovec::__zerovec_internal_reexport::serde);
+        quote!(
+            impl #serde_path::Serialize for #ule_name {
+                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: #serde_path::Serializer {
+                    let this = #zerofrom_fq_path::zero_from(self);
+                    <#name as #serde_path::Serialize>::serialize(&this, serializer)
+                }
+            }
+            impl<'de> #serde_path::Deserialize<'de> for zerovec::__zerovec_internal_reexport::boxed::Box<#ule_name> {
+                fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: #serde_path::Deserializer<'de> {
+                    let this = <#name as #serde_path::Deserialize>::deserialize(deserializer)?;
+                    Ok(zerovec::ule::encode_varule_to_box(&this))
+                }
+            }
+        )
+    } else {
+        quote!()
+    };
+
     quote!(
         #input
 
@@ -272,6 +296,8 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
         #maybe_ord_impls
 
         #zmkv
+
+        #maybe_serde_impl
     )
 }
 

--- a/utils/zerovec/derive/src/varule.rs
+++ b/utils/zerovec/derive/src/varule.rs
@@ -194,11 +194,12 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
     let semi = utils::semi_for(fields);
     let repr_attr = utils::repr_for(fields);
     let field_inits = utils::wrap_field_inits(&field_inits, fields);
+    let vis = &input.vis;
 
     let varule_struct: DeriveInput = parse_quote!(
         #[repr(#repr_attr)]
         #[derive(PartialEq, Eq)]
-        struct #ule_name #field_inits #semi
+        #vis struct #ule_name #field_inits #semi
     );
 
     let derived = derive_impl(&varule_struct);

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -123,6 +123,8 @@ pub use crate::zerovec::{ZeroSlice, ZeroVec};
 pub mod __zerovec_internal_reexport {
     pub use zerofrom::ZeroFrom;
 
+    pub use alloc::boxed;
+
     #[cfg(feature = "serde")]
     pub use serde;
 }

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -122,6 +122,9 @@ pub use crate::zerovec::{ZeroSlice, ZeroVec};
 #[doc(hidden)]
 pub mod __zerovec_internal_reexport {
     pub use zerofrom::ZeroFrom;
+
+    #[cfg(feature = "serde")]
+    pub use serde;
 }
 
 pub mod maps {

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -123,7 +123,7 @@ pub use crate::map2d::map::ZeroMap2d;
 pub use crate::varzerovec::{slice::VarZeroSlice, vec::VarZeroVec};
 pub use crate::zerovec::{ZeroSlice, ZeroVec};
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "derive")]
 pub use zerovec_derive::{make_ule, make_varule};
 
 #[doc(hidden)]

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -21,9 +21,13 @@
 //! Clients upgrading to `zerovec` benefit from zero heap allocations when deserializing
 //! read-only data.
 //!
-//! This crate has two optional features: `serde` and `yoke`. `serde` allows serializing and deserializing
+//! This crate has three optional features: `serde`, `yoke`, and `derive`. `serde` allows serializing and deserializing
 //! `zerovec`'s abstractions via [`serde`](https://docs.rs/serde), and `yoke` enables implementations of `Yokeable`
 //! from the [`yoke`](https://docs.rs/yoke/) crate.
+//!
+//! `derive` makes it easier to use custom types in these collections by providing the [`#[make_ule]`](crate::make_ule) and
+//! [`#[make_varule]`](crate::make_varule) proc macros, which generate appropriate [`ULE`](crate::ule::ULE) and
+//! [`VarULE`](crate::ule::VarULE)-conformant types for a given "normal" type.
 //!
 //! # Performance
 //!
@@ -118,6 +122,9 @@ pub use crate::map::map::ZeroMap;
 pub use crate::map2d::map::ZeroMap2d;
 pub use crate::varzerovec::{slice::VarZeroSlice, vec::VarZeroVec};
 pub use crate::zerovec::{ZeroSlice, ZeroVec};
+
+#[cfg(feature = "serde")]
+pub use zerovec_derive::{make_ule, make_varule};
 
 #[doc(hidden)]
 pub mod __zerovec_internal_reexport {

--- a/utils/zerovec/src/ule/custom.rs
+++ b/utils/zerovec/src/ule/custom.rs
@@ -5,6 +5,9 @@
 //! This module contains documentation for defining custom VarULE types,
 //! especially those using complex custom dynamically sized types.
 //!
+//! In *most cases* you should be able to create custom VarULE types using
+//! [`#[make_varule]`](crate::make_ule).
+//!
 //! # Example
 //!
 //! For example, if your regular stack type is:

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -26,7 +26,7 @@ use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
 use core::{mem, slice};
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "derive")]
 pub use zerovec_derive::{VarULE, ULE};
 
 /// Fixed-width, byte-aligned data that can be cast to and from a little-endian byte slice.

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -26,7 +26,13 @@ use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
 use core::{mem, slice};
 
+#[cfg(feature = "serde")]
+pub use zerovec_derive::{VarULE, ULE};
+
 /// Fixed-width, byte-aligned data that can be cast to and from a little-endian byte slice.
+///
+/// If you need to implement this trait, consider using [`#[make_ule]`](crate::make_ule) or
+///  [`#[derive(ULE)]`](macro@ULE) instead.
 ///
 /// Types that are not fixed-width can implement [`VarULE`] instead.
 ///
@@ -142,6 +148,8 @@ where
 }
 
 /// A trait for any type that has a 1:1 mapping with an unaligned little-endian (ULE) type.
+///
+/// If you need to implement this trait, consider using [`#[make_varule]`](crate::make_ule) instead.
 pub trait AsULE: Copy {
     /// The ULE type corresponding to `Self`.
     ///
@@ -224,6 +232,9 @@ where
 }
 
 /// Variable-width, byte-aligned data that can be cast to and from a little-endian byte slice.
+///
+/// If you need to implement this trait, consider using [`#[make_varule]`](crate::make_varule) or
+///  [`#[derive(VarULE)]`](macro@VarULE) instead.
 ///
 /// This trait is mostly for unsized types like `str` and `[T]`. It can be implemented on sized types;
 /// however, it is much more preferable to use [`ULE`] for that purpose. The [`custom`] module contains


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/1079

This is the final bit of proc macro work; which allows the zerovec crate to autogenerate serde impls for the ULE/VarULE types.

Aside from some docs improvements, this is basically the final bit of work before the zerovec crate can be considered fully polished (#1475).


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->