### PR TITLE
Apply opt-level='s'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ exclude = ["provider/testdata/data/const"]
 #   error: options `-C embed-bitcode=no` and `-C lto` are incompatible
 [profile.release]
 lto = true
+opt-level = 's'
 
 # Enable debug information specifically for memory profiling.
 # https://docs.rs/dhat/0.2.1/dhat/#configuration


### PR DESCRIPTION
Draft PR to measure the impact of setting `opt-level='s'`

See https://github.com/unicode-org/icu4x/issues/2040