### PR TITLE
Move Formatted[Zoned]DateTime over to preextracting the date time input info

### DIFF
--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -19,7 +19,7 @@ use zerovec::ule::AsULE;
 pub struct Era(pub TinyStr16);
 
 /// Representation of a formattable year.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Year {
     /// The era containing the year.
@@ -66,7 +66,7 @@ impl fmt::Display for MonthCode {
     }
 }
 /// Representation of a formattable month.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Month {
     /// The month number in this given year. For calendars with leap months, all months after
@@ -82,7 +82,7 @@ pub struct Month {
 /// A struct containing various details about the position of the day within a year. It is returned
 // by the [`day_of_year_info()`](trait.DateInput.html#tymethod.day_of_year_info) method of the
 // [`DateInput`] trait.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct DayOfYearInfo {
     /// The current day of the year, 1-based.
@@ -99,6 +99,7 @@ pub struct DayOfYearInfo {
 
 /// A day number in a month. Usually 1-based.
 #[allow(clippy::exhaustive_structs)] // this is a newtype
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DayOfMonth(pub u32);
 
 /// A week number in a month. Usually 1-based.

--- a/components/datetime/src/any.rs
+++ b/components/datetime/src/any.rs
@@ -210,7 +210,7 @@ impl AnyDateTimeFormat {
     pub fn format<'l, T>(
         &'l self,
         value: &'l T,
-    ) -> Result<FormattedDateTime<'l, T>, DateTimeFormatError>
+    ) -> Result<FormattedDateTime<'l>, DateTimeFormatError>
     where
         T: DateTimeInput<Calendar = AnyCalendar>,
     {

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -148,7 +148,7 @@ pub(crate) struct ExtractedDateTimeInput {
 /// A [`ZonedDateTimeInput`] type with all of the fields pre-extracted
 ///
 /// See [`ZonedDateTimeInput`] for documentation on individual fields
-pub(crate) struct ExtractedTimeZoneInput {
+pub(crate) struct ExtractedZonedDateTimeInput {
     date_time_input: ExtractedDateTimeInput,
     gmt_offset: GmtOffset,
     time_zone_id: Option<TimeZoneBcp47Id>,
@@ -174,7 +174,7 @@ impl ExtractedDateTimeInput {
     }
 }
 
-impl ExtractedTimeZoneInput {
+impl ExtractedZonedDateTimeInput {
     /// Construct given an instance of a [`ZonedDateTimeInput`].
     pub(crate) fn extract_from<T: ZonedDateTimeInput>(input: &T) -> Self {
         Self {
@@ -226,7 +226,7 @@ impl IsoTimeInput for ExtractedDateTimeInput {
     }
 }
 
-impl DateInput for ExtractedTimeZoneInput {
+impl DateInput for ExtractedZonedDateTimeInput {
     /// This actually doesn't matter, by the time we use this
     /// it's purely internal raw code where calendars are irrelevant
     type Calendar = icu_calendar::any_calendar::AnyCalendar;
@@ -250,7 +250,7 @@ impl DateInput for ExtractedTimeZoneInput {
     }
 }
 
-impl IsoTimeInput for ExtractedTimeZoneInput {
+impl IsoTimeInput for ExtractedZonedDateTimeInput {
     fn hour(&self) -> Option<IsoHour> {
         self.date_time_input.hour
     }
@@ -265,7 +265,7 @@ impl IsoTimeInput for ExtractedTimeZoneInput {
     }
 }
 
-impl TimeZoneInput for ExtractedTimeZoneInput {
+impl TimeZoneInput for ExtractedZonedDateTimeInput {
     fn gmt_offset(&self) -> GmtOffset {
         self.gmt_offset
     }

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -132,7 +132,7 @@ pub(crate) struct DateTimeInputWithLocale<'data, T: DateTimeInput> {
 /// A [`DateTimeInput`] type with all of the fields pre-extracted
 ///
 /// See [`DateTimeInput`] for documentation on individual fields
-struct ExtractedDateTimeInput {
+pub(crate) struct ExtractedDateTimeInput {
     year: Option<Year>,
     month: Option<Month>,
     day_of_month: Option<DayOfMonth>,
@@ -148,7 +148,7 @@ struct ExtractedDateTimeInput {
 /// A [`ZonedDateTimeInput`] type with all of the fields pre-extracted
 ///
 /// See [`ZonedDateTimeInput`] for documentation on individual fields
-struct ExtractedTimeZoneInput {
+pub(crate) struct ExtractedTimeZoneInput {
     date_time_input: ExtractedDateTimeInput,
     gmt_offset: GmtOffset,
     time_zone_id: Option<TimeZoneBcp47Id>,
@@ -158,7 +158,7 @@ struct ExtractedTimeZoneInput {
 
 impl ExtractedDateTimeInput {
     /// Construct given an instance of a [`DateTimeInput`].
-    fn extract_from<T: DateTimeInput>(input: &T) -> Self {
+    pub(crate) fn extract_from<T: DateTimeInput>(input: &T) -> Self {
         Self {
             year: input.year(),
             month: input.month(),
@@ -176,7 +176,7 @@ impl ExtractedDateTimeInput {
 
 impl ExtractedTimeZoneInput {
     /// Construct given an instance of a [`ZonedDateTimeInput`].
-    fn extract_from<T: ZonedDateTimeInput>(input: &T) -> Self {
+    pub(crate) fn extract_from<T: ZonedDateTimeInput>(input: &T) -> Self {
         Self {
             date_time_input: ExtractedDateTimeInput::extract_from(input),
             gmt_offset: input.gmt_offset(),

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -77,13 +77,13 @@ pub trait TimeZoneInput {
     fn gmt_offset(&self) -> GmtOffset;
 
     /// The IANA time-zone identifier.
-    fn time_zone_id(&self) -> Option<&TimeZoneBcp47Id>;
+    fn time_zone_id(&self) -> Option<TimeZoneBcp47Id>;
 
     /// The metazone identifier.
-    fn metazone_id(&self) -> Option<&MetaZoneId>;
+    fn metazone_id(&self) -> Option<MetaZoneId>;
 
     /// The time variant (e.g. "daylight", "standard")
-    fn time_variant(&self) -> Option<&TinyStr8>;
+    fn time_variant(&self) -> Option<TinyStr8>;
 }
 
 /// A combination of a formattable calendar date and ISO time.
@@ -180,9 +180,9 @@ impl ExtractedTimeZoneInput {
         Self {
             date_time_input: ExtractedDateTimeInput::extract_from(input),
             gmt_offset: input.gmt_offset(),
-            time_zone_id: input.time_zone_id().cloned(),
-            metazone_id: input.metazone_id().cloned(),
-            time_variant: input.time_variant().cloned(),
+            time_zone_id: input.time_zone_id(),
+            metazone_id: input.metazone_id(),
+            time_variant: input.time_variant(),
         }
     }
 }
@@ -269,14 +269,14 @@ impl TimeZoneInput for ExtractedTimeZoneInput {
     fn gmt_offset(&self) -> GmtOffset {
         self.gmt_offset
     }
-    fn time_zone_id(&self) -> Option<&TimeZoneBcp47Id> {
-        self.time_zone_id.as_ref()
+    fn time_zone_id(&self) -> Option<TimeZoneBcp47Id> {
+        self.time_zone_id
     }
-    fn metazone_id(&self) -> Option<&MetaZoneId> {
-        self.metazone_id.as_ref()
+    fn metazone_id(&self) -> Option<MetaZoneId> {
+        self.metazone_id
     }
-    fn time_variant(&self) -> Option<&TinyStr8> {
-        self.time_variant.as_ref()
+    fn time_variant(&self) -> Option<TinyStr8> {
+        self.time_variant
     }
 }
 

--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -139,7 +139,7 @@ impl<C: CldrCalendar> DateTimeFormat<C> {
     /// but [`FormattedDateTime`] will grow with methods for iterating over fields, extracting information
     /// about formatted date and so on.
     #[inline]
-    pub fn format<'l, T>(&'l self, value: &'l T) -> FormattedDateTime<'l, T>
+    pub fn format<'l, T>(&'l self, value: &'l T) -> FormattedDateTime<'l>
     where
         T: DateTimeInput<Calendar = C>,
     {

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -2,7 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::date::{DateTimeInput, DateTimeInputWithLocale, LocalizedDateTimeInput};
+use crate::date::{
+    DateTimeInput, DateTimeInputWithLocale, ExtractedDateTimeInput, LocalizedDateTimeInput,
+};
 use crate::error::DateTimeFormatError as Error;
 use crate::fields::{self, Field, FieldLength, FieldSymbol, Second, Week, Year};
 use crate::pattern::{
@@ -47,30 +49,24 @@ use writeable::Writeable;
 ///
 /// let _ = format!("Date: {}", formatted_date);
 /// ```
-pub struct FormattedDateTime<'l, T>
-where
-    T: DateTimeInput,
-{
+pub struct FormattedDateTime<'l> {
     pub(crate) patterns: &'l DataPayload<PatternPluralsFromPatternsV1Marker>,
     pub(crate) date_symbols: Option<&'l provider::calendar::DateSymbolsV1<'l>>,
     pub(crate) time_symbols: Option<&'l provider::calendar::TimeSymbolsV1<'l>>,
-    pub(crate) datetime: &'l T,
+    pub(crate) datetime: ExtractedDateTimeInput,
     pub(crate) week_data: Option<&'l WeekDataV1>,
     pub(crate) locale: &'l Locale,
     pub(crate) ordinal_rules: Option<&'l PluralRules>,
     pub(crate) fixed_decimal_format: &'l FixedDecimalFormat,
 }
 
-impl<'l, T> Writeable for FormattedDateTime<'l, T>
-where
-    T: DateTimeInput,
-{
+impl<'l> Writeable for FormattedDateTime<'l> {
     fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
         write_pattern_plurals(
             &self.patterns.get().0,
             self.date_symbols,
             self.time_symbols,
-            self.datetime,
+            &self.datetime,
             self.week_data,
             self.ordinal_rules,
             self.fixed_decimal_format,
@@ -83,10 +79,7 @@ where
     // TODO(#489): Implement write_len
 }
 
-impl<'l, T> fmt::Display for FormattedDateTime<'l, T>
-where
-    T: DateTimeInput,
-{
+impl<'l> fmt::Display for FormattedDateTime<'l> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.write_to(f)
     }

--- a/components/datetime/src/format/zoned_datetime.rs
+++ b/components/datetime/src/format/zoned_datetime.rs
@@ -5,7 +5,9 @@
 //! A collection of code for formatting DateTimes with time zones.
 
 use crate::date::ZonedDateTimeInput;
-use crate::date::{LocalizedDateTimeInput, ZonedDateTimeInputWithLocale};
+use crate::date::{
+    ExtractedZonedDateTimeInput, LocalizedDateTimeInput, ZonedDateTimeInputWithLocale,
+};
 use crate::error::DateTimeFormatError as Error;
 use crate::fields::{self, FieldSymbol};
 use crate::pattern::{runtime, PatternItem};
@@ -16,32 +18,23 @@ use writeable::Writeable;
 use super::datetime;
 
 #[allow(missing_docs)] // TODO(#686) - Add missing docs.
-pub struct FormattedZonedDateTime<'l, T>
-where
-    T: ZonedDateTimeInput,
-{
+pub struct FormattedZonedDateTime<'l> {
     pub(crate) zoned_datetime_format: &'l raw::ZonedDateTimeFormat,
-    pub(crate) zoned_datetime: &'l T,
+    pub(crate) zoned_datetime: ExtractedZonedDateTimeInput,
 }
 
-impl<'l, T> Writeable for FormattedZonedDateTime<'l, T>
-where
-    T: ZonedDateTimeInput,
-{
+impl<'l> Writeable for FormattedZonedDateTime<'l> {
     fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
-        write_pattern(self.zoned_datetime_format, self.zoned_datetime, sink)
+        write_pattern(self.zoned_datetime_format, &self.zoned_datetime, sink)
             .map_err(|_| core::fmt::Error)
     }
 
     // TODO(#489): Implement write_len
 }
 
-impl<'l, T> fmt::Display for FormattedZonedDateTime<'l, T>
-where
-    T: ZonedDateTimeInput,
-{
+impl<'l> fmt::Display for FormattedZonedDateTime<'l> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write_pattern(self.zoned_datetime_format, self.zoned_datetime, f)
+        write_pattern(self.zoned_datetime_format, &self.zoned_datetime, f)
             .map_err(|_| core::fmt::Error)
     }
 }

--- a/components/datetime/src/mock/time_zone.rs
+++ b/components/datetime/src/mock/time_zone.rs
@@ -104,15 +104,15 @@ impl TimeZoneInput for MockTimeZone {
         self.gmt_offset
     }
 
-    fn time_zone_id(&self) -> Option<&TimeZoneBcp47Id> {
-        self.time_zone_id.as_ref()
+    fn time_zone_id(&self) -> Option<TimeZoneBcp47Id> {
+        self.time_zone_id
     }
 
-    fn metazone_id(&self) -> Option<&MetaZoneId> {
-        self.metazone_id.as_ref()
+    fn metazone_id(&self) -> Option<MetaZoneId> {
+        self.metazone_id
     }
 
-    fn time_variant(&self) -> Option<&TinyStr8> {
-        self.time_variant.as_ref()
+    fn time_variant(&self) -> Option<TinyStr8> {
+        self.time_variant
     }
 }

--- a/components/datetime/src/mock/zoned_datetime.rs
+++ b/components/datetime/src/mock/zoned_datetime.rs
@@ -149,15 +149,15 @@ impl TimeZoneInput for MockZonedDateTime {
         self.time_zone.gmt_offset()
     }
 
-    fn time_zone_id(&self) -> Option<&TimeZoneBcp47Id> {
+    fn time_zone_id(&self) -> Option<TimeZoneBcp47Id> {
         self.time_zone.time_zone_id()
     }
 
-    fn metazone_id(&self) -> Option<&MetaZoneId> {
+    fn metazone_id(&self) -> Option<MetaZoneId> {
         self.time_zone.metazone_id()
     }
 
-    fn time_variant(&self) -> Option<&TinyStr8> {
+    fn time_variant(&self) -> Option<TinyStr8> {
         self.time_zone.time_variant()
     }
 }

--- a/components/datetime/src/raw/datetime.rs
+++ b/components/datetime/src/raw/datetime.rs
@@ -28,8 +28,8 @@ use icu_plurals::{provider::OrdinalV1Marker, PluralRules};
 use icu_provider::prelude::*;
 
 use crate::{
-    date::DateTimeInput, pattern::runtime::PatternPlurals, provider, DateTimeFormatError,
-    FormattedDateTime,
+    date::DateTimeInput, date::ExtractedDateTimeInput, pattern::runtime::PatternPlurals, provider,
+    DateTimeFormatError, FormattedDateTime,
 };
 
 /// This is the internal "raw" version of [crate::DateTimeFormat], i.e. a version of DateTimeFormat
@@ -170,7 +170,7 @@ impl DateTimeFormat {
     /// Takes a [`DateTimeInput`] implementer and returns an instance of a [`FormattedDateTime`]
     /// that contains all information necessary to display a formatted date and operate on it.
     #[inline]
-    pub fn format<'l, T>(&'l self, value: &'l T) -> FormattedDateTime<'l, T>
+    pub fn format<'l, T>(&'l self, value: &'l T) -> FormattedDateTime<'l>
     where
         T: DateTimeInput,
     {
@@ -178,7 +178,7 @@ impl DateTimeFormat {
             patterns: &self.patterns,
             date_symbols: self.date_symbols.as_ref().map(|s| s.get()),
             time_symbols: self.time_symbols.as_ref().map(|s| s.get()),
-            datetime: value,
+            datetime: ExtractedDateTimeInput::extract_from(value),
             week_data: self.week_data.as_ref().map(|s| s.get()),
             locale: &self.locale,
             ordinal_rules: self.ordinal_rules.as_ref(),

--- a/components/datetime/src/raw/datetime.rs
+++ b/components/datetime/src/raw/datetime.rs
@@ -174,6 +174,7 @@ impl DateTimeFormat {
     where
         T: DateTimeInput,
     {
+        // Todo: optimize extraction #2143
         FormattedDateTime {
             patterns: &self.patterns,
             date_symbols: self.date_symbols.as_ref().map(|s| s.get()),

--- a/components/datetime/src/raw/zoned_datetime.rs
+++ b/components/datetime/src/raw/zoned_datetime.rs
@@ -13,6 +13,7 @@ use icu_plurals::{provider::OrdinalV1Marker, PluralRules};
 use icu_provider::prelude::*;
 
 use crate::{
+    date::ExtractedZonedDateTimeInput,
     date::ZonedDateTimeInput,
     format::{
         datetime,
@@ -174,13 +175,13 @@ impl ZonedDateTimeFormat {
     /// Takes a [`ZonedDateTimeInput`] implementer and returns an instance of a [`FormattedZonedDateTime`]
     /// that contains all information necessary to display a formatted zoned datetime and operate on it.
     #[inline]
-    pub fn format<'l, T>(&'l self, value: &'l T) -> FormattedZonedDateTime<'l, T>
+    pub fn format<'l, T>(&'l self, value: &'l T) -> FormattedZonedDateTime<'l>
     where
         T: ZonedDateTimeInput,
     {
         FormattedZonedDateTime {
             zoned_datetime_format: self,
-            zoned_datetime: value,
+            zoned_datetime: ExtractedZonedDateTimeInput::extract_from(value),
         }
     }
 

--- a/components/datetime/src/raw/zoned_datetime.rs
+++ b/components/datetime/src/raw/zoned_datetime.rs
@@ -179,6 +179,7 @@ impl ZonedDateTimeFormat {
     where
         T: ZonedDateTimeInput,
     {
+        // Todo: optimize extraction #2143
         FormattedZonedDateTime {
             zoned_datetime_format: self,
             zoned_datetime: ExtractedZonedDateTimeInput::extract_from(value),

--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -936,7 +936,7 @@ impl FormatTimeZone for GenericNonLocationLongFormat {
             .and_then(|metazones| {
                 time_zone
                     .time_zone_id()
-                    .and_then(|tz| metazones.overrides.get(tz))
+                    .and_then(|tz| metazones.overrides.get(&tz))
             })
             .or_else(|| {
                 data_payloads
@@ -946,7 +946,7 @@ impl FormatTimeZone for GenericNonLocationLongFormat {
                     .and_then(|metazones| {
                         time_zone
                             .metazone_id()
-                            .and_then(|mz| metazones.defaults.get(mz))
+                            .and_then(|mz| metazones.defaults.get(&mz))
                     })
             });
 
@@ -974,7 +974,7 @@ impl FormatTimeZone for GenericNonLocationShortFormat {
             .and_then(|metazones| {
                 time_zone
                     .time_zone_id()
-                    .and_then(|tz| metazones.overrides.get(tz))
+                    .and_then(|tz| metazones.overrides.get(&tz))
             })
             .or_else(|| {
                 data_payloads
@@ -984,7 +984,7 @@ impl FormatTimeZone for GenericNonLocationShortFormat {
                     .and_then(|metazones| {
                         time_zone
                             .metazone_id()
-                            .and_then(|mz| metazones.defaults.get(mz))
+                            .and_then(|mz| metazones.defaults.get(&mz))
                     })
             });
 
@@ -1013,7 +1013,7 @@ impl FormatTimeZone for SpecificNonLocationShortFormat {
                 time_zone.time_zone_id().and_then(|tz| {
                     time_zone
                         .time_variant()
-                        .and_then(|variant| metazones.overrides.get(tz, variant).ok())
+                        .and_then(|variant| metazones.overrides.get(&tz, &variant).ok())
                 })
             })
             .or_else(|| {
@@ -1025,7 +1025,7 @@ impl FormatTimeZone for SpecificNonLocationShortFormat {
                         time_zone.metazone_id().and_then(|mz| {
                             time_zone
                                 .time_variant()
-                                .and_then(|variant| metazones.defaults.get(mz, variant).ok())
+                                .and_then(|variant| metazones.defaults.get(&mz, &variant).ok())
                         })
                     })
             });
@@ -1055,7 +1055,7 @@ impl FormatTimeZone for SpecificNonLocationLongFormat {
                 time_zone.time_zone_id().and_then(|tz| {
                     time_zone
                         .time_variant()
-                        .and_then(|variant| metazones.overrides.get(tz, variant).ok())
+                        .and_then(|variant| metazones.overrides.get(&tz, &variant).ok())
                 })
             })
             .or_else(|| {
@@ -1067,7 +1067,7 @@ impl FormatTimeZone for SpecificNonLocationLongFormat {
                         time_zone.metazone_id().and_then(|mz| {
                             time_zone
                                 .time_variant()
-                                .and_then(|variant| metazones.defaults.get(mz, variant).ok())
+                                .and_then(|variant| metazones.defaults.get(&mz, &variant).ok())
                         })
                     })
             });
@@ -1140,7 +1140,7 @@ impl FormatTimeZone for GenericLocationFormat {
             .exemplar_cities
             .as_ref()
             .map(|p| p.get())
-            .and_then(|cities| time_zone.time_zone_id().and_then(|id| cities.0.get(id)))
+            .and_then(|cities| time_zone.time_zone_id().and_then(|id| cities.0.get(&id)))
             .map(|location| {
                 data_payloads
                     .zone_formats
@@ -1248,7 +1248,7 @@ impl FormatTimeZone for ExemplarCityFormat {
             .exemplar_cities
             .as_ref()
             .map(|p| p.get())
-            .and_then(|cities| time_zone.time_zone_id().and_then(|id| cities.0.get(id)));
+            .and_then(|cities| time_zone.time_zone_id().and_then(|id| cities.0.get(&id)));
 
         match formatted_exemplar_city {
             Some(ftz) => Ok(sink.write_str(ftz)),

--- a/components/datetime/src/zoned_datetime.rs
+++ b/components/datetime/src/zoned_datetime.rs
@@ -201,7 +201,7 @@ impl<C: CldrCalendar> ZonedDateTimeFormat<C> {
     /// but [`FormattedZonedDateTime`] will grow with methods for iterating over fields, extracting information
     /// about formatted date and so on.
     #[inline]
-    pub fn format<'l, T>(&'l self, value: &'l T) -> FormattedZonedDateTime<'l, T>
+    pub fn format<'l, T>(&'l self, value: &'l T) -> FormattedZonedDateTime<'l>
     where
         T: ZonedDateTimeInput,
     {


### PR DESCRIPTION
The primary motivation here is to allow for AnyCalendar to convert inputs from incorrect calendars as necessary, which is not possible in the current infrastructure since FormattedDateTime requires a borrowed input. Rather than replace it with some kind of Either/Cow system, we've decided to preextract all the fields.

DTF/ZDTF do know in advance what fields will be necessary. It may be a potentially useful optimization for them to extract only the necessary fields when calling format(), which can be done without breaking backcompat.

We should get codesize wins from FormattedDateTime no longer being generic in codebases that are formatting different types of datetimes.

I think this PR opens up to a lot more cleanups, e.g. ZonedDateTimeInputWithLocale no longer needs to be generic either. I have not made such fixups since I expect @dminor to be changing a lot of this code soon anyway, but it sets the stage for this


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->