### PR TITLE
More impls in zerovec crate

### DIFF
--- a/utils/zerovec/src/flexzerovec/crabbake.rs
+++ b/utils/zerovec/src/flexzerovec/crabbake.rs
@@ -47,14 +47,14 @@ mod test {
 
         // README: Except for the '::zerovec' instead of 'zerovec',
         // this string should be identical to the code above.
-        pub const BAKED_VEC_STR: &'static str = "unsafe {
+        pub const BAKED_VEC_STR: &str = "unsafe {
             ::zerovec::vecs::FlexZeroSlice::from_byte_slice_unchecked(&[
                 2u8, 1u8, 0u8, 22u8, 0u8, 77u8, 1u8, 92u8, 17u8
             ])
             .as_flexzerovec()
         }";
 
-        pub const BAKED_SLICE: &'static FlexZeroSlice = unsafe {
+        pub const BAKED_SLICE: &FlexZeroSlice = unsafe {
             zerovec::vecs::FlexZeroSlice::from_byte_slice_unchecked(&[
                 2u8, 1u8, 0u8, 22u8, 0u8, 77u8, 1u8, 92u8, 17u8
             ])
@@ -62,7 +62,7 @@ mod test {
 
         // README: Except for the '::zerovec' instead of 'zerovec',
         // this string should be identical to the code above.
-        pub const BAKED_SLICE_STR: &'static str = "unsafe {
+        pub const BAKED_SLICE_STR: &str = "unsafe {
             ::zerovec::vecs::FlexZeroSlice::from_byte_slice_unchecked(&[
                 2u8, 1u8, 0u8, 22u8, 0u8, 77u8, 1u8, 92u8, 17u8
             ])
@@ -74,7 +74,7 @@ mod test {
         let reference: FlexZeroVec = FlexZeroVec::parse_byte_slice(BYTES).expect("parse");
         assert_eq!(baked::BAKED_VEC, reference);
         let mut ctx = crabbake::CrateEnv::default();
-        let actual_tokens = reference.bake(&mut ctx);
+        let actual_tokens = reference.bake(&ctx);
         assert_eq!(
             actual_tokens.to_string(),
             TokenStream::from_str(baked::BAKED_VEC_STR)
@@ -88,7 +88,7 @@ mod test {
         let reference: &FlexZeroSlice = FlexZeroSlice::parse_byte_slice(BYTES).expect("parse");
         assert_eq!(baked::BAKED_SLICE, reference);
         let mut ctx = crabbake::CrateEnv::default();
-        let actual_tokens = reference.bake(&mut ctx);
+        let actual_tokens = reference.bake(&ctx);
         assert_eq!(
             actual_tokens.to_string(),
             TokenStream::from_str(baked::BAKED_SLICE_STR)

--- a/utils/zerovec/src/flexzerovec/crabbake.rs
+++ b/utils/zerovec/src/flexzerovec/crabbake.rs
@@ -73,7 +73,7 @@ mod test {
     fn test_baked_vec() {
         let reference: FlexZeroVec = FlexZeroVec::parse_byte_slice(BYTES).expect("parse");
         assert_eq!(baked::BAKED_VEC, reference);
-        let mut ctx = crabbake::CrateEnv::default();
+        let ctx = crabbake::CrateEnv::default();
         let actual_tokens = reference.bake(&ctx);
         assert_eq!(
             actual_tokens.to_string(),
@@ -87,7 +87,7 @@ mod test {
     fn test_baked_slice() {
         let reference: &FlexZeroSlice = FlexZeroSlice::parse_byte_slice(BYTES).expect("parse");
         assert_eq!(baked::BAKED_SLICE, reference);
-        let mut ctx = crabbake::CrateEnv::default();
+        let ctx = crabbake::CrateEnv::default();
         let actual_tokens = reference.bake(&ctx);
         assert_eq!(
             actual_tokens.to_string(),

--- a/utils/zerovec/src/flexzerovec/crabbake.rs
+++ b/utils/zerovec/src/flexzerovec/crabbake.rs
@@ -1,0 +1,99 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use super::{FlexZeroSlice, FlexZeroVec};
+use crabbake::*;
+
+impl Bakeable for FlexZeroVec<'_> {
+    fn bake(&self, env: &CrateEnv) -> TokenStream {
+        env.insert("core");
+        env.insert("zerovec");
+        let bytes = self.as_bytes();
+        quote! { unsafe { ::zerovec::vecs::FlexZeroSlice::from_byte_slice_unchecked(&[#(#bytes),*]).as_flexzerovec() } }
+    }
+}
+
+impl Bakeable for &FlexZeroSlice {
+    fn bake(&self, env: &CrateEnv) -> TokenStream {
+        env.insert("core");
+        env.insert("zerovec");
+        let bytes = self.as_bytes();
+        quote! { unsafe { ::zerovec::vecs::FlexZeroSlice::from_byte_slice_unchecked(&[#(#bytes),*]) } }
+    }
+}
+
+#[cfg(test)]
+#[allow(non_camel_case_types)]
+mod test {
+    use super::{FlexZeroSlice, FlexZeroVec};
+    use core::str::FromStr;
+    use crabbake::{Bakeable, TokenStream};
+
+    // [1, 22, 333, 4444];
+    const BYTES: &[u8] = &[2, 0x01, 0x00, 0x16, 0x00, 0x4D, 0x01, 0x5C, 0x11];
+
+    #[rustfmt::skip]
+    mod baked {
+        use crate as zerovec;
+        use super::{FlexZeroSlice, FlexZeroVec};
+
+        pub const BAKED_VEC: FlexZeroVec<'static> = unsafe {
+            zerovec::vecs::FlexZeroSlice::from_byte_slice_unchecked(&[
+                2u8, 1u8, 0u8, 22u8, 0u8, 77u8, 1u8, 92u8, 17u8
+            ])
+            .as_flexzerovec()
+        };
+
+        // README: Except for the '::zerovec' instead of 'zerovec',
+        // this string should be identical to the code above.
+        pub const BAKED_VEC_STR: &'static str = "unsafe {
+            ::zerovec::vecs::FlexZeroSlice::from_byte_slice_unchecked(&[
+                2u8, 1u8, 0u8, 22u8, 0u8, 77u8, 1u8, 92u8, 17u8
+            ])
+            .as_flexzerovec()
+        }";
+
+        pub const BAKED_SLICE: &'static FlexZeroSlice = unsafe {
+            zerovec::vecs::FlexZeroSlice::from_byte_slice_unchecked(&[
+                2u8, 1u8, 0u8, 22u8, 0u8, 77u8, 1u8, 92u8, 17u8
+            ])
+        };
+
+        // README: Except for the '::zerovec' instead of 'zerovec',
+        // this string should be identical to the code above.
+        pub const BAKED_SLICE_STR: &'static str = "unsafe {
+            ::zerovec::vecs::FlexZeroSlice::from_byte_slice_unchecked(&[
+                2u8, 1u8, 0u8, 22u8, 0u8, 77u8, 1u8, 92u8, 17u8
+            ])
+        }";
+    }
+
+    #[test]
+    fn test_baked_vec() {
+        let reference: FlexZeroVec = FlexZeroVec::parse_byte_slice(BYTES).expect("parse");
+        assert_eq!(baked::BAKED_VEC, reference);
+        let mut ctx = crabbake::CrateEnv::default();
+        let actual_tokens = reference.bake(&mut ctx);
+        assert_eq!(
+            actual_tokens.to_string(),
+            TokenStream::from_str(baked::BAKED_VEC_STR)
+                .unwrap()
+                .to_string()
+        );
+    }
+
+    #[test]
+    fn test_baked_slice() {
+        let reference: &FlexZeroSlice = FlexZeroSlice::parse_byte_slice(BYTES).expect("parse");
+        assert_eq!(baked::BAKED_SLICE, reference);
+        let mut ctx = crabbake::CrateEnv::default();
+        let actual_tokens = reference.bake(&mut ctx);
+        assert_eq!(
+            actual_tokens.to_string(),
+            TokenStream::from_str(baked::BAKED_SLICE_STR)
+                .unwrap()
+                .to_string()
+        );
+    }
+}

--- a/utils/zerovec/src/flexzerovec/mod.rs
+++ b/utils/zerovec/src/flexzerovec/mod.rs
@@ -8,6 +8,12 @@ pub(crate) mod owned;
 pub(crate) mod slice;
 pub(crate) mod vec;
 
+#[cfg(feature = "crabbake")]
+mod crabbake;
+
+#[cfg(feature = "serde")]
+mod serde;
+
 pub use owned::FlexZeroVecOwned;
 pub(crate) use slice::chunk_to_usize;
 pub use slice::FlexZeroSlice;

--- a/utils/zerovec/src/flexzerovec/serde.rs
+++ b/utils/zerovec/src/flexzerovec/serde.rs
@@ -1,0 +1,180 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use super::{FlexZeroSlice, FlexZeroVec};
+use alloc::vec::Vec;
+use core::fmt;
+use serde::de::{self, Deserialize, Deserializer, SeqAccess, Visitor};
+#[cfg(feature = "serde")]
+use serde::ser::{Serialize, SerializeSeq, Serializer};
+
+struct FlexZeroVecVisitor {}
+
+impl Default for FlexZeroVecVisitor {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+impl<'de> Visitor<'de> for FlexZeroVecVisitor {
+    type Value = FlexZeroVec<'de>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a sequence or borrowed buffer of bytes")
+    }
+
+    fn visit_borrowed_bytes<E>(self, bytes: &'de [u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        FlexZeroVec::parse_byte_slice(bytes).map_err(de::Error::custom)
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut vec: Vec<usize> = if let Some(capacity) = seq.size_hint() {
+            Vec::with_capacity(capacity)
+        } else {
+            Vec::new()
+        };
+        while let Some(value) = seq.next_element::<usize>()? {
+            vec.push(value);
+        }
+        Ok(vec.into_iter().collect())
+    }
+}
+
+/// This impl can be made available by enabling the optional `serde` feature of the `zerovec` crate
+impl<'de, 'a> Deserialize<'de> for FlexZeroVec<'a>
+where
+    'de: 'a,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let visitor = FlexZeroVecVisitor::default();
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_seq(visitor)
+        } else {
+            deserializer.deserialize_bytes(visitor)
+        }
+    }
+}
+
+/// This impl can be made available by enabling the optional `serde` feature of the `zerovec` crate
+impl<'de, 'a> Deserialize<'de> for &'a FlexZeroSlice
+where
+    'de: 'a,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            Err(de::Error::custom(
+                "&FlexZeroSlice cannot be deserialized from human-readable formats",
+            ))
+        } else {
+            let deserialized: FlexZeroVec<'a> = FlexZeroVec::deserialize(deserializer)?;
+            let borrowed = if let FlexZeroVec::Borrowed(b) = deserialized {
+                b
+            } else {
+                return Err(de::Error::custom(
+                    "&FlexZeroSlice can only deserialize in zero-copy ways",
+                ));
+            };
+            Ok(borrowed)
+        }
+    }
+}
+
+/// This impl can be made available by enabling the optional `serde` feature of the `zerovec` crate
+impl Serialize for FlexZeroVec<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            let mut seq = serializer.serialize_seq(Some(self.len()))?;
+            for value in self.iter() {
+                seq.serialize_element(&value)?;
+            }
+            seq.end()
+        } else {
+            serializer.serialize_bytes(self.as_bytes())
+        }
+    }
+}
+
+/// This impl can be made available by enabling the optional `serde` feature of the `zerovec` crate
+impl Serialize for FlexZeroSlice {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.as_flexzerovec().serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+#[allow(non_camel_case_types)]
+mod test {
+    use super::{FlexZeroSlice, FlexZeroVec};
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct DeriveTest_FlexZeroVec<'data> {
+        #[serde(borrow)]
+        _data: FlexZeroVec<'data>,
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct DeriveTest_FlexZeroSlice<'data> {
+        #[serde(borrow)]
+        _data: &'data FlexZeroSlice,
+    }
+
+    // [1, 22, 333, 4444];
+    const BYTES: &[u8] = &[2, 0x01, 0x00, 0x16, 0x00, 0x4D, 0x01, 0x5C, 0x11];
+    const JSON_STR: &str = "[1,22,333,4444]";
+    const BINCODE_BUF: &[u8] = &[9, 0, 0, 0, 0, 0, 0, 0, 2, 1, 0, 22, 0, 77, 1, 92, 17];
+
+    #[test]
+    fn test_serde_json() {
+        let zerovec_orig: FlexZeroVec = FlexZeroVec::parse_byte_slice(BYTES).expect("parse");
+        let json_str = serde_json::to_string(&zerovec_orig).expect("serialize");
+        assert_eq!(JSON_STR, json_str);
+        // FlexZeroVec should deserialize from JSON to either Vec or FlexZeroVec
+        let vec_new: Vec<usize> =
+            serde_json::from_str(&json_str).expect("deserialize from buffer to Vec");
+        assert_eq!(zerovec_orig.to_vec(), vec_new);
+        let zerovec_new: FlexZeroVec =
+            serde_json::from_str(&json_str).expect("deserialize from buffer to FlexZeroVec");
+        assert_eq!(zerovec_orig.to_vec(), zerovec_new.to_vec());
+        assert!(matches!(zerovec_new, FlexZeroVec::Owned(_)));
+    }
+
+    #[test]
+    fn test_serde_bincode() {
+        let zerovec_orig: FlexZeroVec = FlexZeroVec::parse_byte_slice(BYTES).expect("parse");
+        let bincode_buf = bincode::serialize(&zerovec_orig).expect("serialize");
+        assert_eq!(BINCODE_BUF, bincode_buf);
+        let zerovec_new: FlexZeroVec =
+            bincode::deserialize(&bincode_buf).expect("deserialize from buffer to FlexZeroVec");
+        assert_eq!(zerovec_orig.to_vec(), zerovec_new.to_vec());
+        assert!(matches!(zerovec_new, FlexZeroVec::Borrowed(_)));
+    }
+
+    #[test]
+    fn test_vzv_borrowed() {
+        let zerovec_orig: &FlexZeroSlice = FlexZeroSlice::parse_byte_slice(BYTES).expect("parse");
+        let bincode_buf = bincode::serialize(&zerovec_orig).expect("serialize");
+        assert_eq!(BINCODE_BUF, bincode_buf);
+        let zerovec_new: &FlexZeroSlice =
+            bincode::deserialize(&bincode_buf).expect("deserialize from buffer to FlexZeroSlice");
+        assert_eq!(zerovec_orig.to_vec(), zerovec_new.to_vec());
+    }
+}

--- a/utils/zerovec/src/flexzerovec/serde.rs
+++ b/utils/zerovec/src/flexzerovec/serde.rs
@@ -9,13 +9,8 @@ use serde::de::{self, Deserialize, Deserializer, SeqAccess, Visitor};
 #[cfg(feature = "serde")]
 use serde::ser::{Serialize, SerializeSeq, Serializer};
 
+#[derive(Default)]
 struct FlexZeroVecVisitor {}
-
-impl Default for FlexZeroVecVisitor {
-    fn default() -> Self {
-        Self {}
-    }
-}
 
 impl<'de> Visitor<'de> for FlexZeroVecVisitor {
     type Value = FlexZeroVec<'de>;

--- a/utils/zerovec/src/flexzerovec/slice.rs
+++ b/utils/zerovec/src/flexzerovec/slice.rs
@@ -160,7 +160,7 @@ impl FlexZeroSlice {
 
     /// Borrows this `FlexZeroSlice` as a [`FlexZeroVec::Borrowed`].
     #[inline]
-    pub fn as_flexzerovec(&self) -> FlexZeroVec {
+    pub const fn as_flexzerovec(&self) -> FlexZeroVec {
         FlexZeroVec::Borrowed(self)
     }
 

--- a/utils/zerovec/src/map/crabbake.rs
+++ b/utils/zerovec/src/map/crabbake.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::{maps::ZeroMapKV, ZeroMap, maps::ZeroMapBorrowed};
+use crate::{maps::ZeroMapBorrowed, maps::ZeroMapKV, ZeroMap};
 use crabbake::*;
 
 impl<'a, K, V> Bakeable for ZeroMap<'a, K, V>

--- a/utils/zerovec/src/map/crabbake.rs
+++ b/utils/zerovec/src/map/crabbake.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::{maps::ZeroMapKV, ZeroMap};
+use crate::{maps::ZeroMapKV, ZeroMap, maps::ZeroMapBorrowed};
 use crabbake::*;
 
 impl<'a, K, V> Bakeable for ZeroMap<'a, K, V>
@@ -17,5 +17,20 @@ where
         let keys = self.keys.bake(env);
         let values = self.values.bake(env);
         quote! { unsafe { #[allow(unused_unsafe)] ::zerovec::ZeroMap::from_parts_unchecked(#keys, #values) } }
+    }
+}
+
+impl<'a, K, V> Bakeable for ZeroMapBorrowed<'a, K, V>
+where
+    K: ZeroMapKV<'a> + ?Sized,
+    V: ZeroMapKV<'a> + ?Sized,
+    &'a K::Slice: Bakeable,
+    &'a V::Slice: Bakeable,
+{
+    fn bake(&self, env: &CrateEnv) -> TokenStream {
+        env.insert("zerovec");
+        let keys = self.keys.bake(env);
+        let values = self.values.bake(env);
+        quote! { unsafe { #[allow(unused_unsafe)] ::zerovec::maps::ZeroMapBorrowed::from_parts_unchecked(#keys, #values) } }
     }
 }

--- a/utils/zerovec/src/map2d/crabbake.rs
+++ b/utils/zerovec/src/map2d/crabbake.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::{maps::ZeroMapKV, ZeroMap2d};
+use crate::{maps::ZeroMapKV, ZeroMap2d, maps::ZeroMap2dBorrowed};
 use crabbake::*;
 
 impl<'a, K0, K1, V> Bakeable for ZeroMap2d<'a, K0, K1, V>
@@ -21,5 +21,24 @@ where
         let keys1 = self.keys1.bake(env);
         let values = self.values.bake(env);
         quote! { unsafe { #[allow(unused_unsafe)] ::zerovec::ZeroMap2d::from_parts_unchecked(#keys0, #joiner, #keys1, #values) } }
+    }
+}
+
+impl<'a, K0, K1, V> Bakeable for ZeroMap2dBorrowed<'a, K0, K1, V>
+where
+    K0: ZeroMapKV<'a> + ?Sized,
+    K1: ZeroMapKV<'a> + ?Sized,
+    V: ZeroMapKV<'a> + ?Sized,
+    &'a K0::Slice: Bakeable,
+    &'a K1::Slice: Bakeable,
+    &'a V::Slice: Bakeable,
+{
+    fn bake(&self, env: &CrateEnv) -> TokenStream {
+        env.insert("zerovec");
+        let keys0 = self.keys0.bake(env);
+        let joiner = self.joiner.bake(env);
+        let keys1 = self.keys1.bake(env);
+        let values = self.values.bake(env);
+        quote! { unsafe { #[allow(unused_unsafe)] ::zerovec::maps::ZeroMap2dBorrowed::from_parts_unchecked(#keys0, #joiner, #keys1, #values) } }
     }
 }

--- a/utils/zerovec/src/map2d/crabbake.rs
+++ b/utils/zerovec/src/map2d/crabbake.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::{maps::ZeroMapKV, ZeroMap2d, maps::ZeroMap2dBorrowed};
+use crate::{maps::ZeroMap2dBorrowed, maps::ZeroMapKV, ZeroMap2d};
 use crabbake::*;
 
 impl<'a, K0, K1, V> Bakeable for ZeroMap2d<'a, K0, K1, V>

--- a/utils/zerovec/src/varzerovec/crabbake.rs
+++ b/utils/zerovec/src/varzerovec/crabbake.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::{ule::VarULE, VarZeroVec};
+use crate::{ule::VarULE, VarZeroSlice, VarZeroVec};
 use crabbake::*;
 
 impl<T: VarULE + ?Sized> Bakeable for VarZeroVec<'_, T> {
@@ -11,5 +11,14 @@ impl<T: VarULE + ?Sized> Bakeable for VarZeroVec<'_, T> {
         let bytes = self.as_bytes();
         // Safe because self.as_bytes is a safe input
         quote! { unsafe { ::zerovec::VarZeroVec::from_bytes_unchecked(&[#(#bytes),*]) } }
+    }
+}
+
+impl<T: VarULE + ?Sized> Bakeable for &VarZeroSlice<T> {
+    fn bake(&self, env: &CrateEnv) -> TokenStream {
+        env.insert("zerovec");
+        let bytes = self.as_bytes();
+        // Safe because self.as_bytes is a safe input
+        quote! { unsafe { ::zerovec::VarZeroSlice::from_bytes_unchecked(&[#(#bytes),*]) } }
     }
 }

--- a/utils/zerovec/src/yoke_impls.rs
+++ b/utils/zerovec/src/yoke_impls.rs
@@ -290,55 +290,101 @@ where
 #[allow(non_camel_case_types)]
 mod test {
     use super::*;
-    use crate::{VarZeroSlice, ZeroSlice};
+    use crate::{vecs::FlexZeroSlice, VarZeroSlice, ZeroSlice};
+
+    // Note: The following derives cover Yoke as well as Serde and CrabBake. These may partially
+    // duplicate tests elsewhere in this crate, but they are here for completeness.
 
     #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "crabbake", derive(crabbake::Bakeable), crabbake(path = zerovec::yoke_impl::test))]
     struct DeriveTest_ZeroVec<'data> {
+        #[cfg_attr(feature = "serde", serde(borrow))]
         _data: ZeroVec<'data, u16>,
     }
 
-    #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
-    struct DeriveTest_FlexZeroVec<'data> {
-        _data: FlexZeroVec<'data>,
+    #[derive(yoke::Yokeable)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "crabbake", derive(crabbake::Bakeable), crabbake(path = zerovec::yoke_impl::test))]
+    struct DeriveTest_ZeroSlice<'data> {
+        #[cfg_attr(feature = "serde", serde(borrow))]
+        _data: &'data ZeroSlice<u16>,
     }
 
     #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "crabbake", derive(crabbake::Bakeable), crabbake(path = zerovec::yoke_impl::test))]
+    struct DeriveTest_FlexZeroVec<'data> {
+        #[cfg_attr(feature = "serde", serde(borrow))]
+        _data: FlexZeroVec<'data>,
+    }
+
+    #[derive(yoke::Yokeable)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "crabbake", derive(crabbake::Bakeable), crabbake(path = zerovec::yoke_impl::test))]
+    struct DeriveTest_FlexZeroSlice<'data> {
+        #[cfg_attr(feature = "serde", serde(borrow))]
+        _data: &'data FlexZeroSlice,
+    }
+
+    #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "crabbake", derive(crabbake::Bakeable), crabbake(path = zerovec::yoke_impl::test))]
     struct DeriveTest_VarZeroVec<'data> {
+        #[cfg_attr(feature = "serde", serde(borrow))]
         _data: VarZeroVec<'data, str>,
     }
 
     #[derive(yoke::Yokeable)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "crabbake", derive(crabbake::Bakeable), crabbake(path = zerovec::yoke_impl::test))]
     struct DeriveTest_VarZeroSlice<'data> {
+        #[cfg_attr(feature = "serde", serde(borrow))]
         _data: &'data VarZeroSlice<str>,
     }
 
     #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "crabbake", derive(crabbake::Bakeable), crabbake(path = zerovec::yoke_impl::test))]
     #[yoke(prove_covariance_manually)]
     struct DeriveTest_ZeroMap<'data> {
+        #[cfg_attr(feature = "serde", serde(borrow))]
         _data: ZeroMap<'data, [u8], str>,
     }
 
     #[derive(yoke::Yokeable)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "crabbake", derive(crabbake::Bakeable), crabbake(path = zerovec::yoke_impl::test))]
     #[yoke(prove_covariance_manually)]
     struct DeriveTest_ZeroMapBorrowed<'data> {
+        #[cfg_attr(feature = "serde", serde(borrow))]
         _data: ZeroMapBorrowed<'data, [u8], str>,
     }
 
     #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "crabbake", derive(crabbake::Bakeable), crabbake(path = zerovec::yoke_impl::test))]
     #[yoke(prove_covariance_manually)]
     struct DeriveTest_ZeroMapWithULE<'data> {
+        #[cfg_attr(feature = "serde", serde(borrow))]
         _data: ZeroMap<'data, ZeroSlice<u32>, str>,
     }
 
     #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "crabbake", derive(crabbake::Bakeable), crabbake(path = zerovec::yoke_impl::test))]
     #[yoke(prove_covariance_manually)]
     struct DeriveTest_ZeroMap2d<'data> {
+        #[cfg_attr(feature = "serde", serde(borrow))]
         _data: ZeroMap2d<'data, u16, u16, str>,
     }
 
     #[derive(yoke::Yokeable)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "crabbake", derive(crabbake::Bakeable), crabbake(path = zerovec::yoke_impl::test))]
     #[yoke(prove_covariance_manually)]
     struct DeriveTest_ZeroMap2dBorrowed<'data> {
+        #[cfg_attr(feature = "serde", serde(borrow))]
         _data: ZeroMap2dBorrowed<'data, u16, u16, str>,
     }
 }

--- a/utils/zerovec/src/zerofrom_impls.rs
+++ b/utils/zerovec/src/zerofrom_impls.rs
@@ -28,6 +28,16 @@ where
     }
 }
 
+impl<'zf, T> ZeroFrom<'zf, ZeroSlice<T>> for &'zf ZeroSlice<T>
+where
+    T: 'static + AsULE + ?Sized,
+{
+    #[inline]
+    fn zero_from(other: &'zf ZeroSlice<T>) -> Self {
+        other
+    }
+}
+
 impl<'zf> ZeroFrom<'zf, FlexZeroVec<'_>> for FlexZeroVec<'zf> {
     #[inline]
     fn zero_from(other: &'zf FlexZeroVec<'_>) -> Self {
@@ -39,6 +49,13 @@ impl<'zf> ZeroFrom<'zf, FlexZeroSlice> for FlexZeroVec<'zf> {
     #[inline]
     fn zero_from(other: &'zf FlexZeroSlice) -> Self {
         FlexZeroVec::Borrowed(&*other)
+    }
+}
+
+impl<'zf> ZeroFrom<'zf, FlexZeroSlice> for &'zf FlexZeroSlice {
+    #[inline]
+    fn zero_from(other: &'zf FlexZeroSlice) -> Self {
+        other
     }
 }
 
@@ -59,6 +76,16 @@ where
     #[inline]
     fn zero_from(other: &'zf VarZeroVec<'_, T>) -> Self {
         other.as_slice().into()
+    }
+}
+
+impl<'zf, T> ZeroFrom<'zf, VarZeroSlice<T>> for &'zf VarZeroSlice<T>
+where
+    T: 'static + VarULE + ?Sized,
+{
+    #[inline]
+    fn zero_from(other: &'zf VarZeroSlice<T>) -> Self {
+        other
     }
 }
 

--- a/utils/zerovec/src/zerovec/crabbake.rs
+++ b/utils/zerovec/src/zerovec/crabbake.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use super::ZeroVec;
-use crate::ule::AsULE;
+use crate::{ule::AsULE, ZeroSlice};
 use crabbake::*;
 
 impl<T> Bakeable for ZeroVec<'_, T>
@@ -15,5 +15,17 @@ where
         env.insert("zerovec");
         let bytes = self.as_bytes();
         quote! { unsafe { ::zerovec::ZeroVec::from_bytes_unchecked(&[#(#bytes),*]) } }
+    }
+}
+
+impl<T> Bakeable for &ZeroSlice<T>
+where
+    T: AsULE + ?Sized,
+{
+    fn bake(&self, env: &CrateEnv) -> TokenStream {
+        env.insert("core");
+        env.insert("zerovec");
+        let bytes = self.as_bytes();
+        quote! { unsafe { ::zerovec::ZeroSlice::from_bytes_unchecked(&[#(#bytes),*]) } }
     }
 }


### PR DESCRIPTION
I keep hitting more impls that are missing. This PR adds even more.

CC @robertbastian because I added a Bakeable test in this PR to one type. It compares a string of code to actual code. If you like the style, I think we should add these to everywhere we have a Bakeable impl.