### PR TITLE
LanguageIdentifier merge

### DIFF
--- a/components/locale_canonicalizer/src/locale_canonicalizer.rs
+++ b/components/locale_canonicalizer/src/locale_canonicalizer.rs
@@ -258,6 +258,7 @@ fn update_langid(
 ) -> CanonicalizationResult {
     let mut modified = false;
 
+    //XXX: langid.merge_subtags(Some(language), script, region, None);
     if langid.language.is_empty() && !language.is_empty() {
         langid.language = language;
         modified = true;

--- a/components/locid/src/helpers.rs
+++ b/components/locid/src/helpers.rs
@@ -43,6 +43,15 @@ impl<T> ShortVec<T> {
             ShortVec::Multi(v) => v.as_slice(),
         }
     }
+
+    // pub fn contains(&self, needle: &T) -> bool
+    // where T: PartialEq {
+    //     match self {
+    //         ShortVec::Empty => false,
+    //         ShortVec::Single(v) => v == needle,
+    //         ShortVec::Multi(v) => v.contains(needle),
+    //     }
+    // }
 }
 
 impl<T> From<Vec<T>> for ShortVec<T> {

--- a/components/locid/src/langid.rs
+++ b/components/locid/src/langid.rs
@@ -283,6 +283,36 @@ impl LanguageIdentifier {
         }
         Ok(())
     }
+
+    pub fn merge(&mut self, other: &LanguageIdentifier, r#override: bool) {
+        if !other.language.is_empty() && (self.language.is_empty() || r#override) {
+            self.language = other.language;
+        }
+        if other.script.is_some() && (self.script.is_none() || r#override) {
+            self.script = other.script;
+        }
+        if other.region.is_some() && (self.region.is_none() || r#override) {
+            self.region = other.region;
+        }
+        if !other.variants.is_empty() {
+            self.variants.merge(&other.variants);
+        }
+    }
+
+    pub fn merge_subtags(
+        &mut self,
+        language: Option<subtags::Language>,
+        script: Option<subtags::Script>,
+        region: Option<subtags::Region>,
+        variants: Option<subtags::Variants>,
+    ) {
+        self.language = language.unwrap_or(self.language);
+        self.script = script.or(self.script);
+        self.region = region.or(self.region);
+        if let Some(v) = variants {
+            self.variants.merge(&v);
+        }
+    }
 }
 
 impl AsRef<LanguageIdentifier> for LanguageIdentifier {

--- a/components/locid/src/subtags/variants.rs
+++ b/components/locid/src/subtags/variants.rs
@@ -104,6 +104,20 @@ impl Variants {
     {
         self.deref().iter().map(|t| t.as_str()).try_for_each(f)
     }
+
+    pub fn merge(&mut self, other: &Self) {
+        if self.is_empty() {
+            self.0 = other.0.clone();
+        } else {
+            let mut merged = self.to_vec();
+            for v in other.iter() {
+                if let Err(idx) = merged.binary_search(v) {
+                    merged.insert(idx, *v);
+                }
+            }
+            self.0 = merged.into();
+        }
+    }
 }
 
 impl_writeable_for_subtag_list!(Variants, "macos", "posix");


### PR DESCRIPTION
POC of a merge functionality for LID.

The idea behind this is that we start accumulating code that is meant to merge subtags either only if they're missing or unconditionally when present in "other".

I don't plan to build the whole `merge` for Locale yet, but starting with LID should give us a good way to converge all those uses and we can then extend it to Locale as needed.