### PR TITLE
More Bidi FFI APIs

### DIFF
--- a/ffi/diplomat/c/include/ICU4XBidi.h
+++ b/ffi/diplomat/c/include/ICU4XBidi.h
@@ -17,7 +17,15 @@ typedef struct ICU4XBidi ICU4XBidi;
 
 diplomat_result_box_ICU4XBidi_void ICU4XBidi_try_new(const ICU4XDataProvider* provider);
 
-ICU4XBidiInfo* ICU4XBidi_for_text(const ICU4XBidi* self, const char* text_data, size_t text_len);
+ICU4XBidiInfo* ICU4XBidi_for_text(const ICU4XBidi* self, const char* text_data, size_t text_len, uint8_t default_level);
+
+bool ICU4XBidi_level_is_rtl(uint8_t level);
+
+bool ICU4XBidi_level_is_ltr(uint8_t level);
+
+uint8_t ICU4XBidi_level_rtl();
+
+uint8_t ICU4XBidi_level_ltr();
 void ICU4XBidi_destroy(ICU4XBidi* self);
 
 #ifdef __cplusplus

--- a/ffi/diplomat/c/include/ICU4XBidiInfo.h
+++ b/ffi/diplomat/c/include/ICU4XBidiInfo.h
@@ -16,6 +16,10 @@ typedef struct ICU4XBidiInfo ICU4XBidiInfo;
 size_t ICU4XBidiInfo_paragraph_count(const ICU4XBidiInfo* self);
 
 ICU4XBidiParagraph* ICU4XBidiInfo_paragraph_at(const ICU4XBidiInfo* self, size_t n);
+
+size_t ICU4XBidiInfo_size(const ICU4XBidiInfo* self);
+
+uint8_t ICU4XBidiInfo_level_at(const ICU4XBidiInfo* self, size_t pos);
 void ICU4XBidiInfo_destroy(ICU4XBidiInfo* self);
 
 #ifdef __cplusplus

--- a/ffi/diplomat/c/include/ICU4XBidiParagraph.h
+++ b/ffi/diplomat/c/include/ICU4XBidiParagraph.h
@@ -27,10 +27,6 @@ size_t ICU4XBidiParagraph_range_end(const ICU4XBidiParagraph* self);
 diplomat_result_void_void ICU4XBidiParagraph_reorder_line(const ICU4XBidiParagraph* self, size_t range_start, size_t range_end, DiplomatWriteable* out);
 
 uint8_t ICU4XBidiParagraph_level_at(const ICU4XBidiParagraph* self, size_t pos);
-
-bool ICU4XBidiParagraph_level_is_rtl(uint8_t level);
-
-bool ICU4XBidiParagraph_level_is_ltr(uint8_t level);
 void ICU4XBidiParagraph_destroy(ICU4XBidiParagraph* self);
 
 #ifdef __cplusplus

--- a/ffi/diplomat/cpp/docs/source/bidi_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/bidi_ffi.rst
@@ -11,10 +11,33 @@
         Creates a new :cpp:class:`ICU4XBidi` from locale data.
         See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/bidi/struct.BidiClassAdapter.html#method.new>`__ for more information.
 
-    .. cpp:function:: ICU4XBidiInfo for_text(const std::string_view text) const
+    .. cpp:function:: ICU4XBidiInfo for_text(const std::string_view text, uint8_t default_level) const
 
         Use the data loaded in this object to process a string and calculate bidi information
+        Takes in a Level for the default level, if it is an invalid value it will default to LTR
         See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html#method.new_with_data_source>`__ for more information.
+
+    .. cpp:function:: static bool level_is_rtl(uint8_t level)
+
+        Check if a Level returned by level_at is an RTL level.
+        Invalid levels (numbers greater than 125) will be assumed LTR
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_rtl>`__ for more information.
+
+    .. cpp:function:: static bool level_is_ltr(uint8_t level)
+
+        Check if a Level returned by level_at is an LTR level.
+        Invalid levels (numbers greater than 125) will be assumed LTR
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_ltr>`__ for more information.
+
+    .. cpp:function:: static uint8_t level_rtl()
+
+        Get a basic RTL Level value
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.rtl>`__ for more information.
+
+    .. cpp:function:: static uint8_t level_ltr()
+
+        Get a simple LTR Level value
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.ltr>`__ for more information.
 
 .. cpp:enum-struct:: ICU4XBidiDirection
 
