### PR TITLE
Improve calendar-specific date/datetime constructors

### DIFF
--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -4,9 +4,8 @@
 
 //! This module contains types and implementations for the Buddhist calendar
 
-use crate::iso::{Iso, IsoDateInner, IsoDay, IsoMonth, IsoYear};
+use crate::iso::{Iso, IsoDateInner, IsoYear};
 use crate::{types, Calendar, Date, DateDuration, DateDurationUnit, DateTime, DateTimeError};
-use core::convert::TryInto;
 use tinystr::tinystr;
 
 /// The number of years the Buddhist Era is ahead of C.E. by
@@ -102,29 +101,22 @@ impl Date<Buddhist> {
     /// Years are specified as BE years.
     ///
     /// ```rust
-    /// use icu::calendar::{Date,
-    ///                     iso::IsoYear,
-    ///                     iso::IsoMonth,
-    ///                     iso::IsoDay};
+    /// use icu::calendar::Date;
     /// use std::convert::TryFrom;
     ///
-    /// let iso_year = IsoYear(1970);
-    /// let iso_month = IsoMonth::try_from(1).unwrap();
-    /// let iso_day = IsoDay::try_from(2).unwrap();
+    /// let date_buddhist = Date::new_buddhist_date(1970, 1, 2).unwrap();
     ///
-    /// // Conversion from ISO to Buddhist
-    /// let date_buddhist = Date::new_buddhist_date(iso_year, iso_month, iso_day).unwrap();
-    ///
-    /// assert_eq!(date_buddhist.year().number, 2513);
+    /// assert_eq!(date_buddhist.year().number, 1970);
     /// assert_eq!(date_buddhist.month().number, 1);
     /// assert_eq!(date_buddhist.day_of_month().0, 2);
     /// ```
     pub fn new_buddhist_date(
-        year: IsoYear,
-        month: IsoMonth,
-        day: IsoDay,
+        year: i32,
+        month: u8,
+        day: u8,
     ) -> Result<Date<Buddhist>, DateTimeError> {
-        Date::new_iso_date(year, month, day).map(|d| Date::new_from_iso(d, Buddhist))
+        Date::new_iso_date_from_integers(year - BUDDHIST_ERA_OFFSET, month, day)
+            .map(|d| Date::new_from_iso(d, Buddhist))
     }
 }
 
