### PR TITLE
Update to latest stable Rust

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -818,9 +818,9 @@ jobs:
 
     - name: Install prerequisites for wasm build
       run: |
-        rustup component add rust-src
         rustup toolchain list
         rustup toolchain install nightly-2021-01-31
+        rustup component add rust-src --toolchain nightly-2021-01-31
 
     - name: Setup output data directory
       run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -154,10 +154,10 @@ jobs:
         rustup target add thumbv8m.main-none-eabihf --toolchain nightly-2022-01-31
         rustup target add x86_64-unknown-linux-gnu --toolchain nightly-2022-01-31
     - name: Set up Clang-13
-      uses: egor-tensin/setup-clang@v1
-      with:
-        version: 13
-        platform: x64
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 13
     - name: Get cargo-make version
       id: cargo-make-version
       run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -148,11 +148,11 @@ jobs:
       run: rustup show
     - name: Load cortex target for no_std build.
       run: |
-        rustup install nightly-2021-12-22
-        rustup component add --toolchain nightly-2021-12-22 rust-src
-        rustup target add thumbv7m-none-eabi --toolchain nightly-2021-12-22
-        rustup target add thumbv8m.main-none-eabihf --toolchain nightly-2021-12-22
-        rustup target add x86_64-unknown-linux-gnu --toolchain nightly-2021-12-22
+        rustup install nightly-2021-01-31
+        rustup component add --toolchain nightly-2021-01-31 rust-src
+        rustup target add thumbv7m-none-eabi --toolchain nightly-2021-01-31
+        rustup target add thumbv8m.main-none-eabihf --toolchain nightly-2021-01-31
+        rustup target add x86_64-unknown-linux-gnu --toolchain nightly-2021-01-31
     - name: Get cargo-make version
       id: cargo-make-version
       run: |
@@ -269,10 +269,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Load nightly Rust toolchain for WASM.
         run: |
-          rustup install nightly-2021-12-22
-          rustup target add wasm32-unknown-unknown --toolchain nightly-2021-12-22
-          rustup target add wasm32-unknown-emscripten --toolchain nightly-2021-12-22
-          rustup component add rust-src --toolchain nightly-2021-12-22
+          rustup install nightly-2021-01-31
+          rustup target add wasm32-unknown-unknown --toolchain nightly-2021-01-31
+          rustup target add wasm32-unknown-emscripten --toolchain nightly-2021-01-31
+          rustup component add rust-src --toolchain nightly-2021-01-31
 
       - name: Install npm dependencies from cache
         uses: actions/cache@v2
@@ -664,12 +664,12 @@ jobs:
       # then this line is no longer needed.
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-12-22
+          toolchain: nightly-2021-01-31
           override: true
 
       - name: Run the example with dhat-rs to collect memory information
         run: |
-          cargo run --package icu_benchmark_memory -- --os ${{ matrix.os }} ${{ matrix.examples }} --toolchain nightly-2021-12-22
+          cargo run --package icu_benchmark_memory -- --os ${{ matrix.os }} ${{ matrix.examples }} --toolchain nightly-2021-01-31
 
       # Benchmarking & dashboards job > (unmerged PR only) Convert benchmark output into
       # dashboard HTML in a commit of a branch of the local repo.
@@ -820,7 +820,7 @@ jobs:
       run: |
         rustup component add rust-src
         rustup toolchain list
-        rustup toolchain install nightly-2021-12-22
+        rustup toolchain install nightly-2021-01-31
 
     - name: Setup output data directory
       run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -827,7 +827,7 @@ jobs:
         mkdir -p benchmarks/binsize/${{ matrix.type }}
 
     - name: Build wasm executables
