### PR TITLE
Refactor ZeroMap2d and add get_by functions

### DIFF
--- a/provider/datagen/src/bin/fingerprint-data.rs
+++ b/provider/datagen/src/bin/fingerprint-data.rs
@@ -106,12 +106,8 @@ fn main() -> eyre::Result<()> {
         let map = provider.get_map();
         for key in all_keys {
             let hash = key.get_hash();
-            if let Some(iter) = map.iter_keys1(&hash) {
-                for locale in iter {
-                    let data = map
-                        .get(&hash, locale)
-                        .expect("Key found in iter_keys1 should work");
-
+            if let Some(cursor) = map.get0(&hash) {
+                for (locale, data) in cursor.iter1() {
                     let mut hasher = Sha256::new();
                     hasher.update(&data);
                     let result = hasher.finalize();

--- a/utils/zerovec/src/map/vecs.rs
+++ b/utils/zerovec/src/map/vecs.rs
@@ -267,7 +267,9 @@ where
         range: Range<usize>,
     ) -> Option<Result<usize, usize>> {
         let subslice = self.get_subslice(range)?;
-        Some(ZeroSlice::binary_search_by(subslice, |probe| predicate(&probe)))
+        Some(ZeroSlice::binary_search_by(subslice, |probe| {
+            predicate(&probe)
+        }))
     }
     fn zvl_get(&self, index: usize) -> Option<&T::ULE> {
         self.get_ule_ref(index)

--- a/utils/zerovec/src/map2d/borrowed.rs
+++ b/utils/zerovec/src/map2d/borrowed.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::ule::AsULE;
-use crate::{ZeroSlice, ZeroVec};
+use crate::ZeroSlice;
 
 use core::fmt;
 
@@ -250,10 +250,12 @@ where
 
 impl<'a, K0, K1, V> ZeroMap2dBorrowed<'a, K0, K1, V>
 where
-    K0: ZeroMapKV<'a> + ?Sized + Ord,
-    K1: ZeroMapKV<'a> + ?Sized + Ord,
-    V: ZeroMapKV<'a, Container = ZeroVec<'a, V>> + ?Sized,
+    K0: ZeroMapKV<'a> + Ord,
+    K1: ZeroMapKV<'a> + Ord,
+    V: ZeroMapKV<'a, GetType = V::ULE>,
     V: AsULE + Copy,
+    K0: ?Sized,
+    K1: ?Sized,
 {
     /// For cases when `V` is fixed-size, obtain a direct copy of `V` instead of `V::ULE`
     pub fn get_copied(&self, key0: &K0, key1: &K1) -> Result<V, KeyError> {

--- a/utils/zerovec/src/map2d/borrowed.rs
+++ b/utils/zerovec/src/map2d/borrowed.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::ule::AsULE;
-use crate::{ZeroSlice, ZeroVec};
+use crate::{ZeroMap2d, ZeroSlice, ZeroVec};
 
 use core::fmt;
 use core::ops::Range;
@@ -167,7 +167,7 @@ where
     K1: ?Sized,
     V: ?Sized,
 {
-    /// Get the value associated with `key`, if it exists.
+    /// Get the value associated with `key0` and `key1`, if it exists.
     ///
     /// This is able to return values that live longer than the map itself
     /// since they borrow directly from the backing buffer. This is the
@@ -195,23 +195,24 @@ where
     /// assert_eq!(borrow, Ok("foo"));
     /// ```
     pub fn get(&self, key0: &K0, key1: &K1) -> Result<&'a V::GetType, KeyError> {
-        let (_, range) = self.get_range_for_key0(key0).ok_or(KeyError::K0)?;
-        debug_assert!(range.start < range.end); // '<' because every key0 should have a key1
-        debug_assert!(range.end <= self.keys1.zvl_len());
-        #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-        let index = range.start
-            + self
-                .keys1
-                .zvl_binary_search_in_range(key1, range)
-                .unwrap()
-                .map_err(|_| KeyError::K1)?;
-        // This unwrap is protected by the invariant keys1.len() == values.len(),
-        // the above debug_assert!, and the contract of zvl_binary_search_in_range.
-        #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-        Ok(self.values.zvl_get(index).unwrap())
+        self.get0(key0)
+            .ok_or(KeyError::K0)?
+            .get1(key1)
+            .ok_or(KeyError::K1)
     }
+}
 
-    /// Returns whether `key0` is contained in this map
+impl<'a, K0, K1, V> ZeroMap2dBorrowed<'a, K0, K1, V>
+where
+    K0: ZeroMapKV<'a> + Ord,
+    K1: ZeroMapKV<'a>,
+    V: ZeroMapKV<'a>,
+    K0: ?Sized,
+    K1: ?Sized,
+    V: ?Sized,
+{
+    /// Gets a cursor for `key0`. If `None`, then `key0` is not in the map. If `Some`,
+    /// then `key0` is in the map, and `key1` can be queried.
     ///
     /// ```rust
     /// use zerovec::maps::ZeroMap2dBorrowed;
@@ -221,58 +222,61 @@ where
     /// map.insert(&1, "one", "foo");
     /// map.insert(&2, "two", "bar");
     /// let borrowed = map.as_borrowed();
-    /// assert_eq!(borrowed.contains_key0(&1), true);
-    /// assert_eq!(borrowed.contains_key0(&3), false);
+    /// assert!(matches!(borrowed.get0(&1), Some(_)));
+    /// assert!(matches!(borrowed.get0(&3), None));
     /// ```
-    pub fn contains_key0(&self, key0: &K0) -> bool {
-        self.keys0.zvl_binary_search(key0).is_ok()
+    #[inline]
+    pub fn get0<'l>(&'l self, key0: &K0) -> Option<ZeroMap2dCursorBorrowed<'a, 'a, K0, K1, V>> {
+        let key0_index = self.keys0.zvl_binary_search(key0).ok()?;
+        Some(ZeroMap2dCursorBorrowed {
+            keys0: self.keys0,
+            joiner: self.joiner,
+            keys1: self.keys1,
+            values: self.values,
+            key0_index,
+        })
     }
+}
 
+impl<'a, K0, K1, V> ZeroMap2dBorrowed<'a, K0, K1, V>
+where
+    K0: ZeroMapKV<'a>,
+    K1: ZeroMapKV<'a>,
+    V: ZeroMapKV<'a>,
+    K0: ?Sized,
+    K1: ?Sized,
+    V: ?Sized,
+{
     /// Produce an ordered iterator over keys0
-    pub fn iter_keys0<'b>(&'b self) -> impl Iterator<Item = &'b <K0 as ZeroMapKV<'a>>::GetType> {
-        #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-        (0..self.keys0.zvl_len()).map(move |idx| self.keys0.zvl_get(idx).unwrap())
-    }
-
-    /// Produce an ordered iterator over keys1 for a particular key0, if key0 exists
-    pub fn iter_keys1<'b>(
-        &'b self,
-        key0: &K0,
-    ) -> Option<impl Iterator<Item = &'b <K1 as ZeroMapKV<'a>>::GetType>> {
-        let (_, range) = self.get_range_for_key0(key0)?;
-        #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-        Some(range.map(move |idx| self.keys1.zvl_get(idx).unwrap()))
+    pub fn iter0<'l>(
+        &'l self,
+    ) -> impl Iterator<Item = ZeroMap2dCursorBorrowed<'a, 'a, K0, K1, V>> + '_ {
+        (0..self.keys0.zvl_len()).map(move |idx| ZeroMap2dCursorBorrowed {
+            keys0: self.keys0,
+            joiner: self.joiner,
+            keys1: self.keys1,
+            values: self.values,
+            key0_index: idx,
+        })
     }
 
     /// Produce an iterator over values, ordered by the pair (key0,key1)
     pub fn iter_values<'b>(&'b self) -> impl Iterator<Item = &'b <V as ZeroMapKV<'a>>::GetType> {
-        #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
+        #[allow(clippy::unwrap_used)] // Iterating over a ZeroVecLike requires this pattern
         (0..self.values.zvl_len()).map(move |idx| self.values.zvl_get(idx).unwrap())
     }
+}
 
+impl<'a, K0, K1, V> ZeroMap2dBorrowed<'a, K0, K1, V>
+where
+    K0: ZeroMapKV<'a>,
+    K1: ZeroMapKV<'a> + Ord,
+    V: ZeroMapKV<'a>,
+    K0: ?Sized,
+    K1: ?Sized,
+    V: ?Sized,
+{
     // INTERNAL ROUTINES FOLLOW //
-
-    /// Given a value that may exist in keys0, returns the corresponding range of keys1
-    fn get_range_for_key0(&self, key0: &K0) -> Option<(usize, Range<usize>)> {
-        let key0_index = self.keys0.zvl_binary_search(key0).ok()?;
-        Some((key0_index, self.get_range_for_key0_index(key0_index)))
-    }
-
-    /// Given an index into the joiner array, returns the corresponding range of keys1
-    fn get_range_for_key0_index(&self, key0_index: usize) -> Range<usize> {
-        debug_assert!(key0_index < self.joiner.len());
-        let start = if key0_index == 0 {
-            0
-        } else {
-            // The unwrap is protected by the debug_assert above
-            #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-            self.joiner.get(key0_index - 1).unwrap()
-        };
-        // The unwrap is protected by the debug_assert above
-        #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-        let limit = self.joiner.get(key0_index).unwrap();
-        (start as usize)..(limit as usize)
-    }
 }
 
 impl<'a, K0, K1, V> ZeroMap2dBorrowed<'a, K0, K1, V>
@@ -280,21 +284,14 @@ where
     K0: ZeroMapKV<'a> + ?Sized + Ord,
     K1: ZeroMapKV<'a> + ?Sized + Ord,
     V: ZeroMapKV<'a, Container = ZeroVec<'a, V>> + ?Sized,
-    V: AsULE + Ord + Copy + 'static,
+    V: AsULE + Copy,
 {
     /// For cases when `V` is fixed-size, obtain a direct copy of `V` instead of `V::ULE`
-    pub fn get_copied(&self, key0: &K0, key1: &K1) -> Option<V> {
-        let (_, range) = self.get_range_for_key0(key0)?;
-        debug_assert!(range.start < range.end); // '<' because every key0 should have a key1
-        debug_assert!(range.end <= self.keys1.zvl_len());
-        #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-        let index = range.start
-            + self
-                .keys1
-                .zvl_binary_search_in_range(key1, range)
-                .unwrap()
-                .ok()?;
-        self.values.get(index)
+    pub fn get_copied(&self, key0: &K0, key1: &K1) -> Result<V, KeyError> {
+        self.get0(key0)
+            .ok_or(KeyError::K0)?
+            .get1_copied(key1)
+            .ok_or(KeyError::K1)
     }
 }
 
@@ -338,5 +335,139 @@ where
             .field("keys1", &self.keys1)
             .field("values", &self.values)
             .finish()
+    }
+}
+
+pub struct ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>
+where
+    K0: ZeroMapKV<'a>,
+    K1: ZeroMapKV<'a>,
+    V: ZeroMapKV<'a>,
+    K0: ?Sized,
+    K1: ?Sized,
+    V: ?Sized,
+{
+    keys0: &'l <<K0 as ZeroMapKV<'a>>::Container as ZeroVecLike<K0>>::BorrowedVariant,
+    joiner: &'l ZeroSlice<u32>,
+    keys1: &'l <<K1 as ZeroMapKV<'a>>::Container as ZeroVecLike<K1>>::BorrowedVariant,
+    values: &'l <<V as ZeroMapKV<'a>>::Container as ZeroVecLike<V>>::BorrowedVariant,
+    key0_index: usize,
+}
+
+impl<'l, 'a, K0, K1, V> ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>
+where
+    K0: ZeroMapKV<'a>,
+    K1: ZeroMapKV<'a>,
+    V: ZeroMapKV<'a>,
+    K0: ?Sized,
+    K1: ?Sized,
+    V: ?Sized,
+{
+    pub(crate) fn from_cow(cow: &'l ZeroMap2d<'a, K0, K1, V>, key0_index: usize) -> Self {
+        Self {
+            keys0: cow.keys0.zvl_as_borrowed(),
+            joiner: &cow.joiner,
+            keys1: cow.keys1.zvl_as_borrowed(),
+            values: cow.values.zvl_as_borrowed(),
+            key0_index,
+        }
+    }
+
+    pub fn key0(&self) -> &'l K0::GetType {
+        self.keys0.zvl_get(self.key0_index).unwrap()
+    }
+
+    /// Produce an ordered iterator over keys1 for a particular key0, if key0 exists
+    pub fn iter1(
+        &self,
+    ) -> impl Iterator<
+        Item = (
+            &'l <K1 as ZeroMapKV<'a>>::GetType,
+            &'l <V as ZeroMapKV<'a>>::GetType,
+        ),
+    > + '_ {
+        let range = self.get_range();
+        #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
+        range.map(move |idx| {
+            (
+                self.keys1.zvl_get(idx).unwrap(),
+                self.values.zvl_get(idx).unwrap(),
+            )
+        })
+    }
+
+    /// Given key0_index, returns the corresponding range of keys1
+    fn get_range(&self) -> Range<usize> {
+        debug_assert!(self.key0_index < self.joiner.len());
+        let start = if self.key0_index == 0 {
+            0
+        } else {
+            #[allow(clippy::unwrap_used)] // protected by the debug_assert above
+            self.joiner.get(self.key0_index - 1).unwrap()
+        };
+        #[allow(clippy::unwrap_used)] // protected by the debug_assert above
+        let limit = self.joiner.get(self.key0_index).unwrap();
+        (start as usize)..(limit as usize)
+    }
+}
+
+impl<'l, 'a, K0, K1, V> ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>
+where
+    K0: ZeroMapKV<'a>,
+    K1: ZeroMapKV<'a> + Ord,
+    V: ZeroMapKV<'a>,
+    K0: ?Sized,
+    K1: ?Sized,
+    V: ?Sized,
+{
+    pub fn get1(&self, key1: &K1) -> Option<&'l V::GetType> {
+        let key1_index = self.get_key1_index(key1)?;
+        #[allow(clippy::unwrap_used)] // key1_index is valid
+        Some(self.values.zvl_get(key1_index).unwrap())
+    }
+
+    // pub fn get1_by(&self, predicate: impl FnMut(&K1) -> Ordering) -> Option<&V::GetType> {
+    //     let range = self.map.get_range_for_key0_index(self.key0_index);
+    //     debug_assert!(range.start < range.end); // '<' because every key0 should have a key1
+    //     debug_assert!(range.end <= self.map.keys1.zvl_len());
+    //     #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
+    //     let index = range.start
+    //         + self
+    //             .map
+    //             .keys1
+    //             .zvl_binary_search_in_range(key1, range)
+    //             .expect("in-bounds range")
+    //             .ok()?;
+    //     // This unwrap is protected by the invariant keys1.len() == values.len(),
+    //     // the above debug_assert!, and the contract of zvl_binary_search_in_range.
+    //     #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
+    //     Some(self.map.values.zvl_get(index).unwrap())
+    // }
+
+    /// Given key0_index and key1, returns the index into the values array
+    fn get_key1_index(&self, key1: &K1) -> Option<usize> {
+        let range = self.get_range();
+        debug_assert!(range.start < range.end); // '<' because every key0 should have a key1
+        debug_assert!(range.end <= self.keys1.zvl_len());
+        let start = range.start;
+        #[allow(clippy::expect_used)] // protected by the debug_assert above
+        let binary_search_result = self
+            .keys1
+            .zvl_binary_search_in_range(key1, range)
+            .expect("in-bounds range");
+        binary_search_result.ok().map(move |s| s + start)
+    }
+}
+
+impl<'l, 'a, K0, K1, V> ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>
+where
+    K0: ZeroMapKV<'a> + ?Sized,
+    K1: ZeroMapKV<'a> + ?Sized + Ord,
+    V: ZeroMapKV<'a, Container = ZeroVec<'a, V>>,
+    V: AsULE + Copy,
+{
+    pub fn get1_copied(&self, key1: &K1) -> Option<V> {
+        let key1_index = self.get_key1_index(key1)?;
+        self.values.get(key1_index)
     }
 }

