### PR TITLE
Prototype of key registry

### DIFF
--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -73,3 +73,4 @@ postcard = { version = "0.7.0", default-features = false, optional = true }
 serde_json = "1.0"
 static_assertions = "1.1"
 icu_locid_macros = { version = "0.5", path = "../../components/locid/macros" }
+postcard = { version = "0.7.0", default-features = false, features = ["alloc"] }

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -141,6 +141,8 @@ pub mod marker;
 #[macro_use]
 mod resource;
 #[cfg(feature = "serde")]
+pub mod registry;
+#[cfg(feature = "serde")]
 pub mod serde;
 pub mod struct_provider;
 

--- a/provider/core/src/registry.rs
+++ b/provider/core/src/registry.rs
@@ -1,0 +1,110 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use crate::prelude::*;
+use core::fmt::Debug;
+use yoke::trait_hack::YokeTraitHack;
+use yoke::Yokeable;
+
+pub trait KeyRegistry {
+    // Calls `ConcreteDataCallback::callback::<M>();` for the appropriate marker type M
+    fn run_with_concrete_data<R>(
+        &self,
+        key: ResourceKey,
+        callback: &mut impl ConcreteDataCallback<R>,
+    ) -> Result<R, DataError>;
+}
+
+pub trait ConcreteDataCallback<R> {
+    fn callback<M: DataMarker + 'static>(&mut self) -> Result<R, DataError>
+    where
+        for<'a> &'a <M::Yokeable as Yokeable<'a>>::Output: serde::Serialize,
+        for<'de> YokeTraitHack<<M::Yokeable as Yokeable<'de>>::Output>: serde::Deserialize<'de>,
+        for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Debug;
+}
+
+#[macro_export]
+macro_rules! define_key_registry(
+    ($registry:ident, $($key:path => $marker:path),*) => {
+        pub struct $registry;
+
+        impl $crate::registry::KeyRegistry for $registry {
+            fn run_with_concrete_data<R>(&self, key: ResourceKey, callback: &mut impl ConcreteDataCallback<R>) -> Result<R, DataError> {
+                $(
+                    if key.get_hash() == $key.get_hash() {
+                        return callback.callback::<$marker>()
+                    }
+
+                )*
+
+                Err(DataErrorKind::MissingResourceKey.with_key(key))
+            }
+        }
+    }
+);
+
+#[cfg(all(test, feature = "deserialize_postcard_07"))]
+mod tests {
+    use super::*;
+    use crate::hello_world::*;
+    use crate::serde::SerializeMarker;
+    use core::fmt::Write;
+    use icu_locid_macros::langid;
+
+    define_key_registry!(HelloRegistry, HelloWorldV1Marker::KEY => HelloWorldV1Marker);
+
+    #[test]
+    fn test_registry_simple() {
+        let provider = HelloWorldProvider::new_with_placeholder_data();
+        erased_test_registry_simple(provider);
+    }
+
+    // Separate function so that we can assume the data marker type has been erased alread
+    fn erased_test_registry_simple(provider: impl DynProvider<SerializeMarker>) {
+        let request = DataRequest {
+            options: langid!("bn").into(),
+            metadata: Default::default(),
+        };
+        let payload = provider
+            .load_payload(HelloWorldV1Marker::KEY, &request)
+            .unwrap()
+            .payload
+            .unwrap();
+        let mut callback = MyHelloCallback(payload);
+        let value = HelloRegistry
+            .run_with_concrete_data(HelloWorldV1Marker::KEY, &mut callback)
+            .unwrap();
+
+        assert_eq!(value, "HelloWorldV1 { message: \"ওহে বিশ\\u{9cd}ব\" }");
+    }
+
+    struct MyHelloCallback(DataPayload<SerializeMarker>);
+
+    impl ConcreteDataCallback<String> for MyHelloCallback {
+        fn callback<M: DataMarker>(&mut self) -> Result<String, DataError>
+        where
+            for<'a> &'a <M::Yokeable as Yokeable<'a>>::Output: serde::Serialize,
+            for<'de> YokeTraitHack<<M::Yokeable as Yokeable<'de>>::Output>: serde::Deserialize<'de>,
+            for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Debug,
+        {
+            let mut s = postcard::Serializer {
+                output: postcard::flavors::AllocVec(vec![]),
+            };
+
+            {
+                let mut erased_s = Box::new(<dyn erased_serde::Serializer>::erase(&mut s));
+                self.0.serialize(&mut *erased_s)?;
+            }
+
+            let reified_data: YokeTraitHack<<M::Yokeable as Yokeable>::Output> =
+                postcard::from_bytes(&s.output.0)?;
+
+            let mut out = String::new();
+            // We use Debug here since we're trying to test that concrete impls can be called in generic contexts
+            // so we don't want to reference HelloWorld here
+            write!(&mut out, "{:?}", reified_data).unwrap();
+            Ok(out)
+        }
+    }
+}

--- a/utils/yoke/src/trait_hack.rs
+++ b/utils/yoke/src/trait_hack.rs
@@ -254,6 +254,7 @@
 //! ```
 
 use core::mem;
+use core::fmt;
 
 /// A wrapper around a type `T`, forwarding trait calls down to the inner type.
 ///
@@ -307,5 +308,11 @@ where
         D: serde::de::Deserializer<'de>,
     {
         T::deserialize(deserializer).map(YokeTraitHack)
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for YokeTraitHack<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
     }
 }


### PR DESCRIPTION
This is a prototype of my work for #1512

An annoying thing is that the callback trait has to define all the bounds it needs on the trait itself. Currently those are Ser/De and Debug, but I can forsee us needing Any as well, and perhaps CrabBake too. A way to simplify the bounds would be to define ConcreteSerializingCallback and ConcreteAnyCallback and ConcreteBothCallback. On the other hand, every type in the registry *should* support all these traits anyway.

A slightly different solution would be to give the registry the job of working with the data provider and casting the result. I don't prefer this because I feel like those are things that are better built *on top of* this abstraction. There are a lot of combinations of providers and marker types that could be used here.

Thoughts?

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->