### PR TITLE
Fixup FFI features

### DIFF
--- a/ffi/capi_cdylib/Cargo.toml
+++ b/ffi/capi_cdylib/Cargo.toml
@@ -37,10 +37,13 @@ icu_capi = { version = "0.1", path = "../diplomat", default-features = false }
 
 # Please keep features/cargo-all-features lists in sync with the icu_capi crate
 [features]
-default = ["provider_fs", "provider_static"]
+default = ["provider_fs", "provider_static", "deserialize_postcard_07", "deserialize_json"]
 provider_fs = ["icu_capi/provider_fs"]
 provider_static = ["icu_capi/provider_static"]
 smaller_static = ["icu_capi/smaller_static"]
+deserialize_json = ["icu_capi/deserialize_json"]
+deserialize_postcard_07 = ["icu_capi/deserialize_postcard_07"]
+deserialize_bincode_1 = ["icu_capi/deserialize_bincode_1"]
 
 [package.metadata.cargo-all-features]
 # Omit most optional dependency features from permutation testing

--- a/ffi/capi_staticlib/Cargo.toml
+++ b/ffi/capi_staticlib/Cargo.toml
@@ -37,10 +37,13 @@ icu_capi = { version = "0.1", path = "../diplomat", default-features = false }
 
 # Please keep features/cargo-all-features lists in sync with the icu_capi crate
 [features]
-default = ["provider_fs", "provider_static"]
+default = ["provider_fs", "provider_static", "deserialize_postcard_07", "deserialize_json"]
 provider_fs = ["icu_capi/provider_fs"]
 provider_static = ["icu_capi/provider_static"]
 smaller_static = ["icu_capi/smaller_static"]
+deserialize_json = ["icu_capi/deserialize_json"]
+deserialize_postcard_07 = ["icu_capi/deserialize_postcard_07"]
+deserialize_bincode_1 = ["icu_capi/deserialize_bincode_1"]
 
 # Enables size-optimized builds on x86_64
 x86tiny = ["dlmalloc"]

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -36,10 +36,13 @@ denylist = ["bench", "smaller_static"]
 
 # Please keep the features list in sync with the icu_capi_staticlib crate
 [features]
-default = ["provider_fs", "provider_static"]
+default = ["provider_fs", "provider_static", "deserialize_postcard_07", "deserialize_json"]
 provider_fs = ["icu_provider_fs"]
 provider_static = ["icu_testdata"]
 smaller_static = ["provider_static"]
+deserialize_json = ["icu_provider/deserialize_json"]
+deserialize_postcard_07 = ["icu_provider/deserialize_postcard_07"]
+deserialize_bincode_1 = ["icu_provider/deserialize_bincode_1"]
 
 [dependencies]
 fixed_decimal = { path = "../../utils/fixed_decimal", features = ["ryu"] }
@@ -48,7 +51,7 @@ icu_locale_canonicalizer = { path = "../../components/locale_canonicalizer", fea
 icu_locid = { path = "../../components/locid", features = ["serde"] }
 icu_plurals = { path = "../../components/plurals/", features = ["serde"] }
 icu_properties = { path = "../../components/properties/", features = ["serde"] }
-icu_provider = { path = "../../provider/core", features = ["serde", "deserialize_json", "deserialize_bincode_1", "deserialize_postcard_07"] }
+icu_provider = { path = "../../provider/core", features = ["serde"] }
 icu_provider_adapters = { path = "../../provider/adapters" }
 icu_provider_blob = { path = "../../provider/blob" }
 icu_segmenter = { path = "../../experimental/segmenter", features = ["serde"] }

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -48,7 +48,7 @@ icu_locale_canonicalizer = { path = "../../components/locale_canonicalizer", fea
 icu_locid = { path = "../../components/locid", features = ["serde"] }
 icu_plurals = { path = "../../components/plurals/", features = ["serde"] }
 icu_properties = { path = "../../components/properties/", features = ["serde"] }
-icu_provider = { path = "../../provider/core", features = ["serde"] }
+icu_provider = { path = "../../provider/core", features = ["serde", "deserialize_json", "deserialize_bincode_1", "deserialize_postcard_07"] }
 icu_provider_adapters = { path = "../../provider/adapters" }
 icu_provider_blob = { path = "../../provider/blob" }
 icu_segmenter = { path = "../../experimental/segmenter", features = ["serde"] }

--- a/ffi/freertos/Cargo.toml
+++ b/ffi/freertos/Cargo.toml
@@ -32,11 +32,12 @@ crate-type = ["staticlib", "rlib"]
 path = "src/lib.rs"
 
 [dependencies]
-icu_capi = { version = "0.1", path = "../diplomat" }
+icu_capi = { version = "0.1", path = "../diplomat", default-features = false }
 
 [target.'cfg(target_os = "none")'.dependencies]
 freertos-rust = { version = "0.1.2" }
 cortex-m = { version = "0.7.3" }
 
 [features]
-wearos = ["icu_capi/smaller_static"]
+# Currently we don't enable anything here as WearOS loads data manually, but the feature remains for future use
+wearos = []

--- a/ffi/freertos/src/lib.rs
+++ b/ffi/freertos/src/lib.rs
@@ -44,3 +44,9 @@ mod stuff {
         loop {}
     }
 }
+
+// Needed for rust runtime stuff
+//
+// renamed so you can't accidentally use it
+#[cfg(not(target_os = "none"))]
+extern crate std as rust_std;


### PR DESCRIPTION
Our CI was passing, but local `cargo make ci-job-ffi` wasn't working unless you ran the correct build first. This adds features to all the FFI crates for the various deserialization backends, enabling some by default.

Also cleans up the stuff used in WearOS.




<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->