--- a/utils/zerovec/src/map2d/borrowed.rs
+++ b/utils/zerovec/src/map2d/borrowed.rs
@@ -7,7 +7,7 @@ use crate::ZeroSlice;
 
 use core::fmt;
 
-use crate::map::{ZeroMapKV};
+use crate::map::ZeroMapKV;
 use crate::map::{BorrowedZeroVecLike, ZeroVecLike};
 use crate::map2d::{KeyError, ZeroMap2dCursor};
 
@@ -241,9 +241,7 @@ where
     V: ?Sized,
 {
     /// Produce an ordered iterator over keys0
-    pub fn iter0<'l>(
-        &'l self,
-    ) -> impl Iterator<Item = ZeroMap2dCursor<'a, 'a, K0, K1, V>> + '_ {
+    pub fn iter0<'l>(&'l self) -> impl Iterator<Item = ZeroMap2dCursor<'a, 'a, K0, K1, V>> + '_ {
         (0..self.keys0.zvl_len()).map(move |idx| ZeroMap2dCursor::from_borrowed(self, idx))
     }
 }

--- a/utils/zerovec/src/map2d/borrowed.rs
+++ b/utils/zerovec/src/map2d/borrowed.rs
@@ -5,8 +5,8 @@
 use crate::ule::AsULE;
 use crate::ZeroSlice;
 
