### PR TITLE
#1717 adding negative 0 example

### DIFF
--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -49,6 +49,14 @@ const_assert!(core::mem::size_of::<usize>() >= core::mem::size_of::<u16>());
 ///
 /// dec.multiply_pow10(-2);
 /// assert_eq!("2.50", dec.to_string());
+///
+/// // IEEE 754 for floating point defines the sign bit separate
+/// // from the mantissa and exponent, allowing for -0.
+/// let zero = FixedDecimal::from(0);
+/// let negative_zero = FixedDecimal::from(0).negated();
+/// assert_eq!("0", zero.to_string());
+/// assert_eq!("-0", negative_zero.to_string());
+/// assert_ne!(zero, negative_zero)
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct FixedDecimal {

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -325,12 +325,12 @@ impl FixedDecimal {
     ///
     /// dec.negate();
     /// assert_eq!("42", dec.to_string());
-    /// 
+    ///
     /// // Negative zero example
     /// let zero = FixedDecimal::from(0);
     /// let mut negative_zero = FixedDecimal::from(0);
     /// negative_zero.negate();
-    /// 
+    ///
     /// assert_eq!("0", zero.to_string());
     /// assert_eq!("-0", negative_zero.to_string());
     /// assert_ne!(zero, negative_zero);
@@ -966,7 +966,7 @@ impl FixedDecimal {
     /// ```rust
     /// use fixed_decimal::{DoublePrecision, FixedDecimal};
     /// use writeable::Writeable;
-    /// 
+    ///
     /// // IEEE 754 for floating point defines the sign bit separate
     /// // from the mantissa and exponent, allowing for -0.
     /// let negative_zero = FixedDecimal::try_from_f64(

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -348,7 +348,6 @@ impl FixedDecimal {
     /// use fixed_decimal::FixedDecimal;
     ///
     /// assert_eq!(FixedDecimal::from(-42), FixedDecimal::from(42).negated());
-    /// assert_ne!(FixedDecimal::from(0), FixedDecimal::from(0).negated());
     /// ```
     pub fn negated(mut self) -> Self {
         self.negate();

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -49,14 +49,6 @@ const_assert!(core::mem::size_of::<usize>() >= core::mem::size_of::<u16>());
 ///
 /// dec.multiply_pow10(-2);
 /// assert_eq!("2.50", dec.to_string());
-///
-/// // IEEE 754 for floating point defines the sign bit separate
-/// // from the mantissa and exponent, allowing for -0.
-/// let zero = FixedDecimal::from(0);
-/// let negative_zero = FixedDecimal::from(0).negated();
-/// assert_eq!("0", zero.to_string());
-/// assert_eq!("-0", negative_zero.to_string());
-/// assert_ne!(zero, negative_zero);
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct FixedDecimal {
@@ -318,6 +310,7 @@ impl FixedDecimal {
     }
 
     /// Change the value from negative to positive or from positive to negative, modifying self.
+    /// Negative zero is supported.
     ///
     /// # Examples
     ///
@@ -332,6 +325,15 @@ impl FixedDecimal {
     ///
     /// dec.negate();
     /// assert_eq!("42", dec.to_string());
+    /// 
+    /// // Negative zero example
+    /// let zero = FixedDecimal::from(0);
+    /// let mut negative_zero = FixedDecimal::from(0);
+    /// negative_zero.negate();
+    /// 
+    /// assert_eq!("0", zero.to_string());
+    /// assert_eq!("-0", negative_zero.to_string());
+    /// assert_ne!(zero, negative_zero);
     /// ```
     pub fn negate(&mut self) {
         self.is_negative = !self.is_negative;
@@ -346,6 +348,7 @@ impl FixedDecimal {
     /// use fixed_decimal::FixedDecimal;
     ///
     /// assert_eq!(FixedDecimal::from(-42), FixedDecimal::from(42).negated());
+    /// assert_ne!(FixedDecimal::from(0), FixedDecimal::from(0).negated());
     /// ```
     pub fn negated(mut self) -> Self {
         self.negate();
@@ -956,14 +959,20 @@ impl FixedDecimal {
     /// )
     /// .expect("Finite, integer-valued quantity");
     /// assert_eq!(decimal.write_to_string(), "12345678000");
+    /// ```
     ///
+    /// Negative zero is supported.
+    ///
+    /// ```rust
+    /// use fixed_decimal::{DoublePrecision, FixedDecimal};
+    /// use writeable::Writeable;
+    /// 
     /// // IEEE 754 for floating point defines the sign bit separate
     /// // from the mantissa and exponent, allowing for -0.
     /// let negative_zero = FixedDecimal::try_from_f64(
     ///     -0.0,
     ///      DoublePrecision::Integer
     /// ).expect("Negative zero");
-    /// assert_eq!(negative_zero.write_to_string(), "-0");
     /// ```
     pub fn try_from_f64(float: f64, precision: DoublePrecision) -> Result<Self, Error> {
         let mut decimal = Self::new_from_f64_raw(float)?;

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -56,7 +56,7 @@ const_assert!(core::mem::size_of::<usize>() >= core::mem::size_of::<u16>());
 /// let negative_zero = FixedDecimal::from(0).negated();
 /// assert_eq!("0", zero.to_string());
 /// assert_eq!("-0", negative_zero.to_string());
-/// assert_ne!(zero, negative_zero)
+/// assert_ne!(zero, negative_zero);
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct FixedDecimal {
@@ -956,6 +956,14 @@ impl FixedDecimal {
     /// )
     /// .expect("Finite, integer-valued quantity");
     /// assert_eq!(decimal.write_to_string(), "12345678000");
+    ///
+    /// // IEEE 754 for floating point defines the sign bit separate
+    /// // from the mantissa and exponent, allowing for -0.
+    /// let negative_zero = FixedDecimal::try_from_f64(
+    ///     -0.0,
+    ///      DoublePrecision::Integer
+    /// ).expect("Negative zero");
+    /// assert_eq!(negative_zero.write_to_string(), "-0");
     /// ```
     pub fn try_from_f64(float: f64, precision: DoublePrecision) -> Result<Self, Error> {
         let mut decimal = Self::new_from_f64_raw(float)?;

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -972,6 +972,7 @@ impl FixedDecimal {
     ///     -0.0,
     ///      DoublePrecision::Integer
     /// ).expect("Negative zero");
+    /// assert_eq!(negative_zero.write_to_string(), "-0");
     /// ```
     pub fn try_from_f64(float: f64, precision: DoublePrecision) -> Result<Self, Error> {
         let mut decimal = Self::new_from_f64_raw(float)?;


### PR DESCRIPTION
Supplementing  `utils/fixed_decimal_src/decimal.rs` main example with comment and example demonstrating negative 0. 

Fixes #1717 