### PR TITLE
Start emitting month codes from the calendar crate, switch ISO to ArithmeticDate

### DIFF
--- a/components/calendar/README.md
+++ b/components/calendar/README.md
@@ -30,7 +30,7 @@ let mut date_iso = Date::new_iso_date_from_integers(1992, 9, 2)
 
 assert_eq!(date_iso.day_of_week(), IsoWeekday::Wednesday);
 assert_eq!(date_iso.year().number, 1992);
-assert_eq!(date_iso.month().number, 9);
+assert_eq!(date_iso.month().ordinal_month, 9);
 assert_eq!(date_iso.day_of_month().0, 2);
 
 // Answering questions about days in month and year.
@@ -40,13 +40,13 @@ assert_eq!(date_iso.days_in_month(), 30);
 // Advancing date in-place by 1 year, 2 months, 3 weeks, 4 days.
 date_iso.add(DateDuration::new(1, 2, 3, 4));
 assert_eq!(date_iso.year().number, 1993);
-assert_eq!(date_iso.month().number, 11);
+assert_eq!(date_iso.month().ordinal_month, 11);
 assert_eq!(date_iso.day_of_month().0, 27);
 
 // Reverse date advancement.
 date_iso.add(DateDuration::new(-1, -2, -3, -4));
 assert_eq!(date_iso.year().number, 1992);
-assert_eq!(date_iso.month().number, 9);
+assert_eq!(date_iso.month().ordinal_month, 9);
 assert_eq!(date_iso.day_of_month().0, 2);
 
 // Creating ISO date: 2022-01-30.
@@ -62,7 +62,7 @@ assert_eq!(duration.days, 28);
 // Create new date with date advancement. Reassign to new variable.
 let mutated_date_iso = date_iso.added(DateDuration::new(1, 2, 3, 4));
 assert_eq!(mutated_date_iso.year().number, 1993);
-assert_eq!(mutated_date_iso.month().number, 11);
+assert_eq!(mutated_date_iso.month().ordinal_month, 11);
 assert_eq!(mutated_date_iso.day_of_month().0, 27);
 ```
 
@@ -76,19 +76,19 @@ let mut date_iso = Date::new_iso_date_from_integers(1992, 9, 2)
     .expect("Failed to initialize ISO Date instance.");
 
 assert_eq!(date_iso.year().number, 1992);
-assert_eq!(date_iso.month().number, 9);
+assert_eq!(date_iso.month().ordinal_month, 9);
 assert_eq!(date_iso.day_of_month().0, 2);
 
 // Conversion into Indian calendar: 1914-08-02.
 let date_indian = date_iso.to_calendar(Indian);
 assert_eq!(date_indian.year().number, 1914);
-assert_eq!(date_indian.month().number, 8);
+assert_eq!(date_indian.month().ordinal_month, 8);
 assert_eq!(date_indian.day_of_month().0, 30);
 
 // Conversion into Buddhist calendar: 2535-09-02.
 let date_buddhist = date_iso.to_calendar(Buddhist);
 assert_eq!(date_buddhist.year().number, 2535);
-assert_eq!(date_buddhist.month().number, 9);
+assert_eq!(date_buddhist.month().ordinal_month, 9);
 assert_eq!(date_buddhist.day_of_month().0, 2);
 ```
 
