### PR TITLE
Various ZeroVec derive improvements

### DIFF
--- a/utils/zerovec/README.md
+++ b/utils/zerovec/README.md
@@ -101,7 +101,7 @@ struct Date {
 
 // custom variable sized VarULE type for VarZeroVec
 #[zerovec::make_varule(PersonULE)]
-#[zerovec::serde]
+#[zerovec::derive(Serialize, Deserialize)] // add Serde impls to PersonULE
 #[derive(Clone, PartialEq, Eq, Ord, PartialOrd, serde::Serialize, serde::Deserialize)]
 struct Person<'a> {
     birthday: Date,

--- a/utils/zerovec/derive/examples/make.rs
+++ b/utils/zerovec/derive/examples/make.rs
@@ -44,13 +44,12 @@ enum OutOfOrderEnum {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd)]
 #[make_ule(NoKVULE)]
-#[zerovec::skip_kv]
+#[zerovec::skip_derive(ZeroMapKV)]
 struct NoKV(u8, char);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[make_ule(NoOrdULE)]
-#[zerovec::skip_ord]
-#[zerovec::skip_kv]
+#[zerovec::skip_derive(ZeroMapKV, Ord)]
 struct NoOrd(u8, char);
 
 fn test_zerovec<T: ule::AsULE + Debug + PartialEq>(slice: &[T]) {

--- a/utils/zerovec/derive/examples/make.rs
+++ b/utils/zerovec/derive/examples/make.rs
@@ -20,6 +20,7 @@ struct TupleStruct(u8, char);
 #[make_ule(EnumULE)]
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Debug)]
+#[zerovec::derive(Debug)]
 enum Enum {
     A = 0,
     B = 1,

--- a/utils/zerovec/derive/examples/make_var.rs
+++ b/utils/zerovec/derive/examples/make_var.rs
@@ -9,7 +9,7 @@ use zerovec::*;
 
 #[make_varule(VarStructULE)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
-#[zerovec::serde]
+#[zerovec::derive(Serialize, Deserialize)]
 struct VarStruct<'a> {
     a: u32,
     b: char,
@@ -19,7 +19,7 @@ struct VarStruct<'a> {
 
 #[make_varule(VarStructOutOfOrderULE)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
-#[zerovec::serde]
+#[zerovec::derive(Serialize, Deserialize)]
 struct VarStructOutOfOrder<'a> {
     a: u32,
     #[serde(borrow)]
@@ -30,25 +30,24 @@ struct VarStructOutOfOrder<'a> {
 
 #[make_varule(VarTupleStructULE)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
-#[zerovec::serde]
+#[zerovec::derive(Serialize, Deserialize)]
 struct VarTupleStruct<'a>(u32, char, #[serde(borrow)] VarZeroVec<'a, str>);
 
 #[make_varule(NoKVULE)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
-#[zerovec::skip_kv]
-#[zerovec::serde]
+#[zerovec::skip_derive(ZeroMapKV)]
+#[zerovec::derive(Serialize, Deserialize)]
 struct NoKV<'a>(u32, char, #[serde(borrow)] VarZeroVec<'a, str>);
 
 #[make_varule(NoOrdULE)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
-#[zerovec::skip_kv]
-#[zerovec::skip_ord]
-#[zerovec::serde]
+#[zerovec::skip_derive(ZeroMapKV, Ord)]
+#[zerovec::derive(Serialize, Deserialize)]
 struct NoOrd<'a>(u32, char, #[serde(borrow)] VarZeroVec<'a, str>);
 
 #[make_varule(MultiFieldStructULE)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
-#[zerovec::serde]
+#[zerovec::derive(Serialize, Deserialize)]
 struct MultiFieldStruct<'a> {
     a: u32,
     b: char,
@@ -62,7 +61,7 @@ struct MultiFieldStruct<'a> {
 
 #[make_varule(MultiFieldTupleULE)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
-#[zerovec::serde]
+#[zerovec::derive(Serialize, Deserialize)]
 struct MultiFieldTuple<'a>(
     u8,
     char,

