### PR TITLE
Fix feature in calendar benches

### DIFF
--- a/components/calendar/benches/date.rs
+++ b/components/calendar/benches/date.rs
@@ -29,7 +29,6 @@ fn bench_date<A: AsCalendar>(date: &mut Date<A>) {
     let _ = black_box(date.to_iso());
 }
 
-#[cfg(feature = "bench")]
 fn bench_calendar<C: Clone + Calendar>(
     group: &mut BenchmarkGroup<WallTime>,
     name: &str,


### PR DESCRIPTION
Not sure why CI didn't catch this; maybe build-all-features it isn't building `--all-targets`.