### PR TITLE
Add FFI for UAX 29 Segmenters

### DIFF
--- a/ffi/diplomat/c/include/ICU4XGraphemeClusterBreakIteratorLatin1.h
+++ b/ffi/diplomat/c/include/ICU4XGraphemeClusterBreakIteratorLatin1.h
@@ -1,0 +1,21 @@
+#ifndef ICU4XGraphemeClusterBreakIteratorLatin1_H
+#define ICU4XGraphemeClusterBreakIteratorLatin1_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XGraphemeClusterBreakIteratorLatin1 ICU4XGraphemeClusterBreakIteratorLatin1;
+
+int32_t ICU4XGraphemeClusterBreakIteratorLatin1_next(ICU4XGraphemeClusterBreakIteratorLatin1* self);
+void ICU4XGraphemeClusterBreakIteratorLatin1_destroy(ICU4XGraphemeClusterBreakIteratorLatin1* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/c/include/ICU4XGraphemeClusterBreakIteratorUtf16.h
+++ b/ffi/diplomat/c/include/ICU4XGraphemeClusterBreakIteratorUtf16.h
@@ -1,0 +1,21 @@
+#ifndef ICU4XGraphemeClusterBreakIteratorUtf16_H
+#define ICU4XGraphemeClusterBreakIteratorUtf16_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XGraphemeClusterBreakIteratorUtf16 ICU4XGraphemeClusterBreakIteratorUtf16;
+
+int32_t ICU4XGraphemeClusterBreakIteratorUtf16_next(ICU4XGraphemeClusterBreakIteratorUtf16* self);
+void ICU4XGraphemeClusterBreakIteratorUtf16_destroy(ICU4XGraphemeClusterBreakIteratorUtf16* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/c/include/ICU4XGraphemeClusterBreakIteratorUtf8.h
+++ b/ffi/diplomat/c/include/ICU4XGraphemeClusterBreakIteratorUtf8.h
@@ -1,0 +1,21 @@
+#ifndef ICU4XGraphemeClusterBreakIteratorUtf8_H
+#define ICU4XGraphemeClusterBreakIteratorUtf8_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XGraphemeClusterBreakIteratorUtf8 ICU4XGraphemeClusterBreakIteratorUtf8;
+
+int32_t ICU4XGraphemeClusterBreakIteratorUtf8_next(ICU4XGraphemeClusterBreakIteratorUtf8* self);
+void ICU4XGraphemeClusterBreakIteratorUtf8_destroy(ICU4XGraphemeClusterBreakIteratorUtf8* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/c/include/ICU4XGraphemeClusterBreakSegmenter.h
+++ b/ffi/diplomat/c/include/ICU4XGraphemeClusterBreakSegmenter.h
@@ -1,0 +1,32 @@
+#ifndef ICU4XGraphemeClusterBreakSegmenter_H
+#define ICU4XGraphemeClusterBreakSegmenter_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XGraphemeClusterBreakSegmenter ICU4XGraphemeClusterBreakSegmenter;
+#include "ICU4XDataProvider.h"
+#include "diplomat_result_box_ICU4XGraphemeClusterBreakSegmenter_ICU4XError.h"
+#include "ICU4XGraphemeClusterBreakIteratorUtf8.h"
+#include "ICU4XGraphemeClusterBreakIteratorUtf16.h"
+#include "ICU4XGraphemeClusterBreakIteratorLatin1.h"
+
+diplomat_result_box_ICU4XGraphemeClusterBreakSegmenter_ICU4XError ICU4XGraphemeClusterBreakSegmenter_try_new(const ICU4XDataProvider* provider);
+
+ICU4XGraphemeClusterBreakIteratorUtf8* ICU4XGraphemeClusterBreakSegmenter_segment_utf8(const ICU4XGraphemeClusterBreakSegmenter* self, const char* input_data, size_t input_len);
+
+ICU4XGraphemeClusterBreakIteratorUtf16* ICU4XGraphemeClusterBreakSegmenter_segment_utf16(const ICU4XGraphemeClusterBreakSegmenter* self, const uint16_t* input_data, size_t input_len);
+
+ICU4XGraphemeClusterBreakIteratorLatin1* ICU4XGraphemeClusterBreakSegmenter_segment_latin1(const ICU4XGraphemeClusterBreakSegmenter* self, const uint8_t* input_data, size_t input_len);
+void ICU4XGraphemeClusterBreakSegmenter_destroy(ICU4XGraphemeClusterBreakSegmenter* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/c/include/ICU4XSentenceBreakIteratorLatin1.h
+++ b/ffi/diplomat/c/include/ICU4XSentenceBreakIteratorLatin1.h
@@ -1,0 +1,21 @@
+#ifndef ICU4XSentenceBreakIteratorLatin1_H
+#define ICU4XSentenceBreakIteratorLatin1_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XSentenceBreakIteratorLatin1 ICU4XSentenceBreakIteratorLatin1;
+
+int32_t ICU4XSentenceBreakIteratorLatin1_next(ICU4XSentenceBreakIteratorLatin1* self);
+void ICU4XSentenceBreakIteratorLatin1_destroy(ICU4XSentenceBreakIteratorLatin1* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/c/include/ICU4XSentenceBreakIteratorUtf16.h
+++ b/ffi/diplomat/c/include/ICU4XSentenceBreakIteratorUtf16.h
@@ -1,0 +1,21 @@
+#ifndef ICU4XSentenceBreakIteratorUtf16_H
+#define ICU4XSentenceBreakIteratorUtf16_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XSentenceBreakIteratorUtf16 ICU4XSentenceBreakIteratorUtf16;
+
+int32_t ICU4XSentenceBreakIteratorUtf16_next(ICU4XSentenceBreakIteratorUtf16* self);
+void ICU4XSentenceBreakIteratorUtf16_destroy(ICU4XSentenceBreakIteratorUtf16* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/c/include/ICU4XSentenceBreakIteratorUtf8.h
+++ b/ffi/diplomat/c/include/ICU4XSentenceBreakIteratorUtf8.h
@@ -1,0 +1,21 @@
+#ifndef ICU4XSentenceBreakIteratorUtf8_H
+#define ICU4XSentenceBreakIteratorUtf8_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XSentenceBreakIteratorUtf8 ICU4XSentenceBreakIteratorUtf8;
+
+int32_t ICU4XSentenceBreakIteratorUtf8_next(ICU4XSentenceBreakIteratorUtf8* self);
+void ICU4XSentenceBreakIteratorUtf8_destroy(ICU4XSentenceBreakIteratorUtf8* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/c/include/ICU4XSentenceBreakSegmenter.h
+++ b/ffi/diplomat/c/include/ICU4XSentenceBreakSegmenter.h
@@ -1,0 +1,32 @@
+#ifndef ICU4XSentenceBreakSegmenter_H
+#define ICU4XSentenceBreakSegmenter_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XSentenceBreakSegmenter ICU4XSentenceBreakSegmenter;
+#include "ICU4XDataProvider.h"
+#include "diplomat_result_box_ICU4XSentenceBreakSegmenter_ICU4XError.h"
+#include "ICU4XSentenceBreakIteratorUtf8.h"
+#include "ICU4XSentenceBreakIteratorUtf16.h"
+#include "ICU4XSentenceBreakIteratorLatin1.h"
+
+diplomat_result_box_ICU4XSentenceBreakSegmenter_ICU4XError ICU4XSentenceBreakSegmenter_try_new(const ICU4XDataProvider* provider);
+
+ICU4XSentenceBreakIteratorUtf8* ICU4XSentenceBreakSegmenter_segment_utf8(const ICU4XSentenceBreakSegmenter* self, const char* input_data, size_t input_len);
+
+ICU4XSentenceBreakIteratorUtf16* ICU4XSentenceBreakSegmenter_segment_utf16(const ICU4XSentenceBreakSegmenter* self, const uint16_t* input_data, size_t input_len);
+
+ICU4XSentenceBreakIteratorLatin1* ICU4XSentenceBreakSegmenter_segment_latin1(const ICU4XSentenceBreakSegmenter* self, const uint8_t* input_data, size_t input_len);
+void ICU4XSentenceBreakSegmenter_destroy(ICU4XSentenceBreakSegmenter* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/c/include/ICU4XWordBreakIteratorLatin1.h
+++ b/ffi/diplomat/c/include/ICU4XWordBreakIteratorLatin1.h
@@ -1,0 +1,21 @@
+#ifndef ICU4XWordBreakIteratorLatin1_H
+#define ICU4XWordBreakIteratorLatin1_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XWordBreakIteratorLatin1 ICU4XWordBreakIteratorLatin1;
+
+int32_t ICU4XWordBreakIteratorLatin1_next(ICU4XWordBreakIteratorLatin1* self);
+void ICU4XWordBreakIteratorLatin1_destroy(ICU4XWordBreakIteratorLatin1* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/c/include/ICU4XWordBreakIteratorUtf16.h
+++ b/ffi/diplomat/c/include/ICU4XWordBreakIteratorUtf16.h
@@ -1,0 +1,21 @@
+#ifndef ICU4XWordBreakIteratorUtf16_H
+#define ICU4XWordBreakIteratorUtf16_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XWordBreakIteratorUtf16 ICU4XWordBreakIteratorUtf16;
+
+int32_t ICU4XWordBreakIteratorUtf16_next(ICU4XWordBreakIteratorUtf16* self);
+void ICU4XWordBreakIteratorUtf16_destroy(ICU4XWordBreakIteratorUtf16* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/c/include/ICU4XWordBreakIteratorUtf8.h
+++ b/ffi/diplomat/c/include/ICU4XWordBreakIteratorUtf8.h
@@ -1,0 +1,21 @@
+#ifndef ICU4XWordBreakIteratorUtf8_H
+#define ICU4XWordBreakIteratorUtf8_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XWordBreakIteratorUtf8 ICU4XWordBreakIteratorUtf8;
+
+int32_t ICU4XWordBreakIteratorUtf8_next(ICU4XWordBreakIteratorUtf8* self);
+void ICU4XWordBreakIteratorUtf8_destroy(ICU4XWordBreakIteratorUtf8* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/c/include/ICU4XWordBreakSegmenter.h
+++ b/ffi/diplomat/c/include/ICU4XWordBreakSegmenter.h
@@ -1,0 +1,32 @@
+#ifndef ICU4XWordBreakSegmenter_H
+#define ICU4XWordBreakSegmenter_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XWordBreakSegmenter ICU4XWordBreakSegmenter;
+#include "ICU4XDataProvider.h"
+#include "diplomat_result_box_ICU4XWordBreakSegmenter_ICU4XError.h"
+#include "ICU4XWordBreakIteratorUtf8.h"
+#include "ICU4XWordBreakIteratorUtf16.h"
+#include "ICU4XWordBreakIteratorLatin1.h"
+
+diplomat_result_box_ICU4XWordBreakSegmenter_ICU4XError ICU4XWordBreakSegmenter_try_new(const ICU4XDataProvider* provider);
+
+ICU4XWordBreakIteratorUtf8* ICU4XWordBreakSegmenter_segment_utf8(const ICU4XWordBreakSegmenter* self, const char* input_data, size_t input_len);
+
+ICU4XWordBreakIteratorUtf16* ICU4XWordBreakSegmenter_segment_utf16(const ICU4XWordBreakSegmenter* self, const uint16_t* input_data, size_t input_len);
+
+ICU4XWordBreakIteratorLatin1* ICU4XWordBreakSegmenter_segment_latin1(const ICU4XWordBreakSegmenter* self, const uint8_t* input_data, size_t input_len);
+void ICU4XWordBreakSegmenter_destroy(ICU4XWordBreakSegmenter* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/c/include/diplomat_result_box_ICU4XGraphemeClusterBreakSegmenter_ICU4XError.h
+++ b/ffi/diplomat/c/include/diplomat_result_box_ICU4XGraphemeClusterBreakSegmenter_ICU4XError.h
@@ -1,0 +1,24 @@
+#ifndef diplomat_result_box_ICU4XGraphemeClusterBreakSegmenter_ICU4XError_H
+#define diplomat_result_box_ICU4XGraphemeClusterBreakSegmenter_ICU4XError_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+typedef struct ICU4XGraphemeClusterBreakSegmenter ICU4XGraphemeClusterBreakSegmenter;
+#include "ICU4XError.h"
+typedef struct diplomat_result_box_ICU4XGraphemeClusterBreakSegmenter_ICU4XError {
+    union {
+        ICU4XGraphemeClusterBreakSegmenter* ok;
+        ICU4XError err;
+    };
+    bool is_ok;
+} diplomat_result_box_ICU4XGraphemeClusterBreakSegmenter_ICU4XError;
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/c/include/diplomat_result_box_ICU4XSentenceBreakSegmenter_ICU4XError.h
+++ b/ffi/diplomat/c/include/diplomat_result_box_ICU4XSentenceBreakSegmenter_ICU4XError.h
@@ -1,0 +1,24 @@
+#ifndef diplomat_result_box_ICU4XSentenceBreakSegmenter_ICU4XError_H
+#define diplomat_result_box_ICU4XSentenceBreakSegmenter_ICU4XError_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+typedef struct ICU4XSentenceBreakSegmenter ICU4XSentenceBreakSegmenter;
+#include "ICU4XError.h"
+typedef struct diplomat_result_box_ICU4XSentenceBreakSegmenter_ICU4XError {
+    union {
+        ICU4XSentenceBreakSegmenter* ok;
+        ICU4XError err;
+    };
+    bool is_ok;
+} diplomat_result_box_ICU4XSentenceBreakSegmenter_ICU4XError;
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/c/include/diplomat_result_box_ICU4XWordBreakSegmenter_ICU4XError.h
+++ b/ffi/diplomat/c/include/diplomat_result_box_ICU4XWordBreakSegmenter_ICU4XError.h
@@ -1,0 +1,24 @@
+#ifndef diplomat_result_box_ICU4XWordBreakSegmenter_ICU4XError_H
+#define diplomat_result_box_ICU4XWordBreakSegmenter_ICU4XError_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+typedef struct ICU4XWordBreakSegmenter ICU4XWordBreakSegmenter;
+#include "ICU4XError.h"
+typedef struct diplomat_result_box_ICU4XWordBreakSegmenter_ICU4XError {
+    union {
+        ICU4XWordBreakSegmenter* ok;
+        ICU4XError err;
+    };
+    bool is_ok;
+} diplomat_result_box_ICU4XWordBreakSegmenter_ICU4XError;
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/cpp/docs/source/index.rst
+++ b/ffi/diplomat/cpp/docs/source/index.rst
@@ -16,7 +16,10 @@ Documentation
    properties_maps_ffi
    properties_sets_ffi
    provider_ffi
+   segmenter_grapheme_ffi
    segmenter_line_ffi
+   segmenter_sentence_ffi
+   segmenter_word_ffi
 
 Indices and tables
 ==================

--- a/ffi/diplomat/cpp/docs/source/segmenter_grapheme_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/segmenter_grapheme_ffi.rst
@@ -21,7 +21,7 @@
 
 .. cpp:class:: ICU4XGraphemeClusterBreakSegmenter
 
-    An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
+    An ICU4X grapheme-cluster-break segmenter, capable of finding grapheme cluster breakpoints in strings.
     See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html>`__ for more information.
 
     .. cpp:function:: static diplomat::result<ICU4XGraphemeClusterBreakSegmenter, ICU4XError> try_new(const ICU4XDataProvider& provider)

--- a/ffi/diplomat/cpp/docs/source/segmenter_grapheme_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/segmenter_grapheme_ffi.rst
@@ -1,0 +1,45 @@
+``segmenter_grapheme::ffi``
+===========================
+
+.. cpp:class:: ICU4XGraphemeClusterBreakIteratorLatin1
+
+    .. cpp:function:: int32_t next()
+
+        Finds the next breakpoint. Returns -1 if at the end of the string or if the index is out of range of a 32-bit signed integer.
+
+.. cpp:class:: ICU4XGraphemeClusterBreakIteratorUtf16
+
+    .. cpp:function:: int32_t next()
+
+        Finds the next breakpoint. Returns -1 if at the end of the string or if the index is out of range of a 32-bit signed integer.
+
+.. cpp:class:: ICU4XGraphemeClusterBreakIteratorUtf8
+
+    .. cpp:function:: int32_t next()
+
+        Finds the next breakpoint. Returns -1 if at the end of the string or if the index is out of range of a 32-bit signed integer.
+
+.. cpp:class:: ICU4XGraphemeClusterBreakSegmenter
+
+    An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
+    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html>`__ for more information.
+
+    .. cpp:function:: static diplomat::result<ICU4XGraphemeClusterBreakSegmenter, ICU4XError> try_new(const ICU4XDataProvider& provider)
+
+        Construct an :cpp:class:`ICU4XGraphemeClusterBreakSegmenter`.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.try_new>`__ for more information.
+
+    .. cpp:function:: ICU4XGraphemeClusterBreakIteratorUtf8 segment_utf8(const std::string_view input) const
+
+        Segments a UTF-8 string.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_str>`__ for more information.
+
+    .. cpp:function:: ICU4XGraphemeClusterBreakIteratorUtf16 segment_utf16(const diplomat::span<uint16_t> input) const
+
+        Segments a UTF-16 string.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_utf16>`__ for more information.
+
+    .. cpp:function:: ICU4XGraphemeClusterBreakIteratorLatin1 segment_latin1(const diplomat::span<uint8_t> input) const
+
+        Segments a Latin-1 string.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_latin1>`__ for more information.

--- a/ffi/diplomat/cpp/docs/source/segmenter_sentence_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/segmenter_sentence_ffi.rst
@@ -1,0 +1,45 @@
+``segmenter_sentence::ffi``
+===========================
+
+.. cpp:class:: ICU4XSentenceBreakIteratorLatin1
+
+    .. cpp:function:: int32_t next()
+
+        Finds the next breakpoint. Returns -1 if at the end of the string or if the index is out of range of a 32-bit signed integer.
+
+.. cpp:class:: ICU4XSentenceBreakIteratorUtf16
+
+    .. cpp:function:: int32_t next()
+
+        Finds the next breakpoint. Returns -1 if at the end of the string or if the index is out of range of a 32-bit signed integer.
+
+.. cpp:class:: ICU4XSentenceBreakIteratorUtf8
+
+    .. cpp:function:: int32_t next()
+
+        Finds the next breakpoint. Returns -1 if at the end of the string or if the index is out of range of a 32-bit signed integer.
+
+.. cpp:class:: ICU4XSentenceBreakSegmenter
+
+    An ICU4X sentence-break segmenter, capable of finding sentence breakpoints in strings.
+    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.SentenceBreakSegmenter.html>`__ for more information.
+
+    .. cpp:function:: static diplomat::result<ICU4XSentenceBreakSegmenter, ICU4XError> try_new(const ICU4XDataProvider& provider)
+
+        Construct an :cpp:class:`ICU4XSentenceBreakSegmenter`.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.SentenceBreakSegmenter.html#method.try_new>`__ for more information.
+
+    .. cpp:function:: ICU4XSentenceBreakIteratorUtf8 segment_utf8(const std::string_view input) const
+
+        Segments a UTF-8 string.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.SentenceBreakSegmenter.html#method.segment_str>`__ for more information.
+
+    .. cpp:function:: ICU4XSentenceBreakIteratorUtf16 segment_utf16(const diplomat::span<uint16_t> input) const
+
+        Segments a UTF-16 string.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.SentenceBreakSegmenter.html#method.segment_utf16>`__ for more information.
+
+    .. cpp:function:: ICU4XSentenceBreakIteratorLatin1 segment_latin1(const diplomat::span<uint8_t> input) const
+
+        Segments a Latin-1 string.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.SentenceBreakSegmenter.html#method.segment_latin1>`__ for more information.

--- a/ffi/diplomat/cpp/docs/source/segmenter_word_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/segmenter_word_ffi.rst
@@ -1,0 +1,45 @@
+``segmenter_word::ffi``
+=======================
+
+.. cpp:class:: ICU4XWordBreakIteratorLatin1
+
+    .. cpp:function:: int32_t next()
+
+        Finds the next breakpoint. Returns -1 if at the end of the string or if the index is out of range of a 32-bit signed integer.
+
+.. cpp:class:: ICU4XWordBreakIteratorUtf16
+
+    .. cpp:function:: int32_t next()
+
+        Finds the next breakpoint. Returns -1 if at the end of the string or if the index is out of range of a 32-bit signed integer.
+
+.. cpp:class:: ICU4XWordBreakIteratorUtf8
+
+    .. cpp:function:: int32_t next()
+
+        Finds the next breakpoint. Returns -1 if at the end of the string or if the index is out of range of a 32-bit signed integer.
+
+.. cpp:class:: ICU4XWordBreakSegmenter
+
+    An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
+    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.WordBreakSegmenter.html>`__ for more information.
+
+    .. cpp:function:: static diplomat::result<ICU4XWordBreakSegmenter, ICU4XError> try_new(const ICU4XDataProvider& provider)
+
+        Construct an :cpp:class:`ICU4XWordBreakSegmenter`.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.WordBreakSegmenter.html#method.try_new>`__ for more information.
+
+    .. cpp:function:: ICU4XWordBreakIteratorUtf8 segment_utf8(const std::string_view input) const
+
+        Segments a UTF-8 string.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.WordBreakSegmenter.html#method.segment_str>`__ for more information.
+
+    .. cpp:function:: ICU4XWordBreakIteratorUtf16 segment_utf16(const diplomat::span<uint16_t> input) const
+
+        Segments a UTF-16 string.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.WordBreakSegmenter.html#method.segment_utf16>`__ for more information.
+
+    .. cpp:function:: ICU4XWordBreakIteratorLatin1 segment_latin1(const diplomat::span<uint8_t> input) const
+
+        Segments a Latin-1 string.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.WordBreakSegmenter.html#method.segment_latin1>`__ for more information.

--- a/ffi/diplomat/cpp/examples/segmenter/test.cpp
+++ b/ffi/diplomat/cpp/examples/segmenter/test.cpp
@@ -3,7 +3,10 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 #include "../../include/ICU4XDataProvider.hpp"
+#include "../../include/ICU4XGraphemeClusterBreakSegmenter.hpp"
 #include "../../include/ICU4XLineBreakSegmenter.hpp"
+#include "../../include/ICU4XSentenceBreakSegmenter.hpp"
+#include "../../include/ICU4XWordBreakSegmenter.hpp"
 
 #include <iostream>
 #include <string_view>
@@ -48,6 +51,42 @@ void test_line(const std::string_view& str) {
     iterate_breakpoints(iterator);
 }
 
+void test_grapheme(const std::string_view& str) {
+    const auto provider = ICU4XDataProvider::create_test();
+    const auto segmenter = ICU4XWordBreakSegmenter::try_new(provider).ok().value();
+    cout << "Finding grapheme cluster breakpoints in string:" << endl
+         << str << endl;
+    print_ruler(str.size());
+
+    cout << "Grapheme cluster breakpoints:";
+    auto iterator = segmenter.segment_utf8(str);
+    iterate_breakpoints(iterator);
+}
+
+void test_word(const std::string_view& str) {
+    const auto provider = ICU4XDataProvider::create_test();
+    const auto segmenter = ICU4XGraphemeClusterBreakSegmenter::try_new(provider).ok().value();
+    cout << "Finding word breakpoints in string:" << endl
+         << str << endl;
+    print_ruler(str.size());
+
+    cout << "Word breakpoints:";
+    auto iterator = segmenter.segment_utf8(str);
+    iterate_breakpoints(iterator);
+}
+
+void test_sentence(const std::string_view& str) {
+    const auto provider = ICU4XDataProvider::create_test();
+    const auto segmenter = ICU4XSentenceBreakSegmenter::try_new(provider).ok().value();
+    cout << "Finding sentence breakpoints in string:" << endl
+         << str << endl;
+    print_ruler(str.size());
+
+    cout << "Sentence breakpoints:";
+    auto iterator = segmenter.segment_utf8(str);
+    iterate_breakpoints(iterator);
+}
+
 int main(int argc, char* argv[]) {
     std::string_view str;
     if (argc >= 2) {
@@ -59,5 +98,13 @@ int main(int argc, char* argv[]) {
     test_line(str);
     cout << endl;
 
+    test_grapheme(str);
+    cout << endl;
+
+    test_word(str);
+    cout << endl;
+
+    test_sentence(str);
+    cout << endl;
     return 0;
 }

--- a/ffi/diplomat/cpp/examples/segmenter/test.cpp
+++ b/ffi/diplomat/cpp/examples/segmenter/test.cpp
@@ -2,16 +2,53 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#include "../../include/ICU4XLineBreakSegmenter.hpp"
 #include "../../include/ICU4XDataProvider.hpp"
+#include "../../include/ICU4XLineBreakSegmenter.hpp"
 
 #include <iostream>
 #include <string_view>
 
-int main(int argc, char* argv[]) {
-    ICU4XDataProvider provider = ICU4XDataProvider::create_test();
-    ICU4XLineBreakSegmenter segmenter = ICU4XLineBreakSegmenter::try_new(provider).ok().value();
+using std::cout;
+using std::endl;
 
+void print_ruler(size_t str_len) {
+    for (size_t i = 0; i < str_len; i++) {
+        if (i % 10 == 0) {
+            cout << "0";
+        } else if (i % 5 == 0) {
+            cout << "5";
+        } else {
+            cout << ".";
+        }
+    }
+    cout << endl;
+}
+
+template <typename Iterator>
+void iterate_breakpoints(Iterator& iterator) {
+    while (true) {
+        int32_t breakpoint = iterator.next();
+        if (breakpoint == -1) {
+            break;
+        }
+        cout << " " << breakpoint;
+    }
+    cout << endl;
+}
+
+void test_line(const std::string_view& str) {
+    const auto provider = ICU4XDataProvider::create_test();
+    const auto segmenter = ICU4XLineBreakSegmenter::try_new(provider).ok().value();
+    cout << "Finding line breakpoints in string:" << endl
+         << str << endl;
+    print_ruler(str.size());
+
+    cout << "Line breakpoints:";
+    auto iterator = segmenter.segment_utf8(str);
+    iterate_breakpoints(iterator);
+}
+
+int main(int argc, char* argv[]) {
     std::string_view str;
     if (argc >= 2) {
         str = argv[1];
@@ -19,29 +56,8 @@ int main(int argc, char* argv[]) {
         str = "The quick brown fox jumps over the lazy dog.";
     }
 
-    std::cout << "Segmenting string:" << std::endl << str << std::endl;
-    for (size_t i=0; i<str.size(); i++) {
-        if (i % 10 == 0) {
-            std::cout << "0";
-        } else if (i % 5 == 0) {
-            std::cout << "5";
-        } else {
-            std::cout << ".";
-        }
-    }
-    std::cout << std::endl;
-
-    ICU4XLineBreakIteratorUtf8 iterator = segmenter.segment_utf8(str);
-
-    std::cout << "Breakpoints:";
-    while (true) {
-        int32_t breakpoint = iterator.next();
-        if (breakpoint == -1) {
-            break;
-        }
-        std::cout << " " << breakpoint;
-    }
-    std::cout << std::endl;
+    test_line(str);
+    cout << endl;
 
     return 0;
 }

--- a/ffi/diplomat/cpp/examples/segmenter/test.cpp
+++ b/ffi/diplomat/cpp/examples/segmenter/test.cpp
@@ -53,7 +53,7 @@ void test_line(const std::string_view& str) {
 
 void test_grapheme(const std::string_view& str) {
     const auto provider = ICU4XDataProvider::create_test();
-    const auto segmenter = ICU4XWordBreakSegmenter::try_new(provider).ok().value();
+    const auto segmenter = ICU4XGraphemeClusterBreakSegmenter::try_new(provider).ok().value();
     cout << "Finding grapheme cluster breakpoints in string:" << endl
          << str << endl;
     print_ruler(str.size());
@@ -65,7 +65,7 @@ void test_grapheme(const std::string_view& str) {
 
 void test_word(const std::string_view& str) {
     const auto provider = ICU4XDataProvider::create_test();
-    const auto segmenter = ICU4XGraphemeClusterBreakSegmenter::try_new(provider).ok().value();
+    const auto segmenter = ICU4XWordBreakSegmenter::try_new(provider).ok().value();
     cout << "Finding word breakpoints in string:" << endl
          << str << endl;
     print_ruler(str.size());

--- a/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakIteratorLatin1.h
+++ b/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakIteratorLatin1.h
@@ -1,0 +1,21 @@
+#ifndef ICU4XGraphemeClusterBreakIteratorLatin1_H
+#define ICU4XGraphemeClusterBreakIteratorLatin1_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XGraphemeClusterBreakIteratorLatin1 ICU4XGraphemeClusterBreakIteratorLatin1;
+
+int32_t ICU4XGraphemeClusterBreakIteratorLatin1_next(ICU4XGraphemeClusterBreakIteratorLatin1* self);
+void ICU4XGraphemeClusterBreakIteratorLatin1_destroy(ICU4XGraphemeClusterBreakIteratorLatin1* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakIteratorLatin1.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakIteratorLatin1.hpp
@@ -1,0 +1,47 @@
+#ifndef ICU4XGraphemeClusterBreakIteratorLatin1_HPP
+#define ICU4XGraphemeClusterBreakIteratorLatin1_HPP
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <algorithm>
+#include <memory>
+#include <variant>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+namespace capi {
+#include "ICU4XGraphemeClusterBreakIteratorLatin1.h"
+}
+
+
+/**
+ * A destruction policy for using ICU4XGraphemeClusterBreakIteratorLatin1 with std::unique_ptr.
+ */
+struct ICU4XGraphemeClusterBreakIteratorLatin1Deleter {
+  void operator()(capi::ICU4XGraphemeClusterBreakIteratorLatin1* l) const noexcept {
+    capi::ICU4XGraphemeClusterBreakIteratorLatin1_destroy(l);
+  }
+};
+class ICU4XGraphemeClusterBreakIteratorLatin1 {
+ public:
+
+  /**
+   * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+   * out of range of a 32-bit signed integer.
+   */
+  int32_t next();
+  inline const capi::ICU4XGraphemeClusterBreakIteratorLatin1* AsFFI() const { return this->inner.get(); }
+  inline capi::ICU4XGraphemeClusterBreakIteratorLatin1* AsFFIMut() { return this->inner.get(); }
+  inline ICU4XGraphemeClusterBreakIteratorLatin1(capi::ICU4XGraphemeClusterBreakIteratorLatin1* i) : inner(i) {}
+  ICU4XGraphemeClusterBreakIteratorLatin1() = default;
+  ICU4XGraphemeClusterBreakIteratorLatin1(ICU4XGraphemeClusterBreakIteratorLatin1&&) noexcept = default;
+  ICU4XGraphemeClusterBreakIteratorLatin1& operator=(ICU4XGraphemeClusterBreakIteratorLatin1&& other) noexcept = default;
+ private:
+  std::unique_ptr<capi::ICU4XGraphemeClusterBreakIteratorLatin1, ICU4XGraphemeClusterBreakIteratorLatin1Deleter> inner;
+};
+
+
+inline int32_t ICU4XGraphemeClusterBreakIteratorLatin1::next() {
+  return capi::ICU4XGraphemeClusterBreakIteratorLatin1_next(this->inner.get());
+}
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakIteratorUtf16.h
+++ b/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakIteratorUtf16.h
@@ -1,0 +1,21 @@
+#ifndef ICU4XGraphemeClusterBreakIteratorUtf16_H
+#define ICU4XGraphemeClusterBreakIteratorUtf16_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XGraphemeClusterBreakIteratorUtf16 ICU4XGraphemeClusterBreakIteratorUtf16;
+
+int32_t ICU4XGraphemeClusterBreakIteratorUtf16_next(ICU4XGraphemeClusterBreakIteratorUtf16* self);
+void ICU4XGraphemeClusterBreakIteratorUtf16_destroy(ICU4XGraphemeClusterBreakIteratorUtf16* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakIteratorUtf16.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakIteratorUtf16.hpp
@@ -1,0 +1,47 @@
+#ifndef ICU4XGraphemeClusterBreakIteratorUtf16_HPP
+#define ICU4XGraphemeClusterBreakIteratorUtf16_HPP
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <algorithm>
+#include <memory>
+#include <variant>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+namespace capi {
+#include "ICU4XGraphemeClusterBreakIteratorUtf16.h"
+}
+
+
+/**
+ * A destruction policy for using ICU4XGraphemeClusterBreakIteratorUtf16 with std::unique_ptr.
+ */
+struct ICU4XGraphemeClusterBreakIteratorUtf16Deleter {
+  void operator()(capi::ICU4XGraphemeClusterBreakIteratorUtf16* l) const noexcept {
+    capi::ICU4XGraphemeClusterBreakIteratorUtf16_destroy(l);
+  }
+};
+class ICU4XGraphemeClusterBreakIteratorUtf16 {
+ public:
+
+  /**
+   * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+   * out of range of a 32-bit signed integer.
+   */
+  int32_t next();
+  inline const capi::ICU4XGraphemeClusterBreakIteratorUtf16* AsFFI() const { return this->inner.get(); }
+  inline capi::ICU4XGraphemeClusterBreakIteratorUtf16* AsFFIMut() { return this->inner.get(); }
+  inline ICU4XGraphemeClusterBreakIteratorUtf16(capi::ICU4XGraphemeClusterBreakIteratorUtf16* i) : inner(i) {}
+  ICU4XGraphemeClusterBreakIteratorUtf16() = default;
+  ICU4XGraphemeClusterBreakIteratorUtf16(ICU4XGraphemeClusterBreakIteratorUtf16&&) noexcept = default;
+  ICU4XGraphemeClusterBreakIteratorUtf16& operator=(ICU4XGraphemeClusterBreakIteratorUtf16&& other) noexcept = default;
+ private:
+  std::unique_ptr<capi::ICU4XGraphemeClusterBreakIteratorUtf16, ICU4XGraphemeClusterBreakIteratorUtf16Deleter> inner;
+};
+
+
+inline int32_t ICU4XGraphemeClusterBreakIteratorUtf16::next() {
+  return capi::ICU4XGraphemeClusterBreakIteratorUtf16_next(this->inner.get());
+}
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakIteratorUtf8.h
+++ b/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakIteratorUtf8.h
@@ -1,0 +1,21 @@
+#ifndef ICU4XGraphemeClusterBreakIteratorUtf8_H
+#define ICU4XGraphemeClusterBreakIteratorUtf8_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XGraphemeClusterBreakIteratorUtf8 ICU4XGraphemeClusterBreakIteratorUtf8;
+
+int32_t ICU4XGraphemeClusterBreakIteratorUtf8_next(ICU4XGraphemeClusterBreakIteratorUtf8* self);
+void ICU4XGraphemeClusterBreakIteratorUtf8_destroy(ICU4XGraphemeClusterBreakIteratorUtf8* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakIteratorUtf8.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakIteratorUtf8.hpp
@@ -1,0 +1,47 @@
+#ifndef ICU4XGraphemeClusterBreakIteratorUtf8_HPP
+#define ICU4XGraphemeClusterBreakIteratorUtf8_HPP
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <algorithm>
+#include <memory>
+#include <variant>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+namespace capi {
+#include "ICU4XGraphemeClusterBreakIteratorUtf8.h"
+}
+
+
+/**
+ * A destruction policy for using ICU4XGraphemeClusterBreakIteratorUtf8 with std::unique_ptr.
+ */
+struct ICU4XGraphemeClusterBreakIteratorUtf8Deleter {
+  void operator()(capi::ICU4XGraphemeClusterBreakIteratorUtf8* l) const noexcept {
+    capi::ICU4XGraphemeClusterBreakIteratorUtf8_destroy(l);
+  }
+};
+class ICU4XGraphemeClusterBreakIteratorUtf8 {
+ public:
+
+  /**
+   * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+   * out of range of a 32-bit signed integer.
+   */
+  int32_t next();
+  inline const capi::ICU4XGraphemeClusterBreakIteratorUtf8* AsFFI() const { return this->inner.get(); }
+  inline capi::ICU4XGraphemeClusterBreakIteratorUtf8* AsFFIMut() { return this->inner.get(); }
+  inline ICU4XGraphemeClusterBreakIteratorUtf8(capi::ICU4XGraphemeClusterBreakIteratorUtf8* i) : inner(i) {}
+  ICU4XGraphemeClusterBreakIteratorUtf8() = default;
+  ICU4XGraphemeClusterBreakIteratorUtf8(ICU4XGraphemeClusterBreakIteratorUtf8&&) noexcept = default;
+  ICU4XGraphemeClusterBreakIteratorUtf8& operator=(ICU4XGraphemeClusterBreakIteratorUtf8&& other) noexcept = default;
+ private:
+  std::unique_ptr<capi::ICU4XGraphemeClusterBreakIteratorUtf8, ICU4XGraphemeClusterBreakIteratorUtf8Deleter> inner;
+};
+
+
+inline int32_t ICU4XGraphemeClusterBreakIteratorUtf8::next() {
+  return capi::ICU4XGraphemeClusterBreakIteratorUtf8_next(this->inner.get());
+}
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakSegmenter.h
+++ b/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakSegmenter.h
@@ -1,0 +1,32 @@
+#ifndef ICU4XGraphemeClusterBreakSegmenter_H
+#define ICU4XGraphemeClusterBreakSegmenter_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XGraphemeClusterBreakSegmenter ICU4XGraphemeClusterBreakSegmenter;
+#include "ICU4XDataProvider.h"
+#include "diplomat_result_box_ICU4XGraphemeClusterBreakSegmenter_ICU4XError.h"
+#include "ICU4XGraphemeClusterBreakIteratorUtf8.h"
+#include "ICU4XGraphemeClusterBreakIteratorUtf16.h"
+#include "ICU4XGraphemeClusterBreakIteratorLatin1.h"
+
+diplomat_result_box_ICU4XGraphemeClusterBreakSegmenter_ICU4XError ICU4XGraphemeClusterBreakSegmenter_try_new(const ICU4XDataProvider* provider);
+
+ICU4XGraphemeClusterBreakIteratorUtf8* ICU4XGraphemeClusterBreakSegmenter_segment_utf8(const ICU4XGraphemeClusterBreakSegmenter* self, const char* input_data, size_t input_len);
+
+ICU4XGraphemeClusterBreakIteratorUtf16* ICU4XGraphemeClusterBreakSegmenter_segment_utf16(const ICU4XGraphemeClusterBreakSegmenter* self, const uint16_t* input_data, size_t input_len);
+
+ICU4XGraphemeClusterBreakIteratorLatin1* ICU4XGraphemeClusterBreakSegmenter_segment_latin1(const ICU4XGraphemeClusterBreakSegmenter* self, const uint8_t* input_data, size_t input_len);
+void ICU4XGraphemeClusterBreakSegmenter_destroy(ICU4XGraphemeClusterBreakSegmenter* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakSegmenter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakSegmenter.hpp
@@ -1,0 +1,101 @@
+#ifndef ICU4XGraphemeClusterBreakSegmenter_HPP
+#define ICU4XGraphemeClusterBreakSegmenter_HPP
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <algorithm>
+#include <memory>
+#include <variant>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+namespace capi {
+#include "ICU4XGraphemeClusterBreakSegmenter.h"
+}
+
+class ICU4XDataProvider;
+class ICU4XGraphemeClusterBreakSegmenter;
+#include "ICU4XError.hpp"
+class ICU4XGraphemeClusterBreakIteratorUtf8;
+class ICU4XGraphemeClusterBreakIteratorUtf16;
+class ICU4XGraphemeClusterBreakIteratorLatin1;
+
+/**
+ * A destruction policy for using ICU4XGraphemeClusterBreakSegmenter with std::unique_ptr.
+ */
+struct ICU4XGraphemeClusterBreakSegmenterDeleter {
+  void operator()(capi::ICU4XGraphemeClusterBreakSegmenter* l) const noexcept {
+    capi::ICU4XGraphemeClusterBreakSegmenter_destroy(l);
+  }
+};
+
+/**
+ * An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
+ * 
+ * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html) for more information.
+ */
+class ICU4XGraphemeClusterBreakSegmenter {
+ public:
+
+  /**
+   * Construct an [`ICU4XGraphemeClusterBreakSegmenter`].
+   * 
+   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.try_new) for more information.
+   */
+  static diplomat::result<ICU4XGraphemeClusterBreakSegmenter, ICU4XError> try_new(const ICU4XDataProvider& provider);
+
+  /**
+   * Segments a UTF-8 string.
+   * 
+   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_str) for more information.
+   */
+  ICU4XGraphemeClusterBreakIteratorUtf8 segment_utf8(const std::string_view input) const;
+
+  /**
+   * Segments a UTF-16 string.
+   * 
+   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_utf16) for more information.
+   */
+  ICU4XGraphemeClusterBreakIteratorUtf16 segment_utf16(const diplomat::span<uint16_t> input) const;
+
+  /**
+   * Segments a Latin-1 string.
+   * 
+   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_latin1) for more information.
+   */
+  ICU4XGraphemeClusterBreakIteratorLatin1 segment_latin1(const diplomat::span<uint8_t> input) const;
+  inline const capi::ICU4XGraphemeClusterBreakSegmenter* AsFFI() const { return this->inner.get(); }
+  inline capi::ICU4XGraphemeClusterBreakSegmenter* AsFFIMut() { return this->inner.get(); }
+  inline ICU4XGraphemeClusterBreakSegmenter(capi::ICU4XGraphemeClusterBreakSegmenter* i) : inner(i) {}
+  ICU4XGraphemeClusterBreakSegmenter() = default;
+  ICU4XGraphemeClusterBreakSegmenter(ICU4XGraphemeClusterBreakSegmenter&&) noexcept = default;
+  ICU4XGraphemeClusterBreakSegmenter& operator=(ICU4XGraphemeClusterBreakSegmenter&& other) noexcept = default;
+ private:
+  std::unique_ptr<capi::ICU4XGraphemeClusterBreakSegmenter, ICU4XGraphemeClusterBreakSegmenterDeleter> inner;
+};
+
+#include "ICU4XDataProvider.hpp"
+#include "ICU4XGraphemeClusterBreakIteratorUtf8.hpp"
+#include "ICU4XGraphemeClusterBreakIteratorUtf16.hpp"
+#include "ICU4XGraphemeClusterBreakIteratorLatin1.hpp"
+
+inline diplomat::result<ICU4XGraphemeClusterBreakSegmenter, ICU4XError> ICU4XGraphemeClusterBreakSegmenter::try_new(const ICU4XDataProvider& provider) {
+  auto diplomat_result_raw_out_value = capi::ICU4XGraphemeClusterBreakSegmenter_try_new(provider.AsFFI());
+  diplomat::result<ICU4XGraphemeClusterBreakSegmenter, ICU4XError> diplomat_result_out_value;
+  if (diplomat_result_raw_out_value.is_ok) {
+    diplomat_result_out_value = diplomat::Ok(ICU4XGraphemeClusterBreakSegmenter(diplomat_result_raw_out_value.ok));
+  } else {
+    diplomat_result_out_value = diplomat::Err(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
+  }
+  return diplomat_result_out_value;
+}
+inline ICU4XGraphemeClusterBreakIteratorUtf8 ICU4XGraphemeClusterBreakSegmenter::segment_utf8(const std::string_view input) const {
+  return ICU4XGraphemeClusterBreakIteratorUtf8(capi::ICU4XGraphemeClusterBreakSegmenter_segment_utf8(this->inner.get(), input.data(), input.size()));
+}
+inline ICU4XGraphemeClusterBreakIteratorUtf16 ICU4XGraphemeClusterBreakSegmenter::segment_utf16(const diplomat::span<uint16_t> input) const {
+  return ICU4XGraphemeClusterBreakIteratorUtf16(capi::ICU4XGraphemeClusterBreakSegmenter_segment_utf16(this->inner.get(), input.data(), input.size()));
+}
+inline ICU4XGraphemeClusterBreakIteratorLatin1 ICU4XGraphemeClusterBreakSegmenter::segment_latin1(const diplomat::span<uint8_t> input) const {
+  return ICU4XGraphemeClusterBreakIteratorLatin1(capi::ICU4XGraphemeClusterBreakSegmenter_segment_latin1(this->inner.get(), input.data(), input.size()));
+}
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakSegmenter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakSegmenter.hpp
@@ -30,7 +30,8 @@ struct ICU4XGraphemeClusterBreakSegmenterDeleter {
 };
 
 /**
- * An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
+ * An ICU4X grapheme-cluster-break segmenter, capable of finding grapheme cluster breakpoints
+ * in strings.
  * 
  * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html) for more information.
  */

--- a/ffi/diplomat/cpp/include/ICU4XSentenceBreakIteratorLatin1.h
+++ b/ffi/diplomat/cpp/include/ICU4XSentenceBreakIteratorLatin1.h
@@ -1,0 +1,21 @@
+#ifndef ICU4XSentenceBreakIteratorLatin1_H
+#define ICU4XSentenceBreakIteratorLatin1_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XSentenceBreakIteratorLatin1 ICU4XSentenceBreakIteratorLatin1;
+
+int32_t ICU4XSentenceBreakIteratorLatin1_next(ICU4XSentenceBreakIteratorLatin1* self);
+void ICU4XSentenceBreakIteratorLatin1_destroy(ICU4XSentenceBreakIteratorLatin1* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XSentenceBreakIteratorLatin1.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XSentenceBreakIteratorLatin1.hpp
@@ -1,0 +1,47 @@
+#ifndef ICU4XSentenceBreakIteratorLatin1_HPP
+#define ICU4XSentenceBreakIteratorLatin1_HPP
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <algorithm>
+#include <memory>
+#include <variant>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+namespace capi {
+#include "ICU4XSentenceBreakIteratorLatin1.h"
+}
+
+
+/**
+ * A destruction policy for using ICU4XSentenceBreakIteratorLatin1 with std::unique_ptr.
+ */
+struct ICU4XSentenceBreakIteratorLatin1Deleter {
+  void operator()(capi::ICU4XSentenceBreakIteratorLatin1* l) const noexcept {
+    capi::ICU4XSentenceBreakIteratorLatin1_destroy(l);
+  }
+};
+class ICU4XSentenceBreakIteratorLatin1 {
+ public:
+
+  /**
+   * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+   * out of range of a 32-bit signed integer.
+   */
+  int32_t next();
+  inline const capi::ICU4XSentenceBreakIteratorLatin1* AsFFI() const { return this->inner.get(); }
+  inline capi::ICU4XSentenceBreakIteratorLatin1* AsFFIMut() { return this->inner.get(); }
+  inline ICU4XSentenceBreakIteratorLatin1(capi::ICU4XSentenceBreakIteratorLatin1* i) : inner(i) {}
+  ICU4XSentenceBreakIteratorLatin1() = default;
+  ICU4XSentenceBreakIteratorLatin1(ICU4XSentenceBreakIteratorLatin1&&) noexcept = default;
+  ICU4XSentenceBreakIteratorLatin1& operator=(ICU4XSentenceBreakIteratorLatin1&& other) noexcept = default;
+ private:
+  std::unique_ptr<capi::ICU4XSentenceBreakIteratorLatin1, ICU4XSentenceBreakIteratorLatin1Deleter> inner;
+};
+
+
+inline int32_t ICU4XSentenceBreakIteratorLatin1::next() {
+  return capi::ICU4XSentenceBreakIteratorLatin1_next(this->inner.get());
+}
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XSentenceBreakIteratorUtf16.h
+++ b/ffi/diplomat/cpp/include/ICU4XSentenceBreakIteratorUtf16.h
@@ -1,0 +1,21 @@
+#ifndef ICU4XSentenceBreakIteratorUtf16_H
+#define ICU4XSentenceBreakIteratorUtf16_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XSentenceBreakIteratorUtf16 ICU4XSentenceBreakIteratorUtf16;
+
+int32_t ICU4XSentenceBreakIteratorUtf16_next(ICU4XSentenceBreakIteratorUtf16* self);
+void ICU4XSentenceBreakIteratorUtf16_destroy(ICU4XSentenceBreakIteratorUtf16* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XSentenceBreakIteratorUtf16.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XSentenceBreakIteratorUtf16.hpp
@@ -1,0 +1,47 @@
+#ifndef ICU4XSentenceBreakIteratorUtf16_HPP
+#define ICU4XSentenceBreakIteratorUtf16_HPP
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <algorithm>
+#include <memory>
+#include <variant>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+namespace capi {
+#include "ICU4XSentenceBreakIteratorUtf16.h"
+}
+
+
+/**
+ * A destruction policy for using ICU4XSentenceBreakIteratorUtf16 with std::unique_ptr.
+ */
+struct ICU4XSentenceBreakIteratorUtf16Deleter {
+  void operator()(capi::ICU4XSentenceBreakIteratorUtf16* l) const noexcept {
+    capi::ICU4XSentenceBreakIteratorUtf16_destroy(l);
+  }
+};
+class ICU4XSentenceBreakIteratorUtf16 {
+ public:
+
+  /**
+   * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+   * out of range of a 32-bit signed integer.
+   */
+  int32_t next();
+  inline const capi::ICU4XSentenceBreakIteratorUtf16* AsFFI() const { return this->inner.get(); }
+  inline capi::ICU4XSentenceBreakIteratorUtf16* AsFFIMut() { return this->inner.get(); }
+  inline ICU4XSentenceBreakIteratorUtf16(capi::ICU4XSentenceBreakIteratorUtf16* i) : inner(i) {}
+  ICU4XSentenceBreakIteratorUtf16() = default;
+  ICU4XSentenceBreakIteratorUtf16(ICU4XSentenceBreakIteratorUtf16&&) noexcept = default;
+  ICU4XSentenceBreakIteratorUtf16& operator=(ICU4XSentenceBreakIteratorUtf16&& other) noexcept = default;
+ private:
+  std::unique_ptr<capi::ICU4XSentenceBreakIteratorUtf16, ICU4XSentenceBreakIteratorUtf16Deleter> inner;
+};
+
+
+inline int32_t ICU4XSentenceBreakIteratorUtf16::next() {
+  return capi::ICU4XSentenceBreakIteratorUtf16_next(this->inner.get());
+}
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XSentenceBreakIteratorUtf8.h
+++ b/ffi/diplomat/cpp/include/ICU4XSentenceBreakIteratorUtf8.h
@@ -1,0 +1,21 @@
+#ifndef ICU4XSentenceBreakIteratorUtf8_H
+#define ICU4XSentenceBreakIteratorUtf8_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XSentenceBreakIteratorUtf8 ICU4XSentenceBreakIteratorUtf8;
+
+int32_t ICU4XSentenceBreakIteratorUtf8_next(ICU4XSentenceBreakIteratorUtf8* self);
+void ICU4XSentenceBreakIteratorUtf8_destroy(ICU4XSentenceBreakIteratorUtf8* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XSentenceBreakIteratorUtf8.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XSentenceBreakIteratorUtf8.hpp
@@ -1,0 +1,47 @@
+#ifndef ICU4XSentenceBreakIteratorUtf8_HPP
+#define ICU4XSentenceBreakIteratorUtf8_HPP
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <algorithm>
+#include <memory>
+#include <variant>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+namespace capi {
+#include "ICU4XSentenceBreakIteratorUtf8.h"
+}
+
+
+/**
+ * A destruction policy for using ICU4XSentenceBreakIteratorUtf8 with std::unique_ptr.
+ */
+struct ICU4XSentenceBreakIteratorUtf8Deleter {
+  void operator()(capi::ICU4XSentenceBreakIteratorUtf8* l) const noexcept {
+    capi::ICU4XSentenceBreakIteratorUtf8_destroy(l);
+  }
+};
+class ICU4XSentenceBreakIteratorUtf8 {
+ public:
+
+  /**
+   * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+   * out of range of a 32-bit signed integer.
+   */
+  int32_t next();
+  inline const capi::ICU4XSentenceBreakIteratorUtf8* AsFFI() const { return this->inner.get(); }
+  inline capi::ICU4XSentenceBreakIteratorUtf8* AsFFIMut() { return this->inner.get(); }
+  inline ICU4XSentenceBreakIteratorUtf8(capi::ICU4XSentenceBreakIteratorUtf8* i) : inner(i) {}
+  ICU4XSentenceBreakIteratorUtf8() = default;
+  ICU4XSentenceBreakIteratorUtf8(ICU4XSentenceBreakIteratorUtf8&&) noexcept = default;
+  ICU4XSentenceBreakIteratorUtf8& operator=(ICU4XSentenceBreakIteratorUtf8&& other) noexcept = default;
+ private:
+  std::unique_ptr<capi::ICU4XSentenceBreakIteratorUtf8, ICU4XSentenceBreakIteratorUtf8Deleter> inner;
+};
+
+
+inline int32_t ICU4XSentenceBreakIteratorUtf8::next() {
+  return capi::ICU4XSentenceBreakIteratorUtf8_next(this->inner.get());
+}
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XSentenceBreakSegmenter.h
+++ b/ffi/diplomat/cpp/include/ICU4XSentenceBreakSegmenter.h
@@ -1,0 +1,32 @@
+#ifndef ICU4XSentenceBreakSegmenter_H
+#define ICU4XSentenceBreakSegmenter_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XSentenceBreakSegmenter ICU4XSentenceBreakSegmenter;
+#include "ICU4XDataProvider.h"
+#include "diplomat_result_box_ICU4XSentenceBreakSegmenter_ICU4XError.h"
+#include "ICU4XSentenceBreakIteratorUtf8.h"
+#include "ICU4XSentenceBreakIteratorUtf16.h"
+#include "ICU4XSentenceBreakIteratorLatin1.h"
+
+diplomat_result_box_ICU4XSentenceBreakSegmenter_ICU4XError ICU4XSentenceBreakSegmenter_try_new(const ICU4XDataProvider* provider);
+
+ICU4XSentenceBreakIteratorUtf8* ICU4XSentenceBreakSegmenter_segment_utf8(const ICU4XSentenceBreakSegmenter* self, const char* input_data, size_t input_len);
+
+ICU4XSentenceBreakIteratorUtf16* ICU4XSentenceBreakSegmenter_segment_utf16(const ICU4XSentenceBreakSegmenter* self, const uint16_t* input_data, size_t input_len);
+
+ICU4XSentenceBreakIteratorLatin1* ICU4XSentenceBreakSegmenter_segment_latin1(const ICU4XSentenceBreakSegmenter* self, const uint8_t* input_data, size_t input_len);
+void ICU4XSentenceBreakSegmenter_destroy(ICU4XSentenceBreakSegmenter* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XSentenceBreakSegmenter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XSentenceBreakSegmenter.hpp
@@ -1,0 +1,101 @@
+#ifndef ICU4XSentenceBreakSegmenter_HPP
+#define ICU4XSentenceBreakSegmenter_HPP
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <algorithm>
+#include <memory>
+#include <variant>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+namespace capi {
+#include "ICU4XSentenceBreakSegmenter.h"
+}
+
+class ICU4XDataProvider;
+class ICU4XSentenceBreakSegmenter;
+#include "ICU4XError.hpp"
+class ICU4XSentenceBreakIteratorUtf8;
+class ICU4XSentenceBreakIteratorUtf16;
+class ICU4XSentenceBreakIteratorLatin1;
+
+/**
+ * A destruction policy for using ICU4XSentenceBreakSegmenter with std::unique_ptr.
+ */
+struct ICU4XSentenceBreakSegmenterDeleter {
+  void operator()(capi::ICU4XSentenceBreakSegmenter* l) const noexcept {
+    capi::ICU4XSentenceBreakSegmenter_destroy(l);
+  }
+};
+
+/**
+ * An ICU4X sentence-break segmenter, capable of finding sentence breakpoints in strings.
+ * 
+ * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.SentenceBreakSegmenter.html) for more information.
+ */
+class ICU4XSentenceBreakSegmenter {
+ public:
+
+  /**
+   * Construct an [`ICU4XSentenceBreakSegmenter`].
+   * 
+   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.SentenceBreakSegmenter.html#method.try_new) for more information.
+   */
+  static diplomat::result<ICU4XSentenceBreakSegmenter, ICU4XError> try_new(const ICU4XDataProvider& provider);
+
+  /**
+   * Segments a UTF-8 string.
+   * 
+   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.SentenceBreakSegmenter.html#method.segment_str) for more information.
+   */
+  ICU4XSentenceBreakIteratorUtf8 segment_utf8(const std::string_view input) const;
+
+  /**
+   * Segments a UTF-16 string.
+   * 
+   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.SentenceBreakSegmenter.html#method.segment_utf16) for more information.
+   */
+  ICU4XSentenceBreakIteratorUtf16 segment_utf16(const diplomat::span<uint16_t> input) const;
+
+  /**
+   * Segments a Latin-1 string.
+   * 
+   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.SentenceBreakSegmenter.html#method.segment_latin1) for more information.
+   */
+  ICU4XSentenceBreakIteratorLatin1 segment_latin1(const diplomat::span<uint8_t> input) const;
+  inline const capi::ICU4XSentenceBreakSegmenter* AsFFI() const { return this->inner.get(); }
+  inline capi::ICU4XSentenceBreakSegmenter* AsFFIMut() { return this->inner.get(); }
+  inline ICU4XSentenceBreakSegmenter(capi::ICU4XSentenceBreakSegmenter* i) : inner(i) {}
+  ICU4XSentenceBreakSegmenter() = default;
+  ICU4XSentenceBreakSegmenter(ICU4XSentenceBreakSegmenter&&) noexcept = default;
+  ICU4XSentenceBreakSegmenter& operator=(ICU4XSentenceBreakSegmenter&& other) noexcept = default;
+ private:
+  std::unique_ptr<capi::ICU4XSentenceBreakSegmenter, ICU4XSentenceBreakSegmenterDeleter> inner;
+};
+
+#include "ICU4XDataProvider.hpp"
+#include "ICU4XSentenceBreakIteratorUtf8.hpp"
+#include "ICU4XSentenceBreakIteratorUtf16.hpp"
+#include "ICU4XSentenceBreakIteratorLatin1.hpp"
+
+inline diplomat::result<ICU4XSentenceBreakSegmenter, ICU4XError> ICU4XSentenceBreakSegmenter::try_new(const ICU4XDataProvider& provider) {
+  auto diplomat_result_raw_out_value = capi::ICU4XSentenceBreakSegmenter_try_new(provider.AsFFI());
+  diplomat::result<ICU4XSentenceBreakSegmenter, ICU4XError> diplomat_result_out_value;
+  if (diplomat_result_raw_out_value.is_ok) {
+    diplomat_result_out_value = diplomat::Ok(ICU4XSentenceBreakSegmenter(diplomat_result_raw_out_value.ok));
+  } else {
+    diplomat_result_out_value = diplomat::Err(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
+  }
+  return diplomat_result_out_value;
+}
+inline ICU4XSentenceBreakIteratorUtf8 ICU4XSentenceBreakSegmenter::segment_utf8(const std::string_view input) const {
+  return ICU4XSentenceBreakIteratorUtf8(capi::ICU4XSentenceBreakSegmenter_segment_utf8(this->inner.get(), input.data(), input.size()));
+}
+inline ICU4XSentenceBreakIteratorUtf16 ICU4XSentenceBreakSegmenter::segment_utf16(const diplomat::span<uint16_t> input) const {
+  return ICU4XSentenceBreakIteratorUtf16(capi::ICU4XSentenceBreakSegmenter_segment_utf16(this->inner.get(), input.data(), input.size()));
+}
+inline ICU4XSentenceBreakIteratorLatin1 ICU4XSentenceBreakSegmenter::segment_latin1(const diplomat::span<uint8_t> input) const {
+  return ICU4XSentenceBreakIteratorLatin1(capi::ICU4XSentenceBreakSegmenter_segment_latin1(this->inner.get(), input.data(), input.size()));
+}
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XWordBreakIteratorLatin1.h
+++ b/ffi/diplomat/cpp/include/ICU4XWordBreakIteratorLatin1.h
@@ -1,0 +1,21 @@
+#ifndef ICU4XWordBreakIteratorLatin1_H
+#define ICU4XWordBreakIteratorLatin1_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XWordBreakIteratorLatin1 ICU4XWordBreakIteratorLatin1;
+
+int32_t ICU4XWordBreakIteratorLatin1_next(ICU4XWordBreakIteratorLatin1* self);
+void ICU4XWordBreakIteratorLatin1_destroy(ICU4XWordBreakIteratorLatin1* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XWordBreakIteratorLatin1.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XWordBreakIteratorLatin1.hpp
@@ -1,0 +1,47 @@
+#ifndef ICU4XWordBreakIteratorLatin1_HPP
+#define ICU4XWordBreakIteratorLatin1_HPP
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <algorithm>
+#include <memory>
+#include <variant>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+namespace capi {
+#include "ICU4XWordBreakIteratorLatin1.h"
+}
+
+
+/**
+ * A destruction policy for using ICU4XWordBreakIteratorLatin1 with std::unique_ptr.
+ */
+struct ICU4XWordBreakIteratorLatin1Deleter {
+  void operator()(capi::ICU4XWordBreakIteratorLatin1* l) const noexcept {
+    capi::ICU4XWordBreakIteratorLatin1_destroy(l);
+  }
+};
+class ICU4XWordBreakIteratorLatin1 {
+ public:
+
+  /**
+   * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+   * out of range of a 32-bit signed integer.
+   */
+  int32_t next();
+  inline const capi::ICU4XWordBreakIteratorLatin1* AsFFI() const { return this->inner.get(); }
+  inline capi::ICU4XWordBreakIteratorLatin1* AsFFIMut() { return this->inner.get(); }
+  inline ICU4XWordBreakIteratorLatin1(capi::ICU4XWordBreakIteratorLatin1* i) : inner(i) {}
+  ICU4XWordBreakIteratorLatin1() = default;
+  ICU4XWordBreakIteratorLatin1(ICU4XWordBreakIteratorLatin1&&) noexcept = default;
+  ICU4XWordBreakIteratorLatin1& operator=(ICU4XWordBreakIteratorLatin1&& other) noexcept = default;
+ private:
+  std::unique_ptr<capi::ICU4XWordBreakIteratorLatin1, ICU4XWordBreakIteratorLatin1Deleter> inner;
+};
+
+
+inline int32_t ICU4XWordBreakIteratorLatin1::next() {
+  return capi::ICU4XWordBreakIteratorLatin1_next(this->inner.get());
+}
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XWordBreakIteratorUtf16.h
+++ b/ffi/diplomat/cpp/include/ICU4XWordBreakIteratorUtf16.h
@@ -1,0 +1,21 @@
+#ifndef ICU4XWordBreakIteratorUtf16_H
+#define ICU4XWordBreakIteratorUtf16_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XWordBreakIteratorUtf16 ICU4XWordBreakIteratorUtf16;
+
+int32_t ICU4XWordBreakIteratorUtf16_next(ICU4XWordBreakIteratorUtf16* self);
+void ICU4XWordBreakIteratorUtf16_destroy(ICU4XWordBreakIteratorUtf16* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XWordBreakIteratorUtf16.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XWordBreakIteratorUtf16.hpp
@@ -1,0 +1,47 @@
+#ifndef ICU4XWordBreakIteratorUtf16_HPP
+#define ICU4XWordBreakIteratorUtf16_HPP
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <algorithm>
+#include <memory>
+#include <variant>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+namespace capi {
+#include "ICU4XWordBreakIteratorUtf16.h"
+}
+
+
+/**
+ * A destruction policy for using ICU4XWordBreakIteratorUtf16 with std::unique_ptr.
+ */
+struct ICU4XWordBreakIteratorUtf16Deleter {
+  void operator()(capi::ICU4XWordBreakIteratorUtf16* l) const noexcept {
+    capi::ICU4XWordBreakIteratorUtf16_destroy(l);
+  }
+};
+class ICU4XWordBreakIteratorUtf16 {
+ public:
+
+  /**
+   * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+   * out of range of a 32-bit signed integer.
+   */
+  int32_t next();
+  inline const capi::ICU4XWordBreakIteratorUtf16* AsFFI() const { return this->inner.get(); }
+  inline capi::ICU4XWordBreakIteratorUtf16* AsFFIMut() { return this->inner.get(); }
+  inline ICU4XWordBreakIteratorUtf16(capi::ICU4XWordBreakIteratorUtf16* i) : inner(i) {}
+  ICU4XWordBreakIteratorUtf16() = default;
+  ICU4XWordBreakIteratorUtf16(ICU4XWordBreakIteratorUtf16&&) noexcept = default;
+  ICU4XWordBreakIteratorUtf16& operator=(ICU4XWordBreakIteratorUtf16&& other) noexcept = default;
+ private:
+  std::unique_ptr<capi::ICU4XWordBreakIteratorUtf16, ICU4XWordBreakIteratorUtf16Deleter> inner;
+};
+
+
+inline int32_t ICU4XWordBreakIteratorUtf16::next() {
+  return capi::ICU4XWordBreakIteratorUtf16_next(this->inner.get());
+}
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XWordBreakIteratorUtf8.h
+++ b/ffi/diplomat/cpp/include/ICU4XWordBreakIteratorUtf8.h
@@ -1,0 +1,21 @@
+#ifndef ICU4XWordBreakIteratorUtf8_H
+#define ICU4XWordBreakIteratorUtf8_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XWordBreakIteratorUtf8 ICU4XWordBreakIteratorUtf8;
+
+int32_t ICU4XWordBreakIteratorUtf8_next(ICU4XWordBreakIteratorUtf8* self);
+void ICU4XWordBreakIteratorUtf8_destroy(ICU4XWordBreakIteratorUtf8* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XWordBreakIteratorUtf8.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XWordBreakIteratorUtf8.hpp
@@ -1,0 +1,47 @@
+#ifndef ICU4XWordBreakIteratorUtf8_HPP
+#define ICU4XWordBreakIteratorUtf8_HPP
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <algorithm>
+#include <memory>
+#include <variant>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+namespace capi {
+#include "ICU4XWordBreakIteratorUtf8.h"
+}
+
+
+/**
+ * A destruction policy for using ICU4XWordBreakIteratorUtf8 with std::unique_ptr.
+ */
+struct ICU4XWordBreakIteratorUtf8Deleter {
+  void operator()(capi::ICU4XWordBreakIteratorUtf8* l) const noexcept {
+    capi::ICU4XWordBreakIteratorUtf8_destroy(l);
+  }
+};
+class ICU4XWordBreakIteratorUtf8 {
+ public:
+
+  /**
+   * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+   * out of range of a 32-bit signed integer.
+   */
+  int32_t next();
+  inline const capi::ICU4XWordBreakIteratorUtf8* AsFFI() const { return this->inner.get(); }
+  inline capi::ICU4XWordBreakIteratorUtf8* AsFFIMut() { return this->inner.get(); }
+  inline ICU4XWordBreakIteratorUtf8(capi::ICU4XWordBreakIteratorUtf8* i) : inner(i) {}
+  ICU4XWordBreakIteratorUtf8() = default;
+  ICU4XWordBreakIteratorUtf8(ICU4XWordBreakIteratorUtf8&&) noexcept = default;
+  ICU4XWordBreakIteratorUtf8& operator=(ICU4XWordBreakIteratorUtf8&& other) noexcept = default;
+ private:
+  std::unique_ptr<capi::ICU4XWordBreakIteratorUtf8, ICU4XWordBreakIteratorUtf8Deleter> inner;
+};
+
+
+inline int32_t ICU4XWordBreakIteratorUtf8::next() {
+  return capi::ICU4XWordBreakIteratorUtf8_next(this->inner.get());
+}
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XWordBreakSegmenter.h
+++ b/ffi/diplomat/cpp/include/ICU4XWordBreakSegmenter.h
@@ -1,0 +1,32 @@
+#ifndef ICU4XWordBreakSegmenter_H
+#define ICU4XWordBreakSegmenter_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ICU4XWordBreakSegmenter ICU4XWordBreakSegmenter;
+#include "ICU4XDataProvider.h"
+#include "diplomat_result_box_ICU4XWordBreakSegmenter_ICU4XError.h"
+#include "ICU4XWordBreakIteratorUtf8.h"
+#include "ICU4XWordBreakIteratorUtf16.h"
+#include "ICU4XWordBreakIteratorLatin1.h"
+
+diplomat_result_box_ICU4XWordBreakSegmenter_ICU4XError ICU4XWordBreakSegmenter_try_new(const ICU4XDataProvider* provider);
+
+ICU4XWordBreakIteratorUtf8* ICU4XWordBreakSegmenter_segment_utf8(const ICU4XWordBreakSegmenter* self, const char* input_data, size_t input_len);
+
+ICU4XWordBreakIteratorUtf16* ICU4XWordBreakSegmenter_segment_utf16(const ICU4XWordBreakSegmenter* self, const uint16_t* input_data, size_t input_len);
+
+ICU4XWordBreakIteratorLatin1* ICU4XWordBreakSegmenter_segment_latin1(const ICU4XWordBreakSegmenter* self, const uint8_t* input_data, size_t input_len);
+void ICU4XWordBreakSegmenter_destroy(ICU4XWordBreakSegmenter* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XWordBreakSegmenter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XWordBreakSegmenter.hpp
@@ -1,0 +1,101 @@
+#ifndef ICU4XWordBreakSegmenter_HPP
+#define ICU4XWordBreakSegmenter_HPP
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <algorithm>
+#include <memory>
+#include <variant>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+namespace capi {
+#include "ICU4XWordBreakSegmenter.h"
+}
+
+class ICU4XDataProvider;
+class ICU4XWordBreakSegmenter;
+#include "ICU4XError.hpp"
+class ICU4XWordBreakIteratorUtf8;
+class ICU4XWordBreakIteratorUtf16;
+class ICU4XWordBreakIteratorLatin1;
+
+/**
+ * A destruction policy for using ICU4XWordBreakSegmenter with std::unique_ptr.
+ */
+struct ICU4XWordBreakSegmenterDeleter {
+  void operator()(capi::ICU4XWordBreakSegmenter* l) const noexcept {
+    capi::ICU4XWordBreakSegmenter_destroy(l);
+  }
+};
+
+/**
+ * An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
+ * 
+ * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.WordBreakSegmenter.html) for more information.
+ */
+class ICU4XWordBreakSegmenter {
+ public:
+
+  /**
+   * Construct an [`ICU4XWordBreakSegmenter`].
+   * 
+   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.WordBreakSegmenter.html#method.try_new) for more information.
+   */
+  static diplomat::result<ICU4XWordBreakSegmenter, ICU4XError> try_new(const ICU4XDataProvider& provider);
+
+  /**
+   * Segments a UTF-8 string.
+   * 
+   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.WordBreakSegmenter.html#method.segment_str) for more information.
+   */
+  ICU4XWordBreakIteratorUtf8 segment_utf8(const std::string_view input) const;
+
+  /**
+   * Segments a UTF-16 string.
+   * 
+   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.WordBreakSegmenter.html#method.segment_utf16) for more information.
+   */
+  ICU4XWordBreakIteratorUtf16 segment_utf16(const diplomat::span<uint16_t> input) const;
+
+  /**
+   * Segments a Latin-1 string.
+   * 
+   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.WordBreakSegmenter.html#method.segment_latin1) for more information.
+   */
+  ICU4XWordBreakIteratorLatin1 segment_latin1(const diplomat::span<uint8_t> input) const;
+  inline const capi::ICU4XWordBreakSegmenter* AsFFI() const { return this->inner.get(); }
+  inline capi::ICU4XWordBreakSegmenter* AsFFIMut() { return this->inner.get(); }
+  inline ICU4XWordBreakSegmenter(capi::ICU4XWordBreakSegmenter* i) : inner(i) {}
+  ICU4XWordBreakSegmenter() = default;
+  ICU4XWordBreakSegmenter(ICU4XWordBreakSegmenter&&) noexcept = default;
+  ICU4XWordBreakSegmenter& operator=(ICU4XWordBreakSegmenter&& other) noexcept = default;
+ private:
+  std::unique_ptr<capi::ICU4XWordBreakSegmenter, ICU4XWordBreakSegmenterDeleter> inner;
+};
+
+#include "ICU4XDataProvider.hpp"
+#include "ICU4XWordBreakIteratorUtf8.hpp"
+#include "ICU4XWordBreakIteratorUtf16.hpp"
+#include "ICU4XWordBreakIteratorLatin1.hpp"
+
+inline diplomat::result<ICU4XWordBreakSegmenter, ICU4XError> ICU4XWordBreakSegmenter::try_new(const ICU4XDataProvider& provider) {
+  auto diplomat_result_raw_out_value = capi::ICU4XWordBreakSegmenter_try_new(provider.AsFFI());
+  diplomat::result<ICU4XWordBreakSegmenter, ICU4XError> diplomat_result_out_value;
+  if (diplomat_result_raw_out_value.is_ok) {
+    diplomat_result_out_value = diplomat::Ok(ICU4XWordBreakSegmenter(diplomat_result_raw_out_value.ok));
+  } else {
+    diplomat_result_out_value = diplomat::Err(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
+  }
+  return diplomat_result_out_value;
+}
+inline ICU4XWordBreakIteratorUtf8 ICU4XWordBreakSegmenter::segment_utf8(const std::string_view input) const {
+  return ICU4XWordBreakIteratorUtf8(capi::ICU4XWordBreakSegmenter_segment_utf8(this->inner.get(), input.data(), input.size()));
+}
+inline ICU4XWordBreakIteratorUtf16 ICU4XWordBreakSegmenter::segment_utf16(const diplomat::span<uint16_t> input) const {
+  return ICU4XWordBreakIteratorUtf16(capi::ICU4XWordBreakSegmenter_segment_utf16(this->inner.get(), input.data(), input.size()));
+}
+inline ICU4XWordBreakIteratorLatin1 ICU4XWordBreakSegmenter::segment_latin1(const diplomat::span<uint8_t> input) const {
+  return ICU4XWordBreakIteratorLatin1(capi::ICU4XWordBreakSegmenter_segment_latin1(this->inner.get(), input.data(), input.size()));
+}
+#endif

--- a/ffi/diplomat/cpp/include/diplomat_result_box_ICU4XGraphemeClusterBreakSegmenter_ICU4XError.h
+++ b/ffi/diplomat/cpp/include/diplomat_result_box_ICU4XGraphemeClusterBreakSegmenter_ICU4XError.h
@@ -1,0 +1,24 @@
+#ifndef diplomat_result_box_ICU4XGraphemeClusterBreakSegmenter_ICU4XError_H
+#define diplomat_result_box_ICU4XGraphemeClusterBreakSegmenter_ICU4XError_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+typedef struct ICU4XGraphemeClusterBreakSegmenter ICU4XGraphemeClusterBreakSegmenter;
+#include "ICU4XError.h"
+typedef struct diplomat_result_box_ICU4XGraphemeClusterBreakSegmenter_ICU4XError {
+    union {
+        ICU4XGraphemeClusterBreakSegmenter* ok;
+        ICU4XError err;
+    };
+    bool is_ok;
+} diplomat_result_box_ICU4XGraphemeClusterBreakSegmenter_ICU4XError;
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/cpp/include/diplomat_result_box_ICU4XSentenceBreakSegmenter_ICU4XError.h
+++ b/ffi/diplomat/cpp/include/diplomat_result_box_ICU4XSentenceBreakSegmenter_ICU4XError.h
@@ -1,0 +1,24 @@
+#ifndef diplomat_result_box_ICU4XSentenceBreakSegmenter_ICU4XError_H
+#define diplomat_result_box_ICU4XSentenceBreakSegmenter_ICU4XError_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+typedef struct ICU4XSentenceBreakSegmenter ICU4XSentenceBreakSegmenter;
+#include "ICU4XError.h"
+typedef struct diplomat_result_box_ICU4XSentenceBreakSegmenter_ICU4XError {
+    union {
+        ICU4XSentenceBreakSegmenter* ok;
+        ICU4XError err;
+    };
+    bool is_ok;
+} diplomat_result_box_ICU4XSentenceBreakSegmenter_ICU4XError;
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/cpp/include/diplomat_result_box_ICU4XWordBreakSegmenter_ICU4XError.h
+++ b/ffi/diplomat/cpp/include/diplomat_result_box_ICU4XWordBreakSegmenter_ICU4XError.h
@@ -1,0 +1,24 @@
+#ifndef diplomat_result_box_ICU4XWordBreakSegmenter_ICU4XError_H
+#define diplomat_result_box_ICU4XWordBreakSegmenter_ICU4XError_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+typedef struct ICU4XWordBreakSegmenter ICU4XWordBreakSegmenter;
+#include "ICU4XError.h"
+typedef struct diplomat_result_box_ICU4XWordBreakSegmenter_ICU4XError {
+    union {
+        ICU4XWordBreakSegmenter* ok;
+        ICU4XError err;
+    };
+    bool is_ok;
+} diplomat_result_box_ICU4XWordBreakSegmenter_ICU4XError;
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ffi/diplomat/src/lib.rs
+++ b/ffi/diplomat/src/lib.rs
@@ -43,7 +43,10 @@ pub mod pluralrules;
 pub mod properties_maps;
 pub mod properties_sets;
 pub mod provider;
+pub mod segmenter_grapheme;
 pub mod segmenter_line;
+pub mod segmenter_sentence;
+pub mod segmenter_word;
 
 #[cfg(target_arch = "wasm32")]
 mod wasm_glue;

--- a/ffi/diplomat/src/segmenter_grapheme.rs
+++ b/ffi/diplomat/src/segmenter_grapheme.rs
@@ -17,7 +17,8 @@ pub mod ffi {
     };
 
     #[diplomat::opaque]
-    /// An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
+    /// An ICU4X grapheme-cluster-break segmenter, capable of finding grapheme cluster breakpoints
+    /// in strings.
     #[diplomat::rust_link(icu_segmenter::GraphemeClusterBreakSegmenter, Struct)]
     pub struct ICU4XGraphemeClusterBreakSegmenter(GraphemeClusterBreakSegmenter);
 

--- a/ffi/diplomat/src/segmenter_grapheme.rs
+++ b/ffi/diplomat/src/segmenter_grapheme.rs
@@ -1,0 +1,138 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+#[diplomat::bridge]
+pub mod ffi {
+    use crate::errors::ffi::ICU4XError;
+    use crate::provider::ffi::ICU4XDataProvider;
+    use alloc::boxed::Box;
+    use core::convert::TryFrom;
+    use diplomat_runtime::DiplomatResult;
+    use icu_provider::ResourceProvider;
+    use icu_segmenter::{
+        GraphemeClusterBreakDataV1Marker, GraphemeClusterBreakIterator,
+        GraphemeClusterBreakIteratorLatin1, GraphemeClusterBreakIteratorUtf16,
+        GraphemeClusterBreakSegmenter,
+    };
+
+    #[diplomat::opaque]
+    /// An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
+    #[diplomat::rust_link(icu_segmenter::GraphemeClusterBreakSegmenter, Struct)]
+    pub struct ICU4XGraphemeClusterBreakSegmenter(GraphemeClusterBreakSegmenter);
+
+    #[diplomat::opaque]
+    pub struct ICU4XGraphemeClusterBreakIteratorUtf8<'a>(GraphemeClusterBreakIterator<'a, 'a>);
+
+    #[diplomat::opaque]
+    pub struct ICU4XGraphemeClusterBreakIteratorUtf16<'a>(
+        GraphemeClusterBreakIteratorUtf16<'a, 'a>,
+    );
+
+    #[diplomat::opaque]
+    pub struct ICU4XGraphemeClusterBreakIteratorLatin1<'a>(
+        GraphemeClusterBreakIteratorLatin1<'a, 'a>,
+    );
+
+    impl ICU4XGraphemeClusterBreakSegmenter {
+        /// Construct an [`ICU4XGraphemeClusterBreakSegmenter`].
+        #[diplomat::rust_link(icu_segmenter::GraphemeClusterBreakSegmenter::try_new, FnInStruct)]
+        pub fn try_new(
+            provider: &ICU4XDataProvider,
+        ) -> DiplomatResult<Box<ICU4XGraphemeClusterBreakSegmenter>, ICU4XError> {
+            use icu_provider::serde::AsDeserializingBufferProvider;
+            let provider = provider.0.as_deserializing();
+            Self::try_new_impl(&provider)
+        }
+
+        fn try_new_impl<D>(
+            provider: &D,
+        ) -> DiplomatResult<Box<ICU4XGraphemeClusterBreakSegmenter>, ICU4XError>
+        where
+            D: ResourceProvider<GraphemeClusterBreakDataV1Marker> + ?Sized,
+        {
+            GraphemeClusterBreakSegmenter::try_new(provider)
+                .map(|o| Box::new(ICU4XGraphemeClusterBreakSegmenter(o)))
+                .map_err(Into::into)
+                .into()
+        }
+
+        /// Segments a UTF-8 string.
+        #[diplomat::rust_link(
+            icu_segmenter::GraphemeClusterBreakSegmenter::segment_str,
+            FnInStruct
+        )]
+        pub fn segment_utf8<'a>(
+            &'a self,
+            input: &'a str,
+        ) -> Box<ICU4XGraphemeClusterBreakIteratorUtf8<'a>> {
+            Box::new(ICU4XGraphemeClusterBreakIteratorUtf8(
+                self.0.segment_str(input),
+            ))
+        }
+
+        /// Segments a UTF-16 string.
+        #[diplomat::rust_link(
+            icu_segmenter::GraphemeClusterBreakSegmenter::segment_utf16,
+            FnInStruct
+        )]
+        pub fn segment_utf16<'a>(
+            &'a self,
+            input: &'a [u16],
+        ) -> Box<ICU4XGraphemeClusterBreakIteratorUtf16<'a>> {
+            Box::new(ICU4XGraphemeClusterBreakIteratorUtf16(
+                self.0.segment_utf16(input),
+            ))
+        }
+
+        /// Segments a Latin-1 string.
+        #[diplomat::rust_link(
+            icu_segmenter::GraphemeClusterBreakSegmenter::segment_latin1,
+            FnInStruct
+        )]
+        pub fn segment_latin1<'a>(
+            &'a self,
+            input: &'a [u8],
+        ) -> Box<ICU4XGraphemeClusterBreakIteratorLatin1<'a>> {
+            Box::new(ICU4XGraphemeClusterBreakIteratorLatin1(
+                self.0.segment_latin1(input),
+            ))
+        }
+    }
+
+    impl<'a> ICU4XGraphemeClusterBreakIteratorUtf8<'a> {
+        /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+        /// out of range of a 32-bit signed integer.
+        #[allow(clippy::should_implement_trait)]
+        pub fn next(&mut self) -> i32 {
+            self.0
+                .next()
+                .and_then(|u| i32::try_from(u).ok())
+                .unwrap_or(-1)
+        }
+    }
+
+    impl<'a> ICU4XGraphemeClusterBreakIteratorUtf16<'a> {
+        /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+        /// out of range of a 32-bit signed integer.
+        #[allow(clippy::should_implement_trait)]
+        pub fn next(&mut self) -> i32 {
+            self.0
+                .next()
+                .and_then(|u| i32::try_from(u).ok())
+                .unwrap_or(-1)
+        }
+    }
+
+    impl<'a> ICU4XGraphemeClusterBreakIteratorLatin1<'a> {
+        /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+        /// out of range of a 32-bit signed integer.
+        #[allow(clippy::should_implement_trait)]
+        pub fn next(&mut self) -> i32 {
+            self.0
+                .next()
+                .and_then(|u| i32::try_from(u).ok())
+                .unwrap_or(-1)
+        }
+    }
+}

--- a/ffi/diplomat/src/segmenter_sentence.rs
+++ b/ffi/diplomat/src/segmenter_sentence.rs
@@ -1,0 +1,120 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+#[diplomat::bridge]
+pub mod ffi {
+    use crate::errors::ffi::ICU4XError;
+    use crate::provider::ffi::ICU4XDataProvider;
+    use alloc::boxed::Box;
+    use core::convert::TryFrom;
+    use diplomat_runtime::DiplomatResult;
+    use icu_provider::ResourceProvider;
+    use icu_segmenter::{
+        SentenceBreakDataV1Marker, SentenceBreakIterator, SentenceBreakIteratorLatin1,
+        SentenceBreakIteratorUtf16, SentenceBreakSegmenter,
+    };
+
+    #[diplomat::opaque]
+    /// An ICU4X sentence-break segmenter, capable of finding sentence breakpoints in strings.
+    #[diplomat::rust_link(icu_segmenter::SentenceBreakSegmenter, Struct)]
+    pub struct ICU4XSentenceBreakSegmenter(SentenceBreakSegmenter);
+
+    #[diplomat::opaque]
+    pub struct ICU4XSentenceBreakIteratorUtf8<'a>(SentenceBreakIterator<'a, 'a>);
+
+    #[diplomat::opaque]
+    pub struct ICU4XSentenceBreakIteratorUtf16<'a>(SentenceBreakIteratorUtf16<'a, 'a>);
+
+    #[diplomat::opaque]
+    pub struct ICU4XSentenceBreakIteratorLatin1<'a>(SentenceBreakIteratorLatin1<'a, 'a>);
+
+    impl ICU4XSentenceBreakSegmenter {
+        /// Construct an [`ICU4XSentenceBreakSegmenter`].
+        #[diplomat::rust_link(icu_segmenter::SentenceBreakSegmenter::try_new, FnInStruct)]
+        pub fn try_new(
+            provider: &ICU4XDataProvider,
+        ) -> DiplomatResult<Box<ICU4XSentenceBreakSegmenter>, ICU4XError> {
+            use icu_provider::serde::AsDeserializingBufferProvider;
+            let provider = provider.0.as_deserializing();
+            Self::try_new_impl(&provider)
+        }
+
+        fn try_new_impl<D>(
+            provider: &D,
+        ) -> DiplomatResult<Box<ICU4XSentenceBreakSegmenter>, ICU4XError>
+        where
+            D: ResourceProvider<SentenceBreakDataV1Marker> + ?Sized,
+        {
+            SentenceBreakSegmenter::try_new(provider)
+                .map(|o| Box::new(ICU4XSentenceBreakSegmenter(o)))
+                .map_err(Into::into)
+                .into()
+        }
+
+        /// Segments a UTF-8 string.
+        #[diplomat::rust_link(icu_segmenter::SentenceBreakSegmenter::segment_str, FnInStruct)]
+        pub fn segment_utf8<'a>(
+            &'a self,
+            input: &'a str,
+        ) -> Box<ICU4XSentenceBreakIteratorUtf8<'a>> {
+            Box::new(ICU4XSentenceBreakIteratorUtf8(self.0.segment_str(input)))
+        }
+
+        /// Segments a UTF-16 string.
+        #[diplomat::rust_link(icu_segmenter::SentenceBreakSegmenter::segment_utf16, FnInStruct)]
+        pub fn segment_utf16<'a>(
+            &'a self,
+            input: &'a [u16],
+        ) -> Box<ICU4XSentenceBreakIteratorUtf16<'a>> {
+            Box::new(ICU4XSentenceBreakIteratorUtf16(self.0.segment_utf16(input)))
+        }
+
+        /// Segments a Latin-1 string.
+        #[diplomat::rust_link(icu_segmenter::SentenceBreakSegmenter::segment_latin1, FnInStruct)]
+        pub fn segment_latin1<'a>(
+            &'a self,
+            input: &'a [u8],
+        ) -> Box<ICU4XSentenceBreakIteratorLatin1<'a>> {
+            Box::new(ICU4XSentenceBreakIteratorLatin1(
+                self.0.segment_latin1(input),
+            ))
+        }
+    }
+
+    impl<'a> ICU4XSentenceBreakIteratorUtf8<'a> {
+        /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+        /// out of range of a 32-bit signed integer.
+        #[allow(clippy::should_implement_trait)]
+        pub fn next(&mut self) -> i32 {
+            self.0
+                .next()
+                .and_then(|u| i32::try_from(u).ok())
+                .unwrap_or(-1)
+        }
+    }
+
+    impl<'a> ICU4XSentenceBreakIteratorUtf16<'a> {
+        /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+        /// out of range of a 32-bit signed integer.
+        #[allow(clippy::should_implement_trait)]
+        pub fn next(&mut self) -> i32 {
+            self.0
+                .next()
+                .and_then(|u| i32::try_from(u).ok())
+                .unwrap_or(-1)
+        }
+    }
+
+    impl<'a> ICU4XSentenceBreakIteratorLatin1<'a> {
+        /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+        /// out of range of a 32-bit signed integer.
+        #[allow(clippy::should_implement_trait)]
+        pub fn next(&mut self) -> i32 {
+            self.0
+                .next()
+                .and_then(|u| i32::try_from(u).ok())
+                .unwrap_or(-1)
+        }
+    }
+}

--- a/ffi/diplomat/src/segmenter_word.rs
+++ b/ffi/diplomat/src/segmenter_word.rs
@@ -1,0 +1,115 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+#[diplomat::bridge]
+pub mod ffi {
+    use crate::errors::ffi::ICU4XError;
+    use crate::provider::ffi::ICU4XDataProvider;
+    use alloc::boxed::Box;
+    use core::convert::TryFrom;
+    use diplomat_runtime::DiplomatResult;
+    use icu_provider::ResourceProvider;
+    use icu_segmenter::{
+        UCharDictionaryBreakDataV1Marker, WordBreakDataV1Marker, WordBreakIterator,
+        WordBreakIteratorLatin1, WordBreakIteratorUtf16, WordBreakSegmenter,
+    };
+
+    #[diplomat::opaque]
+    /// An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
+    #[diplomat::rust_link(icu_segmenter::WordBreakSegmenter, Struct)]
+    pub struct ICU4XWordBreakSegmenter(WordBreakSegmenter);
+
+    #[diplomat::opaque]
+    pub struct ICU4XWordBreakIteratorUtf8<'a>(WordBreakIterator<'a, 'a>);
+
+    #[diplomat::opaque]
+    pub struct ICU4XWordBreakIteratorUtf16<'a>(WordBreakIteratorUtf16<'a, 'a>);
+
+    #[diplomat::opaque]
+    pub struct ICU4XWordBreakIteratorLatin1<'a>(WordBreakIteratorLatin1<'a, 'a>);
+
+    impl ICU4XWordBreakSegmenter {
+        /// Construct an [`ICU4XWordBreakSegmenter`].
+        #[diplomat::rust_link(icu_segmenter::WordBreakSegmenter::try_new, FnInStruct)]
+        pub fn try_new(
+            provider: &ICU4XDataProvider,
+        ) -> DiplomatResult<Box<ICU4XWordBreakSegmenter>, ICU4XError> {
+            use icu_provider::serde::AsDeserializingBufferProvider;
+            let provider = provider.0.as_deserializing();
+            Self::try_new_impl(&provider)
+        }
+
+        fn try_new_impl<D>(provider: &D) -> DiplomatResult<Box<ICU4XWordBreakSegmenter>, ICU4XError>
+        where
+            D: ResourceProvider<WordBreakDataV1Marker>
+                + ResourceProvider<UCharDictionaryBreakDataV1Marker>
+                + ?Sized,
+        {
+            WordBreakSegmenter::try_new(provider)
+                .map(|o| Box::new(ICU4XWordBreakSegmenter(o)))
+                .map_err(Into::into)
+                .into()
+        }
+
+        /// Segments a UTF-8 string.
+        #[diplomat::rust_link(icu_segmenter::WordBreakSegmenter::segment_str, FnInStruct)]
+        pub fn segment_utf8<'a>(&'a self, input: &'a str) -> Box<ICU4XWordBreakIteratorUtf8<'a>> {
+            Box::new(ICU4XWordBreakIteratorUtf8(self.0.segment_str(input)))
+        }
+
+        /// Segments a UTF-16 string.
+        #[diplomat::rust_link(icu_segmenter::WordBreakSegmenter::segment_utf16, FnInStruct)]
+        pub fn segment_utf16<'a>(
+            &'a self,
+            input: &'a [u16],
+        ) -> Box<ICU4XWordBreakIteratorUtf16<'a>> {
+            Box::new(ICU4XWordBreakIteratorUtf16(self.0.segment_utf16(input)))
+        }
+
+        /// Segments a Latin-1 string.
+        #[diplomat::rust_link(icu_segmenter::WordBreakSegmenter::segment_latin1, FnInStruct)]
+        pub fn segment_latin1<'a>(
+            &'a self,
+            input: &'a [u8],
+        ) -> Box<ICU4XWordBreakIteratorLatin1<'a>> {
+            Box::new(ICU4XWordBreakIteratorLatin1(self.0.segment_latin1(input)))
+        }
+    }
+
+    impl<'a> ICU4XWordBreakIteratorUtf8<'a> {
+        /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+        /// out of range of a 32-bit signed integer.
+        #[allow(clippy::should_implement_trait)]
+        pub fn next(&mut self) -> i32 {
+            self.0
+                .next()
+                .and_then(|u| i32::try_from(u).ok())
+                .unwrap_or(-1)
+        }
+    }
+
+    impl<'a> ICU4XWordBreakIteratorUtf16<'a> {
+        /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+        /// out of range of a 32-bit signed integer.
+        #[allow(clippy::should_implement_trait)]
+        pub fn next(&mut self) -> i32 {
+            self.0
+                .next()
+                .and_then(|u| i32::try_from(u).ok())
+                .unwrap_or(-1)
+        }
+    }
+
+    impl<'a> ICU4XWordBreakIteratorLatin1<'a> {
+        /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+        /// out of range of a 32-bit signed integer.
+        #[allow(clippy::should_implement_trait)]
+        pub fn next(&mut self) -> i32 {
+            self.0
+                .next()
+                .and_then(|u| i32::try_from(u).ok())
+                .unwrap_or(-1)
+        }
+    }
+}