-      run: cargo make wasm-examples
+      run: cargo make -v wasm-examples
 
     - name: gzip wasm executables if requested
       if: ${{ matrix.type == 'gz' }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -148,11 +148,11 @@ jobs:
       run: rustup show
     - name: Load cortex target for no_std build.
       run: |
-        rustup install nightly-2021-01-31
-        rustup component add --toolchain nightly-2021-01-31 rust-src
-        rustup target add thumbv7m-none-eabi --toolchain nightly-2021-01-31
-        rustup target add thumbv8m.main-none-eabihf --toolchain nightly-2021-01-31
-        rustup target add x86_64-unknown-linux-gnu --toolchain nightly-2021-01-31
+        rustup install nightly-2022-01-31
+        rustup component add --toolchain nightly-2022-01-31 rust-src
+        rustup target add thumbv7m-none-eabi --toolchain nightly-2022-01-31
+        rustup target add thumbv8m.main-none-eabihf --toolchain nightly-2022-01-31
+        rustup target add x86_64-unknown-linux-gnu --toolchain nightly-2022-01-31
     - name: Get cargo-make version
       id: cargo-make-version
       run: |
@@ -269,10 +269,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Load nightly Rust toolchain for WASM.
         run: |
-          rustup install nightly-2021-01-31
-          rustup target add wasm32-unknown-unknown --toolchain nightly-2021-01-31
-          rustup target add wasm32-unknown-emscripten --toolchain nightly-2021-01-31
-          rustup component add rust-src --toolchain nightly-2021-01-31
+          rustup install nightly-2022-01-31
+          rustup target add wasm32-unknown-unknown --toolchain nightly-2022-01-31
+          rustup target add wasm32-unknown-emscripten --toolchain nightly-2022-01-31
+          rustup component add rust-src --toolchain nightly-2022-01-31
 
       - name: Install npm dependencies from cache
         uses: actions/cache@v2
@@ -664,12 +664,12 @@ jobs:
       # then this line is no longer needed.
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-01-31
+          toolchain: nightly-2022-01-31
           override: true
 
       - name: Run the example with dhat-rs to collect memory information
         run: |
-          cargo run --package icu_benchmark_memory -- --os ${{ matrix.os }} ${{ matrix.examples }} --toolchain nightly-2021-01-31
+          cargo run --package icu_benchmark_memory -- --os ${{ matrix.os }} ${{ matrix.examples }} --toolchain nightly-2022-01-31
 
       # Benchmarking & dashboards job > (unmerged PR only) Convert benchmark output into
       # dashboard HTML in a commit of a branch of the local repo.
@@ -819,15 +819,15 @@ jobs:
     - name: Install prerequisites for wasm build
       run: |
         rustup toolchain list
-        rustup toolchain install nightly-2021-01-31
-        rustup component add rust-src --toolchain nightly-2021-01-31
+        rustup toolchain install nightly-2022-01-31
+        rustup component add --toolchain nightly-2022-01-31 rust-src
 
     - name: Setup output data directory
       run: |
         mkdir -p benchmarks/binsize/${{ matrix.type }}
 
     - name: Build wasm executables
-      run: cargo make -v wasm-examples
+      run: cargo make wasm-examples
 
     - name: gzip wasm executables if requested
       if: ${{ matrix.type == 'gz' }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -153,6 +153,11 @@ jobs:
         rustup target add thumbv7m-none-eabi --toolchain nightly-2022-01-31
         rustup target add thumbv8m.main-none-eabihf --toolchain nightly-2022-01-31
         rustup target add x86_64-unknown-linux-gnu --toolchain nightly-2022-01-31
+    - name: Set up Clang-13
+      uses: egor-tensin/setup-clang@v1
+      with:
+        version: 13
+        platform: x64
     - name: Get cargo-make version
       id: cargo-make-version
       run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,16 +60,16 @@ Our wider testsuite is organized as `ci-job-foo` make tasks corresponding to eac
  - `cargo make ci-job-test`: Runs `cargo test` on all the crates. This takes a while but is the main way of ensuring that nothing has been broken.
  - `cargo make ci-job-clippy`: Runs `cargo clippy` on all the crates.
  - `cargo make ci-job-ffi`: Runs all of the FFI tests; mostly important if you're changing the FFI interface. This has several additional dependencies:
-     + Rust toolchain `nightly-2021-12-22`: `rustup install nightly-2021-12-22`
-         * `rust-src` for that toolchain: `rustup component add --toolchain nightly-2021-12-22 rust-src`
-         * Various targets for that toolchain: `rustup target add thumbv7m-none-eabi --toolchain nightly-2021-12-22`, `rustup target add thumbv8m.main-none-eabihf --toolchain nightly-2021-12-22`, `rustup target add x86_64-unknown-linux-gnu --toolchain nightly-2021-12-22`
+     + Rust toolchain `nightly-2022-01-31`: `rustup install nightly-2022-01-31`
+         * `rust-src` for that toolchain: `rustup component add --toolchain nightly-2022-01-31 rust-src`
+         * Various targets for that toolchain: `rustup target add thumbv7m-none-eabi --toolchain nightly-2022-01-31`, `rustup target add thumbv8m.main-none-eabihf --toolchain nightly-2022-01-31`, `rustup target add x86_64-unknown-linux-gnu --toolchain nightly-2022-01-31`
      + [`Diplomat`](https://github.com/rust-diplomat/diplomat) installed at the appropriate version: `cargo make diplomat-install`
      + [`Sphinx`](https://www.sphinx-doc.org/en/master/) on Python3: `pip3 install sphinx sphinx-rtd-theme`
  - `cargo make ci-job-wasm`: Runs WASM tests; mostly important if you're changing the FFI interface. This also has a couple additional dependencies:
      + Node.js version 14. This is typically not the one offered by the package manager; get it from the NodeJS website or `nvm`.
-     + Rust toolchain `nightly-2021-12-22`: `rustup install nightly-2021-12-22`
-         * `rust-src` for that toolchain: `rustup component add --toolchain nightly-2021-12-22 rust-src`
-         * Various WASM targets for that toolchain: `rustup target add wasm32-unknown-unknown --toolchain nightly-2021-12-22`, `rustup target add wasm32-unknown-emscripten --toolchain nightly-2021-12-22`
+     + Rust toolchain `nightly-2022-01-31`: `rustup install nightly-2022-01-31`
+         * `rust-src` for that toolchain: `rustup component add --toolchain nightly-2022-01-31 rust-src`
+         * Various WASM targets for that toolchain: `rustup target add wasm32-unknown-unknown --toolchain nightly-2022-01-31`, `rustup target add wasm32-unknown-emscripten --toolchain nightly-2022-01-31`
      + [`Twiggy`](https://github.com/rustwasm/twiggy) (at least 0.7.0: `cargo install twiggy`
      + [`emsdk`](https://github.com/emscripten-core/emsdk): Make sure to `./emsdk activate latest` it into your shell
  - `cargo make ci-job-features`: This is a pretty slow test that tries to build all ICU4X crates with all feature combinations. It has an additional dependency:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ Our wider testsuite is organized as `ci-job-foo` make tasks corresponding to eac
          * `rust-src` for that toolchain: `rustup component add --toolchain nightly-2022-01-31 rust-src`
          * Various targets for that toolchain: `rustup target add thumbv7m-none-eabi --toolchain nightly-2022-01-31`, `rustup target add thumbv8m.main-none-eabihf --toolchain nightly-2022-01-31`, `rustup target add x86_64-unknown-linux-gnu --toolchain nightly-2022-01-31`
      + [`Diplomat`](https://github.com/rust-diplomat/diplomat) installed at the appropriate version: `cargo make diplomat-install`
+     + `clang-13` and `lld-13` with the `gold` plugin (APT package `llvm-13`)
      + [`Sphinx`](https://www.sphinx-doc.org/en/master/) on Python3: `pip3 install sphinx sphinx-rtd-theme`
  - `cargo make ci-job-wasm`: Runs WASM tests; mostly important if you're changing the FFI interface. This also has a couple additional dependencies:
      + Node.js version 14. This is typically not the one offered by the package manager; get it from the NodeJS website or `nvm`.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [tasks.check-no-features]
-description = "Check ICU4X build with no features (covered in CI via cargo build-all-features)"
+description = "Check ICU4X build with no features (covered in CI via cargo check-all-features)"
 category = "ICU4X Development"
 command = "cargo"
 args = ["check", "--all-targets", "--no-default-features"]
@@ -69,7 +69,7 @@ dependencies = [
 description = "Run all tests for the CI 'features' job"
 category = "CI"
 dependencies = [
-    "build-all-features",
+    "check-all-features",
 ]
 
 [tasks.ci-job-fmt]

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -307,11 +307,10 @@ impl FromStr for GmtOffset {
     /// let offset3: GmtOffset = "-09:30".parse().expect("Failed to parse a GMT offset.");
     /// ```
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        let offset_sign;
-        match input.chars().next() {
-            Some('+') => offset_sign = 1,
-            /* ASCII  */ Some('-') => offset_sign = -1,
-            /* U+2212 */ Some('−') => offset_sign = -1,
+        let offset_sign = match input.chars().next() {
+            Some('+') => 1,
+            /* ASCII  */ Some('-') => -1,
+            /* U+2212 */ Some('−') => -1,
             Some('Z') => return Ok(Self(0)),
             _ => return Err(DateTimeError::InvalidTimeZoneOffset),
         };

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -235,7 +235,8 @@ impl TryFrom<char> for FieldSymbol {
         .or_else(|_| Day::try_from(ch).map(Self::Day))
         .or_else(|_| Weekday::try_from(ch).map(Self::Weekday))
         .or_else(|_| DayPeriod::try_from(ch).map(Self::DayPeriod))
-        .or_else(|_| Hour::try_from(ch).map(Self::Hour)).or({
+        .or_else(|_| Hour::try_from(ch).map(Self::Hour))
+        .or({
             if ch == 'm' {
                 Ok(Self::Minute)
             } else {

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -235,8 +235,7 @@ impl TryFrom<char> for FieldSymbol {
         .or_else(|_| Day::try_from(ch).map(Self::Day))
         .or_else(|_| Weekday::try_from(ch).map(Self::Weekday))
         .or_else(|_| DayPeriod::try_from(ch).map(Self::DayPeriod))
-        .or_else(|_| Hour::try_from(ch).map(Self::Hour))
-        .or_else(|_| {
+        .or_else(|_| Hour::try_from(ch).map(Self::Hour)).or({
             if ch == 'm' {
                 Ok(Self::Minute)
             } else {

--- a/components/datetime/src/provider/date_time.rs
+++ b/components/datetime/src/provider/date_time.rs
@@ -271,9 +271,9 @@ impl<'data> DateTimeSymbols for provider::calendar::DateSymbolsV1<'data> {
                     let symbols = match length {
                         fields::FieldLength::Wide => widths.wide.as_ref(),
                         fields::FieldLength::Narrow => widths.narrow.as_ref(),
-                        fields::FieldLength::Six => widths
-                            .short
-                            .as_ref().or(widths.abbreviated.as_ref()),
+                        fields::FieldLength::Six => {
+                            widths.short.as_ref().or(widths.abbreviated.as_ref())
+                        }
                         _ => widths.abbreviated.as_ref(),
                     };
                     if let Some(symbols) = symbols {

--- a/components/datetime/src/provider/date_time.rs
+++ b/components/datetime/src/provider/date_time.rs
@@ -273,8 +273,7 @@ impl<'data> DateTimeSymbols for provider::calendar::DateSymbolsV1<'data> {
                         fields::FieldLength::Narrow => widths.narrow.as_ref(),
                         fields::FieldLength::Six => widths
                             .short
-                            .as_ref()
-                            .or_else(|| widths.abbreviated.as_ref()),
+                            .as_ref().or(widths.abbreviated.as_ref()),
                         _ => widths.abbreviated.as_ref(),
                     };
                     if let Some(symbols) = symbols {

--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -148,7 +148,8 @@ impl TimeZoneFormat {
         let zone_symbols = patterns
             .get()
             .0
-            .patterns_iter().flat_map(|pattern| pattern.items.iter())
+            .patterns_iter()
+            .flat_map(|pattern| pattern.items.iter())
             .filter_map(|item| match item {
                 PatternItem::Field(field) => Some(field),
                 _ => None,

--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -148,9 +148,7 @@ impl TimeZoneFormat {
         let zone_symbols = patterns
             .get()
             .0
-            .patterns_iter()
-            .map(|pattern| pattern.items.iter())
-            .flatten()
+            .patterns_iter().flat_map(|pattern| pattern.items.iter())
             .filter_map(|item| match item {
                 PatternItem::Field(field) => Some(field),
                 _ => None,
@@ -1106,7 +1104,7 @@ impl FormatTimeZone for LocalizedGmtFormat {
                     )
                     .replace("mm", &TimeZoneFormat::format_offset_minutes(time_zone))
                     .replace(
-                        "H",
+                        'H',
                         &TimeZoneFormat::format_offset_hours(time_zone, ZeroPadding::Off),
                     ),
             ))

--- a/components/datetime/tests/pattern_serialization.rs
+++ b/components/datetime/tests/pattern_serialization.rs
@@ -20,7 +20,7 @@ struct PatternFixtures {
 }
 
 fn get_pattern_fixtures() -> PatternFixtures {
-    let file = File::open("./tests/fixtures/tests/patterns.json".to_string())
+    let file = File::open("./tests/fixtures/tests/patterns.json")
         .expect("Unable to open ./tests/fixtures/tests/patterns.json");
     let reader = BufReader::new(file);
     serde_json::from_reader(reader).expect("Unable to deserialize pattern fixtures.")

--- a/components/datetime/tests/skeleton_serialization.rs
+++ b/components/datetime/tests/skeleton_serialization.rs
@@ -16,7 +16,7 @@ struct SkeletonFixtures {
 }
 
 fn get_skeleton_fixtures() -> Vec<String> {
-    let file = File::open("./tests/fixtures/tests/skeletons.json".to_string())
+    let file = File::open("./tests/fixtures/tests/skeletons.json")
         .expect("Unable to open ./tests/fixtures/tests/skeletons.json");
     let reader = BufReader::new(file);
     let fixtures: SkeletonFixtures =

--- a/components/locid/src/parser/langid.rs
+++ b/components/locid/src/parser/langid.rs
@@ -26,16 +26,15 @@ pub fn parse_language_identifier_from_iter(
     iter: &mut SubtagIterator,
     mode: ParserMode,
 ) -> Result<LanguageIdentifier, ParserError> {
-    let language;
     let mut script = None;
     let mut region = None;
     let mut variants = Vec::new();
 
-    if let Some(subtag) = iter.next() {
-        language = subtags::Language::from_bytes(subtag)?;
+    let language = if let Some(subtag) = iter.next() {
+        subtags::Language::from_bytes(subtag)?
     } else {
         return Err(ParserError::InvalidLanguage);
-    }
+    };
 
     let mut position = ParserPosition::Script;
 

--- a/experimental/segmenter/src/line.rs
+++ b/experimental/segmenter/src/line.rs
@@ -443,7 +443,7 @@ impl<'l, 's, Y: LineBreakType<'l, 's>> Iterator for LineBreakIterator<'l, 's, Y>
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.is_eof() {
+        if self.check_eof() {
             return None;
         }
 
@@ -582,7 +582,7 @@ impl<'l, 's, Y: LineBreakType<'l, 's>> Iterator for LineBreakIterator<'l, 's, Y>
 
 impl<'l, 's, Y: LineBreakType<'l, 's>> LineBreakIterator<'l, 's, Y> {
     #[inline]
-    fn is_eof(&mut self) -> bool {
+    fn check_eof(&mut self) -> bool {
         if self.current_pos_data.is_none() {
             self.current_pos_data = self.iter.next();
             if self.current_pos_data.is_none() {

--- a/ffi/diplomat/c/examples/fixeddecimal_tiny/Makefile
+++ b/ffi/diplomat/c/examples/fixeddecimal_tiny/Makefile
@@ -13,8 +13,8 @@ $(ALL_RUST):
 $(ALL_HEADERS):
 
 GCC := gcc
-CLANG := clang-12
-LLD := lld-12
+CLANG := clang-13
+LLD := lld-13
 
 
 ../../../../../target/debug/libicu_capi_staticlib.a: $(ALL_RUST)

--- a/ffi/diplomat/c/examples/fixeddecimal_tiny/Makefile
+++ b/ffi/diplomat/c/examples/fixeddecimal_tiny/Makefile
@@ -21,10 +21,10 @@ LLD := lld-12
 	cargo build -p icu_capi_staticlib
 
 ../../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi_staticlib.a: $(ALL_RUST)
-	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" cargo +nightly-2021-12-22 panic-abort-build -p icu_capi_staticlib --target x86_64-unknown-linux-gnu --no-default-features --features x86tiny
+	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" cargo +nightly-2022-01-31 panic-abort-build -p icu_capi_staticlib --target x86_64-unknown-linux-gnu --no-default-features --features x86tiny
 
 ../../../../../target/x86_64-unknown-linux-gnu/release/libicu_capi_staticlib.a: $(ALL_RUST)
-	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" cargo +nightly-2021-12-22 panic-abort-build -p icu_capi_staticlib --target x86_64-unknown-linux-gnu --no-default-features --features x86tiny --features smaller_static --release
+	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" cargo +nightly-2022-01-31 panic-abort-build -p icu_capi_staticlib --target x86_64-unknown-linux-gnu --no-default-features --features x86tiny --features smaller_static --release
 
 # Naive target: no optimizations, full std
 optim0.elf: ../../../../../target/debug/libicu_capi_staticlib.a $(ALL_HEADERS) test.c

--- a/ffi/diplomat/c/examples/fixeddecimal_tiny/README.md
+++ b/ffi/diplomat/c/examples/fixeddecimal_tiny/README.md
@@ -9,7 +9,7 @@ https://github.com/rust-lang/rust/issues/60059
 You also need to install the correct toolchains:
 
 ```bash
-$ rustup install nightly-2021-12-22
-$ rustup component add --toolchain nightly-2021-12-22 rust-src
-$ rustup target add x86_64-unknown-linux-gnu --toolchain nightly-2021-12-22
+$ rustup install nightly-2022-01-31
+$ rustup component add --toolchain nightly-2022-01-31 rust-src
+$ rustup target add x86_64-unknown-linux-gnu --toolchain nightly-2022-01-31
 ```

--- a/ffi/diplomat/cpp/examples/fixeddecimal_wasm/Makefile
+++ b/ffi/diplomat/cpp/examples/fixeddecimal_wasm/Makefile
@@ -22,7 +22,7 @@ a.out: ../../../../../target/debug/libicu_capi_staticlib.a $(ALL_HEADERS) test.c
 	$(CXX) -std=c++17 test.cpp ../../../../../target/debug/libicu_capi_staticlib.a -ldl -lpthread -lm -g
 
 ../../../../../target/wasm32-unknown-emscripten/release/libicu_capi_staticlib.a: $(ALL_RUST)
-	RUSTFLAGS="-Cpanic=abort" cargo +nightly-2021-12-22 build --release -p icu_capi_staticlib --target wasm32-unknown-emscripten -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
+	RUSTFLAGS="-Cpanic=abort" cargo +nightly-2022-01-31 build --release -p icu_capi_staticlib --target wasm32-unknown-emscripten -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 
 web-version.html: ../../../../../target/wasm32-unknown-emscripten/release/libicu_capi_staticlib.a $(ALL_HEADERS) test.cpp
 	$(EMCC) -std=c++17 test.cpp ../../../../../target/wasm32-unknown-emscripten/release/libicu_capi_staticlib.a -ldl -lpthread -lm -g  -o web-version.html --bind --emrun -sENVIRONMENT=web -sWASM=1 -sEXPORT_ES6=1 -sMODULARIZE=1

--- a/provider/datagen/src/cldr/transform/decimal/decimal_pattern.rs
+++ b/provider/datagen/src/cldr/transform/decimal/decimal_pattern.rs
@@ -49,7 +49,8 @@ impl FromStr for DecimalSubPattern {
         };
         #[allow(clippy::indexing_slicing)] // TODO(#1668) Clippy exceptions need docs or fixing.
         let j = subpattern[i..]
-            .find(|c: char| !matches!(c, '#' | '0' | ',' | '.')).unwrap_or(subpattern.len() - i)
+            .find(|c: char| !matches!(c, '#' | '0' | ',' | '.'))
+            .unwrap_or(subpattern.len() - i)
             + i;
         #[allow(clippy::indexing_slicing)] // TODO(#1668) Clippy exceptions need docs or fixing.
         let prefix = &subpattern[..i];

--- a/provider/datagen/src/cldr/transform/decimal/decimal_pattern.rs
+++ b/provider/datagen/src/cldr/transform/decimal/decimal_pattern.rs
@@ -49,8 +49,7 @@ impl FromStr for DecimalSubPattern {
         };
         #[allow(clippy::indexing_slicing)] // TODO(#1668) Clippy exceptions need docs or fixing.
         let j = subpattern[i..]
-            .find(|c: char| !matches!(c, '#' | '0' | ',' | '.'))
-            .unwrap_or_else(|| subpattern.len() - i)
+            .find(|c: char| !matches!(c, '#' | '0' | ',' | '.')).unwrap_or(subpattern.len() - i)
             + i;
         #[allow(clippy::indexing_slicing)] // TODO(#1668) Clippy exceptions need docs or fixing.
         let prefix = &subpattern[..i];
@@ -112,8 +111,8 @@ impl DecimalPattern {
             .map(|subpattern| (subpattern.prefix.as_str(), subpattern.suffix.as_str()))
             .unwrap_or_else(|| ("-", ""));
         AffixesV1 {
-            prefix: Cow::Owned(signed_affixes.0.replace("-", sign_str)),
-            suffix: Cow::Owned(signed_affixes.1.replace("-", sign_str)),
+            prefix: Cow::Owned(signed_affixes.0.replace('-', sign_str)),
+            suffix: Cow::Owned(signed_affixes.1.replace('-', sign_str)),
         }
     }
 }

--- a/provider/datagen/src/segmenter/transform.rs
+++ b/provider/datagen/src/segmenter/transform.rs
@@ -347,13 +347,12 @@ impl SegmenterRuleProvider {
         simple_properties_count += 1;
 
         for p in &segmenter.tables {
-            let property_index;
-            if !properties_names.contains(&p.name) {
+            let property_index = if !properties_names.contains(&p.name) {
                 properties_names.push(p.name.clone());
-                property_index = (properties_names.len() - 1) as u8;
+                (properties_names.len() - 1) as u8
             } else {
                 continue;
-            }
+            };
 
             if p.left.is_none() && p.right.is_none() && p.codepoint.is_none() {
                 // If any values aren't set, this is builtin type.
@@ -527,12 +526,11 @@ impl SegmenterRuleProvider {
         let mut break_state_table = vec![UNKNOWN_RULE; rule_size];
 
         for rule in &segmenter.rules {
-            let break_state;
-            if let Some(state) = rule.break_state {
-                break_state = if state { BREAK_RULE } else { KEEP_RULE };
+            let break_state = if let Some(state) = rule.break_state {
+                if state { BREAK_RULE } else { KEEP_RULE }
             } else {
-                break_state = NOT_MATCH_RULE;
-            }
+                NOT_MATCH_RULE
+            };
 
             for l in &rule.left {
                 if l == "Any" {

--- a/provider/datagen/src/segmenter/transform.rs
+++ b/provider/datagen/src/segmenter/transform.rs
@@ -527,7 +527,11 @@ impl SegmenterRuleProvider {
 
         for rule in &segmenter.rules {
             let break_state = if let Some(state) = rule.break_state {
-                if state { BREAK_RULE } else { KEEP_RULE }
+                if state {
+                    BREAK_RULE
+                } else {
+                    KEEP_RULE
+                }
             } else {
                 NOT_MATCH_RULE
             };

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
 # Version updated on 2022-01-14
-channel = "1.58"
+channel = "1.60"

--- a/tools/benchmark/memory/src/main.rs
+++ b/tools/benchmark/memory/src/main.rs
@@ -74,7 +74,7 @@ fn process_cli_args() -> ProcessedArgs {
 
         toolchain: matches
             .value_of("TOOLCHAIN")
-            .unwrap_or("nightly-2021-12-22")
+            .unwrap_or("nightly-2022-01-31")
             .to_string(),
     }
 }

--- a/tools/benchmark/memory/src/main.rs
+++ b/tools/benchmark/memory/src/main.rs
@@ -103,7 +103,7 @@ fn extract_bytes_from_log_line(preamble: &str, text: &str) -> u64 {
         .get(start..end)
         .expect("Unable to get a substring.")
         .trim()
-        .replace(",", "")
+        .replace(',', "")
         .parse::<u64>()
         .expect("Unable to parse the byte amount");
 }

--- a/tools/scripts/ffi.toml
+++ b/tools/scripts/ffi.toml
@@ -140,7 +140,7 @@ exec --fail-on-error diplomat-tool cpp ./cpp/include --docs ./cpp/docs/source
 [tasks.build-wearos-ffi]
 description = "Build ICU4X CAPI for Cortex"
 category = "ICU4X FFI"
-toolchain = "nightly-2021-12-22"
+toolchain = "nightly-2022-01-31"
 env = { "RUSTFLAGS" = "-Ctarget-cpu=cortex-m33 -Cpanic=abort" }
 command = "cargo"
 args = ["build", "--package", "icu_freertos",
@@ -152,7 +152,7 @@ args = ["build", "--package", "icu_freertos",
 [tasks.test-nostd]
 description = "Ensure ICU4X core builds on no-std"
 category = "ICU4X FFI"
-toolchain = "nightly-2021-12-22"
+toolchain = "nightly-2022-01-31"
 command = "cargo"
 args = ["build", "--package", "icu", "--target", "thumbv7m-none-eabi"]
 

--- a/tools/scripts/tests.toml
+++ b/tools/scripts/tests.toml
@@ -4,6 +4,14 @@
 
 # This is a cargo-make file included in the toplevel Makefile.toml
 
+[tasks.check-all-features]
+description = "Build all permutations of all features"
+category = "ICU4X Development"
+install_crate = { crate_name = "cargo-all-features", binary = "cargo-check-all-features", test_arg = ["--help"] }
+install_crate_args = ["--version", "^1.4"]
+command = "cargo"
+args = ["check-all-features"]
+
 [tasks.build-all-features]
 description = "Build all permutations of all features"
 category = "ICU4X Development"

--- a/tools/scripts/valgrind.toml
+++ b/tools/scripts/valgrind.toml
@@ -8,7 +8,7 @@
 description = "Pre-build artifacts for use with the Valgrind task"
 category = "ICU4X Valgrind"
 command = "cargo"
-toolchain = "nightly-2021-12-22"
+toolchain = "nightly-2022-01-31"
 # Add features here and below if a desired example is not being built
 args = [
     "build", "--examples",
@@ -34,7 +34,7 @@ mkdir benchmarks
 mkdir benchmarks/valgrind
 
 # Re-run the build command only to generate the JSON output (--message-format=json)
-output = exec cargo +nightly-2021-12-22 build --examples --message-format=json --features icu_benchmark_macros/rust_global_allocator --features zerovec/serde --profile bench -Z unstable-options
+output = exec cargo +nightly-2022-01-31 build --examples --message-format=json --features icu_benchmark_macros/rust_global_allocator --features zerovec/serde --profile bench -Z unstable-options
 if ${output.code}
     trigger_error "Build failed! To debug, build examples with `--features icu_benchmark_macros/rust_global_allocator`"
 end

--- a/tools/scripts/wasm.toml
+++ b/tools/scripts/wasm.toml
@@ -8,7 +8,7 @@
 description = "Build WASM FFI into the target directory (dev mode)"
 category = "ICU4X WASM"
 install_crate = { rustup_component_name = "rust-src" }
-toolchain = "nightly-2021-12-22"
+toolchain = "nightly-2022-01-31"
 command = "cargo"
 args = ["wasm-build-dev", "--package", "icu_capi_cdylib"]
 
@@ -16,7 +16,7 @@ args = ["wasm-build-dev", "--package", "icu_capi_cdylib"]
 description = "Build WASM FFI into the target directory (release mode)"
 category = "ICU4X WASM"
 install_crate = { rustup_component_name = "rust-src" }
-toolchain = "nightly-2021-12-22"
+toolchain = "nightly-2022-01-31"
 # We don't care about panics in release mode because most incorrect inputs are handled by result types.
 env = { "RUSTFLAGS" = "-C panic=abort -C opt-level=s" }
 command = "cargo"
@@ -26,7 +26,7 @@ args = ["wasm-build-release", "--package", "icu_capi_cdylib"]
 description = "Build WASM examples into the target directory"
 category = "ICU4X WASM"
 install_crate = { rustup_component_name = "rust-src" }
-toolchain = "nightly-2021-12-22"
+toolchain = "nightly-2022-01-31"
 # We don't care about panics in release mode because most incorrect inputs are handled by result types.
 env = { "RUSTFLAGS" = "-C panic=abort -C opt-level=s" }
 command = "cargo"
@@ -77,7 +77,7 @@ exit_on_error true
 
 # Re-run the build command only to generate the JSON output (--message-format=json)
 set_env RUSTFLAGS "-C panic=abort -C opt-level=s"
-output = exec cargo +nightly-2021-12-22 wasm-build-release --message-format=json --examples --workspace --features zerovec/serde --exclude icu_datagen
+output = exec cargo +nightly-2022-01-31 wasm-build-release --message-format=json --examples --workspace --features zerovec/serde --exclude icu_datagen
 if ${output.code}
     echo ${output.stderr}
     trigger_error "Build failed! See output above."

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -362,8 +362,8 @@ where
     where
         T: Ord,
     {
-        if !self.is_empty() {
-            let mut prev = self.get(0).unwrap();
+        if let Some(first) = self.get(0) {
+            let mut prev = first;
             for element in self.iter().skip(1) {
                 if element.cmp(prev) != Ordering::Greater {
                     return false;
@@ -430,8 +430,8 @@ where
     where
         T: Ord,
     {
-        if !self.is_empty() {
-            let mut prev = self.get(0).unwrap();
+        if let Some(first) = self.get(0) {
+            let mut prev = first;
             for element in self.iter().skip(1) {
                 if element.cmp(prev) != Ordering::Greater {
                     return false;

--- a/utils/zerovec/src/map2d/map.rs
+++ b/utils/zerovec/src/map2d/map.rs
@@ -476,9 +476,11 @@ where
             0
         } else {
             // The unwrap is protected by the debug_assert above
+            #[allow(clippy::unwrap_used)]
             self.joiner.get(key0_index - 1).unwrap()
         };
         // The unwrap is protected by the debug_assert above
+        #[allow(clippy::unwrap_used)]
         let limit = self.joiner.get(key0_index).unwrap();
         (start as usize)..(limit as usize)
     }
@@ -494,6 +496,7 @@ where
                 } else {
                     debug_assert!(key0_index <= self.joiner.len());
                     // The unwrap is protected by the debug_assert above and key0_index != 0
+                    #[allow(clippy::unwrap_used)]
                     self.joiner.get(key0_index - 1).unwrap()
                 };
                 self.keys0.zvl_insert(key0_index, key0);
@@ -545,6 +548,7 @@ where
     }
 
     #[cfg(debug_assertions)]
+    #[allow(clippy::unwrap_used)] // this is an assertion function
     pub(crate) fn check_invariants(&self) {
         debug_assert_eq!(self.keys0.zvl_len(), self.joiner.len());
         debug_assert_eq!(self.keys1.zvl_len(), self.values.zvl_len());
@@ -561,7 +565,6 @@ where
             };
             let j1 = self.joiner.get(i).unwrap() as usize;
             debug_assert_ne!(j0, j1);
-            #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
             for j in (j0 + 1)..j1 {
                 let m0 = self.keys1.zvl_get(j - 1).unwrap();
                 let m1 = self.keys1.zvl_get(j).unwrap();

--- a/utils/zerovec/src/ule/encode.rs
+++ b/utils/zerovec/src/ule/encode.rs
@@ -339,7 +339,7 @@ mod test {
             a.iter()
                 .map(|x| x
                     .iter()
-                    .map(|y| y.iter().copied().collect::<Vec<u8>>())
+                    .map(|y| y.to_vec())
                     .collect::<Vec<Vec<u8>>>())
                 .collect::<Vec<Vec<Vec<u8>>>>(),
             u8_3d_vec

--- a/utils/zerovec/src/ule/encode.rs
+++ b/utils/zerovec/src/ule/encode.rs
@@ -337,10 +337,7 @@ mod test {
         let d: VZV<VZS<[u8]>> = VarZeroVec::from(u8_3d_vzv_brackets);
         assert_eq!(
             a.iter()
-                .map(|x| x
-                    .iter()
-                    .map(|y| y.to_vec())
-                    .collect::<Vec<Vec<u8>>>())
+                .map(|x| x.iter().map(|y| y.to_vec()).collect::<Vec<Vec<u8>>>())
                 .collect::<Vec<Vec<Vec<u8>>>>(),
             u8_3d_vec
         );


### PR DESCRIPTION
This brings in support for named feature dependencies, which gives us the final form of https://github.com/unicode-org/icu4x/issues/1320. I haven't yet started using the feature.

The nightly chosen is one near to the nightly corresponding to the release, but includes a stableish LLVM version so that `test-c-tiny` may work. (We have a narrow range of dates for this: weak dependencies were introduced mid-Jan and LLVM was updated early Feb)




<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->