### PR TITLE
Replace constructor new_unchecked() with getter number()

### DIFF
--- a/components/calendar/README.md
+++ b/components/calendar/README.md
@@ -111,10 +111,10 @@ assert_eq!(datetime_iso.date.day_of_week(), IsoWeekday::Wednesday);
 assert_eq!(datetime_iso.date.year().number, 1992);
 assert_eq!(datetime_iso.date.month().number, 9);
 assert_eq!(datetime_iso.date.day_of_month().0, 2);
-assert_eq!(datetime_iso.time.hour, IsoHour::new_unchecked(8));
-assert_eq!(datetime_iso.time.minute, IsoMinute::new_unchecked(59));
-assert_eq!(datetime_iso.time.second, IsoSecond::new_unchecked(0));
-assert_eq!(datetime_iso.time.nanosecond, NanoSecond::new_unchecked(0));
+assert_eq!(datetime_iso.time.hour.number(), 8);
+assert_eq!(datetime_iso.time.minute.number(), 59);
+assert_eq!(datetime_iso.time.second.number(), 0);
+assert_eq!(datetime_iso.time.nanosecond.number(), 0);
 
 // Advancing date by 1 year, 2 months, 3 weeks, 4 days.
 datetime_iso.date.add(DateDuration::new(1, 2, 3, 4));