-use core::fmt;
 use core::cmp::Ordering;
+use core::fmt;
 
 use crate::map::ZeroMapKV;
 use crate::map::{BorrowedZeroVecLike, ZeroVecLike};
@@ -244,7 +244,10 @@ where
     /// assert!(matches!(borrowed.get0_by(|probe| probe.cmp(&1)), Some(_)));
     /// assert!(matches!(borrowed.get0_by(|probe| probe.cmp(&3)), None));
     /// ```
-    pub fn get0_by<'l>(&'l self, predicate: impl FnMut(&K0) -> Ordering) -> Option<ZeroMap2dCursor<'a, 'a, K0, K1, V>> {
+    pub fn get0_by<'l>(
+        &'l self,
+        predicate: impl FnMut(&K0) -> Ordering,
+    ) -> Option<ZeroMap2dCursor<'a, 'a, K0, K1, V>> {
         let key0_index = self.keys0.zvl_binary_search_by(predicate).ok()?;
         Some(ZeroMap2dCursor::from_borrowed(self, key0_index))
     }

--- a/utils/zerovec/src/map2d/borrowed.rs
+++ b/utils/zerovec/src/map2d/borrowed.rs
@@ -6,6 +6,7 @@ use crate::ule::AsULE;
 use crate::ZeroSlice;
 
 use core::fmt;
+use core::cmp::Ordering;
 
 use crate::map::ZeroMapKV;
 use crate::map::{BorrowedZeroVecLike, ZeroVecLike};
@@ -228,6 +229,41 @@ where
     pub fn get0<'l>(&'l self, key0: &K0) -> Option<ZeroMap2dCursor<'a, 'a, K0, K1, V>> {
         let key0_index = self.keys0.zvl_binary_search(key0).ok()?;
         Some(ZeroMap2dCursor::from_borrowed(self, key0_index))
+    }
+
+    /// Binary search the map for `key0`, returning a cursor.
+    ///
+    /// ```rust
+    /// use zerovec::maps::ZeroMap2dBorrowed;
+    /// use zerovec::ZeroMap2d;
+    ///
+    /// let mut map = ZeroMap2d::new();
+    /// map.insert(&1, "one", "foo");
+    /// map.insert(&2, "two", "bar");
+    /// let borrowed = map.as_borrowed();
+    /// assert!(matches!(borrowed.get0_by(|probe| probe.cmp(&1)), Some(_)));
+    /// assert!(matches!(borrowed.get0_by(|probe| probe.cmp(&3)), None));
+    /// ```
+    pub fn get0_by<'l>(&'l self, predicate: impl FnMut(&K0) -> Ordering) -> Option<ZeroMap2dCursor<'a, 'a, K0, K1, V>> {
+        let key0_index = self.keys0.zvl_binary_search_by(predicate).ok()?;
+        Some(ZeroMap2dCursor::from_borrowed(self, key0_index))
+    }
+
+    /// Returns whether `key0` is contained in this map
+    ///
+    /// ```rust
+    /// use zerovec::maps::ZeroMap2dBorrowed;
+    /// use zerovec::ZeroMap2d;
+    ///
+    /// let mut map = ZeroMap2d::new();
+    /// map.insert(&1, "one", "foo");
+    /// map.insert(&2, "two", "bar");
+    /// let borrowed = map.as_borrowed();
+    /// assert_eq!(borrowed.contains_key0(&1), true);
+    /// assert_eq!(borrowed.contains_key0(&3), false);
+    /// ```
+    pub fn contains_key0(&self, key0: &K0) -> bool {
+        self.keys0.zvl_binary_search(key0).is_ok()
     }
 }
 

--- a/utils/zerovec/src/map2d/borrowed.rs
+++ b/utils/zerovec/src/map2d/borrowed.rs
@@ -3,14 +3,13 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::ule::AsULE;
-use crate::{ZeroMap2d, ZeroSlice, ZeroVec};
+use crate::{ZeroSlice, ZeroVec};
 
 use core::fmt;
-use core::ops::Range;
 
-use crate::map::ZeroMapKV;
+use crate::map::{ZeroMapKV};
 use crate::map::{BorrowedZeroVecLike, ZeroVecLike};
-use crate::map2d::KeyError;
+use crate::map2d::{KeyError, ZeroMap2dCursorBorrowed};
 
 /// A borrowed-only version of [`ZeroMap2d`](super::ZeroMap2d)
 ///
@@ -228,13 +227,7 @@ where
     #[inline]
     pub fn get0<'l>(&'l self, key0: &K0) -> Option<ZeroMap2dCursorBorrowed<'a, 'a, K0, K1, V>> {
         let key0_index = self.keys0.zvl_binary_search(key0).ok()?;
-        Some(ZeroMap2dCursorBorrowed {
-            keys0: self.keys0,
-            joiner: self.joiner,
-            keys1: self.keys1,
-            values: self.values,
-            key0_index,
-        })
+        Some(ZeroMap2dCursorBorrowed::from_borrowed(self, key0_index))
     }
 }
 
@@ -251,13 +244,7 @@ where
     pub fn iter0<'l>(
         &'l self,
     ) -> impl Iterator<Item = ZeroMap2dCursorBorrowed<'a, 'a, K0, K1, V>> + '_ {
-        (0..self.keys0.zvl_len()).map(move |idx| ZeroMap2dCursorBorrowed {
-            keys0: self.keys0,
-            joiner: self.joiner,
-            keys1: self.keys1,
-            values: self.values,
-            key0_index: idx,
-        })
+        (0..self.keys0.zvl_len()).map(move |idx| ZeroMap2dCursorBorrowed::from_borrowed(self, idx))
     }
 }
 
@@ -329,151 +316,5 @@ where
             .field("keys1", &self.keys1)
             .field("values", &self.values)
             .finish()
