### PR TITLE
Define "magnitude" and introduce "position" concepts in FixedDecimal

### DIFF
--- a/ffi/diplomat/c/include/ICU4XFixedDecimal.h
+++ b/ffi/diplomat/c/include/ICU4XFixedDecimal.h
@@ -28,11 +28,11 @@ bool ICU4XFixedDecimal_multiply_pow10(ICU4XFixedDecimal* self, int16_t power);
 
 void ICU4XFixedDecimal_negate(ICU4XFixedDecimal* self);
 
-void ICU4XFixedDecimal_pad_left(ICU4XFixedDecimal* self, uint16_t digits);
+void ICU4XFixedDecimal_pad_left(ICU4XFixedDecimal* self, int16_t position);
 
-void ICU4XFixedDecimal_truncate_left(ICU4XFixedDecimal* self, int16_t magnitude);
+void ICU4XFixedDecimal_truncate_left(ICU4XFixedDecimal* self, int16_t position);
 
-void ICU4XFixedDecimal_pad_right(ICU4XFixedDecimal* self, uint16_t negative_magnitude);
+void ICU4XFixedDecimal_pad_right(ICU4XFixedDecimal* self, int16_t position);
 
 void ICU4XFixedDecimal_to_string(const ICU4XFixedDecimal* self, DiplomatWriteable* to);
 void ICU4XFixedDecimal_destroy(ICU4XFixedDecimal* self);

--- a/ffi/diplomat/cpp/docs/source/fixed_decimal_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/fixed_decimal_ffi.rst
@@ -50,19 +50,19 @@
         Invert the sign of the :cpp:class:`ICU4XFixedDecimal`.
         See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.negate>`__ for more information.
 
-    .. cpp:function:: void pad_left(uint16_t digits)
+    .. cpp:function:: void pad_left(int16_t position)
 
-        Zero-pad the :cpp:class:`ICU4XFixedDecimal` on the left to a particular number of integer digits
+        Zero-pad the :cpp:class:`ICU4XFixedDecimal` on the left to a particular position
         See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_left>`__ for more information.
 
-    .. cpp:function:: void truncate_left(int16_t magnitude)
+    .. cpp:function:: void truncate_left(int16_t position)
 
-        Truncate the :cpp:class:`ICU4XFixedDecimal` on the left to a particular magnitude, deleting digits if necessary. This is useful for, e.g. abbreviating years ("2022" -> "22")
+        Truncate the :cpp:class:`ICU4XFixedDecimal` on the left to a particular position, deleting digits if necessary. This is useful for, e.g. abbreviating years ("2022" -> "22")
         See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.truncate_left>`__ for more information.
 
-    .. cpp:function:: void pad_right(uint16_t negative_magnitude)
+    .. cpp:function:: void pad_right(int16_t position)
 
-        Zero-pad the :cpp:class:`ICU4XFixedDecimal` on the right to a particular (negative) magnitude
+        Zero-pad the :cpp:class:`ICU4XFixedDecimal` on the right to a particular position
         See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_right>`__ for more information.
 
     .. cpp:function:: template<typename W> void to_string_to_writeable(W& to) const

--- a/ffi/diplomat/cpp/examples/fixeddecimal/test.cpp
+++ b/ffi/diplomat/cpp/examples/fixeddecimal/test.cpp
@@ -48,7 +48,7 @@ int main() {
         return 1;
     }
 
