### PR TITLE
Include module name to disambiguate `icu_datetime::pattern::reference::Pattern` and `icu_datetime::pattern::runtime::Pattern`

### DIFF
--- a/components/datetime/src/format/zoned_datetime.rs
+++ b/components/datetime/src/format/zoned_datetime.rs
@@ -8,7 +8,7 @@ use crate::date::ZonedDateTimeInput;
 use crate::date::{LocalizedDateTimeInput, ZonedDateTimeInputWithLocale};
 use crate::error::DateTimeFormatError as Error;
 use crate::fields::{self, FieldSymbol};
-use crate::pattern::{runtime::Pattern, PatternItem};
+use crate::pattern::{runtime, PatternItem};
 use crate::{raw, FormattedTimeZone};
 use core::fmt;
 use writeable::Writeable;
@@ -84,7 +84,7 @@ where
 }
 
 fn write_field<T, W>(
-    pattern: &Pattern,
+    pattern: &runtime::Pattern,
     field: fields::Field,
     zoned_datetime_format: &raw::ZonedDateTimeFormat,
     loc_datetime: &impl LocalizedDateTimeInput<T>,

--- a/components/datetime/src/pattern/hour_cycle.rs
+++ b/components/datetime/src/pattern/hour_cycle.rs
@@ -2,8 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use super::{runtime::Pattern, PatternItem};
-use crate::pattern::{reference, runtime};
+use super::{reference, runtime, PatternItem};
 use crate::{fields, options::preferences};
 #[cfg(feature = "datagen")]
 use crate::{provider, skeleton};
@@ -119,7 +118,7 @@ impl CoarseHourCycle {
 /// and between h23 and h24. This function is naive as it is assumed that this application of
 /// the hour cycle will not change between h1x to h2x.
 pub(crate) fn naively_apply_preferences(
-    pattern: &mut Pattern,
+    pattern: &mut runtime::Pattern,
     preferences: &Option<preferences::Bag>,
 ) {
     // If there is a preference overiding the hour cycle, apply it now.

--- a/components/datetime/src/pattern/runtime/generic.rs
+++ b/components/datetime/src/pattern/runtime/generic.rs
@@ -102,7 +102,7 @@ impl From<&GenericPattern<'_>> for reference::GenericPattern {
 
 impl fmt::Display for GenericPattern<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        let reference = crate::pattern::reference::GenericPattern::from(self);
+        let reference = reference::GenericPattern::from(self);
         reference.fmt(formatter)
     }
 }
@@ -111,7 +111,7 @@ impl FromStr for GenericPattern<'_> {
     type Err = PatternError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let reference = crate::pattern::reference::GenericPattern::from_str(s)?;
+        let reference = reference::GenericPattern::from_str(s)?;
         Ok(Self::from(&reference))
     }
 }

--- a/components/datetime/src/pattern/runtime/helpers.rs
+++ b/components/datetime/src/pattern/runtime/helpers.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use super::super::{runtime, PatternItem};
+use super::{super::PatternItem, Pattern};
 use zerovec::ule::AsULE;
 
 /// Helper function which takes a runtime `Pattern` and calls
@@ -16,10 +16,7 @@ use zerovec::ule::AsULE;
 /// item to be replaced allocating the `Pattern` only if needed.
 ///
 /// For a variant that replaces all matching instances, see `maybe_replace`.
