### PR TITLE
Remove lifetime from ZeroVecLike

### DIFF
--- a/utils/zerovec/src/map/borrowed.rs
+++ b/utils/zerovec/src/map/borrowed.rs
@@ -113,7 +113,15 @@ where
                 <<V as ZeroMapKV<'a>>::Container as ZeroVecLike<V>>::BorrowedVariant::zvl_new_borrowed(),
         }
     }
+}
 
+impl<'a, K, V> ZeroMapBorrowed<'a, K, V>
+where
+    K: ZeroMapKV<'a>,
+    V: ZeroMapKV<'a>,
+    K: ?Sized,
+    V: ?Sized,
+{
     /// The number of elements in the [`ZeroMapBorrowed`]
     pub fn len(&self) -> usize {
         self.values.zvl_len()
@@ -311,7 +319,7 @@ where
         PartialEq<<<V as ZeroMapKV<'b>>::Container as ZeroVecLike<V>>::BorrowedVariant>,
 {
     fn eq(&self, other: &ZeroMapBorrowed<'b, K, V>) -> bool {
-        self.keys.eq(&other.keys) && self.values.eq(&other.values)
+        self.keys.eq(other.keys) && self.values.eq(other.values)
     }
 }
 

--- a/utils/zerovec/src/map/kv.rs
+++ b/utils/zerovec/src/map/kv.rs
@@ -19,6 +19,8 @@ pub trait ZeroMapKV<'a> {
     /// The container that can be used with this type: [`ZeroVec`] or [`VarZeroVec`].
     type Container: MutableZeroVecLike<'a, Self, GetType = Self::GetType, OwnedType = Self::OwnedType>
         + Sized;
+    // TODO: Consider adding Slice here
+    // type Slice: ZeroVecLike<Self, GetType = Self::GetType> + ?Sized;
     /// The type produced by `Container::get()`
     ///
     /// This type will be predetermined by the choice of `Self::Container`:

--- a/utils/zerovec/src/map/map.rs
+++ b/utils/zerovec/src/map/map.rs
@@ -290,9 +290,9 @@ where
     > {
         (0..self.keys.zvl_len()).map(move |idx| {
             (
-                #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
+                #[allow(clippy::unwrap_used)] // idx is in-range
                 self.keys.zvl_get(idx).unwrap(),
-                #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
+                #[allow(clippy::unwrap_used)] // idx is in-range
                 self.values.zvl_get(idx).unwrap(),
             )
         })
@@ -300,13 +300,13 @@ where
 
     /// Produce an ordered iterator over keys
     pub fn iter_keys<'b>(&'b self) -> impl Iterator<Item = &'b <K as ZeroMapKV<'a>>::GetType> {
-        #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
+        #[allow(clippy::unwrap_used)] // idx is in-range
         (0..self.keys.zvl_len()).map(move |idx| self.keys.zvl_get(idx).unwrap())
     }
 
     /// Produce an iterator over values, ordered by keys
     pub fn iter_values<'b>(&'b self) -> impl Iterator<Item = &'b <V as ZeroMapKV<'a>>::GetType> {
-        #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
+        #[allow(clippy::unwrap_used)] // idx is in-range
         (0..self.values.zvl_len()).map(move |idx| self.values.zvl_get(idx).unwrap())
     }
 }

--- a/utils/zerovec/src/map2d/borrowed.rs
+++ b/utils/zerovec/src/map2d/borrowed.rs
@@ -45,10 +45,10 @@ where
     K1: ?Sized,
     V: ?Sized,
 {
-    pub(crate) keys0: <<K0 as ZeroMapKV<'a>>::Container as ZeroVecLike<'a, K0>>::BorrowedVariant,
+    pub(crate) keys0: &'a <<K0 as ZeroMapKV<'a>>::Container as ZeroVecLike<K0>>::BorrowedVariant,
     pub(crate) joiner: &'a ZeroSlice<u32>,
-    pub(crate) keys1: <<K1 as ZeroMapKV<'a>>::Container as ZeroVecLike<'a, K1>>::BorrowedVariant,
-    pub(crate) values: <<V as ZeroMapKV<'a>>::Container as ZeroVecLike<'a, V>>::BorrowedVariant,
+    pub(crate) keys1: &'a <<K1 as ZeroMapKV<'a>>::Container as ZeroVecLike<K1>>::BorrowedVariant,
+    pub(crate) values: &'a <<V as ZeroMapKV<'a>>::Container as ZeroVecLike<V>>::BorrowedVariant,
 }
 
 impl<'a, K0, K1, V> Copy for ZeroMap2dBorrowed<'a, K0, K1, V>
