### PR TITLE
Make list_formatter data *almost* zero-copy

### DIFF
--- a/components/list/Cargo.toml
+++ b/components/list/Cargo.toml
@@ -43,7 +43,7 @@ path = "src/lib.rs"
 [features]
 default = ["icu4x_human_readable_de"]
 std = ["icu_provider/std", "icu_locid/std", "regex-automata/std", "regex-automata/alloc"]
-provider_serde = ["serde", "zerovec/serde", "deduplicating_array"]
+provider_serde = ["serde", "icu_provider/serde", "zerovec/serde", "deduplicating_array"]
 provider_transform_internals = ["provider_serde", "std"]
 icu4x_human_readable_de = ["provider_serde", "regex-automata/alloc"]
 

--- a/components/list/src/string_matcher.rs
+++ b/components/list/src/string_matcher.rs
@@ -53,6 +53,8 @@ impl<'de: 'data, 'data> serde::Deserialize<'de> for StringMatcher<'data> {
     where
         D: serde::de::Deserializer<'de>,
     {
+        use icu_provider::serde::borrow_de_utils::CowBytesWrap;
+
         #[cfg(feature = "icu4x_human_readable_de")]
         if deserializer.is_human_readable() {
             return StringMatcher::new(<&str>::deserialize(deserializer)?).map_err(|e| {
@@ -70,7 +72,7 @@ impl<'de: 'data, 'data> serde::Deserialize<'de> for StringMatcher<'data> {
             });
         }
 
-        let dfa_bytes = <Cow<'de, [u8]>>::deserialize(deserializer)?;
+        let dfa_bytes = <CowBytesWrap<'de>>::deserialize(deserializer)?.0;
 
         // Verify safety invariant
         DFA::from_bytes(&dfa_bytes).map_err(|e| {

--- a/provider/core/src/serde/borrow_de_utils.rs
+++ b/provider/core/src/serde/borrow_de_utils.rs
@@ -9,7 +9,12 @@ use serde::Deserialize;
 #[derive(Deserialize)]
 #[serde(transparent)]
 // Cows fail to borrow in some situations (array, option), but structs of Cows don't.
-pub struct CowWrap<'data>(#[serde(borrow)] Cow<'data, str>);
+pub struct CowWrap<'data>(#[serde(borrow)] pub Cow<'data, str>);
+
+#[derive(Deserialize)]
+#[serde(transparent)]
+// Cows fail to borrow in some situations (array, option), but structs of Cows don't.
+pub struct CowBytesWrap<'data>(#[serde(borrow)] pub Cow<'data, [u8]>);
 
 pub fn array_of_cow<'de, D, const N: usize>(deserializer: D) -> Result<[Cow<'de, str>; N], D::Error>
 where

