### PR TITLE
Validate the length of last_primaries

### DIFF
--- a/experimental/collator/src/comparison.rs
+++ b/experimental/collator/src/comparison.rs
@@ -20,7 +20,7 @@ use crate::provider::CollationJamoV1Marker;
 use crate::provider::CollationMetadataV1Marker;
 use crate::provider::CollationReorderingV1Marker;
 use crate::provider::CollationSpecialPrimariesV1Marker;
-use crate::{AlternateHandling, CollatorOptions, Strength};
+use crate::{AlternateHandling, CollatorOptions, MaxVariable, Strength};
 use alloc::string::ToString;
 use core::char::{decode_utf16, DecodeUtf16Error, REPLACEMENT_CHARACTER};
 use core::cmp::Ordering;
@@ -224,6 +224,11 @@ impl Collator {
             let special_primaries: DataPayload<CollationSpecialPrimariesV1Marker> = data_provider
                 .load_resource(&DataRequest::default())?
                 .take_payload()?;
+            // `variant_count` isn't stable yet:
+            // https://github.com/rust-lang/rust/issues/73662
+            if special_primaries.get().last_primaries.len() <= (MaxVariable::Currency as usize) {
+                return Err(CollatorError::MalformedData);
+            }
             Some(special_primaries)
         } else {
             None

--- a/experimental/collator/src/provider.rs
+++ b/experimental/collator/src/provider.rs
@@ -269,6 +269,8 @@ pub struct CollationSpecialPrimariesV1<'data> {
 
 impl<'data> CollationSpecialPrimariesV1<'data> {
     pub(crate) fn last_primary_for_group(&self, max_variable: MaxVariable) -> u32 {
+        // `unwrap` is OK, because `Collator::try_new` validates the length.
+        //
         // Minus one to generate the right lower 16 bits from the high 16 bits.
         // See parse.cpp in genrb and getLastPrimaryForGroup in ICU4C.
         (u32::from(self.last_primaries.get(max_variable as usize).unwrap()) << 16) - 1


### PR DESCRIPTION
This seems much simpler than a custom impl of `Deserialize`.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->