-pub fn maybe_replace_first(
-    pattern: &mut runtime::Pattern,
-    f: impl Fn(&PatternItem) -> Option<PatternItem>,
-) {
+pub fn maybe_replace_first(pattern: &mut Pattern, f: impl Fn(&PatternItem) -> Option<PatternItem>) {
     let result = pattern
         .items
         .iter()
@@ -41,10 +38,7 @@ pub fn maybe_replace_first(
 ///
 /// For a variant that replaces just the first matching instance,
 /// see `maybe_replace_first`.
-pub fn maybe_replace(
-    pattern: &mut runtime::Pattern,
-    f: impl Fn(&PatternItem) -> Option<PatternItem>,
-) {
+pub fn maybe_replace(pattern: &mut Pattern, f: impl Fn(&PatternItem) -> Option<PatternItem>) {
     let result = pattern
         .items
         .iter()

--- a/components/datetime/src/provider/calendar/mod.rs
+++ b/components/datetime/src/provider/calendar/mod.rs
@@ -47,7 +47,7 @@ pub struct DatePatternsV1<'data> {
 
 pub mod patterns {
     use super::*;
-    use crate::pattern::runtime::{GenericPattern, Pattern, PatternPlurals};
+    use crate::pattern::runtime::{self, GenericPattern, PatternPlurals};
     use icu_provider::{yoke, zerofrom};
 
     #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
@@ -59,13 +59,13 @@ pub mod patterns {
     #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
     pub struct LengthPatternsV1<'data> {
         #[cfg_attr(feature = "serde", serde(borrow))]
-        pub full: Pattern<'data>,
+        pub full: runtime::Pattern<'data>,
         #[cfg_attr(feature = "serde", serde(borrow))]
-        pub long: Pattern<'data>,
+        pub long: runtime::Pattern<'data>,
         #[cfg_attr(feature = "serde", serde(borrow))]
-        pub medium: Pattern<'data>,
+        pub medium: runtime::Pattern<'data>,
         #[cfg_attr(feature = "serde", serde(borrow))]
-        pub short: Pattern<'data>,
+        pub short: runtime::Pattern<'data>,
     }
 
     #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]

--- a/components/datetime/src/skeleton/helpers.rs
+++ b/components/datetime/src/skeleton/helpers.rs
@@ -10,8 +10,8 @@ use crate::{
     fields::{self, Field, FieldLength, FieldSymbol},
     options::{components, length},
     pattern::{
-        hour_cycle, runtime,
-        runtime::{Pattern, PatternPlurals},
+        hour_cycle,
+        runtime::{self, PatternPlurals},
         PatternItem, TimeGranularity,
     },
     provider::calendar::{patterns::GenericLengthPatternsV1, DateSkeletonPatternsV1},
@@ -90,7 +90,7 @@ pub enum BestSkeleton<T> {
 /// This function swaps out the the time zone name field for the appropriate one. Skeleton matching
 /// only needs to find a single "v" field, and then the time zone name can expand from there.
 fn naively_apply_time_zone_name(
-    pattern: &mut Pattern,
+    pattern: &mut runtime::Pattern,
     time_zone_name: &Option<components::TimeZoneName>,
 ) {
     // If there is a preference overiding the hour cycle, apply it now.
@@ -179,7 +179,7 @@ pub fn create_best_pattern_for_fields<'data>(
             BestSkeleton::AllFieldsMatch(fields) => (Some(fields), false),
             BestSkeleton::NoMatch => (None, true),
         };
-    let time_pattern: Option<Pattern<'data>> = time_patterns.map(|pattern_plurals| {
+    let time_pattern: Option<runtime::Pattern<'data>> = time_patterns.map(|pattern_plurals| {
         let mut pattern =
             pattern_plurals.expect_pattern("Only date patterns can contain plural variants");
         hour_cycle::naively_apply_preferences(&mut pattern, &components.preferences);
@@ -301,7 +301,7 @@ fn group_fields_by_type(fields: &[Field]) -> FieldsByType {
 /// Alters given Pattern so that its fields have the same length as 'fields'.
 ///
 ///  For example the "d MMM y" pattern will be changed to "d MMMM y" given fields ["y", "MMMM", "d"].
-fn adjust_pattern_field_lengths(fields: &[Field], pattern: &mut Pattern) {
+fn adjust_pattern_field_lengths(fields: &[Field], pattern: &mut runtime::Pattern) {
     runtime::helpers::maybe_replace(pattern, |item| {
         if let PatternItem::Field(pattern_field) = item {
             if let Some(requested_field) = fields
@@ -326,7 +326,7 @@ fn adjust_pattern_field_lengths(fields: &[Field], pattern: &mut Pattern) {
 /// pattern should be adjusted by appending the locale’s decimal separator, followed by the sequence
 /// of ‘S’ characters from the requested skeleton.
 /// (see https://unicode.org/reports/tr35/tr35-dates.html#Matching_Skeletons)
-fn append_fractional_seconds(pattern: &mut Pattern, fields: &[Field]) {
+fn append_fractional_seconds(pattern: &mut runtime::Pattern, fields: &[Field]) {
     if let Some(requested_field) = fields
         .iter()
         .find(|field| field.symbol == FieldSymbol::Second(fields::Second::FractionalSecond))
@@ -346,7 +346,7 @@ fn append_fractional_seconds(pattern: &mut Pattern, fields: &[Field]) {
                 }
             }
         }
-        *pattern = Pattern::from(items);
+        *pattern = runtime::Pattern::from(items);
         pattern.time_granularity = TimeGranularity::Nanoseconds;
     }
 }
@@ -482,7 +482,7 @@ pub fn get_best_available_format_pattern<'data>(
             // A single field was requested and the best pattern either includes extra fields or can't be adjusted to match
             // (e.g. text vs numeric). We return the field instead of the matched pattern.
             return BestSkeleton::AllFieldsMatch(
-                Pattern::from(vec![PatternItem::Field(*field)]).into(),
+                runtime::Pattern::from(vec![PatternItem::Field(*field)]).into(),
             );
         }
     }

--- a/components/datetime/src/skeleton/mod.rs
+++ b/components/datetime/src/skeleton/mod.rs
@@ -23,7 +23,7 @@ mod test {
     use crate::{
         fields::{Day, Field, FieldLength, Month, Weekday},
         options::components,
-        pattern::runtime::Pattern,
+        pattern::runtime,
         provider::calendar::{
             DatePatternsV1Marker, DateSkeletonPatternsV1, DateSkeletonPatternsV1Marker, SkeletonV1,
         },
@@ -181,7 +181,7 @@ mod test {
         let mut skeletons = LiteMap::new();
         skeletons.insert(
             SkeletonV1::try_from("EEEE").unwrap(),
-            Pattern::from_str("weekday EEEE").unwrap().into(),
+            runtime::Pattern::from_str("weekday EEEE").unwrap().into(),
         );
         let skeletons = DateSkeletonPatternsV1(skeletons);
 

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -14,7 +14,7 @@ use icu_calendar::{
 use icu_datetime::provider::time_zones::{MetaZoneId, TimeZoneBcp47Id};
 use icu_datetime::{
     mock::{parse_gregorian_from_str, zoned_datetime::MockZonedDateTime},
-    pattern::runtime::Pattern,
+    pattern::runtime,
     provider::{
         calendar::{DatePatternsV1Marker, DateSkeletonPatternsV1Marker, DateSymbolsV1Marker},
         week_data::WeekDataV1Marker,
@@ -271,8 +271,8 @@ fn test_dayperiod_patterns() {
                 let datetime = parse_gregorian_from_str(dt_input).unwrap();
                 for DayPeriodExpectation { patterns, expected } in &test_case.expectations {
                     for pattern_input in patterns {
-                        let new_pattern1: Pattern = pattern_input.parse().unwrap();
-                        let new_pattern2: Pattern = pattern_input.parse().unwrap();
+                        let new_pattern1: runtime::Pattern = pattern_input.parse().unwrap();
+                        let new_pattern2: runtime::Pattern = pattern_input.parse().unwrap();
                         patterns_data.with_mut(move |data| {
                             data.time_h11_h12.long = new_pattern1;
                             data.time_h23_h24.long = new_pattern2;
@@ -435,8 +435,8 @@ fn test_time_zone_patterns() {
         } in &test.expectations
         {
             for pattern_input in patterns {
-                let new_pattern1: Pattern = pattern_input.parse().unwrap();
-                let new_pattern2: Pattern = pattern_input.parse().unwrap();
+                let new_pattern1: runtime::Pattern = pattern_input.parse().unwrap();
+                let new_pattern2: runtime::Pattern = pattern_input.parse().unwrap();
                 patterns_data.with_mut(move |data| {
                     data.time_h11_h12.long = new_pattern1;
                     data.time_h23_h24.long = new_pattern2;

--- a/components/datetime/tests/pattern_serialization.rs
+++ b/components/datetime/tests/pattern_serialization.rs
@@ -4,7 +4,7 @@
 
 #![cfg(all(test, feature = "datagen"))]
 
-use icu_datetime::pattern::reference::Pattern;
+use icu_datetime::pattern::reference;
 use std::{fs::File, io::BufReader};
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -53,7 +53,7 @@ fn test_pattern_json_serialization_roundtrip() {
         // Wrap the string in quotes so it's a JSON string.
         let json_in: String = serde_json::to_string(pattern_string).unwrap();
 
-        let pattern: Pattern = match serde_json::from_str(&json_in) {
+        let pattern: reference::Pattern = match serde_json::from_str(&json_in) {
             Ok(p) => p,
             Err(err) => {
                 panic!(
@@ -107,7 +107,7 @@ fn test_pattern_bincode_serialization_roundtrip() {
         // Wrap the string in quotes so it's a JSON string.
         let json_in: String = serde_json::to_string(pattern_string).unwrap();
 
-        let pattern: Pattern = match serde_json::from_str(&json_in) {
+        let pattern: reference::Pattern = match serde_json::from_str(&json_in) {
             Ok(p) => p,
             Err(err) => {
                 panic!(
@@ -148,7 +148,7 @@ fn test_pattern_json_errors() {
         let json_in: String = serde_json::to_string(pattern).unwrap();
 
         // Wrap the string in quotes so it's a JSON string.
-        match serde_json::from_str::<Pattern>(&json_in) {
+        match serde_json::from_str::<reference::Pattern>(&json_in) {
             Ok(_) => panic!("Expected an invalid pattern. {}", json_in),
             Err(serde_err) => {
                 assert_eq!(format!("{}", serde_err), *error);


### PR DESCRIPTION
Resolves #1889