-    }
-}
-
-pub struct ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>
-where
-    K0: ZeroMapKV<'a>,
-    K1: ZeroMapKV<'a>,
-    V: ZeroMapKV<'a>,
-    K0: ?Sized,
-    K1: ?Sized,
-    V: ?Sized,
-{
-    keys0: &'l <<K0 as ZeroMapKV<'a>>::Container as ZeroVecLike<K0>>::BorrowedVariant,
-    joiner: &'l ZeroSlice<u32>,
-    keys1: &'l <<K1 as ZeroMapKV<'a>>::Container as ZeroVecLike<K1>>::BorrowedVariant,
-    values: &'l <<V as ZeroMapKV<'a>>::Container as ZeroVecLike<V>>::BorrowedVariant,
-    // Invariant: key0_index is in range
-    key0_index: usize,
-}
-
-impl<'l, 'a, K0, K1, V> ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>
-where
-    K0: ZeroMapKV<'a>,
-    K1: ZeroMapKV<'a>,
-    V: ZeroMapKV<'a>,
-    K0: ?Sized,
-    K1: ?Sized,
-    V: ?Sized,
-{
-    /// `key0_index` must be in range
-    pub(crate) fn from_cow(cow: &'l ZeroMap2d<'a, K0, K1, V>, key0_index: usize) -> Self {
-        debug_assert!(key0_index < cow.joiner.len());
-        Self {
-            keys0: cow.keys0.zvl_as_borrowed(),
-            joiner: &cow.joiner,
-            keys1: cow.keys1.zvl_as_borrowed(),
-            values: cow.values.zvl_as_borrowed(),
-            key0_index,
-        }
-    }
-
-    /// Returns the key0 corresponding to the cursor position.
-    pub fn key0(&self) -> &'l K0::GetType {
-        #[allow(clippy::unwrap_used)] // safe by invariant on `self.key0_index`
-        self.keys0.zvl_get(self.key0_index).unwrap()
-    }
-
-    /// Produce an ordered iterator over keys1 for a particular key0, if key0 exists
-    pub fn iter1(
-        &self,
-    ) -> impl Iterator<
-        Item = (
-            &'l <K1 as ZeroMapKV<'a>>::GetType,
-            &'l <V as ZeroMapKV<'a>>::GetType,
-        ),
-    > + '_ {
-        let range = self.get_range();
-        #[allow(clippy::unwrap_used)] // `self.get_range()` returns a valid range
-        range.map(move |idx| {
-            (
-                self.keys1.zvl_get(idx).unwrap(),
-                self.values.zvl_get(idx).unwrap(),
-            )
-        })
-    }
-
-    /// Given key0_index, returns the corresponding range of keys1, which will be valid
-    pub(super) fn get_range(&self) -> Range<usize> {
-        debug_assert!(self.key0_index < self.joiner.len());
-        let start = if self.key0_index == 0 {
-            0
-        } else {
-            #[allow(clippy::unwrap_used)] // protected by the debug_assert above
-            self.joiner.get(self.key0_index - 1).unwrap()
-        };
-        #[allow(clippy::unwrap_used)] // protected by the debug_assert above
-        let limit = self.joiner.get(self.key0_index).unwrap();
-        // These two assertions are true based on the invariants of ZeroMap2d
-        debug_assert!(start < limit);
-        debug_assert!((limit as usize) < self.values.zvl_len());
-        (start as usize)..(limit as usize)
-    }
-
-    pub(super) fn get_key0_index(&self) -> usize {
-        self.key0_index
-    }
-}
-
-impl<'l, 'a, K0, K1, V> ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>
-where
-    K0: ZeroMapKV<'a>,
-    K1: ZeroMapKV<'a> + Ord,
-    V: ZeroMapKV<'a>,
-    K0: ?Sized,
-    K1: ?Sized,
-    V: ?Sized,
-{
-    pub fn get1(&self, key1: &K1) -> Option<&'l V::GetType> {
-        let key1_index = self.get_key1_index(key1)?;
-        #[allow(clippy::unwrap_used)] // key1_index is valid
-        Some(self.values.zvl_get(key1_index).unwrap())
-    }
-
-    // pub fn get1_by(&self, predicate: impl FnMut(&K1) -> Ordering) -> Option<&V::GetType> {
-    //     let range = self.map.get_range_for_key0_index(self.key0_index);
-    //     debug_assert!(range.start < range.end); // '<' because every key0 should have a key1
-    //     debug_assert!(range.end <= self.map.keys1.zvl_len());
-    //     #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-    //     let index = range.start
-    //         + self
-    //             .map
-    //             .keys1
-    //             .zvl_binary_search_in_range(key1, range)
-    //             .expect("in-bounds range")
-    //             .ok()?;
-    //     // This unwrap is protected by the invariant keys1.len() == values.len(),
-    //     // the above debug_assert!, and the contract of zvl_binary_search_in_range.
-    //     #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-    //     Some(self.map.values.zvl_get(index).unwrap())
-    // }
-
-    /// Given key0_index and key1, returns the index into the values array
-    fn get_key1_index(&self, key1: &K1) -> Option<usize> {
-        let range = self.get_range();
-        debug_assert!(range.start < range.end); // '<' because every key0 should have a key1
-        debug_assert!(range.end <= self.keys1.zvl_len());
-        let start = range.start;
-        #[allow(clippy::expect_used)] // protected by the debug_assert above
-        let binary_search_result = self
-            .keys1
-            .zvl_binary_search_in_range(key1, range)
-            .expect("in-bounds range");
-        binary_search_result.ok().map(move |s| s + start)
-    }
-}
-
-impl<'l, 'a, K0, K1, V> ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>
-where
-    K0: ZeroMapKV<'a> + ?Sized,
-    K1: ZeroMapKV<'a> + ?Sized + Ord,
-    V: ZeroMapKV<'a, Container = ZeroVec<'a, V>>,
-    V: AsULE + Copy,
-{
-    pub fn get1_copied(&self, key1: &K1) -> Option<V> {
-        let key1_index = self.get_key1_index(key1)?;
-        self.values.get(key1_index)
     }
 }

--- a/utils/zerovec/src/map2d/borrowed.rs
+++ b/utils/zerovec/src/map2d/borrowed.rs
@@ -9,7 +9,7 @@ use core::fmt;
 
 use crate::map::{ZeroMapKV};
 use crate::map::{BorrowedZeroVecLike, ZeroVecLike};
-use crate::map2d::{KeyError, ZeroMap2dCursorBorrowed};
+use crate::map2d::{KeyError, ZeroMap2dCursor};
 
 /// A borrowed-only version of [`ZeroMap2d`](super::ZeroMap2d)
 ///
@@ -225,9 +225,9 @@ where
     /// assert!(matches!(borrowed.get0(&3), None));
     /// ```
     #[inline]
-    pub fn get0<'l>(&'l self, key0: &K0) -> Option<ZeroMap2dCursorBorrowed<'a, 'a, K0, K1, V>> {
+    pub fn get0<'l>(&'l self, key0: &K0) -> Option<ZeroMap2dCursor<'a, 'a, K0, K1, V>> {
         let key0_index = self.keys0.zvl_binary_search(key0).ok()?;
-        Some(ZeroMap2dCursorBorrowed::from_borrowed(self, key0_index))
+        Some(ZeroMap2dCursor::from_borrowed(self, key0_index))
     }
 }
 
@@ -243,8 +243,8 @@ where
     /// Produce an ordered iterator over keys0
     pub fn iter0<'l>(
         &'l self,
-    ) -> impl Iterator<Item = ZeroMap2dCursorBorrowed<'a, 'a, K0, K1, V>> + '_ {
-        (0..self.keys0.zvl_len()).map(move |idx| ZeroMap2dCursorBorrowed::from_borrowed(self, idx))
+    ) -> impl Iterator<Item = ZeroMap2dCursor<'a, 'a, K0, K1, V>> + '_ {
+        (0..self.keys0.zvl_len()).map(move |idx| ZeroMap2dCursor::from_borrowed(self, idx))
     }
 }
 

--- a/utils/zerovec/src/map2d/borrowed.rs
+++ b/utils/zerovec/src/map2d/borrowed.rs
@@ -259,12 +259,6 @@ where
             key0_index: idx,
         })
     }
-
-    /// Produce an iterator over values, ordered by the pair (key0,key1)
-    pub fn iter_values<'b>(&'b self) -> impl Iterator<Item = &'b <V as ZeroMapKV<'a>>::GetType> {
-        #[allow(clippy::unwrap_used)] // Iterating over a ZeroVecLike requires this pattern
-        (0..self.values.zvl_len()).map(move |idx| self.values.zvl_get(idx).unwrap())
-    }
 }
 
 impl<'a, K0, K1, V> ZeroMap2dBorrowed<'a, K0, K1, V>

--- a/utils/zerovec/src/map2d/borrowed.rs
+++ b/utils/zerovec/src/map2d/borrowed.rs
@@ -250,18 +250,6 @@ where
 
 impl<'a, K0, K1, V> ZeroMap2dBorrowed<'a, K0, K1, V>
 where
-    K0: ZeroMapKV<'a>,
-    K1: ZeroMapKV<'a> + Ord,
-    V: ZeroMapKV<'a>,
-    K0: ?Sized,
-    K1: ?Sized,
-    V: ?Sized,
-{
-    // INTERNAL ROUTINES FOLLOW //
-}
-
-impl<'a, K0, K1, V> ZeroMap2dBorrowed<'a, K0, K1, V>
-where
     K0: ZeroMapKV<'a> + ?Sized + Ord,
     K1: ZeroMapKV<'a> + ?Sized + Ord,
     V: ZeroMapKV<'a, Container = ZeroVec<'a, V>> + ?Sized,

