### PR TITLE
Adding to README of tinystr/TinyAsciiStr

### DIFF
--- a/utils/tinystr/README.md
+++ b/utils/tinystr/README.md
@@ -4,7 +4,9 @@
 
 It includes [`TinyAsciiStr`], a core API for representing small ASCII-only bounded length strings.
 
-It is optimized for operations on strings of size 8 or smaller. When use cases involve comparison and conversion of strings for lowercase/uppercase/titlecase, or checking numeric/alphabetic/alphanumeric, `TinyAsciiStr` is the edge performance library.
+It is optimized for operations on strings of size 8 or smaller. When use cases involve comparison
+and conversion of strings for lowercase/uppercase/titlecase, or checking
+numeric/alphabetic/alphanumeric, `TinyAsciiStr` is the edge performance library.
 
 ## Examples
 
@@ -31,7 +33,8 @@ assert_eq!(s2.is_ascii_alphanumeric(), false);
 
 ## Details
 
-When strings are of size 8 or smaller, the struct transforms the strings as `u32`/`u64` and uses bitmasking to provide basic string manipulation operations:
+When strings are of size 8 or smaller, the struct transforms the strings as `u32`/`u64` and uses
+bitmasking to provide basic string manipulation operations:
 * `is_ascii_numeric`
 * `is_ascii_alphabetic`
 * `is_ascii_alphanumeric`

--- a/utils/tinystr/README.md
+++ b/utils/tinystr/README.md
@@ -3,23 +3,48 @@
 `tinystr` is a utility crate of the [`ICU4X`] project.
 
 It includes [`TinyAsciiStr`], a core API for representing small ASCII-only bounded length strings.
-It is optimized for operations on strings of size 8 or smaller.
 
-## Examples
+It is optimized for operations on strings of size 8 or smaller. When use cases involve comparison
+and conversion of strings for lowercase/uppercase/titlecase, or checking numeric/alphabetic/alphanumeric,
+`TinyAsciiStr` is the edge performance library.
+
+### Examples
 
 ```rust
 use tinystr::TinyAsciiStr;
-use tinystr::tinystr;
 
-let ex_1 = TinyAsciiStr::<3>::try_from_raw(*b"USD");
-let ex_2: TinyAsciiStr::<4> = "test".parse().expect("Failed to parse.");
+let s1: TinyAsciiStr::<4> = "tEsT".parse().expect("Failed to parse.");
 
-assert_eq!(
-    ex_1,
-    Ok(tinystr!(3, "USD"))
-);
-assert!(ex_2.is_ascii_lowercase());
+assert_eq!(s1, "tEsT");
+assert_eq!(s1.to_ascii_uppercase(), "TEST");
+assert_eq!(s1.to_ascii_lowercase(), "test");
+assert_eq!(s1.to_ascii_titlecase(), "Test");
+assert_eq!(s1.is_ascii_alphanumeric(), true);
+assert_eq!(s1.is_ascii_numeric(), false);
+
+let s2 = TinyAsciiStr::<8>::try_from_raw(*b"New York").expect("Failed to parse.");
+
+assert_eq!(s2, "New York");
+assert_eq!(s2.to_ascii_uppercase(), "NEW YORK");
+assert_eq!(s2.to_ascii_lowercase(), "new york");
+assert_eq!(s2.to_ascii_titlecase(), "New york");
+assert_eq!(s2.is_ascii_alphanumeric(), false);
 ```
+
+### Details
+
+When strings are of size 8 or smaller, the struct transforms the strings as `u32`/`u64`
+and uses bitmasking to provide basic string manipulation operations:
+* is_ascii_numeric
+* is_ascii_alphabetic
+* is_ascii_alphanumeric
+* to_ascii_lowercase
+* to_ascii_uppercase
+* to_ascii_titlecase
+* PartialEq
+
+`TinyAsciiStr` will fall back to `u8` character manipulation for strings of length greater
+than 8.
 
 [`ICU4X`]: ../icu/index.html
 

