### PR TITLE
Parse POSIX time-zone strings using Combine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "console"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1725,6 +1735,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "icu_provider_tzif"
+version = "0.1.0"
+dependencies = [
+ "combine",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "experimental/normalizer",
     "experimental/segmenter",
     "experimental/segmenter_lstm",
+    "experimental/tzif",
     "ffi/capi_cdylib",
     "ffi/diplomat",
     "ffi/capi_staticlib",

--- a/experimental/tzif/Cargo.toml
+++ b/experimental/tzif/Cargo.toml
@@ -1,0 +1,17 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+[package]
+name = "icu_provider_tzif"
+author = ["The ICU4X Project Developers"]
+version = "0.1.0"
+edition = "2021"
+readme = "README.md"
+license-file = "LICENSE"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+combine = "4.6.4"
+

--- a/experimental/tzif/LICENSE
+++ b/experimental/tzif/LICENSE
@@ -1,0 +1,331 @@
+Except as otherwise noted below, ICU4X is licensed under the Apache
+License, Version 2.0 (included below) or the MIT license (included
+below), at your option. Unless importing data or code in the manner
+stated below, any contribution intentionally submitted for inclusion
+in ICU4X by you, as defined in the Apache-2.0 license, shall be dual
+licensed in the foregoing manner, without any additional terms or
+conditions.
+
+As exceptions to the above:
+* Portions of ICU4X that have been adapted from ICU4C and/or ICU4J are
+under the Unicode license (included below) and/or the ICU license
+(included below) as indicated by source code comments.
+* Unicode data incorporated in ICU4X is under the Unicode license
+(included below).
+* Your contributions may import code from ICU4C and/or ICU4J and
+Unicode data under these licenses. Indicate the license and the ICU4C
+or ICU4J origin in source code comments.
+
+- - - -
+
+Apache License, version 2.0
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+- - - -
+
+MIT License
+
+Copyright The ICU4X Authors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+- - - -
+
+Unicode License
+
+COPYRIGHT AND PERMISSION NOTICE (ICU 58 and later)
+
+Copyright © 1991-2020 Unicode, Inc. All rights reserved.
+Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Unicode data files and any associated documentation
+(the "Data Files") or Unicode software and any associated documentation
+(the "Software") to deal in the Data Files or Software
+without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, and/or sell copies of
+the Data Files or Software, and to permit persons to whom the Data Files
+or Software are furnished to do so, provided that either
+(a) this copyright and permission notice appear with all copies
+of the Data Files or Software, or
+(b) this copyright and permission notice appear in associated
+Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in these Data Files or Software without prior
+written authorization of the copyright holder.
+
+- - - -
+
+ICU License - ICU 1.8.1 to ICU 57.1
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright (c) 1995-2016 International Business Machines Corporation and others
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, and/or sell copies of the Software, and to permit persons
+to whom the Software is furnished to do so, provided that the above
+copyright notice(s) and this permission notice appear in all copies of
+the Software and that both the above copyright notice(s) and this
+permission notice appear in supporting documentation.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
+SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
+RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale, use
+or other dealings in this Software without prior written authorization
+of the copyright holder.
+
+All trademarks and registered trademarks mentioned herein are the
+property of their respective owners.
+
+- - - -

--- a/experimental/tzif/README.md
+++ b/experimental/tzif/README.md
@@ -1,0 +1,7 @@
+# icu_provider_tzif [![crates.io](https://img.shields.io/crates/v/icu_provider_tzif)](https://crates.io/crates/icu_provider_tzif)
+
+A parser for TZIF files inteded for use with the ICU4X DataProvider.
+
+## More Information
+
+For more information on development, authorship, contributing etc. please visit [`ICU4X home page`](https://github.com/unicode-org/icu4x).

--- a/experimental/tzif/src/data/mod.rs
+++ b/experimental/tzif/src/data/mod.rs
@@ -1,0 +1,10 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+/// Structs for holding data encoded by POSIX time-zone strings, as specified by
+/// <https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html>
+pub mod posix;
+
+/// Simple structs for keeping track of seconds, hours, and minutes with the type system.
+pub mod time;

--- a/experimental/tzif/src/data/posix.rs
+++ b/experimental/tzif/src/data/posix.rs
@@ -1,0 +1,70 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use super::time::Seconds;
+
+/// A struct to hold a time-zone variant name and its offset.
+/// The offset is how many hours must be added to the time to reach UTC.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZoneVariantInfo {
+    /// The name of the time-zone variant.
+    pub name: String,
+    /// The offset time in seconds that must be added to reach UTC.
+    pub offset: Seconds,
+}
+
+/// A struct to hold a DST transition date.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransitionDate {
+    /// The day on which the transition occurrs.
+    pub day: TransitionDay,
+    /// The time in seconds in which the transition occurrs.
+    pub time: Seconds,
+}
+
+/// A struct for defining a DST transition day.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransitionDay {
+    /// The day of the year, ignoring Feb. 29 on leap years. Designated by `Jn`.
+    ///
+    /// Ranges from [1, 365]
+    NoLeap(u16),
+
+    /// The day of the year, accounting for Feb. 29 on leap years. Designated by `n`.
+    ///
+    /// Ranges from [0, 365]
+    WithLeap(u16),
+
+    /// The month, week, day value. Designated by `M.w.d`.
+    ///
+    /// `M` ranges from [1, 12].
+    ///
+    /// `w` ranges from [1, 5].
+    ///
+    /// `d` ranges from [0, 6].
+    Mwd(u16, u16, u16),
+}
+
+/// A struct for holding DST transition info.
+#[derive(Debug, PartialEq, Eq)]
+pub struct DstTransitionInfo {
+    /// The zone variant info including name and offset.
+    pub variant_info: ZoneVariantInfo,
+
+    /// The DST transition start date.
+    pub start_date: TransitionDate,
+
+    /// The DST transition end date.
+    pub end_date: TransitionDate,
+}
+
+/// A struct for holding data encoded by a POSIX time-zone string.
+#[derive(Debug, PartialEq, Eq)]
+pub struct PosixTzString {
+    /// The variant info of the STD time-zone variant.
+    pub std_info: ZoneVariantInfo,
+
+    /// The variant info of the DST time-zone variant if present.
+    pub dst_info: Option<DstTransitionInfo>,
+}

