### PR TITLE
Rename ZeroVec::from_slice and add new method for const-constructed ZeroSlice

### DIFF
--- a/experimental/char16trie/README.md
+++ b/experimental/char16trie/README.md
@@ -26,7 +26,7 @@ use zerovec::ZeroVec;
 // A Char16Trie containing the ASCII characters mapping 'a' to 1 and 'ab'
 // to 100.
 let trie_data = vec![48, 97, 176, 98, 32868];
-let trie = Char16Trie::new(ZeroVec::from_slice(trie_data.as_slice()));
+let trie = Char16Trie::new(ZeroVec::from_slice_or_alloc(trie_data.as_slice()));
 
 let mut iter = trie.iter();
 let res = iter.next('a');

--- a/experimental/char16trie/src/char16trie.rs
+++ b/experimental/char16trie/src/char16trie.rs
@@ -163,7 +163,7 @@ impl<'a> Char16TrieIterator<'a> {
     ///
     /// // A Char16Trie containing the ASCII characters 'a' and 'b'.
     /// let trie_data = vec![48, 97, 176, 98, 32868];
-    /// let trie = Char16Trie::new(ZeroVec::from_slice(trie_data.as_slice()));
+    /// let trie = Char16Trie::new(ZeroVec::from_slice_or_alloc(trie_data.as_slice()));
     ///
     /// let mut iter = trie.iter();
     /// let res = iter.next('a');
@@ -196,7 +196,7 @@ impl<'a> Char16TrieIterator<'a> {
     ///
     /// // A Char16Trie containing the ASCII characters 'a' and 'b'.
     /// let trie_data = vec![48, 97, 176, 98, 32868];
-    /// let trie = Char16Trie::new(ZeroVec::from_slice(trie_data.as_slice()));
+    /// let trie = Char16Trie::new(ZeroVec::from_slice_or_alloc(trie_data.as_slice()));
     ///
     /// let mut iter = trie.iter();
     /// let res = iter.next('a');
@@ -229,7 +229,7 @@ impl<'a> Char16TrieIterator<'a> {
     ///
     /// // A Char16Trie containing the ASCII characters 'a' and 'b'.
     /// let trie_data = vec![48, 97, 176, 98, 32868];
-    /// let trie = Char16Trie::new(ZeroVec::from_slice(trie_data.as_slice()));
+    /// let trie = Char16Trie::new(ZeroVec::from_slice_or_alloc(trie_data.as_slice()));
     ///
     /// let mut iter = trie.iter();
     /// let res = iter.next_u16('a' as u16);

--- a/experimental/char16trie/src/lib.rs
+++ b/experimental/char16trie/src/lib.rs
@@ -28,7 +28,7 @@
 //! // A Char16Trie containing the ASCII characters mapping 'a' to 1 and 'ab'
 //! // to 100.
 //! let trie_data = vec![48, 97, 176, 98, 32868];
-//! let trie = Char16Trie::new(ZeroVec::from_slice(trie_data.as_slice()));
+//! let trie = Char16Trie::new(ZeroVec::from_slice_or_alloc(trie_data.as_slice()));
 //!
 //! let mut iter = trie.iter();
 //! let res = iter.next('a');

--- a/experimental/char16trie/tests/trie_tests.rs
+++ b/experimental/char16trie/tests/trie_tests.rs
@@ -10,7 +10,7 @@ use zerovec::ZeroVec;
 #[test]
 fn char16trie_test_empty() {
     let trie_data = test_util::load_char16trie_data("tests/testdata/empty.toml");
-    let trie = Char16Trie::new(ZeroVec::from_slice(trie_data.as_slice()));
+    let trie = Char16Trie::new(ZeroVec::from_slice_or_alloc(trie_data.as_slice()));
     let res = trie.iter().next('h');
     assert_eq!(res, TrieResult::NoMatch);
 }
@@ -18,7 +18,7 @@ fn char16trie_test_empty() {
 #[test]
 fn char16trie_test_a() {
     let trie_data = test_util::load_char16trie_data("tests/testdata/test_a.toml");
-    let trie = Char16Trie::new(ZeroVec::from_slice(trie_data.as_slice()));
+    let trie = Char16Trie::new(ZeroVec::from_slice_or_alloc(trie_data.as_slice()));
 
     let mut iter = trie.iter();
     let res = iter.next('h');
@@ -34,7 +34,7 @@ fn char16trie_test_a() {
 #[test]
 fn char16trie_test_a_b() {
     let trie_data = test_util::load_char16trie_data("tests/testdata/test_a_ab.toml");
-    let trie = Char16Trie::new(ZeroVec::from_slice(trie_data.as_slice()));
+    let trie = Char16Trie::new(ZeroVec::from_slice_or_alloc(trie_data.as_slice()));
 
     let mut iter = trie.iter();
     let res = iter.next('a');
@@ -54,7 +54,7 @@ fn char16trie_test_a_b() {
 #[test]
 fn char16trie_test_shortest_branch() {
     let trie_data = test_util::load_char16trie_data("tests/testdata/test_shortest_branch.toml");
-    let trie = Char16Trie::new(ZeroVec::from_slice(trie_data.as_slice()));
+    let trie = Char16Trie::new(ZeroVec::from_slice_or_alloc(trie_data.as_slice()));
 
     let mut iter = trie.iter();
     let res = iter.next('a');
@@ -72,7 +72,7 @@ fn char16trie_test_shortest_branch() {
 #[test]
 fn char16trie_test_branches() {
     let trie_data = test_util::load_char16trie_data("tests/testdata/test_branches.toml");
-    let trie = Char16Trie::new(ZeroVec::from_slice(trie_data.as_slice()));
+    let trie = Char16Trie::new(ZeroVec::from_slice_or_alloc(trie_data.as_slice()));
 
     for (query, expected) in [
         ("a", TrieResult::FinalValue(0x10)),
@@ -105,7 +105,7 @@ fn char16trie_test_branches() {
 #[test]
 fn char16trie_test_long_sequence() {
     let trie_data = test_util::load_char16trie_data("tests/testdata/test_long_sequence.toml");
-    let trie = Char16Trie::new(ZeroVec::from_slice(trie_data.as_slice()));
+    let trie = Char16Trie::new(ZeroVec::from_slice_or_alloc(trie_data.as_slice()));
 
     for (query, expected) in [
         ("a", TrieResult::Intermediate(-1)),
@@ -146,7 +146,7 @@ fn char16trie_test_long_sequence() {
 #[test]
 fn char16trie_test_long_branch() {
     let trie_data = test_util::load_char16trie_data("tests/testdata/test_long_branch.toml");
-    let trie = Char16Trie::new(ZeroVec::from_slice(trie_data.as_slice()));
+    let trie = Char16Trie::new(ZeroVec::from_slice_or_alloc(trie_data.as_slice()));
 
     for (query, expected) in [
         ("a", TrieResult::FinalValue(-2)),
@@ -197,7 +197,7 @@ fn char16trie_test_long_branch() {
 #[test]
 fn char16trie_test_compact() {
     let trie_data = test_util::load_char16trie_data("tests/testdata/test_compact.toml");
-    let trie = Char16Trie::new(ZeroVec::from_slice(trie_data.as_slice()));
+    let trie = Char16Trie::new(ZeroVec::from_slice_or_alloc(trie_data.as_slice()));
 
     for (query, expected) in [
         ("+", TrieResult::Intermediate(0)),
@@ -236,7 +236,7 @@ fn char16trie_test_compact() {
 #[test]
 fn char16trie_test_months() {
     let trie_data = test_util::load_char16trie_data("tests/testdata/months.toml");
-    let trie = Char16Trie::new(ZeroVec::from_slice(trie_data.as_slice()));
+    let trie = Char16Trie::new(ZeroVec::from_slice_or_alloc(trie_data.as_slice()));
 
     let mut iter = trie.iter();
     for (chr, expected) in [

--- a/utils/codepointtrie/src/planes.rs
+++ b/utils/codepointtrie/src/planes.rs
@@ -290,7 +290,7 @@ mod tests {
         let index_array_as_bytes: &[u8] = super::INDEX_ARRAY_AS_BYTES;
         let index_zv_bytes: ZeroVec<u16> =
             ZeroVec::parse_byte_slice(index_array_as_bytes).expect("infallible");
-        let index_zv_aligned: ZeroVec<u16> = ZeroVec::from_slice(INDEX_ARRAY);
+        let index_zv_aligned: ZeroVec<u16> = ZeroVec::from_slice_or_alloc(INDEX_ARRAY);
         assert_eq!(index_zv_bytes, index_zv_aligned);
     }
 }

--- a/utils/codepointtrie/tests/planes_test.rs
+++ b/utils/codepointtrie/tests/planes_test.rs
@@ -60,8 +60,8 @@ fn planes_trie_deserialize_check_test() {
         trie_type: trie_type_enum,
     };
 
-    let data = ZeroVec::from_slice(code_point_trie_struct.data_8.as_ref().unwrap());
-    let index = ZeroVec::from_slice(&code_point_trie_struct.index);
+    let data = ZeroVec::from_slice_or_alloc(code_point_trie_struct.data_8.as_ref().unwrap());
+    let index = ZeroVec::from_slice_or_alloc(&code_point_trie_struct.index);
     let trie_result: Result<CodePointTrie<u8>, Error> =
         CodePointTrie::try_new(trie_header, index, data);
     let act_planes_trie = trie_result.unwrap();

--- a/utils/codepointtrie/tests/test_util.rs
+++ b/utils/codepointtrie/tests/test_util.rs
@@ -237,11 +237,11 @@ pub fn run_deserialize_test_from_test_data(test_file_path: &str) {
         trie_type: trie_type_enum,
     };
 
-    let index = ZeroVec::from_slice(&test_struct.index);
+    let index = ZeroVec::from_slice_or_alloc(&test_struct.index);
 
     match (test_struct.data_8, test_struct.data_16, test_struct.data_32) {
         (Some(data_8), _, _) => {
-            let data = ZeroVec::from_slice(&data_8);
+            let data = ZeroVec::from_slice_or_alloc(&data_8);
             let trie_result: Result<CodePointTrie<u8>, Error> =
                 CodePointTrie::try_new(trie_header, index, data);
             assert!(trie_result.is_ok(), "Could not construct trie");
@@ -256,7 +256,7 @@ pub fn run_deserialize_test_from_test_data(test_file_path: &str) {
         }
 
         (_, Some(data_16), _) => {
-            let data = ZeroVec::from_slice(&data_16);
+            let data = ZeroVec::from_slice_or_alloc(&data_16);
             let trie_result: Result<CodePointTrie<u16>, Error> =
                 CodePointTrie::try_new(trie_header, index, data);
             assert!(trie_result.is_ok(), "Could not construct trie");
@@ -271,7 +271,7 @@ pub fn run_deserialize_test_from_test_data(test_file_path: &str) {
         }
 
         (_, _, Some(data_32)) => {
-            let data = ZeroVec::from_slice(&data_32);
+            let data = ZeroVec::from_slice_or_alloc(&data_32);
             let trie_result: Result<CodePointTrie<u32>, Error> =
                 CodePointTrie::try_new(trie_header, index, data);
             assert!(trie_result.is_ok(), "Could not construct trie");

--- a/utils/uniset/src/uniset.rs
+++ b/utils/uniset/src/uniset.rs
@@ -83,12 +83,12 @@ impl<'data> UnicodeSet<'data> {
     /// use icu_uniset::UnicodeSetError;
     /// use zerovec::ZeroVec;
     /// let valid = [0x0, 0x10000];
-    /// let inv_list: ZeroVec<u32> = ZeroVec::from_slice(&valid);
+    /// let inv_list: ZeroVec<u32> = ZeroVec::from_slice_or_alloc(&valid);
     /// let result = UnicodeSet::from_inversion_list(inv_list);
     /// assert!(matches!(result, UnicodeSet));
     ///
     /// let invalid: Vec<u32> = vec![0x0, 0x80, 0x3];
-    /// let inv_list: ZeroVec<u32> = ZeroVec::from_slice(&invalid);
+    /// let inv_list: ZeroVec<u32> = ZeroVec::from_slice_or_alloc(&invalid);
     /// let result = UnicodeSet::from_inversion_list(inv_list);
     /// assert!(matches!(result, Err(UnicodeSetError::InvalidSet(_))));
     /// if let Err(UnicodeSetError::InvalidSet(actual)) = result {
@@ -117,7 +117,7 @@ impl<'data> UnicodeSet<'data> {
     /// The inversion list must be of even length, sorted ascending non-overlapping,
     /// and within the bounds of `0x0 -> 0x10FFFF` inclusive, and end points being exclusive.
     ///
-    /// Note: The slice may be cloned on certain platforms; for more information, see [`ZeroVec::from_slice`].
+    /// Note: The slice may be cloned on certain platforms; for more information, see [`ZeroVec::from_slice_or_alloc`].
     ///
     /// # Examples
     ///
@@ -137,7 +137,7 @@ impl<'data> UnicodeSet<'data> {
     /// }
     /// ```
     pub fn from_inversion_list_slice(inv_list: &'data [u32]) -> Result<Self, UnicodeSetError> {
-        let inv_list_zv: ZeroVec<u32> = ZeroVec::from_slice(inv_list);
+        let inv_list_zv: ZeroVec<u32> = ZeroVec::from_slice_or_alloc(inv_list);
         UnicodeSet::from_inversion_list(inv_list_zv)
     }
 
@@ -207,7 +207,7 @@ impl<'data> UnicodeSet<'data> {
     /// ```
     pub fn all() -> Self {
         Self {
-            inv_list: ZeroVec::<u32>::from_slice(ALL_SLICE),
+            inv_list: ZeroVec::<u32>::from_slice_or_alloc(ALL_SLICE),
             size: (char::MAX as usize) + 1,
         }
     }
@@ -233,7 +233,7 @@ impl<'data> UnicodeSet<'data> {
     /// ```
     pub fn bmp() -> Self {
         Self {
-            inv_list: ZeroVec::<u32>::from_slice(BMP_INV_LIST_SLICE),
+            inv_list: ZeroVec::<u32>::from_slice_or_alloc(BMP_INV_LIST_SLICE),
             size: (BMP_MAX as usize) + 1,
         }
     }
@@ -542,7 +542,7 @@ mod tests {
     #[test]
     fn test_unicodeset_try_from_vec_error() {
         let check = vec![0x1, 0x1, 0x2, 0x3, 0x4];
-        let inv_list = ZeroVec::from_slice(&check);
+        let inv_list = ZeroVec::from_slice_or_alloc(&check);
         let set = UnicodeSet::from_inversion_list(inv_list);
         assert!(matches!(set, Err(UnicodeSetError::InvalidSet(_))));
         if let Err(UnicodeSetError::InvalidSet(actual)) = set {
@@ -638,7 +638,7 @@ mod tests {
         assert_eq!(expected as usize, check.size());
         let inv_list_vec: Vec<u32> = vec![];
         let check = UnicodeSet {
-            inv_list: ZeroVec::from_slice(&inv_list_vec),
+            inv_list: ZeroVec::from_slice_or_alloc(&inv_list_vec),
             size: 0,
         };
         assert_eq!(check.size(), 0);
@@ -648,7 +648,7 @@ mod tests {
     fn test_unicodeset_is_empty() {
         let inv_list_vec: Vec<u32> = vec![];
         let check = UnicodeSet {
-            inv_list: ZeroVec::from_slice(&inv_list_vec),
+            inv_list: ZeroVec::from_slice_or_alloc(&inv_list_vec),
             size: 0,
         };
         assert!(check.is_empty());

--- a/utils/uniset/src/uniset.rs
+++ b/utils/uniset/src/uniset.rs
@@ -8,7 +8,7 @@ use alloc::vec::Vec;
 use core::{char, ops::RangeBounds, ops::RangeInclusive};
 use yoke::Yokeable;
 use zerofrom::ZeroFrom;
-use zerovec::{ule::AsULE, ZeroVec};
+use zerovec::{ule::AsULE, ZeroSlice, ZeroVec};
 
 use super::UnicodeSetError;
 use crate::utils::{deconstruct_range, is_valid_zv};
@@ -17,10 +17,15 @@ use crate::utils::{deconstruct_range, is_valid_zv};
 const BMP_MAX: u32 = 0xFFFF;
 
 /// Represents the inversion list for a set of all code points in the Basic Multilingual Plane.
-const BMP_INV_LIST_SLICE: &[u32] = &[0x0, BMP_MAX + 1];
+const BMP_INV_LIST_SLICE: &ZeroSlice<u32> =
+    ZeroSlice::<u32>::from_ule_slice_const(&<u32 as AsULE>::ULE::from_array([0x0, BMP_MAX + 1]));
 
 /// Represents the inversion list for all of the code points in the Unicode range.
-const ALL_SLICE: &[u32] = &[0x0, (char::MAX as u32) + 1];
+const ALL_SLICE: &ZeroSlice<u32> =
+    ZeroSlice::<u32>::from_ule_slice_const(&<u32 as AsULE>::ULE::from_array([
+        0x0,
+        (char::MAX as u32) + 1,
+    ]));
 
 /// A membership wrapper for [`UnicodeSet`].
 ///
@@ -207,7 +212,7 @@ impl<'data> UnicodeSet<'data> {
     /// ```
     pub fn all() -> Self {
         Self {
-            inv_list: ZeroVec::<u32>::from_slice_or_alloc(ALL_SLICE),
+            inv_list: ALL_SLICE.as_zerovec(),
             size: (char::MAX as usize) + 1,
         }
     }
@@ -233,7 +238,7 @@ impl<'data> UnicodeSet<'data> {
     /// ```
     pub fn bmp() -> Self {
         Self {
-            inv_list: ZeroVec::<u32>::from_slice_or_alloc(BMP_INV_LIST_SLICE),
+            inv_list: BMP_INV_LIST_SLICE.as_zerovec(),
             size: (BMP_MAX as usize) + 1,
         }
     }

--- a/utils/uniset/src/utils.rs
+++ b/utils/uniset/src/utils.rs
@@ -49,44 +49,44 @@ mod tests {
 
     #[test]
     fn test_is_valid_zv() {
-        let check = ZeroVec::from_slice(&[0x2, 0x3, 0x4, 0x5]);
+        let check = ZeroVec::from_slice_or_alloc(&[0x2, 0x3, 0x4, 0x5]);
         assert!(is_valid_zv(&check));
     }
 
     #[test]
     fn test_is_valid_zv_empty() {
         let v: Vec<u32> = vec![];
-        let check = ZeroVec::from_slice(&v);
+        let check = ZeroVec::from_slice_or_alloc(&v);
         assert!(is_valid_zv(&check));
     }
 
     #[test]
     fn test_is_valid_zv_overlapping() {
-        let check = ZeroVec::from_slice(&[0x2, 0x5, 0x4, 0x6]);
+        let check = ZeroVec::from_slice_or_alloc(&[0x2, 0x5, 0x4, 0x6]);
         assert!(!is_valid_zv(&check));
     }
 
     #[test]
     fn test_is_valid_zv_out_of_order() {
-        let check = ZeroVec::from_slice(&[0x5, 0x4, 0x5, 0x6, 0x7]);
+        let check = ZeroVec::from_slice_or_alloc(&[0x5, 0x4, 0x5, 0x6, 0x7]);
         assert!(!is_valid_zv(&check));
     }
 
     #[test]
     fn test_is_valid_zv_duplicate() {
-        let check = ZeroVec::from_slice(&[0x1, 0x2, 0x3, 0x3, 0x5]);
+        let check = ZeroVec::from_slice_or_alloc(&[0x1, 0x2, 0x3, 0x3, 0x5]);
         assert!(!is_valid_zv(&check));
     }
 
     #[test]
     fn test_is_valid_zv_odd() {
-        let check = ZeroVec::from_slice(&[0x1, 0x2, 0x3, 0x4, 0x5]);
+        let check = ZeroVec::from_slice_or_alloc(&[0x1, 0x2, 0x3, 0x4, 0x5]);
         assert!(!is_valid_zv(&check));
     }
 
     #[test]
     fn test_is_valid_zv_out_of_range() {
-        let check = ZeroVec::from_slice(&[0x1, 0x2, 0x3, 0x4, (char::MAX as u32) + 1]);
+        let check = ZeroVec::from_slice_or_alloc(&[0x1, 0x2, 0x3, 0x4, (char::MAX as u32) + 1]);
         assert!(!is_valid_zv(&check));
     }
 

--- a/utils/zerovec/README.md
+++ b/utils/zerovec/README.md
@@ -66,8 +66,8 @@ pub struct DataStruct<'data> {
 }
 
 let data = DataStruct {
-    nums: ZeroVec::from_slice(&[211, 281, 421, 461]),
-    chars: ZeroVec::from_slice(&['ö', '冇', 'म']),
+    nums: ZeroVec::from_slice_or_alloc(&[211, 281, 421, 461]),
+    chars: ZeroVec::from_slice_or_alloc(&['ö', '冇', 'म']),
     strs: VarZeroVec::from(&["hello", "world"]),
 };
 let bincode_bytes = bincode::serialize(&data)

--- a/utils/zerovec/benches/zerovec.rs
+++ b/utils/zerovec/benches/zerovec.rs
@@ -53,7 +53,7 @@ where
     buffer.0.push(0);
     buffer
         .0
-        .extend(ZeroVec::from_slice(vec.as_slice()).as_bytes());
+        .extend(ZeroVec::from_slice_or_alloc(vec.as_slice()).as_bytes());
     ZeroVec::<T>::parse_byte_slice(&buffer.0[1..]).unwrap()
 }
 

--- a/utils/zerovec/benches/zerovec_serde.rs
+++ b/utils/zerovec/benches/zerovec_serde.rs
@@ -68,7 +68,7 @@ fn u32_benches(c: &mut Criterion) {
     });
 
     c.bench_function("zerovec_serde/serialize/u32/zerovec", |b| {
-        b.iter(|| bincode::serialize(&ZeroVec::from_slice(black_box(TEST_SLICE))));
+        b.iter(|| bincode::serialize(&ZeroVec::from_slice_or_alloc(black_box(TEST_SLICE))));
     });
 
     c.bench_function("zerovec_serde/deserialize_sum/u32/zerovec", |b| {
@@ -101,11 +101,12 @@ fn char_benches(c: &mut Criterion) {
     });
 
     c.bench_function("zerovec_serde/serialize/char/zerovec", |b| {
-        b.iter(|| bincode::serialize(&ZeroVec::from_slice(black_box(ORIGINAL_CHARS))));
+        b.iter(|| bincode::serialize(&ZeroVec::from_slice_or_alloc(black_box(ORIGINAL_CHARS))));
     });
 
     c.bench_function("zerovec_serde/deserialize/char/zerovec", |b| {
-        let buffer = bincode::serialize(&ZeroVec::from_slice(black_box(ORIGINAL_CHARS))).unwrap();
+        let buffer =
+            bincode::serialize(&ZeroVec::from_slice_or_alloc(black_box(ORIGINAL_CHARS))).unwrap();
         b.iter(|| bincode::deserialize::<ZeroVec<char>>(&buffer));
     });
 }
@@ -114,7 +115,7 @@ fn char_benches(c: &mut Criterion) {
 fn stress_benches(c: &mut Criterion) {
     let number_vec = random_numbers(100);
     let bincode_vec = bincode::serialize(&number_vec).unwrap();
-    let zerovec_aligned = ZeroVec::from_slice(number_vec.as_slice());
+    let zerovec_aligned = ZeroVec::from_slice_or_alloc(number_vec.as_slice());
     let bincode_zerovec = bincode::serialize(&zerovec_aligned).unwrap();
 
     // *** Deserialize vec of 100 `u32` ***

--- a/utils/zerovec/examples/zv_serde.rs
+++ b/utils/zerovec/examples/zv_serde.rs
@@ -29,7 +29,7 @@ const POSTCARD_BYTES: [u8; 33] = [
 #[allow(dead_code)]
 fn serialize() {
     let data = DataStruct {
-        nums: ZeroVec::from_slice(&U16_SLICE),
+        nums: ZeroVec::from_slice_or_alloc(&U16_SLICE),
     };
     let postcard_bytes = postcard::to_stdvec(&data).expect("Serialization should be successful");
     println!("Postcard bytes: {:#x?}", postcard_bytes);

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -69,8 +69,8 @@
 //! }
 //!
 //! let data = DataStruct {
-//!     nums: ZeroVec::from_slice(&[211, 281, 421, 461]),
-//!     chars: ZeroVec::from_slice(&['ö', '冇', 'म']),
+//!     nums: ZeroVec::from_slice_or_alloc(&[211, 281, 421, 461]),
+//!     chars: ZeroVec::from_slice_or_alloc(&['ö', '冇', 'म']),
 //!     strs: VarZeroVec::from(&["hello", "world"]),
 //! };
 //! let bincode_bytes = bincode::serialize(&data)

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -506,7 +506,7 @@ mod test {
 
     #[test]
     fn test_zerovec_binary_search_in_range() {
-        let zv: ZeroVec<u16> = ZeroVec::from_slice(&[11, 22, 33, 44, 55, 66, 77]);
+        let zv: ZeroVec<u16> = ZeroVec::from_slice_or_alloc(&[11, 22, 33, 44, 55, 66, 77]);
 
         // Full range search
         assert_eq!(zv.zvl_binary_search_in_range(&11, 0..7), Some(Ok(0)));

--- a/utils/zerovec/src/ule/encode.rs
+++ b/utils/zerovec/src/ule/encode.rs
@@ -293,12 +293,12 @@ mod test {
         type ZS<T> = ZeroSlice<T>;
         type VZS<T> = VarZeroSlice<T>;
 
-        let u8_zerovec: ZeroVec<u8> = ZeroVec::from_slice(&U8_ARRAY);
+        let u8_zerovec: ZeroVec<u8> = ZeroVec::from_slice_or_alloc(&U8_ARRAY);
         let u8_2d_zerovec: [ZeroVec<u8>; 2] = [u8_zerovec.clone(), u8_zerovec.clone()];
         let u8_2d_vec: Vec<Vec<u8>> = vec![U8_ARRAY.into(), U8_ARRAY.into()];
         let u8_3d_vec: Vec<Vec<Vec<u8>>> = vec![u8_2d_vec.clone(), u8_2d_vec.clone()];
 
-        let u32_zerovec: ZeroVec<u32> = ZeroVec::from_slice(&U32_ARRAY);
+        let u32_zerovec: ZeroVec<u32> = ZeroVec::from_slice_or_alloc(&U32_ARRAY);
         let u32_2d_zerovec: [ZeroVec<u32>; 2] = [u32_zerovec.clone(), u32_zerovec.clone()];
         let u32_2d_vec: Vec<Vec<u32>> = vec![U32_ARRAY.into(), U32_ARRAY.into()];
         let u32_3d_vec: Vec<Vec<Vec<u32>>> = vec![u32_2d_vec.clone(), u32_2d_vec.clone()];

--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -86,7 +86,7 @@ where
     Owned(Vec<T::ULE>),
 
     /// A borrowed `ZeroVec<T>`. This will typically be constructed by [`ZeroVec::parse_byte_slice()`],
-    /// [`ZeroVec::from_slice()`], or deserializers capable of doing zero-copy deserialization.
+    /// [`ZeroVec::from_slice_or_alloc()`], or deserializers capable of doing zero-copy deserialization.
     ///
     /// If you already have a slice of `[T::ULE]`s, you can directly construct one of these.
     ///
@@ -551,13 +551,13 @@ where
     /// let bytes: &[u8] = &[0xD3, 0x00, 0x19, 0x01, 0xA5, 0x01, 0xCD, 0x01];
     /// let nums: &[u16] = &[211, 281, 421, 461];
     ///
-    /// let zerovec = ZeroVec::from_slice(nums);
+    /// let zerovec = ZeroVec::from_slice_or_alloc_or_alloc(nums);
     ///
     /// // Note: zerovec could be either borrowed or owned.
     /// assert_eq!(bytes, zerovec.as_bytes());
     /// ```
     #[inline]
-    pub fn from_slice(slice: &'a [T]) -> Self {
+    pub fn from_slice_or_alloc(slice: &'a [T]) -> Self {
         Self::try_from_slice(slice).unwrap_or_else(|| Self::alloc_from_slice(slice))
     }
 }
@@ -705,7 +705,7 @@ mod tests {
     #[test]
     fn test_get() {
         {
-            let zerovec = ZeroVec::from_slice(TEST_SLICE);
+            let zerovec = ZeroVec::from_slice_or_alloc(TEST_SLICE);
             assert_eq!(zerovec.get(0), Some(TEST_SLICE[0]));
             assert_eq!(zerovec.get(1), Some(TEST_SLICE[1]));
             assert_eq!(zerovec.get(2), Some(TEST_SLICE[2]));
@@ -721,7 +721,7 @@ mod tests {
     #[test]
     fn test_binary_search() {
         {
-            let zerovec = ZeroVec::from_slice(TEST_SLICE);
+            let zerovec = ZeroVec::from_slice_or_alloc(TEST_SLICE);
             assert_eq!(Ok(3), zerovec.binary_search(&0x0e0d0c));
             assert_eq!(Err(3), zerovec.binary_search(&0x0c0d0c));
         }

--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -551,7 +551,7 @@ where
     /// let bytes: &[u8] = &[0xD3, 0x00, 0x19, 0x01, 0xA5, 0x01, 0xCD, 0x01];
     /// let nums: &[u16] = &[211, 281, 421, 461];
     ///
-    /// let zerovec = ZeroVec::from_slice_or_alloc_or_alloc(nums);
+    /// let zerovec = ZeroVec::from_slice_or_alloc(nums);
     ///
     /// // Note: zerovec could be either borrowed or owned.
     /// assert_eq!(bytes, zerovec.as_bytes());

--- a/utils/zerovec/src/zerovec/serde.rs
+++ b/utils/zerovec/src/zerovec/serde.rs
@@ -139,13 +139,13 @@ mod test {
 
     #[test]
     fn test_serde_json() {
-        let zerovec_orig = ZeroVec::from_slice(TEST_SLICE);
+        let zerovec_orig = ZeroVec::from_slice_or_alloc(TEST_SLICE);
         let json_str = serde_json::to_string(&zerovec_orig).expect("serialize");
         assert_eq!(JSON_STR, json_str);
         // ZeroVec should deserialize from JSON to either Vec or ZeroVec
         let vec_new: Vec<u32> =
             serde_json::from_str(&json_str).expect("deserialize from buffer to Vec");
-        assert_eq!(zerovec_orig, ZeroVec::<u32>::from_slice(vec_new.as_slice()));
+        assert_eq!(zerovec_orig, ZeroVec::<u32>::from_slice_or_alloc(vec_new.as_slice()));
         let zerovec_new: ZeroVec<u32> =
             serde_json::from_str(&json_str).expect("deserialize from buffer to ZeroVec");
         assert_eq!(zerovec_orig, zerovec_new);
@@ -154,7 +154,7 @@ mod test {
 
     #[test]
     fn test_serde_bincode() {
-        let zerovec_orig = ZeroVec::from_slice(TEST_SLICE);
+        let zerovec_orig = ZeroVec::from_slice_or_alloc(TEST_SLICE);
         let bincode_buf = bincode::serialize(&zerovec_orig).expect("serialize");
         assert_eq!(BINCODE_BUF, bincode_buf);
         // ZeroVec should deserialize from Bincode to ZeroVec but not Vec
@@ -168,7 +168,7 @@ mod test {
     #[test]
     fn test_chars_valid() {
         // 1-byte, 2-byte, 3-byte, and 4-byte character in UTF-8 (not as relevant in UTF-32)
-        let zerovec_orig = ZeroVec::from_slice(&['w', 'ω', '文', '𑄃']);
+        let zerovec_orig = ZeroVec::from_slice_or_alloc(&['w', 'ω', '文', '𑄃']);
         let bincode_buf = bincode::serialize(&zerovec_orig).expect("serialize");
         let zerovec_new: ZeroVec<char> =
             bincode::deserialize(&bincode_buf).expect("deserialize from buffer to ZeroVec");
@@ -179,7 +179,7 @@ mod test {
     #[test]
     fn test_chars_invalid() {
         // 119 and 120 are valid, but not 0xD800 (high surrogate)
-        let zerovec_orig: ZeroVec<u32> = ZeroVec::from_slice(&[119, 0xD800, 120]);
+        let zerovec_orig: ZeroVec<u32> = ZeroVec::from_slice_or_alloc(&[119, 0xD800, 120]);
         let bincode_buf = bincode::serialize(&zerovec_orig).expect("serialize");
         let zerovec_result = bincode::deserialize::<ZeroVec<char>>(&bincode_buf);
         assert!(matches!(zerovec_result, Err(_)));

--- a/utils/zerovec/src/zerovec/serde.rs
+++ b/utils/zerovec/src/zerovec/serde.rs
@@ -145,7 +145,10 @@ mod test {
         // ZeroVec should deserialize from JSON to either Vec or ZeroVec
         let vec_new: Vec<u32> =
             serde_json::from_str(&json_str).expect("deserialize from buffer to Vec");
-        assert_eq!(zerovec_orig, ZeroVec::<u32>::from_slice_or_alloc(vec_new.as_slice()));
+        assert_eq!(
+            zerovec_orig,
+            ZeroVec::<u32>::from_slice_or_alloc(vec_new.as_slice())
+        );
         let zerovec_new: ZeroVec<u32> =
             serde_json::from_str(&json_str).expect("deserialize from buffer to ZeroVec");
         assert_eq!(zerovec_orig, zerovec_new);

--- a/utils/zerovec/src/zerovec/slice.rs
+++ b/utils/zerovec/src/zerovec/slice.rs
@@ -15,6 +15,21 @@ use core::ops::Range;
 /// This type can be used inside [`VarZeroVec<T>`](crate::VarZeroVec) and [`ZeroMap`](crate::ZeroMap):
 /// This essentially allows for the construction of zero-copy types isomorphic to `Vec<Vec<T>>` by instead
 /// using `VarZeroVec<ZeroSlice<T>>`. See the [`VarZeroVec`](crate::VarZeroVec) docs for an example.
+///
+/// # Examples
+///
+/// Const-construct a ZeroSlice of u16:
+///
+/// ```
+/// use zerovec::ZeroSlice;
+/// use zerovec::ule::AsULE;
+///
+/// const DATA: &ZeroSlice<u16> = ZeroSlice::<u16>::from_ule_slice_const(
+///     &<u16 as AsULE>::ULE::from_array([211, 281, 421, 32973])
+/// );
+///
+/// assert_eq!(DATA.get(1), Some(281));
+/// ```
 #[repr(transparent)]
 pub struct ZeroSlice<T: AsULE>([T::ULE]);
 

--- a/utils/zerovec/src/zerovec/slice.rs
+++ b/utils/zerovec/src/zerovec/slice.rs
@@ -161,7 +161,7 @@ where
     ///
     /// assert_eq!(
     ///     zerovec.get_subslice(1..3),
-    ///     Some(&*ZeroVec::from_slice(&[0x0119, 0x01A5]))
+    ///     Some(&*ZeroVec::from_slice_or_alloc(&[0x0119, 0x01A5]))
     /// );
     /// assert_eq!(zerovec.get_subslice(3..5), None);
     /// ```


### PR DESCRIPTION
Fixes #1431

What we *actually* want, I think, is `zeroslice![...]` that can take the place of `vec![...]`.