### PR TITLE
Support non-Ord values in ZeroMap

### DIFF
--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -119,7 +119,15 @@ where
     pub fn is_empty(&self) -> bool {
         self.values.zvl_len() == 0
     }
+}
 
+impl<'a, K, V> ZeroMapBorrowed<'a, K, V>
+where
+    K: ZeroMapKV<'a> + Ord,
+    V: ZeroMapKV<'a>,
+    K: ?Sized,
+    V: ?Sized,
+{
     /// Get the value associated with `key`, if it exists.
     ///
     /// This is able to return values that live longer than the map itself
@@ -190,7 +198,15 @@ where
     pub fn contains_key(&self, key: &K) -> bool {
         self.keys.zvl_binary_search(key).is_ok()
     }
+}
 
+impl<'a, K, V> ZeroMapBorrowed<'a, K, V>
+where
+    K: ZeroMapKV<'a>,
+    V: ZeroMapKV<'a>,
+    K: ?Sized,
+    V: ?Sized,
+{
     /// Produce an ordered iterator over key-value pairs
     pub fn iter<'b>(
         &'b self,
@@ -227,7 +243,7 @@ where
 
 impl<'a, K, V> ZeroMapBorrowed<'a, K, V>
 where
-    K: ZeroMapKV<'a> + ?Sized,
+    K: ZeroMapKV<'a> + ?Sized + Ord,
     V: ZeroMapKV<'a, Container = ZeroVec<'a, V>> + ?Sized,
     V: AsULE + Ord + Copy + 'static,
 {

--- a/utils/zerovec/src/map/kv.rs
+++ b/utils/zerovec/src/map/kv.rs
@@ -54,7 +54,7 @@ impl_sized_kv!(i64);
 impl_sized_kv!(i128);
 impl_sized_kv!(char);
 
-impl<'a, T: AsULE + Ord + 'static> ZeroMapKV<'a> for Option<T> {
+impl<'a, T: AsULE + 'static> ZeroMapKV<'a> for Option<T> {
     type Container = ZeroVec<'a, Option<T>>;
     type GetType = <Option<T> as AsULE>::ULE;
     type OwnedType = Option<T>;
@@ -63,7 +63,6 @@ impl<'a, T: AsULE + Ord + 'static> ZeroMapKV<'a> for Option<T> {
 impl<'a, T> ZeroMapKV<'a> for OptionVarULE<T>
 where
     T: VarULE + ?Sized,
-    T: Ord,
 {
     type Container = VarZeroVec<'a, OptionVarULE<T>>;
     type GetType = OptionVarULE<T>;
@@ -79,14 +78,13 @@ impl<'a> ZeroMapKV<'a> for str {
 impl<'a, T> ZeroMapKV<'a> for [T]
 where
     T: ULE + AsULE<ULE = T>,
-    T: Ord,
 {
     type Container = VarZeroVec<'a, [T]>;
     type GetType = [T];
     type OwnedType = Box<[T]>;
 }
 
-impl<'a, T: AsULE + 'static + Ord> ZeroMapKV<'a> for ZeroSlice<T> {
+impl<'a, T: AsULE + 'static> ZeroMapKV<'a> for ZeroSlice<T> {
     type Container = VarZeroVec<'a, ZeroSlice<T>>;
     type GetType = ZeroSlice<T>;
     type OwnedType = Box<ZeroSlice<T>>;

--- a/utils/zerovec/src/map/kv.rs
+++ b/utils/zerovec/src/map/kv.rs
@@ -53,6 +53,8 @@ impl_sized_kv!(i32);
 impl_sized_kv!(i64);
 impl_sized_kv!(i128);
 impl_sized_kv!(char);
+impl_sized_kv!(f32);
+impl_sized_kv!(f64);
 
 impl<'a, T: AsULE + 'static> ZeroMapKV<'a> for Option<T> {
     type Container = ZeroVec<'a, Option<T>>;

--- a/utils/zerovec/src/map/map.rs
+++ b/utils/zerovec/src/map/map.rs
@@ -313,7 +313,7 @@ where
 
 impl<'a, K, V> ZeroMap<'a, K, V>
 where
-    K: ZeroMapKV<'a> + ?Sized,
+    K: ZeroMapKV<'a> + ?Sized + Ord,
     V: ZeroMapKV<'a, Container = VarZeroVec<'a, V>> + ?Sized,
     V: VarULE,
 {

--- a/utils/zerovec/src/map/map.rs
+++ b/utils/zerovec/src/map/map.rs
@@ -98,7 +98,6 @@ where
             values: V::Container::zvl_new(),
         }
     }
-
     /// Construct a new [`ZeroMap`] with a given capacity
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
@@ -139,7 +138,12 @@ where
         self.keys.zvl_reserve(additional);
         self.values.zvl_reserve(additional);
     }
-
+}
+impl<'a, K, V> ZeroMap<'a, K, V>
+where
+    K: ZeroMapKV<'a> + ?Sized + Ord,
+    V: ZeroMapKV<'a> + ?Sized,
+{
     /// Get the value associated with `key`, if it exists.
     ///
     /// For fixed-size ([`AsULE`]) `V` types, this _will_ return
@@ -268,7 +272,13 @@ where
         self.values.zvl_push(value);
         None
     }
+}
 
