### PR TITLE
Enable license header check for C & C++ files

### DIFF
--- a/tools/scripts/tidy.toml
+++ b/tools/scripts/tidy.toml
@@ -25,7 +25,7 @@ script = '''
 exit_on_error true
 
 # Check files matching these patterns.
-glob_pattern_array = array "./**/*.rs" "./**/*.yml" "./**/*.toml" "./**/*.rst" "./**/*.bat"
+glob_pattern_array = array "./**/*.rs" "./**/*.yml" "./**/*.toml" "./**/*.rst" "./**/*.bat" "./**/*.c" "./**/*.cpp"
 
 # Skip the files matching these patterns.
 glob_skip_pattern_array = array "**/target/**/*.rs" "ffi/diplomat/cpp/docs/**/*" "ffi/diplomat/wasm/docs/**/*" "**/node_modules/**/*" "provider/testdata/data/**/*"


### PR DESCRIPTION
Enable `*.c` and `*.cpp` to cover the sample code, e.g in
`ffi/diplomat/cpp/examples`. `*.h` and `*.hpp` are not checked because the
headers generated via diplomat do not contain ICU4X license header.