### PR TITLE
Calendar benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,11 +1292,13 @@ dependencies = [
 name = "icu_calendar"
 version = "0.6.0"
 dependencies = [
+ "criterion",
  "displaydoc",
  "icu",
  "icu_locid",
  "icu_provider",
  "serde",
+ "serde_json",
  "tinystr 0.6.0",
  "zerovec",
 ]

--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -45,4 +45,11 @@ serde = { version = "1.0", default-features = false, features = ["derive", "allo
 zerovec = { version = "0.7", path = "../../utils/zerovec", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
+criterion = "0.3"
 icu = { path = "../icu", default-features = false }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[[bench]]
+name = "date"
+harness = false

--- a/components/calendar/benches/date.rs
+++ b/components/calendar/benches/date.rs
@@ -1,0 +1,148 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+mod fixtures;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use icu_calendar::{Date, DateDuration};
+
+fn date_benches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("date");
+    let fxs = fixtures::get_dates_fixture().unwrap();
+
+    // General overview is dealing in just ISO.
+    group.bench_function("calendar/date/overview", |b| {
+        use icu::calendar::{iso::IsoDay, iso::IsoMonth, iso::IsoYear};
+        use std::convert::TryFrom;
+
+        b.iter(|| {
+            for fx in &fxs.0 {
+                // Instantion
+                let iso_year = IsoYear(fx.year);
+                let iso_month = IsoMonth::try_from(fx.month).unwrap();
+                let iso_day = IsoDay::try_from(fx.day).unwrap();
+                let mut iso_insantiated_date_iso =
+                    Date::new_iso_date(iso_year, iso_month, iso_day).unwrap();
+                let mut int_instantiated_date_iso =
+                    Date::new_iso_date_from_integers(fx.year, fx.month, fx.day).unwrap();
+
+                // Arithmetic. black_box used to avoid compiler optimization.
+                iso_insantiated_date_iso.add(DateDuration::new(
+                    black_box(1),
+                    black_box(2),
+                    black_box(3),
+                    black_box(4),
+                ));
+                int_instantiated_date_iso.add(DateDuration::new(
+                    black_box(1),
+                    black_box(2),
+                    black_box(3),
+                    black_box(4),
+                ));
+
+                // Retrieving vals
+                let _ = iso_insantiated_date_iso.year().number;
+                let _ = iso_insantiated_date_iso.month().number;
+                let _ = iso_insantiated_date_iso.day_of_month().0;
+                let _ = int_instantiated_date_iso.year().number;
+                let _ = int_instantiated_date_iso.month().number;
+                let _ = int_instantiated_date_iso.day_of_month().0;
+            }
+        })
+    });
+
+    #[cfg(feature = "bench")]
+    group.bench_function("calendar/date/buddhist", |b| {
+        use icu::calendar::buddhist::Buddhist;
+
+        b.iter(|| {
+            for fx in &fxs.0 {
+                // Instantion
+                let mut instantiated_date_buddhist =
+                    Date::new_buddhist_date(fx.year, fx.month, fx.day).unwrap();
+
+                // Conversion from ISO
+                let date_iso = Date::new_iso_date_from_integers(fx.year, fx.month, fx.day).unwrap();
+                let mut converted_date_buddhist = Date::new_from_iso(date_iso, Buddhist);
+
+                // Arithmetic. black_box used to avoid compiler optimization.
+                instantiated_date_buddhist.add(DateDuration::new(
+                    black_box(1),
+                    black_box(2),
+                    black_box(3),
+                    black_box(4),
+                ));
+                converted_date_buddhist.add(DateDuration::new(
+                    black_box(1),
+                    black_box(2),
+                    black_box(3),
+                    black_box(4),
+                ));
+
+                // Retrieving vals
+                let _ = instantiated_date_buddhist.year().number;
+                let _ = instantiated_date_buddhist.month().number;
+                let _ = instantiated_date_buddhist.day_of_month().0;
+                let _ = converted_date_buddhist.year().number;
+                let _ = converted_date_buddhist.month().number;
+                let _ = converted_date_buddhist.day_of_month().0;
+
+                // Conversion to ISO.
+                let _ = instantiated_date_buddhist.to_iso();
+                let _ = converted_date_buddhist.to_iso();
+            }
+        })
+    });
+
+    #[cfg(feature = "bench")]
+    group.bench_function("calendar/date/julian", |b| {
+        use icu::calendar::julian::Julian;
+
+        b.iter(|| {
+            for fx in &fxs.0 {
+                // Instantion
+                let mut instantiated_date_julian =
+                    Date::new_julian_date(fx.year, fx.month, fx.day).unwrap();
+
+                // Conversion from ISO
+                let date_iso = Date::new_iso_date_from_integers(fx.year, fx.month, fx.day).unwrap();
+                let mut converted_date_julian = Date::new_from_iso(date_iso, Julian);
+
+                // Arithmetic. black_box used to avoid compiler optimization.
+                instantiated_date_julian.add(DateDuration::new(
+                    black_box(1),
+                    black_box(2),
+                    black_box(3),
+                    black_box(4),
+                ));
+                converted_date_julian.add(DateDuration::new(
+                    black_box(1),
+                    black_box(2),
+                    black_box(3),
+                    black_box(4),
+                ));
+
+                // Retrieving vals
+                let _ = instantiated_date_julian.year().number;
+                let _ = instantiated_date_julian.month().number;
+                let _ = instantiated_date_julian.day_of_month().0;
+                let _ = converted_date_julian.year().number;
+                let _ = converted_date_julian.month().number;
+                let _ = converted_date_julian.day_of_month().0;
+
+                // Conversion to ISO.
+                let _ = instantiated_date_julian.to_iso();
+                let _ = converted_date_julian.to_iso();
+            }
+        })
+    });
+
+    // TODO: Run-through example for all calendar types.
+    // TODO: Same style done for DateTime.
+
+    group.finish();
+}
+
+criterion_group!(benches, date_benches);
+criterion_main!(benches);

--- a/components/calendar/benches/fixtures/datetimes.json
+++ b/components/calendar/benches/fixtures/datetimes.json
@@ -1,0 +1,82 @@
+[
+    {
+        "year": 1990,
+        "month": 1,
+        "day": 20,
+        "hour": 14,
+        "minute": 12,
+        "second": 1
+    },
+    {
+        "year": 1996,
+        "month": 10,
+        "day": 31,
+        "hour": 2,
+        "minute": 55,
+        "second": 12
+    },
+    {
+        "year": 2000,
+        "month": 3,
+        "day": 23,
+        "hour": 1,
+        "minute": 34,
+        "second": 35
+    },
+    {
+        "year": 2010,
+        "month": 5,
+        "day": 10,
+        "hour": 9,
+        "minute": 31,
+        "second": 12
+    },
+    {
+        "year": 2020,
+        "month": 9,
+        "day": 13,
+        "hour": 23,
+        "minute": 1,
+        "second": 12
+    },
+    {
+        "year": 1881,
+        "month": 11,
+        "day": 22,
+        "hour": 3,
+        "minute": 27,
+        "second": 59
+    },
+    {
+        "year": 1720,
+        "month": 8,
+        "day": 1,
+        "hour": 13,
+        "minute": 24,
+        "second": 13
+    },
+    {
+        "year": 1630,
+        "month": 3,
+        "day": 4,
+        "hour": 3,
+        "minute": 1,
+        "second": 1
+    },
+    {
+        "year": 1540,
+        "month": 7,
+        "day": 8,
+        "hour": 8,
+        "minute": 2,
+        "second": 12
+    },
+    {
+        "year": 1024,
+        "month": 8,
+        "day": 16,
+        "hour": 19,
+        "minute": 31,
+        "second": 2
+    }
+]

--- a/components/calendar/benches/fixtures/mod.rs
+++ b/components/calendar/benches/fixtures/mod.rs
@@ -1,0 +1,16 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+pub mod structs;
+
+use std::fs::File;
+use std::io::BufReader;
+
+#[allow(dead_code)]
+pub fn get_dates_fixture() -> std::io::Result<structs::DateFixture> {
+    let file = File::open("./benches/fixtures/datetimes.json")?;
+    let reader = BufReader::new(file);
+
+    Ok(serde_json::from_reader(reader)?)
+}

--- a/components/calendar/benches/fixtures/structs.rs
+++ b/components/calendar/benches/fixtures/structs.rs
@@ -1,0 +1,18 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DateFixture(pub Vec<Test>);
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Test {
+    pub year: i32,
+    pub month: u8,
+    pub day: u8,
+    pub hour: u8,
+    pub minute: u8,
+    pub second: u8,
+}


### PR DESCRIPTION
Initial drafting of Calendar benchmarks. Overview focuses only on ISO, and does instantiation, arithmetic, and value retrieval across several ISO input dates. Drill-downs go into each calendar type, with instantiation, Conversion from ISO, Arithmetic, Retrieving vals, and Conversion to ISO.

If this general framework looks good, then next steps are...

* Create bench functions for all calendar types `calendar/date/X`
* Create DateTime bench function file