### PR TITLE
Use dictionary segmenter for word.

### DIFF
--- a/experimental/segmenter/src/complex.rs
+++ b/experimental/segmenter/src/complex.rs
@@ -1,0 +1,109 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use alloc::vec::Vec;
+use icu_provider::DataPayload;
+
+use crate::language::*;
+use crate::provider::*;
+use crate::DictionarySegmenter;
+
+// Use the LSTM when the feature is enabled.
+#[cfg(feature = "lstm")]
+use crate::lstm::{get_best_lstm_model, LstmSegmenter};
+
+/// Return UTF-16 segment offset array using dictionary or lstm segmenter.
+pub fn complex_language_segment_utf16(
+    payload: &DataPayload<UCharDictionaryBreakDataV1Marker>,
+    input: &[u16],
+) -> Vec<usize> {
+    let mut result: Vec<usize> = Vec::new();
+    let lang_iter = LanguageIteratorUtf16::new(input);
+    let mut offset = 0;
+    for str_per_lang in lang_iter {
+        #[cfg(feature = "lstm")]
+        {
+            if let Some(model) = get_best_lstm_model(str_per_lang[0] as u32) {
+                if let Ok(segmenter) = LstmSegmenter::try_new(model) {
+                    let breaks = segmenter.segment_utf16(&str_per_lang);
+                    let mut r: Vec<usize> = breaks.map(|n| offset + n).collect();
+                    result.append(&mut r);
+                    offset += str_per_lang.len();
+                    result.push(offset);
+                    continue;
+                }
+            }
+        }
+
+        // TODO:
+        // To support multiple dictionary, we have to pass multiple payloads per language.
+        if let Ok(segmenter) = DictionarySegmenter::try_new(payload) {
+            let breaks = segmenter.segment_utf16(&str_per_lang);
+            let mut r: Vec<usize> = breaks.map(|n| offset + n).collect();
+            result.append(&mut r);
+            offset += str_per_lang.len();
+            continue;
+        }
+
+        offset += str_per_lang.len();
+        result.push(offset);
+    }
+    result
+}
+
+/// Return UTF-8 segment offset array using dictionary or lstm segmenter.
+pub fn complex_language_segment_str(
+    payload: &DataPayload<UCharDictionaryBreakDataV1Marker>,
+    input: &str,
+) -> Vec<usize> {
+    let mut result: Vec<usize> = Vec::new();
+    let lang_iter = LanguageIterator::new(input);
+    let mut offset = 0;
+    for str_per_lang in lang_iter {
+        #[cfg(feature = "lstm")]
+        {
+            if let Some(model) = get_best_lstm_model(str_per_lang.chars().next().unwrap() as u32) {
+                if let Ok(segmenter) = LstmSegmenter::try_new(model) {
+                    let breaks = segmenter.segment_str(&str_per_lang);
+                    let mut r: Vec<usize> = breaks.map(|n| offset + n).collect();
+                    result.append(&mut r);
+                    offset += str_per_lang.chars().fold(0, |n, c| n + c.len_utf8());
+                    result.push(offset);
+                    continue;
+                }
+            }
+        }
+
+        // TODO:
+        // To support multiple dictionary, we have to pass multiple payloads per language.
+        if let Ok(segmenter) = DictionarySegmenter::try_new(payload) {
+            let breaks = segmenter.segment_str(&str_per_lang);
+            let mut r: Vec<usize> = breaks.map(|n| offset + n).collect();
+            result.append(&mut r);
+            offset += str_per_lang.chars().fold(0, |n, c| n + c.len_utf8());
+            continue;
+        }
+
+        offset += str_per_lang.chars().fold(0, |n, c| n + c.len_utf8());
+        result.push(offset);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thai_word_break() {
+        const TEST_STR: &str = "ภาษาไทยภาษาไทย";
+        let payload = Default::default();
+        let breaks = complex_language_segment_str(&payload, TEST_STR);
+        assert_eq!(breaks, [12, 21, 33, 42], "Thai test by UTF-8");
+
+        let utf16: Vec<u16> = TEST_STR.encode_utf16().collect();
+        let breaks = complex_language_segment_utf16(&payload, &utf16);
+        assert_eq!(breaks, [4, 7, 11, 14], "Thai test by UTF-16");
+    }
+}

--- a/experimental/segmenter/src/grapheme.rs
+++ b/experimental/segmenter/src/grapheme.rs
@@ -46,6 +46,7 @@ impl GraphemeClusterBreakSegmenter {
             current_pos_data: None,
             result_cache: Vec::new(),
             data: self.payload.get(),
+            dictionary_payload: None,
         }
     }
 