@@ -124,10 +124,10 @@ datetime_iso.time = Time::try_new(14, 30, 0, 0).expect("Failed to initialize Tim
 assert_eq!(datetime_iso.date.year().number, 1993);
 assert_eq!(datetime_iso.date.month().number, 11);
 assert_eq!(datetime_iso.date.day_of_month().0, 27);
-assert_eq!(datetime_iso.time.hour, IsoHour::new_unchecked(14));
-assert_eq!(datetime_iso.time.minute, IsoMinute::new_unchecked(30));
-assert_eq!(datetime_iso.time.second, IsoSecond::new_unchecked(0));
-assert_eq!(datetime_iso.time.nanosecond, NanoSecond::new_unchecked(0));
+assert_eq!(datetime_iso.time.hour.number(), 14);
+assert_eq!(datetime_iso.time.minute.number(), 30);
+assert_eq!(datetime_iso.time.second.number(), 0);
+assert_eq!(datetime_iso.time.nanosecond.number(), 0);
 ```
 [`ICU4X`]: ../icu/index.html
 

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -28,9 +28,9 @@
 //! assert_eq!(datetime_buddhist.date.year().number, 2513);
 //! assert_eq!(datetime_buddhist.date.month().number, 1);
 //! assert_eq!(datetime_buddhist.date.day_of_month().0, 2);
-//! assert_eq!(datetime_buddhist.time.hour, IsoHour::new_unchecked(13));
-//! assert_eq!(datetime_buddhist.time.minute, IsoMinute::new_unchecked(1));
-//! assert_eq!(datetime_buddhist.time.second, IsoSecond::new_unchecked(0));
+//! assert_eq!(datetime_buddhist.time.hour.number(), 13);
+//! assert_eq!(datetime_buddhist.time.minute.number(), 1);
+//! assert_eq!(datetime_buddhist.time.second.number(), 0);
 //! ```
 
 use crate::iso::{Iso, IsoDateInner, IsoYear};
@@ -164,9 +164,9 @@ impl DateTime<Buddhist> {
     /// assert_eq!(datetime_buddhist.date.year().number, 1970);
     /// assert_eq!(datetime_buddhist.date.month().number, 1);
     /// assert_eq!(datetime_buddhist.date.day_of_month().0, 2);
-    /// assert_eq!(datetime_buddhist.time.hour, IsoHour::new_unchecked(13));
-    /// assert_eq!(datetime_buddhist.time.minute, IsoMinute::new_unchecked(1));
-    /// assert_eq!(datetime_buddhist.time.second, IsoSecond::new_unchecked(0));
+    /// assert_eq!(datetime_buddhist.time.hour.number(), 13);
+    /// assert_eq!(datetime_buddhist.time.minute.number(), 1);
+    /// assert_eq!(datetime_buddhist.time.second.number(), 0);
     /// ```
     pub fn new_buddhist_datetime(
         year: i32,

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -28,9 +28,9 @@
 //! assert_eq!(datetime_coptic.date.year().number, 1686);
 //! assert_eq!(datetime_coptic.date.month().number, 4);
 //! assert_eq!(datetime_coptic.date.day_of_month().0, 24);
-//! assert_eq!(datetime_coptic.time.hour, IsoHour::new_unchecked(13));
-//! assert_eq!(datetime_coptic.time.minute, IsoMinute::new_unchecked(1));
-//! assert_eq!(datetime_coptic.time.second, IsoSecond::new_unchecked(0));
+//! assert_eq!(datetime_coptic.time.hour.number(), 13);
+//! assert_eq!(datetime_coptic.time.minute.number(), 1);
+//! assert_eq!(datetime_coptic.time.second.number(), 0);
 //! ```
 
 use crate::iso::{Iso, IsoYear};
@@ -240,9 +240,9 @@ impl DateTime<Coptic> {
     /// assert_eq!(datetime_coptic.date.year().number, 1686);
     /// assert_eq!(datetime_coptic.date.month().number, 5);
     /// assert_eq!(datetime_coptic.date.day_of_month().0, 6);
-    /// assert_eq!(datetime_coptic.time.hour, IsoHour::new_unchecked(13));
-    /// assert_eq!(datetime_coptic.time.minute, IsoMinute::new_unchecked(1));
-    /// assert_eq!(datetime_coptic.time.second, IsoSecond::new_unchecked(0));
+    /// assert_eq!(datetime_coptic.time.hour.number(), 13);
+    /// assert_eq!(datetime_coptic.time.minute.number(), 1);
+    /// assert_eq!(datetime_coptic.time.second.number(), 0);
     /// ```
     pub fn new_coptic_datetime(
         year: i32,

--- a/components/calendar/src/datetime.rs
+++ b/components/calendar/src/datetime.rs
@@ -21,9 +21,9 @@ use crate::{AsCalendar, Date, Iso};
 /// assert_eq!(datetime_iso.date.year().number, 1970);
 /// assert_eq!(datetime_iso.date.month().number, 1);
 /// assert_eq!(datetime_iso.date.day_of_month().0, 2);
-/// assert_eq!(datetime_iso.time.hour, IsoHour::new_unchecked(13));
-/// assert_eq!(datetime_iso.time.minute, IsoMinute::new_unchecked(1));
-/// assert_eq!(datetime_iso.time.second, IsoSecond::new_unchecked(0));
+/// assert_eq!(datetime_iso.time.hour.number(), 13);
+/// assert_eq!(datetime_iso.time.minute.number(), 1);
+/// assert_eq!(datetime_iso.time.second.number(), 0);
 /// ```
 #[derive(Debug)]
 #[allow(clippy::exhaustive_structs)] // this type is stable

--- a/components/calendar/src/ethiopic.rs
+++ b/components/calendar/src/ethiopic.rs
@@ -28,9 +28,9 @@
 //! assert_eq!(datetime_ethiopic.date.year().number, 1962);
 //! assert_eq!(datetime_ethiopic.date.month().number, 4);
 //! assert_eq!(datetime_ethiopic.date.day_of_month().0, 24);
-//! assert_eq!(datetime_ethiopic.time.hour, IsoHour::new_unchecked(13));
-//! assert_eq!(datetime_ethiopic.time.minute, IsoMinute::new_unchecked(1));
-//! assert_eq!(datetime_ethiopic.time.second, IsoSecond::new_unchecked(0));
+//! assert_eq!(datetime_ethiopic.time.hour.number(), 13);
+//! assert_eq!(datetime_ethiopic.time.minute.number(), 1);
+//! assert_eq!(datetime_ethiopic.time.second.number(), 0);
 //! ```
 
 use crate::coptic::Coptic;
@@ -262,9 +262,9 @@ impl DateTime<Ethiopic> {
     /// assert_eq!(datetime_ethiopic.date.year().number, 2014);
     /// assert_eq!(datetime_ethiopic.date.month().number, 8);
     /// assert_eq!(datetime_ethiopic.date.day_of_month().0, 25);
-    /// assert_eq!(datetime_ethiopic.time.hour, IsoHour::new_unchecked(13));
-    /// assert_eq!(datetime_ethiopic.time.minute, IsoMinute::new_unchecked(1));
-    /// assert_eq!(datetime_ethiopic.time.second, IsoSecond::new_unchecked(0));
+    /// assert_eq!(datetime_ethiopic.time.hour.number(), 13);
+    /// assert_eq!(datetime_ethiopic.time.minute.number(), 1);
+    /// assert_eq!(datetime_ethiopic.time.second.number(), 0);
     /// ```
     pub fn new_ethiopic_datetime(
         year: i32,

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -28,9 +28,9 @@
 //! assert_eq!(datetime_gregorian.date.year().number, 1970);
 //! assert_eq!(datetime_gregorian.date.month().number, 1);
 //! assert_eq!(datetime_gregorian.date.day_of_month().0, 2);
-//! assert_eq!(datetime_gregorian.time.hour, IsoHour::new_unchecked(13));
-//! assert_eq!(datetime_gregorian.time.minute, IsoMinute::new_unchecked(1));
-//! assert_eq!(datetime_gregorian.time.second, IsoSecond::new_unchecked(0));
+//! assert_eq!(datetime_gregorian.time.hour.number(), 13);
+//! assert_eq!(datetime_gregorian.time.minute.number(), 1);
+//! assert_eq!(datetime_gregorian.time.second.number(), 0);
 //! ```
 
 use crate::iso::{Iso, IsoDateInner, IsoDay, IsoMonth, IsoYear};
@@ -164,9 +164,9 @@ impl DateTime<Gregorian> {
     /// assert_eq!(datetime_gregorian.date.year().number, 1970);
     /// assert_eq!(datetime_gregorian.date.month().number, 1);
     /// assert_eq!(datetime_gregorian.date.day_of_month().0, 2);
-    /// assert_eq!(datetime_gregorian.time.hour, IsoHour::new_unchecked(13));
-    /// assert_eq!(datetime_gregorian.time.minute, IsoMinute::new_unchecked(1));
-    /// assert_eq!(datetime_gregorian.time.second, IsoSecond::new_unchecked(0));
+    /// assert_eq!(datetime_gregorian.time.hour.number(), 13);
+    /// assert_eq!(datetime_gregorian.time.minute.number(), 1);
+    /// assert_eq!(datetime_gregorian.time.second.number(), 0);
     /// ```
     pub fn new_gregorian_datetime_from_integers(
         year: i32,

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -28,9 +28,9 @@
 //! assert_eq!(datetime_indian.date.year().number, 1892);
 //! assert_eq!(datetime_indian.date.month().number, 1);
 //! assert_eq!(datetime_indian.date.day_of_month().0, 2);
-//! assert_eq!(datetime_indian.time.hour, IsoHour::new_unchecked(13));
-//! assert_eq!(datetime_indian.time.minute, IsoMinute::new_unchecked(1));
-//! assert_eq!(datetime_indian.time.second, IsoSecond::new_unchecked(0));
+//! assert_eq!(datetime_indian.time.hour.number(), 13);
+//! assert_eq!(datetime_indian.time.minute.number(), 1);
+//! assert_eq!(datetime_indian.time.second.number(), 0);
 //! ```
 
 use crate::iso::{Iso, IsoYear};
@@ -223,9 +223,9 @@ impl DateTime<Indian> {
     /// assert_eq!(datetime_indian.date.year().number, 1891);
     /// assert_eq!(datetime_indian.date.month().number, 10);
     /// assert_eq!(datetime_indian.date.day_of_month().0, 12);
-    /// assert_eq!(datetime_indian.time.hour, IsoHour::new_unchecked(13));
-    /// assert_eq!(datetime_indian.time.minute, IsoMinute::new_unchecked(1));
-    /// assert_eq!(datetime_indian.time.second, IsoSecond::new_unchecked(0));
+    /// assert_eq!(datetime_indian.time.hour.number(), 13);
+    /// assert_eq!(datetime_indian.time.minute.number(), 1);
+    /// assert_eq!(datetime_indian.time.second.number(), 0);
     /// ```
     pub fn new_indian_datetime(
         year: i32,

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -24,9 +24,9 @@
 //! assert_eq!(datetime_iso.date.year().number, 1970);
 //! assert_eq!(datetime_iso.date.month().number, 1);
 //! assert_eq!(datetime_iso.date.day_of_month().0, 2);
-//! assert_eq!(datetime_iso.time.hour, IsoHour::new_unchecked(13));
-//! assert_eq!(datetime_iso.time.minute, IsoMinute::new_unchecked(1));
-//! assert_eq!(datetime_iso.time.second, IsoSecond::new_unchecked(0));
+//! assert_eq!(datetime_iso.time.hour.number(), 13);
+//! assert_eq!(datetime_iso.time.minute.number(), 1);
+//! assert_eq!(datetime_iso.time.second.number(), 0);
 //! ```
 
 use crate::{types, Calendar, Date, DateDuration, DateDurationUnit, DateTime, DateTimeError};
@@ -393,9 +393,9 @@ impl DateTime<Iso> {
     /// assert_eq!(datetime_iso.date.year().number, 1970);
     /// assert_eq!(datetime_iso.date.month().number, 1);
     /// assert_eq!(datetime_iso.date.day_of_month().0, 2);
-    /// assert_eq!(datetime_iso.time.hour, IsoHour::new_unchecked(13));
-    /// assert_eq!(datetime_iso.time.minute, IsoMinute::new_unchecked(1));
-    /// assert_eq!(datetime_iso.time.second, IsoSecond::new_unchecked(0));
+    /// assert_eq!(datetime_iso.time.hour.number(), 13);
+    /// assert_eq!(datetime_iso.time.minute.number(), 1);
+    /// assert_eq!(datetime_iso.time.second.number(), 0);
     /// ```
     pub fn new_iso_datetime_from_integers(
         year: i32,

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -40,9 +40,9 @@
 //!     datetime_japanese.date.year().era,
 //!     Era(tinystr!(16, "showa"))
 //! );
-//! assert_eq!(datetime_japanese.time.hour, IsoHour::new_unchecked(13));
-//! assert_eq!(datetime_japanese.time.minute, IsoMinute::new_unchecked(1));
-//! assert_eq!(datetime_japanese.time.second, IsoSecond::new_unchecked(0));
+//! assert_eq!(datetime_japanese.time.hour.number(), 13);
+//! assert_eq!(datetime_japanese.time.minute.number(), 1);
+//! assert_eq!(datetime_japanese.time.second.number(), 0);
 //! ```
 
 use crate::iso::{Iso, IsoDateInner};

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -28,9 +28,9 @@
 //! assert_eq!(datetime_julian.date.year().number, 1969);
 //! assert_eq!(datetime_julian.date.month().number, 12);
 //! assert_eq!(datetime_julian.date.day_of_month().0, 20);
-//! assert_eq!(datetime_julian.time.hour, IsoHour::new_unchecked(13));
-//! assert_eq!(datetime_julian.time.minute, IsoMinute::new_unchecked(1));
-//! assert_eq!(datetime_julian.time.second, IsoSecond::new_unchecked(0));
+//! assert_eq!(datetime_julian.time.hour.number(), 13);
+//! assert_eq!(datetime_julian.time.minute.number(), 1);
+//! assert_eq!(datetime_julian.time.second.number(), 0);
 //! ```
 
 use crate::iso::{Iso, IsoYear};
@@ -271,9 +271,9 @@ impl DateTime<Julian> {
     /// assert_eq!(datetime_julian.date.year().number, 1969);
     /// assert_eq!(datetime_julian.date.month().number, 12);
     /// assert_eq!(datetime_julian.date.day_of_month().0, 20);
-    /// assert_eq!(datetime_julian.time.hour, IsoHour::new_unchecked(13));
-    /// assert_eq!(datetime_julian.time.minute, IsoMinute::new_unchecked(1));
-    /// assert_eq!(datetime_julian.time.second, IsoSecond::new_unchecked(0));
+    /// assert_eq!(datetime_julian.time.hour.number(), 13);
+    /// assert_eq!(datetime_julian.time.minute.number(), 1);
+    /// assert_eq!(datetime_julian.time.second.number(), 0);
     /// ```
     pub fn new_julian_datetime(
         year: i32,

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -113,10 +113,10 @@
 //! assert_eq!(datetime_iso.date.year().number, 1992);
 //! assert_eq!(datetime_iso.date.month().number, 9);
 //! assert_eq!(datetime_iso.date.day_of_month().0, 2);
-//! assert_eq!(datetime_iso.time.hour, IsoHour::new_unchecked(8));
-//! assert_eq!(datetime_iso.time.minute, IsoMinute::new_unchecked(59));
-//! assert_eq!(datetime_iso.time.second, IsoSecond::new_unchecked(0));
-//! assert_eq!(datetime_iso.time.nanosecond, NanoSecond::new_unchecked(0));
+//! assert_eq!(datetime_iso.time.hour.number(), 8);
+//! assert_eq!(datetime_iso.time.minute.number(), 59);
+//! assert_eq!(datetime_iso.time.second.number(), 0);
+//! assert_eq!(datetime_iso.time.nanosecond.number(), 0);
 //!
 //! // Advancing date by 1 year, 2 months, 3 weeks, 4 days.
 //! datetime_iso.date.add(DateDuration::new(1, 2, 3, 4));
@@ -126,10 +126,10 @@
 //! assert_eq!(datetime_iso.date.year().number, 1993);
 //! assert_eq!(datetime_iso.date.month().number, 11);
 //! assert_eq!(datetime_iso.date.day_of_month().0, 27);
-//! assert_eq!(datetime_iso.time.hour, IsoHour::new_unchecked(14));
-//! assert_eq!(datetime_iso.time.minute, IsoMinute::new_unchecked(30));
-//! assert_eq!(datetime_iso.time.second, IsoSecond::new_unchecked(0));
-//! assert_eq!(datetime_iso.time.nanosecond, NanoSecond::new_unchecked(0));
+//! assert_eq!(datetime_iso.time.hour.number(), 14);
+//! assert_eq!(datetime_iso.time.minute.number(), 30);
+//! assert_eq!(datetime_iso.time.second.number(), 0);
+//! assert_eq!(datetime_iso.time.nanosecond.number(), 0);
 //! ```
 //! [`ICU4X`]: ../icu/index.html
 

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -116,9 +116,9 @@ macro_rules! dt_unit {
         pub struct $name($storage);
 
         impl $name {
-            /// Do not validate the numeric input for this component.
-            pub const fn new_unchecked(input: $storage) -> Self {
-                Self(input)
+            /// Gets the numeric value for this component.
+            pub const fn number(&self) -> $storage {
+                self.0
             }
         }
 


### PR DESCRIPTION
Something I noticed from reviewing #1866. The `new_unchecked` functions in `icu_calendar` are wholly unused except for docs examples, and they are not functions we should generally be encouraging people to use. I replaced them with a `.number()` getter.