### PR TITLE
Better properties return values

### DIFF
--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -361,18 +361,16 @@ pub mod properties {
     //!
     //! // A binary property as a `UnicodeSet`
     //!
-    //! let payload = sets::get_emoji(&provider).expect("The data should be valid");
-    //! let data_struct = payload.get();
-    //! let emoji = &data_struct.inv_list;
+    //! let data = sets::get_emoji(&provider).expect("The data should be valid");
+    //! let emoji = data.as_borrowed();
     //!
     //! assert!(emoji.contains('🎃')); // U+1F383 JACK-O-LANTERN
     //! assert!(!emoji.contains('木')); // U+6728
     //!
     //! // An individual enumerated property value as a `UnicodeSet`
     //!
-    //! let payload = maps::get_general_category(&provider).expect("The data should be valid");
-    //! let data_struct = payload.get();
-    //! let gc = &data_struct.code_point_trie;
+    //! let data = maps::get_general_category(&provider).expect("The data should be valid");
+    //! let gc = data.as_borrowed();
     //! let line_sep = gc.get_set_for_value(GeneralCategory::LineSeparator);
     //!
     //! assert!(line_sep.contains_u32(0x2028));
@@ -386,12 +384,11 @@ pub mod properties {
     //!
     //! let provider = icu_testdata::get_provider();
     //!
-    //! let payload = maps::get_script(&provider).expect("The data should be valid");
-    //! let data_struct = payload.get();
-    //! let script = &data_struct.code_point_trie;
+    //! let data = maps::get_script(&provider).expect("The data should be valid");
+    //! let script = data.as_borrowed();
     //!
-    //! assert_eq!(script.get('🎃' as u32), Script::Common); // U+1F383 JACK-O-LANTERN
-    //! assert_eq!(script.get('木' as u32), Script::Han); // U+6728
+    //! assert_eq!(script.get('🎃'), Script::Common); // U+1F383 JACK-O-LANTERN
+    //! assert_eq!(script.get('木'), Script::Han); // U+6728
     //! ```
     //!
     //! ## Property data for `Script` and `Script_Extensions`

--- a/components/properties/README.md
+++ b/components/properties/README.md
@@ -22,18 +22,16 @@ let provider = icu_testdata::get_provider();
 
 // A binary property as a `UnicodeSet`
 
-let payload = sets::get_emoji(&provider).expect("The data should be valid");
-let data_struct = payload.get();
-let emoji = &data_struct.inv_list;
+let data = sets::get_emoji(&provider).expect("The data should be valid");
+let emoji = data.as_borrowed();
 
 assert!(emoji.contains('🎃')); // U+1F383 JACK-O-LANTERN
 assert!(!emoji.contains('木')); // U+6728
 
 // An individual enumerated property value as a `UnicodeSet`
 
-let payload = maps::get_general_category(&provider).expect("The data should be valid");
-let data_struct = payload.get();
-let gc = &data_struct.code_point_trie;
+let data = maps::get_general_category(&provider).expect("The data should be valid");
+let gc = data.as_borrowed();
 let line_sep = gc.get_set_for_value(GeneralCategory::LineSeparator);
 
 assert!(line_sep.contains_u32(0x2028));
@@ -47,12 +45,11 @@ use icu::properties::{maps, Script};
 
 let provider = icu_testdata::get_provider();
 
-let payload = maps::get_script(&provider).expect("The data should be valid");
-let data_struct = payload.get();
-let script = &data_struct.code_point_trie;
+let map = maps::get_script(&provider).expect("The data should be valid");
+let script = map.as_borrowed();
 
-assert_eq!(script.get('🎃' as u32), Script::Common); // U+1F383 JACK-O-LANTERN
-assert_eq!(script.get('木' as u32), Script::Han); // U+6728
+assert_eq!(script.get('🎃'), Script::Common); // U+1F383 JACK-O-LANTERN
+assert_eq!(script.get('木'), Script::Han); // U+6728
 ```
 
 [`ICU4X`]: ../icu/index.html

--- a/components/properties/src/bidi.rs
+++ b/components/properties/src/bidi.rs
@@ -46,10 +46,10 @@
 //! assert_eq!(display, concat!["a", "b", "c", "ג", "ב", "א",]);
 //! ```
 
+use crate::maps::CodePointMapDataBorrowed;
 use crate::props::BidiClass;
 use unicode_bidi::data_source::BidiDataSource;
 use unicode_bidi::BidiClass as DataSourceBidiClass;
-use crate::maps::CodePointMapDataBorrowed;
 
 /// An adapter to convert from icu4x `BidiClass` to `unicode_bidi::BidiClass`.
 ///

--- a/components/properties/src/bidi.rs
+++ b/components/properties/src/bidi.rs
@@ -65,9 +65,8 @@ use unicode_bidi::BidiClass as DataSourceBidiClass;
 /// let provider = icu_testdata::get_provider();
 ///
 /// let data = maps::get_bidi_class(&provider).expect("The data should be valid");
-/// let bc = data.as_borrowed();
 ///
-/// let adapter = BidiClassAdapter::new(bc);
+/// let adapter = BidiClassAdapter::new(data.as_borrowed());
 /// assert_eq!(adapter.bidi_class('a'), DataSourceBidiClass::L);
 /// assert_eq!(adapter.bidi_class('ع'), DataSourceBidiClass::AL);
 /// ```
@@ -97,9 +96,8 @@ impl<'a> BidiDataSource for BidiClassAdapter<'a> {
     /// let provider = icu_testdata::get_provider();
     ///
     /// let data = maps::get_bidi_class(&provider).expect("The data should be valid");
-    /// let bc = data.as_borrowed();
     ///
-    /// let adapter = BidiClassAdapter::new(bc);
+    /// let adapter = BidiClassAdapter::new(data.as_borrowed());
     /// assert_eq!(adapter.bidi_class('a'), DataSourceBidiClass::L);
     /// ```
     ///

--- a/components/properties/src/lib.rs
+++ b/components/properties/src/lib.rs
@@ -32,9 +32,8 @@
 //!
 //! // An individual enumerated property value as a `UnicodeSet`
 //!
-//! let payload = maps::get_general_category(&provider).expect("The data should be valid");
-//! let data_struct = payload.get();
-//! let gc = &data_struct.code_point_trie;
+//! let data = maps::get_general_category(&provider).expect("The data should be valid");
+//! let gc = data.as_borrowed();
 //! let line_sep = gc.get_set_for_value(GeneralCategory::LineSeparator);
 //!
 //! assert!(line_sep.contains_u32(0x2028));
@@ -48,12 +47,11 @@
 //!
 //! let provider = icu_testdata::get_provider();
 //!
-//! let payload = maps::get_script(&provider).expect("The data should be valid");
-//! let data_struct = payload.get();
-//! let script = &data_struct.code_point_trie;
+//! let map = maps::get_script(&provider).expect("The data should be valid");
+//! let script = map.as_borrowed();
 //!
-//! assert_eq!(script.get('🎃' as u32), Script::Common); // U+1F383 JACK-O-LANTERN
-//! assert_eq!(script.get('木' as u32), Script::Han); // U+6728
+//! assert_eq!(script.get('🎃'), Script::Common); // U+1F383 JACK-O-LANTERN
+//! assert_eq!(script.get('木'), Script::Han); // U+6728
 //! ```
 //!
 //! [`ICU4X`]: ../icu/index.html

--- a/components/properties/src/lib.rs
+++ b/components/properties/src/lib.rs
@@ -24,9 +24,8 @@
 //!
 //! // A binary property as a `UnicodeSet`
 //!
-//! let payload = sets::get_emoji(&provider).expect("The data should be valid");
-//! let data_struct = payload.get();
-//! let emoji = &data_struct.inv_list;
+//! let data = sets::get_emoji(&provider).expect("The data should be valid");
+//! let emoji = data.as_borrowed();
 //!
 //! assert!(emoji.contains('🎃')); // U+1F383 JACK-O-LANTERN
 //! assert!(!emoji.contains('木')); // U+6728

--- a/components/properties/src/maps.rs
+++ b/components/properties/src/maps.rs
@@ -149,7 +149,7 @@ macro_rules! make_map_property {
 make_map_property! {
     property: "General_Category";
     marker: GeneralCategoryProperty;
-    value: GeneralCategory;
+    value: crate::GeneralCategory;
     resource_marker: GeneralCategoryV1Marker;
     func:
     /// Return a [`CodePointTrie`] for the General_Category Unicode enumerated property. See [`GeneralCategory`].
@@ -178,7 +178,7 @@ make_map_property! {
 make_map_property! {
     property: "Bidi_Class";
     marker: BidiClassProperty;
-    value: BidiClass;
+    value: crate::BidiClass;
     resource_marker: BidiClassV1Marker;
     func:
     /// Return a [`CodePointTrie`] for the Bidi_Class Unicode enumerated property. See [`BidiClass`].
@@ -207,7 +207,7 @@ make_map_property! {
 make_map_property! {
     property: "Script";
     marker: ScriptProperty;
-    value: Script;
+    value: crate::Script;
     resource_marker: ScriptV1Marker;
     func:
     /// Return a [`CodePointTrie`] for the Script Unicode enumerated property. See [`Script`].
@@ -236,7 +236,7 @@ make_map_property! {
 make_map_property! {
     property: "East_Asian_Width";
     marker: EastAsianWidthProperty;
-    value: EastAsianWidth;
+    value: crate::EastAsianWidth;
     resource_marker: EastAsianWidthV1Marker;
     func:
     /// Return a [`CodePointTrie`] for the East_Asian_Width Unicode enumerated
@@ -262,7 +262,7 @@ make_map_property! {
 make_map_property! {
     property: "Line_Break";
     marker: LineBreakProperty;
-    value: LineBreak;
+    value: crate::LineBreak;
     resource_marker: LineBreakV1Marker;
     func:
     /// Return a [`CodePointTrie`] for the Line_Break Unicode enumerated
@@ -288,7 +288,7 @@ make_map_property! {
 make_map_property! {
     property: "Grapheme_Cluster_Break";
     marker: GraphemeClusterBreakProperty;
-    value: GraphemeClusterBreak;
+    value: crate::GraphemeClusterBreak;
     resource_marker: GraphemeClusterBreakV1Marker;
     func:
     /// Return a [`CodePointTrie`] for the Grapheme_Cluster_Break Unicode enumerated
@@ -314,7 +314,7 @@ make_map_property! {
 make_map_property! {
     property: "Word_Break";
     marker: WordBreakProperty;
-    value: WordBreak;
+    value: crate::WordBreak;
     resource_marker: WordBreakV1Marker;
     func:
     /// Return a [`CodePointTrie`] for the Word_Break Unicode enumerated
@@ -340,7 +340,7 @@ make_map_property! {
 make_map_property! {
     property: "Sentence_Break";
     marker: SentenceBreakProperty;
-    value: SentenceBreak;
+    value: crate::SentenceBreak;
     resource_marker: SentenceBreakV1Marker;
     func:
     /// Return a [`CodePointTrie`] for the Sentence_Break Unicode enumerated
@@ -366,7 +366,7 @@ make_map_property! {
 make_map_property! {
     property: "Canonical_Combining_Class";
     marker: CanonicalCombiningClassProperty;
-    value: CanonicalCombiningClass;
+    value: crate::CanonicalCombiningClass;
     resource_marker: CanonicalCombiningClassV1Marker;
     func:
     /// Return a [`CodePointTrie`] for the Canonical_Combining_Class Unicode property. See

--- a/components/properties/src/maps.rs
+++ b/components/properties/src/maps.rs
@@ -45,7 +45,7 @@ impl<T: TrieValue> CodePointMapData<T> {
     /// This avoids a potential small cost per [`Self::get()`] call by consolidating it
     /// up front.
     #[inline]
-    pub fn as_borrowed<'a>(&'a self) -> CodePointMapDataBorrowed<'a, T> {
+    pub fn as_borrowed(&self) -> CodePointMapDataBorrowed<'_, T> {
         CodePointMapDataBorrowed {
             map: self.data.get(),
         }

--- a/components/properties/src/maps.rs
+++ b/components/properties/src/maps.rs
@@ -379,7 +379,7 @@ make_map_property! {
     /// let sb = data.as_borrowed();;
     ///
     /// assert_eq!(sb.get('a'), CanonicalCombiningClass::NotReordered); // U+0061: LATIN SMALL LETTER A
-    /// assert_eq!(sb.get(0x0301), CanonicalCombiningClass::Above); // U+0301: COMBINING ACUTE ACCENT
+    /// assert_eq!(sb.get_u32(0x0301), CanonicalCombiningClass::Above); // U+0301: COMBINING ACUTE ACCENT
     /// ```
     ///
     /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie

--- a/components/properties/src/maps.rs
+++ b/components/properties/src/maps.rs
@@ -133,7 +133,7 @@ impl<T: TrieValue> CodePointMapData<T> {
     /// otherwise allocating a new [`CodePointTrie`].
     ///
     /// The data backing this is extensible and supports multiple implementations.
-    /// Currently it is always [`CodePointTrie`], however in the future more backends may be
+    /// Currently it is always [`CodePointTrie`]; however in the future more backends may be
     /// added, and users may select which at data generation time.
     ///
     /// If using this function it is preferable to stick to [`CodePointTrie`] representations
@@ -199,8 +199,7 @@ impl<'a, T: TrieValue> CodePointMapDataBorrowed<'a, T> {
     /// Get a [`CodePointSetData`] for all elements corresponding to a particular value
     pub fn get_set_for_value(&self, value: T) -> CodePointSetData {
         let set = self.map.code_point_trie.get_set_for_value(value);
-        let set = UnicodePropertyV1 { inv_list: set };
-        CodePointSetData::from_data(DataPayload::<ErasedSetlikeMarker>::from_owned(set))
+        CodePointSetData::from_unicode_set(set);
     }
 }
 

--- a/components/properties/src/maps.rs
+++ b/components/properties/src/maps.rs
@@ -162,13 +162,12 @@ make_map_property! {
     ///
     /// let provider = icu_testdata::get_provider();
     ///
-    /// let payload =
+    /// let data =
     ///     maps::get_general_category(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let gc = &data_struct.code_point_trie;
-    /// assert_eq!(gc.get('木' as u32), GeneralCategory::OtherLetter);  // U+6728
-    /// assert_eq!(gc.get('🎃' as u32), GeneralCategory::OtherSymbol);  // U+1F383 JACK-O-LANTERN
+    /// let gc = data.as_borrowed();
+    /// assert_eq!(gc.get('木'), GeneralCategory::OtherLetter);  // U+6728
+    /// assert_eq!(gc.get('🎃'), GeneralCategory::OtherSymbol);  // U+1F383 JACK-O-LANTERN
     /// ```
     ///
     /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
@@ -191,13 +190,12 @@ make_map_property! {
     ///
     /// let provider = icu_testdata::get_provider();
     ///
-    /// let payload =
+    /// let data =
     ///     maps::get_bidi_class(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let bc = &data_struct.code_point_trie;
-    /// assert_eq!(bc.get('y' as u32), BidiClass::LeftToRight);  // U+0079
-    /// assert_eq!(bc.get('ع' as u32), BidiClass::ArabicLetter);  // U+0639
+    /// let bc = data.as_borrowed();
+    /// assert_eq!(bc.get('y'), BidiClass::LeftToRight);  // U+0079
+    /// assert_eq!(bc.get('ع'), BidiClass::ArabicLetter);  // U+0639
     /// ```
     ///
     /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
@@ -220,13 +218,12 @@ make_map_property! {
     ///
     /// let provider = icu_testdata::get_provider();
     ///
-    /// let payload =
+    /// let data =
     ///     maps::get_script(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let script = &data_struct.code_point_trie;
-    /// assert_eq!(script.get('木' as u32), Script::Han);  // U+6728
-    /// assert_eq!(script.get('🎃' as u32), Script::Common);  // U+1F383 JACK-O-LANTERN
+    /// let script = data.as_borrowed();
+    /// assert_eq!(script.get('木'), Script::Han);  // U+6728
+    /// assert_eq!(script.get('🎃'), Script::Common);  // U+1F383 JACK-O-LANTERN
     /// ```
     ///
     /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
@@ -248,11 +245,11 @@ make_map_property! {
     /// use icu::properties::{maps, EastAsianWidth};
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload = maps::get_east_asian_width(&provider).expect("The data should be valid!");
+    /// let data = maps::get_east_asian_width(&provider).expect("The data should be valid!");
     /// let eaw = &payload.get().code_point_trie;
     ///
-    /// assert_eq!(eaw.get('ｱ' as u32), EastAsianWidth::Halfwidth); // U+FF71: Halfwidth Katakana Letter A
-    /// assert_eq!(eaw.get('ア' as u32), EastAsianWidth::Wide); //U+30A2: Katakana Letter A
+    /// assert_eq!(eaw.get('ｱ'), EastAsianWidth::Halfwidth); // U+FF71: Halfwidth Katakana Letter A
+    /// assert_eq!(eaw.get('ア'), EastAsianWidth::Wide); //U+30A2: Katakana Letter A
     /// ```
     ///
     /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
@@ -274,11 +271,11 @@ make_map_property! {
     /// use icu::properties::{maps, LineBreak};
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload = maps::get_line_break(&provider).expect("The data should be valid!");
+    /// let data = maps::get_line_break(&provider).expect("The data should be valid!");
     /// let lb = &payload.get().code_point_trie;
     ///
-    /// assert_eq!(lb.get(')' as u32), LineBreak::CloseParenthesis); // U+0029: Right Parenthesis
-    /// assert_eq!(lb.get('ぁ' as u32), LineBreak::ConditionalJapaneseStarter); //U+3041: Hiragana Letter Small A
+    /// assert_eq!(lb.get(')'), LineBreak::CloseParenthesis); // U+0029: Right Parenthesis
+    /// assert_eq!(lb.get('ぁ'), LineBreak::ConditionalJapaneseStarter); //U+3041: Hiragana Letter Small A
     /// ```
     ///
     /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
@@ -300,11 +297,11 @@ make_map_property! {
     /// use icu::properties::{maps, GraphemeClusterBreak};
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload = maps::get_grapheme_cluster_break(&provider).expect("The data should be valid!");
+    /// let data = maps::get_grapheme_cluster_break(&provider).expect("The data should be valid!");
     /// let gcb = &payload.get().code_point_trie;
     ///
-    /// assert_eq!(gcb.get('🇦' as u32), GraphemeClusterBreak::RegionalIndicator); // U+1F1E6: Regional Indicator Symbol Letter A
-    /// assert_eq!(gcb.get('ำ' as u32), GraphemeClusterBreak::SpacingMark); //U+0E33: Thai Character Sara Am
+    /// assert_eq!(gcb.get('🇦'), GraphemeClusterBreak::RegionalIndicator); // U+1F1E6: Regional Indicator Symbol Letter A
+    /// assert_eq!(gcb.get('ำ'), GraphemeClusterBreak::SpacingMark); //U+0E33: Thai Character Sara Am
     /// ```
     ///
     /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
@@ -326,11 +323,11 @@ make_map_property! {
     /// use icu::properties::{maps, WordBreak};
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload = maps::get_word_break(&provider).expect("The data should be valid!");
+    /// let data = maps::get_word_break(&provider).expect("The data should be valid!");
     /// let wb = &payload.get().code_point_trie;
     ///
-    /// assert_eq!(wb.get('.' as u32), WordBreak::MidNumLet); // U+002E: Full Stop
-    /// assert_eq!(wb.get('，' as u32), WordBreak::MidNum); // U+FF0C: Fullwidth Comma
+    /// assert_eq!(wb.get('.'), WordBreak::MidNumLet); // U+002E: Full Stop
+    /// assert_eq!(wb.get('，'), WordBreak::MidNum); // U+FF0C: Fullwidth Comma
     /// ```
     ///
     /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
@@ -352,11 +349,11 @@ make_map_property! {
     /// use icu::properties::{maps, SentenceBreak};
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload = maps::get_sentence_break(&provider).expect("The data should be valid!");
+    /// let data = maps::get_sentence_break(&provider).expect("The data should be valid!");
     /// let sb = &payload.get().code_point_trie;
     ///
-    /// assert_eq!(sb.get('９' as u32), SentenceBreak::Numeric); // U+FF19: Fullwidth Digit Nine
-    /// assert_eq!(sb.get(',' as u32), SentenceBreak::SContinue); // U+002C: Comma
+    /// assert_eq!(sb.get('９'), SentenceBreak::Numeric); // U+FF19: Fullwidth Digit Nine
+    /// assert_eq!(sb.get(','), SentenceBreak::SContinue); // U+002C: Comma
     /// ```
     ///
     /// [`CodePointTrie`]: icu_codepointtrie::CodePointTrie
@@ -378,10 +375,10 @@ make_map_property! {
     /// use icu::properties::{maps, CanonicalCombiningClass};
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload = maps::get_canonical_combining_class(&provider).expect("The data should be valid!");
+    /// let data = maps::get_canonical_combining_class(&provider).expect("The data should be valid!");
     /// let sb = &payload.get().code_point_trie;
     ///
-    /// assert_eq!(sb.get('a' as u32), CanonicalCombiningClass::NotReordered); // U+0061: LATIN SMALL LETTER A
+    /// assert_eq!(sb.get('a'), CanonicalCombiningClass::NotReordered); // U+0061: LATIN SMALL LETTER A
     /// assert_eq!(sb.get(0x0301), CanonicalCombiningClass::Above); // U+0301: COMBINING ACUTE ACCENT
     /// ```
     ///

--- a/components/properties/src/maps.rs
+++ b/components/properties/src/maps.rs
@@ -41,6 +41,24 @@ impl<T: TrieValue> CodePointMapData<T> {
     ///
     /// This avoids a potential small cost per [`Self::get()`] call by consolidating it
     /// up front.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu::properties::{maps, GeneralCategory};
+    /// use icu_codepointtrie::CodePointTrie;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    ///
+    /// let data =
+    ///     maps::get_general_category(&provider)
+    ///         .expect("The data should be valid");
+    ///
+    /// let gc = data.as_borrowed();
+    ///
+    /// assert_eq!(gc.get('木'), GeneralCategory::OtherLetter);  // U+6728
+    /// assert_eq!(gc.get('🎃'), GeneralCategory::OtherSymbol);  // U+1F383 JACK-O-LANTERN
+    /// ```
     #[inline]
     pub fn as_borrowed(&self) -> CodePointMapDataBorrowed<'_, T> {
         CodePointMapDataBorrowed {
@@ -49,11 +67,41 @@ impl<T: TrieValue> CodePointMapData<T> {
     }
 
     /// Get the value this map has associated with code point `ch`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu::properties::{maps, GeneralCategory};
+    /// use icu_codepointtrie::CodePointTrie;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    ///
+    /// let gc =
+    ///     maps::get_general_category(&provider)
+    ///         .expect("The data should be valid");
+    /// assert_eq!(gc.get('木'), GeneralCategory::OtherLetter);  // U+6728
+    /// assert_eq!(gc.get('🎃'), GeneralCategory::OtherSymbol);  // U+1F383 JACK-O-LANTERN
+    /// ```
     pub fn get(&self, ch: char) -> T {
         self.data.get().code_point_trie.get(ch as u32)
     }
 
     /// Get the value this map has associated with code point `ch`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu::properties::{maps, GeneralCategory};
+    /// use icu_codepointtrie::CodePointTrie;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    ///
+    /// let gc =
+    ///     maps::get_general_category(&provider)
+    ///         .expect("The data should be valid");
+    /// assert_eq!(gc.get_u32(0x6728), GeneralCategory::OtherLetter);  // U+6728 (木)
+    /// assert_eq!(gc.get_u32(0x1F383), GeneralCategory::OtherSymbol);  // U+1F383 JACK-O-LANTERN
+    /// ```
     pub fn get_u32(&self, ch: u32) -> T {
         self.data.get().code_point_trie.get(ch)
     }
@@ -105,11 +153,45 @@ pub struct CodePointMapDataBorrowed<'a, T: TrieValue> {
 
 impl<'a, T: TrieValue> CodePointMapDataBorrowed<'a, T> {
     /// Get the value this map has associated with code point `ch`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu::properties::{maps, GeneralCategory};
+    /// use icu_codepointtrie::CodePointTrie;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    ///
+    /// let data =
+    ///     maps::get_general_category(&provider)
+    ///         .expect("The data should be valid");
+    /// let gc = data.as_borrowed();
+    ///
+    /// assert_eq!(gc.get('木'), GeneralCategory::OtherLetter);  // U+6728
+    /// assert_eq!(gc.get('🎃'), GeneralCategory::OtherSymbol);  // U+1F383 JACK-O-LANTERN
+    /// ```
     pub fn get(&self, ch: char) -> T {
         self.map.code_point_trie.get(ch as u32)
     }
 
     /// Get the value this map has associated with code point `ch`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu::properties::{maps, GeneralCategory};
+    /// use icu_codepointtrie::CodePointTrie;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    ///
+    /// let data =
+    ///     maps::get_general_category(&provider)
+    ///         .expect("The data should be valid");
+    /// let gc = data.as_borrowed();
+    ///
+    /// assert_eq!(gc.get_u32(0x6728), GeneralCategory::OtherLetter);  // U+6728 (木)
+    /// assert_eq!(gc.get_u32(0x1F383), GeneralCategory::OtherSymbol);  // U+1F383 JACK-O-LANTERN
+    /// ```
     pub fn get_u32(&self, ch: u32) -> T {
         self.map.code_point_trie.get(ch)
     }

--- a/components/properties/src/maps.rs
+++ b/components/properties/src/maps.rs
@@ -33,6 +33,7 @@ pub struct CodePointMapData<T: TrieValue> {
 
 /// Private marker type for CodePointMapData
 /// to work for all same-value map properties at once
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 struct ErasedMaplikeMarker<T>(PhantomData<T>);
 impl<T: TrieValue> DataMarker for ErasedMaplikeMarker<T> {
     type Yokeable = UnicodePropertyMapV1<'static, T>;
@@ -92,6 +93,7 @@ impl<T: TrieValue> CodePointMapData<T> {
 
 /// A borrowed wrapper around code point set data, returned by
 /// [`CodePointSetData::as_borrowed()`]. More efficient to query.
+#[derive(Clone, Copy)]
 pub struct CodePointMapDataBorrowed<'a, T: TrieValue> {
     map: &'a UnicodePropertyMapV1<'a, T>,
 }

--- a/components/properties/src/maps.rs
+++ b/components/properties/src/maps.rs
@@ -107,6 +107,24 @@ impl<T: TrieValue> CodePointMapData<T> {
     }
 
     /// Get a [`CodePointSetData`] for all elements corresponding to a particular value
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu::properties::{maps, GeneralCategory};
+    /// use icu_codepointtrie::CodePointTrie;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    ///
+    /// let gc =
+    ///     maps::get_general_category(&provider)
+    ///         .expect("The data should be valid");
+    ///
+    /// let other_letter_set = gc.get_set_for_value(GeneralCategory::OtherLetter);
+    ///
+    /// assert!(other_letter_set.contains('木'));  // U+6728
+    /// assert!(!other_letter_set.contains('🎃'));  // U+1F383 JACK-O-LANTERN
+    /// ```
     pub fn get_set_for_value(&self, value: T) -> CodePointSetData {
         let set = self.data.get().code_point_trie.get_set_for_value(value);
         CodePointSetData::from_unicode_set(set)
@@ -197,6 +215,25 @@ impl<'a, T: TrieValue> CodePointMapDataBorrowed<'a, T> {
     }
 
     /// Get a [`CodePointSetData`] for all elements corresponding to a particular value
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu::properties::{maps, GeneralCategory};
+    /// use icu_codepointtrie::CodePointTrie;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    ///
+    /// let data =
+    ///     maps::get_general_category(&provider)
+    ///         .expect("The data should be valid");
+    /// let gc = data.as_borrowed();
+    ///
+    /// let other_letter_set = gc.get_set_for_value(GeneralCategory::OtherLetter);
+    ///
+    /// assert!(other_letter_set.contains('木'));  // U+6728
+    /// assert!(!other_letter_set.contains('🎃'));  // U+1F383 JACK-O-LANTERN
+    /// ```
     pub fn get_set_for_value(&self, value: T) -> CodePointSetData {
         let set = self.map.code_point_trie.get_set_for_value(value);
         CodePointSetData::from_unicode_set(set)

--- a/components/properties/src/maps.rs
+++ b/components/properties/src/maps.rs
@@ -246,7 +246,7 @@ make_map_property! {
     ///
     /// let provider = icu_testdata::get_provider();
     /// let data = maps::get_east_asian_width(&provider).expect("The data should be valid!");
-    /// let eaw = &payload.get().code_point_trie;
+    /// let eaw = data.as_borrowed();;
     ///
     /// assert_eq!(eaw.get('ｱ'), EastAsianWidth::Halfwidth); // U+FF71: Halfwidth Katakana Letter A
     /// assert_eq!(eaw.get('ア'), EastAsianWidth::Wide); //U+30A2: Katakana Letter A
@@ -272,7 +272,7 @@ make_map_property! {
     ///
     /// let provider = icu_testdata::get_provider();
     /// let data = maps::get_line_break(&provider).expect("The data should be valid!");
-    /// let lb = &payload.get().code_point_trie;
+    /// let lb = data.as_borrowed();
     ///
     /// assert_eq!(lb.get(')'), LineBreak::CloseParenthesis); // U+0029: Right Parenthesis
     /// assert_eq!(lb.get('ぁ'), LineBreak::ConditionalJapaneseStarter); //U+3041: Hiragana Letter Small A
@@ -298,7 +298,7 @@ make_map_property! {
     ///
     /// let provider = icu_testdata::get_provider();
     /// let data = maps::get_grapheme_cluster_break(&provider).expect("The data should be valid!");
-    /// let gcb = &payload.get().code_point_trie;
+    /// let gcb = data.as_borrowed();
     ///
     /// assert_eq!(gcb.get('🇦'), GraphemeClusterBreak::RegionalIndicator); // U+1F1E6: Regional Indicator Symbol Letter A
     /// assert_eq!(gcb.get('ำ'), GraphemeClusterBreak::SpacingMark); //U+0E33: Thai Character Sara Am
@@ -324,7 +324,7 @@ make_map_property! {
     ///
     /// let provider = icu_testdata::get_provider();
     /// let data = maps::get_word_break(&provider).expect("The data should be valid!");
-    /// let wb = &payload.get().code_point_trie;
+    /// let wb = data.as_borrowed();
     ///
     /// assert_eq!(wb.get('.'), WordBreak::MidNumLet); // U+002E: Full Stop
     /// assert_eq!(wb.get('，'), WordBreak::MidNum); // U+FF0C: Fullwidth Comma
@@ -350,7 +350,7 @@ make_map_property! {
     ///
     /// let provider = icu_testdata::get_provider();
     /// let data = maps::get_sentence_break(&provider).expect("The data should be valid!");
-    /// let sb = &payload.get().code_point_trie;
+    /// let sb = data.as_borrowed();;
     ///
     /// assert_eq!(sb.get('９'), SentenceBreak::Numeric); // U+FF19: Fullwidth Digit Nine
     /// assert_eq!(sb.get(','), SentenceBreak::SContinue); // U+002C: Comma
@@ -376,7 +376,7 @@ make_map_property! {
     ///
     /// let provider = icu_testdata::get_provider();
     /// let data = maps::get_canonical_combining_class(&provider).expect("The data should be valid!");
-    /// let sb = &payload.get().code_point_trie;
+    /// let sb = data.as_borrowed();;
     ///
     /// assert_eq!(sb.get('a'), CanonicalCombiningClass::NotReordered); // U+0061: LATIN SMALL LETTER A
     /// assert_eq!(sb.get(0x0301), CanonicalCombiningClass::Above); // U+0301: COMBINING ACUTE ACCENT

--- a/components/properties/src/maps.rs
+++ b/components/properties/src/maps.rs
@@ -14,7 +14,7 @@
 
 use crate::error::PropertiesError;
 use crate::provider::*;
-use crate::sets::{CodePointSetData, ErasedSetlikeMarker};
+use crate::sets::CodePointSetData;
 #[cfg(doc)]
 use crate::*;
 use core::marker::PhantomData;
@@ -199,7 +199,7 @@ impl<'a, T: TrieValue> CodePointMapDataBorrowed<'a, T> {
     /// Get a [`CodePointSetData`] for all elements corresponding to a particular value
     pub fn get_set_for_value(&self, value: T) -> CodePointSetData {
         let set = self.map.code_point_trie.get_set_for_value(value);
-        CodePointSetData::from_unicode_set(set);
+        CodePointSetData::from_unicode_set(set)
     }
 }
 

--- a/components/properties/src/maps.rs
+++ b/components/properties/src/maps.rs
@@ -22,9 +22,6 @@ use core::ops::RangeInclusive;
 use icu_codepointtrie::{CodePointMapRange, TrieValue};
 use icu_provider::prelude::*;
 
-/// TODO(#1239): Finalize this API.
-pub type CodePointMapResult<M> = Result<DataPayload<M>, PropertiesError>;
-
 /// A wrapper around code point set data, returned by property getters for
 /// unicode sets.
 pub struct CodePointMapData<T: TrieValue> {

--- a/components/properties/src/maps.rs
+++ b/components/properties/src/maps.rs
@@ -82,9 +82,7 @@ impl<T: TrieValue> CodePointMapData<T> {
     where
         M: DataMarker<Yokeable = UnicodePropertyMapV1<'static, T>>,
     {
-        Self {
-            data: data.map_project(|m, _| m),
-        }
+        Self { data: data.cast() }
     }
 }
 

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -304,44 +304,43 @@ impl GeneralCategoryGroup {
     /// use icu_codepointtrie::CodePointTrie;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload = maps::get_general_category(&provider).expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let gc = &data_struct.code_point_trie;
+    /// let data = maps::get_general_category(&provider).expect("The data should be valid");
+    /// let gc = data.as_borrowed();
     ///
-    /// assert_eq!(gc.get('A' as u32), GeneralCategory::UppercaseLetter);
-    /// assert!(GeneralCategoryGroup::CasedLetter.contains(gc.get('A' as u32)));
+    /// assert_eq!(gc.get('A'), GeneralCategory::UppercaseLetter);
+    /// assert!(GeneralCategoryGroup::CasedLetter.contains(gc.get('A')));
     ///
     /// // U+0B1E ORIYA LETTER NYA
-    /// assert_eq!(gc.get('ଞ' as u32), GeneralCategory::OtherLetter);
-    /// assert!(GeneralCategoryGroup::Letter.contains(gc.get('ଞ' as u32)));
-    /// assert!(!GeneralCategoryGroup::CasedLetter.contains(gc.get('ଞ' as u32)));
+    /// assert_eq!(gc.get('ଞ'), GeneralCategory::OtherLetter);
+    /// assert!(GeneralCategoryGroup::Letter.contains(gc.get('ଞ')));
+    /// assert!(!GeneralCategoryGroup::CasedLetter.contains(gc.get('ଞ')));
     ///
     /// // U+0301 COMBINING ACUTE ACCENT
-    /// assert_eq!(gc.get(0x0301), GeneralCategory::NonspacingMark);
-    /// assert!(GeneralCategoryGroup::Mark.contains(gc.get(0x0301)));
-    /// assert!(!GeneralCategoryGroup::Letter.contains(gc.get(0x0301)));
+    /// assert_eq!(gc.get_u32(0x0301), GeneralCategory::NonspacingMark);
+    /// assert!(GeneralCategoryGroup::Mark.contains(gc.get_u32(0x0301)));
+    /// assert!(!GeneralCategoryGroup::Letter.contains(gc.get_u32(0x0301)));
     ///
-    /// assert_eq!(gc.get('0' as u32), GeneralCategory::DecimalNumber);
-    /// assert!(GeneralCategoryGroup::Number.contains(gc.get('0' as u32)));
-    /// assert!(!GeneralCategoryGroup::Mark.contains(gc.get('0' as u32)));
+    /// assert_eq!(gc.get('0'), GeneralCategory::DecimalNumber);
+    /// assert!(GeneralCategoryGroup::Number.contains(gc.get('0')));
+    /// assert!(!GeneralCategoryGroup::Mark.contains(gc.get('0')));
     ///
-    /// assert_eq!(gc.get('(' as u32), GeneralCategory::OpenPunctuation);
-    /// assert!(GeneralCategoryGroup::Punctuation.contains(gc.get('(' as u32)));
-    /// assert!(!GeneralCategoryGroup::Number.contains(gc.get('(' as u32)));
+    /// assert_eq!(gc.get('('), GeneralCategory::OpenPunctuation);
+    /// assert!(GeneralCategoryGroup::Punctuation.contains(gc.get('(')));
+    /// assert!(!GeneralCategoryGroup::Number.contains(gc.get('(')));
     ///
     /// // U+2713 CHECK MARK
-    /// assert_eq!(gc.get('✓' as u32), GeneralCategory::OtherSymbol);
-    /// assert!(GeneralCategoryGroup::Symbol.contains(gc.get('✓' as u32)));
-    /// assert!(!GeneralCategoryGroup::Punctuation.contains(gc.get('✓' as u32)));
+    /// assert_eq!(gc.get('✓'), GeneralCategory::OtherSymbol);
+    /// assert!(GeneralCategoryGroup::Symbol.contains(gc.get('✓')));
+    /// assert!(!GeneralCategoryGroup::Punctuation.contains(gc.get('✓')));
     ///
-    /// assert_eq!(gc.get(' ' as u32), GeneralCategory::SpaceSeparator);
-    /// assert!(GeneralCategoryGroup::Separator.contains(gc.get(' ' as u32)));
-    /// assert!(!GeneralCategoryGroup::Symbol.contains(gc.get(' ' as u32)));
+    /// assert_eq!(gc.get(' '), GeneralCategory::SpaceSeparator);
+    /// assert!(GeneralCategoryGroup::Separator.contains(gc.get(' ')));
+    /// assert!(!GeneralCategoryGroup::Symbol.contains(gc.get(' ')));
     ///
     /// // U+E007F CANCEL TAG
-    /// assert_eq!(gc.get(0xE007F), GeneralCategory::Format);
-    /// assert!(GeneralCategoryGroup::Other.contains(gc.get(0xE007F)));
-    /// assert!(!GeneralCategoryGroup::Separator.contains(gc.get(0xE007F)));
+    /// assert_eq!(gc.get_u32(0xE007F), GeneralCategory::Format);
+    /// assert!(GeneralCategoryGroup::Other.contains(gc.get_u32(0xE007F)));
+    /// assert!(!GeneralCategoryGroup::Separator.contains(gc.get_u32(0xE007F)));
     /// ```
     pub fn contains(&self, val: GeneralCategory) -> bool {
         0 != (1 << (val as u32)) & self.0

--- a/components/properties/src/sets.rs
+++ b/components/properties/src/sets.rs
@@ -29,6 +29,7 @@ pub struct CodePointSetData {
 
 /// Private marker type for CodePointSetData
 /// to work for all set properties at once
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub(crate) struct ErasedSetlikeMarker;
 impl DataMarker for ErasedSetlikeMarker {
     type Yokeable = UnicodePropertyV1<'static>;
@@ -84,6 +85,7 @@ impl CodePointSetData {
 
 /// A borrowed wrapper around code point set data, returned by
 /// [`CodePointSetData::as_borrowed()`]. More efficient to query.
+#[derive(Clone, Copy)]
 pub struct CodePointSetDataBorrowed<'a> {
     set: &'a UnicodePropertyV1<'a>,
 }

--- a/components/properties/src/sets.rs
+++ b/components/properties/src/sets.rs
@@ -1613,8 +1613,6 @@ pub fn get_for_general_category_group(
 ) -> Result<UnicodeSet<'static>, PropertiesError> {
     let gc_map_payload = maps::get_general_category(provider)?;
     let matching_gc_ranges = gc_map_payload
-        .get()
-        .code_point_trie
         .iter_ranges()
         .filter(|cpm_range| (1 << cpm_range.value as u32) & enum_val.0 != 0)
         .map(|cpm_range| cpm_range.range);

--- a/components/properties/src/sets.rs
+++ b/components/properties/src/sets.rs
@@ -41,6 +41,20 @@ impl CodePointSetData {
     ///
     /// If calling multiple times, consider calling [`Self::as_borrowed()`]
     /// first
+    ///
+    /// ```rust
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let alphabetic =
+    ///     sets::get_alphabetic(&provider)
+    ///         .expect("The data should be valid");
+    ///
+    /// assert!(!alphabetic.contains('3'));
+    /// assert!(!alphabetic.contains('੩'));  // U+0A69 GURMUKHI DIGIT THREE
+    /// assert!(alphabetic.contains('A'));
+    /// assert!(alphabetic.contains('Ä'));  // U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS
+    /// ```
     #[inline]
     pub fn contains(&self, ch: char) -> bool {
         self.data.get().inv_list.contains(ch)
@@ -50,6 +64,18 @@ impl CodePointSetData {
     ///
     /// If calling multiple times, consider calling [`Self::as_borrowed()`]
     /// first
+    ///
+    /// ```rust
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let alphabetic =
+    ///     sets::get_alphabetic(&provider)
+    ///         .expect("The data should be valid");
+    ///
+    /// assert!(!alphabetic.contains_u32(0x0A69));  // U+0A69 GURMUKHI DIGIT THREE
+    /// assert!(alphabetic.contains_u32(0x00C4));  // U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS
+    /// ```
     #[inline]
     pub fn contains_u32(&self, ch: u32) -> bool {
         self.data.get().inv_list.contains_u32(ch)
@@ -59,6 +85,20 @@ impl CodePointSetData {
     ///
     /// This avoids a potential small cost per [`Self::contains()`] call by consolidating it
     /// up front.
+    ///
+    /// ```rust
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let data =
+    ///     sets::get_alphabetic(&provider)
+    ///         .expect("The data should be valid");
+    ///
+    /// let alphabetic = data.as_borrowed();
+    ///
+    /// assert!(!alphabetic.contains('3'));
+    /// assert!(alphabetic.contains('A'));
+    /// ```
     #[inline]
     pub fn as_borrowed(&self) -> CodePointSetDataBorrowed<'_> {
         CodePointSetDataBorrowed {
@@ -101,12 +141,40 @@ pub struct CodePointSetDataBorrowed<'a> {
 
 impl<'a> CodePointSetDataBorrowed<'a> {
     /// Check if the set contains a character
+    ///
+    /// ```rust
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let data =
+    ///     sets::get_alphabetic(&provider)
+    ///         .expect("The data should be valid");
+    /// let alphabetic = data.as_borrowed();
+    ///
+    /// assert!(!alphabetic.contains('3'));
+    /// assert!(!alphabetic.contains('੩'));  // U+0A69 GURMUKHI DIGIT THREE
+    /// assert!(alphabetic.contains('A'));
+    /// assert!(alphabetic.contains('Ä'));  // U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS
+    /// ```
     #[inline]
     pub fn contains(&self, ch: char) -> bool {
         self.set.inv_list.contains(ch)
     }
 
     /// Check if the set contains a character as a UTF32 code unit
+    ///
+    /// ```rust
+    /// use icu_properties::sets;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let data =
+    ///     sets::get_alphabetic(&provider)
+    ///         .expect("The data should be valid");
+    /// let alphabetic = data.as_borrowed();
+    ///
+    /// assert!(!alphabetic.contains_u32(0x0A69));  // U+0A69 GURMUKHI DIGIT THREE
+    /// assert!(alphabetic.contains_u32(0x00C4));  // U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS
+    /// ```
     #[inline]
     pub fn contains_u32(&self, ch: u32) -> bool {
         self.set.inv_list.contains_u32(ch)

--- a/components/properties/src/sets.rs
+++ b/components/properties/src/sets.rs
@@ -29,8 +29,7 @@ pub struct CodePointSetData {
 
 /// Private marker type for CodePointSetData
 /// to work for all set properties at once
-
-struct ErasedSetlikeMarker;
+pub(crate) struct ErasedSetlikeMarker;
 impl DataMarker for ErasedSetlikeMarker {
     type Yokeable = UnicodePropertyV1<'static>;
 }
@@ -77,7 +76,7 @@ impl CodePointSetData {
     }
 }
 
-/// A borrowed wrapper around code point set data, returned by 
+/// A borrowed wrapper around code point set data, returned by
 /// [`CodePointSetData::as_borrowed()`]. More efficient to query.
 pub struct CodePointSetDataBorrowed<'a> {
     set: &'a UnicodePropertyV1<'a>,

--- a/components/properties/src/sets.rs
+++ b/components/properties/src/sets.rs
@@ -1638,7 +1638,7 @@ mod tests {
         use icu::properties::Script;
 
         let provider = icu_testdata::get_provider();
-        let data = maps::get_script(&provider).expect("The data should be valid");
+        let payload = maps::get_script(&provider).expect("The data should be valid");
         let data_struct = payload.get();
         let script = &data_struct.code_point_trie;
         let thai = script.get_set_for_value(Script::Thai);

--- a/components/properties/src/sets.rs
+++ b/components/properties/src/sets.rs
@@ -127,7 +127,7 @@ impl CodePointSetData {
     /// otherwise allocating a new [`UnicodeSet`].
     ///
     /// The data backing this is extensible and supports multiple implementations.
-    /// Currently it is always [`UnicodeSet`], however in the future more backends may be
+    /// Currently it is always [`UnicodeSet`]; however in the future more backends may be
     /// added, and users may select which at data generation time.
     ///
     /// If using this function it is preferable to stick to [`UnicodeSet`] representations

--- a/components/properties/src/sets.rs
+++ b/components/properties/src/sets.rs
@@ -125,11 +125,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_ascii_hex_digit(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let ascii_hex_digit = &data_struct.inv_list;
+    /// let ascii_hex_digit = data.as_borrowed();;
     ///
     /// assert!(ascii_hex_digit.contains('3'));
     /// assert!(!ascii_hex_digit.contains('੩'));  // U+0A69 GURMUKHI DIGIT THREE
@@ -163,11 +162,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_alphabetic(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let alphabetic = &data_struct.inv_list;
+    /// let alphabetic = data.as_borrowed();;
     ///
     /// assert!(!alphabetic.contains('3'));
     /// assert!(!alphabetic.contains('੩'));  // U+0A69 GURMUKHI DIGIT THREE
@@ -192,11 +190,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_bidi_control(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let bidi_control = &data_struct.inv_list;
+    /// let bidi_control = data.as_borrowed();;
     ///
     /// assert!(bidi_control.contains_u32(0x200F));  // RIGHT-TO-LEFT MARK
     /// assert!(!bidi_control.contains('ش'));  // U+0634 ARABIC LETTER SHEEN
@@ -218,11 +215,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_bidi_mirrored(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let bidi_mirrored = &data_struct.inv_list;
+    /// let bidi_mirrored = data.as_borrowed();;
     ///
     /// assert!(bidi_mirrored.contains('['));
     /// assert!(bidi_mirrored.contains(']'));
@@ -256,11 +252,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_cased(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let cased = &data_struct.inv_list;
+    /// let cased = data.as_borrowed();;
     ///
     /// assert!(cased.contains('Ꙡ'));  // U+A660 CYRILLIC CAPITAL LETTER REVERSED TSE
     /// assert!(!cased.contains('ދ'));  // U+078B THAANA LETTER DHAALU
@@ -282,11 +277,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_case_ignorable(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let case_ignorable = &data_struct.inv_list;
+    /// let case_ignorable = data.as_borrowed();;
     ///
     /// assert!(case_ignorable.contains(':'));
     /// assert!(!case_ignorable.contains('λ'));  // U+03BB GREEK SMALL LETTER LAMDA
@@ -319,11 +313,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_changes_when_casefolded(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let changes_when_casefolded = &data_struct.inv_list;
+    /// let changes_when_casefolded = data.as_borrowed();;
     ///
     /// assert!(changes_when_casefolded.contains('ß'));  // U+00DF LATIN SMALL LETTER SHARP S
     /// assert!(!changes_when_casefolded.contains('ᜉ'));  // U+1709 TAGALOG LETTER PA
@@ -355,11 +348,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_changes_when_nfkc_casefolded(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let changes_when_nfkc_casefolded = &data_struct.inv_list;
+    /// let changes_when_nfkc_casefolded = data.as_borrowed();;
     ///
     /// assert!(changes_when_nfkc_casefolded.contains('🄵'));  // U+1F135 SQUARED LATIN CAPITAL LETTER F
     /// assert!(!changes_when_nfkc_casefolded.contains('f'));
@@ -381,11 +373,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_changes_when_lowercased(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let changes_when_lowercased = &data_struct.inv_list;
+    /// let changes_when_lowercased = data.as_borrowed();;
     ///
     /// assert!(changes_when_lowercased.contains('Ⴔ'));  // U+10B4 GEORGIAN CAPITAL LETTER PHAR
     /// assert!(!changes_when_lowercased.contains('ფ'));  // U+10E4 GEORGIAN LETTER PHAR
@@ -407,11 +398,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_changes_when_titlecased(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let changes_when_titlecased = &data_struct.inv_list;
+    /// let changes_when_titlecased = data.as_borrowed();;
     ///
     /// assert!(changes_when_titlecased.contains('æ'));  // U+00E6 LATIN SMALL LETTER AE
     /// assert!(!changes_when_titlecased.contains('Æ'));  // U+00E6 LATIN CAPITAL LETTER AE
@@ -433,11 +423,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_changes_when_uppercased(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let changes_when_uppercased = &data_struct.inv_list;
+    /// let changes_when_uppercased = data.as_borrowed();;
     ///
     /// assert!(changes_when_uppercased.contains('ւ'));  // U+0582 ARMENIAN SMALL LETTER YIWN
     /// assert!(!changes_when_uppercased.contains('Ւ'));  // U+0552 ARMENIAN CAPITAL LETTER YIWN
@@ -460,11 +449,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_dash(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let dash = &data_struct.inv_list;
+    /// let dash = data.as_borrowed();;
     ///
     /// assert!(dash.contains('⸺'));  // U+2E3A TWO-EM DASH
     /// assert!(dash.contains('-'));  // U+002D
@@ -488,11 +476,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_deprecated(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let deprecated = &data_struct.inv_list;
+    /// let deprecated = data.as_borrowed();;
     ///
     /// assert!(deprecated.contains('ឣ'));  // U+17A3 KHMER INDEPENDENT VOWEL QAQ
     /// assert!(!deprecated.contains('A'));
@@ -517,11 +504,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_default_ignorable_code_point(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let default_ignorable_code_point = &data_struct.inv_list;
+    /// let default_ignorable_code_point = data.as_borrowed();;
     ///
     /// assert!(default_ignorable_code_point.contains_u32(0x180B));  // MONGOLIAN FREE VARIATION SELECTOR ONE
     /// assert!(!default_ignorable_code_point.contains('E'));
@@ -543,11 +529,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_diacritic(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let diacritic = &data_struct.inv_list;
+    /// let diacritic = data.as_borrowed();;
     ///
     /// assert!(diacritic.contains('\u{05B3}'));  // HEBREW POINT HATAF QAMATS
     /// assert!(!diacritic.contains('א'));  // U+05D0 HEBREW LETTER ALEF
@@ -569,11 +554,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_emoji_modifier_base(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let emoji_modifier_base = &data_struct.inv_list;
+    /// let emoji_modifier_base = data.as_borrowed();;
     ///
     /// assert!(emoji_modifier_base.contains('✊'));  // U+270A RAISED FIST
     /// assert!(!emoji_modifier_base.contains('⛰'));  // U+26F0 MOUNTAIN
@@ -596,11 +580,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_emoji_component(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let emoji_component = &data_struct.inv_list;
+    /// let emoji_component = data.as_borrowed();;
     ///
     /// assert!(emoji_component.contains('🇹'));  // U+1F1F9 REGIONAL INDICATOR SYMBOL LETTER T
     /// assert!(emoji_component.contains_u32(0x20E3));  // COMBINING ENCLOSING KEYCAP
@@ -624,11 +607,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_emoji_modifier(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let emoji_modifier = &data_struct.inv_list;
+    /// let emoji_modifier = data.as_borrowed();;
     ///
     /// assert!(emoji_modifier.contains_u32(0x1F3FD));  // EMOJI MODIFIER FITZPATRICK TYPE-4
     /// assert!(!emoji_modifier.contains_u32(0x200C));  // ZERO WIDTH NON-JOINER
@@ -650,11 +632,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_emoji(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let emoji = &data_struct.inv_list;
+    /// let emoji = data.as_borrowed();;
     ///
     /// assert!(emoji.contains('🔥'));  // U+1F525 FIRE
     /// assert!(!emoji.contains('V'));
@@ -676,11 +657,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_emoji_presentation(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let emoji_presentation = &data_struct.inv_list;
+    /// let emoji_presentation = data.as_borrowed();;
     ///
     /// assert!(emoji_presentation.contains('🦬')); // U+1F9AC BISON
     /// assert!(!emoji_presentation.contains('♻'));  // U+267B BLACK UNIVERSAL RECYCLING SYMBOL
@@ -703,11 +683,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_extender(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let extender = &data_struct.inv_list;
+    /// let extender = data.as_borrowed();;
     ///
     /// assert!(extender.contains('ヾ'));  // U+30FE KATAKANA VOICED ITERATION MARK
     /// assert!(extender.contains('ー'));  // U+30FC KATAKANA-HIRAGANA PROLONGED SOUND MARK
@@ -731,11 +710,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_extended_pictographic(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let extended_pictographic = &data_struct.inv_list;
+    /// let extended_pictographic = data.as_borrowed();;
     ///
     /// assert!(extended_pictographic.contains('🥳')); // U+1F973 FACE WITH PARTY HORN AND PARTY HAT
     /// assert!(!extended_pictographic.contains('🇪'));  // U+1F1EA REGIONAL INDICATOR SYMBOL LETTER E
@@ -769,11 +747,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_grapheme_base(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let grapheme_base = &data_struct.inv_list;
+    /// let grapheme_base = data.as_borrowed();;
     ///
     /// assert!(grapheme_base.contains('ക'));  // U+0D15 MALAYALAM LETTER KA
     /// assert!(grapheme_base.contains('\u{0D3F}'));  // U+0D3F MALAYALAM VOWEL SIGN I
@@ -797,11 +774,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_grapheme_extend(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let grapheme_extend = &data_struct.inv_list;
+    /// let grapheme_extend = data.as_borrowed();;
     ///
     /// assert!(!grapheme_extend.contains('ക'));  // U+0D15 MALAYALAM LETTER KA
     /// assert!(!grapheme_extend.contains('\u{0D3F}'));  // U+0D3F MALAYALAM VOWEL SIGN I
@@ -836,11 +812,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_hex_digit(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let hex_digit = &data_struct.inv_list;
+    /// let hex_digit = data.as_borrowed();;
     ///
     /// assert!(hex_digit.contains('0'));
     /// assert!(!hex_digit.contains('੩'));  // U+0A69 GURMUKHI DIGIT THREE
@@ -880,11 +855,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_id_continue(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let id_continue = &data_struct.inv_list;
+    /// let id_continue = data.as_borrowed();;
     ///
     /// assert!(id_continue.contains('x'));
     /// assert!(id_continue.contains('1'));
@@ -911,11 +885,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_ideographic(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let ideographic = &data_struct.inv_list;
+    /// let ideographic = data.as_borrowed();;
     ///
     /// assert!(ideographic.contains('川'));  // U+5DDD CJK UNIFIED IDEOGRAPH-5DDD
     /// assert!(!ideographic.contains('밥'));  // U+BC25 HANGUL SYLLABLE BAB
@@ -939,11 +912,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_id_start(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let id_start = &data_struct.inv_list;
+    /// let id_start = data.as_borrowed();;
     ///
     /// assert!(id_start.contains('x'));
     /// assert!(!id_start.contains('1'));
@@ -969,11 +941,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_ids_binary_operator(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let ids_binary_operator = &data_struct.inv_list;
+    /// let ids_binary_operator = data.as_borrowed();;
     ///
     /// assert!(ids_binary_operator.contains_u32(0x2FF5));  // IDEOGRAPHIC DESCRIPTION CHARACTER SURROUND FROM ABOVE
     /// assert!(!ids_binary_operator.contains_u32(0x3006));  // IDEOGRAPHIC CLOSING MARK
@@ -995,11 +966,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_ids_trinary_operator(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let ids_trinary_operator = &data_struct.inv_list;
+    /// let ids_trinary_operator = data.as_borrowed();;
     ///
     /// assert!(ids_trinary_operator.contains_u32(0x2FF2));  // IDEOGRAPHIC DESCRIPTION CHARACTER LEFT TO MIDDLE AND RIGHT
     /// assert!(ids_trinary_operator.contains_u32(0x2FF3));  // IDEOGRAPHIC DESCRIPTION CHARACTER ABOVE TO MIDDLE AND BELOW
@@ -1025,11 +995,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_join_control(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let join_control = &data_struct.inv_list;
+    /// let join_control = data.as_borrowed();;
     ///
     /// assert!(join_control.contains_u32(0x200C));  // ZERO WIDTH NON-JOINER
     /// assert!(join_control.contains_u32(0x200D));  // ZERO WIDTH JOINER
@@ -1052,11 +1021,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_logical_order_exception(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let logical_order_exception = &data_struct.inv_list;
+    /// let logical_order_exception = data.as_borrowed();;
     ///
     /// assert!(logical_order_exception.contains('ແ'));  // U+0EC1 LAO VOWEL SIGN EI
     /// assert!(!logical_order_exception.contains('ະ'));  // U+0EB0 LAO VOWEL SIGN A
@@ -1078,11 +1046,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_lowercase(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let lowercase = &data_struct.inv_list;
+    /// let lowercase = data.as_borrowed();;
     ///
     /// assert!(lowercase.contains('a'));
     /// assert!(!lowercase.contains('A'));
@@ -1104,11 +1071,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_math(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let math = &data_struct.inv_list;
+    /// let math = data.as_borrowed();;
     ///
     /// assert!(math.contains('='));
     /// assert!(math.contains('+'));
@@ -1134,11 +1100,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_noncharacter_code_point(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let noncharacter_code_point = &data_struct.inv_list;
+    /// let noncharacter_code_point = data.as_borrowed();;
     ///
     /// assert!(noncharacter_code_point.contains_u32(0xFDD0));
     /// assert!(noncharacter_code_point.contains_u32(0xFFFF));
@@ -1203,11 +1168,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_pattern_syntax(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let pattern_syntax = &data_struct.inv_list;
+    /// let pattern_syntax = data.as_borrowed();;
     ///
     /// assert!(pattern_syntax.contains('{'));
     /// assert!(pattern_syntax.contains('⇒'));  // U+21D2 RIGHTWARDS DOUBLE ARROW
@@ -1232,11 +1196,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_pattern_white_space(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let pattern_white_space = &data_struct.inv_list;
+    /// let pattern_white_space = data.as_borrowed();;
     ///
     /// assert!(pattern_white_space.contains(' '));
     /// assert!(pattern_white_space.contains_u32(0x2029));  // PARAGRAPH SEPARATOR
@@ -1282,11 +1245,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_quotation_mark(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let quotation_mark = &data_struct.inv_list;
+    /// let quotation_mark = data.as_borrowed();;
     ///
     /// assert!(quotation_mark.contains('\''));
     /// assert!(quotation_mark.contains('„'));  // U+201E DOUBLE LOW-9 QUOTATION MARK
@@ -1309,11 +1271,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_radical(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let radical = &data_struct.inv_list;
+    /// let radical = data.as_borrowed();;
     ///
     /// assert!(radical.contains('⺆'));  // U+2E86 CJK RADICAL BOX
     /// assert!(!radical.contains('丹'));  // U+F95E CJK COMPATIBILITY IDEOGRAPH-F95E
@@ -1335,11 +1296,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_regional_indicator(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let regional_indicator = &data_struct.inv_list;
+    /// let regional_indicator = data.as_borrowed();;
     ///
     /// assert!(regional_indicator.contains('🇹'));  // U+1F1F9 REGIONAL INDICATOR SYMBOL LETTER T
     /// assert!(!regional_indicator.contains('Ⓣ'));  // U+24C9 CIRCLED LATIN CAPITAL LETTER T
@@ -1363,11 +1323,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_soft_dotted(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let soft_dotted = &data_struct.inv_list;
+    /// let soft_dotted = data.as_borrowed();;
     ///
     /// assert!(soft_dotted.contains('і'));  //U+0456 CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
     /// assert!(!soft_dotted.contains('ı'));  // U+0131 LATIN SMALL LETTER DOTLESS I
@@ -1411,11 +1370,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_sentence_terminal(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let sentence_terminal = &data_struct.inv_list;
+    /// let sentence_terminal = data.as_borrowed();;
     ///
     /// assert!(sentence_terminal.contains('.'));
     /// assert!(sentence_terminal.contains('?'));
@@ -1440,11 +1398,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_terminal_punctuation(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let terminal_punctuation = &data_struct.inv_list;
+    /// let terminal_punctuation = data.as_borrowed();;
     ///
     /// assert!(terminal_punctuation.contains('.'));
     /// assert!(terminal_punctuation.contains('?'));
@@ -1469,11 +1426,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_unified_ideograph(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let unified_ideograph = &data_struct.inv_list;
+    /// let unified_ideograph = data.as_borrowed();;
     ///
     /// assert!(unified_ideograph.contains('川'));  // U+5DDD CJK UNIFIED IDEOGRAPH-5DDD
     /// assert!(unified_ideograph.contains('木'));  // U+6728 CJK UNIFIED IDEOGRAPH-6728
@@ -1496,11 +1452,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_uppercase(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let uppercase = &data_struct.inv_list;
+    /// let uppercase = data.as_borrowed();;
     ///
     /// assert!(uppercase.contains('U'));
     /// assert!(!uppercase.contains('u'));
@@ -1522,11 +1477,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_variation_selector(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let variation_selector = &data_struct.inv_list;
+    /// let variation_selector = data.as_borrowed();;
     ///
     /// assert!(variation_selector.contains_u32(0x180D));  // MONGOLIAN FREE VARIATION SELECTOR THREE
     /// assert!(!variation_selector.contains_u32(0x303E));  // IDEOGRAPHIC VARIATION INDICATOR
@@ -1552,11 +1506,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_white_space(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let white_space = &data_struct.inv_list;
+    /// let white_space = data.as_borrowed();;
     ///
     /// assert!(white_space.contains(' '));
     /// assert!(white_space.contains_u32(0x000A));  // NEW LINE
@@ -1592,11 +1545,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_xid_continue(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let xid_continue = &data_struct.inv_list;
+    /// let xid_continue = data.as_borrowed();;
     ///
     /// assert!(xid_continue.contains('x'));
     /// assert!(xid_continue.contains('1'));
@@ -1624,11 +1576,10 @@ make_set_property! {
     /// use icu_properties::sets;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let payload =
+    /// let data =
     ///     sets::get_xid_start(&provider)
     ///         .expect("The data should be valid");
-    /// let data_struct = payload.get();
-    /// let xid_start = &data_struct.inv_list;
+    /// let xid_start = data.as_borrowed();;
     ///
     /// assert!(xid_start.contains('x'));
     /// assert!(!xid_start.contains('1'));
@@ -1687,7 +1638,7 @@ mod tests {
         use icu::properties::Script;
 
         let provider = icu_testdata::get_provider();
-        let payload = maps::get_script(&provider).expect("The data should be valid");
+        let data = maps::get_script(&provider).expect("The data should be valid");
         let data_struct = payload.get();
         let script = &data_struct.code_point_trie;
         let thai = script.get_set_for_value(Script::Thai);

--- a/components/properties/src/sets.rs
+++ b/components/properties/src/sets.rs
@@ -1674,8 +1674,7 @@ mod tests {
             let category_set = sets::get_for_general_category_group(&provider, category)
                 .expect("The data should be valid");
 
-            let data =
-                maps::get_general_category(&provider).expect("The data should be valid");
+            let data = maps::get_general_category(&provider).expect("The data should be valid");
             let gc = data.as_borrowed();
 
             let mut builder = UnicodeSetBuilder::new();

--- a/components/properties/src/sets.rs
+++ b/components/properties/src/sets.rs
@@ -59,7 +59,7 @@ impl CodePointSetData {
     /// This avoids a potential small cost per [`Self::contains()`] call by consolidating it
     /// up front.
     #[inline]
-    pub fn as_borrowed<'a>(&'a self) -> CodePointSetDataBorrowed<'a> {
+    pub fn as_borrowed(&self) -> CodePointSetDataBorrowed<'_> {
         CodePointSetDataBorrowed {
             set: self.data.get(),
         }
@@ -78,7 +78,7 @@ impl CodePointSetData {
 
     // TODO: we should instead integrate better with UnicodeSetBuilder
     #[doc(hidden)]
-    pub fn as_unicodeset<'a>(&'a self) -> &'a UnicodeSet<'a> {
+    pub fn as_unicodeset(&self) -> &'_ UnicodeSet<'_> {
         &self.data.get().inv_list
     }
 }

--- a/experimental/collator/src/comparison.rs
+++ b/experimental/collator/src/comparison.rs
@@ -28,7 +28,9 @@ use icu_locid::Locale;
 use icu_normalizer::provider::CanonicalDecompositionDataV1Marker;
 use icu_normalizer::provider::CanonicalDecompositionTablesV1Marker;
 use icu_normalizer::Decomposition;
+use icu_properties::maps::CodePointMapData;
 use icu_properties::provider::CanonicalCombiningClassV1Marker;
+use icu_properties::CanonicalCombiningClass;
 use icu_provider::DataPayload;
 use icu_provider::DataRequest;
 use icu_provider::ResourceOptions;
@@ -68,7 +70,7 @@ pub struct Collator {
     reordering: Option<DataPayload<CollationReorderingV1Marker>>,
     decompositions: DataPayload<CanonicalDecompositionDataV1Marker>,
     tables: DataPayload<CanonicalDecompositionTablesV1Marker>,
-    ccc: DataPayload<CanonicalCombiningClassV1Marker>,
+    ccc: CodePointMapData<CanonicalCombiningClass>,
     lithuanian_dot_above: bool,
 }
 
@@ -215,8 +217,7 @@ impl Collator {
             .load_resource(&DataRequest::default())?
             .take_payload()?;
 
-        let ccc: DataPayload<CanonicalCombiningClassV1Marker> =
-            icu_properties::maps::get_canonical_combining_class(data_provider)?;
+        let ccc = icu_properties::maps::get_canonical_combining_class(data_provider)?;
 
         let mut altered_defaults = CollatorOptions::new();
 
@@ -274,13 +275,13 @@ impl Collator {
                 left.chars(),
                 self.decompositions.get(),
                 self.tables.get(),
-                &self.ccc.get().code_point_trie,
+                self.ccc.as_borrowed(),
             )
             .cmp(Decomposition::new(
                 right.chars(),
                 self.decompositions.get(),
                 self.tables.get(),
-                &self.ccc.get().code_point_trie,
+                self.ccc.as_borrowed(),
             ));
         }
         ret
@@ -295,13 +296,13 @@ impl Collator {
                 left.chars(),
                 self.decompositions.get(),
                 self.tables.get(),
-                &self.ccc.get().code_point_trie,
+                self.ccc.as_borrowed(),
             )
             .cmp(Decomposition::new(
                 right.chars(),
                 self.decompositions.get(),
                 self.tables.get(),
-                &self.ccc.get().code_point_trie,
+                self.ccc.as_borrowed(),
             ));
         }
         ret
@@ -318,13 +319,13 @@ impl Collator {
                 left.chars(),
                 self.decompositions.get(),
                 self.tables.get(),
-                &self.ccc.get().code_point_trie,
+                self.ccc.as_borrowed(),
             )
             .cmp(Decomposition::new(
                 right.chars(),
                 self.decompositions.get(),
                 self.tables.get(),
-                &self.ccc.get().code_point_trie,
+                self.ccc.as_borrowed(),
             ));
         }
         ret
@@ -413,7 +414,7 @@ impl Collator {
             &self.diacritics.get().secondaries,
             self.decompositions.get(),
             self.tables.get(),
-            &self.ccc.get().code_point_trie,
+            self.ccc.as_borrowed(),
             numeric_primary,
             self.lithuanian_dot_above,
         );
@@ -429,7 +430,7 @@ impl Collator {
             &self.diacritics.get().secondaries,
             self.decompositions.get(),
             self.tables.get(),
-            &self.ccc.get().code_point_trie,
+            self.ccc.as_borrowed(),
             numeric_primary,
             self.lithuanian_dot_above,
         );

--- a/experimental/collator/src/elements.rs
+++ b/experimental/collator/src/elements.rs
@@ -656,10 +656,7 @@ impl CharacterAndClass {
 
 // This trivial function exists as a borrow check helper.
 #[inline(always)]
-fn sort_slice_by_ccc<'data>(
-    slice: &mut [char],
-    ccc: CodePointMapDataBorrowed<'data, CanonicalCombiningClass>,
-) {
+fn sort_slice_by_ccc(slice: &mut [char], ccc: CodePointMapDataBorrowed<CanonicalCombiningClass>) {
     slice.sort_by_key(|cc| ccc.get(*cc));
 }
 

--- a/experimental/collator/src/elements.rs
+++ b/experimental/collator/src/elements.rs
@@ -25,6 +25,7 @@ use icu_normalizer::provider::DecompositionDataV1;
 use icu_normalizer::provider::DecompositionTablesV1;
 use icu_normalizer::u24::EMPTY_U24;
 use icu_normalizer::u24::U24;
+use icu_properties::maps::CodePointMapDataBorrowed;
 use icu_properties::CanonicalCombiningClass;
 use icu_uniset::UnicodeSet;
 use smallvec::SmallVec;
@@ -646,10 +647,10 @@ impl CharacterAndClass {
     pub fn character_and_ccc(&self) -> (char, CanonicalCombiningClass) {
         (self.character(), self.ccc())
     }
-    pub fn set_ccc_from_trie(&mut self, ccc: &CodePointTrie<CanonicalCombiningClass>) {
+    pub fn set_ccc_from_trie(&mut self, ccc: CodePointMapDataBorrowed<CanonicalCombiningClass>) {
         debug_assert_eq!(self.0 >> 24, 0xFF, "This method has already been called!");
         let scalar = self.0 & 0xFFFFFF;
-        self.0 = ((ccc.get(scalar).0 as u32) << 24) | scalar;
+        self.0 = ((ccc.get_u32(scalar).0 as u32) << 24) | scalar;
     }
 }
 
@@ -657,9 +658,9 @@ impl CharacterAndClass {
 #[inline(always)]
 fn sort_slice_by_ccc<'data>(
     slice: &mut [char],
-    ccc: &CodePointTrie<'data, CanonicalCombiningClass>,
+    ccc: CodePointMapDataBorrowed<'data, CanonicalCombiningClass>,
 ) {
-    slice.sort_by_key(|cc| ccc.get(u32::from(*cc)));
+    slice.sort_by_key(|cc| ccc.get(*cc));
 }
 
 /// Iterator that transforms an iterator over `char` into an iterator
@@ -719,7 +720,7 @@ where
     /// NFD complex decompositions on supplementary planes
     scalars32: &'data ZeroSlice<U24>,
     /// Canonical Combining Class data.
-    ccc: &'data CodePointTrie<'data, CanonicalCombiningClass>,
+    ccc: CodePointMapDataBorrowed<'data, CanonicalCombiningClass>,
     /// If numeric mode is enabled, the 8 high bits of the numeric primary.
     /// `None` if disabled.
     numeric_primary: Option<u8>,
@@ -743,7 +744,7 @@ where
         diacritics: &'data ZeroSlice<u16>,
         decompositions: &'data DecompositionDataV1,
         tables: &'data DecompositionTablesV1,
-        ccc: &'data CodePointTrie<'data, CanonicalCombiningClass>,
+        ccc: CodePointMapDataBorrowed<'data, CanonicalCombiningClass>,
         numeric_primary: Option<u8>,
         lithuanian_dot_above: bool,
     ) -> Self {
@@ -1602,12 +1603,11 @@ where
                                                 let mut longest_matching_index = 0;
                                                 let mut attempt = 0;
                                                 let mut i = 0;
-                                                most_recent_skipped_ccc =
-                                                    self.ccc.get(u32::from(ch));
+                                                most_recent_skipped_ccc = self.ccc.get(ch);
                                                 loop {
                                                     let ahead = self.look_ahead(looked_ahead + i);
                                                     if let Some(ch) = ahead {
-                                                        let ccc = self.ccc.get(u32::from(ch));
+                                                        let ccc = self.ccc.get(ch);
                                                         if ccc
                                                             == CanonicalCombiningClass::NotReordered
                                                         {

--- a/experimental/normalizer/src/lib.rs
+++ b/experimental/normalizer/src/lib.rs
@@ -284,10 +284,10 @@ impl CharacterAndClass {
 
 // This function exists as a borrow check helper.
 #[inline(always)]
-fn assign_ccc_and_sort_combining<'data>(
+fn assign_ccc_and_sort_combining(
     slice: &mut [CharacterAndClass],
     combining_start: usize,
-    ccc: CodePointMapDataBorrowed<'data, CanonicalCombiningClass>,
+    ccc: CodePointMapDataBorrowed<CanonicalCombiningClass>,
 ) {
     slice.iter_mut().for_each(|cc| cc.set_ccc_from_trie(ccc));
     // Slicing succeeds by construction; we've always ensured that `combining_start`
@@ -298,9 +298,9 @@ fn assign_ccc_and_sort_combining<'data>(
 
 // This function exists as a borrow check helper.
 #[inline(always)]
-fn sort_slice_by_ccc<'data>(
+fn sort_slice_by_ccc(
     slice: &mut [CharacterAndClass],
-    ccc: CodePointMapDataBorrowed<'data, CanonicalCombiningClass>,
+    ccc: CodePointMapDataBorrowed<CanonicalCombiningClass>,
 ) {
     // We don't look up the canonical combining class for starters
     // of for single combining characters between starters. When

--- a/ffi/diplomat/src/bidi.rs
+++ b/ffi/diplomat/src/bidi.rs
@@ -10,8 +10,7 @@ pub mod ffi {
     use core::fmt::Write;
     use icu_properties::bidi::BidiClassAdapter;
     use icu_properties::maps;
-    use icu_properties::provider::BidiClassV1Marker;
-    use icu_provider::DataPayload;
+    use icu_properties::BidiClass;
     use unicode_bidi::BidiInfo;
     use unicode_bidi::Level;
     use unicode_bidi::Paragraph;
@@ -29,7 +28,7 @@ pub mod ffi {
     /// An ICU4X Bidi object, containing loaded bidi data
     #[diplomat::rust_link(icu::properties::bidi::BidiClassAdapter, Struct)]
     // #[diplomat::rust_link(icu::properties::maps::get_bidi_class, Struct)]
-    pub struct ICU4XBidi(pub DataPayload<BidiClassV1Marker>);
+    pub struct ICU4XBidi(pub maps::CodePointMapData<BidiClass>);
 
     impl ICU4XBidi {
         /// Creates a new [`ICU4XBidi`] from locale data.
@@ -52,8 +51,8 @@ pub mod ffi {
             text: &'text str,
             default_level: u8,
         ) -> Box<ICU4XBidiInfo<'text>> {
-            let data = self.0.get();
-            let adapter = BidiClassAdapter::new(&data.code_point_trie);
+            let data = self.0.as_borrowed();
+            let adapter = BidiClassAdapter::new(data);
 
             Box::new(ICU4XBidiInfo(BidiInfo::new_with_data_source(
                 &adapter,

--- a/ffi/diplomat/src/properties_maps.rs
+++ b/ffi/diplomat/src/properties_maps.rs
@@ -2,20 +2,11 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-struct ErasedCodePointMap16MarkerV1;
-
-use icu_provider::DataMarker;
-impl DataMarker for ErasedCodePointMap16MarkerV1 {
-    type Yokeable = <icu_properties::provider::ScriptV1Marker as DataMarker>::Yokeable;
-}
-
 #[diplomat::bridge]
 pub mod ffi {
-    use super::ErasedCodePointMap16MarkerV1;
     use crate::provider::ffi::ICU4XDataProvider;
     use alloc::boxed::Box;
-    use icu_properties::maps;
-    use icu_provider::prelude::DataPayload;
+    use icu_properties::{maps, Script};
 
     use crate::errors::ffi::ICU4XError;
     use diplomat_runtime::DiplomatResult;
@@ -23,7 +14,7 @@ pub mod ffi {
     #[diplomat::opaque]
     /// An ICU4X Unicode Set Property object, capable of querying whether a code point is contained in a set based on a Unicode property. For properties whose values fit into 16 bits.
     #[diplomat::rust_link(icu_properties, Mod)]
-    pub struct ICU4XCodePointMapData16(DataPayload<ErasedCodePointMap16MarkerV1>);
+    pub struct ICU4XCodePointMapData16(maps::CodePointMapData<Script>);
 
     pub struct ICU4XCodePointMapData16Response {
         /// The [`ICU4XCodePointMapData16`], if creation was successful.
@@ -41,7 +32,7 @@ pub mod ffi {
             use icu_provider::serde::AsDeserializingBufferProvider;
             let provider = provider.0.as_deserializing();
             maps::get_script(&provider)
-                .map(|data| Box::new(ICU4XCodePointMapData16(DataPayload::cast(data))))
+                .map(|data| Box::new(ICU4XCodePointMapData16(data)))
                 .map_err(Into::into)
                 .into()
         }
@@ -49,7 +40,7 @@ pub mod ffi {
         /// Gets the value for a code point.
         #[diplomat::rust_link(icu_codepointtrie::codepointtrie::CodePointTrie::get_u32, FnInStruct)]
         pub fn get(&self, cp: char) -> u16 {
-            self.0.get().code_point_trie.get(cp.into()).0
+            self.0.get(cp).0
         }
     }
 }

--- a/ffi/diplomat/src/properties_sets.rs
+++ b/ffi/diplomat/src/properties_sets.rs
@@ -2,20 +2,11 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-struct ErasedCodePointSetMarkerV1;
-
-use icu_provider::DataMarker;
-impl DataMarker for ErasedCodePointSetMarkerV1 {
-    type Yokeable = <icu_properties::provider::AsciiHexDigitV1Marker as DataMarker>::Yokeable;
-}
-
 #[diplomat::bridge]
 pub mod ffi {
-    use super::ErasedCodePointSetMarkerV1;
     use crate::provider::ffi::ICU4XDataProvider;
     use alloc::boxed::Box;
     use icu_properties::sets;
-    use icu_provider::prelude::DataPayload;
 
     use crate::errors::ffi::ICU4XError;
     use diplomat_runtime::DiplomatResult;
@@ -23,7 +14,7 @@ pub mod ffi {
     #[diplomat::opaque]
     /// An ICU4X Unicode Set Property object, capable of querying whether a code point is contained in a set based on a Unicode property.
     #[diplomat::rust_link(icu_properties, Mod)]
-    pub struct ICU4XCodePointSetData(DataPayload<ErasedCodePointSetMarkerV1>);
+    pub struct ICU4XCodePointSetData(sets::CodePointSetData);
 
     impl ICU4XCodePointSetData {
         /// Gets a set for Unicode property ascii_hex_digit from a [`ICU4XDataProvider`].
@@ -34,7 +25,7 @@ pub mod ffi {
             use icu_provider::serde::AsDeserializingBufferProvider;
             let provider = provider.0.as_deserializing();
             sets::get_ascii_hex_digit(&provider)
-                .map(|data| Box::new(ICU4XCodePointSetData(DataPayload::cast(data))))
+                .map(|data| Box::new(ICU4XCodePointSetData(data)))
                 .map_err(Into::into)
                 .into()
         }
@@ -42,7 +33,7 @@ pub mod ffi {
         /// Checks whether the code point is in the set.
         #[diplomat::rust_link(icu_uniset::UnicodeSet::contains, FnInStruct)]
         pub fn contains(&self, cp: char) -> bool {
-            self.0.get().inv_list.contains(cp)
+            self.0.contains(cp)
         }
     }
 }

--- a/provider/datagen/src/transform/cldr/list/mod.rs
+++ b/provider/datagen/src/transform/cldr/list/mod.rs
@@ -107,7 +107,7 @@ impl<M: ResourceMarker<Yokeable = ListFormatterPatternsV1<'static>>> ResourcePro
                         .map_err(|e| DataError::custom("data for CodePointTrie of Script")
                             .with_display_context(&e))?
                         .get_set_for_value(icu_properties::Script::Hebrew)
-                        .as_unicodeset()
+                        .to_unicode_set()
                         .iter_ranges()
                         .map(|range| format!(r#"\u{:04x}-\u{:04x}"#, range.start(), range.end()))
                         .fold(String::new(), |a, b| a + &b)

--- a/provider/datagen/src/transform/cldr/list/mod.rs
+++ b/provider/datagen/src/transform/cldr/list/mod.rs
@@ -106,9 +106,8 @@ impl<M: ResourceMarker<Yokeable = ListFormatterPatternsV1<'static>>> ResourcePro
                         )
                         .map_err(|e| DataError::custom("data for CodePointTrie of Script")
                             .with_display_context(&e))?
-                        .get()
-                        .code_point_trie
                         .get_set_for_value(icu_properties::Script::Hebrew)
+                        .as_unicodeset()
                         .iter_ranges()
                         .map(|range| format!(r#"\u{:04x}-\u{:04x}"#, range.start(), range.end()))
                         .fold(String::new(), |a, b| a + &b)

--- a/provider/datagen/src/transform/segmenter/mod.rs
+++ b/provider/datagen/src/transform/segmenter/mod.rs
@@ -215,9 +215,9 @@ fn get_line_segmenter_value_from_name(name: &str) -> LineBreak {
     }
 }
 
-fn is_cjk_fullwidth(eaw: &CodePointTrie<EastAsianWidth>, codepoint: u32) -> bool {
+fn is_cjk_fullwidth(eaw: maps::CodePointMapDataBorrowed<EastAsianWidth>, codepoint: u32) -> bool {
     matches!(
-        eaw.get(codepoint),
+        eaw.get_u32(codepoint),
         EastAsianWidth::Ambiguous | EastAsianWidth::Fullwidth | EastAsianWidth::Wide
     )
 }
@@ -255,34 +255,31 @@ impl SegmenterRuleProvider {
         // Load enumerate Unicode property dependencies.
         let cp_map_provider = EnumeratedPropertyCodePointTrieProvider::from(&self.source);
 
-        let payload = maps::get_word_break(&cp_map_provider).expect("The data should be valid!");
-        let wb = &payload.get().code_point_trie;
+        let data = maps::get_word_break(&cp_map_provider).expect("The data should be valid!");
+        let wb = data.as_borrowed();
 
-        let payload =
+        let data =
             maps::get_grapheme_cluster_break(&cp_map_provider).expect("The data should be valid!");
-        let gb = &payload.get().code_point_trie;
+        let gb = data.as_borrowed();
 
-        let payload =
-            maps::get_sentence_break(&cp_map_provider).expect("The data should be valid!");
-        let sb = &payload.get().code_point_trie;
+        let data = maps::get_sentence_break(&cp_map_provider).expect("The data should be valid!");
+        let sb = data.as_borrowed();
 
-        let payload = maps::get_line_break(&cp_map_provider).expect("The data should be valid!");
-        let lb = &payload.get().code_point_trie;
+        let data = maps::get_line_break(&cp_map_provider).expect("The data should be valid!");
+        let lb = data.as_borrowed();
 
-        let payload =
-            maps::get_east_asian_width(&cp_map_provider).expect("The data should be valid!");
-        let eaw = &payload.get().code_point_trie;
+        let data = maps::get_east_asian_width(&cp_map_provider).expect("The data should be valid!");
+        let eaw = data.as_borrowed();
 
-        let payload =
-            maps::get_general_category(&cp_map_provider).expect("The data should be valid!");
-        let gc = &payload.get().code_point_trie;
+        let data = maps::get_general_category(&cp_map_provider).expect("The data should be valid!");
+        let gc = data.as_borrowed();
 
         // Load binary Unicode property dependencies.
         let uniset_provider = BinaryPropertyUnicodeSetDataProvider::from(&self.source);
 
-        let payload =
+        let data =
             sets::get_extended_pictographic(&uniset_provider).expect("The data should be valid!");
-        let extended_pictographic = &payload.get().inv_list;
+        let extended_pictographic = data.as_borrowed();
 
         // As of Unicode 14.0.0, the break property and the largest codepoint defined in UCD are
         // summarized in the following list. See details in the property txt in
@@ -340,7 +337,7 @@ impl SegmenterRuleProvider {
                             // Word break property doesn't define SA, but we will use non-UAX29 rules.
                             // SA property is within 0..U+0x20000
                             for c in 0..0x20000 {
-                                if lb.get(c) == LineBreak::ComplexContext {
+                                if lb.get_u32(c) == LineBreak::ComplexContext {
                                     properties_map[c as usize] = property_index
                                 }
                             }
@@ -349,7 +346,7 @@ impl SegmenterRuleProvider {
 
                         let prop = get_word_segmenter_value_from_name(&*p.name);
                         for c in 0..(UAX29_CODEPOINT_TABLE_LEN as u32) {
-                            if wb.get(c) == prop {
+                            if wb.get_u32(c) == prop {
                                 properties_map[c as usize] = property_index;
                             }
                         }
@@ -372,7 +369,7 @@ impl SegmenterRuleProvider {
 
                         let prop = get_grapheme_segmenter_value_from_name(&*p.name);
                         for c in 0..(UAX29_CODEPOINT_TABLE_LEN as u32) {
-                            if gb.get(c) == prop {
+                            if gb.get_u32(c) == prop {
                                 properties_map[c as usize] = property_index;
                             }
                         }
@@ -382,7 +379,7 @@ impl SegmenterRuleProvider {
                     "sentence" => {
                         let prop = get_sentence_segmenter_value_from_name(&*p.name);
                         for c in 0..(UAX29_CODEPOINT_TABLE_LEN as u32) {
-                            if sb.get(c) == prop {
+                            if sb.get_u32(c) == prop {
                                 properties_map[c as usize] = property_index;
                             }
                         }
@@ -398,16 +395,16 @@ impl SegmenterRuleProvider {
                             || p.name == "PR_EAW"
                         {
                             for i in 0..0x20000 {
-                                match lb.get(i) {
+                                match lb.get_u32(i) {
                                     LineBreak::OpenPunctuation => {
                                         if (p.name == "OP_OP30"
-                                            && (eaw.get(i) != EastAsianWidth::Fullwidth
-                                                && eaw.get(i) != EastAsianWidth::Halfwidth
-                                                && eaw.get(i) != EastAsianWidth::Wide))
+                                            && (eaw.get_u32(i) != EastAsianWidth::Fullwidth
+                                                && eaw.get_u32(i) != EastAsianWidth::Halfwidth
+                                                && eaw.get_u32(i) != EastAsianWidth::Wide))
                                             || (p.name == "OP_EA"
-                                                && (eaw.get(i) == EastAsianWidth::Fullwidth
-                                                    || eaw.get(i) == EastAsianWidth::Halfwidth
-                                                    || eaw.get(i) == EastAsianWidth::Wide))
+                                                && (eaw.get_u32(i) == EastAsianWidth::Fullwidth
+                                                    || eaw.get_u32(i) == EastAsianWidth::Halfwidth
+                                                    || eaw.get_u32(i) == EastAsianWidth::Wide))
                                         {
                                             properties_map[i as usize] = property_index;
                                         }
@@ -416,9 +413,9 @@ impl SegmenterRuleProvider {
                                     LineBreak::CloseParenthesis => {
                                         // CP_EA is unused on the latest spec.
                                         if p.name == "CP_EA"
-                                            && (eaw.get(i) == EastAsianWidth::Fullwidth
-                                                || eaw.get(i) == EastAsianWidth::Halfwidth
-                                                || eaw.get(i) == EastAsianWidth::Wide)
+                                            && (eaw.get_u32(i) == EastAsianWidth::Fullwidth
+                                                || eaw.get_u32(i) == EastAsianWidth::Halfwidth
+                                                || eaw.get_u32(i) == EastAsianWidth::Wide)
                                         {
                                             properties_map[i as usize] = property_index;
                                         }
@@ -426,7 +423,7 @@ impl SegmenterRuleProvider {
 
                                     LineBreak::Ideographic => {
                                         if p.name == "ID_CN"
-                                            && gc.get(i) == GeneralCategory::Unassigned
+                                            && gc.get_u32(i) == GeneralCategory::Unassigned
                                         {
                                             if let Some(c) = char::from_u32(i) {
                                                 if extended_pictographic.contains(c) {
@@ -456,7 +453,7 @@ impl SegmenterRuleProvider {
 
                         let prop = get_line_segmenter_value_from_name(&*p.name);
                         for c in 0..0x20000 {
-                            if lb.get(c) == prop {
+                            if lb.get_u32(c) == prop {
                                 properties_map[c as usize] = property_index;
                             }
                         }


### PR DESCRIPTION
Progress towards https://github.com/unicode-org/icu4x/issues/1239

This introduces `CodePointSetData` and `CodePointMapData<T>`, wrappers around the actual data structs that have the final public APIs for these types. Borrowed versions of these types are added as well to avoid repeated Yoke `.get()`s. This ends up with the resultant user code looking similar but not identical.

This also makes CodePointMapData accept `.get(char)` by default, making it more consistent.

This does not yet add support for multiple data backends as planned, rather it sets the stage for this by making the precise data struct no longer relevant to the user. Multiple data backends can then be done entirely in this code

Some open questions:

## Handling UnicodeSet-specific stuff

There are a couple places where we need to accept the underlying `UnicodeSet`. one is when we're using `UnicodeSetBuilder`, and one is in datagen where we want to call `iter_ranges()`. Currently I've added a hidden `.as_unicodeset()` so that we can land this change and continue afterwards, but we should get rid of it. This was discussed in the third section of [this doc](https://docs.google.com/document/d/1gVEV_cSrdCSk1WxKVthdcIB1XenrcB-wDyanRAwMbUI/edit#heading=h.usoiorcf2ky4), but I never got a clear answer on what kind of trait we wanted.

I *think* what we need here is a UnicodeSetLike trait in the `icu_uniset` crate that is used in UnicodeSetBuilder. However, I'm hesitant to take this step because UnicodeSetBuilder relies on a lot of precise implementation details of UnicodeSet: if, in the future, we added a second data backend to UnicodeSetData, it may not be able to provide those same APIs. I think this is something @echeran and @sffc need to figure out. I'm wondering if an `.as_unicodeset()` returning an `Option<UnicodeSet>` may perhaps be the best option for such low level access?

I think in a lot of discussions around this folks have mentioned the need for a trait, but I'm still not clear on what precisely the trait should abstract over given that there are many layers of abstraction here. The trait could simply abstract over `.contains()` or `.get()`, but that's only really useful if _users_ wish to abstract over stuff like that, and it's not clear they would need to. On the other hand, the trait could abstract over enough internal details that UnicodeSetBuilder can work, but then we have trouble with perhaps pinning down the implementation too strongly.

I do think a fair amount of this work can be done in the UnicodeSet crate, one potential solution is:

 - UnicodeSetLike trait,  accepted by UnicodeSetBuilder
 - UnicodeSet implements it
 - CodePointTrieToSet wrapper that converts CPT into something implementing UnicodeSetLike (so that you don't even need to reallocate a unicodeset to use UnicodeSetBuilder)

We then figure out if the `icu_properties` types should also implement these traits, or if they ought to allow you conditional access to the underlying types when you need to do things like this. I can imagine users writing code that will use UnicodeSetBuilder when the underlying data is UnicodeSet, but OtherImplementationBuilder when the underlying data is OtherImplementation.

(n.b. we probably should rename UnicodeSet to CPSet, but I'm using the current names for now)

## Should the APIs be duplicated between payload and borrowed types?

Currently we have CodePointSetDataBorrowed and CodePointSetData, with identical APIs but the borrowed version being "better" in many cases (whereas the normal version is more convenient). Should we just drive people towards the borrowed version for some or all of the APIs? I like having cleaner APIs for when people don't need the borrowed stuff (and there are many map APIs where the borrowed version isn't super relevant), but perhaps we can just consistently drive people to one API.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->