### PR TITLE
Consistently use `datagen` and `serialize` features for serde work

### DIFF
--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -25,7 +25,8 @@ include = [
 
 [features]
 std = []
-provider_serde = ["serde", "litemap/serde_serialize", "zerovec/serde", "tinystr/serde"]
+serialize = ["serde", "litemap/serde", "zerovec/serde", "tinystr/serde"]
+datagen = ["serialize", "litemap/serde_serialize"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/components/calendar/src/arithmetic.rs
+++ b/components/calendar/src/arithmetic.rs
@@ -10,10 +10,7 @@ pub mod week_of {
 
     /// Information about how a given calendar assigns weeks to a year or month.
     #[derive(Clone, Copy, Debug)]
-    #[cfg_attr(
-        feature = "provider_serde",
-        derive(serde::Serialize, serde::Deserialize)
-    )]
+    #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
     pub struct CalendarInfo {
         /// The first day of a week.
         pub first_weekday: IsoWeekday,

--- a/components/calendar/src/provider.rs
+++ b/components/calendar/src/provider.rs
@@ -18,10 +18,8 @@ use zerovec::ZeroVec;
 #[derive(
     Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Debug, yoke::Yokeable, zerofrom::ZeroFrom,
 )]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct EraStartDate {
     pub year: i32,
     pub month: u8,
@@ -30,14 +28,12 @@ pub struct EraStartDate {
 
 #[icu_provider::data_struct(JapaneseErasV1Marker = "calendar/japanese@1")]
 #[derive(Debug, PartialEq, Clone, Default)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct JapaneseErasV1<'data> {
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub dates_to_historical_eras: ZeroVec<'data, (EraStartDate, TinyStr16)>,
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub dates_to_eras: ZeroVec<'data, (EraStartDate, TinyStr16)>,
 }
 

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -356,10 +356,7 @@ impl FromStr for GmtOffset {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[allow(missing_docs)] // The weekday variants should be self-obvious.
 #[repr(i8)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum IsoWeekday {
     Monday = 1,
     Tuesday,

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -52,7 +52,7 @@ icu = { path = "../icu", default-features = false }
 icu_benchmark_macros = { version = "0.5", path = "../../tools/benchmark/macros" }
 icu_provider = { version = "0.5", path = "../../provider/core" }
 icu_testdata = { version = "0.5", path = "../../provider/testdata", features = ["static"] }
-icu_calendar = { version = "0.5", path = "../calendar", features = ["provider_serde"] }
+icu_calendar = { version = "0.5", path = "../calendar", features = ["serialize"] }
 icu_locid_macros = { version = "0.5", path = "../locid/macros" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -64,15 +64,15 @@ bench = false  # This option is required for Benchmark CI
 
 [features]
 std = ["icu_provider/std", "icu_locid/std", "icu_calendar/std"]
-default = ["provider_serde"]
+default = ["serialize"]
 bench = []
-provider_serde = ["serde", "litemap/serde_serialize", "smallvec/serde", "litemap/serde", "zerovec/serde", "tinystr/serde", "icu_calendar/provider_serde", "icu_provider/serde"]
-provider_transform_internals = ["std"]
+serialize = ["serde", "litemap/serde", "zerovec/serde", "tinystr/serde", "smallvec/serde", "icu_calendar/serde", "icu_provider/serialize"]
+datagen = ["serialize", "icu_calendar/datagen", "icu_provider/datagen", "litemap/serde_serialize", "std"]
 
 [[bench]]
 name = "datetime"
 harness = false
-required-features = ["provider_serde"]
+required-features = ["serialize"]
 
 [[bench]]
 name = "pattern"
@@ -81,8 +81,8 @@ required-features = ["bench"]
 
 [[test]]
 name = "datetime"
-required-features = ["provider_serde"]
+required-features = ["serialize"]
 
 [[example]]
 name = "work_log"
-required-features = ["provider_serde"]
+required-features = ["serialize"]

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -66,7 +66,7 @@ bench = false  # This option is required for Benchmark CI
 std = ["icu_provider/std", "icu_locid/std", "icu_calendar/std"]
 default = ["serialize"]
 bench = []
-serialize = ["serde", "litemap/serde", "zerovec/serde", "tinystr/serde", "smallvec/serde", "icu_calendar/serde", "icu_provider/serialize"]
+serialize = ["serde", "litemap/serde", "zerovec/serde", "tinystr/serde", "smallvec/serde", "icu_calendar/serialize", "icu_provider/serialize"]
 datagen = ["serialize", "icu_calendar/datagen", "icu_provider/datagen", "litemap/serde_serialize", "std"]
 
 [[bench]]

--- a/components/datetime/src/fields/length.rs
+++ b/components/datetime/src/fields/length.rs
@@ -15,8 +15,7 @@ pub enum LengthError {
 impl std::error::Error for LengthError {}
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]
-#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
-#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum FieldLength {
     One = 1,
     TwoDigit = 2,

--- a/components/datetime/src/fields/length.rs
+++ b/components/datetime/src/fields/length.rs
@@ -15,10 +15,8 @@ pub enum LengthError {
 impl std::error::Error for LengthError {}
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub enum FieldLength {
     One = 1,
     TwoDigit = 2,

--- a/components/datetime/src/fields/macros.rs
+++ b/components/datetime/src/fields/macros.rs
@@ -49,10 +49,8 @@ macro_rules! field_type {
         #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Copy, yoke::Yokeable, zerofrom::ZeroFrom)]
         // FIXME: This should be replaced with a custom derive.
         // See: https://github.com/unicode-org/icu4x/issues/1044
-        #[cfg_attr(
-            feature = "provider_serde",
-            derive(serde::Serialize, serde::Deserialize)
-        )]
+        #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+        #[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
         #[allow(clippy::enum_variant_names)]
         #[repr(u8)]
         #[zerovec::make_ule($ule_name)]

--- a/components/datetime/src/fields/macros.rs
+++ b/components/datetime/src/fields/macros.rs
@@ -49,8 +49,7 @@ macro_rules! field_type {
         #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Copy, yoke::Yokeable, zerofrom::ZeroFrom)]
         // FIXME: This should be replaced with a custom derive.
         // See: https://github.com/unicode-org/icu4x/issues/1044
-        #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
-        #[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
+        #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
         #[allow(clippy::enum_variant_names)]
         #[repr(u8)]
         #[zerovec::make_ule($ule_name)]

--- a/components/datetime/src/fields/mod.rs
+++ b/components/datetime/src/fields/mod.rs
@@ -27,10 +27,8 @@ pub enum Error {
 impl std::error::Error for Error {}
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct Field {
     pub symbol: FieldSymbol,
     pub length: FieldLength,

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -23,8 +23,7 @@ pub enum SymbolError {
 impl std::error::Error for SymbolError {}
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
-#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
-#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum FieldSymbol {
     Era,
     Year(Year),

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -23,10 +23,8 @@ pub enum SymbolError {
 impl std::error::Error for SymbolError {}
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub enum FieldSymbol {
     Era,
     Year(Year),

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -380,7 +380,7 @@ pub fn analyze_patterns(
 mod tests {
     use super::*;
     #[test]
-    #[cfg(feature = "provider_serde")]
+    #[cfg(feature = "serialize")]
     fn test_basic() {
         use crate::provider::calendar::DateSymbolsV1Marker;
         use icu_calendar::DateTime;

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -80,12 +80,12 @@ use crate::{
 use alloc::vec::Vec;
 
 use super::preferences;
-#[cfg(feature = "serde")]
+#[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
 /// See the [module-level](./index.html) docs for more information.
 #[derive(Debug, Clone, PartialEq, Default, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Bag {
     /// Include the era, such as "AD" or "CE".
     pub era: Option<Text>,
@@ -331,7 +331,7 @@ impl Bag {
 /// and second.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serialize",
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
@@ -345,7 +345,7 @@ pub enum Numeric {
 /// A text component for the `components::`[`Bag`]. It is used for the era and weekday.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serialize",
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
@@ -361,7 +361,7 @@ pub enum Text {
 /// Options for displaying a Year for the `components::`[`Bag`].
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serialize",
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
@@ -381,7 +381,7 @@ pub enum Year {
 /// Options for displaying a Month for the `components::`[`Bag`].
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serialize",
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
@@ -406,7 +406,7 @@ pub enum Month {
 // TODO(#488): make visible once fully supported.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serialize",
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
@@ -425,7 +425,7 @@ pub enum Week {
 /// options.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serialize",
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]

--- a/components/datetime/src/options/length.rs
+++ b/components/datetime/src/options/length.rs
@@ -43,7 +43,7 @@
 //! and it is strongly recommended to never write tests that expect a particular formatted output.
 
 use super::preferences;
-#[cfg(feature = "serde")]
+#[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
 /// A structure to represent the set of lengths in which the [`DateTimeInput`] implementer should be formatted to.
@@ -78,7 +78,7 @@ use serde::{Deserialize, Serialize};
 /// [`UTS #35: Unicode LDML 4. Dates`]: https://unicode.org/reports/tr35/tr35-dates.html
 /// [`Element dateFormats`]: https://unicode.org/reports/tr35/tr35-dates.html#dateFormats
 #[derive(Debug, Clone, PartialEq, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Bag {
     /// Configure the date part of the datetime.
     pub date: Option<Date>,
@@ -126,7 +126,7 @@ impl Default for Bag {
 /// [`Element dateFormats`]: https://unicode.org/reports/tr35/tr35-dates.html#dateFormats
 /// [`DateTimeFormat`]: super::super::DateTimeFormat
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum Date {
     /// Full length, usually with weekday name.
     ///
@@ -139,7 +139,7 @@ pub enum Date {
     /// "вторник, 21 января 2020 г.";      // ru
     /// "2020年1月21日火曜日";               // ja
     /// ```
-    #[cfg_attr(feature = "serde", serde(rename = "full"))]
+    #[cfg_attr(feature = "serialize", serde(rename = "full"))]
     Full,
     /// Long length, with wide month name.
     ///
@@ -152,7 +152,7 @@ pub enum Date {
     /// "10 сентября 2020 г.";    // ru
     /// "2020年9月10日";           // ja
     /// ```
-    #[cfg_attr(feature = "serde", serde(rename = "long"))]
+    #[cfg_attr(feature = "serialize", serde(rename = "long"))]
     Long,
     /// Medium length.
     ///
@@ -165,7 +165,7 @@ pub enum Date {
     /// "20 февр. 2020 г.";    // ru
     /// "2020/02/20";          // ja
     /// ```
-    #[cfg_attr(feature = "serde", serde(rename = "medium"))]
+    #[cfg_attr(feature = "serialize", serde(rename = "medium"))]
     Medium,
     /// Short length, usually with numeric month.
     ///
@@ -178,7 +178,7 @@ pub enum Date {
     /// "30.01.2020";   // ru
     /// "2020/01/30";   // ja
     /// ```
-    #[cfg_attr(feature = "serde", serde(rename = "short"))]
+    #[cfg_attr(feature = "serialize", serde(rename = "short"))]
     Short,
 }
 
@@ -210,7 +210,7 @@ pub enum Date {
 /// [`Element dateFormats`]: https://unicode.org/reports/tr35/tr35-dates.html#timeFormats
 /// [`DateTimeFormat`]: super::super::DateTimeFormat
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum Time {
     /// Full length, with spelled out time zone name.
     ///
@@ -223,7 +223,7 @@ pub enum Time {
     /// "08:25:07 Тихоокеанское стандартное время";      // ru
     /// "8時25分07秒 アメリカ太平洋標準時";                  // ja
     /// ```
-    #[cfg_attr(feature = "serde", serde(rename = "full"))]
+    #[cfg_attr(feature = "serialize", serde(rename = "full"))]
     Full,
     /// Full length, usually with short time-zone code.
     ///
@@ -236,7 +236,7 @@ pub enum Time {
     /// "08:25:07 GMT-8";       // ru
     /// "8:25:07 GMT-8";        // ja
     /// ```
-    #[cfg_attr(feature = "serde", serde(rename = "long"))]
+    #[cfg_attr(feature = "serialize", serde(rename = "long"))]
     Long,
     /// Full length, usually with seconds.
     ///
@@ -249,7 +249,7 @@ pub enum Time {
     /// "08:25:07";     // ru
     /// "8:25:07";      // ja
     /// ```
-    #[cfg_attr(feature = "serde", serde(rename = "medium"))]
+    #[cfg_attr(feature = "serialize", serde(rename = "medium"))]
     Medium,
     /// Full length, usually without seconds.
     ///
@@ -262,6 +262,6 @@ pub enum Time {
     /// "08:25";     // ru
     /// "8:25";      // ja
     /// ```
-    #[cfg_attr(feature = "serde", serde(rename = "short"))]
+    #[cfg_attr(feature = "serialize", serde(rename = "short"))]
     Short,
 }

--- a/components/datetime/src/options/preferences.rs
+++ b/components/datetime/src/options/preferences.rs
@@ -26,7 +26,7 @@
 //! ```
 use crate::fields;
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
 /// Stores user preferences which may affect the result of date and time formatting.
@@ -41,18 +41,18 @@ use serde::{Deserialize, Serialize};
 /// };
 /// ```
 #[derive(Debug, Clone, PartialEq, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Bag {
     /// The hour cycle can be adjusts according to user preferences, for instance at the OS-level.
     /// That preference can be applied here to change the hour cycle from the default for the
     /// given locale.
-    #[cfg_attr(feature = "serde", serde(rename = "hourCycle"))]
+    #[cfg_attr(feature = "serialize", serde(rename = "hourCycle"))]
     pub hour_cycle: Option<HourCycle>,
 }
 
 /// A user preference for adjusting how the hour component is displayed.
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum HourCycle {
     /// Hour is formatted to be in range 1-24 where midnight is 24:00.
     ///
@@ -64,7 +64,7 @@ pub enum HourCycle {
     /// "19:00";
     /// "23:21";
     /// ```
-    #[cfg_attr(feature = "serde", serde(rename = "h24"))]
+    #[cfg_attr(feature = "serialize", serde(rename = "h24"))]
     H24,
     /// Hour is formatted to be in range 0-23 where midnight is 00:00.
     ///
@@ -76,7 +76,7 @@ pub enum HourCycle {
     /// "19:00";
     /// "23:21";
     /// ```
-    #[cfg_attr(feature = "serde", serde(rename = "h23"))]
+    #[cfg_attr(feature = "serialize", serde(rename = "h23"))]
     H23,
     /// Hour is formatted to be in range 1-12 where midnight is 12:00.
     ///
@@ -88,7 +88,7 @@ pub enum HourCycle {
     /// "7:00";
     /// "11:21";
     /// ```
-    #[cfg_attr(feature = "serde", serde(rename = "h12"))]
+    #[cfg_attr(feature = "serialize", serde(rename = "h12"))]
     H12,
     /// Hour is formatted to be in range 0-11 where midnight is 00:00.
     ///
@@ -100,7 +100,7 @@ pub enum HourCycle {
     /// "7:00";
     /// "11:21";
     /// ```
-    #[cfg_attr(feature = "serde", serde(rename = "h11"))]
+    #[cfg_attr(feature = "serialize", serde(rename = "h11"))]
     H11,
 }
 

--- a/components/datetime/src/pattern/common/mod.rs
+++ b/components/datetime/src/pattern/common/mod.rs
@@ -4,5 +4,5 @@
 
 //! Code paths that are shared between `reference` and `runtime`
 //! `Pattern` modules.
-#[cfg(feature = "provider_serde")]
+#[cfg(feature = "serialize")]
 mod serde;

--- a/components/datetime/src/pattern/common/serde.rs
+++ b/components/datetime/src/pattern/common/serde.rs
@@ -93,7 +93,7 @@ mod reference {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "datagen"))]
     mod test {
         use super::*;
 
@@ -201,7 +201,7 @@ mod runtime {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "datagen"))]
     mod test {
         use super::*;
 
@@ -331,7 +331,7 @@ mod runtime {
             }
         }
 
-        #[cfg(test)]
+        #[cfg(all(test, feature = "datagen"))]
         mod test {
             use super::*;
             use icu_plurals::PluralCategory;
@@ -438,7 +438,7 @@ mod runtime {
             }
         }
 
-        #[cfg(test)]
+        #[cfg(all(test, feature = "datagen"))]
         mod test {
             use super::*;
 

--- a/components/datetime/src/pattern/common/serde.rs
+++ b/components/datetime/src/pattern/common/serde.rs
@@ -3,8 +3,11 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::pattern::{PatternItem, TimeGranularity};
-use ::serde::{de, ser, Deserialize, Deserializer, Serialize};
-use alloc::{fmt, format, string::ToString, vec::Vec};
+use ::serde::{de, Deserialize, Deserializer};
+use alloc::{fmt, format, vec::Vec};
+
+#[cfg(feature = "datagen")]
+use ::serde::{ser, Serialize};
 
 mod reference {
     use super::*;
@@ -12,7 +15,8 @@ mod reference {
 
     /// A helper struct that is shaped exactly like `runtime::Pattern`
     /// and is used to aid in quick deserialization.
-    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    #[derive(Debug, Clone, PartialEq, Deserialize)]
+    #[cfg_attr(feature = "datagen", derive(Serialize))]
     struct PatternForSerde {
         pub items: Vec<PatternItem>,
         pub(crate) time_granularity: TimeGranularity,
@@ -74,6 +78,7 @@ mod reference {
         }
     }
 
+    #[cfg(feature = "datagen")]
     impl Serialize for Pattern {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
@@ -115,12 +120,12 @@ mod reference {
 mod runtime {
     use super::*;
     use crate::pattern::{runtime::Pattern, PatternItem};
-    use alloc::string::ToString;
     use zerovec::ZeroVec;
 
     /// A helper struct that is shaped exactly like `runtime::Pattern`
     /// and is used to aid in quick deserialization.
-    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    #[derive(Debug, Clone, PartialEq, Deserialize)]
+    #[cfg_attr(feature = "datagen", derive(Serialize))]
     struct PatternForSerde<'data> {
         #[serde(borrow)]
         pub items: ZeroVec<'data, PatternItem>,
@@ -181,6 +186,7 @@ mod runtime {
         }
     }
 
+    #[cfg(feature = "datagen")]
     impl Serialize for Pattern<'_> {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
@@ -223,12 +229,12 @@ mod runtime {
         // Postcard can't handle enums not discriminated at compilation time.
         use super::*;
         use crate::pattern::runtime::{PatternPlurals, PluralPattern};
-        use alloc::string::ToString;
         use core::fmt;
 
         /// A helper struct that is shaped exactly like `runtime::PatternPlurals`
         /// and is used to aid in quick deserialization.
-        #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+        #[derive(Debug, Clone, PartialEq, Deserialize)]
+        #[cfg_attr(feature = "datagen", derive(Serialize))]
         #[allow(clippy::large_enum_variant)]
         enum PatternPluralsForSerde<'data> {
             #[serde(borrow)]
@@ -301,6 +307,7 @@ mod runtime {
             }
         }
 
+        #[cfg(feature = "datagen")]
         impl Serialize for PatternPlurals<'_> {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
@@ -415,6 +422,7 @@ mod runtime {
             }
         }
 
+        #[cfg(feature = "datagen")]
         impl Serialize for GenericPattern<'_> {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where

--- a/components/datetime/src/pattern/hour_cycle.rs
+++ b/components/datetime/src/pattern/hour_cycle.rs
@@ -5,17 +5,15 @@
 use super::{runtime::Pattern, PatternItem};
 use crate::pattern::{reference, runtime};
 use crate::{fields, options::preferences};
-#[cfg(feature = "provider_transform_internals")]
+#[cfg(feature = "datagen")]
 use crate::{provider, skeleton};
 use icu_provider::{yoke, zerofrom};
 
 /// Used to represent either H11/H12, or H23/H24. Skeletons only store these
 /// hour cycles as H12 or H23.
 #[derive(Debug, PartialEq, Clone, Copy, yoke::Yokeable, zerofrom::ZeroFrom)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub enum CoarseHourCycle {
     /// Can either be fields::Hour::H11 or fields::Hour::H12
     H11H12,
@@ -54,7 +52,7 @@ impl CoarseHourCycle {
     /// Invoke the pattern matching machinery to transform the hour cycle of a pattern. This provides
     /// a safe mapping from a h11/h12 to h23/h24 for transforms.
     #[doc(hidden)]
-    #[cfg(feature = "provider_transform_internals")]
+    #[cfg(feature = "datagen")]
     pub fn apply_on_pattern<'data>(
         &self,
         date_time: &provider::calendar::patterns::GenericLengthPatternsV1<'data>,

--- a/components/datetime/src/pattern/hour_cycle.rs
+++ b/components/datetime/src/pattern/hour_cycle.rs
@@ -12,8 +12,7 @@ use icu_provider::{yoke, zerofrom};
 /// Used to represent either H11/H12, or H23/H24. Skeletons only store these
 /// hour cycles as H12 or H23.
 #[derive(Debug, PartialEq, Clone, Copy, yoke::Yokeable, zerofrom::ZeroFrom)]
-#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
-#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum CoarseHourCycle {
     /// Can either be fields::Hour::H11 or fields::Hour::H12
     H11H12,

--- a/components/datetime/src/pattern/item/generic.rs
+++ b/components/datetime/src/pattern/item/generic.rs
@@ -3,10 +3,8 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 #[derive(Debug, PartialEq, Clone, Copy)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub enum GenericPatternItem {
     Placeholder(u8),
     Literal(char),

--- a/components/datetime/src/pattern/item/mod.rs
+++ b/components/datetime/src/pattern/item/mod.rs
@@ -11,10 +11,8 @@ use core::convert::TryFrom;
 pub use generic::GenericPatternItem;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub enum PatternItem {
     Field(Field),
     Literal(char),

--- a/components/datetime/src/pattern/mod.rs
+++ b/components/datetime/src/pattern/mod.rs
@@ -20,10 +20,8 @@ pub use item::{GenericPatternItem, PatternItem};
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, yoke::Yokeable, zerofrom::ZeroFrom,
 )]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub(crate) enum TimeGranularity {
     None,
     Hours,

--- a/components/datetime/src/pattern/runtime/plural.rs
+++ b/components/datetime/src/pattern/runtime/plural.rs
@@ -14,25 +14,23 @@ use icu_provider::{yoke, zerofrom};
 
 /// A collection of plural variants of a pattern.
 #[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(::serde::Serialize, ::serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct PluralPattern<'data> {
     /// The field that 'variants' are predicated on.
     pivot_field: Week,
 
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub(crate) zero: Option<Pattern<'data>>,
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub(crate) one: Option<Pattern<'data>>,
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub(crate) two: Option<Pattern<'data>>,
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub(crate) few: Option<Pattern<'data>>,
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub(crate) many: Option<Pattern<'data>>,
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub(crate) other: Pattern<'data>,
 }
 

--- a/components/datetime/src/provider/calendar/mod.rs
+++ b/components/datetime/src/provider/calendar/mod.rs
@@ -15,31 +15,29 @@ pub use symbols::*;
 
 #[icu_provider::data_struct(DatePatternsV1Marker = "datetime/lengths@1")]
 #[derive(Debug, PartialEq, Clone, Default)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct DatePatternsV1<'data> {
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub date: patterns::LengthPatternsV1<'data>,
 
     /// These patterns are common uses of time formatting, broken down by the length of the
     /// pattern. Users can override the hour cycle with a preference, so there are two
     /// pattern groups stored here. Note that the pattern will contain either h11 or h12.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub time_h11_h12: patterns::LengthPatternsV1<'data>,
 
     /// These patterns are common uses of time formatting, broken down by the length of the
     /// pattern. Users can override the hour cycle with a preference, so there are two
     /// pattern groups stored here. Note that the pattern will contain either h23 or h24.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub time_h23_h24: patterns::LengthPatternsV1<'data>,
 
     /// By default a locale will prefer one hour cycle type over another.
     pub preferred_hour_cycle: pattern::CoarseHourCycle,
 
     /// Patterns used to combine date and time length patterns into full date_time patterns.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub length_combinations: patterns::GenericLengthPatternsV1<'data>,
 }
 
@@ -49,61 +47,53 @@ pub mod patterns {
     use icu_provider::{yoke, zerofrom};
 
     #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
-    #[cfg_attr(
-        feature = "provider_serde",
-        derive(serde::Serialize, serde::Deserialize)
-    )]
+    #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+    #[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
     pub struct LengthPatternsV1<'data> {
-        #[cfg_attr(feature = "provider_serde", serde(borrow))]
+        #[cfg_attr(feature = "serialize", serde(borrow))]
         pub full: Pattern<'data>,
-        #[cfg_attr(feature = "provider_serde", serde(borrow))]
+        #[cfg_attr(feature = "serialize", serde(borrow))]
         pub long: Pattern<'data>,
-        #[cfg_attr(feature = "provider_serde", serde(borrow))]
+        #[cfg_attr(feature = "serialize", serde(borrow))]
         pub medium: Pattern<'data>,
-        #[cfg_attr(feature = "provider_serde", serde(borrow))]
+        #[cfg_attr(feature = "serialize", serde(borrow))]
         pub short: Pattern<'data>,
     }
 
     #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
-    #[cfg_attr(
-        feature = "provider_serde",
-        derive(serde::Serialize, serde::Deserialize)
-    )]
+    #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+    #[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
     pub struct LengthPatternPluralsV1<'data> {
-        #[cfg_attr(feature = "provider_serde", serde(borrow))]
+        #[cfg_attr(feature = "serialize", serde(borrow))]
         pub full: PatternPlurals<'data>,
-        #[cfg_attr(feature = "provider_serde", serde(borrow))]
+        #[cfg_attr(feature = "serialize", serde(borrow))]
         pub long: PatternPlurals<'data>,
-        #[cfg_attr(feature = "provider_serde", serde(borrow))]
+        #[cfg_attr(feature = "serialize", serde(borrow))]
         pub medium: PatternPlurals<'data>,
-        #[cfg_attr(feature = "provider_serde", serde(borrow))]
+        #[cfg_attr(feature = "serialize", serde(borrow))]
         pub short: PatternPlurals<'data>,
     }
 
     #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
-    #[cfg_attr(
-        feature = "provider_serde",
-        derive(serde::Serialize, serde::Deserialize)
-    )]
+    #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+    #[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
     pub struct GenericLengthPatternsV1<'data> {
-        #[cfg_attr(feature = "provider_serde", serde(borrow))]
+        #[cfg_attr(feature = "serialize", serde(borrow))]
         pub full: GenericPattern<'data>,
-        #[cfg_attr(feature = "provider_serde", serde(borrow))]
+        #[cfg_attr(feature = "serialize", serde(borrow))]
         pub long: GenericPattern<'data>,
-        #[cfg_attr(feature = "provider_serde", serde(borrow))]
+        #[cfg_attr(feature = "serialize", serde(borrow))]
         pub medium: GenericPattern<'data>,
-        #[cfg_attr(feature = "provider_serde", serde(borrow))]
+        #[cfg_attr(feature = "serialize", serde(borrow))]
         pub short: GenericPattern<'data>,
     }
 
     #[icu_provider::data_struct]
     #[derive(Debug, PartialEq, Clone, Default)]
-    #[cfg_attr(
-        feature = "provider_serde",
-        derive(serde::Serialize, serde::Deserialize)
-    )]
+    #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+    #[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
     pub struct PatternPluralsV1<'data>(
-        #[cfg_attr(feature = "provider_serde", serde(borrow))] pub PatternPlurals<'data>,
+        #[cfg_attr(feature = "serialize", serde(borrow))] pub PatternPlurals<'data>,
     );
 
     impl<'data> From<PatternPlurals<'data>> for PatternPluralsV1<'data> {

--- a/components/datetime/src/provider/calendar/skeletons.rs
+++ b/components/datetime/src/provider/calendar/skeletons.rs
@@ -14,12 +14,10 @@ use litemap::LiteMap;
 
 #[icu_provider::data_struct(DateSkeletonPatternsV1Marker = "datetime/skeletons@1")]
 #[derive(Debug, PartialEq, Clone, Default)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct DateSkeletonPatternsV1<'data>(
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     #[zerofrom(clone)]
     pub LiteMap<SkeletonV1, PatternPlurals<'data>>,
 );
@@ -31,10 +29,8 @@ pub struct DateSkeletonPatternsV1<'data>(
 /// The `Skeleton` is an "exotic type" in the serialization process, and handles its own
 /// custom serialization practices.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct SkeletonV1(pub Skeleton);
 
 impl TryFrom<&str> for SkeletonV1 {

--- a/components/datetime/src/provider/calendar/symbols.rs
+++ b/components/datetime/src/provider/calendar/symbols.rs
@@ -145,7 +145,7 @@ symbols!(
     }
 );
 
-#[cfg(all(test, feature = "serialize"))]
+#[cfg(all(test, feature = "datagen"))]
 mod test {
     use super::*;
 

--- a/components/datetime/src/provider/calendar/symbols.rs
+++ b/components/datetime/src/provider/calendar/symbols.rs
@@ -10,34 +10,30 @@ use zerovec::ZeroMap;
 
 #[icu_provider::data_struct(DateSymbolsV1Marker = "datetime/symbols@1")]
 #[derive(Debug, PartialEq, Clone, Default)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 #[yoke(prove_covariance_manually)]
 pub struct DateSymbolsV1<'data> {
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub months: months::ContextsV1<'data>,
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub weekdays: weekdays::ContextsV1<'data>,
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub day_periods: day_periods::ContextsV1<'data>,
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub eras: Eras<'data>,
 }
 
 #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 #[yoke(prove_covariance_manually)]
 pub struct Eras<'data> {
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub names: ZeroMap<'data, str, str>,
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub abbr: ZeroMap<'data, str, str>,
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub narrow: ZeroMap<'data, str, str>,
 }
 
@@ -47,44 +43,48 @@ macro_rules! symbols {
             use super::*;
 
             #[derive(Debug, PartialEq, Clone, Default, zerofrom::ZeroFrom, yoke::Yokeable)]
-            #[cfg_attr(feature="provider_serde", derive(serde::Serialize, serde::Deserialize))]
+            #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+            #[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
             $symbols
 
             // UTS 35 specifies that `format` widths are mandatory
             // except of `short`.
             #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
-            #[cfg_attr(feature="provider_serde", derive(serde::Serialize, serde::Deserialize))]
+            #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+            #[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
             pub struct FormatWidthsV1<'data> {
-                #[cfg_attr(feature = "provider_serde", serde(borrow))]
+                #[cfg_attr(feature = "serialize", serde(borrow))]
                 pub abbreviated: SymbolsV1<'data>,
-                #[cfg_attr(feature = "provider_serde", serde(borrow))]
+                #[cfg_attr(feature = "serialize", serde(borrow))]
                 pub narrow: SymbolsV1<'data>,
-                #[cfg_attr(feature = "provider_serde", serde(borrow))]
+                #[cfg_attr(feature = "serialize", serde(borrow))]
                 pub short: Option<SymbolsV1<'data>>,
-                #[cfg_attr(feature = "provider_serde", serde(borrow))]
+                #[cfg_attr(feature = "serialize", serde(borrow))]
                 pub wide: SymbolsV1<'data>,
             }
 
             // UTS 35 specifies that `stand_alone` widths are optional
             #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
-            #[cfg_attr(feature="provider_serde", derive(serde::Serialize, serde::Deserialize))]
+            #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+            #[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
             pub struct StandAloneWidthsV1<'data> {
-                #[cfg_attr(feature = "provider_serde", serde(borrow))]
+                #[cfg_attr(feature = "serialize", serde(borrow))]
                 pub abbreviated: Option<SymbolsV1<'data>>,
-                #[cfg_attr(feature = "provider_serde", serde(borrow))]
+                #[cfg_attr(feature = "serialize", serde(borrow))]
                 pub narrow: Option<SymbolsV1<'data>>,
-                #[cfg_attr(feature = "provider_serde", serde(borrow))]
+                #[cfg_attr(feature = "serialize", serde(borrow))]
                 pub short: Option<SymbolsV1<'data>>,
-                #[cfg_attr(feature = "provider_serde", serde(borrow))]
+                #[cfg_attr(feature = "serialize", serde(borrow))]
                 pub wide: Option<SymbolsV1<'data>>,
             }
 
             #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
-            #[cfg_attr(feature="provider_serde", derive(serde::Serialize, serde::Deserialize))]
+            #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+            #[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
             pub struct ContextsV1<'data> {
-                #[cfg_attr(feature = "provider_serde", serde(borrow))]
+                #[cfg_attr(feature = "serialize", serde(borrow))]
                 pub format: FormatWidthsV1<'data>,
-                #[cfg_attr(feature = "provider_serde", serde(borrow))]
+                #[cfg_attr(feature = "serialize", serde(borrow))]
                 pub stand_alone: Option<StandAloneWidthsV1<'data>>,
             }
         }
@@ -95,7 +95,7 @@ symbols!(
     months,
     pub struct SymbolsV1<'data>(
         #[cfg_attr(
-            feature = "provider_serde",
+            feature = "serialize",
             serde(
                 borrow,
                 deserialize_with = "icu_provider::serde::borrow_de_utils::array_of_cow"
@@ -109,7 +109,7 @@ symbols!(
     weekdays,
     pub struct SymbolsV1<'data>(
         #[cfg_attr(
-            feature = "provider_serde",
+            feature = "serialize",
             serde(
                 borrow,
                 deserialize_with = "icu_provider::serde::borrow_de_utils::array_of_cow"
@@ -122,12 +122,12 @@ symbols!(
 symbols!(
     day_periods,
     pub struct SymbolsV1<'data> {
-        #[cfg_attr(feature = "provider_serde", serde(borrow))]
+        #[cfg_attr(feature = "serialize", serde(borrow))]
         pub am: Cow<'data, str>,
-        #[cfg_attr(feature = "provider_serde", serde(borrow))]
+        #[cfg_attr(feature = "serialize", serde(borrow))]
         pub pm: Cow<'data, str>,
         #[cfg_attr(
-            feature = "provider_serde",
+            feature = "serialize",
             serde(
                 borrow,
                 deserialize_with = "icu_provider::serde::borrow_de_utils::option_of_cow"
@@ -135,7 +135,7 @@ symbols!(
         )]
         pub noon: Option<Cow<'data, str>>,
         #[cfg_attr(
-            feature = "provider_serde",
+            feature = "serialize",
             serde(
                 borrow,
                 deserialize_with = "icu_provider::serde::borrow_de_utils::option_of_cow"
@@ -145,7 +145,7 @@ symbols!(
     }
 );
 
-#[cfg(all(test, feature = "provider_serde"))]
+#[cfg(all(test, feature = "serialize"))]
 mod test {
     use super::*;
 

--- a/components/datetime/src/provider/time_zones.rs
+++ b/components/datetime/src/provider/time_zones.rs
@@ -11,34 +11,32 @@ use zerovec::{ZeroMap, ZeroMap2d};
 /// See CLDR-JSON timeZoneNames.json for more context.
 #[icu_provider::data_struct(TimeZoneFormatsV1Marker = "time_zone/formats@1")]
 #[derive(PartialEq, Debug, Clone, Default)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 #[yoke(prove_covariance_manually)]
 pub struct TimeZoneFormatsV1<'data> {
     /// The hour format for displaying GMT offsets.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     #[cfg_attr(
-        feature = "provider_serde",
+        feature = "serialize",
         serde(deserialize_with = "icu_provider::serde::borrow_de_utils::tuple_of_cow")
     )]
     pub hour_format: (Cow<'data, str>, Cow<'data, str>),
     /// The localized GMT-offset format.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub gmt_format: Cow<'data, str>,
     /// The localized GMT format with no offset.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub gmt_zero_format: Cow<'data, str>,
     /// The format string for a region.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub region_format: Cow<'data, str>,
     /// The format strings for region format variants
     /// e.g. daylight, standard.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub region_format_variants: ZeroMap<'data, TinyStr8, str>,
     /// The format string to fall back to if data is unavailable.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub fallback_format: Cow<'data, str>,
 }
 
@@ -46,30 +44,26 @@ pub struct TimeZoneFormatsV1<'data> {
 /// See CLDR-JSON timeZoneNames.json for more context.
 #[icu_provider::data_struct(ExemplarCitiesV1Marker = "time_zone/exemplar_cities@1")]
 #[derive(PartialEq, Debug, Clone, Default)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 #[yoke(prove_covariance_manually)]
 pub struct ExemplarCitiesV1<'data>(
-    #[cfg_attr(feature = "provider_serde", serde(borrow))] pub ZeroMap<'data, str, str>,
+    #[cfg_attr(feature = "serialize", serde(borrow))] pub ZeroMap<'data, str, str>,
 );
 
 /// An ICU4X mapping to the long-form generic metazone names.
 /// See CLDR-JSON timeZoneNames.json for more context.
 #[icu_provider::data_struct(MetaZoneGenericNamesLongV1Marker = "time_zone/generic_long@1")]
 #[derive(PartialEq, Debug, Clone, Default)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 #[yoke(prove_covariance_manually)]
 pub struct MetaZoneGenericNamesLongV1<'data> {
     /// The default mapping between metazone id and localized metazone name.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub defaults: ZeroMap<'data, str, str>,
     /// The override mapping between timezone id and localized metazone name.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub overrides: ZeroMap<'data, str, str>,
 }
 
@@ -77,17 +71,15 @@ pub struct MetaZoneGenericNamesLongV1<'data> {
 /// See CLDR-JSON timeZoneNames.json for more context.
 #[icu_provider::data_struct(MetaZoneGenericNamesShortV1Marker = "time_zone/generic_short@1")]
 #[derive(PartialEq, Debug, Clone, Default)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 #[yoke(prove_covariance_manually)]
 pub struct MetaZoneGenericNamesShortV1<'data> {
     /// The default mapping between metazone id and localized metazone name.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub defaults: ZeroMap<'data, str, str>,
     /// The override mapping between timezone id and localized metazone name.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub overrides: ZeroMap<'data, str, str>,
 }
 
@@ -96,17 +88,15 @@ pub struct MetaZoneGenericNamesShortV1<'data> {
 /// See CLDR-JSON timeZoneNames.json for more context.
 #[icu_provider::data_struct(MetaZoneSpecificNamesLongV1Marker = "time_zone/specific_long@1")]
 #[derive(PartialEq, Debug, Clone, Default)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 #[yoke(prove_covariance_manually)]
 pub struct MetaZoneSpecificNamesLongV1<'data> {
     /// The default mapping between metazone id and localized metazone name.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub defaults: ZeroMap2d<'data, str, TinyStr8, str>,
     /// The override mapping between timezone id and localized metazone name.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub overrides: ZeroMap2d<'data, str, TinyStr8, str>,
 }
 
@@ -115,16 +105,14 @@ pub struct MetaZoneSpecificNamesLongV1<'data> {
 /// See CLDR-JSON timeZoneNames.json for more context.
 #[icu_provider::data_struct(MetaZoneSpecificNamesShortV1Marker = "time_zone/specific_short@1")]
 #[derive(PartialEq, Debug, Clone, Default)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 #[yoke(prove_covariance_manually)]
 pub struct MetaZoneSpecificNamesShortV1<'data> {
     /// The default mapping between metazone id and localized metazone name.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub defaults: ZeroMap2d<'data, str, TinyStr8, str>,
     /// The override mapping between timezone id and localized metazone name.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub overrides: ZeroMap2d<'data, str, TinyStr8, str>,
 }

--- a/components/datetime/src/provider/week_data.rs
+++ b/components/datetime/src/provider/week_data.rs
@@ -8,8 +8,6 @@ use icu_provider::prelude::*;
 /// See CLDR-JSON's weekData.json for more context.
 #[icu_provider::data_struct(WeekDataV1Marker = "datetime/week_data@1")]
 #[derive(Clone, Copy, Default)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct WeekDataV1(pub icu_calendar::arithmetic::week_of::CalendarInfo);

--- a/components/datetime/src/skeleton/helpers.rs
+++ b/components/datetime/src/skeleton/helpers.rs
@@ -436,7 +436,7 @@ pub fn get_best_available_format_pattern<'data>(
 
     // Modify the resulting pattern to have fields of the same length.
     if prefer_matched_pattern {
-        #[cfg(not(feature = "provider_transform_internals"))]
+        #[cfg(not(feature = "datagen"))]
         panic!("This code branch should only be run when transforming provider code.");
     } else {
         closest_format_pattern.for_each_mut(|pattern| {

--- a/components/datetime/src/skeleton/mod.rs
+++ b/components/datetime/src/skeleton/mod.rs
@@ -8,12 +8,12 @@ mod error;
 mod helpers;
 pub mod reference;
 pub mod runtime;
-#[cfg(feature = "provider_serde")]
+#[cfg(feature = "serialize")]
 mod serde;
 pub use error::*;
 pub use helpers::*;
 
-#[cfg(all(test, feature = "provider_serde"))]
+#[cfg(all(test, feature = "serialize"))]
 mod test {
     use super::reference::Skeleton;
     use super::*;
@@ -340,7 +340,7 @@ mod test {
     /// trusted, test that the bincode gets validated correctly.
     struct TestInvalidSkeleton(Vec<Field>);
 
-    #[cfg(feature = "provider_serde")]
+    #[cfg(feature = "serialize")]
     impl Serialize for TestInvalidSkeleton {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
@@ -355,7 +355,7 @@ mod test {
         }
     }
 
-    #[cfg(feature = "provider_transform_internals")]
+    #[cfg(feature = "datagen")]
     fn assert_pattern_to_skeleton(pattern: &str, skeleton: &str, message: &str) {
         assert_eq!(
             serde_json::to_string(skeleton).expect("Failed to transform skeleton to string."),
@@ -371,7 +371,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "provider_transform_internals")]
+    #[cfg(feature = "datagen")]
     fn test_pattern_to_skeleton() {
         assert_pattern_to_skeleton("H:mm:ss v", "Hmmssv", "Test a complicated time pattern");
         assert_pattern_to_skeleton(

--- a/components/datetime/src/skeleton/mod.rs
+++ b/components/datetime/src/skeleton/mod.rs
@@ -13,7 +13,7 @@ mod serde;
 pub use error::*;
 pub use helpers::*;
 
-#[cfg(all(test, feature = "serialize"))]
+#[cfg(all(test, feature = "datagen"))]
 mod test {
     use super::reference::Skeleton;
     use super::*;

--- a/components/datetime/src/skeleton/reference.rs
+++ b/components/datetime/src/skeleton/reference.rs
@@ -4,7 +4,7 @@
 
 use super::error::SkeletonError;
 use crate::fields::{self, Field, FieldLength, FieldSymbol};
-#[cfg(feature = "provider_transform_internals")]
+#[cfg(feature = "datagen")]
 use crate::pattern::reference::Pattern;
 use alloc::vec::Vec;
 use core::convert::TryFrom;
@@ -62,7 +62,7 @@ impl From<Vec<fields::Field>> for Skeleton {
 /// At the time of this writing, it's being used for applying hour cycle preferences and should not
 /// be exposed as a public API for end users.
 #[doc(hidden)]
-#[cfg(feature = "provider_transform_internals")]
+#[cfg(feature = "datagen")]
 impl From<&Pattern> for Skeleton {
     fn from(pattern: &Pattern) -> Self {
         let mut fields: SmallVec<[fields::Field; 5]> = SmallVec::new();

--- a/components/datetime/src/skeleton/serde.rs
+++ b/components/datetime/src/skeleton/serde.rs
@@ -3,7 +3,6 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use alloc::format;
-use alloc::string::ToString;
 use core::convert::TryFrom;
 use smallvec::SmallVec;
 
@@ -11,8 +10,9 @@ pub mod reference {
     use super::*;
     use crate::skeleton::reference::Skeleton;
 
-    use serde::{de, ser, Deserialize, Deserializer, Serialize};
-
+    #[cfg(feature = "datagen")]
+    use ::serde::{ser, Serialize};
+    use serde::{de, Deserialize, Deserializer};
     /// This is an implementation of the serde deserialization visitor pattern.
     #[allow(clippy::upper_case_acronyms)]
     pub(super) struct DeserializeSkeletonUTS35String;
@@ -56,6 +56,7 @@ pub mod reference {
         }
     }
 
+    #[cfg(feature = "datagen")]
     impl Serialize for Skeleton {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
@@ -73,12 +74,12 @@ pub mod reference {
 }
 
 pub mod runtime {
-    use super::*;
     use crate::skeleton::runtime::Skeleton;
     use zerovec::ZeroVec;
 
-    use serde::{de, ser, Deserialize, Deserializer, Serialize};
-
+    #[cfg(feature = "datagen")]
+    use ::serde::{ser, Serialize};
+    use serde::{de, Deserialize, Deserializer};
     /// This is an implementation of the serde deserialization visitor pattern.
     #[allow(clippy::upper_case_acronyms)]
     struct DeserializeSkeletonUTS35String;
@@ -115,6 +116,7 @@ pub mod runtime {
         }
     }
 
+    #[cfg(feature = "datagen")]
     impl Serialize for Skeleton<'_> {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#![cfg(feature = "serde")]
+#![cfg(feature = "serialize")]
 
 mod fixtures;
 mod patterns;

--- a/components/datetime/tests/fixtures/mod.rs
+++ b/components/datetime/tests/fixtures/mod.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#![cfg(feature = "serde")]
+#![cfg(feature = "serialize")]
 
 pub mod structs;
 

--- a/components/datetime/tests/fixtures/structs.rs
+++ b/components/datetime/tests/fixtures/structs.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#![cfg(feature = "serde")]
+#![cfg(feature = "serialize")]
 
 //! This file contains the serde representaitons of the JSON files located in
 //! components/datetime/tests/fixtures/tests

--- a/components/datetime/tests/pattern_serialization.rs
+++ b/components/datetime/tests/pattern_serialization.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#![cfg(all(test, feature = "serialize"))]
+#![cfg(all(test, feature = "datagen"))]
 
 use icu_datetime::pattern::reference::Pattern;
 use std::{fs::File, io::BufReader};

--- a/components/datetime/tests/pattern_serialization.rs
+++ b/components/datetime/tests/pattern_serialization.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#![cfg(all(test, feature = "provider_serde"))]
+#![cfg(all(test, feature = "serialize"))]
 
 use icu_datetime::pattern::reference::Pattern;
 use std::{fs::File, io::BufReader};

--- a/components/datetime/tests/skeleton_serialization.rs
+++ b/components/datetime/tests/skeleton_serialization.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#![cfg(all(test, feature = "serialize"))]
+#![cfg(all(test, feature = "datagen"))]
 
 use icu_datetime::skeleton::reference::Skeleton;
 use std::{fs::File, io::BufReader};

--- a/components/datetime/tests/skeleton_serialization.rs
+++ b/components/datetime/tests/skeleton_serialization.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#![cfg(all(test, feature = "provider_serde"))]
+#![cfg(all(test, feature = "serialize"))]
 
 use icu_datetime::skeleton::reference::Skeleton;
 use std::{fs::File, io::BufReader};

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -51,9 +51,10 @@ getrandom = { version = "0.2", features = ["js"] }
 
 [features]
 std = ["icu_locid/std", "icu_provider/std", "fixed_decimal/std"]
-default = ["provider_serde"]
+default = ["serialize"]
 bench = []
-provider_serde = ["serde"]
+serialize = ["serde"]
+datagen = ["serialize"]
 
 [[bench]]
 name = "fixed_decimal_format"
@@ -61,4 +62,4 @@ harness = false
 
 [[example]]
 name = "code_line_diff"
-required-features = ["provider_serde"]
+required-features = ["serialize"]

--- a/components/decimal/src/provider.rs
+++ b/components/decimal/src/provider.rs
@@ -11,27 +11,23 @@ use icu_provider::{yoke, zerofrom};
 
 /// A collection of strings to affix to a decimal number.
 #[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct AffixesV1<'data> {
     /// String to prepend before the decimal number.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub prefix: Cow<'data, str>,
 
     /// String to append after the decimal number.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub suffix: Cow<'data, str>,
 }
 
 /// A collection of settings expressing where to put grouping separators in a decimal number.
 /// For example, `1,000,000` has two grouping separators, positioned along every 3 digits.
 #[derive(Debug, PartialEq, Clone, yoke::Yokeable, Copy, zerofrom::ZeroFrom)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct GroupingSizesV1 {
     /// The size of the first (lowest-magnitude) group.
     pub primary: u8,
@@ -47,25 +43,23 @@ pub struct GroupingSizesV1 {
 /// Symbols and metadata required for formatting a [`FixedDecimal`](crate::FixedDecimal).
 #[icu_provider::data_struct(DecimalSymbolsV1Marker = "decimal/symbols@1")]
 #[derive(Debug, PartialEq, Clone)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct DecimalSymbolsV1<'data> {
     /// Prefix and suffix to apply when a negative sign is needed.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub minus_sign_affixes: AffixesV1<'data>,
 
     /// Prefix and suffix to apply when a plus sign is needed.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub plus_sign_affixes: AffixesV1<'data>,
 
     /// Character used to separate the integer and fraction parts of the number.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub decimal_separator: Cow<'data, str>,
 
     /// Character used to separate groups in the integer part of the number.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub grouping_separator: Cow<'data, str>,
 
     /// Settings used to determine where to place groups in the integer part of the number.

--- a/components/icu/Cargo.toml
+++ b/components/icu/Cargo.toml
@@ -99,17 +99,17 @@ std = [
     "icu_properties/std",
     "fixed_decimal/std"
 ]
-default = ["provider_serde"]
+default = ["serialize"]
 serde = [
     "icu_locid/serde"
 ]
-provider_serde = [
-    "icu_datetime/provider_serde",
-    "icu_decimal/provider_serde",
-    "icu_locale_canonicalizer/provider_serde",
-    "icu_plurals/provider_serde",
-    "icu_properties/provider_serde",
-    "icu_list/provider_serde",
+serialize = [
+    "icu_datetime/serialize",
+    "icu_decimal/serialize",
+    "icu_locale_canonicalizer/serialize",
+    "icu_plurals/serialize",
+    "icu_properties/serialize",
+    "icu_list/serialize",
 ]
 icu4x_human_readable_de = [
     "icu_list/icu4x_human_readable_de"

--- a/components/icu/README.md
+++ b/components/icu/README.md
@@ -36,10 +36,10 @@ an [`FsDataProvider`] with locally available subset of data.
 ICU4X components share a set of common features that control whether core pieces of
 functionality are compiled. These features are:
 
-- `provider_serde`: Whether to include Serde Serialize/Deserialize implementations for
-  ICU4X locale data structs, such as [`SymbolsV1`]. (On by default)
-- `serde`: Whether to include Serde Serialize/Deserialize implementations for core libary
-  types, such as [`Locale`].
+- `serialize`: Whether to include Serde Deserialize implementations for
+  ICU4X locale data structs, such as [`SymbolsV1`], and Serialize/Deserialize implementations
+  for core libary types, such as [`Locale`] (On by default)
+- `datagen`: Whether to include Serde Serialize and other data generation traits for ICU4X locale data structs.
 - `bench`: Whether to enable exhaustive benchmarks. This can be enabled on individual crates
   when running `cargo bench`.
 - `experimental`: Whether to enable experimental preview features. Modules enabled with

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -38,10 +38,10 @@
 //! ICU4X components share a set of common features that control whether core pieces of
 //! functionality are compiled. These features are:
 //!
-//! - `provider_serde`: Whether to include Serde Serialize/Deserialize implementations for
-//!   ICU4X locale data structs, such as [`SymbolsV1`]. (On by default)
-//! - `serde`: Whether to include Serde Serialize/Deserialize implementations for core libary
-//!   types, such as [`Locale`].
+//! - `serialize`: Whether to include Serde Deserialize implementations for
+//!   ICU4X locale data structs, such as [`SymbolsV1`], and Serialize/Deserialize implementations
+//!   for core libary types, such as [`Locale`] (On by default)
+//! - `datagen`: Whether to include Serde Serialize and other data generation traits for ICU4X locale data structs.
 //! - `bench`: Whether to enable exhaustive benchmarks. This can be enabled on individual crates
 //!   when running `cargo bench`.
 //! - `experimental`: Whether to enable experimental preview features. Modules enabled with

--- a/components/list/Cargo.toml
+++ b/components/list/Cargo.toml
@@ -43,10 +43,10 @@ path = "src/lib.rs"
 [features]
 default = ["icu4x_human_readable_de"]
 std = ["icu_provider/std", "icu_locid/std", "regex-automata/std", "regex-automata/alloc"]
-provider_serde = ["serde", "icu_provider/serde", "zerovec/serde", "deduplicating_array"]
-provider_transform_internals = ["provider_serde", "std"]
-icu4x_human_readable_de = ["provider_serde", "regex-automata/alloc"]
+serialize = ["serde", "icu_provider/serde", "zerovec/serde", "deduplicating_array"]
+datagen = ["serialize", "std"]
+icu4x_human_readable_de = ["serialize", "regex-automata/alloc"]
 
 [[example]]
 name = "and_list"
-required-features = ["provider_serde"]
+required-features = ["serialize"]

--- a/components/list/src/list_formatter.rs
+++ b/components/list/src/list_formatter.rs
@@ -178,7 +178,7 @@ impl<'a, W: Writeable + 'a, I: Iterator<Item = W> + Clone + 'a> Writeable for Li
     }
 }
 
-#[cfg(all(test, feature = "provider_transform_internals"))]
+#[cfg(all(test, feature = "datagen"))]
 mod tests {
     use super::*;
     use writeable::{assert_writeable_eq, assert_writeable_parts_eq};

--- a/components/list/src/provider.rs
+++ b/components/list/src/provider.rs
@@ -20,15 +20,10 @@ use writeable::{LengthHint, Writeable};
     UnitListV1Marker = "list/unit@1"
 )]
 #[derive(Clone, Debug)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Deserialize, serde::Serialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct ListFormatterPatternsV1<'data>(
-    #[cfg_attr(
-        feature = "provider_serde",
-        serde(borrow, with = "deduplicating_array")
-    )]
+    #[cfg_attr(feature = "serialize", serde(borrow, with = "deduplicating_array"))]
     /// The patterns in the order start, middle, end, pair, short_start, short_middle,
     /// short_end, short_pair, narrow_start, narrow_middle, narrow_end, narrow_pair,
     [ConditionalListJoinerPattern<'data>; 12],
@@ -74,43 +69,37 @@ impl<'data> ListFormatterPatternsV1<'data> {
 
 /// A pattern that can behave conditionally on the next element.
 #[derive(Clone, Debug, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Deserialize, serde::Serialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub(crate) struct ConditionalListJoinerPattern<'data> {
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     default: ListJoinerPattern<'data>,
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     special_case: Option<SpecialCasePattern<'data>>,
 }
 
 #[derive(Clone, Debug, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Deserialize, serde::Serialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 struct SpecialCasePattern<'data> {
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     condition: StringMatcher<'data>,
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pattern: ListJoinerPattern<'data>,
 }
 
 /// A pattern containing two numeric placeholders ("{0}, and {1}.")
 #[derive(Clone, Debug, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Deserialize, serde::Serialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 struct ListJoinerPattern<'data> {
     /// The pattern string without the placeholders
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     string: Cow<'data, str>,
     /// The index of the first placeholder. Always 0 for CLDR
     /// data, so we don't need to serialize it. In-memory we
     /// have free space for it as index_1 doesn't fill a word.
-    #[cfg_attr(feature = "provider_serde", serde(skip))]
+    #[cfg_attr(feature = "serialize", serde(skip))]
     index_0: u8,
     /// The index of the second placeholder
     index_1: u8,
@@ -157,7 +146,7 @@ impl<'data> ListJoinerPattern<'data> {
     }
 }
 
-#[cfg(feature = "provider_transform_internals")]
+#[cfg(feature = "datagen")]
 mod datagen {
     use super::*;
     use icu_provider::DataError;
@@ -254,7 +243,7 @@ mod datagen {
     }
 }
 
-#[cfg(all(test, feature = "provider_transform_internals"))]
+#[cfg(all(test, feature = "datagen"))]
 pub(crate) mod test {
     use super::*;
 

--- a/components/list/src/string_matcher.rs
+++ b/components/list/src/string_matcher.rs
@@ -3,10 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use alloc::borrow::Cow;
-#[cfg(any(
-    feature = "icu4x_human_readable_de",
-    feature = "provider_transform_internals"
-))]
+#[cfg(any(feature = "icu4x_human_readable_de", feature = "datagen"))]
 use alloc::string::ToString;
 use icu_provider::{yoke, zerofrom};
 use regex_automata::dfa::sparse::DFA;
@@ -25,7 +22,7 @@ impl PartialEq for StringMatcher<'_> {
     }
 }
 
-#[cfg(feature = "provider_serde")]
+#[cfg(feature = "serialize")]
 impl serde::Serialize for StringMatcher<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -47,7 +44,7 @@ impl serde::Serialize for StringMatcher<'_> {
     }
 }
 
-#[cfg(feature = "provider_serde")]
+#[cfg(feature = "serialize")]
 impl<'de: 'data, 'data> serde::Deserialize<'de> for StringMatcher<'data> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -88,10 +85,7 @@ impl<'de: 'data, 'data> serde::Deserialize<'de> for StringMatcher<'data> {
 }
 
 impl<'data> StringMatcher<'data> {
-    #[cfg(any(
-        feature = "provider_transform_internals",
-        feature = "icu4x_human_readable_de",
-    ))]
+    #[cfg(any(feature = "datagen", feature = "icu4x_human_readable_de",))]
     pub fn new(pattern: &str) -> Result<Self, icu_provider::DataError> {
         use regex_automata::{
             dfa::dense::{Builder, Config},
@@ -129,7 +123,7 @@ impl<'data> StringMatcher<'data> {
     }
 }
 
-#[cfg(all(test, feature = "provider_transform_internals"))]
+#[cfg(all(test, feature = "datagen"))]
 mod test {
     use super::*;
 

--- a/components/locale_canonicalizer/Cargo.toml
+++ b/components/locale_canonicalizer/Cargo.toml
@@ -49,9 +49,10 @@ bench = false  # This option is required for Benchmark CI
 path = "src/lib.rs"
 
 [features]
-default = ["provider_serde"]
+default = ["serialize"]
 bench = []
-provider_serde = ["icu_locid/serde", "litemap/serde_serialize", "serde"]
+serialize = ["serde", "icu_locid/serde", "litemap/serde"]
+datagen = ["serialize", "litemap/serde_serialize"]
 
 [[bench]]
 name = "locale_canonicalizer"
@@ -59,4 +60,4 @@ harness = false
 
 [[test]]
 name = "locale_canonicalizer"
-required-features = ["provider_serde"]
+required-features = ["serialize"]

--- a/components/locale_canonicalizer/src/provider.rs
+++ b/components/locale_canonicalizer/src/provider.rs
@@ -14,10 +14,9 @@ use tinystr::TinyAsciiStr;
 
 #[icu_provider::data_struct(AliasesV1Marker = "locale_canonicalizer/aliases@1")]
 #[derive(Debug, PartialEq, Clone, Default)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
+
 /// This alias data is used for locale canonicalization. Each field defines a
 /// mapping from an old identifier to a new identifier, based upon the rules in
 /// from <http://unicode.org/reports/tr35/#LocaleId_Canonicalization>. The data
@@ -68,10 +67,8 @@ pub struct AliasesV1 {
 
 #[icu_provider::data_struct(LikelySubtagsV1Marker = "locale_canonicalizer/likelysubtags@1")]
 #[derive(Debug, PartialEq, Clone, Default)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 /// This likely subtags data is used for the minimize and maximize operations.
 /// Each field defines a mapping from an old identifier to a new identifier,
 /// based upon the rules in

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -56,9 +56,10 @@ bench = false  # This option is required for Benchmark CI
 
 [features]
 std = ["icu_locid/std", "icu_provider/std"]
-default = ["provider_serde"]
+default = ["serialize"]
 bench = []
-provider_serde = ["serde", "zerovec/serde"]
+serialize = ["serde", "zerovec/serde"]
+datagen = ["serialize"]
 
 [[bench]]
 name = "operands"
@@ -67,25 +68,25 @@ harness = false
 [[bench]]
 name = "parser"
 harness = false
-required-features = ["provider_serde"]
+required-features = ["serialize"]
 
 [[bench]]
 name = "pluralrules"
 harness = false
-required-features = ["provider_serde"]
+required-features = ["serialize"]
 
 [[test]]
 name = "plurals"
-required-features = ["provider_serde"]
+required-features = ["serialize"]
 
 [[test]]
 name = "operands"
-required-features = ["provider_serde", "std"]
+required-features = ["serialize", "std"]
 
 [[example]]
 name = "unread_emails"
-required-features = ["provider_serde"]
+required-features = ["serialize"]
 
 [[example]]
 name = "elevator_floors"
-required-features = ["provider_serde"]
+required-features = ["serialize"]

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -139,10 +139,8 @@ pub enum PluralRuleType {
 /// assert_eq!(pr.select(5_usize), PluralCategory::Other);
 /// ```
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Ord, PartialOrd)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub enum PluralCategory {
     /// CLDR "zero" plural category. Used in Arabic and Latvian, among others.
     ///

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -19,21 +19,19 @@ use icu_provider::{yoke, zerofrom};
     OrdinalV1Marker = "plurals/ordinal@1"
 )]
 #[derive(Default, Clone, PartialEq, Debug)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 #[allow(missing_docs)] // TODO(#1029) - Add missing docs.
 pub struct PluralRulesV1<'data> {
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub zero: Option<Rule<'data>>,
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub one: Option<Rule<'data>>,
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub two: Option<Rule<'data>>,
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub few: Option<Rule<'data>>,
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub many: Option<Rule<'data>>,
 }
 

--- a/components/plurals/src/rules/runtime/ast.rs
+++ b/components/plurals/src/rules/runtime/ast.rs
@@ -355,7 +355,7 @@ impl AsULE for RangeOrValue {
     }
 }
 
-#[cfg(feature = "provider_serde")]
+#[cfg(feature = "serialize")]
 mod serde {
     use super::*;
     use ::serde::{de, ser, Deserialize, Deserializer, Serialize};

--- a/components/properties/Cargo.toml
+++ b/components/properties/Cargo.toml
@@ -49,5 +49,6 @@ path = "src/lib.rs"
 
 [features]
 std = ["icu_provider/std"]
-default = ["provider_serde"]
-provider_serde = ["serde"]
+default = ["serialize"]
+serialize = ["serde"]
+datagen = ["serialize"]

--- a/components/properties/src/provider.rs
+++ b/components/properties/src/provider.rs
@@ -142,13 +142,11 @@ pub mod key {
 /// A set of characters with a particular property.
 #[icu_provider::data_struct(UnicodePropertyV1Marker)]
 #[derive(Debug, Eq, PartialEq, Clone)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct UnicodePropertyV1<'data> {
     /// The set of characters, represented as an inversion list
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub inv_list: UnicodeSet<'data>,
 }
 
@@ -180,13 +178,11 @@ impl<'data> From<UnicodePropertyV1<'data>> for UnicodeSet<'data> {
 
 /// A map efficiently storing data about individual characters.
 #[derive(Debug, Eq, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct UnicodePropertyMapV1<'data, T: TrieValue> {
     /// A codepoint trie storing the data
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub code_point_trie: CodePointTrie<'data, T>,
 }
 
@@ -218,12 +214,10 @@ impl<T: TrieValue> icu_provider::DataMarker for UnicodePropertyMapV1Marker<T> {
 /// A data structure efficiently storing `Script` and `Script_Extensions` property data.
 #[icu_provider::data_struct(ScriptWithExtensionsPropertyV1Marker)]
 #[derive(Debug, Eq, PartialEq, Clone)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct ScriptWithExtensionsPropertyV1<'data> {
     /// A special data structure for `Script` and `Script_Extensions`.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub data: ScriptWithExtensions<'data>,
 }

--- a/docs/design/data_pipeline.md
+++ b/docs/design/data_pipeline.md
@@ -79,7 +79,7 @@ Data provider structs should implement `Default`, returning generic, invariant d
 
 The name of the data provider struct should include its schema version; for example, `SampleDataStructV1` has schema version 1. Data provider structs should *not* use `#[non_exhaustive]`. If new fields are to be added, a new schema version must be introduced, like `SampleDataStructV2`.
 
-The `"provider_serde"` feature flag is relevant to data struct construction: it should be used to enable Serde on the data provider structs.
+The `"datagen"` feature flag is relevant to data struct construction: it should be used to enable Serde on the data provider structs.
 
 Here is an example of a `provider.rs` boilerplate for a component:
 
@@ -93,10 +93,8 @@ pub mod key {
 
 /// This is a sample data struct.
 #[derive(Debug, PartialEq, Clone)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "serialize", derive(Deserialize))]
+#[cfg_attr(feature = "datagen", derive(Serialize))]
 pub struct SampleDataStructV1<'data> {
     /// This field is always present, and it may be borrowed or owned.
     pub normal_value: Cow<'data, str>,

--- a/docs/tutorials/writing_a_new_data_struct.md
+++ b/docs/tutorials/writing_a_new_data_struct.md
@@ -122,21 +122,19 @@ The following example shows all the pieces that make up the data pipeline for `D
 ```rust
 #[icu_provider::data_struct]
 #[derive(Debug, PartialEq, Clone)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "serialize", derive(Deserialize))]
+#[cfg_attr(feature = "datagen", derive(Serialize))]
 pub struct DecimalSymbolsV1<'data> {
     /// Prefix and suffix to apply when a negative sign is needed.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub minus_sign_affixes: AffixesV1<'data>,
 
     /// Prefix and suffix to apply when a plus sign is needed.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub plus_sign_affixes: AffixesV1<'data>,
 
     /// Character used to separate the integer and fraction parts of the number.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub decimal_separator: Cow<'data, str>,
 
     // ...

--- a/experimental/char16trie/Cargo.toml
+++ b/experimental/char16trie/Cargo.toml
@@ -21,5 +21,4 @@ serde = { version = "1.0", features = ["derive"] }
 path = "src/lib.rs"
 
 [features]
-default = ["provider_serde"]
-provider_serde = ["serde"]
+default = ["serde"]

--- a/experimental/segmenter/Cargo.toml
+++ b/experimental/segmenter/Cargo.toml
@@ -54,6 +54,7 @@ name = "complex_word"
 required-features = ["lstm"]
 
 [features]
-default = ["provider_serde"]
+default = ["serialize"]
 lstm = ["icu_segmenter_lstm"]
-provider_serde = ["serde"]
+serialize = ["serde"]
+datagen = ["serialize"]

--- a/experimental/segmenter/src/provider.rs
+++ b/experimental/segmenter/src/provider.rs
@@ -17,17 +17,15 @@ use zerovec::{ZeroSlice, ZeroVec};
     SentenceBreakDataV1Marker = "segmenter/sentence@1"
 )]
 #[derive(Debug, PartialEq, Clone)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct RuleBreakDataV1<'data> {
     /// Property table for rule-based breaking.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub property_table: RuleBreakPropertyTable<'data>,
 
     /// Break state table for rule-based breaking.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub break_state_table: RuleBreakStateTable<'data>,
 
     /// Number of properties; should be the square root of the length of [`Self::break_state_table`].
@@ -41,34 +39,28 @@ pub struct RuleBreakDataV1<'data> {
 
 /// Property table for rule-based breaking.
 #[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct RuleBreakPropertyTable<'data>(
-    #[cfg_attr(feature = "provider_serde", serde(borrow))] pub ZeroVec<'data, u8>,
+    #[cfg_attr(feature = "serialize", serde(borrow))] pub ZeroVec<'data, u8>,
 );
 
 /// Break state table for rule-based breaking.
 #[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct RuleBreakStateTable<'data>(
-    #[cfg_attr(feature = "provider_serde", serde(borrow))] pub ZeroVec<'data, i8>,
+    #[cfg_attr(feature = "serialize", serde(borrow))] pub ZeroVec<'data, i8>,
 );
 
 /// char16trie data for dictionary break
 #[icu_provider::data_struct(UCharDictionaryBreakDataV1Marker = "segmenter/char16trie@1")]
 #[derive(Debug, PartialEq, Clone)]
-#[cfg_attr(
-    feature = "provider_serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct UCharDictionaryBreakDataV1<'data> {
     /// Dictionary data of char16trie.
-    #[cfg_attr(feature = "provider_serde", serde(borrow))]
+    #[cfg_attr(feature = "serialize", serde(borrow))]
     pub trie_data: ZeroVec<'data, u16>,
 }
 

--- a/provider/cldr/Cargo.toml
+++ b/provider/cldr/Cargo.toml
@@ -38,10 +38,10 @@ all-features = true
 [dependencies]
 icu_provider = { version = "0.5", path = "../../provider/core", features = ["serialize", "datagen"] }
 icu_locid = { version = "0.5", path = "../../components/locid" }
-icu_plurals = { version = "0.5", path = "../../components/plurals" }
+icu_plurals = { version = "0.5", path = "../../components/plurals", features = ["datagen"] }
 icu_datetime = { version = "0.5", path = "../../components/datetime", features = ["datagen"] }
-icu_locale_canonicalizer = { version = "0.5", path = "../../components/locale_canonicalizer" }
-icu_decimal = { version = "0.5", path = "../../components/decimal" }
+icu_locale_canonicalizer = { version = "0.5", path = "../../components/locale_canonicalizer", features = ["datagen"] }
+icu_decimal = { version = "0.5", path = "../../components/decimal", features = ["datagen"] }
 icu_calendar = { version = "0.5", path = "../../components/calendar", features = ["datagen"] }
 icu_list = { version = "0.5", path = "../../components/list", features = ["datagen"]}
 itertools = "0.10"

--- a/provider/cldr/Cargo.toml
+++ b/provider/cldr/Cargo.toml
@@ -39,11 +39,11 @@ all-features = true
 icu_provider = { version = "0.5", path = "../../provider/core", features = ["serialize", "datagen"] }
 icu_locid = { version = "0.5", path = "../../components/locid" }
 icu_plurals = { version = "0.5", path = "../../components/plurals" }
-icu_datetime = { version = "0.5", path = "../../components/datetime", features = ["provider_transform_internals"] }
+icu_datetime = { version = "0.5", path = "../../components/datetime", features = ["datagen"] }
 icu_locale_canonicalizer = { version = "0.5", path = "../../components/locale_canonicalizer" }
 icu_decimal = { version = "0.5", path = "../../components/decimal" }
-icu_calendar = { version = "0.5", path = "../../components/calendar", features = ["provider_serde"] }
-icu_list = { version = "0.5", path = "../../components/list", features = ["provider_transform_internals"]}
+icu_calendar = { version = "0.5", path = "../../components/calendar", features = ["datagen"] }
+icu_list = { version = "0.5", path = "../../components/list", features = ["datagen"]}
 itertools = "0.10"
 json = "0.12"
 litemap = { version = "0.3.0", path = "../../utils/litemap/" }
@@ -57,7 +57,7 @@ tinystr = { path = "../../utils/tinystr", version = "0.5.0", features = ["alloc"
 displaydoc = { version = "0.2.3", default-features = false }
 icu_locid_macros = { version = "0.5", path = "../../components/locid/macros" }
 icu_provider_uprops = { version = "0.5", path = "../../provider/uprops", features = ["log"] }
-icu_properties = { version = "0.5", path = "../../components/properties", features = ["provider_serde", "std"] }
+icu_properties = { version = "0.5", path = "../../components/properties", features = ["datagen", "std"] }
 zerovec = { version = "0.6", path = "../../utils/zerovec"}
 
 # Dependencies for the download feature

--- a/provider/segmenter/Cargo.toml
+++ b/provider/segmenter/Cargo.toml
@@ -25,10 +25,10 @@ include = [
 
 [dependencies]
 icu_codepointtrie = { version = "0.3.3", path = "../../utils/codepointtrie" }
-icu_properties = { version = "0.5", path = "../../components/properties", features = ["provider_serde"] }
+icu_properties = { version = "0.5", path = "../../components/properties", features = ["datagen"] }
 icu_provider = { version = "0.5", path = "../../provider/core", features = ["serialize", "macros"] }
 icu_provider_uprops = { version = "0.5", path = "../../provider/uprops" }
-icu_segmenter = { version = "0.1", path = "../../experimental/segmenter", features = ["provider_serde"] }
+icu_segmenter = { version = "0.1", path = "../../experimental/segmenter", features = ["datagen"] }
 icu_testdata = { version = "0.5", path = "../../provider/testdata" }
 serde = { version = "1.0", features = ["derive"] }
 toml = { version = "0.5" }

--- a/provider/uprops/Cargo.toml
+++ b/provider/uprops/Cargo.toml
@@ -29,10 +29,10 @@ all-features = true
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
 icu_casemapping = { version = "0.1", path = "../../experimental/casemapping", features = ["provider_serde", "provider_transform_internals"], optional = true }
-icu_codepointtrie = { version = "0.3.3", path = "../../utils/codepointtrie", features = ["provider_serde"] }
-icu_properties = { version = "0.5", path = "../../components/properties", features = ["provider_serde", "std"] }
+icu_codepointtrie = { version = "0.3.3", path = "../../utils/codepointtrie", features = ["serialize"] }
+icu_properties = { version = "0.5", path = "../../components/properties", features = ["datagen", "std"] }
 icu_provider = { version = "0.5", path = "../../provider/core", features = ["serialize", "std", "datagen"] }
-icu_uniset = { version = "0.4.1", path = "../../utils/uniset", features = ["provider_serde"] }
+icu_uniset = { version = "0.4.1", path = "../../utils/uniset", features = ["serialize"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = { version = "0.5" }
 zerovec = { version = "0.6", path = "../../utils/zerovec", features = ["serde", "yoke"] }

--- a/utils/codepointtrie/Cargo.toml
+++ b/utils/codepointtrie/Cargo.toml
@@ -49,5 +49,5 @@ bench = false  # This option is required for Benchmark CI
 path = "src/lib.rs"
 
 [features]
-default = ["provider_serde"]
-provider_serde = ["serde"]
+default = ["serialize"]
+serialize = ["serde"]

--- a/utils/litemap/src/serde.rs
+++ b/utils/litemap/src/serde.rs
@@ -6,8 +6,10 @@ use super::LiteMap;
 use core::fmt;
 use core::marker::PhantomData;
 use serde::de::{MapAccess, SeqAccess, Visitor};
-use serde::ser::SerializeMap;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer};
+
+#[cfg(feature = "serde_serialize")]
+use serde::{ser::SerializeMap, Serialize, Serializer};
 
 #[cfg(feature = "serde_serialize")]
 impl<K: Serialize, V: Serialize> Serialize for LiteMap<K, V> {

--- a/utils/uniset/Cargo.toml
+++ b/utils/uniset/Cargo.toml
@@ -53,7 +53,7 @@ path = "src/lib.rs"
 
 [features]
 bench = []
-provider_serde = ["serde"]
+serialize = ["serde"]
 
 [[bench]]
 name = "inv_list"


### PR DESCRIPTION
Builds on https://github.com/unicode-org/icu4x/pull/1699 

Fixes https://github.com/unicode-org/icu4x/issues/1320

Note: the decision in #1320 was to use `serde` and `datagen`; we'll be able to name features `serde` after current Rust beta hits stable (Apr 8). Given that it's relatively soon, I opted to use a temporary feature name `"serialize"` which we can replace with `"serde" = ["dep:serde", ...]` once that is supported. This PR gets the larger changes out of the way.




<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->