+impl<'a, K, V> ZeroMap<'a, K, V>
+where
+    K: ZeroMapKV<'a> + ?Sized,
+    V: ZeroMapKV<'a> + ?Sized,
+{
     /// Produce an ordered iterator over key-value pairs
     pub fn iter<'b>(
         &'b self,
@@ -349,7 +359,7 @@ where
 
 impl<'a, K, V> ZeroMap<'a, K, V>
 where
-    K: ZeroMapKV<'a> + ?Sized,
+    K: ZeroMapKV<'a> + ?Sized + Ord,
     V: ZeroMapKV<'a, Container = ZeroVec<'a, V>> + ?Sized,
     V: AsULE + Copy,
 {
@@ -390,7 +400,14 @@ where
         let index = self.keys.zvl_binary_search_by(predicate).ok()?;
         ZeroSlice::get(&*self.values, index)
     }
+}
 
+impl<'a, K, V> ZeroMap<'a, K, V>
+where
+    K: ZeroMapKV<'a> + ?Sized,
+    V: ZeroMapKV<'a, Container = ZeroVec<'a, V>> + ?Sized,
+    V: AsULE + Copy,
+{
     /// Similar to [`Self::iter()`] except it returns a direct copy of the values instead of references
     /// to `V::ULE`, in cases when `V` is fixed-size
     pub fn iter_copied_values<'b>(
@@ -495,7 +512,7 @@ impl<'a, A, B, K, V> FromIterator<(A, B)> for ZeroMap<'a, K, V>
 where
     A: Borrow<K>,
     B: Borrow<V>,
-    K: ZeroMapKV<'a> + ?Sized,
+    K: ZeroMapKV<'a> + ?Sized + Ord,
     V: ZeroMapKV<'a> + ?Sized,
 {
     fn from_iter<T>(iter: T) -> Self

--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// This impl can be made available by enabling the optional `serde` feature of the `zerovec` crate
 impl<'a, K, V> Serialize for ZeroMap<'a, K, V>
 where
-    K: ZeroMapKV<'a> + Serialize + ?Sized,
+    K: ZeroMapKV<'a> + Serialize + ?Sized + Ord,
     V: ZeroMapKV<'a> + Serialize + ?Sized,
     K::Container: Serialize,
     V::Container: Serialize,
@@ -37,7 +37,7 @@ where
 /// This impl can be made available by enabling the optional `serde` feature of the `zerovec` crate
 impl<'a, K, V> Serialize for ZeroMapBorrowed<'a, K, V>
 where
-    K: ZeroMapKV<'a> + Serialize + ?Sized,
+    K: ZeroMapKV<'a> + Serialize + ?Sized + Ord,
     V: ZeroMapKV<'a> + Serialize + ?Sized,
     K::Container: Serialize,
     V::Container: Serialize,
@@ -53,7 +53,7 @@ where
 /// Modified example from https://serde.rs/deserialize-map.html
 struct ZeroMapMapVisitor<'a, K, V>
 where
-    K: ZeroMapKV<'a> + ?Sized,
+    K: ZeroMapKV<'a> + ?Sized + Ord,
     V: ZeroMapKV<'a> + ?Sized,
 {
     #[allow(clippy::type_complexity)] // it's a marker type, complexity doesn't matter
@@ -62,7 +62,7 @@ where
 
 impl<'a, K, V> ZeroMapMapVisitor<'a, K, V>
 where
-    K: ZeroMapKV<'a> + ?Sized,
+    K: ZeroMapKV<'a> + ?Sized + Ord,
     V: ZeroMapKV<'a> + ?Sized,
 {
     fn new() -> Self {

--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -24,8 +24,8 @@ where
         if serializer.is_human_readable() {
             let mut map = serializer.serialize_map(Some(self.len()))?;
             for (k, v) in self.iter() {
-                K::Container::t_with_ser(k, |k| map.serialize_key(k))?;
-                V::Container::t_with_ser(v, |v| map.serialize_value(v))?;
+                K::Container::zvl_get_as_t(k, |k| map.serialize_key(k))?;
+                V::Container::zvl_get_as_t(v, |v| map.serialize_value(v))?;
             }
             map.end()
         } else {

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -55,7 +55,9 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
     /// The length of this vector
     fn zvl_len(&self) -> usize;
     /// Check if this vector is in ascending order according to `T`s `Ord` impl
-    fn zvl_is_ascending(&self) -> bool;
+    fn zvl_is_ascending(&self) -> bool
+    where
+        T: Ord;
     /// Check if this vector is empty
     fn zvl_is_empty(&self) -> bool {
         self.zvl_len() == 0
@@ -156,7 +158,7 @@ pub trait MutableZeroVecLike<'a, T: ?Sized>: ZeroVecLike<'a, T> {
 
 impl<'a, T> ZeroVecLike<'a, T> for ZeroVec<'a, T>
 where
-    T: 'a + AsULE + Ord + Copy,
+    T: 'a + AsULE + Copy,
 {
     type GetType = T::ULE;
     type BorrowedVariant = &'a ZeroSlice<T>;
@@ -189,7 +191,10 @@ where
     fn zvl_len(&self) -> usize {
         ZeroSlice::len(self)
     }
-    fn zvl_is_ascending(&self) -> bool {
+    fn zvl_is_ascending(&self) -> bool
+    where
+        T: Ord,
+    {
         #[allow(clippy::indexing_slicing)] // TODO(#1668) Clippy exceptions need docs or fixing.
         self.as_ule_slice()
             .windows(2)
@@ -219,7 +224,7 @@ where
 
 impl<'a, T> ZeroVecLike<'a, T> for &'a ZeroSlice<T>
 where
-    T: AsULE + Ord + Copy,
+    T: AsULE + Copy,
 {
     type GetType = T::ULE;
     type BorrowedVariant = &'a ZeroSlice<T>;
@@ -252,7 +257,10 @@ where
     fn zvl_len(&self) -> usize {
         ZeroSlice::len(*self)
     }
-    fn zvl_is_ascending(&self) -> bool {
+    fn zvl_is_ascending(&self) -> bool
+    where
+        T: Ord,
+    {
         #[allow(clippy::indexing_slicing)] // TODO(#1668) Clippy exceptions need docs or fixing.
         self.as_ule_slice()
             .windows(2)
@@ -277,7 +285,7 @@ where
 
 impl<'a, T> BorrowedZeroVecLike<'a, T> for &'a ZeroSlice<T>
 where
-    T: AsULE + Ord + Copy,
+    T: AsULE + Copy,
 {
     fn zvl_get_borrowed(&self, index: usize) -> Option<&'a T::ULE> {
         self.as_ule_slice().get(index)
@@ -286,7 +294,7 @@ where
 
 impl<'a, T> MutableZeroVecLike<'a, T> for ZeroVec<'a, T>
 where
-    T: AsULE + Ord + Copy + 'static,
+    T: AsULE + Copy + 'static,
 {
     type OwnedType = T;
     fn zvl_insert(&mut self, index: usize, value: &T) {
@@ -321,7 +329,6 @@ where
 impl<'a, T> ZeroVecLike<'a, T> for VarZeroVec<'a, T>
 where
     T: VarULE,
-    T: Ord,
     T: ?Sized,
 {
     type GetType = T;
@@ -351,7 +358,10 @@ where
     fn zvl_len(&self) -> usize {
         self.len()
     }
-    fn zvl_is_ascending(&self) -> bool {
+    fn zvl_is_ascending(&self) -> bool
+    where
+        T: Ord,
+    {
         if !self.is_empty() {
             let mut prev = self.get(0).unwrap();
             for element in self.iter().skip(1) {
@@ -387,7 +397,6 @@ where
 impl<'a, T> ZeroVecLike<'a, T> for &'a VarZeroSlice<T>
 where
     T: VarULE,
-    T: Ord,
     T: ?Sized,
 {
     type GetType = T;
@@ -417,7 +426,10 @@ where
     fn zvl_len(&self) -> usize {
         self.len()
     }
-    fn zvl_is_ascending(&self) -> bool {
+    fn zvl_is_ascending(&self) -> bool
+    where
+        T: Ord,
+    {
         if !self.is_empty() {
             let mut prev = self.get(0).unwrap();
             for element in self.iter().skip(1) {
@@ -449,7 +461,6 @@ where
 impl<'a, T> BorrowedZeroVecLike<'a, T> for &'a VarZeroSlice<T>
 where
     T: VarULE,
-    T: Ord,
     T: ?Sized,
 {
     fn zvl_get_borrowed(&self, index: usize) -> Option<&'a T> {
@@ -460,7 +471,6 @@ where
 impl<'a, T> MutableZeroVecLike<'a, T> for VarZeroVec<'a, T>
 where
     T: VarULE,
-    T: Ord,
     T: ?Sized,
 {
     type OwnedType = Box<T>;

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -32,7 +32,9 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
     /// Search for a key in a sorted vector, returns `Ok(index)` if found,
     /// returns `Err(insert_index)` if not found, where `insert_index` is the
     /// index where it should be inserted to maintain sort order.
-    fn zvl_binary_search(&self, k: &T) -> Result<usize, usize>;
+    fn zvl_binary_search(&self, k: &T) -> Result<usize, usize>
+    where
+        T: Ord;
     /// Search for a key within a certain range in a sorted vector. Returns `None` if the
     /// range is out of bounds, and `Ok` or `Err` in the same way as `zvl_binary_search`.
     /// Indices are returned relative to the start of the range.
@@ -40,7 +42,9 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
         &self,
         k: &T,
         range: Range<usize>,
-    ) -> Option<Result<usize, usize>>;
+    ) -> Option<Result<usize, usize>>
+    where
+        T: Ord;
 
     /// Search for a key in a sorted vector by a predicate, returns `Ok(index)` if found,
     /// returns `Err(insert_index)` if not found, where `insert_index` is the
@@ -84,7 +88,10 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
     /// Compare this type with a `Self::GetType`. This must produce the same result as
     /// if `g` were converted to `Self`
     #[inline]
-    fn t_cmp_get(t: &T, g: &Self::GetType) -> Ordering where T: Ord {
+    fn t_cmp_get(t: &T, g: &Self::GetType) -> Ordering
+    where
+        T: Ord,
+    {
         Self::zvl_get_as_t(g, |g| t.cmp(g))
     }
 
@@ -157,14 +164,16 @@ where
     fn zvl_new() -> Self {
         Self::new()
     }
-    fn zvl_binary_search(&self, k: &T) -> Result<usize, usize> {
+    fn zvl_binary_search(&self, k: &T) -> Result<usize, usize>
+    where
+        T: Ord,
+    {
         ZeroSlice::binary_search(self, k)
     }
-    fn zvl_binary_search_in_range(
-        &self,
-        k: &T,
-        range: Range<usize>,
-    ) -> Option<Result<usize, usize>> {
+    fn zvl_binary_search_in_range(&self, k: &T, range: Range<usize>) -> Option<Result<usize, usize>>
+    where
+        T: Ord,
+    {
         let zs: &ZeroSlice<T> = &*self;
         zs.zvl_binary_search_in_range(k, range)
     }
@@ -218,14 +227,16 @@ where
     fn zvl_new() -> Self {
         ZeroSlice::from_ule_slice(&[])
     }
-    fn zvl_binary_search(&self, k: &T) -> Result<usize, usize> {
+    fn zvl_binary_search(&self, k: &T) -> Result<usize, usize>
+    where
+        T: Ord,
+    {
         ZeroSlice::binary_search(*self, k)
     }
-    fn zvl_binary_search_in_range(
-        &self,
-        k: &T,
-        range: Range<usize>,
-    ) -> Option<Result<usize, usize>> {
+    fn zvl_binary_search_in_range(&self, k: &T, range: Range<usize>) -> Option<Result<usize, usize>>
+    where
+        T: Ord,
+    {
         let subslice = self.get_subslice(range)?;
         Some(ZeroSlice::binary_search(subslice, k))
     }
@@ -319,14 +330,16 @@ where
     fn zvl_new() -> Self {
         Self::new()
     }
-    fn zvl_binary_search(&self, k: &T) -> Result<usize, usize> {
+    fn zvl_binary_search(&self, k: &T) -> Result<usize, usize>
+    where
+        T: Ord,
+    {
         self.binary_search(k)
     }
-    fn zvl_binary_search_in_range(
-        &self,
-        k: &T,
-        range: Range<usize>,
-    ) -> Option<Result<usize, usize>> {
+    fn zvl_binary_search_in_range(&self, k: &T, range: Range<usize>) -> Option<Result<usize, usize>>
+    where
+        T: Ord,
+    {
         self.binary_search_in_range(k, range)
     }
     fn zvl_binary_search_by(&self, predicate: impl FnMut(&T) -> Ordering) -> Result<usize, usize> {
@@ -383,14 +396,16 @@ where
     fn zvl_new() -> Self {
         VarZeroSlice::new_empty()
     }
-    fn zvl_binary_search(&self, k: &T) -> Result<usize, usize> {
+    fn zvl_binary_search(&self, k: &T) -> Result<usize, usize>
+    where
+        T: Ord,
+    {
         self.binary_search(k)
     }
-    fn zvl_binary_search_in_range(
-        &self,
-        k: &T,
-        range: Range<usize>,
-    ) -> Option<Result<usize, usize>> {
+    fn zvl_binary_search_in_range(&self, k: &T, range: Range<usize>) -> Option<Result<usize, usize>>
+    where
+        T: Ord,
+    {
         self.binary_search_in_range(k, range)
     }
     fn zvl_binary_search_by(&self, predicate: impl FnMut(&T) -> Ordering) -> Result<usize, usize> {

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -93,7 +93,7 @@ pub trait ZeroVecLike<'a, T: ?Sized> {
     ///
     /// This uses a callback because it's not possible to return owned-or-borrowed
     /// types without GATs
-    fn t_with_ser<R>(g: &Self::GetType, f: impl FnOnce(&T) -> R) -> R;
+    fn zvl_get_as_t<R>(g: &Self::GetType, f: impl FnOnce(&T) -> R) -> R;
 }
 
 /// Trait abstracting over [`ZeroVec`] and [`VarZeroVec`], for use in [`ZeroMap`](super::ZeroMap). **You
@@ -200,7 +200,7 @@ where
         T::from_unaligned(*a).cmp(&T::from_unaligned(*b))
     }
 
-    fn t_with_ser<R>(g: &Self::GetType, f: impl FnOnce(&T) -> R) -> R {
+    fn zvl_get_as_t<R>(g: &Self::GetType, f: impl FnOnce(&T) -> R) -> R {
         f(&T::from_unaligned(*g))
     }
 }
@@ -263,7 +263,7 @@ where
         T::from_unaligned(*a).cmp(&T::from_unaligned(*b))
     }
 
-    fn t_with_ser<R>(g: &Self::GetType, f: impl FnOnce(&T) -> R) -> R {
+    fn zvl_get_as_t<R>(g: &Self::GetType, f: impl FnOnce(&T) -> R) -> R {
         f(&T::from_unaligned(*g))
     }
 }
@@ -378,7 +378,7 @@ where
     }
 
     #[inline]
-    fn t_with_ser<R>(g: &Self::GetType, f: impl FnOnce(&T) -> R) -> R {
+    fn zvl_get_as_t<R>(g: &Self::GetType, f: impl FnOnce(&T) -> R) -> R {
         f(g)
     }
 }
@@ -446,7 +446,7 @@ where
     }
 
     #[inline]
-    fn t_with_ser<R>(g: &Self::GetType, f: impl FnOnce(&T) -> R) -> R {
+    fn zvl_get_as_t<R>(g: &Self::GetType, f: impl FnOnce(&T) -> R) -> R {
         f(g)
     }
 }

--- a/utils/zerovec/src/map2d/borrowed.rs
+++ b/utils/zerovec/src/map2d/borrowed.rs
@@ -140,7 +140,17 @@ where
     pub fn is_empty(&self) -> bool {
         self.values.zvl_len() == 0
     }
+}
 
+impl<'a, K0, K1, V> ZeroMap2dBorrowed<'a, K0, K1, V>
+where
+    K0: ZeroMapKV<'a> + Ord,
+    K1: ZeroMapKV<'a> + Ord,
+    V: ZeroMapKV<'a>,
+    K0: ?Sized,
+    K1: ?Sized,
+    V: ?Sized,
+{
     /// Get the value associated with `key`, if it exists.
     ///
     /// This is able to return values that live longer than the map itself
@@ -251,8 +261,8 @@ where
 
 impl<'a, K0, K1, V> ZeroMap2dBorrowed<'a, K0, K1, V>
 where
-    K0: ZeroMapKV<'a> + ?Sized,
-    K1: ZeroMapKV<'a> + ?Sized,
+    K0: ZeroMapKV<'a> + ?Sized + Ord,
+    K1: ZeroMapKV<'a> + ?Sized + Ord,
     V: ZeroMapKV<'a, Container = ZeroVec<'a, V>> + ?Sized,
     V: AsULE + Ord + Copy + 'static,
 {

--- a/utils/zerovec/src/map2d/map.rs
+++ b/utils/zerovec/src/map2d/map.rs
@@ -184,7 +184,17 @@ where
         self.keys1.zvl_reserve(additional);
         self.values.zvl_reserve(additional);
     }
+}
 
+impl<'a, K0, K1, V> ZeroMap2d<'a, K0, K1, V>
+where
+    K0: ZeroMapKV<'a> + Ord,
+    K1: ZeroMapKV<'a> + Ord,
+    V: ZeroMapKV<'a>,
+    K0: ?Sized,
+    K1: ?Sized,
+    V: ?Sized,
+{
     /// Get the value associated with `key0` and `key1`, if it exists.
     ///
     /// ```rust
@@ -563,8 +573,8 @@ where
 
 impl<'a, K0, K1, V> ZeroMap2d<'a, K0, K1, V>
 where
-    K0: ZeroMapKV<'a> + ?Sized,
-    K1: ZeroMapKV<'a> + ?Sized,
+    K0: ZeroMapKV<'a> + ?Sized + Ord,
+    K1: ZeroMapKV<'a> + ?Sized + Ord,
     V: ZeroMapKV<'a, Container = ZeroVec<'a, V>> + ?Sized,
     V: AsULE + Copy,
 {
@@ -679,8 +689,8 @@ where
     A: Borrow<K0>,
     B: Borrow<K1>,
     C: Borrow<V>,
-    K0: ZeroMapKV<'a> + ?Sized,
-    K1: ZeroMapKV<'a> + ?Sized,
+    K0: ZeroMapKV<'a> + ?Sized + Ord,
+    K1: ZeroMapKV<'a> + ?Sized + Ord,
     V: ZeroMapKV<'a> + ?Sized,
 {
     fn from_iter<T>(iter: T) -> Self

--- a/utils/zerovec/src/map2d/serde.rs
+++ b/utils/zerovec/src/map2d/serde.rs
@@ -31,7 +31,7 @@ where
             let mut values_it = self.iter_values();
             let mut serde_map = serializer.serialize_map(None)?;
             for (key0_index, key0) in self.iter_keys0().enumerate() {
-                K0::Container::t_with_ser(key0, |k| serde_map.serialize_key(k))?;
+                K0::Container::zvl_get_as_t(key0, |k| serde_map.serialize_key(k))?;
                 let inner_map = ZeroMap2dInnerMapSerialize {
                     key0_index,
                     map: self,
@@ -76,9 +76,9 @@ where
         let mut serde_map = serializer.serialize_map(None)?;
         #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
         for key1 in self.map.iter_keys1_by_index(self.key0_index).unwrap() {
-            K1::Container::t_with_ser(key1, |k| serde_map.serialize_key(k))?;
+            K1::Container::zvl_get_as_t(key1, |k| serde_map.serialize_key(k))?;
             let v = self.values_it.borrow_mut().next().unwrap();
-            V::Container::t_with_ser(v, |v| serde_map.serialize_value(v))?;
+            V::Container::zvl_get_as_t(v, |v| serde_map.serialize_value(v))?;
         }
         serde_map.end()
     }

--- a/utils/zerovec/src/map2d/serde.rs
+++ b/utils/zerovec/src/map2d/serde.rs
@@ -16,8 +16,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// This impl can be made available by enabling the optional `serde` feature of the `zerovec` crate
 impl<'a, K0, K1, V> Serialize for ZeroMap2d<'a, K0, K1, V>
 where
-    K0: ZeroMapKV<'a> + Serialize + ?Sized,
-    K1: ZeroMapKV<'a> + Serialize + ?Sized,
+    K0: ZeroMapKV<'a> + Serialize + ?Sized + Ord,
+    K1: ZeroMapKV<'a> + Serialize + ?Sized + Ord,
     V: ZeroMapKV<'a> + Serialize + ?Sized,
     K0::Container: Serialize,
     K1::Container: Serialize,
@@ -50,8 +50,8 @@ where
 /// Helper struct for human-serializing the inner map of a ZeroMap2d
 struct ZeroMap2dInnerMapSerialize<'a, 'l, K0, K1, V, I>
 where
-    K0: ZeroMapKV<'a> + ?Sized,
-    K1: ZeroMapKV<'a> + ?Sized,
+    K0: ZeroMapKV<'a> + ?Sized + Ord,
+    K1: ZeroMapKV<'a> + ?Sized + Ord,
     V: ZeroMapKV<'a> + ?Sized,
 {
     pub key0_index: usize,
@@ -61,8 +61,8 @@ where
 
 impl<'a, 'l, K0, K1, V, I> Serialize for ZeroMap2dInnerMapSerialize<'a, 'l, K0, K1, V, I>
 where
-    K0: ZeroMapKV<'a> + Serialize + ?Sized,
-    K1: ZeroMapKV<'a> + Serialize + ?Sized,
+    K0: ZeroMapKV<'a> + Serialize + ?Sized + Ord,
+    K1: ZeroMapKV<'a> + Serialize + ?Sized + Ord,
     V: ZeroMapKV<'a> + Serialize + ?Sized,
     K0::Container: Serialize,
     K1::Container: Serialize,
@@ -87,8 +87,8 @@ where
 /// This impl can be made available by enabling the optional `serde` feature of the `zerovec` crate
 impl<'a, K0, K1, V> Serialize for ZeroMap2dBorrowed<'a, K0, K1, V>
 where
-    K0: ZeroMapKV<'a> + Serialize + ?Sized,
-    K1: ZeroMapKV<'a> + Serialize + ?Sized,
+    K0: ZeroMapKV<'a> + Serialize + ?Sized + Ord,
+    K1: ZeroMapKV<'a> + Serialize + ?Sized + Ord,
     V: ZeroMapKV<'a> + Serialize + ?Sized,
     K0::Container: Serialize,
     K1::Container: Serialize,
@@ -105,8 +105,8 @@ where
 /// Modified example from https://serde.rs/deserialize-map.html
 struct ZeroMap2dMapVisitor<'a, K0, K1, V>
 where
-    K0: ZeroMapKV<'a> + ?Sized,
-    K1: ZeroMapKV<'a> + ?Sized,
+    K0: ZeroMapKV<'a> + ?Sized + Ord,
+    K1: ZeroMapKV<'a> + ?Sized + Ord,
     V: ZeroMapKV<'a> + ?Sized,
 {
     #[allow(clippy::type_complexity)] // it's a marker type, complexity doesn't matter
@@ -115,8 +115,8 @@ where
 
 impl<'a, K0, K1, V> ZeroMap2dMapVisitor<'a, K0, K1, V>
 where
-    K0: ZeroMapKV<'a> + ?Sized,
-    K1: ZeroMapKV<'a> + ?Sized,
+    K0: ZeroMapKV<'a> + ?Sized + Ord,
+    K1: ZeroMapKV<'a> + ?Sized + Ord,
     V: ZeroMapKV<'a> + ?Sized,
 {
     fn new() -> Self {
@@ -128,8 +128,8 @@ where
 
 impl<'a, 'de, K0, K1, V> Visitor<'de> for ZeroMap2dMapVisitor<'a, K0, K1, V>
 where
-    K0: ZeroMapKV<'a> + Ord + ?Sized,
-    K1: ZeroMapKV<'a> + Ord + ?Sized,
+    K0: ZeroMapKV<'a> + Ord + ?Sized + Ord,
+    K1: ZeroMapKV<'a> + Ord + ?Sized + Ord,
     V: ZeroMapKV<'a> + ?Sized,
     K1::Container: Deserialize<'de>,
     V::Container: Deserialize<'de>,


### PR DESCRIPTION
We only need `Ord` for keys, not values, this removes the restrictions from the ZMKV/ZVLike trait suite and instead moves them to specific methods.