### PR TITLE
`locale!` macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,11 @@ icu_provider_fs = "0.2"
 ```
 
 ```rust
-use icu::locid::langid;
-use icu::locid::Locale;
+use icu::locid::locale;
 use icu::datetime::{DateTimeFormat, mock::datetime::MockDateTime, options::length};
 use icu_provider_fs::FsDataProvider;
 
 fn main() {
-    let loc: Locale = langid!("pl").into();
-
     let date: MockDateTime = "2020-10-14T13:21:00".parse()
         .expect("Failed to parse a datetime.");
 
@@ -52,7 +49,7 @@ fn main() {
         ..Default::default()
     }.into();
 
-    let dtf = DateTimeFormat::try_new(loc, &provider, &options)
+    let dtf = DateTimeFormat::try_new(locale!("pl"), &provider, &options)
         .expect("Failed to initialize DateTimeFormat");
 
     let formatted_date = dtf.format(&date);

--- a/components/datetime/README.md
+++ b/components/datetime/README.md
@@ -11,14 +11,11 @@ used to quickly format any date and time provided.
 ## Examples
 
 ```rust
-use icu::locid::Locale;
-use icu::locid::langid;
+use icu::locid::locale;
 use icu::calendar::Gregorian;
 use icu::datetime::{DateTimeFormat, DateTimeFormatOptions, mock::parse_gregorian_from_str, options::length};
 
 let provider = icu_testdata::get_provider();
-
-let locale: Locale = langid!("en").into();
 
 // See the next code example for a more ergonomic example with .into().
 let options = DateTimeFormatOptions::Length(length::Bag {
@@ -27,7 +24,7 @@ let options = DateTimeFormatOptions::Length(length::Bag {
     ..Default::default()
 });
 
-let dtf = DateTimeFormat::<Gregorian>::try_new(locale, &provider, &options)
+let dtf = DateTimeFormat::<Gregorian>::try_new(locale!("en"), &provider, &options)
     .expect("Failed to create DateTimeFormat instance.");
 
 
@@ -42,8 +39,6 @@ The options can be created more ergonomically using the `Into` trait to automati
 convert a [`options::length::Bag`] into a [`DateTimeFormatOptions::Length`].
 
 ```rust
-use icu::locid::Locale;
-use icu::locid::langid;
 use icu::calendar::Gregorian;
 use icu::datetime::{DateTimeFormat, DateTimeFormatOptions, options::length};
 let options = length::Bag {

--- a/components/datetime/examples/work_log.rs
+++ b/components/datetime/examples/work_log.rs
@@ -12,8 +12,7 @@ icu_benchmark_macros::static_setup!();
 use icu_calendar::{DateTime, Gregorian};
 use icu_datetime::mock::parse_gregorian_from_str;
 use icu_datetime::{options::length, DateTimeFormat};
-use icu_locid::langid;
-use icu_locid::Locale;
+use icu_locid::locale;
 
 const DATES_ISO: &[&str] = &[
     "2001-09-08T18:46:40:000",
@@ -41,8 +40,6 @@ fn print(_input: &str, _value: Option<usize>) {
 fn main(_argc: isize, _argv: *const *const u8) -> isize {
     icu_benchmark_macros::main_setup!();
 
-    let locale: Locale = langid!("en").into();
-
     let provider = icu_testdata::get_static_provider();
 
     let dates = DATES_ISO
@@ -58,7 +55,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
         ..Default::default()
     };
 
-    let dtf = DateTimeFormat::<Gregorian>::try_new(locale, &provider, &options.into())
+    let dtf = DateTimeFormat::<Gregorian>::try_new(locale!("en"), &provider, &options.into())
         .expect("Failed to create DateTimeFormat instance.");
     {
         print("\n====== Work Log (en) example ============", None);

--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -32,13 +32,10 @@ use crate::{date::DateTimeInput, CldrCalendar, DateTimeFormatError, FormattedDat
 /// # Examples
 ///
 /// ```
-/// use icu::locid::Locale;
-/// use icu::locid::langid;
+/// use icu::locid::locale;
 /// use icu::datetime::{DateTimeFormat, options::length};
 /// use icu::calendar::{DateTime, Gregorian};
 /// use icu_provider::inv::InvariantDataProvider;
-///
-/// let locale: Locale = langid!("en").into();
 ///
 /// let provider = InvariantDataProvider;
 ///
@@ -47,7 +44,7 @@ use crate::{date::DateTimeInput, CldrCalendar, DateTimeFormatError, FormattedDat
 ///     time: Some(length::Time::Short),
 ///     ..Default::default()
 /// };
-/// let dtf = DateTimeFormat::<Gregorian>::try_new(locale, &provider, &options.into())
+/// let dtf = DateTimeFormat::<Gregorian>::try_new(locale!("en"), &provider, &options.into())
 ///     .expect("Failed to create DateTimeFormat instance.");
 ///
 ///
@@ -69,19 +66,16 @@ impl<C: CldrCalendar> DateTimeFormat<C> {
     /// # Examples
     ///
     /// ```
-    /// use icu::locid::Locale;
-    /// use icu::locid::langid;
+    /// use icu::locid::locale;
     /// use icu::calendar::Gregorian;
     /// use icu::datetime::{DateTimeFormat, DateTimeFormatOptions};
     /// use icu_provider::inv::InvariantDataProvider;
-    ///
-    /// let locale: Locale = langid!("en").into();
     ///
     /// let provider = InvariantDataProvider;
     ///
     /// let options = DateTimeFormatOptions::default();
     ///
-    /// let dtf = DateTimeFormat::<Gregorian>::try_new(locale, &provider, &options);
+    /// let dtf = DateTimeFormat::<Gregorian>::try_new(locale!("en"), &provider, &options);
     ///
     /// assert_eq!(dtf.is_ok(), true);
     /// ```
@@ -112,12 +106,10 @@ impl<C: CldrCalendar> DateTimeFormat<C> {
     /// # Examples
     ///
     /// ```
-    /// use icu::locid::Locale;
-    /// use icu::locid::langid;
     /// use icu::datetime::{DateTimeFormat, DateTimeFormatOptions};
     /// use icu::calendar::{DateTime, Gregorian};
     /// use icu_provider::inv::InvariantDataProvider;
-    /// # let locale: Locale = langid!("en").into();
+    /// # let locale = icu::locid::locale!("en");
     /// # let provider = InvariantDataProvider;
     /// # let options = DateTimeFormatOptions::default();
     /// let dtf = DateTimeFormat::<Gregorian>::try_new(locale, &provider, &options)
@@ -148,12 +140,10 @@ impl<C: CldrCalendar> DateTimeFormat<C> {
     /// # Examples
     ///
     /// ```
-    /// use icu::locid::Locale;
-    /// use icu::locid::langid;
     /// use icu::datetime::{DateTimeFormat, DateTimeFormatOptions};
     /// use icu::calendar::{DateTime, Gregorian};
     /// use icu_provider::inv::InvariantDataProvider;
-    /// # let locale: Locale = langid!("en").into();
+    /// # let locale = icu::locid::locale!("en");
     /// # let provider = InvariantDataProvider;
     /// # let options = DateTimeFormatOptions::default();
     /// let dtf = DateTimeFormat::<Gregorian>::try_new(locale, &provider, &options.into())
@@ -182,12 +172,10 @@ impl<C: CldrCalendar> DateTimeFormat<C> {
     /// # Examples
     ///
     /// ```
-    /// use icu::locid::Locale;
-    /// use icu::locid::langid;
     /// use icu::datetime::{DateTimeFormat, DateTimeFormatOptions};
     /// use icu::calendar::{DateTime, Gregorian};
     /// use icu_provider::inv::InvariantDataProvider;
-    /// # let locale: Locale = langid!("en").into();
+    /// # let locale = icu::locid::locale!("en");
     /// # let provider = InvariantDataProvider;
     /// # let options = DateTimeFormatOptions::default();
     /// let dtf = DateTimeFormat::<Gregorian>::try_new(locale, &provider, &options.into())
@@ -216,8 +204,7 @@ impl<C: CldrCalendar> DateTimeFormat<C> {
     ///     options::{components, length},
     ///     DateTimeFormat, DateTimeFormatOptions,
     /// };
-    /// use icu::locid::langid;
-    /// use icu::locid::Locale;
+    /// use icu::locid::locale;
     ///
     /// let options = DateTimeFormatOptions::Length(length::Bag {
     ///     date: Some(length::Date::Medium),
@@ -225,9 +212,8 @@ impl<C: CldrCalendar> DateTimeFormat<C> {
     ///     preferences: None,
     /// });
     ///
-    /// let locale: Locale = langid!("en").into();
     /// let provider = icu_testdata::get_provider();
-    /// let dtf = DateTimeFormat::<Gregorian>::try_new(locale, &provider, &options)
+    /// let dtf = DateTimeFormat::<Gregorian>::try_new(locale!("en"), &provider, &options)
     ///     .expect("Failed to create DateTimeFormat instance.");
     ///
     /// assert_eq!(

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -31,15 +31,12 @@ use writeable::Writeable;
 /// # Examples
 ///
 /// ```
-/// use icu::locid::Locale;
-/// use icu::locid::langid;
-/// use icu::datetime::{DateTimeFormat, DateTimeFormatOptions};
+/// use icu::locid::locale;
+/// use icu::datetime::DateTimeFormat;
 /// use icu::calendar::{DateTime, Gregorian};
-/// use icu_provider::inv::InvariantDataProvider;
-/// let locale: Locale = langid!("en").into();
-/// # let provider = InvariantDataProvider;
-/// # let options = DateTimeFormatOptions::default();
-/// let dtf = DateTimeFormat::<Gregorian>::try_new(locale, &provider, &options)
+/// # let provider = icu_provider::inv::InvariantDataProvider;
+/// # let options = icu::datetime::DateTimeFormatOptions::default();
+/// let dtf = DateTimeFormat::<Gregorian>::try_new(locale!("en"), &provider, &options)
 ///     .expect("Failed to create DateTimeFormat instance.");
 ///
 /// let datetime = DateTime::new_gregorian_datetime_from_integers(2020, 9, 1, 12, 34, 28)

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -15,14 +15,11 @@
 //! # Examples
 //!
 //! ```
-//! use icu::locid::Locale;
-//! use icu::locid::langid;
+//! use icu::locid::locale;
 //! use icu::calendar::Gregorian;
 //! use icu::datetime::{DateTimeFormat, DateTimeFormatOptions, mock::parse_gregorian_from_str, options::length};
 //!
 //! let provider = icu_testdata::get_provider();
-//!
-//! let locale: Locale = langid!("en").into();
 //!
 //! // See the next code example for a more ergonomic example with .into().
 //! let options = DateTimeFormatOptions::Length(length::Bag {
@@ -31,7 +28,7 @@
 //!     ..Default::default()
 //! });
 //!
-//! let dtf = DateTimeFormat::<Gregorian>::try_new(locale, &provider, &options)
+//! let dtf = DateTimeFormat::<Gregorian>::try_new(locale!("en"), &provider, &options)
 //!     .expect("Failed to create DateTimeFormat instance.");
 //!
 //!
@@ -46,12 +43,10 @@
 //! convert a [`options::length::Bag`] into a [`DateTimeFormatOptions::Length`].
 //!
 //! ```
-//! use icu::locid::Locale;
-//! use icu::locid::langid;
 //! use icu::calendar::Gregorian;
 //! use icu::datetime::{DateTimeFormat, DateTimeFormatOptions, options::length};
 //! # let provider = icu_testdata::get_provider();
-//! # let locale: Locale = langid!("en").into();
+//! # let locale = icu::locid::locale!("en");
 //! let options = length::Bag {
 //!     date: Some(length::Date::Medium),
 //!     time: Some(length::Time::Short),

--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -62,17 +62,15 @@ where
 /// # Examples
 ///
 /// ```
-/// use icu_locid::Locale;
-/// use icu::locid::langid;
+/// use icu_locid::locale;
 /// use icu_datetime::{TimeZoneFormat, TimeZoneFormatConfig};
 /// use icu_datetime::date::GmtOffset;
 /// use icu_datetime::mock::time_zone::MockTimeZone;
 /// use icu_provider::inv::InvariantDataProvider;
 ///
-/// let locale: Locale = langid!("en").into();
 /// let provider = InvariantDataProvider;
 ///
-/// let tzf = TimeZoneFormat::try_from_config(locale, TimeZoneFormatConfig::GenericNonLocationLong, &provider)
+/// let tzf = TimeZoneFormat::try_from_config(locale!("en"), TimeZoneFormatConfig::GenericNonLocationLong, &provider)
 ///     .expect("Failed to create TimeZoneFormat");
 ///
 /// let time_zone = MockTimeZone::new(
@@ -222,16 +220,14 @@ impl TimeZoneFormat {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::Locale;
-    /// use icu::locid::langid;
+    /// use icu_locid::locale;
     /// use icu_datetime::{TimeZoneFormat, TimeZoneFormatConfig};
     /// use icu_datetime::mock::time_zone::MockTimeZone;
     /// use icu_provider::inv::InvariantDataProvider;
     ///
-    /// let locale: Locale = langid!("en").into();
     /// let provider = InvariantDataProvider;
     ///
-    /// let tzf = TimeZoneFormat::try_from_config(locale, TimeZoneFormatConfig::LocalizedGMT, &provider);
+    /// let tzf = TimeZoneFormat::try_from_config(locale!("en"), TimeZoneFormatConfig::LocalizedGMT, &provider);
     ///
     /// assert!(tzf.is_ok());
     /// ```
@@ -312,17 +308,15 @@ impl TimeZoneFormat {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::Locale;
-    /// use icu::locid::langid;
+    /// use icu_locid::locale;
     /// use icu_datetime::{TimeZoneFormat, TimeZoneFormatConfig};
     /// use icu_datetime::date::GmtOffset;
     /// use icu_datetime::mock::time_zone::MockTimeZone;
     /// use icu_provider::inv::InvariantDataProvider;
     ///
-    /// let locale: Locale = langid!("en").into();
     /// let provider = InvariantDataProvider;
     ///
-    /// let tzf = TimeZoneFormat::try_from_config(locale, TimeZoneFormatConfig::LocalizedGMT, &provider)
+    /// let tzf = TimeZoneFormat::try_from_config(locale!("en"), TimeZoneFormatConfig::LocalizedGMT, &provider)
     ///     .expect("Failed to create TimeZoneFormat");
     ///
     /// let time_zone = MockTimeZone::new(
@@ -350,17 +344,15 @@ impl TimeZoneFormat {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::Locale;
-    /// use icu::locid::langid;
+    /// use icu_locid::locale;
     /// use icu_datetime::{TimeZoneFormat, TimeZoneFormatConfig};
     /// use icu_datetime::date::GmtOffset;
     /// use icu_datetime::mock::time_zone::MockTimeZone;
     /// use icu_provider::inv::InvariantDataProvider;
     ///
-    /// let locale: Locale = langid!("en").into();
     /// let provider = InvariantDataProvider;
     ///
-    /// let tzf = TimeZoneFormat::try_from_config(locale, TimeZoneFormatConfig::LocalizedGMT, &provider)
+    /// let tzf = TimeZoneFormat::try_from_config(locale!("en"), TimeZoneFormatConfig::LocalizedGMT, &provider)
     ///     .expect("Failed to create TimeZoneFormat");
     ///
     /// let time_zone = MockTimeZone::new(
@@ -389,17 +381,15 @@ impl TimeZoneFormat {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::Locale;
-    /// use icu::locid::langid;
+    /// use icu_locid::locale;
     /// use icu_datetime::{TimeZoneFormat, TimeZoneFormatConfig};
     /// use icu_datetime::date::GmtOffset;
     /// use icu_datetime::mock::time_zone::MockTimeZone;
     /// use icu_provider::inv::InvariantDataProvider;
     ///
-    /// let locale: Locale = langid!("en").into();
     /// let provider = InvariantDataProvider;
     ///
-    /// let tzf = TimeZoneFormat::try_from_config(locale, TimeZoneFormatConfig::LocalizedGMT, &provider)
+    /// let tzf = TimeZoneFormat::try_from_config(locale!("en"), TimeZoneFormatConfig::LocalizedGMT, &provider)
     ///     .expect("Failed to create TimeZoneFormat");
     ///
     /// let time_zone = MockTimeZone::new(

--- a/components/datetime/src/zoned_datetime.rs
+++ b/components/datetime/src/zoned_datetime.rs
@@ -36,14 +36,11 @@ use crate::{
 /// # Examples
 ///
 /// ```
-/// use icu::locid::Locale;
-/// use icu::locid::langid;
+/// use icu::locid::locale;
 /// use icu::calendar::Gregorian;
 /// use icu::datetime::{ZonedDateTimeFormat, options::length};
 /// use icu::datetime::mock::zoned_datetime::MockZonedDateTime;
 /// use icu_provider::inv::InvariantDataProvider;
-///
-/// let locale: Locale = langid!("en").into();
 ///
 /// let date_provider = InvariantDataProvider;
 /// let zone_provider = InvariantDataProvider;
@@ -54,7 +51,7 @@ use crate::{
 ///     time: Some(length::Time::Short),
 ///     ..Default::default()
 /// };
-/// let zdtf = ZonedDateTimeFormat::<Gregorian>::try_new(locale, &date_provider, &zone_provider, &plural_provider, &options.into())
+/// let zdtf = ZonedDateTimeFormat::<Gregorian>::try_new(locale!("en"), &date_provider, &zone_provider, &plural_provider, &options.into())
 ///     .expect("Failed to create DateTimeFormat instance.");
 ///
 ///
@@ -74,14 +71,11 @@ impl<C: CldrCalendar> ZonedDateTimeFormat<C> {
     /// # Examples
     ///
     /// ```
-    /// use icu::locid::Locale;
-    /// use icu::locid::langid;
+    /// use icu::locid::locale;
     /// use icu::calendar::Gregorian;
     /// use icu::datetime::{ZonedDateTimeFormat, DateTimeFormatOptions};
     /// use icu::datetime::mock::zoned_datetime::MockZonedDateTime;
     /// use icu_provider::inv::InvariantDataProvider;
-    ///
-    /// let locale: Locale = langid!("en").into();
     ///
     /// let date_provider = InvariantDataProvider;
     /// let zone_provider = InvariantDataProvider;
@@ -89,7 +83,7 @@ impl<C: CldrCalendar> ZonedDateTimeFormat<C> {
     ///
     /// let options = DateTimeFormatOptions::default();
     ///
-    /// let zdtf = ZonedDateTimeFormat::<Gregorian>::try_new(locale, &date_provider, &zone_provider, &plural_provider, &options);
+    /// let zdtf = ZonedDateTimeFormat::<Gregorian>::try_new(locale!("en"), &date_provider, &zone_provider, &plural_provider, &options);
     ///
     /// assert_eq!(zdtf.is_ok(), true);
     /// ```
@@ -137,17 +131,15 @@ impl<C: CldrCalendar> ZonedDateTimeFormat<C> {
     /// # Examples
     ///
     /// ```
-    /// use icu::locid::Locale;
-    /// use icu::locid::langid;
     /// use icu::calendar::Gregorian;
-    /// use icu::datetime::{ZonedDateTimeFormat, DateTimeFormatOptions};
+    /// use icu::datetime::ZonedDateTimeFormat;
     /// use icu::datetime::mock::zoned_datetime::MockZonedDateTime;
     /// use icu_provider::inv::InvariantDataProvider;
-    /// # let locale: Locale = langid!("en").into();
+    /// # let locale = icu::locid::locale!("en");
     /// # let date_provider = InvariantDataProvider;
     /// # let zone_provider = InvariantDataProvider;
     /// # let plural_provider = InvariantDataProvider;
-    /// # let options = DateTimeFormatOptions::default();
+    /// # let options = icu::datetime::DateTimeFormatOptions::default();
     /// let zdtf = ZonedDateTimeFormat::<Gregorian>::try_new(locale, &date_provider, &zone_provider, &plural_provider, &options)
     ///     .expect("Failed to create ZonedDateTimeFormat instance.");
     ///
@@ -177,17 +169,15 @@ impl<C: CldrCalendar> ZonedDateTimeFormat<C> {
     /// # Examples
     ///
     /// ```
-    /// use icu::locid::Locale;
-    /// use icu::locid::langid;
     /// use icu::calendar::Gregorian;
-    /// use icu::datetime::{ZonedDateTimeFormat, DateTimeFormatOptions};
+    /// use icu::datetime::ZonedDateTimeFormat;
     /// use icu::datetime::mock::zoned_datetime::MockZonedDateTime;
-    /// use icu_provider::inv::InvariantDataProvider;
-    /// # let locale: Locale = langid!("en").into();
+    /// # use icu_provider::inv::InvariantDataProvider;
+    /// # let locale = icu::locid::locale!("en");
     /// # let date_provider = InvariantDataProvider;
     /// # let zone_provider = InvariantDataProvider;
     /// # let plural_provider = InvariantDataProvider;
-    /// # let options = DateTimeFormatOptions::default();
+    /// # let options = icu::datetime::DateTimeFormatOptions::default();
     /// let zdtf = ZonedDateTimeFormat::<Gregorian>::try_new(locale, &date_provider, &zone_provider, &plural_provider, &options.into())
     ///     .expect("Failed to create ZonedDateTimeFormat instance.");
     ///
@@ -215,17 +205,15 @@ impl<C: CldrCalendar> ZonedDateTimeFormat<C> {
     /// # Examples
     ///
     /// ```
-    /// use icu::locid::Locale;
-    /// use icu::locid::langid;
     /// use icu::calendar::Gregorian;
-    /// use icu::datetime::{ZonedDateTimeFormat, DateTimeFormatOptions};
+    /// use icu::datetime::ZonedDateTimeFormat;
     /// use icu::datetime::mock::zoned_datetime::MockZonedDateTime;
     /// use icu_provider::inv::InvariantDataProvider;
-    /// # let locale: Locale = langid!("en").into();
+    /// # let locale = icu::locid::locale!("en");
     /// # let date_provider = InvariantDataProvider;
     /// # let zone_provider = InvariantDataProvider;
     /// # let plural_provider = InvariantDataProvider;
-    /// # let options = DateTimeFormatOptions::default();
+    /// # let options = icu::datetime::DateTimeFormatOptions::default();
     /// let zdtf = ZonedDateTimeFormat::<Gregorian>::try_new(locale, &date_provider, &zone_provider, &plural_provider, &options.into())
     ///     .expect("Failed to create ZonedDateTimeFormat instance.");
     ///

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -538,8 +538,7 @@ fn constructing_datetime_format_with_time_zone_pattern_symbols_is_err() {
         options::length::{Bag, Time},
         DateTimeFormatOptions,
     };
-    use icu_locid::langid;
-    use icu_locid::Locale;
+    use icu_locid::locale;
 
     let options = DateTimeFormatOptions::Length(Bag {
         // Full has time-zone symbols.
@@ -547,9 +546,8 @@ fn constructing_datetime_format_with_time_zone_pattern_symbols_is_err() {
         ..Default::default()
     });
 
-    let locale: Locale = langid!("en").into();
     let provider = icu_testdata::get_provider();
-    let result = DateTimeFormat::<Gregorian>::try_new(locale, &provider, &options);
+    let result = DateTimeFormat::<Gregorian>::try_new(locale!("en"), &provider, &options);
 
     assert!(result.is_err());
 }

--- a/components/datetime/tests/resolved_components.rs
+++ b/components/datetime/tests/resolved_components.rs
@@ -7,13 +7,11 @@ use icu_datetime::{
     options::{components, length, preferences},
     DateTimeFormat, DateTimeFormatOptions,
 };
-use icu_locid::langid;
-use icu_locid::Locale;
+use icu_locid::locale;
 
 fn assert_resolved_components(options: &DateTimeFormatOptions, bag: &components::Bag) {
-    let locale: Locale = langid!("en").into();
     let provider = icu_testdata::get_provider();
-    let dtf = DateTimeFormat::<Gregorian>::try_new(locale, &provider, options)
+    let dtf = DateTimeFormat::<Gregorian>::try_new(locale!("en"), &provider, options)
         .expect("Failed to create a DateTimeFormat.");
 
     assert_eq!(dtf.resolve_components(), *bag);

--- a/components/decimal/README.md
+++ b/components/decimal/README.md
@@ -14,13 +14,11 @@ follow [icu4x#275](https://github.com/unicode-org/icu4x/issues/275).
 
 ```rust
 use icu::decimal::FixedDecimalFormat;
-use icu::locid::Locale;
-use icu::locid::langid;
+use icu::locid::locale;
 use writeable::Writeable;
 
-let locale: Locale = langid!("bn").into();
 let provider = icu_testdata::get_provider();
-let fdf = FixedDecimalFormat::try_new(locale, &provider, Default::default())
+let fdf = FixedDecimalFormat::try_new(locale!("bn"), &provider, Default::default())
     .expect("Data should load successfully");
 
 let fixed_decimal = 1000007.into();
@@ -38,9 +36,8 @@ use icu::decimal::FixedDecimalFormat;
 use icu::locid::Locale;
 use writeable::Writeable;
 
-let locale = Locale::und();
 let provider = icu_provider::inv::InvariantDataProvider;
-let fdf = FixedDecimalFormat::try_new(locale, &provider, Default::default())
+let fdf = FixedDecimalFormat::try_new(Locale::und(), &provider, Default::default())
     .expect("Data should load successfully");
 
 let fixed_decimal = FixedDecimal::from(200050)

--- a/components/decimal/examples/code_line_diff.rs
+++ b/components/decimal/examples/code_line_diff.rs
@@ -9,8 +9,7 @@
 
 use fixed_decimal::FixedDecimal;
 use icu_decimal::{options, FixedDecimalFormat};
-use icu_locid::langid;
-use icu_locid::Locale;
+use icu_locid::locale;
 use writeable::Writeable;
 
 icu_benchmark_macros::static_setup!();
@@ -27,14 +26,12 @@ const LINES_REMOVED_ADDED: [(i64, i64); 5] = [
 fn main(_argc: isize, _argv: *const *const u8) -> isize {
     icu_benchmark_macros::main_setup!();
 
-    let locale: Locale = langid!("bn").into();
-
     let provider = icu_testdata::get_static_provider();
 
     let mut options: options::FixedDecimalFormatOptions = Default::default();
     options.sign_display = options::SignDisplay::ExceptZero;
 
-    let fdf = FixedDecimalFormat::try_new(locale, &provider, options)
+    let fdf = FixedDecimalFormat::try_new(locale!("bn"), &provider, options)
         .expect("Failed to create FixedDecimalFormat instance.");
 
     for line in LINES_REMOVED_ADDED.iter() {

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -18,13 +18,11 @@
 //!
 //! ```
 //! use icu::decimal::FixedDecimalFormat;
-//! use icu::locid::Locale;
-//! use icu::locid::langid;
+//! use icu::locid::locale;
 //! use writeable::Writeable;
 //!
-//! let locale: Locale = langid!("bn").into();
 //! let provider = icu_testdata::get_provider();
-//! let fdf = FixedDecimalFormat::try_new(locale, &provider, Default::default())
+//! let fdf = FixedDecimalFormat::try_new(locale!("bn"), &provider, Default::default())
 //!     .expect("Data should load successfully");
 //!
 //! let fixed_decimal = 1000007.into();
@@ -42,9 +40,8 @@
 //! use icu::locid::Locale;
 //! use writeable::Writeable;
 //!
-//! let locale = Locale::und();
 //! let provider = icu_provider::inv::InvariantDataProvider;
-//! let fdf = FixedDecimalFormat::try_new(locale, &provider, Default::default())
+//! let fdf = FixedDecimalFormat::try_new(Locale::und(), &provider, Default::default())
 //!     .expect("Data should load successfully");
 //!
 //! let fixed_decimal = FixedDecimal::from(200050)

--- a/components/icu/README.md
+++ b/components/icu/README.md
@@ -51,13 +51,10 @@ functionality are compiled. These features are:
 ## Example
 
 ```rust
-use icu::locid::Locale;
-use icu::locid::langid;
+use icu::locid::locale;
 use icu::datetime::{DateTimeFormat, options::length, mock::parse_gregorian_from_str};
 
 let provider = icu_testdata::get_provider();
-
-let locale: Locale = langid!("en").into();
 
 let options = length::Bag {
     date: Some(length::Date::Long),
@@ -65,7 +62,7 @@ let options = length::Bag {
     ..Default::default()
 }.into();
 
-let dtf = DateTimeFormat::try_new(locale, &provider, &options)
+let dtf = DateTimeFormat::try_new(locale!("en"), &provider, &options)
     .expect("Failed to create DateTimeFormat instance.");
 
 let date = parse_gregorian_from_str("2020-09-12T12:35:00")

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -53,13 +53,10 @@
 //! # Example
 //!
 //! ```
-//! use icu::locid::Locale;
-//! use icu::locid::langid;
+//! use icu::locid::locale;
 //! use icu::datetime::{DateTimeFormat, options::length, mock::parse_gregorian_from_str};
 //!
 //! let provider = icu_testdata::get_provider();
-//!
-//! let locale: Locale = langid!("en").into();
 //!
 //! let options = length::Bag {
 //!     date: Some(length::Date::Long),
@@ -67,7 +64,7 @@
 //!     ..Default::default()
 //! }.into();
 //!
-//! let dtf = DateTimeFormat::try_new(locale, &provider, &options)
+//! let dtf = DateTimeFormat::try_new(locale!("en"), &provider, &options)
 //!     .expect("Failed to create DateTimeFormat instance.");
 //!
 //! let date = parse_gregorian_from_str("2020-09-12T12:35:00")
@@ -121,13 +118,10 @@ pub mod datetime {
     //! # Examples
     //!
     //! ```
-    //! use icu::locid::Locale;
-    //! use icu::locid::langid;
+    //! use icu::locid::locale;
     //! use icu::datetime::{DateTimeFormat, options::length, mock::parse_gregorian_from_str};
     //!
     //! let provider = icu_testdata::get_provider();
-    //!
-    //! let locale: Locale = langid!("en").into();
     //!
     //! let options = length::Bag {
     //!     date: Some(length::Date::Medium),
@@ -135,7 +129,7 @@ pub mod datetime {
     //!     ..Default::default()
     //! }.into();
     //!
-    //! let dtf = DateTimeFormat::try_new(locale, &provider, &options)
+    //! let dtf = DateTimeFormat::try_new(locale!("en"), &provider, &options)
     //!     .expect("Failed to create DateTimeFormat instance.");
     //!
     //! let date = parse_gregorian_from_str("2020-09-12T12:35:00")
@@ -162,13 +156,11 @@ pub mod decimal {
     //!
     //! ```
     //! use icu::decimal::FixedDecimalFormat;
-    //! use icu::locid::Locale;
-    //! use icu::locid::langid;
+    //! use icu::locid::locale;
     //! use writeable::Writeable;
     //!
-    //! let locale: Locale = langid!("bn").into();
     //! let provider = icu_testdata::get_provider();
-    //! let fdf = FixedDecimalFormat::try_new(locale, &provider, Default::default())
+    //! let fdf = FixedDecimalFormat::try_new(locale!("bn"), &provider, Default::default())
     //!     .expect("Data should load successfully");
     //!
     //! let fixed_decimal = 1000007.into();
@@ -186,9 +178,8 @@ pub mod decimal {
     //! use icu::locid::Locale;
     //! use writeable::Writeable;
     //!
-    //! let locale = Locale::und();
     //! let provider = icu_provider::inv::InvariantDataProvider;
-    //! let fdf = FixedDecimalFormat::try_new(locale, &provider, Default::default())
+    //! let fdf = FixedDecimalFormat::try_new(Locale::und(), &provider, Default::default())
     //!     .expect("Data should load successfully");
     //!
     //! let fixed_decimal = FixedDecimal::from(200050)
@@ -275,23 +266,16 @@ pub mod locid {
     //! # Examples
     //!
     //! ```
-    //! use icu::locid::Locale;
-    //! use icu::locid::subtags::{Language, Region};
+    //! use icu::locid::{language, locale, region};
     //!
-    //! let mut loc: Locale = "en-US".parse()
-    //!     .expect("Parsing failed.");
+    //! let mut loc = locale!("en-US").clone();
     //!
-    //! let lang: Language = "en".parse()
-    //!     .expect("Parsing failed.");
-    //! let region: Region = "US".parse()
-    //!     .expect("Parsing failed.");
-    //!
-    //! assert_eq!(loc.id.language, lang);
+    //! assert_eq!(loc.id.language, language!("en"));
     //! assert_eq!(loc.id.script, None);
-    //! assert_eq!(loc.id.region, Some(region));
+    //! assert_eq!(loc.id.region, Some(region!("US")));
     //! assert_eq!(loc.id.variants.len(), 0);
     //!
-    //! let region: Region = "GB".parse().expect("Parsing failed.");
+    //! let region = region!("GB");
     //! loc.id.region = Some(region);
     //!
     //! assert_eq!(loc.to_string(), "en-GB");
@@ -331,11 +315,9 @@ pub mod plurals {
     //! use icu::locid::langid;
     //! use icu::plurals::{PluralRules, PluralRuleType, PluralCategory};
     //!
-    //! let lid = langid!("en");
-    //!
     //! let provider = icu_testdata::get_provider();
     //!
-    //! let pr = PluralRules::try_new(lid, &provider, PluralRuleType::Cardinal)
+    //! let pr = PluralRules::try_new(langid!("en"), &provider, PluralRuleType::Cardinal)
     //!     .expect("Failed to construct a PluralRules struct.");
     //!
     //! assert_eq!(pr.select(5_usize), PluralCategory::Other);
@@ -493,14 +475,12 @@ pub mod list {
     //! ## Format a list of strings in Spanish
     //!
     //! ```
-    //! use icu_list::{ListFormatter, ListStyle};
-    //! use icu_locid::Locale;
-    //! use icu_locid::langid;
+    //! use icu::list::{ListFormatter, ListStyle};
+    //! use icu::locid::locale;
     //! use writeable::Writeable;
     //!
-    //! let locale: Locale = langid!("es").into();
     //! let provider = icu_testdata::get_provider();
-    //! let list_formatter = ListFormatter::try_new_and(locale, &provider, ListStyle::Wide)
+    //! let list_formatter = ListFormatter::try_new_and(locale!("es"), &provider, ListStyle::Wide)
     //!     .expect("Data should load successfully");
     //!
     //! assert_eq!(

--- a/components/list/README.md
+++ b/components/list/README.md
@@ -9,13 +9,11 @@ writeable::Writeable)s as lists in a locale-sensitive way.
 
 ```rust
 use icu_list::{ListFormatter, ListStyle};
-use icu_locid::Locale;
-use icu_locid::langid;
+use icu_locid::locale;
 use writeable::Writeable;
 
-let locale: Locale = langid!("es").into();
 let provider = icu_testdata::get_provider();
-let list_formatter = ListFormatter::try_new_and(locale, &provider, ListStyle::Wide)
+let list_formatter = ListFormatter::try_new_and(locale!("es"), &provider, ListStyle::Wide)
     .expect("Data should load successfully");
 
 assert_eq!(

--- a/components/list/src/lib.rs
+++ b/components/list/src/lib.rs
@@ -13,13 +13,11 @@
 //!
 //! ```
 //! use icu_list::{ListFormatter, ListStyle};
-//! use icu_locid::Locale;
-//! use icu_locid::langid;
+//! use icu_locid::locale;
 //! use writeable::Writeable;
 //!
-//! let locale: Locale = langid!("es").into();
 //! let provider = icu_testdata::get_provider();
-//! let list_formatter = ListFormatter::try_new_and(locale, &provider, ListStyle::Wide)
+//! let list_formatter = ListFormatter::try_new_and(locale!("es"), &provider, ListStyle::Wide)
 //!     .expect("Data should load successfully");
 //!
 //! assert_eq!(

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -52,7 +52,7 @@ use core::str::FromStr;
 /// `_` separators to `-` and adjusting casing to conform to the Unicode standard.
 ///
 /// Any bogus subtags will cause the parsing to fail with an error.
-/// No subtag validation is performed.
+/// No subtag validation or canonicalization is performed.
 ///
 /// # Examples
 ///

--- a/components/locid/src/macros.rs
+++ b/components/locid/src/macros.rs
@@ -9,13 +9,11 @@
 /// # Examples
 ///
 /// ```
-/// use icu::locid::subtags::Language;
-/// use icu::locid::language;
+/// use icu::locid::{language, subtags::Language};
 ///
 /// const DE: Language = language!("DE");
 ///
-/// let de: Language = "DE".parse()
-///     .expect("Failed to parse language subtag.");
+/// let de: Language = "DE".parse().unwrap();
 ///
 /// assert_eq!(DE, "de");
 /// assert_eq!(DE, de);
@@ -42,13 +40,11 @@ macro_rules! language {
 /// # Examples
 ///
 /// ```
-/// use icu::locid::subtags::Script;
-/// use icu::locid::script;
+/// use icu::locid::{script, subtags::Script};
 ///
 /// const ARAB: Script = script!("aRAB");
 ///
-/// let arab: Script = "aRaB".parse()
-///     .expect("Failed to parse script subtag.");
+/// let arab: Script = "aRaB".parse().unwrap();
 ///
 /// assert_eq!(ARAB, "Arab");
 /// assert_eq!(ARAB, arab);
@@ -75,13 +71,11 @@ macro_rules! script {
 /// # Examples
 ///
 /// ```
-/// use icu::locid::subtags::Region;
-/// use icu::locid::region;
+/// use icu::locid::{region, subtags::Region};
 ///
 /// const CN: Region = region!("cn");
 ///
-/// let cn: Region = "cn".parse()
-///     .expect("Failed to parse region subtag.");
+/// let cn: Region = "cn".parse().unwrap();
 ///
 /// assert_eq!(CN, "CN");
 /// assert_eq!(CN, cn);
@@ -108,13 +102,11 @@ macro_rules! region {
 /// # Examples
 ///
 /// ```
-/// use icu::locid::subtags::Variant;
-/// use icu::locid::variant;
+/// use icu::locid::{variant, subtags::Variant};
 ///
 /// const POSIX: Variant = variant!("Posix");
 ///
-/// let posix: Variant = "Posix".parse()
-///     .expect("Failed to parse variant subtag.");
+/// let posix: Variant = "Posix".parse().unwrap();
 ///
 /// assert_eq!(POSIX, "posix");
 /// assert_eq!(POSIX, posix);
@@ -134,27 +126,25 @@ macro_rules! variant {
     }};
 }
 
-/// A macro allowing for compile-time construction of valid [`LanguageIdentifier`].
+/// A macro allowing for compile-time construction of valid [`LanguageIdentifier`]s.
 ///
 /// The macro will perform syntax canonicalization of the tag.
 ///
 /// # Examples
 ///
 /// ```
-/// use icu::locid::LanguageIdentifier;
-/// use icu::locid::langid;
+/// use icu::locid::{LanguageIdentifier, langid};
 ///
 /// const DE_AT: LanguageIdentifier = langid!("de_at");
 ///
-/// let de_at: LanguageIdentifier = "de_at".parse()
-///     .expect("Failed to parse language identifier.");
+/// let de_at: LanguageIdentifier = "de_at".parse().unwrap();
 ///
 /// assert_eq!(DE_AT, "de-AT");
 /// assert_eq!(DE_AT, de_at);
 /// ```
 ///
 /// *Note*: As of Rust 1.47, the macro cannot produce language identifier
-/// with variants in the const mode pending [`Heap Allocations in Constants`].
+/// with variants due to const limitations (see [`Heap Allocations in Constants`]).
 ///
 /// [`LanguageIdentifier`]: crate::LanguageIdentifier
 /// [`Heap Allocations in Constants`]: https://github.com/rust-lang/const-eval/issues/20
@@ -170,7 +160,53 @@ macro_rules! langid {
                     variants: $crate::subtags::Variants::new(),
                 },
                 #[allow(clippy::panic)] // const context
-                _ => panic!(concat!("Invalid language code: ", $langid)),
+                _ => panic!(concat!("Invalid language code: ", $langid, " . Note that variant tags are not \
+                                        supported by the langid! macro, use runtime parsing instead.")),
+            };
+        R
+    }};
+}
+
+/// A macro allowing for compile-time construction of valid [`Locale`]s.
+///
+/// The macro will perform syntax canonicalization of the tag.
+///
+/// # Examples
+///
+/// ```
+/// use icu::locid::{Locale, locale};
+///
+/// const DE_AT: Locale = locale!("de_at");
+///
+/// let de_at: Locale = "de_at".parse().unwrap();
+///
+/// assert_eq!(DE_AT, "de-AT");
+/// assert_eq!(DE_AT, de_at);
+/// ```
+///
+/// *Note*: As of Rust 1.47, the macro cannot produce locales with variants or
+/// Unicode extensions due to const limitations (see [`Heap Allocations in Constants`]).
+///
+/// [`Locale`]: crate::Locale
+/// [`Heap Allocations in Constants`]: https://github.com/rust-lang/const-eval/issues/20
+#[macro_export]
+macro_rules! locale {
+    ($locale:literal) => {{
+        const R: $crate::Locale =
+            match $crate::LanguageIdentifier::from_bytes_without_variants($locale.as_bytes()) {
+                Ok((language, script, region)) => $crate::Locale {
+                    id: $crate::LanguageIdentifier {
+                        language,
+                        script,
+                        region,
+                        variants: $crate::subtags::Variants::new(),
+                    },
+                    extensions: $crate::extensions::Extensions::new(),
+                },
+                #[allow(clippy::panic)] // const context
+                _ => panic!(concat!("Invalid language code: ", $locale, " . Note that variant tags and \
+                                        Unicode extensions are not supported by the locale! macro, use \
+                                        runtime parsing instead.")),
             };
         R
     }};
@@ -183,6 +219,7 @@ mod test {
     const REGION_US: crate::subtags::Region = region!("us");
     const VARIANT_MACOS: crate::subtags::Variant = variant!("MACOS");
     const LANGID: crate::LanguageIdentifier = langid!("de-Arab-AT");
+    const LOCALE: crate::Locale = locale!("de-Arab-AT");
 
     #[test]
     fn language() {
@@ -227,5 +264,14 @@ mod test {
         assert_eq!(langid.to_string(), "de-Arab-AT");
         assert_eq!(LANGID.to_string(), "de-Arab-AT");
         assert_eq!(langid, LANGID);
+    }
+
+    #[test]
+    fn locale() {
+        let locale = locale!("de_Arab_aT");
+        
+        assert_eq!(locale.to_string(), "de-Arab-AT");
+        assert_eq!(LOCALE.to_string(), "de-Arab-AT");
+        assert_eq!(locale, LOCALE);
     }
 }

--- a/components/plurals/README.md
+++ b/components/plurals/README.md
@@ -25,11 +25,9 @@ appropriate [`Plural Category`].
 use icu::locid::langid;
 use icu::plurals::{PluralRules, PluralRuleType, PluralCategory};
 
-let lid = langid!("en");
-
 let provider = icu_testdata::get_provider();
 
-let pr = PluralRules::try_new(lid, &provider, PluralRuleType::Cardinal)
+let pr = PluralRules::try_new(langid!("en"), &provider, PluralRuleType::Cardinal)
     .expect("Failed to construct a PluralRules struct.");
 
 assert_eq!(pr.select(5_usize), PluralCategory::Other);

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -27,11 +27,9 @@
 //! use icu::locid::langid;
 //! use icu::plurals::{PluralRules, PluralRuleType, PluralCategory};
 //!
-//! let lid = langid!("en");
-//!
 //! let provider = icu_testdata::get_provider();
 //!
-//! let pr = PluralRules::try_new(lid, &provider, PluralRuleType::Cardinal)
+//! let pr = PluralRules::try_new(langid!("en"), &provider, PluralRuleType::Cardinal)
 //!     .expect("Failed to construct a PluralRules struct.");
 //!
 //! assert_eq!(pr.select(5_usize), PluralCategory::Other);
@@ -139,11 +137,9 @@ pub enum PluralRuleType {
 /// use icu::plurals::{PluralRules, PluralRuleType, PluralCategory};
 /// use icu_provider::inv::InvariantDataProvider;
 ///
-/// let lid = langid!("en");
-///
 /// let dp = InvariantDataProvider;
 ///
-/// let pr = PluralRules::try_new(lid, &dp, PluralRuleType::Cardinal)
+/// let pr = PluralRules::try_new(langid!("en"), &dp, PluralRuleType::Cardinal)
 ///     .expect("Failed to construct a PluralRules struct.");
 ///
 /// assert_eq!(pr.select(5_usize), PluralCategory::Other);
@@ -266,11 +262,9 @@ impl PluralCategory {
 /// use icu::plurals::{PluralRules, PluralRuleType, PluralCategory};
 /// use icu_provider::inv::InvariantDataProvider;
 ///
-/// let lid = langid!("en");
-///
 /// let dp = InvariantDataProvider;
 ///
-/// let pr = PluralRules::try_new(lid, &dp, PluralRuleType::Cardinal)
+/// let pr = PluralRules::try_new(langid!("en"), &dp, PluralRuleType::Cardinal)
 ///     .expect("Failed to construct a PluralRules struct.");
 ///
 /// assert_eq!(pr.select(5_usize), PluralCategory::Other);
@@ -335,11 +329,9 @@ impl PluralRules {
     /// use icu::locid::langid;
     /// use icu::plurals::{PluralRules, PluralCategory};
     ///
-    /// let lid = langid!("ru");
-    ///
     /// let dp = icu_testdata::get_provider();
     ///
-    /// let rules = PluralRules::try_new_cardinal(lid, &dp)
+    /// let rules = PluralRules::try_new_cardinal(langid!("ru"), &dp)
     ///     .expect("Data should be present");
     ///
     /// assert_eq!(rules.select(2_usize), PluralCategory::Few);
@@ -382,11 +374,9 @@ impl PluralRules {
     /// use icu::locid::langid;
     /// use icu::plurals::{PluralRules, PluralCategory};
     ///
-    /// let lid = langid!("ru");
-    ///
     /// let dp = icu_testdata::get_provider();
     ///
-    /// let rules = PluralRules::try_new_ordinal(lid, &dp)
+    /// let rules = PluralRules::try_new_ordinal(langid!("ru"), &dp)
     ///     .expect("Data should be present");
     ///
     /// assert_eq!(rules.select(2_usize), PluralCategory::Other);
@@ -423,11 +413,9 @@ impl PluralRules {
     /// use icu::plurals::{PluralRules, PluralRuleType, PluralCategory};
     /// use icu_provider::inv::InvariantDataProvider;
     ///
-    /// let lid = langid!("en");
-    ///
     /// let dp = InvariantDataProvider;
     ///
-    /// let pr = PluralRules::try_new(lid, &dp, PluralRuleType::Cardinal)
+    /// let pr = PluralRules::try_new(langid!("en"), &dp, PluralRuleType::Cardinal)
     ///     .expect("Failed to construct a PluralRules struct.");
     ///
     /// match pr.select(1_usize) {
@@ -454,11 +442,9 @@ impl PluralRules {
     /// use icu::plurals::{PluralCategory, PluralOperands};
     /// use icu_provider::inv::InvariantDataProvider;
     /// #
-    /// # let lid = langid!("en");
-    /// #
     /// # let dp = InvariantDataProvider;
     /// #
-    /// # let pr = PluralRules::try_new(lid, &dp, PluralRuleType::Cardinal)
+    /// # let pr = PluralRules::try_new(langid!("en"), &dp, PluralRuleType::Cardinal)
     /// #     .expect("Failed to construct a PluralRules struct.");
     ///
     /// let operands = PluralOperands::try_from(-5)
@@ -507,11 +493,9 @@ impl PluralRules {
     /// use icu::plurals::{PluralRules, PluralRuleType, PluralCategory};
     /// use icu_provider::inv::InvariantDataProvider;
     ///
-    /// let lid = langid!("fr");
-    ///
     /// let dp = icu_testdata::get_provider();
     ///
-    /// let pr = PluralRules::try_new(lid, &dp, PluralRuleType::Cardinal)
+    /// let pr = PluralRules::try_new(langid!("fr"), &dp, PluralRuleType::Cardinal)
     ///     .expect("Failed to construct a PluralRules struct.");
     ///
     /// let mut categories = pr.categories();

--- a/docs/tutorials/intro.md
+++ b/docs/tutorials/intro.md
@@ -93,11 +93,10 @@ It's a bit unergonomic to have to perform the parsing of them at runtime and han
 For that purpose, ICU4X provides a macro one can use to parse it at compilation time:
 
 ```rust
-use icu::locid::Locale;
-use icu::locid::langid;
+use icu::locid::locale;
 
 fn main() {
-    let loc: Locale = langid!("ES-AR").into();
+    let loc = locale!("ES-AR");
 
     if loc.id.language == "es" {
         println!("¡Hola amigo!");
@@ -109,7 +108,7 @@ fn main() {
 
 In this case, the parsing is performed at compilation time, so we don't need to handle an error case. Try passing an malformed identifier, like "foo-bar" and try to call `cargo check`.
 
-*Notice:* ICU4X does not expose yet a macro for `locale!` compile time parsing. Instead, `langid!` macro constructs a `LanguageIdentifier`, which we then `Into` a `Locale`.
+*Notice:* The compile time macros `langid!`, and `locale!` don't support variants or extension tags, as storing these requires allocation. If you have such a tag you need to use runtime parsing.
 
 Next, let's add some more complex functionality.
 
@@ -190,14 +189,11 @@ fn main() {
 While this app doesn't do anything on its own yet, we now have a loaded data provider, and can use it to format a date:
 
 ```rust
-use icu::locid::langid;
-use icu::locid::Locale;
+use icu::locid::locale;
 use icu::datetime::{DateTimeFormat, mock::datetime::MockDateTime, options::length};
 use icu_provider_fs::FsDataProvider;
 
 fn main() {
-    let loc: Locale = langid!("pl").into();
-
     let date: MockDateTime = "2020-10-14T13:21:00".parse()
         .expect("Failed to parse a datetime.");
 
@@ -210,7 +206,7 @@ fn main() {
         ..Default::default()
     }.into();
 
-    let dtf = DateTimeFormat::try_new(loc, &provider, &options)
+    let dtf = DateTimeFormat::try_new(locale!("pl"), &provider, &options)
         .expect("Failed to initialize DateTimeFormat");
 
     let formatted_date = dtf.format(&date);

--- a/ffi/ecma402/src/pluralrules.rs
+++ b/ffi/ecma402/src/pluralrules.rs
@@ -286,27 +286,27 @@ impl PluralRules {
 mod testing {
     use ecma402_traits::pluralrules;
     use ecma402_traits::pluralrules::PluralRules;
-    use icu::locid::Locale;
+    use icu::locid::{locale, Locale};
     use icu::plurals::PluralRulesError;
 
     #[test]
     fn plurals_per_locale() -> Result<(), PluralRulesError> {
         #[derive(Debug, Clone)]
         struct TestCase {
-            locale: &'static str,
+            locale: Locale,
             opts: pluralrules::Options,
             numbers: Vec<f64>,
             expected: Vec<&'static str>,
         }
         let tests = vec![
             TestCase {
-                locale: "ar",
+                locale: locale!("ar"),
                 opts: Default::default(),
                 numbers: vec![0.0, 1.0, 2.0, 5.0, 6.0, 18.0],
                 expected: vec!["zero", "one", "two", "few", "few", "many"],
             },
             TestCase {
-                locale: "ar",
+                locale: locale!("ar"),
                 opts: pluralrules::Options {
                     in_type: pluralrules::options::Type::Ordinal,
                     ..Default::default()
@@ -315,13 +315,13 @@ mod testing {
                 expected: vec!["other", "other", "other", "other", "other", "other"],
             },
             TestCase {
-                locale: "sr",
+                locale: locale!("sr"),
                 opts: Default::default(),
                 numbers: vec![0.0, 1.0, 2.0, 5.0, 6.0, 18.0],
                 expected: vec!["other", "one", "few", "other", "other", "other"],
             },
             TestCase {
-                locale: "sr",
+                locale: locale!("sr"),
                 opts: pluralrules::Options {
                     in_type: pluralrules::options::Type::Ordinal,
                     ..Default::default()
@@ -332,8 +332,7 @@ mod testing {
         ];
         let provider = icu_testdata::get_provider();
         for test in tests {
-            let l: Locale = test.locale.parse().expect("locale exists");
-            let l = crate::Locale::FromLocale(l);
+            let l = crate::Locale::FromLocale(test.locale);
             let plr = super::PluralRules::try_new_with_provider(l, test.clone().opts, &provider)?;
             let actual = test
                 .numbers

--- a/provider/blob/examples/simple_static.rs
+++ b/provider/blob/examples/simple_static.rs
@@ -6,11 +6,9 @@ use icu::locid::langid;
 use icu::plurals::{PluralCategory, PluralRuleType, PluralRules};
 
 fn main() {
-    let lid = langid!("en");
-
     let dp = icu_testdata::get_static_provider();
 
-    let pr = PluralRules::try_new(lid, &dp, PluralRuleType::Cardinal)
+    let pr = PluralRules::try_new(langid!("en"), &dp, PluralRuleType::Cardinal)
         .expect("Failed to construct a PluralRules struct.");
 
     assert_eq!(pr.select(5_usize), PluralCategory::Other);


### PR DESCRIPTION
This works similarly to the `langid!` macro, i.e. it doesn't support variants and extension tags. However it allows us to replace most instances of
```rust
let locale: Locale = langid!("foo").into();
locale
```
by just
```rust
locale!("foo")
```