--- a/utils/zerovec/src/map2d/cursor.rs
+++ b/utils/zerovec/src/map2d/cursor.rs
@@ -1,0 +1,181 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use crate::ule::AsULE;
+use crate::{ZeroMap2d, ZeroSlice, ZeroVec};
+
+use core::ops::Range;
+
+use crate::map::ZeroMapKV;
+use crate::map::ZeroVecLike;
+
+use super::ZeroMap2dBorrowed;
+
+pub struct ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>
+where
+    K0: ZeroMapKV<'a>,
+    K1: ZeroMapKV<'a>,
+    V: ZeroMapKV<'a>,
+    K0: ?Sized,
+    K1: ?Sized,
+    V: ?Sized,
+{
+    keys0: &'l <<K0 as ZeroMapKV<'a>>::Container as ZeroVecLike<K0>>::BorrowedVariant,
+    joiner: &'l ZeroSlice<u32>,
+    keys1: &'l <<K1 as ZeroMapKV<'a>>::Container as ZeroVecLike<K1>>::BorrowedVariant,
+    values: &'l <<V as ZeroMapKV<'a>>::Container as ZeroVecLike<V>>::BorrowedVariant,
+    // Invariant: key0_index is in range
+    key0_index: usize,
+}
+
+impl<'a, K0, K1, V> ZeroMap2dCursorBorrowed<'a, 'a, K0, K1, V>
+where
+    K0: ZeroMapKV<'a>,
+    K1: ZeroMapKV<'a>,
+    V: ZeroMapKV<'a>,
+    K0: ?Sized,
+    K1: ?Sized,
+    V: ?Sized,
+{
+    /// `key0_index` must be in range
+    pub(crate) fn from_borrowed(borrowed: &ZeroMap2dBorrowed<'a, K0, K1, V>, key0_index: usize) -> Self {
+        debug_assert!(key0_index < borrowed.joiner.len());
+        ZeroMap2dCursorBorrowed {
+            keys0: borrowed.keys0,
+            joiner: borrowed.joiner,
+            keys1: borrowed.keys1,
+            values: borrowed.values,
+            key0_index,
+        }
+    }
+}
+
+impl<'l, 'a, K0, K1, V> ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>
+where
+    K0: ZeroMapKV<'a>,
+    K1: ZeroMapKV<'a>,
+    V: ZeroMapKV<'a>,
+    K0: ?Sized,
+    K1: ?Sized,
+    V: ?Sized,
+{
+    /// `key0_index` must be in range
+    pub(crate) fn from_cow(cow: &'l ZeroMap2d<'a, K0, K1, V>, key0_index: usize) -> Self {
+        debug_assert!(key0_index < cow.joiner.len());
+        Self {
+            keys0: cow.keys0.zvl_as_borrowed(),
+            joiner: &cow.joiner,
+            keys1: cow.keys1.zvl_as_borrowed(),
+            values: cow.values.zvl_as_borrowed(),
+            key0_index,
+        }
+    }
+
+    /// Returns the key0 corresponding to the cursor position.
+    pub fn key0(&self) -> &'l K0::GetType {
+        #[allow(clippy::unwrap_used)] // safe by invariant on `self.key0_index`
+        self.keys0.zvl_get(self.key0_index).unwrap()
+    }
+
+    /// Produce an ordered iterator over keys1 for a particular key0, if key0 exists
+    pub fn iter1(
+        &self,
+    ) -> impl Iterator<
+        Item = (
+            &'l <K1 as ZeroMapKV<'a>>::GetType,
+            &'l <V as ZeroMapKV<'a>>::GetType,
+        ),
+    > + '_ {
+        let range = self.get_range();
+        #[allow(clippy::unwrap_used)] // `self.get_range()` returns a valid range
+        range.map(move |idx| {
+            (
+                self.keys1.zvl_get(idx).unwrap(),
+                self.values.zvl_get(idx).unwrap(),
+            )
+        })
+    }
+
+    /// Given key0_index, returns the corresponding range of keys1, which will be valid
+    pub(super) fn get_range(&self) -> Range<usize> {
+        debug_assert!(self.key0_index < self.joiner.len());
+        let start = if self.key0_index == 0 {
+            0
+        } else {
+            #[allow(clippy::unwrap_used)] // protected by the debug_assert above
+            self.joiner.get(self.key0_index - 1).unwrap()
+        };
+        #[allow(clippy::unwrap_used)] // protected by the debug_assert above
+        let limit = self.joiner.get(self.key0_index).unwrap();
+        // These two assertions are true based on the invariants of ZeroMap2d
+        debug_assert!(start < limit);
+        debug_assert!((limit as usize) < self.values.zvl_len());
+        (start as usize)..(limit as usize)
+    }
+
+    pub(super) fn get_key0_index(&self) -> usize {
+        self.key0_index
+    }
+}
+
+impl<'l, 'a, K0, K1, V> ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>
+where
+    K0: ZeroMapKV<'a>,
+    K1: ZeroMapKV<'a> + Ord,
+    V: ZeroMapKV<'a>,
+    K0: ?Sized,
+    K1: ?Sized,
+    V: ?Sized,
+{
+    pub fn get1(&self, key1: &K1) -> Option<&'l V::GetType> {
+        let key1_index = self.get_key1_index(key1)?;
+        #[allow(clippy::unwrap_used)] // key1_index is valid
+        Some(self.values.zvl_get(key1_index).unwrap())
+    }
+
+    // pub fn get1_by(&self, predicate: impl FnMut(&K1) -> Ordering) -> Option<&V::GetType> {
+    //     let range = self.map.get_range_for_key0_index(self.key0_index);
+    //     debug_assert!(range.start < range.end); // '<' because every key0 should have a key1
+    //     debug_assert!(range.end <= self.map.keys1.zvl_len());
+    //     #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
+    //     let index = range.start
+    //         + self
+    //             .map
+    //             .keys1
+    //             .zvl_binary_search_in_range(key1, range)
+    //             .expect("in-bounds range")
+    //             .ok()?;
+    //     // This unwrap is protected by the invariant keys1.len() == values.len(),
+    //     // the above debug_assert!, and the contract of zvl_binary_search_in_range.
+    //     #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
+    //     Some(self.map.values.zvl_get(index).unwrap())
+    // }
+
+    /// Given key0_index and key1, returns the index into the values array
+    fn get_key1_index(&self, key1: &K1) -> Option<usize> {
+        let range = self.get_range();
+        debug_assert!(range.start < range.end); // '<' because every key0 should have a key1
+        debug_assert!(range.end <= self.keys1.zvl_len());
+        let start = range.start;
+        #[allow(clippy::expect_used)] // protected by the debug_assert above
+        let binary_search_result = self
+            .keys1
+            .zvl_binary_search_in_range(key1, range)
+            .expect("in-bounds range");
+        binary_search_result.ok().map(move |s| s + start)
+    }
+}
+
+impl<'l, 'a, K0, K1, V> ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>
+where
+    K0: ZeroMapKV<'a> + ?Sized,
+    K1: ZeroMapKV<'a> + ?Sized + Ord,
+    V: ZeroMapKV<'a, Container = ZeroVec<'a, V>>,
+    V: AsULE + Copy,
+{
+    pub fn get1_copied(&self, key1: &K1) -> Option<V> {
+        let key1_index = self.get_key1_index(key1)?;
+        self.values.get(key1_index)
+    }
+}

--- a/utils/zerovec/src/map2d/cursor.rs
+++ b/utils/zerovec/src/map2d/cursor.rs
@@ -111,7 +111,7 @@ where
         let limit = self.joiner.get(self.key0_index).unwrap();
         // These two assertions are true based on the invariants of ZeroMap2d
         debug_assert!(start < limit);
-        debug_assert!((limit as usize) < self.values.zvl_len());
+        debug_assert!((limit as usize) <= self.values.zvl_len());
         (start as usize)..(limit as usize)
     }
 }

--- a/utils/zerovec/src/map2d/cursor.rs
+++ b/utils/zerovec/src/map2d/cursor.rs
@@ -12,7 +12,7 @@ use crate::map::ZeroVecLike;
 
 use super::ZeroMap2dBorrowed;
 
-pub struct ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>
+pub struct ZeroMap2dCursor<'l, 'a, K0, K1, V>
 where
     K0: ZeroMapKV<'a>,
     K1: ZeroMapKV<'a>,
@@ -29,7 +29,7 @@ where
     key0_index: usize,
 }
 
-impl<'a, K0, K1, V> ZeroMap2dCursorBorrowed<'a, 'a, K0, K1, V>
+impl<'a, K0, K1, V> ZeroMap2dCursor<'a, 'a, K0, K1, V>
 where
     K0: ZeroMapKV<'a>,
     K1: ZeroMapKV<'a>,
@@ -41,7 +41,7 @@ where
     /// `key0_index` must be in range
     pub(crate) fn from_borrowed(borrowed: &ZeroMap2dBorrowed<'a, K0, K1, V>, key0_index: usize) -> Self {
         debug_assert!(key0_index < borrowed.joiner.len());
-        ZeroMap2dCursorBorrowed {
+        ZeroMap2dCursor {
             keys0: borrowed.keys0,
             joiner: borrowed.joiner,
             keys1: borrowed.keys1,
@@ -51,7 +51,7 @@ where
     }
 }
 
-impl<'l, 'a, K0, K1, V> ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>
+impl<'l, 'a, K0, K1, V> ZeroMap2dCursor<'l, 'a, K0, K1, V>
 where
     K0: ZeroMapKV<'a>,
     K1: ZeroMapKV<'a>,
@@ -119,7 +119,7 @@ where
     }
 }
 