--- a/utils/zerovec/derive/examples/make_var.rs
+++ b/utils/zerovec/derive/examples/make_var.rs
@@ -9,7 +9,7 @@ use zerovec::*;
 
 #[make_varule(VarStructULE)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
-#[zerovec::derive(Serialize, Deserialize)]
+#[zerovec::derive(Serialize, Deserialize, Debug)]
 struct VarStruct<'a> {
     a: u32,
     b: char,
@@ -19,7 +19,7 @@ struct VarStruct<'a> {
 
 #[make_varule(VarStructOutOfOrderULE)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
-#[zerovec::derive(Serialize, Deserialize)]
+#[zerovec::derive(Serialize, Deserialize, Debug)]
 struct VarStructOutOfOrder<'a> {
     a: u32,
     #[serde(borrow)]
@@ -30,24 +30,24 @@ struct VarStructOutOfOrder<'a> {
 
 #[make_varule(VarTupleStructULE)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
-#[zerovec::derive(Serialize, Deserialize)]
+#[zerovec::derive(Serialize, Deserialize, Debug)]
 struct VarTupleStruct<'a>(u32, char, #[serde(borrow)] VarZeroVec<'a, str>);
 
 #[make_varule(NoKVULE)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
 #[zerovec::skip_derive(ZeroMapKV)]
-#[zerovec::derive(Serialize, Deserialize)]
+#[zerovec::derive(Serialize, Deserialize, Debug)]
 struct NoKV<'a>(u32, char, #[serde(borrow)] VarZeroVec<'a, str>);
 
 #[make_varule(NoOrdULE)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
 #[zerovec::skip_derive(ZeroMapKV, Ord)]
-#[zerovec::derive(Serialize, Deserialize)]
+#[zerovec::derive(Serialize, Deserialize, Debug)]
 struct NoOrd<'a>(u32, char, #[serde(borrow)] VarZeroVec<'a, str>);
 
 #[make_varule(MultiFieldStructULE)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
-#[zerovec::derive(Serialize, Deserialize)]
+#[zerovec::derive(Serialize, Deserialize, Debug)]
 struct MultiFieldStruct<'a> {
     a: u32,
     b: char,
@@ -61,7 +61,7 @@ struct MultiFieldStruct<'a> {
 
 #[make_varule(MultiFieldTupleULE)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
-#[zerovec::derive(Serialize, Deserialize)]
+#[zerovec::derive(Serialize, Deserialize, Debug)]
 struct MultiFieldTuple<'a>(
     u8,
     char,

--- a/utils/zerovec/derive/src/make_ule.rs
+++ b/utils/zerovec/derive/src/make_ule.rs
@@ -65,10 +65,25 @@ pub fn make_ule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStream
         )
     };
 
+    let maybe_debug = if attrs.debug {
+        quote!(
+            impl core::fmt::Debug for #ule_name {
+                fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                    let this = <#name as zerovec::ule::AsULE>::from_unaligned(*self);
+                    <#name as core::fmt::Debug>::fmt(&this, f)
+                }
+            }
+        )
+    } else {
+        quote!()
+    };
+
     quote!(
         #input
 
         #ule_stuff
+
+        #maybe_debug
 
         #zmkv
     )

