### PR TITLE
Substituting unwrap() for expect() in examples

### DIFF
--- a/components/calendar/README.md
+++ b/components/calendar/README.md
@@ -28,7 +28,9 @@ use icu_calendar::{Date,
                    types::IsoWeekday};
 
 // Creating ISO date: 1992-09-02.
-let mut date_iso = Date::new_iso_date_from_integers(1992, 9, 2).unwrap();
+let mut date_iso = Date::new_iso_date_from_integers(1992, 9, 2)
+    .expect("Failed to initialize ISO Date instance.");
+
 assert_eq!(date_iso.day_of_week(), IsoWeekday::Wednesday);
 assert_eq!(date_iso.year().number, 1992);
 assert_eq!(date_iso.month().number, 9);
@@ -51,7 +53,8 @@ assert_eq!(date_iso.month().number, 9);
 assert_eq!(date_iso.day_of_month().0, 2);
 
 // Creating ISO date: 2022-01-30.
-let newer_date_iso = Date::new_iso_date_from_integers(2022, 1, 30).unwrap();
+let newer_date_iso = Date::new_iso_date_from_integers(2022, 1, 30)
+    .expect("Failed to initialize ISO Date instance.");
 
 // Comparing dates: 2022-01-30 and 1992-09-02.
 let duration = newer_date_iso.until(&date_iso, DateDurationUnit::Years, DateDurationUnit::Days);
@@ -74,7 +77,9 @@ use icu_calendar::{Date,
                    indian::Indian};
 
 // Creating ISO date: 1992-09-02.
-let mut date_iso = Date::new_iso_date_from_integers(1992, 9, 2).unwrap();
+let mut date_iso = Date::new_iso_date_from_integers(1992, 9, 2)
+    .expect("Failed to initialize ISO Date instance.");
+
 assert_eq!(date_iso.year().number, 1992);
 assert_eq!(date_iso.month().number, 9);
 assert_eq!(date_iso.day_of_month().0, 2);
@@ -108,7 +113,9 @@ use icu_calendar::{DateTime,
                    types::Time};
 
 // Creating ISO date: 1992-09-02 8:59
-let mut datetime_iso = DateTime::new_iso_datetime_from_integers(1992, 9, 2, 8, 59, 0).unwrap();
+let mut datetime_iso = DateTime::new_iso_datetime_from_integers(1992, 9, 2, 8, 59, 0)
+    .expect("Failed to initialize ISO DateTime instance.");
+
 assert_eq!(datetime_iso.date.day_of_week(), IsoWeekday::Wednesday);
 assert_eq!(datetime_iso.date.year().number, 1992);
 assert_eq!(datetime_iso.date.month().number, 9);
@@ -121,7 +128,8 @@ assert_eq!(datetime_iso.time.nanosecond, NanoSecond::new_unchecked(0));
 // Advancing date by 1 year, 2 months, 3 weeks, 4 days.
 datetime_iso.date.add(DateDuration::new(1, 2, 3, 4));
 // New time of 14:30
-datetime_iso.time = Time::try_new(14, 30, 0, 0).unwrap();
+datetime_iso.time = Time::try_new(14, 30, 0, 0)
+    .expect("Failed to initialize Time instance.");
 
 assert_eq!(datetime_iso.date.year().number, 1993);
 assert_eq!(datetime_iso.date.month().number, 11);

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -10,11 +10,13 @@
 //!                     buddhist::Buddhist};
 //!
 //! // `Date` type
-//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2).unwrap();
+//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+//!     .expect("Failed to initialize ISO Date instance.");
 //! let date_buddhist = Date::new_from_iso(date_iso, Buddhist);
 //!
 //! // `DateTime` type
-//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0).unwrap();
+//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+//!     .expect("Failed to initialize ISO DateTime instance.");
 //! let datetime_buddhist = DateTime::new_from_iso(datetime_iso, Buddhist);
 //!
 //! // `Date` checks