-impl<'l, 'a, K0, K1, V> ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>
+impl<'l, 'a, K0, K1, V> ZeroMap2dCursor<'l, 'a, K0, K1, V>
 where
     K0: ZeroMapKV<'a>,
     K1: ZeroMapKV<'a> + Ord,
@@ -167,7 +167,7 @@ where
     }
 }
 
-impl<'l, 'a, K0, K1, V> ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>
+impl<'l, 'a, K0, K1, V> ZeroMap2dCursor<'l, 'a, K0, K1, V>
 where
     K0: ZeroMapKV<'a> + ?Sized,
     K1: ZeroMapKV<'a> + ?Sized + Ord,

--- a/utils/zerovec/src/map2d/cursor.rs
+++ b/utils/zerovec/src/map2d/cursor.rs
@@ -5,8 +5,8 @@
 use crate::ule::AsULE;
 use crate::{ZeroMap2d, ZeroSlice};
 
-use core::ops::Range;
 use core::fmt;
+use core::ops::Range;
 
 use crate::map::ZeroMapKV;
 use crate::map::ZeroVecLike;
@@ -42,7 +42,10 @@ where
     V: ?Sized,
 {
     /// `key0_index` must be in range
-    pub(crate) fn from_borrowed(borrowed: &ZeroMap2dBorrowed<'a, K0, K1, V>, key0_index: usize) -> Self {
+    pub(crate) fn from_borrowed(
+        borrowed: &ZeroMap2dBorrowed<'a, K0, K1, V>,
+        key0_index: usize,
+    ) -> Self {
         debug_assert!(key0_index < borrowed.joiner.len());
         ZeroMap2dCursor {
             keys0: borrowed.keys0,
@@ -90,7 +93,7 @@ where
     }
 
     /// Produce an ordered iterator over keys1 for a particular key0.
-    /// 
+    ///
     /// For an example, see [`ZeroMap2d::iter0()`].
     pub fn iter1(
         &self,

--- a/utils/zerovec/src/map2d/cursor.rs
+++ b/utils/zerovec/src/map2d/cursor.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::ule::AsULE;
-use crate::{ZeroMap2d, ZeroSlice, ZeroVec};
+use crate::{ZeroMap2d, ZeroSlice};
 
 use core::ops::Range;
 use core::fmt;
@@ -190,11 +190,10 @@ impl<'l, 'a, K0, K1, V> ZeroMap2dCursor<'l, 'a, K0, K1, V>
 where
     K0: ZeroMapKV<'a>,
     K1: ZeroMapKV<'a> + Ord,
-    V: ZeroMapKV<'a, Container = ZeroVec<'a, V>>,
+    V: ZeroMapKV<'a, GetType = V::ULE>,
     V: AsULE + Copy,
     K0: ?Sized,
     K1: ?Sized,
-    V: ?Sized,
 {
     /// For cases when `V` is fixed-size, obtain a direct copy of `V` instead of `V::ULE`
     ///
@@ -210,7 +209,9 @@ where
     /// ```
     pub fn get1_copied(&self, key1: &K1) -> Option<V> {
         let key1_index = self.get_key1_index(key1)?;
-        self.values.get(key1_index)
+        #[allow(clippy::unwrap_used)] // key1_index is valid
+        let ule = self.values.zvl_get(key1_index).unwrap();
+        Some(V::from_unaligned(*ule))
     }
 }
 

--- a/utils/zerovec/src/map2d/cursor.rs
+++ b/utils/zerovec/src/map2d/cursor.rs
@@ -21,6 +21,7 @@ where
     K1: ?Sized,
     V: ?Sized,
 {
+    // Invariant: these fields have the same invariants as they do in ZeroMap2d
     keys0: &'l <<K0 as ZeroMapKV<'a>>::Container as ZeroVecLike<K0>>::BorrowedVariant,
     joiner: &'l ZeroSlice<u32>,
     keys1: &'l <<K1 as ZeroMapKV<'a>>::Container as ZeroVecLike<K1>>::BorrowedVariant,
@@ -112,10 +113,6 @@ where
         debug_assert!(start < limit);
         debug_assert!((limit as usize) < self.values.zvl_len());
         (start as usize)..(limit as usize)
-    }
-
-    pub(super) fn get_key0_index(&self) -> usize {
-        self.key0_index
     }
 }
 

--- a/utils/zerovec/src/map2d/map.rs
+++ b/utils/zerovec/src/map2d/map.rs
@@ -499,6 +499,22 @@ where
     K1: ?Sized,
     V: ?Sized,
 {
+    /// Gets a cursor for `key0`. If `None`, then `key0` is not in the map. If `Some`,
+    /// then `key0` is in the map, and `key1` can be queried.
+    ///
+    /// ```rust
+    /// use zerovec::ZeroMap2d;
+    ///
+    /// let mut map = ZeroMap2d::new();
+    /// map.insert(&1u32, "one", "foo");
+    /// map.insert(&2, "one", "bar");
+    /// map.insert(&2, "two", "baz");
+    /// assert_eq!(map.get0(&1).unwrap().get1("one").unwrap(), "foo");
+    /// assert_eq!(map.get0(&1).unwrap().get1("two"), None);
+    /// assert_eq!(map.get0(&2).unwrap().get1("one").unwrap(), "bar");
+    /// assert_eq!(map.get0(&2).unwrap().get1("two").unwrap(), "baz");
+    /// assert_eq!(map.get0(&3), None);
+    /// ```
     #[inline]
     pub fn get0<'l>(&'l self, key0: &K0) -> Option<ZeroMap2dCursor<'l, 'a, K0, K1, V>> {
         let key0_index = self.keys0.zvl_binary_search(key0).ok()?;

--- a/utils/zerovec/src/map2d/map.rs
+++ b/utils/zerovec/src/map2d/map.rs
@@ -522,6 +522,23 @@ where
         Some(ZeroMap2dCursor::from_cow(self, key0_index))
     }
 
+    /// Binary search the map for `key0`, returning a cursor.
+    ///
+    /// ```rust
+    /// use zerovec::maps::ZeroMap2dBorrowed;
+    /// use zerovec::ZeroMap2d;
+    ///
+    /// let mut map = ZeroMap2d::new();
+    /// map.insert(&1, "one", "foo");
+    /// map.insert(&2, "two", "bar");
+    /// assert!(matches!(map.get0_by(|probe| probe.cmp(&1)), Some(_)));
+    /// assert!(matches!(map.get0_by(|probe| probe.cmp(&3)), None));
+    /// ```
+    pub fn get0_by<'l>(&'l self, predicate: impl FnMut(&K0) -> Ordering) -> Option<ZeroMap2dCursor<'l, 'a, K0, K1, V>> {
+        let key0_index = self.keys0.zvl_binary_search_by(predicate).ok()?;
+        Some(ZeroMap2dCursor::from_cow(self, key0_index))
+    }
+
     /// Returns whether `key0` is contained in this map
     ///
     /// ```rust

--- a/utils/zerovec/src/map2d/map.rs
+++ b/utils/zerovec/src/map2d/map.rs
@@ -303,7 +303,8 @@ where
     /// assert_eq!(map.remove(&1, "one"), Err(KeyError::K0));
     /// ```
     pub fn remove(&mut self, key0: &K0, key1: &K1) -> Result<V::OwnedType, KeyError> {
-        let (key0_index, range) = self.get_range_for_key0(key0).ok_or(KeyError::K0)?;
+        let key0_index = self.keys0.zvl_binary_search(key0).map_err(|_| KeyError::K0)?;
+        let range = self.get_range_for_key0_index(key0_index);
         debug_assert!(range.start < range.end); // '<' because every key0 should have a key1
         debug_assert!(range.end <= self.keys1.zvl_len());
         // The above debug_assert! protects the unwrap() below
@@ -415,12 +416,6 @@ where
     }
 
     // INTERNAL ROUTINES FOLLOW //
-
-    /// Given a value that may exist in keys0, returns the corresponding range of keys1
-    fn get_range_for_key0(&self, key0: &K0) -> Option<(usize, Range<usize>)> {
-        let cursor = self.get0(key0)?;
-        Some((cursor.get_key0_index(), cursor.get_range()))
-    }
 
     /// Given an index into the joiner array, returns the corresponding range of keys1
     fn get_range_for_key0_index(&self, key0_index: usize) -> Range<usize> {

--- a/utils/zerovec/src/map2d/map.rs
+++ b/utils/zerovec/src/map2d/map.rs
@@ -414,13 +414,6 @@ where
         None
     }
 
-    /// Produce an iterator over values, ordered by the pair (key0,key1)
-    pub fn iter_values<'b>(&'b self) -> impl Iterator<Item = &'b <V as ZeroMapKV<'a>>::GetType> {
-        // The unwrap is protected because we are looping over the range of indices in the vec
-        #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-        (0..self.values.zvl_len()).map(move |idx| self.values.zvl_get(idx).unwrap())
-    }
-
     // INTERNAL ROUTINES FOLLOW //
 
     /// Given a value that may exist in keys0, returns the corresponding range of keys1

--- a/utils/zerovec/src/map2d/map.rs
+++ b/utils/zerovec/src/map2d/map.rs
@@ -230,8 +230,8 @@ where
     /// ```
     pub fn iter0<'l>(
         &'l self,
-    ) -> impl Iterator<Item = ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>> + 'l {
-        (0..self.keys0.zvl_len()).map(move |idx| ZeroMap2dCursorBorrowed::from_cow(self, idx))
+    ) -> impl Iterator<Item = ZeroMap2dCursor<'l, 'a, K0, K1, V>> + 'l {
+        (0..self.keys0.zvl_len()).map(move |idx| ZeroMap2dCursor::from_cow(self, idx))
     }
 }
 
