### PR TITLE
Bump yoke to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bincode",
  "serde",
@@ -3202,7 +3202,7 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/experimental/casemapping/Cargo.toml
+++ b/experimental/casemapping/Cargo.toml
@@ -28,7 +28,7 @@ icu_codepointtrie = { version = "0.3", path = "../../utils/codepointtrie" }
 icu_locid = { version = "0.5", path = "../../components/locid" }
 icu_provider = { version = "0.5", path = "../../provider/core", features = ["macros"] }
 icu_uniset = { version = "0.4", path = "../../utils/uniset" }
-yoke = { path = "../../utils/yoke", version = "0.4", features = ["derive"] }
+yoke = { version = "0.5.0", path = "../../utils/yoke", features = ["derive"] }
 zerovec = { version = "0.6", path = "../../utils/zerovec", features = ["yoke"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 

--- a/experimental/segmenter_lstm/Cargo.toml
+++ b/experimental/segmenter_lstm/Cargo.toml
@@ -29,7 +29,7 @@ litemap = { version = "0.3.0", path = "../../utils/litemap", features = ["serde_
 serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
 ndarray = { version = "0.15", features = ["serde"] }
 unicode-segmentation = "1.3.0"
-yoke = { version = "0.4.1", path = "../../utils/yoke", features = ["serde", "derive"] }
+yoke = { version = "0.5.0", path = "../../utils/yoke", features = ["serde", "derive"] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/provider/blob/Cargo.toml
+++ b/provider/blob/Cargo.toml
@@ -33,7 +33,7 @@ serde = { version = "1.0", default-features = false, features = ["alloc"] }
 postcard = { version = "0.7.0", default-features = false }
 erased-serde = { version = "0.3", default-features = false, features = ["alloc"] }
 writeable = { version = "0.3", path = "../../utils/writeable" }
-yoke = { version = "0.4.1", path = "../../utils/yoke" }
+yoke = { version = "0.5.0", path = "../../utils/yoke" }
 zerovec = { version = "0.6", path = "../../utils/zerovec", features = ["serde", "yoke"] }
 
 # For the export feature

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -55,7 +55,7 @@ icu_locid = { version = "0.5", path = "../../components/locid" }
 tinystr = { path = "../../utils/tinystr", version = "0.5.0", features = ["alloc"], default-features = false }
 writeable = { version = "0.3", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
-yoke = { version = "0.4.1", path = "../../utils/yoke", features = ["serde", "derive"] }
+yoke = { version = "0.5.0", path = "../../utils/yoke", features = ["serde", "derive"] }
 zerofrom = { version = "0.1.0", path = "../../utils/zerofrom", features = ["derive"] }
 zerovec = { version = "0.6.0", path = "../../utils/zerovec" , features = ["derive"]}
 litemap = { version = "0.3.0", path = "../../utils/litemap" }

--- a/utils/codepointtrie/Cargo.toml
+++ b/utils/codepointtrie/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 displaydoc = { version = "0.2.3", default-features = false }
 icu_uniset = { version = "0.4.1", path = "../uniset" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
-yoke = { version = "0.4.1", path = "../yoke", features = ["derive"] }
+yoke = { version = "0.5.0", path = "../yoke", features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../zerofrom", features = ["derive"] }
 zerovec = { version = "0.6", path = "../zerovec", features = ["yoke"] }
 

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -30,7 +30,7 @@ all-features = true
 [dependencies]
 serde = {version = "1", optional = true, default-features = false, features = ["alloc"]}
 serde_json = { version = "1", optional = true, default-features = false, features = ["alloc"]}
-yoke = { version = "0.4.1", path = "../yoke", features = ["derive"], optional = true }
+yoke = { version = "0.5.0", path = "../yoke", features = ["derive"], optional = true }
 
 [dev-dependencies]
 serde = "1"

--- a/utils/uniset/Cargo.toml
+++ b/utils/uniset/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 tinystr = { path = "../tinystr", version = "0.5.0", features = ["alloc"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
-yoke = { version = "0.4.1", path = "../yoke", features = ["derive"] }
+yoke = { version = "0.5.0", path = "../yoke", features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../zerofrom", features = ["derive"] }
 zerovec = { version = "0.6", path = "../zerovec", features = ["yoke"] }
 

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "yoke"
-version = "0.4.1"
+version = "0.5.0"
 description = "Abstraction allowing borrowed data to be carried along with the backing data it borrows from"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2018"
@@ -32,7 +32,7 @@ all-features = true
 [dependencies]
 stable_deref_trait = { version = "1.2.0", features = ["alloc"], default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
-yoke-derive = { path = "./derive", version = "0.4.2", optional = true }
+yoke-derive = { path = "./derive", version = "0.5.0", optional = true }
 zerofrom = { path = "../zerofrom", version = "0.1.0", default-features = false, optional = true} 
 
 [dev-dependencies]

--- a/utils/yoke/derive/Cargo.toml
+++ b/utils/yoke/derive/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "yoke-derive"
-version = "0.4.2"
+version = "0.5.0"
 description = "Custom derive for the yoke crate"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "LICENSE"
@@ -26,5 +26,5 @@ syn = { version = "1.0.73", features = ["derive", "fold"] }
 synstructure = "0.12.4"
 
 [dev-dependencies]
-yoke = { version = "0.4.1", path = "..", features = ["derive"]}
+yoke = { version = "0.5.0", path = "..", features = ["derive"]}
 zerovec = { version = "0.6", path = "../../zerovec", features = ["yoke"] }

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -29,7 +29,7 @@ all-features = true
 # TODO(1708): Rename this back to "serde"
 dep_serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"], package = "serde" }
 serde_json = { version = "1", optional = true, default-features = false, features = ["alloc"]}
-yoke = { version = "0.4.1", path = "../yoke", optional = true }
+yoke = { version = "0.5.0", path = "../yoke", optional = true }
 zerofrom = { version = "0.1.0", path = "../zerofrom" }
 zerovec-derive = {version = "0.6.0", path = "./derive", optional = true}
 
@@ -46,7 +46,7 @@ rand = "0.8"
 rand_pcg = "0.3"
 rand_distr = "0.4"
 getrandom = { version = "0.2", features = ["js"] }
-yoke = { version = "0.4.1", path = "../yoke", features = ["derive"] }
+yoke = { version = "0.5.0", path = "../yoke", features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../zerofrom", features = ["derive"] }
 
 [features]


### PR DESCRIPTION
Should not have been 0.4.1, we removed ZeroCopyFrom and that's a breaking change

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->