### PR TITLE
Remove stable_deref_trait/alloc from yoke's default feature set

### DIFF
--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -30,7 +30,7 @@ default = ["alloc", "zerofrom"]
 all-features = true
 
 [dependencies]
-stable_deref_trait = { version = "1.2.0", features = ["alloc"], default-features = false }
+stable_deref_trait = { version = "1.2.0", default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
 yoke-derive = { path = "./derive", version = "0.6.0", optional = true }
 zerofrom = { path = "../zerofrom", version = "0.1.0", default-features = false, optional = true} 


### PR DESCRIPTION
Given that this feature is also enabled by the alloc feature, this looks like a mistake. If it's not, it should definitely have a comment explaining why this is required.