### PR TITLE
Changes to CI and benchmarks:

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -574,19 +574,6 @@ jobs:
           comment-on-alert: true
           alert-comment-cc-users: '@sffc,@zbraniecki,@echeran'
 
-      # Benchmarking & dashboards job > Upload output dashboard HTML to "persist" the files across jobs within the same workflow.
-
-      - name: Switch branch to get result of benchmark pages output (merge to main only)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
-        run: git checkout gh-pages
-
-      - name: Upload updated benchmark data (merge to main only)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
-        uses: actions/upload-artifact@v2
-        with:
-          path: ./benchmarks/perf/**  # use wildcard pattern to preserve dir structure of uploaded files
-          name: benchmark-perf
-
   # Run examples with dhat-rs in order to collect memory heap size metrics. These
   # metrics will then be charted over time. See tools/benchmark/memory/README.md for
   # more information.
@@ -706,21 +693,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
           alert-comment-cc-users: '@sffc,@zbraniecki,@echeran'
-
-      # Benchmarking & dashboards job > Upload output dashboard HTML to "persist" the
-      # files across jobs within the same workflow.
-
-      - name: Switch branch to get result of benchmark pages output (merge to main only)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
-        run: git checkout gh-pages
-
-      - name: Upload updated benchmark data (merge to main only)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
-        uses: actions/upload-artifact@v2
-        with:
-          # Use wildcard pattern to preserve dir structure of uploaded files:
-          path: ./benchmarks/memory/**
-          name: benchmark-memory
 
   # Binary size benchmark: build and size wasm binaries; creates ndjson output data format
 
@@ -864,19 +836,6 @@ jobs:
         comment-on-alert: true
         alert-comment-cc-users: '@gnrunge,@sffc,@zbraniecki,@echeran'
 
-    - name: Switch to branch gh-pages for benchmark data storage (merge to main only)
-      # Only for PRs that merge into the ICU4X mainline
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
-      run: git checkout gh-pages
-
-    - name: Upload binsize with benchmark data in ndjson format (merge to main only)
-      # Only for PRs that merge into the ICU4X mainline.
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
-      uses: actions/upload-artifact@v2
-      with:
-        path: ./benchmarks/binsize/**
-        name: benchmark-binsize
-
   # Data size benchmark: track size of provider/testdata/data/testdata.postcard (total data size).
 
   datasize:
@@ -927,19 +886,6 @@ jobs:
         comment-on-alert: true
         alert-comment-cc-users: '@gnrunge,@sffc,@zbraniecki,@echeran'
 
-    - name: Switch to branch gh-pages for benchmark data storage (merge to main only)
-      # Only for PRs that merge into the ICU4X mainline
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
-      run: git checkout gh-pages
-
-    - name: Upload datasize with benchmark data in ndjson format (merge to main only)
-      # Only for PRs that merge into the ICU4X mainline.
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
-      uses: actions/upload-artifact@v2
-      with:
-        path: ./benchmarks/datasize/**
-        name: benchmark-datasize
-
   # Docs job
 
   doc:
@@ -966,6 +912,7 @@ jobs:
       with:
         path: target/doc/**
         name: doc
+        retention-days: 1
 
   # Doc-GH-Pages job
 
@@ -974,7 +921,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    needs: [check, tidy, benchmark, memory, binsize, doc]
+    needs: [check, tidy, benchmark, memory, binsize, datasize, doc]
 
     ## Only create docs for merges/pushes to main (skip PRs).
     ## Multiple unfinished PRs should not clobber docs from approved code.
@@ -986,55 +933,25 @@ jobs:
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
+    - name: Switch to benchmark data storage branch.
+      run: |
+        git fetch
+        git checkout gh-pages
+
     # TODO(#234) re-include cache steps, also using Rust version in cache key
-
-    - name: Create (ensure existence of) folder suitable for copying to external repo
-      run: mkdir -p copy-to-ext-repo
-
-    - name: Create (ensure existence of) folder for benchmark data to copy
-      run: mkdir -p copy-to-ext-repo/benchmarks/perf
-
-    - name: Create (ensure existence of) folder for memory benchmark data to copy
-      run: mkdir -p copy-to-ext-repo/benchmarks/memory
-
-    - name: Create (ensure existence of) folder for binary size benchmark data to copy
-      run: mkdir -p copy-to-ext-repo/benchmarks/binsize
-
-    # Doc-GH-Pages job > Download benchmark dashboard files from previous jobs into folder of files to copy to remote repo
-
-    - name: Download previous content destined for GH pages
-      uses: actions/download-artifact@v2
-      with:
-        path: ./copy-to-ext-repo/benchmarks/perf
-        name: benchmark-perf
-
-    # Doc-GH-Pages job > Download benchmark dashboard files from previous jobs into folder of files to copy to remote repo
-    - name: Download previous content destined for GH pages
-      uses: actions/download-artifact@v2
-      with:
-        path: ./copy-to-ext-repo/benchmarks/memory
-        name: benchmark-memory
-
-    # Doc-GH-Pages job > Download benchmark dashboard files from previous jobs into folder of files to copy to remote repo
-    - name: Download previous content destined for GH pages
-      uses: actions/download-artifact@v2
-      with:
-        path: ./copy-to-ext-repo/benchmarks/binsize
-        name: benchmark-binsize
 
     # Doc-GH-Pages job > Download docs files from previous jobs into folder of files to copy to remote repo
     - name: Download previous content destined for GH pages
       uses: actions/download-artifact@v2
       with:
-        path: ./copy-to-ext-repo/doc
+        path: doc
         name: doc
 
     # Doc-GH-Pages job > Generate placeholder root index.html to redirect to `icu4x` crate
 
     - name: Create doc /index.html
       run: |
-        mkdir -p copy-to-ext-repo
-        cat > copy-to-ext-repo/index.html <<EOL
+        cat > index.html <<EOL
         <!doctype html>
         <html>
           <head>
@@ -1066,5 +983,5 @@ jobs:
         deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         external_repository: unicode-org/icu4x-docs
         publish_branch: gh-pages
-        publish_dir: copy-to-ext-repo
+        publish_dir: ./
         commit_message: Rust API docs + benchmark dashboards -> GH Pages

--- a/README.md
+++ b/README.md
@@ -103,5 +103,5 @@ The [binary size benchmarks](docs/process/benchmarking.md) run on Ubuntu, and ar
 * [wasm binaries](https://unicode-org.github.io/icu4x-docs/benchmarks/binsize/wasm/)
 * [gzip'd wasm binaries](https://unicode-org.github.io/icu4x-docs/benchmarks/binsize/gz)
 
-The data size benchmark tracks size of "provider/testdata/data/testdata.postcard" and runs on Ubuntu.
+The data size benchmark tracks size of `provider/testdata/data/testdata.postcard` and runs on Linux.
 * [data size](https://unicode-org.github.io/icu4x-docs/benchmarks/datasize)

--- a/README.md
+++ b/README.md
@@ -102,3 +102,6 @@ The [binary size benchmarks](docs/process/benchmarking.md) run on Ubuntu, and ar
 
 * [wasm binaries](https://unicode-org.github.io/icu4x-docs/benchmarks/binsize/wasm/)
 * [gzip'd wasm binaries](https://unicode-org.github.io/icu4x-docs/benchmarks/binsize/gz)
+
+The data size benchmark tracks size of "provider/testdata/data/testdata.postcard" and runs on Ubuntu.
+* [data size](https://unicode-org.github.io/icu4x-docs/benchmarks/datasize)


### PR DESCRIPTION
- Access the benchmark result data that is to be forwarded to the
  publishing repository directly from the gh-pages branch. No need
  to upload and download artifacts anymore.
- Set retention period to 1 day for the one remaining artifact, which is from
  doc generation.
- Datasize benchmark results are forwarded to the publishing repository.

Updates the root README.md accordingly.

Solves #1578.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->