### PR TITLE
ZeroVec docs for locales

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,6 +1247,7 @@ dependencies = [
  "displaydoc",
  "icu",
  "icu_benchmark_macros",
+ "icu_locid_macros",
  "serde",
  "serde_json",
  "tinystr 0.5.0",

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -46,6 +46,7 @@ icu = { path = "../icu", default-features = false }
 icu_benchmark_macros = { version = "0.5", path = "../../tools/benchmark/macros" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+icu_locid_macros = { path = "macros" }
 
 [lib]
 path = "src/lib.rs"

--- a/components/locid/src/lib.rs
+++ b/components/locid/src/lib.rs
@@ -65,6 +65,8 @@ mod parser;
 #[cfg(feature = "serde")]
 mod serde;
 pub mod subtags;
+#[cfg(feature = "zerovec")]
+pub mod zerovec;
 
 pub use langid::LanguageIdentifier;
 pub use locale::Locale;

--- a/components/locid/src/zerovec.rs
+++ b/components/locid/src/zerovec.rs
@@ -1,0 +1,121 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+//! Documentation on zero-copy deserialization of locale types.
+//!
+//! [`Locale`] and [`LanguageIdentifier`] are highly structured types that cannot be directly
+//! stored in a zero-copy data structure, such as those provided by the [`zerovec`] crate.
+//! This page explains how to indirectly store these types in a [`zerovec`].
+//!
+//! There are two main use cases, which have different solutions:
+//!
+//! 1. **Lookup:** You need to locate a locale in a zero-copy vector, such as when querying a map.
+//! 2. **Obtain:** You have a locale stored in a zero-copy vector, and you need to obtain a proper
+//!    [`Locale`] or [`LanguageIdentifier`] for use elsewhere in your program.
+//!
+//! # Lookup
+//!
+//! To perform lookup, store the BCP-47 byte array for the locale, and then use
+//! [`Locale::cmp_bytes()`] to perform an efficient, zero-allocation lookup.
+//!
+//! ```
+//! use std::str::FromStr;
+//! use icu_locid::Locale;
+//! use zerovec::ZeroMap;
+//!
+//! // ZeroMap from locales to integers
+//! let data: &[(&[u8], u32)] = &[
+//!     (b"de-DE-u-hc-h12", 5),
+//!     (b"en-US-u-ca-buddhist", 10),
+//!     (b"my-MM", 15),
+//!     (b"sr-Cyrl-ME", 20),
+//!     (b"zh-TW", 25),
+//! ];
+//! let zm: ZeroMap<[u8], u32> = data.iter().copied().collect();
+//!
+//! // Get the value associated with a locale
+//! let loc: Locale = "en-US-u-ca-buddhist".parse().unwrap();
+//! let value = zm.get_copied_by(|bytes| loc.cmp_bytes(bytes).reverse());
+//! assert_eq!(value, Some(10));
+//! ```
+//!
+//! # Obtain
+//!
+//! Obtaining a [`Locale`] or [`LanguageIdentifier`] is not generally a zero-copy operation, since
+//! both of these types may require memory allocation. If possible, architect your code such that
+//! you do not need to obtain a structured type.
+//!
+//! If need the structured type, such as if you need to manipulate it in some way, there are two
+//! options: storing subtags, and storing a string for parsing.
+//!
+//! ## Storing Subtags
+//!
+//! If the data being stored only contains a limited number of subtags, you can store them as a
+//! tuple, and then construct the [`LanguageIdentifier`] externally.
+//!
+//! ```
+//! use icu_locid::LanguageIdentifier;
+//! use icu_locid::subtags::{Language, Script, Region};
+//! use icu_locid_macros::{language, script, region, langid};
+//! use zerovec::ZeroMap;
+//!
+//! // ZeroMap from integer to LSR (language-script-region)
+//! let data: &[(u32, (Language, Option<Script>, Option<Region>))] = &[
+//!     (5, (language!("de"), None, Some(region!("DE")))),
+//!     (10, (language!("en"), None, Some(region!("US")))),
+//!     (15, (language!("my"), None, Some(region!("MM")))),
+//!     (20, (language!("sr"), Some(script!("Cyrl")), Some(region!("ME")))),
+//!     (25, (language!("zh"), None, Some(region!("TW")))),
+//! ];
+//! let zm: ZeroMap<u32, (Language, Option<Script>, Option<Region>)> =
+//!     data.iter().copied().collect();
+//!
+//! // Construct a LanguageIdentifier from a tuple entry
+//! let value = zm.get_copied(&25).expect("element is present");
+//! let mut lid = LanguageIdentifier::default();
+//! lid.language = value.0;
+//! lid.script = value.1;
+//! lid.region = value.2;
+//!
+//! assert_eq!(lid, langid!("zh-TW"));
+//! ```
+//!
+//! ## Storing Strings
+//!
+//! If it is necessary to store and obtain an arbitrary locale, it is currently recommended to
+//! store a BCP-47 string and parse it when needed.
+//!
+//! However, before doing this, consider the architecture and whether this can be avoided.
+//!
+//! ```
+//! use icu_locid::Locale;
+//! use icu_locid_macros::langid;
+//! use zerovec::ZeroMap;
+//!
+//! // ZeroMap from integer to locale string
+//! let data: &[(u32, &[u8])] = &[
+//!     (5, b"de-DE-u-hc-h12"),
+//!     (10, b"en-US-u-ca-buddhist"),
+//!     (15, b"my-MM"),
+//!     (20, b"sr-Cyrl-ME"),
+//!     (25, b"zh-TW"),
+//! ];
+//! let zm: ZeroMap<u32, [u8]> = data.iter().copied().collect();
+//!
+//! // Construct a Locale by parsing the string.
+//! let value = zm.get(&25).expect("element is present");
+//! let loc = Locale::from_bytes(value);
+//!
+//! assert_eq!(loc, Ok(langid!("zh-TW").into()));
+//! ```
+//!
+//! Note that since the string is stored in an unparsed state, it is not safe to `unwrap` the
+//! result from `Locale::from_bytes()`. See
+//! [icu4x#831](https://github.com/unicode-org/icu4x/issues/831)
+//! for a discussion on potential data models that could ensure that the locale is valid during
+//! deserialization.
+//!
+//! [`Locale`]: crate::Locale
+//! [`Locale::cmp_bytes()`]: crate::Locale::cmp_bytes()
+//! [`LanguageIdentifier`]: crate::LanguageIdentifier

--- a/components/locid/src/zerovec.rs
+++ b/components/locid/src/zerovec.rs
@@ -86,7 +86,10 @@
 //! If it is necessary to store and obtain an arbitrary locale, it is currently recommended to
 //! store a BCP-47 string and parse it when needed.
 //!
-//! However, before doing this, consider the architecture and whether this can be avoided.
+//! Since the string is stored in an unparsed state, it is not safe to `unwrap` the result from
+//! `Locale::from_bytes()`. See [icu4x#831](https://github.com/unicode-org/icu4x/issues/831)
+//! for a discussion on potential data models that could ensure that the locale is valid during
+//! deserialization.
 //!
 //! ```
 //! use icu_locid::Locale;
@@ -109,12 +112,6 @@
 //!
 //! assert_eq!(loc, Ok(langid!("zh-TW").into()));
 //! ```
-//!
-//! Note that since the string is stored in an unparsed state, it is not safe to `unwrap` the
-//! result from `Locale::from_bytes()`. See
-//! [icu4x#831](https://github.com/unicode-org/icu4x/issues/831)
-//! for a discussion on potential data models that could ensure that the locale is valid during
-//! deserialization.
 //!
 //! [`Locale`]: crate::Locale
 //! [`Locale::cmp_bytes()`]: crate::Locale::cmp_bytes()

--- a/utils/zerovec/src/map/map.rs
+++ b/utils/zerovec/src/map/map.rs
@@ -346,9 +346,41 @@ where
     V: ZeroMapKV<'a, Container = ZeroVec<'a, V>> + ?Sized,
     V: AsULE + Copy,
 {
-    /// For cases when `V` is fixed-size, obtain a direct copy of `V` instead of `V::ULE`
+    /// For cases when `V` is fixed-size, obtain a direct copy of `V` instead of `V::ULE`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zerovec::ZeroMap;
+    ///
+    /// let mut map = ZeroMap::new();
+    /// map.insert(&1, &'a');
+    /// map.insert(&2, &'b');
+    /// assert_eq!(map.get_copied(&1), Some('a'));
+    /// assert_eq!(map.get_copied(&3), None);
     pub fn get_copied(&self, key: &K) -> Option<V> {
         let index = self.keys.zvl_binary_search(key).ok()?;
+        ZeroSlice::get(&*self.values, index)
+    }
+
+    /// Binary search the map with `predicate` to find a key, returning the value.
+    ///
+    /// For cases when `V` is fixed-size, use this method to obtain a direct copy of `V`
+    /// instead of `V::ULE`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zerovec::ZeroMap;
+    ///
+    /// let mut map = ZeroMap::new();
+    /// map.insert(&1, &'a');
+    /// map.insert(&2, &'b');
+    /// assert_eq!(map.get_copied_by(|probe| probe.cmp(&1)), Some('a'));
+    /// assert_eq!(map.get_copied_by(|probe| probe.cmp(&3)), None);
+    /// ```
+    pub fn get_copied_by(&self, predicate: impl FnMut(&K) -> Ordering) -> Option<V> {
+        let index = self.keys.zvl_binary_search_by(predicate).ok()?;
         ZeroSlice::get(&*self.values, index)
     }
 


### PR DESCRIPTION
Depends on #1723 or #1724

I wrote up a documentation page with the currently recommend state of zero-copy locales from #831. I added it as an otherwise empty "zerovec" module in the locid crate.

I'm marking this as Draft because the second example does not yet compile (it needs #1723 or #1724).