### PR TITLE
fix(datetime): Return singleton patterns for single field bags.

### DIFF
--- a/components/datetime/src/skeleton/helpers.rs
+++ b/components/datetime/src/skeleton/helpers.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use alloc::vec;
 use alloc::vec::Vec;
 use core::cmp::Ordering;
 
@@ -421,6 +422,16 @@ pub fn get_best_available_format_pattern<'data>(
             closest_format_pattern = Some(pattern);
             closest_distance = distance;
             closest_missing_fields = missing_fields;
+        }
+    }
+
+    if !prefer_matched_pattern && closest_distance >= TEXT_VS_NUMERIC_DISTANCE {
+        if let [field] = fields {
+            // A single field was requested and the best pattern either includes extra fields or can't be adjusted to match
+            // (e.g. text vs numeric). We return the field instead of the matched pattern.
+            return BestSkeleton::AllFieldsMatch(
+                Pattern::from(vec![PatternItem::Field(*field)]).into(),
+            );
         }
     }
 

--- a/components/datetime/src/skeleton/mod.rs
+++ b/components/datetime/src/skeleton/mod.rs
@@ -178,11 +178,12 @@ mod test {
     #[test]
     fn test_skeleton_no_match() {
         let components = components::Bag {
+            hour: Some(components::Numeric::Numeric),
             time_zone_name: Some(components::TimeZoneName::LongSpecific),
             ..Default::default()
         };
         let requested_fields = components.to_vec_fields();
-        // Construct a set of skeletons that do not use the time zone symbol.
+        // Construct a set of skeletons that do not use the hour nor time zone symbols.
         let mut skeletons = LiteMap::new();
         skeletons.insert(
             SkeletonV1::try_from("EEEE").unwrap(),

--- a/components/datetime/tests/fixtures/tests/components-partial-matches.json
+++ b/components/datetime/tests/fixtures/tests/components-partial-matches.json
@@ -16,6 +16,39 @@
         }
     },
     {
+        "description": "Singleton fields are returned directly if there are no singleton matches (m -> hm)",
+        "input": {
+            "value": "2002-12-31T08:05:07.000",
+            "options": {
+                "components": {
+                    "minute": "two-digit"
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "en": "05"
+            }
+        }
+    },
+    {
+        "description": "Singleton fields are returned directly if there are no singleton matches (G -> Gy)",
+        "input": {
+            "value": "2002-12-31T08:05:07.000",
+            "options": {
+                "components": {
+                    "era": "long"
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "en": "Anno Domini",
+                "fr": "après Jésus-Christ"
+            }
+        }
+    },
+    {
         "description": "Partial match for hs -> hms -> h:mm:s a",
         "input": {
             "value": "2002-12-31T08:05:07.000",

--- a/components/datetime/tests/fixtures/tests/components-partial-matches.json
+++ b/components/datetime/tests/fixtures/tests/components-partial-matches.json
@@ -1,6 +1,6 @@
 [
     {
-        "description": "Partial match for m -> hm -> h:m a",
+        "description": "Singleton fields are returned directly if there are no singleton matches (m -> hm)",
         "input": {
             "value": "2002-12-31T08:05:07.000",
             "options": {
@@ -11,8 +11,7 @@
         },
         "output": {
             "values": {
-                "en": "8:5 AM",
-                "fr": "8:5 AM"
+                "en": "5"
             }
         }
     },

--- a/components/datetime/tests/fixtures/tests/components_hour_cycle.json
+++ b/components/datetime/tests/fixtures/tests/components_hour_cycle.json
@@ -143,5 +143,73 @@
                 "ar": "24:25"
             }
         }
+    },
+    {
+        "description": "h11 with singleton h",
+        "input": {
+            "value": "2002-12-31T00:05:07.000",
+            "options": {
+                "components": {
+                    "hour": "numeric",
+                    "preferences": { "hourCycle": "h11" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "en": "0 AM"
+            }
+        }
+    },
+    {
+        "description": "h12 with singleton h",
+        "input": {
+            "value": "2002-12-31T00:05:07.000",
+            "options": {
+                "components": {
+                    "hour": "numeric",
+                    "preferences": { "hourCycle": "h12" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "en": "12 AM"
+            }
+        }
+    },
+    {
+        "description": "h23 with singleton h",
+        "input": {
+            "value": "2002-12-31T00:05:07.000",
+            "options": {
+                "components": {
+                    "hour": "numeric",
+                    "preferences": { "hourCycle": "h23" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "en": "00"
+            }
+        }
+    },
+    {
+        "description": "h24 with singleton h",
+        "input": {
+            "value": "2002-12-31T00:05:07.000",
+            "options": {
+                "components": {
+                    "hour": "numeric",
+                    "preferences": { "hourCycle": "h24" }
+                }
+            }
+        },
+        "output": {
+            "values": {
+                "en": "24"
+            }
+        }
     }
 ]


### PR DESCRIPTION
Singleton field patterns are returned as-is if `prefer_matched_pattern = false` and either:
1. All matching patterns have extra symbols.
2. The matching pattern would differ from the field due to either:
  2.a. Textual/numeric differences which UTS 35 says should not be adjusted.
  2.b. Semantic differences (e.g. 'd' vs 'F'). We don't adjust these & UTS is unclear on the subject.

The `prefer_matched_pattern` constraint is for consistency with `CoarseHourCycle::apply_on_pattern` which shouldn't stray from existing patterns. Removing it does not yield any datagen differences however.

Concerning augmenting `BestSkeleton` with a new enum for this use case, it doesn't seem like the codebase would benefit from it:
 - outside of helpers.rs, all callers conflate `AllFieldsMatch` & `MissingOrExtraFields`. 
 - helpers.rs uses the distinction to check whether it should try processing date & time fields separately which doesn't apply to singleton inputs.
 
Fixes #1581 



<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->