### PR TITLE
Set databake version to 0.1.0 for publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "databake"
-version = "0.4.0"
+version = "0.1.0"
 dependencies = [
  "databake-derive",
  "proc-macro2",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "databake-derive"
-version = "0.4.0"
+version = "0.1.0"
 dependencies = [
  "databake",
  "proc-macro2",

--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -44,7 +44,7 @@ icu_provider = { version = "0.6", path = "../../provider/core", features = ["mac
 icu_locid = { version = "0.6", path = "../../components/locid" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 zerovec = { version = "0.7", path = "../../utils/zerovec", default-features = false, features = ["derive"] }
-databake = { version = "0.4", path = "../../utils/databake", optional = true, features = ["derive"] }
+databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -46,7 +46,7 @@ serde-tuple-vec-map = { version = "1.0", optional = true }
 smallvec = "1.6"
 displaydoc = { version = "0.2.3", default-features = false }
 either = { version = "1.6.1", default-features = false }
-databake = { path = "../../utils/databake", optional = true, features = ["derive"]}
+databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"]}
 fixed_decimal = { version = "0.3", path = "../../utils/fixed_decimal" }
 
 [dev-dependencies]

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -37,7 +37,7 @@ fixed_decimal = { version = "0.3", path = "../../utils/fixed_decimal" }
 writeable = { version = "0.4", path = "../../utils/writeable" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 displaydoc = { version = "0.2.3", default-features = false }
-databake = { path = "../../utils/databake", optional = true, features = ["derive"]}
+databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"]}
 
 [dev-dependencies]
 criterion = "0.3"

--- a/components/list/Cargo.toml
+++ b/components/list/Cargo.toml
@@ -28,7 +28,7 @@ zerovec = { version = "0.7", path = "../../utils/zerovec", features = ["yoke"] }
 deduplicating_array = { version = "0.1", path = "../../utils/deduplicating_array", optional = true }
 regex-automata = { version = "0.2", default-features = false }
 writeable = { version = "0.4", path = "../../utils/writeable" }
-databake = { version = "0.4", path = "../../utils/databake", optional = true, features = ["derive"]}
+databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"]}
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/components/locale_canonicalizer/Cargo.toml
+++ b/components/locale_canonicalizer/Cargo.toml
@@ -36,7 +36,7 @@ icu_provider = { version = "0.6", path = "../../provider/core", features = ["mac
 serde = { version = "1.0", features = ["derive", "alloc"], optional = true, default-features = false }
 tinystr = { path = "../../utils/tinystr", version = "0.6.0", default-features = false, features = ["alloc", "zerovec"] }
 zerovec = { path = "../../utils/zerovec", version = "0.7.0", features = ["yoke"] }
-databake = { version = "0.4", path = "../../utils/databake", optional = true, features = ["derive"] }
+databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -40,7 +40,7 @@ writeable = { version = "0.4", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
 zerovec = { version = "0.7", path = "../../utils/zerovec", optional = true }
 litemap = { version = "0.4", path = "../../utils/litemap" }
-databake = { version = "0.4", path = "../../utils/databake", optional = true, features = ["derive"]}
+databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"]}
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -38,7 +38,7 @@ icu_locid = { version = "0.6", path = "../locid" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 displaydoc = { version = "0.2.3", default-features = false }
 zerovec = { version = "0.7", path = "../../utils/zerovec", features = ["yoke"] }
-databake = { version = "0.4", path = "../../utils/databake", optional = true, features = ["derive"]}
+databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"]}
 
 [dev-dependencies]
 criterion = "0.3"

--- a/components/properties/Cargo.toml
+++ b/components/properties/Cargo.toml
@@ -39,7 +39,7 @@ icu_uniset = { version = "0.5", path = "../../utils/uniset"}
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 zerovec = { version = "0.7", path = "../../utils/zerovec", features = ["derive"] }
 unicode-bidi = { version = "0.3.8", optional = true, default-features = false }
-databake = { version = "0.4", path = "../../utils/databake", optional = true, features = ["derive"]}
+databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"]}
 
 [dev-dependencies]
 icu = { path = "../icu", default-features = false }

--- a/experimental/casemapping/Cargo.toml
+++ b/experimental/casemapping/Cargo.toml
@@ -31,7 +31,7 @@ icu_uniset = { version = "0.5", path = "../../utils/uniset" }
 yoke = { version = "0.6.0", path = "../../utils/yoke", features = ["derive"] }
 zerovec = { version = "0.7", path = "../../utils/zerovec", features = ["yoke"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
-databake = { path = "../../utils/databake", optional = true, features = ["derive"]}
+databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"]}
 
 [lib]
 path = "src/lib.rs"

--- a/experimental/char16trie/Cargo.toml
+++ b/experimental/char16trie/Cargo.toml
@@ -28,7 +28,7 @@ include = [
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 zerovec = { version = "0.7", path = "../../utils/zerovec", features = ["yoke"] }
-databake = { version = "0.4", path = "../../utils/databake", optional = true, features = ["derive"] }
+databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../../utils/zerofrom", features = ["derive"]  }
 
 [dev-dependencies]

--- a/experimental/collator/Cargo.toml
+++ b/experimental/collator/Cargo.toml
@@ -45,7 +45,7 @@ serde = { version = "1.0", default-features = false, features = ["derive", "allo
 zerovec = { version = "0.7", path = "../../utils/zerovec", features = ["serde"] }
 utf8_iter = "1.0"
 utf16_iter = "1.0"
-databake = { version = "0.4", path = "../../utils/databake", optional = true, features = ["derive"] }
+databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../../utils/zerofrom" }
 
 [dev-dependencies]

--- a/experimental/normalizer/Cargo.toml
+++ b/experimental/normalizer/Cargo.toml
@@ -42,7 +42,7 @@ icu_uniset = { version = "0.5", path = "../../utils/uniset" }
 icu_properties = { version = "0.6", path = "../../components/properties" }
 utf8_iter = "1.0"
 utf16_iter = "1.0"
-databake = { version = "0.4", path = "../../utils/databake", optional = true, features = ["derive"] }
+databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../../utils/zerofrom" }
 icu_char16trie = { version = "0.1", path = "../../experimental/char16trie" }
 

--- a/experimental/segmenter/Cargo.toml
+++ b/experimental/segmenter/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "1.0", default-features = false, features = ["derive", "allo
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
 zerovec = { version = "0.7", path = "../../utils/zerovec", features = ["yoke"] }
-databake = { version = "0.4", path = "../../utils/databake", optional = true, features = ["derive"] }
+databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"] }
 ndarray = { git = "https://github.com/rust-ndarray/ndarray", rev = "31244100631382bb8ee30721872a928bfdf07f44", default-features = false, optional = true, features = ["serde"] }
 unicode-segmentation = { version = "1.3.0", optional = true }
 num-traits = { version = "0.2", optional = true }

--- a/provider/adapters/Cargo.toml
+++ b/provider/adapters/Cargo.toml
@@ -29,7 +29,7 @@ icu_locid = { version = "0.6.0", path = "../../components/locid", features = ["z
 yoke = { version = "0.6.0", path = "../../utils/yoke" }
 zerovec = { path = "../../utils/zerovec", features = ["yoke"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
-databake = { version = "0.4", path = "../../utils/databake", optional = true, features = ["derive"]}
+databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"]}
 tinystr = { path = "../../utils/tinystr", features = ["zerovec"] }
 
 [dev-dependencies]

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -73,7 +73,7 @@ postcard = { version = "1.0.0-alpha.4", default-features = false, optional = tru
 # Datagen
 dhat = { version = "0.3.0", optional = true }
 erased-serde = { version = "0.3", optional = true, default-features = false, features = ["alloc"] }
-databake = { version = "0.4.0", path = "../../utils/databake", optional = true, features = ["derive"] }
+databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -72,7 +72,7 @@ tinystr = { path = "../../utils/tinystr", version = "0.6", features = ["alloc", 
 toml = "0.5"
 zerovec = { version = "0.7", path = "../../utils/zerovec", features = ["serde", "yoke"] }
 quote = "1.0.9"
-databake = { version = "0.4", path = "../../utils/databake"}
+databake = { version = "0.1.0", path = "../../utils/databake"}
 proc-macro2 = "1.0"
 crlify = { version = "1", path = "../../utils/crlify"}
 syn = {version = "1.0", features = ["parsing"] }

--- a/utils/codepointtrie/Cargo.toml
+++ b/utils/codepointtrie/Cargo.toml
@@ -39,7 +39,7 @@ zerofrom = { version = "0.1.0", path = "../zerofrom", features = ["derive"] }
 zerovec = { version = "0.7", path = "../zerovec", features = ["yoke"] }
 
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
-databake = { version = "0.4", path = "../../utils/databake", features = ["derive"], optional = true }
+databake = { version = "0.1.0", path = "../../utils/databake", features = ["derive"], optional = true }
 
 [dev-dependencies]
 postcard = { version = "1.0.0-alpha.4", features = ["alloc"] }

--- a/utils/databake/Cargo.toml
+++ b/utils/databake/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "databake"
 description = "Trait that lets structs represent themselves as (const) Rust expressions"
-version = "0.4.0"
+version = "0.1.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"
@@ -34,4 +34,4 @@ derive = ["databake-derive"]
 proc-macro2 = "1.0.27"
 quote = "1.0.9"
 syn = { version = "1.0.73", features = ["derive", "fold"] }
-databake-derive = { version = "0.4.0", path = "./derive", optional = true}
+databake-derive = { version = "0.1.0", path = "./derive", optional = true}

--- a/utils/databake/derive/Cargo.toml
+++ b/utils/databake/derive/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "databake-derive"
 description = "Custom derive for the databake crate"
-version = "0.4.0"
+version = "0.1.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"
@@ -36,4 +36,4 @@ syn = { version = "1.0.73", features = ["derive", "fold"] }
 synstructure = "0.12.4"
 
 [dev-dependencies]
-databake = { version = "0.4.0", path = "..", features = ["derive"]}
+databake = { version = "0.1.0", path = "..", features = ["derive"]}

--- a/utils/tinystr/Cargo.toml
+++ b/utils/tinystr/Cargo.toml
@@ -29,7 +29,7 @@ all-features = true
 displaydoc = { version = "0.2.3", default-features = false }
 serde = { version = "1.0.123", optional = true, default-features = false, features = ["alloc"] }
 zerovec = { version = "0.7", path = "../../utils/zerovec", optional = true }
-databake = { version = "0.4", path = "../../utils/databake", optional = true }
+databake = { version = "0.1.0", path = "../../utils/databake", optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }

--- a/utils/uniset/Cargo.toml
+++ b/utils/uniset/Cargo.toml
@@ -38,7 +38,7 @@ displaydoc = { version = "0.2.3", default-features = false }
 yoke = { version = "0.6.0", path = "../yoke", features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../zerofrom", features = ["derive"] }
 zerovec = { version = "0.7", path = "../zerovec", features = ["yoke"] }
-databake = { version = "0.4", path = "../../utils/databake", features = ["derive"], optional = true }
+databake = { version = "0.1.0", path = "../../utils/databake", features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1.0", optional = true, default-features = false, features =
 yoke = { version = "0.6.0", path = "../yoke", optional = true }
 zerofrom = { version = "0.1.0", path = "../zerofrom" }
 zerovec-derive = {version = "0.6.0", path = "./derive", optional = true}
-databake = { version = "0.4", path = "../../utils/databake", features = ["derive"], optional = true }
+databake = { version = "0.1.0", path = "../../utils/databake", features = ["derive"], optional = true }
 
 [dev-dependencies]
 icu_benchmark_macros = { version = "0.6", path = "../../tools/benchmark/macros" }


### PR DESCRIPTION
We should get the name on crates.io soon, and start at 0.1.0. We can later update the published `crabbake` crate to point here instead.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->