### PR TITLE
Issue1363 clippy lints

### DIFF
--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -2,6 +2,12 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+#![deny(
+    clippy::indexing_slicing,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic
+)]
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 
 //! The `icu_calendar` crate contains the core types used by ICU4X for dealing
@@ -16,7 +22,6 @@
 //! Gregorian calendars respectively.
 extern crate alloc;
 
-#[allow(clippy::indexing_slicing, clippy::expect_used, clippy::panic)]
 pub mod arithmetic;
 pub mod buddhist;
 mod calendar;

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -16,6 +16,7 @@
 //! Gregorian calendars respectively.
 extern crate alloc;
 
+#[allow(indexing_slicing, expect_used, panic)]
 pub mod arithmetic;
 pub mod buddhist;
 mod calendar;

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -16,7 +16,7 @@
 //! Gregorian calendars respectively.
 extern crate alloc;
 
-#[allow(indexing_slicing, expect_used, panic)]
+#[allow(clippy::indexing_slicing, clippy::expect_used, clippy::panic)]
 pub mod arithmetic;
 pub mod buddhist;
 mod calendar;


### PR DESCRIPTION
Initial draft for [issue 1363](https://github.com/unicode-org/icu4x/issues/1363).

**Observation** : These lints are marked as unknown lints while running `cargo build`

```
warning: unknown lint: `indexing_slicing`
  --> components/calendar/src/lib.rs:19:9
   |
19 | #[allow(indexing_slicing, expect_used, panic)]
   |         ^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unknown_lints)]` on by default

warning: unknown lint: `expect_used`
  --> components/calendar/src/lib.rs:19:27
   |
19 | #[allow(indexing_slicing, expect_used, panic)]
   |                           ^^^^^^^^^^^

warning: unknown lint: `panic`
  --> components/calendar/src/lib.rs:19:40
   |
19 | #[allow(indexing_slicing, expect_used, panic)]
   |                                        ^^^^^```