### PR TITLE
Clean up Hangul math in Composition

### DIFF
--- a/experimental/normalizer/src/lib.rs
+++ b/experimental/normalizer/src/lib.rs
@@ -147,13 +147,13 @@ const HANGUL_S_BASE: u32 = 0xAC00;
 const HANGUL_L_BASE: u32 = 0x1100;
 /// Vowel jamo base
 const HANGUL_V_BASE: u32 = 0x1161;
-/// Trail jamo base
+/// Trail jamo base (deliberately off by one to account for the absence of a trail)
 const HANGUL_T_BASE: u32 = 0x11A7;
 /// Lead jamo count
 const HANGUL_L_COUNT: u32 = 19;
 /// Vowel jamo count
 const HANGUL_V_COUNT: u32 = 21;
-/// Trail jamo count
+/// Trail jamo count (deliberately off by one to account for the absence of a trail)
 const HANGUL_T_COUNT: u32 = 28;
 /// Vowel jamo count times trail jamo count
 const HANGUL_N_COUNT: u32 = 588;
@@ -962,7 +962,7 @@ where
                         // Unicode Standard 14.0, page 146
                         let lv = u32::from(starter) - HANGUL_S_BASE;
                         debug_assert_eq!(lv % HANGUL_T_COUNT, 0);
-                        debug_assert!(in_range_len(next_starter, HANGUL_T_BASE, HANGUL_T_COUNT));
+                        debug_assert!(in_inclusive_range(next_starter, '\u{11A8}', '\u{11C2}'));
                         let lvt = lv + (u32::from(next_starter) - HANGUL_T_BASE);
                         // Safe, because the inputs are known to be in range.
                         starter = unsafe { char::from_u32_unchecked(HANGUL_S_BASE + lvt) };
@@ -990,12 +990,11 @@ where
 
             if let Some(potential) = self.decomposition.buffer.get(self.decomposition.buffer_pos) {
                 let potential_c = potential.character();
-                let t = u32::from(potential_c).wrapping_sub(HANGUL_T_BASE);
-                if t < HANGUL_T_COUNT {
+                if in_inclusive_range(potential_c, '\u{11A8}', '\u{11C2}') {
                     // Hangul trail
                     let lv = u32::from(starter).wrapping_sub(HANGUL_S_BASE);
                     if lv < HANGUL_S_COUNT && lv % HANGUL_T_COUNT == 0 {
-                        let lvt = lv + t;
+                        let lvt = lv + u32::from(potential_c) - HANGUL_T_BASE;
                         // Safe, because the inputs are known to be in range.
                         starter = unsafe { char::from_u32_unchecked(HANGUL_S_BASE + lvt) };
 
@@ -1087,7 +1086,7 @@ where
                     // Won't combine backwards anyway.
                     return Some(starter);
                 }
-                if in_range_len(pending_starter, HANGUL_T_BASE, HANGUL_T_COUNT) {
+                if in_inclusive_range(pending_starter, '\u{11A8}', '\u{11C2}') {
                     // Hangul trail
                     let lv = u32::from(starter).wrapping_sub(HANGUL_S_BASE);
                     if lv < HANGUL_S_COUNT && lv % HANGUL_T_COUNT == 0 {

--- a/experimental/normalizer/src/tests.rs
+++ b/experimental/normalizer/src/tests.rs
@@ -312,3 +312,31 @@ fn test_conformance() {
             .eq(strings[4].chars()));
     }
 }
+
+#[test]
+fn test_hangul() {
+    use icu_uniset::{UnicodeSet, UnicodeSetBuilder};
+    use zerofrom::ZeroFrom;
+    let builder = UnicodeSetBuilder::new();
+    let set: UnicodeSet = builder.build();
+
+    let data_provider = icu_testdata::get_provider();
+
+    let normalizer: ComposingNormalizer = ComposingNormalizer::try_new_nfc(&data_provider).unwrap();
+    {
+        let mut norm_iter = normalizer.normalize_iter("A\u{AC00}\u{11A7}".chars());
+        // Pessimize passthrough to avoid hiding bugs.
+        norm_iter
+            .decomposition
+            .potential_passthrough_and_not_backward_combining = Some(ZeroFrom::zero_from(&set));
+        assert!(norm_iter.eq("A\u{AC00}\u{11A7}".chars()));
+    }
+    {
+        let mut norm_iter = normalizer.normalize_iter("A\u{AC00}\u{11C2}".chars());
+        // Pessimize passthrough to avoid hiding bugs.
+        norm_iter
+            .decomposition
+            .potential_passthrough_and_not_backward_combining = Some(ZeroFrom::zero_from(&set));
+        assert!(norm_iter.eq("A\u{AC1B}".chars()));
+    }
+}


### PR DESCRIPTION
Use named constants instead of magic values. Use wrapping_sub with HANGUL_S_BASE.