--- a/experimental/tzif/src/data/time.rs
+++ b/experimental/tzif/src/data/time.rs
@@ -1,0 +1,47 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use std::ops::{Add, Sub};
+
+/// The seconds unit of time.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Seconds(pub i32);
+
+/// The minutes unit of time.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Minutes(pub i32);
+
+/// The hours unit of time.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Hours(pub i32);
+
+impl Add for Seconds {
+    type Output = Seconds;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Seconds(self.0 + rhs.0)
+    }
+}
+
+impl Sub for Seconds {
+    type Output = Seconds;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Seconds(self.0 - rhs.0)
+    }
+}
+
+impl Minutes {
+    /// Returns the number of minutes in seconds.
+    pub fn as_seconds(self) -> Seconds {
+        Seconds(self.0 * 60)
+    }
+}
+
+impl Hours {
+    /// Returns the number of hours in seconds.
+    pub fn as_seconds(self) -> Seconds {
+        Seconds(self.0 * 60 * 60)
+    }
+}

--- a/experimental/tzif/src/lib.rs
+++ b/experimental/tzif/src/lib.rs
@@ -6,3 +6,5 @@
 
 #![warn(missing_docs)]
 
+/// The parsed data representations.
+pub mod data;

--- a/experimental/tzif/src/lib.rs
+++ b/experimental/tzif/src/lib.rs
@@ -1,0 +1,8 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+//! A parser for TZIF files inteded for use with the ICU4X DataProvider.
+
+#![warn(missing_docs)]
+

--- a/experimental/tzif/src/lib.rs
+++ b/experimental/tzif/src/lib.rs
@@ -8,3 +8,6 @@
 
 /// The parsed data representations.
 pub mod data;
+
+/// The parser implementations.
+pub mod parse;

--- a/experimental/tzif/src/parse/mod.rs
+++ b/experimental/tzif/src/parse/mod.rs
@@ -1,0 +1,29 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use combine::parser::combinator::Either;
+use combine::parser::error::{unexpected_any, Unexpected};
+use combine::parser::token::Value;
+use combine::{value, Parser, Stream};
+
+/// Parser definition for POSIX time-zone strings as specified by
+/// <https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html>
+pub mod posix;
+
+/// Ensures that the predicate is [`true`], otherwise returns an error with the provided
+/// messages though combine's error machinery.
+fn ensure<Input: Stream, L>(
+    output: L,
+    predicate: impl FnOnce(&L) -> bool,
+    message: &'static str,
+) -> Either<Value<Input, L>, Unexpected<Input, L, &'static str>>
+where
+    L: Clone,
+{
+    if predicate(&output) {
+        value(output).left()
+    } else {
+        Parser::right(unexpected_any(message))
+    }
+}

--- a/experimental/tzif/src/parse/posix.rs
+++ b/experimental/tzif/src/parse/posix.rs
@@ -42,7 +42,7 @@ where
         byte(b'>'),
         many1::<Vec<u8>, _, _>(satisfy(|byte| byte != b'>')),
     )
-    .map(|name| dbg!(String::from_utf8_lossy(&name).to_string()))
+    .map(|name| String::from_utf8_lossy(&name).to_string())
 }
 
 /// The string specifies the name of the time zone variant. It must be three or more characters
@@ -71,7 +71,7 @@ where
     .then(|name| {
         ensure(
             name,
-            |name| dbg!(name).as_bytes()[0] != b':',
+            |name| name.as_bytes()[0] != b':',
             "zone variant name starts with a leading ':' but should not",
         )
     })

