### PR TITLE
Re-enable LTO on default release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,12 +58,13 @@ members = [
 ]
 exclude = ["provider/testdata/data/const"]
 
+# LTO is needed for WASM and other size-optimized builds,
+# and it improve the performance of benchmarks
 [profile.release]
+lto = true
 
-# LTO is needed for WASM and other size-optimized builds
 [profile.release-opt-size]
 inherits = "release"
-lto = true
 opt-level = "s"
 
 # Enable debug information specifically for memory profiling.


### PR DESCRIPTION
I removed LTO by default in https://github.com/unicode-org/icu4x/pull/2043, but it seems to have reduced performance on several benchmarks. This PR adds it back again. It seems like LTO increases performance at the cost of higher compile times.