@@ -36,6 +59,15 @@
     .. cpp:function:: std::optional<ICU4XBidiParagraph> paragraph_at(size_t n) const
 
         Get the nth paragraph, returning None if out of bounds
+
+    .. cpp:function:: size_t size() const
+
+        The number of bytes in this full text
+
+    .. cpp:function:: uint8_t level_at(size_t pos) const
+
+        Get the BIDI level at a particular byte index in the full text. This integer is conceptually a ``unicode_bidi::Level``, and can be further inspected using the static methods on ICU4XBidi.
+        Returns 0 (equivalent to ``Level::ltr()``) on error
 
 .. cpp:class:: ICU4XBidiParagraph
 
@@ -76,17 +108,6 @@
 
     .. cpp:function:: uint8_t level_at(size_t pos) const
 
-        Get the BIDI level. This integer is conceptually a ``unicode_bidi::Level``, and can be further inspected using the static methods on this class.
+        Get the BIDI level at a particular byte index in this paragraph. This integer is conceptually a ``unicode_bidi::Level``, and can be further inspected using the static methods on ICU4XBidi.
+        Returns 0 (equivalent to ``Level::ltr()``) on error
         See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at>`__ for more information.
-
-    .. cpp:function:: static bool level_is_rtl(uint8_t level)
-
-        Check if a Level returned by level_at is an RTL level.
-        Invalid levels (numbers greater than 125) will be assumed LTR
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_rtl>`__ for more information.
-
-    .. cpp:function:: static bool level_is_ltr(uint8_t level)
-
-        Check if a Level returned by level_at is an LTR level.
-        Invalid levels (numbers greater than 125) will be assumed LTR
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_ltr>`__ for more information.

--- a/ffi/diplomat/cpp/examples/bidi/test.cpp
+++ b/ffi/diplomat/cpp/examples/bidi/test.cpp
@@ -35,7 +35,7 @@ int main() {
         "ג"
         "ב"
         "א";
-    auto bidi_info = bidi.for_text(str);
+    auto bidi_info = bidi.for_text(str, ICU4XBidi::level_ltr());
     auto n_para = bidi_info.paragraph_count();
     if (n_para != 2) {
         std::cout << "Expected 2 paragraphs, found " << n_para << std::endl;
@@ -53,7 +53,7 @@ int main() {
     // The first paragraph's first strongly directional character is RTL
     uint8_t level = para.level_at(0);
     std::cout << "Level of first paragraph at index 0 is " << unsigned(level) << std::endl;
-    if (!ICU4XBidiParagraph::level_is_rtl(level)) {
+    if (!ICU4XBidi::level_is_rtl(level)) {
         std::cout << "Expected level at index 0 to be RTL" << std::endl;
         return 1;
     }
@@ -77,7 +77,7 @@ int main() {
     // The second paragraph's first strongly directional character is LTR
     level = para.level_at(0);
     std::cout << "Level of second paragraph at index 0 is " << unsigned(level) << std::endl;
-    if (!ICU4XBidiParagraph::level_is_ltr(level)) {
+    if (!ICU4XBidi::level_is_ltr(level)) {
         std::cout << "Expected level at index 0 to be LTR" << std::endl;
         return 1;
     }

--- a/ffi/diplomat/cpp/include/ICU4XBidi.h
+++ b/ffi/diplomat/cpp/include/ICU4XBidi.h
@@ -17,7 +17,15 @@ typedef struct ICU4XBidi ICU4XBidi;
 
 diplomat_result_box_ICU4XBidi_void ICU4XBidi_try_new(const ICU4XDataProvider* provider);
 
-ICU4XBidiInfo* ICU4XBidi_for_text(const ICU4XBidi* self, const char* text_data, size_t text_len);
+ICU4XBidiInfo* ICU4XBidi_for_text(const ICU4XBidi* self, const char* text_data, size_t text_len, uint8_t default_level);
+
+bool ICU4XBidi_level_is_rtl(uint8_t level);
+
+bool ICU4XBidi_level_is_ltr(uint8_t level);
+
+uint8_t ICU4XBidi_level_rtl();
+
+uint8_t ICU4XBidi_level_ltr();
 void ICU4XBidi_destroy(ICU4XBidi* self);
 
 #ifdef __cplusplus

--- a/ffi/diplomat/cpp/include/ICU4XBidi.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XBidi.hpp
@@ -44,9 +44,43 @@ class ICU4XBidi {
   /**
    * Use the data loaded in this object to process a string and calculate bidi information
    * 
+   * Takes in a Level for the default level, if it is an invalid value it will default to LTR
+   * 
    * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html#method.new_with_data_source) for more information.
    */
-  ICU4XBidiInfo for_text(const std::string_view text) const;
+  ICU4XBidiInfo for_text(const std::string_view text, uint8_t default_level) const;
+
+  /**
+   * Check if a Level returned by level_at is an RTL level.
+   * 
+   * Invalid levels (numbers greater than 125) will be assumed LTR
+   * 
+   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_rtl) for more information.
+   */
+  static bool level_is_rtl(uint8_t level);
+
+  /**
+   * Check if a Level returned by level_at is an LTR level.
+   * 
+   * Invalid levels (numbers greater than 125) will be assumed LTR
+   * 
+   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_ltr) for more information.
+   */
+  static bool level_is_ltr(uint8_t level);
+
+  /**
+   * Get a basic RTL Level value
+   * 
+   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.rtl) for more information.
+   */
+  static uint8_t level_rtl();
+
+  /**
+   * Get a simple LTR Level value
+   * 
+   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.ltr) for more information.
+   */
+  static uint8_t level_ltr();
   inline const capi::ICU4XBidi* AsFFI() const { return this->inner.get(); }
   inline capi::ICU4XBidi* AsFFIMut() { return this->inner.get(); }
   inline ICU4XBidi(capi::ICU4XBidi* i) : inner(i) {}
@@ -70,7 +104,19 @@ inline diplomat::result<ICU4XBidi, std::monostate> ICU4XBidi::try_new(const ICU4
   }
   return diplomat_result_out_value;
 }
-inline ICU4XBidiInfo ICU4XBidi::for_text(const std::string_view text) const {
-  return ICU4XBidiInfo(capi::ICU4XBidi_for_text(this->inner.get(), text.data(), text.size()));
+inline ICU4XBidiInfo ICU4XBidi::for_text(const std::string_view text, uint8_t default_level) const {
+  return ICU4XBidiInfo(capi::ICU4XBidi_for_text(this->inner.get(), text.data(), text.size(), default_level));
+}
+inline bool ICU4XBidi::level_is_rtl(uint8_t level) {
+  return capi::ICU4XBidi_level_is_rtl(level);
+}
+inline bool ICU4XBidi::level_is_ltr(uint8_t level) {
+  return capi::ICU4XBidi_level_is_ltr(level);
+}
+inline uint8_t ICU4XBidi::level_rtl() {
+  return capi::ICU4XBidi_level_rtl();
+}
+inline uint8_t ICU4XBidi::level_ltr() {
+  return capi::ICU4XBidi_level_ltr();
 }
 #endif

--- a/ffi/diplomat/cpp/include/ICU4XBidiInfo.h
+++ b/ffi/diplomat/cpp/include/ICU4XBidiInfo.h
@@ -16,6 +16,10 @@ typedef struct ICU4XBidiInfo ICU4XBidiInfo;
 size_t ICU4XBidiInfo_paragraph_count(const ICU4XBidiInfo* self);
 
 ICU4XBidiParagraph* ICU4XBidiInfo_paragraph_at(const ICU4XBidiInfo* self, size_t n);
+
+size_t ICU4XBidiInfo_size(const ICU4XBidiInfo* self);
+
+uint8_t ICU4XBidiInfo_level_at(const ICU4XBidiInfo* self, size_t pos);
 void ICU4XBidiInfo_destroy(ICU4XBidiInfo* self);
 
 #ifdef __cplusplus

--- a/ffi/diplomat/cpp/include/ICU4XBidiInfo.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XBidiInfo.hpp
@@ -41,6 +41,20 @@ class ICU4XBidiInfo {
    * Get the nth paragraph, returning None if out of bounds
    */
   std::optional<ICU4XBidiParagraph> paragraph_at(size_t n) const;
+
+  /**
+   * The number of bytes in this full text
+   */
+  size_t size() const;
+
+  /**
+   * Get the BIDI level at a particular byte index in the full text.
+   * This integer is conceptually a `unicode_bidi::Level`,
+   * and can be further inspected using the static methods on ICU4XBidi.
+   * 
+   * Returns 0 (equivalent to `Level::ltr()`) on error
+   */
+  uint8_t level_at(size_t pos) const;
   inline const capi::ICU4XBidiInfo* AsFFI() const { return this->inner.get(); }
   inline capi::ICU4XBidiInfo* AsFFIMut() { return this->inner.get(); }
   inline ICU4XBidiInfo(capi::ICU4XBidiInfo* i) : inner(i) {}
@@ -65,5 +79,11 @@ inline std::optional<ICU4XBidiParagraph> ICU4XBidiInfo::paragraph_at(size_t n) c
     diplomat_optional_out_value = std::nullopt;
   }
   return diplomat_optional_out_value;
+}
+inline size_t ICU4XBidiInfo::size() const {
+  return capi::ICU4XBidiInfo_size(this->inner.get());
+}
+inline uint8_t ICU4XBidiInfo::level_at(size_t pos) const {
+  return capi::ICU4XBidiInfo_level_at(this->inner.get(), pos);
 }
 #endif

--- a/ffi/diplomat/cpp/include/ICU4XBidiParagraph.h
+++ b/ffi/diplomat/cpp/include/ICU4XBidiParagraph.h
@@ -27,10 +27,6 @@ size_t ICU4XBidiParagraph_range_end(const ICU4XBidiParagraph* self);
 diplomat_result_void_void ICU4XBidiParagraph_reorder_line(const ICU4XBidiParagraph* self, size_t range_start, size_t range_end, DiplomatWriteable* out);
 
 uint8_t ICU4XBidiParagraph_level_at(const ICU4XBidiParagraph* self, size_t pos);
-
-bool ICU4XBidiParagraph_level_is_rtl(uint8_t level);
-
-bool ICU4XBidiParagraph_level_is_ltr(uint8_t level);
 void ICU4XBidiParagraph_destroy(ICU4XBidiParagraph* self);
 
 #ifdef __cplusplus

--- a/ffi/diplomat/cpp/include/ICU4XBidiParagraph.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XBidiParagraph.hpp
@@ -80,30 +80,15 @@ class ICU4XBidiParagraph {
   diplomat::result<std::string, std::monostate> reorder_line(size_t range_start, size_t range_end) const;
 
   /**
-   * Get the BIDI level. This integer is conceptually a `unicode_bidi::Level`,
-   * and can be further inspected using the static methods on this class.
+   * Get the BIDI level at a particular byte index in this paragraph.
+   * This integer is conceptually a `unicode_bidi::Level`,
+   * and can be further inspected using the static methods on ICU4XBidi.
+   * 
+   * Returns 0 (equivalent to `Level::ltr()`) on error
    * 
    * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at) for more information.
    */
   uint8_t level_at(size_t pos) const;
-
-  /**
-   * Check if a Level returned by level_at is an RTL level.
-   * 
-   * Invalid levels (numbers greater than 125) will be assumed LTR
-   * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_rtl) for more information.
-   */
-  static bool level_is_rtl(uint8_t level);
-
-  /**
-   * Check if a Level returned by level_at is an LTR level.
-   * 
-   * Invalid levels (numbers greater than 125) will be assumed LTR
-   * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_ltr) for more information.
-   */
-  static bool level_is_ltr(uint8_t level);
   inline const capi::ICU4XBidiParagraph* AsFFI() const { return this->inner.get(); }
   inline capi::ICU4XBidiParagraph* AsFFIMut() { return this->inner.get(); }
   inline ICU4XBidiParagraph(capi::ICU4XBidiParagraph* i) : inner(i) {}
@@ -162,11 +147,5 @@ inline diplomat::result<std::string, std::monostate> ICU4XBidiParagraph::reorder
 }
 inline uint8_t ICU4XBidiParagraph::level_at(size_t pos) const {
   return capi::ICU4XBidiParagraph_level_at(this->inner.get(), pos);
-}
-inline bool ICU4XBidiParagraph::level_is_rtl(uint8_t level) {
-  return capi::ICU4XBidiParagraph_level_is_rtl(level);
-}
-inline bool ICU4XBidiParagraph::level_is_ltr(uint8_t level) {
-  return capi::ICU4XBidiParagraph_level_is_ltr(level);
 }
 #endif

--- a/ffi/diplomat/src/bidi.rs
+++ b/ffi/diplomat/src/bidi.rs
@@ -47,12 +47,18 @@ pub mod ffi {
         ///
         /// Takes in a Level for the default level, if it is an invalid value it will default to LTR
         #[diplomat::rust_link(unicode_bidi::BidiInfo::new_with_data_source, FnInStruct)]
-        pub fn for_text<'text>(&self, text: &'text str, default_level: u8) -> Box<ICU4XBidiInfo<'text>> {
+        pub fn for_text<'text>(
+            &self,
+            text: &'text str,
+            default_level: u8,
+        ) -> Box<ICU4XBidiInfo<'text>> {
             let data = self.0.get();
             let adapter = BidiClassAdapter::new(&data.code_point_trie);
 
             Box::new(ICU4XBidiInfo(BidiInfo::new_with_data_source(
-                &adapter, text, Level::new(default_level).ok(),
+                &adapter,
+                text,
+                Level::new(default_level).ok(),
             )))
         }
 

--- a/ffi/diplomat/src/bidi.rs
+++ b/ffi/diplomat/src/bidi.rs
@@ -121,11 +121,11 @@ pub mod ffi {
         ///
         /// Returns 0 (equivalent to `Level::ltr()`) on error
         pub fn level_at(&self, pos: usize) -> u8 {
-            if pos >= self.size() {
-                return 0;
+            if let Some(l) = self.0.levels.get(pos) {
+                l.number()
+            } else {
+                0
             }
-
-            self.0.levels[pos].number()
         }
     }
 

--- a/ffi/diplomat/wasm/docs/bidi_ffi.rst
+++ b/ffi/diplomat/wasm/docs/bidi_ffi.rst
@@ -11,10 +11,33 @@
         Creates a new :js:class:`ICU4XBidi` from locale data.
         See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/bidi/struct.BidiClassAdapter.html#method.new>`__ for more information.
 
