### PR TITLE
1712: add TinyAsciStr::is_ascii_alphabetic_lowercase, TinyAsciStr::is_ascii_alphabetic_titlecase, TinyAsciStr::is_ascii_alphabetic_uppercase

### DIFF
--- a/components/locid/src/subtags/language.rs
+++ b/components/locid/src/subtags/language.rs
@@ -102,7 +102,7 @@ impl Language {
             .map_err(|_| ParserError::InvalidSubtag)?;
         let is_valid = match s.len() {
             // LANGUAGE_LENGTH
-            2..=3 => s.is_ascii_alphabetic() && s.is_ascii_lowercase(),
+            2..=3 => s.is_ascii_alphabetic_lowercase(),
             _ => false,
         };
         if is_valid {

--- a/components/locid/src/subtags/region.rs
+++ b/components/locid/src/subtags/region.rs
@@ -87,7 +87,7 @@ impl Region {
         let s = TinyAsciiStr::<{ core::mem::size_of::<Self>() }>::try_from_raw(v)
             .map_err(|_| ParserError::InvalidSubtag)?;
         let is_valid = match s.len() {
-            REGION_ALPHA_LENGTH => s.is_ascii_alphabetic() && s.is_ascii_uppercase(),
+            REGION_ALPHA_LENGTH => s.is_ascii_alphabetic_uppercase(),
             REGION_NUM_LENGTH => s.is_ascii_numeric(),
             _ => false,
         };

--- a/components/locid/src/subtags/script.rs
+++ b/components/locid/src/subtags/script.rs
@@ -82,7 +82,7 @@ impl Script {
         let s = TinyAsciiStr::<{ core::mem::size_of::<Self>() }>::try_from_raw(v)
             .map_err(|_| ParserError::InvalidSubtag)?;
         let is_valid = match s.len() {
-            SCRIPT_LENGTH => s.is_ascii_alphabetic() && s.is_ascii_titlecase(),
+            SCRIPT_LENGTH => s.is_ascii_alphabetic_titlecase(),
             _ => false,
         };
         if is_valid {

--- a/utils/tinystr/src/ascii.rs
+++ b/utils/tinystr/src/ascii.rs
@@ -861,9 +861,9 @@ mod test {
         fn check<const N: usize>() {
             check_operation(
                 |s| {
-                    // Convert alphabetic
+                    // Check alphabetic
                     s.chars().all(|c| c.is_ascii_alphabetic()) &&
-                    // Convert lowercase
+                    // Check lowercase
                     s == TinyAsciiStr::<16>::from_str(s)
                         .unwrap()
                         .to_ascii_lowercase()
@@ -885,9 +885,9 @@ mod test {
         fn check<const N: usize>() {
             check_operation(
                 |s| {
-                    // Convert alphabetic
+                    // Check alphabetic
                     s.chars().all(|c| c.is_ascii_alphabetic()) &&
-                    // Convert titlecase
+                    // Check titlecase
                     s == TinyAsciiStr::<16>::from_str(s)
                         .unwrap()
                         .to_ascii_titlecase()
@@ -909,9 +909,9 @@ mod test {
         fn check<const N: usize>() {
             check_operation(
                 |s| {
-                    // Convert alphabetic
+                    // Check alphabetic
                     s.chars().all(|c| c.is_ascii_alphabetic()) &&
-                    // Convert uppercase
+                    // Check uppercase
                     s == TinyAsciiStr::<16>::from_str(s)
                         .unwrap()
                         .to_ascii_uppercase()

--- a/utils/tinystr/src/ascii.rs
+++ b/utils/tinystr/src/ascii.rs
@@ -473,7 +473,7 @@ impl<const N: usize> TinyAsciiStr<N> {
         )
     }
 
-    /// Checks if the value is composed of ASCII alphabetic upper  case characters:
+    /// Checks if the value is composed of ASCII alphabetic upper case characters:
     ///
     ///  * U+0041 'A' ..= U+005A 'Z',
     ///

--- a/utils/tinystr/src/int_ops.rs
+++ b/utils/tinystr/src/int_ops.rs
@@ -106,8 +106,6 @@ impl Aligned4 {
         let alpha = !(lower + 0x1f1f_1f1f) | (lower + 0x0505_0505);
         // See explanatory comments in is_ascii_lowercase
         let invalid_case = !(word + 0x3f3f_3f3f) | (word + 0x2525_2525);
-        // (alpha & mask)  == 0
-        // (invalid_case & 0x8080_8080) == 0x8080_8080
         (alpha & mask) ^ (invalid_case & 0x8080_8080) == 0x8080_8080
     }
 

--- a/utils/tinystr/src/int_ops.rs
+++ b/utils/tinystr/src/int_ops.rs
@@ -100,39 +100,33 @@ impl Aligned4 {
 
     pub const fn is_ascii_alphabetic_lowercase(&self) -> bool {
         let word = self.0;
-        // See explanatory comments in is_ascii_alphabetic
+        // `mask` sets all NUL bytes to 0.
         let mask = (word + 0x7f7f_7f7f) & 0x8080_8080;
-        let lower = word | 0x2020_2020;
-        let alpha = !(lower + 0x1f1f_1f1f) | (lower + 0x0505_0505);
-        // See explanatory comments in is_ascii_lowercase
-        let invalid_case = !(word + 0x3f3f_3f3f) | (word + 0x2525_2525);
-        (alpha & mask) ^ (invalid_case & 0x8080_8080) == 0x8080_8080
+        // `lower_alpha` sets all lowercase ASCII characters to 0 and all others to 1.
+        let lower_alpha = !(word + 0x1f1f_1f1f) | (word + 0x0505_0505);
+        // The overall string is valid if every character passes at least one test.
+        // We performed two tests here: non-NUL (`mask`) and lowercase ASCII character (`alpha`).
+        (lower_alpha & mask) == 0
     }
 
     pub const fn is_ascii_alphabetic_titlecase(&self) -> bool {
         let word = self.0;
-        // See explanatory comments in is_ascii_alphabetic
+        // See explanatory comments in is_ascii_alphabetic_lowercase
         let mask = (word + 0x7f7f_7f7f) & 0x8080_8080;
-        let lower = word | 0x2020_2020;
-        let alpha = !(lower + 0x1f1f_1f1f) | (lower + 0x0505_0505);
-        // See explanatory comments in is_ascii_lowercase
-        let invalid_case = if cfg!(target_endian = "little") {
-            !(word + 0x3f3f_3f1f) | (word + 0x2525_2505)
+        let title_case = if cfg!(target_endian = "little") {
+            !(word + 0x1f1f_1f3f) | (word + 0x0505_0525)
         } else {
-            !(word + 0x1f3f_3f3f) | (word + 0x0525_2525)
+            !(word + 0x3f1f_1f1f) | (word + 0x2505_0505)
         };
-        (alpha & mask) ^ (invalid_case & 0x8080_8080) == 0x8080_8080
+        (title_case & mask) == 0
     }
 
     pub const fn is_ascii_alphabetic_uppercase(&self) -> bool {
         let word = self.0;
-        // See explanatory comments in is_ascii_alphabetic
+        // See explanatory comments in is_ascii_alphabetic_lowercase
         let mask = (word + 0x7f7f_7f7f) & 0x8080_8080;
-        let lower = word | 0x2020_2020;
-        let alpha = !(lower + 0x1f1f_1f1f) | (lower + 0x0505_0505);
-        // See explanatory comments in is_ascii_lowercase
-        let invalid_case = !(word + 0x1f1f_1f1f) | (word + 0x0505_0505);
-        (alpha & mask) ^ (invalid_case & 0x8080_8080) == 0x8080_8080
+        let upper_alpha = !(word + 0x3f3f_3f3f) | (word + 0x2525_2525);
+        (upper_alpha & mask) == 0
     }
 
     pub const fn to_ascii_lowercase(&self) -> Self {
@@ -238,36 +232,33 @@ impl Aligned8 {
 
     pub const fn is_ascii_alphabetic_lowercase(&self) -> bool {
         let word = self.0;
+        // `mask` sets all NUL bytes to 0.
         let mask = (word + 0x7f7f_7f7f_7f7f_7f7f) & 0x8080_8080_8080_8080;
-        let lower = word | 0x2020_2020_2020_2020;
-        let alpha = !(lower + 0x1f1f_1f1f_1f1f_1f1f) | (lower + 0x0505_0505_0505_0505);
-
-        let invalid_case = !(word + 0x3f3f_3f3f_3f3f_3f3f) | (word + 0x2525_2525_2525_2525);
-        (alpha & mask) ^ (invalid_case & 0x8080_8080_8080_8080) == 0x8080_8080_8080_8080
+        // `lower_alpha` sets all lowercase ASCII characters to 0 and all others to 1.
+        let lower_alpha = !(word + 0x1f1f_1f1f_1f1f_1f1f) | (word + 0x0505_0505_0505_0505);
+        // The overall string is valid if every character passes at least one test.
+        // We performed two tests here: non-NUL (`mask`) and lowercase ASCII character (`alpha`).
+        (lower_alpha & mask) == 0
     }
 
     pub const fn is_ascii_alphabetic_titlecase(&self) -> bool {
         let word = self.0;
+        // See explanatory comments in is_ascii_alphabetic_lowercase
         let mask = (word + 0x7f7f_7f7f_7f7f_7f7f) & 0x8080_8080_8080_8080;
-        let lower = word | 0x2020_2020_2020_2020;
-        let alpha = !(lower + 0x1f1f_1f1f_1f1f_1f1f) | (lower + 0x0505_0505_0505_0505);
-
-        let invalid_case = if cfg!(target_endian = "little") {
-            !(word + 0x3f3f_3f3f_3f3f_3f1f) | (word + 0x2525_2525_2525_2505)
+        let title_case = if cfg!(target_endian = "little") {
+            !(word + 0x1f1f_1f1f_1f1f_1f3f) | (word + 0x0505_0505_0505_0525)
         } else {
-            !(word + 0x1f3f_3f3f_3f3f_3f3f) | (word + 0x0525_2525_2525_2525)
+            !(word + 0x3f1f_1f1f_1f1f_1f1f) | (word + 0x2505_0505_0505_0505)
         };
-        (alpha & mask) ^ (invalid_case & 0x8080_8080_8080_8080) == 0x8080_8080_8080_8080
+        (title_case & mask) == 0
     }
 
     pub const fn is_ascii_alphabetic_uppercase(&self) -> bool {
         let word = self.0;
+        // See explanatory comments in is_ascii_alphabetic_lowercase
         let mask = (word + 0x7f7f_7f7f_7f7f_7f7f) & 0x8080_8080_8080_8080;
-        let lower = word | 0x2020_2020_2020_2020;
-        let alpha = !(lower + 0x1f1f_1f1f_1f1f_1f1f) | (lower + 0x0505_0505_0505_0505);
-
-        let invalid_case = !(word + 0x1f1f_1f1f_1f1f_1f1f) | (word + 0x0505_0505_0505_0505);
-        (alpha & mask) ^ (invalid_case & 0x8080_8080_8080_8080) == 0x8080_8080_8080_8080
+        let upper_alpha = !(word + 0x3f3f_3f3f_3f3f_3f3f) | (word + 0x2525_2525_2525_2525);
+        (upper_alpha & mask) == 0
     }
 
     pub const fn to_ascii_lowercase(&self) -> Self {

--- a/utils/tinystr/src/int_ops.rs
+++ b/utils/tinystr/src/int_ops.rs
@@ -98,6 +98,45 @@ impl Aligned4 {
         (invalid_case & 0x8080_8080) == 0x8080_8080
     }
 
+    pub const fn is_ascii_alphabetic_lowercase(&self) -> bool {
+        let word = self.0;
+        // See explanatory comments in is_ascii_alphabetic
+        let mask = (word + 0x7f7f_7f7f) & 0x8080_8080;
+        let lower = word | 0x2020_2020;
+        let alpha = !(lower + 0x1f1f_1f1f) | (lower + 0x0505_0505);
+        // See explanatory comments in is_ascii_lowercase
+        let invalid_case = !(word + 0x3f3f_3f3f) | (word + 0x2525_2525);
+        // (alpha & mask)  == 0
+        // (invalid_case & 0x8080_8080) == 0x8080_8080
+        (alpha & mask) ^ (invalid_case & 0x8080_8080) == 0x8080_8080
+    }
+
+    pub const fn is_ascii_alphabetic_titlecase(&self) -> bool {
+        let word = self.0;
+        // See explanatory comments in is_ascii_alphabetic
+        let mask = (word + 0x7f7f_7f7f) & 0x8080_8080;
+        let lower = word | 0x2020_2020;
+        let alpha = !(lower + 0x1f1f_1f1f) | (lower + 0x0505_0505);
+        // See explanatory comments in is_ascii_lowercase
+        let invalid_case = if cfg!(target_endian = "little") {
+            !(word + 0x3f3f_3f1f) | (word + 0x2525_2505)
+        } else {
+            !(word + 0x1f3f_3f3f) | (word + 0x0525_2525)
+        };
+        (alpha & mask) ^ (invalid_case & 0x8080_8080) == 0x8080_8080
+    }
+
+    pub const fn is_ascii_alphabetic_uppercase(&self) -> bool {
+        let word = self.0;
+        // See explanatory comments in is_ascii_alphabetic
+        let mask = (word + 0x7f7f_7f7f) & 0x8080_8080;
+        let lower = word | 0x2020_2020;
+        let alpha = !(lower + 0x1f1f_1f1f) | (lower + 0x0505_0505);
+        // See explanatory comments in is_ascii_lowercase
+        let invalid_case = !(word + 0x1f1f_1f1f) | (word + 0x0505_0505);
+        (alpha & mask) ^ (invalid_case & 0x8080_8080) == 0x8080_8080
+    }
+
     pub const fn to_ascii_lowercase(&self) -> Self {
         let word = self.0;
         let result = word | (((word + 0x3f3f_3f3f) & !(word + 0x2525_2525) & 0x8080_8080) >> 2);
@@ -197,6 +236,40 @@ impl Aligned8 {
         let word = self.0;
         let invalid_case = !(word + 0x1f1f_1f1f_1f1f_1f1f) | (word + 0x0505_0505_0505_0505);
         (invalid_case & 0x8080_8080_8080_8080) == 0x8080_8080_8080_8080
+    }
+
+    pub const fn is_ascii_alphabetic_lowercase(&self) -> bool {
+        let word = self.0;
+        let mask = (word + 0x7f7f_7f7f_7f7f_7f7f) & 0x8080_8080_8080_8080;
+        let lower = word | 0x2020_2020_2020_2020;
+        let alpha = !(lower + 0x1f1f_1f1f_1f1f_1f1f) | (lower + 0x0505_0505_0505_0505);
+
+        let invalid_case = !(word + 0x3f3f_3f3f_3f3f_3f3f) | (word + 0x2525_2525_2525_2525);
+        (alpha & mask) ^ (invalid_case & 0x8080_8080_8080_8080) == 0x8080_8080_8080_8080
+    }
+
+    pub const fn is_ascii_alphabetic_titlecase(&self) -> bool {
+        let word = self.0;
+        let mask = (word + 0x7f7f_7f7f_7f7f_7f7f) & 0x8080_8080_8080_8080;
+        let lower = word | 0x2020_2020_2020_2020;
+        let alpha = !(lower + 0x1f1f_1f1f_1f1f_1f1f) | (lower + 0x0505_0505_0505_0505);
+
+        let invalid_case = if cfg!(target_endian = "little") {
+            !(word + 0x3f3f_3f3f_3f3f_3f1f) | (word + 0x2525_2525_2525_2505)
+        } else {
+            !(word + 0x1f3f_3f3f_3f3f_3f3f) | (word + 0x0525_2525_2525_2525)
+        };
+        (alpha & mask) ^ (invalid_case & 0x8080_8080_8080_8080) == 0x8080_8080_8080_8080
+    }
+
+    pub const fn is_ascii_alphabetic_uppercase(&self) -> bool {
+        let word = self.0;
+        let mask = (word + 0x7f7f_7f7f_7f7f_7f7f) & 0x8080_8080_8080_8080;
+        let lower = word | 0x2020_2020_2020_2020;
+        let alpha = !(lower + 0x1f1f_1f1f_1f1f_1f1f) | (lower + 0x0505_0505_0505_0505);
+
+        let invalid_case = !(word + 0x1f1f_1f1f_1f1f_1f1f) | (word + 0x0505_0505_0505_0505);
+        (alpha & mask) ^ (invalid_case & 0x8080_8080_8080_8080) == 0x8080_8080_8080_8080
     }
 
     pub const fn to_ascii_lowercase(&self) -> Self {


### PR DESCRIPTION
Following issue https://github.com/unicode-org/icu4x/issues/1712

Adds functionality for:
* TinyAsciStr:: is_ascii_alphabetic_lowercase
* TinyAsciStr:: is_ascii_alphabetic_titlecase
* TinyAsciStr:: is_ascii_alphabetic_uppercase

Substitutes related `s.is_ascii_alphabetic() && s.is_ascii_Xcase()` calls in neighboring libraries with equivalents