### PR TITLE
Add make_forking_provider! macro

### DIFF
--- a/provider/core/src/fork/by_key.rs
+++ b/provider/core/src/fork/by_key.rs
@@ -103,6 +103,7 @@ use alloc::vec::Vec;
 ///     .expect_err("Should stop at the first provider, even though the second has data");
 /// # }
 /// ```
+#[derive(Debug, PartialEq, Eq)]
 pub struct ForkByKeyProvider<P0, P1>(pub P0, pub P1);
 
 impl<P0, P1> BufferProvider for ForkByKeyProvider<P0, P1>

--- a/provider/core/src/fork/macros.rs
+++ b/provider/core/src/fork/macros.rs
@@ -21,9 +21,11 @@
 /// // Combine them into one:
 /// let forking1 = icu_provider::make_forking_provider!(
 ///     ForkByKeyProvider,
-///     Provider1::default(),
-///     Provider2::default(),
-///     Provider3::default()
+///     [
+///         Provider1::default(),
+///         Provider2::default(),
+///         Provider3::default(),
+///     ]
 /// );
 ///
 /// // This is equivalent to:
@@ -40,12 +42,12 @@
 #[macro_export]
 macro_rules! make_forking_provider {
     // Base case:
-    ($combo_p:path, $a:expr, $b:expr) => {
+    ($combo_p:path, [ $a:expr, $b:expr, ]) => {
         $combo_p($a, $b)
     };
     // General list:
-    ($combo_p:path, $a:expr, $b:expr, $($c:expr),+ ) => {
-        $combo_p($a, $crate::make_forking_provider!($combo_p, $b, $($c),+ ))
+    ($combo_p:path, [ $a:expr, $b:expr, $($c:expr),+, ]) => {
+        $combo_p($a, $crate::make_forking_provider!($combo_p, [ $b, $($c),+, ]))
     };
 }
 
@@ -62,9 +64,11 @@ mod test {
     fn test_make_forking_provider() {
         make_forking_provider!(
             crate::fork::by_key::ForkByKeyProvider,
-            Provider1::default(),
-            Provider2::default(),
-            Provider3::default()
+            [
+                Provider1::default(),
+                Provider2::default(),
+                Provider3::default(),
+            ]
         );
     }
 }

--- a/provider/core/src/fork/macros.rs
+++ b/provider/core/src/fork/macros.rs
@@ -1,0 +1,70 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+/// Make a forking data provider with an arbitrary number of inner providers
+/// that are known at build time.
+///
+/// # Examples
+///
+/// ```
+/// use icu_provider::fork::by_key::ForkByKeyProvider;
+///
+/// // Some empty example providers:
+/// #[derive(Default, PartialEq, Debug)]
+/// struct Provider1;
+/// #[derive(Default, PartialEq, Debug)]
+/// struct Provider2;
+/// #[derive(Default, PartialEq, Debug)]
+/// struct Provider3;
+///
+/// // Combine them into one:
+/// let forking1 = icu_provider::make_forking_provider!(
+///     ForkByKeyProvider,
+///     Provider1::default(),
+///     Provider2::default(),
+///     Provider3::default()
+/// );
+///
+/// // This is equivalent to:
+/// let forking2 = ForkByKeyProvider(
+///     Provider1::default(),
+///     ForkByKeyProvider(
+///         Provider2::default(),
+///         Provider3::default()
+///     )
+/// );
+///
+/// assert_eq!(forking1, forking2);
+/// ```
+#[macro_export]
+macro_rules! make_forking_provider {
+    // Base case:
+    ($combo_p:path, $a:expr, $b:expr) => {
+        $combo_p($a, $b)
+    };
+    // General list:
+    ($combo_p:path, $a:expr, $b:expr, $($c:expr),+ ) => {
+        $combo_p($a, $crate::make_forking_provider!($combo_p, $b, $($c),+ ))
+    };
+}
+
+#[cfg(test)]
+mod test {
+    #[derive(Default)]
+    struct Provider1;
+    #[derive(Default)]
+    struct Provider2;
+    #[derive(Default)]
+    struct Provider3;
+
+    #[test]
+    fn test_make_forking_provider() {
+        make_forking_provider!(
+            crate::fork::by_key::ForkByKeyProvider,
+            Provider1::default(),
+            Provider2::default(),
+            Provider3::default()
+        );
+    }
+}

--- a/provider/core/src/fork/mod.rs
+++ b/provider/core/src/fork/mod.rs
@@ -5,3 +5,6 @@
 //! Providers that combine multiple other providers.
 
 pub mod by_key;
+
+#[macro_use]
+mod macros;


### PR DESCRIPTION
This gives a friendlier mechanism to create forking data providers without trait objects.