### PR TITLE
Progress on non_exhaustive everywhere

### DIFF
--- a/components/calendar/src/arithmetic.rs
+++ b/components/calendar/src/arithmetic.rs
@@ -11,6 +11,7 @@ pub mod week_of {
     /// Information about how a given calendar assigns weeks to a year or month.
     #[derive(Clone, Copy, Debug)]
     #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+    #[allow(clippy::exhaustive_structs)] // this type is stable
     pub struct CalendarInfo {
         /// The first day of a week.
         pub first_weekday: IsoWeekday,
@@ -119,6 +120,7 @@ pub mod week_of {
 
     /// The year or month that a calendar assigns a week to relative to the year/month that it is in.
     #[derive(Debug, PartialEq)]
+    #[allow(clippy::exhaustive_enums)] // this type is stable
     pub enum RelativeUnit {
         /// A week that is assigned to previous year/month. e.g. 2021-01-01 is week 54 of 2020 per the ISO calendar.
         Previous,
@@ -130,6 +132,7 @@ pub mod week_of {
 
     /// The week number assigned to a given week according to a calendar.
     #[derive(Debug, PartialEq)]
+    #[allow(clippy::exhaustive_structs)] // this type is stable
     pub struct WeekOf {
         /// Week of month/year. 1 based.
         pub week: u16,

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -21,6 +21,7 @@ const BUDDHIST_ERA_OFFSET: i32 = 543;
 /// however it has a different zero year: 1 AD = 544 BE
 ///
 /// [cal]: https://en.wikipedia.org/wiki/Thai_solar_calendar
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Buddhist;
 
 impl Calendar for Buddhist {

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -7,6 +7,7 @@ use core::convert::TryInto;
 use core::marker::PhantomData;
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct ArithmeticDate<C: CalendarArithmetic> {
     pub year: i32,
     /// 1-based month of year

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -15,7 +15,8 @@ use core::marker::PhantomData;
 use tinystr::tinystr;
 
 #[derive(Copy, Clone, Debug, Hash, Default, Eq, PartialEq)]
-// The Coptic Calendar
+#[allow(clippy::exhaustive_structs)] // this type is stable
+                                     // The Coptic Calendar
 pub struct Coptic;
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]

--- a/components/calendar/src/datetime.rs
+++ b/components/calendar/src/datetime.rs
@@ -11,6 +11,7 @@ use crate::{AsCalendar, Date, Iso};
 /// e.g. `Rc<C>`, via the [`AsCalendar`] trait, much like
 /// [`Date`]
 #[derive(Debug)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct DateTime<A: AsCalendar> {
     pub date: Date<A>,
     pub time: Time,

--- a/components/calendar/src/duration.rs
+++ b/components/calendar/src/duration.rs
@@ -8,6 +8,7 @@ use core::marker::PhantomData;
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 /// A duration between two dates
+#[allow(clippy::exhaustive_structs)] // this type should be stable (and is intended to be constructed manually)
 pub struct DateDuration<C: Calendar + ?Sized> {
     /// The number of years
     pub years: i32,
@@ -24,6 +25,7 @@ pub struct DateDuration<C: Calendar + ?Sized> {
 /// A "duration unit" used to specify the minimum or maximum duration of time to
 /// care about
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[allow(clippy::exhaustive_enums)] // this type should be stable
 pub enum DateDurationUnit {
     /// Duration in years
     Years,

--- a/components/calendar/src/error.rs
+++ b/components/calendar/src/error.rs
@@ -10,6 +10,7 @@ impl std::error::Error for DateTimeError {}
 /// A list of possible error outcomes for working with various inputs to DateTime inputs
 /// and operations.
 #[derive(Display, Debug, Copy, Clone)]
+#[non_exhaustive]
 pub enum DateTimeError {
     /// An input could not be parsed.
     #[displaydoc("Could not parse as integer")]

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -10,6 +10,7 @@ use core::convert::TryInto;
 use tinystr::tinystr;
 
 #[derive(Copy, Clone, Debug, Default)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 /// The Gregorian Calendar
 pub struct Gregorian;
 

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -9,9 +9,9 @@ use crate::{types, Calendar, Date, DateDuration, DateDurationUnit, DateTime, Dat
 use core::convert::TryInto;
 use tinystr::tinystr;
 
+/// The Gregorian Calendar
 #[derive(Copy, Clone, Debug, Default)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
-/// The Gregorian Calendar
 pub struct Gregorian;
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -12,9 +12,9 @@ use crate::{
 use core::marker::PhantomData;
 use tinystr::tinystr;
 
+/// The Indian national calendar
 #[derive(Copy, Clone, Debug, Hash, Default, Eq, PartialEq)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
-                                     // The Indian national calendar
 pub struct Indian;
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -13,7 +13,8 @@ use core::marker::PhantomData;
 use tinystr::tinystr;
 
 #[derive(Copy, Clone, Debug, Hash, Default, Eq, PartialEq)]
-// The Indian national calendar
+#[allow(clippy::exhaustive_structs)] // this type is stable
+                                     // The Indian national calendar
 pub struct Indian;
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -12,16 +12,20 @@ use tinystr::tinystr;
 const EPOCH: i32 = 1;
 
 #[derive(Copy, Clone, Debug, Default)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 /// The ISO Calendar
 pub struct Iso;
 
 /// A 1-indexed representation of an ISO day
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct IsoDay(u8);
 /// A 1-indexed representation of an ISO month
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct IsoMonth(u8);
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 /// An ISO year. Year 0 == 1 BCE
 pub struct IsoYear(pub i32);
 

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -18,14 +18,12 @@ pub struct Iso;
 
 /// A 1-indexed representation of an ISO day
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
-#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct IsoDay(u8);
 /// A 1-indexed representation of an ISO month
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
-#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct IsoMonth(u8);
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[allow(clippy::exhaustive_structs)] // newtype
 /// An ISO year. Year 0 == 1 BCE
 pub struct IsoYear(pub i32);
 

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -10,8 +10,8 @@ use crate::{types, Calendar, Date, DateDuration, DateDurationUnit};
 use icu_provider::prelude::*;
 use tinystr::{tinystr, TinyStr16};
 
-#[derive(Clone, Debug, Default)]
 /// The Japanese Calendar
+#[derive(Clone, Debug, Default)]
 pub struct Japanese {
     eras: DataPayload<provider::JapaneseErasV1Marker>,
 }

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -17,9 +17,9 @@ use tinystr::tinystr;
 // 1st Jan of 1st year Julian is equivalent to December 30th of 0th year of ISO year
 const JULIAN_EPOCH: i32 = -1;
 
+/// The Julian calendar
 #[derive(Copy, Clone, Debug, Hash, Default, Eq, PartialEq)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
-                                     // The Julian calendar
 pub struct Julian;
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -18,7 +18,8 @@ use tinystr::tinystr;
 const JULIAN_EPOCH: i32 = -1;
 
 #[derive(Copy, Clone, Debug, Hash, Default, Eq, PartialEq)]
-// The Julian calendar
+#[allow(clippy::exhaustive_structs)] // this type is stable
+                                     // The Julian calendar
 pub struct Julian;
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -10,7 +10,9 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        clippy::exhaustive_enums
     )
 )]
 

--- a/components/calendar/src/provider.rs
+++ b/components/calendar/src/provider.rs
@@ -8,6 +8,9 @@
 
 #![allow(clippy::indexing_slicing)] // TODO(#1668) Clippy exceptions need docs or fixing.
 
+// Provider structs must be stable
+#![allow(clippy::exhaustive_structs)]
+
 use core::str::FromStr;
 use icu_provider::{yoke, zerofrom};
 use tinystr::TinyStr16;

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -11,12 +11,13 @@ use core::ops::{Add, Sub};
 use core::str::FromStr;
 use tinystr::{TinyStr16, TinyStr8};
 
-/// TODO(#486): Implement era codes.
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[allow(clippy::exhaustive_structs)] // this type is a stable wrapper
 pub struct Era(pub TinyStr16);
 
 /// Representation of a formattable year.
 #[derive(Clone, Debug, PartialEq)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Year {
     /// The era containing the year.
     pub era: Era,
@@ -31,10 +32,12 @@ pub struct Year {
 
 /// TODO(#486): Implement month codes.
 #[derive(Clone, Debug, PartialEq)]
+#[allow(clippy::exhaustive_structs)] // this type is a stable wrapper
 pub struct MonthCode(pub TinyStr8);
 
 /// Representation of a formattable month.
 #[derive(Clone, Debug, PartialEq)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Month {
     /// A month number in a year. In normal years, this is usually the 1-based month index. In leap
     /// years, this is what the month number would have been in a non-leap year.
@@ -56,6 +59,7 @@ pub struct Month {
 // by the [`day_of_year_info()`](trait.DateInput.html#tymethod.day_of_year_info) method of the
 // [`DateInput`] trait.
 #[derive(Clone, Debug, PartialEq)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct DayOfYearInfo {
     /// The current day of the year, 1-based.
     pub day_of_year: u32,
@@ -70,18 +74,22 @@ pub struct DayOfYearInfo {
 }
 
 /// A day number in a month. Usually 1-based.
+#[allow(clippy::exhaustive_structs)] // this is stable
 pub struct DayOfMonth(pub u32);
 
 /// A week number in a month. Usually 1-based.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(clippy::exhaustive_structs)] // this is stable
 pub struct WeekOfMonth(pub u32);
 
 /// A week number in a year. Usually 1-based.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(clippy::exhaustive_structs)] // this is stable
 pub struct WeekOfYear(pub u32);
 
 /// A day of week in month. 1-based.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct DayOfWeekInMonth(pub u32);
 
 impl From<DayOfMonth> for DayOfWeekInMonth {
@@ -208,6 +216,7 @@ dt_unit!(
 );
 
 #[derive(Debug, Copy, Clone)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Time {
     /// 0-based hour.
     pub hour: IsoHour,
@@ -242,6 +251,7 @@ impl Time {
 /// A placeholder for fractional seconds support. See [Issue #485](https://github.com/unicode-org/icu4x/issues/485)
 /// for tracking the support of this feature.
 #[derive(Clone, Debug, PartialEq)]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum FractionalSecond {
     /// The millisecond component of the fractional second.
     Millisecond(u16),
@@ -384,6 +394,7 @@ impl FromStr for GmtOffset {
 #[allow(missing_docs)] // The weekday variants should be self-obvious.
 #[repr(i8)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[allow(clippy::exhaustive_enums)] // This is stable
 pub enum IsoWeekday {
     Monday = 1,
     Tuesday,

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -32,7 +32,7 @@ pub struct Year {
 
 /// TODO(#486): Implement month codes.
 #[derive(Clone, Debug, PartialEq)]
-#[allow(clippy::exhaustive_structs)] // this type is a stable wrapper
+#[allow(clippy::exhaustive_structs)] // newtype
 pub struct MonthCode(pub TinyStr8);
 
 /// Representation of a formattable month.
@@ -74,22 +74,22 @@ pub struct DayOfYearInfo {
 }
 
 /// A day number in a month. Usually 1-based.
-#[allow(clippy::exhaustive_structs)] // this is stable
+#[allow(clippy::exhaustive_structs)] // newtype
 pub struct DayOfMonth(pub u32);
 
 /// A week number in a month. Usually 1-based.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[allow(clippy::exhaustive_structs)] // this is stable
+#[allow(clippy::exhaustive_structs)] // newtype
 pub struct WeekOfMonth(pub u32);
 
 /// A week number in a year. Usually 1-based.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[allow(clippy::exhaustive_structs)] // this is stable
+#[allow(clippy::exhaustive_structs)] // newtype
 pub struct WeekOfYear(pub u32);
 
 /// A day of week in month. 1-based.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[allow(clippy::exhaustive_structs)] // newtype
 pub struct DayOfWeekInMonth(pub u32);
 
 impl From<DayOfMonth> for DayOfWeekInMonth {

--- a/components/datetime/README.md
+++ b/components/datetime/README.md
@@ -18,11 +18,9 @@ use icu::datetime::{DateTimeFormat, DateTimeFormatOptions, mock::parse_gregorian
 let provider = icu_testdata::get_provider();
 
 // See the next code example for a more ergonomic example with .into().
-let options = DateTimeFormatOptions::Length(length::Bag {
-    date: Some(length::Date::Medium),
-    time: Some(length::Time::Short),
-    ..Default::default()
-});
+let options = DateTimeFormatOptions::Length(length::Bag::new(
+    Some(length::Date::Medium), Some(length::Time::Short),
+));
 
 let dtf = DateTimeFormat::<Gregorian>::try_new(locale!("en"), &provider, &options)
     .expect("Failed to create DateTimeFormat instance.");
@@ -41,11 +39,7 @@ convert a [`options::length::Bag`] into a [`DateTimeFormatOptions::Length`].
 ```rust
 use icu::calendar::Gregorian;
 use icu::datetime::{DateTimeFormat, DateTimeFormatOptions, options::length};
-let options = length::Bag {
-    date: Some(length::Date::Medium),
-    time: Some(length::Time::Short),
-    ..Default::default()
-}.into();
+let options = length::Bag::new(Some(length::Date::Medium), Some(length::Time::Short)).into();
 
 let dtf = DateTimeFormat::<Gregorian>::try_new(locale, &provider, &options);
 ```

--- a/components/datetime/README.md
+++ b/components/datetime/README.md
@@ -18,7 +18,7 @@ use icu::datetime::{DateTimeFormat, DateTimeFormatOptions, mock::parse_gregorian
 let provider = icu_testdata::get_provider();
 
 // See the next code example for a more ergonomic example with .into().
-let options = DateTimeFormatOptions::Length(length::Bag::new(
+let options = DateTimeFormatOptions::Length(length::Bag::from_date_time_style(
     Some(length::Date::Medium), Some(length::Time::Short),
 ));
 
@@ -39,7 +39,7 @@ convert a [`options::length::Bag`] into a [`DateTimeFormatOptions::Length`].
 ```rust
 use icu::calendar::Gregorian;
 use icu::datetime::{DateTimeFormat, DateTimeFormatOptions, options::length};
-let options = length::Bag::new(Some(length::Date::Medium), Some(length::Time::Short)).into();
+let options = length::Bag::from_date_time_style(Some(length::Date::Medium), Some(length::Time::Short)).into();
 
 let dtf = DateTimeFormat::<Gregorian>::try_new(locale, &provider, &options);
 ```

--- a/components/datetime/examples/work_log.rs
+++ b/components/datetime/examples/work_log.rs
@@ -49,11 +49,10 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
         .collect::<Result<Vec<DateTime<Gregorian>>, _>>()
         .expect("Failed to parse dates.");
 
-    let options = length::Bag {
-        date: Some(length::Date::Medium),
-        time: Some(length::Time::Short),
-        ..Default::default()
-    };
+    let mut options = length::Bag::default();
+
+    options.date = Some(length::Date::Medium);
+    options.time = Some(length::Time::Short);
 
     let dtf = DateTimeFormat::<Gregorian>::try_new(locale!("en"), &provider, &options.into())
         .expect("Failed to create DateTimeFormat instance.");

--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -39,11 +39,8 @@ use crate::{date::DateTimeInput, CldrCalendar, DateTimeFormatError, FormattedDat
 ///
 /// let provider = InvariantDataProvider;
 ///
-/// let options = length::Bag {
-///     date: Some(length::Date::Medium),
-///     time: Some(length::Time::Short),
-///     ..Default::default()
-/// };
+/// let mut options = length::Bag::new(Some(length::Date::Medium), Some(length::Time::Short));
+///
 /// let dtf = DateTimeFormat::<Gregorian>::try_new(locale!("en"), &provider, &options.into())
 ///     .expect("Failed to create DateTimeFormat instance.");
 ///
@@ -206,24 +203,20 @@ impl<C: CldrCalendar> DateTimeFormat<C> {
     /// };
     /// use icu::locid::locale;
     ///
-    /// let options = DateTimeFormatOptions::Length(length::Bag {
-    ///     date: Some(length::Date::Medium),
-    ///     time: None,
-    ///     preferences: None,
-    /// });
+    /// let options = DateTimeFormatOptions::Length(length::Bag::new(Some(length::Date::Medium), None));
     ///
     /// let provider = icu_testdata::get_provider();
     /// let dtf = DateTimeFormat::<Gregorian>::try_new(locale!("en"), &provider, &options)
     ///     .expect("Failed to create DateTimeFormat instance.");
     ///
+    /// let mut expected_components_bag = components::Bag::default();
+    /// expected_components_bag.year = Some(components::Year::Numeric);
+    /// expected_components_bag.month = Some(components::Month::Short);
+    /// expected_components_bag.day = Some(components::Day::NumericDayOfMonth);
+    ///
     /// assert_eq!(
     ///     dtf.resolve_components(),
-    ///     components::Bag {
-    ///         year: Some(components::Year::Numeric),
-    ///         month: Some(components::Month::Short),
-    ///         day: Some(components::Day::NumericDayOfMonth),
-    ///         ..Default::default()
-    ///     }
+    ///     expected_components_bag
     /// );
     /// ```
     pub fn resolve_components(&self) -> components::Bag {

--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -39,7 +39,7 @@ use crate::{date::DateTimeInput, CldrCalendar, DateTimeFormatError, FormattedDat
 ///
 /// let provider = InvariantDataProvider;
 ///
-/// let mut options = length::Bag::new(Some(length::Date::Medium), Some(length::Time::Short));
+/// let mut options = length::Bag::from_date_time_style(Some(length::Date::Medium), Some(length::Time::Short));
 ///
 /// let dtf = DateTimeFormat::<Gregorian>::try_new(locale!("en"), &provider, &options.into())
 ///     .expect("Failed to create DateTimeFormat instance.");
@@ -203,7 +203,7 @@ impl<C: CldrCalendar> DateTimeFormat<C> {
     /// };
     /// use icu::locid::locale;
     ///
-    /// let options = DateTimeFormatOptions::Length(length::Bag::new(Some(length::Date::Medium), None));
+    /// let options = DateTimeFormatOptions::Length(length::Bag::from_date_time_style(Some(length::Date::Medium), None));
     ///
     /// let provider = icu_testdata::get_provider();
     /// let dtf = DateTimeFormat::<Gregorian>::try_new(locale!("en"), &provider, &options)

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -13,6 +13,7 @@ use tinystr::TinyStr16;
 
 /// A list of possible error outcomes for the [`DateTimeFormat`](crate::DateTimeFormat) struct.
 #[derive(Display, Debug, Copy, Clone)]
+#[non_exhaustive]
 pub enum DateTimeFormatError {
     /// An error originating from parsing a pattern.
     #[displaydoc("{0}")]

--- a/components/datetime/src/fields/length.rs
+++ b/components/datetime/src/fields/length.rs
@@ -6,6 +6,7 @@ use core::cmp::{Ord, PartialOrd};
 use displaydoc::Display;
 
 #[derive(Display, Debug, PartialEq, Copy, Clone)]
+#[non_exhaustive]
 pub enum LengthError {
     #[displaydoc("Invalid length")]
     InvalidLength,

--- a/components/datetime/src/fields/mod.rs
+++ b/components/datetime/src/fields/mod.rs
@@ -18,6 +18,7 @@ use core::{
 };
 
 #[derive(Display, Debug, Copy, Clone)]
+#[non_exhaustive]
 pub enum Error {
     #[displaydoc("Field {0:?} is not a valid length")]
     InvalidLength(FieldSymbol),

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -8,6 +8,7 @@ use displaydoc::Display;
 use icu_provider::{yoke, zerofrom};
 
 #[derive(Display, Debug, PartialEq, Copy, Clone)]
+#[non_exhaustive]
 pub enum SymbolError {
     /// Invalid field symbol index.
     #[displaydoc("Invalid field symbol index: {0}")]

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -22,7 +22,7 @@
 //! let provider = icu_testdata::get_provider();
 //!
 //! // See the next code example for a more ergonomic example with .into().
-//! let options = DateTimeFormatOptions::Length(length::Bag::new(
+//! let options = DateTimeFormatOptions::Length(length::Bag::from_date_time_style(
 //!     Some(length::Date::Medium), Some(length::Time::Short),
 //! ));
 //!
@@ -45,7 +45,7 @@
 //! use icu::datetime::{DateTimeFormat, DateTimeFormatOptions, options::length};
 //! # let provider = icu_testdata::get_provider();
 //! # let locale = icu::locid::locale!("en");
-//! let options = length::Bag::new(Some(length::Date::Medium), Some(length::Time::Short)).into();
+//! let options = length::Bag::from_date_time_style(Some(length::Date::Medium), Some(length::Time::Short)).into();
 //!
 //! let dtf = DateTimeFormat::<Gregorian>::try_new(locale, &provider, &options);
 //! ```

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -78,7 +78,9 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        clippy::exhaustive_enums
     )
 )]
 

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -22,11 +22,9 @@
 //! let provider = icu_testdata::get_provider();
 //!
 //! // See the next code example for a more ergonomic example with .into().
-//! let options = DateTimeFormatOptions::Length(length::Bag {
-//!     date: Some(length::Date::Medium),
-//!     time: Some(length::Time::Short),
-//!     ..Default::default()
-//! });
+//! let options = DateTimeFormatOptions::Length(length::Bag::new(
+//!     Some(length::Date::Medium), Some(length::Time::Short),
+//! ));
 //!
 //! let dtf = DateTimeFormat::<Gregorian>::try_new(locale!("en"), &provider, &options)
 //!     .expect("Failed to create DateTimeFormat instance.");
@@ -47,11 +45,7 @@
 //! use icu::datetime::{DateTimeFormat, DateTimeFormatOptions, options::length};
 //! # let provider = icu_testdata::get_provider();
 //! # let locale = icu::locid::locale!("en");
-//! let options = length::Bag {
-//!     date: Some(length::Date::Medium),
-//!     time: Some(length::Time::Short),
-//!     ..Default::default()
-//! }.into();
+//! let options = length::Bag::new(Some(length::Date::Medium), Some(length::Time::Short)).into();
 //!
 //! let dtf = DateTimeFormat::<Gregorian>::try_new(locale, &provider, &options);
 //! ```

--- a/components/datetime/src/mock/time_zone.rs
+++ b/components/datetime/src/mock/time_zone.rs
@@ -34,6 +34,7 @@ use core::str::FromStr;
 ///     .expect("Failed to parse a time zone.");
 /// ```
 #[derive(Debug, Default)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct MockTimeZone {
     /// The GMT offset in seconds.
     pub gmt_offset: GmtOffset,

--- a/components/datetime/src/mock/zoned_datetime.rs
+++ b/components/datetime/src/mock/zoned_datetime.rs
@@ -42,6 +42,7 @@ use icu_calendar::{DateTime, Gregorian};
 /// ```
 /// [`ZonedDateTimeFormat`]: crate::zoned_datetime::ZonedDateTimeFormat
 #[derive(Debug)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct MockZonedDateTime {
     /// The datetime component.
     pub datetime: DateTime<Gregorian>,

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -86,6 +86,7 @@ use serde::{Deserialize, Serialize};
 /// See the [module-level](./index.html) docs for more information.
 #[derive(Debug, Clone, PartialEq, Default, Copy)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Bag {
     /// Include the era, such as "AD" or "CE".
     pub era: Option<Text>,
@@ -341,6 +342,7 @@ impl Bag {
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum Numeric {
     /// Display the numeric value. For instance in a year this would be "1970".
     Numeric,
@@ -355,6 +357,7 @@ pub enum Numeric {
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum Text {
     /// Display the long form of the text, such as "Wednesday" for the weekday.
     Long,
@@ -371,6 +374,7 @@ pub enum Text {
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum Year {
     /// The numeric value of the year, such as "2018" for 2018-12-31.
     Numeric,
@@ -391,6 +395,7 @@ pub enum Year {
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum Month {
     /// The numeric value of the month, such as "4".
     Numeric,
@@ -416,6 +421,7 @@ pub enum Month {
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum Week {
     /// The week of the month, such as the "3" in "week 3 of January".
     WeekOfMonth,
@@ -432,6 +438,7 @@ pub enum Week {
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum Day {
     /// The numeric value of the day of month, such as the "2" in July 2 1984.
     NumericDayOfMonth,
@@ -451,6 +458,7 @@ pub enum Day {
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum TimeZoneName {
     // UTS-35 fields: z..zzz
     //

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -44,18 +44,13 @@
 //! use icu::datetime::DateTimeFormatOptions;
 //! use icu::datetime::options::components;
 //!
-//! let bag = components::Bag {
-//!     year: Some(components::Year::Numeric),
-//!     month: Some(components::Month::Long),
-//!     day: Some(components::Day::NumericDayOfMonth),
+//! let mut bag = components::Bag::default();
+//! bag.year = Some(components::Year::Numeric);
+//! bag.month = Some(components::Month::Long);
+//! bag.day = Some(components::Day::NumericDayOfMonth);
 //!
-//!     hour: Some(components::Numeric::TwoDigit),
-//!     minute: Some(components::Numeric::TwoDigit),
-//!
-//!     preferences: None,
-//!
-//!     ..Default::default()
-//! };
+//! bag.hour = Some(components::Numeric::TwoDigit);
+//! bag.minute = Some(components::Numeric::TwoDigit);
 //!
 //! // The options can be created manually.
 //! let options = DateTimeFormatOptions::Components(bag);
@@ -86,7 +81,7 @@ use serde::{Deserialize, Serialize};
 /// See the [module-level](./index.html) docs for more information.
 #[derive(Debug, Clone, PartialEq, Default, Copy)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[non_exhaustive]
 pub struct Bag {
     /// Include the era, such as "AD" or "CE".
     pub era: Option<Text>,
@@ -116,6 +111,13 @@ pub struct Bag {
 }
 
 impl Bag {
+    /// Creates an empty components bag
+    ///
+    /// Has the same behavior as the [`Default`] implementation on this type.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
     #[allow(clippy::wrong_self_convention)]
     /// Converts the components::Bag into a Vec<Field>. The fields will be ordered in from most
     /// significant field to least significant. This is the order the fields are listed in
@@ -342,7 +344,7 @@ impl Bag {
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
-#[allow(clippy::exhaustive_enums)] // this type is stable
+#[non_exhaustive]
 pub enum Numeric {
     /// Display the numeric value. For instance in a year this would be "1970".
     Numeric,
@@ -357,7 +359,7 @@ pub enum Numeric {
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
-#[allow(clippy::exhaustive_enums)] // this type is stable
+#[non_exhaustive]
 pub enum Text {
     /// Display the long form of the text, such as "Wednesday" for the weekday.
     Long,
@@ -374,7 +376,7 @@ pub enum Text {
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
-#[allow(clippy::exhaustive_enums)] // this type is stable
+#[non_exhaustive]
 pub enum Year {
     /// The numeric value of the year, such as "2018" for 2018-12-31.
     Numeric,
@@ -395,7 +397,7 @@ pub enum Year {
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
-#[allow(clippy::exhaustive_enums)] // this type is stable
+#[non_exhaustive]
 pub enum Month {
     /// The numeric value of the month, such as "4".
     Numeric,
@@ -421,7 +423,7 @@ pub enum Month {
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
-#[allow(clippy::exhaustive_enums)] // this type is stable
+#[non_exhaustive]
 pub enum Week {
     /// The week of the month, such as the "3" in "week 3 of January".
     WeekOfMonth,
@@ -438,7 +440,7 @@ pub enum Week {
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
-#[allow(clippy::exhaustive_enums)] // this type is stable
+#[non_exhaustive]
 pub enum Day {
     /// The numeric value of the day of month, such as the "2" in July 2 1984.
     NumericDayOfMonth,
@@ -458,7 +460,7 @@ pub enum Day {
     derive(Serialize, Deserialize),
     serde(rename_all = "kebab-case")
 )]
-#[allow(clippy::exhaustive_enums)] // this type is stable
+#[non_exhaustive]
 pub enum TimeZoneName {
     // UTS-35 fields: z..zzz
     //

--- a/components/datetime/src/options/length.rs
+++ b/components/datetime/src/options/length.rs
@@ -79,6 +79,7 @@ use serde::{Deserialize, Serialize};
 /// [`Element dateFormats`]: https://unicode.org/reports/tr35/tr35-dates.html#dateFormats
 #[derive(Debug, Clone, PartialEq, Copy)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Bag {
     /// Configure the date part of the datetime.
     pub date: Option<Date>,
@@ -126,6 +127,7 @@ impl Default for Bag {
 /// [`Element dateFormats`]: https://unicode.org/reports/tr35/tr35-dates.html#dateFormats
 /// [`DateTimeFormat`]: super::super::DateTimeFormat
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum Date {
     /// Full length, usually with weekday name.
@@ -211,6 +213,7 @@ pub enum Date {
 /// [`DateTimeFormat`]: super::super::DateTimeFormat
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum Time {
     /// Full length, with spelled out time zone name.
     ///

--- a/components/datetime/src/options/length.rs
+++ b/components/datetime/src/options/length.rs
@@ -21,11 +21,10 @@
 //! use icu::datetime::DateTimeFormatOptions;
 //! use icu::datetime::options::length;
 //!
-//! let bag = length::Bag {
-//!      date: Some(length::Date::Medium), // `Medium` length connector will be used
-//!      time: Some(length::Time::Short),
-//!      preferences: None,
-//! };
+//! let bag = length::Bag::new(
+//!     Some(length::Date::Medium), // "medium" date connector will be used
+//!     Some(length::Time::Short)
+//! );
 //!
 //! let options = DateTimeFormatOptions::Length(bag);
 //! ```
@@ -58,11 +57,11 @@ use serde::{Deserialize, Serialize};
 /// use icu::datetime::DateTimeFormatOptions;
 /// use icu::datetime::options::length;
 ///
-/// let bag = length::Bag {
-///      date: Some(length::Date::Medium),
-///      time: Some(length::Time::Short),
-///      preferences: None,
-/// };
+/// let bag = length::Bag::new(
+///     Some(length::Date::Medium),
+///     Some(length::Time::Short)
+/// );
+///
 ///
 /// let options = DateTimeFormatOptions::Length(bag);
 /// ```
@@ -79,7 +78,7 @@ use serde::{Deserialize, Serialize};
 /// [`Element dateFormats`]: https://unicode.org/reports/tr35/tr35-dates.html#dateFormats
 #[derive(Debug, Clone, PartialEq, Copy)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[non_exhaustive]
 pub struct Bag {
     /// Configure the date part of the datetime.
     pub date: Option<Date>,
@@ -90,6 +89,7 @@ pub struct Bag {
 }
 
 impl Default for Bag {
+    /// Constructs a Bag with long date and time options
     fn default() -> Self {
         Self {
             date: Some(Date::Long),
@@ -99,6 +99,27 @@ impl Default for Bag {
     }
 }
 
+impl Bag {
+    /// Constructs a Bag with all fields set to None
+    ///
+    /// Note that the [`Default`] implementation returns long date and time options
+    pub fn empty() -> Self {
+        Self {
+            date: None,
+            time: None,
+            preferences: None,
+        }
+    }
+
+    /// Constructs a Bag given a date and time field (preferences set to None)
+    pub fn new(date: Option<Date>, time: Option<Time>) -> Self {
+        Self {
+            date,
+            time,
+            preferences: None,
+        }
+    }
+}
 /// Represents different lengths a [`DateTimeInput`] implementer can be formatted into.
 /// Each length has associated best pattern for it for a given locale.
 ///
@@ -109,12 +130,7 @@ impl Default for Bag {
 /// ```
 /// use icu::datetime::options::length;
 ///
-/// let bag = length::Bag {
-///     date: Some(length::Date::Long),
-///     time: None,
-///
-///     preferences: None,
-/// };
+/// let bag = length::Bag::new(Some(length::Date::Long), None);
 /// ```
 ///
 /// The available lengths correspond to [`UTS #35: Unicode LDML 4. Dates`], section 2.4 [`Element dateFormats`].
@@ -127,8 +143,8 @@ impl Default for Bag {
 /// [`Element dateFormats`]: https://unicode.org/reports/tr35/tr35-dates.html#dateFormats
 /// [`DateTimeFormat`]: super::super::DateTimeFormat
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[allow(clippy::exhaustive_enums)] // this type is stable
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub enum Date {
     /// Full length, usually with weekday name.
     ///
@@ -194,12 +210,7 @@ pub enum Date {
 /// ```
 /// use icu::datetime::options::length;
 ///
-/// let bag = length::Bag {
-///     date: None,
-///     time: Some(length::Time::Medium),
-///
-///     preferences: None,
-/// };
+/// let bag = length::Bag::new(None, Some(length::Time::Medium));
 /// ```
 ///
 /// The available lengths correspond to [`UTS #35: Unicode LDML 4. Dates`], section 2.4 [`Element timeFormats`].
@@ -213,7 +224,7 @@ pub enum Date {
 /// [`DateTimeFormat`]: super::super::DateTimeFormat
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-#[allow(clippy::exhaustive_enums)] // this type is stable
+#[non_exhaustive]
 pub enum Time {
     /// Full length, with spelled out time zone name.
     ///

--- a/components/datetime/src/options/length.rs
+++ b/components/datetime/src/options/length.rs
@@ -21,7 +21,7 @@
 //! use icu::datetime::DateTimeFormatOptions;
 //! use icu::datetime::options::length;
 //!
-//! let bag = length::Bag::new(
+//! let bag = length::Bag::from_date_time_style(
 //!     Some(length::Date::Medium), // "medium" date connector will be used
 //!     Some(length::Time::Short)
 //! );
@@ -57,7 +57,7 @@ use serde::{Deserialize, Serialize};
 /// use icu::datetime::DateTimeFormatOptions;
 /// use icu::datetime::options::length;
 ///
-/// let bag = length::Bag::new(
+/// let bag = length::Bag::from_date_time_style(
 ///     Some(length::Date::Medium),
 ///     Some(length::Time::Short)
 /// );
@@ -112,7 +112,7 @@ impl Bag {
     }
 
     /// Constructs a Bag given a date and time field (preferences set to None)
-    pub fn new(date: Option<Date>, time: Option<Time>) -> Self {
+    pub fn from_date_time_style(date: Option<Date>, time: Option<Time>) -> Self {
         Self {
             date,
             time,
@@ -130,7 +130,7 @@ impl Bag {
 /// ```
 /// use icu::datetime::options::length;
 ///
-/// let bag = length::Bag::new(Some(length::Date::Long), None);
+/// let bag = length::Bag::from_date_time_style(Some(length::Date::Long), None);
 /// ```
 ///
 /// The available lengths correspond to [`UTS #35: Unicode LDML 4. Dates`], section 2.4 [`Element dateFormats`].
@@ -210,7 +210,7 @@ pub enum Date {
 /// ```
 /// use icu::datetime::options::length;
 ///
-/// let bag = length::Bag::new(None, Some(length::Time::Medium));
+/// let bag = length::Bag::from_date_time_style(None, Some(length::Time::Medium));
 /// ```
 ///
 /// The available lengths correspond to [`UTS #35: Unicode LDML 4. Dates`], section 2.4 [`Element timeFormats`].

--- a/components/datetime/src/options/mod.rs
+++ b/components/datetime/src/options/mod.rs
@@ -56,6 +56,7 @@ pub mod preferences;
 /// At the moment only the [`length::Bag`] works, and we plan to extend that to support
 /// `ECMA402` like components bag later.
 #[derive(Debug, Clone)]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum DateTimeFormatOptions {
     /// Bag of lengths for date and time.
     Length(length::Bag),

--- a/components/datetime/src/options/mod.rs
+++ b/components/datetime/src/options/mod.rs
@@ -18,12 +18,7 @@
 //! use icu::datetime::{DateTimeFormatOptions, options::length};
 //!
 //! let options = DateTimeFormatOptions::Length(
-//!     length::Bag {
-//!          date: Some(length::Date::Medium),
-//!          time: Some(length::Time::Short),
-//!         ..Default::default()
-//!     }
-//! );
+//!     length::Bag::new(Some(length::Date::Medium), Some(length::Time::Short)));
 //! ```
 //!
 //! At the moment only the [`length::Bag`] works, and we plan to extend that to support
@@ -45,18 +40,13 @@ pub mod preferences;
 /// use icu::datetime::{DateTimeFormatOptions, options::length};
 ///
 /// let options = DateTimeFormatOptions::Length(
-///     length::Bag {
-///          date: Some(length::Date::Medium),
-///          time: Some(length::Time::Short),
-///         ..Default::default()
-///     }
-/// );
+///     length::Bag::new(Some(length::Date::Medium), Some(length::Time::Short)));
 /// ```
 ///
 /// At the moment only the [`length::Bag`] works, and we plan to extend that to support
 /// `ECMA402` like components bag later.
 #[derive(Debug, Clone)]
-#[allow(clippy::exhaustive_enums)] // this type is stable
+#[non_exhaustive]
 pub enum DateTimeFormatOptions {
     /// Bag of lengths for date and time.
     Length(length::Bag),

--- a/components/datetime/src/options/mod.rs
+++ b/components/datetime/src/options/mod.rs
@@ -18,7 +18,7 @@
 //! use icu::datetime::{DateTimeFormatOptions, options::length};
 //!
 //! let options = DateTimeFormatOptions::Length(
-//!     length::Bag::new(Some(length::Date::Medium), Some(length::Time::Short)));
+//!     length::Bag::from_date_time_style(Some(length::Date::Medium), Some(length::Time::Short)));
 //! ```
 //!
 //! At the moment only the [`length::Bag`] works, and we plan to extend that to support
@@ -40,7 +40,7 @@ pub mod preferences;
 /// use icu::datetime::{DateTimeFormatOptions, options::length};
 ///
 /// let options = DateTimeFormatOptions::Length(
-///     length::Bag::new(Some(length::Date::Medium), Some(length::Time::Short)));
+///     length::Bag::from_date_time_style(Some(length::Date::Medium), Some(length::Time::Short)));
 /// ```
 ///
 /// At the moment only the [`length::Bag`] works, and we plan to extend that to support

--- a/components/datetime/src/options/preferences.rs
+++ b/components/datetime/src/options/preferences.rs
@@ -42,6 +42,7 @@ use serde::{Deserialize, Serialize};
 /// ```
 #[derive(Debug, Clone, PartialEq, Copy)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Bag {
     /// The hour cycle can be adjusts according to user preferences, for instance at the OS-level.
     /// That preference can be applied here to change the hour cycle from the default for the
@@ -53,6 +54,7 @@ pub struct Bag {
 /// A user preference for adjusting how the hour component is displayed.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum HourCycle {
     /// Hour is formatted to be in range 1-24 where midnight is 24:00.
     ///

--- a/components/datetime/src/pattern/error.rs
+++ b/components/datetime/src/pattern/error.rs
@@ -11,6 +11,7 @@ use displaydoc::Display;
 /// Serde will generate an error such as:
 /// "invalid value: unclosed literal in pattern, expected a valid UTS 35 pattern string at line 1 column 12"
 #[derive(Display, Debug, PartialEq, Copy, Clone)]
+#[non_exhaustive]
 pub enum PatternError {
     #[displaydoc("{0:?} invalid field length in pattern")]
     FieldLengthInvalid(fields::FieldSymbol),

--- a/components/datetime/src/pattern/hour_cycle.rs
+++ b/components/datetime/src/pattern/hour_cycle.rs
@@ -13,6 +13,7 @@ use icu_provider::{yoke, zerofrom};
 /// hour cycles as H12 or H23.
 #[derive(Debug, PartialEq, Clone, Copy, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum CoarseHourCycle {
     /// Can either be fields::Hour::H11 or fields::Hour::H12
     H11H12,

--- a/components/datetime/src/pattern/item/generic.rs
+++ b/components/datetime/src/pattern/item/generic.rs
@@ -5,6 +5,7 @@
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
 #[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum GenericPatternItem {
     Placeholder(u8),
     Literal(char),

--- a/components/datetime/src/pattern/item/mod.rs
+++ b/components/datetime/src/pattern/item/mod.rs
@@ -13,6 +13,7 @@ pub use generic::GenericPatternItem;
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
 #[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum PatternItem {
     Field(Field),
     Literal(char),

--- a/components/datetime/src/pattern/reference/generic.rs
+++ b/components/datetime/src/pattern/reference/generic.rs
@@ -10,6 +10,7 @@ use super::{
 use alloc::vec::Vec;
 use core::str::FromStr;
 
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct GenericPattern {
     pub items: Vec<GenericPatternItem>,
 }

--- a/components/datetime/src/pattern/runtime/generic.rs
+++ b/components/datetime/src/pattern/runtime/generic.rs
@@ -13,6 +13,7 @@ use icu_provider::{yoke, zerofrom};
 use zerovec::ZeroVec;
 
 #[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct GenericPattern<'data> {
     pub items: ZeroVec<'data, GenericPatternItem>,
 }

--- a/components/datetime/src/pattern/runtime/plural.rs
+++ b/components/datetime/src/pattern/runtime/plural.rs
@@ -129,6 +129,7 @@ impl<'data> PluralPattern<'data> {
 /// Either a single Pattern or a collection of pattern when there are plural variants.
 #[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[allow(clippy::large_enum_variant)]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum PatternPlurals<'data> {
     /// A collection of pattern variants for when plurals differ.
     MultipleVariants(PluralPattern<'data>),

--- a/components/datetime/src/provider/mod.rs
+++ b/components/datetime/src/provider/mod.rs
@@ -2,6 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+// Provider structs must be stable
+#![allow(clippy::exhaustive_structs)]
+
 //! Data provider struct definitions for this ICU4X component.
 //!
 //! Read more about data providers: [`icu_provider`]

--- a/components/datetime/src/skeleton/error.rs
+++ b/components/datetime/src/skeleton/error.rs
@@ -11,6 +11,7 @@ use displaydoc::Display;
 /// Serde will generate an error such as:
 /// "invalid value: unclosed literal in pattern, expected a valid UTS 35 pattern string at line 1 column 12"
 #[derive(Display, Debug, Copy, Clone)]
+#[non_exhaustive]
 pub enum SkeletonError {
     #[displaydoc("field too long in skeleton")]
     InvalidFieldLength,

--- a/components/datetime/src/skeleton/helpers.rs
+++ b/components/datetime/src/skeleton/helpers.rs
@@ -81,6 +81,7 @@ const REQUESTED_SYMBOL_MISSING: u32 = 10000;
 /// there is no attempt to add on missing fields. This enum encodes the variants for the current
 /// search for a best skeleton.
 #[derive(Debug, PartialEq, Clone)]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum BestSkeleton<T> {
     AllFieldsMatch(T),
     MissingOrExtraFields(T),

--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -740,6 +740,7 @@ impl TimeZoneFormat {
 
 /// Determines which ISO-8601 format should be used to format a [`GmtOffset`](crate::date::GmtOffset).
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum IsoFormat {
     /// ISO-8601 Basic Format.
     /// Formats zero-offset numerically.
@@ -764,6 +765,7 @@ pub enum IsoFormat {
 
 /// Whether the minutes field should be optional or required in ISO-8601 format.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum IsoMinutes {
     /// Minutes are always displayed.
     Required,
@@ -774,6 +776,7 @@ pub enum IsoMinutes {
 
 /// Whether the seconds field should be optional or excluded in ISO-8601 format.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum IsoSeconds {
     /// Seconds are displayed only if they are non-zero.
     Optional,
@@ -784,6 +787,7 @@ pub enum IsoSeconds {
 
 /// Whether a field should be zero-padded in ISO-8601 format.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum ZeroPadding {
     /// Add zero-padding.
     On,
@@ -794,6 +798,7 @@ pub enum ZeroPadding {
 
 /// A config enum for initializing TimeZoneFormat.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub enum TimeZoneFormatConfig {
     GenericNonLocationLong,                     // Pacific Time
     GenericNonLocationShort,                    // PT
@@ -806,6 +811,7 @@ pub enum TimeZoneFormatConfig {
 
 /// An enum for fallback formats.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub enum FallbackFormat {
     Iso8601(IsoFormat, IsoMinutes, IsoSeconds),
     LocalizedGmt,
@@ -819,6 +825,7 @@ impl Default for FallbackFormat {
 
 /// A bag of options to define how time zone will be formatted.
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct TimeZoneFormatOptions {
     pub fallback_format: FallbackFormat,
 }

--- a/components/datetime/src/zoned_datetime.rs
+++ b/components/datetime/src/zoned_datetime.rs
@@ -49,11 +49,7 @@ use crate::{
 /// let zone_provider = InvariantDataProvider;
 /// let plural_provider = InvariantDataProvider;
 ///
-/// let options = length::Bag {
-///     date: Some(length::Date::Medium),
-///     time: Some(length::Time::Short),
-///     ..Default::default()
-/// };
+/// let options = length::Bag::new(Some(length::Date::Medium), Some(length::Time::Short));
 /// let zdtf = ZonedDateTimeFormat::<Gregorian>::try_new(locale!("en"), &date_provider, &zone_provider, &plural_provider, &options.into(), &TimeZoneFormatOptions::default())
 ///     .expect("Failed to create DateTimeFormat instance.");
 ///

--- a/components/datetime/src/zoned_datetime.rs
+++ b/components/datetime/src/zoned_datetime.rs
@@ -49,7 +49,7 @@ use crate::{
 /// let zone_provider = InvariantDataProvider;
 /// let plural_provider = InvariantDataProvider;
 ///
-/// let options = length::Bag::new(Some(length::Date::Medium), Some(length::Time::Short));
+/// let options = length::Bag::from_date_time_style(Some(length::Date::Medium), Some(length::Time::Short));
 /// let zdtf = ZonedDateTimeFormat::<Gregorian>::try_new(locale!("en"), &date_provider, &zone_provider, &plural_provider, &options.into(), &TimeZoneFormatOptions::default())
 ///     .expect("Failed to create DateTimeFormat instance.");
 ///

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -568,11 +568,9 @@ fn constructing_datetime_format_with_time_zone_pattern_symbols_is_err() {
     };
     use icu_locid::locale;
 
-    let options = DateTimeFormatOptions::Length(Bag {
-        // Full has time-zone symbols.
-        time: Some(Time::Full),
-        ..Default::default()
-    });
+    let mut length_bag = Bag::default();
+    length_bag.time = Some(Time::Full);
+    let options = DateTimeFormatOptions::Length(length_bag);
 
     let provider = icu_testdata::get_provider();
     let result = DateTimeFormat::<Gregorian>::try_new(locale!("en"), &provider, &options);

--- a/components/datetime/tests/resolved_components.rs
+++ b/components/datetime/tests/resolved_components.rs
@@ -72,7 +72,7 @@ fn test_components_bag() {
     input_bag.minute = Some(components::Numeric::TwoDigit);
     input_bag.second = Some(components::Numeric::TwoDigit);
     input_bag.preferences = None;
-    let mut output_bag = input_bag.clone();
+    let mut output_bag = input_bag; // make a copy
     output_bag.month = Some(components::Month::Short);
     output_bag.preferences = Some(preferences::Bag {
         hour_cycle: Some(preferences::HourCycle::H23),

--- a/components/datetime/tests/resolved_components.rs
+++ b/components/datetime/tests/resolved_components.rs
@@ -19,91 +19,63 @@ fn assert_resolved_components(options: &DateTimeFormatOptions, bag: &components:
 
 #[test]
 fn test_length_date() {
-    assert_resolved_components(
-        &DateTimeFormatOptions::Length(length::Bag {
-            date: Some(length::Date::Medium),
-            time: None,
-            preferences: None,
-        }),
-        &components::Bag {
-            year: Some(components::Year::Numeric),
-            month: Some(components::Month::Short),
-            day: Some(components::Day::NumericDayOfMonth),
-            ..Default::default()
-        },
-    );
+    let mut length_bag = length::Bag::empty();
+    length_bag.date = Some(length::Date::Medium);
+
+    let mut components_bag = components::Bag::default();
+    components_bag.year = Some(components::Year::Numeric);
+    components_bag.month = Some(components::Month::Short);
+    components_bag.day = Some(components::Day::NumericDayOfMonth);
+    assert_resolved_components(&DateTimeFormatOptions::Length(length_bag), &components_bag);
 }
 
 #[test]
 fn test_length_time() {
-    assert_resolved_components(
-        &DateTimeFormatOptions::Length(length::Bag {
-            date: None,
-            time: Some(length::Time::Medium),
-            preferences: None,
-        }),
-        &components::Bag {
-            hour: Some(components::Numeric::Numeric),
-            minute: Some(components::Numeric::TwoDigit),
-            second: Some(components::Numeric::TwoDigit),
-            preferences: Some(preferences::Bag {
-                hour_cycle: Some(preferences::HourCycle::H12),
-            }),
-            ..Default::default()
-        },
-    );
+    let mut length_bag = length::Bag::empty();
+    length_bag.time = Some(length::Time::Medium);
+    let mut components_bag = components::Bag::default();
+    components_bag.hour = Some(components::Numeric::Numeric);
+    components_bag.minute = Some(components::Numeric::TwoDigit);
+    components_bag.second = Some(components::Numeric::TwoDigit);
+    components_bag.preferences = Some(preferences::Bag {
+        hour_cycle: Some(preferences::HourCycle::H12),
+    });
+    assert_resolved_components(&DateTimeFormatOptions::Length(length_bag), &components_bag);
 }
 
 #[test]
 fn test_length_time_preferences() {
-    assert_resolved_components(
-        &DateTimeFormatOptions::Length(length::Bag {
-            date: None,
-            time: Some(length::Time::Medium),
-            preferences: Some(preferences::Bag {
-                hour_cycle: Some(preferences::HourCycle::H24),
-            }),
-        }),
-        &components::Bag {
-            hour: Some(components::Numeric::TwoDigit),
-            minute: Some(components::Numeric::TwoDigit),
-            second: Some(components::Numeric::TwoDigit),
-            preferences: Some(preferences::Bag {
-                hour_cycle: Some(preferences::HourCycle::H24),
-            }),
-            ..Default::default()
-        },
-    );
+    let mut length_bag = length::Bag::empty();
+    length_bag.time = Some(length::Time::Medium);
+    length_bag.preferences = Some(preferences::Bag {
+        hour_cycle: Some(preferences::HourCycle::H24),
+    });
+    let mut components_bag = components::Bag::default();
+    components_bag.hour = Some(components::Numeric::TwoDigit);
+    components_bag.minute = Some(components::Numeric::TwoDigit);
+    components_bag.second = Some(components::Numeric::TwoDigit);
+    components_bag.preferences = Some(preferences::Bag {
+        hour_cycle: Some(preferences::HourCycle::H24),
+    });
+    assert_resolved_components(&DateTimeFormatOptions::Length(length_bag), &components_bag);
 }
 
 #[test]
 fn test_components_bag() {
-    assert_resolved_components(
-        &DateTimeFormatOptions::Components(components::Bag {
-            era: Some(components::Text::Short),
-            year: Some(components::Year::Numeric),
-            month: Some(components::Month::Numeric),
-            day: Some(components::Day::TwoDigitDayOfMonth),
-            weekday: Some(components::Text::Long),
-            hour: Some(components::Numeric::Numeric),
-            minute: Some(components::Numeric::TwoDigit),
-            second: Some(components::Numeric::TwoDigit),
-            preferences: None,
-            ..Default::default()
-        }),
-        &components::Bag {
-            era: Some(components::Text::Short),
-            year: Some(components::Year::Numeric),
-            month: Some(components::Month::Short),
-            day: Some(components::Day::TwoDigitDayOfMonth),
-            weekday: Some(components::Text::Long),
-            hour: Some(components::Numeric::Numeric),
-            minute: Some(components::Numeric::TwoDigit),
-            second: Some(components::Numeric::TwoDigit),
-            preferences: Some(preferences::Bag {
-                hour_cycle: Some(preferences::HourCycle::H23),
-            }),
-            ..Default::default()
-        },
-    );
+    let mut input_bag = components::Bag::default();
+    input_bag.era = Some(components::Text::Short);
+    input_bag.year = Some(components::Year::Numeric);
+    input_bag.month = Some(components::Month::Numeric);
+    input_bag.day = Some(components::Day::TwoDigitDayOfMonth);
+    input_bag.weekday = Some(components::Text::Long);
+    input_bag.hour = Some(components::Numeric::Numeric);
+    input_bag.minute = Some(components::Numeric::TwoDigit);
+    input_bag.second = Some(components::Numeric::TwoDigit);
+    input_bag.preferences = None;
+    let mut output_bag = input_bag.clone();
+    output_bag.month = Some(components::Month::Short);
+    output_bag.preferences = Some(preferences::Bag {
+        hour_cycle: Some(preferences::HourCycle::H23),
+    });
+    assert_resolved_components(&DateTimeFormatOptions::Components(input_bag), &output_bag);
 }

--- a/components/decimal/src/error.rs
+++ b/components/decimal/src/error.rs
@@ -8,6 +8,7 @@ use displaydoc::Display;
 
 #[allow(missing_docs)] // TODO(#1025) - Add missing docs.
 #[derive(Display, Debug, Copy, Clone)]
+#[non_exhaustive]
 pub enum Error {
     #[displaydoc("error loading data: {0}")]
     Data(icu_provider::DataError),

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -61,7 +61,9 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        clippy::exhaustive_enums
     )
 )]
 

--- a/components/decimal/src/options.rs
+++ b/components/decimal/src/options.rs
@@ -7,12 +7,22 @@
 /// A bag of options defining how numbers will be formatted by
 /// [`FixedDecimalFormat`](crate::FixedDecimalFormat).
 #[derive(Debug, Eq, PartialEq, Clone, Default)]
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[non_exhaustive]
 pub struct FixedDecimalFormatOptions {
     /// When to render grouping separators.
     pub grouping_strategy: GroupingStrategy,
     /// When to render the sign.
     pub sign_display: SignDisplay,
+}
+
+impl FixedDecimalFormatOptions {
+    /// Construct a new [`FixedDecimalFormatOptions`] from its components
+    pub fn new(grouping_strategy: GroupingStrategy, sign_display: SignDisplay) -> Self {
+        Self {
+            grouping_strategy,
+            sign_display,
+        }
+    }
 }
 
 /// Configuration for how often to render grouping separators.

--- a/components/decimal/src/options.rs
+++ b/components/decimal/src/options.rs
@@ -7,6 +7,7 @@
 /// A bag of options defining how numbers will be formatted by
 /// [`FixedDecimalFormat`](crate::FixedDecimalFormat).
 #[derive(Debug, Eq, PartialEq, Clone, Default)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct FixedDecimalFormatOptions {
     /// When to render grouping separators.
     pub grouping_strategy: GroupingStrategy,

--- a/components/decimal/src/provider.rs
+++ b/components/decimal/src/provider.rs
@@ -6,6 +6,9 @@
 //!
 //! Read more about data providers: [`icu_provider`]
 
+// Provider structs must be stable
+#![allow(clippy::exhaustive_structs)]
+
 use alloc::borrow::Cow;
 use icu_provider::{yoke, zerofrom};
 

--- a/components/icu/README.md
+++ b/components/icu/README.md
@@ -53,11 +53,7 @@ use icu::datetime::{DateTimeFormat, options::length, mock::parse_gregorian_from_
 
 let provider = icu_testdata::get_provider();
 
-let options = length::Bag {
-    date: Some(length::Date::Long),
-    time: Some(length::Time::Medium),
-    ..Default::default()
-}.into();
+let options = length::Bag::from_date_time_style(Some(length::Date::Medium), Some(length::Time::Short)).into();
 
 let dtf = DateTimeFormat::try_new(locale!("en"), &provider, &options)
     .expect("Failed to create DateTimeFormat instance.");

--- a/components/icu/README.md
+++ b/components/icu/README.md
@@ -53,7 +53,7 @@ use icu::datetime::{DateTimeFormat, options::length, mock::parse_gregorian_from_
 
 let provider = icu_testdata::get_provider();
 
-let options = length::Bag::from_date_time_style(Some(length::Date::Medium), Some(length::Time::Short)).into();
+let options = length::Bag::from_date_time_style(Some(length::Date::Long), Some(length::Time::Medium)).into();
 
 let dtf = DateTimeFormat::try_new(locale!("en"), &provider, &options)
     .expect("Failed to create DateTimeFormat instance.");

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -55,11 +55,7 @@
 //!
 //! let provider = icu_testdata::get_provider();
 //!
-//! let options = length::Bag {
-//!     date: Some(length::Date::Long),
-//!     time: Some(length::Time::Medium),
-//!     ..Default::default()
-//! }.into();
+//! let options = length::Bag::from_date_time_style(Some(length::Date::Medium), Some(length::Time::Short)).into();
 //!
 //! let dtf = DateTimeFormat::try_new(locale!("en"), &provider, &options)
 //!     .expect("Failed to create DateTimeFormat instance.");
@@ -120,7 +116,7 @@ pub mod datetime {
     //!
     //! let provider = icu_testdata::get_provider();
     //!
-    //! let options = length::Bag::new(Some(length::Date::Medium), Some(length::Time::Short)).into();
+    //! let options = length::Bag::from_date_time_style(Some(length::Date::Medium), Some(length::Time::Short)).into();
     //! let dtf = DateTimeFormat::try_new(locale!("en"), &provider, &options)
     //!     .expect("Failed to create DateTimeFormat instance.");
     //!

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -120,12 +120,7 @@ pub mod datetime {
     //!
     //! let provider = icu_testdata::get_provider();
     //!
-    //! let options = length::Bag {
-    //!     date: Some(length::Date::Medium),
-    //!     time: Some(length::Time::Short),
-    //!     ..Default::default()
-    //! }.into();
-    //!
+    //! let options = length::Bag::new(Some(length::Date::Medium), Some(length::Time::Short)).into();
     //! let dtf = DateTimeFormat::try_new(locale!("en"), &provider, &options)
     //!     .expect("Failed to create DateTimeFormat instance.");
     //!

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -55,7 +55,7 @@
 //!
 //! let provider = icu_testdata::get_provider();
 //!
-//! let options = length::Bag::from_date_time_style(Some(length::Date::Medium), Some(length::Time::Short)).into();
+//! let options = length::Bag::from_date_time_style(Some(length::Date::Long), Some(length::Time::Medium)).into();
 //!
 //! let dtf = DateTimeFormat::try_new(locale!("en"), &provider, &options)
 //!     .expect("Failed to create DateTimeFormat instance.");

--- a/components/locid/src/extensions/mod.rs
+++ b/components/locid/src/extensions/mod.rs
@@ -61,6 +61,7 @@ use crate::parser::ParserError;
 use crate::parser::SubtagIterator;
 /// Defines the type of extension.
 #[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord, Copy)]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum ExtensionType {
     /// Transform Extension Type marked as `t`.
     Transform,
@@ -89,6 +90,7 @@ impl ExtensionType {
 /// A map of extensions associated with a given [`Locale`](crate::Locale).
 #[derive(Debug, Default, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 #[allow(missing_docs)] // TODO(#1028) - Add missing docs.
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Extensions {
     pub unicode: Unicode,
     pub transform: Transform,

--- a/components/locid/src/extensions/mod.rs
+++ b/components/locid/src/extensions/mod.rs
@@ -61,7 +61,7 @@ use crate::parser::ParserError;
 use crate::parser::SubtagIterator;
 /// Defines the type of extension.
 #[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord, Copy)]
-#[allow(clippy::exhaustive_enums)] // this type is stable
+#[non_exhaustive]
 pub enum ExtensionType {
     /// Transform Extension Type marked as `t`.
     Transform,
@@ -90,7 +90,7 @@ impl ExtensionType {
 /// A map of extensions associated with a given [`Locale`](crate::Locale).
 #[derive(Debug, Default, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 #[allow(missing_docs)] // TODO(#1028) - Add missing docs.
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[non_exhaustive]
 pub struct Extensions {
     pub unicode: Unicode,
     pub transform: Transform,

--- a/components/locid/src/extensions/transform/mod.rs
+++ b/components/locid/src/extensions/transform/mod.rs
@@ -79,7 +79,7 @@ use litemap::LiteMap;
 /// [`Unicode Locale Identifier`]: https://unicode.org/reports/tr35/#Unicode_locale_identifier
 #[derive(Clone, PartialEq, Eq, Debug, Default, Hash, PartialOrd, Ord)]
 #[allow(missing_docs)] // TODO(#1028) - Add missing docs.
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[non_exhaustive]
 pub struct Transform {
     pub lang: Option<LanguageIdentifier>,
     pub fields: Fields,

--- a/components/locid/src/extensions/transform/mod.rs
+++ b/components/locid/src/extensions/transform/mod.rs
@@ -79,6 +79,7 @@ use litemap::LiteMap;
 /// [`Unicode Locale Identifier`]: https://unicode.org/reports/tr35/#Unicode_locale_identifier
 #[derive(Clone, PartialEq, Eq, Debug, Default, Hash, PartialOrd, Ord)]
 #[allow(missing_docs)] // TODO(#1028) - Add missing docs.
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Transform {
     pub lang: Option<LanguageIdentifier>,
     pub fields: Fields,

--- a/components/locid/src/extensions/unicode/mod.rs
+++ b/components/locid/src/extensions/unicode/mod.rs
@@ -75,7 +75,7 @@ use litemap::LiteMap;
 /// ```
 #[derive(Clone, PartialEq, Eq, Debug, Default, Hash, PartialOrd, Ord)]
 #[allow(missing_docs)] // TODO(#1028) - Add missing docs.
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[non_exhaustive]
 pub struct Unicode {
     pub keywords: Keywords,
     pub attributes: Attributes,

--- a/components/locid/src/extensions/unicode/mod.rs
+++ b/components/locid/src/extensions/unicode/mod.rs
@@ -75,6 +75,7 @@ use litemap::LiteMap;
 /// ```
 #[derive(Clone, PartialEq, Eq, Debug, Default, Hash, PartialOrd, Ord)]
 #[allow(missing_docs)] // TODO(#1028) - Add missing docs.
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Unicode {
     pub keywords: Keywords,
     pub attributes: Attributes,

--- a/components/locid/src/langid.rs
+++ b/components/locid/src/langid.rs
@@ -60,6 +60,7 @@ use alloc::string::ToString;
 ///
 /// [`Unicode BCP47 Language Identifier`]: https://unicode.org/reports/tr35/tr35.html#Unicode_language_identifier
 #[derive(Default, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
+#[allow(clippy::exhaustive_structs)] // This struct is stable (and invoked by a macro)
 pub struct LanguageIdentifier {
     /// Language subtag of the language identifier.
     pub language: subtags::Language,

--- a/components/locid/src/lib.rs
+++ b/components/locid/src/lib.rs
@@ -70,7 +70,9 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        clippy::exhaustive_enums
     )
 )]
 #![warn(missing_docs)]

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -70,6 +70,7 @@ use core::str::FromStr;
 /// [`Unicode Locale Identifier`]: https://unicode.org/reports/tr35/tr35.html#Unicode_locale_identifier
 #[derive(Default, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 #[allow(missing_docs)] // TODO(#1028) - Add missing docs.
+#[allow(clippy::exhaustive_structs)] // This struct is stable (and invoked by a macro)
 pub struct Locale {
     // Language component of the Locale
     pub id: LanguageIdentifier,

--- a/components/locid/src/parser/errors.rs
+++ b/components/locid/src/parser/errors.rs
@@ -8,6 +8,7 @@ use displaydoc::Display;
 /// while parsing [`LanguageIdentifier`](crate::LanguageIdentifier), [`Locale`](crate::Locale),
 /// [`subtags`](crate::subtags) or [`extensions`](crate::extensions).
 #[derive(Display, Debug, PartialEq, Copy, Clone)]
+#[non_exhaustive]
 pub enum ParserError {
     /// Invalid language subtag.
     ///

--- a/components/plurals/src/error.rs
+++ b/components/plurals/src/error.rs
@@ -9,6 +9,7 @@ use icu_provider::prelude::DataError;
 /// A list of possible error outcomes for the [`PluralRules`](crate::PluralRules) struct.
 ///
 #[derive(Display, Debug, Clone, Copy)]
+#[non_exhaustive]
 pub enum PluralRulesError {
     /// A parsing error for the plural rules.
     #[displaydoc("Parser error: {0}")]

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -71,7 +71,9 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        clippy::exhaustive_enums
     )
 )]
 
@@ -95,6 +97,7 @@ use rules::runtime::test_rule;
 /// A type of a plural rule which can be associated with the [`PluralRules`] struct.
 ///
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum PluralRuleType {
     /// Cardinal plural forms express quantities of units such as time, currency or distance,
     /// used in conjunction with a number expressed in decimal digits (i.e. "2", not "two").
@@ -147,6 +150,7 @@ pub enum PluralRuleType {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Ord, PartialOrd)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
 #[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum PluralCategory {
     /// CLDR "zero" plural category. Used in Arabic and Latvian, among others.
     ///

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -101,6 +101,7 @@ impl PluralOperands {
 }
 
 #[derive(Display, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum OperandsError {
     /// Input to the Operands parsing was empty.
     #[displaydoc("Input to the Operands parsing was empty")]

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -33,28 +33,28 @@ use fixed_decimal::FixedDecimal;
 ///
 /// ```
 /// use icu::plurals::PluralOperands;
-/// assert_eq!(PluralOperands {
-///    i: 2,
-///    v: 0,
-///    w: 0,
-///    f: 0,
-///    t: 0,
-///    c: 0,
-/// }, PluralOperands::from(2_usize))
+/// assert_eq!(PluralOperands::new(
+///    2, // i
+///    0, // v
+///    0, // w
+///    0, // f
+///    0, // t
+///    0, // c
+/// ), PluralOperands::from(2_usize))
 /// ```
 ///
 /// From &str
 ///
 /// ```
 /// use icu::plurals::PluralOperands;
-/// assert_eq!(Ok(PluralOperands {
-///    i: 123,
-///    v: 2,
-///    w: 2,
-///    f: 45,
-///    t: 45,
-///    c: 0,
-/// }), "123.45".parse())
+/// assert_eq!(Ok(PluralOperands::new(
+///    123, // i
+///    2, // v
+///    2, // w
+///    45, // f
+///    45, // t
+///    0, // c
+/// )), "123.45".parse())
 /// ```
 ///
 /// From [`FixedDecimal`]
@@ -62,17 +62,17 @@ use fixed_decimal::FixedDecimal;
 /// ```
 /// use fixed_decimal::FixedDecimal;
 /// use icu::plurals::PluralOperands;
-/// assert_eq!(Ok(PluralOperands {
-///    i: 123,
-///    v: 2,
-///    w: 2,
-///    f: 45,
-///    t: 45,
-///    c: 0,
-/// }), FixedDecimal::from(12345).multiplied_pow10(-2).map(|d| (&d).into()))
+/// assert_eq!(Ok(PluralOperands::new(
+///    123, // i
+///    2, // v
+///    2, // w
+///    45, // f
+///    45, // t
+///    0, // c
+/// )), FixedDecimal::from(12345).multiplied_pow10(-2).map(|d| (&d).into()))
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[non_exhaustive]
 pub struct PluralOperands {
     /// Integer value of input
     pub i: u64,
@@ -89,6 +89,10 @@ pub struct PluralOperands {
 }
 
 impl PluralOperands {
+    /// Construct a new [`PluralOperands`] given its various fields (documented on the struct)
+    pub fn new(i: u64, v: usize, w: usize, f: u64, t: u64, c: usize) -> Self {
+        Self { i, v, w, f, t, c }
+    }
     /// Returns the number represented by this [`PluralOperands`] as floating point.
     /// The precision of the number returned is up to the representation accuracy
     /// of a double.

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -72,6 +72,7 @@ use fixed_decimal::FixedDecimal;
 /// }), FixedDecimal::from(12345).multiplied_pow10(-2).map(|d| (&d).into()))
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct PluralOperands {
     /// Integer value of input
     pub i: u64,

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -2,6 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+// Provider structs must be stable
+#![allow(clippy::exhaustive_structs)]
+
 //! Data provider struct definitions for this ICU4X component.
 //!
 //! Read more about data providers: [`icu_provider`]

--- a/components/plurals/src/rules/mod.rs
+++ b/components/plurals/src/rules/mod.rs
@@ -31,14 +31,14 @@
 //!
 //! ```
 //! use icu::plurals::PluralOperands;
-//! PluralOperands {
-//!     i: 1,
-//!     v: 0,
-//!     w: 0,
-//!     f: 0,
-//!     t: 0,
-//!     c: 0,
-//! };
+//! PluralOperands::new(
+//!     1, // i
+//!     0, // v
+//!     0, // w
+//!     0, // f
+//!     0, // t
+//!     0, // c
+//! );
 //! ```
 //!
 //! Now, the system will parse the first rule, assigned to [`PluralCategory::One`], and

--- a/components/plurals/src/rules/reference/ast.rs
+++ b/components/plurals/src/rules/reference/ast.rs
@@ -86,6 +86,7 @@ use core::ops::RangeInclusive;
 /// [`AndConditions`]: AndCondition
 #[derive(Debug, Clone, PartialEq)]
 #[allow(missing_docs)] // TODO(#1029) - Add missing docs.
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Rule {
     pub condition: Condition,
     pub samples: Option<Samples>,
@@ -127,6 +128,7 @@ pub struct Rule {
 ///
 /// [`AndConditions`]: AndCondition
 #[derive(Debug, Clone, PartialEq)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Condition(pub Vec<AndCondition>);
 
 /// An incomplete AST representation of a plural rule. Comprises a vector of [`Relations`].
@@ -168,6 +170,7 @@ pub struct Condition(pub Vec<AndCondition>);
 ///
 /// [`Relations`]: Relation
 #[derive(Debug, Clone, PartialEq)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct AndCondition(pub Vec<Relation>);
 
 /// An incomplete AST representation of a plural rule. Comprises an [`Expression`], an [`Operator`], and a [`RangeList`].
@@ -198,6 +201,7 @@ pub struct AndCondition(pub Vec<Relation>);
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 #[allow(missing_docs)] // TODO(#1029) - Add missing docs.
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Relation {
     pub expression: Expression,
     pub operator: Operator,
@@ -215,6 +219,7 @@ pub struct Relation {
 ///
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[allow(missing_docs)] // TODO(#1029) - Add missing docs.
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum Operator {
     Eq,
     NotEq,
@@ -244,6 +249,7 @@ pub enum Operator {
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 #[allow(missing_docs)] // TODO(#1029) - Add missing docs.
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Expression {
     pub operand: Operand,
     pub modulus: Option<Value>,
@@ -269,6 +275,7 @@ pub struct Expression {
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[allow(missing_docs)] // TODO(#1029) - Add missing docs.
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum Operand {
     /// Absolute value of input
     N,
@@ -314,6 +321,7 @@ pub enum Operand {
 ///
 /// [`RangeListItems`]: RangeListItem
 #[derive(Debug, Clone, PartialEq)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct RangeList(pub Vec<RangeListItem>);
 
 /// An enum of items that appear in a [`RangeList`]: `Range` or a `Value`.
@@ -338,6 +346,7 @@ pub struct RangeList(pub Vec<RangeListItem>);
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 #[allow(missing_docs)] // TODO(#1029) - Add missing docs.
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum RangeListItem {
     Range(RangeInclusive<Value>),
     Value(Value),
@@ -362,6 +371,7 @@ pub enum RangeListItem {
 /// RangeListItem::Value(Value(99));
 /// ```
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Value(pub u64);
 
 /// A sample of example values that match the given rule.
@@ -393,6 +403,7 @@ pub struct Value(pub u64);
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 #[allow(missing_docs)] // TODO(#1029) - Add missing docs.
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Samples {
     pub integer: Option<SampleList>,
     pub decimal: Option<SampleList>,
@@ -420,6 +431,7 @@ pub struct Samples {
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 #[allow(missing_docs)] // TODO(#1029) - Add missing docs.
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct SampleList {
     pub sample_ranges: Vec<SampleRange>,
     pub ellipsis: bool,
@@ -442,6 +454,7 @@ pub struct SampleList {
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 #[allow(missing_docs)] // TODO(#1029) - Add missing docs.
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct SampleRange {
     pub lower_val: DecimalValue,
     pub upper_val: Option<DecimalValue>,
@@ -460,4 +473,5 @@ pub struct SampleRange {
 /// DecimalValue("1.00".to_string());
 /// ```
 #[derive(Debug, Clone, PartialEq)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct DecimalValue(pub String);

--- a/components/plurals/src/rules/reference/lexer.rs
+++ b/components/plurals/src/rules/reference/lexer.rs
@@ -27,6 +27,7 @@ pub enum Token {
 }
 
 #[derive(Display, Debug)]
+#[non_exhaustive]
 pub enum LexerError {
     #[displaydoc("Expected byte: {0}")]
     ExpectedByte(u8),

--- a/components/plurals/src/rules/reference/parser.rs
+++ b/components/plurals/src/rules/reference/parser.rs
@@ -13,6 +13,7 @@ use displaydoc::Display;
 
 #[derive(Display, Debug, PartialEq, Eq, Copy, Clone)]
 #[allow(clippy::enum_variant_names)]
+#[non_exhaustive]
 pub enum ParserError {
     #[displaydoc("expected 'AND' condition")]
     ExpectedAndCondition,

--- a/components/plurals/src/rules/runtime/ast.rs
+++ b/components/plurals/src/rules/runtime/ast.rs
@@ -14,10 +14,12 @@ use zerovec::{
 };
 
 #[derive(yoke::Yokeable, zerofrom::ZeroFrom, Clone, PartialEq, Debug)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Rule<'data>(pub VarZeroVec<'data, RelationULE>);
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 #[repr(u8)]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum AndOr {
     Or,
     And,
@@ -25,6 +27,7 @@ pub enum AndOr {
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 #[repr(u8)]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum Polarity {
     Negative,
     Positive,
@@ -33,6 +36,7 @@ pub enum Polarity {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 #[repr(u8)]
 #[zerovec::make_ule(OperandULE)]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum Operand {
     N = 0,
     I = 1,
@@ -45,6 +49,7 @@ pub enum Operand {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd)]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum RangeOrValue {
     Range(u32, u32),
     Value(u32),

--- a/components/plurals/src/rules/runtime/ast.rs
+++ b/components/plurals/src/rules/runtime/ast.rs
@@ -36,7 +36,7 @@ pub enum Polarity {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 #[repr(u8)]
 #[zerovec::make_ule(OperandULE)]
-#[allow(clippy::exhaustive_enums)] // this type is stable
+#[non_exhaustive]
 pub enum Operand {
     N = 0,
     I = 1,

--- a/components/plurals/tests/fixtures/mod.rs
+++ b/components/plurals/tests/fixtures/mod.rs
@@ -65,14 +65,9 @@ pub enum PluralOperandsInput {
 impl From<PluralOperandsInput> for PluralOperands {
     fn from(input: PluralOperandsInput) -> Self {
         match input {
-            PluralOperandsInput::List(operands) => Self {
-                i: operands.1,
-                v: operands.2,
-                w: operands.3,
-                f: operands.4,
-                t: operands.5,
-                c: operands.6,
-            },
+            PluralOperandsInput::List(operands) => Self::new(
+                operands.1, operands.2, operands.3, operands.4, operands.5, operands.6,
+            ),
             PluralOperandsInput::Struct {
                 n,
                 i,
@@ -81,14 +76,14 @@ impl From<PluralOperandsInput> for PluralOperands {
                 f,
                 t,
                 c,
-            } => Self {
-                i: i.unwrap_or_else(|| n.unwrap_or(0_f64) as u64),
-                v: v.unwrap_or(0),
-                w: w.unwrap_or(0),
-                f: f.unwrap_or(0),
-                t: t.unwrap_or(0),
-                c: c.unwrap_or(0),
-            },
+            } => Self::new(
+                i.unwrap_or_else(|| n.unwrap_or(0_f64) as u64),
+                v.unwrap_or(0),
+                w.unwrap_or(0),
+                f.unwrap_or(0),
+                t.unwrap_or(0),
+                c.unwrap_or(0),
+            ),
             PluralOperandsInput::String(num) => num
                 .parse()
                 .expect("Failed to parse a number into operands."),

--- a/components/properties/src/error.rs
+++ b/components/properties/src/error.rs
@@ -9,6 +9,7 @@ use icu_provider::DataError;
 impl std::error::Error for PropertiesError {}
 
 #[derive(Display, Debug, Copy, Clone)]
+#[non_exhaustive]
 pub enum PropertiesError {
     /// An error occurred while loading data
     #[displaydoc("{0}")]

--- a/components/properties/src/lib.rs
+++ b/components/properties/src/lib.rs
@@ -76,7 +76,9 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        clippy::exhaustive_enums
     )
 )]
 

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -48,7 +48,7 @@ pub enum EnumeratedProperty {
 /// For more information, see [Unicode Standard Annex #9](https://unicode.org/reports/tr41/tr41-28.html#UAX9).
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[allow(clippy::exhaustive_structs)] // newtype
 #[repr(transparent)]
 #[zerovec::make_ule(BidiClassULE)]
 pub struct BidiClass(pub u8);
@@ -179,7 +179,7 @@ pub enum GeneralCategory {
 ///
 /// See `UCharCategory` and `U_GET_GC_MASK` in ICU4C.
 #[derive(Copy, Clone, PartialEq, Debug, Eq)]
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[allow(clippy::exhaustive_structs)] // newtype
 #[repr(transparent)]
 pub struct GeneralCategoryGroup(pub(crate) u32);
 
@@ -368,7 +368,7 @@ impl From<GeneralCategory> for GeneralCategoryGroup {
 /// See `UScriptCode` in ICU4C.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[allow(clippy::exhaustive_structs)] // newtype
 #[repr(transparent)]
 #[zerovec::make_ule(ScriptULE)]
 pub struct Script(pub u16);
@@ -548,7 +548,7 @@ impl Script {
 /// The numeric value is compatible with `UEastAsianWidth` in ICU4C.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[allow(clippy::exhaustive_structs)] // newtype
 #[repr(transparent)]
 #[zerovec::make_ule(EastAsianWidthULE)]
 pub struct EastAsianWidth(pub u8);
@@ -572,7 +572,7 @@ impl EastAsianWidth {
 /// The numeric value is compatible with `ULineBreak` in ICU4C.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[allow(clippy::exhaustive_structs)] // newtype
 #[repr(transparent)]
 #[zerovec::make_ule(LineBreakULE)]
 pub struct LineBreak(pub u8);
@@ -675,7 +675,7 @@ impl GraphemeClusterBreak {
 /// The numeric value is compatible with `UWordBreakValues` in ICU4C.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[allow(clippy::exhaustive_structs)] // newtype
 #[repr(transparent)]
 #[zerovec::make_ule(WordBreakULE)]
 pub struct WordBreak(pub u8);
@@ -720,7 +720,7 @@ impl WordBreak {
 /// The numeric value is compatible with `USentenceBreak` in ICU4C.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[allow(clippy::exhaustive_structs)] // newtype
 #[repr(transparent)]
 #[zerovec::make_ule(SentenceBreakULE)]
 pub struct SentenceBreak(pub u8);
@@ -750,7 +750,7 @@ impl SentenceBreak {
 /// <https://www.unicode.org/reports/tr15/>.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[allow(clippy::exhaustive_structs)] // newtype
 #[repr(transparent)]
 #[zerovec::make_ule(CanonicalCombiningClassULE)]
 pub struct CanonicalCombiningClass(pub u8);

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -48,6 +48,7 @@ pub enum EnumeratedProperty {
 /// For more information, see [Unicode Standard Annex #9](https://unicode.org/reports/tr41/tr41-28.html#UAX9).
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 #[repr(transparent)]
 #[zerovec::make_ule(BidiClassULE)]
 pub struct BidiClass(pub u8);
@@ -89,6 +90,7 @@ impl BidiClass {
 /// It does not support grouped categories (eg `Letter`). For grouped categories, use [`GeneralCategoryGroup`].
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_enums)] // this type is stable
 #[zerovec::make_ule(GeneralCategoryULE)]
 #[repr(u8)]
 pub enum GeneralCategory {
@@ -177,6 +179,7 @@ pub enum GeneralCategory {
 ///
 /// See `UCharCategory` and `U_GET_GC_MASK` in ICU4C.
 #[derive(Copy, Clone, PartialEq, Debug, Eq)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 #[repr(transparent)]
 pub struct GeneralCategoryGroup(pub(crate) u32);
 
@@ -365,6 +368,7 @@ impl From<GeneralCategory> for GeneralCategoryGroup {
 /// See `UScriptCode` in ICU4C.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 #[repr(transparent)]
 #[zerovec::make_ule(ScriptULE)]
 pub struct Script(pub u16);
@@ -544,6 +548,7 @@ impl Script {
 /// The numeric value is compatible with `UEastAsianWidth` in ICU4C.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 #[repr(transparent)]
 #[zerovec::make_ule(EastAsianWidthULE)]
 pub struct EastAsianWidth(pub u8);
@@ -567,6 +572,7 @@ impl EastAsianWidth {
 /// The numeric value is compatible with `ULineBreak` in ICU4C.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 #[repr(transparent)]
 #[zerovec::make_ule(LineBreakULE)]
 pub struct LineBreak(pub u8);
@@ -628,6 +634,7 @@ impl LineBreak {
 /// The numeric value is compatible with `UGraphemeClusterBreak` in ICU4C.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 #[repr(transparent)]
 #[zerovec::make_ule(GraphemeClusterBreakULE)]
 pub struct GraphemeClusterBreak(pub u8);
@@ -668,6 +675,7 @@ impl GraphemeClusterBreak {
 /// The numeric value is compatible with `UWordBreakValues` in ICU4C.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 #[repr(transparent)]
 #[zerovec::make_ule(WordBreakULE)]
 pub struct WordBreak(pub u8);
@@ -712,6 +720,7 @@ impl WordBreak {
 /// The numeric value is compatible with `USentenceBreak` in ICU4C.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 #[repr(transparent)]
 #[zerovec::make_ule(SentenceBreakULE)]
 pub struct SentenceBreak(pub u8);
@@ -741,6 +750,7 @@ impl SentenceBreak {
 /// <https://www.unicode.org/reports/tr15/>.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 #[repr(transparent)]
 #[zerovec::make_ule(CanonicalCombiningClassULE)]
 pub struct CanonicalCombiningClass(pub u8);

--- a/components/properties/src/provider.rs
+++ b/components/properties/src/provider.rs
@@ -2,6 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+// Provider structs must be stable
+#![allow(clippy::exhaustive_structs)]
+
 //! Data provider struct definitions for this ICU4X component.
 //!
 //! Read more about data providers: [`icu_provider`]

--- a/components/properties/src/script.rs
+++ b/components/properties/src/script.rs
@@ -38,6 +38,7 @@ const SCRIPT_X_SCRIPT_VAL: u16 = (1 << SCRIPT_VAL_LENGTH) - 1;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(transparent)]
 #[doc(hidden)] // `ScriptWithExt` not intended as public-facing but for `ScriptWithExtensions` constructor
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct ScriptWithExt(pub u16);
 
 #[allow(missing_docs)] // These constants don't need individual documentation.

--- a/ffi/diplomat/src/decimal.rs
+++ b/ffi/diplomat/src/decimal.rs
@@ -100,25 +100,22 @@ pub mod ffi {
         {
             let langid = locale.0.as_ref().clone();
 
-            if let Result::Ok(fdf) = FixedDecimalFormat::try_new(
-                langid,
-                provider,
-                FixedDecimalFormatOptions {
-                    grouping_strategy: match options.grouping_strategy {
-                        ICU4XFixedDecimalGroupingStrategy::Auto => GroupingStrategy::Auto,
-                        ICU4XFixedDecimalGroupingStrategy::Never => GroupingStrategy::Never,
-                        ICU4XFixedDecimalGroupingStrategy::Always => GroupingStrategy::Always,
-                        ICU4XFixedDecimalGroupingStrategy::Min2 => GroupingStrategy::Min2,
-                    },
-                    sign_display: match options.sign_display {
-                        ICU4XFixedDecimalSignDisplay::Auto => SignDisplay::Auto,
-                        ICU4XFixedDecimalSignDisplay::Never => SignDisplay::Never,
-                        ICU4XFixedDecimalSignDisplay::Always => SignDisplay::Always,
-                        ICU4XFixedDecimalSignDisplay::ExceptZero => SignDisplay::ExceptZero,
-                        ICU4XFixedDecimalSignDisplay::Negative => SignDisplay::Negative,
-                    },
-                },
-            ) {
+            let grouping_strategy = match options.grouping_strategy {
+                ICU4XFixedDecimalGroupingStrategy::Auto => GroupingStrategy::Auto,
+                ICU4XFixedDecimalGroupingStrategy::Never => GroupingStrategy::Never,
+                ICU4XFixedDecimalGroupingStrategy::Always => GroupingStrategy::Always,
+                ICU4XFixedDecimalGroupingStrategy::Min2 => GroupingStrategy::Min2,
+            };
+            let sign_display = match options.sign_display {
+                ICU4XFixedDecimalSignDisplay::Auto => SignDisplay::Auto,
+                ICU4XFixedDecimalSignDisplay::Never => SignDisplay::Never,
+                ICU4XFixedDecimalSignDisplay::Always => SignDisplay::Always,
+                ICU4XFixedDecimalSignDisplay::ExceptZero => SignDisplay::ExceptZero,
+                ICU4XFixedDecimalSignDisplay::Negative => SignDisplay::Negative,
+            };
+            let options = FixedDecimalFormatOptions::new(grouping_strategy, sign_display);
+
+            if let Result::Ok(fdf) = FixedDecimalFormat::try_new(langid, provider, options) {
                 Ok(Box::new(ICU4XFixedDecimalFormat(fdf))).into()
             } else {
                 Err(()).into()

--- a/ffi/diplomat/src/pluralrules.rs
+++ b/ffi/diplomat/src/pluralrules.rs
@@ -77,14 +77,9 @@ pub mod ffi {
         /// FFI version of `PluralRules::select()`.
         /// See [the Rust docs](https://unicode-org.github.io/icu4x-docs/doc/icu_plurals/struct.PluralRules.html#method.select) for more details.
         pub fn select(&self, op: ICU4XPluralOperands) -> ICU4XPluralCategory {
-            let res = self.0.select(PluralOperands {
-                i: op.i,
-                v: op.v,
-                w: op.w,
-                f: op.f,
-                t: op.t,
-                c: op.c,
-            });
+            let res = self
+                .0
+                .select(PluralOperands::new(op.i, op.v, op.w, op.f, op.t, op.c));
 
             match res {
                 PluralCategory::Zero => ICU4XPluralCategory::Zero,

--- a/ffi/ecma402/src/pluralrules.rs
+++ b/ffi/ecma402/src/pluralrules.rs
@@ -211,14 +211,7 @@ pub(crate) mod internal {
                     minimum_significant_digits: 3,
                     maximum_significant_digits: 4,
                 },
-                expected: PluralOperands {
-                    i: 1,
-                    v: 2,
-                    w: 1,
-                    f: 50,
-                    t: 5,
-                    c: 0,
-                },
+                expected: PluralOperands::new(1, 2, 1, 50, 5, 0),
             }];
             for test in tests {
                 let actual = to_icu4x_operands(test.n, test.opts.clone());


### PR DESCRIPTION
Progress on #170, #383

This adds the clippy lint to the decimal, plurals, locid, datetime, props, and calendar crates.





<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->