@@ -60,6 +61,7 @@ impl GraphemeClusterBreakSegmenter {
             current_pos_data: None,
             result_cache: Vec::new(),
             data: self.payload.get(),
+            dictionary_payload: None,
         }
     }
 
@@ -74,6 +76,7 @@ impl GraphemeClusterBreakSegmenter {
             current_pos_data: None,
             result_cache: Vec::new(),
             data: self.payload.get(),
+            dictionary_payload: None,
         }
     }
 }

--- a/experimental/segmenter/src/lib.rs
+++ b/experimental/segmenter/src/lib.rs
@@ -136,6 +136,7 @@
 
 extern crate alloc;
 
+mod complex;
 mod dictionary;
 mod indices;
 mod language;
@@ -156,18 +157,6 @@ extern crate lazy_static;
 // Use the LSTM when the feature is enabled.
 #[cfg(feature = "lstm")]
 mod lstm;
-
-// No-op functions when LSTM is disabled.
-#[cfg(not(feature = "lstm"))]
-mod lstm {
-    use alloc::vec::Vec;
-    pub fn get_line_break_utf16(_: &[u16]) -> Option<Vec<usize>> {
-        None
-    }
-    pub fn get_line_break_utf8(_: &str) -> Option<Vec<usize>> {
-        None
-    }
-}
 
 pub use crate::dictionary::{DictionaryBreakIterator, DictionarySegmenter};
 pub use crate::grapheme::{

--- a/experimental/segmenter/src/lstm.rs
+++ b/experimental/segmenter/src/lstm.rs
@@ -6,8 +6,8 @@ use crate::language::*;
 
 use alloc::string::String;
 use alloc::string::ToString;
-use alloc::vec::Vec;
 use core::char::decode_utf16;
+use icu_provider::DataError;
 use icu_provider::DataPayload;
 use icu_segmenter_lstm::lstm::Lstm;
 use icu_segmenter_lstm::structs;
@@ -28,20 +28,18 @@ lazy_static! {
 }
 
 // LSTM model depends on language, So we have to switch models per language.
-fn get_best_lstm_model(codepoint: u32) -> Lstm {
-    // TODO:
-    // DataPayLoad isn't thread safe. We need anything static version.
+pub fn get_best_lstm_model(codepoint: u32) -> Option<DataPayload<structs::LstmDataMarker>> {
     let lang = get_language(codepoint);
     match lang {
-        Language::Thai => Lstm::try_new(DataPayload::from_owned(THAI_LSTM.clone())).unwrap(),
-        Language::Burmese => Lstm::try_new(DataPayload::from_owned(BURMESE_LSTM.clone())).unwrap(),
-        _ => panic!("Unsupported"),
+        Language::Thai => Some(DataPayload::from_owned(THAI_LSTM.clone())),
+        Language::Burmese => Some(DataPayload::from_owned(BURMESE_LSTM.clone())),
+        _ => None,
     }
 }
 
 // A word break iterator using LSTM model. Input string have to be same language.
 
-struct LstmSegmenterIterator {
+pub struct LstmSegmenterIterator {
     input: String,
     bies_str: String,
     pos: usize,
@@ -75,7 +73,7 @@ impl LstmSegmenterIterator {
     }
 }
 
-struct LstmSegmenterIteratorUtf16 {
+pub struct LstmSegmenterIteratorUtf16 {
     bies_str: String,
     pos: usize,
 }
@@ -96,8 +94,11 @@ impl Iterator for LstmSegmenterIteratorUtf16 {
 }
 
 impl LstmSegmenterIteratorUtf16 {
-    pub fn new(lstm: &Lstm, input: &str) -> Self {
-        let lstm_output = lstm.word_segmenter(input);
+    pub fn new(lstm: &Lstm, input: &[u16]) -> Self {
+        let input: String = decode_utf16(input.iter().cloned())
+            .map(|r| r.unwrap())
+            .collect();
+        let lstm_output = lstm.word_segmenter(&input);
         Self {
             bies_str: lstm_output,
             pos: 0,
@@ -105,81 +106,48 @@ impl LstmSegmenterIteratorUtf16 {
     }
 }
 
-pub fn get_line_break_utf8(input: &str) -> Option<Vec<usize>> {
-    let mut result: Vec<usize> = Vec::new();
-    let mut lang_iter = LanguageIterator::new(input);
-    let mut offset = 0;
-    loop {
-        let str_per_lang = lang_iter.next();
-        if str_per_lang.is_none() {
-            break;
-        }
-        if offset != 0 {
-            result.push(offset);
-        }
-
-        let str_per_lang = str_per_lang.unwrap();
-        let lstm = get_best_lstm_model(str_per_lang.chars().next().unwrap() as u32);
-        let lstm_iter = LstmSegmenterIterator::new(&lstm, &str_per_lang);
-        let mut r: Vec<usize> = lstm_iter.map(|n| offset + n).collect();
-        result.append(&mut r);
-        offset += str_per_lang.len();
-    }
-    if result.is_empty() {
-        return None;
-    }
-    Some(result)
+pub struct LstmSegmenter {
+    lstm: Lstm,
 }
 
-pub fn get_line_break_utf16(input: &[u16]) -> Option<Vec<usize>> {
-    let s: String = decode_utf16(input.iter().cloned())
-        .map(|r| r.unwrap())
-        .collect();
-    let mut result: Vec<usize> = Vec::new();
-    let mut offset = 0;
-    for str_per_lang in LanguageIterator::new(&s) {
-        if offset != 0 {
-            // language break
-            result.push(offset);
-        }
+impl LstmSegmenter {
+    pub fn try_new(payload: DataPayload<structs::LstmDataMarker>) -> Result<Self, DataError> {
+        let lstm = Lstm::try_new(payload).unwrap();
 
-        let lstm = get_best_lstm_model(str_per_lang.chars().next().unwrap() as u32);
-        let lstm_iter = LstmSegmenterIteratorUtf16::new(&lstm, &str_per_lang);
-        let mut r: Vec<usize> = lstm_iter.map(|n| offset + n).collect();
-        result.append(&mut r);
-        offset += str_per_lang.chars().fold(0, |n, c| n + c.len_utf16());
+        Ok(Self { lstm })
     }
-    if result.is_empty() {
-        return None;
+
+    /// Create a dictionary based break iterator for an `str` (a UTF-8 string).
+    pub fn segment_str<'s>(&self, input: &str) -> LstmSegmenterIterator {
+        LstmSegmenterIterator::new(&self.lstm, input)
     }
-    Some(result)
+
+    /// Create a dictionary based break iterator for a UTF-16 string.
+    pub fn segment_utf16<'s>(&self, input: &[u16]) -> LstmSegmenterIteratorUtf16 {
+        LstmSegmenterIteratorUtf16::new(&self.lstm, &input)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::lstm::get_line_break_utf16;
-    use crate::lstm::get_line_break_utf8;
+    use crate::lstm::*;
 
     #[test]
     fn thai_word_break() {
         const TEST_STR: &str = "ภาษาไทยภาษาไทย";
 
-        let breaks = get_line_break_utf8(TEST_STR);
-        assert_eq!(breaks.unwrap(), [12, 21, 33], "Thai test");
-    }
+        let payload = get_best_lstm_model(TEST_STR.chars().next().unwrap() as u32).unwrap();
+        let segmenter = LstmSegmenter::try_new(payload).unwrap();
+        let breaks: Vec<usize> = segmenter.segment_str(TEST_STR).collect();
+        assert_eq!(breaks, [12, 21, 33], "Thai test");
 
-    #[test]
-    fn thai_word_break_utf16() {
-        let text: [u16; 14] = [
-            0x0e20, 0x0e32, 0x0e29, 0x0e32, 0x0e44, 0x0e17, 0x0e22, 0x0e20, 0x0e32, 0x0e29, 0x0e32,
-            0x0e44, 0x0e17, 0x0e22,
-        ];
-        let breaks = get_line_break_utf16(&text);
-        assert_eq!(breaks.unwrap(), [4, 7, 11], "Thai test");
+        let utf16: Vec<u16> = TEST_STR.encode_utf16().collect();
+        let breaks: Vec<usize> = segmenter.segment_utf16(&utf16).collect();
+        assert_eq!(breaks, [4, 7, 11], "Thai test");
 
-        let text: [u16; 4] = [0x0e20, 0x0e32, 0x0e29, 0x0e32];
-        let breaks = get_line_break_utf16(&text);
-        assert_eq!(breaks, None, "Thai test");
+        //let utf16: [u16; 4] = [0x0e20, 0x0e32, 0x0e29, 0x0e32];
+        //let breaks: Vec<usize> = segmenter.segment_utf16(&utf16).collect();
+        //assert_eq!(breaks, [4], "Thai test");
     }
 
     #[test]
@@ -187,35 +155,15 @@ mod tests {
         // "Burmese Language" in Burmese
         const TEST_STR: &str = "မြန်မာဘာသာစကား";
 
-        let breaks = get_line_break_utf8(TEST_STR);
+        let payload = get_best_lstm_model(TEST_STR.chars().next().unwrap() as u32).unwrap();
+        let segmenter = LstmSegmenter::try_new(payload).unwrap();
+        let breaks: Vec<usize> = segmenter.segment_str(TEST_STR).collect();
         // LSTM model breaks more characters, but it is better to return [30].
-        assert_eq!(breaks.unwrap(), [12, 18, 30], "Burmese test");
-    }
+        assert_eq!(breaks, [12, 18, 30], "Burmese test");
 
-    #[test]
-    fn burmese_word_break_utf16() {
-        // "Burmese Language" in Burmese
-        let text: [u16; 14] = [
-            0x1019, 0x103c, 0x1014, 0x103a, 0x1019, 0x102c, 0x1018, 0x102c, 0x101e, 0x102c, 0x1005,
-            0x1000, 0x102c, 0x1038,
-        ];
-        let breaks = get_line_break_utf16(&text);
+        let utf16: Vec<u16> = TEST_STR.encode_utf16().collect();
+        let breaks: Vec<usize> = segmenter.segment_utf16(&utf16).collect();
         // LSTM model breaks more characters, but it is better to return [10].
-        assert_eq!(breaks.unwrap(), [4, 6, 10], "Burmese utf-16 test");
-    }
-
-    #[test]
-    fn combined_word_break() {
-        const TEST_STR_THAI: &str = "ภาษาไทยภาษาไทย";
-        const TEST_STR_BURMESE: &str = "ဗမာနွယ်ဘာသာစကားမျာ";
-        let mut sample = String::from(TEST_STR_THAI);
-        sample.push_str(TEST_STR_BURMESE);
-
-        let breaks = get_line_break_utf8(&sample);
-        assert_eq!(
-            breaks.unwrap(),
-            [12, 21, 33, 42, 51, 63, 75, 87],
-            "Combined test"
-        );
+        assert_eq!(breaks, [4, 6, 10], "Burmese utf-16 test");
     }
 }

--- a/experimental/segmenter/src/lstm.rs
+++ b/experimental/segmenter/src/lstm.rs
@@ -118,13 +118,13 @@ impl LstmSegmenter {
     }
 
     /// Create a dictionary based break iterator for an `str` (a UTF-8 string).
-    pub fn segment_str<'s>(&self, input: &str) -> LstmSegmenterIterator {
+    pub fn segment_str(&self, input: &str) -> LstmSegmenterIterator {
         LstmSegmenterIterator::new(&self.lstm, input)
     }
 
     /// Create a dictionary based break iterator for a UTF-16 string.
-    pub fn segment_utf16<'s>(&self, input: &[u16]) -> LstmSegmenterIteratorUtf16 {
-        LstmSegmenterIteratorUtf16::new(&self.lstm, &input)
+    pub fn segment_utf16(&self, input: &[u16]) -> LstmSegmenterIteratorUtf16 {
+        LstmSegmenterIteratorUtf16::new(&self.lstm, input)
     }
 }
 

--- a/experimental/segmenter/src/rule_segmenter.rs
+++ b/experimental/segmenter/src/rule_segmenter.rs
@@ -4,6 +4,8 @@
 
 use crate::provider::RuleBreakDataV1;
 use crate::symbols::*;
+use crate::UCharDictionaryBreakDataV1Marker;
+use icu_provider::DataPayload;
 
 /// A trait allowing for RuleBreakIterator to be generalized to multiple string
 /// encoding methods and granularity such as grapheme cluster, word, etc.
@@ -37,6 +39,7 @@ pub struct RuleBreakIterator<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> {
     pub(crate) current_pos_data: Option<(usize, Y::CharType)>,
     pub(crate) result_cache: alloc::vec::Vec<usize>,
     pub(crate) data: &'l RuleBreakDataV1<'l>,
+    pub(crate) dictionary_payload: Option<&'l DataPayload<UCharDictionaryBreakDataV1Marker>>,
 }
 
 impl<'l, 's, Y: RuleBreakType<'l, 's>> Iterator for RuleBreakIterator<'l, 's, Y> {

--- a/experimental/segmenter/src/sentence.rs
+++ b/experimental/segmenter/src/sentence.rs
@@ -44,6 +44,7 @@ impl SentenceBreakSegmenter {
             current_pos_data: None,
             result_cache: Vec::new(),
             data: self.payload.get(),
+            dictionary_payload: None,
         }
     }
 
@@ -58,6 +59,7 @@ impl SentenceBreakSegmenter {
             current_pos_data: None,
             result_cache: Vec::new(),
             data: self.payload.get(),
+            dictionary_payload: None,
         }
     }
 
@@ -69,6 +71,7 @@ impl SentenceBreakSegmenter {
             current_pos_data: None,
             result_cache: Vec::new(),
             data: self.payload.get(),
+            dictionary_payload: None,
         }
     }
 }

--- a/experimental/segmenter/src/word.rs
+++ b/experimental/segmenter/src/word.rs
@@ -8,27 +8,10 @@ use alloc::vec::Vec;
 use core::str::CharIndices;
 use icu_provider::prelude::*;
 
+use crate::complex::*;
 use crate::indices::{Latin1Indices, Utf16Indices};
-use crate::lstm::get_line_break_utf16;
-use crate::lstm::get_line_break_utf8;
 use crate::provider::*;
 use crate::rule_segmenter::*;
-
-fn get_complex_language_break(input: &[u16]) -> Vec<usize> {
-    if let Some(mut ret) = get_line_break_utf16(input) {
-        ret.push(input.len());
-        return ret;
-    }
-    [input.len()].to_vec()
-}
-
-fn get_complex_language_break_utf8(input: &str) -> Vec<usize> {
-    if let Some(mut ret) = get_line_break_utf8(input) {
-        ret.push(input.len());
-        return ret;
-    }
-    [input.len()].to_vec()
-}
 
 /// Word break iterator for an `str` (a UTF-8 string).
 pub type WordBreakIterator<'l, 's> = RuleBreakIterator<'l, 's, WordBreakType>;
@@ -43,17 +26,30 @@ pub type WordBreakIteratorUtf16<'l, 's> = RuleBreakIterator<'l, 's, WordBreakTyp
 /// encodings. Please see the [module-level documentation](crate) for its usages.
 pub struct WordBreakSegmenter {
     payload: DataPayload<WordBreakDataV1Marker>,
+    dictionary_payload: DataPayload<UCharDictionaryBreakDataV1Marker>,
 }
 
 impl WordBreakSegmenter {
     pub fn try_new<D>(provider: &D) -> Result<Self, DataError>
     where
-        D: ResourceProvider<WordBreakDataV1Marker> + ?Sized,
+        D: ResourceProvider<WordBreakDataV1Marker>
+            + ResourceProvider<UCharDictionaryBreakDataV1Marker>
+            + ?Sized,
     {
         let payload = provider
             .load_resource(&DataRequest::default())?
             .take_payload()?;
-        Ok(Self { payload })
+
+        // TODO: Use `provider` parameter after we support loading dictionary data from the
+        // production-ready providers.
+        let inv_provider = icu_provider::inv::InvariantDataProvider;
+        let dictionary_payload = inv_provider
+            .load_resource(&DataRequest::default())?
+            .take_payload()?;
+        Ok(Self {
+            payload,
+            dictionary_payload,
+        })
     }
 
     /// Create a word break iterator for an `str` (a UTF-8 string).
@@ -64,6 +60,7 @@ impl WordBreakSegmenter {
             current_pos_data: None,
             result_cache: Vec::new(),
             data: self.payload.get(),
+            dictionary_payload: Some(&self.dictionary_payload),
         }
     }
 
@@ -75,6 +72,7 @@ impl WordBreakSegmenter {
             current_pos_data: None,
             result_cache: Vec::new(),
             data: self.payload.get(),
+            dictionary_payload: None,
         }
     }
 
@@ -86,6 +84,7 @@ impl WordBreakSegmenter {
             current_pos_data: None,
             result_cache: Vec::new(),
             data: self.payload.get(),
+            dictionary_payload: Some(&self.dictionary_payload),
         }
     }
 }
@@ -123,7 +122,7 @@ impl<'l, 's> RuleBreakType<'l, 's> for WordBreakType {
         // Restore iterator to move to head of complex string
         iter.iter = start_iter;
         iter.current_pos_data = start_point;
-        let breaks = get_complex_language_break_utf8(&s);
+        let breaks = complex_language_segment_str(iter.dictionary_payload?, &s);
         iter.result_cache = breaks;
         let mut i = iter.current_pos_data.unwrap().1.len_utf8();
         loop {
@@ -197,7 +196,7 @@ impl<'l, 's> RuleBreakType<'l, 's> for WordBreakTypeUtf16 {
         // Restore iterator to move to head of complex string
         iter.iter = start_iter;
         iter.current_pos_data = start_point;
-        let breaks = get_complex_language_break(&s);
+        let breaks = complex_language_segment_utf16(iter.dictionary_payload?, &s);
         let mut i = 1;
         iter.result_cache = breaks;
         // result_cache vector is utf-16 index that is in BMP.

--- a/experimental/segmenter_lstm/Cargo.toml
+++ b/experimental/segmenter_lstm/Cargo.toml
@@ -27,6 +27,7 @@ include = [
 icu_provider = { version = "0.6", path = "../../provider/core", features = ["macros"] }
 litemap = { version = "0.4.0", path = "../../utils/litemap", features = ["serde_serialize"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
+serde_json = { version = "1.0", default-features = false, features = ["std"] }
 ndarray = { version = "0.15", features = ["serde"] }
 unicode-segmentation = "1.3.0"
 yoke = { version = "0.5.0", path = "../../utils/yoke", features = ["serde", "derive"] }

--- a/experimental/segmenter_lstm/src/structs.rs
+++ b/experimental/segmenter_lstm/src/structs.rs
@@ -44,3 +44,12 @@ pub struct LstmData<'data> {
     #[zerofrom(clone)]
     pub mat9: Array1<f32>,
 }
+
+impl<'data> Default for LstmData<'data> {
+    fn default() -> Self {
+        const THAI_MODEL: &[u8; 373466] =
+            include_bytes!("../../segmenter/tests/testdata/json/core/segmenter_lstm@1/th.json");
+
+        serde_json::from_slice(THAI_MODEL).expect("JSON syntax error")
+    }
+}


### PR DESCRIPTION
I would like to merge LSTM segmeter and dictionary segmenter.  `complex_language_segment_utf16` and `complex_language_segment_utf8` will use both segmenter for each language. Actually dictionary segmenter uses Thai dictionary only for this complex segmenter now. (What good way to use multiple payload?, but I don't resolve this issue yet.)