### PR TITLE
Post 0.6 release fixes

### DIFF
--- a/components/list/Cargo.toml
+++ b/components/list/Cargo.toml
@@ -28,7 +28,7 @@ zerovec = { version = "0.7", path = "../../utils/zerovec", features = ["yoke"] }
 deduplicating_array = { version = "0.1", path = "../../utils/deduplicating_array", optional = true }
 regex-automata = { version = "0.2", default-features = false }
 writeable = { version = "0.4", path = "../../utils/writeable" }
-crabbake = { path = "../../experimental/crabbake", optional = true, features = ["derive"]}
+crabbake = { version = "0.4", path = "../../experimental/crabbake", optional = true, features = ["derive"]}
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -17,7 +17,8 @@ Once the release is complete, the assigned release driver will:
   * Coverage
   * Performance / Memory / Size benchmarks
   * Cargo.toml files
-    * Cargo.toml files need to specify versions for each dependency.
+    * Cargo.toml files need to specify versions for each entry in `dependencies`.
+    * Cargo.toml should not specify versions for each entry in `dev-dependencies`.
     * Ensure that any new packages have suitable version numbers.
     * Ensure that the Cargo.toml file includes a set of fields consistent with other ICU4X packages.
 * Build a changelog for the release

--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -16,15 +16,20 @@ Once the release is complete, the assigned release driver will:
   * Documentation
   * Coverage
   * Performance / Memory / Size benchmarks
+  * Cargo.toml files
+    * Cargo.toml files need to specify versions for each dependency.
+    * Ensure that any new packages have suitable version numbers.
+    * Ensure that the Cargo.toml file includes a set of fields consistent with other ICU4X packages.
 * Build a changelog for the release
   * You can use commands like `git log icu@0.4.1..@ -- components/plurals/src/` to figure out what has changed in each component since the last release
