### PR TITLE
Add LanguageIdentifier iai benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,19 +1090,6 @@ name = "iai"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71a816c97c42258aa5834d07590b718b4c9a598944cd39a52dc25b351185d678"
-dependencies = [
- "iai_macro",
-]
-
-[[package]]
-name = "iai_macro"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25527f85bec406de3d16b9059f1122cb55bc21fc82edd868870d90232c46bd8b"
-dependencies = [
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "icu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,6 +1090,19 @@ name = "iai"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71a816c97c42258aa5834d07590b718b4c9a598944cd39a52dc25b351185d678"
+dependencies = [
+ "iai_macro",
+]
+
+[[package]]
+name = "iai_macro"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25527f85bec406de3d16b9059f1122cb55bc21fc82edd868870d90232c46bd8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "icu"
@@ -1388,6 +1401,7 @@ version = "0.5.0"
 dependencies = [
  "criterion",
  "displaydoc",
+ "iai",
  "icu",
  "icu_benchmark_macros",
  "litemap",

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -48,6 +48,7 @@ icu_benchmark_macros = { version = "0.5", path = "../../tools/benchmark/macros" 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 postcard = { version = "0.7.0", default-features = false, features = ["use-std"] }
+iai = { version = "0.1.1", default-features = false, features = ["macro"] }
 
 [lib]
 path = "src/lib.rs"
@@ -71,6 +72,11 @@ harness = false
 [[bench]]
 name = "locale"
 harness = false
+
+[[bench]]
+name = "iai_langid"
+harness = false
+required-features = ["bench"]
 
 [[example]]
 name = "filter_langids"

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -48,7 +48,7 @@ icu_benchmark_macros = { version = "0.5", path = "../../tools/benchmark/macros" 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 postcard = { version = "0.7.0", default-features = false, features = ["use-std"] }
-iai = { version = "0.1.1", default-features = false, features = ["macro"] }
+iai = "0.1.1"
 
 [lib]
 path = "src/lib.rs"

--- a/components/locid/benches/iai_langid.rs
+++ b/components/locid/benches/iai_langid.rs
@@ -1,0 +1,95 @@
+use icu_locid::{langid, language, region, LanguageIdentifier};
+
+const LIDS: &[LanguageIdentifier] = &[
+    langid!("en"),
+    langid!("pl"),
+    langid!("fr-CA"),
+    langid!("zh-Hans"),
+    langid!("en-US"),
+    langid!("en-Latn-US"),
+    langid!("sr-Cyrl-BA"),
+];
+
+const LIDS_STR: &[&str] = &[
+    "en",
+    "pl",
+    "fr-CA",
+    "zh-Hans",
+    "en-US",
+    "en-Latn-US",
+    "sr-Cyrl-BA",
+];
+
+fn bench_langid_constr() {
+    // Tests the instructions required to construct a LID from an str.
+
+    let _: Vec<LanguageIdentifier> = LIDS_STR
+        .iter()
+        .map(|l| l.parse().expect("Failed to parse"))
+        .collect();
+}
+
+fn bench_langid_compare_components() {
+    // Tests the cost of comparing LID components.
+
+    let result = LIDS
+        .iter()
+        .filter(|l| l.language == language!("en") && l.region == Some(region!("US")))
+        .count();
+
+    assert_eq!(result, 2);
+}
+
+fn bench_langid_compare_components_str() {
+    // Tests the cost of comparing LID components to str.
+
+    let result = LIDS
+        .iter()
+        .filter(|l| l.language == "en" && l.region.map(|r| r == "US").unwrap_or(false))
+        .count();
+
+    assert_eq!(result, 2);
+}
+
+fn bench_langid_matching() {
+    // Tests matching a LID against other LIDs.
+
+    let lid = langid!("en_us");
+
+    let count = LIDS.iter().filter(|l| lid == **l).count();
+    assert_eq!(count, 1);
+}
+
+fn bench_langid_matching_str() {
+    // Tests matching a LID against list of str.
+
+    let lid = langid!("en_us");
+
+    let count = LIDS_STR.iter().filter(|l| lid == **l).count();
+    assert_eq!(count, 1);
+}
+
+fn bench_langid_serialize() {
+    // Tests serialization of LIDs.
+
+    let _: Vec<String> = LIDS.iter().map(|l| l.to_string()).collect();
+}
+
+fn bench_langid_canonicalize() {
+    // Tests canonicalization of strings.
+
+    let _: Vec<String> = LIDS_STR
+        .iter()
+        .map(|l| LanguageIdentifier::canonicalize(l).expect("Canonicalization failed"))
+        .collect();
+}
+
+iai::main!(
+    bench_langid_constr,
+    bench_langid_compare_components,
+    bench_langid_compare_components_str,
+    bench_langid_matching,
+    bench_langid_matching_str,
+    bench_langid_serialize,
+    bench_langid_canonicalize,
+);

--- a/components/locid/benches/iai_langid.rs
+++ b/components/locid/benches/iai_langid.rs
@@ -1,3 +1,7 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
 use icu_locid::{langid, language, region, LanguageIdentifier};
 
 const LIDS: &[LanguageIdentifier] = &[

--- a/components/locid/benches/iai_langid.rs
+++ b/components/locid/benches/iai_langid.rs
@@ -55,6 +55,20 @@ fn bench_langid_compare_components_str() {
     assert_eq!(result, 2);
 }
 
+fn bench_langid_cmp_bytes() {
+    // Tests the cost of comparing a langid against byte strings.
+    use core::cmp::Ordering;
+
+    let lid = langid!("en_us");
+
+    let result = LIDS_STR
+        .iter()
+        .filter(|s| lid.cmp_bytes(s.as_bytes()) == Ordering::Equal)
+        .count();
+
+    assert_eq!(result, 1);
+}
+
 fn bench_langid_matching() {
     // Tests matching a LID against other LIDs.
 
@@ -92,6 +106,7 @@ iai::main!(
     bench_langid_constr,
     bench_langid_compare_components,
     bench_langid_compare_components_str,
+    bench_langid_cmp_bytes,
     bench_langid_matching,
     bench_langid_matching_str,
     bench_langid_serialize,


### PR DESCRIPTION
Adding first IAI benchmarks. I kept it minimal to get over the hump of how to add iai benches, and then I hope to get help spreading iai benchmarks to other components.

The limitation is that iai works only with valgrind and valgrind currently is not available on M1 archs and I doubt we'll have it on Windows. That leaves intel macs and linux.

I worked it around on my m1 MBA by installing Ubuntu `multipass`.

The results are:

```
bench_langid_constr
  Instructions:                2659 (No change)
  L1 Accesses:                 3348 (No change)
  L2 Accesses:                    2 (No change)
  RAM Accesses:                  47 (No change)
  Estimated Cycles:            5003 (No change)

bench_langid_compare_components
  Instructions:                   3 (No change)
  L1 Accesses:                    2 (No change)
  L2 Accesses:                    2 (No change)
  RAM Accesses:                   0 (No change)
  Estimated Cycles:              12 (No change)

bench_langid_compare_components_str
  Instructions:                  10 (No change)
  L1 Accesses:                   12 (No change)
  L2 Accesses:                    2 (No change)
  RAM Accesses:                   0 (No change)
  Estimated Cycles:              22 (No change)

bench_langid_matching
  Instructions:                   3 (No change)
  L1 Accesses:                    2 (No change)
  L2 Accesses:                    2 (No change)
  RAM Accesses:                   0 (No change)
  Estimated Cycles:              12 (No change)

bench_langid_matching_str
  Instructions:                1260 (No change)
  L1 Accesses:                 1412 (No change)
  L2 Accesses:                    3 (No change)
  RAM Accesses:                  23 (No change)
  Estimated Cycles:            2232 (No change)

bench_langid_serialize
  Instructions:                4588 (No change)
  L1 Accesses:                 6656 (No change)
  L2 Accesses:                   11 (No change)
  RAM Accesses:                  42 (No change)
  Estimated Cycles:            8181 (No change)

bench_langid_canonicalize
  Instructions:                6964 (No change)
  L1 Accesses:                 9694 (No change)
  L2 Accesses:                   14 (No change)
  RAM Accesses:                  67 (No change)
  Estimated Cycles:           12109 (No change)
```