### PR TITLE
Make lib.rs boilerplate consistent across ICU4X

### DIFF
--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -2,9 +2,10 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
-    not(any(test, feature = "std")),
-    no_std,
+    not(test),
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -75,9 +75,10 @@
 //! [`Length`]: options::length
 //! [`DateTime`]: icu_calendar::DateTime
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
-    not(any(test, feature = "std")),
-    no_std,
+    not(test),
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,
@@ -85,6 +86,7 @@
         clippy::panic
     )
 )]
+
 extern crate alloc;
 
 mod calendar;

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -56,9 +56,10 @@
 //!
 //! [`FixedDecimalFormat`]: FixedDecimalFormat
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
-    not(any(test, feature = "std")),
-    no_std,
+    not(test),
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -83,9 +83,10 @@
 //! [`Locale`]: crate::locid::Locale
 //! [`SymbolsV1`]: crate::decimal::provider::DecimalSymbolsV1
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
-    not(any(test, feature = "std")),
-    no_std,
+    not(test),
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,

--- a/components/icu4x/src/lib.rs
+++ b/components/icu4x/src/lib.rs
@@ -3,14 +3,3 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 //! `icu4x` is an alias to the [`icu`](../icu/index.html) package.
-
-#![cfg_attr(
-    not(any(test, feature = "std")),
-    no_std,
-    deny(
-        clippy::indexing_slicing,
-        clippy::unwrap_used,
-        clippy::expect_used,
-        clippy::panic
-    )
-)]

--- a/components/locale_canonicalizer/src/lib.rs
+++ b/components/locale_canonicalizer/src/lib.rs
@@ -78,9 +78,10 @@
 //! [`UTS #35: Unicode LDML 3. Likely Subtags`]: https://www.unicode.org/reports/tr35/#Likely_Subtags.
 //! [`UTS #35: Unicode LDML 3. LocaleId Canonicalization`]: http://unicode.org/reports/tr35/#LocaleId_Canonicalization,
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
-    not(any(test, feature = "std")),
-    no_std,
+    not(test),
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,

--- a/components/locid/src/lib.rs
+++ b/components/locid/src/lib.rs
@@ -50,10 +50,10 @@
 //! [`ICU4X`]: ../icu/index.html
 //! [`Unicode Extensions`]: extensions
 
-#![warn(missing_docs)]
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
-    not(any(feature = "std", test)),
-    no_std,
+    not(test),
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,
@@ -61,6 +61,7 @@
         clippy::panic
     )
 )]
+#![warn(missing_docs)]
 
 extern crate alloc;
 

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -65,9 +65,10 @@
 //! [`Language Plural Rules`]: https://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules
 //! [`CLDR`]: http://cldr.unicode.org/
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
-    not(any(test, feature = "std")),
-    no_std,
+    not(test),
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,

--- a/components/properties/src/lib.rs
+++ b/components/properties/src/lib.rs
@@ -68,9 +68,10 @@
 //! [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
 //! [`sets`]: crate::sets
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
-    not(any(test, feature = "std")),
-    no_std,
+    not(test),
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,

--- a/docs/process/boilerplate.md
+++ b/docs/process/boilerplate.md
@@ -4,11 +4,16 @@ This file contains explanations of ICU4X-specific conventions on boilerplate (ex
 
 ## Library annotations
 
-In order to assert that library crates conform to the ICU4X style guide, the following annotation should be present in every *lib.rs* file. It forces the crate to be `no_std` and have no unannotated panicky behavior, except in test mode:
+In order to assert that library crates conform to the ICU4X style guide, the following annotation should be present in every *lib.rs* file. The annotations do the following:
 
+1. Set the crate to be `no_std`
+2. Enforce no unannotated panicky behavior, except in test mode
+3. Require every exported method to be documented
+
+    // https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+    #![cfg_attr(not(test), no_std)]
     #![cfg_attr(
         not(test),
-        no_std,
         deny(
             clippy::indexing_slicing,
             clippy::unwrap_used,
@@ -16,7 +21,21 @@ In order to assert that library crates conform to the ICU4X style guide, the fol
             clippy::panic
         )
     )]
+    #![warn(missing_docs)]
 