--- a/ffi/diplomat/wasm/docs/index.rst
+++ b/ffi/diplomat/wasm/docs/index.rst
@@ -16,7 +16,10 @@ Documentation
    properties_maps_ffi
    properties_sets_ffi
    provider_ffi
+   segmenter_grapheme_ffi
    segmenter_line_ffi
+   segmenter_sentence_ffi
+   segmenter_word_ffi
 
 Indices and tables
 ==================

--- a/ffi/diplomat/wasm/docs/segmenter_grapheme_ffi.rst
+++ b/ffi/diplomat/wasm/docs/segmenter_grapheme_ffi.rst
@@ -1,0 +1,49 @@
+``segmenter_grapheme::ffi``
+===========================
+
+.. js:class:: ICU4XGraphemeClusterBreakIteratorLatin1
+
+    .. js:function:: next()
+
+        Finds the next breakpoint. Returns -1 if at the end of the string or if the index is out of range of a 32-bit signed integer.
+
+.. js:class:: ICU4XGraphemeClusterBreakIteratorUtf16
+
+    .. js:function:: next()
+
+        Finds the next breakpoint. Returns -1 if at the end of the string or if the index is out of range of a 32-bit signed integer.
+
+.. js:class:: ICU4XGraphemeClusterBreakIteratorUtf8
+
+    .. js:function:: next()
+
+        Finds the next breakpoint. Returns -1 if at the end of the string or if the index is out of range of a 32-bit signed integer.
+
+.. js:class:: ICU4XGraphemeClusterBreakSegmenter
+
+    An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
+    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html>`__ for more information.
+
+    .. js:staticfunction:: try_new(provider)
+
+        Construct an :js:class:`ICU4XGraphemeClusterBreakSegmenter`.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.try_new>`__ for more information.
+
+    .. js:function:: segment_utf8(input)
+
+        Segments a UTF-8 string.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_str>`__ for more information.
+
+    .. js:function:: segment_utf16(input)
+
+        Segments a UTF-16 string.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_utf16>`__ for more information.
+
+        - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
+
+    .. js:function:: segment_latin1(input)
+
+        Segments a Latin-1 string.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_latin1>`__ for more information.
+
+        - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.

--- a/ffi/diplomat/wasm/docs/segmenter_grapheme_ffi.rst
+++ b/ffi/diplomat/wasm/docs/segmenter_grapheme_ffi.rst
@@ -21,7 +21,7 @@
 
 .. js:class:: ICU4XGraphemeClusterBreakSegmenter
 
-    An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
+    An ICU4X grapheme-cluster-break segmenter, capable of finding grapheme cluster breakpoints in strings.
     See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html>`__ for more information.
 
     .. js:staticfunction:: try_new(provider)