@@ -106,7 +106,7 @@ let mut datetime_iso = DateTime::new_iso_datetime_from_integers(1992, 9, 2, 8, 5
 
 assert_eq!(datetime_iso.date.day_of_week(), IsoWeekday::Wednesday);
 assert_eq!(datetime_iso.date.year().number, 1992);
-assert_eq!(datetime_iso.date.month().number, 9);
+assert_eq!(datetime_iso.date.month().ordinal_month, 9);
 assert_eq!(datetime_iso.date.day_of_month().0, 2);
 assert_eq!(datetime_iso.time.hour.number(), 8);
 assert_eq!(datetime_iso.time.minute.number(), 59);
@@ -119,7 +119,7 @@ datetime_iso.date.add(DateDuration::new(1, 2, 3, 4));
 datetime_iso.time = Time::try_new(14, 30, 0, 0).expect("Failed to initialize Time instance.");
 
 assert_eq!(datetime_iso.date.year().number, 1993);
-assert_eq!(datetime_iso.date.month().number, 11);
+assert_eq!(datetime_iso.date.month().ordinal_month, 11);
 assert_eq!(datetime_iso.date.day_of_month().0, 27);
 assert_eq!(datetime_iso.time.hour.number(), 14);
 assert_eq!(datetime_iso.time.minute.number(), 30);

--- a/components/calendar/README.md
+++ b/components/calendar/README.md
@@ -25,7 +25,7 @@ as well as the calendar type.
 use icu_calendar::{types::IsoWeekday, Date, DateDuration, DateDurationUnit};
 
 // Creating ISO date: 1992-09-02.
-let mut date_iso = Date::new_iso_date_from_integers(1992, 9, 2)
+let mut date_iso = Date::new_iso_date(1992, 9, 2)
     .expect("Failed to initialize ISO Date instance.");
 
 assert_eq!(date_iso.day_of_week(), IsoWeekday::Wednesday);
@@ -50,7 +50,7 @@ assert_eq!(date_iso.month().ordinal_month, 9);
 assert_eq!(date_iso.day_of_month().0, 2);
 
 // Creating ISO date: 2022-01-30.
-let newer_date_iso = Date::new_iso_date_from_integers(2022, 1, 30)
+let newer_date_iso = Date::new_iso_date(2022, 1, 30)
     .expect("Failed to initialize ISO Date instance.");
 
 // Comparing dates: 2022-01-30 and 1992-09-02.
@@ -72,7 +72,7 @@ Example of converting an ISO date across Indian and Buddhist calendars.
 use icu_calendar::{buddhist::Buddhist, indian::Indian, Date};
 
 // Creating ISO date: 1992-09-02.
-let mut date_iso = Date::new_iso_date_from_integers(1992, 9, 2)
+let mut date_iso = Date::new_iso_date(1992, 9, 2)
     .expect("Failed to initialize ISO Date instance.");
 
 assert_eq!(date_iso.year().number, 1992);
@@ -101,7 +101,7 @@ year, and calendar type. Additionally, `DateTime` objects contain an accessible
 use icu_calendar::{types::IsoWeekday, types::Time, DateDuration, DateTime};
 
 // Creating ISO date: 1992-09-02 8:59
-let mut datetime_iso = DateTime::new_iso_datetime_from_integers(1992, 9, 2, 8, 59, 0)
+let mut datetime_iso = DateTime::new_iso_datetime(1992, 9, 2, 8, 59, 0)
     .expect("Failed to initialize ISO DateTime instance.");
 
 assert_eq!(datetime_iso.date.day_of_week(), IsoWeekday::Wednesday);

--- a/components/calendar/benches/date.rs
+++ b/components/calendar/benches/date.rs
@@ -24,7 +24,7 @@ fn bench_date<A: AsCalendar>(date: &mut Date<A>) {
 
     // Retrieving vals
     let _ = black_box(date.year().number);
-    let _ = black_box(date.month().number);
+    let _ = black_box(date.month().ordinal_month);
     let _ = black_box(date.day_of_month().0);
 
     // Conversion to ISO.

--- a/components/calendar/benches/date.rs
+++ b/components/calendar/benches/date.rs
@@ -46,7 +46,7 @@ fn bench_calendar<C: Clone + Calendar>(
                 let mut instantiated_date_calendar = calendar_date_init(fx.year, fx.month, fx.day);
 
                 // Conversion from ISO
-                let date_iso = Date::new_iso_date_from_integers(fx.year, fx.month, fx.day).unwrap();
+                let date_iso = Date::new_iso_date(fx.year, fx.month, fx.day).unwrap();
                 let mut converted_date_calendar = Date::new_from_iso(date_iso, calendar.clone());
 
                 bench_date(&mut instantiated_date_calendar);
@@ -69,7 +69,7 @@ fn bench_calendar_iso_types<C: Clone + Calendar>(
         b.iter(|| {
             for fx in &fxs.0 {
                 // Conversion from ISO
-                let date_iso = Date::new_iso_date_from_integers(fx.year, fx.month, fx.day).unwrap();
+                let date_iso = Date::new_iso_date(fx.year, fx.month, fx.day).unwrap();
                 let mut converted_date_calendar = Date::new_from_iso(date_iso, calendar.clone());
 
                 // Instantion from ISO

--- a/components/calendar/benches/datetime.rs
+++ b/components/calendar/benches/datetime.rs
@@ -50,7 +50,7 @@ fn bench_calendar<C: Clone + Calendar>(
                 );
 
                 // Conversion from ISO
-                let datetime_iso = DateTime::new_iso_datetime_from_integers(
+                let datetime_iso = DateTime::new_iso_datetime(
                     fx.year, fx.month, fx.day, fx.hour, fx.minute, fx.second,
                 )
                 .unwrap();
@@ -73,7 +73,7 @@ fn datetime_benches(c: &mut Criterion) {
         "calendar/overview",
         &fxs,
         icu::calendar::iso::Iso,
-        |y, m, d, h, min, s| DateTime::new_iso_datetime_from_integers(y, m, d, h, min, s).unwrap(),
+        |y, m, d, h, min, s| DateTime::new_iso_datetime(y, m, d, h, min, s).unwrap(),
     );
 
     #[cfg(feature = "bench")]

--- a/components/calendar/benches/datetime.rs
+++ b/components/calendar/benches/datetime.rs
@@ -24,7 +24,7 @@ fn bench_datetime<A: AsCalendar>(datetime: &mut DateTime<A>) {
 
     // Retrieving vals
     let _ = black_box(datetime.date.year().number);
-    let _ = black_box(datetime.date.month().number);
+    let _ = black_box(datetime.date.month().ordinal_month);
     let _ = black_box(datetime.date.day_of_month().0);
     let _ = black_box(datetime.time.hour);
     let _ = black_box(datetime.time.minute);

--- a/components/calendar/examples/iso_date_manipulations.rs
+++ b/components/calendar/examples/iso_date_manipulations.rs
@@ -33,7 +33,7 @@ fn print<A: Calendar>(_date_input: &Date<A>) {
         let formatted_date = format!(
             "Year: {}, Month: {}, Day: {}",
             _date_input.year().number,
-            _date_input.month().number,
+            _date_input.month().ordinal_month,
             _date_input.day_of_month().0,
         );
 

--- a/components/calendar/examples/iso_date_manipulations.rs
+++ b/components/calendar/examples/iso_date_manipulations.rs
@@ -42,7 +42,7 @@ fn print<A: Calendar>(_date_input: &Date<A>) {
 }
 
 fn tuple_to_iso_date(date: (i32, u8, u8)) -> Result<Date<Iso>, DateTimeError> {
-    Date::new_iso_date_from_integers(date.0, date.1, date.2)
+    Date::new_iso_date(date.0, date.1, date.2)
 }
 
 #[no_mangle]

--- a/components/calendar/examples/iso_datetime_manipulations.rs
+++ b/components/calendar/examples/iso_datetime_manipulations.rs
@@ -33,7 +33,7 @@ fn print<A: Calendar>(_datetime_input: &DateTime<A>) {
         let formatted_datetime = format!(
             "Year: {}, Month: {}, Day: {}, Hour: {}, Minute: {}, Second: {}",
             _datetime_input.date.year().number,
-            _datetime_input.date.month().number,
+            _datetime_input.date.month().ordinal_month,
             _datetime_input.date.day_of_month().0,
             u8::from(_datetime_input.time.hour),
             u8::from(_datetime_input.time.minute),

--- a/components/calendar/examples/iso_datetime_manipulations.rs
+++ b/components/calendar/examples/iso_datetime_manipulations.rs
@@ -45,7 +45,7 @@ fn print<A: Calendar>(_datetime_input: &DateTime<A>) {
 }
 
 fn tuple_to_iso_datetime(date: (i32, u8, u8, u8, u8, u8)) -> Result<DateTime<Iso>, DateTimeError> {
-    DateTime::new_iso_datetime_from_integers(date.0, date.1, date.2, date.3, date.4, date.5)
+    DateTime::new_iso_datetime(date.0, date.1, date.2, date.3, date.4, date.5)
 }
 
 #[no_mangle]

--- a/components/calendar/src/arithmetic.rs
+++ b/components/calendar/src/arithmetic.rs
@@ -374,7 +374,7 @@ pub mod week_of {
             let month = ((yyyymmdd / 100) % 100) as u8;
             let day = (yyyymmdd % 100) as u8;
 
-            let date = Date::new_iso_date_from_integers(year, month, day)?;
+            let date = Date::new_iso_date(year, month, day)?;
             let previous_month = date.clone().added(DateDuration::new(0, -1, 0, 0));
 
             week_of(

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -8,12 +8,12 @@
 //! use icu::calendar::{buddhist::Buddhist, Date, DateTime};
 //!
 //! // `Date` type
-//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+//! let date_iso = Date::new_iso_date(1970, 1, 2)
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_buddhist = Date::new_from_iso(date_iso, Buddhist);
 //!
 //! // `DateTime` type
-//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+//! let datetime_iso = DateTime::new_iso_datetime(1970, 1, 2, 13, 1, 0)
 //!     .expect("Failed to initialize ISO DateTime instance.");
 //! let datetime_buddhist = DateTime::new_from_iso(datetime_iso, Buddhist);
 //!

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -32,7 +32,7 @@
 //! ```
 
 use crate::any_calendar::AnyCalendarKind;
-use crate::iso::{Iso, IsoDateInner, IsoYear};
+use crate::iso::{Iso, IsoDateInner};
 use crate::{types, Calendar, Date, DateDuration, DateDurationUnit, DateTime, DateTimeError};
 use tinystr::tinystr;
 
@@ -92,7 +92,7 @@ impl Calendar for Buddhist {
 
     /// The calendar-specific year represented by `date`
     fn year(&self, date: &Self::DateInner) -> types::Year {
-        iso_year_as_buddhist(date.year)
+        iso_year_as_buddhist(date.0.year)
     }
 
     /// The calendar-specific month represented by `date`
@@ -107,13 +107,13 @@ impl Calendar for Buddhist {
 
     /// Information of the day of the year
     fn day_of_year_info(&self, date: &Self::DateInner) -> types::DayOfYearInfo {
-        let prev_year = IsoYear(date.year.0 - 1);
-        let next_year = IsoYear(date.year.0 + 1);
+        let prev_year = date.0.year - 1;
+        let next_year = date.0.year + 1;
         types::DayOfYearInfo {
             day_of_year: Iso::day_of_year(*date),
-            days_in_year: Iso::days_in_year(date.year),
+            days_in_year: Iso::days_in_year_direct(date.0.year),
             prev_year: iso_year_as_buddhist(prev_year),
-            days_in_prev_year: Iso::days_in_year(prev_year),
+            days_in_prev_year: Iso::days_in_year_direct(prev_year),
             next_year: iso_year_as_buddhist(next_year),
         }
     }
@@ -148,7 +148,7 @@ impl Date<Buddhist> {
         month: u8,
         day: u8,
     ) -> Result<Date<Buddhist>, DateTimeError> {
-        Date::new_iso_date_from_integers(year - BUDDHIST_ERA_OFFSET, month, day)
+        Date::new_iso_date(year - BUDDHIST_ERA_OFFSET, month, day)
             .map(|d| Date::new_from_iso(d, Buddhist))
     }
 }
@@ -186,11 +186,11 @@ impl DateTime<Buddhist> {
     }
 }
 
-fn iso_year_as_buddhist(year: IsoYear) -> types::Year {
-    let buddhist_year = year.0 + BUDDHIST_ERA_OFFSET;
+fn iso_year_as_buddhist(year: i32) -> types::Year {
+    let buddhist_year = year + BUDDHIST_ERA_OFFSET;
     types::Year {
         era: types::Era(tinystr!(16, "be")),
         number: buddhist_year,
-        related_iso: year.0,
+        related_iso: year,
     }
 }

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -19,12 +19,12 @@
 //!
 //! // `Date` checks
 //! assert_eq!(date_buddhist.year().number, 2513);
-//! assert_eq!(date_buddhist.month().number, 1);
+//! assert_eq!(date_buddhist.month().ordinal_month, 1);
 //! assert_eq!(date_buddhist.day_of_month().0, 2);
 //!
 //! // `DateTime` type
 //! assert_eq!(datetime_buddhist.date.year().number, 2513);
-//! assert_eq!(datetime_buddhist.date.month().number, 1);
+//! assert_eq!(datetime_buddhist.date.month().ordinal_month, 1);
 //! assert_eq!(datetime_buddhist.date.day_of_month().0, 2);
 //! assert_eq!(datetime_buddhist.time.hour.number(), 13);
 //! assert_eq!(datetime_buddhist.time.minute.number(), 1);
@@ -140,7 +140,7 @@ impl Date<Buddhist> {
     ///     Date::new_buddhist_date(1970, 1, 2).expect("Failed to initialize Buddhist Date instance.");
     ///
     /// assert_eq!(date_buddhist.year().number, 1970);
-    /// assert_eq!(date_buddhist.month().number, 1);
+    /// assert_eq!(date_buddhist.month().ordinal_month, 1);
     /// assert_eq!(date_buddhist.day_of_month().0, 2);
     /// ```
     pub fn new_buddhist_date(
@@ -165,7 +165,7 @@ impl DateTime<Buddhist> {
     ///     .expect("Failed to initialize Buddhist DateTime instance.");
     ///
     /// assert_eq!(datetime_buddhist.date.year().number, 1970);
-    /// assert_eq!(datetime_buddhist.date.month().number, 1);
+    /// assert_eq!(datetime_buddhist.date.month().ordinal_month, 1);
     /// assert_eq!(datetime_buddhist.date.day_of_month().0, 2);
     /// assert_eq!(datetime_buddhist.time.hour.number(), 13);
     /// assert_eq!(datetime_buddhist.time.minute.number(), 1);

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -5,6 +5,7 @@
 use crate::{types, Calendar, DateDuration, DateDurationUnit};
 use core::convert::TryInto;
 use core::marker::PhantomData;
+use tinystr::tinystr;
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
@@ -131,5 +132,36 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
     #[inline]
     pub fn day_of_month(&self) -> types::DayOfMonth {
         types::DayOfMonth(self.day.into())
+    }
+
+    /// The [`types::Month`] for the current month (with month code) for a solar calendar
+    /// Lunar calendars should not use this method and instead manually implement a month code
+    /// resolver.
+    ///
+    /// Returns "und" if run with months that are out of bounds for the current
+    /// calendar.
+    #[inline]
+    pub fn solar_month(&self) -> types::Month {
+        let code = match self.month {
+            a if a > C::months_for_every_year() => tinystr!(8, "und"),
+            1 => tinystr!(8, "M01"),
+            2 => tinystr!(8, "M02"),
+            3 => tinystr!(8, "M03"),
+            4 => tinystr!(8, "M04"),
+            5 => tinystr!(8, "M05"),
+            6 => tinystr!(8, "M06"),
+            7 => tinystr!(8, "M07"),
+            8 => tinystr!(8, "M08"),
+            9 => tinystr!(8, "M09"),
+            10 => tinystr!(8, "M10"),
+            11 => tinystr!(8, "M11"),
+            12 => tinystr!(8, "M12"),
+            13 => tinystr!(8, "M13"),
+            _ => tinystr!(8, "und"),
+        };
+        types::Month {
+            ordinal_month: self.month as u32,
+            code: types::MonthCode(code),
+        }
     }
 }

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -26,6 +26,15 @@ pub trait CalendarArithmetic: Calendar {
 
 impl<C: CalendarArithmetic> ArithmeticDate<C> {
     #[inline]
+    pub fn new(year: i32, month: u8, day: u8) -> Self {
+        ArithmeticDate {
+            year,
+            month,
+            day,
+            marker: PhantomData,
+        }
+    }
+    #[inline]
     pub fn offset_date(&mut self, mut offset: DateDuration<C>) {
         self.year += offset.years;
         self.month += offset.months as u8;

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -40,7 +40,6 @@ use crate::{
 };
 use core::convert::TryInto;
 use core::marker::PhantomData;
-use tinystr::tinystr;
 
 /// The Coptic calendar
 #[derive(Copy, Clone, Debug, Hash, Default, Eq, PartialEq)]

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -8,12 +8,12 @@
 //! use icu::calendar::{coptic::Coptic, Date, DateTime};
 //!
 //! // `Date` type
-//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+//! let date_iso = Date::new_iso_date(1970, 1, 2)
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_coptic = Date::new_from_iso(date_iso, Coptic);
 //!
 //! // `DateTime` type
-//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+//! let datetime_iso = DateTime::new_iso_datetime(1970, 1, 2, 13, 1, 0)
 //!     .expect("Failed to initialize ISO DateTime instance.");
 //! let datetime_coptic = DateTime::new_from_iso(datetime_iso, Coptic);
 //!

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -123,10 +123,7 @@ impl Calendar for Coptic {
     }
 
     fn month(&self, date: &Self::DateInner) -> types::Month {
-        types::Month {
-            ordinal_month: date.0.month.into(),
-            code: types::MonthCode(tinystr!(8, "TODO")),
-        }
+        date.0.solar_month()
     }
 
     fn day_of_month(&self, date: &Self::DateInner) -> types::DayOfMonth {

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -32,7 +32,7 @@
 //! ```
 
 use crate::any_calendar::AnyCalendarKind;
-use crate::iso::{Iso, IsoYear};
+use crate::iso::Iso;
 use crate::julian::Julian;
 use crate::{
     types, ArithmeticDate, Calendar, CalendarArithmetic, Date, DateDuration, DateDurationUnit,
@@ -134,14 +134,14 @@ impl Calendar for Coptic {
     }
 
     fn day_of_year_info(&self, date: &Self::DateInner) -> types::DayOfYearInfo {
-        let prev_year = IsoYear(date.0.year - 1);
-        let next_year = IsoYear(date.0.year + 1);
+        let prev_year = date.0.year - 1;
+        let next_year = date.0.year + 1;
         types::DayOfYearInfo {
             day_of_year: date.0.day_of_year(),
             days_in_year: date.0.days_in_year(),
-            prev_year: prev_year.into(),
-            days_in_prev_year: Coptic::days_in_year_direct(prev_year.0),
-            next_year: next_year.into(),
+            prev_year: crate::gregorian::year_as_gregorian(prev_year),
+            days_in_prev_year: Coptic::days_in_year_direct(prev_year),
+            next_year: crate::gregorian::year_as_gregorian(next_year),
         }
     }
 

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -19,12 +19,12 @@
 //!
 //! // `Date` checks
 //! assert_eq!(date_coptic.year().number, 1686);
-//! assert_eq!(date_coptic.month().number, 4);
+//! assert_eq!(date_coptic.month().ordinal_month, 4);
 //! assert_eq!(date_coptic.day_of_month().0, 24);
 //!
 //! // `DateTime` type
 //! assert_eq!(datetime_coptic.date.year().number, 1686);
-//! assert_eq!(datetime_coptic.date.month().number, 4);
+//! assert_eq!(datetime_coptic.date.month().ordinal_month, 4);
 //! assert_eq!(datetime_coptic.date.day_of_month().0, 24);
 //! assert_eq!(datetime_coptic.time.hour.number(), 13);
 //! assert_eq!(datetime_coptic.time.minute.number(), 1);
@@ -124,7 +124,7 @@ impl Calendar for Coptic {
 
     fn month(&self, date: &Self::DateInner) -> types::Month {
         types::Month {
-            number: date.0.month.into(),
+            ordinal_month: date.0.month.into(),
             code: types::MonthCode(tinystr!(8, "TODO")),
         }
     }
@@ -211,7 +211,7 @@ impl Date<Coptic> {
     ///     Date::new_coptic_date(1686, 5, 6).expect("Failed to initialize Coptic Date instance.");
     ///
     /// assert_eq!(date_coptic.year().number, 1686);
-    /// assert_eq!(date_coptic.month().number, 5);
+    /// assert_eq!(date_coptic.month().ordinal_month, 5);
     /// assert_eq!(date_coptic.day_of_month().0, 6);
     /// ```
     pub fn new_coptic_date(year: i32, month: u8, day: u8) -> Result<Date<Coptic>, DateTimeError> {
@@ -241,7 +241,7 @@ impl DateTime<Coptic> {
     ///     .expect("Failed to initialize Coptic DateTime instance.");
     ///
     /// assert_eq!(datetime_coptic.date.year().number, 1686);
-    /// assert_eq!(datetime_coptic.date.month().number, 5);
+    /// assert_eq!(datetime_coptic.date.month().ordinal_month, 5);
     /// assert_eq!(datetime_coptic.date.day_of_month().0, 6);
     /// assert_eq!(datetime_coptic.time.hour.number(), 13);
     /// assert_eq!(datetime_coptic.time.minute.number(), 1);

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -69,7 +69,7 @@ impl<'a, C> Deref for Ref<'a, C> {
 /// use icu::calendar::Date;
 ///
 /// // Example: creation of ISO date from integers.
-/// let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+/// let date_iso = Date::new_iso_date(1970, 1, 2)
 ///     .expect("Failed to initialize ISO Date instance.");
 ///
 /// assert_eq!(date_iso.year().number, 1970);

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -73,7 +73,7 @@ impl<'a, C> Deref for Ref<'a, C> {
 ///     .expect("Failed to initialize ISO Date instance.");
 ///
 /// assert_eq!(date_iso.year().number, 1970);
-/// assert_eq!(date_iso.month().number, 1);
+/// assert_eq!(date_iso.month().ordinal_month, 1);
 /// assert_eq!(date_iso.day_of_month().0, 2);
 /// ```
 pub struct Date<A: AsCalendar> {

--- a/components/calendar/src/datetime.rs
+++ b/components/calendar/src/datetime.rs
@@ -20,7 +20,7 @@ use crate::{AsCalendar, Calendar, Date, Iso};
 ///     .expect("Failed to initialize ISO DateTime instance.");
 ///
 /// assert_eq!(datetime_iso.date.year().number, 1970);
-/// assert_eq!(datetime_iso.date.month().number, 1);
+/// assert_eq!(datetime_iso.date.month().ordinal_month, 1);
 /// assert_eq!(datetime_iso.date.day_of_month().0, 2);
 /// assert_eq!(datetime_iso.time.hour.number(), 13);
 /// assert_eq!(datetime_iso.time.minute.number(), 1);

--- a/components/calendar/src/datetime.rs
+++ b/components/calendar/src/datetime.rs
@@ -16,7 +16,7 @@ use crate::{AsCalendar, Calendar, Date, Iso};
 /// use icu::calendar::DateTime;
 ///
 /// // Example: Construction of ISO datetime from integers.
-/// let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+/// let datetime_iso = DateTime::new_iso_datetime(1970, 1, 2, 13, 1, 0)
 ///     .expect("Failed to initialize ISO DateTime instance.");
 ///
 /// assert_eq!(datetime_iso.date.year().number, 1970);

--- a/components/calendar/src/ethiopic.rs
+++ b/components/calendar/src/ethiopic.rs
@@ -19,12 +19,12 @@
 //!
 //! // `Date` checks
 //! assert_eq!(date_ethiopic.year().number, 1962);
-//! assert_eq!(date_ethiopic.month().number, 4);
+//! assert_eq!(date_ethiopic.month().ordinal_month, 4);
 //! assert_eq!(date_ethiopic.day_of_month().0, 24);
 //!
 //! // `DateTime` type
 //! assert_eq!(datetime_ethiopic.date.year().number, 1962);
-//! assert_eq!(datetime_ethiopic.date.month().number, 4);
+//! assert_eq!(datetime_ethiopic.date.month().ordinal_month, 4);
 //! assert_eq!(datetime_ethiopic.date.day_of_month().0, 24);
 //! assert_eq!(datetime_ethiopic.time.hour.number(), 13);
 //! assert_eq!(datetime_ethiopic.time.minute.number(), 1);
@@ -139,7 +139,7 @@ impl Calendar for Ethiopic {
 
     fn month(&self, date: &Self::DateInner) -> types::Month {
         types::Month {
-            number: date.0.month.into(),
+            ordinal_month: date.0.month.into(),
             code: types::MonthCode(tinystr!(8, "TODO")),
         }
     }
@@ -235,7 +235,7 @@ impl Date<Ethiopic> {
     ///     Date::new_ethiopic_date(2014, 8, 25).expect("Failed to initialize Ethopic Date instance.");
     ///
     /// assert_eq!(date_ethiopic.year().number, 2014);
-    /// assert_eq!(date_ethiopic.month().number, 8);
+    /// assert_eq!(date_ethiopic.month().ordinal_month, 8);
     /// assert_eq!(date_ethiopic.day_of_month().0, 25);
     /// ```
     pub fn new_ethiopic_date(
@@ -269,7 +269,7 @@ impl DateTime<Ethiopic> {
     ///     .expect("Failed to initialize Ethiopic DateTime instance.");
     ///
     /// assert_eq!(datetime_ethiopic.date.year().number, 2014);
-    /// assert_eq!(datetime_ethiopic.date.month().number, 8);
+    /// assert_eq!(datetime_ethiopic.date.month().ordinal_month, 8);
     /// assert_eq!(datetime_ethiopic.date.day_of_month().0, 25);
     /// assert_eq!(datetime_ethiopic.time.hour.number(), 13);
     /// assert_eq!(datetime_ethiopic.time.minute.number(), 1);

--- a/components/calendar/src/ethiopic.rs
+++ b/components/calendar/src/ethiopic.rs
@@ -122,10 +122,7 @@ impl Calendar for Ethiopic {
     }
 
     fn month(&self, date: &Self::DateInner) -> types::Month {
-        types::Month {
-            ordinal_month: date.0.month.into(),
-            code: types::MonthCode(tinystr!(8, "TODO")),
-        }
+        date.0.solar_month()
     }
 
     fn day_of_month(&self, date: &Self::DateInner) -> types::DayOfMonth {

--- a/components/calendar/src/ethiopic.rs
+++ b/components/calendar/src/ethiopic.rs
@@ -33,7 +33,7 @@
 
 use crate::any_calendar::AnyCalendarKind;
 use crate::coptic::Coptic;
-use crate::iso::{Iso, IsoYear};
+use crate::iso::Iso;
 use crate::julian::Julian;
 use crate::{
     types, ArithmeticDate, Calendar, CalendarArithmetic, Date, DateDuration, DateDurationUnit,
@@ -118,23 +118,7 @@ impl Calendar for Ethiopic {
     }
 
     fn year(&self, date: &Self::DateInner) -> types::Year {
-        if self.0 {
-            types::Year {
-                era: types::Era(tinystr!(16, "mundi")),
-                number: date.0.year,
-                related_iso: date.0.year + 5493 + 8,
-            }
-        } else {
-            types::Year {
-                era: if date.0.year > 0 {
-                    types::Era(tinystr!(16, "incarnation"))
-                } else {
-                    types::Era(tinystr!(16, "before-incar"))
-                },
-                number: date.0.year,
-                related_iso: date.0.year + 5493 + 8,
-            }
-        }
+        Self::year_as_ethiopic(date.0.year, self.0)
     }
 
     fn month(&self, date: &Self::DateInner) -> types::Month {
@@ -149,14 +133,14 @@ impl Calendar for Ethiopic {
     }
 
     fn day_of_year_info(&self, date: &Self::DateInner) -> types::DayOfYearInfo {
-        let prev_year = IsoYear(date.0.year - 1);
-        let next_year = IsoYear(date.0.year + 1);
+        let prev_year = date.0.year - 1;
+        let next_year = date.0.year + 1;
         types::DayOfYearInfo {
             day_of_year: date.0.day_of_year(),
             days_in_year: date.0.days_in_year(),
-            prev_year: prev_year.into(),
-            days_in_prev_year: Ethiopic::days_in_year_direct(prev_year.0),
-            next_year: next_year.into(),
+            prev_year: Self::year_as_ethiopic(prev_year, self.0),
+            days_in_prev_year: Ethiopic::days_in_year_direct(prev_year),
+            next_year: Self::year_as_ethiopic(next_year, self.0),
         }
     }
 
@@ -221,6 +205,26 @@ impl Ethiopic {
             366
         } else {
             365
+        }
+    }
+
+    fn year_as_ethiopic(year: i32, amete_alem: bool) -> types::Year {
+        if amete_alem {
+            types::Year {
+                era: types::Era(tinystr!(16, "mundi")),
+                number: year,
+                related_iso: year + 5493 + 8,
+            }
+        } else {
+            types::Year {
+                era: if year > 0 {
+                    types::Era(tinystr!(16, "incarnation"))
+                } else {
+                    types::Era(tinystr!(16, "before-incar"))
+                },
+                number: year,
+                related_iso: year + 5493 + 8,
+            }
         }
     }
 }

--- a/components/calendar/src/ethiopic.rs
+++ b/components/calendar/src/ethiopic.rs
@@ -8,12 +8,12 @@
 //! use icu::calendar::{ethiopic::Ethiopic, Date, DateTime};
 //!
 //! // `Date` type
-//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+//! let date_iso = Date::new_iso_date(1970, 1, 2)
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_ethiopic = Date::new_from_iso(date_iso, Ethiopic::new());
 //!
 //! // `DateTime` type
-//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+//! let datetime_iso = DateTime::new_iso_datetime(1970, 1, 2, 13, 1, 0)
 //!     .expect("Failed to initialize ISO DateTime instance.");
 //! let datetime_ethiopic = DateTime::new_from_iso(datetime_iso, Ethiopic::new());
 //!
@@ -297,7 +297,7 @@ mod test {
     #[test]
     fn test_leap_year() {
         // 11th September 2023 in gregorian is 6/13/2015 in ethiopic
-        let iso_date = Date::new_iso_date_from_integers(2023, 9, 11).unwrap();
+        let iso_date = Date::new_iso_date(2023, 9, 11).unwrap();
         let ethiopic_date = Ethiopic::new().date_from_iso(iso_date);
         assert_eq!(ethiopic_date.0.year, 2015);
         assert_eq!(ethiopic_date.0.month, 13);
@@ -306,7 +306,7 @@ mod test {
 
     #[test]
     fn test_iso_to_ethiopic_conversion_and_back() {
-        let iso_date = Date::new_iso_date_from_integers(1970, 1, 2).unwrap();
+        let iso_date = Date::new_iso_date(1970, 1, 2).unwrap();
         let date_ethiopic = Date::new_from_iso(iso_date, Ethiopic::new());
 
         assert_eq!(date_ethiopic.inner.0.year, 1962);
@@ -315,7 +315,7 @@ mod test {
 
         assert_eq!(
             date_ethiopic.to_iso(),
-            Date::new_iso_date_from_integers(1970, 1, 2).unwrap()
+            Date::new_iso_date(1970, 1, 2).unwrap()
         );
     }
 }

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -19,12 +19,12 @@
 //!
 //! // `Date` checks
 //! assert_eq!(date_gregorian.year().number, 1970);
-//! assert_eq!(date_gregorian.month().number, 1);
+//! assert_eq!(date_gregorian.month().ordinal_month, 1);
 //! assert_eq!(date_gregorian.day_of_month().0, 2);
 //!
 //! // `DateTime` type
 //! assert_eq!(datetime_gregorian.date.year().number, 1970);
-//! assert_eq!(datetime_gregorian.date.month().number, 1);
+//! assert_eq!(datetime_gregorian.date.month().ordinal_month, 1);
 //! assert_eq!(datetime_gregorian.date.day_of_month().0, 2);
 //! assert_eq!(datetime_gregorian.time.hour.number(), 13);
 //! assert_eq!(datetime_gregorian.time.minute.number(), 1);
@@ -140,7 +140,7 @@ impl Date<Gregorian> {
     ///     .expect("Failed to initialize Gregorian Date instance.");
     ///
     /// assert_eq!(date_gregorian.year().number, 1970);
-    /// assert_eq!(date_gregorian.month().number, 1);
+    /// assert_eq!(date_gregorian.month().ordinal_month, 1);
     /// assert_eq!(date_gregorian.day_of_month().0, 2);
     /// ```
     pub fn new_gregorian_date(
@@ -164,7 +164,7 @@ impl DateTime<Gregorian> {
     ///     .expect("Failed to initialize Gregorian DateTime instance.");
     ///
     /// assert_eq!(datetime_gregorian.date.year().number, 1970);
-    /// assert_eq!(datetime_gregorian.date.month().number, 1);
+    /// assert_eq!(datetime_gregorian.date.month().ordinal_month, 1);
     /// assert_eq!(datetime_gregorian.date.day_of_month().0, 2);
     /// assert_eq!(datetime_gregorian.time.hour.number(), 13);
     /// assert_eq!(datetime_gregorian.time.minute.number(), 1);

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -86,7 +86,7 @@ impl Calendar for Gregorian {
 
     /// The calendar-specific year represented by `date`
     fn year(&self, date: &Self::DateInner) -> types::Year {
-        year_as_gregorian(date.0.0.year)
+        year_as_gregorian(date.0 .0.year)
     }
 
     /// The calendar-specific month represented by `date`
@@ -101,11 +101,11 @@ impl Calendar for Gregorian {
 
     /// Information of the day of the year
     fn day_of_year_info(&self, date: &Self::DateInner) -> types::DayOfYearInfo {
-        let prev_year = date.0.0.year - 1;
-        let next_year = date.0.0.year + 1;
+        let prev_year = date.0 .0.year - 1;
+        let next_year = date.0 .0.year + 1;
         types::DayOfYearInfo {
             day_of_year: Iso::day_of_year(date.0),
-            days_in_year: Iso::days_in_year_direct(date.0.0.year),
+            days_in_year: Iso::days_in_year_direct(date.0 .0.year),
             prev_year: year_as_gregorian(prev_year),
             days_in_prev_year: Iso::days_in_year_direct(prev_year),
             next_year: year_as_gregorian(next_year),
@@ -127,7 +127,7 @@ impl Date<Gregorian> {
     /// Years are specified as ISO years.
     ///
     /// ```rust
-    /// use icu::calendar::{iso::IsoDay, iso::IsoMonth, iso::IsoYear, Date};
+    /// use icu::calendar::{Date};
     /// use std::convert::TryFrom;
     ///
     /// // Conversion from ISO to Gregorian

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -8,12 +8,12 @@
 //! use icu::calendar::{gregorian::Gregorian, Date, DateTime};
 //!
 //! // `Date` type
-//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+//! let date_iso = Date::new_iso_date(1970, 1, 2)
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_gregorian = Date::new_from_iso(date_iso, Gregorian);
 //!
 //! // `DateTime` type
-//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+//! let datetime_iso = DateTime::new_iso_datetime(1970, 1, 2, 13, 1, 0)
 //!     .expect("Failed to initialize ISO DateTime instance.");
 //! let datetime_gregorian = DateTime::new_from_iso(datetime_iso, Gregorian);
 //!

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -32,7 +32,7 @@
 //! ```
 
 use crate::any_calendar::AnyCalendarKind;
-use crate::iso::{Iso, IsoYear};
+use crate::iso::Iso;
 use crate::{
     types, ArithmeticDate, Calendar, CalendarArithmetic, Date, DateDuration, DateDurationUnit,
     DateTime, DateTimeError,
@@ -70,7 +70,7 @@ impl CalendarArithmetic for Indian {
     }
 
     fn is_leap_year(year: i32) -> bool {
-        Iso::is_leap_year(IsoYear(year + 78))
+        Iso::is_leap_year(year + 78)
     }
 }
 
@@ -79,7 +79,7 @@ impl Calendar for Indian {
     fn date_from_iso(&self, iso: Date<Iso>) -> IndianDateInner {
         let day_of_year = Iso::day_of_year(*iso.inner());
         IndianDateInner(ArithmeticDate::date_from_year_day(
-            iso.inner().year.0 - 78,
+            iso.inner().0.year - 78,
             day_of_year,
         ))
     }

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -8,12 +8,12 @@
 //! use icu::calendar::{indian::Indian, Date, DateTime};
 //!
 //! // `Date` type
-//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+//! let date_iso = Date::new_iso_date(1970, 1, 2)
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_indian = Date::new_from_iso(date_iso, Indian);
 //!
 //! // `DateTime` type
-//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+//! let datetime_iso = DateTime::new_iso_datetime(1970, 1, 2, 13, 1, 0)
 //!     .expect("Failed to initialize ISO DateTime instance.");
 //! let datetime_indian = DateTime::new_from_iso(datetime_iso, Indian);
 //!

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -19,12 +19,12 @@
 //!
 //! // `Date` checks
 //! assert_eq!(date_indian.year().number, 1892);
-//! assert_eq!(date_indian.month().number, 1);
+//! assert_eq!(date_indian.month().ordinal_month, 1);
 //! assert_eq!(date_indian.day_of_month().0, 2);
 //!
 //! // `DateTime` type
 //! assert_eq!(datetime_indian.date.year().number, 1892);
-//! assert_eq!(datetime_indian.date.month().number, 1);
+//! assert_eq!(datetime_indian.date.month().ordinal_month, 1);
 //! assert_eq!(datetime_indian.date.day_of_month().0, 2);
 //! assert_eq!(datetime_indian.time.hour.number(), 13);
 //! assert_eq!(datetime_indian.time.minute.number(), 1);
@@ -131,7 +131,7 @@ impl Calendar for Indian {
 
     fn month(&self, date: &Self::DateInner) -> types::Month {
         types::Month {
-            number: date.0.month.into(),
+            ordinal_month: date.0.month.into(),
             code: types::MonthCode(tinystr!(8, "TODO")),
         }
     }
@@ -194,7 +194,7 @@ impl Date<Indian> {
     ///     Date::new_indian_date(1891, 10, 12).expect("Failed to initialize Indian Date instance.");
     ///
     /// assert_eq!(date_indian.year().number, 1891);
-    /// assert_eq!(date_indian.month().number, 10);
+    /// assert_eq!(date_indian.month().ordinal_month, 10);
     /// assert_eq!(date_indian.day_of_month().0, 12);
     /// ```
     pub fn new_indian_date(year: i32, month: u8, day: u8) -> Result<Date<Indian>, DateTimeError> {
@@ -224,7 +224,7 @@ impl DateTime<Indian> {
     ///     .expect("Failed to initialize Indian DateTime instance.");
     ///
     /// assert_eq!(datetime_indian.date.year().number, 1891);
-    /// assert_eq!(datetime_indian.date.month().number, 10);
+    /// assert_eq!(datetime_indian.date.month().ordinal_month, 10);
     /// assert_eq!(datetime_indian.date.day_of_month().0, 12);
     /// assert_eq!(datetime_indian.time.hour.number(), 13);
     /// assert_eq!(datetime_indian.time.minute.number(), 1);

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -130,10 +130,7 @@ impl Calendar for Indian {
     }
 
     fn month(&self, date: &Self::DateInner) -> types::Month {
-        types::Month {
-            ordinal_month: date.0.month.into(),
-            code: types::MonthCode(tinystr!(8, "TODO")),
-        }
+        date.0.solar_month()
     }
 
     fn day_of_month(&self, date: &Self::DateInner) -> types::DayOfMonth {

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -191,10 +191,7 @@ impl Calendar for Iso {
 
     /// The calendar-specific month represented by `date`
     fn month(&self, date: &Self::DateInner) -> types::Month {
-        types::Month {
-            ordinal_month: date.0.month.into(),
-            code: types::MonthCode(tinystr!(8, "TODO")),
-        }
+        date.0.solar_month()
     }
 
     /// The calendar-specific day-of-month represented by `date`

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -547,10 +547,10 @@ mod test {
         let a = a.inner();
         let b = b.inner();
         DateDuration::new(
-            a.year.0 - b.year.0,
-            a.month.0 as i32 - b.month.0 as i32,
+            a.0.year - b.0.year,
+            a.0.month as i32 - b.0.month as i32,
             0,
-            a.day.0 as i32 - b.day.0 as i32,
+            a.0.day as i32 - b.0.day as i32,
         )
     }
 

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -31,13 +31,14 @@
 
 use crate::any_calendar::AnyCalendarKind;
 use crate::{types, Calendar, Date, DateDuration, DateDurationUnit, DateTime, DateTimeError};
+use crate::{ArithmeticDate, CalendarArithmetic};
 use core::convert::{TryFrom, TryInto};
 use tinystr::tinystr;
 
 // The georgian epoch is equivalent to first day in fixed day measurement
 const EPOCH: i32 = 1;
 
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
 /// The ISO Calendar
 pub struct Iso;
@@ -125,43 +126,25 @@ impl From<IsoDay> for types::DayOfMonth {
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 /// The inner date type used for representing Date<Iso>
-pub struct IsoDateInner {
-    pub(crate) day: IsoDay,
-    pub(crate) month: IsoMonth,
-    pub(crate) year: IsoYear,
-}
+pub struct IsoDateInner(pub(crate) ArithmeticDate<Iso>);
 
-impl IsoDateInner {
-    pub fn add_months(&mut self, months: i32) {
-        // Get a zero-indexed new month
-        let new_month = (self.month.0 as i32 - 1) + months;
-        if new_month >= 0 {
-            self.year.0 += new_month / 12;
-            self.month.0 = ((new_month % 12) + 1) as u8;
-        } else {
-            // subtract full years
-            self.year.0 -= (-new_month) / 12;
-            // subtract a partial year
-            self.year.0 -= 1;
-            // adding 13 since months are 1-indexed
-            self.month.0 = (13 + (new_month % 12)) as u8
+impl CalendarArithmetic for Iso {
+    fn month_days(year: i32, month: u8) -> u8 {
+        match month {
+            4 | 6 | 9 | 11 => 30,
+            2 if Self::is_leap_year(year) => 29,
+            2 => 28,
+            1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+            _ => 0,
         }
     }
 
-    pub(crate) fn jan_1(year: IsoYear) -> Self {
-        Self {
-            day: IsoDay(1),
-            month: IsoMonth(1),
-            year,
-        }
+    fn months_for_every_year() -> u8 {
+        12
     }
 
-    pub(crate) fn dec_31(year: IsoYear) -> Self {
-        Self {
-            day: IsoDay(31),
-            month: IsoMonth(12),
-            year,
-        }
+    fn is_leap_year(year: i32) -> bool {
+        year % 4 == 0 && (year % 400 == 0 || year % 100 != 0)
     }
 }
 
@@ -175,20 +158,16 @@ impl Calendar for Iso {
         Date::from_raw(*date, Iso)
     }
 
-    fn months_in_year(&self, _date: &Self::DateInner) -> u8 {
-        12
+    fn months_in_year(&self, date: &Self::DateInner) -> u8 {
+        date.0.months_in_year()
     }
 
     fn days_in_year(&self, date: &Self::DateInner) -> u32 {
-        if Self::is_leap_year(date.year) {
-            366
-        } else {
-            365
-        }
+        date.0.days_in_year()
     }
 
     fn days_in_month(&self, date: &Self::DateInner) -> u8 {
-        Self::days_in_month(date.year, date.month)
+        date.0.days_in_month()
     }
 
     fn day_of_week(&self, date: &Self::DateInner) -> types::IsoWeekday {
@@ -197,7 +176,7 @@ impl Calendar for Iso {
 
         // The days of the week are the same every 400 years
         // so we normalize to the nearest multiple of 400
-        let years_since_400 = date.year.0 % 400;
+        let years_since_400 = date.0.year % 400;
         let leap_years_since_400 = years_since_400 / 4 - years_since_400 / 100;
         // The number of days to the current year
         let days_to_current_year = 365 * years_since_400 + leap_years_since_400;
@@ -206,8 +185,8 @@ impl Calendar for Iso {
 
         // Corresponding months from
         // https://en.wikipedia.org/wiki/Determination_of_the_day_of_the_week#Corresponding_months
-        let month_offset = if Self::is_leap_year(date.year) {
-            match date.month.0 {
+        let month_offset = if Self::is_leap_year(date.0.year) {
+            match date.0.month {
                 10 => 0,
                 5 => 1,
                 2 | 8 => 2,
@@ -218,7 +197,7 @@ impl Calendar for Iso {
                 _ => unreachable!(),
             }
         } else {
-            match date.month.0 {
+            match date.0.month {
                 1 | 10 => 0,
                 5 => 1,
                 8 => 2,
@@ -229,53 +208,18 @@ impl Calendar for Iso {
                 _ => unreachable!(),
             }
         };
-
         let january_1_2000 = 5; // Saturday
-        let day_offset = (january_1_2000 + year_offset + month_offset + date.day.0 as i32) % 7;
+        let day_offset = (january_1_2000 + year_offset + month_offset + date.0.day as i32) % 7;
 
         // We calculated in a zero-indexed fashion, but ISO specifies one-indexed
         types::IsoWeekday::from((day_offset + 1) as usize)
     }
 
-    fn offset_date(&self, date: &mut Self::DateInner, mut offset: DateDuration<Self>) {
-        date.year.0 += offset.years;
-        date.add_months(offset.months);
-        offset.months = 0;
-
-        offset.days += offset.weeks * 7;
-
-        // Normalize date to beginning of month
-        offset.days += date.day.0 as i32 - 1;
-        date.day.0 = 1;
-
-        while offset.days != 0 {
-            if offset.days < 0 {
-                date.add_months(-1);
-                let month_days = self.days_in_month(date);
-                if (-offset.days) > month_days as i32 {
-                    offset.days += month_days as i32;
-                } else {
-                    // Add 1 since we are subtracting from the first day of the
-                    // *next* month
-                    date.day.0 = 1 + (month_days as i8 + offset.days as i8) as u8;
-                    offset.days = 0;
-                }
-            } else {
-                let month_days = self.days_in_month(date);
-                // >= because we date.day is 1, so adding the number of days in the month
-                // will still have the same effect
-                if offset.days >= month_days as i32 {
-                    date.add_months(1);
-                    offset.days -= month_days as i32;
-                } else {
-                    date.day.0 += offset.days as u8;
-                    offset.days = 0;
-                }
-            }
-        }
+    fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
+        date.0.offset_date(offset);
     }
 
-    #[allow(clippy::field_reassign_with_default)] // it's more clear this way
+    #[allow(clippy::field_reassign_with_default)]
     fn until(
         &self,
         date1: &Self::DateInner,
@@ -284,40 +228,39 @@ impl Calendar for Iso {
         _largest_unit: DateDurationUnit,
         _smallest_unit: DateDurationUnit,
     ) -> DateDuration<Self> {
-        let mut difference = DateDuration::default();
-        // TODO (Manishearth) handle the unit bounds and rounding behavior
-        // (perhaps share code with icu_datetime)
-        difference.years = date1.year.0 - date2.year.0;
-        difference.months = date1.month.0 as i32 - date2.month.0 as i32;
-        difference.days = date1.day.0 as i32 - date2.day.0 as i32;
-
-        difference
+        date1.0.until(date2.0, _largest_unit, _smallest_unit)
     }
 
     /// The calendar-specific year represented by `date`
     fn year(&self, date: &Self::DateInner) -> types::Year {
-        date.year.into()
+        types::Year {
+            era: types::Era(tinystr!(16, "default")),
+            number: date.0.year,
+            related_iso: date.0.year,
+        }
     }
 
     /// The calendar-specific month represented by `date`
     fn month(&self, date: &Self::DateInner) -> types::Month {
-        date.month.into()
+        types::Month {
+            ordinal_month: date.0.month.into(),
+            code: types::MonthCode(tinystr!(8, "TODO")),
+        }
     }
 
     /// The calendar-specific day-of-month represented by `date`
     fn day_of_month(&self, date: &Self::DateInner) -> types::DayOfMonth {
-        date.day.into()
+        date.0.day_of_month()
     }
 
-    /// Information of the day of the year
     fn day_of_year_info(&self, date: &Self::DateInner) -> types::DayOfYearInfo {
-        let prev_year = IsoYear(date.year.0 - 1);
-        let next_year = IsoYear(date.year.0 + 1);
+        let prev_year = IsoYear(date.0.year - 1);
+        let next_year = IsoYear(date.0.year + 1);
         types::DayOfYearInfo {
-            day_of_year: Iso::day_of_year(*date),
-            days_in_year: Iso::days_in_year(date.year),
+            day_of_year: date.0.day_of_year(),
+            days_in_year: date.0.days_in_year(),
             prev_year: prev_year.into(),
-            days_in_prev_year: Iso::days_in_year(prev_year),
+            days_in_prev_year: Iso::days_in_year_direct(prev_year.0),
             next_year: next_year.into(),
         }
     }
@@ -332,57 +275,29 @@ impl Calendar for Iso {
 }
 
 impl Date<Iso> {
-    /// Construct a new ISO Date.
-    ///
-    /// ```rust
-    /// use icu::calendar::{iso::IsoDay, iso::IsoMonth, iso::IsoYear, Date};
-    /// use std::convert::TryFrom;
-    ///
-    /// let iso_year = IsoYear(1996);
-    /// let iso_month = IsoMonth::try_from(2).expect("Failed to initialize IsoMonth instance.");
-    /// let iso_day = IsoDay::try_from(3).expect("Failed to initialize IsoDay instance.");
-    ///
-    /// // Creation of ISO date
-    /// let date_iso = Date::new_iso_date(iso_year, iso_month, iso_day)
-    ///     .expect("Failed to initialize ISO Date instance.");
-    ///
-    /// assert_eq!(date_iso.year().number, 1996);
-    /// assert_eq!(date_iso.month().ordinal_month, 2);
-    /// assert_eq!(date_iso.day_of_month().0, 3);
-    /// ```
-    pub fn new_iso_date(
-        year: IsoYear,
-        month: IsoMonth,
-        day: IsoDay,
-    ) -> Result<Date<Iso>, DateTimeError> {
-        if day.0 > 28 {
-            let bound = Iso::days_in_month(year, month);
-            if day.0 > bound {
-                return Err(DateTimeError::OutOfRange);
-            }
-        }
-
-        Ok(Date::from_raw(IsoDateInner { day, month, year }, Iso))
-    }
-
     /// Construct a new ISO date from integers.
     ///
     /// ```rust
     /// use icu::calendar::Date;
     ///
-    /// let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+    /// let date_iso = Date::new_iso_date(1970, 1, 2)
     ///     .expect("Failed to initialize ISO Date instance.");
     ///
     /// assert_eq!(date_iso.year().number, 1970);
     /// assert_eq!(date_iso.month().ordinal_month, 1);
     /// assert_eq!(date_iso.day_of_month().0, 2);
     /// ```
-    pub fn new_iso_date_from_integers(
-        year: i32,
-        month: u8,
-        day: u8,
-    ) -> Result<Date<Iso>, DateTimeError> {
-        Self::new_iso_date(year.into(), month.try_into()?, day.try_into()?)
+    pub fn new_iso_date(year: i32, month: u8, day: u8) -> Result<Date<Iso>, DateTimeError> {
+        if !(1..=12).contains(&month) {
+            return Err(DateTimeError::OutOfRange);
+        }
+        if day == 0 || day > Iso::days_in_month(year, month) {
+            return Err(DateTimeError::OutOfRange);
+        }
+        Ok(Date::from_raw(
+            IsoDateInner(ArithmeticDate::new(year, month, day)),
+            Iso,
+        ))
     }
 }
 
@@ -392,7 +307,7 @@ impl DateTime<Iso> {
     /// ```rust
     /// use icu::calendar::DateTime;
     ///
-    /// let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+    /// let datetime_iso = DateTime::new_iso_datetime(1970, 1, 2, 13, 1, 0)
     ///     .expect("Failed to initialize ISO DateTime instance.");
     ///
     /// assert_eq!(datetime_iso.date.year().number, 1970);
@@ -402,7 +317,7 @@ impl DateTime<Iso> {
     /// assert_eq!(datetime_iso.time.minute.number(), 1);
     /// assert_eq!(datetime_iso.time.second.number(), 0);
     /// ```
-    pub fn new_iso_datetime_from_integers(
+    pub fn new_iso_datetime(
         year: i32,
         month: u8,
         day: u8,
@@ -411,7 +326,7 @@ impl DateTime<Iso> {
         second: u8,
     ) -> Result<DateTime<Iso>, DateTimeError> {
         Ok(DateTime {
-            date: Date::new_iso_date_from_integers(year, month, day)?,
+            date: Date::new_iso_date(year, month, day)?,
             time: types::Time::try_new(hour, minute, second, 0)?,
         })
     }
@@ -423,14 +338,9 @@ impl Iso {
         Self
     }
 
-    /// Check if a given ISO year is a leap year
-    pub fn is_leap_year(year: IsoYear) -> bool {
-        year.0 % 4 == 0 && (year.0 % 400 == 0 || year.0 % 100 != 0)
-    }
-
     /// Count the number of days in a given month/year combo
-    fn days_in_month(year: IsoYear, month: IsoMonth) -> u8 {
-        match month.0 {
+    fn days_in_month(year: i32, month: u8) -> u8 {
+        match month {
             4 | 6 | 9 | 11 => 30,
             2 if Self::is_leap_year(year) => 29,
             2 => 28,
@@ -438,7 +348,7 @@ impl Iso {
         }
     }
 
-    pub(crate) fn days_in_year(year: IsoYear) -> u32 {
+    pub(crate) fn days_in_year_direct(year: i32) -> u32 {
         if Self::is_leap_year(year) {
             366
         } else {
@@ -452,30 +362,46 @@ impl Iso {
     // Lisp code reference: https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L1167-L1189
     pub(crate) fn fixed_from_iso(date: IsoDateInner) -> i32 {
         // Calculate days per year
-        let mut fixed: i32 = EPOCH - 1 + 365 * (date.year.0 - 1);
+        let mut fixed: i32 = EPOCH - 1 + 365 * (date.0.year - 1);
         // Adjust for leap year logic
-        fixed += ((date.year.0 - 1) / 4) - ((date.year.0 - 1) / 100) + ((date.year.0 - 1) / 400);
+        fixed += ((date.0.year - 1) / 4) - ((date.0.year - 1) / 100) + ((date.0.year - 1) / 400);
         // Days of current year
-        fixed += (367 * (date.month.0 as i32) - 362) / 12;
+        fixed += (367 * (date.0.month as i32) - 362) / 12;
         // Leap year adjustment for the current year
-        fixed += if date.month.0 <= 2 {
+        fixed += if date.0.month <= 2 {
             0
-        } else if Self::is_leap_year(date.year) {
+        } else if Self::is_leap_year(date.0.year) {
             -1
         } else {
             -2
         };
         // Days passed in current month
-        fixed + (date.day.0 as i32)
+        fixed + (date.0.day as i32)
     }
 
     fn fixed_from_iso_integers(year: i32, month: i32, day: i32) -> i32 {
         #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
         Self::fixed_from_iso(
-            *Date::new_iso_date_from_integers(year, month as u8, day as u8)
+            *Date::new_iso_date(year, month as u8, day as u8)
                 .unwrap()
                 .inner(),
         )
+    }
+    pub(crate) fn iso_from_year_day(year: i32, year_day: u32) -> Date<Iso> {
+        let mut month = 1;
+        let mut day = year_day as i32;
+        while month <= 12 {
+            let month_days = Self::days_in_month(year, month) as i32;
+            if day <= month_days {
+                break;
+            } else {
+                day -= month_days;
+                month += 1;
+            }
+        }
+
+        #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
+        Date::new_iso_date(year, month, day.try_into().unwrap()).unwrap()
     }
 
     // Lisp code reference: https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L1191-L1217
@@ -513,7 +439,7 @@ impl Iso {
         let prior_days = date - Self::iso_new_year(year);
         let correction = if date < Self::fixed_from_iso_integers(year, 3, 1) {
             0
-        } else if Self::is_leap_year(IsoYear::from(year)) {
+        } else if Self::is_leap_year(year) {
             1
         } else {
             2
@@ -521,24 +447,7 @@ impl Iso {
         let month = (12 * (prior_days + correction) + 373) / 367;
         let day = date - Self::fixed_from_iso_integers(year, month, 1) + 1;
         #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-        Date::new_iso_date_from_integers(year, month as u8, day as u8).unwrap()
-    }
-
-    pub(crate) fn iso_from_year_day(year: i32, year_day: u32) -> Date<Iso> {
-        let mut month = 1;
-        let mut day = year_day as i32;
-        while month <= 12 {
-            let month_days = Self::days_in_month(IsoYear(year), IsoMonth(month)) as i32;
-            if day <= month_days {
-                break;
-            } else {
-                day -= month_days;
-                month += 1;
-            }
-        }
-
-        #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-        Date::new_iso_date_from_integers(year, month, day.try_into().unwrap()).unwrap()
+        Date::new_iso_date(year, month as u8, day as u8).unwrap()
     }
 
     pub(crate) fn day_of_year(date: IsoDateInner) -> u32 {
@@ -546,23 +455,32 @@ impl Iso {
         // offset from "30 days in each month" (in non leap years)
         let month_offset = [0, 1, -1, 0, 0, 1, 1, 2, 3, 3, 4, 4];
         #[allow(clippy::indexing_slicing)] // TODO(#1668) Clippy exceptions need docs or fixing.
-        let mut offset = month_offset[date.month.0 as usize - 1];
-        if Self::is_leap_year(date.year) && date.month.0 > 2 {
+        let mut offset = month_offset[date.0.month as usize - 1];
+        if Self::is_leap_year(date.0.year) && date.0.month > 2 {
             // Months after February in a leap year are offset by one less
             offset += 1;
         }
-        let prev_month_days = (30 * (date.month.0 as i32 - 1) + offset) as u32;
+        let prev_month_days = (30 * (date.0.month as i32 - 1) + offset) as u32;
 
-        prev_month_days + date.day.0 as u32
+        prev_month_days + date.0.day as u32
+    }
+}
+
+impl IsoDateInner {
+    pub(crate) fn jan_1(year: i32) -> Self {
+        Self(ArithmeticDate::new(year, 1, 1))
+    }
+    pub(crate) fn dec_31(year: i32) -> Self {
+        Self(ArithmeticDate::new(year, 12, 1))
     }
 }
 
 impl From<&'_ IsoDateInner> for crate::provider::EraStartDate {
     fn from(other: &'_ IsoDateInner) -> Self {
         Self {
-            year: other.year.0,
-            month: other.month.0,
-            day: other.day.0,
+            year: other.0.year,
+            month: other.0.month,
+            day: other.0.day,
         }
     }
 }

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -17,12 +17,12 @@
 //!
 //! // `Date` checks
 //! assert_eq!(date_iso.year().number, 1970);
-//! assert_eq!(date_iso.month().number, 1);
+//! assert_eq!(date_iso.month().ordinal_month, 1);
 //! assert_eq!(date_iso.day_of_month().0, 2);
 //!
 //! // `DateTime` type
 //! assert_eq!(datetime_iso.date.year().number, 1970);
-//! assert_eq!(datetime_iso.date.month().number, 1);
+//! assert_eq!(datetime_iso.date.month().ordinal_month, 1);
 //! assert_eq!(datetime_iso.date.day_of_month().0, 2);
 //! assert_eq!(datetime_iso.time.hour.number(), 13);
 //! assert_eq!(datetime_iso.time.minute.number(), 1);
@@ -110,7 +110,7 @@ impl From<IsoYear> for types::Year {
 impl From<IsoMonth> for types::Month {
     fn from(month: IsoMonth) -> types::Month {
         types::Month {
-            number: month.0 as u32,
+            ordinal_month: month.0 as u32,
             // TODO(#486): Implement month codes
             code: types::MonthCode(tinystr!(8, "TODO")),
         }
@@ -347,7 +347,7 @@ impl Date<Iso> {
     ///     .expect("Failed to initialize ISO Date instance.");
     ///
     /// assert_eq!(date_iso.year().number, 1996);
-    /// assert_eq!(date_iso.month().number, 2);
+    /// assert_eq!(date_iso.month().ordinal_month, 2);
     /// assert_eq!(date_iso.day_of_month().0, 3);
     /// ```
     pub fn new_iso_date(
@@ -374,7 +374,7 @@ impl Date<Iso> {
     ///     .expect("Failed to initialize ISO Date instance.");
     ///
     /// assert_eq!(date_iso.year().number, 1970);
-    /// assert_eq!(date_iso.month().number, 1);
+    /// assert_eq!(date_iso.month().ordinal_month, 1);
     /// assert_eq!(date_iso.day_of_month().0, 2);
     /// ```
     pub fn new_iso_date_from_integers(
@@ -396,7 +396,7 @@ impl DateTime<Iso> {
     ///     .expect("Failed to initialize ISO DateTime instance.");
     ///
     /// assert_eq!(datetime_iso.date.year().number, 1970);
-    /// assert_eq!(datetime_iso.date.month().number, 1);
+    /// assert_eq!(datetime_iso.date.month().ordinal_month, 1);
     /// assert_eq!(datetime_iso.date.day_of_month().0, 2);
     /// assert_eq!(datetime_iso.time.hour.number(), 13);
     /// assert_eq!(datetime_iso.time.minute.number(), 1);

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -8,11 +8,11 @@
 //! use icu::calendar::{Date, DateTime};
 //!
 //! // `Date` type
-//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+//! let date_iso = Date::new_iso_date(1970, 1, 2)
 //!     .expect("Failed to initialize ISO Date instance.");
 //!
 //! // `DateTime` type
-//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+//! let datetime_iso = DateTime::new_iso_datetime(1970, 1, 2, 13, 1, 0)
 //!     .expect("Failed to initialize ISO DateTime instance.");
 //!
 //! // `Date` checks
@@ -494,21 +494,21 @@ mod test {
     fn test_day_of_week() {
         // June 23, 2021 is a Wednesday
         assert_eq!(
-            Date::new_iso_date_from_integers(2021, 6, 23)
+            Date::new_iso_date(2021, 6, 23)
                 .unwrap()
                 .day_of_week(),
             IsoWeekday::Wednesday,
         );
         // Feb 2, 1983 was a Wednesday
         assert_eq!(
-            Date::new_iso_date_from_integers(1983, 2, 2)
+            Date::new_iso_date(1983, 2, 2)
                 .unwrap()
                 .day_of_week(),
             IsoWeekday::Wednesday,
         );
         // Jan 21, 2021 was a Tuesday
         assert_eq!(
-            Date::new_iso_date_from_integers(2020, 1, 21)
+            Date::new_iso_date(2020, 1, 21)
                 .unwrap()
                 .day_of_week(),
             IsoWeekday::Tuesday,
@@ -519,7 +519,7 @@ mod test {
     fn test_day_of_year() {
         // June 23, 2021 was day 174
         assert_eq!(
-            Date::new_iso_date_from_integers(2021, 6, 23)
+            Date::new_iso_date(2021, 6, 23)
                 .unwrap()
                 .day_of_year_info()
                 .day_of_year,
@@ -527,7 +527,7 @@ mod test {
         );
         // June 23, 2020 was day 175
         assert_eq!(
-            Date::new_iso_date_from_integers(2020, 6, 23)
+            Date::new_iso_date(2020, 6, 23)
                 .unwrap()
                 .day_of_year_info()
                 .day_of_year,
@@ -535,7 +535,7 @@ mod test {
         );
         // Feb 2, 1983 was a Wednesday
         assert_eq!(
-            Date::new_iso_date_from_integers(1983, 2, 2)
+            Date::new_iso_date(1983, 2, 2)
                 .unwrap()
                 .day_of_year_info()
                 .day_of_year,
@@ -556,8 +556,8 @@ mod test {
 
     #[test]
     fn test_offset() {
-        let today = Date::new_iso_date_from_integers(2021, 6, 23).unwrap();
-        let today_plus_5000 = Date::new_iso_date_from_integers(2035, 3, 2).unwrap();
+        let today = Date::new_iso_date(2021, 6, 23).unwrap();
+        let today_plus_5000 = Date::new_iso_date(2035, 3, 2).unwrap();
         let offset = today.clone().added(DateDuration::new(0, 0, 0, 5000));
         assert_eq!(offset, today_plus_5000);
         let offset = today
@@ -565,8 +565,8 @@ mod test {
             .added(simple_subtract(&today_plus_5000, &today));
         assert_eq!(offset, today_plus_5000);
 
-        let today = Date::new_iso_date_from_integers(2021, 6, 23).unwrap();
-        let today_minus_5000 = Date::new_iso_date_from_integers(2007, 10, 15).unwrap();
+        let today = Date::new_iso_date(2021, 6, 23).unwrap();
+        let today_minus_5000 = Date::new_iso_date(2007, 10, 15).unwrap();
         let offset = today.clone().added(DateDuration::new(0, 0, 0, -5000));
         assert_eq!(offset, today_minus_5000);
         let offset = today
@@ -577,33 +577,33 @@ mod test {
 
     #[test]
     fn test_offset_at_month_boundary() {
-        let today = Date::new_iso_date_from_integers(2020, 2, 28).unwrap();
-        let today_plus_2 = Date::new_iso_date_from_integers(2020, 3, 1).unwrap();
+        let today = Date::new_iso_date(2020, 2, 28).unwrap();
+        let today_plus_2 = Date::new_iso_date(2020, 3, 1).unwrap();
         let offset = today.added(DateDuration::new(0, 0, 0, 2));
         assert_eq!(offset, today_plus_2);
 
-        let today = Date::new_iso_date_from_integers(2020, 2, 28).unwrap();
-        let today_plus_3 = Date::new_iso_date_from_integers(2020, 3, 2).unwrap();
+        let today = Date::new_iso_date(2020, 2, 28).unwrap();
+        let today_plus_3 = Date::new_iso_date(2020, 3, 2).unwrap();
         let offset = today.added(DateDuration::new(0, 0, 0, 3));
         assert_eq!(offset, today_plus_3);
 
-        let today = Date::new_iso_date_from_integers(2020, 2, 28).unwrap();
-        let today_plus_1 = Date::new_iso_date_from_integers(2020, 2, 29).unwrap();
+        let today = Date::new_iso_date(2020, 2, 28).unwrap();
+        let today_plus_1 = Date::new_iso_date(2020, 2, 29).unwrap();
         let offset = today.added(DateDuration::new(0, 0, 0, 1));
         assert_eq!(offset, today_plus_1);
 
-        let today = Date::new_iso_date_from_integers(2019, 2, 28).unwrap();
-        let today_plus_2 = Date::new_iso_date_from_integers(2019, 3, 2).unwrap();
+        let today = Date::new_iso_date(2019, 2, 28).unwrap();
+        let today_plus_2 = Date::new_iso_date(2019, 3, 2).unwrap();
         let offset = today.added(DateDuration::new(0, 0, 0, 2));
         assert_eq!(offset, today_plus_2);
 
-        let today = Date::new_iso_date_from_integers(2019, 2, 28).unwrap();
-        let today_plus_1 = Date::new_iso_date_from_integers(2019, 3, 1).unwrap();
+        let today = Date::new_iso_date(2019, 2, 28).unwrap();
+        let today_plus_1 = Date::new_iso_date(2019, 3, 1).unwrap();
         let offset = today.added(DateDuration::new(0, 0, 0, 1));
         assert_eq!(offset, today_plus_1);
 
-        let today = Date::new_iso_date_from_integers(2020, 3, 1).unwrap();
-        let today_minus_1 = Date::new_iso_date_from_integers(2020, 2, 29).unwrap();
+        let today = Date::new_iso_date(2020, 3, 1).unwrap();
+        let today_minus_1 = Date::new_iso_date(2020, 2, 29).unwrap();
         let offset = today.added(DateDuration::new(0, 0, 0, -1));
         assert_eq!(offset, today_minus_1);
     }

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -146,8 +146,8 @@ impl Calendar for Japanese {
 
     /// Information of the day of the year
     fn day_of_year_info(&self, date: &Self::DateInner) -> types::DayOfYearInfo {
-        let prev_dec_31 = IsoDateInner::dec_31((date.inner.0.year - 1).into());
-        let next_jan_1 = IsoDateInner::jan_1((date.inner.0.year + 1).into());
+        let prev_dec_31 = IsoDateInner::dec_31(date.inner.0.year - 1);
+        let next_jan_1 = IsoDateInner::jan_1(date.inner.0.year + 1);
 
         let prev_dec_31 = self.date_from_iso(Date::from_raw(prev_dec_31, Iso));
         let next_jan_1 = self.date_from_iso(Date::from_raw(next_jan_1, Iso));

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -14,12 +14,12 @@
 //! let japanese_calendar = Japanese::try_new(&provider).expect("Cannot load japanese data");
 //!
 //! // `Date` type
-//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+//! let date_iso = Date::new_iso_date(1970, 1, 2)
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_japanese = Date::new_from_iso(date_iso, japanese_calendar.clone());
 //!
 //! // `DateTime` type
-//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+//! let datetime_iso = DateTime::new_iso_datetime(1970, 1, 2, 13, 1, 0)
 //!     .expect("Failed to initialize ISO DateTime instance.");
 //! let datetime_japanese = DateTime::new_from_iso(datetime_iso, japanese_calendar.clone());
 //!

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -25,13 +25,13 @@
 //!
 //! // `Date` checks
 //! assert_eq!(date_japanese.year().number, 45);
-//! assert_eq!(date_japanese.month().number, 1);
+//! assert_eq!(date_japanese.month().ordinal_month, 1);
 //! assert_eq!(date_japanese.day_of_month().0, 2);
 //! assert_eq!(date_japanese.year().era, Era(tinystr!(16, "showa")));
 //!
 //! // `DateTime` type
 //! assert_eq!(datetime_japanese.date.year().number, 45);
-//! assert_eq!(datetime_japanese.date.month().number, 1);
+//! assert_eq!(datetime_japanese.date.month().ordinal_month, 1);
 //! assert_eq!(datetime_japanese.date.day_of_month().0, 2);
 //! assert_eq!(
 //!     datetime_japanese.date.year().era,

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -130,7 +130,7 @@ impl Calendar for Japanese {
         types::Year {
             era: types::Era(date.era),
             number: date.adjusted_year(),
-            related_iso: date.inner.year.0,
+            related_iso: date.inner.0.year,
         }
     }
 
@@ -146,16 +146,16 @@ impl Calendar for Japanese {
 
     /// Information of the day of the year
     fn day_of_year_info(&self, date: &Self::DateInner) -> types::DayOfYearInfo {
-        let prev_dec_31 = IsoDateInner::dec_31((date.inner.year.0 - 1).into());
-        let next_jan_1 = IsoDateInner::jan_1((date.inner.year.0 + 1).into());
+        let prev_dec_31 = IsoDateInner::dec_31((date.inner.0.year - 1).into());
+        let next_jan_1 = IsoDateInner::jan_1((date.inner.0.year + 1).into());
 
         let prev_dec_31 = self.date_from_iso(Date::from_raw(prev_dec_31, Iso));
         let next_jan_1 = self.date_from_iso(Date::from_raw(next_jan_1, Iso));
         types::DayOfYearInfo {
-            day_of_year: Iso::day_of_year(date.inner),
-            days_in_year: Iso::days_in_year(date.inner.year),
+            day_of_year: Iso::days_in_year_direct(date.inner.0.year),
+            days_in_year: Iso::days_in_year_direct(date.inner.0.year),
             prev_year: self.year(&prev_dec_31),
-            days_in_prev_year: Iso::days_in_year(prev_dec_31.inner.year),
+            days_in_prev_year: Iso::days_in_year_direct(prev_dec_31.inner.0.year),
             next_year: self.year(&next_jan_1),
         }
     }
@@ -177,7 +177,7 @@ impl JapaneseDateInner {
         // the era start date are for the first era (Currently, taika-645),
         // where we elect to still report the year as year 1 when it is in the same
         // Gregorian year, and use zero/negative years before that.
-        self.inner.year.0 - self.era_start + 1
+        self.inner.0.year - self.era_start + 1
     }
 }
 

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -32,7 +32,7 @@
 //! ```
 
 use crate::any_calendar::AnyCalendarKind;
-use crate::iso::{Iso, IsoYear};
+use crate::iso::Iso;
 use crate::{
     types, ArithmeticDate, Calendar, CalendarArithmetic, Date, DateDuration, DateDurationUnit,
     DateTime, DateTimeError,
@@ -138,14 +138,14 @@ impl Calendar for Julian {
     }
 
     fn day_of_year_info(&self, date: &Self::DateInner) -> types::DayOfYearInfo {
-        let prev_year = IsoYear(date.0.year - 1);
-        let next_year = IsoYear(date.0.year + 1);
+        let prev_year = date.0.year - 1;
+        let next_year = date.0.year + 1;
         types::DayOfYearInfo {
             day_of_year: date.0.day_of_year(),
             days_in_year: date.0.days_in_year(),
-            prev_year: prev_year.into(),
-            days_in_prev_year: Julian::days_in_year_direct(prev_year.0),
-            next_year: next_year.into(),
+            prev_year: crate::gregorian::year_as_gregorian(prev_year),
+            days_in_prev_year: Julian::days_in_year_direct(prev_year),
+            next_year: crate::gregorian::year_as_gregorian(next_year),
         }
     }
 

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -126,10 +126,7 @@ impl Calendar for Julian {
 
     /// The calendar-specific month represented by `date`
     fn month(&self, date: &Self::DateInner) -> types::Month {
-        types::Month {
-            ordinal_month: date.0.month.into(),
-            code: types::MonthCode(tinystr!(8, "TODO")),
-        }
+        date.0.solar_month()
     }
 
     /// The calendar-specific day-of-month represented by `date`

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -8,12 +8,12 @@
 //! use icu::calendar::{julian::Julian, Date, DateTime};
 //!
 //! // `Date` type
-//! let date_iso = Date::new_iso_date_from_integers(1970, 1, 2)
+//! let date_iso = Date::new_iso_date(1970, 1, 2)
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_julian = Date::new_from_iso(date_iso, Julian);
 //!
 //! // `DateTime` type
-//! let datetime_iso = DateTime::new_iso_datetime_from_integers(1970, 1, 2, 13, 1, 0)
+//! let datetime_iso = DateTime::new_iso_datetime(1970, 1, 2, 13, 1, 0)
 //!     .expect("Failed to initialize ISO DateTime instance.");
 //! let datetime_julian = DateTime::new_from_iso(datetime_iso, Julian);
 //!
@@ -300,28 +300,28 @@ mod test {
     #[test]
     fn test_day_iso_to_julian() {
         // March 1st 200 is same on both calendars
-        let iso_date = Date::new_iso_date_from_integers(200, 3, 1).unwrap();
+        let iso_date = Date::new_iso_date(200, 3, 1).unwrap();
         let julian_date = Julian.date_from_iso(iso_date);
         assert_eq!(julian_date.0.year, 200);
         assert_eq!(julian_date.0.month, 3);
         assert_eq!(julian_date.0.day, 1);
 
         // Feb 28th, 200 (iso) = Feb 29th, 200 (julian)
-        let iso_date = Date::new_iso_date_from_integers(200, 2, 28).unwrap();
+        let iso_date = Date::new_iso_date(200, 2, 28).unwrap();
         let julian_date = Julian.date_from_iso(iso_date);
         assert_eq!(julian_date.0.year, 200);
         assert_eq!(julian_date.0.month, 2);
         assert_eq!(julian_date.0.day, 29);
 
         // March 1st 400 (iso) = Feb 29th, 400 (julian)
-        let iso_date = Date::new_iso_date_from_integers(400, 3, 1).unwrap();
+        let iso_date = Date::new_iso_date(400, 3, 1).unwrap();
         let julian_date = Julian.date_from_iso(iso_date);
         assert_eq!(julian_date.0.year, 400);
         assert_eq!(julian_date.0.month, 2);
         assert_eq!(julian_date.0.day, 29);
 
         // Jan 1st, 2022 (iso) = Dec 19, 2021 (julian)
-        let iso_date = Date::new_iso_date_from_integers(2022, 1, 1).unwrap();
+        let iso_date = Date::new_iso_date(2022, 1, 1).unwrap();
         let julian_date = Julian.date_from_iso(iso_date);
         assert_eq!(julian_date.0.year, 2021);
         assert_eq!(julian_date.0.month, 12);
@@ -333,31 +333,31 @@ mod test {
         // March 1st 200 is same on both calendars
         let julian_date = Date::new_julian_date(200, 3, 1).unwrap();
         let iso_date = Julian.date_to_iso(julian_date.inner());
-        let iso_expected_date = Date::new_iso_date_from_integers(200, 3, 1).unwrap();
+        let iso_expected_date = Date::new_iso_date(200, 3, 1).unwrap();
         assert_eq!(iso_date, iso_expected_date);
 
         // Feb 28th, 200 (iso) = Feb 29th, 200 (julian)
         let julian_date = Date::new_julian_date(200, 2, 29).unwrap();
         let iso_date = Julian.date_to_iso(julian_date.inner());
-        let iso_expected_date = Date::new_iso_date_from_integers(200, 2, 28).unwrap();
+        let iso_expected_date = Date::new_iso_date(200, 2, 28).unwrap();
         assert_eq!(iso_date, iso_expected_date);
 
         // March 1st 400 (iso) = Feb 29th, 400 (julian)
         let julian_date = Date::new_julian_date(400, 2, 29).unwrap();
         let iso_date = Julian.date_to_iso(julian_date.inner());
-        let iso_expected_date = Date::new_iso_date_from_integers(400, 3, 1).unwrap();
+        let iso_expected_date = Date::new_iso_date(400, 3, 1).unwrap();
         assert_eq!(iso_date, iso_expected_date);
 
         // Jan 1st, 2022 (iso) = Dec 19, 2021 (julian)
         let julian_date = Date::new_julian_date(2021, 12, 19).unwrap();
         let iso_date = Julian.date_to_iso(julian_date.inner());
-        let iso_expected_date = Date::new_iso_date_from_integers(2022, 1, 1).unwrap();
+        let iso_expected_date = Date::new_iso_date(2022, 1, 1).unwrap();
         assert_eq!(iso_date, iso_expected_date);
 
         // March 1st, 2022 (iso) = Feb 16, 2022 (julian)
         let julian_date = Date::new_julian_date(2022, 2, 16).unwrap();
         let iso_date = Julian.date_to_iso(julian_date.inner());
-        let iso_expected_date = Date::new_iso_date_from_integers(2022, 3, 1).unwrap();
+        let iso_expected_date = Date::new_iso_date(2022, 3, 1).unwrap();
         assert_eq!(iso_date, iso_expected_date);
     }
 }

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -19,12 +19,12 @@
 //!
 //! // `Date` checks
 //! assert_eq!(date_julian.year().number, 1969);
-//! assert_eq!(date_julian.month().number, 12);
+//! assert_eq!(date_julian.month().ordinal_month, 12);
 //! assert_eq!(date_julian.day_of_month().0, 20);
 //!
 //! // `DateTime` type
 //! assert_eq!(datetime_julian.date.year().number, 1969);
-//! assert_eq!(datetime_julian.date.month().number, 12);
+//! assert_eq!(datetime_julian.date.month().ordinal_month, 12);
 //! assert_eq!(datetime_julian.date.day_of_month().0, 20);
 //! assert_eq!(datetime_julian.time.hour.number(), 13);
 //! assert_eq!(datetime_julian.time.minute.number(), 1);
@@ -127,7 +127,7 @@ impl Calendar for Julian {
     /// The calendar-specific month represented by `date`
     fn month(&self, date: &Self::DateInner) -> types::Month {
         types::Month {
-            number: date.0.month.into(),
+            ordinal_month: date.0.month.into(),
             code: types::MonthCode(tinystr!(8, "TODO")),
         }
     }
@@ -240,7 +240,7 @@ impl Date<Julian> {
     ///     Date::new_julian_date(1969, 12, 20).expect("Failed to initialize Julian Date instance.");
     ///
     /// assert_eq!(date_julian.year().number, 1969);
-    /// assert_eq!(date_julian.month().number, 12);
+    /// assert_eq!(date_julian.month().ordinal_month, 12);
     /// assert_eq!(date_julian.day_of_month().0, 20);
     /// ```
     pub fn new_julian_date(year: i32, month: u8, day: u8) -> Result<Date<Julian>, DateTimeError> {
@@ -272,7 +272,7 @@ impl DateTime<Julian> {
     ///     .expect("Failed to initialize Julian DateTime instance.");
     ///
     /// assert_eq!(datetime_julian.date.year().number, 1969);
-    /// assert_eq!(datetime_julian.date.month().number, 12);
+    /// assert_eq!(datetime_julian.date.month().ordinal_month, 12);
     /// assert_eq!(datetime_julian.date.day_of_month().0, 20);
     /// assert_eq!(datetime_julian.time.hour.number(), 13);
     /// assert_eq!(datetime_julian.time.minute.number(), 1);

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -39,7 +39,6 @@ use crate::{
 };
 use core::convert::TryInto;
 use core::marker::PhantomData;
-use tinystr::tinystr;
 
 // Julian epoch is equivalent to fixed_from_iso of December 30th of 0 year
 // 1st Jan of 1st year Julian is equivalent to December 30th of 0th year of ISO year

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -27,7 +27,7 @@
 //! use icu_calendar::{types::IsoWeekday, Date, DateDuration, DateDurationUnit};
 //!
 //! // Creating ISO date: 1992-09-02.
-//! let mut date_iso = Date::new_iso_date_from_integers(1992, 9, 2)
+//! let mut date_iso = Date::new_iso_date(1992, 9, 2)
 //!     .expect("Failed to initialize ISO Date instance.");
 //!
 //! assert_eq!(date_iso.day_of_week(), IsoWeekday::Wednesday);
@@ -52,7 +52,7 @@
 //! assert_eq!(date_iso.day_of_month().0, 2);
 //!
 //! // Creating ISO date: 2022-01-30.
-//! let newer_date_iso = Date::new_iso_date_from_integers(2022, 1, 30)
+//! let newer_date_iso = Date::new_iso_date(2022, 1, 30)
 //!     .expect("Failed to initialize ISO Date instance.");
 //!
 //! // Comparing dates: 2022-01-30 and 1992-09-02.
@@ -74,7 +74,7 @@
 //! use icu_calendar::{buddhist::Buddhist, indian::Indian, Date};
 //!
 //! // Creating ISO date: 1992-09-02.
-//! let mut date_iso = Date::new_iso_date_from_integers(1992, 9, 2)
+//! let mut date_iso = Date::new_iso_date(1992, 9, 2)
 //!     .expect("Failed to initialize ISO Date instance.");
 //!
 //! assert_eq!(date_iso.year().number, 1992);
@@ -103,7 +103,7 @@
 //! use icu_calendar::{types::IsoWeekday, types::Time, DateDuration, DateTime};
 //!
 //! // Creating ISO date: 1992-09-02 8:59
-//! let mut datetime_iso = DateTime::new_iso_datetime_from_integers(1992, 9, 2, 8, 59, 0)
+//! let mut datetime_iso = DateTime::new_iso_datetime(1992, 9, 2, 8, 59, 0)
 //!     .expect("Failed to initialize ISO DateTime instance.");
 //!
 //! assert_eq!(datetime_iso.date.day_of_week(), IsoWeekday::Wednesday);

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -32,7 +32,7 @@
 //!
 //! assert_eq!(date_iso.day_of_week(), IsoWeekday::Wednesday);
 //! assert_eq!(date_iso.year().number, 1992);
-//! assert_eq!(date_iso.month().number, 9);
+//! assert_eq!(date_iso.month().ordinal_month, 9);
 //! assert_eq!(date_iso.day_of_month().0, 2);
 //!
 //! // Answering questions about days in month and year.
@@ -42,13 +42,13 @@
 //! // Advancing date in-place by 1 year, 2 months, 3 weeks, 4 days.
 //! date_iso.add(DateDuration::new(1, 2, 3, 4));
 //! assert_eq!(date_iso.year().number, 1993);
-//! assert_eq!(date_iso.month().number, 11);
+//! assert_eq!(date_iso.month().ordinal_month, 11);
 //! assert_eq!(date_iso.day_of_month().0, 27);
 //!
 //! // Reverse date advancement.
 //! date_iso.add(DateDuration::new(-1, -2, -3, -4));
 //! assert_eq!(date_iso.year().number, 1992);
-//! assert_eq!(date_iso.month().number, 9);
+//! assert_eq!(date_iso.month().ordinal_month, 9);
 //! assert_eq!(date_iso.day_of_month().0, 2);
 //!
 //! // Creating ISO date: 2022-01-30.
@@ -64,7 +64,7 @@
 //! // Create new date with date advancement. Reassign to new variable.
 //! let mutated_date_iso = date_iso.added(DateDuration::new(1, 2, 3, 4));
 //! assert_eq!(mutated_date_iso.year().number, 1993);
-//! assert_eq!(mutated_date_iso.month().number, 11);
+//! assert_eq!(mutated_date_iso.month().ordinal_month, 11);
 //! assert_eq!(mutated_date_iso.day_of_month().0, 27);
 //! ```
 //!
@@ -78,19 +78,19 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //!
 //! assert_eq!(date_iso.year().number, 1992);
-//! assert_eq!(date_iso.month().number, 9);
+//! assert_eq!(date_iso.month().ordinal_month, 9);
 //! assert_eq!(date_iso.day_of_month().0, 2);
 //!
 //! // Conversion into Indian calendar: 1914-08-02.
 //! let date_indian = date_iso.to_calendar(Indian);
 //! assert_eq!(date_indian.year().number, 1914);
-//! assert_eq!(date_indian.month().number, 8);
+//! assert_eq!(date_indian.month().ordinal_month, 8);
 //! assert_eq!(date_indian.day_of_month().0, 30);
 //!
 //! // Conversion into Buddhist calendar: 2535-09-02.
 //! let date_buddhist = date_iso.to_calendar(Buddhist);
 //! assert_eq!(date_buddhist.year().number, 2535);
-//! assert_eq!(date_buddhist.month().number, 9);
+//! assert_eq!(date_buddhist.month().ordinal_month, 9);
 //! assert_eq!(date_buddhist.day_of_month().0, 2);
 //! ```
 //!
@@ -108,7 +108,7 @@
 //!
 //! assert_eq!(datetime_iso.date.day_of_week(), IsoWeekday::Wednesday);
 //! assert_eq!(datetime_iso.date.year().number, 1992);
-//! assert_eq!(datetime_iso.date.month().number, 9);
+//! assert_eq!(datetime_iso.date.month().ordinal_month, 9);
 //! assert_eq!(datetime_iso.date.day_of_month().0, 2);
 //! assert_eq!(datetime_iso.time.hour.number(), 8);
 //! assert_eq!(datetime_iso.time.minute.number(), 59);
@@ -121,7 +121,7 @@
 //! datetime_iso.time = Time::try_new(14, 30, 0, 0).expect("Failed to initialize Time instance.");
 //!
 //! assert_eq!(datetime_iso.date.year().number, 1993);
-//! assert_eq!(datetime_iso.date.month().number, 11);
+//! assert_eq!(datetime_iso.date.month().ordinal_month, 11);
 //! assert_eq!(datetime_iso.date.day_of_month().0, 27);
 //! assert_eq!(datetime_iso.time.hour.number(), 14);
 //! assert_eq!(datetime_iso.time.minute.number(), 30);

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -39,17 +39,11 @@ pub struct MonthCode(pub TinyStr8);
 #[derive(Clone, Debug, PartialEq)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Month {
-    /// A month number in a year. In normal years, this is usually the 1-based month index. In leap
-    /// years, this is what the month number would have been in a non-leap year.
+    /// The month number in this given year. For calendars with leap months, all months after
+    /// the leap month will end up with an incremented number.
     ///
-    /// For example:
-    ///
-    /// - January = 1
-    /// - December = 12
-    /// - Adar, Adar I, and Adar II = 6
-    ///
-    /// The `code` property is used to distinguish between unique months in leap years.
-    pub number: u32,
+    /// In general, prefer using the month code in generic code.
+    pub ordinal_month: u32,
 
     /// The month code, used to distinguish months during leap years.
     pub code: MonthCode,

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -240,7 +240,7 @@ where
                         .datetime()
                         .month()
                         .ok_or(Error::MissingInputField)?
-                        .number,
+                        .ordinal_month,
                 ),
                 field.length,
             )?,
@@ -255,7 +255,7 @@ where
                             .datetime()
                             .month()
                             .ok_or(Error::MissingInputField)?
-                            .number as usize
+                            .ordinal_month as usize
                             - 1,
                     )?;
                 w.write_str(symbol)?


### PR DESCRIPTION
This moves the calendar crate over to emitting month codes., but they are not yet used anywhere.

The bulk of this PR is actually refactoring ISO to use ArithmeticDate (and avoid code duplication). I could not completely switch it over because of https://github.com/unicode-org/icu4x/issues/2052, but this should make it easier to fix that in the future.

The old IsoDateInner used typesafe month/day types but the type safety is contextual and tends to get in the way more than it helps. Furthermore, it leads to less code sharing and ISO becomes a weird special snowflake.

Once this lands i'll move on to getting formatting to use this, and finally getting the Calendar trait to support generic construction of dates based on this.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->