-* [Tag the Release](https://github.com/unicode-org/icu4x/releases)
 * `cargo publish` each `util/` as necessary (See [Publishing utils](#Publishing utils))
+  * Note that you may have circular dependencies involving dev-dependencies. In this case, comment out the problematic dependency and use `cargo publish --allow-dirty`
 * `cargo publish` each component and meta component
 * `cargo publish` all crates under `ffi/`, starting with `ffi/diplomat`.
 * Add `icu4x-release` group as owners to each new component you're publishing
   * `cargo owner -a github:unicode-org:icu4x-release`
 * Ensure that the steps in `docs/tutorials/intro.md` still work with updated version numbers
+* [Tag the Release](https://github.com/unicode-org/icu4x/releases)
 * Announce the release to public
 
 

--- a/docs/tutorials/intro.md
+++ b/docs/tutorials/intro.md
@@ -42,7 +42,7 @@ The result is a new directory `~/projects/icu/myapp` with a file `./src/main.rs`
 
 ```toml
 [dependencies]
-icu = "0.2"
+icu = "0.6"
 ```
 
 After saving the changes, calling `cargo check` should vendor in `ICU4X` dependency.
@@ -136,8 +136,8 @@ First, we need to register our choice of the provider in `~/projects/icu/myapp/C
 
 ```
 [dependencies]
-icu = "0.5"
-icu_testdata = "0.5"
+icu = "0.6"
+icu_testdata = "0.6"
 ```
 
 and then we can use it in our code:
@@ -152,7 +152,7 @@ While this app doesn't do anything on its own yet, we now have a loaded data pro
 
 ```rust
 use icu::locid::locale;
-use icu::datetime::{DateTimeFormat, mock::parse_gregorian_from_str, options::length};
+use icu::datetime::{DateTimeFormat, DateTimeFormatOptions, mock::parse_gregorian_from_str, options::length};
 
 fn main() {
     let date = parse_gregorian_from_str("2020-10-14T13:21:00")
@@ -192,8 +192,8 @@ If you have ICU4X data on the file system in a JSON format, it can be loaded via
 
 ```toml
 [dependencies]
-icu = "0.5"
-icu_provider_fs = {version = "0.5" , features = ["deserialize_json"]}
+icu = "0.6"
+icu_provider_fs = {version = "0.6" , features = ["deserialize_json"]}
 ```
 
 ```rs
@@ -220,8 +220,8 @@ The `datagen` component has a binary application which will fetch the CLDR data 
 ```
 git clone https://github.com/unicode-org/icu4x
 cd icu4x
-git checkout icu@0.5.0
-cargo run --bin icu4x-datagen --features download -- \
+git checkout icu@0.6.0
+cargo run --bin icu4x-datagen --features bin -- \
     --cldr-tag 41.0.0 \
     --uprops-tag release-71-1 \
     --out ~/projects/icu/icu4x-data \
@@ -247,7 +247,7 @@ After that step, it should be possible to navigate to `~/projects/icu/icu4x-data
 
 # 6. Summary
 
-This concludes this introduction tutorial. 
+This concludes this introduction tutorial.
 
 With the help of `DateTimeFormat`, `Locale` and `DataProvider` we formatted a date to Japanese, but that's just a start.
 

--- a/experimental/char16trie/Cargo.toml
+++ b/experimental/char16trie/Cargo.toml
@@ -4,8 +4,24 @@
 
 [package]
 name = "icu_char16trie"
+description = "Implementation of ICU UCharTrie"
+authors = ["The ICU4X Project Developers"]
+repository = "https://github.com/unicode-org/icu4x"
+license-file = "LICENSE"
 version = "0.1.0"
 edition = "2021"
+categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
+include = [
+    "data/*",
+    "src/**/*",
+    "examples/**/*",
+    "benches/**/*",
+    "tests/**/*",
+    "Cargo.toml",
+    "LICENSE",
+    "README.md"
+]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/experimental/crabbake/Cargo.toml
+++ b/experimental/crabbake/Cargo.toml
@@ -34,4 +34,4 @@ derive = ["crabbake-derive"]
 proc-macro2 = "1.0.27"
 quote = "1.0.9"
 syn = { version = "1.0.73", features = ["derive", "fold"] }
-crabbake-derive = { path = "./derive", optional = true}
+crabbake-derive = { version = "0.4.0", path = "./derive", optional = true}

--- a/experimental/segmenter/Cargo.toml
+++ b/experimental/segmenter/Cargo.toml
@@ -35,7 +35,7 @@ icu_segmenter_lstm = { version = "0.1", path = "../segmenter_lstm", optional = t
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
-zerovec = { path = "../../utils/zerovec", features = ["yoke"] }
+zerovec = { version = "0.7", path = "../../utils/zerovec", features = ["yoke"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -67,4 +67,4 @@ icu_testdata = { version = "0.6", path = "../../provider/testdata", optional = t
 log = { version = "0.4" }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "none")))'.dependencies]
-icu_provider_fs = { path = "../../provider/fs/", optional = true }
+icu_provider_fs = { version = "0.6", path = "../../provider/fs/", optional = true }

--- a/provider/adapters/Cargo.toml
+++ b/provider/adapters/Cargo.toml
@@ -24,9 +24,9 @@ include = [
 ]
 
 [dependencies]
-icu_provider = { path = "../core" }
-icu_locid = { path = "../../components/locid" }
-yoke = { path = "../../utils/yoke" }
+icu_provider = { version = "0.6.0", path = "../core" }
+icu_locid = { version = "0.6.0", path = "../../components/locid" }
+yoke = { version = "0.5.0", path = "../../utils/yoke" }
 
 [features]
 std = ["icu_locid/std"]

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -74,7 +74,7 @@ postcard = { version = "0.7.0", default-features = false, optional = true }
 # Datagen
 dhat = { version = "0.3.0", optional = true }
 erased-serde = { version = "0.3", optional = true, default-features = false, features = ["alloc"] }
-crabbake = { path = "../../experimental/crabbake", optional = true, features = ["derive"] }
+crabbake = { version = "0.4.0", path = "../../experimental/crabbake", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -47,7 +47,7 @@ icu_segmenter = { version = "0.6", path = "../../experimental/segmenter", featur
 
 # ICU provider infrastructure
 icu_provider = { version = "0.6", path = "../core", features = ["std", "log_error_context"]}
-icu_provider_adapters = { path = "../adapters", features = ["datagen"] }
+icu_provider_adapters = { version = "0.6", path = "../adapters", features = ["datagen"] }
 icu_provider_blob = { version = "0.6", path = "../blob", features = ["export"] }
 icu_provider_fs = { version = "0.6", path = "../fs", features = ["export"] }
 
@@ -69,7 +69,7 @@ tinystr = { path = "../../utils/tinystr", version = "0.6", features = ["alloc", 
 toml = "0.5"
 zerovec = { version = "0.7", path = "../../utils/zerovec", features = ["serde_serialize", "yoke"] }
 quote = "1.0.9"
-crabbake = { path = "../../experimental/crabbake"}
+crabbake = { version = "0.4", path = "../../experimental/crabbake"}
 proc-macro2 = "1.0"
 crlify = { version = "1", path = "../../utils/crlify"}
 syn = {version = "1.0", features = ["parsing"] }


### PR DESCRIPTION
This updates missing data in the Cargo.toml files, adds to the release.md file and updates intro.md.

The datetime example in intro.md results in a compiler panic, I will file a separate issue for that.