-    decimal.pad_right(4);
+    decimal.pad_right(-4);
     out = fdf.format(decimal).ok().value();
     std::cout << "Formatted left-padded float value is " << out << std::endl;
     if (out != "১০০.০১০০") {
@@ -64,7 +64,7 @@ int main() {
         return 1;
     }
 
-    decimal.truncate_left(2);
+    decimal.truncate_left(3);
     out = fdf.format(decimal).ok().value();
     std::cout << "Formatted truncated float value is " << out << std::endl;
     if (out != "১০০.০১০০") {

--- a/ffi/diplomat/cpp/include/ICU4XFixedDecimal.h
+++ b/ffi/diplomat/cpp/include/ICU4XFixedDecimal.h
@@ -28,11 +28,11 @@ bool ICU4XFixedDecimal_multiply_pow10(ICU4XFixedDecimal* self, int16_t power);
 
 void ICU4XFixedDecimal_negate(ICU4XFixedDecimal* self);
 
-void ICU4XFixedDecimal_pad_left(ICU4XFixedDecimal* self, uint16_t digits);
+void ICU4XFixedDecimal_pad_left(ICU4XFixedDecimal* self, int16_t position);
 
-void ICU4XFixedDecimal_truncate_left(ICU4XFixedDecimal* self, int16_t magnitude);
+void ICU4XFixedDecimal_truncate_left(ICU4XFixedDecimal* self, int16_t position);
 
-void ICU4XFixedDecimal_pad_right(ICU4XFixedDecimal* self, uint16_t negative_magnitude);
+void ICU4XFixedDecimal_pad_right(ICU4XFixedDecimal* self, int16_t position);
 
 void ICU4XFixedDecimal_to_string(const ICU4XFixedDecimal* self, DiplomatWriteable* to);
 void ICU4XFixedDecimal_destroy(ICU4XFixedDecimal* self);

--- a/ffi/diplomat/cpp/include/ICU4XFixedDecimal.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XFixedDecimal.hpp
@@ -85,26 +85,26 @@ class ICU4XFixedDecimal {
   void negate();
 
   /**
-   * Zero-pad the [`ICU4XFixedDecimal`] on the left to a particular number of integer digits
+   * Zero-pad the [`ICU4XFixedDecimal`] on the left to a particular position
    * 
    * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_left) for more information.
    */
-  void pad_left(uint16_t digits);
+  void pad_left(int16_t position);
 
   /**
-   * Truncate the [`ICU4XFixedDecimal`] on the left to a particular magnitude, deleting digits if necessary. This is useful for, e.g. abbreviating years
+   * Truncate the [`ICU4XFixedDecimal`] on the left to a particular position, deleting digits if necessary. This is useful for, e.g. abbreviating years
    * ("2022" -> "22")
    * 
    * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.truncate_left) for more information.
    */
-  void truncate_left(int16_t magnitude);
+  void truncate_left(int16_t position);
 
   /**
-   * Zero-pad the [`ICU4XFixedDecimal`] on the right to a particular (negative) magnitude
+   * Zero-pad the [`ICU4XFixedDecimal`] on the right to a particular position
    * 
    * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_right) for more information.
    */
-  void pad_right(uint16_t negative_magnitude);
+  void pad_right(int16_t position);
 
   /**
    * Format the [`ICU4XFixedDecimal`] as a string.
@@ -181,14 +181,14 @@ inline bool ICU4XFixedDecimal::multiply_pow10(int16_t power) {
 inline void ICU4XFixedDecimal::negate() {
   capi::ICU4XFixedDecimal_negate(this->inner.get());
 }
-inline void ICU4XFixedDecimal::pad_left(uint16_t digits) {
-  capi::ICU4XFixedDecimal_pad_left(this->inner.get(), digits);
+inline void ICU4XFixedDecimal::pad_left(int16_t position) {
+  capi::ICU4XFixedDecimal_pad_left(this->inner.get(), position);
 }
-inline void ICU4XFixedDecimal::truncate_left(int16_t magnitude) {
-  capi::ICU4XFixedDecimal_truncate_left(this->inner.get(), magnitude);
+inline void ICU4XFixedDecimal::truncate_left(int16_t position) {
+  capi::ICU4XFixedDecimal_truncate_left(this->inner.get(), position);
 }
-inline void ICU4XFixedDecimal::pad_right(uint16_t negative_magnitude) {
-  capi::ICU4XFixedDecimal_pad_right(this->inner.get(), negative_magnitude);
+inline void ICU4XFixedDecimal::pad_right(int16_t position) {
+  capi::ICU4XFixedDecimal_pad_right(this->inner.get(), position);
 }
 template<typename W> inline void ICU4XFixedDecimal::to_string_to_writeable(W& to) const {
   capi::DiplomatWriteable to_writer = diplomat::WriteableTrait<W>::Construct(to);

--- a/ffi/diplomat/src/fixed_decimal.rs
+++ b/ffi/diplomat/src/fixed_decimal.rs
@@ -104,23 +104,23 @@ pub mod ffi {
             self.0.negate()
         }
 
-        /// Zero-pad the [`ICU4XFixedDecimal`] on the left to a particular number of integer digits
+        /// Zero-pad the [`ICU4XFixedDecimal`] on the left to a particular position
         #[diplomat::rust_link(fixed_decimal::decimal::FixedDecimal::pad_left, FnInStruct)]
-        pub fn pad_left(&mut self, digits: u16) {
-            self.0.pad_left(digits)
+        pub fn pad_left(&mut self, position: i16) {
+            self.0.pad_left(position)
         }
 
-        /// Truncate the [`ICU4XFixedDecimal`] on the left to a particular magnitude, deleting digits if necessary. This is useful for, e.g. abbreviating years
+        /// Truncate the [`ICU4XFixedDecimal`] on the left to a particular position, deleting digits if necessary. This is useful for, e.g. abbreviating years
         /// ("2022" -> "22")
         #[diplomat::rust_link(fixed_decimal::decimal::FixedDecimal::truncate_left, FnInStruct)]
-        pub fn truncate_left(&mut self, magnitude: i16) {
-            self.0.truncate_left(magnitude)
+        pub fn truncate_left(&mut self, position: i16) {
+            self.0.truncate_left(position)
         }
 
-        /// Zero-pad the [`ICU4XFixedDecimal`] on the right to a particular (negative) magnitude
+        /// Zero-pad the [`ICU4XFixedDecimal`] on the right to a particular position
         #[diplomat::rust_link(fixed_decimal::decimal::FixedDecimal::pad_right, FnInStruct)]
-        pub fn pad_right(&mut self, negative_magnitude: u16) {
-            self.0.pad_right(negative_magnitude)
+        pub fn pad_right(&mut self, position: i16) {
+            self.0.pad_right(position)
         }
 
         /// Format the [`ICU4XFixedDecimal`] as a string.

--- a/ffi/diplomat/wasm/docs/fixed_decimal_ffi.rst
+++ b/ffi/diplomat/wasm/docs/fixed_decimal_ffi.rst
@@ -50,19 +50,19 @@
         Invert the sign of the :js:class:`ICU4XFixedDecimal`.
         See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.negate>`__ for more information.
 
-    .. js:function:: pad_left(digits)
+    .. js:function:: pad_left(position)
 
-        Zero-pad the :js:class:`ICU4XFixedDecimal` on the left to a particular number of integer digits
+        Zero-pad the :js:class:`ICU4XFixedDecimal` on the left to a particular position
         See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_left>`__ for more information.
 
-    .. js:function:: truncate_left(magnitude)
+    .. js:function:: truncate_left(position)
 
-        Truncate the :js:class:`ICU4XFixedDecimal` on the left to a particular magnitude, deleting digits if necessary. This is useful for, e.g. abbreviating years ("2022" -> "22")
+        Truncate the :js:class:`ICU4XFixedDecimal` on the left to a particular position, deleting digits if necessary. This is useful for, e.g. abbreviating years ("2022" -> "22")
         See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.truncate_left>`__ for more information.
 
-    .. js:function:: pad_right(negative_magnitude)
+    .. js:function:: pad_right(position)
 
-        Zero-pad the :js:class:`ICU4XFixedDecimal` on the right to a particular (negative) magnitude
+        Zero-pad the :js:class:`ICU4XFixedDecimal` on the right to a particular position
         See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_right>`__ for more information.
 
     .. js:function:: to_string()

--- a/ffi/diplomat/wasm/lib/api.mjs
+++ b/ffi/diplomat/wasm/lib/api.mjs
@@ -687,16 +687,16 @@ export class ICU4XFixedDecimal {
     const diplomat_out = wasm.ICU4XFixedDecimal_negate(this.underlying);
   }
 
-  pad_left(digits) {
-    const diplomat_out = wasm.ICU4XFixedDecimal_pad_left(this.underlying, digits);
+  pad_left(position) {
+    const diplomat_out = wasm.ICU4XFixedDecimal_pad_left(this.underlying, position);
   }
 
-  truncate_left(magnitude) {
-    const diplomat_out = wasm.ICU4XFixedDecimal_truncate_left(this.underlying, magnitude);
+  truncate_left(position) {
+    const diplomat_out = wasm.ICU4XFixedDecimal_truncate_left(this.underlying, position);
   }
 
-  pad_right(negative_magnitude) {
-    const diplomat_out = wasm.ICU4XFixedDecimal_pad_right(this.underlying, negative_magnitude);
+  pad_right(position) {
+    const diplomat_out = wasm.ICU4XFixedDecimal_pad_right(this.underlying, position);
   }
 
   to_string() {

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -39,6 +39,37 @@ const_assert!(core::mem::size_of::<usize>() >= core::mem::size_of::<u16>());
 /// [#166](https://github.com/unicode-org/icu4x/issues/166). In the mean time, a third-party
 /// float-to-string library may be used.
 ///
+/// # Magnitude and Position
+///
+/// Each digit in a `FixedDecimal` is indexed by a *magnitude*, or the digit's power of 10.
+/// Illustration for the number "12.34":
+///
+/// | Magnitude | Digit | Description      |
+/// |-----------|-------|------------------|
+/// | 1         | 1     | Tens place       |
+/// | 0         | 2     | Ones place       |
+/// | -1        | 3     | Tenths place     |
+/// | -2        | 4     | Hundredths place |
+///
+/// Some functions deal with a *position* for the purpose of padding, truncating, or rounding a
+/// number. In these cases, the position is the index on the right side of the digit of the
+/// corresponding magnitude. Illustration:
+///
+/// ```text
+/// Position:   2   0  -2
+/// Number:     |1|2.3|4|
+/// Position:     1  -1
+/// ```
+///
+/// Expected output of various operations, all with input "12.34":
+///
+/// | Operation       | Position  | Expected Result |
+/// |-----------------|-----------|-----------------|
+/// | Truncate Left   | 1         | 10              |
+/// | Truncate Right  | -1        | 12.3            |
+/// | Pad Left        | 4         | 0012.34         |
+/// | Pad Right       | -4        | 12.3400         |
+///
 /// # Examples
 ///
 /// ```
@@ -409,8 +440,12 @@ impl FixedDecimal {
         self
     }
 
-    /// Zero-pad the number on the left to a particular number of integer digits,
+    /// Zero-pad the number on the left to a particular position,
     /// returning the result.
+    ///
+    /// Negative numbers have no effect.
+    /// 
+    /// Also see [`FixedDecimal::truncated_left()`].
     ///
     /// # Examples
     ///
@@ -427,12 +462,16 @@ impl FixedDecimal {
     ///
     /// assert_eq!("42", dec.clone().padded_left(1).to_string());
     /// ```
-    pub fn padded_left(mut self, digits: u16) -> Self {
-        self.pad_left(digits);
+    pub fn padded_left(mut self, position: i16) -> Self {
+        self.pad_left(position);
         self
     }
 
-    /// Zero-pad the number on the left to a particular number of integer digits.
+    /// Zero-pad the number on the left to a particular position.
+    ///
+    /// Negative numbers have no effect.
+    /// 
+    /// Also see [`FixedDecimal::truncate_left()`].
     ///
     /// # Examples
     ///
@@ -454,99 +493,103 @@ impl FixedDecimal {
     /// dec.pad_left(1);
     /// assert_eq!("42", dec.to_string());
     /// ```
-    pub fn pad_left(&mut self, digits: u16) {
-        let mut magnitude = if digits == 0 {
-            0
-        } else if digits > (i16::MAX as u16) + 1 {
-            i16::MAX
-        } else {
-            (digits - 1) as i16
-        };
-        if magnitude < 0 {
-            magnitude = 0;
+    pub fn pad_left(&mut self, position: i16) {
+        if position <= 0 {
+            return;
         }
+        let mut magnitude = position - 1;
         // Do not truncate nonzero digits
         if magnitude <= self.magnitude {
             magnitude = self.magnitude;
         }
-
         self.upper_magnitude = magnitude;
     }
 
-    /// Truncate the number on the left to a particular magnitude, deleting
+    /// Truncate the number on the left to a particular position, deleting
     /// digits if necessary, returning the result.
+    /// 
+    /// Also see [`FixedDecimal::padded_left()`].
     ///
     /// # Examples
     ///
     /// ```
     /// use fixed_decimal::FixedDecimal;
     ///
-    /// let mut dec = FixedDecimal::from(4235);
-    /// assert_eq!("4235", dec.to_string());
+    /// let mut dec = FixedDecimal::from(4235970).multiplied_pow10(-3).expect("in-bounds");
+    /// assert_eq!("4235.970", dec.to_string());
     ///
-    /// assert_eq!("4235", dec.clone().truncated_left(5).to_string());
+    /// assert_eq!("04235.970", dec.clone().truncated_left(5).to_string());
     ///
-    /// assert_eq!("235", dec.clone().truncated_left(2).to_string());
+    /// assert_eq!("35.970", dec.clone().truncated_left(2).to_string());
     ///
-    /// assert_eq!("35", dec.clone().truncated_left(1).to_string());
+    /// assert_eq!("5.970", dec.clone().truncated_left(1).to_string());
     ///
-    /// assert_eq!("5", dec.clone().truncated_left(0).to_string());
+    /// assert_eq!("0.970", dec.clone().truncated_left(0).to_string());
     ///
-    /// assert_eq!("0", dec.clone().truncated_left(-1).to_string());
+    /// assert_eq!("0.070", dec.clone().truncated_left(-1).to_string());
+    ///
+    /// assert_eq!("0.000", dec.clone().truncated_left(-2).to_string());
+    ///
+    /// assert_eq!("0.0000", dec.clone().truncated_left(-4).to_string());
     /// ```
-    pub fn truncated_left(mut self, magnitude: i16) -> Self {
-        self.truncate_left(magnitude);
+    pub fn truncated_left(mut self, position: i16) -> Self {
+        self.truncate_left(position);
         self
     }
 
-    /// Truncate the number on the left to a particular magnitude, deleting
+    /// Truncate the number on the left to a particular position, deleting
     /// digits if necessary.
+    /// 
+    /// Also see [`FixedDecimal::pad_left()`].
     ///
     /// # Examples
     ///
     /// ```
     /// use fixed_decimal::FixedDecimal;
     ///
-    /// let mut dec = FixedDecimal::from(4235);
-    /// assert_eq!("4235", dec.to_string());
+    /// let mut dec = FixedDecimal::from(4235970).multiplied_pow10(-3).expect("in-bounds");
+    /// assert_eq!("4235.970", dec.to_string());
     ///
     /// dec.truncate_left(5);
-    /// assert_eq!("4235", dec.to_string());
+    /// assert_eq!("04235.970", dec.to_string());
     ///
     /// dec.truncate_left(2);
-    /// assert_eq!("235", dec.to_string());
+    /// assert_eq!("35.970", dec.to_string());
     ///
     /// dec.truncate_left(1);
-    /// assert_eq!("35", dec.to_string());
+    /// assert_eq!("5.970", dec.to_string());
     ///
     /// dec.truncate_left(0);
-    /// assert_eq!("5", dec.to_string());
+    /// assert_eq!("0.970", dec.to_string());
     ///
     /// dec.truncate_left(-1);
-    /// assert_eq!("0", dec.to_string());
+    /// assert_eq!("0.070", dec.to_string());
     ///
     /// dec.truncate_left(-2);
-    /// assert_eq!("0", dec.to_string());
+    /// assert_eq!("0.000", dec.to_string());
+    ///
+    /// dec.truncate_left(-4);
+    /// assert_eq!("0.0000", dec.to_string());
     /// ```
-    pub fn truncate_left(&mut self, magnitude: i16) {
+    pub fn truncate_left(&mut self, position: i16) {
+        self.lower_magnitude = cmp::min(self.lower_magnitude, position);
+        self.upper_magnitude = if position <= 0 { 0 } else { position - 1 };
+        if position <= self.nonzero_magnitude_right() {
+            self.digits.clear();
+            self.magnitude = 0;
+            #[cfg(debug_assertions)]
+            self.check_invariants();
+            return;
+        }
+        let magnitude = position - 1;
         if self.magnitude >= magnitude {
-            let positive_magnitude = if magnitude > 0 { magnitude } else { 0 };
             let cut = crate::ops::i16_abs_sub(self.magnitude, magnitude) as usize;
-            if cut >= self.digits.len() {
-                self.digits.clear();
-                self.magnitude = 0;
-                self.upper_magnitude = positive_magnitude;
-                #[cfg(debug_assertions)]
-                self.check_invariants();
-                return;
-            }
             let _ = self.digits.drain(0..cut).count();
             // Count number of leading zeroes
             let extra_zeroes = self.digits.iter().position(|x| *x != 0).unwrap_or(0);
             let _ = self.digits.drain(0..extra_zeroes).count();
             debug_assert!(!self.digits.is_empty());
             self.magnitude = crate::ops::i16_sub_unsigned(magnitude, extra_zeroes as u16);
-            self.upper_magnitude = positive_magnitude;
         }
         #[cfg(debug_assertions)]
         self.check_invariants();
@@ -598,10 +641,8 @@ impl FixedDecimal {
             .take_while(|&digit| *digit == 0)
             .count();
 
-        self.digits.truncate(crate::ops::i16_sub_unsigned(
-            self.digits.len() as i16,
-            no_of_trailing_zeros as u16,
-        ) as usize);
+        self.digits
+            .truncate(self.digits.len() - no_of_trailing_zeros);
 
         if self.digits.is_empty() {
             self.magnitude = 0;
@@ -611,66 +652,63 @@ impl FixedDecimal {
         self.check_invariants();
     }
 
-    /// Truncate the number on the right to a particular magnitude, deleting
+    /// Truncate the number on the right to a particular position, deleting
     /// digits if necessary.
+    ///
+    /// Also see [`FixedDecimal::padded_right()`].
     ///
     /// # Examples
     ///
     /// ```
     /// use fixed_decimal::FixedDecimal;
     ///
-    /// let dec = FixedDecimal::from(4235);
-    /// assert_eq!("4235", dec.to_string());
+    /// let mut dec = FixedDecimal::from(4235970).multiplied_pow10(-3).expect("in-bounds");
+    /// assert_eq!("4235.970", dec.to_string());
     ///
-    /// assert_eq!("4235.00000", dec.clone().truncated_right(-5).to_string());
-    ///
-    /// assert_eq!("4230", dec.clone().truncated_right(1).to_string());
+    /// assert_eq!("4235.97000", dec.clone().truncated_right(-5).to_string());
     ///
     /// assert_eq!("4230", dec.clone().truncated_right(1).to_string());
-    ///
-    /// assert_eq!("4235", dec.clone().truncated_right(0).to_string());
     ///
     /// assert_eq!("4200", dec.clone().truncated_right(2).to_string());
     ///
-    /// assert_eq!("00000000000", dec.clone().truncated_right(10).to_string());
+    /// assert_eq!("00000", dec.clone().truncated_right(5).to_string());
     /// ```
-    pub fn truncated_right(mut self, magnitude: i16) -> Self {
-        self.truncate_right(magnitude);
+    pub fn truncated_right(mut self, position: i16) -> Self {
+        self.truncate_right(position);
         self
     }
 
-    /// Truncate the number on the right to a particular magnitude, deleting
+    /// Truncate the number on the right to a particular position, deleting
     /// digits if necessary.
+    ///
+    /// Also see [`FixedDecimal::pad_right()`].
     ///
     /// # Examples
     ///
     /// ```
     /// use fixed_decimal::FixedDecimal;
     /// # use std::str::FromStr;
-    /// let mut dec = FixedDecimal::from(4235 as i32);
-    /// assert_eq!("4235", dec.to_string());
+    ///
+    /// let mut dec = FixedDecimal::from(4235970).multiplied_pow10(-3).expect("in-bounds");
+    /// assert_eq!("4235.970", dec.to_string());
     ///
     /// dec.truncate_right(-5);
-    /// assert_eq!("4235.00000", dec.to_string());
+    /// assert_eq!("4235.97000", dec.to_string());
     ///
-    /// dec.truncate_right(1);
-    /// assert_eq!("4230", dec.to_string());
-    ///
-    /// dec.truncate_right(1);
-    /// assert_eq!("4230", dec.to_string());
+    /// dec.truncate_right(-1);
+    /// assert_eq!("4235.9", dec.to_string());
     ///
     /// dec.truncate_right(0);
+    /// assert_eq!("4235", dec.to_string());
+    ///
+    /// dec.truncate_right(1);
     /// assert_eq!("4230", dec.to_string());
     ///
     /// dec.truncate_right(5);
-    /// assert_eq!("000000", dec.to_string());
+    /// assert_eq!("00000", dec.to_string());
     ///
     /// dec.truncate_right(2);
-    /// assert_eq!("000000", dec.to_string());
-    ///
-    /// let mut dec = FixedDecimal::from(4235 as i32);
-    /// dec.truncate_right(10);
-    /// assert_eq!("00000000000", dec.to_string());
+    /// assert_eq!("00000", dec.to_string());
     ///
     /// let mut dec = FixedDecimal::from_str("-99.999").unwrap();
     /// dec.truncate_right(-2);
@@ -684,13 +722,20 @@ impl FixedDecimal {
     /// dec.truncate_right(-1);
     /// assert_eq!("0.0", dec.to_string());
     /// ```
-    pub fn truncate_right(&mut self, n: i16) {
-        self.lower_magnitude = cmp::min(n, 0);
-        self.upper_magnitude = cmp::max(self.upper_magnitude, n);
+    pub fn truncate_right(&mut self, position: i16) {
+        self.lower_magnitude = cmp::min(position, 0);
+        if position == i16::MIN {
+            // Nothing more to do
+            #[cfg(debug_assertions)]
+            self.check_invariants();
+            return;
+        }
+        let magnitude = position - 1;
+        self.upper_magnitude = cmp::max(self.upper_magnitude, magnitude);
 
-        if n <= self.magnitude {
+        if magnitude <= self.magnitude {
             self.digits
-                .truncate(crate::ops::i16_abs_sub(self.magnitude, n) as usize + 1);
+                .truncate(crate::ops::i16_abs_sub(self.magnitude, magnitude) as usize);
             self.remove_trailing_zeros_from_digits_list();
         } else {
             self.digits.clear();
@@ -701,7 +746,7 @@ impl FixedDecimal {
         self.check_invariants();
     }
 
-    /// Ceils the number to the power ten of n.
+    /// Take the ceiling of the number at a particular position.
     ///
     /// # Examples
     ///
@@ -726,24 +771,24 @@ impl FixedDecimal {
     /// assert_eq!("100.00", dec.to_string());
     ///
     /// let mut dec = FixedDecimal::from_str("99.999").unwrap();
-    /// dec.ceil(-10);
-    /// assert_eq!("99.9990000000", dec.to_string());
+    /// dec.ceil(-5);
+    /// assert_eq!("99.99900", dec.to_string());
     ///
     /// let mut dec = FixedDecimal::from_str("-99.999").unwrap();
-    /// dec.ceil(-10);
-    /// assert_eq!("-99.9990000000", dec.to_string());
+    /// dec.ceil(-5);
+    /// assert_eq!("-99.99900", dec.to_string());
     ///
     /// let mut dec = FixedDecimal::from_str("-99.999").unwrap();
     /// dec.ceil(-2);
     /// assert_eq!("-99.99", dec.to_string());
     ///
     /// let mut dec = FixedDecimal::from_str("99.999").unwrap();
-    /// dec.ceil(10);
-    /// assert_eq!("10000000000", dec.to_string());
+    /// dec.ceil(4);
+    /// assert_eq!("10000", dec.to_string());
     ///
     /// let mut dec = FixedDecimal::from_str("-99.999").unwrap();
-    /// dec.ceil(10);
-    /// assert_eq!("-00000000000", dec.to_string());
+    /// dec.ceil(4);
+    /// assert_eq!("-0000", dec.to_string());
     ///
     /// let mut dec = FixedDecimal::from_str("0.009").unwrap();
     /// dec.ceil(-1);
@@ -753,10 +798,9 @@ impl FixedDecimal {
     /// dec.ceil(-1);
     /// assert_eq!("-0.0", dec.to_string());
     /// ```
-    pub fn ceil(&mut self, n: i16) {
+    pub fn ceil(&mut self, position: i16) {
         if self.is_negative {
-            self.truncate_right(n);
-
+            self.truncate_right(position);
             #[cfg(debug_assertions)]
             self.check_invariants();
             return;
@@ -766,7 +810,7 @@ impl FixedDecimal {
         let before_truncate_is_zero = self.is_zero();
         let before_truncate_is_bottom_magnitude = self.nonzero_magnitude_right();
         let before_truncate_magnitude = self.magnitude;
-        self.truncate_right(n);
+        self.truncate_right(position);
 
         if before_truncate_is_zero {
             #[cfg(debug_assertions)]
@@ -775,13 +819,13 @@ impl FixedDecimal {
         }
 
         // Now, the number is positive and not zero before truncation.
-        if n <= before_truncate_is_bottom_magnitude {
+        if position <= before_truncate_is_bottom_magnitude {
             #[cfg(debug_assertions)]
             self.check_invariants();
             return;
         }
 
-        if n <= before_truncate_magnitude {
+        if position <= before_truncate_magnitude {
             let result = self.increment_abs_by_one();
             if result.is_err() {
                 // Do nothing for now.
@@ -794,13 +838,14 @@ impl FixedDecimal {
 
         debug_assert!(self.digits.is_empty());
         self.digits.push(1);
-        self.magnitude = n;
+        self.magnitude = position;
+        self.upper_magnitude = cmp::max(self.upper_magnitude, position);
 
         #[cfg(debug_assertions)]
         self.check_invariants();
     }
 
-    /// Floors the number to the power ten of n.
+    /// Take the floor of the number at a particular position.
     ///
     /// # Examples
     ///
@@ -830,20 +875,24 @@ impl FixedDecimal {
     ///
     /// let mut dec = FixedDecimal::from_str("99.999").unwrap();
     /// dec.floor(10);
-    /// assert_eq!("00000000000", dec.to_string());
+    /// assert_eq!("0000000000", dec.to_string());
     ///
     /// let mut dec = FixedDecimal::from_str("-99.999").unwrap();
     /// dec.floor(10);
     /// assert_eq!("-10000000000", dec.to_string());
     /// ```
-    pub fn floor(&mut self, n: i16) {
+    pub fn floor(&mut self, position: i16) {
         self.negate();
-        self.ceil(n);
+        self.ceil(position);
         self.negate();
     }
 
-    /// Zero-pad the number on the right to a particular (negative) magnitude. Will truncate
+    /// Zero-pad the number on the right to a particular (negative) position. Will truncate
     /// trailing zeros if necessary, but will not truncate other digits, returning the result.
+    /// 
+    /// Positive numbers have no effect.
+    ///
+    /// Also see [`FixedDecimal::truncated_right()`].
     ///
     /// # Examples
     ///
@@ -854,21 +903,25 @@ impl FixedDecimal {
     /// let mut dec = FixedDecimal::from_str("123.456").unwrap();
     /// assert_eq!("123.456", dec.to_string());
     ///
-    /// assert_eq!("123.456", dec.clone().padded_right(1).to_string());
+    /// assert_eq!("123.456", dec.clone().padded_right(-1).to_string());
     ///
-    /// assert_eq!("123.456", dec.clone().padded_right(2).to_string());
+    /// assert_eq!("123.456", dec.clone().padded_right(-2).to_string());
     ///
-    /// assert_eq!("123.4560", dec.clone().padded_right(4).to_string());
+    /// assert_eq!("123.456000", dec.clone().padded_right(-6).to_string());
     ///
-    /// assert_eq!("123.456000", dec.clone().padded_right(6).to_string());
+    /// assert_eq!("123.4560", dec.clone().padded_right(-4).to_string());
     /// ```
-    pub fn padded_right(mut self, negative_magnitude: u16) -> Self {
-        self.pad_right(negative_magnitude);
+    pub fn padded_right(mut self, position: i16) -> Self {
+        self.pad_right(position);
         self
     }
 
-    /// Zero-pad the number on the right to a particular (negative) magnitude. Will truncate
+    /// Zero-pad the number on the right to a particular (negative) position. Will truncate
     /// trailing zeros if necessary, but will not truncate other digits.
+    /// 
+    /// Positive numbers have no effect.
+    ///
+    /// Also see [`FixedDecimal::truncate_right()`].
     ///
     /// # Examples
     ///
@@ -879,30 +932,28 @@ impl FixedDecimal {
     /// let mut dec = FixedDecimal::from_str("123.456").unwrap();
     /// assert_eq!("123.456", dec.to_string());
     ///
-    /// dec.pad_right(1);
+    /// dec.pad_right(-1);
     /// assert_eq!("123.456", dec.to_string());
     ///
-    /// dec.pad_right(2);
+    /// dec.pad_right(-2);
     /// assert_eq!("123.456", dec.to_string());
     ///
-    /// dec.pad_right(4);
-    /// assert_eq!("123.4560", dec.to_string());
-    ///
-    /// dec.pad_right(6);
+    /// dec.pad_right(-6);
     /// assert_eq!("123.456000", dec.to_string());
+    ///
+    /// dec.pad_right(-4);
+    /// assert_eq!("123.4560", dec.to_string());
     /// ```
-    pub fn pad_right(&mut self, negative_magnitude: u16) {
-        let mut magnitude = if negative_magnitude > (i16::MAX as u16) {
-            i16::MIN
-        } else {
-            -(negative_magnitude as i16)
-        };
+    pub fn pad_right(&mut self, position: i16) {
+        if position >= 0 {
+            return;
+        }
         let bottom_magnitude = self.nonzero_magnitude_right();
+        let mut magnitude = position;
         // Do not truncate nonzero digits
         if magnitude >= bottom_magnitude {
             magnitude = bottom_magnitude;
         }
-
         self.lower_magnitude = magnitude;
         #[cfg(debug_assertions)]
         self.check_invariants();
@@ -2357,13 +2408,13 @@ fn test_truncate() {
     assert_eq!("1000", dec.to_string());
 
     dec.truncate_left(2);
-    assert_eq!("000", dec.to_string());
+    assert_eq!("00", dec.to_string());
 
     dec.truncate_left(0);
     assert_eq!("0", dec.to_string());
 
     dec.truncate_left(3);
-    assert_eq!("0", dec.to_string());
+    assert_eq!("000", dec.to_string());
 
     let mut dec = FixedDecimal::from_str("0.456").unwrap();
     assert_eq!("0.456", dec.to_string());
@@ -2372,20 +2423,20 @@ fn test_truncate() {
     assert_eq!("0.456", dec.to_string());
 
     dec.truncate_left(-1);
-    assert_eq!("0.456", dec.to_string());
-
-    dec.truncate_left(-2);
     assert_eq!("0.056", dec.to_string());
 
-    dec.truncate_left(-3);
+    dec.truncate_left(-2);
     assert_eq!("0.006", dec.to_string());
 
-    dec.truncate_left(-4);
+    dec.truncate_left(-3);
     assert_eq!("0.000", dec.to_string());
+
+    dec.truncate_left(-4);
+    assert_eq!("0.0000", dec.to_string());
 
     let mut dec = FixedDecimal::from_str("100.01").unwrap();
     dec.truncate_left(1);
-    assert_eq!("00.01", dec.to_string());
+    assert_eq!("0.01", dec.to_string());
 }
 
 #[test]
@@ -2393,19 +2444,13 @@ fn test_pad_left_bounds() {
     let mut dec = FixedDecimal::from_str("299792.458").unwrap();
     let max_integer_digits = core::i16::MAX as usize + 1;
 
-    dec.pad_left(core::u16::MAX);
+    dec.pad_left(core::i16::MAX - 1);
     assert_eq!(
-        max_integer_digits,
+        max_integer_digits - 2,
         dec.to_string().split_once('.').unwrap().0.len()
     );
 
-    dec.pad_left(core::i16::MAX as u16 + 1);
-    assert_eq!(
-        max_integer_digits,
-        dec.to_string().split_once('.').unwrap().0.len()
-    );
-
-    dec.pad_left(core::i16::MAX as u16);
+    dec.pad_left(core::i16::MAX);
     assert_eq!(
         max_integer_digits - 1,
         dec.to_string().split_once('.').unwrap().0.len()
@@ -2417,21 +2462,15 @@ fn test_pad_right_bounds() {
     let mut dec = FixedDecimal::from_str("299792.458").unwrap();
     let max_fractional_digits = -(core::i16::MIN as isize) as usize;
 
-    dec.pad_right(core::u16::MAX);
-    assert_eq!(
-        max_fractional_digits,
-        dec.to_string().split_once('.').unwrap().1.len()
-    );
-
-    dec.pad_right(core::i16::MAX as u16 + 1);
-    assert_eq!(
-        max_fractional_digits,
-        dec.to_string().split_once('.').unwrap().1.len()
-    );
-
-    dec.pad_right(core::i16::MAX as u16);
+    dec.pad_right(core::i16::MIN + 1);
     assert_eq!(
         max_fractional_digits - 1,
+        dec.to_string().split_once('.').unwrap().1.len()
+    );
+
+    dec.pad_right(core::i16::MIN);
+    assert_eq!(
+        max_fractional_digits,
         dec.to_string().split_once('.').unwrap().1.len()
     );
 }

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -444,7 +444,7 @@ impl FixedDecimal {
     /// returning the result.
     ///
     /// Negative numbers have no effect.
-    /// 
+    ///
     /// Also see [`FixedDecimal::truncated_left()`].
     ///
     /// # Examples
@@ -470,7 +470,7 @@ impl FixedDecimal {
     /// Zero-pad the number on the left to a particular position.
     ///
     /// Negative numbers have no effect.
-    /// 
+    ///
     /// Also see [`FixedDecimal::truncate_left()`].
     ///
     /// # Examples
@@ -507,7 +507,7 @@ impl FixedDecimal {
 
     /// Truncate the number on the left to a particular position, deleting
     /// digits if necessary, returning the result.
-    /// 
+    ///
     /// Also see [`FixedDecimal::padded_left()`].
     ///
     /// # Examples
@@ -539,7 +539,7 @@ impl FixedDecimal {
 
     /// Truncate the number on the left to a particular position, deleting
     /// digits if necessary.
-    /// 
+    ///
     /// Also see [`FixedDecimal::pad_left()`].
     ///
     /// # Examples
@@ -889,7 +889,7 @@ impl FixedDecimal {
 
     /// Zero-pad the number on the right to a particular (negative) position. Will truncate
     /// trailing zeros if necessary, but will not truncate other digits, returning the result.
-    /// 
+    ///
     /// Positive numbers have no effect.
     ///
     /// Also see [`FixedDecimal::truncated_right()`].
@@ -918,7 +918,7 @@ impl FixedDecimal {
 
     /// Zero-pad the number on the right to a particular (negative) position. Will truncate
     /// trailing zeros if necessary, but will not truncate other digits.
-    /// 
+    ///
     /// Positive numbers have no effect.
     ///
     /// Also see [`FixedDecimal::truncate_right()`].


### PR DESCRIPTION
Fixes #1958

I introduced the concept of a "position" and changed all the rounding, padding, and truncating APIs to use it. This makes the behavior a lot more understandable overall.

**This PR introduces the following breaking changes:**

1. `FixedDecimal::pad_left` previously took `u16`, but now it takes `i16`. The same numerical value that was previously used should continue to work.
2. `FixedDecimal::truncate_left` previously took `magnitude`, and now it takes `position`. The numerical value must be *decreased by 1* to get the same behavior: if you had `.truncate_left(3)`, you should now write `.truncate_left(2)`. Additionally, `truncate_left` implies `pad_left`.
3. `FixedDecimal::pad_right` previously took `u16`, but now it takes `i16`. Negating the value previously passed to the function should result in the same behavior: if you had `.pad_right(3)`, you should now write `.pad_right(-3)`.