### PR TITLE
Add convenience From<subtag> for LanguageIdentifier and Locale

### DIFF
--- a/components/locid/src/langid.rs
+++ b/components/locid/src/langid.rs
@@ -353,27 +353,6 @@ impl From<subtags::Language> for LanguageIdentifier {
 /// use icu::locid::script;
 ///
 /// let script = script!("latn");
-/// let li = LanguageIdentifier::from(script);
-///
-/// assert_eq!(li.script.unwrap(), "Latn");
-/// assert_eq!(li, "und-Latn");
-/// ```
-impl From<subtags::Script> for LanguageIdentifier {
-    fn from(script: subtags::Script) -> Self {
-        Self {
-            script: Some(script),
-            ..Default::default()
-        }
-    }
-}
-
-/// # Examples
-///
-/// ```
-/// use icu::locid::LanguageIdentifier;
-/// use icu::locid::script;
-///
-/// let script = script!("latn");
 /// let li = LanguageIdentifier::from(Some(script));
 ///
 /// assert_eq!(li.script.unwrap(), "Latn");
@@ -383,27 +362,6 @@ impl From<Option<subtags::Script>> for LanguageIdentifier {
     fn from(script: Option<subtags::Script>) -> Self {
         Self {
             script,
-            ..Default::default()
-        }
-    }
-}
-
-/// # Examples
-///
-/// ```
-/// use icu::locid::LanguageIdentifier;
-/// use icu::locid::region;
-///
-/// let region = region!("US");
-/// let li = LanguageIdentifier::from(region);
-///
-/// assert_eq!(li.region.unwrap(), "US");
-/// assert_eq!(li, "und-US");
-/// ```
-impl From<subtags::Region> for LanguageIdentifier {
-    fn from(region: subtags::Region) -> Self {
-        Self {
-            region: Some(region),
             ..Default::default()
         }
     }

--- a/components/locid/src/langid.rs
+++ b/components/locid/src/langid.rs
@@ -324,3 +324,94 @@ impl PartialEq<str> for LanguageIdentifier {
         iter.next() == None
     }
 }
+
+/// # Examples
+///
+/// ```
+/// use icu::locid::LanguageIdentifier;
+/// use icu::locid::language;
+///
+/// let language = language!("en");
+/// let li = LanguageIdentifier::from(language);
+///
+/// assert_eq!(li.language, "en");
+/// assert_eq!(li, "en");
+/// ```
+impl From<subtags::Language> for LanguageIdentifier {
+    fn from(language: subtags::Language) -> Self {
+        Self {
+            language,
+            ..Default::default()
+        }
+    }
+}
+
+/// # Examples
+///
+/// ```
+/// use icu::locid::LanguageIdentifier;
+/// use icu::locid::script;
+///
+/// let script = script!("latn");
+/// let li = LanguageIdentifier::from(script);
+///
+/// assert_eq!(li.script.unwrap(), "Latn");
+/// assert_eq!(li, "und-Latn");
+/// ```
+impl From<subtags::Script> for LanguageIdentifier {
+    fn from(script: subtags::Script) -> Self {
+        Self {
+            script: Some(script),
+            ..Default::default()
+        }
+    }
+}
+
+/// # Examples
+///
+/// ```
+/// use icu::locid::LanguageIdentifier;
+/// use icu::locid::region;
+///
+/// let region = region!("US");
+/// let li = LanguageIdentifier::from(region);
+///
+/// assert_eq!(li.region.unwrap(), "US");
+/// assert_eq!(li, "und-US");
+/// ```
+impl From<subtags::Region> for LanguageIdentifier {
+    fn from(region: subtags::Region) -> Self {
+        Self {
+            region: Some(region),
+            ..Default::default()
+        }
+    }
+}
+
+/// # Examples
+///
+/// ```
+/// use icu::locid::LanguageIdentifier;
+/// use icu::locid::{language, script, region};
+///
+/// let lang = language!("en");
+/// let script = script!("Latn");
+/// let region = region!("US");
+/// let li = LanguageIdentifier::from((lang, script, region));
+///
+/// assert_eq!(li.language, "en");
+/// assert_eq!(li.script.unwrap(), "Latn");
+/// assert_eq!(li.region.unwrap(), "US");
+/// assert_eq!(li.variants.len(), 0);
+/// assert_eq!(li, "en-Latn-US");
+/// ```
+impl From<(subtags::Language, subtags::Script, subtags::Region)> for LanguageIdentifier {
+    fn from(lsr: (subtags::Language, subtags::Script, subtags::Region)) -> Self {
+        Self {
+            language: lsr.0,
+            script: Some(lsr.1),
+            region: Some(lsr.2),
+            ..Default::default()
+        }
+    }
+}

--- a/components/locid/src/langid.rs
+++ b/components/locid/src/langid.rs
@@ -371,6 +371,27 @@ impl From<subtags::Script> for LanguageIdentifier {
 ///
 /// ```
 /// use icu::locid::LanguageIdentifier;
+/// use icu::locid::script;
+///
+/// let script = script!("latn");
+/// let li = LanguageIdentifier::from(Some(script));
+///
+/// assert_eq!(li.script.unwrap(), "Latn");
+/// assert_eq!(li, "und-Latn");
+/// ```
+impl From<Option<subtags::Script>> for LanguageIdentifier {
+    fn from(script: Option<subtags::Script>) -> Self {
+        Self {
+            script,
+            ..Default::default()
+        }
+    }
+}
+
+/// # Examples
+///
+/// ```
+/// use icu::locid::LanguageIdentifier;
 /// use icu::locid::region;
 ///
 /// let region = region!("US");
@@ -392,12 +413,33 @@ impl From<subtags::Region> for LanguageIdentifier {
 ///
 /// ```
 /// use icu::locid::LanguageIdentifier;
+/// use icu::locid::region;
+///
+/// let region = region!("US");
+/// let li = LanguageIdentifier::from(Some(region));
+///
+/// assert_eq!(li.region.unwrap(), "US");
+/// assert_eq!(li, "und-US");
+/// ```
+impl From<Option<subtags::Region>> for LanguageIdentifier {
+    fn from(region: Option<subtags::Region>) -> Self {
+        Self {
+            region,
+            ..Default::default()
+        }
+    }
+}
+
+/// # Examples
+///
+/// ```
+/// use icu::locid::LanguageIdentifier;
 /// use icu::locid::{language, script, region};
 ///
 /// let lang = language!("en");
 /// let script = script!("Latn");
 /// let region = region!("US");
-/// let li = LanguageIdentifier::from((lang, script, region));
+/// let li = LanguageIdentifier::from((lang, Some(script), Some(region)));
 ///
 /// assert_eq!(li.language, "en");
 /// assert_eq!(li.script.unwrap(), "Latn");
@@ -405,12 +447,24 @@ impl From<subtags::Region> for LanguageIdentifier {
 /// assert_eq!(li.variants.len(), 0);
 /// assert_eq!(li, "en-Latn-US");
 /// ```
-impl From<(subtags::Language, subtags::Script, subtags::Region)> for LanguageIdentifier {
-    fn from(lsr: (subtags::Language, subtags::Script, subtags::Region)) -> Self {
+impl
+    From<(
+        subtags::Language,
+        Option<subtags::Script>,
+        Option<subtags::Region>,
+    )> for LanguageIdentifier
+{
+    fn from(
+        lsr: (
+            subtags::Language,
+            Option<subtags::Script>,
+            Option<subtags::Region>,
+        ),
+    ) -> Self {
         Self {
             language: lsr.0,
-            script: Some(lsr.1),
-            region: Some(lsr.2),
+            script: lsr.1,
+            region: lsr.2,
             ..Default::default()
         }
     }

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -369,13 +369,13 @@ impl From<subtags::Language> for Locale {
 /// use icu::locid::script;
 ///
 /// let script = script!("latn");
-/// let loc = Locale::from(script);
+/// let loc = Locale::from(Some(script));
 ///
 /// assert_eq!(loc.id.script.unwrap(), "Latn");
 /// assert_eq!(loc, "und-Latn");
 /// ```
-impl From<subtags::Script> for Locale {
-    fn from(script: subtags::Script) -> Self {
+impl From<Option<subtags::Script>> for Locale {
+    fn from(script: Option<subtags::Script>) -> Self {
         Self {
             id: script.into(),
             ..Default::default()
@@ -390,13 +390,13 @@ impl From<subtags::Script> for Locale {
 /// use icu::locid::region;
 ///
 /// let region = region!("US");
-/// let loc = Locale::from(region);
+/// let loc = Locale::from(Some(region));
 ///
 /// assert_eq!(loc.id.region.unwrap(), "US");
 /// assert_eq!(loc, "und-US");
 /// ```
-impl From<subtags::Region> for Locale {
-    fn from(region: subtags::Region) -> Self {
+impl From<Option<subtags::Region>> for Locale {
+    fn from(region: Option<subtags::Region>) -> Self {
         Self {
             id: region.into(),
             ..Default::default()
@@ -413,7 +413,7 @@ impl From<subtags::Region> for Locale {
 /// let lang = language!("en");
 /// let script = script!("Latn");
 /// let region = region!("US");
-/// let loc = Locale::from((lang, script, region));
+/// let loc = Locale::from((lang, Some(script), Some(region)));
 ///
 /// assert_eq!(loc.id.language, "en");
 /// assert_eq!(loc.id.script.unwrap(), "Latn");
@@ -421,8 +421,20 @@ impl From<subtags::Region> for Locale {
 /// assert_eq!(loc.id.variants.len(), 0);
 /// assert_eq!(loc, "en-Latn-US");
 /// ```
-impl From<(subtags::Language, subtags::Script, subtags::Region)> for Locale {
-    fn from(lsr: (subtags::Language, subtags::Script, subtags::Region)) -> Self {
+impl
+    From<(
+        subtags::Language,
+        Option<subtags::Script>,
+        Option<subtags::Region>,
+    )> for Locale
+{
+    fn from(
+        lsr: (
+            subtags::Language,
+            Option<subtags::Script>,
+            Option<subtags::Region>,
+        ),
+    ) -> Self {
         Self {
             id: lsr.into(),
             ..Default::default()

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -340,3 +340,92 @@ impl PartialEq<str> for Locale {
         iter.next() == None
     }
 }
+
+/// # Examples
+///
+/// ```
+/// use icu::locid::Locale;
+/// use icu::locid::language;
+///
+/// let language = language!("en");
+/// let loc = Locale::from(language);
+///
+/// assert_eq!(loc.id.language, "en");
+/// assert_eq!(loc, "en");
+/// ```
+impl From<subtags::Language> for Locale {
+    fn from(language: subtags::Language) -> Self {
+        Self {
+            id: language.into(),
+            ..Default::default()
+        }
+    }
+}
+
+/// # Examples
+///
+/// ```
+/// use icu::locid::Locale;
+/// use icu::locid::script;
+///
+/// let script = script!("latn");
+/// let loc = Locale::from(script);
+///
+/// assert_eq!(loc.id.script.unwrap(), "Latn");
+/// assert_eq!(loc, "und-Latn");
+/// ```
+impl From<subtags::Script> for Locale {
+    fn from(script: subtags::Script) -> Self {
+        Self {
+            id: script.into(),
+            ..Default::default()
+        }
+    }
+}
+
+/// # Examples
+///
+/// ```
+/// use icu::locid::Locale;
+/// use icu::locid::region;
+///
+/// let region = region!("US");
+/// let loc = Locale::from(region);
+///
+/// assert_eq!(loc.id.region.unwrap(), "US");
+/// assert_eq!(loc, "und-US");
+/// ```
+impl From<subtags::Region> for Locale {
+    fn from(region: subtags::Region) -> Self {
+        Self {
+            id: region.into(),
+            ..Default::default()
+        }
+    }
+}
+
+/// # Examples
+///
+/// ```
+/// use icu::locid::Locale;
+/// use icu::locid::{language, script, region};
+///
+/// let lang = language!("en");
+/// let script = script!("Latn");
+/// let region = region!("US");
+/// let loc = Locale::from((lang, script, region));
+///
+/// assert_eq!(loc.id.language, "en");
+/// assert_eq!(loc.id.script.unwrap(), "Latn");
+/// assert_eq!(loc.id.region.unwrap(), "US");
+/// assert_eq!(loc.id.variants.len(), 0);
+/// assert_eq!(loc, "en-Latn-US");
+/// ```
+impl From<(subtags::Language, subtags::Script, subtags::Region)> for Locale {
+    fn from(lsr: (subtags::Language, subtags::Script, subtags::Region)) -> Self {
+        Self {
+            id: lsr.into(),
+            ..Default::default()
+        }
+    }
+}


### PR DESCRIPTION
This is a spin-off for #1749.

For now I'm just adding single subtag and LSR. If we want we will later be able to add pairs (language+script, language+region etc.).