@@ -86,6 +86,9 @@ where
     K0: ZeroMapKV<'a>,
     K1: ZeroMapKV<'a>,
     V: ZeroMapKV<'a>,
+    <<K0 as ZeroMapKV<'a>>::Container as ZeroVecLike<K0>>::BorrowedVariant: 'static,
+    <<K1 as ZeroMapKV<'a>>::Container as ZeroVecLike<K1>>::BorrowedVariant: 'static,
+    <<V as ZeroMapKV<'a>>::Container as ZeroVecLike<V>>::BorrowedVariant: 'static,
     K0: ?Sized,
     K1: ?Sized,
     V: ?Sized,
@@ -100,6 +103,9 @@ where
     K0: ZeroMapKV<'a>,
     K1: ZeroMapKV<'a>,
     V: ZeroMapKV<'a>,
+    <<K0 as ZeroMapKV<'a>>::Container as ZeroVecLike<K0>>::BorrowedVariant: 'static,
+    <<K1 as ZeroMapKV<'a>>::Container as ZeroVecLike<K1>>::BorrowedVariant: 'static,
+    <<V as ZeroMapKV<'a>>::Container as ZeroVecLike<V>>::BorrowedVariant: 'static,
     K0: ?Sized,
     K1: ?Sized,
     V: ?Sized,
@@ -120,17 +126,27 @@ where
     pub fn new() -> Self {
         Self {
             keys0:
-                <<K0 as ZeroMapKV<'a>>::Container as ZeroVecLike<'a, K0>>::BorrowedVariant::zvl_new(
+                <<K0 as ZeroMapKV<'a>>::Container as ZeroVecLike<K0>>::BorrowedVariant::zvl_new_borrowed(
                 ),
             joiner: Default::default(),
             keys1:
-                <<K1 as ZeroMapKV<'a>>::Container as ZeroVecLike<'a, K1>>::BorrowedVariant::zvl_new(
+                <<K1 as ZeroMapKV<'a>>::Container as ZeroVecLike<K1>>::BorrowedVariant::zvl_new_borrowed(
                 ),
             values:
-                <<V as ZeroMapKV<'a>>::Container as ZeroVecLike<'a, V>>::BorrowedVariant::zvl_new(),
+                <<V as ZeroMapKV<'a>>::Container as ZeroVecLike<V>>::BorrowedVariant::zvl_new_borrowed(),
         }
     }
+}
 