--- a/utils/zerovec/derive/src/make_ule.rs
+++ b/utils/zerovec/derive/src/make_ule.rs
@@ -164,6 +164,8 @@ fn make_ule_enum_impl(
 
     let vis = &input.vis;
 
+    let doc = format!("[`ULE`](zerovec::ule::ULE) type for {name}");
+
     // Safety (based on the safety checklist on the ULE trait):
     //  1. ULE type does not include any uninitialized or padding bytes.
     //     (achieved by `#[repr(transparent)]` on a type that satisfies this invariant
@@ -179,6 +181,7 @@ fn make_ule_enum_impl(
         #[repr(transparent)]
         #[derive(Copy, Clone, PartialEq, Eq)]
         #maybe_ord_derives
+        #[doc = #doc]
         #vis struct #ule_name(u8);
 
         unsafe impl zerovec::ule::ULE for #ule_name {
@@ -258,9 +261,12 @@ fn make_ule_struct_impl(
     let repr_attr = utils::repr_for(&struc.fields);
     let vis = &input.vis;
 
+    let doc = format!("[`ULE`](zerovec::ule::ULE) type for {name}");
+
     let ule_struct: DeriveInput = parse_quote!(
         #[repr(#repr_attr)]
         #[derive(Copy, Clone, PartialEq, Eq)]
+        #[doc = #doc]
         #vis struct #ule_name #field_inits #semi
     );
     let derived = crate::ule::derive_impl(&ule_struct);

--- a/utils/zerovec/derive/src/make_varule.rs
+++ b/utils/zerovec/derive/src/make_varule.rs
@@ -179,8 +179,9 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
         )
     };
 
-    let maybe_serde_impl = if attrs.serde {
-        let serde_path = quote!(zerovec::__zerovec_internal_reexport::serde);
+    let serde_path = quote!(zerovec::__zerovec_internal_reexport::serde);
+
+    let maybe_ser = if attrs.serialize {
         quote!(
             impl #serde_path::Serialize for #ule_name {
                 fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: #serde_path::Serializer {
@@ -188,6 +189,13 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
                     <#name as #serde_path::Serialize>::serialize(&this, serializer)
                 }
             }
+        )
+    } else {
+        quote!()
+    };
+
+    let maybe_de = if attrs.deserialize {
+        quote!(
             impl<'de> #serde_path::Deserialize<'de> for zerovec::__zerovec_internal_reexport::boxed::Box<#ule_name> {
                 fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: #serde_path::Deserializer<'de> {
                     let this = <#name as #serde_path::Deserialize>::deserialize(deserializer)?;
@@ -214,7 +222,9 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
 
         #zmkv
 
-        #maybe_serde_impl
+        #maybe_ser
+
+        #maybe_de
     )
 }
 

--- a/utils/zerovec/derive/src/make_varule.rs
+++ b/utils/zerovec/derive/src/make_varule.rs
@@ -24,11 +24,11 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
         .to_compile_error();
     }
 
-    let (skip_kv, skip_ord, serde) =
-        match utils::extract_attributes_common(&mut input.attrs, "make_ule") {
-            Ok(val) => val,
-            Err(e) => return e.to_compile_error(),
-        };
+    let sp = input.span();
+    let attrs = match utils::extract_attributes_common(&mut input.attrs, sp, true) {
+        Ok(val) => val,
+        Err(e) => return e.to_compile_error(),
+    };
 
     let lt = input.generics.lifetimes().next();
 