-    .. js:function:: for_text(text)
+    .. js:function:: for_text(text, default_level)
 
         Use the data loaded in this object to process a string and calculate bidi information
+        Takes in a Level for the default level, if it is an invalid value it will default to LTR
         See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html#method.new_with_data_source>`__ for more information.
+
+    .. js:staticfunction:: level_is_rtl(level)
+
+        Check if a Level returned by level_at is an RTL level.
+        Invalid levels (numbers greater than 125) will be assumed LTR
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_rtl>`__ for more information.
+
+    .. js:staticfunction:: level_is_ltr(level)
+
+        Check if a Level returned by level_at is an LTR level.
+        Invalid levels (numbers greater than 125) will be assumed LTR
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_ltr>`__ for more information.
+
+    .. js:staticfunction:: level_rtl()
+
+        Get a basic RTL Level value
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.rtl>`__ for more information.
+
+    .. js:staticfunction:: level_ltr()
+
+        Get a simple LTR Level value
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.ltr>`__ for more information.
 
 .. js:class:: ICU4XBidiDirection
 
@@ -30,6 +53,15 @@
     .. js:function:: paragraph_at(n)
 
         Get the nth paragraph, returning None if out of bounds
+
+    .. js:function:: size()
+
+        The number of bytes in this full text
+
+    .. js:function:: level_at(pos)
+
+        Get the BIDI level at a particular byte index in the full text. This integer is conceptually a ``unicode_bidi::Level``, and can be further inspected using the static methods on ICU4XBidi.
+        Returns 0 (equivalent to ``Level::ltr()``) on error
 
 .. js:class:: ICU4XBidiParagraph
 