--- a/ffi/diplomat/wasm/docs/segmenter_sentence_ffi.rst
+++ b/ffi/diplomat/wasm/docs/segmenter_sentence_ffi.rst
@@ -1,0 +1,49 @@
+``segmenter_sentence::ffi``
+===========================
+
+.. js:class:: ICU4XSentenceBreakIteratorLatin1
+
+    .. js:function:: next()
+
+        Finds the next breakpoint. Returns -1 if at the end of the string or if the index is out of range of a 32-bit signed integer.
+
+.. js:class:: ICU4XSentenceBreakIteratorUtf16
+
+    .. js:function:: next()
+
+        Finds the next breakpoint. Returns -1 if at the end of the string or if the index is out of range of a 32-bit signed integer.
+
+.. js:class:: ICU4XSentenceBreakIteratorUtf8
+
+    .. js:function:: next()
+
+        Finds the next breakpoint. Returns -1 if at the end of the string or if the index is out of range of a 32-bit signed integer.
+
+.. js:class:: ICU4XSentenceBreakSegmenter
+
+    An ICU4X sentence-break segmenter, capable of finding sentence breakpoints in strings.
+    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.SentenceBreakSegmenter.html>`__ for more information.
+
+    .. js:staticfunction:: try_new(provider)
+
+        Construct an :js:class:`ICU4XSentenceBreakSegmenter`.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.SentenceBreakSegmenter.html#method.try_new>`__ for more information.
+
+    .. js:function:: segment_utf8(input)
+
+        Segments a UTF-8 string.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.SentenceBreakSegmenter.html#method.segment_str>`__ for more information.
+
+    .. js:function:: segment_utf16(input)
+
+        Segments a UTF-16 string.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.SentenceBreakSegmenter.html#method.segment_utf16>`__ for more information.
+
+        - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
+
+    .. js:function:: segment_latin1(input)
+
+        Segments a Latin-1 string.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.SentenceBreakSegmenter.html#method.segment_latin1>`__ for more information.
+
+        - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.