@@ -145,7 +145,7 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
     let zerofrom_fq_path =
         quote!(<#name as zerovec::__zerovec_internal_reexport::ZeroFrom<#ule_name>>);
 
-    let maybe_ord_impls = if skip_ord {
+    let maybe_ord_impls = if attrs.skip_ord {
         quote!()
     } else {
         quote!(
@@ -167,7 +167,7 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
         )
     };
 
-    let zmkv = if skip_kv {
+    let zmkv = if attrs.skip_kv {
         quote!()
     } else {
         quote!(
@@ -179,7 +179,7 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
         )
     };
 
-    let maybe_serde_impl = if serde {
+    let maybe_serde_impl = if attrs.serde {
         let serde_path = quote!(zerovec::__zerovec_internal_reexport::serde);
         quote!(
             impl #serde_path::Serialize for #ule_name {

--- a/utils/zerovec/derive/src/make_varule.rs
+++ b/utils/zerovec/derive/src/make_varule.rs
@@ -112,9 +112,11 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
     let field_inits = utils::wrap_field_inits(&field_inits, fields);
     let vis = &input.vis;
 
+    let doc = format!("[`VarULE`](zerovec::ule::VarULE) type for {name}");
     let varule_struct: DeriveInput = parse_quote!(
         #[repr(#repr_attr)]
         #[derive(PartialEq, Eq)]
+        #[doc = #doc]
         #vis struct #ule_name #field_inits #semi
     );
 

--- a/utils/zerovec/derive/src/make_varule.rs
+++ b/utils/zerovec/derive/src/make_varule.rs
@@ -167,6 +167,19 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
         )
     };
 
+    let maybe_debug = if attrs.debug {
+        quote!(
+            impl core::fmt::Debug for #ule_name {
+                fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                    let this = #zerofrom_fq_path::zero_from(self);
+                    <#name as core::fmt::Debug>::fmt(&this, f)
+                }
+            }
+        )
+    } else {
+        quote!()
+    };
+
     let zmkv = if attrs.skip_kv {
         quote!()
     } else {
@@ -225,6 +238,8 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
         #maybe_ser
 
         #maybe_de
+
+        #maybe_debug
     )
 }
 

--- a/utils/zerovec/derive/src/utils.rs
+++ b/utils/zerovec/derive/src/utils.rs
@@ -171,7 +171,10 @@ pub fn extract_parenthetical_zerovec_attrs(
                 let list = match parse2::<IdentListAttribute>(a.tokens.clone()) {
                     Ok(l) => l,
                     Err(_) => {
-                        error = Some(Error::new(a.span(), format!("#[zerovec::name(..)] takes in a comma separated list of identifiers")));
+                        error = Some(Error::new(
+                            a.span(),
+                            "#[zerovec::name(..)] takes in a comma separated list of identifiers",
+                        ));
                         return false;
                     }
                 };

--- a/utils/zerovec/derive/src/utils.rs
+++ b/utils/zerovec/derive/src/utils.rs
@@ -83,7 +83,7 @@ pub(crate) fn generate_per_field_offsets<'a>(
     mut per_field_code: impl FnMut(&FieldInfo<'a>, &Ident, &Ident) -> TokenStream2, // (code, remaining_offset)
 ) -> (TokenStream2, syn::Ident) {
     let mut prev_offset_ident = Ident::new("ZERO", Span::call_site());
-    let mut code = quote!(const ZERO: usize = 0);
+    let mut code = quote!(const ZERO: usize = 0;);
 
     for (i, field_info) in fields.iter().enumerate() {
         let field = &field_info.field;

--- a/utils/zerovec/derive/src/utils.rs
+++ b/utils/zerovec/derive/src/utils.rs
@@ -202,12 +202,13 @@ pub fn extract_zerovec_attributes(attrs: &mut Vec<Attribute>) -> Vec<Attribute> 
     ret
 }
 
-#[derive(Default)]
+#[derive(Default, Copy, Clone)]
 pub struct ZeroVecAttrs {
     pub skip_kv: bool,
     pub skip_ord: bool,
     pub serialize: bool,
     pub deserialize: bool,
+    pub debug: bool,
 }
 
 /// Removes all known zerovec:: attributes from attrs and validates them
@@ -237,6 +238,8 @@ pub fn extract_attributes_common(
             attrs.serialize = true;
         } else if ident == "Deserialize" {
             attrs.deserialize = true;
+        } else if ident == "Debug" {
+            attrs.debug = true;
         } else {
             return Err(Error::new(
                 ident.span(),

--- a/utils/zerovec/derive/src/utils.rs
+++ b/utils/zerovec/derive/src/utils.rs
@@ -17,23 +17,24 @@ pub fn has_valid_repr(attrs: &[Attribute], predicate: impl Fn(&Ident) -> bool + 
         .iter()
         .filter(|a| a.path.get_ident().map(|a| a == "repr").unwrap_or(false))
         .any(|a| {
-            parse2::<ReprAttribute>(a.tokens.clone())
+            parse2::<IdentListAttribute>(a.tokens.clone())
                 .ok()
-                .and_then(|s| s.reprs.iter().find(|s| predicate(s)).map(|_| ()))
+                .and_then(|s| s.idents.iter().find(|s| predicate(s)).map(|_| ()))
                 .is_some()
         })
 }
 
-struct ReprAttribute {
-    reprs: Punctuated<Ident, Token![,]>,
+// An attribute that is a list of idents
+struct IdentListAttribute {
+    idents: Punctuated<Ident, Token![,]>,
 }
 
-impl Parse for ReprAttribute {
+impl Parse for IdentListAttribute {
     fn parse(input: ParseStream) -> Result<Self> {
         let content;
         let _paren = parenthesized!(content in input);
-        Ok(ReprAttribute {
-            reprs: content.parse_terminated(Ident::parse)?,
+        Ok(IdentListAttribute {
+            idents: content.parse_terminated(Ident::parse)?,
         })
     }
 }
@@ -154,26 +155,38 @@ impl<'a> FieldInfo<'a> {
     }
 }
 
-/// Extracts a single `zerovec::name` attribute
-pub fn extract_zerovec_attribute_named(
+/// Extracts all `zerovec::name(..)` attribute
+pub fn extract_parenthetical_zerovec_attrs(
     attrs: &mut Vec<Attribute>,
     name: &str,
-) -> Option<Attribute> {
-    let mut ret = None;
+) -> Result<Vec<Ident>> {
+    let mut ret = vec![];
+    let mut error = None;
     attrs.retain(|a| {
         // skip the "zerovec" part
         let second_segment = a.path.segments.iter().nth(1);
 
         if let Some(second) = second_segment {
-            if second.ident == name && ret.is_none() {
-                ret = Some(a.clone());
+            if second.ident == name {
+                let list = match parse2::<IdentListAttribute>(a.tokens.clone()) {
+                    Ok(l) => l,
+                    Err(_) => {
+                        error = Some(Error::new(a.span(), format!("#[zerovec::name(..)] takes in a comma separated list of identifiers")));
+                        return false;
+                    }
+                };
+                ret.extend(list.idents.iter().cloned());
                 return false;
             }
         }
 
         true
     });
-    ret
+
+    if let Some(error) = error {
+        return Err(error);
+    }
+    Ok(ret)
 }
 
 /// Removes all attributes with `zerovec` in the name and places them in a separate vector
@@ -189,22 +202,12 @@ pub fn extract_zerovec_attributes(attrs: &mut Vec<Attribute>) -> Vec<Attribute> 
     ret
 }
 
-pub fn check_attr_empty(attr: &Option<Attribute>, name: &str) -> Result<()> {
-    if let Some(ref attr) = *attr {
-        if !attr.tokens.is_empty() {
-            return Err(Error::new(
-                attr.span(),
-                format!("#[zerovec::{name}] does not support arguments"),
-            ));
-        }
-    }
-    Ok(())
-}
-
+#[derive(Default)]
 pub struct ZeroVecAttrs {
     pub skip_kv: bool,
     pub skip_ord: bool,
-    pub serde: bool,
+    pub serialize: bool,
+    pub deserialize: bool,
 }
 
 /// Removes all known zerovec:: attributes from attrs and validates them
@@ -215,9 +218,8 @@ pub fn extract_attributes_common(
 ) -> Result<ZeroVecAttrs> {
     let mut zerovec_attrs = extract_zerovec_attributes(attrs);
 
-    let skip_kv = extract_zerovec_attribute_named(&mut zerovec_attrs, "skip_kv");
-    let skip_ord = extract_zerovec_attribute_named(&mut zerovec_attrs, "skip_ord");
-    let serde = extract_zerovec_attribute_named(&mut zerovec_attrs, "serde");
+    let derive = extract_parenthetical_zerovec_attrs(&mut zerovec_attrs, "derive")?;
+    let skip = extract_parenthetical_zerovec_attrs(&mut zerovec_attrs, "skip_derive")?;
 
     let name = if is_var { "make_varule" } else { "make_ule" };
 
@@ -228,24 +230,42 @@ pub fn extract_attributes_common(
         ));
     }
 
-    check_attr_empty(&skip_kv, "skip_kv")?;
-    check_attr_empty(&skip_ord, "skip_ord")?;
-    check_attr_empty(&serde, "serde")?;
+    let mut attrs = ZeroVecAttrs::default();
 
-    let skip_kv = skip_kv.is_some();
-    let skip_ord = skip_ord.is_some();
-    let serde = serde.is_some();
+    for ident in derive {
+        if ident == "Serialize" {
+            attrs.serialize = true;
+        } else if ident == "Deserialize" {
+            attrs.deserialize = true;
+        } else {
+            return Err(Error::new(
+                ident.span(),
+                format!(
+                    "Found unknown derive attribute for #[{name}]: #[zerovec::derive({ident})]"
+                ),
+            ));
+        }
+    }
 
-    if serde && !is_var {
+    for ident in skip {
+        if ident == "ZeroMapKV" {
+            attrs.skip_kv = true;
+        } else if ident == "Ord" {
+            attrs.skip_ord = true;
+        } else {
+            return Err(Error::new(
+                ident.span(),
+                format!("Found unknown derive attribute for #[{name}]: #[zerovec::skip_derive({ident})]"),
+            ));
+        }
+    }
+
+    if (attrs.serialize || attrs.deserialize) && !is_var {
         return Err(Error::new(
             span,
-            "#[make_ule] does not support #[zerovec::serde]",
+            "#[make_ule] does not support #[zerovec::derive(Serialize, Deserialize)]",
         ));
     }
 
-    Ok(ZeroVecAttrs {
-        skip_kv,
-        skip_ord,
-        serde,
-    })
+    Ok(attrs)
 }

--- a/utils/zerovec/derive/src/varule.rs
+++ b/utils/zerovec/derive/src/varule.rs
@@ -60,7 +60,7 @@ pub fn derive_impl(
     } else {
         // no ULE subfields
         (
-            quote!(const ZERO: usize = 0),
+            quote!(const ZERO: usize = 0;),
             Ident::new("ZERO", Span::call_site()),
         )
     };

--- a/utils/zerovec/derive/src/varule.rs
+++ b/utils/zerovec/derive/src/varule.rs
@@ -60,7 +60,9 @@ pub fn derive_impl(
     } else {
         // no ULE subfields
         (
-            quote!(const ZERO: usize = 0;),
+            quote!(
+                const ZERO: usize = 0;
+            ),
             Ident::new("ZERO", Span::call_site()),
         )
     };

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -306,16 +306,23 @@ pub mod vecs {
 ///
 /// The type must be [`Copy`], [`PartialEq`], and [`Eq`].
 ///
-/// Certain custom derives can be inherited to the [`ULE`] type with `#[zerovec::derive(...)]`. For example, if the type has a `Debug` impl,
-/// `#[zerovec::derive(Debug)]` will generate one for the generated [`ULE`] type. Currently `Debug` is the only trait supported here.
+/// `#[make_ule]` will automatically derive the following traits on the [`ULE`] type:
 ///
-/// By default this attribute will also autogenerate a [`ZeroMapKV`] implementation, which requires
-/// [`Ord`] and [`PartialOrd`] on `Self`. You can opt out of this with `#[zerovec::skip_derive(ZeroMapKV)]`.
+/// - [`Ord`] and [`PartialOrd`]
+/// - [`ZeroMapKV`]
 ///
-/// This implementation will also by default autogenerate [`Ord`] and [`PartialOrd`] on the [`ULE`] type based on
-/// the implementation on `Self`. You can opt out of this with `#[zerovec::skip_derive(Ord)]`
+/// To disable one of the automatic derives, use `#[zerovec::skip_derive(...)]` like so: `#[zerovec::skip_derive(ZeroMapKV)]`.
+/// `Ord` and `PartialOrd` are implemented as a unit and can only be disabled as a group with `#[zerovec::skip_derive(Ord)]`.
 ///
-/// For enums, this implementation will generate a crate-public `fn new_from_u8(value: u8) -> Option<Self>`
+/// The following traits are available to derive, but not automatic:
+///
+/// - [`Debug`]
+///
+/// To enable one of these additional derives, use `#[zerovec::derive(...)]` like so: `#[zerovec::derive(Debug)]`.
+///
+/// In most cases these derives will defer to the impl of the same trait on the current type, so such impls must exist.
+///
+/// For enums, this attribute will generate a crate-public `fn new_from_u8(value: u8) -> Option<Self>`
 /// method on the main type that allows one to construct the value from a u8. If this method is desired
 /// to be more public, it should be wrapped.
 ///
@@ -374,16 +381,23 @@ pub use zerovec_derive::make_ule;
 /// to convert the [`VarULE`] type back to this type in a cheap, zero-copy way (see the example below
 /// for more details).
 ///
-/// Certain custom derives can be inherited to the [`VarULE`] type with `#[zerovec::derive(...)]`. For example, if the type has a `Debug` impl,
-/// `#[zerovec::derive(Debug)]` will generate one for the generated [`VarULE`] type.
+/// `#[make_varule]` will automatically derive the following traits on the [`VarULE`] type:
 ///
-/// Similarly, `#[zerovec::derive(Serialize, Deserialize)]` will add the appropriate [`serde::Serialize`](dep_serde::Serialize)
-/// and [`serde::Deserialize`](dep_serde::Deserialize) impls for the generated [`VarULE`] type, provided the type
-/// itself has these traits implemented. Such impls are required to support human-readable serialization of the VarZeroVec.
-/// This needs the `serde`/`serde_serialize` features to be enabled on the `zerovec` crate to work.
+/// - [`Ord`] and [`PartialOrd`]
+/// - [`ZeroMapKV`]
 ///
-/// By default this attribute will also autogenerate a [`ZeroMapKV`] implementation, which requires
-/// [`Ord`] and [`PartialOrd`] on the [`VarULE`] type. You can opt out of this with `#[zerovec::skip_derive(ZeroMapKV)]`.
+/// To disable one of the automatic derives, use `#[zerovec::skip_derive(...)]` like so: `#[zerovec::skip_derive(ZeroMapKV)]`.
+/// `Ord` and `PartialOrd` are implemented as a unit and can only be disabled as a group with `#[zerovec::skip_derive(Ord)]`.
+///
+/// The following traits are available to derive, but not automatic:
+///
+/// - [`Debug`]
+/// - [`Serialize`](dep_serde::Serialize)
+/// - [`Deserialize`](dep_serde::Deserialize)
+///
+/// To enable one of these additional derives, use `#[zerovec::derive(...)]` like so: `#[zerovec::derive(Debug)]`.
+///
+/// In most cases these derives will defer to the impl of the same trait on the current type, so such impls must exist.
 ///
 /// This implementation will also by default autogenerate [`Ord`] and [`PartialOrd`] on the [`VarULE`] type based on
 /// the implementation on `Self`. You can opt out of this with `#[zerovec::skip_derive(Ord)]`

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -110,7 +110,7 @@
 //!
 //! // custom variable sized VarULE type for VarZeroVec
 //! #[zerovec::make_varule(PersonULE)]
-//! #[zerovec::serde]
+//! #[zerovec::derive(Serialize, Deserialize)] // add Serde impls to PersonULE
 //! #[derive(Clone, PartialEq, Eq, Ord, PartialOrd, serde::Serialize, serde::Deserialize)]
 //! # #[serde(crate = "dep_serde")]
 //! struct Person<'a> {
@@ -306,11 +306,14 @@ pub mod vecs {
 ///
 /// The type must be [`Copy`], [`PartialEq`], and [`Eq`].
 ///
+/// Certain custom derives can be inherited to the [`ULE`] type with `#[zerovec::derive(...)]`. For example, if the type has a `Debug` impl,
+/// `#[zerovec::derive(Debug)]` will generate one for the generated [`ULE`] type. Currently `Debug` is the only trait supported here.
+///
 /// By default this attribute will also autogenerate a [`ZeroMapKV`] implementation, which requires
-/// [`Ord`] and [`PartialOrd`] on `Self`. You can opt out of this with `#[zerovec::skip_kv]`.
+/// [`Ord`] and [`PartialOrd`] on `Self`. You can opt out of this with `#[zerovec::skip_derive(ZeroMapKV)]`.
 ///
 /// This implementation will also by default autogenerate [`Ord`] and [`PartialOrd`] on the [`ULE`] type based on
-/// the implementation on `Self`. You can opt out of this with `#[zerovec::skip_ord]`
+/// the implementation on `Self`. You can opt out of this with `#[zerovec::skip_derive(Ord)]`
 ///
 /// For enums, this implementation will generate a crate-public `fn new_from_u8(value: u8) -> Option<Self>`
 /// method on the main type that allows one to construct the value from a u8. If this method is desired
@@ -371,16 +374,19 @@ pub use zerovec_derive::make_ule;
 /// to convert the [`VarULE`] type back to this type in a cheap, zero-copy way (see the example below
 /// for more details).
 ///
-/// Provided the type implements [`serde::Serialize`](dep_serde::Serialize) and [`serde::Deserialize`](dep_serde::Deserialize), this attribute can also generate
-/// the relevant serialize/deserialize implementations for the [`VarULE`] type if you apply the `#[zerovec::serde]`
-/// attribute. Those impls are required to support human-readable serialization of the VarZeroVec.
+/// Certain custom derives can be inherited to the [`VarULE`] type with `#[zerovec::derive(...)]`. For example, if the type has a `Debug` impl,
+/// `#[zerovec::derive(Debug)]` will generate one for the generated [`VarULE`] type.
+///
+/// Similarly, `#[zerovec::derive(Serialize, Deserialize)]` will add the appropriate [`serde::Serialize`](dep_serde::Serialize)
+/// and [`serde::Deserialize`](dep_serde::Deserialize) impls for the generated [`VarULE`] type, provided the type
+/// itself has these traits implemented. Such impls are required to support human-readable serialization of the VarZeroVec.
 /// This needs the `serde`/`serde_serialize` features to be enabled on the `zerovec` crate to work.
 ///
 /// By default this attribute will also autogenerate a [`ZeroMapKV`] implementation, which requires
-/// [`Ord`] and [`PartialOrd`] on the [`VarULE`] type. You can opt out of this with `#[zerovec::skip_kv]`.
+/// [`Ord`] and [`PartialOrd`] on the [`VarULE`] type. You can opt out of this with `#[zerovec::skip_derive(ZeroMapKV)]`.
 ///
 /// This implementation will also by default autogenerate [`Ord`] and [`PartialOrd`] on the [`VarULE`] type based on
-/// the implementation on `Self`. You can opt out of this with `#[zerovec::skip_ord]`
+/// the implementation on `Self`. You can opt out of this with `#[zerovec::skip_derive(Ord)]`
 ///
 /// Note that this implementation will autogenerate [`EncodeAsVarULE`] impls for _both_ `Self` and `&Self`
 /// for convenience. This allows for a little more flexibility encoding slices.
@@ -412,7 +418,7 @@ pub use zerovec_derive::make_ule;
 ///
 /// // custom variable sized VarULE type for VarZeroVec
 /// #[zerovec::make_varule(PersonULE)]
-/// #[zerovec::serde]
+/// #[zerovec::derive(Serialize, Deserialize)]
 /// #[derive(Clone, PartialEq, Eq, Ord, PartialOrd, serde::Serialize, serde::Deserialize)]
 /// # #[serde(crate = "dep_serde")]
 /// struct Person<'a> {


### PR DESCRIPTION
This contains:

 - Fixing the parsing error @robertbastian was hitting
 - Switching `make_ule`/`make_varule` over to accepting `#[zerovec::derive(Serialize, Deserialize, ..)]` and `#[zerovec::skip_derive(ZeroMapKV, Ord)]`, allowing the list of supported traits to be extended in the future. It also feels cleaner.
 - Splitting `#[zerovec::serde]` into supporting individual enabling of ser/de impls
 - Adding `#[zeromap::derive(Debug)]`


I've been meaning to do most of this for a while but I noticed that https://github.com/unicode-org/icu4x/pull/1777 needed a bunch of this so I ended up quickly writing it out.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->