### PR TITLE
Update diplomat dep to 0.3

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -203,13 +203,19 @@ jobs:
           ~/.cargo/bin/diplomat-tool.exe
         key: ${{ runner.os }}-diplomat-${{ steps.diplomat-version.outputs.rev }}
 
-    - name: Install Diplomat
-      if: steps.diplomat-cache.outputs.cache-hit != 'true'
+    - name: Install Diplomat (git hash)
+      if: steps.diplomat-cache.outputs.cache-hit != 'true' && !contains(steps.diplomat-version.outputs.rev, '.')
       uses: actions-rs/cargo@v1.0.1
       with:
         command: install
-        # Keep this in sync with ffi/capi/Cargo.toml
         args: --git https://github.com/rust-diplomat/diplomat.git --rev ${{ steps.diplomat-version.outputs.rev }} diplomat-tool
+
+    - name: Install Diplomat (versioned)
+      if: steps.diplomat-cache.outputs.cache-hit != 'true' && contains(steps.diplomat-version.outputs.rev, '.')
+      uses: actions-rs/cargo@v1.0.1
+      with:
+        command: install
+        args: --git https://github.com/rust-diplomat/diplomat.git --version ${{ steps.diplomat-version.outputs.rev }} diplomat-tool
 
     - name: Build
       uses: actions-rs/cargo@v1.0.1

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -372,13 +372,19 @@ jobs:
             ~/.cargo/bin/diplomat-tool.exe
           key: ${{ runner.os }}-diplomat-${{ steps.diplomat-version.outputs.rev }}
 
-      - name: Install Diplomat
-        if: steps.diplomat-cache.outputs.cache-hit != 'true'
+      - name: Install Diplomat (git hash)
+        if: steps.diplomat-cache.outputs.cache-hit != 'true' && !contains(steps.diplomat-version.outputs.rev, '.')
         uses: actions-rs/cargo@v1.0.1
         with:
           command: install
-          # Keep this in sync with ffi/capi/Cargo.toml
           args: --git https://github.com/rust-diplomat/diplomat.git --rev ${{ steps.diplomat-version.outputs.rev }} diplomat-tool
+
+      - name: Install Diplomat (versioned)
+        if: steps.diplomat-cache.outputs.cache-hit != 'true' && contains(steps.diplomat-version.outputs.rev, '.')
+        uses: actions-rs/cargo@v1.0.1
+        with:
+          command: install
+          args: --git https://github.com/rust-diplomat/diplomat.git --version ${{ steps.diplomat-version.outputs.rev }} diplomat-tool
 
       - name: Build
         uses: actions-rs/cargo@v1.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,7 @@ version = "0.1.0"
 
 [[package]]
 name = "icu4x_ecma402"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "ecma402_traits",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "icu_capi"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