-Crates whose panics are not yet annotated may have simply:
+Not all crates are yet able to be annotated in this way. Annotations may be omitted and added when able.
 
-    #![cfg_attr(not(test), no_std)]
+If the crate has an `std` feature, specify this in the first line:
+
+    // https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+    #![cfg_attr(not(any(test, feature = "std")), no_std)]
+    #![cfg_attr(
+        not(test),
+        deny(
+            clippy::indexing_slicing,
+            clippy::unwrap_used,
+            clippy::expect_used,
+            clippy::panic
+        )
+    )]
+    #![warn(missing_docs)]

--- a/ffi/diplomat/src/lib.rs
+++ b/ffi/diplomat/src/lib.rs
@@ -2,15 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#![cfg_attr(
-    any(
-        all(feature = "freertos", not(feature = "x86tiny")),
-        all(feature = "x86tiny", not(feature = "freertos")),
-    ),
-    feature(alloc_error_handler)
-)]
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
 #![no_std]
-#![allow(clippy::upper_case_acronyms)]
 #![cfg_attr(
     not(test),
     deny(
@@ -20,6 +13,15 @@
         clippy::panic
     )
 )]
+#![allow(clippy::upper_case_acronyms)]
+#![cfg_attr(
+    any(
+        all(feature = "freertos", not(feature = "x86tiny")),
+        all(feature = "x86tiny", not(feature = "freertos")),
+    ),
+    feature(alloc_error_handler)
+)]
+
 //! This module contains the source of truth for the [Diplomat](https://github.com/rust-diplomat/diplomat)-generated
 //! FFI bindings. This generates the C, C++ and Wasm bindings. This module also contains the C
 //! FFI for ICU4X.

--- a/ffi/ecma402/src/lib.rs
+++ b/ffi/ecma402/src/lib.rs
@@ -5,7 +5,6 @@
 //! This crate provides an experimental implementation of the `ECMA-402` traits using `ICU4X` library.
 
 // https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/ffi/ecma402/src/lib.rs
+++ b/ffi/ecma402/src/lib.rs
@@ -4,8 +4,10 @@
 
 //! This crate provides an experimental implementation of the `ECMA-402` traits using `ICU4X` library.
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
-    not(any(test, feature = "std")),
+    not(test),
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,
@@ -13,6 +15,7 @@
         clippy::panic
     )
 )]
+
 use icu::locid::LanguageIdentifier;
 
 /// Implements ECMA-402 [`Intl.PluralRules`][link].

--- a/provider/adapters/src/lib.rs
+++ b/provider/adapters/src/lib.rs
@@ -8,7 +8,17 @@
 //! - Use the [`either`] module to choose between multiple provider types at runtime.
 //! - Use the [`filter`] module to programmatically reject certain data requests.
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::indexing_slicing,
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic
+    )
+)]
 
 extern crate alloc;
 

--- a/provider/blob/src/export/blob_exporter.rs
+++ b/provider/blob/src/export/blob_exporter.rs
@@ -28,6 +28,7 @@ impl<'w> BlobExporter<'w> {
 }
 
 impl DataExporter<SerializeMarker> for BlobExporter<'_> {
+    #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
     fn put_payload(
         &self,
         key: ResourceKey,
@@ -47,6 +48,7 @@ impl DataExporter<SerializeMarker> for BlobExporter<'_> {
         Ok(())
     }
 
