### PR TITLE
Update release process doc to include doc_comment_in_code_block_width rustfmt option

### DIFF
--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -8,7 +8,7 @@ Over the last month before the release target date, we'll discuss the checklist 
 
 Once the release is complete, the assigned release driver will:
 
-* Run `cargo +nightly fmt -- --config=format_code_in_doc_comments=true` to prettify our docs
+* Run `cargo +nightly fmt -- --config=format_code_in_doc_comments=true --config=doc_comment_code_block_width=80` to prettify our docs
 * Run `cargo make full-data` to make sure full datagen works
 * Verify that the milestone and checklist are complete
 * Verify with component owners that they're ready for release


### PR DESCRIPTION
Followup from https://github.com/unicode-org/icu4x/pull/1899

I haven't checked in the actual formatting but it looks pretty good overall.

I could check in such an update later?

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->