@@ -139,9 +131,9 @@ impl DateTime<Buddhist> {
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
     ///
-    /// let datetime_buddhist = DateTime::new_buddhist_datetime_from_integers(2513, 1, 2, 13, 1, 0).unwrap();
+    /// let datetime_buddhist = DateTime::new_buddhist_datetime_from_integers(1970, 1, 2, 13, 1, 0).unwrap();
     ///
-    /// assert_eq!(datetime_buddhist.date.year().number, 2513);
+    /// assert_eq!(datetime_buddhist.date.year().number, 1970);
     /// assert_eq!(datetime_buddhist.date.month().number, 1);
     /// assert_eq!(datetime_buddhist.date.day_of_month().0, 2);
     /// assert_eq!(datetime_buddhist.time.hour, IsoHour::new_unchecked(13));
@@ -156,9 +148,8 @@ impl DateTime<Buddhist> {
         minute: u8,
         second: u8,
     ) -> Result<DateTime<Buddhist>, DateTimeError> {
-        let iso_year = year - BUDDHIST_ERA_OFFSET;
         Ok(DateTime {
-            date: Date::new_buddhist_date(iso_year.into(), month.try_into()?, day.try_into()?)?,
+            date: Date::new_buddhist_date(year, month, day)?,
             time: types::Time::try_new(hour, minute, second, 0)?,
         })
     }

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -131,7 +131,7 @@ impl DateTime<Buddhist> {
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
     ///
-    /// let datetime_buddhist = DateTime::new_buddhist_datetime_from_integers(1970, 1, 2, 13, 1, 0).unwrap();
+    /// let datetime_buddhist = DateTime::new_buddhist_datetime(1970, 1, 2, 13, 1, 0).unwrap();
     ///
     /// assert_eq!(datetime_buddhist.date.year().number, 1970);
     /// assert_eq!(datetime_buddhist.date.month().number, 1);
@@ -140,7 +140,7 @@ impl DateTime<Buddhist> {
     /// assert_eq!(datetime_buddhist.time.minute, IsoMinute::new_unchecked(1));
     /// assert_eq!(datetime_buddhist.time.second, IsoSecond::new_unchecked(0));
     /// ```
-    pub fn new_buddhist_datetime_from_integers(
+    pub fn new_buddhist_datetime(
         year: i32,
         month: u8,
         day: u8,

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -16,8 +16,8 @@ use tinystr::tinystr;
 
 /// The Coptic calendar
 #[derive(Copy, Clone, Debug, Hash, Default, Eq, PartialEq)]
-#[non_exhaustive]
 pub struct Coptic;
+
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct CopticDateInner(pub(crate) ArithmeticDate<Coptic>);
@@ -123,11 +123,6 @@ impl Calendar for Coptic {
 }
 
 impl Coptic {
-    /// Construct a new Coptic Calendar
-    pub fn new() -> Self {
-        Self
-    }
-
     // "Fixed" is a day count representation of calendars staring from Jan 1st of year 1 of the Georgian Calendar.
     // The fixed date algorithms are from
     // Dershowitz, Nachum, and Edward M. Reingold. _Calendrical calculations_. Cambridge University Press, 2008.

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -19,7 +19,6 @@ use tinystr::tinystr;
 #[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Coptic;
 
-
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct CopticDateInner(pub(crate) ArithmeticDate<Coptic>);
 

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -160,7 +160,7 @@ impl Coptic {
         let day = date + 1 - Self::fixed_from_coptic_integers(year, month, 1);
 
         #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-        *Date::new_coptic_date_from_integers(year, month as u8, day as u8)
+        *Date::new_coptic_date(year, month as u8, day as u8)
             .unwrap()
             .inner()
     }
@@ -180,13 +180,13 @@ impl Date<Coptic> {
     /// ```rust
     /// use icu::calendar::Date;
     ///
-    /// let date_coptic = Date::new_coptic_date_from_integers(1686, 5, 6).unwrap();
+    /// let date_coptic = Date::new_coptic_date(1686, 5, 6).unwrap();
     ///
     /// assert_eq!(date_coptic.year().number, 1686);
     /// assert_eq!(date_coptic.month().number, 5);
     /// assert_eq!(date_coptic.day_of_month().0, 6);
     /// ```
-    pub fn new_coptic_date_from_integers(
+    pub fn new_coptic_date(
         year: i32,
         month: u8,
         day: u8,
@@ -216,7 +216,7 @@ impl DateTime<Coptic> {
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
     ///
-    /// let datetime_coptic = DateTime::new_coptic_datetime_from_integers(1686, 5, 6, 13, 1, 0).unwrap();
+    /// let datetime_coptic = DateTime::new_coptic_datetime(1686, 5, 6, 13, 1, 0).unwrap();
     ///
     /// assert_eq!(datetime_coptic.date.year().number, 1686);
     /// assert_eq!(datetime_coptic.date.month().number, 5);
@@ -225,7 +225,7 @@ impl DateTime<Coptic> {
     /// assert_eq!(datetime_coptic.time.minute, IsoMinute::new_unchecked(1));
     /// assert_eq!(datetime_coptic.time.second, IsoSecond::new_unchecked(0));
     /// ```
-    pub fn new_coptic_datetime_from_integers(
+    pub fn new_coptic_datetime(
         year: i32,
         month: u8,
         day: u8,
@@ -234,7 +234,7 @@ impl DateTime<Coptic> {
         second: u8,
     ) -> Result<DateTime<Coptic>, DateTimeError> {
         Ok(DateTime {
-            date: Date::new_coptic_date_from_integers(year, month, day)?,
+            date: Date::new_coptic_date(year, month, day)?,
             time: types::Time::try_new(hour, minute, second, 0)?,
         })
     }

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -186,11 +186,7 @@ impl Date<Coptic> {
     /// assert_eq!(date_coptic.month().number, 5);
     /// assert_eq!(date_coptic.day_of_month().0, 6);
     /// ```
-    pub fn new_coptic_date(
-        year: i32,
-        month: u8,
-        day: u8,
-    ) -> Result<Date<Coptic>, DateTimeError> {
+    pub fn new_coptic_date(year: i32, month: u8, day: u8) -> Result<Date<Coptic>, DateTimeError> {
         let inner = ArithmeticDate {
             year,
             month,

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -16,6 +16,7 @@ use tinystr::tinystr;
 
 /// The Coptic calendar
 #[derive(Copy, Clone, Debug, Hash, Default, Eq, PartialEq)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Coptic;
 
 

--- a/components/calendar/src/ethiopic.rs
+++ b/components/calendar/src/ethiopic.rs
@@ -169,7 +169,7 @@ impl Ethiopic {
         let coptic_date = Coptic::coptic_from_fixed(date + coptic_epoch - ethiopic_epoch);
 
         #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-        *Date::new_ethiopic_date_from_integers(
+        *Date::new_ethiopic_date(
             coptic_date.0.year,
             coptic_date.0.month,
             coptic_date.0.day,
@@ -193,13 +193,13 @@ impl Date<Ethiopic> {
     /// ```rust
     /// use icu::calendar::Date;
     ///
-    /// let date_ethiopic = Date::new_ethiopic_date_from_integers(2014, 8, 25).unwrap();
+    /// let date_ethiopic = Date::new_ethiopic_date(2014, 8, 25).unwrap();
     ///
     /// assert_eq!(date_ethiopic.year().number, 2014);
     /// assert_eq!(date_ethiopic.month().number, 8);
     /// assert_eq!(date_ethiopic.day_of_month().0, 25);
     /// ```
-    pub fn new_ethiopic_date_from_integers(
+    pub fn new_ethiopic_date(
         year: i32,
         month: u8,
         day: u8,
@@ -233,7 +233,7 @@ impl DateTime<Ethiopic> {
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
     ///
-    /// let datetime_ethiopic = DateTime::new_ethiopic_datetime_from_integers(2014, 8, 25, 13, 1, 0, 0).unwrap();
+    /// let datetime_ethiopic = DateTime::new_ethiopic_datetime(2014, 8, 25, 13, 1, 0, 0).unwrap();
     ///
     /// assert_eq!(datetime_ethiopic.date.year().number, 2014);
     /// assert_eq!(datetime_ethiopic.date.month().number, 8);
@@ -242,7 +242,7 @@ impl DateTime<Ethiopic> {
     /// assert_eq!(datetime_ethiopic.time.minute, IsoMinute::new_unchecked(1));
     /// assert_eq!(datetime_ethiopic.time.second, IsoSecond::new_unchecked(0));
     /// ```
-    pub fn new_ethiopic_datetime_from_integers(
+    pub fn new_ethiopic_datetime(
         year: i32,
         month: u8,
         day: u8,
@@ -252,7 +252,7 @@ impl DateTime<Ethiopic> {
         fraction: u32,
     ) -> Result<DateTime<Ethiopic>, DateTimeError> {
         Ok(DateTime {
-            date: Date::new_ethiopic_date_from_integers(year, month, day)?,
+            date: Date::new_ethiopic_date(year, month, day)?,
             time: types::Time::try_new(hour, minute, second, fraction)?,
         })
     }

--- a/components/calendar/src/ethiopic.rs
+++ b/components/calendar/src/ethiopic.rs
@@ -169,13 +169,9 @@ impl Ethiopic {
         let coptic_date = Coptic::coptic_from_fixed(date + coptic_epoch - ethiopic_epoch);
 
         #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-        *Date::new_ethiopic_date(
-            coptic_date.0.year,
-            coptic_date.0.month,
-            coptic_date.0.day,
-        )
-        .unwrap()
-        .inner()
+        *Date::new_ethiopic_date(coptic_date.0.year, coptic_date.0.month, coptic_date.0.day)
+            .unwrap()
+            .inner()
     }
 
     fn days_in_year_direct(year: i32) -> u32 {

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -164,11 +164,7 @@ impl Date<Indian> {
     /// assert_eq!(date_indian.month().number, 10);
     /// assert_eq!(date_indian.day_of_month().0, 12);
     /// ```
-    pub fn new_indian_date(
-        year: i32,
-        month: u8,
-        day: u8,
-    ) -> Result<Date<Indian>, DateTimeError> {
+    pub fn new_indian_date(year: i32, month: u8, day: u8) -> Result<Date<Indian>, DateTimeError> {
         let inner = ArithmeticDate {
             year,
             month,

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -158,13 +158,13 @@ impl Date<Indian> {
     /// ```rust
     /// use icu::calendar::Date;
     ///
-    /// let date_indian = Date::new_indian_date_from_integers(1891, 10, 12).unwrap();
+    /// let date_indian = Date::new_indian_date(1891, 10, 12).unwrap();
     ///
     /// assert_eq!(date_indian.year().number, 1891);
     /// assert_eq!(date_indian.month().number, 10);
     /// assert_eq!(date_indian.day_of_month().0, 12);
     /// ```
-    pub fn new_indian_date_from_integers(
+    pub fn new_indian_date(
         year: i32,
         month: u8,
         day: u8,
@@ -194,7 +194,7 @@ impl DateTime<Indian> {
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
     ///
-    /// let datetime_indian = DateTime::new_indian_datetime_from_integers(1891, 10, 12, 13, 1, 0).unwrap();
+    /// let datetime_indian = DateTime::new_indian_datetime(1891, 10, 12, 13, 1, 0).unwrap();
     ///
     /// assert_eq!(datetime_indian.date.year().number, 1891);
     /// assert_eq!(datetime_indian.date.month().number, 10);
@@ -203,7 +203,7 @@ impl DateTime<Indian> {
     /// assert_eq!(datetime_indian.time.minute, IsoMinute::new_unchecked(1));
     /// assert_eq!(datetime_indian.time.second, IsoSecond::new_unchecked(0));
     /// ```
-    pub fn new_indian_datetime_from_integers(
+    pub fn new_indian_datetime(
         year: i32,
         month: u8,
         day: u8,
@@ -212,7 +212,7 @@ impl DateTime<Indian> {
         second: u8,
     ) -> Result<DateTime<Indian>, DateTimeError> {
         Ok(DateTime {
-            date: Date::new_indian_date_from_integers(year, month, day)?,
+            date: Date::new_indian_date(year, month, day)?,
             time: types::Time::try_new(hour, minute, second, 0)?,
         })
     }

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -192,7 +192,7 @@ impl Julian {
         let day = date - Self::fixed_from_julian_integers(year, month, 1) + 1;
 
         #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-        *Date::new_julian_date_from_integers(year, month as u8, day as u8)
+        *Date::new_julian_date(year, month as u8, day as u8)
             .unwrap()
             .inner()
     }
@@ -204,13 +204,13 @@ impl Date<Julian> {
     /// ```rust
     /// use icu::calendar::Date;
     ///
-    /// let date_julian = Date::new_julian_date_from_integers(1969, 12, 20).unwrap();
+    /// let date_julian = Date::new_julian_date(1969, 12, 20).unwrap();
     ///
     /// assert_eq!(date_julian.year().number, 1969);
     /// assert_eq!(date_julian.month().number, 12);
     /// assert_eq!(date_julian.day_of_month().0, 20);
     /// ```
-    pub fn new_julian_date_from_integers(
+    pub fn new_julian_date(
         year: i32,
         month: u8,
         day: u8,
@@ -242,7 +242,7 @@ impl DateTime<Julian> {
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
     ///
-    /// let datetime_julian = DateTime::new_julian_datetime_from_integers(1969, 12, 20, 13, 1, 0).unwrap();
+    /// let datetime_julian = DateTime::new_julian_datetime(1969, 12, 20, 13, 1, 0).unwrap();
     ///
     /// assert_eq!(datetime_julian.date.year().number, 1969);
     /// assert_eq!(datetime_julian.date.month().number, 12);
@@ -251,7 +251,7 @@ impl DateTime<Julian> {
     /// assert_eq!(datetime_julian.time.minute, IsoMinute::new_unchecked(1));
     /// assert_eq!(datetime_julian.time.second, IsoSecond::new_unchecked(0));
     /// ```
-    pub fn new_julian_datetime_from_integers(
+    pub fn new_julian_datetime(
         year: i32,
         month: u8,
         day: u8,
@@ -260,7 +260,7 @@ impl DateTime<Julian> {
         second: u8,
     ) -> Result<DateTime<Julian>, DateTimeError> {
         Ok(DateTime {
-            date: Date::new_julian_date_from_integers(year, month, day)?,
+            date: Date::new_julian_date(year, month, day)?,
             time: types::Time::try_new(hour, minute, second, 0)?,
         })
     }
@@ -304,31 +304,31 @@ mod test {
     #[test]
     fn test_day_julian_to_iso() {
         // March 1st 200 is same on both calendars
-        let julian_date = Date::new_julian_date_from_integers(200, 3, 1).unwrap();
+        let julian_date = Date::new_julian_date(200, 3, 1).unwrap();
         let iso_date = Julian.date_to_iso(julian_date.inner());
         let iso_expected_date = Date::new_iso_date_from_integers(200, 3, 1).unwrap();
         assert_eq!(iso_date, iso_expected_date);
 
         // Feb 28th, 200 (iso) = Feb 29th, 200 (julian)
-        let julian_date = Date::new_julian_date_from_integers(200, 2, 29).unwrap();
+        let julian_date = Date::new_julian_date(200, 2, 29).unwrap();
         let iso_date = Julian.date_to_iso(julian_date.inner());
         let iso_expected_date = Date::new_iso_date_from_integers(200, 2, 28).unwrap();
         assert_eq!(iso_date, iso_expected_date);
 
         // March 1st 400 (iso) = Feb 29th, 400 (julian)
-        let julian_date = Date::new_julian_date_from_integers(400, 2, 29).unwrap();
+        let julian_date = Date::new_julian_date(400, 2, 29).unwrap();
         let iso_date = Julian.date_to_iso(julian_date.inner());
         let iso_expected_date = Date::new_iso_date_from_integers(400, 3, 1).unwrap();
         assert_eq!(iso_date, iso_expected_date);
 
         // Jan 1st, 2022 (iso) = Dec 19, 2021 (julian)
-        let julian_date = Date::new_julian_date_from_integers(2021, 12, 19).unwrap();
+        let julian_date = Date::new_julian_date(2021, 12, 19).unwrap();
         let iso_date = Julian.date_to_iso(julian_date.inner());
         let iso_expected_date = Date::new_iso_date_from_integers(2022, 1, 1).unwrap();
         assert_eq!(iso_date, iso_expected_date);
 
         // March 1st, 2022 (iso) = Feb 16, 2022 (julian)
-        let julian_date = Date::new_julian_date_from_integers(2022, 2, 16).unwrap();
+        let julian_date = Date::new_julian_date(2022, 2, 16).unwrap();
         let iso_date = Julian.date_to_iso(julian_date.inner());
         let iso_expected_date = Date::new_iso_date_from_integers(2022, 3, 1).unwrap();
         assert_eq!(iso_date, iso_expected_date);

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -210,11 +210,7 @@ impl Date<Julian> {
     /// assert_eq!(date_julian.month().number, 12);
     /// assert_eq!(date_julian.day_of_month().0, 20);
     /// ```
-    pub fn new_julian_date(
-        year: i32,
-        month: u8,
-        day: u8,
-    ) -> Result<Date<Julian>, DateTimeError> {
+    pub fn new_julian_date(year: i32, month: u8, day: u8) -> Result<Date<Julian>, DateTimeError> {
         let inner = ArithmeticDate {
             year,
             month,

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -48,7 +48,7 @@ fn test_fixture(fixture_name: &str) {
         let input_value = parse_gregorian_from_str(&fx.input.value).unwrap();
         let input_buddhist = input_value.to_calendar(Buddhist);
         let input_japanese = input_value.to_calendar(japanese);
-        let input_coptic = input_value.to_calendar(Coptic::new());
+        let input_coptic = input_value.to_calendar(Coptic);
         let input_indian = input_value.to_calendar(Indian);
 
         let description = match fx.description {


### PR DESCRIPTION
- The buddhist calendar should construct from Buddhist values
 - `_from_integers` should only be necessary for methods where there's ambiguity


cc @andrewpollack


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->