+    #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
     fn close(&mut self) -> Result<(), DataError> {
         let zm = self
             .resources

--- a/provider/blob/src/lib.rs
+++ b/provider/blob/src/lib.rs
@@ -35,9 +35,10 @@
 //! [`BufferProvider`]: icu_provider::BufferProvider
 //! [`icu4x-datagen`]: https://github.com/unicode-org/icu4x/tree/main/tools/datagen#readme
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
-    not(any(test, feature = "std")),
-    no_std,
+    not(test),
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,

--- a/provider/core/src/datagen/heap_measure.rs
+++ b/provider/core/src/datagen/heap_measure.rs
@@ -30,6 +30,11 @@ impl DataPayload<BufferMarker> {
     /// Ideally, this number should be zero.
     ///
     /// [`dhat`]'s profiler must be initialized before using this.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not in postcard-0.7 format.
+    #[allow(clippy::expect_used)] // The function documents when panics may occur.
     pub fn attempt_zero_copy_heap_size<M>(self) -> HeapStats
     where
         M: DataMarker,

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -103,6 +103,8 @@ impl HelloWorldProvider {
             .iter()
             .map(|(loc, value)| {
                 (
+                    // TODO(#348): Use a const function to construct the langids.
+                    #[allow(clippy::unwrap_used)]
                     LanguageIdentifier::from_str(loc).unwrap(),
                     Cow::Borrowed(*value),
                 )

--- a/provider/core/src/helpers.rs
+++ b/provider/core/src/helpers.rs
@@ -92,6 +92,8 @@ fn test_escape_for_json() {
 /// 4. FxHash is designed to output 32-bit or 64-bit values, whereas SHA outputs more bits,
 ///    such that truncation would be required in order to fit into a u32, partially reducing
 ///    the benefit of a cryptographically secure algorithm
+// The indexing operations in this function have been reviewed in detail and won't panic.
+#[allow(clippy::indexing_slicing)]
 pub const fn fxhash_32(bytes: &[u8], ignore_leading: usize, ignore_trailing: usize) -> u32 {
     // This code is adapted from https://github.com/rust-lang/rustc-hash,
     // whose license text is reproduced below.

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -117,9 +117,10 @@
 //! [`FsDataProvider`]: ../icu_provider_fs/struct.FsDataProvider.html
 //! [`BlobDataProvider`]: ../icu_provider_blob/struct.BlobDataProvider.html
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
-    not(any(test, feature = "std")),
-    no_std,
+    not(test),
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,

--- a/provider/core/src/resource.rs
+++ b/provider/core/src/resource.rs
@@ -141,6 +141,8 @@ impl ResourceKey {
 
     #[doc(hidden)]
     // Error is a str of the expected character class and the index where it wasn't encountered
+    // The indexing operations in this function have been reviewed in detail and won't panic.
+    #[allow(clippy::indexing_slicing)]
     pub const fn construct_internal(path: &'static str) -> Result<Self, (&'static str, usize)> {
         if path.len() < leading_tag!().len() + trailing_tag!().len() {
             return Err(("tag", 0));

--- a/provider/fs/src/lib.rs
+++ b/provider/fs/src/lib.rs
@@ -89,6 +89,7 @@
 //!
 //! [`ICU4X`]: ../icu/index.html
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
 #![cfg_attr(
     not(test),
     deny(

--- a/provider/macros/src/lib.rs
+++ b/provider/macros/src/lib.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
 #![cfg_attr(
     not(test),
     deny(

--- a/provider/testdata/src/blob.rs
+++ b/provider/testdata/src/blob.rs
@@ -17,6 +17,8 @@ const STATIC_STR_DATA: &[u8] = include_bytes!(concat!(
 /// Get a `DataProvider`, loading from the statically initialized bincode blob.
 /// Panics if unable to load the data.
 pub fn get_static_provider() -> StaticDataProvider {
+    // The statically compiled data file is valid.
+    #[allow(clippy::expect_used)]
     StaticDataProvider::new_from_static_blob(STATIC_STR_DATA)
         .expect("Deserialization should succeed")
 }
@@ -25,6 +27,8 @@ pub fn get_static_provider() -> StaticDataProvider {
 /// containing only bn/en decimal symbols
 /// Panics if unable to load the data.
 pub fn get_smaller_static_provider() -> StaticDataProvider {
+    // The statically compiled data file is valid.
+    #[allow(clippy::expect_used)]
     StaticDataProvider::new_from_static_blob(SMALLER_STATIC_STR_DATA)
         .expect("Deserialization should succeed")
 }

--- a/provider/testdata/src/fs.rs
+++ b/provider/testdata/src/fs.rs
@@ -6,7 +6,12 @@ use icu_provider_fs::FsDataProvider;
 use std::path::PathBuf;
 
 /// Get a `DataProvider`, loading from the test data JSON directory.
+///
+/// # Panics
+///
 /// Panics if unable to load the data.
+// The function is documented to allow panics.
+#[allow(clippy::panic)]
 pub fn get_provider() -> FsDataProvider {
     let path: PathBuf = match std::env::var_os("ICU4X_TESTDATA_DIR") {
         Some(val) => val.into(),

--- a/provider/testdata/src/lib.rs
+++ b/provider/testdata/src/lib.rs
@@ -61,9 +61,10 @@
 //!
 //! [`ICU4X`]: ../icu/index.html
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
-    not(any(test, feature = "std")),
-    no_std,
+    not(test),
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,

--- a/provider/uprops/src/lib.rs
+++ b/provider/uprops/src/lib.rs
@@ -17,6 +17,7 @@
 //! [`FsDataProvider`]: ../icu_provider_fs/struct.FsDataProvider.html
 //! [`StaticDataProvider`]: ../icu_provider_blob/struct.StaticDataProvider.html
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
 #![cfg_attr(
     not(test),
     deny(

--- a/tools/benchmark/macros/src/lib.rs
+++ b/tools/benchmark/macros/src/lib.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-// If no features or all features are present, define empty macros
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
 #![cfg_attr(
     not(test),
     deny(
@@ -13,6 +13,7 @@
     )
 )]
 
+// If no features or all features are present, define empty macros
 #[cfg(any(
     not(any(feature = "benchmark_memory", feature = "rust_global_allocator")),
     all(feature = "benchmark_memory", feature = "rust_global_allocator"),

--- a/utils/codepointtrie/src/lib.rs
+++ b/utils/codepointtrie/src/lib.rs
@@ -31,9 +31,10 @@
 //!
 //! [`ICU4X`]: ../icu/index.html
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(test), no_std)]
 #![cfg_attr(
     not(test),
-    no_std,
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,

--- a/utils/deduplicating_array/src/lib.rs
+++ b/utils/deduplicating_array/src/lib.rs
@@ -28,9 +28,10 @@
 //! This implies that singleton integer arrays cannot be used as array elements (they do work in Bincode,
 //! but there's really not much point in using them).
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(test), no_std)]
 #![cfg_attr(
     not(test),
-    no_std,
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,

--- a/utils/fixed_decimal/src/lib.rs
+++ b/utils/fixed_decimal/src/lib.rs
@@ -38,9 +38,10 @@
 //!
 //! [`ICU4X`]: ../icu/index.html
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
-    not(any(feature = "std", test)),
-    no_std,
+    not(test),
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,

--- a/utils/litemap/src/lib.rs
+++ b/utils/litemap/src/lib.rs
@@ -16,9 +16,10 @@
 //! and upgrades itself gracefully for larger inputs.
 //!
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(test), no_std)]
 #![cfg_attr(
     not(test),
-    no_std,
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,

--- a/utils/pattern/src/lib.rs
+++ b/utils/pattern/src/lib.rs
@@ -106,6 +106,7 @@
 //! [`ICU4X`]: ../icu/index.html
 //! [`FromStr`]: std::str::FromStr
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
 #![cfg_attr(
     not(test),
     deny(

--- a/utils/tinystr/src/lib.rs
+++ b/utils/tinystr/src/lib.rs
@@ -3,9 +3,9 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(test), no_std)]
 #![cfg_attr(
     not(test),
-    no_std,
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,

--- a/utils/uniset/src/lib.rs
+++ b/utils/uniset/src/lib.rs
@@ -49,10 +49,10 @@
 //!
 //! [`ICU4X`]: ../icu/index.html
 
-#![warn(missing_docs)]
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
-    not(any(test, feature = "std")),
-    no_std,
+    not(test),
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,
@@ -60,6 +60,7 @@
         clippy::panic
     )
 )]
+#![warn(missing_docs)]
 
 extern crate alloc;
 

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -2,9 +2,10 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(test), no_std)]
 #![cfg_attr(
     not(test),
-    no_std,
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -35,8 +35,6 @@
         clippy::panic
     )
 )]
-#![warn(missing_docs)]
-
 // The lifetimes here are important for safety and explicitly writing
 // them out is good even when redundant
 #![allow(clippy::needless_lifetimes)]

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -24,9 +24,10 @@
 //!
 //! See the documentation of [`Yoke`] for more details.
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(test), no_std)]
 #![cfg_attr(