+impl<'a, K0, K1, V> ZeroMap2dBorrowed<'a, K0, K1, V>
+where
+    K0: ZeroMapKV<'a>,
+    K1: ZeroMapKV<'a>,
+    V: ZeroMapKV<'a>,
+    K0: ?Sized,
+    K1: ?Sized,
+    V: ?Sized,
+{
     /// The number of elements in the [`ZeroMap2dBorrowed`]
     pub fn len(&self) -> usize {
         self.values.zvl_len()
@@ -192,7 +208,7 @@ where
         // This unwrap is protected by the invariant keys1.len() == values.len(),
         // the above debug_assert!, and the contract of zvl_binary_search_in_range.
         #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-        Ok(self.values.zvl_get_borrowed(index).unwrap())
+        Ok(self.values.zvl_get(index).unwrap())
     }
 
     /// Returns whether `key0` is contained in this map
@@ -291,18 +307,18 @@ where
     K0: for<'c> ZeroMapKV<'c> + ?Sized,
     K1: for<'c> ZeroMapKV<'c> + ?Sized,
     V: for<'c> ZeroMapKV<'c> + ?Sized,
-    <<K0 as ZeroMapKV<'a>>::Container as ZeroVecLike<'a, K0>>::BorrowedVariant:
-        PartialEq<<<K0 as ZeroMapKV<'b>>::Container as ZeroVecLike<'b, K0>>::BorrowedVariant>,
-    <<K1 as ZeroMapKV<'a>>::Container as ZeroVecLike<'a, K1>>::BorrowedVariant:
-        PartialEq<<<K1 as ZeroMapKV<'b>>::Container as ZeroVecLike<'b, K1>>::BorrowedVariant>,
-    <<V as ZeroMapKV<'a>>::Container as ZeroVecLike<'a, V>>::BorrowedVariant:
-        PartialEq<<<V as ZeroMapKV<'b>>::Container as ZeroVecLike<'b, V>>::BorrowedVariant>,
+    <<K0 as ZeroMapKV<'a>>::Container as ZeroVecLike<K0>>::BorrowedVariant:
+        PartialEq<<<K0 as ZeroMapKV<'b>>::Container as ZeroVecLike<K0>>::BorrowedVariant>,
+    <<K1 as ZeroMapKV<'a>>::Container as ZeroVecLike<K1>>::BorrowedVariant:
+        PartialEq<<<K1 as ZeroMapKV<'b>>::Container as ZeroVecLike<K1>>::BorrowedVariant>,
+    <<V as ZeroMapKV<'a>>::Container as ZeroVecLike<V>>::BorrowedVariant:
+        PartialEq<<<V as ZeroMapKV<'b>>::Container as ZeroVecLike<V>>::BorrowedVariant>,
 {
     fn eq(&self, other: &ZeroMap2dBorrowed<'b, K0, K1, V>) -> bool {
-        self.keys0.eq(&other.keys0)
+        self.keys0.eq(other.keys0)
             && self.joiner.eq(other.joiner)
-            && self.keys1.eq(&other.keys1)
-            && self.values.eq(&other.values)
+            && self.keys1.eq(other.keys1)
+            && self.values.eq(other.values)
     }
 }
 
@@ -311,9 +327,9 @@ where
     K0: ZeroMapKV<'a> + ?Sized,
     K1: ZeroMapKV<'a> + ?Sized,
     V: ZeroMapKV<'a> + ?Sized,
-    <<K0 as ZeroMapKV<'a>>::Container as ZeroVecLike<'a, K0>>::BorrowedVariant: fmt::Debug,
-    <<K1 as ZeroMapKV<'a>>::Container as ZeroVecLike<'a, K1>>::BorrowedVariant: fmt::Debug,
-    <<V as ZeroMapKV<'a>>::Container as ZeroVecLike<'a, V>>::BorrowedVariant: fmt::Debug,
+    <<K0 as ZeroMapKV<'a>>::Container as ZeroVecLike<K0>>::BorrowedVariant: fmt::Debug,
+    <<K1 as ZeroMapKV<'a>>::Container as ZeroVecLike<K1>>::BorrowedVariant: fmt::Debug,
+    <<V as ZeroMapKV<'a>>::Container as ZeroVecLike<V>>::BorrowedVariant: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         f.debug_struct("ZeroMap2dBorrowed")

--- a/utils/zerovec/src/yoke_impls.rs
+++ b/utils/zerovec/src/yoke_impls.rs
@@ -122,9 +122,9 @@ unsafe impl<'a, K, V> Yokeable<'a> for ZeroMapBorrowed<'static, K, V>
 where
     K: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
     V: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
-    <<K as ZeroMapKV<'static>>::Container as ZeroVecLike<'static, K>>::BorrowedVariant:
+    &'static <<K as ZeroMapKV<'static>>::Container as ZeroVecLike<K>>::BorrowedVariant:
         for<'b> Yokeable<'b>,
-    <<V as ZeroMapKV<'static>>::Container as ZeroVecLike<'static, V>>::BorrowedVariant:
+    &'static <<V as ZeroMapKV<'static>>::Container as ZeroVecLike<V>>::BorrowedVariant:
         for<'b> Yokeable<'b>,
 {
     type Output = ZeroMapBorrowed<'a, K, V>;
@@ -219,11 +219,11 @@ where
     K0: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
     K1: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
     V: 'static + for<'b> ZeroMapKV<'b> + ?Sized,
-    <<K0 as ZeroMapKV<'static>>::Container as ZeroVecLike<'static, K0>>::BorrowedVariant:
+    &'static <<K0 as ZeroMapKV<'static>>::Container as ZeroVecLike<K0>>::BorrowedVariant:
         for<'b> Yokeable<'b>,
-    <<K1 as ZeroMapKV<'static>>::Container as ZeroVecLike<'static, K1>>::BorrowedVariant:
+    &'static <<K1 as ZeroMapKV<'static>>::Container as ZeroVecLike<K1>>::BorrowedVariant:
         for<'b> Yokeable<'b>,
-    <<V as ZeroMapKV<'static>>::Container as ZeroVecLike<'static, V>>::BorrowedVariant:
+    &'static <<V as ZeroMapKV<'static>>::Container as ZeroVecLike<V>>::BorrowedVariant:
         for<'b> Yokeable<'b>,
 {
     type Output = ZeroMap2dBorrowed<'a, K0, K1, V>;


### PR DESCRIPTION
I moved the functions in the ZeroVecLike trait that required a lifetime up into MutableZeroVecLike. After doing this, I was able to implement ZeroVecLike on the DST `[Var]ZeroSlice` directly, rather than `&[Var]ZeroSlice`, which will enable more code sharing between ZeroMap and ZeroMapBorrowed (in a subsequent PR).

How this relates to vertical fallback and code size: I want this in order to add `get_by` to ZeroMap2d, which is needed in order to support complex resource lookup in the blob provider, which is needed for vertical fallback. We currently convert the locale to a string before performing the lookup. This is long-standing tech debt that hurts code size.