@@ -424,7 +424,7 @@ where
 
     /// Given an index into the joiner array, returns the corresponding range of keys1
     fn get_range_for_key0_index(&self, key0_index: usize) -> Range<usize> {
-        ZeroMap2dCursorBorrowed::from_cow(self, key0_index).get_range()
+        ZeroMap2dCursor::from_cow(self, key0_index).get_range()
     }
 
     /// Same as `get_range_for_key0`, but creates key0 if it doesn't already exist
@@ -526,9 +526,9 @@ where
     V: ?Sized,
 {
     #[inline]
-    pub fn get0<'l>(&'l self, key0: &K0) -> Option<ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>> {
+    pub fn get0<'l>(&'l self, key0: &K0) -> Option<ZeroMap2dCursor<'l, 'a, K0, K1, V>> {
         let key0_index = self.keys0.zvl_binary_search(key0).ok()?;
-        Some(ZeroMap2dCursorBorrowed::from_cow(self, key0_index))
+        Some(ZeroMap2dCursor::from_cow(self, key0_index))
     }
 
     /// Returns whether `key0` is contained in this map

--- a/utils/zerovec/src/map2d/map.rs
+++ b/utils/zerovec/src/map2d/map.rs
@@ -560,10 +560,13 @@ where
 
 impl<'a, K0, K1, V> ZeroMap2d<'a, K0, K1, V>
 where
-    K0: ZeroMapKV<'a> + ?Sized + Ord,
-    K1: ZeroMapKV<'a> + ?Sized + Ord,
+    K0: ZeroMapKV<'a> + Ord,
+    K1: ZeroMapKV<'a> + Ord,
     V: ZeroMapKV<'a, Container = ZeroVec<'a, V>>,
     V: AsULE + Copy + 'static,
+    K0: ?Sized,
+    K1: ?Sized,
+    V: ?Sized,
 {
     /// For cases when `V` is fixed-size, obtain a direct copy of `V` instead of `V::ULE`
     ///

--- a/utils/zerovec/src/map2d/map.rs
+++ b/utils/zerovec/src/map2d/map.rs
@@ -228,9 +228,7 @@ where
     ///
     /// assert_eq!(total_value, 22);
     /// ```
-    pub fn iter0<'l>(
-        &'l self,
-    ) -> impl Iterator<Item = ZeroMap2dCursor<'l, 'a, K0, K1, V>> + 'l {
+    pub fn iter0<'l>(&'l self) -> impl Iterator<Item = ZeroMap2dCursor<'l, 'a, K0, K1, V>> + 'l {
         (0..self.keys0.zvl_len()).map(move |idx| ZeroMap2dCursor::from_cow(self, idx))
     }
 
@@ -349,7 +347,10 @@ where
     /// assert_eq!(map.remove(&1, "one"), Err(KeyError::K0));
     /// ```
     pub fn remove(&mut self, key0: &K0, key1: &K1) -> Result<V::OwnedType, KeyError> {
-        let key0_index = self.keys0.zvl_binary_search(key0).map_err(|_| KeyError::K0)?;
+        let key0_index = self
+            .keys0
+            .zvl_binary_search(key0)
+            .map_err(|_| KeyError::K0)?;
         let range = self.get_range_for_key0_index(key0_index);
         debug_assert!(range.start < range.end); // '<' because every key0 should have a key1
         debug_assert!(range.end <= self.keys1.zvl_len());

--- a/utils/zerovec/src/map2d/map.rs
+++ b/utils/zerovec/src/map2d/map.rs
@@ -534,7 +534,10 @@ where
     /// assert!(matches!(map.get0_by(|probe| probe.cmp(&1)), Some(_)));
     /// assert!(matches!(map.get0_by(|probe| probe.cmp(&3)), None));
     /// ```
-    pub fn get0_by<'l>(&'l self, predicate: impl FnMut(&K0) -> Ordering) -> Option<ZeroMap2dCursor<'l, 'a, K0, K1, V>> {
+    pub fn get0_by<'l>(
+        &'l self,
+        predicate: impl FnMut(&K0) -> Ordering,
+    ) -> Option<ZeroMap2dCursor<'l, 'a, K0, K1, V>> {
         let key0_index = self.keys0.zvl_binary_search_by(predicate).ok()?;
         Some(ZeroMap2dCursor::from_cow(self, key0_index))
     }

--- a/utils/zerovec/src/map2d/map.rs
+++ b/utils/zerovec/src/map2d/map.rs
@@ -418,24 +418,13 @@ where
 
     /// Given a value that may exist in keys0, returns the corresponding range of keys1
     fn get_range_for_key0(&self, key0: &K0) -> Option<(usize, Range<usize>)> {
-        let key0_index = self.keys0.zvl_binary_search(key0).ok()?;
-        Some((key0_index, self.get_range_for_key0_index(key0_index)))
+        let cursor = self.get0(key0)?;
+        Some((cursor.get_key0_index(), cursor.get_range()))
     }
 
     /// Given an index into the joiner array, returns the corresponding range of keys1
     fn get_range_for_key0_index(&self, key0_index: usize) -> Range<usize> {
-        debug_assert!(key0_index < self.joiner.len());
-        let start = if key0_index == 0 {
-            0
-        } else {
-            // The unwrap is protected by the debug_assert above
-            #[allow(clippy::unwrap_used)]
-            self.joiner.get(key0_index - 1).unwrap()
-        };
-        // The unwrap is protected by the debug_assert above
-        #[allow(clippy::unwrap_used)]
-        let limit = self.joiner.get(key0_index).unwrap();
-        (start as usize)..(limit as usize)
+        ZeroMap2dCursorBorrowed::from_cow(self, key0_index).get_range()
     }
 
     /// Same as `get_range_for_key0`, but creates key0 if it doesn't already exist

--- a/utils/zerovec/src/map2d/map.rs
+++ b/utils/zerovec/src/map2d/map.rs
@@ -566,11 +566,10 @@ impl<'a, K0, K1, V> ZeroMap2d<'a, K0, K1, V>
 where
     K0: ZeroMapKV<'a> + Ord,
     K1: ZeroMapKV<'a> + Ord,
-    V: ZeroMapKV<'a, Container = ZeroVec<'a, V>>,
+    V: ZeroMapKV<'a, GetType = V::ULE>,
     V: AsULE + Copy + 'static,
     K0: ?Sized,
     K1: ?Sized,
