### PR TITLE
Deprecate yoke's `badly` methods

### DIFF
--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -65,7 +65,7 @@ impl BlobDataProvider {
     /// Create a [`BlobDataProvider`] from a blob of ICU4X data.
     pub fn new_from_blob<B: Into<RcWrap>>(blob: B) -> Result<Self, DataError> {
         Ok(BlobDataProvider {
-            data: Yoke::try_attach_to_cart_badly(blob.into(), |bytes| {
+            data: Yoke::try_attach_to_cart(blob.into(), |bytes| {
                 BlobSchema::deserialize(&mut postcard::Deserializer::from_bytes(bytes)).map(
                     |blob| {
                         let BlobSchema::V001(blob) = blob;

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -263,7 +263,7 @@ where
     /// use icu_provider::yoke::Yoke;
     ///
     /// let payload = DataPayload::<HelloWorldV1Marker>::try_from_yoked_buffer(
-    ///     Yoke::attach_to_cart_badly("{\"message\":\"Hello World\"}".as_bytes().into(), |b| b),
+    ///     Yoke::attach_to_cart("{\"message\":\"Hello World\"}".as_bytes().into(), |b| b),
     ///     (),
     ///     |bytes, _, _| serde_json::from_slice(bytes),
     /// )
@@ -708,7 +708,7 @@ impl DataPayload<BufferMarker> {
     /// can be obtained from a `&[u8]`.
     pub fn from_rc_buffer(buffer: RcWrap) -> Self {
         Self {
-            yoke: Yoke::attach_to_cart_badly(buffer, |b| b).wrap_cart_in_option(),
+            yoke: Yoke::attach_to_cart(buffer, |b| b).wrap_cart_in_option(),
         }
     }
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-# Version updated on 2022-01-14
-channel = "1.60"
+# Version updated on 2022-05-23
+channel = "1.61"

--- a/utils/yoke/src/trait_hack.rs
+++ b/utils/yoke/src/trait_hack.rs
@@ -248,7 +248,7 @@
 //! {
 //!     fn demo(data: u32) -> Self {
 //!         let rc_u32: Rc<u32> = Rc::new(data);
-//!         Yoke::attach_to_cart_badly(rc_u32, |u| {
+//!         Yoke::attach_to_cart(rc_u32, |u| {
 //!             YokeTraitHack::<<Y as Yokeable>::Output>::demo(*u).0
 //!         })
 //!     }

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -88,15 +88,9 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, C> {
     ///
     /// See also [`Yoke::try_attach_to_cart()`] to return a `Result` from the closure.
     ///
-    /// Call sites for this function may not compile; if this happens, use
-    /// [`Yoke::attach_to_cart_badly()`] instead.
-    ///
     /// # Examples
     ///
-    /// The following code does not currently compile.
-    /// See [#1061](https://github.com/unicode-org/icu4x/issues/1061).
-    ///
-    /// ```compile_fail
+    /// ```
     /// # use yoke::{Yoke, Yokeable};
     /// # use std::rc::Rc;
     /// # use std::borrow::Cow;
@@ -130,10 +124,6 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, C> {
 
     /// Construct a [`Yoke`] by yokeing an object to a cart. If an error occurs in the
     /// deserializer function, the error is passed up to the caller.
-    ///
-    /// Call sites for this function may not compile; if this happens, use
-    /// [`Yoke::try_attach_to_cart_badly()`] instead.
-    /// See [#1061](https://github.com/unicode-org/icu4x/issues/1061).
     pub fn try_attach_to_cart<E, F>(cart: C, f: F) -> Result<Self, E>
     where
         F: for<'de> FnOnce(&'de <C as Deref>::Target) -> Result<<Y as Yokeable<'de>>::Output, E>,

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -88,7 +88,7 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, C> {
     ///
     /// See also [`Yoke::try_attach_to_cart()`] to return a `Result` from the closure.
     ///
-    /// Call sites for this function did not compile pre-1.61; if this still happens, use
+    /// Call sites for this function may not compile pre-1.61; if this still happens, use
     /// [`Yoke::try_attach_to_cart_badly()`] and file a bug.
     ///
     /// # Examples
@@ -128,7 +128,7 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, C> {
     /// Construct a [`Yoke`] by yokeing an object to a cart. If an error occurs in the
     /// deserializer function, the error is passed up to the caller.
     ///
-    /// Call sites for this function did not compile pre-1.61; if this still happens, use
+    /// Call sites for this function may not compile pre-1.61; if this still happens, use
     /// [`Yoke::try_attach_to_cart_badly()`] and file a bug.
     pub fn try_attach_to_cart<E, F>(cart: C, f: F) -> Result<Self, E>
     where

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -89,7 +89,7 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, C> {
     /// See also [`Yoke::try_attach_to_cart()`] to return a `Result` from the closure.
     ///
     /// Call sites for this function may not compile pre-1.61; if this still happens, use
-    /// [`Yoke::try_attach_to_cart_badly()`] and file a bug.
+    /// [`Yoke::attach_to_cart_badly()`] and file a bug.
     ///
     /// # Examples
     ///

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -88,6 +88,9 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, C> {
     ///
     /// See also [`Yoke::try_attach_to_cart()`] to return a `Result` from the closure.
     ///
+    /// Call sites for this function did not compile pre-1.61; if this still happens, use
+    /// [`Yoke::try_attach_to_cart_badly()`] and file a bug.
+    ///
     /// # Examples
     ///
     /// ```
@@ -124,6 +127,9 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, C> {
 
     /// Construct a [`Yoke`] by yokeing an object to a cart. If an error occurs in the
     /// deserializer function, the error is passed up to the caller.
+    ///
+    /// Call sites for this function did not compile pre-1.61; if this still happens, use
+    /// [`Yoke::try_attach_to_cart_badly()`] and file a bug.
     pub fn try_attach_to_cart<E, F>(cart: C, f: F) -> Result<Self, E>
     where
         F: for<'de> FnOnce(&'de <C as Deref>::Target) -> Result<<Y as Yokeable<'de>>::Output, E>,

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -93,7 +93,9 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, C> {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
+    /// # // ignored because while it works on stable, our coverage CI is still on an old
+    /// # // nightly that would require attach_to_cart_badly.
     /// # use yoke::{Yoke, Yokeable};
     /// # use std::rc::Rc;
     /// # use std::borrow::Cow;

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -142,7 +142,7 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, C> {
     }
 
     /// Use [`Yoke::attach_to_cart()`].
-    /// 
+    ///
     /// This was needed because the pre-1.61 compiler couldn't always handle the FnOnce trait bound.
     #[deprecated]
     pub fn attach_to_cart_badly(

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -66,7 +66,7 @@ use alloc::sync::Arc;
 ///
 /// fn load_object(filename: &str) -> Yoke<Cow<'static, str>, Rc<[u8]>> {
 ///     let rc: Rc<[u8]> = load_from_cache(filename);
-///     Yoke::<Cow<'static, str>, Rc<[u8]>>::attach_to_cart_badly(rc, |data: &[u8]| {
+///     Yoke::<Cow<'static, str>, Rc<[u8]>>::attach_to_cart(rc, |data: &[u8]| {
 ///         // essentially forcing a #[serde(borrow)]
 ///         Cow::Borrowed(bincode::deserialize(data).unwrap())
 ///     })
@@ -143,75 +143,26 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, C> {
         })
     }
 
-    /// Construct a [`Yoke`] by yokeing an object to a cart in a closure.
-    ///
-    /// For a version of this function that takes a `FnOnce` instead of a raw function pointer,
-    /// see [`Yoke::attach_to_cart()`].
-    ///
-    /// # Example
-    ///
-    /// For example, we can use this to store zero-copy deserialized data in a cache:
-    ///
-    /// ```rust
-    /// # use yoke::{Yoke, Yokeable};
-    /// # use std::rc::Rc;
-    /// # use std::borrow::Cow;
-    /// # fn load_from_cache(_filename: &str) -> Rc<[u8]> {
-    /// #     // dummy implementation
-    /// #     Rc::new([0x5, 0, 0, 0, 0, 0, 0, 0, 0x68, 0x65, 0x6c, 0x6c, 0x6f])
-    /// # }
-    ///
-    /// fn load_object(filename: &str) -> Yoke<Cow<'static, str>, Rc<[u8]>> {
-    ///     let rc: Rc<[u8]> = load_from_cache(filename);
-    ///     Yoke::<Cow<'static, str>, Rc<[u8]>>::attach_to_cart_badly(rc, |data: &[u8]| {
-    ///         // essentially forcing a #[serde(borrow)]
-    ///         Cow::Borrowed(bincode::deserialize(data).unwrap())
-    ///     })
-    /// }
-    ///
-    /// let yoke: Yoke<Cow<str>, _> = load_object("filename.bincode");
-    /// assert_eq!(&**yoke.get(), "hello");
-    /// assert!(matches!(yoke.get(), &Cow::Borrowed(_)));
-    /// ```
+    /// Use [`Yoke::attach_to_cart()`].
+    /// 
+    /// This was needed because the pre-1.61 compiler couldn't always handle the FnOnce trait bound.
+    #[deprecated]
     pub fn attach_to_cart_badly(
         cart: C,
         f: for<'de> fn(&'de <C as Deref>::Target) -> <Y as Yokeable<'de>>::Output,
     ) -> Self {
-        let deserialized = f(cart.deref());
-        Self {
-            yokeable: unsafe { Y::make(deserialized) },
-            cart,
-        }
+        Self::attach_to_cart(cart, f)
     }
 
-    /// Construct a [`Yoke`] by yokeing an object to a cart. If an error occurs in the
-    /// deserializer function, the error is passed up to the caller.
+    /// Use [`Yoke::try_attach_to_cart()`].
     ///
-    /// For a version of this function that takes a `FnOnce` instead of a raw function pointer,
-    /// see [`Yoke::try_attach_to_cart()`].
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use yoke::{Yoke, Yokeable};
-    /// # use std::rc::Rc;
-    /// # use std::borrow::Cow;
-    /// let rc = Rc::new([0xb, 0xa, 0xd]);
-    ///
-    /// let yoke_result: Result<Yoke<Cow<str>, Rc<[u8]>>, _> =
-    ///     Yoke::try_attach_to_cart_badly(rc, |data: &[u8]| bincode::deserialize(data));
-    ///
-    /// assert!(matches!(yoke_result, Err(_)));
-    /// ```
+    /// This was needed because the pre-1.61 compiler couldn't always handle the FnOnce trait bound.
+    #[deprecated]
     pub fn try_attach_to_cart_badly<E>(
         cart: C,
         f: for<'de> fn(&'de <C as Deref>::Target) -> Result<<Y as Yokeable<'de>>::Output, E>,
     ) -> Result<Self, E> {
-        let deserialized = f(cart.deref())?;
-        Ok(Self {
-            yokeable: unsafe { Y::make(deserialized) },
-            cart,
-        })
+        Self::try_attach_to_cart(cart, f)
     }
 }
 
@@ -236,7 +187,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// #
     /// # fn load_object(filename: &str) -> Yoke<Cow<'static, str>, Rc<[u8]>> {
     /// #     let rc: Rc<[u8]> = load_from_cache(filename);
-    /// #     Yoke::<Cow<'static, str>, Rc<[u8]>>::attach_to_cart_badly(rc, |data: &[u8]| {
+    /// #     Yoke::<Cow<'static, str>, Rc<[u8]>>::attach_to_cart(rc, |data: &[u8]| {
     /// #         Cow::Borrowed(bincode::deserialize(data).unwrap())
     /// #     })
     /// # }
@@ -350,7 +301,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// #
     /// # fn load_object(filename: &str) -> Yoke<Bar<'static>, Rc<[u8]>> {
     /// #     let rc: Rc<[u8]> = load_from_cache(filename);
-    /// #     Yoke::<Bar<'static>, Rc<[u8]>>::attach_to_cart_badly(rc, |data: &[u8]| {
+    /// #     Yoke::<Bar<'static>, Rc<[u8]>>::attach_to_cart(rc, |data: &[u8]| {
     /// #         // A real implementation would properly deserialize `Bar` as a whole
     /// #         Bar {
     /// #             numbers: Cow::Borrowed(bincode::deserialize(data).unwrap()),
@@ -820,8 +771,8 @@ impl<Y: for<'a> Yokeable<'a>, C: 'static + Sized> Yoke<Y, Rc<C>> {
     /// let buffer1: Rc<String> = Rc::new("   foo bar baz  ".into());
     /// let buffer2: Box<String> = Box::new("  baz quux  ".into());
     ///
-    /// let yoke1 = Yoke::<&'static str, _>::attach_to_cart_badly(buffer1, |rc| rc.trim());
-    /// let yoke2 = Yoke::<&'static str, _>::attach_to_cart_badly(buffer2, |b| b.trim());
+    /// let yoke1 = Yoke::<&'static str, _>::attach_to_cart(buffer1, |rc| rc.trim());
+    /// let yoke2 = Yoke::<&'static str, _>::attach_to_cart(buffer2, |b| b.trim());
     ///
     /// let erased1: Yoke<_, ErasedRcCart> = yoke1.erase_rc_cart();
     /// // Wrap the Box in an Rc to make it compatible
@@ -864,8 +815,8 @@ impl<Y: for<'a> Yokeable<'a>, C: 'static + Sized> Yoke<Y, Box<C>> {
     /// let buffer1: Rc<String> = Rc::new("   foo bar baz  ".into());
     /// let buffer2: Box<String> = Box::new("  baz quux  ".into());
     ///
-    /// let yoke1 = Yoke::<&'static str, _>::attach_to_cart_badly(buffer1, |rc| rc.trim());
-    /// let yoke2 = Yoke::<&'static str, _>::attach_to_cart_badly(buffer2, |b| b.trim());
+    /// let yoke1 = Yoke::<&'static str, _>::attach_to_cart(buffer1, |rc| rc.trim());
+    /// let yoke2 = Yoke::<&'static str, _>::attach_to_cart(buffer2, |b| b.trim());
     ///
     /// // Wrap the Rc in an Box to make it compatible
     /// let erased1: Yoke<_, ErasedBoxCart> = yoke1.wrap_cart_in_box().erase_box_cart();

--- a/utils/yoke/tests/bincode.rs
+++ b/utils/yoke/tests/bincode.rs
@@ -17,7 +17,7 @@ fn load_from_cache(_filename: &str) -> Rc<[u8]> {
 
 fn load_object(filename: &str) -> Yoke<Bar<'static>, Rc<[u8]>> {
     let rc: Rc<[u8]> = load_from_cache(filename);
-    Yoke::<Bar<'static>, Rc<[u8]>>::attach_to_cart_badly(rc, |data: &[u8]| {
+    Yoke::<Bar<'static>, Rc<[u8]>>::attach_to_cart(rc, |data: &[u8]| {
         // A real implementation would properly deserialize `Bar` as a whole
         Bar {
             numbers: Cow::Borrowed(bincode::deserialize(data).unwrap()),

--- a/utils/yoke/tests/bincode.rs
+++ b/utils/yoke/tests/bincode.rs
@@ -17,7 +17,7 @@ fn load_from_cache(_filename: &str) -> Rc<[u8]> {
 
 fn load_object(filename: &str) -> Yoke<Bar<'static>, Rc<[u8]>> {
     let rc: Rc<[u8]> = load_from_cache(filename);
-    Yoke::<Bar<'static>, Rc<[u8]>>::attach_to_cart(rc, |data: &[u8]| {
+    Yoke::<Bar<'static>, Rc<[u8]>>::attach_to_cart_badly(rc, |data: &[u8]| {
         // A real implementation would properly deserialize `Bar` as a whole
         Bar {
             numbers: Cow::Borrowed(bincode::deserialize(data).unwrap()),


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->