-    all(not(test), not(doc)),
-    no_std,
+    not(test),
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,
@@ -34,6 +35,8 @@
         clippy::panic
     )
 )]
+#![warn(missing_docs)]
+
 // The lifetimes here are important for safety and explicitly writing
 // them out is good even when redundant
 #![allow(clippy::needless_lifetimes)]

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -25,7 +25,7 @@
 //! See the documentation of [`Yoke`] for more details.
 
 // https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(all(not(test), not(doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/utils/zerofrom/derive/src/lib.rs
+++ b/utils/zerofrom/derive/src/lib.rs
@@ -3,6 +3,8 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 //! Custom derives for `ZeroFrom` from the `zerofrom` crate.
+
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
 #![cfg_attr(
     not(test),
     deny(

--- a/utils/zerofrom/src/lib.rs
+++ b/utils/zerofrom/src/lib.rs
@@ -6,9 +6,10 @@
 //!
 //! See the documentation of [`ZeroFrom`] for more details.
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(test), no_std)]
 #![cfg_attr(
-    all(not(test), not(doc)),
-    no_std,
+    not(test),
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,
@@ -16,6 +17,7 @@
         clippy::panic
     )
 )]
+
 // The lifetimes here are important for safety and explicitly writing
 // them out is good even when redundant
 #![allow(clippy::needless_lifetimes)]

