### PR TITLE
Add `new_X_(date|datetime)_from_integers` examples

### DIFF
--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -97,7 +97,28 @@ impl Calendar for Buddhist {
 }
 
 impl Date<Buddhist> {
-    /// Construct a new Buddhist Date
+    /// Construct a new Buddhist Date.
+    ///
+    /// Years are specified as BE years.
+    ///
+    /// ```rust
+    /// use icu::calendar::{Date,
+    ///                     iso::IsoYear,
+    ///                     iso::IsoMonth,
+    ///                     iso::IsoDay};
+    /// use std::convert::TryFrom;
+    ///
+    /// let iso_year = IsoYear(1736);
+    /// let iso_month = IsoMonth::try_from(2).unwrap();
+    /// let iso_day = IsoDay::try_from(3).unwrap();
+    ///
+    /// // Conversion from ISO to Buddhist
+    /// let date_buddhist = Date::new_buddhist_date(iso_year, iso_month, iso_day).unwrap();
+    ///
+    /// assert_eq!(date_buddhist.year().number, 2279);
+    /// assert_eq!(date_buddhist.month().number, 2);
+    /// assert_eq!(date_buddhist.day_of_month().0, 3);
+    /// ```
     pub fn new_buddhist_date(
         year: IsoYear,
         month: IsoMonth,
@@ -108,9 +129,25 @@ impl Date<Buddhist> {
 }
 
 impl DateTime<Buddhist> {
-    /// Construct a new Buddhist datetime from integers
+    /// Construct a new Buddhist datetime from integers.
     ///
-    /// Years are specified as BE years
+    /// Years are specified as BE years.
+    /// 
+    /// ```rust
+    /// use icu::calendar::{DateTime,
+    ///                     types::IsoHour,
+    ///                     types::IsoMinute,
+    ///                     types::IsoSecond};
+    /// 
+    /// let datetime_buddhist = DateTime::new_buddhist_datetime_from_integers(2279, 2, 3, 13, 1, 0).unwrap();
+    ///
+    /// assert_eq!(datetime_buddhist.date.year().number, 2279);
+    /// assert_eq!(datetime_buddhist.date.month().number, 2);
+    /// assert_eq!(datetime_buddhist.date.day_of_month().0, 3);
+    /// assert_eq!(datetime_buddhist.time.hour, IsoHour::new_unchecked(13));
+    /// assert_eq!(datetime_buddhist.time.minute, IsoMinute::new_unchecked(1));
+    /// assert_eq!(datetime_buddhist.time.second, IsoSecond::new_unchecked(0));
+    /// ```
     pub fn new_buddhist_datetime_from_integers(
         year: i32,
         month: u8,

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -108,16 +108,16 @@ impl Date<Buddhist> {
     ///                     iso::IsoDay};
     /// use std::convert::TryFrom;
     ///
-    /// let iso_year = IsoYear(1736);
-    /// let iso_month = IsoMonth::try_from(2).unwrap();
-    /// let iso_day = IsoDay::try_from(3).unwrap();
+    /// let iso_year = IsoYear(1970);
+    /// let iso_month = IsoMonth::try_from(1).unwrap();
+    /// let iso_day = IsoDay::try_from(2).unwrap();
     ///
     /// // Conversion from ISO to Buddhist
     /// let date_buddhist = Date::new_buddhist_date(iso_year, iso_month, iso_day).unwrap();
     ///
-    /// assert_eq!(date_buddhist.year().number, 2279);
-    /// assert_eq!(date_buddhist.month().number, 2);
-    /// assert_eq!(date_buddhist.day_of_month().0, 3);
+    /// assert_eq!(date_buddhist.year().number, 2513);
+    /// assert_eq!(date_buddhist.month().number, 1);
+    /// assert_eq!(date_buddhist.day_of_month().0, 2);
     /// ```
     pub fn new_buddhist_date(
         year: IsoYear,
@@ -132,18 +132,18 @@ impl DateTime<Buddhist> {
     /// Construct a new Buddhist datetime from integers.
     ///
     /// Years are specified as BE years.
-    /// 
+    ///
     /// ```rust
     /// use icu::calendar::{DateTime,
     ///                     types::IsoHour,
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
-    /// 
-    /// let datetime_buddhist = DateTime::new_buddhist_datetime_from_integers(2279, 2, 3, 13, 1, 0).unwrap();
     ///
-    /// assert_eq!(datetime_buddhist.date.year().number, 2279);
-    /// assert_eq!(datetime_buddhist.date.month().number, 2);
-    /// assert_eq!(datetime_buddhist.date.day_of_month().0, 3);
+    /// let datetime_buddhist = DateTime::new_buddhist_datetime_from_integers(2513, 1, 2, 13, 1, 0).unwrap();
+    ///
+    /// assert_eq!(datetime_buddhist.date.year().number, 2513);
+    /// assert_eq!(datetime_buddhist.date.month().number, 1);
+    /// assert_eq!(datetime_buddhist.date.day_of_month().0, 2);
     /// assert_eq!(datetime_buddhist.time.hour, IsoHour::new_unchecked(13));
     /// assert_eq!(datetime_buddhist.time.minute, IsoMinute::new_unchecked(1));
     /// assert_eq!(datetime_buddhist.time.second, IsoSecond::new_unchecked(0));

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -180,11 +180,11 @@ impl Date<Coptic> {
     /// ```rust
     /// use icu::calendar::Date;
     ///
-    /// let date_coptic = Date::new_coptic_date_from_integers(1736, 2, 3).unwrap();
+    /// let date_coptic = Date::new_coptic_date_from_integers(1686, 5, 6).unwrap();
     ///
-    /// assert_eq!(date_coptic.year().number, 1736);
-    /// assert_eq!(date_coptic.month().number, 2);
-    /// assert_eq!(date_coptic.day_of_month().0, 3);
+    /// assert_eq!(date_coptic.year().number, 1686);
+    /// assert_eq!(date_coptic.month().number, 5);
+    /// assert_eq!(date_coptic.day_of_month().0, 6);
     /// ```
     pub fn new_coptic_date_from_integers(
         year: i32,
@@ -215,11 +215,12 @@ impl DateTime<Coptic> {
     ///                     types::IsoHour,
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
-    /// 
-    /// let datetime_coptic = DateTime::new_coptic_datetime_from_integers(1736, 2, 3, 13, 1, 0).unwrap();
-    /// assert_eq!(datetime_coptic.date.year().number, 1736);
-    /// assert_eq!(datetime_coptic.date.month().number, 2);
-    /// assert_eq!(datetime_coptic.date.day_of_month().0, 3);
+    ///
+    /// let datetime_coptic = DateTime::new_coptic_datetime_from_integers(1686, 5, 6, 13, 1, 0).unwrap();
+    ///
+    /// assert_eq!(datetime_coptic.date.year().number, 1686);
+    /// assert_eq!(datetime_coptic.date.month().number, 5);
+    /// assert_eq!(datetime_coptic.date.day_of_month().0, 6);
     /// assert_eq!(datetime_coptic.time.hour, IsoHour::new_unchecked(13));
     /// assert_eq!(datetime_coptic.time.minute, IsoMinute::new_unchecked(1));
     /// assert_eq!(datetime_coptic.time.second, IsoSecond::new_unchecked(0));

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -175,7 +175,17 @@ impl Coptic {
 }
 
 impl Date<Coptic> {
-    /// Construct new Coptic Date
+    /// Construct new Coptic Date.
+    ///
+    /// ```rust
+    /// use icu::calendar::Date;
+    ///
+    /// let date_coptic = Date::new_coptic_date_from_integers(1736, 2, 3).unwrap();
+    ///
+    /// assert_eq!(date_coptic.year().number, 1736);
+    /// assert_eq!(date_coptic.month().number, 2);
+    /// assert_eq!(date_coptic.day_of_month().0, 3);
+    /// ```
     pub fn new_coptic_date_from_integers(
         year: i32,
         month: u8,
@@ -198,7 +208,22 @@ impl Date<Coptic> {
 }
 
 impl DateTime<Coptic> {
-    /// Construct a new Coptic datetime from integers
+    /// Construct a new Coptic datetime from integers.
+    ///
+    /// ```rust
+    /// use icu::calendar::{DateTime,
+    ///                     types::IsoHour,
+    ///                     types::IsoMinute,
+    ///                     types::IsoSecond};
+    /// 
+    /// let datetime_coptic = DateTime::new_coptic_datetime_from_integers(1736, 2, 3, 13, 1, 0).unwrap();
+    /// assert_eq!(datetime_coptic.date.year().number, 1736);
+    /// assert_eq!(datetime_coptic.date.month().number, 2);
+    /// assert_eq!(datetime_coptic.date.day_of_month().0, 3);
+    /// assert_eq!(datetime_coptic.time.hour, IsoHour::new_unchecked(13));
+    /// assert_eq!(datetime_coptic.time.minute, IsoMinute::new_unchecked(1));
+    /// assert_eq!(datetime_coptic.time.second, IsoSecond::new_unchecked(0));
+    /// ```
     pub fn new_coptic_datetime_from_integers(
         year: i32,
         month: u8,

--- a/components/calendar/src/ethiopic.rs
+++ b/components/calendar/src/ethiopic.rs
@@ -188,7 +188,17 @@ impl Ethiopic {
 }
 
 impl Date<Ethiopic> {
-    /// Construct new Ethiopic Date
+    /// Construct new Ethiopic Date.
+    ///
+    /// ```rust
+    /// use icu::calendar::Date;
+    ///
+    /// let date_ethiopic = Date::new_ethiopic_date_from_integers(1736, 2, 3).unwrap();
+    ///
+    /// assert_eq!(date_ethiopic.year().number, 1736);
+    /// assert_eq!(date_ethiopic.month().number, 2);
+    /// assert_eq!(date_ethiopic.day_of_month().0, 3);
+    /// ```
     pub fn new_ethiopic_date_from_integers(
         year: i32,
         month: u8,
@@ -215,7 +225,22 @@ impl Date<Ethiopic> {
 }
 
 impl DateTime<Ethiopic> {
-    /// Construct a new Ethiopic datetime from integers
+    /// Construct a new Ethiopic datetime from integers.
+    /// 
+    /// ```rust
+    /// use icu::calendar::{DateTime,
+    ///                     types::IsoHour,
+    ///                     types::IsoMinute,
+    ///                     types::IsoSecond};
+    /// 
+    /// let datetime_ethiopic = DateTime::new_ethiopic_datetime_from_integers(1736, 2, 3, 13, 1, 0, 0).unwrap();
+    /// assert_eq!(datetime_ethiopic.date.year().number, 1736);
+    /// assert_eq!(datetime_ethiopic.date.month().number, 2);
+    /// assert_eq!(datetime_ethiopic.date.day_of_month().0, 3);
+    /// assert_eq!(datetime_ethiopic.time.hour, IsoHour::new_unchecked(13));
+    /// assert_eq!(datetime_ethiopic.time.minute, IsoMinute::new_unchecked(1));
+    /// assert_eq!(datetime_ethiopic.time.second, IsoSecond::new_unchecked(0));
+    /// ```
     pub fn new_ethiopic_datetime_from_integers(
         year: i32,
         month: u8,

--- a/components/calendar/src/ethiopic.rs
+++ b/components/calendar/src/ethiopic.rs
@@ -193,11 +193,11 @@ impl Date<Ethiopic> {
     /// ```rust
     /// use icu::calendar::Date;
     ///
-    /// let date_ethiopic = Date::new_ethiopic_date_from_integers(1736, 2, 3).unwrap();
+    /// let date_ethiopic = Date::new_ethiopic_date_from_integers(2014, 8, 25).unwrap();
     ///
-    /// assert_eq!(date_ethiopic.year().number, 1736);
-    /// assert_eq!(date_ethiopic.month().number, 2);
-    /// assert_eq!(date_ethiopic.day_of_month().0, 3);
+    /// assert_eq!(date_ethiopic.year().number, 2014);
+    /// assert_eq!(date_ethiopic.month().number, 8);
+    /// assert_eq!(date_ethiopic.day_of_month().0, 25);
     /// ```
     pub fn new_ethiopic_date_from_integers(
         year: i32,
@@ -226,17 +226,18 @@ impl Date<Ethiopic> {
 
 impl DateTime<Ethiopic> {
     /// Construct a new Ethiopic datetime from integers.
-    /// 
+    ///
     /// ```rust
     /// use icu::calendar::{DateTime,
     ///                     types::IsoHour,
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
-    /// 
-    /// let datetime_ethiopic = DateTime::new_ethiopic_datetime_from_integers(1736, 2, 3, 13, 1, 0, 0).unwrap();
-    /// assert_eq!(datetime_ethiopic.date.year().number, 1736);
-    /// assert_eq!(datetime_ethiopic.date.month().number, 2);
-    /// assert_eq!(datetime_ethiopic.date.day_of_month().0, 3);
+    ///
+    /// let datetime_ethiopic = DateTime::new_ethiopic_datetime_from_integers(2014, 8, 25, 13, 1, 0, 0).unwrap();
+    ///
+    /// assert_eq!(datetime_ethiopic.date.year().number, 2014);
+    /// assert_eq!(datetime_ethiopic.date.month().number, 8);
+    /// assert_eq!(datetime_ethiopic.date.day_of_month().0, 25);
     /// assert_eq!(datetime_ethiopic.time.hour, IsoHour::new_unchecked(13));
     /// assert_eq!(datetime_ethiopic.time.minute, IsoMinute::new_unchecked(1));
     /// assert_eq!(datetime_ethiopic.time.second, IsoSecond::new_unchecked(0));

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -91,7 +91,28 @@ impl Calendar for Gregorian {
 }
 
 impl Date<Gregorian> {
-    /// Construct a new Gregorian Date
+    /// Construct a new Gregorian Date.
+    ///
+    /// Years are specified as ISO years.
+    ///
+    /// ```rust
+    /// use icu::calendar::{Date,
+    ///                     iso::IsoYear,
+    ///                     iso::IsoMonth,
+    ///                     iso::IsoDay};
+    /// use std::convert::TryFrom;
+    ///
+    /// let iso_year = IsoYear(1996);
+    /// let iso_month = IsoMonth::try_from(2).unwrap();
+    /// let iso_day = IsoDay::try_from(3).unwrap();
+    ///
+    /// // Conversion from ISO to Gregorian
+    /// let date_gregorian = Date::new_gregorian_date(iso_year, iso_month, iso_day).unwrap();
+    ///
+    /// assert_eq!(date_gregorian.year().number, 1996);
+    /// assert_eq!(date_gregorian.month().number, 2);
+    /// assert_eq!(date_gregorian.day_of_month().0, 3);
+    /// ```
     pub fn new_gregorian_date(
         year: IsoYear,
         month: IsoMonth,
@@ -102,9 +123,24 @@ impl Date<Gregorian> {
 }
 
 impl DateTime<Gregorian> {
-    /// Construct a new Gregorian datetime from integers
+    /// Construct a new Gregorian datetime from integers.
     ///
-    /// Years are specified as ISO years
+    /// Years are specified as ISO years.
+    ///
+    /// ```rust
+    /// use icu::calendar::{DateTime,
+    ///                     types::IsoHour,
+    ///                     types::IsoMinute,
+    ///                     types::IsoSecond};
+    ///
+    /// let datetime_gregorian = DateTime::new_gregorian_datetime_from_integers(1996, 2, 3, 13, 1, 0, 0).unwrap();
+    /// assert_eq!(datetime_gregorian.date.year().number, 1996);
+    /// assert_eq!(datetime_gregorian.date.month().number, 2);
+    /// assert_eq!(datetime_gregorian.date.day_of_month().0, 3);
+    /// assert_eq!(datetime_gregorian.time.hour, IsoHour::new_unchecked(13));
+    /// assert_eq!(datetime_gregorian.time.minute, IsoMinute::new_unchecked(1));
+    /// assert_eq!(datetime_gregorian.time.second, IsoSecond::new_unchecked(0));
+    /// ```
     pub fn new_gregorian_datetime_from_integers(
         year: i32,
         month: u8,

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -102,16 +102,16 @@ impl Date<Gregorian> {
     ///                     iso::IsoDay};
     /// use std::convert::TryFrom;
     ///
-    /// let iso_year = IsoYear(1996);
-    /// let iso_month = IsoMonth::try_from(2).unwrap();
-    /// let iso_day = IsoDay::try_from(3).unwrap();
+    /// let iso_year = IsoYear(1970);
+    /// let iso_month = IsoMonth::try_from(1).unwrap();
+    /// let iso_day = IsoDay::try_from(2).unwrap();
     ///
     /// // Conversion from ISO to Gregorian
     /// let date_gregorian = Date::new_gregorian_date(iso_year, iso_month, iso_day).unwrap();
     ///
-    /// assert_eq!(date_gregorian.year().number, 1996);
-    /// assert_eq!(date_gregorian.month().number, 2);
-    /// assert_eq!(date_gregorian.day_of_month().0, 3);
+    /// assert_eq!(date_gregorian.year().number, 1970);
+    /// assert_eq!(date_gregorian.month().number, 1);
+    /// assert_eq!(date_gregorian.day_of_month().0, 2);
     /// ```
     pub fn new_gregorian_date(
         year: IsoYear,
@@ -133,10 +133,11 @@ impl DateTime<Gregorian> {
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
     ///
-    /// let datetime_gregorian = DateTime::new_gregorian_datetime_from_integers(1996, 2, 3, 13, 1, 0, 0).unwrap();
-    /// assert_eq!(datetime_gregorian.date.year().number, 1996);
-    /// assert_eq!(datetime_gregorian.date.month().number, 2);
-    /// assert_eq!(datetime_gregorian.date.day_of_month().0, 3);
+    /// let datetime_gregorian = DateTime::new_gregorian_datetime_from_integers(1970, 1, 2, 13, 1, 0, 0).unwrap();
+    ///
+    /// assert_eq!(datetime_gregorian.date.year().number, 1970);
+    /// assert_eq!(datetime_gregorian.date.month().number, 1);
+    /// assert_eq!(datetime_gregorian.date.day_of_month().0, 2);
     /// assert_eq!(datetime_gregorian.time.hour, IsoHour::new_unchecked(13));
     /// assert_eq!(datetime_gregorian.time.minute, IsoMinute::new_unchecked(1));
     /// assert_eq!(datetime_gregorian.time.second, IsoSecond::new_unchecked(0));

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -158,11 +158,11 @@ impl Date<Indian> {
     /// ```rust
     /// use icu::calendar::Date;
     ///
-    /// let date_indian = Date::new_indian_date_from_integers(1996, 2, 3).unwrap();
+    /// let date_indian = Date::new_indian_date_from_integers(1891, 10, 12).unwrap();
     ///
-    /// assert_eq!(date_indian.year().number, 1996);
-    /// assert_eq!(date_indian.month().number, 2);
-    /// assert_eq!(date_indian.day_of_month().0, 3);
+    /// assert_eq!(date_indian.year().number, 1891);
+    /// assert_eq!(date_indian.month().number, 10);
+    /// assert_eq!(date_indian.day_of_month().0, 12);
     /// ```
     pub fn new_indian_date_from_integers(
         year: i32,
@@ -194,11 +194,11 @@ impl DateTime<Indian> {
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
     ///
-    /// let datetime_indian = DateTime::new_indian_datetime_from_integers(1736, 2, 3, 13, 1, 0).unwrap();
+    /// let datetime_indian = DateTime::new_indian_datetime_from_integers(1891, 10, 12, 13, 1, 0).unwrap();
     ///
-    /// assert_eq!(datetime_indian.date.year().number, 1736);
-    /// assert_eq!(datetime_indian.date.month().number, 2);
-    /// assert_eq!(datetime_indian.date.day_of_month().0, 3);
+    /// assert_eq!(datetime_indian.date.year().number, 1891);
+    /// assert_eq!(datetime_indian.date.month().number, 10);
+    /// assert_eq!(datetime_indian.date.day_of_month().0, 12);
     /// assert_eq!(datetime_indian.time.hour, IsoHour::new_unchecked(13));
     /// assert_eq!(datetime_indian.time.minute, IsoMinute::new_unchecked(1));
     /// assert_eq!(datetime_indian.time.second, IsoSecond::new_unchecked(0));

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -153,7 +153,17 @@ impl Indian {
 }
 
 impl Date<Indian> {
-    /// Construct new Indian Date
+    /// Construct new Indian Date.
+    ///
+    /// ```rust
+    /// use icu::calendar::Date;
+    ///
+    /// let date_indian = Date::new_indian_date_from_integers(1996, 2, 3).unwrap();
+    ///
+    /// assert_eq!(date_indian.year().number, 1996);
+    /// assert_eq!(date_indian.month().number, 2);
+    /// assert_eq!(date_indian.day_of_month().0, 3);
+    /// ```
     pub fn new_indian_date_from_integers(
         year: i32,
         month: u8,
@@ -176,7 +186,23 @@ impl Date<Indian> {
 }
 
 impl DateTime<Indian> {
-    /// Construct a new Indian datetime from integers
+    /// Construct a new Indian datetime from integers.
+    ///
+    /// ```rust
+    /// use icu::calendar::{DateTime,
+    ///                     types::IsoHour,
+    ///                     types::IsoMinute,
+    ///                     types::IsoSecond};
+    ///
+    /// let datetime_indian = DateTime::new_indian_datetime_from_integers(1736, 2, 3, 13, 1, 0).unwrap();
+    ///
+    /// assert_eq!(datetime_indian.date.year().number, 1736);
+    /// assert_eq!(datetime_indian.date.month().number, 2);
+    /// assert_eq!(datetime_indian.date.day_of_month().0, 3);
+    /// assert_eq!(datetime_indian.time.hour, IsoHour::new_unchecked(13));
+    /// assert_eq!(datetime_indian.time.minute, IsoMinute::new_unchecked(1));
+    /// assert_eq!(datetime_indian.time.second, IsoSecond::new_unchecked(0));
+    /// ```
     pub fn new_indian_datetime_from_integers(
         year: i32,
         month: u8,

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -302,7 +302,26 @@ impl Calendar for Iso {
 }
 
 impl Date<Iso> {
-    /// Construct a new ISO Date
+    /// Construct a new ISO Date.
+    ///
+    /// ```rust
+    /// use icu::calendar::{Date,
+    ///                     iso::IsoYear,
+    ///                     iso::IsoMonth,
+    ///                     iso::IsoDay};
+    /// use std::convert::TryFrom;
+    ///
+    /// let iso_year = IsoYear(1996);
+    /// let iso_month = IsoMonth::try_from(2).unwrap();
+    /// let iso_day = IsoDay::try_from(3).unwrap();
+    ///
+    /// // Creation of ISO date
+    /// let date_iso = Date::new_iso_date(iso_year, iso_month, iso_day).unwrap();
+    ///
+    /// assert_eq!(date_iso.year().number, 1996);
+    /// assert_eq!(date_iso.month().number, 2);
+    /// assert_eq!(date_iso.day_of_month().0, 3);
+    /// ```
     pub fn new_iso_date(
         year: IsoYear,
         month: IsoMonth,
@@ -318,7 +337,17 @@ impl Date<Iso> {
         Ok(Date::from_raw(IsoDateInner { day, month, year }, Iso))
     }
 
-    /// Construct a new ISO date from integers
+    /// Construct a new ISO date from integers.
+    ///
+    /// ```rust
+    /// use icu::calendar::Date;
+    ///
+    /// let date_iso = Date::new_iso_date_from_integers(1996, 2, 3).unwrap();
+    ///
+    /// assert_eq!(date_iso.year().number, 1996);
+    /// assert_eq!(date_iso.month().number, 2);
+    /// assert_eq!(date_iso.day_of_month().0, 3);
+    /// ```
     pub fn new_iso_date_from_integers(
         year: i32,
         month: u8,
@@ -329,7 +358,23 @@ impl Date<Iso> {
 }
 
 impl DateTime<Iso> {
-    /// Construct a new ISO date from integers
+    /// Construct a new ISO date from integers.
+    ///
+    /// ```rust
+    /// use icu::calendar::{DateTime,
+    ///                     types::IsoHour,
+    ///                     types::IsoMinute,
+    ///                     types::IsoSecond};
+    ///
+    /// let datetime_iso = DateTime::new_iso_datetime_from_integers(1736, 2, 3, 13, 1, 0).unwrap();
+    ///
+    /// assert_eq!(datetime_iso.date.year().number, 1736);
+    /// assert_eq!(datetime_iso.date.month().number, 2);
+    /// assert_eq!(datetime_iso.date.day_of_month().0, 3);
+    /// assert_eq!(datetime_iso.time.hour, IsoHour::new_unchecked(13));
+    /// assert_eq!(datetime_iso.time.minute, IsoMinute::new_unchecked(1));
+    /// assert_eq!(datetime_iso.time.second, IsoSecond::new_unchecked(0));
+    /// ```
     pub fn new_iso_datetime_from_integers(
         year: i32,
         month: u8,

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -342,11 +342,11 @@ impl Date<Iso> {
     /// ```rust
     /// use icu::calendar::Date;
     ///
-    /// let date_iso = Date::new_iso_date_from_integers(1996, 2, 3).unwrap();
+    /// let date_iso = Date::new_iso_date_from_integers(1970, 1, 2).unwrap();
     ///
-    /// assert_eq!(date_iso.year().number, 1996);
-    /// assert_eq!(date_iso.month().number, 2);
-    /// assert_eq!(date_iso.day_of_month().0, 3);
+    /// assert_eq!(date_iso.year().number, 1970);
+    /// assert_eq!(date_iso.month().number, 1);
+    /// assert_eq!(date_iso.day_of_month().0, 2);
     /// ```
     pub fn new_iso_date_from_integers(
         year: i32,
@@ -366,11 +366,11 @@ impl DateTime<Iso> {
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
     ///
-    /// let datetime_iso = DateTime::new_iso_datetime_from_integers(1736, 2, 3, 13, 1, 0).unwrap();
+    /// let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0).unwrap();
     ///
-    /// assert_eq!(datetime_iso.date.year().number, 1736);
-    /// assert_eq!(datetime_iso.date.month().number, 2);
-    /// assert_eq!(datetime_iso.date.day_of_month().0, 3);
+    /// assert_eq!(datetime_iso.date.year().number, 1970);
+    /// assert_eq!(datetime_iso.date.month().number, 1);
+    /// assert_eq!(datetime_iso.date.day_of_month().0, 2);
     /// assert_eq!(datetime_iso.time.hour, IsoHour::new_unchecked(13));
     /// assert_eq!(datetime_iso.time.minute, IsoMinute::new_unchecked(1));
     /// assert_eq!(datetime_iso.time.second, IsoSecond::new_unchecked(0));

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -199,7 +199,17 @@ impl Julian {
 }
 
 impl Date<Julian> {
-    /// Construct new Julian Date
+    /// Construct new Julian Date.
+    ///
+    /// ```rust
+    /// use icu::calendar::Date;
+    ///
+    /// let date_julian = Date::new_julian_date_from_integers(1996, 2, 3).unwrap();
+    ///
+    /// assert_eq!(date_julian.year().number, 1996);
+    /// assert_eq!(date_julian.month().number, 2);
+    /// assert_eq!(date_julian.day_of_month().0, 3);
+    /// ```
     pub fn new_julian_date_from_integers(
         year: i32,
         month: u8,
@@ -224,7 +234,23 @@ impl Date<Julian> {
 }
 
 impl DateTime<Julian> {
-    /// Constrict a new Julian datetime form integers
+    /// Constrict a new Julian datetime form integers.
+    ///
+    /// ```rust
+    /// use icu::calendar::{DateTime,
+    ///                     types::IsoHour,
+    ///                     types::IsoMinute,
+    ///                     types::IsoSecond};
+    ///
+    /// let datetime_julian = DateTime::new_julian_datetime_from_integers(1996, 2, 3, 13, 1, 0).unwrap();
+    ///
+    /// assert_eq!(datetime_julian.date.year().number, 1996);
+    /// assert_eq!(datetime_julian.date.month().number, 2);
+    /// assert_eq!(datetime_julian.date.day_of_month().0, 3);
+    /// assert_eq!(datetime_julian.time.hour, IsoHour::new_unchecked(13));
+    /// assert_eq!(datetime_julian.time.minute, IsoMinute::new_unchecked(1));
+    /// assert_eq!(datetime_julian.time.second, IsoSecond::new_unchecked(0));
+    /// ```
     pub fn new_julian_datetime_from_integers(
         year: i32,
         month: u8,

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -204,11 +204,11 @@ impl Date<Julian> {
     /// ```rust
     /// use icu::calendar::Date;
     ///
-    /// let date_julian = Date::new_julian_date_from_integers(1996, 2, 3).unwrap();
+    /// let date_julian = Date::new_julian_date_from_integers(1969, 12, 20).unwrap();
     ///
-    /// assert_eq!(date_julian.year().number, 1996);
-    /// assert_eq!(date_julian.month().number, 2);
-    /// assert_eq!(date_julian.day_of_month().0, 3);
+    /// assert_eq!(date_julian.year().number, 1969);
+    /// assert_eq!(date_julian.month().number, 12);
+    /// assert_eq!(date_julian.day_of_month().0, 20);
     /// ```
     pub fn new_julian_date_from_integers(
         year: i32,
@@ -242,11 +242,11 @@ impl DateTime<Julian> {
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
     ///
-    /// let datetime_julian = DateTime::new_julian_datetime_from_integers(1996, 2, 3, 13, 1, 0).unwrap();
+    /// let datetime_julian = DateTime::new_julian_datetime_from_integers(1969, 12, 20, 13, 1, 0).unwrap();
     ///
-    /// assert_eq!(datetime_julian.date.year().number, 1996);
-    /// assert_eq!(datetime_julian.date.month().number, 2);
-    /// assert_eq!(datetime_julian.date.day_of_month().0, 3);
+    /// assert_eq!(datetime_julian.date.year().number, 1969);
+    /// assert_eq!(datetime_julian.date.month().number, 12);
+    /// assert_eq!(datetime_julian.date.day_of_month().0, 20);
     /// assert_eq!(datetime_julian.time.hour, IsoHour::new_unchecked(13));
     /// assert_eq!(datetime_julian.time.minute, IsoMinute::new_unchecked(1));
     /// assert_eq!(datetime_julian.time.second, IsoSecond::new_unchecked(0));


### PR DESCRIPTION
Adding examples for each calendar type for `new_X_date_from_integers` and `new_X_datetime_from_integers`:
* Examples show how to create, along with assertions to demonstrate and assure functionality.
* Arbitrarily chose "January 2, 1970" in ISO calendar as corresponding date for each example. Originally wanted start of Unix time, but January 1 reduced glanceability.
* Japanese did not have a  `new_X_(date|datetime)_from_integers`, so this has been omitted for this PR.

Part of https://github.com/unicode-org/icu4x/issues/1791