### PR TITLE
Fixing typo on Julian example

### DIFF
--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -234,7 +234,7 @@ impl Date<Julian> {
 }
 
 impl DateTime<Julian> {
-    /// Constrict a new Julian datetime form integers.
+    /// Construct a new Julian datetime from integers.
     ///
     /// ```rust
     /// use icu::calendar::{DateTime,


### PR DESCRIPTION
My additions came with a typo on a Julian example. This fixes that