### PR TITLE
Make time_zone/formats@1 fully zero-copy

### DIFF
--- a/components/datetime/src/provider/time_zones.rs
+++ b/components/datetime/src/provider/time_zones.rs
@@ -19,6 +19,7 @@ use zerovec::{ZeroMap, ZeroMap2d};
 pub struct TimeZoneFormatsV1<'data> {
     /// The hour format for displaying GMT offsets.
     #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "provider_serde", serde(deserialize_with = "icu_provider::serde::borrow_de_utils::tuple_of_cow"))]
     pub hour_format: (Cow<'data, str>, Cow<'data, str>),
     /// The localized GMT-offset format.
     #[cfg_attr(feature = "provider_serde", serde(borrow))]

--- a/components/datetime/src/provider/time_zones.rs
+++ b/components/datetime/src/provider/time_zones.rs
@@ -19,7 +19,10 @@ use zerovec::{ZeroMap, ZeroMap2d};
 pub struct TimeZoneFormatsV1<'data> {
     /// The hour format for displaying GMT offsets.
     #[cfg_attr(feature = "provider_serde", serde(borrow))]
-    #[cfg_attr(feature = "provider_serde", serde(deserialize_with = "icu_provider::serde::borrow_de_utils::tuple_of_cow"))]
+    #[cfg_attr(
+        feature = "provider_serde",
+        serde(deserialize_with = "icu_provider::serde::borrow_de_utils::tuple_of_cow")
+    )]
     pub hour_format: (Cow<'data, str>, Cow<'data, str>),
     /// The localized GMT-offset format.
     #[cfg_attr(feature = "provider_serde", serde(borrow))]

--- a/provider/core/src/serde/borrow_de_utils.rs
+++ b/provider/core/src/serde/borrow_de_utils.rs
@@ -26,6 +26,14 @@ where
     <Option<CowWrap<'de>>>::deserialize(deserializer).map(|opt| opt.map(|wrap| wrap.0))
 }
 
+pub fn tuple_of_cow<'de, D>(deserializer: D) -> Result<(Cow<'de, str>, Cow<'de, str>), D::Error>
+where
+    D: Deserializer<'de>,
+    (CowWrap<'de>, CowWrap<'de>): Deserialize<'de>,
+{
+    <(CowWrap<'de>, CowWrap<'de>)>::deserialize(deserializer).map(|x| (x.0 .0, x.1 .0))
+}
+
 #[test]
 fn test_option() {
     #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -36,6 +44,20 @@ fn test_option() {
     let data_new = serde_json::from_str::<Demo>(&json).expect("deserialize");
     assert_eq!(data_orig, data_new);
     assert!(matches!(data_new.0, Some(Cow::Borrowed(_))));
+}
+
+#[test]
+fn test_tuple() {
+    #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+    struct Demo<'s>(
+        #[serde(borrow, deserialize_with = "tuple_of_cow")] (Cow<'s, str>, Cow<'s, str>),
+    );
+
+    let data_orig = Demo(("Hello world".into(), "Hello earth".into()));
+    let json = serde_json::to_string(&data_orig).expect("serialize");
+    let data_new = serde_json::from_str::<Demo>(&json).expect("deserialize");
+    assert_eq!(data_orig, data_new);
+    assert!(matches!(data_new.0, (Cow::Borrowed(_), Cow::Borrowed(_))));
 }
 
 #[test]


### PR DESCRIPTION
Part of https://github.com/unicode-org/icu4x/issues/856, part of https://github.com/unicode-org/icu4x/issues/876

We're getting payoffs from https://github.com/unicode-org/icu4x/pull/1670 already!

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->