### PR TITLE
Minor fixes to yoke docs; publish new yoke/yoke-derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bincode",
  "serde",
@@ -3202,7 +3202,7 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/experimental/segmenter_lstm/Cargo.toml
+++ b/experimental/segmenter_lstm/Cargo.toml
@@ -29,7 +29,7 @@ litemap = { version = "0.3.0", path = "../../utils/litemap", features = ["serde_
 serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
 ndarray = { version = "0.15", features = ["serde"] }
 unicode-segmentation = "1.3.0"
-yoke = { version = "0.4.0", path = "../../utils/yoke", features = ["serde", "derive"] }
+yoke = { version = "0.4.1", path = "../../utils/yoke", features = ["serde", "derive"] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/provider/blob/Cargo.toml
+++ b/provider/blob/Cargo.toml
@@ -33,7 +33,7 @@ serde = { version = "1.0", default-features = false, features = ["alloc"] }
 postcard = { version = "0.7.0", default-features = false }
 erased-serde = { version = "0.3", default-features = false, features = ["alloc"] }
 writeable = { version = "0.3", path = "../../utils/writeable" }
-yoke = { version = "0.4.0", path = "../../utils/yoke" }
+yoke = { version = "0.4.1", path = "../../utils/yoke" }
 zerovec = { version = "0.6", path = "../../utils/zerovec", features = ["serde", "yoke"] }
 
 # For the export feature

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -55,7 +55,7 @@ icu_locid = { version = "0.5", path = "../../components/locid" }
 tinystr = { path = "../../utils/tinystr", version = "0.5.0", features = ["alloc"], default-features = false }
 writeable = { version = "0.3", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
-yoke = { version = "0.4.0", path = "../../utils/yoke", features = ["serde", "derive"] }
+yoke = { version = "0.4.1", path = "../../utils/yoke", features = ["serde", "derive"] }
 zerofrom = { version = "0.1.0", path = "../../utils/zerofrom", features = ["derive"] }
 zerovec = { version = "0.6.0", path = "../../utils/zerovec" , features = ["derive"]}
 litemap = { version = "0.3.0", path = "../../utils/litemap" }

--- a/utils/codepointtrie/Cargo.toml
+++ b/utils/codepointtrie/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 displaydoc = { version = "0.2.3", default-features = false }
 icu_uniset = { version = "0.4.1", path = "../uniset" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
-yoke = { version = "0.4.0", path = "../yoke", features = ["derive"] }
+yoke = { version = "0.4.1", path = "../yoke", features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../zerofrom", features = ["derive"] }
 zerovec = { version = "0.6", path = "../zerovec", features = ["yoke"] }
 

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -30,7 +30,7 @@ all-features = true
 [dependencies]
 serde = {version = "1", optional = true, default-features = false, features = ["alloc"]}
 serde_json = { version = "1", optional = true, default-features = false, features = ["alloc"]}
-yoke = { version = "0.4.0", path = "../yoke", features = ["derive"], optional = true }
+yoke = { version = "0.4.1", path = "../yoke", features = ["derive"], optional = true }
 
 [dev-dependencies]
 serde = "1"

--- a/utils/uniset/Cargo.toml
+++ b/utils/uniset/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 tinystr = { path = "../tinystr", version = "0.5.0", features = ["alloc"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
-yoke = { version = "0.4.0", path = "../yoke", features = ["derive"] }
+yoke = { version = "0.4.1", path = "../yoke", features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../zerofrom", features = ["derive"] }
 zerovec = { version = "0.6", path = "../zerovec", features = ["yoke"] }
 

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "yoke"
-version = "0.4.0"
+version = "0.4.1"
 description = "Abstraction allowing borrowed data to be carried along with the backing data it borrows from"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2018"
@@ -32,7 +32,7 @@ all-features = true
 [dependencies]
 stable_deref_trait = { version = "1.2.0", features = ["alloc"], default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
-yoke-derive = { path = "./derive", version = "0.4.1", optional = true }
+yoke-derive = { path = "./derive", version = "0.4.2", optional = true }
 zerofrom = { path = "../zerofrom", version = "0.1.0", default-features = false, optional = true} 
 
 [dev-dependencies]

--- a/utils/yoke/README.md
+++ b/utils/yoke/README.md
@@ -2,7 +2,7 @@
 
 This crate provides [`Yoke<Y, C>`][Yoke], which allows one to "yoke" a zero-copy deserialized
 object(say, a [`Cow<'a, str>`](alloc::borrow::Cow)) to the source it was deserialized from, (say, an [`Rc<[u8]>`](alloc::rc::Rc)),
-known as a "cart", producing a type that looks like `Yoke<Cow<'static, str>, Rc<[u8]>>`
+known in this crate as a "cart", producing a type that looks like `Yoke<Cow<'static, str>, Rc<[u8]>>`
 and can be moved around with impunity.
 
 Succinctly, this allows one to "erase" static lifetimes and turn them into dynamic ones, similarly
@@ -16,7 +16,7 @@ abstraction, potentially with an owned variant (like [`Cow`](alloc::borrow::Cow)
 The key behind this crate is [`Yoke::get()`], where calling [`.get()`][Yoke::get] on a type like
 `Yoke<Cow<'static, str>, _>` will get you a short-lived `&'a Cow<'a, str>`, restricted to the
 lifetime of the borrow used during [`.get()`](Yoke::get). This is entirely safe since the `Cow` borrows from
-the cart type, which cannot be interfered with as long as the `Yoke` is borrowed by [`.get()`](Yoke::get).
+the cart type `C`, which cannot be interfered with as long as the `Yoke` is borrowed by [`.get()`](Yoke::get).
 [`.get()`](Yoke::get) protects access by essentially reifying the erased lifetime to a safe local one
 when necessary.
 

--- a/utils/yoke/README.md
+++ b/utils/yoke/README.md
@@ -1,7 +1,7 @@
 # yoke [![crates.io](https://img.shields.io/crates/v/yoke)](https://crates.io/crates/yoke)
 
-This crate provides [`Yoke<Y, C>`][Yoke], which allows one to "yoke" a zero-copy deserialized
-object(say, a [`Cow<'a, str>`](alloc::borrow::Cow)) to the source it was deserialized from, (say, an [`Rc<[u8]>`](alloc::rc::Rc)),
+This crate provides [`Yoke<Y, C>`][Yoke], which allows one to "yoke" (attach) a zero-copy deserialized
+object (say, a [`Cow<'a, str>`](alloc::borrow::Cow)) to the source it was deserialized from, (say, an [`Rc<[u8]>`](alloc::rc::Rc)),
 known in this crate as a "cart", producing a type that looks like `Yoke<Cow<'static, str>, Rc<[u8]>>`
 and can be moved around with impunity.
 

--- a/utils/yoke/derive/Cargo.toml
+++ b/utils/yoke/derive/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "yoke-derive"
-version = "0.4.1"
+version = "0.4.2"
 description = "Custom derive for the yoke crate"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "LICENSE"
@@ -26,5 +26,5 @@ syn = { version = "1.0.73", features = ["derive", "fold"] }
 synstructure = "0.12.4"
 
 [dev-dependencies]
-yoke = { version = "0.4.0", path = "..", features = ["derive"]}
+yoke = { version = "0.4.1", path = "..", features = ["derive"]}
 zerovec = { version = "0.6", path = "../../zerovec", features = ["yoke"] }

--- a/utils/yoke/src/either.rs
+++ b/utils/yoke/src/either.rs
@@ -5,8 +5,8 @@
 //! Types to enable polymorphic carts.
 
 use crate::CloneableCart;
-use crate::Yoke;
-use crate::Yokeable;
+
+
 use core::ops::Deref;
 use stable_deref_trait::StableDeref;
 
@@ -96,33 +96,4 @@ where
     C0: CloneableCart,
     C1: CloneableCart,
 {
-}
-
-impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
-    /// Helper function allowing one to wrap the cart type in an [`EitherCart`].
-    ///
-    /// This function wraps the cart into the `A` variant. To wrap it into the
-    /// `B` variant, use [`Self::wrap_cart_in_either_b()`].
-    ///
-    /// For an example, see [`EitherCart`].
-    #[inline]
-    pub fn wrap_cart_in_either_a<B>(self) -> Yoke<Y, EitherCart<C, B>> {
-        unsafe {
-            // safe because the cart is preserved, just wrapped
-            self.replace_cart(EitherCart::A)
-        }
-    }
-    /// Helper function allowing one to wrap the cart type in an [`EitherCart`].
-    ///
-    /// This function wraps the cart into the `B` variant. To wrap it into the
-    /// `A` variant, use [`Self::wrap_cart_in_either_a()`].
-    ///
-    /// For an example, see [`EitherCart`].
-    #[inline]
-    pub fn wrap_cart_in_either_b<A>(self) -> Yoke<Y, EitherCart<A, C>> {
-        unsafe {
-            // safe because the cart is preserved, just wrapped
-            self.replace_cart(EitherCart::B)
-        }
-    }
 }

--- a/utils/yoke/src/either.rs
+++ b/utils/yoke/src/either.rs
@@ -18,7 +18,7 @@ use stable_deref_trait::StableDeref;
 /// All relevant Cart traits are implemented for `EitherCart`, and carts can be
 /// safely wrapped in an `EitherCart`.
 ///
-/// Also see [`Yoke::erase_box_cart()`].
+/// Also see [`Yoke::erase_box_cart()`](crate::Yoke::erase_box_cart).
 ///
 /// # Examples
 ///

--- a/utils/yoke/src/either.rs
+++ b/utils/yoke/src/either.rs
@@ -6,7 +6,6 @@
 
 use crate::CloneableCart;
 
-
 use core::ops::Deref;
 use stable_deref_trait::StableDeref;
 

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -4,7 +4,7 @@
 
 //! This crate provides [`Yoke<Y, C>`][Yoke], which allows one to "yoke" a zero-copy deserialized
 //! object(say, a [`Cow<'a, str>`](alloc::borrow::Cow)) to the source it was deserialized from, (say, an [`Rc<[u8]>`](alloc::rc::Rc)),
-//! known as a "cart", producing a type that looks like `Yoke<Cow<'static, str>, Rc<[u8]>>`
+//! known in this crate as a "cart", producing a type that looks like `Yoke<Cow<'static, str>, Rc<[u8]>>`
 //! and can be moved around with impunity.
 //!
 //! Succinctly, this allows one to "erase" static lifetimes and turn them into dynamic ones, similarly
@@ -18,7 +18,7 @@
 //! The key behind this crate is [`Yoke::get()`], where calling [`.get()`][Yoke::get] on a type like
 //! `Yoke<Cow<'static, str>, _>` will get you a short-lived `&'a Cow<'a, str>`, restricted to the
 //! lifetime of the borrow used during [`.get()`](Yoke::get). This is entirely safe since the `Cow` borrows from
-//! the cart type, which cannot be interfered with as long as the `Yoke` is borrowed by [`.get()`](Yoke::get).
+//! the cart type `C`, which cannot be interfered with as long as the `Yoke` is borrowed by [`.get()`](Yoke::get).
 //! [`.get()`](Yoke::get) protects access by essentially reifying the erased lifetime to a safe local one
 //! when necessary.
 //!

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -2,8 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-//! This crate provides [`Yoke<Y, C>`][Yoke], which allows one to "yoke" a zero-copy deserialized
-//! object(say, a [`Cow<'a, str>`](alloc::borrow::Cow)) to the source it was deserialized from, (say, an [`Rc<[u8]>`](alloc::rc::Rc)),
+//! This crate provides [`Yoke<Y, C>`][Yoke], which allows one to "yoke" (attach) a zero-copy deserialized
+//! object (say, a [`Cow<'a, str>`](alloc::borrow::Cow)) to the source it was deserialized from, (say, an [`Rc<[u8]>`](alloc::rc::Rc)),
 //! known in this crate as a "cart", producing a type that looks like `Yoke<Cow<'static, str>, Rc<[u8]>>`
 //! and can be moved around with impunity.
 //!

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -6,6 +6,7 @@
 use crate::erased::{ErasedBoxCart, ErasedRcCart};
 use crate::trait_hack::YokeTraitHack;
 use crate::IsCovariant;
+use crate::either::EitherCart;
 use crate::Yokeable;
 use core::marker::PhantomData;
 use core::ops::Deref;
@@ -922,6 +923,36 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
         }
     }
 }
+
+impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
+    /// Helper function allowing one to wrap the cart type in an [`EitherCart`].
+    ///
+    /// This function wraps the cart into the `A` variant. To wrap it into the
+    /// `B` variant, use [`Self::wrap_cart_in_either_b()`].
+    ///
+    /// For an example, see [`EitherCart`].
+    #[inline]
+    pub fn wrap_cart_in_either_a<B>(self) -> Yoke<Y, EitherCart<C, B>> {
+        unsafe {
+            // safe because the cart is preserved, just wrapped
+            self.replace_cart(EitherCart::A)
+        }
+    }
+    /// Helper function allowing one to wrap the cart type in an [`EitherCart`].
+    ///
+    /// This function wraps the cart into the `B` variant. To wrap it into the
+    /// `A` variant, use [`Self::wrap_cart_in_either_a()`].
+    ///
+    /// For an example, see [`EitherCart`].
+    #[inline]
+    pub fn wrap_cart_in_either_b<A>(self) -> Yoke<Y, EitherCart<A, C>> {
+        unsafe {
+            // safe because the cart is preserved, just wrapped
+            self.replace_cart(EitherCart::B)
+        }
+    }
+}
+
 
 /// Safety docs for project()
 ///

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -2,11 +2,11 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::either::EitherCart;
 #[cfg(feature = "alloc")]
 use crate::erased::{ErasedBoxCart, ErasedRcCart};
 use crate::trait_hack::YokeTraitHack;
 use crate::IsCovariant;
-use crate::either::EitherCart;
 use crate::Yokeable;
 use core::marker::PhantomData;
 use core::ops::Deref;
@@ -952,7 +952,6 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
         }
     }
 }
-
 
 /// Safety docs for project()
 ///

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -40,7 +40,7 @@ use alloc::sync::Arc;
 /// The key behind this type is [`Yoke::get()`], where calling [`.get()`][Yoke::get] on a type like
 /// `Yoke<Cow<'static, str>, _>` will get you a short-lived `&'a Cow<'a, str>`, restricted to the
 /// lifetime of the borrow used during `.get()`. This is entirely safe since the `Cow` borrows from
-/// the cart type, which cannot be interfered with as long as the `Yoke` is borrowed by `.get
+/// the cart type `C`, which cannot be interfered with as long as the `Yoke` is borrowed by `.get
 /// ()`. `.get()` protects access by essentially reifying the erased lifetime to a safe local one
 /// when necessary.
 ///
@@ -325,9 +325,9 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     ///
     /// - `f()` must not panic
     /// - References from the yokeable `Y` should still be valid for the lifetime of the
-    ///   returned cart type.
+    ///   returned cart type `C`.
     ///
-    /// Typically, this means implementing `f` as something which _wraps_ the inner cart type.
+    /// Typically, this means implementing `f` as something which _wraps_ the inner cart type `C`.
     /// `Yoke` only really cares about destructors for its carts so it's fine to erase other
     /// information about the cart, as long as the backing data will still be destroyed at the
     /// same time.
@@ -429,7 +429,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
         self.yokeable.transform_mut(f)
     }
 
-    /// Helper function allowing one to wrap the cart type in an `Option<T>`.
+    /// Helper function allowing one to wrap the cart type `C` in an `Option<T>`.
     #[inline]
     pub fn wrap_cart_in_option(self) -> Yoke<Y, Option<C>> {
         unsafe {
@@ -543,7 +543,7 @@ unsafe impl<T: CloneableCart> CloneableCart for Option<T> {}
 unsafe impl<'a, T: ?Sized> CloneableCart for &'a T {}
 unsafe impl CloneableCart for () {}
 
-/// Clone requires that the cart derefs to the same address after it is cloned. This works for
+/// Clone requires that the cart type `C` derefs to the same address after it is cloned. This works for
 /// Rc, Arc, and &'a T.
 ///
 /// For other cart types, clone `.backing_cart()` and re-use `.attach_to_cart()`; however, doing
@@ -811,14 +811,14 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
 impl<Y: for<'a> Yokeable<'a>, C: 'static + Sized> Yoke<Y, Rc<C>> {
     /// Allows type-erasing the cart in a `Yoke<Y, Rc<C>>`.
     ///
-    /// The yoke only carries around a cart type for its destructor,
+    /// The yoke only carries around a cart type `C` for its destructor,
     /// since it needs to be able to guarantee that its internal references
     /// are valid for the lifetime of the Yoke. As such, the actual type of the
     /// Cart is not very useful unless you wish to extract data out of it
     /// via [`Yoke::backing_cart()`]. Erasing the cart allows for one to mix
     /// [`Yoke`]s obtained from different sources.
     ///
-    /// In case the cart type is not already `Rc<T>`, you can use
+    /// In case the cart type `C` is not already an `Rc<T>`, you can use
     /// [`Yoke::wrap_cart_in_rc()`] to wrap it.
     ///
     /// # Example
@@ -856,14 +856,14 @@ impl<Y: for<'a> Yokeable<'a>, C: 'static + Sized> Yoke<Y, Rc<C>> {
 impl<Y: for<'a> Yokeable<'a>, C: 'static + Sized> Yoke<Y, Box<C>> {
     /// Allows type-erasing the cart in a `Yoke<Y, Box<C>>`.
     ///
-    /// The yoke only carries around a cart type for its destructor,
+    /// The yoke only carries around a cart type `C` for its destructor,
     /// since it needs to be able to guarantee that its internal references
     /// are valid for the lifetime of the Yoke. As such, the actual type of the
     /// Cart is not very useful unless you wish to extract data out of it
     /// via [`Yoke::backing_cart()`]. Erasing the cart allows for one to mix
     /// [`Yoke`]s obtained from different sources.
     ///
-    /// In case the cart type is not already `Box<T>`, you can use
+    /// In case the cart type `C` is not already `Box<T>`, you can use
     /// [`Yoke::wrap_cart_in_box()`] to wrap it.
     ///
     /// # Example
@@ -899,7 +899,7 @@ impl<Y: for<'a> Yokeable<'a>, C: 'static + Sized> Yoke<Y, Box<C>> {
 
 #[cfg(feature = "alloc")]
 impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
-    /// Helper function allowing one to wrap the cart type in a `Box<T>`.
+    /// Helper function allowing one to wrap the cart type `C` in a `Box<T>`.
     /// Can be paired with [`Yoke::erase_box_cart()`]
     ///
     /// Available with the `"alloc"` feature enabled.
@@ -910,7 +910,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
             self.replace_cart(Box::new)
         }
     }
-    /// Helper function allowing one to wrap the cart type in an `Rc<T>`.
+    /// Helper function allowing one to wrap the cart type `C` in an `Rc<T>`.
     /// Can be paired with [`Yoke::erase_rc_cart()`], or generally used
     /// to make the [`Yoke`] cloneable.
     ///
@@ -925,7 +925,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
 }
 
 impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
-    /// Helper function allowing one to wrap the cart type in an [`EitherCart`].
+    /// Helper function allowing one to wrap the cart type `C` in an [`EitherCart`].
     ///
     /// This function wraps the cart into the `A` variant. To wrap it into the
     /// `B` variant, use [`Self::wrap_cart_in_either_b()`].
@@ -938,7 +938,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
             self.replace_cart(EitherCart::A)
         }
     }