--- a/utils/zerofrom/src/lib.rs
+++ b/utils/zerofrom/src/lib.rs
@@ -17,7 +17,6 @@
         clippy::panic
     )
 )]
-
 // The lifetimes here are important for safety and explicitly writing
 // them out is good even when redundant
 #![allow(clippy::needless_lifetimes)]

--- a/utils/zerovec/README.md
+++ b/utils/zerovec/README.md
@@ -188,7 +188,6 @@ The benches used to generate the above table can be found in the `benches` direc
 `zeromap` benches are named by convention, e.g. `zeromap/deserialize/small`, `zeromap/lookup/large`. The type
 is appended for baseline comparisons, e.g. `zeromap/lookup/small/hashmap`.
 
-
 ## More Information
 
 For more information on development, authorship, contributing etc. please visit [`ICU4X home page`](https://github.com/unicode-org/icu4x).

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -83,7 +83,11 @@ pub(crate) fn generate_ule_validators<'a>(
 ) -> (TokenStream2, syn::Ident) {
     utils::generate_per_field_offsets(iter, |field, prev_offset_ident, size_ident, _| {
         let ty = &field.ty;
-        quote!(<#ty as zerovec::ule::ULE>::validate_byte_slice(&bytes[#prev_offset_ident .. #prev_offset_ident + #size_ident])?;)
+        quote!(
+            // This won't panic because the function returns if the byte slice is not the right length
+            #[allow(clippy::indexing_slicing)]
+            <#ty as zerovec::ule::ULE>::validate_byte_slice(&bytes[#prev_offset_ident .. #prev_offset_ident + #size_ident])?;
+        )
     })
 }
 

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -192,10 +192,11 @@
 //! The benches used to generate the above table can be found in the `benches` directory in the project repository.
 //! `zeromap` benches are named by convention, e.g. `zeromap/deserialize/small`, `zeromap/lookup/large`. The type
 //! is appended for baseline comparisons, e.g. `zeromap/lookup/small/hashmap`.
-//!
+
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
-    not(any(test, feature = "std")),
-    no_std,
+    not(test),
     deny(
         clippy::indexing_slicing,
         clippy::unwrap_used,

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -69,6 +69,8 @@ macro_rules! impl_byte_slice_size {
             pub const fn from_array<const N: usize>(arr: [$unsigned; N]) -> [Self; N] {
                 let mut result = [RawBytesULE([0; $size]); N];
                 let mut i = 0;
+                // Won't panic because i < N and arr has length N
+                #[allow(clippy::indexing_slicing)]
                 while i < N {
                     result[i].0 = arr[i].to_le_bytes();
                     i += 1;


### PR DESCRIPTION
Follow-up to #1650

I fixed the boilerplate, which uncovered a few more places to add suppression.

CC @ozghimire 