@@ -131,7 +133,8 @@ impl Date<Buddhist> {
     /// use icu::calendar::Date;
     /// use std::convert::TryFrom;
     ///
-    /// let date_buddhist = Date::new_buddhist_date(1970, 1, 2).unwrap();
+    /// let date_buddhist = Date::new_buddhist_date(1970, 1, 2)
+    ///     .expect("Failed to initialize Buddhist Date instance.");
     ///
     /// assert_eq!(date_buddhist.year().number, 1970);
     /// assert_eq!(date_buddhist.month().number, 1);
@@ -158,7 +161,8 @@ impl DateTime<Buddhist> {
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
     ///
-    /// let datetime_buddhist = DateTime::new_buddhist_datetime(1970, 1, 2, 13, 1, 0).unwrap();
+    /// let datetime_buddhist = DateTime::new_buddhist_datetime(1970, 1, 2, 13, 1, 0)
+    ///     .expect("Failed to initialize Buddhist DateTime instance.");
     ///
     /// assert_eq!(datetime_buddhist.date.year().number, 1970);
     /// assert_eq!(datetime_buddhist.date.month().number, 1);

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -10,11 +10,13 @@
 //!                     coptic::Coptic};
 //!
 //! // `Date` type
-//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2).unwrap();
+//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+//!     .expect("Failed to initialize ISO Date instance.");
 //! let date_coptic = Date::new_from_iso(date_iso, Coptic);
 //!
 //! // `DateTime` type
-//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0).unwrap();
+//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+//!     .expect("Failed to initialize ISO DateTime instance.");
 //! let datetime_coptic = DateTime::new_from_iso(datetime_iso, Coptic);
 //!
 //! // `Date` checks
@@ -202,7 +204,8 @@ impl Date<Coptic> {
     /// ```rust
     /// use icu::calendar::Date;
     ///
-    /// let date_coptic = Date::new_coptic_date(1686, 5, 6).unwrap();
+    /// let date_coptic = Date::new_coptic_date(1686, 5, 6)
+    ///     .expect("Failed to initialize Coptic Date instance.");
     ///
     /// assert_eq!(date_coptic.year().number, 1686);
     /// assert_eq!(date_coptic.month().number, 5);
@@ -234,7 +237,8 @@ impl DateTime<Coptic> {
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
     ///
-    /// let datetime_coptic = DateTime::new_coptic_datetime(1686, 5, 6, 13, 1, 0).unwrap();
+    /// let datetime_coptic = DateTime::new_coptic_datetime(1686, 5, 6, 13, 1, 0)
+    ///     .expect("Failed to initialize Coptic DateTime instance.");
     ///
     /// assert_eq!(datetime_coptic.date.year().number, 1686);
     /// assert_eq!(datetime_coptic.date.month().number, 5);

--- a/components/calendar/src/ethiopic.rs
+++ b/components/calendar/src/ethiopic.rs
@@ -10,11 +10,13 @@
 //!                     ethiopic::Ethiopic};
 //!
 //! // `Date` type
-//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2).unwrap();
+//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+//!     .expect("Failed to initialize ISO Date instance.");
 //! let date_ethiopic = Date::new_from_iso(date_iso, Ethiopic);
 //!
 //! // `DateTime` type
-//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0).unwrap();
+//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+//!     .expect("Failed to initialize ISO DateTime instance.");
 //! let datetime_ethiopic = DateTime::new_from_iso(datetime_iso, Ethiopic);
 //!
 //! // `Date` checks
@@ -216,7 +218,8 @@ impl Date<Ethiopic> {
     /// ```rust
     /// use icu::calendar::Date;
     ///
-    /// let date_ethiopic = Date::new_ethiopic_date(2014, 8, 25).unwrap();
+    /// let date_ethiopic = Date::new_ethiopic_date(2014, 8, 25)
+    ///     .expect("Failed to initialize Ethopic Date instance.");
     ///
     /// assert_eq!(date_ethiopic.year().number, 2014);
     /// assert_eq!(date_ethiopic.month().number, 8);
@@ -256,7 +259,8 @@ impl DateTime<Ethiopic> {
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
     ///
-    /// let datetime_ethiopic = DateTime::new_ethiopic_datetime(2014, 8, 25, 13, 1, 0, 0).unwrap();
+    /// let datetime_ethiopic = DateTime::new_ethiopic_datetime(2014, 8, 25, 13, 1, 0, 0)
+    ///     .expect("Failed to initialize Ethiopic DateTime instance.");
     ///
     /// assert_eq!(datetime_ethiopic.date.year().number, 2014);
     /// assert_eq!(datetime_ethiopic.date.month().number, 8);

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -10,11 +10,13 @@
 //!                     gregorian::Gregorian};
 //!
 //! // `Date` type
-//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2).unwrap();
+//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+//!     .expect("Failed to initialize ISO Date instance.");
 //! let date_gregorian = Date::new_from_iso(date_iso, Gregorian);
 //!
 //! // `DateTime` type
-//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0).unwrap();
+//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+//!     .expect("Failed to initialize ISO DateTime instance.");
 //! let datetime_gregorian = DateTime::new_from_iso(datetime_iso, Gregorian);
 //!
 //! // `Date` checks
@@ -130,11 +132,14 @@ impl Date<Gregorian> {
     /// use std::convert::TryFrom;
     ///
     /// let iso_year = IsoYear(1970);
-    /// let iso_month = IsoMonth::try_from(1).unwrap();
-    /// let iso_day = IsoDay::try_from(2).unwrap();
+    /// let iso_month = IsoMonth::try_from(1)
+    ///     .expect("Failed to initialize IsoMonth instance.");
+    /// let iso_day = IsoDay::try_from(2)
+    ///     .expect("Failed to initialize IsoDay instance.");
     ///
     /// // Conversion from ISO to Gregorian
-    /// let date_gregorian = Date::new_gregorian_date(iso_year, iso_month, iso_day).unwrap();
+    /// let date_gregorian = Date::new_gregorian_date(iso_year, iso_month, iso_day)
+    ///     .expect("Failed to initialize Gregorian Date instance.");
     ///
     /// assert_eq!(date_gregorian.year().number, 1970);
     /// assert_eq!(date_gregorian.month().number, 1);
@@ -160,7 +165,8 @@ impl DateTime<Gregorian> {
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
     ///
-    /// let datetime_gregorian = DateTime::new_gregorian_datetime_from_integers(1970, 1, 2, 13, 1, 0, 0).unwrap();
+    /// let datetime_gregorian = DateTime::new_gregorian_datetime_from_integers(1970, 1, 2, 13, 1, 0, 0)
+    ///     .expect("Failed to initialize Gregorian DateTime instance.");
     ///
     /// assert_eq!(datetime_gregorian.date.year().number, 1970);
     /// assert_eq!(datetime_gregorian.date.month().number, 1);

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -10,11 +10,13 @@
 //!                     indian::Indian};
 //!
 //! // `Date` type
-//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2).unwrap();
+//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+//!     .expect("Failed to initialize ISO Date instance.");
 //! let date_indian = Date::new_from_iso(date_iso, Indian);
 //!
 //! // `DateTime` type
-//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0).unwrap();
+//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+//!     .expect("Failed to initialize ISO DateTime instance.");
 //! let datetime_indian = DateTime::new_from_iso(datetime_iso, Indian);
 //!
 //! // `Date` checks
@@ -185,7 +187,8 @@ impl Date<Indian> {
     /// ```rust
     /// use icu::calendar::Date;
     ///
-    /// let date_indian = Date::new_indian_date(1891, 10, 12).unwrap();
+    /// let date_indian = Date::new_indian_date(1891, 10, 12)
+    ///     .expect("Failed to initialize Indian Date instance.");
     ///
     /// assert_eq!(date_indian.year().number, 1891);
     /// assert_eq!(date_indian.month().number, 10);
@@ -217,7 +220,8 @@ impl DateTime<Indian> {
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
     ///
-    /// let datetime_indian = DateTime::new_indian_datetime(1891, 10, 12, 13, 1, 0).unwrap();
+    /// let datetime_indian = DateTime::new_indian_datetime(1891, 10, 12, 13, 1, 0)
+    ///     .expect("Failed to initialize Indian DateTime instance.");
     ///
     /// assert_eq!(datetime_indian.date.year().number, 1891);
     /// assert_eq!(datetime_indian.date.month().number, 10);

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -9,10 +9,12 @@
 //!                     types::IsoHour, types::IsoMinute, types::IsoSecond};
 //!
 //! // `Date` type
-//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2).unwrap();
+//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+//!     .expect("Failed to initialize ISO Date instance.");
 //!
 //! // `DateTime` type
-//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0).unwrap();
+//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+//!     .expect("Failed to initialize ISO DateTime instance.");
 //!
 //! // `Date` checks
 //! assert_eq!(date_iso.year().number, 1970);
@@ -330,17 +332,18 @@ impl Date<Iso> {
     ///
     /// ```rust
     /// use icu::calendar::{Date,
-    ///                     iso::IsoYear,
-    ///                     iso::IsoMonth,
-    ///                     iso::IsoDay};
+    ///                     iso::IsoYear, iso::IsoMonth, iso::IsoDay};
     /// use std::convert::TryFrom;
     ///
     /// let iso_year = IsoYear(1996);
-    /// let iso_month = IsoMonth::try_from(2).unwrap();
-    /// let iso_day = IsoDay::try_from(3).unwrap();
+    /// let iso_month = IsoMonth::try_from(2)
+    ///     .expect("Failed to initialize IsoMonth instance.");
+    /// let iso_day = IsoDay::try_from(3)
+    ///     .expect("Failed to initialize IsoDay instance.");
     ///
     /// // Creation of ISO date
-    /// let date_iso = Date::new_iso_date(iso_year, iso_month, iso_day).unwrap();
+    /// let date_iso = Date::new_iso_date(iso_year, iso_month, iso_day)
+    ///     .expect("Failed to initialize ISO Date instance.");
     ///
     /// assert_eq!(date_iso.year().number, 1996);
     /// assert_eq!(date_iso.month().number, 2);
@@ -366,7 +369,8 @@ impl Date<Iso> {
     /// ```rust
     /// use icu::calendar::Date;
     ///
-    /// let date_iso = Date::new_iso_date_from_integers(1970, 1, 2).unwrap();
+    /// let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+    ///     .expect("Failed to initialize ISO Date instance.");
     ///
     /// assert_eq!(date_iso.year().number, 1970);
     /// assert_eq!(date_iso.month().number, 1);
@@ -386,11 +390,10 @@ impl DateTime<Iso> {
     ///
     /// ```rust
     /// use icu::calendar::{DateTime,
-    ///                     types::IsoHour,
-    ///                     types::IsoMinute,
-    ///                     types::IsoSecond};
+    ///                     types::IsoHour, types::IsoMinute, types::IsoSecond};
     ///
-    /// let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0).unwrap();
+    /// let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+    ///     .expect("Failed to initialize ISO DateTime instance.");
     ///
     /// assert_eq!(datetime_iso.date.year().number, 1970);
     /// assert_eq!(datetime_iso.date.month().number, 1);

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -10,11 +10,13 @@
 //!                     julian::Julian};
 //!
 //! // `Date` type
-//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2).unwrap();
+//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+//!     .expect("Failed to initialize ISO Date instance.");
 //! let date_julian = Date::new_from_iso(date_iso, Julian);
 //!
 //! // `DateTime` type
-//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0).unwrap();
+//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+//!     .expect("Failed to initialize ISO DateTime instance.");
 //! let datetime_julian = DateTime::new_from_iso(datetime_iso, Julian);
 //!
 //! // `Date` checks
@@ -231,7 +233,8 @@ impl Date<Julian> {
     /// ```rust
     /// use icu::calendar::Date;
     ///
-    /// let date_julian = Date::new_julian_date(1969, 12, 20).unwrap();
+    /// let date_julian = Date::new_julian_date(1969, 12, 20)
+    ///     .expect("Failed to initialize Julian Date instance.");
     ///
     /// assert_eq!(date_julian.year().number, 1969);
     /// assert_eq!(date_julian.month().number, 12);
@@ -265,7 +268,8 @@ impl DateTime<Julian> {
     ///                     types::IsoMinute,
     ///                     types::IsoSecond};
     ///
-    /// let datetime_julian = DateTime::new_julian_datetime(1969, 12, 20, 13, 1, 0).unwrap();
+    /// let datetime_julian = DateTime::new_julian_datetime(1969, 12, 20, 13, 1, 0)
+    ///     .expect("Failed to initialize Julian DateTime instance.");
     ///
     /// assert_eq!(datetime_julian.date.year().number, 1969);
     /// assert_eq!(datetime_julian.date.month().number, 12);

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -30,7 +30,9 @@
 //!                    types::IsoWeekday};
 //!
 //! // Creating ISO date: 1992-09-02.
-//! let mut date_iso = Date::new_iso_date_from_integers(1992, 9, 2).unwrap();
+//! let mut date_iso = Date::new_iso_date_from_integers(1992, 9, 2)
+//!     .expect("Failed to initialize ISO Date instance.");
+//!
 //! assert_eq!(date_iso.day_of_week(), IsoWeekday::Wednesday);
 //! assert_eq!(date_iso.year().number, 1992);
 //! assert_eq!(date_iso.month().number, 9);
@@ -53,7 +55,8 @@
 //! assert_eq!(date_iso.day_of_month().0, 2);
 //!
 //! // Creating ISO date: 2022-01-30.
-//! let newer_date_iso = Date::new_iso_date_from_integers(2022, 1, 30).unwrap();
+//! let newer_date_iso = Date::new_iso_date_from_integers(2022, 1, 30)
+//!     .expect("Failed to initialize ISO Date instance.");
 //!
 //! // Comparing dates: 2022-01-30 and 1992-09-02.
 //! let duration = newer_date_iso.until(&date_iso, DateDurationUnit::Years, DateDurationUnit::Days);
@@ -76,7 +79,9 @@
 //!                    indian::Indian};
 //!
 //! // Creating ISO date: 1992-09-02.
-//! let mut date_iso = Date::new_iso_date_from_integers(1992, 9, 2).unwrap();
+//! let mut date_iso = Date::new_iso_date_from_integers(1992, 9, 2)
+//!     .expect("Failed to initialize ISO Date instance.");
+//!
 //! assert_eq!(date_iso.year().number, 1992);
 //! assert_eq!(date_iso.month().number, 9);
 //! assert_eq!(date_iso.day_of_month().0, 2);
@@ -110,7 +115,9 @@
 //!                    types::Time};
 //!
 //! // Creating ISO date: 1992-09-02 8:59
-//! let mut datetime_iso = DateTime::new_iso_datetime_from_integers(1992, 9, 2, 8, 59, 0).unwrap();
+//! let mut datetime_iso = DateTime::new_iso_datetime_from_integers(1992, 9, 2, 8, 59, 0)
+//!     .expect("Failed to initialize ISO DateTime instance.");
+//!
 //! assert_eq!(datetime_iso.date.day_of_week(), IsoWeekday::Wednesday);
 //! assert_eq!(datetime_iso.date.year().number, 1992);
 //! assert_eq!(datetime_iso.date.month().number, 9);
@@ -123,7 +130,8 @@
 //! // Advancing date by 1 year, 2 months, 3 weeks, 4 days.
 //! datetime_iso.date.add(DateDuration::new(1, 2, 3, 4));
 //! // New time of 14:30
-//! datetime_iso.time = Time::try_new(14, 30, 0, 0).unwrap();
+//! datetime_iso.time = Time::try_new(14, 30, 0, 0)
+//!     .expect("Failed to initialize Time instance.");
 //!
 //! assert_eq!(datetime_iso.date.year().number, 1993);
 //! assert_eq!(datetime_iso.date.month().number, 11);


### PR DESCRIPTION
* From suggestion in https://github.com/unicode-org/icu4x/pull/1866, `icu_calendar` examples that use `unwrap()` now use `expect()` to explain what the failure means.

E.g.:
```
// Old
let mut date_iso = Date::new_iso_date_from_integers(1992, 9, 2).unwrap();

// New
let mut date_iso = Date::new_iso_date_from_integers(1992, 9, 2)
    .expect("Failed to initialize ISO Date instance.");
```