--- a/utils/tinystr/README.md
+++ b/utils/tinystr/README.md
@@ -12,7 +12,7 @@ use tinystr::TinyAsciiStr;
 use tinystr::tinystr;
 
 let ex_1 = TinyAsciiStr::<3>::try_from_raw(*b"USD");
-let ex_2 = TinyAsciiStr::<4> = "test".parse().expect("Failed to parse.");
+let ex_2: TinyAsciiStr::<4> = "test".parse().expect("Failed to parse.");
 
 assert_eq!(
     ex_1,

--- a/utils/tinystr/README.md
+++ b/utils/tinystr/README.md
@@ -4,11 +4,9 @@
 
 It includes [`TinyAsciiStr`], a core API for representing small ASCII-only bounded length strings.
 
-It is optimized for operations on strings of size 8 or smaller. When use cases involve comparison
-and conversion of strings for lowercase/uppercase/titlecase, or checking numeric/alphabetic/alphanumeric,
-`TinyAsciiStr` is the edge performance library.
+It is optimized for operations on strings of size 8 or smaller. When use cases involve comparison and conversion of strings for lowercase/uppercase/titlecase, or checking numeric/alphabetic/alphanumeric, `TinyAsciiStr` is the edge performance library.
 
-### Examples
+## Examples
 
 ```rust
 use tinystr::TinyAsciiStr;
@@ -31,20 +29,18 @@ assert_eq!(s2.to_ascii_titlecase(), "New york");
 assert_eq!(s2.is_ascii_alphanumeric(), false);
 ```
 
-### Details
+## Details
 
-When strings are of size 8 or smaller, the struct transforms the strings as `u32`/`u64`
-and uses bitmasking to provide basic string manipulation operations:
-* is_ascii_numeric
-* is_ascii_alphabetic
-* is_ascii_alphanumeric
-* to_ascii_lowercase
-* to_ascii_uppercase
-* to_ascii_titlecase
-* PartialEq
+When strings are of size 8 or smaller, the struct transforms the strings as `u32`/`u64` and uses bitmasking to provide basic string manipulation operations:
+* `is_ascii_numeric`
+* `is_ascii_alphabetic`
+* `is_ascii_alphanumeric`
+* `to_ascii_lowercase`
+* `to_ascii_uppercase`
+* `to_ascii_titlecase`
+* `PartialEq`
 
-`TinyAsciiStr` will fall back to `u8` character manipulation for strings of length greater
-than 8.
+`TinyAsciiStr` will fall back to `u8` character manipulation for strings of length greater than 8.
 
 [`ICU4X`]: ../icu/index.html
 

--- a/utils/tinystr/README.md
+++ b/utils/tinystr/README.md
@@ -2,7 +2,7 @@
 
 `tinystr` is a utility crate of the [`ICU4X`] project.
 
-It includes [`TinyAsciiStr`], a core API for representing small ASCII-only bounded length strings. 
+It includes [`TinyAsciiStr`], a core API for representing small ASCII-only bounded length strings.
 It is optimized for operations on strings of size 8 or smaller.
 
 ## Examples
@@ -22,7 +22,6 @@ assert!(ex_2.is_ascii_lowercase());
 ```
 
 [`ICU4X`]: ../icu/index.html
-
 
 ## More Information
 

--- a/utils/tinystr/README.md
+++ b/utils/tinystr/README.md
@@ -1,5 +1,27 @@
 # tinystr [![crates.io](https://img.shields.io/crates/v/tinystr)](https://crates.io/crates/tinystr)
 
+`tinystr` is a utility crate of the [`ICU4X`] project.
+
+It includes [`TinyAsciiStr`], a core API for representing small ASCII-only bounded length strings. 
+It is optimized for operations on strings of size 8 or smaller.
+
+## Examples
+
+```rust
+use tinystr::TinyAsciiStr;
+use tinystr::tinystr;
+
+let ex_1 = TinyAsciiStr::<3>::try_from_raw(*b"USD");
+let ex_2 = TinyAsciiStr::<4> = "test".parse().expect("Failed to parse.");
+
+assert_eq!(
+    ex_1,
+    Ok(tinystr!(3, "USD"))
+);
+assert!(ex_2.is_ascii_lowercase());
+```
+
+[`ICU4X`]: ../icu/index.html
 
 
 ## More Information

--- a/utils/tinystr/src/lib.rs
+++ b/utils/tinystr/src/lib.rs
@@ -2,6 +2,29 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+//! `tinystr` is a utility crate of the [`ICU4X`] project.
+//!
+//! It includes [`TinyAsciiStr`], a core API for representing small ASCII-only bounded length strings.
+//! It is optimized for operations on strings of size 8 or smaller.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use tinystr::TinyAsciiStr;
+//! use tinystr::tinystr;
+//!
+//! let ex_1 = TinyAsciiStr::<3>::try_from_raw(*b"USD");
+//! let ex_2 = TinyAsciiStr::<4> = "test".parse().expect("Failed to parse.");
+//!
+//! assert_eq!(
+//!     ex_1,
+//!     Ok(tinystr!(3, "USD"))
+//! );
+//! assert!(ex_2.is_ascii_lowercase());
+//! ```
+//!
+//! [`ICU4X`]: ../icu/index.html
+
 // https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(

--- a/utils/tinystr/src/lib.rs
+++ b/utils/tinystr/src/lib.rs
@@ -5,23 +5,49 @@
 //! `tinystr` is a utility crate of the [`ICU4X`] project.
 //!
 //! It includes [`TinyAsciiStr`], a core API for representing small ASCII-only bounded length strings.
-//! It is optimized for operations on strings of size 8 or smaller.
 //!
-//! # Examples
+//! It is optimized for operations on strings of size 8 or smaller. When use cases involve comparison
+//! and conversion of strings for lowercase/uppercase/titlecase, or checking numeric/alphabetic/alphanumeric,
+//! `TinyAsciiStr` is the edge performance library.
+//!
+//! ## Examples
 //!
 //! ```rust
 //! use tinystr::TinyAsciiStr;
-//! use tinystr::tinystr;
 //!
-//! let ex_1 = TinyAsciiStr::<3>::try_from_raw(*b"USD");
-//! let ex_2: TinyAsciiStr::<4> = "test".parse().expect("Failed to parse.");
+//! let s1: TinyAsciiStr::<4> = "tEsT".parse().expect("Failed to parse.");
 //!
-//! assert_eq!(
-//!     ex_1,
-//!     Ok(tinystr!(3, "USD"))
-//! );
-//! assert!(ex_2.is_ascii_lowercase());
+//! assert_eq!(s1, "tEsT");
+//! assert_eq!(s1.to_ascii_uppercase(), "TEST");
+//! assert_eq!(s1.to_ascii_lowercase(), "test");
+//! assert_eq!(s1.to_ascii_titlecase(), "Test");
+//! assert_eq!(s1.is_ascii_alphanumeric(), true);
+//! assert_eq!(s1.is_ascii_numeric(), false);
+//!
+//! let s2 = TinyAsciiStr::<8>::try_from_raw(*b"New York").expect("Failed to parse.");
+//!
+//! assert_eq!(s2, "New York");
+//! assert_eq!(s2.to_ascii_uppercase(), "NEW YORK");
+//! assert_eq!(s2.to_ascii_lowercase(), "new york");
+//! assert_eq!(s2.to_ascii_titlecase(), "New york");
+//! assert_eq!(s2.is_ascii_alphanumeric(), false);
 //! ```
+//!
+//! ## Details
+//!
+//! When strings are of size 8 or smaller, the struct transforms the strings as `u32`/`u64`
+//! and uses bitmasking to provide basic string manipulation operations:
+//! * is_ascii_numeric
+//! * is_ascii_alphabetic
+//! * is_ascii_alphanumeric
+//! * to_ascii_lowercase
+//! * to_ascii_uppercase
+//! * to_ascii_titlecase
+//! * PartialEq
+//!
+//! `TinyAsciiStr` will fall back to `u8` character manipulation for strings of length greater
+//! than 8.
+
 //!
 //! [`ICU4X`]: ../icu/index.html
 

--- a/utils/tinystr/src/lib.rs
+++ b/utils/tinystr/src/lib.rs
@@ -14,7 +14,7 @@
 //! use tinystr::tinystr;
 //!
 //! let ex_1 = TinyAsciiStr::<3>::try_from_raw(*b"USD");
-//! let ex_2 = TinyAsciiStr::<4> = "test".parse().expect("Failed to parse.");
+//! let ex_2: TinyAsciiStr::<4> = "test".parse().expect("Failed to parse.");
 //!
 //! assert_eq!(
 //!     ex_1,

--- a/utils/tinystr/src/lib.rs
+++ b/utils/tinystr/src/lib.rs
@@ -6,7 +6,9 @@
 //!
 //! It includes [`TinyAsciiStr`], a core API for representing small ASCII-only bounded length strings.
 //!
-//! It is optimized for operations on strings of size 8 or smaller. When use cases involve comparison and conversion of strings for lowercase/uppercase/titlecase, or checking numeric/alphabetic/alphanumeric, `TinyAsciiStr` is the edge performance library.
+//! It is optimized for operations on strings of size 8 or smaller. When use cases involve comparison
+//! and conversion of strings for lowercase/uppercase/titlecase, or checking
+//! numeric/alphabetic/alphanumeric, `TinyAsciiStr` is the edge performance library.
 //!
 //! # Examples
 //!
@@ -33,7 +35,8 @@
 //!
 //! # Details
 //!
-//! When strings are of size 8 or smaller, the struct transforms the strings as `u32`/`u64` and uses bitmasking to provide basic string manipulation operations:
+//! When strings are of size 8 or smaller, the struct transforms the strings as `u32`/`u64` and uses
+//! bitmasking to provide basic string manipulation operations:
 //! * `is_ascii_numeric`
 //! * `is_ascii_alphabetic`
 //! * `is_ascii_alphanumeric`

--- a/utils/tinystr/src/lib.rs
+++ b/utils/tinystr/src/lib.rs
@@ -6,11 +6,9 @@
 //!
 //! It includes [`TinyAsciiStr`], a core API for representing small ASCII-only bounded length strings.
 //!
-//! It is optimized for operations on strings of size 8 or smaller. When use cases involve comparison
-//! and conversion of strings for lowercase/uppercase/titlecase, or checking numeric/alphabetic/alphanumeric,
-//! `TinyAsciiStr` is the edge performance library.
+//! It is optimized for operations on strings of size 8 or smaller. When use cases involve comparison and conversion of strings for lowercase/uppercase/titlecase, or checking numeric/alphabetic/alphanumeric, `TinyAsciiStr` is the edge performance library.
 //!
-//! ## Examples
+//! # Examples
 //!
 //! ```rust
 //! use tinystr::TinyAsciiStr;
@@ -33,20 +31,18 @@
 //! assert_eq!(s2.is_ascii_alphanumeric(), false);
 //! ```
 //!
-//! ## Details
+//! # Details
 //!
-//! When strings are of size 8 or smaller, the struct transforms the strings as `u32`/`u64`
-//! and uses bitmasking to provide basic string manipulation operations:
-//! * is_ascii_numeric
-//! * is_ascii_alphabetic
-//! * is_ascii_alphanumeric
-//! * to_ascii_lowercase
-//! * to_ascii_uppercase
-//! * to_ascii_titlecase
-//! * PartialEq
+//! When strings are of size 8 or smaller, the struct transforms the strings as `u32`/`u64` and uses bitmasking to provide basic string manipulation operations:
+//! * `is_ascii_numeric`
+//! * `is_ascii_alphabetic`
+//! * `is_ascii_alphanumeric`
+//! * `to_ascii_lowercase`
+//! * `to_ascii_uppercase`
+//! * `to_ascii_titlecase`
+//! * `PartialEq`
 //!
-//! `TinyAsciiStr` will fall back to `u8` character manipulation for strings of length greater
-//! than 8.
+//! `TinyAsciiStr` will fall back to `u8` character manipulation for strings of length greater than 8.
 
 //!
 //! [`ICU4X`]: ../icu/index.html


### PR DESCRIPTION
While working on `tinystr` and `TinyAsciiStr`, I've added a small blurb onto the README with what I've found