### PR TITLE
Macroify properties

### DIFF
--- a/components/properties/src/maps.rs
+++ b/components/properties/src/maps.rs
@@ -15,9 +15,9 @@
 use crate::error::PropertiesError;
 use crate::provider::*;
 use crate::*;
-use BidiClass;
 use icu_codepointtrie::TrieValue;
 use icu_provider::prelude::*;
+use BidiClass;
 
 /// TODO(#1239): Finalize this API.
 pub type CodePointMapResult<T> =

--- a/components/properties/src/maps.rs
+++ b/components/properties/src/maps.rs
@@ -13,9 +13,7 @@
 //! [`TR44`]: https://www.unicode.org/reports/tr44
 
 use crate::error::PropertiesError;
-use crate::props::BidiClass;
 use crate::provider::*;
-use crate::*;
 use icu_codepointtrie::TrieValue;
 use icu_provider::prelude::*;
 
@@ -35,227 +33,267 @@ where
     Ok(property_payload)
 }
 
-/// Return a [`CodePointTrie`] for the General_Category Unicode enumerated property. See [`GeneralCategory`].
-///
-/// # Example
-///
-/// ```
-/// use icu::properties::{maps, GeneralCategory};
-/// use icu_codepointtrie::CodePointTrie;
-///
-/// let provider = icu_testdata::get_provider();
-///
-/// let payload =
-///     maps::get_general_category(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let gc = &data_struct.code_point_trie;
-/// assert_eq!(gc.get('木' as u32), GeneralCategory::OtherLetter);  // U+6728
-/// assert_eq!(gc.get('🎃' as u32), GeneralCategory::OtherSymbol);  // U+1F383 JACK-O-LANTERN
-/// ```
-///
-/// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
-pub fn get_general_category<D>(provider: &D) -> CodePointMapResult<GeneralCategory>
-where
-    D: DynProvider<UnicodePropertyMapV1Marker<GeneralCategory>> + ?Sized,
-{
-    get_cp_map(provider, key::GENERAL_CATEGORY_V1)
+macro_rules! make_map_property {
+    (
+        // currently unused
+        property: $prop_name:expr;
+        // currently unused
+        marker: $marker_name:ident;
+        value: $value_ty:path;
+        key: $key_name:expr;
+        func:
+        $(#[$attr:meta])*
+        pub fn $funcname:ident();
+    ) => {
+        $(#[$attr])*
+        pub fn $funcname<D>(provider: &D) -> CodePointMapResult<$value_ty>
+        where
+            D: DynProvider<UnicodePropertyMapV1Marker<$value_ty>> + ?Sized,
+        {
+            get_cp_map(provider, $key_name)
+        }
+    }
 }
 
-/// Return a [`CodePointTrie`] for the Bidi_Class Unicode enumerated property. See [`BidiClass`].
-///
-/// # Example
-///
-/// ```
-/// use icu::properties::{maps, BidiClass};
-/// use icu_codepointtrie::CodePointTrie;
-///
-/// let provider = icu_testdata::get_provider();
-///
-/// let payload =
-///     maps::get_bidi_class(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let bc = &data_struct.code_point_trie;
-/// assert_eq!(bc.get('y' as u32), BidiClass::LeftToRight);  // U+0079
-/// assert_eq!(bc.get('ع' as u32), BidiClass::ArabicLetter);  // U+0639
-/// ```
-///
-/// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
-pub fn get_bidi_class<D>(provider: &D) -> CodePointMapResult<BidiClass>
-where
-    D: DynProvider<UnicodePropertyMapV1Marker<BidiClass>> + ?Sized,
-{
-    get_cp_map(provider, key::BIDI_CLASS)
+make_map_property! {
+    property: "General_Category";
+    marker: GeneralCategoryProperty;
+    value: crate::props::GeneralCategory;
+    key: crate::provider::key::GENERAL_CATEGORY_V1;
+    func:
+    /// Return a [`CodePointTrie`] for the General_Category Unicode enumerated property. See [`GeneralCategory`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu::properties::{maps, GeneralCategory};
+    /// use icu_codepointtrie::CodePointTrie;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    ///
+    /// let payload =
+    ///     maps::get_general_category(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let gc = &data_struct.code_point_trie;
+    /// assert_eq!(gc.get('木' as u32), GeneralCategory::OtherLetter);  // U+6728
+    /// assert_eq!(gc.get('🎃' as u32), GeneralCategory::OtherSymbol);  // U+1F383 JACK-O-LANTERN
+    /// ```
+    ///
+    /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
+    pub fn get_general_category();
 }
 
-/// Return a [`CodePointTrie`] for the Script Unicode enumerated property. See [`Script`].
-///
-/// # Example
-///
-/// ```
-/// use icu::properties::{maps, Script};
-/// use icu_codepointtrie::CodePointTrie;
-///
-/// let provider = icu_testdata::get_provider();
-///
-/// let payload =
-///     maps::get_script(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let script = &data_struct.code_point_trie;
-/// assert_eq!(script.get('木' as u32), Script::Han);  // U+6728
-/// assert_eq!(script.get('🎃' as u32), Script::Common);  // U+1F383 JACK-O-LANTERN
-/// ```
-///
-/// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
-pub fn get_script<D>(provider: &D) -> CodePointMapResult<Script>
-where
-    D: DynProvider<UnicodePropertyMapV1Marker<Script>> + ?Sized,
-{
-    get_cp_map(provider, key::SCRIPT_V1)
+make_map_property! {
+    property: "Bidi_Class";
+    marker: BidiClassProperty;
+    value: crate::props::BidiClass;
+    key: crate::provider::key::BIDI_CLASS;
+    func:
+    /// Return a [`CodePointTrie`] for the Bidi_Class Unicode enumerated property. See [`BidiClass`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu::properties::{maps, BidiClass};
+    /// use icu_codepointtrie::CodePointTrie;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    ///
+    /// let payload =
+    ///     maps::get_bidi_class(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let bc = &data_struct.code_point_trie;
+    /// assert_eq!(bc.get('y' as u32), BidiClass::LeftToRight);  // U+0079
+    /// assert_eq!(bc.get('ع' as u32), BidiClass::ArabicLetter);  // U+0639
+    /// ```
+    ///
+    /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
+    pub fn get_bidi_class();
 }
 
-/// Return a [`CodePointTrie`] for the East_Asian_Width Unicode enumerated
-/// property. See [`EastAsianWidth`].
-///
-/// # Example
-///
-/// ```
-/// use icu::properties::{maps, EastAsianWidth};
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload = maps::get_east_asian_width(&provider).expect("The data should be valid!");
-/// let eaw = &payload.get().code_point_trie;
-///
-/// assert_eq!(eaw.get('ｱ' as u32), EastAsianWidth::Halfwidth); // U+FF71: Halfwidth Katakana Letter A
-/// assert_eq!(eaw.get('ア' as u32), EastAsianWidth::Wide); //U+30A2: Katakana Letter A
-/// ```
-///
-/// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
-pub fn get_east_asian_width<D>(provider: &D) -> CodePointMapResult<EastAsianWidth>
-where
-    D: DynProvider<UnicodePropertyMapV1Marker<EastAsianWidth>> + ?Sized,
-{
-    get_cp_map(provider, key::EAST_ASIAN_WIDTH_V1)
+make_map_property! {
+    property: "Script";
+    marker: ScriptProperty;
+    value: crate::props::Script;
+    key: crate::provider::key::SCRIPT_V1;
+    func:
+    /// Return a [`CodePointTrie`] for the Script Unicode enumerated property. See [`Script`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu::properties::{maps, Script};
+    /// use icu_codepointtrie::CodePointTrie;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    ///
+    /// let payload =
+    ///     maps::get_script(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let script = &data_struct.code_point_trie;
+    /// assert_eq!(script.get('木' as u32), Script::Han);  // U+6728
+    /// assert_eq!(script.get('🎃' as u32), Script::Common);  // U+1F383 JACK-O-LANTERN
+    /// ```
+    ///
+    /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
+    pub fn get_script();
 }
 
-/// Return a [`CodePointTrie`] for the Line_Break Unicode enumerated
-/// property. See [`LineBreak`].
-///
-/// # Example
-///
-/// ```
-/// use icu::properties::{maps, LineBreak};
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload = maps::get_line_break(&provider).expect("The data should be valid!");
-/// let lb = &payload.get().code_point_trie;
-///
-/// assert_eq!(lb.get(')' as u32), LineBreak::CloseParenthesis); // U+0029: Right Parenthesis
-/// assert_eq!(lb.get('ぁ' as u32), LineBreak::ConditionalJapaneseStarter); //U+3041: Hiragana Letter Small A
-/// ```
-///
-/// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
-pub fn get_line_break<D>(provider: &D) -> CodePointMapResult<LineBreak>
-where
-    D: DynProvider<UnicodePropertyMapV1Marker<LineBreak>> + ?Sized,
-{
-    get_cp_map(provider, key::LINE_BREAK_V1)
+make_map_property! {
+    property: "East_Asian_Width";
+    marker: EastAsianWidthProperty;
+    value: crate::props::EastAsianWidth;
+    key: crate::provider::key::EAST_ASIAN_WIDTH_V1;
+    func:
+    /// Return a [`CodePointTrie`] for the East_Asian_Width Unicode enumerated
+    /// property. See [`EastAsianWidth`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu::properties::{maps, EastAsianWidth};
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload = maps::get_east_asian_width(&provider).expect("The data should be valid!");
+    /// let eaw = &payload.get().code_point_trie;
+    ///
+    /// assert_eq!(eaw.get('ｱ' as u32), EastAsianWidth::Halfwidth); // U+FF71: Halfwidth Katakana Letter A
+    /// assert_eq!(eaw.get('ア' as u32), EastAsianWidth::Wide); //U+30A2: Katakana Letter A
+    /// ```
+    ///
+    /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
+    pub fn get_east_asian_width();
 }
 
-/// Return a [`CodePointTrie`] for the Grapheme_Cluster_Break Unicode enumerated
-/// property. See [`GraphemeClusterBreak`].
-///
-/// # Example
-///
-/// ```
-/// use icu::properties::{maps, GraphemeClusterBreak};
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload = maps::get_grapheme_cluster_break(&provider).expect("The data should be valid!");
-/// let gcb = &payload.get().code_point_trie;
-///
-/// assert_eq!(gcb.get('🇦' as u32), GraphemeClusterBreak::RegionalIndicator); // U+1F1E6: Regional Indicator Symbol Letter A
-/// assert_eq!(gcb.get('ำ' as u32), GraphemeClusterBreak::SpacingMark); //U+0E33: Thai Character Sara Am
-/// ```
-///
-/// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
-pub fn get_grapheme_cluster_break<D>(provider: &D) -> CodePointMapResult<GraphemeClusterBreak>
-where
-    D: DynProvider<UnicodePropertyMapV1Marker<GraphemeClusterBreak>> + ?Sized,
-{
-    get_cp_map(provider, key::GRAPHEME_CLUSTER_BREAK_V1)
+make_map_property! {
+    property: "Line_Break";
+    marker: LineBreakProperty;
+    value: crate::props::LineBreak;
+    key: crate::provider::key::LINE_BREAK_V1;
+    func:
+    /// Return a [`CodePointTrie`] for the Line_Break Unicode enumerated
+    /// property. See [`LineBreak`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu::properties::{maps, LineBreak};
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload = maps::get_line_break(&provider).expect("The data should be valid!");
+    /// let lb = &payload.get().code_point_trie;
+    ///
+    /// assert_eq!(lb.get(')' as u32), LineBreak::CloseParenthesis); // U+0029: Right Parenthesis
+    /// assert_eq!(lb.get('ぁ' as u32), LineBreak::ConditionalJapaneseStarter); //U+3041: Hiragana Letter Small A
+    /// ```
+    ///
+    /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
+    pub fn get_line_break();
 }
 
-/// Return a [`CodePointTrie`] for the Word_Break Unicode enumerated
-/// property. See [`WordBreak`].
-///
-/// # Example
-///
-/// ```
-/// use icu::properties::{maps, WordBreak};
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload = maps::get_word_break(&provider).expect("The data should be valid!");
-/// let wb = &payload.get().code_point_trie;
-///
-/// assert_eq!(wb.get('.' as u32), WordBreak::MidNumLet); // U+002E: Full Stop
-/// assert_eq!(wb.get('，' as u32), WordBreak::MidNum); // U+FF0C: Fullwidth Comma
-/// ```
-///
-/// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
-pub fn get_word_break<D>(provider: &D) -> CodePointMapResult<WordBreak>
-where
-    D: DynProvider<UnicodePropertyMapV1Marker<WordBreak>> + ?Sized,
-{
-    get_cp_map(provider, key::WORD_BREAK_V1)
+make_map_property! {
+    property: "Grapheme_Cluster_Break";
+    marker: GraphemeClusterBreakProperty;
+    value: crate::props::GraphemeClusterBreak;
+    key: crate::provider::key::GRAPHEME_CLUSTER_BREAK_V1;
+    func:
+    /// Return a [`CodePointTrie`] for the Grapheme_Cluster_Break Unicode enumerated
+    /// property. See [`GraphemeClusterBreak`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu::properties::{maps, GraphemeClusterBreak};
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload = maps::get_grapheme_cluster_break(&provider).expect("The data should be valid!");
+    /// let gcb = &payload.get().code_point_trie;
+    ///
+    /// assert_eq!(gcb.get('🇦' as u32), GraphemeClusterBreak::RegionalIndicator); // U+1F1E6: Regional Indicator Symbol Letter A
+    /// assert_eq!(gcb.get('ำ' as u32), GraphemeClusterBreak::SpacingMark); //U+0E33: Thai Character Sara Am
+    /// ```
+    ///
+    /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
+    pub fn get_grapheme_cluster_break();
 }
 
-/// Return a [`CodePointTrie`] for the Sentence_Break Unicode enumerated
-/// property. See [`SentenceBreak`].
-///
-/// # Example
-///
-/// ```
-/// use icu::properties::{maps, SentenceBreak};
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload = maps::get_sentence_break(&provider).expect("The data should be valid!");
-/// let sb = &payload.get().code_point_trie;
-///
-/// assert_eq!(sb.get('９' as u32), SentenceBreak::Numeric); // U+FF19: Fullwidth Digit Nine
-/// assert_eq!(sb.get(',' as u32), SentenceBreak::SContinue); // U+002C: Comma
-/// ```
-///
-/// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
-pub fn get_sentence_break<D>(provider: &D) -> CodePointMapResult<SentenceBreak>
-where
-    D: DynProvider<UnicodePropertyMapV1Marker<SentenceBreak>> + ?Sized,
-{
-    get_cp_map(provider, key::SENTENCE_BREAK_V1)
+make_map_property! {
+    property: "Word_Break";
+    marker: WordBreakProperty;
+    value: crate::props::WordBreak;
+    key: crate::provider::key::WORD_BREAK_V1;
+    func:
+    /// Return a [`CodePointTrie`] for the Word_Break Unicode enumerated
+    /// property. See [`WordBreak`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu::properties::{maps, WordBreak};
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload = maps::get_word_break(&provider).expect("The data should be valid!");
+    /// let wb = &payload.get().code_point_trie;
+    ///
+    /// assert_eq!(wb.get('.' as u32), WordBreak::MidNumLet); // U+002E: Full Stop
+    /// assert_eq!(wb.get('，' as u32), WordBreak::MidNum); // U+FF0C: Fullwidth Comma
+    /// ```
+    ///
+    /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
+    pub fn get_word_break();
 }
 
-/// Return a [`CodePointTrie`] for the Canonical_Combining_Class Unicode property. See
-/// [`CanonicalCombiningClass`].
-///
-/// # Example
-///
-/// ```
-/// use icu::properties::{maps, CanonicalCombiningClass};
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload = maps::get_canonical_combining_class(&provider).expect("The data should be valid!");
-/// let sb = &payload.get().code_point_trie;
-///
-/// assert_eq!(sb.get('a' as u32), CanonicalCombiningClass::NotReordered); // U+0061: LATIN SMALL LETTER A
-/// assert_eq!(sb.get(0x0301), CanonicalCombiningClass::Above); // U+0301: COMBINING ACUTE ACCENT
-/// ```
-///
-/// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
-pub fn get_canonical_combining_class<D>(provider: &D) -> CodePointMapResult<CanonicalCombiningClass>
-where
-    D: DynProvider<UnicodePropertyMapV1Marker<CanonicalCombiningClass>> + ?Sized,
-{
-    get_cp_map(provider, key::CANONICAL_COMBINING_CLASS_V1)
+make_map_property! {
+    property: "Sentence_Break";
+    marker: SentenceBreakProperty;
+    value: crate::props::SentenceBreak;
+    key: crate::provider::key::SENTENCE_BREAK_V1;
+    func:
+    /// Return a [`CodePointTrie`] for the Sentence_Break Unicode enumerated
+    /// property. See [`SentenceBreak`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu::properties::{maps, SentenceBreak};
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload = maps::get_sentence_break(&provider).expect("The data should be valid!");
+    /// let sb = &payload.get().code_point_trie;
+    ///
+    /// assert_eq!(sb.get('９' as u32), SentenceBreak::Numeric); // U+FF19: Fullwidth Digit Nine
+    /// assert_eq!(sb.get(',' as u32), SentenceBreak::SContinue); // U+002C: Comma
+    /// ```
+    ///
+    /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
+    pub fn get_sentence_break();
+}
+
+make_map_property! {
+    property: "Canonical_Combining_Class";
+    marker: CanonicalCombiningClassProperty;
+    value: crate::props::CanonicalCombiningClass;
+    key: crate::provider::key::CANONICAL_COMBINING_CLASS_V1;
+    func:
+    /// Return a [`CodePointTrie`] for the Canonical_Combining_Class Unicode property. See
+    /// [`CanonicalCombiningClass`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu::properties::{maps, CanonicalCombiningClass};
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload = maps::get_canonical_combining_class(&provider).expect("The data should be valid!");
+    /// let sb = &payload.get().code_point_trie;
+    ///
+    /// assert_eq!(sb.get('a' as u32), CanonicalCombiningClass::NotReordered); // U+0061: LATIN SMALL LETTER A
+    /// assert_eq!(sb.get(0x0301), CanonicalCombiningClass::Above); // U+0301: COMBINING ACUTE ACCENT
+    /// ```
+    ///
+    /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
+    pub fn get_canonical_combining_class();
 }

--- a/components/properties/src/maps.rs
+++ b/components/properties/src/maps.rs
@@ -14,6 +14,8 @@
 
 use crate::error::PropertiesError;
 use crate::provider::*;
+use crate::*;
+use BidiClass;
 use icu_codepointtrie::TrieValue;
 use icu_provider::prelude::*;
 
@@ -58,7 +60,7 @@ macro_rules! make_map_property {
 make_map_property! {
     property: "General_Category";
     marker: GeneralCategoryProperty;
-    value: crate::props::GeneralCategory;
+    value: GeneralCategory;
     key: crate::provider::key::GENERAL_CATEGORY_V1;
     func:
     /// Return a [`CodePointTrie`] for the General_Category Unicode enumerated property. See [`GeneralCategory`].
@@ -87,7 +89,7 @@ make_map_property! {
 make_map_property! {
     property: "Bidi_Class";
     marker: BidiClassProperty;
-    value: crate::props::BidiClass;
+    value: BidiClass;
     key: crate::provider::key::BIDI_CLASS;
     func:
     /// Return a [`CodePointTrie`] for the Bidi_Class Unicode enumerated property. See [`BidiClass`].
@@ -116,7 +118,7 @@ make_map_property! {
 make_map_property! {
     property: "Script";
     marker: ScriptProperty;
-    value: crate::props::Script;
+    value: Script;
     key: crate::provider::key::SCRIPT_V1;
     func:
     /// Return a [`CodePointTrie`] for the Script Unicode enumerated property. See [`Script`].
@@ -145,7 +147,7 @@ make_map_property! {
 make_map_property! {
     property: "East_Asian_Width";
     marker: EastAsianWidthProperty;
-    value: crate::props::EastAsianWidth;
+    value: EastAsianWidth;
     key: crate::provider::key::EAST_ASIAN_WIDTH_V1;
     func:
     /// Return a [`CodePointTrie`] for the East_Asian_Width Unicode enumerated
@@ -171,7 +173,7 @@ make_map_property! {
 make_map_property! {
     property: "Line_Break";
     marker: LineBreakProperty;
-    value: crate::props::LineBreak;
+    value: LineBreak;
     key: crate::provider::key::LINE_BREAK_V1;
     func:
     /// Return a [`CodePointTrie`] for the Line_Break Unicode enumerated
@@ -197,7 +199,7 @@ make_map_property! {
 make_map_property! {
     property: "Grapheme_Cluster_Break";
     marker: GraphemeClusterBreakProperty;
-    value: crate::props::GraphemeClusterBreak;
+    value: GraphemeClusterBreak;
     key: crate::provider::key::GRAPHEME_CLUSTER_BREAK_V1;
     func:
     /// Return a [`CodePointTrie`] for the Grapheme_Cluster_Break Unicode enumerated
@@ -223,7 +225,7 @@ make_map_property! {
 make_map_property! {
     property: "Word_Break";
     marker: WordBreakProperty;
-    value: crate::props::WordBreak;
+    value: WordBreak;
     key: crate::provider::key::WORD_BREAK_V1;
     func:
     /// Return a [`CodePointTrie`] for the Word_Break Unicode enumerated
@@ -249,7 +251,7 @@ make_map_property! {
 make_map_property! {
     property: "Sentence_Break";
     marker: SentenceBreakProperty;
-    value: crate::props::SentenceBreak;
+    value: SentenceBreak;
     key: crate::provider::key::SENTENCE_BREAK_V1;
     func:
     /// Return a [`CodePointTrie`] for the Sentence_Break Unicode enumerated
@@ -275,7 +277,7 @@ make_map_property! {
 make_map_property! {
     property: "Canonical_Combining_Class";
     marker: CanonicalCombiningClassProperty;
-    value: crate::props::CanonicalCombiningClass;
+    value: CanonicalCombiningClass;
     key: crate::provider::key::CANONICAL_COMBINING_CLASS_V1;
     func:
     /// Return a [`CodePointTrie`] for the Canonical_Combining_Class Unicode property. See

--- a/components/properties/src/sets.rs
+++ b/components/properties/src/sets.rs
@@ -1590,7 +1590,6 @@ make_set_property! {
     pub fn get_xid_start();
 }
 
-
 //
 // Enumerated property getter fns
 //

--- a/components/properties/src/sets.rs
+++ b/components/properties/src/sets.rs
@@ -40,1405 +40,1556 @@ where
 // Binary property getter fns
 //
 
-/// ASCII characters commonly used for the representation of hexadecimal numbers
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_ascii_hex_digit(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let ascii_hex_digit = &data_struct.inv_list;
-///
-/// assert!(ascii_hex_digit.contains('3'));
-/// assert!(!ascii_hex_digit.contains('੩'));  // U+0A69 GURMUKHI DIGIT THREE
-/// assert!(ascii_hex_digit.contains('A'));
-/// assert!(!ascii_hex_digit.contains('Ä'));  // U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS
-/// ```
-pub fn get_ascii_hex_digit<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::ASCII_HEX_DIGIT_V1)
-}
-
-/// Characters with the Alphabetic or Decimal_Number property
-/// This is defined for POSIX compatibility.
-pub fn get_alnum<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::ALNUM_V1)
-}
-
-/// Alphabetic characters
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_alphabetic(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let alphabetic = &data_struct.inv_list;
-///
-/// assert!(!alphabetic.contains('3'));
-/// assert!(!alphabetic.contains('੩'));  // U+0A69 GURMUKHI DIGIT THREE
-/// assert!(alphabetic.contains('A'));
-/// assert!(alphabetic.contains('Ä'));  // U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS
-/// ```
-pub fn get_alphabetic<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::ALPHABETIC_V1)
-}
-
-/// Format control characters which have specific functions in the Unicode Bidirectional
-/// Algorithm
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_bidi_control(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let bidi_control = &data_struct.inv_list;
-///
-/// assert!(bidi_control.contains_u32(0x200F));  // RIGHT-TO-LEFT MARK
-/// assert!(!bidi_control.contains('ش'));  // U+0634 ARABIC LETTER SHEEN
-/// ```
-pub fn get_bidi_control<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::BIDI_CONTROL_V1)
-}
-
-/// Characters that are mirrored in bidirectional text
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_bidi_mirrored(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let bidi_mirrored = &data_struct.inv_list;
-///
-/// assert!(bidi_mirrored.contains('['));
-/// assert!(bidi_mirrored.contains(']'));
-/// assert!(bidi_mirrored.contains('∑'));  // U+2211 N-ARY SUMMATION
-/// assert!(!bidi_mirrored.contains('ཉ'));  // U+0F49 TIBETAN LETTER NYA
-/// ```
-pub fn get_bidi_mirrored<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::BIDI_MIRRORED_V1)
-}
-
-/// Horizontal whitespace characters
-pub fn get_blank<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::BLANK_V1)
-}
-
-/// Uppercase, lowercase, and titlecase characters
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_cased(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let cased = &data_struct.inv_list;
-///
-/// assert!(cased.contains('Ꙡ'));  // U+A660 CYRILLIC CAPITAL LETTER REVERSED TSE
-/// assert!(!cased.contains('ދ'));  // U+078B THAANA LETTER DHAALU
-/// ```
-pub fn get_cased<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::CASED_V1)
-}
-
-/// Characters which are ignored for casing purposes
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_case_ignorable(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let case_ignorable = &data_struct.inv_list;
-///
-/// assert!(case_ignorable.contains(':'));
-/// assert!(!case_ignorable.contains('λ'));  // U+03BB GREEK SMALL LETTER LAMDA
-/// ```
-pub fn get_case_ignorable<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::CASE_IGNORABLE_V1)
-}
-
-/// Characters that are excluded from composition
-/// See <https://unicode.org/Public/UNIDATA/CompositionExclusions.txt>
-pub fn get_full_composition_exclusion<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::FULL_COMPOSITION_EXCLUSION_V1)
-}
-
-/// Characters whose normalized forms are not stable under case folding
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_changes_when_casefolded(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let changes_when_casefolded = &data_struct.inv_list;
-///
-/// assert!(changes_when_casefolded.contains('ß'));  // U+00DF LATIN SMALL LETTER SHARP S
-/// assert!(!changes_when_casefolded.contains('ᜉ'));  // U+1709 TAGALOG LETTER PA
-/// ```
-pub fn get_changes_when_casefolded<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::CHANGES_WHEN_CASEFOLDED_V1)
-}
-
-/// Characters which may change when they undergo case mapping
-pub fn get_changes_when_casemapped<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::CHANGES_WHEN_CASEMAPPED_V1)
-}
-
-/// Characters which are not identical to their NFKC_Casefold mapping
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_changes_when_nfkc_casefolded(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let changes_when_nfkc_casefolded = &data_struct.inv_list;
-///
-/// assert!(changes_when_nfkc_casefolded.contains('🄵'));  // U+1F135 SQUARED LATIN CAPITAL LETTER F
-/// assert!(!changes_when_nfkc_casefolded.contains('f'));
-/// ```
-pub fn get_changes_when_nfkc_casefolded<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::CHANGES_WHEN_NFKC_CASEFOLDED_V1)
-}
-
-/// Characters whose normalized forms are not stable under a toLowercase mapping
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_changes_when_lowercased(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let changes_when_lowercased = &data_struct.inv_list;
-///
-/// assert!(changes_when_lowercased.contains('Ⴔ'));  // U+10B4 GEORGIAN CAPITAL LETTER PHAR
-/// assert!(!changes_when_lowercased.contains('ფ'));  // U+10E4 GEORGIAN LETTER PHAR
-/// ```
-pub fn get_changes_when_lowercased<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::CHANGES_WHEN_LOWERCASED_V1)
-}
-
-/// Characters whose normalized forms are not stable under a toTitlecase mapping
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_changes_when_titlecased(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let changes_when_titlecased = &data_struct.inv_list;
-///
-/// assert!(changes_when_titlecased.contains('æ'));  // U+00E6 LATIN SMALL LETTER AE
-/// assert!(!changes_when_titlecased.contains('Æ'));  // U+00E6 LATIN CAPITAL LETTER AE
-/// ```
-pub fn get_changes_when_titlecased<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::CHANGES_WHEN_TITLECASED_V1)
-}
-
-/// Characters whose normalized forms are not stable under a toUppercase mapping
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_changes_when_uppercased(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let changes_when_uppercased = &data_struct.inv_list;
-///
-/// assert!(changes_when_uppercased.contains('ւ'));  // U+0582 ARMENIAN SMALL LETTER YIWN
-/// assert!(!changes_when_uppercased.contains('Ւ'));  // U+0552 ARMENIAN CAPITAL LETTER YIWN
-/// ```
-pub fn get_changes_when_uppercased<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::CHANGES_WHEN_UPPERCASED_V1)
-}
-
-/// Punctuation characters explicitly called out as dashes in the Unicode Standard, plus
-/// their compatibility equivalents
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_dash(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let dash = &data_struct.inv_list;
-///
-/// assert!(dash.contains('⸺'));  // U+2E3A TWO-EM DASH
-/// assert!(dash.contains('-'));  // U+002D
-/// assert!(!dash.contains('='));  // U+003D
-/// ```
-pub fn get_dash<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::DASH_V1)
-}
-
-/// Deprecated characters. No characters will ever be removed from the standard, but the
-/// usage of deprecated characters is strongly discouraged.
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_deprecated(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let deprecated = &data_struct.inv_list;
-///
-/// assert!(deprecated.contains('ឣ'));  // U+17A3 KHMER INDEPENDENT VOWEL QAQ
-/// assert!(!deprecated.contains('A'));
-/// ```
-pub fn get_deprecated<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::DEPRECATED_V1)
-}
-
-/// For programmatic determination of default ignorable code points.  New characters that
-/// should be ignored in rendering (unless explicitly supported) will be assigned in these
-/// ranges, permitting programs to correctly handle the default rendering of such
-/// characters when not otherwise supported.
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_default_ignorable_code_point(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let default_ignorable_code_point = &data_struct.inv_list;
-///
-/// assert!(default_ignorable_code_point.contains_u32(0x180B));  // MONGOLIAN FREE VARIATION SELECTOR ONE
-/// assert!(!default_ignorable_code_point.contains('E'));
-/// ```
-pub fn get_default_ignorable_code_point<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::DEFAULT_IGNORABLE_CODE_POINT_V1)
-}
-
-/// Characters that linguistically modify the meaning of another character to which they apply
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_diacritic(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let diacritic = &data_struct.inv_list;
-///
-/// assert!(diacritic.contains('\u{05B3}'));  // HEBREW POINT HATAF QAMATS
-/// assert!(!diacritic.contains('א'));  // U+05D0 HEBREW LETTER ALEF
-/// ```
-pub fn get_diacritic<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::DIACRITIC_V1)
-}
-
-/// Characters that can serve as a base for emoji modifiers
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_emoji_modifier_base(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let emoji_modifier_base = &data_struct.inv_list;
-///
-/// assert!(emoji_modifier_base.contains('✊'));  // U+270A RAISED FIST
-/// assert!(!emoji_modifier_base.contains('⛰'));  // U+26F0 MOUNTAIN
-/// ```
-pub fn get_emoji_modifier_base<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::EMOJI_MODIFIER_BASE_V1)
-}
-
-/// Characters used in emoji sequences that normally do not appear on emoji keyboards as
-/// separate choices, such as base characters for emoji keycaps
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_emoji_component(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let emoji_component = &data_struct.inv_list;
-///
-/// assert!(emoji_component.contains('🇹'));  // U+1F1F9 REGIONAL INDICATOR SYMBOL LETTER T
-/// assert!(emoji_component.contains_u32(0x20E3));  // COMBINING ENCLOSING KEYCAP
-/// assert!(emoji_component.contains('7'));
-/// assert!(!emoji_component.contains('T'));
-/// ```
-pub fn get_emoji_component<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::EMOJI_COMPONENT_V1)
-}
-
-/// Characters that are emoji modifiers
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_emoji_modifier(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let emoji_modifier = &data_struct.inv_list;
-///
-/// assert!(emoji_modifier.contains_u32(0x1F3FD));  // EMOJI MODIFIER FITZPATRICK TYPE-4
-/// assert!(!emoji_modifier.contains_u32(0x200C));  // ZERO WIDTH NON-JOINER
-/// ```
-pub fn get_emoji_modifier<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::EMOJI_MODIFIER_V1)
-}
-
-/// Characters that are emoji
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_emoji(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let emoji = &data_struct.inv_list;
-///
-/// assert!(emoji.contains('🔥'));  // U+1F525 FIRE
-/// assert!(!emoji.contains('V'));
-/// ```
-pub fn get_emoji<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::EMOJI_V1)
-}
-
-/// Characters that have emoji presentation by default
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_emoji_presentation(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let emoji_presentation = &data_struct.inv_list;
-///
-/// assert!(emoji_presentation.contains('🦬')); // U+1F9AC BISON
-/// assert!(!emoji_presentation.contains('♻'));  // U+267B BLACK UNIVERSAL RECYCLING SYMBOL
-/// ```
-pub fn get_emoji_presentation<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::EMOJI_PRESENTATION_V1)
-}
-
-/// Characters whose principal function is to extend the value of a preceding alphabetic
-/// character or to extend the shape of adjacent characters.
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_extender(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let extender = &data_struct.inv_list;
-///
-/// assert!(extender.contains('ヾ'));  // U+30FE KATAKANA VOICED ITERATION MARK
-/// assert!(extender.contains('ー'));  // U+30FC KATAKANA-HIRAGANA PROLONGED SOUND MARK
-/// assert!(!extender.contains('・'));  // U+30FB KATAKANA MIDDLE DOT
-/// ```
-pub fn get_extender<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::EXTENDER_V1)
-}
-
-/// Pictographic symbols, as well as reserved ranges in blocks largely associated with
-/// emoji characters
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_extended_pictographic(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let extended_pictographic = &data_struct.inv_list;
-///
-/// assert!(extended_pictographic.contains('🥳')); // U+1F973 FACE WITH PARTY HORN AND PARTY HAT
-/// assert!(!extended_pictographic.contains('🇪'));  // U+1F1EA REGIONAL INDICATOR SYMBOL LETTER E
-/// ```
-pub fn get_extended_pictographic<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::EXTENDED_PICTOGRAPHIC_V1)
-}
-
-/// Visible characters.
-/// This is defined for POSIX compatibility.
-pub fn get_graph<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::GRAPH_V1)
-}
-
-/// Property used together with the definition of Standard Korean Syllable Block to define
-/// "Grapheme base". See D58 in Chapter 3, Conformance in the Unicode Standard.
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_grapheme_base(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let grapheme_base = &data_struct.inv_list;
-///
-/// assert!(grapheme_base.contains('ക'));  // U+0D15 MALAYALAM LETTER KA
-/// assert!(grapheme_base.contains('\u{0D3F}'));  // U+0D3F MALAYALAM VOWEL SIGN I
-/// assert!(!grapheme_base.contains('\u{0D3E}'));  // U+0D3E MALAYALAM VOWEL SIGN AA
-/// ```
-pub fn get_grapheme_base<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::GRAPHEME_BASE_V1)
-}
-
-/// Property used to define "Grapheme extender". See D59 in Chapter 3, Conformance in the
-/// Unicode Standard.
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_grapheme_extend(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let grapheme_extend = &data_struct.inv_list;
-///
-/// assert!(!grapheme_extend.contains('ക'));  // U+0D15 MALAYALAM LETTER KA
-/// assert!(!grapheme_extend.contains('\u{0D3F}'));  // U+0D3F MALAYALAM VOWEL SIGN I
-/// assert!(grapheme_extend.contains('\u{0D3E}'));  // U+0D3E MALAYALAM VOWEL SIGN AA
-/// ```
-pub fn get_grapheme_extend<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::GRAPHEME_EXTEND_V1)
-}
-
-/// Deprecated property. Formerly proposed for programmatic determination of grapheme
-/// cluster boundaries.
-pub fn get_grapheme_link<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::GRAPHEME_LINK_V1)
-}
-
-/// Characters commonly used for the representation of hexadecimal numbers, plus their
-/// compatibility equivalents
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_hex_digit(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let hex_digit = &data_struct.inv_list;
-///
-/// assert!(hex_digit.contains('0'));
-/// assert!(!hex_digit.contains('੩'));  // U+0A69 GURMUKHI DIGIT THREE
-/// assert!(hex_digit.contains('f'));
-/// assert!(hex_digit.contains('ｆ'));  // U+FF46 FULLWIDTH LATIN SMALL LETTER F
-/// assert!(hex_digit.contains('Ｆ'));  // U+FF26 FULLWIDTH LATIN CAPITAL LETTER F
-/// assert!(!hex_digit.contains('Ä'));  // U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS
-/// ```
-pub fn get_hex_digit<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::HEX_DIGIT_V1)
-}
-
-/// Deprecated property. Dashes which are used to mark connections between pieces of
-/// words, plus the Katakana middle dot.
-pub fn get_hyphen<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::HYPHEN_V1)
-}
-
-/// Characters that can come after the first character in an identifier. If using NFKC to
-/// fold differences between characters, use [`get_xid_continue`] instead.  See
-/// [`Unicode Standard Annex #31`](https://www.unicode.org/reports/tr31/tr31-35.html) for
-/// more details.
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_id_continue(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let id_continue = &data_struct.inv_list;
-///
-/// assert!(id_continue.contains('x'));
-/// assert!(id_continue.contains('1'));
-/// assert!(id_continue.contains('_'));
-/// assert!(id_continue.contains('ߝ'));  // U+07DD NKO LETTER FA
-/// assert!(!id_continue.contains('ⓧ'));  // U+24E7 CIRCLED LATIN SMALL LETTER X
-/// assert!(id_continue.contains_u32(0xFC5E));  // ARABIC LIGATURE SHADDA WITH DAMMATAN ISOLATED FORM
-/// ```
-pub fn get_id_continue<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::ID_CONTINUE_V1)
-}
-
-/// Characters considered to be CJKV (Chinese, Japanese, Korean, and Vietnamese)
-/// ideographs, or related siniform ideographs
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_ideographic(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let ideographic = &data_struct.inv_list;
-///
-/// assert!(ideographic.contains('川'));  // U+5DDD CJK UNIFIED IDEOGRAPH-5DDD
-/// assert!(!ideographic.contains('밥'));  // U+BC25 HANGUL SYLLABLE BAB
-/// ```
-pub fn get_ideographic<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::IDEOGRAPHIC_V1)
-}
-
-/// Characters that can begin an identifier. If using NFKC to fold differences between
-/// characters, use [`get_xid_start`] instead.  See [`Unicode Standard Annex
-/// #31`](https://www.unicode.org/reports/tr31/tr31-35.html) for more details.
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_id_start(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let id_start = &data_struct.inv_list;
-///
-/// assert!(id_start.contains('x'));
-/// assert!(!id_start.contains('1'));
-/// assert!(!id_start.contains('_'));
-/// assert!(id_start.contains('ߝ'));  // U+07DD NKO LETTER FA
-/// assert!(!id_start.contains('ⓧ'));  // U+24E7 CIRCLED LATIN SMALL LETTER X
-/// assert!(id_start.contains_u32(0xFC5E));  // ARABIC LIGATURE SHADDA WITH DAMMATAN ISOLATED FORM
-/// ```
-pub fn get_id_start<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::ID_START_V1)
-}
-
-/// Characters used in Ideographic Description Sequences
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_ids_binary_operator(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let ids_binary_operator = &data_struct.inv_list;
-///
-/// assert!(ids_binary_operator.contains_u32(0x2FF5));  // IDEOGRAPHIC DESCRIPTION CHARACTER SURROUND FROM ABOVE
-/// assert!(!ids_binary_operator.contains_u32(0x3006));  // IDEOGRAPHIC CLOSING MARK
-/// ```
-pub fn get_ids_binary_operator<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::IDS_BINARY_OPERATOR_V1)
-}
-
-/// Characters used in Ideographic Description Sequences
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_ids_trinary_operator(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let ids_trinary_operator = &data_struct.inv_list;
-///
-/// assert!(ids_trinary_operator.contains_u32(0x2FF2));  // IDEOGRAPHIC DESCRIPTION CHARACTER LEFT TO MIDDLE AND RIGHT
-/// assert!(ids_trinary_operator.contains_u32(0x2FF3));  // IDEOGRAPHIC DESCRIPTION CHARACTER ABOVE TO MIDDLE AND BELOW
-/// assert!(!ids_trinary_operator.contains_u32(0x2FF4));
-/// assert!(!ids_trinary_operator.contains_u32(0x2FF5));  // IDEOGRAPHIC DESCRIPTION CHARACTER SURROUND FROM ABOVE
-/// assert!(!ids_trinary_operator.contains_u32(0x3006));  // IDEOGRAPHIC CLOSING MARK
-/// ```
-pub fn get_ids_trinary_operator<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::IDS_TRINARY_OPERATOR_V1)
-}
-
-/// Format control characters which have specific functions for control of cursive joining
-/// and ligation
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_join_control(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let join_control = &data_struct.inv_list;
-///
-/// assert!(join_control.contains_u32(0x200C));  // ZERO WIDTH NON-JOINER
-/// assert!(join_control.contains_u32(0x200D));  // ZERO WIDTH JOINER
-/// assert!(!join_control.contains_u32(0x200E));
-/// ```
-pub fn get_join_control<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::JOIN_CONTROL_V1)
-}
-
-/// A small number of spacing vowel letters occurring in certain Southeast Asian scripts such as Thai and Lao
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_logical_order_exception(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let logical_order_exception = &data_struct.inv_list;
-///
-/// assert!(logical_order_exception.contains('ແ'));  // U+0EC1 LAO VOWEL SIGN EI
-/// assert!(!logical_order_exception.contains('ະ'));  // U+0EB0 LAO VOWEL SIGN A
-/// ```
-pub fn get_logical_order_exception<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::LOGICAL_ORDER_EXCEPTION_V1)
-}
-
-/// Lowercase characters
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_lowercase(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let lowercase = &data_struct.inv_list;
-///
-/// assert!(lowercase.contains('a'));
-/// assert!(!lowercase.contains('A'));
-/// ```
-pub fn get_lowercase<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::LOWERCASE_V1)
-}
-
-/// Characters used in mathematical notation
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_math(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let math = &data_struct.inv_list;
-///
-/// assert!(math.contains('='));
-/// assert!(math.contains('+'));
-/// assert!(!math.contains('-'));
-/// assert!(math.contains('−'));  // U+2212 MINUS SIGN
-/// assert!(!math.contains('/'));
-/// assert!(math.contains('∕'));  // U+2215 DIVISION SLASH
-/// ```
-pub fn get_math<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::MATH_V1)
-}
-
-/// Code points permanently reserved for internal use
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_noncharacter_code_point(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let noncharacter_code_point = &data_struct.inv_list;
-///
-/// assert!(noncharacter_code_point.contains_u32(0xFDD0));
-/// assert!(noncharacter_code_point.contains_u32(0xFFFF));
-/// assert!(!noncharacter_code_point.contains_u32(0x10000));
-/// ```
-pub fn get_noncharacter_code_point<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::NONCHARACTER_CODE_POINT_V1)
-}
-
-/// Characters that are inert under NFC, i.e., they do not interact with adjacent characters
-pub fn get_nfc_inert<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::NFC_INERT_V1)
-}
-
-/// Characters that are inert under NFD, i.e., they do not interact with adjacent characters
-pub fn get_nfd_inert<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::NFD_INERT_V1)
-}
-
-/// Characters that are inert under NFKC, i.e., they do not interact with adjacent characters
-pub fn get_nfkc_inert<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::NFKC_INERT_V1)
-}
-
-/// Characters that are inert under NFKD, i.e., they do not interact with adjacent characters
-pub fn get_nfkd_inert<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::NFKD_INERT_V1)
-}
-
-/// Characters used as syntax in patterns (such as regular expressions). See [`Unicode
-/// Standard Annex #31`](https://www.unicode.org/reports/tr31/tr31-35.html) for more
-/// details.
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_pattern_syntax(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let pattern_syntax = &data_struct.inv_list;
-///
-/// assert!(pattern_syntax.contains('{'));
-/// assert!(pattern_syntax.contains('⇒'));  // U+21D2 RIGHTWARDS DOUBLE ARROW
-/// assert!(!pattern_syntax.contains('0'));
-/// ```
-pub fn get_pattern_syntax<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::PATTERN_SYNTAX_V1)
-}
-
-/// Characters used as whitespace in patterns (such as regular expressions).  See
-/// [`Unicode Standard Annex #31`](https://www.unicode.org/reports/tr31/tr31-35.html) for
-/// more details.
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_pattern_white_space(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let pattern_white_space = &data_struct.inv_list;
-///
-/// assert!(pattern_white_space.contains(' '));
-/// assert!(pattern_white_space.contains_u32(0x2029));  // PARAGRAPH SEPARATOR
-/// assert!(pattern_white_space.contains_u32(0x000A));  // NEW LINE
-/// assert!(!pattern_white_space.contains_u32(0x00A0));  // NO-BREAK SPACE
-/// ```
-pub fn get_pattern_white_space<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::PATTERN_WHITE_SPACE_V1)
-}
-
-/// A small class of visible format controls, which precede and then span a sequence of
-/// other characters, usually digits.
-pub fn get_prepended_concatenation_mark<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::PREPENDED_CONCATENATION_MARK_V1)
-}
-
-/// Printable characters (visible characters and whitespace).
-/// This is defined for POSIX compatibility.
-pub fn get_print<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::PRINT_V1)
-}
-
-/// Punctuation characters that function as quotation marks.
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_quotation_mark(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let quotation_mark = &data_struct.inv_list;
-///
-/// assert!(quotation_mark.contains('\''));
-/// assert!(quotation_mark.contains('„'));  // U+201E DOUBLE LOW-9 QUOTATION MARK
-/// assert!(!quotation_mark.contains('<'));
-/// ```
-pub fn get_quotation_mark<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::QUOTATION_MARK_V1)
-}
-
-/// Characters used in the definition of Ideographic Description Sequences
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_radical(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let radical = &data_struct.inv_list;
-///
-/// assert!(radical.contains('⺆'));  // U+2E86 CJK RADICAL BOX
-/// assert!(!radical.contains('丹'));  // U+F95E CJK COMPATIBILITY IDEOGRAPH-F95E
-/// ```
-pub fn get_radical<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::RADICAL_V1)
-}
-
-/// Regional indicator characters, U+1F1E6..U+1F1FF
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_regional_indicator(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let regional_indicator = &data_struct.inv_list;
-///
-/// assert!(regional_indicator.contains('🇹'));  // U+1F1F9 REGIONAL INDICATOR SYMBOL LETTER T
-/// assert!(!regional_indicator.contains('Ⓣ'));  // U+24C9 CIRCLED LATIN CAPITAL LETTER T
-/// assert!(!regional_indicator.contains('T'));
-/// ```
-pub fn get_regional_indicator<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::REGIONAL_INDICATOR_V1)
-}
-
-/// Characters with a "soft dot", like i or j. An accent placed on these characters causes
-/// the dot to disappear.
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_soft_dotted(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let soft_dotted = &data_struct.inv_list;
-///
-/// assert!(soft_dotted.contains('і'));  //U+0456 CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
-/// assert!(!soft_dotted.contains('ı'));  // U+0131 LATIN SMALL LETTER DOTLESS I
-/// ```
-pub fn get_soft_dotted<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::SOFT_DOTTED_V1)
-}
-
-/// Characters that are starters in terms of Unicode normalization and combining character
-/// sequences
-pub fn get_segment_starter<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::SEGMENT_STARTER_V1)
-}
-
-/// Characters that are either the source of a case mapping or in the target of a case
-/// mapping
-pub fn get_case_sensitive<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::CASE_SENSITIVE_V1)
-}
-
-/// Punctuation characters that generally mark the end of sentences
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_sentence_terminal(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let sentence_terminal = &data_struct.inv_list;
-///
-/// assert!(sentence_terminal.contains('.'));
-/// assert!(sentence_terminal.contains('?'));
-/// assert!(sentence_terminal.contains('᪨'));  // U+1AA8 TAI THAM SIGN KAAN
-/// assert!(!sentence_terminal.contains(','));
-/// assert!(!sentence_terminal.contains('¿'));  // U+00BF INVERTED QUESTION MARK
-/// ```
-pub fn get_sentence_terminal<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::SENTENCE_TERMINAL_V1)
-}
-
-/// Punctuation characters that generally mark the end of textual units
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_terminal_punctuation(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let terminal_punctuation = &data_struct.inv_list;
-///
-/// assert!(terminal_punctuation.contains('.'));
-/// assert!(terminal_punctuation.contains('?'));
-/// assert!(terminal_punctuation.contains('᪨'));  // U+1AA8 TAI THAM SIGN KAAN
-/// assert!(terminal_punctuation.contains(','));
-/// assert!(!terminal_punctuation.contains('¿'));  // U+00BF INVERTED QUESTION MARK
-/// ```
-pub fn get_terminal_punctuation<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::TERMINAL_PUNCTUATION_V1)
-}
-
-/// A property which specifies the exact set of Unified CJK Ideographs in the standard
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_unified_ideograph(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let unified_ideograph = &data_struct.inv_list;
-///
-/// assert!(unified_ideograph.contains('川'));  // U+5DDD CJK UNIFIED IDEOGRAPH-5DDD
-/// assert!(unified_ideograph.contains('木'));  // U+6728 CJK UNIFIED IDEOGRAPH-6728
-/// assert!(!unified_ideograph.contains('𛅸'));  // U+1B178 NUSHU CHARACTER-1B178
-/// ```
-pub fn get_unified_ideograph<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::UNIFIED_IDEOGRAPH_V1)
-}
-
-/// Uppercase characters
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_uppercase(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let uppercase = &data_struct.inv_list;
-///
-/// assert!(uppercase.contains('U'));
-/// assert!(!uppercase.contains('u'));
-/// ```
-pub fn get_uppercase<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::UPPERCASE_V1)
-}
-
-/// Characters that are Variation Selectors.
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_variation_selector(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let variation_selector = &data_struct.inv_list;
-///
-/// assert!(variation_selector.contains_u32(0x180D));  // MONGOLIAN FREE VARIATION SELECTOR THREE
-/// assert!(!variation_selector.contains_u32(0x303E));  // IDEOGRAPHIC VARIATION INDICATOR
-/// assert!(variation_selector.contains_u32(0xFE0F));  // VARIATION SELECTOR-16
-/// assert!(!variation_selector.contains_u32(0xFE10));  // PRESENTATION FORM FOR VERTICAL COMMA
-/// assert!(variation_selector.contains_u32(0xE01EF));  // VARIATION SELECTOR-256
-/// ```
-pub fn get_variation_selector<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::VARIATION_SELECTOR_V1)
-}
-
-/// Spaces, separator characters and other control characters which should be treated by
-/// programming languages as "white space" for the purpose of parsing elements
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_white_space(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let white_space = &data_struct.inv_list;
-///
-/// assert!(white_space.contains(' '));
-/// assert!(white_space.contains_u32(0x000A));  // NEW LINE
-/// assert!(white_space.contains_u32(0x00A0));  // NO-BREAK SPACE
-/// assert!(!white_space.contains_u32(0x200B));  // ZERO WIDTH SPACE
-/// ```
-pub fn get_white_space<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::WHITE_SPACE_V1)
-}
-
-/// Hexadecimal digits
-/// This is defined for POSIX compatibility.
-pub fn get_xdigit<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::XDIGIT_V1)
-}
-
-/// Characters that can begin an identifier.  See [`Unicode Standard Annex
-/// #31`](https://www.unicode.org/reports/tr31/tr31-35.html) for more details.
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_xid_continue(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let xid_continue = &data_struct.inv_list;
-///
-/// assert!(xid_continue.contains('x'));
-/// assert!(xid_continue.contains('1'));
-/// assert!(xid_continue.contains('_'));
-/// assert!(xid_continue.contains('ߝ'));  // U+07DD NKO LETTER FA
-/// assert!(!xid_continue.contains('ⓧ'));  // U+24E7 CIRCLED LATIN SMALL LETTER X
-/// assert!(!xid_continue.contains_u32(0xFC5E));  // ARABIC LIGATURE SHADDA WITH DAMMATAN ISOLATED FORM
-/// ```
-pub fn get_xid_continue<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::XID_CONTINUE_V1)
-}
-
-/// Characters that can come after the first character in an identifier. See [`Unicode
-/// Standard Annex #31`](https://www.unicode.org/reports/tr31/tr31-35.html) for more
-/// details.
-///
-/// # Example
-///
-/// ```
-/// use icu_properties::sets;
-///
-/// let provider = icu_testdata::get_provider();
-/// let payload =
-///     sets::get_xid_start(&provider)
-///         .expect("The data should be valid");
-/// let data_struct = payload.get();
-/// let xid_start = &data_struct.inv_list;
-///
-/// assert!(xid_start.contains('x'));
-/// assert!(!xid_start.contains('1'));
-/// assert!(!xid_start.contains('_'));
-/// assert!(xid_start.contains('ߝ'));  // U+07DD NKO LETTER FA
-/// assert!(!xid_start.contains('ⓧ'));  // U+24E7 CIRCLED LATIN SMALL LETTER X
-/// assert!(!xid_start.contains_u32(0xFC5E));  // ARABIC LIGATURE SHADDA WITH DAMMATAN ISOLATED FORM
-/// ```
-pub fn get_xid_start<D>(provider: &D) -> UnisetResult
-where
-    D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
-{
-    get_uniset(provider, key::XID_START_V1)
+macro_rules! make_set_property {
+    (
+        // currently unused
+        property: $prop_name:expr;
+        // currently unused
+        marker: $marker_name:ident;
+        key: $key_name:expr;
+        func:
+        $(#[$attr:meta])*
+        pub fn $funcname:ident();
+    ) => {
+        $(#[$attr])*
+        pub fn $funcname<D>(provider: &D) -> UnisetResult
+        where
+            D: DynProvider<UnicodePropertyV1Marker> + ?Sized,
+        {
+            get_uniset(provider, $key_name)
+        }
+    }
+}
+
+make_set_property! {
+    property: "ASCII_Hex_Digit";
+    marker: AsciiHexDigitProperty;
+    key: crate::provider::key::ASCII_HEX_DIGIT_V1;
+    func:
+    /// ASCII characters commonly used for the representation of hexadecimal numbers
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_ascii_hex_digit(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let ascii_hex_digit = &data_struct.inv_list;
+    ///
+    /// assert!(ascii_hex_digit.contains('3'));
+    /// assert!(!ascii_hex_digit.contains('੩'));  // U+0A69 GURMUKHI DIGIT THREE
+    /// assert!(ascii_hex_digit.contains('A'));
+    /// assert!(!ascii_hex_digit.contains('Ä'));  // U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS
+    /// ```
+    pub fn get_ascii_hex_digit();
+}
+
+make_set_property! {
+    property: "Alnum";
+    marker: AlnumProperty;
+    key: crate::provider::key::ALNUM_V1;
+    func:
+    /// Characters with the Alphabetic or Decimal_Number property
+    /// This is defined for POSIX compatibility.
+
+    pub fn get_alnum();
+}
+
+make_set_property! {
+    property: "Alphabetic";
+    marker: AlphabeticProperty;
+    key: crate::provider::key::ALPHABETIC_V1;
+    func:
+    /// Alphabetic characters
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_alphabetic(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let alphabetic = &data_struct.inv_list;
+    ///
+    /// assert!(!alphabetic.contains('3'));
+    /// assert!(!alphabetic.contains('੩'));  // U+0A69 GURMUKHI DIGIT THREE
+    /// assert!(alphabetic.contains('A'));
+    /// assert!(alphabetic.contains('Ä'));  // U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS
+    /// ```
+
+    pub fn get_alphabetic();
+}
+
+make_set_property! {
+    property: "Bidi_Control";
+    marker: BidiControlProperty;
+    key: crate::provider::key::BIDI_CONTROL_V1;
+    func:
+    /// Format control characters which have specific functions in the Unicode Bidirectional
+    /// Algorithm
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_bidi_control(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let bidi_control = &data_struct.inv_list;
+    ///
+    /// assert!(bidi_control.contains_u32(0x200F));  // RIGHT-TO-LEFT MARK
+    /// assert!(!bidi_control.contains('ش'));  // U+0634 ARABIC LETTER SHEEN
+    /// ```
+
+    pub fn get_bidi_control();
+}
+
+make_set_property! {
+    property: "Bidi_Mirrored";
+    marker: BidiMirroredProperty;
+    key: crate::provider::key::BIDI_MIRRORED_V1;
+    func:
+    /// Characters that are mirrored in bidirectional text
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_bidi_mirrored(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let bidi_mirrored = &data_struct.inv_list;
+    ///
+    /// assert!(bidi_mirrored.contains('['));
+    /// assert!(bidi_mirrored.contains(']'));
+    /// assert!(bidi_mirrored.contains('∑'));  // U+2211 N-ARY SUMMATION
+    /// assert!(!bidi_mirrored.contains('ཉ'));  // U+0F49 TIBETAN LETTER NYA
+    /// ```
+
+    pub fn get_bidi_mirrored();
+}
+
+make_set_property! {
+    property: "Blank";
+    marker: BlankProperty;
+    key: crate::provider::key::BLANK_V1;
+    func:
+    /// Horizontal whitespace characters
+
+    pub fn get_blank();
+}
+
+make_set_property! {
+    property: "Cased";
+    marker: CasedProperty;
+    key: crate::provider::key::CASED_V1;
+    func:
+    /// Uppercase, lowercase, and titlecase characters
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_cased(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let cased = &data_struct.inv_list;
+    ///
+    /// assert!(cased.contains('Ꙡ'));  // U+A660 CYRILLIC CAPITAL LETTER REVERSED TSE
+    /// assert!(!cased.contains('ދ'));  // U+078B THAANA LETTER DHAALU
+    /// ```
+
+    pub fn get_cased();
+}
+
+make_set_property! {
+    property: "Case_Ignorable";
+    marker: CaseIgnorableProperty;
+    key: crate::provider::key::CASE_IGNORABLE_V1;
+    func:
+    /// Characters which are ignored for casing purposes
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_case_ignorable(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let case_ignorable = &data_struct.inv_list;
+    ///
+    /// assert!(case_ignorable.contains(':'));
+    /// assert!(!case_ignorable.contains('λ'));  // U+03BB GREEK SMALL LETTER LAMDA
+    /// ```
+
+    pub fn get_case_ignorable();
+}
+
+make_set_property! {
+    property: "Full_Composition_Exclusion";
+    marker: FullCompositionExclusionProperty;
+    key: crate::provider::key::FULL_COMPOSITION_EXCLUSION_V1;
+    func:
+    /// Characters that are excluded from composition
+    /// See <https://unicode.org/Public/UNIDATA/CompositionExclusions.txt>
+
+    pub fn get_full_composition_exclusion();
+}
+
+make_set_property! {
+    property: "Changes_When_Casefolded";
+    marker: ChangesWhenCasefoldedProperty;
+    key: crate::provider::key::CHANGES_WHEN_CASEFOLDED_V1;
+    func:
+    /// Characters whose normalized forms are not stable under case folding
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_changes_when_casefolded(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let changes_when_casefolded = &data_struct.inv_list;
+    ///
+    /// assert!(changes_when_casefolded.contains('ß'));  // U+00DF LATIN SMALL LETTER SHARP S
+    /// assert!(!changes_when_casefolded.contains('ᜉ'));  // U+1709 TAGALOG LETTER PA
+    /// ```
+
+    pub fn get_changes_when_casefolded();
+}
+
+make_set_property! {
+    property: "Changes_When_Casemapped";
+    marker: ChangesWhenCasemappedProperty;
+    key: crate::provider::key::CHANGES_WHEN_CASEMAPPED_V1;
+    func:
+    /// Characters which may change when they undergo case mapping
+
+    pub fn get_changes_when_casemapped();
+}
+
+make_set_property! {
+    property: "Changes_When_NFKC_Casefolded";
+    marker: ChangesWhenNfkcCasefoldedProperty;
+    key: crate::provider::key::CHANGES_WHEN_NFKC_CASEFOLDED_V1;
+    func:
+    /// Characters which are not identical to their NFKC_Casefold mapping
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_changes_when_nfkc_casefolded(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let changes_when_nfkc_casefolded = &data_struct.inv_list;
+    ///
+    /// assert!(changes_when_nfkc_casefolded.contains('🄵'));  // U+1F135 SQUARED LATIN CAPITAL LETTER F
+    /// assert!(!changes_when_nfkc_casefolded.contains('f'));
+    /// ```
+
+    pub fn get_changes_when_nfkc_casefolded();
+}
+
+make_set_property! {
+    property: "Changes_When_Lowercased";
+    marker: ChangesWhenLowercasedProperty;
+    key: crate::provider::key::CHANGES_WHEN_LOWERCASED_V1;
+    func:
+    /// Characters whose normalized forms are not stable under a toLowercase mapping
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_changes_when_lowercased(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let changes_when_lowercased = &data_struct.inv_list;
+    ///
+    /// assert!(changes_when_lowercased.contains('Ⴔ'));  // U+10B4 GEORGIAN CAPITAL LETTER PHAR
+    /// assert!(!changes_when_lowercased.contains('ფ'));  // U+10E4 GEORGIAN LETTER PHAR
+    /// ```
+
+    pub fn get_changes_when_lowercased();
+}
+
+make_set_property! {
+    property: "Changes_When_Titlecased";
+    marker: ChangesWhenTitlecasedProperty;
+    key: crate::provider::key::CHANGES_WHEN_TITLECASED_V1;
+    func:
+    /// Characters whose normalized forms are not stable under a toTitlecase mapping
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_changes_when_titlecased(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let changes_when_titlecased = &data_struct.inv_list;
+    ///
+    /// assert!(changes_when_titlecased.contains('æ'));  // U+00E6 LATIN SMALL LETTER AE
+    /// assert!(!changes_when_titlecased.contains('Æ'));  // U+00E6 LATIN CAPITAL LETTER AE
+    /// ```
+
+    pub fn get_changes_when_titlecased();
+}
+
+make_set_property! {
+    property: "Changes_When_Uppercased";
+    marker: ChangesWhenUppercasedProperty;
+    key: crate::provider::key::CHANGES_WHEN_UPPERCASED_V1;
+    func:
+    /// Characters whose normalized forms are not stable under a toUppercase mapping
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_changes_when_uppercased(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let changes_when_uppercased = &data_struct.inv_list;
+    ///
+    /// assert!(changes_when_uppercased.contains('ւ'));  // U+0582 ARMENIAN SMALL LETTER YIWN
+    /// assert!(!changes_when_uppercased.contains('Ւ'));  // U+0552 ARMENIAN CAPITAL LETTER YIWN
+    /// ```
+
+    pub fn get_changes_when_uppercased();
+}
+
+make_set_property! {
+    property: "Dash";
+    marker: DashProperty;
+    key: crate::provider::key::DASH_V1;
+    func:
+    /// Punctuation characters explicitly called out as dashes in the Unicode Standard, plus
+    /// their compatibility equivalents
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_dash(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let dash = &data_struct.inv_list;
+    ///
+    /// assert!(dash.contains('⸺'));  // U+2E3A TWO-EM DASH
+    /// assert!(dash.contains('-'));  // U+002D
+    /// assert!(!dash.contains('='));  // U+003D
+    /// ```
+
+    pub fn get_dash();
+}
+
+make_set_property! {
+    property: "Deprecated";
+    marker: DeprecatedProperty;
+    key: crate::provider::key::DEPRECATED_V1;
+    func:
+    /// Deprecated characters. No characters will ever be removed from the standard, but the
+    /// usage of deprecated characters is strongly discouraged.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_deprecated(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let deprecated = &data_struct.inv_list;
+    ///
+    /// assert!(deprecated.contains('ឣ'));  // U+17A3 KHMER INDEPENDENT VOWEL QAQ
+    /// assert!(!deprecated.contains('A'));
+    /// ```
+
+    pub fn get_deprecated();
+}
+
+make_set_property! {
+    property: "Default_Ignorable_Code_Point";
+    marker: DefaultIgnorableCodePointProperty;
+    key: crate::provider::key::DEFAULT_IGNORABLE_CODE_POINT_V1;
+    func:
+    /// For programmatic determination of default ignorable code points.  New characters that
+    /// should be ignored in rendering (unless explicitly supported) will be assigned in these
+    /// ranges, permitting programs to correctly handle the default rendering of such
+    /// characters when not otherwise supported.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_default_ignorable_code_point(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let default_ignorable_code_point = &data_struct.inv_list;
+    ///
+    /// assert!(default_ignorable_code_point.contains_u32(0x180B));  // MONGOLIAN FREE VARIATION SELECTOR ONE
+    /// assert!(!default_ignorable_code_point.contains('E'));
+    /// ```
+
+    pub fn get_default_ignorable_code_point();
+}
+
+make_set_property! {
+    property: "Diacritic";
+    marker: DiacriticProperty;
+    key: crate::provider::key::DIACRITIC_V1;
+    func:
+    /// Characters that linguistically modify the meaning of another character to which they apply
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_diacritic(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let diacritic = &data_struct.inv_list;
+    ///
+    /// assert!(diacritic.contains('\u{05B3}'));  // HEBREW POINT HATAF QAMATS
+    /// assert!(!diacritic.contains('א'));  // U+05D0 HEBREW LETTER ALEF
+    /// ```
+
+    pub fn get_diacritic();
+}
+
+make_set_property! {
+    property: "Emoji_Modifier_Base";
+    marker: EmojiModifierBaseProperty;
+    key: crate::provider::key::EMOJI_MODIFIER_BASE_V1;
+    func:
+    /// Characters that can serve as a base for emoji modifiers
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_emoji_modifier_base(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let emoji_modifier_base = &data_struct.inv_list;
+    ///
+    /// assert!(emoji_modifier_base.contains('✊'));  // U+270A RAISED FIST
+    /// assert!(!emoji_modifier_base.contains('⛰'));  // U+26F0 MOUNTAIN
+    /// ```
+
+    pub fn get_emoji_modifier_base();
+}
+
+make_set_property! {
+    property: "Emoji_Component";
+    marker: EmojiComponentProperty;
+    key: crate::provider::key::EMOJI_COMPONENT_V1;
+    func:
+    /// Characters used in emoji sequences that normally do not appear on emoji keyboards as
+    /// separate choices, such as base characters for emoji keycaps
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_emoji_component(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let emoji_component = &data_struct.inv_list;
+    ///
+    /// assert!(emoji_component.contains('🇹'));  // U+1F1F9 REGIONAL INDICATOR SYMBOL LETTER T
+    /// assert!(emoji_component.contains_u32(0x20E3));  // COMBINING ENCLOSING KEYCAP
+    /// assert!(emoji_component.contains('7'));
+    /// assert!(!emoji_component.contains('T'));
+    /// ```
+
+    pub fn get_emoji_component();
+}
+
+make_set_property! {
+    property: "Emoji_Modifier";
+    marker: EmojiModifierProperty;
+    key: crate::provider::key::EMOJI_MODIFIER_V1;
+    func:
+    /// Characters that are emoji modifiers
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_emoji_modifier(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let emoji_modifier = &data_struct.inv_list;
+    ///
+    /// assert!(emoji_modifier.contains_u32(0x1F3FD));  // EMOJI MODIFIER FITZPATRICK TYPE-4
+    /// assert!(!emoji_modifier.contains_u32(0x200C));  // ZERO WIDTH NON-JOINER
+    /// ```
+
+    pub fn get_emoji_modifier();
+}
+
+make_set_property! {
+    property: "Emoji";
+    marker: EmojiProperty;
+    key: crate::provider::key::EMOJI_V1;
+    func:
+    /// Characters that are emoji
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_emoji(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let emoji = &data_struct.inv_list;
+    ///
+    /// assert!(emoji.contains('🔥'));  // U+1F525 FIRE
+    /// assert!(!emoji.contains('V'));
+    /// ```
+
+    pub fn get_emoji();
+}
+
+make_set_property! {
+    property: "Emoji_Presentation";
+    marker: EmojiPresentationProperty;
+    key: crate::provider::key::EMOJI_PRESENTATION_V1;
+    func:
+    /// Characters that have emoji presentation by default
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_emoji_presentation(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let emoji_presentation = &data_struct.inv_list;
+    ///
+    /// assert!(emoji_presentation.contains('🦬')); // U+1F9AC BISON
+    /// assert!(!emoji_presentation.contains('♻'));  // U+267B BLACK UNIVERSAL RECYCLING SYMBOL
+    /// ```
+
+    pub fn get_emoji_presentation();
+}
+
+make_set_property! {
+    property: "Extender";
+    marker: ExtenderProperty;
+    key: crate::provider::key::EXTENDER_V1;
+    func:
+    /// Characters whose principal function is to extend the value of a preceding alphabetic
+    /// character or to extend the shape of adjacent characters.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_extender(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let extender = &data_struct.inv_list;
+    ///
+    /// assert!(extender.contains('ヾ'));  // U+30FE KATAKANA VOICED ITERATION MARK
+    /// assert!(extender.contains('ー'));  // U+30FC KATAKANA-HIRAGANA PROLONGED SOUND MARK
+    /// assert!(!extender.contains('・'));  // U+30FB KATAKANA MIDDLE DOT
+    /// ```
+
+    pub fn get_extender();
+}
+
+make_set_property! {
+    property: "Extended_Pictographic";
+    marker: ExtendedPictographicProperty;
+    key: crate::provider::key::EXTENDED_PICTOGRAPHIC_V1;
+    func:
+    /// Pictographic symbols, as well as reserved ranges in blocks largely associated with
+    /// emoji characters
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_extended_pictographic(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let extended_pictographic = &data_struct.inv_list;
+    ///
+    /// assert!(extended_pictographic.contains('🥳')); // U+1F973 FACE WITH PARTY HORN AND PARTY HAT
+    /// assert!(!extended_pictographic.contains('🇪'));  // U+1F1EA REGIONAL INDICATOR SYMBOL LETTER E
+    /// ```
+
+    pub fn get_extended_pictographic();
+}
+
+make_set_property! {
+    property: "Graph";
+    marker: GraphProperty;
+    key: crate::provider::key::GRAPH_V1;
+    func:
+    /// Visible characters.
+    /// This is defined for POSIX compatibility.
+
+    pub fn get_graph();
+}
+
+make_set_property! {
+    property: "Grapheme_Base";
+    marker: GraphemeBaseProperty;
+    key: crate::provider::key::GRAPHEME_BASE_V1;
+    func:
+    /// Property used together with the definition of Standard Korean Syllable Block to define
+    /// "Grapheme base". See D58 in Chapter 3, Conformance in the Unicode Standard.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_grapheme_base(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let grapheme_base = &data_struct.inv_list;
+    ///
+    /// assert!(grapheme_base.contains('ക'));  // U+0D15 MALAYALAM LETTER KA
+    /// assert!(grapheme_base.contains('\u{0D3F}'));  // U+0D3F MALAYALAM VOWEL SIGN I
+    /// assert!(!grapheme_base.contains('\u{0D3E}'));  // U+0D3E MALAYALAM VOWEL SIGN AA
+    /// ```
+
+    pub fn get_grapheme_base();
+}
+
+make_set_property! {
+    property: "Grapheme_Extend";
+    marker: GraphemeExtendProperty;
+    key: crate::provider::key::GRAPHEME_EXTEND_V1;
+    func:
+    /// Property used to define "Grapheme extender". See D59 in Chapter 3, Conformance in the
+    /// Unicode Standard.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_grapheme_extend(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let grapheme_extend = &data_struct.inv_list;
+    ///
+    /// assert!(!grapheme_extend.contains('ക'));  // U+0D15 MALAYALAM LETTER KA
+    /// assert!(!grapheme_extend.contains('\u{0D3F}'));  // U+0D3F MALAYALAM VOWEL SIGN I
+    /// assert!(grapheme_extend.contains('\u{0D3E}'));  // U+0D3E MALAYALAM VOWEL SIGN AA
+    /// ```
+
+    pub fn get_grapheme_extend();
+}
+
+make_set_property! {
+    property: "Grapheme_Link";
+    marker: GraphemeLinkProperty;
+    key: crate::provider::key::GRAPHEME_LINK_V1;
+    func:
+    /// Deprecated property. Formerly proposed for programmatic determination of grapheme
+    /// cluster boundaries.
+
+    pub fn get_grapheme_link();
+}
+
+make_set_property! {
+    property: "Hex_Digit";
+    marker: HexDigitProperty;
+    key: crate::provider::key::HEX_DIGIT_V1;
+    func:
+    /// Characters commonly used for the representation of hexadecimal numbers, plus their
+    /// compatibility equivalents
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_hex_digit(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let hex_digit = &data_struct.inv_list;
+    ///
+    /// assert!(hex_digit.contains('0'));
+    /// assert!(!hex_digit.contains('੩'));  // U+0A69 GURMUKHI DIGIT THREE
+    /// assert!(hex_digit.contains('f'));
+    /// assert!(hex_digit.contains('ｆ'));  // U+FF46 FULLWIDTH LATIN SMALL LETTER F
+    /// assert!(hex_digit.contains('Ｆ'));  // U+FF26 FULLWIDTH LATIN CAPITAL LETTER F
+    /// assert!(!hex_digit.contains('Ä'));  // U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS
+    /// ```
+
+    pub fn get_hex_digit();
+}
+
+make_set_property! {
+    property: "Hyphen";
+    marker: HyphenProperty;
+    key: crate::provider::key::HYPHEN_V1;
+    func:
+    /// Deprecated property. Dashes which are used to mark connections between pieces of
+    /// words, plus the Katakana middle dot.
+
+    pub fn get_hyphen();
+}
+
+make_set_property! {
+    property: "Id_Continue";
+    marker: IdContinueProperty;
+    key: crate::provider::key::ID_CONTINUE_V1;
+    func:
+    /// Characters that can come after the first character in an identifier. If using NFKC to
+    /// fold differences between characters, use [`get_xid_continue`] instead.  See
+    /// [`Unicode Standard Annex #31`](https://www.unicode.org/reports/tr31/tr31-35.html) for
+    /// more details.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_id_continue(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let id_continue = &data_struct.inv_list;
+    ///
+    /// assert!(id_continue.contains('x'));
+    /// assert!(id_continue.contains('1'));
+    /// assert!(id_continue.contains('_'));
+    /// assert!(id_continue.contains('ߝ'));  // U+07DD NKO LETTER FA
+    /// assert!(!id_continue.contains('ⓧ'));  // U+24E7 CIRCLED LATIN SMALL LETTER X
+    /// assert!(id_continue.contains_u32(0xFC5E));  // ARABIC LIGATURE SHADDA WITH DAMMATAN ISOLATED FORM
+    /// ```
+
+    pub fn get_id_continue();
+}
+
+make_set_property! {
+    property: "Ideographic";
+    marker: IdeographicProperty;
+    key: crate::provider::key::IDEOGRAPHIC_V1;
+    func:
+    /// Characters considered to be CJKV (Chinese, Japanese, Korean, and Vietnamese)
+    /// ideographs, or related siniform ideographs
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_ideographic(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let ideographic = &data_struct.inv_list;
+    ///
+    /// assert!(ideographic.contains('川'));  // U+5DDD CJK UNIFIED IDEOGRAPH-5DDD
+    /// assert!(!ideographic.contains('밥'));  // U+BC25 HANGUL SYLLABLE BAB
+    /// ```
+
+    pub fn get_ideographic();
+}
+
+make_set_property! {
+    property: "Id_Start";
+    marker: IdStartProperty;
+    key: crate::provider::key::ID_START_V1;
+    func:
+    /// Characters that can begin an identifier. If using NFKC to fold differences between
+    /// characters, use [`get_xid_start`] instead.  See [`Unicode Standard Annex
+    /// #31`](https://www.unicode.org/reports/tr31/tr31-35.html) for more details.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_id_start(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let id_start = &data_struct.inv_list;
+    ///
+    /// assert!(id_start.contains('x'));
+    /// assert!(!id_start.contains('1'));
+    /// assert!(!id_start.contains('_'));
+    /// assert!(id_start.contains('ߝ'));  // U+07DD NKO LETTER FA
+    /// assert!(!id_start.contains('ⓧ'));  // U+24E7 CIRCLED LATIN SMALL LETTER X
+    /// assert!(id_start.contains_u32(0xFC5E));  // ARABIC LIGATURE SHADDA WITH DAMMATAN ISOLATED FORM
+    /// ```
+
+    pub fn get_id_start();
+}
+
+make_set_property! {
+    property: "Ids_Binary_Operator";
+    marker: IdsBinaryOperatorProperty;
+    key: crate::provider::key::IDS_BINARY_OPERATOR_V1;
+    func:
+    /// Characters used in Ideographic Description Sequences
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_ids_binary_operator(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let ids_binary_operator = &data_struct.inv_list;
+    ///
+    /// assert!(ids_binary_operator.contains_u32(0x2FF5));  // IDEOGRAPHIC DESCRIPTION CHARACTER SURROUND FROM ABOVE
+    /// assert!(!ids_binary_operator.contains_u32(0x3006));  // IDEOGRAPHIC CLOSING MARK
+    /// ```
+
+    pub fn get_ids_binary_operator();
+}
+
+make_set_property! {
+    property: "Ids_Trinary_Operator";
+    marker: IdsTrinaryOperatorProperty;
+    key: crate::provider::key::IDS_TRINARY_OPERATOR_V1;
+    func:
+    /// Characters used in Ideographic Description Sequences
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_ids_trinary_operator(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let ids_trinary_operator = &data_struct.inv_list;
+    ///
+    /// assert!(ids_trinary_operator.contains_u32(0x2FF2));  // IDEOGRAPHIC DESCRIPTION CHARACTER LEFT TO MIDDLE AND RIGHT
+    /// assert!(ids_trinary_operator.contains_u32(0x2FF3));  // IDEOGRAPHIC DESCRIPTION CHARACTER ABOVE TO MIDDLE AND BELOW
+    /// assert!(!ids_trinary_operator.contains_u32(0x2FF4));
+    /// assert!(!ids_trinary_operator.contains_u32(0x2FF5));  // IDEOGRAPHIC DESCRIPTION CHARACTER SURROUND FROM ABOVE
+    /// assert!(!ids_trinary_operator.contains_u32(0x3006));  // IDEOGRAPHIC CLOSING MARK
+    /// ```
+
+    pub fn get_ids_trinary_operator();
+}
+
+make_set_property! {
+    property: "Join_Control";
+    marker: JoinControlProperty;
+    key: crate::provider::key::JOIN_CONTROL_V1;
+    func:
+    /// Format control characters which have specific functions for control of cursive joining
+    /// and ligation
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_join_control(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let join_control = &data_struct.inv_list;
+    ///
+    /// assert!(join_control.contains_u32(0x200C));  // ZERO WIDTH NON-JOINER
+    /// assert!(join_control.contains_u32(0x200D));  // ZERO WIDTH JOINER
+    /// assert!(!join_control.contains_u32(0x200E));
+    /// ```
+
+    pub fn get_join_control();
+}
+
+make_set_property! {
+    property: "Logical_Order_Exception";
+    marker: LogicalOrderExceptionProperty;
+    key: crate::provider::key::LOGICAL_ORDER_EXCEPTION_V1;
+    func:
+    /// A small number of spacing vowel letters occurring in certain Southeast Asian scripts such as Thai and Lao
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_logical_order_exception(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let logical_order_exception = &data_struct.inv_list;
+    ///
+    /// assert!(logical_order_exception.contains('ແ'));  // U+0EC1 LAO VOWEL SIGN EI
+    /// assert!(!logical_order_exception.contains('ະ'));  // U+0EB0 LAO VOWEL SIGN A
+    /// ```
+
+    pub fn get_logical_order_exception();
+}
+
+make_set_property! {
+    property: "Lowercase";
+    marker: LowercaseProperty;
+    key: crate::provider::key::LOWERCASE_V1;
+    func:
+    /// Lowercase characters
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_lowercase(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let lowercase = &data_struct.inv_list;
+    ///
+    /// assert!(lowercase.contains('a'));
+    /// assert!(!lowercase.contains('A'));
+    /// ```
+
+    pub fn get_lowercase();
+}
+
+make_set_property! {
+    property: "Math";
+    marker: MathProperty;
+    key: crate::provider::key::MATH_V1;
+    func:
+    /// Characters used in mathematical notation
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_math(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let math = &data_struct.inv_list;
+    ///
+    /// assert!(math.contains('='));
+    /// assert!(math.contains('+'));
+    /// assert!(!math.contains('-'));
+    /// assert!(math.contains('−'));  // U+2212 MINUS SIGN
+    /// assert!(!math.contains('/'));
+    /// assert!(math.contains('∕'));  // U+2215 DIVISION SLASH
+    /// ```
+
+    pub fn get_math();
+}
+
+make_set_property! {
+    property: "Noncharacter_Code_Point";
+    marker: NoncharacterCodePointProperty;
+    key: crate::provider::key::NONCHARACTER_CODE_POINT_V1;
+    func:
+    /// Code points permanently reserved for internal use
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_noncharacter_code_point(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let noncharacter_code_point = &data_struct.inv_list;
+    ///
+    /// assert!(noncharacter_code_point.contains_u32(0xFDD0));
+    /// assert!(noncharacter_code_point.contains_u32(0xFFFF));
+    /// assert!(!noncharacter_code_point.contains_u32(0x10000));
+    /// ```
+
+    pub fn get_noncharacter_code_point();
+}
+
+make_set_property! {
+    property: "NFC_Inert";
+    marker: NfcInertProperty;
+    key: crate::provider::key::NFC_INERT_V1;
+    func:
+    /// Characters that are inert under NFC, i.e., they do not interact with adjacent characters
+
+    pub fn get_nfc_inert();
+}
+
+make_set_property! {
+    property: "NFD_Inert";
+    marker: NfdInertProperty;
+    key: crate::provider::key::NFD_INERT_V1;
+    func:
+    /// Characters that are inert under NFD, i.e., they do not interact with adjacent characters
+
+    pub fn get_nfd_inert();
+}
+
+make_set_property! {
+    property: "NFKC_Inert";
+    marker: NfkcInertProperty;
+    key: crate::provider::key::NFKC_INERT_V1;
+    func:
+    /// Characters that are inert under NFKC, i.e., they do not interact with adjacent characters
+
+    pub fn get_nfkc_inert();
+}
+
+make_set_property! {
+    property: "NFKD_Inert";
+    marker: NfkdInertProperty;
+    key: crate::provider::key::NFKD_INERT_V1;
+    func:
+    /// Characters that are inert under NFKD, i.e., they do not interact with adjacent characters
+
+    pub fn get_nfkd_inert();
+}
+
+make_set_property! {
+    property: "Pattern_Syntax";
+    marker: PatternSyntaxProperty;
+    key: crate::provider::key::PATTERN_SYNTAX_V1;
+    func:
+    /// Characters used as syntax in patterns (such as regular expressions). See [`Unicode
+    /// Standard Annex #31`](https://www.unicode.org/reports/tr31/tr31-35.html) for more
+    /// details.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_pattern_syntax(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let pattern_syntax = &data_struct.inv_list;
+    ///
+    /// assert!(pattern_syntax.contains('{'));
+    /// assert!(pattern_syntax.contains('⇒'));  // U+21D2 RIGHTWARDS DOUBLE ARROW
+    /// assert!(!pattern_syntax.contains('0'));
+    /// ```
+
+    pub fn get_pattern_syntax();
+}
+
+make_set_property! {
+    property: "Pattern_White_Space";
+    marker: PatternWhiteSpaceProperty;
+    key: crate::provider::key::PATTERN_WHITE_SPACE_V1;
+    func:
+    /// Characters used as whitespace in patterns (such as regular expressions).  See
+    /// [`Unicode Standard Annex #31`](https://www.unicode.org/reports/tr31/tr31-35.html) for
+    /// more details.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_pattern_white_space(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let pattern_white_space = &data_struct.inv_list;
+    ///
+    /// assert!(pattern_white_space.contains(' '));
+    /// assert!(pattern_white_space.contains_u32(0x2029));  // PARAGRAPH SEPARATOR
+    /// assert!(pattern_white_space.contains_u32(0x000A));  // NEW LINE
+    /// assert!(!pattern_white_space.contains_u32(0x00A0));  // NO-BREAK SPACE
+    /// ```
+
+    pub fn get_pattern_white_space();
+}
+
+make_set_property! {
+    property: "Prepended_Concatenation_Mark";
+    marker: PrependedConcatenationMarkProperty;
+    key: crate::provider::key::PREPENDED_CONCATENATION_MARK_V1;
+    func:
+    /// A small class of visible format controls, which precede and then span a sequence of
+    /// other characters, usually digits.
+
+    pub fn get_prepended_concatenation_mark();
+}
+
+make_set_property! {
+    property: "Print";
+    marker: PrintProperty;
+    key: crate::provider::key::PRINT_V1;
+    func:
+    /// Printable characters (visible characters and whitespace).
+    /// This is defined for POSIX compatibility.
+
+    pub fn get_print();
+}
+
+make_set_property! {
+    property: "Quotation_Mark";
+    marker: QuotationMarkProperty;
+    key: crate::provider::key::QUOTATION_MARK_V1;
+    func:
+    /// Punctuation characters that function as quotation marks.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_quotation_mark(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let quotation_mark = &data_struct.inv_list;
+    ///
+    /// assert!(quotation_mark.contains('\''));
+    /// assert!(quotation_mark.contains('„'));  // U+201E DOUBLE LOW-9 QUOTATION MARK
+    /// assert!(!quotation_mark.contains('<'));
+    /// ```
+
+    pub fn get_quotation_mark();
+}
+
+make_set_property! {
+    property: "Radical";
+    marker: RadicalProperty;
+    key: crate::provider::key::RADICAL_V1;
+    func:
+    /// Characters used in the definition of Ideographic Description Sequences
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_radical(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let radical = &data_struct.inv_list;
+    ///
+    /// assert!(radical.contains('⺆'));  // U+2E86 CJK RADICAL BOX
+    /// assert!(!radical.contains('丹'));  // U+F95E CJK COMPATIBILITY IDEOGRAPH-F95E
+    /// ```
+
+    pub fn get_radical();
+}
+
+make_set_property! {
+    property: "Regional_Indicator";
+    marker: RegionalIndicatorProperty;
+    key: crate::provider::key::REGIONAL_INDICATOR_V1;
+    func:
+    /// Regional indicator characters, U+1F1E6..U+1F1FF
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_regional_indicator(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let regional_indicator = &data_struct.inv_list;
+    ///
+    /// assert!(regional_indicator.contains('🇹'));  // U+1F1F9 REGIONAL INDICATOR SYMBOL LETTER T
+    /// assert!(!regional_indicator.contains('Ⓣ'));  // U+24C9 CIRCLED LATIN CAPITAL LETTER T
+    /// assert!(!regional_indicator.contains('T'));
+    /// ```
+
+    pub fn get_regional_indicator();
+}
+
+make_set_property! {
+    property: "Soft_Dotted";
+    marker: SoftDottedProperty;
+    key: crate::provider::key::SOFT_DOTTED_V1;
+    func:
+    /// Characters with a "soft dot", like i or j. An accent placed on these characters causes
+    /// the dot to disappear.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_soft_dotted(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let soft_dotted = &data_struct.inv_list;
+    ///
+    /// assert!(soft_dotted.contains('і'));  //U+0456 CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
+    /// assert!(!soft_dotted.contains('ı'));  // U+0131 LATIN SMALL LETTER DOTLESS I
+    /// ```
+
+    pub fn get_soft_dotted();
+}
+
+make_set_property! {
+    property: "Segment_Starter";
+    marker: SegmentStarterProperty;
+    key: crate::provider::key::SEGMENT_STARTER_V1;
+    func:
+    /// Characters that are starters in terms of Unicode normalization and combining character
+    /// sequences
+
+    pub fn get_segment_starter();
+}
+
+make_set_property! {
+    property: "Case_Sensitive";
+    marker: CaseSensitiveProperty;
+    key: crate::provider::key::CASE_SENSITIVE_V1;
+    func:
+    /// Characters that are either the source of a case mapping or in the target of a case
+    /// mapping
+
+    pub fn get_case_sensitive();
+}
+
+make_set_property! {
+    property: "Sentence_Terminal";
+    marker: SentenceTerminalProperty;
+    key: crate::provider::key::SENTENCE_TERMINAL_V1;
+    func:
+    /// Punctuation characters that generally mark the end of sentences
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_sentence_terminal(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let sentence_terminal = &data_struct.inv_list;
+    ///
+    /// assert!(sentence_terminal.contains('.'));
+    /// assert!(sentence_terminal.contains('?'));
+    /// assert!(sentence_terminal.contains('᪨'));  // U+1AA8 TAI THAM SIGN KAAN
+    /// assert!(!sentence_terminal.contains(','));
+    /// assert!(!sentence_terminal.contains('¿'));  // U+00BF INVERTED QUESTION MARK
+    /// ```
+
+    pub fn get_sentence_terminal();
+}
+
+make_set_property! {
+    property: "Terminal_Punctuation";
+    marker: TerminalPunctuationProperty;
+    key: crate::provider::key::TERMINAL_PUNCTUATION_V1;
+    func:
+    /// Punctuation characters that generally mark the end of textual units
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_terminal_punctuation(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let terminal_punctuation = &data_struct.inv_list;
+    ///
+    /// assert!(terminal_punctuation.contains('.'));
+    /// assert!(terminal_punctuation.contains('?'));
+    /// assert!(terminal_punctuation.contains('᪨'));  // U+1AA8 TAI THAM SIGN KAAN
+    /// assert!(terminal_punctuation.contains(','));
+    /// assert!(!terminal_punctuation.contains('¿'));  // U+00BF INVERTED QUESTION MARK
+    /// ```
+
+    pub fn get_terminal_punctuation();
+}
+
+make_set_property! {
+    property: "Unified_Ideograph";
+    marker: UnifiedIdeographProperty;
+    key: crate::provider::key::UNIFIED_IDEOGRAPH_V1;
+    func:
+    /// A property which specifies the exact set of Unified CJK Ideographs in the standard
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_unified_ideograph(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let unified_ideograph = &data_struct.inv_list;
+    ///
+    /// assert!(unified_ideograph.contains('川'));  // U+5DDD CJK UNIFIED IDEOGRAPH-5DDD
+    /// assert!(unified_ideograph.contains('木'));  // U+6728 CJK UNIFIED IDEOGRAPH-6728
+    /// assert!(!unified_ideograph.contains('𛅸'));  // U+1B178 NUSHU CHARACTER-1B178
+    /// ```
+
+    pub fn get_unified_ideograph();
+}
+
+make_set_property! {
+    property: "Uppercase";
+    marker: UppercaseProperty;
+    key: crate::provider::key::UPPERCASE_V1;
+    func:
+    /// Uppercase characters
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_uppercase(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let uppercase = &data_struct.inv_list;
+    ///
+    /// assert!(uppercase.contains('U'));
+    /// assert!(!uppercase.contains('u'));
+    /// ```
+
+    pub fn get_uppercase();
+}
+
+make_set_property! {
+    property: "Variation_Selector";
+    marker: VariationSelectorProperty;
+    key: crate::provider::key::VARIATION_SELECTOR_V1;
+    func:
+    /// Characters that are Variation Selectors.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_variation_selector(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let variation_selector = &data_struct.inv_list;
+    ///
+    /// assert!(variation_selector.contains_u32(0x180D));  // MONGOLIAN FREE VARIATION SELECTOR THREE
+    /// assert!(!variation_selector.contains_u32(0x303E));  // IDEOGRAPHIC VARIATION INDICATOR
+    /// assert!(variation_selector.contains_u32(0xFE0F));  // VARIATION SELECTOR-16
+    /// assert!(!variation_selector.contains_u32(0xFE10));  // PRESENTATION FORM FOR VERTICAL COMMA
+    /// assert!(variation_selector.contains_u32(0xE01EF));  // VARIATION SELECTOR-256
+    /// ```
+
+    pub fn get_variation_selector();
+}
+
+make_set_property! {
+    property: "White_Space";
+    marker: WhiteSpaceProperty;
+    key: crate::provider::key::WHITE_SPACE_V1;
+    func:
+    /// Spaces, separator characters and other control characters which should be treated by
+    /// programming languages as "white space" for the purpose of parsing elements
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_white_space(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let white_space = &data_struct.inv_list;
+    ///
+    /// assert!(white_space.contains(' '));
+    /// assert!(white_space.contains_u32(0x000A));  // NEW LINE
+    /// assert!(white_space.contains_u32(0x00A0));  // NO-BREAK SPACE
+    /// assert!(!white_space.contains_u32(0x200B));  // ZERO WIDTH SPACE
+    /// ```
+
+    pub fn get_white_space();
+}
+
+make_set_property! {
+    property: "Xdigit";
+    marker: XdigitProperty;
+    key: crate::provider::key::XDIGIT_V1;
+    func:
+    /// Hexadecimal digits
+    /// This is defined for POSIX compatibility.
+
+    pub fn get_xdigit();
+}
+
+make_set_property! {
+    property: "XID_Continue";
+    marker: XidContinueProperty;
+    key: crate::provider::key::XID_CONTINUE_V1;
+    func:
+    /// Characters that can begin an identifier.  See [`Unicode Standard Annex
+    /// #31`](https://www.unicode.org/reports/tr31/tr31-35.html) for more details.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_xid_continue(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let xid_continue = &data_struct.inv_list;
+    ///
+    /// assert!(xid_continue.contains('x'));
+    /// assert!(xid_continue.contains('1'));
+    /// assert!(xid_continue.contains('_'));
+    /// assert!(xid_continue.contains('ߝ'));  // U+07DD NKO LETTER FA
+    /// assert!(!xid_continue.contains('ⓧ'));  // U+24E7 CIRCLED LATIN SMALL LETTER X
+    /// assert!(!xid_continue.contains_u32(0xFC5E));  // ARABIC LIGATURE SHADDA WITH DAMMATAN ISOLATED FORM
+    /// ```
+
+    pub fn get_xid_continue();
+}
+
+make_set_property! {
+    property: "XID_Start";
+    marker: XidStartProperty;
+    key: crate::provider::key::XID_START_V1;
+    func:
+    /// Characters that can come after the first character in an identifier. See [`Unicode
+    /// Standard Annex #31`](https://www.unicode.org/reports/tr31/tr31-35.html) for more
+    /// details.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let payload =
+    ///     sets::get_xid_start(&provider)
+    ///         .expect("The data should be valid");
+    /// let data_struct = payload.get();
+    /// let xid_start = &data_struct.inv_list;
+    ///
+    /// assert!(xid_start.contains('x'));
+    /// assert!(!xid_start.contains('1'));
+    /// assert!(!xid_start.contains('_'));
+    /// assert!(xid_start.contains('ߝ'));  // U+07DD NKO LETTER FA
+    /// assert!(!xid_start.contains('ⓧ'));  // U+24E7 CIRCLED LATIN SMALL LETTER X
+    /// assert!(!xid_start.contains_u32(0xFC5E));  // ARABIC LIGATURE SHADDA WITH DAMMATAN ISOLATED FORM
+    /// ```
+
+    pub fn get_xid_start();
 }
+
 
 //
 // Enumerated property getter fns


### PR DESCRIPTION
This is progress towards https://github.com/unicode-org/icu4x/pull/1333 without any semantic changes. This introduces a couple of macros so that making changes to props code can be done easily in the future.