--- a/ffi/diplomat/wasm/docs/segmenter_word_ffi.rst
+++ b/ffi/diplomat/wasm/docs/segmenter_word_ffi.rst
@@ -1,0 +1,49 @@
+``segmenter_word::ffi``
+=======================
+
+.. js:class:: ICU4XWordBreakIteratorLatin1
+
+    .. js:function:: next()
+
+        Finds the next breakpoint. Returns -1 if at the end of the string or if the index is out of range of a 32-bit signed integer.
+
+.. js:class:: ICU4XWordBreakIteratorUtf16
+
+    .. js:function:: next()
+
+        Finds the next breakpoint. Returns -1 if at the end of the string or if the index is out of range of a 32-bit signed integer.
+
+.. js:class:: ICU4XWordBreakIteratorUtf8
+
+    .. js:function:: next()
+
+        Finds the next breakpoint. Returns -1 if at the end of the string or if the index is out of range of a 32-bit signed integer.
+
+.. js:class:: ICU4XWordBreakSegmenter
+
+    An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
+    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.WordBreakSegmenter.html>`__ for more information.
+
+    .. js:staticfunction:: try_new(provider)
+
+        Construct an :js:class:`ICU4XWordBreakSegmenter`.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.WordBreakSegmenter.html#method.try_new>`__ for more information.
+
+    .. js:function:: segment_utf8(input)
+
+        Segments a UTF-8 string.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.WordBreakSegmenter.html#method.segment_str>`__ for more information.
+
+    .. js:function:: segment_utf16(input)
+
+        Segments a UTF-16 string.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.WordBreakSegmenter.html#method.segment_utf16>`__ for more information.
+
+        - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
+
+    .. js:function:: segment_latin1(input)
+
+        Segments a Latin-1 string.
+        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.WordBreakSegmenter.html#method.segment_latin1>`__ for more information.
+
+        - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.

