### PR TITLE
Fixup t_with_ser error

### DIFF
--- a/utils/zerovec/src/map/serde.rs
+++ b/utils/zerovec/src/map/serde.rs
@@ -28,12 +28,12 @@ where
             // than numbers and strings as map keys. For them, we can serialize
             // as a vec of tuples instead
             if let Some(k) = self.iter_keys().next() {
-                let json = K::Container::t_with_ser(k, |k| serde_json::json!(k));
+                let json = K::Container::zvl_get_as_t(k, |k| serde_json::json!(k));
                 if !json.is_string() && !json.is_number() {
                     let mut seq = serializer.serialize_seq(Some(self.len()))?;
                     for (k, v) in self.iter() {
-                        K::Container::t_with_ser(k, |k| {
-                            V::Container::t_with_ser(v, |v| seq.serialize_element(&(k, v)))
+                        K::Container::zvl_get_as_t(k, |k| {
+                            V::Container::zvl_get_as_t(v, |v| seq.serialize_element(&(k, v)))
                         })?;
                     }
                     return seq.end();


### PR DESCRIPTION
The code from https://github.com/unicode-org/icu4x/pull/1743 had CI'd on an older ICU4X main and did not take into account the changes from https://github.com/unicode-org/icu4x/pull/1761, landed today. This fixes the issue.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->