### PR TITLE
Bump yoke to 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bincode",
  "serde",
@@ -3926,7 +3926,7 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/experimental/casemapping/Cargo.toml
+++ b/experimental/casemapping/Cargo.toml
@@ -28,7 +28,7 @@ icu_codepointtrie = { version = "0.4", path = "../../utils/codepointtrie" }
 icu_locid = { version = "0.6", path = "../../components/locid" }
 icu_provider = { version = "0.6", path = "../../provider/core", features = ["macros"] }
 icu_uniset = { version = "0.5", path = "../../utils/uniset" }
-yoke = { version = "0.5.0", path = "../../utils/yoke", features = ["derive"] }
+yoke = { version = "0.6.0", path = "../../utils/yoke", features = ["derive"] }
 zerovec = { version = "0.7", path = "../../utils/zerovec", features = ["yoke"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 crabbake = { path = "../../experimental/crabbake", optional = true, features = ["derive"]}

--- a/experimental/segmenter_lstm/Cargo.toml
+++ b/experimental/segmenter_lstm/Cargo.toml
@@ -29,7 +29,7 @@ litemap = { version = "0.4.0", path = "../../utils/litemap", features = ["serde"
 serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
 ndarray = { version = "0.15", features = ["serde"] }
 unicode-segmentation = "1.3.0"
-yoke = { version = "0.5.0", path = "../../utils/yoke", features =  ["derive"] }
+yoke = { version = "0.6.0", path = "../../utils/yoke", features =  ["derive"] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/provider/adapters/Cargo.toml
+++ b/provider/adapters/Cargo.toml
@@ -26,7 +26,7 @@ include = [
 [dependencies]
 icu_provider = { version = "0.6.0", path = "../core" }
 icu_locid = { version = "0.6.0", path = "../../components/locid" }
-yoke = { version = "0.5.0", path = "../../utils/yoke" }
+yoke = { version = "0.6.0", path = "../../utils/yoke" }
 
 [features]
 std = ["icu_locid/std"]

--- a/provider/blob/Cargo.toml
+++ b/provider/blob/Cargo.toml
@@ -31,7 +31,7 @@ icu_provider = { version = "0.6", path = "../core", features = ["deserialize_pos
 serde = { version = "1.0", default-features = false, features = ["alloc"] }
 postcard = { version = "0.7.0", default-features = false }
 writeable = { version = "0.4", path = "../../utils/writeable" }
-yoke = { version = "0.5.0", path = "../../utils/yoke" }
+yoke = { version = "0.6.0", path = "../../utils/yoke" }
 zerovec = { version = "0.7", path = "../../utils/zerovec", features = ["serde", "yoke"] }
 
 # For the export feature

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -55,7 +55,7 @@ datagen = ["dhat", "serde", "erased-serde", "crabbake", "std", "serde_json", "sy
 icu_locid = { version = "0.6", path = "../../components/locid" }
 writeable = { version = "0.4", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
-yoke = { version = "0.5.0", path = "../../utils/yoke", features = ["derive"] }
+yoke = { version = "0.6.0", path = "../../utils/yoke", features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../../utils/zerofrom", features = ["derive"] }
 zerovec = { version = "0.7.0", path = "../../utils/zerovec", features = ["derive"]}
 litemap = { version = "0.4.0", path = "../../utils/litemap" }

--- a/utils/codepointtrie/Cargo.toml
+++ b/utils/codepointtrie/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
 icu_uniset = { version = "0.5.0", path = "../uniset" }
-yoke = { version = "0.5.0", path = "../yoke", features = ["derive"] }
+yoke = { version = "0.6.0", path = "../yoke", features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../zerofrom", features = ["derive"] }
 zerovec = { version = "0.7", path = "../zerovec", features = ["yoke"] }
 

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -29,7 +29,7 @@ all-features = true
 
 [dependencies]
 serde = {version = "1", optional = true, default-features = false, features = ["alloc"]}
-yoke = { version = "0.5.0", path = "../yoke", features = ["derive"], optional = true }
+yoke = { version = "0.6.0", path = "../yoke", features = ["derive"], optional = true }
 
 [dev-dependencies]
 serde = "1"

--- a/utils/uniset/Cargo.toml
+++ b/utils/uniset/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 tinystr = { path = "../tinystr", version = "0.6.0", features = ["alloc"], default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
-yoke = { version = "0.5.0", path = "../yoke", features = ["derive"] }
+yoke = { version = "0.6.0", path = "../yoke", features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../zerofrom", features = ["derive"] }
 zerovec = { version = "0.7", path = "../zerovec", features = ["yoke"] }
 crabbake = { version = "0.4", path = "../../experimental/crabbake", features = ["derive"], optional = true }

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "yoke"
-version = "0.5.0"
+version = "0.6.0"
 description = "Abstraction allowing borrowed data to be carried along with the backing data it borrows from"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2018"
@@ -32,7 +32,7 @@ all-features = true
 [dependencies]
 stable_deref_trait = { version = "1.2.0", features = ["alloc"], default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
-yoke-derive = { path = "./derive", version = "0.5.0", optional = true }
+yoke-derive = { path = "./derive", version = "0.6.0", optional = true }
 zerofrom = { path = "../zerofrom", version = "0.1.0", default-features = false, optional = true} 
 
 [dev-dependencies]

--- a/utils/yoke/derive/Cargo.toml
+++ b/utils/yoke/derive/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "yoke-derive"
-version = "0.5.0"
+version = "0.6.0"
 description = "Custom derive for the yoke crate"
 repository = "https://github.com/unicode-org/icu4x"
 license-file = "LICENSE"
@@ -26,5 +26,5 @@ syn = { version = "1.0.73", features = ["derive", "fold"] }
 synstructure = "0.12.4"
 
 [dev-dependencies]
-yoke = { version = "0.5.0", path = "..", features = ["derive"]}
+yoke = { version = "0.6.0", path = "..", features = ["derive"]}
 zerovec = { version = "0.7", path = "../../zerovec", features = ["yoke"] }

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -27,7 +27,7 @@ all-features = true
 
 [dependencies]
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
-yoke = { version = "0.5.0", path = "../yoke", optional = true }
+yoke = { version = "0.6.0", path = "../yoke", optional = true }
 zerofrom = { version = "0.1.0", path = "../zerofrom" }
 zerovec-derive = {version = "0.6.0", path = "./derive", optional = true}
 crabbake = { version = "0.4", path = "../../experimental/crabbake", features = ["derive"], optional = true }
@@ -44,7 +44,7 @@ rand = "0.8"
 rand_pcg = "0.3"
 rand_distr = "0.4"
 getrandom = { version = "0.2", features = ["js"] }
-yoke = { version = "0.5.0", path = "../yoke", features = ["derive"] }
+yoke = { version = "0.6.0", path = "../yoke", features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../zerofrom", features = ["derive"] }
 
 [features]


### PR DESCRIPTION
Main breaking change is the `project` -> `map_project` renaming, but also a lot of the `_badly` methods have been deprecated now.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->