--- a/experimental/tzif/src/parse/posix.rs
+++ b/experimental/tzif/src/parse/posix.rs
@@ -654,9 +654,9 @@ mod test {
         assert_parse_err!(time(12), "00:00:60");
 
         // valid times
-        // assert_parse_eq!(time(12), "12", Seconds(12 * 60 * 60));
-        // assert_parse_eq!(time(12), "+12", Seconds(12 * 60 * 60));
-        // assert_parse_eq!(time(12), "-12", Seconds(-12 * 60 * 60));
+        assert_parse_eq!(time(12), "12", Seconds(12 * 60 * 60));
+        assert_parse_eq!(time(12), "+12", Seconds(12 * 60 * 60));
+        assert_parse_eq!(time(12), "-12", Seconds(-12 * 60 * 60));
         assert_parse_eq!(time(12), "12:15", Seconds(12 * 60 * 60 + 15 * 60));
         assert_parse_eq!(time(12), "-12:15", Seconds(-12 * 60 * 60 - 15 * 60));
         assert_parse_eq!(time(12), "12:30:15", Seconds(12 * 60 * 60 + 30 * 60 + 15));

--- a/experimental/tzif/src/parse/posix.rs
+++ b/experimental/tzif/src/parse/posix.rs
@@ -1,0 +1,906 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use super::ensure;
+use crate::data::posix::{
+    DstTransitionInfo, PosixTzString, TransitionDate, TransitionDay, ZoneVariantInfo,
+};
+use crate::data::time::{Hours, Minutes, Seconds};
+use combine::parser::byte::{byte, digit};
+use combine::{between, choice, many, many1, optional, satisfy, value, ParseError, Parser, Stream};
+
+/// Parses a byte that not a digit, a comma, a plus nor a minus signs.
+fn aplhabetic_zone_variant_name_value<Input>() -> impl Parser<Input, Output = u8>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    satisfy(|byte: u8| {
+        byte.is_ascii_alphabetic() && !matches!(byte, b',' | b'+' | b'-' | b'0'..=b'9')
+    })
+}
+
+/// Parses a string that specifies the name of the time zone variant.
+/// It must not contain embedded digits, commas, nor plus and minus signs.
+fn alphabetic_zone_variant_name<Input>() -> impl Parser<Input, Output = String>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    many(aplhabetic_zone_variant_name_value())
+        .map(|bytes: Vec<u8>| String::from_utf8_lossy(&bytes).to_string())
+}
+
+/// Parses an arbitrary time-zone variant name. This name must be enclosed in angled brackets, e.g. `<name>`.
+fn arbitrary_zone_variant_name<Input>() -> impl Parser<Input, Output = String>
+where
+    Input: Stream<Token = u8>,
+{
+    between(
+        byte(b'<'),
+        byte(b'>'),
+        many1::<Vec<u8>, _, _>(satisfy(|byte| byte != b'>')),
+    )
+    .map(|name| dbg!(String::from_utf8_lossy(&name).to_string()))
+}
+
+/// The string specifies the name of the time zone variant. It must be three or more characters
+/// long and must not contain a leading colon.
+///
+/// The name must not contain embedded digits, commas, plus nor minus signs unless it is specified
+/// as an arbitrary name surrounded by angled brackets, e.g. `<name>`
+///
+/// The angled brackets will not show up in the parsed name.
+fn zone_variant_name<Input>() -> impl Parser<Input, Output = String>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    choice((
+        arbitrary_zone_variant_name(),
+        alphabetic_zone_variant_name(),
+    ))
+    .then(|name| {
+        ensure(
+            name,
+            |name| name.len() >= 3,
+            "zone variant name has as length of less than 3 characters",
+        )
+    })
+    .then(|name| {
+        ensure(
+            name,
+            |name| dbg!(name).as_bytes()[0] != b':',
+            "zone variant name starts with a leading ':' but should not",
+        )
+    })
+}
+
+/// Parses a plus or minus sign.
+fn sign<Input>() -> impl Parser<Input, Output = u8>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    byte(b'+').or(byte(b'-'))
+}
+
+/// Parses one ore more digits.
+fn digits<Input>() -> impl Parser<Input, Output = Vec<u8>>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    many1(digit())
+}
+
+/// Parses a natural number as an i32.
+fn natural<Input>() -> impl Parser<Input, Output = i32>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    digits().map(|digits| {
+        digits
+            .into_iter()
+            .map(|digit| (digit - b'0') as i32)
+            .rev()
+            .zip(0u32..)
+            .map(|(digit, n)| digit * 10i32.pow(n))
+            .sum::<i32>()
+    })
+}
+
+/// Parses a natural number as an i32 and esnures that it falls within `[lower_bound, upper_bound]`.
+fn bounded_natural<Input>(lower_bound: i32, upper_bound: i32) -> impl Parser<Input, Output = i32>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    assert!(
+        lower_bound <= upper_bound,
+        "lower bound {lower_bound} was not less than or equal, upper bound {upper_bound}"
+    );
+    natural().then(move |natural| {
+        ensure(
+            natural,
+            |&natural| lower_bound <= natural && natural <= upper_bound,
+            "natural number was out of bounds",
+        )
+    })
+}
+
+/// Parses an integer as an i32 and esnures that it falls within `[lower_bound, upper_bound]`.
+fn bounded_integer<Input>(lower_bound: i32, upper_bound: i32) -> impl Parser<Input, Output = i32>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    assert!(
+        lower_bound <= upper_bound,
+        "lower bound {lower_bound} was not less than or equal, upper bound {upper_bound}"
+    );
+    (optional(sign()), natural())
+        .map(|(sign, natural)| natural * if matches!(sign, Some(b'-')) { -1 } else { 1 })
+        .then(move |integer| {
+            ensure(
+                integer,
+                |&integer| lower_bound <= integer && integer <= upper_bound,
+                "integer was out of bounds",
+            )
+        })
+}
+
+/// Parses an integer as [`Hours`] and ensures that it falls within `[-bound, bound]`.
+fn hours<Input>(bound: i32) -> impl Parser<Input, Output = Hours>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    bounded_integer(-bound, bound).map(Hours)
+}
+
+/// Parses an integer as [`Minutes`] and ensures that it falls within `[0, 59]`.
+fn minutes<Input>() -> impl Parser<Input, Output = Minutes>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    bounded_natural(0, 59).map(Minutes)
+}
+
+/// Parses an integer as [`Seconds`] and ensures that it falls within `[0, 59]`.
+fn seconds<Input>() -> impl Parser<Input, Output = Seconds>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    bounded_natural(0, 59).map(Seconds)
+}
+
+/// Parses a minutes segment (`:mm`) as part of an `hh:mm:ss` time stamp.
+/// The parsed [`Minutes`] must be within range `[0, 59]`.
+///
+/// If there is no leading colon, defaults to zero minutes.
+fn mm_segment<Input>() -> impl Parser<Input, Output = Minutes>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    optional(byte(b':')).then(|colon| {
+        if colon.is_some() {
+            minutes().left()
+        } else {
+            value(Minutes(0)).right()
+        }
+    })
+}
+
+/// Parses a seconds segment (`:ss`) as part of an `hh:mm:ss` time stamp.
+/// The parsed [`Seconds`] must be within range `[0, 59]`.
+///
+/// If there is no leading colon, defaults to zero minutes.
+fn ss_segment<Input>() -> impl Parser<Input, Output = Seconds>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    optional(byte(b':')).then(|colon| {
+        if colon.is_some() {
+            seconds().left()
+        } else {
+            value(Seconds(0)).right()
+        }
+    })
+}
+
+/// Parses a time value of the form `\[+|-\]hh\[:mm\[:ss\]\]`.
+///
+/// Returns the total time in [`Seconds`].
+fn time<Input>(hour_bound: i32) -> impl Parser<Input, Output = Seconds>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    (hours(hour_bound), mm_segment(), ss_segment()).map(|(hours, minutes, seconds)| {
+        if hours < Hours(0) {
+            hours.as_seconds() - minutes.as_seconds() - seconds
+        } else {
+            hours.as_seconds() + minutes.as_seconds() + seconds
+        }
+    })
+}
+
+/// Parses a time value of the form `\[+|-\]hh\[:mm\[:ss\]\]`.
+///
+/// This is positive if the local time zone is west of the Prime Meridian and negative if it is east.
+/// The hour must be in range `[0, 24]`, and the minute and seconds must be in range `[0, 59]`.
+///
+/// Returns the total time in [`Seconds`].
+fn offset_time<Input>() -> impl Parser<Input, Output = Seconds>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    time(24)
+}
+
+/// Parses the STD time-zone variant info including the variant name and the offset in seconds.
+///
+/// See [`zone_variant_name`] and [`offset_time`] for more information.
+fn std_variant_info<Input>() -> impl Parser<Input, Output = ZoneVariantInfo>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    combine::struct_parser! {
+        ZoneVariantInfo {
+            name: zone_variant_name(),
+            offset: offset_time(),
+        }
+    }
+}
+
+/// Parses the DST time-zone variant info including the variant name and the offset in seconds.
+///
+/// This differs from [`std_variant_info`] in that it takes a predetermined STD offset
+/// offset as an argument. If no explicit DST offset is parsed, it will default to the
+/// STD offset minus one hour.
+fn dst_variant_info<Input>(std_offset: Seconds) -> impl Parser<Input, Output = ZoneVariantInfo>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    combine::struct_parser! {
+        ZoneVariantInfo {
+            name: zone_variant_name(),
+            offset: optional(offset_time()).map(move |time| time.unwrap_or(std_offset - Hours(1).as_seconds())),
+        }
+    }
+}
+
+/// Parses transition day with no specified leading character, e.g. `15`.
+/// This is a value in range `[0, 365]` in which the leap day is considered for leap years.
+fn transition_day_n<Input>() -> impl Parser<Input, Output = TransitionDay>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    bounded_natural(0, 365).map(|natural| TransitionDay::WithLeap(natural as u16))
+}
+
+/// Parses transition day specified by a leading `J`, e.g. `J15`.
+/// This is a value in range `[1, 365]` in which the leap day is never considered.
+fn transition_day_jn<Input>() -> impl Parser<Input, Output = TransitionDay>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    byte(b'J')
+        .then(|_| bounded_natural(1, 365).map(|natural| TransitionDay::NoLeap(natural as u16)))
+}
+
+/// Parses a transition date specified by a leading `M`, e.g. `Mm.w.d`
+/// This specifies day `d` of week `w` of month `m`. The day `d` must be between
+/// 0 (Sunday) and 6 (Saturday). The week `w` must be in range `[1, 5]`;
+/// The week that corresponds to `1` is the first week in which day `d` occurs,
+/// and week 5 specifies the last `d` day in the month. The month `m` should
+/// be between 1 and 12.
+fn transition_day_mwd<Input>() -> impl Parser<Input, Output = TransitionDay>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    byte(b'M')
+        .then(|_| {
+            (
+                bounded_natural(1, 12),
+                byte(b'.').then(|_| bounded_natural(1, 5)),
+                byte(b'.').then(|_| bounded_natural(0, 6)),
+            )
+        })
+        .map(|(m, w, d)| TransitionDay::Mwd(m as u16, w as u16, d as u16))
+}
+
+/// Parses a transition day in any of three unambiguous formats.
+///
+/// See [`transition_day_mwd`], [`transition_day_jn`], and [`transition_day_n`]
+/// for more information.
+fn transition_day<Input>() -> impl Parser<Input, Output = TransitionDay>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    choice((
+        transition_day_mwd(),
+        transition_day_jn(),
+        transition_day_n(),
+    ))
+}
+
+/// Parses a time value of the form `\[+|-\]hh\[:mm\[:ss\]\]`.
+///
+/// This is positive if the local time zone is west of the Prime Meridian and negative if it is east.
+/// The hour must be in range `[-167, 167]`, and the minute and seconds must be in range `[0 and 59]`.
+/// This is an extension to POSIX.1, which only allows hours to be in range `[0 through 24]`.
+fn transition_time<Input>() -> impl Parser<Input, Output = Seconds>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    optional(byte(b'/')).then(|slash| {
+        if slash.is_some() {
+            time(167).left()
+        } else {
+            value(Hours(2).as_seconds()).right()
+        }
+    })
+}
+
+/// Parses a DST transition date including the transition day and the transition time in seconds.
+///
+/// See [`transition_day`] and [`transition_time`] for more information.
+fn transition_date<Input>() -> impl Parser<Input, Output = TransitionDate>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    combine::struct_parser! {
+        TransitionDate {
+            day: transition_day(),
+            time: transition_time(),
+        }
+    }
+}
+
+/// Parses DST transition information including the variant info, and the transition dates.
+///
+/// See [`dst_variant_info`], [`transition_date`] for more information.
+fn dst_transition_info<Input>(std_offset: Seconds) -> impl Parser<Input, Output = DstTransitionInfo>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    combine::struct_parser! {
+        DstTransitionInfo {
+            variant_info: dst_variant_info(std_offset),
+            start_date: byte(b',').then(|_| transition_date()),
+            end_date: byte(b',').then(|_| transition_date()),
+        }
+    }
+}
+
+/// Parses a POSIX time-zone string according to the following specification:
+/// <https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html>
+pub fn posix_tz_string<Input>() -> impl Parser<Input, Output = PosixTzString>
+where
+    Input: Stream<Token = u8>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    std_variant_info().then(|std_info| {
+        let std_offset = std_info.offset;
+        combine::struct_parser! {
+            PosixTzString {
+                std_info: value(std_info),
+                dst_info: optional(dst_transition_info(std_offset)),
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Helper macro to test that a parse should fail with Err().
+    macro_rules! assert_parse_err {
+        ($parser:expr, $src:expr) => {
+            assert!(
+                $parser.parse($src.as_bytes()).is_err(),
+                "expected {}, parse {} as Err(), but got Ok() {:#?}",
+                stringify!($parser),
+                $src,
+                $parser.parse($src.as_bytes()).unwrap().0,
+            )
+        };
+    }
+
+    /// Helper macro to test that a parse should succeed with Ok().
+    macro_rules! assert_parse_ok {
+        ($parser:expr, $src:expr) => {
+            assert!(
+                $parser.parse(($src).as_bytes()).is_ok(),
+                "expected {}, parse {} as Ok(), but got Err() {:#?}",
+                stringify!($parser),
+                $src,
+                $parser.parse($src.as_bytes()),
+            )
+        };
+    }
+
+    /// Helper macro to test the equality of the actual and expected parse.
+    macro_rules! assert_parse_eq {
+        ($parser:expr, $src:expr, $expected:expr) => {
+            assert_parse_ok!($parser, $src);
+            assert_eq!(
+                $parser.parse($src.as_bytes()).unwrap().0,
+                $expected,
+                "expected {:?}, parse as {:?} but got {:?}",
+                $src,
+                $expected,
+                $parser.parse($src.as_bytes()).unwrap().0,
+            )
+        };
+    }
+
+    #[test]
+    fn parse_zone_variant_name() {
+        // invalid alphabetic names
+        assert_parse_err!(zone_variant_name(), "");
+        assert_parse_err!(zone_variant_name(), "a");
+        assert_parse_err!(zone_variant_name(), "ab");
+        assert_parse_err!(zone_variant_name(), "ab,");
+        assert_parse_err!(zone_variant_name(), "ab+");
+        assert_parse_err!(zone_variant_name(), "ab-");
+        assert_parse_err!(zone_variant_name(), "ab0");
+        assert_parse_err!(zone_variant_name(), "ab1");
+        assert_parse_err!(zone_variant_name(), "ab2");
+        assert_parse_err!(zone_variant_name(), "ab3");
+        assert_parse_err!(zone_variant_name(), "ab4");
+        assert_parse_err!(zone_variant_name(), "ab5");
+        assert_parse_err!(zone_variant_name(), "ab6");
+        assert_parse_err!(zone_variant_name(), "ab7");
+        assert_parse_err!(zone_variant_name(), "ab8");
+        assert_parse_err!(zone_variant_name(), "ab9");
+        assert_parse_err!(zone_variant_name(), ":bc");
+        assert_parse_err!(zone_variant_name(), ":abc");
+        assert_parse_err!(zone_variant_name(), ":PDT");
+
+        // invalid arbitrary names
+        assert_parse_err!(zone_variant_name(), "<>");
+        assert_parse_err!(zone_variant_name(), "<a>");
+        assert_parse_err!(zone_variant_name(), "<ab>");
+        assert_parse_err!(zone_variant_name(), "<:abc>");
+        assert_parse_err!(zone_variant_name(), "<:PDT>");
+
+        // valid alphabetic names
+        assert_parse_eq!(zone_variant_name(), "abc", "abc");
+        assert_parse_eq!(zone_variant_name(), "PST", "PST");
+        assert_parse_eq!(zone_variant_name(), "PDT", "PDT");
+        assert_parse_eq!(zone_variant_name(), "GMT", "GMT");
+        assert_parse_eq!(zone_variant_name(), "PST8PDT", "PST");
+
+        // valid arbitrary names
+        assert_parse_eq!(zone_variant_name(), "<1,bc>", "1,bc");
+        assert_parse_eq!(zone_variant_name(), "<+800>", "+800");
+        assert_parse_eq!(zone_variant_name(), "<-800>", "-800");
+        assert_parse_eq!(zone_variant_name(), "<PST8PDT>", "PST8PDT");
+    }
+
+    #[test]
+    fn parse_natural() {
+        // invalid integers
+        assert_parse_err!(natural(), "");
+        assert_parse_err!(natural(), "+");
+        assert_parse_err!(natural(), "-");
+        assert_parse_err!(natural(), "a");
+        assert_parse_err!(natural(), "ab");
+        assert_parse_err!(natural(), "-1");
+
+        // out of bounds
+        assert_parse_err!(bounded_natural(1, 9), "0");
+        assert_parse_err!(bounded_natural(2, 9), "1");
+        assert_parse_err!(bounded_natural(3, 9), "2");
+
+        assert_parse_err!(bounded_natural(0, 9), "10");
+        assert_parse_err!(bounded_natural(0, 8), "9");
+        assert_parse_err!(bounded_natural(0, 7), "8");
+
+        // valid single digits
+        assert_parse_eq!(bounded_natural(0, 9), "0", 0);
+        assert_parse_eq!(bounded_natural(0, 9), "1", 1);
+        assert_parse_eq!(bounded_natural(0, 9), "2", 2);
+        assert_parse_eq!(bounded_natural(0, 9), "3", 3);
+        assert_parse_eq!(bounded_natural(0, 9), "4", 4);
+        assert_parse_eq!(bounded_natural(0, 9), "5", 5);
+        assert_parse_eq!(bounded_natural(0, 9), "6", 6);
+        assert_parse_eq!(bounded_natural(0, 9), "7", 7);
+        assert_parse_eq!(bounded_natural(0, 9), "8", 8);
+        assert_parse_eq!(bounded_natural(0, 9), "9", 9);
+
+        // valid naturals
+        assert_parse_eq!(natural(), "01", 1);
+        assert_parse_eq!(natural(), "002", 2);
+        assert_parse_eq!(natural(), "13", 13);
+        assert_parse_eq!(natural(), "4321", 4321);
+        assert_parse_eq!(natural(), "0543-21", 543);
+        assert_parse_eq!(natural(), "0543+21", 543);
+        assert_parse_eq!(natural(), "12345abc", 12345);
+    }
+
+    #[test]
+    fn parse_integer() {
+        // invalid integers
+        assert_parse_err!(bounded_integer(i32::MIN, i32::MAX), "");
+        assert_parse_err!(bounded_integer(i32::MIN, i32::MAX), "+");
+        assert_parse_err!(bounded_integer(i32::MIN, i32::MAX), "-");
+        assert_parse_err!(bounded_integer(i32::MIN, i32::MAX), "a");
+        assert_parse_err!(bounded_integer(i32::MIN, i32::MAX), "ab");
+        assert_parse_err!(bounded_integer(i32::MIN, i32::MAX), "--1");
+        assert_parse_err!(bounded_integer(i32::MIN, i32::MAX), "++1");
+        assert_parse_err!(bounded_integer(i32::MIN, i32::MAX), "+-1");
+        assert_parse_err!(bounded_integer(i32::MIN, i32::MAX), "-+1");
+
+        // out of bounds
+        assert_parse_err!(bounded_integer(0, 9), "-1");
+        assert_parse_err!(bounded_integer(1, 9), "0");
+        assert_parse_err!(bounded_integer(2, 9), "1");
+
+        assert_parse_err!(bounded_integer(0, 7), "8");
+        assert_parse_err!(bounded_integer(0, 8), "9");
+        assert_parse_err!(bounded_integer(0, 9), "10");
+
+        // valid single digits
+        assert_parse_eq!(bounded_integer(0, 9), "0", 0);
+        assert_parse_eq!(bounded_integer(0, 9), "1", 1);
+        assert_parse_eq!(bounded_integer(0, 9), "2", 2);
+        assert_parse_eq!(bounded_integer(0, 9), "3", 3);
+        assert_parse_eq!(bounded_integer(0, 9), "4", 4);
+        assert_parse_eq!(bounded_integer(0, 9), "5", 5);
+        assert_parse_eq!(bounded_integer(0, 9), "6", 6);
+        assert_parse_eq!(bounded_integer(0, 9), "7", 7);
+        assert_parse_eq!(bounded_integer(0, 9), "8", 8);
+        assert_parse_eq!(bounded_integer(0, 9), "9", 9);
+
+        // valid integers
+        assert_parse_eq!(bounded_integer(i32::MIN, i32::MAX), "+1", 1);
+        assert_parse_eq!(bounded_integer(i32::MIN, i32::MAX), "-5", -5);
+        assert_parse_eq!(bounded_integer(i32::MIN, i32::MAX), "01", 1);
+        assert_parse_eq!(bounded_integer(i32::MIN, i32::MAX), "002", 2);
+        assert_parse_eq!(bounded_integer(i32::MIN, i32::MAX), "13", 13);
+        assert_parse_eq!(bounded_integer(i32::MIN, i32::MAX), "4321", 4321);
+        assert_parse_eq!(bounded_integer(i32::MIN, i32::MAX), "+0543-21", 543);
+        assert_parse_eq!(bounded_integer(i32::MIN, i32::MAX), "-0543+21", -543);
+        assert_parse_eq!(bounded_integer(i32::MIN, i32::MAX), "-12345abc", -12345);
+    }
+
+    #[test]
+    fn parse_hours() {
+        // out of bounds [-2, 2]
+        assert_parse_err!(hours(2), "4");
+        assert_parse_err!(hours(2), "3");
+        assert_parse_err!(hours(2), "-4");
+        assert_parse_err!(hours(2), "-3");
+
+        // within bounds [-2, 2]
+        assert_parse_eq!(hours(2), "2", Hours(2));
+        assert_parse_eq!(hours(2), "1", Hours(1));
+        assert_parse_eq!(hours(2), "0", Hours(0));
+        assert_parse_eq!(hours(2), "+2", Hours(2));
+        assert_parse_eq!(hours(2), "-2", Hours(-2));
+        assert_parse_eq!(hours(2), "-1", Hours(-1));
+        assert_parse_eq!(hours(2), "-0", Hours(0));
+        assert_parse_eq!(hours(2), "+0", Hours(0));
+    }
+
+    #[test]
+    fn parse_minutes() {
+        // out of bounds [0, 60]
+        assert_parse_err!(minutes(), "-2");
+        assert_parse_err!(minutes(), "-1");
+        assert_parse_err!(minutes(), "61");
+        assert_parse_err!(minutes(), "60");
+
+        // within bounds [0, 60]
+        assert_parse_eq!(minutes(), "00", Minutes(0));
+        assert_parse_eq!(minutes(), "01", Minutes(1));
+        assert_parse_eq!(minutes(), "30", Minutes(30));
+        assert_parse_eq!(minutes(), "58", Minutes(58));
+        assert_parse_eq!(minutes(), "59", Minutes(59));
+    }
+
+    #[test]
+    fn parse_seconds() {
+        // out of bounds [0, 60]
+        assert_parse_err!(seconds(), "-2");
+        assert_parse_err!(seconds(), "-1");
+        assert_parse_err!(seconds(), "61");
+        assert_parse_err!(seconds(), "60");
+
+        // within bounds [0, 60]
+        assert_parse_eq!(seconds(), "00", Seconds(0));
+        assert_parse_eq!(seconds(), "01", Seconds(1));
+        assert_parse_eq!(seconds(), "30", Seconds(30));
+        assert_parse_eq!(seconds(), "58", Seconds(58));
+        assert_parse_eq!(seconds(), "59", Seconds(59));
+    }
+
+    #[test]
+    fn parse_time() {
+        // hours out of bounds
+        assert_parse_err!(time(12), "13");
+        assert_parse_err!(time(12), "-13");
+        assert_parse_err!(time(12), "13:00");
+        assert_parse_err!(time(12), "-13:00");
+        assert_parse_err!(time(12), "13:00:00");
+        assert_parse_err!(time(12), "-13:00:00");
+
+        // minutes out of bounds
+        assert_parse_err!(time(12), "00:60");
+        assert_parse_err!(time(12), "00:60:00");
+
+        // seconds out of bounds
+        assert_parse_err!(time(12), "00:00:60");
+
+        // valid times
+        // assert_parse_eq!(time(12), "12", Seconds(12 * 60 * 60));
+        // assert_parse_eq!(time(12), "+12", Seconds(12 * 60 * 60));
+        // assert_parse_eq!(time(12), "-12", Seconds(-12 * 60 * 60));
+        assert_parse_eq!(time(12), "12:15", Seconds(12 * 60 * 60 + 15 * 60));
+        assert_parse_eq!(time(12), "-12:15", Seconds(-12 * 60 * 60 - 15 * 60));
+        assert_parse_eq!(time(12), "12:30:15", Seconds(12 * 60 * 60 + 30 * 60 + 15));
+        assert_parse_eq!(time(12), "-12:30:15", Seconds(-12 * 60 * 60 - 30 * 60 - 15));
+    }
+
+    #[test]
+    fn parse_std_variant_info() {
+        // invalid zone variant info name
+        assert_parse_err!(std_variant_info(), "");
+        assert_parse_err!(std_variant_info(), "P");
+        assert_parse_err!(std_variant_info(), "PS");
+        assert_parse_err!(std_variant_info(), ":PST8");
+
+        // invalid zone variant info hour
+        assert_parse_err!(std_variant_info(), "PST25");
+        assert_parse_err!(std_variant_info(), "PST-25");
+
+        // invalid zone variant info minute
+        assert_parse_err!(std_variant_info(), "PST8:60");
+        assert_parse_err!(std_variant_info(), "PST8:60");
+
+        // invalid zone variant info second
+        assert_parse_err!(std_variant_info(), "PST8:00:60");
+        assert_parse_err!(std_variant_info(), "PST8:00:60");
+
+        // valid zone variant infos
+        assert_parse_eq!(
+            std_variant_info(),
+            "EST+5",
+            ZoneVariantInfo {
+                name: String::from("EST"),
+                offset: Hours(5).as_seconds(),
+            }
+        );
+        assert_parse_eq!(
+            std_variant_info(),
+            "IST-2",
+            ZoneVariantInfo {
+                name: String::from("IST"),
+                offset: Hours(-2).as_seconds(),
+            }
+        );
+        assert_parse_eq!(
+            std_variant_info(),
+            "<0made+up0>-24:59:59",
+            ZoneVariantInfo {
+                name: String::from("0made+up0"),
+                offset: Hours(-24).as_seconds() - Minutes(59).as_seconds() - Seconds(59)
+            }
+        );
+    }
+
+    #[test]
+    fn parse_dst_variant_info() {
+        // invalid zone variant info name
+        assert_parse_err!(dst_variant_info(Seconds(0)), "");
+        assert_parse_err!(dst_variant_info(Seconds(0)), "P");
+        assert_parse_err!(dst_variant_info(Seconds(0)), "PD");
+        assert_parse_err!(dst_variant_info(Seconds(0)), ":PDT8");
+
+        // invalid zone variant info hour
+        assert_parse_err!(dst_variant_info(Seconds(0)), "PDT25");
+        assert_parse_err!(dst_variant_info(Seconds(0)), "PDT-25");
+
+        // invalid zone variant info minute
+        assert_parse_err!(dst_variant_info(Seconds(0)), "PDT8:60");
+        assert_parse_err!(dst_variant_info(Seconds(0)), "PDT8:60");
+
+        // invalid zone variant info second
+        assert_parse_err!(dst_variant_info(Seconds(0)), "PDT8:00:60");
+        assert_parse_err!(dst_variant_info(Seconds(0)), "PDT8:00:60");
+
+        // valid zone variant infos
+        assert_parse_eq!(
+            dst_variant_info(Hours(5).as_seconds()),
+            "EDT",
+            ZoneVariantInfo {
+                name: String::from("EDT"),
+                offset: Hours(4).as_seconds(),
+            }
+        );
+        assert_parse_eq!(
+            dst_variant_info(Hours(-2).as_seconds()),
+            "IDT",
+            ZoneVariantInfo {
+                name: String::from("IDT"),
+                offset: Hours(-3).as_seconds(),
+            }
+        );
+        assert_parse_eq!(
+            dst_variant_info(Seconds(0)),
+            "<0made+up0>-24:59:59",
+            ZoneVariantInfo {
+                name: String::from("0made+up0"),
+                offset: Hours(-24).as_seconds() - Minutes(59).as_seconds() - Seconds(59)
+            }
+        );
+    }
+
+    #[test]
+    fn parse_transition_day() {
+        // invalid transition days
+        assert_parse_err!(transition_day(), "");
+        assert_parse_err!(transition_day(), ":5");
+        assert_parse_err!(transition_day(), "A65");
+
+        // invalid out of bounds
+        assert_parse_err!(transition_day(), "-1");
+        assert_parse_err!(transition_day(), "366");
+        assert_parse_err!(transition_day(), "J0");
+        assert_parse_err!(transition_day(), "J366");
+        assert_parse_err!(transition_day(), "M0.1.0");
+        assert_parse_err!(transition_day(), "M13.1.0");
+        assert_parse_err!(transition_day(), "M1.0.0");
+        assert_parse_err!(transition_day(), "M1.6.0");
+        assert_parse_err!(transition_day(), "M1.1.7");
+
+        // valid transition days
+        assert_parse_eq!(transition_day(), "0", TransitionDay::WithLeap(0));
+        assert_parse_eq!(transition_day(), "365", TransitionDay::WithLeap(365));
+        assert_parse_eq!(transition_day(), "J1", TransitionDay::NoLeap(1));
+        assert_parse_eq!(transition_day(), "J365", TransitionDay::NoLeap(365));
+        assert_parse_eq!(transition_day(), "M1.1.0", TransitionDay::Mwd(1, 1, 0));
+        assert_parse_eq!(transition_day(), "M12.5.6", TransitionDay::Mwd(12, 5, 6));
+    }
+
+    #[test]
+    fn parse_transition_date() {
+        assert_parse_eq!(
+            transition_date(),
+            "0",
+            TransitionDate {
+                day: TransitionDay::WithLeap(0),
+                time: Hours(2).as_seconds(),
+            }
+        );
+        assert_parse_eq!(
+            transition_date(),
+            "M3.4.4/26",
+            TransitionDate {
+                day: TransitionDay::Mwd(3, 4, 4),
+                time: Hours(26).as_seconds(),
+            }
+        );
+        assert_parse_eq!(
+            transition_date(),
+            "J365/25",
+            TransitionDate {
+                day: TransitionDay::NoLeap(365),
+                time: Hours(25).as_seconds(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_dst_transition_info() {
+        assert_parse_eq!(
+            dst_transition_info(Hours(4).as_seconds()),
+            "WARST,J1/0,J365/25",
+            DstTransitionInfo {
+                variant_info: ZoneVariantInfo {
+                    name: String::from("WARST"),
+                    offset: Hours(3).as_seconds()
+                },
+                start_date: TransitionDate {
+                    day: TransitionDay::NoLeap(1),
+                    time: Seconds(0)
+                },
+                end_date: TransitionDate {
+                    day: TransitionDay::NoLeap(365),
+                    time: Hours(25).as_seconds()
+                },
+            }
+        );
+        assert_parse_eq!(
+            dst_transition_info(Hours(-2).as_seconds()),
+            "IDT,M3.4.4/26,M10.5.0",
+            DstTransitionInfo {
+                variant_info: ZoneVariantInfo {
+                    name: String::from("IDT"),
+                    offset: Hours(-3).as_seconds()
+                },
+                start_date: TransitionDate {
+                    day: TransitionDay::Mwd(3, 4, 4),
+                    time: Hours(26).as_seconds(),
+                },
+                end_date: TransitionDate {
+                    day: TransitionDay::Mwd(10, 5, 0),
+                    time: Hours(2).as_seconds()
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn parse_posix_tz_string() {
+        assert_parse_eq!(
+            posix_tz_string(),
+            "WGT3WGST,M3.5.0/-2,M10.5.0/-1",
+            PosixTzString {
+                std_info: ZoneVariantInfo {
+                    name: String::from("WGT"),
+                    offset: Hours(3).as_seconds(),
+                },
+                dst_info: Some(DstTransitionInfo {
+                    variant_info: ZoneVariantInfo {
+                        name: String::from("WGST"),
+                        offset: Hours(2).as_seconds()
+                    },
+                    start_date: TransitionDate {
+                        day: TransitionDay::Mwd(3, 5, 0),
+                        time: Hours(-2).as_seconds(),
+                    },
+                    end_date: TransitionDate {
+                        day: TransitionDay::Mwd(10, 5, 0),
+                        time: Hours(-1).as_seconds(),
+                    },
+                })
+            }
+        );
+        assert_parse_eq!(
+            posix_tz_string(),
+            "WART4WARST,J1/0,J365/25",
+            PosixTzString {
+                std_info: ZoneVariantInfo {
+                    name: String::from("WART"),
+                    offset: Hours(4).as_seconds(),
+                },
+                dst_info: Some(DstTransitionInfo {
+                    variant_info: ZoneVariantInfo {
+                        name: String::from("WARST"),
+                        offset: Hours(3).as_seconds()
+                    },
+                    start_date: TransitionDate {
+                        day: TransitionDay::NoLeap(1),
+                        time: Seconds(0),
+                    },
+                    end_date: TransitionDate {
+                        day: TransitionDay::NoLeap(365),
+                        time: Hours(25).as_seconds(),
+                    },
+                })
+            }
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

Parses POSIX time-zone strings using Combine.

This is the first pull request to ease the burden of the review process and get early feedback.
The subsequent pull request will include the full TZIF parser which will use this parser. 