--- a/ffi/diplomat/wasm/lib/api.mjs
+++ b/ffi/diplomat/wasm/lib/api.mjs
@@ -886,6 +886,141 @@ const ICU4XFixedDecimalSignDisplay_rust_to_js = {
   4: "Negative",
 };
 
+const ICU4XGraphemeClusterBreakIteratorLatin1_box_destroy_registry = new FinalizationRegistry(underlying => {
+  wasm.ICU4XGraphemeClusterBreakIteratorLatin1_destroy(underlying);
+});
+
+export class ICU4XGraphemeClusterBreakIteratorLatin1 {
+  constructor(underlying) {
+    this.underlying = underlying;
+  }
+
+  next() {
+    const diplomat_out = wasm.ICU4XGraphemeClusterBreakIteratorLatin1_next(this.underlying);
+    return diplomat_out;
+  }
+}
+
+const ICU4XGraphemeClusterBreakIteratorUtf16_box_destroy_registry = new FinalizationRegistry(underlying => {
+  wasm.ICU4XGraphemeClusterBreakIteratorUtf16_destroy(underlying);
+});
+
+export class ICU4XGraphemeClusterBreakIteratorUtf16 {
+  constructor(underlying) {
+    this.underlying = underlying;
+  }
+
+  next() {
+    const diplomat_out = wasm.ICU4XGraphemeClusterBreakIteratorUtf16_next(this.underlying);
+    return diplomat_out;
+  }
+}
+
+const ICU4XGraphemeClusterBreakIteratorUtf8_box_destroy_registry = new FinalizationRegistry(underlying => {
+  wasm.ICU4XGraphemeClusterBreakIteratorUtf8_destroy(underlying);
+});
+
+export class ICU4XGraphemeClusterBreakIteratorUtf8 {
+  constructor(underlying) {
+    this.underlying = underlying;
+  }
+
+  next() {
+    const diplomat_out = wasm.ICU4XGraphemeClusterBreakIteratorUtf8_next(this.underlying);
+    return diplomat_out;
+  }
+}
+
+const ICU4XGraphemeClusterBreakSegmenter_box_destroy_registry = new FinalizationRegistry(underlying => {
+  wasm.ICU4XGraphemeClusterBreakSegmenter_destroy(underlying);
+});
+
+export class ICU4XGraphemeClusterBreakSegmenter {
+  constructor(underlying) {
+    this.underlying = underlying;
+  }
+
+  static try_new(provider) {
+    const diplomat_out = (() => {
+      const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
+      const result_tag = {};
+      diplomat_alloc_destroy_registry.register(result_tag, {
+        ptr: diplomat_receive_buffer,
+        size: 5,
+        align: 4,
+      });
+      wasm.ICU4XGraphemeClusterBreakSegmenter_try_new(diplomat_receive_buffer, provider.underlying);
+      const is_ok = (new Uint8Array(wasm.memory.buffer, diplomat_receive_buffer + 4, 1))[0] == 1;
+      if (is_ok) {
+        const ok_value = (() => {
+          const out = new ICU4XGraphemeClusterBreakSegmenter((new Uint32Array(wasm.memory.buffer, diplomat_receive_buffer, 1))[0]);
+          out.owner = result_tag;
+          return out;
+        })();
+        return ok_value;
+      } else {
+        const throw_value = ICU4XError_rust_to_js[(new Int32Array(wasm.memory.buffer, diplomat_receive_buffer, 1))[0]];
+        throw new diplomatRuntime.FFIError(throw_value);
+      }
+    })();
+    return diplomat_out;
+  }
+
+  segment_utf8(input) {
+    let input_diplomat_bytes = (new TextEncoder()).encode(input);
+    let input_diplomat_ptr = wasm.diplomat_alloc(input_diplomat_bytes.length, 1);
+    let input_diplomat_buf = new Uint8Array(wasm.memory.buffer, input_diplomat_ptr, input_diplomat_bytes.length);
+    input_diplomat_buf.set(input_diplomat_bytes, 0);
+    const diplomat_out = (() => {
+      const out = (() => {
+        const out = new ICU4XGraphemeClusterBreakIteratorUtf8(wasm.ICU4XGraphemeClusterBreakSegmenter_segment_utf8(this.underlying, input_diplomat_ptr, input_diplomat_bytes.length));
+        out.owner = null;
+        return out;
+      })();
+      ICU4XGraphemeClusterBreakIteratorUtf8_box_destroy_registry.register(out, out.underlying)
+      return out;
+    })();
+    wasm.diplomat_free(input_diplomat_ptr, input_diplomat_bytes.length, 1);
+    return diplomat_out;
+  }
+
+  segment_utf16(input) {
+    let input_diplomat_bytes = new Uint8Array(input);
+    let input_diplomat_ptr = wasm.diplomat_alloc(input_diplomat_bytes.length, 2);
+    let input_diplomat_buf = new Uint8Array(wasm.memory.buffer, input_diplomat_ptr, input_diplomat_bytes.length);
+    input_diplomat_buf.set(input_diplomat_bytes, 0);
+    const diplomat_out = (() => {
+      const out = (() => {
+        const out = new ICU4XGraphemeClusterBreakIteratorUtf16(wasm.ICU4XGraphemeClusterBreakSegmenter_segment_utf16(this.underlying, input_diplomat_ptr, input_diplomat_bytes.length));
+        out.owner = null;
+        return out;
+      })();
+      ICU4XGraphemeClusterBreakIteratorUtf16_box_destroy_registry.register(out, out.underlying)
+      return out;
+    })();
+    wasm.diplomat_free(input_diplomat_ptr, input_diplomat_bytes.length, 2);
+    return diplomat_out;
+  }
+
+  segment_latin1(input) {
+    let input_diplomat_bytes = new Uint8Array(input);
+    let input_diplomat_ptr = wasm.diplomat_alloc(input_diplomat_bytes.length, 1);
+    let input_diplomat_buf = new Uint8Array(wasm.memory.buffer, input_diplomat_ptr, input_diplomat_bytes.length);
+    input_diplomat_buf.set(input_diplomat_bytes, 0);
+    const diplomat_out = (() => {
+      const out = (() => {
+        const out = new ICU4XGraphemeClusterBreakIteratorLatin1(wasm.ICU4XGraphemeClusterBreakSegmenter_segment_latin1(this.underlying, input_diplomat_ptr, input_diplomat_bytes.length));
+        out.owner = null;
+        return out;
+      })();
+      ICU4XGraphemeClusterBreakIteratorLatin1_box_destroy_registry.register(out, out.underlying)
+      return out;
+    })();
+    wasm.diplomat_free(input_diplomat_ptr, input_diplomat_bytes.length, 1);
+    return diplomat_out;
+  }
+}
+
 const ICU4XLineBreakIteratorLatin1_box_destroy_registry = new FinalizationRegistry(underlying => {
   wasm.ICU4XLineBreakIteratorLatin1_destroy(underlying);
 });
