### PR TITLE
Bring LineBreakDataV1 data structure closer to RuleBreakDataV1

### DIFF
--- a/experimental/segmenter/src/grapheme.rs
+++ b/experimental/segmenter/src/grapheme.rs
@@ -22,9 +22,7 @@ pub type GraphemeClusterBreakIteratorUtf16<'l, 's> =
     RuleBreakIterator<'l, 's, GraphemeClusterBreakTypeUtf16>;
 
 /// Supports loading grapheme cluster break data, and creating grapheme cluster break iterators for
-/// different string encodings. Please see the [module-level documentation] for its usages.
-///
-/// [module-level documentation]: index.html
+/// different string encodings. Please see the [module-level documentation](crate) for its usages.
 pub struct GraphemeClusterBreakSegmenter {
     payload: DataPayload<GraphemeClusterBreakDataV1Marker>,
 }

--- a/experimental/segmenter/src/lib.rs
+++ b/experimental/segmenter/src/lib.rs
@@ -179,7 +179,10 @@ pub use crate::grapheme::{
     GraphemeClusterBreakIterator, GraphemeClusterBreakIteratorLatin1,
     GraphemeClusterBreakIteratorUtf16, GraphemeClusterBreakSegmenter,
 };
-pub use crate::line::*;
+pub use crate::line::{
+    Latin1Char, LineBreakIterator, LineBreakOptions, LineBreakRule, LineBreakSegmenter, Utf16Char,
+    WordBreakRule,
+};
 pub use crate::provider::RuleBreakDataProvider;
 pub use crate::sentence::{
     SentenceBreakIterator, SentenceBreakIteratorLatin1, SentenceBreakIteratorUtf16,

--- a/experimental/segmenter/src/line.rs
+++ b/experimental/segmenter/src/line.rs
@@ -4,6 +4,7 @@
 
 use crate::indices::*;
 use crate::language::*;
+use crate::provider::line_data::*;
 use crate::provider::*;
 
 use alloc::vec;
@@ -11,8 +12,6 @@ use alloc::vec::Vec;
 use core::char;
 use core::str::CharIndices;
 use icu_provider::prelude::*;
-
-include!(concat!(env!("OUT_DIR"), "/generated_line_table.rs"));
 
 // Use the LSTM when the feature is enabled.
 #[cfg(feature = "lstm")]
@@ -303,8 +302,13 @@ fn is_break_utf32_by_loose(
 }
 
 #[inline]
-fn is_break_from_table(rule_table: &LineBreakRuleTable<'_>, left: u8, right: u8) -> bool {
-    let rule = get_break_state_from_table(rule_table, left, right);
+fn is_break_from_table(
+    rule_table: &LineBreakRuleTable<'_>,
+    property_count: u8,
+    left: u8,
+    right: u8,
+) -> bool {
+    let rule = get_break_state_from_table(rule_table, property_count, left, right);
     if rule == KEEP_RULE {
         return false;
     }
@@ -343,10 +347,15 @@ fn is_non_break_by_keepall(left: u8, right: u8) -> bool {
 }
 
 #[inline]
-fn get_break_state_from_table(rule_table: &LineBreakRuleTable<'_>, left: u8, right: u8) -> i8 {
-    let idx = (left as usize) * (rule_table.property_count as usize) + (right as usize);
+fn get_break_state_from_table(
+    rule_table: &LineBreakRuleTable<'_>,
+    property_count: u8,
+    left: u8,
+    right: u8,
+) -> i8 {
+    let idx = (left as usize) * (property_count as usize) + (right as usize);
     // We use unwrap_or to fall back to the base case and prevent panics on bad data.
-    rule_table.table_data.get(idx).unwrap_or(KEEP_RULE)
+    rule_table.0.get(idx).unwrap_or(KEEP_RULE)
 }
 
 #[inline]
@@ -506,8 +515,7 @@ impl<'l, 's, Y: LineBreakType<'l, 's>> Iterator for LineBreakIterator<'l, 's, Y>
             }
 
             // If break_state is equals or grater than 0, it is alias of property.
-            let mut break_state =
-                get_break_state_from_table(&self.data.rule_table, left_prop, right_prop);
+            let mut break_state = self.get_break_state_from_table(left_prop, right_prop);
             if break_state >= 0_i8 {
                 let mut previous_iter = self.iter.clone();
                 let mut previous_pos_data = self.current_pos_data;
@@ -516,11 +524,7 @@ impl<'l, 's, Y: LineBreakType<'l, 's>> Iterator for LineBreakIterator<'l, 's, Y>
                     self.current_pos_data = self.iter.next();
                     if self.current_pos_data.is_none() {
                         // Reached EOF. But we are analyzing multiple characters now, so next break may be previous point.
-                        let break_state = get_break_state_from_table(
-                            &self.data.rule_table,
-                            break_state as u8,
-                            EOT,
-                        );
+                        let break_state = self.get_break_state_from_table(break_state as u8, EOT);
                         if break_state == NOT_MATCH_RULE {
                             self.iter = previous_iter;
                             self.current_pos_data = previous_pos_data;
@@ -531,8 +535,7 @@ impl<'l, 's, Y: LineBreakType<'l, 's>> Iterator for LineBreakIterator<'l, 's, Y>
                     }
 
                     let prop = self.get_linebreak_property();
-                    break_state =
-                        get_break_state_from_table(&self.data.rule_table, break_state as u8, prop);
+                    break_state = self.get_break_state_from_table(break_state as u8, prop);
                     if break_state < 0 {
                         break;
                     }
@@ -551,7 +554,7 @@ impl<'l, 's, Y: LineBreakType<'l, 's>> Iterator for LineBreakIterator<'l, 's, Y>
                 return Some(self.current_pos_data.unwrap().0);
             }
 
-            if is_break_from_table(&self.data.rule_table, left_prop, right_prop) {
+            if self.is_break_from_table(left_prop, right_prop) {
                 return Some(self.current_pos_data.unwrap().0);
             }
         }
@@ -576,6 +579,14 @@ impl<'l, 's, Y: LineBreakType<'l, 's>> LineBreakIterator<'l, 's, Y> {
 
     fn is_break_by_normal(&self) -> bool {
         is_break_utf32_by_normal(self.current_pos_data.unwrap().1.into(), self.options.ja_zh)
+    }
+
+    fn get_break_state_from_table(&self, left: u8, right: u8) -> i8 {
+        get_break_state_from_table(&self.data.rule_table, self.data.property_count, left, right)
+    }
+
+    fn is_break_from_table(&self, left: u8, right: u8) -> bool {
+        is_break_from_table(&self.data.rule_table, self.data.property_count, left, right)
     }
 
     // UAX14 doesn't define line break rules for some languages such as Thai.
@@ -730,9 +741,9 @@ mod tests {
     use super::*;
 
     fn get_linebreak_property(codepoint: char) -> u8 {
-        let property_table = Default::default();
+        let lb_data: LineBreakDataV1 = Default::default();
         get_linebreak_property_with_rule(
-            &property_table,
+            &lb_data.property_table,
             codepoint,
             LineBreakRule::Strict,
             WordBreakRule::Normal,
@@ -758,9 +769,8 @@ mod tests {
     }
 
     fn is_break(left: u8, right: u8) -> bool {
-        let rule_table = Default::default();
-
-        is_break_from_table(&rule_table, left, right)
+        let lb_data: LineBreakDataV1 = Default::default();
+        is_break_from_table(&lb_data.rule_table, lb_data.property_count, left, right)
     }
 
     #[test]

--- a/experimental/segmenter/src/line.rs
+++ b/experimental/segmenter/src/line.rs
@@ -524,7 +524,8 @@ impl<'l, 's, Y: LineBreakType<'l, 's>> Iterator for LineBreakIterator<'l, 's, Y>
                     self.current_pos_data = self.iter.next();
                     if self.current_pos_data.is_none() {
                         // Reached EOF. But we are analyzing multiple characters now, so next break may be previous point.
-                        let break_state = self.get_break_state_from_table(break_state as u8, EOT);
+                        let break_state = self
+                            .get_break_state_from_table(break_state as u8, self.data.eot_property);
                         if break_state == NOT_MATCH_RULE {
                             self.iter = previous_iter;
                             self.current_pos_data = previous_pos_data;

--- a/experimental/segmenter/src/line.rs
+++ b/experimental/segmenter/src/line.rs
@@ -303,12 +303,12 @@ fn is_break_utf32_by_loose(
 
 #[inline]
 fn is_break_from_table(
-    rule_table: &LineBreakRuleTable<'_>,
+    break_state_table: &LineBreakStateTable<'_>,
     property_count: u8,
     left: u8,
     right: u8,
 ) -> bool {
-    let rule = get_break_state_from_table(rule_table, property_count, left, right);
+    let rule = get_break_state_from_table(break_state_table, property_count, left, right);
     if rule == KEEP_RULE {
         return false;
     }
@@ -348,14 +348,14 @@ fn is_non_break_by_keepall(left: u8, right: u8) -> bool {
 
 #[inline]
 fn get_break_state_from_table(
-    rule_table: &LineBreakRuleTable<'_>,
+    break_state_table: &LineBreakStateTable<'_>,
     property_count: u8,
     left: u8,
     right: u8,
 ) -> i8 {
     let idx = (left as usize) * (property_count as usize) + (right as usize);
     // We use unwrap_or to fall back to the base case and prevent panics on bad data.
-    rule_table.0.get(idx).unwrap_or(KEEP_RULE)
+    break_state_table.0.get(idx).unwrap_or(KEEP_RULE)
 }
 
 #[inline]
@@ -582,11 +582,21 @@ impl<'l, 's, Y: LineBreakType<'l, 's>> LineBreakIterator<'l, 's, Y> {
     }
 
     fn get_break_state_from_table(&self, left: u8, right: u8) -> i8 {
-        get_break_state_from_table(&self.data.rule_table, self.data.property_count, left, right)
+        get_break_state_from_table(
+            &self.data.break_state_table,
+            self.data.property_count,
+            left,
+            right,
+        )
     }
 
     fn is_break_from_table(&self, left: u8, right: u8) -> bool {
-        is_break_from_table(&self.data.rule_table, self.data.property_count, left, right)
+        is_break_from_table(
+            &self.data.break_state_table,
+            self.data.property_count,
+            left,
+            right,
+        )
     }
 
     // UAX14 doesn't define line break rules for some languages such as Thai.
@@ -770,7 +780,12 @@ mod tests {
 
     fn is_break(left: u8, right: u8) -> bool {
         let lb_data: LineBreakDataV1 = Default::default();
-        is_break_from_table(&lb_data.rule_table, lb_data.property_count, left, right)
+        is_break_from_table(
+            &lb_data.break_state_table,
+            lb_data.property_count,
+            left,
+            right,
+        )
     }
 
     #[test]

--- a/experimental/segmenter/src/line.rs
+++ b/experimental/segmenter/src/line.rs
@@ -102,9 +102,7 @@ impl Default for LineBreakOptions {
 }
 
 /// Supports loading line break data, and creating line break iterators for different string
-/// encodings. Please see the [module-level documentation] for its usages.
-///
-/// [module-level documentation]: index.html
+/// encodings. Please see the [module-level documentation](crate) for its usages.
 pub struct LineBreakSegmenter {
     options: LineBreakOptions,
     payload: DataPayload<LineBreakDataV1Marker>,
@@ -403,7 +401,7 @@ pub trait LineBreakType<'l, 's> {
 }
 
 /// Implements the [`Iterator`] trait over the line break opportunities of the given string. Please
-/// see the [module-level documentation] for its usages.
+/// see the [module-level documentation](crate) for its usages.
 ///
 /// Lifetimes:
 ///
@@ -411,7 +409,6 @@ pub trait LineBreakType<'l, 's> {
 /// - `'s` = lifetime of the string being segmented
 ///
 /// [`Iterator`]: core::iter::Iterator
-/// [module-level documentation]: index.html
 pub struct LineBreakIterator<'l, 's, Y: LineBreakType<'l, 's> + ?Sized> {
     iter: Y::IterAttr,
     len: usize,

--- a/experimental/segmenter/src/provider.rs
+++ b/experimental/segmenter/src/provider.rs
@@ -35,6 +35,11 @@ pub struct LineBreakDataV1<'data> {
     /// Number of properties; should be the square root of the length of
     /// [`Self::break_state_table`].
     pub property_count: u8,
+
+    pub last_codepoint_property: i8,
+    pub sot_property: u8,
+    pub eot_property: u8,
+    pub complex_property: u8,
 }
 
 impl Default for LineBreakDataV1<'static> {
@@ -45,6 +50,10 @@ impl Default for LineBreakDataV1<'static> {
                 ZeroSlice::from_ule_slice(&line_data::BREAK_STATE_MACHINE_TABLE).as_zerovec(),
             ),
             property_count: line_data::PROPERTY_COUNT,
+            last_codepoint_property: line_data::LAST_CODEPOINT_PROPERTY,
+            sot_property: line_data::PROP_SOT,
+            eot_property: line_data::PROP_EOT,
+            complex_property: line_data::PROP_COMPLEX,
         }
     }
 }

--- a/experimental/segmenter/src/provider.rs
+++ b/experimental/segmenter/src/provider.rs
@@ -28,11 +28,12 @@ pub struct LineBreakDataV1<'data> {
     #[cfg_attr(feature = "provider_serde", serde(borrow))]
     pub property_table: LineBreakPropertyTable<'data>,
 
-    /// Rule table for line breaking.
+    /// Break state table for line breaking.
     #[cfg_attr(feature = "provider_serde", serde(borrow))]
-    pub rule_table: LineBreakRuleTable<'data>,
+    pub break_state_table: LineBreakStateTable<'data>,
 
-    /// Number of properties; should be the square root of the length of [`Self::rule_table`].
+    /// Number of properties; should be the square root of the length of
+    /// [`Self::break_state_table`].
     pub property_count: u8,
 }
 
@@ -40,7 +41,7 @@ impl Default for LineBreakDataV1<'static> {
     fn default() -> Self {
         Self {
             property_table: LineBreakPropertyTable::Borrowed(&line_data::PROPERTY_TABLE),
-            rule_table: LineBreakRuleTable(
+            break_state_table: LineBreakStateTable(
                 ZeroSlice::from_ule_slice(&line_data::BREAK_STATE_MACHINE_TABLE).as_zerovec(),
             ),
             property_count: line_data::PROPERTY_COUNT,
@@ -76,13 +77,13 @@ impl<'zf> zerofrom::ZeroFrom<'zf, LineBreakPropertyTable<'_>> for LineBreakPrope
     }
 }
 
-/// Rule table for line breaking.
+/// Break state table for line breaking.
 #[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[cfg_attr(
     feature = "provider_serde",
     derive(serde::Serialize, serde::Deserialize)
 )]
-pub struct LineBreakRuleTable<'data>(pub ZeroVec<'data, i8>);
+pub struct LineBreakStateTable<'data>(pub ZeroVec<'data, i8>);
 
 /// Pre-processed Unicode data in the form of tables to be used for rule-based breaking.
 #[icu_provider::data_struct(

--- a/experimental/segmenter/src/rule_segmenter.rs
+++ b/experimental/segmenter/src/rule_segmenter.rs
@@ -29,7 +29,7 @@ pub trait RuleBreakType<'l, 's> {
 }
 
 /// Implements the [`Iterator`] trait over the segmenter break opportunities of the given string.
-/// Please see the [module-level documentation] for its usages.
+/// Please see the [module-level documentation](crate) for its usages.
 ///
 /// Lifetimes:
 ///
@@ -37,7 +37,6 @@ pub trait RuleBreakType<'l, 's> {
 /// - `'s` = lifetime of the string being segmented
 ///
 /// [`Iterator`]: core::iter::Iterator
-/// [module-level documentation]: index.html
 pub struct RuleBreakIterator<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> {
     pub(crate) iter: Y::IterAttr,
     pub(crate) len: usize,

--- a/experimental/segmenter/src/sentence.rs
+++ b/experimental/segmenter/src/sentence.rs
@@ -20,9 +20,7 @@ pub type SentenceBreakIteratorLatin1<'l, 's> = RuleBreakIterator<'l, 's, Sentenc
 pub type SentenceBreakIteratorUtf16<'l, 's> = RuleBreakIterator<'l, 's, SentenceBreakTypeUtf16>;
 
 /// Supports loading sentence break data, and creating sentence break iterators for different string
-/// encodings. Please see the [module-level documentation] for its usages.
-///
-/// [module-level documentation]: index.html
+/// encodings. Please see the [module-level documentation](crate) for its usages.
 pub struct SentenceBreakSegmenter {
     payload: DataPayload<SentenceBreakDataV1Marker>,
 }

--- a/experimental/segmenter/src/word.rs
+++ b/experimental/segmenter/src/word.rs
@@ -40,9 +40,7 @@ pub type WordBreakIteratorLatin1<'l, 's> = RuleBreakIterator<'l, 's, WordBreakTy
 pub type WordBreakIteratorUtf16<'l, 's> = RuleBreakIterator<'l, 's, WordBreakTypeUtf16>;
 
 /// Supports loading word break data, and creating word break iterators for different string
-/// encodings. Please see the [module-level documentation] for its usages.
-///
-/// [module-level documentation]: index.html
+/// encodings. Please see the [module-level documentation](crate) for its usages.
 pub struct WordBreakSegmenter {
     payload: DataPayload<WordBreakDataV1Marker>,
 }


### PR DESCRIPTION
This PR brings `LineBreakDataV1` closer to `RuleBreakDataV1` along with improvements to documentation. It also stops implementation details from being public in the documentation, e.g. we accidentally export line data constant in https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/index.html#constants