### PR TITLE
Add comments noting why unsafe blocks are OK

### DIFF
--- a/experimental/collator/src/elements.rs
+++ b/experimental/collator/src/elements.rs
@@ -514,6 +514,8 @@ impl CharacterAndClass {
         CharacterAndClass(u32::from(c) | (0xFF << 24))
     }
     pub fn character(&self) -> char {
+        // Safe, because the low 24 bits came from a `char`
+        // originally.
         unsafe { char::from_u32_unchecked(self.0 & 0xFFFFFF) }
     }
     pub fn ccc(&self) -> CanonicalCombiningClass {

--- a/experimental/collator/src/options.rs
+++ b/experimental/collator/src/options.rs
@@ -358,6 +358,8 @@ impl CollatorOptions {
     /// The maximum character class that `AlternateHandling::Shifted`
     /// applies to.
     pub fn max_variable(&self) -> MaxVariable {
+        // Safe, because we mask two bits and shift them to the low
+        // two bits and the enum has values for 0 to 3, inclusive.
         unsafe {
             core::mem::transmute(
                 ((self.0 & CollatorOptions::MAX_VARIABLE_MASK)


### PR DESCRIPTION
Closes #1909

Note that the one `unsafe` block in `provider.rs` that is not covered here is covered by #1914.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->