@@ -65,17 +97,6 @@
 
     .. js:function:: level_at(pos)
 
-        Get the BIDI level. This integer is conceptually a ``unicode_bidi::Level``, and can be further inspected using the static methods on this class.
+        Get the BIDI level at a particular byte index in this paragraph. This integer is conceptually a ``unicode_bidi::Level``, and can be further inspected using the static methods on ICU4XBidi.
+        Returns 0 (equivalent to ``Level::ltr()``) on error
         See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at>`__ for more information.
-
-    .. js:staticfunction:: level_is_rtl(level)
-
-        Check if a Level returned by level_at is an RTL level.
-        Invalid levels (numbers greater than 125) will be assumed LTR
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_rtl>`__ for more information.
-
-    .. js:staticfunction:: level_is_ltr(level)
-
-        Check if a Level returned by level_at is an LTR level.
-        Invalid levels (numbers greater than 125) will be assumed LTR
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_ltr>`__ for more information.

--- a/ffi/diplomat/wasm/lib/api.mjs
+++ b/ffi/diplomat/wasm/lib/api.mjs
@@ -39,14 +39,14 @@ export class ICU4XBidi {
     return diplomat_out;
   }
 
-  for_text(text) {
+  for_text(text, default_level) {
     let text_diplomat_bytes = (new TextEncoder()).encode(text);
     let text_diplomat_ptr = wasm.diplomat_alloc(text_diplomat_bytes.length, 1);
     let text_diplomat_buf = new Uint8Array(wasm.memory.buffer, text_diplomat_ptr, text_diplomat_bytes.length);
     text_diplomat_buf.set(text_diplomat_bytes, 0);
     const diplomat_out = (() => {
       const out = (() => {
-        const out = new ICU4XBidiInfo(wasm.ICU4XBidi_for_text(this.underlying, text_diplomat_ptr, text_diplomat_bytes.length));
+        const out = new ICU4XBidiInfo(wasm.ICU4XBidi_for_text(this.underlying, text_diplomat_ptr, text_diplomat_bytes.length, default_level));
         out.owner = null;
         return out;
       })();
@@ -54,6 +54,26 @@ export class ICU4XBidi {
       return out;
     })();
     wasm.diplomat_free(text_diplomat_ptr, text_diplomat_bytes.length, 1);
+    return diplomat_out;
+  }
+
+  static level_is_rtl(level) {
+    const diplomat_out = wasm.ICU4XBidi_level_is_rtl(level);
+    return diplomat_out;
+  }
+
+  static level_is_ltr(level) {
+    const diplomat_out = wasm.ICU4XBidi_level_is_ltr(level);
+    return diplomat_out;
+  }
+
+  static level_rtl() {
+    const diplomat_out = wasm.ICU4XBidi_level_rtl();
+    return diplomat_out;
+  }
+
+  static level_ltr() {
+    const diplomat_out = wasm.ICU4XBidi_level_ltr();
     return diplomat_out;
   }
 }
@@ -101,6 +121,16 @@ export class ICU4XBidiInfo {
         return null;
       }
     })();
+    return diplomat_out;
+  }
+
+  size() {
+    const diplomat_out = wasm.ICU4XBidiInfo_size(this.underlying);
+    return diplomat_out;
+  }
+
+  level_at(pos) {
+    const diplomat_out = wasm.ICU4XBidiInfo_level_at(this.underlying, pos);
     return diplomat_out;
   }
 }
@@ -158,16 +188,6 @@ export class ICU4XBidiParagraph {
 
   level_at(pos) {
     const diplomat_out = wasm.ICU4XBidiParagraph_level_at(this.underlying, pos);
-    return diplomat_out;
-  }
-
-  static level_is_rtl(level) {
-    const diplomat_out = wasm.ICU4XBidiParagraph_level_is_rtl(level);
-    return diplomat_out;
-  }
-
-  static level_is_ltr(level) {
-    const diplomat_out = wasm.ICU4XBidiParagraph_level_is_ltr(level);
     return diplomat_out;
   }
 }


### PR DESCRIPTION
Progress on https://github.com/unicode-org/icu4x/issues/1960

This provides the remaining APIs except for `sk_ubidi_reorderVisual` and `sk_ubidi_getDirection`. For the latter I'll be making a unicode-bidi PR, for the former I need @sffc or @younies to have a look and add an appropriate API to unicode-bidi.




<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->