-    V: ?Sized,
 {
     /// For cases when `V` is fixed-size, obtain a direct copy of `V` instead of `V::ULE`
     ///

--- a/utils/zerovec/src/map2d/map.rs
+++ b/utils/zerovec/src/map2d/map.rs
@@ -220,7 +220,7 @@ where
     /// for cursor in map.iter0() {
     ///     for (key1, value) in cursor.iter1() {
     ///         // This code runs for every (key0, key1) pair
-    ///         total_value += key0.as_unsigned_int() as usize;
+    ///         total_value += cursor.key0().as_unsigned_int() as usize;
     ///         total_value += key1.as_unsigned_int() as usize;
     ///         total_value += value.len();
     ///     }
@@ -567,7 +567,7 @@ where
     /// map.insert(&1, &4, &5);
     /// map.insert(&6, &7, &8);
     ///
-    /// assert_eq!(map.get_copied(&6, &7), Some(8));
+    /// assert_eq!(map.get_copied(&6, &7), Ok(8));
     /// ```
     pub fn get_copied(&self, key0: &K0, key1: &K1) -> Result<V, KeyError> {
         self.get0(key0)

--- a/utils/zerovec/src/map2d/mod.rs
+++ b/utils/zerovec/src/map2d/mod.rs
@@ -15,5 +15,5 @@ mod serde;
 
 pub use crate::ZeroMap2d;
 pub use borrowed::ZeroMap2dBorrowed;
-pub use cursor::ZeroMap2dCursorBorrowed;
+pub use cursor::ZeroMap2dCursor;
 pub use map::KeyError;

--- a/utils/zerovec/src/map2d/mod.rs
+++ b/utils/zerovec/src/map2d/mod.rs
@@ -14,4 +14,5 @@ mod serde;
 
 pub use crate::ZeroMap2d;
 pub use borrowed::ZeroMap2dBorrowed;
+pub use borrowed::ZeroMap2dCursorBorrowed;
 pub use map::KeyError;

--- a/utils/zerovec/src/map2d/mod.rs
+++ b/utils/zerovec/src/map2d/mod.rs
@@ -5,6 +5,7 @@
 //! See [`ZeroMap2d`](crate::ZeroMap2d) for details.
 
 mod borrowed;
+mod cursor;
 pub(crate) mod map;
 
 #[cfg(feature = "crabbake")]
@@ -14,5 +15,5 @@ mod serde;
 
 pub use crate::ZeroMap2d;
 pub use borrowed::ZeroMap2dBorrowed;
-pub use borrowed::ZeroMap2dCursorBorrowed;
+pub use cursor::ZeroMap2dCursorBorrowed;
 pub use map::KeyError;

--- a/utils/zerovec/src/map2d/serde.rs
+++ b/utils/zerovec/src/map2d/serde.rs
@@ -31,9 +31,7 @@ where
             let mut serde_map = serializer.serialize_map(None)?;
             for cursor in self.iter0() {
                 K0::Container::zvl_get_as_t(cursor.key0(), |k| serde_map.serialize_key(k))?;
-                let inner_map = ZeroMap2dInnerMapSerialize {
-                    cursor,
-                };
+                let inner_map = ZeroMap2dInnerMapSerialize { cursor };
                 serde_map.serialize_value(&inner_map)?;
             }
             serde_map.end()

--- a/utils/zerovec/src/map2d/serde.rs
+++ b/utils/zerovec/src/map2d/serde.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use super::{ZeroMap2d, ZeroMap2dBorrowed, ZeroMap2dCursorBorrowed};
+use super::{ZeroMap2d, ZeroMap2dBorrowed, ZeroMap2dCursor};
 use crate::map::{MutableZeroVecLike, ZeroMapKV, ZeroVecLike};
 use crate::ZeroVec;
 use alloc::vec::Vec;
@@ -51,7 +51,7 @@ where
     K1: ZeroMapKV<'a> + ?Sized + Ord,
     V: ZeroMapKV<'a> + ?Sized,
 {
-    pub cursor: ZeroMap2dCursorBorrowed<'l, 'a, K0, K1, V>,
+    pub cursor: ZeroMap2dCursor<'l, 'a, K0, K1, V>,
 }
 
 #[cfg(feature = "serde")]

--- a/utils/zerovec/src/map2d/serde.rs
+++ b/utils/zerovec/src/map2d/serde.rs
@@ -30,8 +30,8 @@ where
         if serializer.is_human_readable() {
             let mut values_it = self.iter_values();
             let mut serde_map = serializer.serialize_map(None)?;
-            for (key0_index, key0) in self.iter_keys0().enumerate() {
-                K0::Container::zvl_get_as_t(key0, |k| serde_map.serialize_key(k))?;
+            for (key0_index, cursor) in self.iter0().enumerate() {
+                K0::Container::zvl_get_as_t(cursor.key0(), |k| serde_map.serialize_key(k))?;
                 let inner_map = ZeroMap2dInnerMapSerialize {
                     key0_index,
                     map: self,

--- a/utils/zerovec/src/varzerovec/components.rs
+++ b/utils/zerovec/src/varzerovec/components.rs
@@ -335,6 +335,15 @@ where
         self.binary_search_impl(predicate, self.indices)
     }
 
+    pub fn binary_search_in_range_by(
+        &self,
+        predicate: impl FnMut(&T) -> Ordering,
+        range: Range<usize>,
+    ) -> Option<Result<usize, usize>> {
+        let indices_slice = self.indices.get(range)?;
+        Some(self.binary_search_impl(predicate, indices_slice))
+    }
+
     /// Binary searches a sorted `VarZeroVecComponents<T>` with the given predicate. For more information, see
     /// the primitive function [`binary_search`](slice::binary_search).
     fn binary_search_impl(

--- a/utils/zerovec/src/varzerovec/slice.rs
+++ b/utils/zerovec/src/varzerovec/slice.rs
@@ -373,6 +373,50 @@ where
     pub fn binary_search_by(&self, predicate: impl FnMut(&T) -> Ordering) -> Result<usize, usize> {
         self.as_components().binary_search_by(predicate)
     }
+
+    /// Binary searches a `VarZeroVec<T>` for the given predicate within a certain sorted range.
+    ///
+    /// If the range is out of bounds, returns `None`. Otherwise, returns a `Result` according
+    /// to the behavior of the standard library function [`binary_search`].
+    ///
+    /// The index is returned relative to the start of the range.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use std::str::Utf8Error;
+    /// # use zerovec::ule::ZeroVecError;
+    /// # use zerovec::VarZeroVec;
+    ///
+    /// let strings = vec!["a", "b", "f", "g", "m", "n", "q"];
+    /// let vec = VarZeroVec::<str>::from(&strings);
+    ///
+    /// // Same behavior as binary_search when the range covers the whole slice:
+    /// assert_eq!(vec.binary_search_in_range_by(|v| v.cmp("g"), 0..7), Some(Ok(3)));
+    /// assert_eq!(vec.binary_search_in_range_by(|v| v.cmp("h"), 0..7), Some(Err(4)));
+    ///
+    /// // Will not look outside of the range:
+    /// assert_eq!(vec.binary_search_in_range_by(|v| v.cmp("g"), 0..1), Some(Err(1)));
+    /// assert_eq!(vec.binary_search_in_range_by(|v| v.cmp("g"), 6..7), Some(Err(0)));
+    ///
+    /// // Will return indices relative to the start of the range:
+    /// assert_eq!(vec.binary_search_in_range_by(|v| v.cmp("g"), 1..6), Some(Ok(2)));
+    /// assert_eq!(vec.binary_search_in_range_by(|v| v.cmp("h"), 1..6), Some(Err(3)));
+    ///
+    /// // Will return None if the range is out of bounds:
+    /// assert_eq!(vec.binary_search_in_range_by(|v| v.cmp("x"), 100..200), None);
+    /// assert_eq!(vec.binary_search_in_range_by(|v| v.cmp("x"), 0..200), None);
+    /// # Ok::<(), ZeroVecError>(())
+    /// ```
+    ///
+    /// [`binary_search`]: https://doc.rust-lang.org/std/primitive.slice.html#method.binary_search
+    pub fn binary_search_in_range_by(
+        &self,
+        predicate: impl FnMut(&T) -> Ordering,
+        range: Range<usize>,
+    ) -> Option<Result<usize, usize>> {
+        self.as_components().binary_search_in_range_by(predicate, range)
+    }
 }
 // Safety (based on the safety checklist on the VarULE trait):
 //  1. VarZeroSlice does not include any uninitialized or padding bytes (achieved by `#[repr(transparent)]` on a

--- a/utils/zerovec/src/varzerovec/slice.rs
+++ b/utils/zerovec/src/varzerovec/slice.rs
@@ -415,7 +415,8 @@ where
         predicate: impl FnMut(&T) -> Ordering,
         range: Range<usize>,
     ) -> Option<Result<usize, usize>> {
-        self.as_components().binary_search_in_range_by(predicate, range)
+        self.as_components()
+            .binary_search_in_range_by(predicate, range)
     }
 }
 // Safety (based on the safety checklist on the VarULE trait):


### PR DESCRIPTION
Part of #243

Here's what I want to do:

1. Add a type `ZeroMap2dCursor` that is returned by `zm2d.get0(key0)` and `zm2d.iter0()`, and add `zm2d.get0_by(fn)`
2. The cursor has `.get1(key1)` and `.iter1()` plus `.get1_by(fn)`
3. Remove `KeyError` and instead drive clients to use the new abstraction
4. Reduce duplication between `ZeroMap2d` and `ZeroMap2dBorrowed` by using the same cursor type (if it works)

Temperature check?