@@ -1658,6 +1793,186 @@ export class ICU4XPluralRules {
   }
 }
 
+const ICU4XSentenceBreakIteratorLatin1_box_destroy_registry = new FinalizationRegistry(underlying => {
+  wasm.ICU4XSentenceBreakIteratorLatin1_destroy(underlying);
+});
+
+export class ICU4XSentenceBreakIteratorLatin1 {
+  constructor(underlying) {
+    this.underlying = underlying;
+  }
+
+  next() {
+    const diplomat_out = wasm.ICU4XSentenceBreakIteratorLatin1_next(this.underlying);
+    return diplomat_out;
+  }
+}
+
+const ICU4XSentenceBreakIteratorUtf16_box_destroy_registry = new FinalizationRegistry(underlying => {
+  wasm.ICU4XSentenceBreakIteratorUtf16_destroy(underlying);
+});
+
+export class ICU4XSentenceBreakIteratorUtf16 {
+  constructor(underlying) {
+    this.underlying = underlying;
+  }
+
+  next() {
+    const diplomat_out = wasm.ICU4XSentenceBreakIteratorUtf16_next(this.underlying);
+    return diplomat_out;
+  }
+}
+
+const ICU4XSentenceBreakIteratorUtf8_box_destroy_registry = new FinalizationRegistry(underlying => {
+  wasm.ICU4XSentenceBreakIteratorUtf8_destroy(underlying);
+});
+
+export class ICU4XSentenceBreakIteratorUtf8 {
+  constructor(underlying) {
+    this.underlying = underlying;
+  }
+
+  next() {
+    const diplomat_out = wasm.ICU4XSentenceBreakIteratorUtf8_next(this.underlying);
+    return diplomat_out;
+  }
+}
+
+const ICU4XSentenceBreakSegmenter_box_destroy_registry = new FinalizationRegistry(underlying => {
+  wasm.ICU4XSentenceBreakSegmenter_destroy(underlying);
+});
+
+export class ICU4XSentenceBreakSegmenter {
+  constructor(underlying) {
+    this.underlying = underlying;
+  }
+
+  static try_new(provider) {
+    const diplomat_out = (() => {
+      const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
+      const result_tag = {};
+      diplomat_alloc_destroy_registry.register(result_tag, {
+        ptr: diplomat_receive_buffer,
+        size: 5,
+        align: 4,
+      });
+      wasm.ICU4XSentenceBreakSegmenter_try_new(diplomat_receive_buffer, provider.underlying);
+      const is_ok = (new Uint8Array(wasm.memory.buffer, diplomat_receive_buffer + 4, 1))[0] == 1;
+      if (is_ok) {
+        const ok_value = (() => {
+          const out = new ICU4XSentenceBreakSegmenter((new Uint32Array(wasm.memory.buffer, diplomat_receive_buffer, 1))[0]);
+          out.owner = result_tag;
+          return out;
+        })();
+        return ok_value;
+      } else {
+        const throw_value = ICU4XError_rust_to_js[(new Int32Array(wasm.memory.buffer, diplomat_receive_buffer, 1))[0]];
+        throw new diplomatRuntime.FFIError(throw_value);
+      }
+    })();
+    return diplomat_out;
+  }
+
+  segment_utf8(input) {
+    let input_diplomat_bytes = (new TextEncoder()).encode(input);
+    let input_diplomat_ptr = wasm.diplomat_alloc(input_diplomat_bytes.length, 1);
+    let input_diplomat_buf = new Uint8Array(wasm.memory.buffer, input_diplomat_ptr, input_diplomat_bytes.length);
+    input_diplomat_buf.set(input_diplomat_bytes, 0);
+    const diplomat_out = (() => {
+      const out = (() => {
+        const out = new ICU4XSentenceBreakIteratorUtf8(wasm.ICU4XSentenceBreakSegmenter_segment_utf8(this.underlying, input_diplomat_ptr, input_diplomat_bytes.length));
+        out.owner = null;
+        return out;
+      })();
+      ICU4XSentenceBreakIteratorUtf8_box_destroy_registry.register(out, out.underlying)
+      return out;
+    })();
+    wasm.diplomat_free(input_diplomat_ptr, input_diplomat_bytes.length, 1);
+    return diplomat_out;
+  }
+
+  segment_utf16(input) {
+    let input_diplomat_bytes = new Uint8Array(input);
+    let input_diplomat_ptr = wasm.diplomat_alloc(input_diplomat_bytes.length, 2);
+    let input_diplomat_buf = new Uint8Array(wasm.memory.buffer, input_diplomat_ptr, input_diplomat_bytes.length);
+    input_diplomat_buf.set(input_diplomat_bytes, 0);
+    const diplomat_out = (() => {
+      const out = (() => {
+        const out = new ICU4XSentenceBreakIteratorUtf16(wasm.ICU4XSentenceBreakSegmenter_segment_utf16(this.underlying, input_diplomat_ptr, input_diplomat_bytes.length));
+        out.owner = null;
+        return out;
+      })();
+      ICU4XSentenceBreakIteratorUtf16_box_destroy_registry.register(out, out.underlying)
+      return out;
+    })();
+    wasm.diplomat_free(input_diplomat_ptr, input_diplomat_bytes.length, 2);
+    return diplomat_out;
+  }
+
+  segment_latin1(input) {
+    let input_diplomat_bytes = new Uint8Array(input);
+    let input_diplomat_ptr = wasm.diplomat_alloc(input_diplomat_bytes.length, 1);
+    let input_diplomat_buf = new Uint8Array(wasm.memory.buffer, input_diplomat_ptr, input_diplomat_bytes.length);
+    input_diplomat_buf.set(input_diplomat_bytes, 0);
+    const diplomat_out = (() => {
+      const out = (() => {
+        const out = new ICU4XSentenceBreakIteratorLatin1(wasm.ICU4XSentenceBreakSegmenter_segment_latin1(this.underlying, input_diplomat_ptr, input_diplomat_bytes.length));
+        out.owner = null;
+        return out;
+      })();
+      ICU4XSentenceBreakIteratorLatin1_box_destroy_registry.register(out, out.underlying)
+      return out;
+    })();
+    wasm.diplomat_free(input_diplomat_ptr, input_diplomat_bytes.length, 1);
+    return diplomat_out;
+  }
+}
+
+const ICU4XWordBreakIteratorLatin1_box_destroy_registry = new FinalizationRegistry(underlying => {
+  wasm.ICU4XWordBreakIteratorLatin1_destroy(underlying);
+});
+
+export class ICU4XWordBreakIteratorLatin1 {
+  constructor(underlying) {
+    this.underlying = underlying;
+  }
+
+  next() {
+    const diplomat_out = wasm.ICU4XWordBreakIteratorLatin1_next(this.underlying);
+    return diplomat_out;
+  }
+}
+
+const ICU4XWordBreakIteratorUtf16_box_destroy_registry = new FinalizationRegistry(underlying => {
+  wasm.ICU4XWordBreakIteratorUtf16_destroy(underlying);
+});
+
+export class ICU4XWordBreakIteratorUtf16 {
+  constructor(underlying) {
+    this.underlying = underlying;
+  }
+
+  next() {
+    const diplomat_out = wasm.ICU4XWordBreakIteratorUtf16_next(this.underlying);
+    return diplomat_out;
+  }
+}
+
+const ICU4XWordBreakIteratorUtf8_box_destroy_registry = new FinalizationRegistry(underlying => {
+  wasm.ICU4XWordBreakIteratorUtf8_destroy(underlying);
+});
+
+export class ICU4XWordBreakIteratorUtf8 {
+  constructor(underlying) {
+    this.underlying = underlying;
+  }
+
+  next() {
+    const diplomat_out = wasm.ICU4XWordBreakIteratorUtf8_next(this.underlying);
+    return diplomat_out;
+  }
+}
+
 const ICU4XWordBreakRule_js_to_rust = {
   "Normal": 0,
   "BreakAll": 1,
@@ -1668,3 +1983,93 @@ const ICU4XWordBreakRule_rust_to_js = {
   1: "BreakAll",
   2: "KeepAll",
 };
+
+const ICU4XWordBreakSegmenter_box_destroy_registry = new FinalizationRegistry(underlying => {
+  wasm.ICU4XWordBreakSegmenter_destroy(underlying);
+});
+
+export class ICU4XWordBreakSegmenter {
+  constructor(underlying) {
+    this.underlying = underlying;
+  }
+
+  static try_new(provider) {
+    const diplomat_out = (() => {
+      const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
+      const result_tag = {};
+      diplomat_alloc_destroy_registry.register(result_tag, {
+        ptr: diplomat_receive_buffer,
+        size: 5,
+        align: 4,
+      });
+      wasm.ICU4XWordBreakSegmenter_try_new(diplomat_receive_buffer, provider.underlying);
+      const is_ok = (new Uint8Array(wasm.memory.buffer, diplomat_receive_buffer + 4, 1))[0] == 1;
+      if (is_ok) {
+        const ok_value = (() => {
+          const out = new ICU4XWordBreakSegmenter((new Uint32Array(wasm.memory.buffer, diplomat_receive_buffer, 1))[0]);
+          out.owner = result_tag;
+          return out;
+        })();
+        return ok_value;
+      } else {
+        const throw_value = ICU4XError_rust_to_js[(new Int32Array(wasm.memory.buffer, diplomat_receive_buffer, 1))[0]];
+        throw new diplomatRuntime.FFIError(throw_value);
+      }
+    })();
+    return diplomat_out;
+  }
+
+  segment_utf8(input) {
+    let input_diplomat_bytes = (new TextEncoder()).encode(input);
+    let input_diplomat_ptr = wasm.diplomat_alloc(input_diplomat_bytes.length, 1);
+    let input_diplomat_buf = new Uint8Array(wasm.memory.buffer, input_diplomat_ptr, input_diplomat_bytes.length);
+    input_diplomat_buf.set(input_diplomat_bytes, 0);
+    const diplomat_out = (() => {
+      const out = (() => {
+        const out = new ICU4XWordBreakIteratorUtf8(wasm.ICU4XWordBreakSegmenter_segment_utf8(this.underlying, input_diplomat_ptr, input_diplomat_bytes.length));
+        out.owner = null;
+        return out;
+      })();
+      ICU4XWordBreakIteratorUtf8_box_destroy_registry.register(out, out.underlying)
+      return out;
+    })();
+    wasm.diplomat_free(input_diplomat_ptr, input_diplomat_bytes.length, 1);
+    return diplomat_out;
+  }
+
+  segment_utf16(input) {
+    let input_diplomat_bytes = new Uint8Array(input);
+    let input_diplomat_ptr = wasm.diplomat_alloc(input_diplomat_bytes.length, 2);
+    let input_diplomat_buf = new Uint8Array(wasm.memory.buffer, input_diplomat_ptr, input_diplomat_bytes.length);
+    input_diplomat_buf.set(input_diplomat_bytes, 0);
+    const diplomat_out = (() => {
+      const out = (() => {
+        const out = new ICU4XWordBreakIteratorUtf16(wasm.ICU4XWordBreakSegmenter_segment_utf16(this.underlying, input_diplomat_ptr, input_diplomat_bytes.length));
+        out.owner = null;
+        return out;
+      })();
+      ICU4XWordBreakIteratorUtf16_box_destroy_registry.register(out, out.underlying)
+      return out;
+    })();
+    wasm.diplomat_free(input_diplomat_ptr, input_diplomat_bytes.length, 2);
+    return diplomat_out;
+  }
+
+  segment_latin1(input) {
+    let input_diplomat_bytes = new Uint8Array(input);
+    let input_diplomat_ptr = wasm.diplomat_alloc(input_diplomat_bytes.length, 1);
+    let input_diplomat_buf = new Uint8Array(wasm.memory.buffer, input_diplomat_ptr, input_diplomat_bytes.length);
+    input_diplomat_buf.set(input_diplomat_bytes, 0);
+    const diplomat_out = (() => {
+      const out = (() => {
+        const out = new ICU4XWordBreakIteratorLatin1(wasm.ICU4XWordBreakSegmenter_segment_latin1(this.underlying, input_diplomat_ptr, input_diplomat_bytes.length));
+        out.owner = null;
+        return out;
+      })();
+      ICU4XWordBreakIteratorLatin1_box_destroy_registry.register(out, out.underlying)
+      return out;
+    })();
+    wasm.diplomat_free(input_diplomat_ptr, input_diplomat_bytes.length, 1);
+    return diplomat_out;
+  }
+}


### PR DESCRIPTION
Fixed #1378

Here is the output from the example code:
```
ffi/diplomat/cpp/examples/segmenter $ make
g++ -std=c++17 test.cpp ../../../../../target/debug/libicu_capi_staticlib_test.a -ldl -lpthread -lm -g
./a.out
Finding line breakpoints in string:
The quick brown fox jumps over the lazy dog.
0....5....0....5....0....5....0....5....0...
Line breakpoints: 4 10 16 20 26 31 35 40 44

Finding grapheme cluster breakpoints in string:
The quick brown fox jumps over the lazy dog.
0....5....0....5....0....5....0....5....0...
Grapheme cluster breakpoints: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44

Finding word breakpoints in string:
The quick brown fox jumps over the lazy dog.
0....5....0....5....0....5....0....5....0...
Word breakpoints: 0 3 4 9 10 15 16 19 20 25 26 30 31 34 35 39 40 43 44

Finding sentence breakpoints in string:
The quick brown fox jumps over the lazy dog.
0....5....0....5....0....5....0....5....0...
Sentence breakpoints: 0 44

```