--- a/tools/datagen/src/bin/verify-zero-copy.rs
+++ b/tools/datagen/src/bin/verify-zero-copy.rs
@@ -25,13 +25,31 @@ use std::rc::Rc;
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
-static EXPECTED_VIOLATIONS: &[&str] = &[
+// Types in this list cannot be zero-copy deserialized (and are unlikely to work with CrabBake).
+//
+// Such types contain some data that was allocated during deserializations
+//
+// Every entry in this list is a bug that needs to be addressed before ICU4X 1.0.
+static EXPECTED_NET_VIOLATIONS: &[&str] = &[
+    // https://github.com/unicode-org/icu4x/issues/1678
     "datetime/skeletons@1",
+    // https://github.com/unicode-org/icu4x/issues/1034
+    "locale_canonicalizer/aliases@1",
+    // https://github.com/unicode-org/icu4x/issues/1034
+    "locale_canonicalizer/likelysubtags@1",
+];
+
+// Types in this list can be zero-copy deserialized (and do not contain allocated data),
+// however there is some allocation that occurs during deserialization for validation. This is unlikely to affect
+// CrabBake since CrabBake can bypass validation steps.
+//
+// Entries in this list represent a less-than-ideal state of things, however ICU4X is shippable with violations
+// in this list since it does not affect CrabBake.
+static EXPECTED_TOTAL_VIOLATIONS: &[&str] = &[
+    // Regex DFAs need to be validated, which involved creating a BTreeMap
     "list/and@1",
     "list/or@1",
     "list/unit@1",
-    "locale_canonicalizer/aliases@1",
-    "locale_canonicalizer/likelysubtags@1",
 ];
 
 fn main() -> eyre::Result<()> {
@@ -200,12 +218,17 @@ fn main() -> eyre::Result<()> {
         BlobDataProvider::new_from_rc_blob(Rc::from(blob)).expect("Deserialization should succeed");
 
     // Litemap keeps it sorted, convenient
-    let mut violations: LiteMap<&'static str, u64> = LiteMap::new();
+
+    // violations for net_bytes_allocated
+    let mut net_violations: LiteMap<&'static str, usize> = LiteMap::new();
+    // violations for total_bytes_allocated (but not net_bytes_allocated)
+    let mut total_violations: LiteMap<&'static str, u64> = LiteMap::new();
 
     for key in selected_keys.into_iter() {
         let props_key = key.get_path().starts_with("props/");
 
-        let mut max_violation = 0;
+        let mut max_total_violation = 0;
+        let mut max_net_violation = 0;
 
         for options in converter.supported_options_for_key(key)? {
             let result = provider.load_buffer(
@@ -230,32 +253,60 @@ fn main() -> eyre::Result<()> {
 
             let stats: DataPayload<HeapStatsMarker> =
                 converter.convert(key, payload).map_err(|e| e.1)?;
-            let vio = stats.get().total_bytes_allocated;
-            log::trace!("Key {} with options [{}] takes {} bytes", key, options, vio);
-            max_violation = cmp::max(vio, max_violation);
+            let vio_total = stats.get().total_bytes_allocated;
+            let vio_net = stats.get().net_bytes_allocated;
+            log::trace!(
+                "Key {} with options [{}] takes {} bytes ({} net)",
+                key,
+                options,
+                vio_total,
+                vio_net
+            );
+            max_total_violation = cmp::max(vio_total, max_total_violation);
+            max_net_violation = cmp::max(vio_net, max_net_violation);
         }
-        log::info!("Key {} takes max {} bytes", key, max_violation);
-        if max_violation != 0 {
-            violations.insert(key.get_path(), max_violation);
+        log::info!(
+            "Key {} takes max {} bytes ({} net)",
+            key,
+            max_total_violation,
+            max_net_violation
+        );
+        if max_total_violation != 0 {
+            if max_net_violation != 0 {
+                net_violations.insert(key.get_path(), max_net_violation);
+            } else {
+                total_violations.insert(key.get_path(), max_total_violation);
+            }
         }
     }
 
-    let vio_vec: Vec<_> = violations.iter_keys().copied().collect();
+    let total_vio_vec: Vec<_> = total_violations.iter_keys().copied().collect();
+    let net_vio_vec: Vec<_> = net_violations.iter_keys().copied().collect();
 
-    if vio_vec.is_empty() {
+    if total_vio_vec.is_empty() && net_vio_vec.is_empty() {
         log::info!("Congratulations! All keys are zero-copy");
     } else {
         log::info!("Found the following keys that are not yet zero-copy:");
-        for (name, vio) in violations.iter() {
+        for (name, vio) in net_violations.iter() {
             log::info!("\t{}: max heap size {} bytes", name, vio);
         }
+
+        if !total_vio_vec.is_empty() {
+            log::info!("Also found the following keys that are zero-copy but temporarily allocate during deserialization:");
+
+            for (name, vio) in total_violations.iter() {
+                log::info!("\t{}: allocates a maximum of {} bytes", name, vio);
+            }
+        }
     }
-    if matches.is_present("CHECK") && vio_vec != EXPECTED_VIOLATIONS {
+    if matches.is_present("CHECK")
+        && (total_vio_vec != EXPECTED_TOTAL_VIOLATIONS || net_vio_vec != EXPECTED_NET_VIOLATIONS)
+    {
         eyre::bail!("Expected violations list does not match found violations!\n\
                     If the new list is smaller, please update EXPECTED_VIOLATIONS in verify-zero-copy.rs\n\
                     If it is bigger and that was unexpected, please make sure the key remains zero-copy, or ask ICU4X team members if it is okay\
                     to temporarily allow for this key to be allowlisted.\n\
-                    Expected:\n{:?}\nFound:\n{:?}", EXPECTED_VIOLATIONS, vio_vec)
+                    Expected (net):\n{:?}\nFound (net):\n{:?}\nExpected (total):\n{:?}\nFound (total):\n{:?}", EXPECTED_NET_VIOLATIONS, net_vio_vec, EXPECTED_TOTAL_VIOLATIONS, total_vio_vec)
     }
 
     Ok(())


### PR DESCRIPTION
Unfortunately, this cannot be 100% non-allocating due to the `DFA::from_bytes()` used for verification. I'm not sure what to do about that, technically the _data_ is still zero-copy (and this can be done in a crab-bake-kosher way) but our tool will still complain.

Might be worth allowlisting it for allocating exactly 1408 bytes.

Part of https://github.com/unicode-org/icu4x/issues/1678