### PR TITLE
compute metazone id from time zone id and local timestamp in MockZone…

### DIFF
--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -321,7 +321,7 @@ impl DateTime<Iso> {
                 + i32::from(self.time.hour.number()) * minutes_a_hour
                 + i32::from(self.time.minute.number())
         } else {
-            0
+            -1
         }
     }
 

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -321,7 +321,7 @@ impl DateTime<Iso> {
                 + i32::from(self.time.hour.number()) * minutes_a_hour
                 + i32::from(self.time.minute.number())
         } else {
-            -1
+            unreachable!("DateTime should be created successfully")
         }
     }
 

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -77,7 +77,7 @@ pub trait IsoTimeInput {
 /// All data represented in [`TimeZoneInput`] should be locale-agnostic.
 pub trait TimeZoneInput {
     /// The GMT offset in Nanoseconds.
-    fn gmt_offset(&self) -> GmtOffset;
+    fn gmt_offset(&self) -> Option<GmtOffset>;
 
     /// The IANA time-zone identifier.
     fn time_zone_id(&self) -> Option<TimeZoneBcp47Id>;

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -77,7 +77,7 @@ pub trait IsoTimeInput {
 /// All data represented in [`TimeZoneInput`] should be locale-agnostic.
 pub trait TimeZoneInput {
     /// The GMT offset in Nanoseconds.
-    fn gmt_offset(&self) -> GmtOffset;
+    fn gmt_offset(&self) -> Option<GmtOffset>;
 
     /// The IANA time-zone identifier.
     fn time_zone_id(&self) -> Option<TimeZoneBcp47Id>;
@@ -148,7 +148,7 @@ pub(crate) struct ExtractedDateTimeInput {
 ///
 /// See [`TimeZoneInput`] for documentation on individual fields
 pub(crate) struct ExtractedTimeZoneInput {
-    gmt_offset: GmtOffset,
+    gmt_offset: Option<GmtOffset>,
     time_zone_id: Option<TimeZoneBcp47Id>,
     metazone_id: Option<MetaZoneId>,
     time_variant: Option<TinyStr8>,
@@ -229,7 +229,7 @@ impl IsoTimeInput for ExtractedDateTimeInput {
 }
 
 impl TimeZoneInput for ExtractedTimeZoneInput {
-    fn gmt_offset(&self) -> GmtOffset {
+    fn gmt_offset(&self) -> Option<GmtOffset> {
         self.gmt_offset
     }
     fn time_zone_id(&self) -> Option<TimeZoneBcp47Id> {

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -77,7 +77,7 @@ pub trait IsoTimeInput {
 /// All data represented in [`TimeZoneInput`] should be locale-agnostic.
 pub trait TimeZoneInput {
     /// The GMT offset in Nanoseconds.
-    fn gmt_offset(&self) -> Option<GmtOffset>;
+    fn gmt_offset(&self) -> GmtOffset;
 
     /// The IANA time-zone identifier.
     fn time_zone_id(&self) -> Option<TimeZoneBcp47Id>;

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -30,7 +30,7 @@ pub enum DateTimeFormatterError {
     /// An error originating from a missing field in datetime input.
     /// TODO: How can we return which field was missing?
     #[displaydoc("Missing input field")]
-    MissingInputField,
+    MissingInputField(Option<&'static str>),
     /// An error originating from skeleton matching.
     #[displaydoc("{0}")]
     Skeleton(SkeletonError),

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -208,7 +208,7 @@ where
             let era = datetime
                 .datetime()
                 .year()
-                .ok_or(Error::MissingInputField)?
+                .ok_or(Error::MissingInputField(Some("year")))?
                 .era;
             #[allow(clippy::expect_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
             let symbol = date_symbols
@@ -224,7 +224,7 @@ where
                     datetime
                         .datetime()
                         .year()
-                        .ok_or(Error::MissingInputField)?
+                        .ok_or(Error::MissingInputField(Some("year")))?
                         .number,
                 ),
                 field.length,
@@ -244,7 +244,7 @@ where
                     datetime
                         .datetime()
                         .month()
-                        .ok_or(Error::MissingInputField)?
+                        .ok_or(Error::MissingInputField(Some("month")))?
                         .ordinal,
                 ),
                 field.length,
@@ -259,7 +259,7 @@ where
                         datetime
                             .datetime()
                             .month()
-                            .ok_or(Error::MissingInputField)?
+                            .ok_or(Error::MissingInputField(Some("month")))?
                             .code,
                     )?;
                 w.write_str(symbol)?
@@ -283,7 +283,7 @@ where
             let dow = datetime
                 .datetime()
                 .iso_weekday()
-                .ok_or(Error::MissingInputField)?;
+                .ok_or(Error::MissingInputField(Some("iso_weekday")))?;
             #[allow(clippy::expect_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
             let symbol = date_symbols
                 .expect("Expect date symbols to be present")
@@ -298,7 +298,7 @@ where
                     datetime
                         .datetime()
                         .day_of_month()
-                        .ok_or(Error::MissingInputField)?
+                        .ok_or(Error::MissingInputField(Some("day_of_month")))?
                         .0
                 }
                 fields::Day::DayOfWeekInMonth => datetime.day_of_week_in_month()?.0,
@@ -307,8 +307,12 @@ where
             field.length,
         )?,
         FieldSymbol::Hour(hour) => {
-            let h =
-                usize::from(datetime.datetime().hour().ok_or(Error::MissingInputField)?) as isize;
+            let h = usize::from(
+                datetime
+                    .datetime()
+                    .hour()
+                    .ok_or(Error::MissingInputField(Some("hour")))?,
+            ) as isize;
             let value = match hour {
                 fields::Hour::H11 => h % 12,
                 fields::Hour::H12 => {
@@ -342,7 +346,7 @@ where
                 datetime
                     .datetime()
                     .minute()
-                    .ok_or(Error::MissingInputField)?,
+                    .ok_or(Error::MissingInputField(Some("minute")))?,
             )),
             field.length,
         )?,
@@ -351,7 +355,7 @@ where
                 datetime
                     .datetime()
                     .second()
-                    .ok_or(Error::MissingInputField)?,
+                    .ok_or(Error::MissingInputField(Some("second")))?,
             ));
             if let Some(PatternItem::Field(next_field)) = next_item {
                 if let FieldSymbol::Second(Second::FractionalSecond) = next_field.symbol {
@@ -359,7 +363,7 @@ where
                         datetime
                             .datetime()
                             .nanosecond()
-                            .ok_or(Error::MissingInputField)?,
+                            .ok_or(Error::MissingInputField(Some("nanosecond")))?,
                     ));
 
                     // We only support fixed field length for fractional seconds.
@@ -400,7 +404,10 @@ where
                 .get_symbol_for_day_period(
                     period,
                     field.length,
-                    datetime.datetime().hour().ok_or(Error::MissingInputField)?,
+                    datetime
+                        .datetime()
+                        .hour()
+                        .ok_or(Error::MissingInputField(Some("hour")))?,
                     pattern.time_granularity.is_top_of_hour(
                         datetime.datetime().minute().map(u8::from).unwrap_or(0),
                         datetime.datetime().second().map(u8::from).unwrap_or(0),

--- a/components/datetime/src/format/time_zone.rs
+++ b/components/datetime/src/format/time_zone.rs
@@ -38,10 +38,29 @@ where
                     ) {
                         Ok(Ok(r)) => Ok(r),
                         Ok(Err(e)) => Err(e),
-                        Err(_e) => {
-                            debug_assert!(false, "{:?}", _e);
-                            Err(core::fmt::Error)
-                        }
+                        Err(e) => match e {
+                            DateTimeFormatterError::MissingInputField(Some("gmt_offset")) => {
+                                debug_assert!(
+                                    false,
+                                    "{:?}",
+                                    &self
+                                        .time_zone_format
+                                        .data_payloads
+                                        .zone_formats
+                                        .get()
+                                        .gmt_offset_fallback
+                                );
+                                sink.write_str(
+                                    &self
+                                        .time_zone_format
+                                        .data_payloads
+                                        .zone_formats
+                                        .get()
+                                        .gmt_offset_fallback,
+                                )
+                            }
+                            _ => Err(core::fmt::Error),
+                        },
                     }
                 }
                 TimeZoneFormatterUnit::Iso8601(fallback) => {
@@ -52,10 +71,29 @@ where
                     ) {
                         Ok(Ok(r)) => Ok(r),
                         Ok(Err(e)) => Err(e),
-                        Err(_e) => {
-                            debug_assert!(false, "{:?}", _e);
-                            Err(core::fmt::Error)
-                        }
+                        Err(e) => match e {
+                            DateTimeFormatterError::MissingInputField(Some("gmt_offset")) => {
+                                debug_assert!(
+                                    false,
+                                    "{:?}",
+                                    &self
+                                        .time_zone_format
+                                        .data_payloads
+                                        .zone_formats
+                                        .get()
+                                        .gmt_offset_fallback
+                                );
+                                sink.write_str(
+                                    &self
+                                        .time_zone_format
+                                        .data_payloads
+                                        .zone_formats
+                                        .get()
+                                        .gmt_offset_fallback,
+                                )
+                            }
+                            _ => Err(core::fmt::Error),
+                        },
                     }
                 }
                 _ => Err(core::fmt::Error),

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -88,6 +88,7 @@ pub mod datetime;
 mod error;
 pub mod fields;
 mod format;
+pub mod metazone;
 pub mod mock;
 pub mod options;
 #[doc(hidden)]

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -88,7 +88,7 @@ pub mod datetime;
 mod error;
 pub mod fields;
 mod format;
-#[allow(missing_docs)] // TODO(#686) - Add missing docs.
+/// A module for metazone id calculation.
 pub mod metazone;
 pub mod mock;
 pub mod options;

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -88,6 +88,7 @@ pub mod datetime;
 mod error;
 pub mod fields;
 mod format;
+#[allow(missing_docs)] // TODO(#686) - Add missing docs.
 pub mod metazone;
 pub mod mock;
 pub mod options;

--- a/components/datetime/src/metazone.rs
+++ b/components/datetime/src/metazone.rs
@@ -67,7 +67,7 @@ impl MetaZoneCalculator {
     /// assert_eq!(
     ///     mzc.compute_metazone_from_timezone(
     ///         TimeZoneBcp47Id(tinystr!(8, "gugum")),
-    ///         DateTime::new_iso_datetime(1969, 1, 1, 0, 0, 0).unwrap()
+    ///         &DateTime::new_iso_datetime(1969, 1, 1, 0, 0, 0).unwrap()
     ///     ),
     ///     None
     /// );
@@ -75,7 +75,7 @@ impl MetaZoneCalculator {
     /// assert_eq!(
     ///     mzc.compute_metazone_from_timezone(
     ///         TimeZoneBcp47Id(tinystr!(8, "gugum")),
-    ///         DateTime::new_iso_datetime(1970, 1, 1, 0, 0, 0).unwrap()
+    ///         &DateTime::new_iso_datetime(1970, 1, 1, 0, 0, 0).unwrap()
     ///     ),
     ///     Some(MetaZoneId(tinystr!(4, "guam")))
     /// );
@@ -83,7 +83,7 @@ impl MetaZoneCalculator {
     /// assert_eq!(
     ///     mzc.compute_metazone_from_timezone(
     ///         TimeZoneBcp47Id(tinystr!(8, "gugum")),
-    ///         DateTime::new_iso_datetime(1975, 1, 1, 0, 0, 0).unwrap()
+    ///         &DateTime::new_iso_datetime(1975, 1, 1, 0, 0, 0).unwrap()
     ///     ),
     ///     Some(MetaZoneId(tinystr!(4, "guam")))
     /// );
@@ -91,7 +91,7 @@ impl MetaZoneCalculator {
     /// assert_eq!(
     ///     mzc.compute_metazone_from_timezone(
     ///         TimeZoneBcp47Id(tinystr!(8, "gugum")),
-    ///         DateTime::new_iso_datetime(2000, 12, 22, 15, 0, 0).unwrap()
+    ///         &DateTime::new_iso_datetime(2000, 12, 22, 15, 0, 0).unwrap()
     ///     ),
     ///     Some(MetaZoneId(tinystr!(4, "cham")))
     /// );

--- a/components/datetime/src/metazone.rs
+++ b/components/datetime/src/metazone.rs
@@ -1,0 +1,80 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use crate::provider::time_zones::{MetaZoneId, TimeZoneBcp47Id};
+
+use crate::error::DateTimeFormatError;
+use crate::provider::time_zones::MetaZonePeriodV1Marker;
+use icu_calendar::DateTime;
+use icu_calendar::Iso;
+use icu_locid::Locale;
+use icu_provider::prelude::*;
+
+pub struct MetaZoneCalculator {
+    pub(super) metazone_period: DataPayload<MetaZonePeriodV1Marker>,
+}
+
+impl MetaZoneCalculator {
+    /// Constructor that loads data to calculate metazone id.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu_datetime::mock::time_zone::MockTimeZone;
+    /// use icu_datetime::{TimeZoneFormat, TimeZoneFormatConfig, TimeZoneFormatOptions};
+    /// use icu_locid::locale;
+    /// use icu_provider::inv::InvariantDataProvider;
+    /// use icu::datetime::metazone::MetaZoneCalculator;
+    ///
+    /// let provider = InvariantDataProvider;
+    ///
+    /// let tzf = MetaZoneCalculator::new(
+    ///     locale!("en"),
+    ///     &provider,
+    /// );
+    ///
+    /// assert!(tzf.is_ok());
+    /// ```
+    pub fn new<L, ZP>(locale: L, zone_provider: &ZP) -> Result<Self, DateTimeFormatError>
+    where
+        L: Into<Locale>,
+        ZP: ResourceProvider<MetaZonePeriodV1Marker> + ?Sized,
+    {
+        let locale = locale.into();
+        let metazone_period = zone_provider
+            .load_resource(&DataRequest {
+                options: ResourceOptions::from(&locale),
+                metadata: Default::default(),
+            })?
+            .take_payload()?;
+        Ok(Self { metazone_period })
+    }
+
+    pub fn compute_metazone_from_timezone(
+        self,
+        time_zone_id: TimeZoneBcp47Id,
+        local_datetime: DateTime<Iso>,
+    ) -> Option<MetaZoneId> {
+        if self.metazone_period.get().0.contains_key0(&time_zone_id) {
+            match self.metazone_period.get().0.get0(&time_zone_id) {
+                Some(cursor) => {
+                    let mut metazone_id = None;
+                    let minutes_since_local_unix_epoch =
+                        local_datetime.minutes_since_local_unix_epoch();
+                    for (minutes, id) in cursor.iter1() {
+                        if minutes_since_local_unix_epoch >= minutes {
+                            metazone_id = id
+                        } else {
+                            break;
+                        }
+                    }
+                    metazone_id
+                }
+                None => None,
+            }
+        } else {
+            None
+        }
+    }
+}

--- a/components/datetime/src/metazone.rs
+++ b/components/datetime/src/metazone.rs
@@ -4,7 +4,7 @@
 
 use crate::provider::time_zones::{MetaZoneId, TimeZoneBcp47Id};
 
-use crate::error::DateTimeFormatError;
+use crate::error::DateTimeFormatterError;
 use crate::provider::time_zones::MetaZonePeriodV1Marker;
 use icu_calendar::DateTime;
 use icu_calendar::Iso;
@@ -35,15 +35,15 @@ impl MetaZoneCalculator {
     ///
     /// assert!(mzc.is_ok());
     /// ```
-    pub fn new<L, ZP>(locale: L, zone_provider: &ZP) -> Result<Self, DateTimeFormatError>
+    pub fn new<L, ZP>(locale: L, zone_provider: &ZP) -> Result<Self, DateTimeFormatterError>
     where
         L: Into<Locale>,
-        ZP: ResourceProvider<MetaZonePeriodV1Marker> + ?Sized,
+        ZP: DataProvider<MetaZonePeriodV1Marker> + ?Sized,
     {
         let locale = locale.into();
         let metazone_period = zone_provider
-            .load_resource(&DataRequest {
-                options: ResourceOptions::from(&locale),
+            .load(DataRequest {
+                locale: &DataLocale::from(locale),
                 metadata: Default::default(),
             })?
             .take_payload()?;

--- a/components/datetime/src/mock/time_zone.rs
+++ b/components/datetime/src/mock/time_zone.rs
@@ -26,7 +26,7 @@ use icu_calendar::{DateTime, Iso};
 /// use icu::datetime::mock::time_zone::MockTimeZone;
 ///
 /// let tz1 = MockTimeZone::new(
-///     GmtOffset::default(),
+///     Some(GmtOffset::default()),
 ///     /* time_zone_id */ None,
 ///     /* metazone_id */ None,
 ///     /* time_variaint */ None,
@@ -38,7 +38,7 @@ use icu_calendar::{DateTime, Iso};
 #[allow(clippy::exhaustive_structs)] // this type will not add fields (it is largely an example type)
 pub struct MockTimeZone {
     /// The GMT offset in seconds.
-    pub gmt_offset: GmtOffset,
+    pub gmt_offset: Option<GmtOffset>,
     /// The IANA time-zone identifier
     pub time_zone_id: Option<TimeZoneBcp47Id>,
     /// The CLDR metazone identifier
@@ -52,7 +52,7 @@ impl MockTimeZone {
     /// A GMT offset is required, as it is used as a final fallback for formatting.
     /// The other arguments optionally allow access to more robust formats.
     pub const fn new(
-        gmt_offset: GmtOffset,
+        gmt_offset: Option<GmtOffset>,
         time_zone_id: Option<TimeZoneBcp47Id>,
         metazone_id: Option<MetaZoneId>,
         time_variant: Option<TinyStr8>,
@@ -79,28 +79,25 @@ impl MockTimeZone {
     /// use tinystr::tinystr;
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let mzc = MetaZoneCalculator::new(locale!("en"), &provider);
+    /// let mzc = MetaZoneCalculator::new(locale!("en"), &provider).expect("data exists");
     /// let mut tz = MockTimeZone::new(
-    /// GmtOffset::default(),
+    ///     Some(GmtOffset::default()),
     ///     /* time_zone_id */ Some(TimeZoneBcp47Id(tinystr!(8, "gugum"))),
     ///     /* metazone_id */ None,
     ///     /* time_variaint */ None,
     /// );
     /// tz.try_set_metazone(
-    /// DateTime::new_iso_datetime(1971, 10, 31, 2, 0, 0).unwrap(),
-    /// mzc.unwrap(),
+    ///     &DateTime::new_iso_datetime(1971, 10, 31, 2, 0, 0).unwrap(),
+    ///     &mzc,
     /// );
     /// assert_eq!(tz.metazone_id, Some(MetaZoneId(tinystr!(4, "guam"))));
     /// ```
     pub fn try_set_metazone(
         &mut self,
-        local_datetime: DateTime<Iso>,
-        metazone_calculator: MetaZoneCalculator,
+        local_datetime: &DateTime<Iso>,
+        metazone_calculator: &MetaZoneCalculator,
     ) -> &mut Self {
         if let Some(time_zone_id) = self.time_zone_id {
-            extern crate std;
-            std::println!("try_set_metazone");
-
             self.metazone_id =
                 metazone_calculator.compute_metazone_from_timezone(time_zone_id, local_datetime);
         }
@@ -133,7 +130,10 @@ impl FromStr for MockTimeZone {
     /// let tz3: MockTimeZone = "+02:30".parse().expect("Failed to parse a time zone.");
     /// ```
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        let gmt_offset = GmtOffset::from_str(input)?;
+        let gmt_offset = match GmtOffset::from_str(input) {
+            Ok(offset) => Some(offset),
+            _ => None
+        };
         Ok(Self {
             gmt_offset,
             time_zone_id: None,
@@ -144,7 +144,7 @@ impl FromStr for MockTimeZone {
 }
 
 impl TimeZoneInput for MockTimeZone {
-    fn gmt_offset(&self) -> GmtOffset {
+    fn gmt_offset(&self) -> Option<GmtOffset> {
         self.gmt_offset
     }
 

--- a/components/datetime/src/mock/time_zone.rs
+++ b/components/datetime/src/mock/time_zone.rs
@@ -97,7 +97,7 @@ impl MockTimeZone {
     /// let provider = icu_testdata::get_provider();
     /// let mzc = MetaZoneCalculator::new(locale!("en"), &provider).expect("data exists");
     /// let mut tz = MockTimeZone::new(
-    ///     Some(GmtOffset::default()),
+    ///     /* gmt_offset */ Some("+11".parse().expect("Failed to parse a GMT offset.")),
     ///     /* time_zone_id */ Some(TimeZoneBcp47Id(tinystr!(8, "gugum"))),
     ///     /* metazone_id */ None,
     ///     /* time_variaint */ None,
@@ -146,7 +146,7 @@ impl FromStr for MockTimeZone {
     /// let tz3: MockTimeZone = "+02:30".parse().expect("Failed to parse a time zone.");
     /// ```
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        let gmt_offset = GmtOffset::from_str(input).ok();
+        let gmt_offset = input.parse::<GmtOffset>().ok();
         let gmt_offset_fallback = match "GMT+?".parse::<GmtOffset>() {
             Ok(fallback) => fallback,
             Err(_) => unreachable!("GMT offset fallback should be created successfully"),

--- a/components/datetime/src/mock/time_zone.rs
+++ b/components/datetime/src/mock/time_zone.rs
@@ -6,7 +6,9 @@ use crate::provider::time_zones::{MetaZoneId, TimeZoneBcp47Id};
 use tinystr::TinyStr8;
 
 use crate::date::*;
+use crate::metazone::MetaZoneCalculator;
 use core::str::FromStr;
+use icu_calendar::{DateTime, Iso};
 
 /// A temporary struct that implements [`TimeZoneInput`]
 /// and is used in tests, benchmarks and examples of this component.
@@ -61,6 +63,48 @@ impl MockTimeZone {
             metazone_id,
             time_variant,
         }
+    }
+
+    /// Overwrite the metazone id in MockTimeZone.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::datetime::date::GmtOffset;
+    /// use icu::datetime::metazone::MetaZoneCalculator;
+    /// use icu::datetime::mock::time_zone::MockTimeZone;
+    /// use icu_calendar::DateTime;
+    /// use icu_datetime::provider::time_zones::{MetaZoneId, TimeZoneBcp47Id};
+    /// use icu_locid::locale;
+    /// use tinystr::tinystr;
+    ///
+    /// let provider = icu_testdata::get_provider();
+    /// let mzc = MetaZoneCalculator::new(locale!("en"), &provider);
+    /// let mut tz = MockTimeZone::new(
+    /// GmtOffset::default(),
+    ///     /* time_zone_id */ Some(TimeZoneBcp47Id(tinystr!(8, "gugum"))),
+    ///     /* metazone_id */ None,
+    ///     /* time_variaint */ None,
+    /// );
+    /// tz.try_set_metazone(
+    /// DateTime::new_iso_datetime(1971, 10, 31, 2, 0, 0).unwrap(),
+    /// mzc.unwrap(),
+    /// );
+    /// assert_eq!(tz.metazone_id, Some(MetaZoneId(tinystr!(4, "guam"))));
+    /// ```
+    pub fn try_set_metazone(
+        &mut self,
+        local_datetime: DateTime<Iso>,
+        metazone_calculator: MetaZoneCalculator,
+    ) -> &mut Self {
+        if let Some(time_zone_id) = self.time_zone_id {
+            extern crate std;
+            std::println!("try_set_metazone");
+
+            self.metazone_id =
+                metazone_calculator.compute_metazone_from_timezone(time_zone_id, local_datetime);
+        }
+        self
     }
 }
 

--- a/components/datetime/src/mock/time_zone.rs
+++ b/components/datetime/src/mock/time_zone.rs
@@ -7,8 +7,6 @@ use tinystr::TinyStr8;
 
 use crate::date::*;
 use crate::metazone::MetaZoneCalculator;
-use alloc::string::String;
-use alloc::string::ToString;
 use core::str::FromStr;
 use icu_calendar::{DateTime, Iso};
 
@@ -47,8 +45,6 @@ pub struct MockTimeZone {
     pub metazone_id: Option<MetaZoneId>,
     /// The time variant e.g. "daylight" or "standard"
     pub time_variant: Option<TinyStr8>,
-    /// The fallback of GMT offset if it is set to None.
-    pub gmt_offset_fallback: String,
 }
 
 impl MockTimeZone {
@@ -61,13 +57,11 @@ impl MockTimeZone {
         metazone_id: Option<MetaZoneId>,
         time_variant: Option<TinyStr8>,
     ) -> Self {
-        debug_assert!(gmt_offset.is_some(), "GMT offset unknown: GMT+?");
         Self {
             gmt_offset,
             time_zone_id,
             metazone_id,
             time_variant,
-            gmt_offset_fallback: "GMT+?".to_string(),
         }
     }
 
@@ -137,13 +131,11 @@ impl FromStr for MockTimeZone {
     /// ```
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         let gmt_offset = input.parse::<GmtOffset>().ok();
-        debug_assert!(gmt_offset.is_some(), "GMT offset unknown: GMT+?");
         Ok(Self {
             gmt_offset,
             time_zone_id: None,
             metazone_id: None,
             time_variant: None,
-            gmt_offset_fallback: "GMT+?".to_string(),
         })
     }
 }

--- a/components/datetime/src/mock/time_zone.rs
+++ b/components/datetime/src/mock/time_zone.rs
@@ -7,6 +7,8 @@ use tinystr::TinyStr8;
 
 use crate::date::*;
 use crate::metazone::MetaZoneCalculator;
+use alloc::string::String;
+use alloc::string::ToString;
 use core::str::FromStr;
 use icu_calendar::{DateTime, Iso};
 

--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -74,7 +74,7 @@ where
 /// )
 /// .expect("Failed to create TimeZoneFormatter");
 ///
-/// let time_zone = MockTimeZone::new(GmtOffset::default(), None, None, None);
+/// let time_zone = MockTimeZone::new(Some(GmtOffset::default()), None, None, None);
 ///
 /// let value = tzf.format_to_string(&time_zone);
 /// ```
@@ -618,7 +618,7 @@ impl TimeZoneFormatter {
     /// )
     /// .expect("Failed to create TimeZoneFormatter");
     ///
-    /// let time_zone = MockTimeZone::new(GmtOffset::default(), None, None, None);
+    /// let time_zone = MockTimeZone::new(Some(GmtOffset::default()), None, None, None);
     ///
     /// let _ = tzf.format(&time_zone);
     /// ```
@@ -653,7 +653,7 @@ impl TimeZoneFormatter {
     /// )
     /// .expect("Failed to create TimeZoneFormatter");
     ///
-    /// let time_zone = MockTimeZone::new(GmtOffset::default(), None, None, None);
+    /// let time_zone = MockTimeZone::new(Some(GmtOffset::default()), None, None, None);
     ///
     /// let mut buffer = String::new();
     /// tzf.format_to_write(&mut buffer, &time_zone)
@@ -689,7 +689,7 @@ impl TimeZoneFormatter {
     /// )
     /// .expect("Failed to create TimeZoneFormatter");
     ///
-    /// let time_zone = MockTimeZone::new(GmtOffset::default(), None, None, None);
+    /// let time_zone = MockTimeZone::new(Some(GmtOffset::default()), None, None, None);
     ///
     /// let _ = tzf.format_to_string(&time_zone);
     /// ```

--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -721,8 +721,9 @@ impl TimeZoneFormatter {
                 padding,
             ))
         } else {
-            debug_assert!(false, "GMT offset unknown: GMT+?");
-            Err(DateTimeFormatterError::MissingInputField)
+            Err(DateTimeFormatterError::MissingInputField(Some(
+                "gmt_offset",
+            )))
         }
     }
 
@@ -736,8 +737,9 @@ impl TimeZoneFormatter {
                 ZeroPadding::On,
             ))
         } else {
-            debug_assert!(false, "GMT offset unknown: GMT+?");
-            Err(DateTimeFormatterError::MissingInputField)
+            Err(DateTimeFormatterError::MissingInputField(Some(
+                "gmt_offset",
+            )))
         }
     }
 
@@ -745,15 +747,16 @@ impl TimeZoneFormatter {
     fn format_offset_seconds<W: fmt::Write + ?Sized>(
         sink: &mut W,
         time_zone: &impl TimeZoneInput,
-    ) -> fmt::Result {
+    ) -> Result<fmt::Result, DateTimeFormatterError> {
         if let Some(gmt_offset) = time_zone.gmt_offset() {
-            sink.write_str(&TimeZoneFormatter::format_time_segment(
+            Ok(sink.write_str(&TimeZoneFormatter::format_time_segment(
                 (gmt_offset.raw_offset_seconds() % 3600 % 60).abs() as u8,
                 ZeroPadding::On,
-            ))
+            )))
         } else {
-            debug_assert!(false, "GMT offset unknown: GMT+?");
-            Err(core::fmt::Error)
+            Err(DateTimeFormatterError::MissingInputField(Some(
+                "gmt_offset",
+            )))
         }
     }
 }
@@ -1133,7 +1136,9 @@ impl FormatTimeZone for LocalizedGmtFormat {
                             {
                                 offset_hours
                             } else {
-                                return Err(DateTimeFormatterError::MissingInputField);
+                                return Err(DateTimeFormatterError::MissingInputField(Some(
+                                    "gmt_offset",
+                                )));
                             },
                         )
                         .replace(
@@ -1143,7 +1148,9 @@ impl FormatTimeZone for LocalizedGmtFormat {
                             {
                                 offset_minutes
                             } else {
-                                return Err(DateTimeFormatterError::MissingInputField);
+                                return Err(DateTimeFormatterError::MissingInputField(Some(
+                                    "gmt_offset",
+                                )));
                             },
                         )
                         .replace(
@@ -1153,17 +1160,17 @@ impl FormatTimeZone for LocalizedGmtFormat {
                             {
                                 offset_hours
                             } else {
-                                return Err(DateTimeFormatterError::MissingInputField);
+                                return Err(DateTimeFormatterError::MissingInputField(Some(
+                                    "gmt_offset",
+                                )));
                             },
                         ),
                 ))
             };
         };
-        debug_assert!(
-            time_zone.gmt_offset().is_some(),
-            "GMT offset unknown: GMT+?"
-        );
-        Err(DateTimeFormatterError::MissingInputField)
+        Err(DateTimeFormatterError::MissingInputField(Some(
+            "gmt_offset",
+        )))
     }
 }
 
@@ -1236,7 +1243,9 @@ impl FormatTimeZone for Iso8601Format {
                     return Ok(Err(e));
                 }
             } else {
-                return Err(DateTimeFormatterError::MissingInputField);
+                return Err(DateTimeFormatterError::MissingInputField(Some(
+                    "gmt_offset",
+                )));
             }
 
             match self.minutes {
@@ -1252,7 +1261,9 @@ impl FormatTimeZone for Iso8601Format {
                             return Ok(Err(e));
                         }
                     } else {
-                        return Err(DateTimeFormatterError::MissingInputField);
+                        return Err(DateTimeFormatterError::MissingInputField(Some(
+                            "gmt_offset",
+                        )));
                     }
                 }
                 IsoMinutes::Optional => {
@@ -1269,7 +1280,9 @@ impl FormatTimeZone for Iso8601Format {
                                 return Ok(Err(e));
                             }
                         } else {
-                            return Err(DateTimeFormatterError::MissingInputField);
+                            return Err(DateTimeFormatterError::MissingInputField(Some(
+                                "gmt_offset",
+                            )));
                         }
                     }
                 }
@@ -1283,17 +1296,15 @@ impl FormatTimeZone for Iso8601Format {
                         }
                     }
                     if let Err(e) = TimeZoneFormatter::format_offset_seconds(sink, time_zone) {
-                        return Ok(Err(e));
+                        return Err(e);
                     }
                 }
             }
             return Ok(Ok(()));
         };
-        debug_assert!(
-            time_zone.gmt_offset().is_some(),
-            "GMT offset unknown: GMT+?"
-        );
-        Err(DateTimeFormatterError::MissingInputField)
+        Err(DateTimeFormatterError::MissingInputField(Some(
+            "gmt_offset",
+        )))
     }
 }
 

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -17,7 +17,9 @@ use icu_calendar::{
     provider::JapaneseErasV1Marker,
     AsCalendar, DateTime, Gregorian, Iso,
 };
+use icu_datetime::mock::time_zone::MockTimeZone;
 use icu_datetime::provider::time_zones::{MetaZoneId, TimeZoneBcp47Id};
+use icu_datetime::time_zone::TimeZoneFormatterConfig;
 use icu_datetime::{
     any::AnyDateTimeFormatter,
     mock::{parse_gregorian_from_str, parse_zoned_gregorian_from_str},
@@ -513,6 +515,51 @@ fn test_time_zone_format_configs() {
             }
         }
     }
+}
+
+#[test]
+#[cfg_attr(debug_assertions, should_panic(expected = "GMT+?"))]
+fn test_time_zone_format_gmt_offset_not_set_debug_assert_panic() {
+    let zone_provider = icu_testdata::get_provider();
+    let langid: LanguageIdentifier = "en".parse().unwrap();
+    let time_zone = MockTimeZone::new(
+        None,
+        Some(TimeZoneBcp47Id(tinystr!(8, "uslax"))),
+        Some(MetaZoneId(tinystr!(4, "ampa"))),
+        Some(tinystr!(8, "daylight")),
+    );
+    let tzf = TimeZoneFormatter::try_from_config(
+        langid.clone(),
+        TimeZoneFormatterConfig::LocalizedGMT,
+        &zone_provider,
+        &TimeZoneFormatterOptions::default(),
+    )
+    .unwrap();
+    let mut buffer = String::new();
+    tzf.format_to_write(&mut buffer, &time_zone).unwrap();
+}
+
+#[test]
+#[cfg(not(debug_assertions))]
+fn test_time_zone_format_gmt_offset_not_set_no_debug_assert() {
+    let zone_provider = icu_testdata::get_provider();
+    let langid: LanguageIdentifier = "en".parse().unwrap();
+    let time_zone = MockTimeZone::new(
+        None,
+        Some(TimeZoneBcp47Id(tinystr!(8, "uslax"))),
+        Some(MetaZoneId(tinystr!(4, "ampa"))),
+        Some(tinystr!(8, "daylight")),
+    );
+    let tzf = TimeZoneFormatter::try_from_config(
+        langid.clone(),
+        TimeZoneFormatterConfig::LocalizedGMT,
+        &zone_provider,
+        &TimeZoneFormatterOptions::default(),
+    )
+    .unwrap();
+    let mut buffer = String::new();
+    tzf.format_to_write(&mut buffer, &time_zone).unwrap();
+    assert_eq!(buffer.to_string(), "GMT+?".to_string());
 }
 
 #[test]

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -529,7 +529,7 @@ fn test_time_zone_format_gmt_offset_not_set_debug_assert_panic() {
         Some(tinystr!(8, "daylight")),
     );
     let tzf = TimeZoneFormatter::try_from_config(
-        langid.clone(),
+        langid,
         TimeZoneFormatterConfig::LocalizedGMT,
         &zone_provider,
         &TimeZoneFormatterOptions::default(),
@@ -551,7 +551,7 @@ fn test_time_zone_format_gmt_offset_not_set_no_debug_assert() {
         Some(tinystr!(8, "daylight")),
     );
     let tzf = TimeZoneFormatter::try_from_config(
-        langid.clone(),
+        langid,
         TimeZoneFormatterConfig::LocalizedGMT,
         &zone_provider,
         &TimeZoneFormatterOptions::default(),

--- a/ffi/diplomat/src/errors.rs
+++ b/ffi/diplomat/src/errors.rs
@@ -158,7 +158,7 @@ impl From<DateTimeFormatterError> for ICU4XError {
             DateTimeFormatterError::Pattern(_) => ICU4XError::DateTimeFormatPatternError,
             DateTimeFormatterError::Format(err) => err.into(),
             DateTimeFormatterError::DataProvider(err) => err.into(),
-            DateTimeFormatterError::MissingInputField => {
+            DateTimeFormatterError::MissingInputField(_) => {
                 ICU4XError::DateTimeFormatMissingInputFieldError
             }
             DateTimeFormatterError::Skeleton(_) => ICU4XError::DateTimeFormatSkeletonError,


### PR DESCRIPTION
compute metazone id from time zone id and local timestamp in `MockZonedDateTime` (https://github.com/unicode-org/icu4x/issues/2061)