@@ -1178,14 +1178,14 @@ dependencies = [
 
 [[package]]
 name = "icu_capi_cdylib"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "icu_capi",
 ]
 
 [[package]]
 name = "icu_capi_staticlib"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "dlmalloc",
  "icu_capi",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "icu_freertos"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "cortex-m",
  "freertos-rust",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,8 +603,8 @@ dependencies = [
 
 [[package]]
 name = "diplomat"
-version = "0.2.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=3c75d805e61c0e1b378a7c7aae1523c2db202398#3c75d805e61c0e1b378a7c7aae1523c2db202398"
+version = "0.3.0"
+source = "git+https://github.com/rust-diplomat/diplomat#aed274f13926629e789030fa82c1c204a5c83009"
 dependencies = [
  "diplomat_core",
  "proc-macro2",
@@ -614,13 +614,13 @@ dependencies = [
 
 [[package]]
 name = "diplomat-runtime"
-version = "0.2.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=3c75d805e61c0e1b378a7c7aae1523c2db202398#3c75d805e61c0e1b378a7c7aae1523c2db202398"
+version = "0.3.0"
+source = "git+https://github.com/rust-diplomat/diplomat#aed274f13926629e789030fa82c1c204a5c83009"
 
 [[package]]
 name = "diplomat_core"
-version = "0.2.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=3c75d805e61c0e1b378a7c7aae1523c2db202398#3c75d805e61c0e1b378a7c7aae1523c2db202398"
+version = "0.3.0"
+source = "git+https://github.com/rust-diplomat/diplomat#aed274f13926629e789030fa82c1c204a5c83009"
 dependencies = [
  "impls",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,7 +604,8 @@ dependencies = [
 [[package]]
 name = "diplomat"
 version = "0.3.0"
-source = "git+https://github.com/rust-diplomat/diplomat#aed274f13926629e789030fa82c1c204a5c83009"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b827d7e3428372b0b3d98c243e7d53526b1ddc264586536644e86a3e2ec176f3"
 dependencies = [
  "diplomat_core",
  "proc-macro2",
@@ -615,12 +616,14 @@ dependencies = [
 [[package]]
 name = "diplomat-runtime"
 version = "0.3.0"
-source = "git+https://github.com/rust-diplomat/diplomat#aed274f13926629e789030fa82c1c204a5c83009"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e55ba854b349be22d95ff1f0d7ceec5bd11a68d6389f4e9a673f7e117f0170f4"
 
 [[package]]
 name = "diplomat_core"
 version = "0.3.0"
-source = "git+https://github.com/rust-diplomat/diplomat#aed274f13926629e789030fa82c1c204a5c83009"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbde4faa50fdeda288168cc7f85db22a1f63baecd088fb4a78ca7b5ce7a1f847"
 dependencies = [
  "impls",
  "lazy_static",
@@ -1501,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "icu_segmenter"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "icu_char16trie",

--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -10,6 +10,7 @@ Once the release is complete, the assigned release driver will:
 
 * Verify that the milestone and checklist are complete
 * Verify with component owners that they're ready for release
+* Verify that `ffi/diplomat` depends on a released (not Git) version of Diplomat. Get it published (ask manishearth or sffc) otherwise.
 * Take a bird-eye view at:
   * READMEs
   * Documentation
@@ -20,6 +21,7 @@ Once the release is complete, the assigned release driver will:
 * [Tag the Release](https://github.com/unicode-org/icu4x/releases)
 * `cargo publish` each `util/` as necessary (See [Publishing utils](#Publishing utils))
 * `cargo publish` each component and meta component
+* `cargo publish` all crates under `ffi/`, starting with `ffi/diplomat`.
 * Add `icu4x-release` group as owners to each new component you're publishing
   * `cargo owner -a github:unicode-org:icu4x-release`
 * Ensure that the steps in `docs/tutorials/intro.md` still work with updated version numbers

--- a/experimental/segmenter/Cargo.toml
+++ b/experimental/segmenter/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_segmenter"
 description = "Unicode line breaking and text segmentation algorithms for text boundaries analysis"
-version = "0.1.0"
+version = "0.5.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"

--- a/ffi/capi_cdylib/Cargo.toml
+++ b/ffi/capi_cdylib/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_capi_cdylib"
 description = "C interface to ICU4X"
-version = "0.1.0"
+version = "0.5.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 resolver = "2"
@@ -32,7 +32,7 @@ crate-type = ["cdylib", "rlib"]
 path = "src/lib.rs"
 
 [dependencies]
-icu_capi = { version = "0.1", path = "../diplomat", default-features = false }
+icu_capi = { version = "0.5", path = "../diplomat", default-features = false }
 
 
 # Please keep features/cargo-all-features lists in sync with the icu_capi crate

--- a/ffi/capi_staticlib/Cargo.toml
+++ b/ffi/capi_staticlib/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_capi_staticlib"
 description = "C interface to ICU4X"
-version = "0.1.0"
+version = "0.5.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 resolver = "2"
@@ -32,7 +32,7 @@ crate-type = ["staticlib", "rlib"]
 path = "src/lib.rs"
 
 [dependencies]
-icu_capi = { version = "0.1", path = "../diplomat", default-features = false }
+icu_capi = { version = "0.5", path = "../diplomat", default-features = false }
 
 
 # Please keep features/cargo-all-features lists in sync with the icu_capi crate

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -45,22 +45,22 @@ deserialize_postcard_07 = ["icu_provider/deserialize_postcard_07"]
 deserialize_bincode_1 = ["icu_provider/deserialize_bincode_1"]
 
 [dependencies]
-fixed_decimal = { path = "../../utils/fixed_decimal", features = ["ryu"] }
-icu_decimal = { path = "../../components/decimal/", features = ["serde"] }
-icu_locale_canonicalizer = { path = "../../components/locale_canonicalizer", features = ["serde"] }
-icu_locid = { path = "../../components/locid", features = ["serde"] }
-icu_plurals = { path = "../../components/plurals/", features = ["serde"] }
-icu_properties = { path = "../../components/properties/", features = ["serde"] }
-icu_provider = { path = "../../provider/core", features = ["serde"] }
-icu_provider_adapters = { path = "../../provider/adapters" }
-icu_provider_blob = { path = "../../provider/blob" }
-icu_segmenter = { path = "../../experimental/segmenter", features = ["serde"] }
+fixed_decimal = { version = "0.2.2", path = "../../utils/fixed_decimal", features = ["ryu"] }
+icu_decimal = { version = "0.5", path = "../../components/decimal/", features = ["serde"] }
+icu_locale_canonicalizer = { version = "0.5", path = "../../components/locale_canonicalizer", features = ["serde"] }
+icu_locid = { version = "0.5", path = "../../components/locid", features = ["serde"] }
+icu_plurals = { version = "0.5", path = "../../components/plurals/", features = ["serde"] }
+icu_properties = { version = "0.5", path = "../../components/properties/", features = ["serde"] }
+icu_provider = { version = "0.5", path = "../../provider/core", features = ["serde"] }
+icu_provider_adapters = { version = "0.5", path = "../../provider/adapters" }
+icu_provider_blob = { version = "0.5", path = "../../provider/blob" }
+icu_segmenter = { version = "0.5", path = "../../experimental/segmenter", features = ["serde"] }
 tinystr = { path = "../../utils/tinystr", version = "0.5.0", features = ["alloc"], default-features = false }
-writeable = { path = "../../utils/writeable/" }
+writeable = { version = "0.3", path = "../../utils/writeable/" }
 
 # Run `cargo make diplomat-install` to get the right diplomat binary installed
-diplomat = { git = "https://github.com/rust-diplomat/diplomat", version = "0.3.0" }
-diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", version = "0.3.0" }
+diplomat = { version = "0.3.0" }
+diplomat-runtime = { version = "0.3.0" }
 icu_testdata = { version = "0.5", path = "../../provider/testdata", default-features = false, features = ["static"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -59,8 +59,8 @@ tinystr = { path = "../../utils/tinystr", version = "0.5.0", features = ["alloc"
 writeable = { path = "../../utils/writeable/" }
 
 # Run `cargo make diplomat-install` to get the right diplomat binary installed
-diplomat = { git = "https://github.com/rust-diplomat/diplomat", version = "0.2.0" }
-diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", version = "0.2.0" }
+diplomat = { git = "https://github.com/rust-diplomat/diplomat", version = "0.3.0" }
+diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", version = "0.3.0" }
 icu_testdata = { version = "0.5", path = "../../provider/testdata", default-features = false, features = ["static"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_capi"
 description = "C interface to ICU4X"
-version = "0.1.0"
+version = "0.5.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 resolver = "2"

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -59,8 +59,8 @@ tinystr = { path = "../../utils/tinystr", version = "0.5.0", features = ["alloc"
 writeable = { path = "../../utils/writeable/" }
 
 # Run `cargo make diplomat-install` to get the right diplomat binary installed
-diplomat = { git = "https://github.com/rust-diplomat/diplomat", rev = "3c75d805e61c0e1b378a7c7aae1523c2db202398" }
-diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", rev = "3c75d805e61c0e1b378a7c7aae1523c2db202398" }
+diplomat = { git = "https://github.com/rust-diplomat/diplomat", version = "0.2.0" }
+diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", version = "0.2.0" }
 icu_testdata = { version = "0.5", path = "../../provider/testdata", default-features = false, features = ["static"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/ffi/ecma402/Cargo.toml
+++ b/ffi/ecma402/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu4x_ecma402"
 description = "ECMA-402 API functionality backed by the ICU4X library"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"
@@ -28,7 +28,7 @@ all-features = true
 
 [dependencies]
 ecma402_traits = { version = "0.2.0" }
-icu = { path = "../../components/icu", default-features = false }
+icu = { version = "0.5", path = "../../components/icu", default-features = false }
 icu_provider = { version = "0.5", path = "../../provider/core" }
 icu_plurals = { version = "0.5", path = "../../components/plurals", features = ["std"] }
 

--- a/ffi/freertos/Cargo.toml
+++ b/ffi/freertos/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_freertos"
 description = "C interface to ICU4X"
-version = "0.1.0"
+version = "0.5.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 resolver = "2"
@@ -32,7 +32,7 @@ crate-type = ["staticlib", "rlib"]
 path = "src/lib.rs"
 
 [dependencies]
-icu_capi = { version = "0.1", path = "../diplomat", default-features = false }
+icu_capi = { version = "0.5", path = "../diplomat", default-features = false }
 
 [target.'cfg(target_os = "none")'.dependencies]
 freertos-rust = { version = "0.1.2" }

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -43,7 +43,7 @@ icu_plurals = { version = "0.5", path = "../../components/plurals", features = [
 icu_properties = { version = "0.5", path = "../../components/properties", features = ["datagen"]}
 # (experimental)
 icu_casemapping = { version = "0.1", path = "../../experimental/casemapping", features = ["datagen"], optional = true }
-icu_segmenter = { version = "0.1", path = "../../experimental/segmenter", features = ["datagen"], optional = true }
+icu_segmenter = { version = "0.5", path = "../../experimental/segmenter", features = ["datagen"], optional = true }
 
 # ICU provider infrastructure
 icu_provider = { version = "0.5", path = "../core", features = ["std", "log_error_context"]}

--- a/tools/scripts/ffi.toml
+++ b/tools/scripts/ffi.toml
@@ -177,15 +177,20 @@ for pkg in ${packages}
     if ${e}
         # get pkg.source
         source = map_get ${pkg} source
+        version = map_get ${pkg} version
         # extract the bit between `rev=` and `#`
         handle = split ${source} "rev="
-        hash = array_get ${handle} 1
+        hash_len = array_length ${handle}
+        if eq ${hash_len} 2
+            hash = array_get ${handle} 1
+            release handle
+            handle = split ${hash} "#"
+            version = array_get ${handle} 0
+        end
         release handle
-        handle = split ${hash} "#"
-        rev = array_get ${handle} 0
-        release handle
+
         # print it
-        echo ${rev}
+        echo ${version}
     end
 end
 release --recursive ${metadata}
@@ -200,6 +205,12 @@ script = '''
 exit_on_error true
 rev = exec cargo make --loglevel error diplomat-get-rev
 rev = trim ${rev.stdout}
-echo "Installing Diplomat rev ${rev}"
-exec cargo install --git https://github.com/rust-diplomat/diplomat.git --rev ${rev} diplomat-tool -f
+if contains ${rev} "."
+    echo "Installing Diplomat version ${rev}"
+    exec cargo install --git https://github.com/rust-diplomat/diplomat.git --version ${rev} diplomat-tool -f
+
+else
+    echo "Installing Diplomat rev ${rev}"
+    exec cargo install --git https://github.com/rust-diplomat/diplomat.git --rev ${rev} diplomat-tool -f
+end
 '''


### PR DESCRIPTION
This makes it possible for diplomat to be depended on as a version or git hash, and updates diplomat to 0.3 . 

With this in place, `ffi/` crates can (and should) be published for ICU4X 0.6 (cc @dminor).


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->