### PR TITLE
Remove implicit `Sized` bounds on some type bounds

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -257,7 +257,7 @@ impl AnyCalendar {
         provider: &P,
     ) -> Result<Self, DataError>
     where
-        P: AnyProvider,
+        P: AnyProvider + ?Sized,
     {
         Ok(match kind {
             AnyCalendarKind::Gregorian => AnyCalendar::Gregorian(Gregorian),
@@ -283,7 +283,7 @@ impl AnyCalendar {
         provider: &P,
     ) -> Result<Self, DataError>
     where
-        P: BufferProvider,
+        P: BufferProvider + ?Sized,
     {
         Ok(match kind {
             AnyCalendarKind::Gregorian => AnyCalendar::Gregorian(Gregorian),
@@ -308,7 +308,7 @@ impl AnyCalendar {
     #[cfg(feature = "serde")]
     pub fn try_new_unstable<P>(kind: AnyCalendarKind, provider: &P) -> Result<Self, DataError>
     where
-        P: ResourceProvider<provider::JapaneseErasV1Marker>,
+        P: ResourceProvider<provider::JapaneseErasV1Marker> + ?Sized,
     {
         Ok(match kind {
             AnyCalendarKind::Gregorian => AnyCalendar::Gregorian(Gregorian),

--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -88,7 +88,8 @@ impl<C: CldrCalendar> DateTimeFormat<C> {
             + ResourceProvider<DatePatternsV1Marker>
             + ResourceProvider<DateSkeletonPatternsV1Marker>
             + ResourceProvider<OrdinalV1Marker>
-            + ResourceProvider<WeekDataV1Marker>,
+            + ResourceProvider<WeekDataV1Marker>
+            + ?Sized,
     {
         let mut locale = locale.into();
         // TODO(#419): Resolve the locale calendar with the API calendar.

--- a/components/datetime/src/provider/date_time.rs
+++ b/components/datetime/src/provider/date_time.rs
@@ -64,15 +64,15 @@ fn pattern_for_date_length_inner(data: DatePatternsV1, length: length::Date) -> 
     PatternPlurals::from(pattern)
 }
 
-pub struct PatternSelector<'a, D> {
+pub struct PatternSelector<'a, D: ?Sized> {
     data_provider: &'a D,
     locale: &'a Locale,
 }
 
 // Manual impls needed since `derive(Copy)` inserts
 // a `D: Copy` bound
-impl<D> Copy for PatternSelector<'_, D> {}
-impl<D> Clone for PatternSelector<'_, D> {
+impl<D: ?Sized> Copy for PatternSelector<'_, D> {}
+impl<D: ?Sized> Clone for PatternSelector<'_, D> {
     fn clone(&self) -> Self {
         *self
     }
@@ -80,7 +80,9 @@ impl<D> Clone for PatternSelector<'_, D> {
 
 impl<D> PatternSelector<'_, D>
 where
-    D: ResourceProvider<DatePatternsV1Marker> + ResourceProvider<DateSkeletonPatternsV1Marker>,
+    D: ResourceProvider<DatePatternsV1Marker>
+        + ResourceProvider<DateSkeletonPatternsV1Marker>
+        + ?Sized,
 {
     pub(crate) fn for_options<'a>(
         data_provider: &'a D,

--- a/components/datetime/src/raw/datetime.rs
+++ b/components/datetime/src/raw/datetime.rs
@@ -49,7 +49,8 @@ impl DateTimeFormat {
             + ResourceProvider<DatePatternsV1Marker>
             + ResourceProvider<DateSkeletonPatternsV1Marker>
             + ResourceProvider<OrdinalV1Marker>
-            + ResourceProvider<WeekDataV1Marker>,
+            + ResourceProvider<WeekDataV1Marker>
+            + ?Sized,
     {
         let patterns =
             provider::date_time::PatternSelector::for_options(data_provider, &locale, options)?;

--- a/components/datetime/src/raw/zoned_datetime.rs
+++ b/components/datetime/src/raw/zoned_datetime.rs
@@ -51,7 +51,8 @@ impl ZonedDateTimeFormat {
         DP: ResourceProvider<DateSymbolsV1Marker>
             + ResourceProvider<DatePatternsV1Marker>
             + ResourceProvider<DateSkeletonPatternsV1Marker>
-            + ResourceProvider<WeekDataV1Marker>,
+            + ResourceProvider<WeekDataV1Marker>
+            + ?Sized,
         ZP: ResourceProvider<provider::time_zones::TimeZoneFormatsV1Marker>
             + ResourceProvider<provider::time_zones::ExemplarCitiesV1Marker>
             + ResourceProvider<provider::time_zones::MetaZoneGenericNamesLongV1Marker>
@@ -59,7 +60,7 @@ impl ZonedDateTimeFormat {
             + ResourceProvider<provider::time_zones::MetaZoneSpecificNamesLongV1Marker>
             + ResourceProvider<provider::time_zones::MetaZoneSpecificNamesShortV1Marker>
             + ?Sized,
-        PP: ResourceProvider<OrdinalV1Marker>,
+        PP: ResourceProvider<OrdinalV1Marker> + ?Sized,
     {
         let patterns = provider::date_time::PatternSelector::for_options(
             date_provider,

--- a/components/datetime/src/zoned_datetime.rs
+++ b/components/datetime/src/zoned_datetime.rs
@@ -116,7 +116,8 @@ impl<C: CldrCalendar> ZonedDateTimeFormat<C> {
         DP: ResourceProvider<DateSymbolsV1Marker>
             + ResourceProvider<DatePatternsV1Marker>
             + ResourceProvider<DateSkeletonPatternsV1Marker>
-            + ResourceProvider<WeekDataV1Marker>,
+            + ResourceProvider<WeekDataV1Marker>
+            + ?Sized,
         ZP: ResourceProvider<provider::time_zones::TimeZoneFormatsV1Marker>
             + ResourceProvider<provider::time_zones::ExemplarCitiesV1Marker>
             + ResourceProvider<provider::time_zones::MetaZoneGenericNamesLongV1Marker>
@@ -124,7 +125,7 @@ impl<C: CldrCalendar> ZonedDateTimeFormat<C> {
             + ResourceProvider<provider::time_zones::MetaZoneSpecificNamesLongV1Marker>
             + ResourceProvider<provider::time_zones::MetaZoneSpecificNamesShortV1Marker>
             + ?Sized,
-        PP: ResourceProvider<OrdinalV1Marker>,
+        PP: ResourceProvider<OrdinalV1Marker> + ?Sized,
     {
         let mut locale = locale.into();
         // TODO(#419): Resolve the locale calendar with the API calendar.

--- a/provider/core/src/any.rs
+++ b/provider/core/src/any.rs
@@ -323,7 +323,7 @@ pub trait AsDowncastingAnyProvider {
 
 impl<P> AsDowncastingAnyProvider for P
 where
-    P: AnyProvider,
+    P: AnyProvider + ?Sized,
 {
     #[inline]
     fn as_downcasting(&self) -> DowncastingAnyProvider<P> {


### PR DESCRIPTION
Some functions had unnecessary implicit `Sized` bounds which made it impossible to pass a `&dyn ResourceProvider` as an argument. (https://github.com/boa-dev/boa/pull/2072/files#discussion_r884969345 for context)

This PR adds some missing `?Sized` clauses to several type bounds in order to relax the `Sized` requirement and allow trait objects as arguments.