### PR TITLE
Tweak CollationMetadataV1 documentation and dead code

### DIFF
--- a/experimental/collator/src/comparison.rs
+++ b/experimental/collator/src/comparison.rs
@@ -192,7 +192,7 @@ impl Collator {
         }
 
         let jamo: DataPayload<CollationJamoV1Marker> = data_provider
-            .load_resource(&DataRequest::default())? // TODO: load other jamo tables
+            .load_resource(&DataRequest::default())? // TODO: redesign Korean search collation handling
             .take_payload()?;
 
         if jamo.get().ce32s.len() != JAMO_COUNT {
@@ -210,6 +210,9 @@ impl Collator {
 
         if metadata.alternate_shifted() {
             altered_defaults.set_alternate_handling(Some(AlternateHandling::Shifted));
+        }
+        if metadata.backward_second_level() {
+            altered_defaults.set_backward_second_level(Some(true));
         }
 
         altered_defaults.set_case_first(Some(metadata.case_first()));


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

The main points are:
1. The numeric primary and default strength didn't happen here after all.
2. While there is one invariant in principle, the getter deals with it in a graceful GIGO manner anyway, so validating isn't worthwhile.
