### PR TITLE
Add ZeroMap::get_copied_by

### DIFF
--- a/utils/zerovec/src/map/map.rs
+++ b/utils/zerovec/src/map/map.rs
@@ -346,9 +346,41 @@ where
     V: ZeroMapKV<'a, Container = ZeroVec<'a, V>> + ?Sized,
     V: AsULE + Copy,
 {
-    /// For cases when `V` is fixed-size, obtain a direct copy of `V` instead of `V::ULE`
+    /// For cases when `V` is fixed-size, obtain a direct copy of `V` instead of `V::ULE`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zerovec::ZeroMap;
+    ///
+    /// let mut map = ZeroMap::new();
+    /// map.insert(&1, &'a');
+    /// map.insert(&2, &'b');
+    /// assert_eq!(map.get_copied(&1), Some('a'));
+    /// assert_eq!(map.get_copied(&3), None);
     pub fn get_copied(&self, key: &K) -> Option<V> {
         let index = self.keys.zvl_binary_search(key).ok()?;
+        ZeroSlice::get(&*self.values, index)
+    }
+
+    /// Binary search the map with `predicate` to find a key, returning the value.
+    ///
+    /// For cases when `V` is fixed-size, use this method to obtain a direct copy of `V`
+    /// instead of `V::ULE`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zerovec::ZeroMap;
+    ///
+    /// let mut map = ZeroMap::new();
+    /// map.insert(&1, &'a');
+    /// map.insert(&2, &'b');
+    /// assert_eq!(map.get_copied_by(|probe| probe.cmp(&1)), Some('a'));
+    /// assert_eq!(map.get_copied_by(|probe| probe.cmp(&3)), None);
+    /// ```
+    pub fn get_copied_by(&self, predicate: impl FnMut(&K) -> Ordering) -> Option<V> {
+        let index = self.keys.zvl_binary_search_by(predicate).ok()?;
         ZeroSlice::get(&*self.values, index)
     }
 


### PR DESCRIPTION
We also need `ZeroMap2d::get_by` and `ZeroMap2d::get_copied_by`, but those are more involved.