-    /// Helper function allowing one to wrap the cart type in an [`EitherCart`].
+    /// Helper function allowing one to wrap the cart type `C` in an [`EitherCart`].
     ///
     /// This function wraps the cart into the `B` variant. To wrap it into the
     /// `A` variant, use [`Self::wrap_cart_in_either_a()`].

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -29,7 +29,7 @@ all-features = true
 # TODO(1708): Rename this back to "serde"
 dep_serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"], package = "serde" }
 serde_json = { version = "1", optional = true, default-features = false, features = ["alloc"]}
-yoke = { version = "0.4.0", path = "../yoke", optional = true }
+yoke = { version = "0.4.1", path = "../yoke", optional = true }
 zerofrom = { version = "0.1.0", path = "../zerofrom" }
 zerovec-derive = {version = "0.6.0", path = "./derive", optional = true}
 
@@ -46,7 +46,7 @@ rand = "0.8"
 rand_pcg = "0.3"
 rand_distr = "0.4"
 getrandom = { version = "0.2", features = ["js"] }
-yoke = { version = "0.4.0", path = "../yoke", features = ["derive"] }
+yoke = { version = "0.4.1", path = "../yoke", features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../zerofrom", features = ["derive"] }
 
 [features]


### PR DESCRIPTION
Make it clearer what we mean by "cart", and also make sure the EitherCart functions don't show up before the normal yoke docs

Also contains:

 - yoke 0.4.1
 - yoke-derive 0.4.2


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->