### PR TITLE
Adding high level date and datetime example to base structs, fixing typo

### DIFF
--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -43,7 +43,8 @@ impl<C: Calendar> AsCalendar for Rc<C> {
 /// use icu::calendar::Date;
 ///
 /// // Example: creation of ISO date from integers.
-/// let date_iso = Date::new_iso_date_from_integers(1970, 1, 2).unwrap();
+/// let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+///     .expect("Failed to initialize Date instance.");
 ///
 /// assert_eq!(date_iso.year().number, 1970);
 /// assert_eq!(date_iso.month().number, 1);

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -44,7 +44,7 @@ impl<C: Calendar> AsCalendar for Rc<C> {
 ///
 /// // Example: creation of ISO date from integers.
 /// let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
-///     .expect("Failed to initialize Date instance.");
+///     .expect("Failed to initialize ISO Date instance.");
 ///
 /// assert_eq!(date_iso.year().number, 1970);
 /// assert_eq!(date_iso.month().number, 1);

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -34,10 +34,21 @@ impl<C: Calendar> AsCalendar for Rc<C> {
     }
 }
 
-/// A date for a given calendar
+/// A date for a given calendar.
 ///
 /// This can work with wrappers around [`Calendar`] types,
-/// e.g. `Rc<C>`, via the [`AsCalendar`] trait
+/// e.g. `Rc<C>`, via the [`AsCalendar`] trait.
+///
+/// ```rust
+/// use icu::calendar::Date;
+///
+/// // Example: creation of ISO date from integers.
+/// let date_iso = Date::new_iso_date_from_integers(1970, 1, 2).unwrap();
+///
+/// assert_eq!(date_iso.year().number, 1970);
+/// assert_eq!(date_iso.month().number, 1);
+/// assert_eq!(date_iso.day_of_month().0, 2);
+/// ```
 pub struct Date<A: AsCalendar> {
     pub(crate) inner: <A::Calendar as Calendar>::DateInner,
     calendar: A,

--- a/components/calendar/src/datetime.rs
+++ b/components/calendar/src/datetime.rs
@@ -16,7 +16,7 @@ use crate::{AsCalendar, Date, Iso};
 ///
 /// // Example: Construction of ISO datetime from integers.
 /// let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
-///                             .unwrap();
+///     .expect("Failed to initialize DateTime instance.");
 ///
 /// assert_eq!(datetime_iso.date.year().number, 1970);
 /// assert_eq!(datetime_iso.date.month().number, 1);

--- a/components/calendar/src/datetime.rs
+++ b/components/calendar/src/datetime.rs
@@ -16,7 +16,7 @@ use crate::{AsCalendar, Date, Iso};
 ///
 /// // Example: Construction of ISO datetime from integers.
 /// let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
-///     .expect("Failed to initialize DateTime instance.");
+///     .expect("Failed to initialize ISO DateTime instance.");
 ///
 /// assert_eq!(datetime_iso.date.year().number, 1970);
 /// assert_eq!(datetime_iso.date.month().number, 1);

--- a/components/calendar/src/datetime.rs
+++ b/components/calendar/src/datetime.rs
@@ -5,11 +5,26 @@
 use crate::types::Time;
 use crate::{AsCalendar, Date, Iso};
 
-/// A date+time for a given calendar
+/// A date+time for a given calendar.
 ///
-/// This can work with wrappers arount [`Calendar`](crate::Calendar) types,
+/// This can work with wrappers around [`Calendar`](crate::Calendar) types,
 /// e.g. `Rc<C>`, via the [`AsCalendar`] trait, much like
-/// [`Date`]
+/// [`Date`].
+///
+/// ```rust
+/// use icu::calendar::{DateTime, types::IsoHour, types::IsoMinute, types::IsoSecond};
+///
+/// // Example: Construction of ISO datetime from integers.
+/// let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+///                             .unwrap();
+///
+/// assert_eq!(datetime_iso.date.year().number, 1970);
+/// assert_eq!(datetime_iso.date.month().number, 1);
+/// assert_eq!(datetime_iso.date.day_of_month().0, 2);
+/// assert_eq!(datetime_iso.time.hour, IsoHour::new_unchecked(13));
+/// assert_eq!(datetime_iso.time.minute, IsoMinute::new_unchecked(1));
+/// assert_eq!(datetime_iso.time.second, IsoSecond::new_unchecked(0));
+/// ```
 #[derive(Debug)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct DateTime<A: AsCalendar> {

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -382,7 +382,7 @@ impl Date<Iso> {
 }
 
 impl DateTime<Iso> {
-    /// Construct a new ISO date from integers.
+    /// Construct a new ISO datetime from integers.
     ///
     /// ```rust
     /// use icu::calendar::{DateTime,


### PR DESCRIPTION
* Copying ISO examples of `Date` and `DateTime` to base structs, increasing immediate accessibility to structs
* Fixing a `date` --> `datetime` typo