### PR TITLE
Improve and rename types::Year/types::Month

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -224,7 +224,7 @@ impl Calendar for AnyCalendar {
     }
 
     /// The calendar-specific month represented by `date`
-    fn month(&self, date: &Self::DateInner) -> types::Month {
+    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         match_cal_and_date!(match (self, date): (c, d) => c.month(d))
     }
 

--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -219,7 +219,7 @@ impl Calendar for AnyCalendar {
     }
 
     /// The calendar-specific year represented by `date`
-    fn year(&self, date: &Self::DateInner) -> types::Year {
+    fn year(&self, date: &Self::DateInner) -> types::FormattableYear {
         match_cal_and_date!(match (self, date): (c, d) => c.year(d))
     }
 

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -91,7 +91,7 @@ impl Calendar for Buddhist {
     }
 
     /// The calendar-specific year represented by `date`
-    fn year(&self, date: &Self::DateInner) -> types::Year {
+    fn year(&self, date: &Self::DateInner) -> types::FormattableYear {
         iso_year_as_buddhist(date.0.year)
     }
 
@@ -186,9 +186,9 @@ impl DateTime<Buddhist> {
     }
 }
 
-fn iso_year_as_buddhist(year: i32) -> types::Year {
+fn iso_year_as_buddhist(year: i32) -> types::FormattableYear {
     let buddhist_year = year + BUDDHIST_ERA_OFFSET;
-    types::Year {
+    types::FormattableYear {
         era: types::Era(tinystr!(16, "be")),
         number: buddhist_year,
         related_iso: None,

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -191,6 +191,6 @@ fn iso_year_as_buddhist(year: i32) -> types::Year {
     types::Year {
         era: types::Era(tinystr!(16, "be")),
         number: buddhist_year,
-        related_iso: year,
+        related_iso: None,
     }
 }

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -96,7 +96,7 @@ impl Calendar for Buddhist {
     }
 
     /// The calendar-specific month represented by `date`
-    fn month(&self, date: &Self::DateInner) -> types::Month {
+    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         Iso.month(date)
     }
 

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -60,7 +60,7 @@ pub trait Calendar {
     // fn since(&self, from: &Date<Self>, to: &Date<Self>) -> Duration<Self>, Error;
 
     /// The calendar-specific year represented by `date`
-    fn year(&self, date: &Self::DateInner) -> types::Year;
+    fn year(&self, date: &Self::DateInner) -> types::FormattableYear;
 
     /// The calendar-specific month represented by `date`
     fn month(&self, date: &Self::DateInner) -> types::Month;

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -63,7 +63,7 @@ pub trait Calendar {
     fn year(&self, date: &Self::DateInner) -> types::FormattableYear;
 
     /// The calendar-specific month represented by `date`
-    fn month(&self, date: &Self::DateInner) -> types::Month;
+    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth;
 
     /// The calendar-specific day-of-month represented by `date`
     fn day_of_month(&self, date: &Self::DateInner) -> types::DayOfMonth;

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -143,14 +143,14 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
         types::DayOfMonth(self.day.into())
     }
 
-    /// The [`types::Month`] for the current month (with month code) for a solar calendar
+    /// The [`types::FormattableMonth`] for the current month (with month code) for a solar calendar
     /// Lunar calendars should not use this method and instead manually implement a month code
     /// resolver.
     ///
     /// Returns "und" if run with months that are out of bounds for the current
     /// calendar.
     #[inline]
-    pub fn solar_month(&self) -> types::Month {
+    pub fn solar_month(&self) -> types::FormattableMonth {
         let code = match self.month {
             a if a > C::months_for_every_year() => tinystr!(4, "und"),
             1 => tinystr!(4, "M01"),
@@ -168,7 +168,7 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
             13 => tinystr!(4, "M13"),
             _ => tinystr!(4, "und"),
         };
-        types::Month {
+        types::FormattableMonth {
             ordinal: self.month as u32,
             code: types::MonthCode(code),
         }

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -117,7 +117,7 @@ impl Calendar for Coptic {
         date1.0.until(date2.0, _largest_unit, _smallest_unit)
     }
 
-    fn year(&self, date: &Self::DateInner) -> types::Year {
+    fn year(&self, date: &Self::DateInner) -> types::FormattableYear {
         crate::gregorian::year_as_gregorian(date.0.year)
     }
 

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -121,7 +121,7 @@ impl Calendar for Coptic {
         crate::gregorian::year_as_gregorian(date.0.year)
     }
 
-    fn month(&self, date: &Self::DateInner) -> types::Month {
+    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         date.0.solar_month()
     }
 

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -167,7 +167,7 @@ impl<A: AsCalendar> Date<A> {
 
     /// The calendar-specific month represented by `self`
     #[inline]
-    pub fn month(&self) -> types::Month {
+    pub fn month(&self) -> types::FormattableMonth {
         self.calendar.as_calendar().month(&self.inner)
     }
 

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -161,7 +161,7 @@ impl<A: AsCalendar> Date<A> {
 
     /// The calendar-specific year represented by `self`
     #[inline]
-    pub fn year(&self) -> types::Year {
+    pub fn year(&self) -> types::FormattableYear {
         self.calendar.as_calendar().year(&self.inner)
     }
 

--- a/components/calendar/src/ethiopic.rs
+++ b/components/calendar/src/ethiopic.rs
@@ -122,7 +122,7 @@ impl Calendar for Ethiopic {
         Self::year_as_ethiopic(date.0.year, self.0)
     }
 
-    fn month(&self, date: &Self::DateInner) -> types::Month {
+    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         date.0.solar_month()
     }
 

--- a/components/calendar/src/ethiopic.rs
+++ b/components/calendar/src/ethiopic.rs
@@ -118,7 +118,7 @@ impl Calendar for Ethiopic {
         date1.0.until(date2.0, _largest_unit, _smallest_unit)
     }
 
-    fn year(&self, date: &Self::DateInner) -> types::Year {
+    fn year(&self, date: &Self::DateInner) -> types::FormattableYear {
         Self::year_as_ethiopic(date.0.year, self.0)
     }
 
@@ -206,21 +206,21 @@ impl Ethiopic {
         }
     }
 
-    fn year_as_ethiopic(year: i32, amete_alem: bool) -> types::Year {
+    fn year_as_ethiopic(year: i32, amete_alem: bool) -> types::FormattableYear {
         if amete_alem {
-            types::Year {
+            types::FormattableYear {
                 era: types::Era(tinystr!(16, "mundi")),
                 number: year + 5493,
                 related_iso: None,
             }
         } else if year > 0 {
-            types::Year {
+            types::FormattableYear {
                 era: types::Era(tinystr!(16, "incarnation")),
                 number: year,
                 related_iso: None,
             }
         } else {
-            types::Year {
+            types::FormattableYear {
                 era: types::Era(tinystr!(16, "before-incar")),
                 number: 1 - year,
                 related_iso: None,

--- a/components/calendar/src/ethiopic.rs
+++ b/components/calendar/src/ethiopic.rs
@@ -211,19 +211,19 @@ impl Ethiopic {
             types::Year {
                 era: types::Era(tinystr!(16, "mundi")),
                 number: year + 5493,
-                related_iso: year + 5493 + 8,
+                related_iso: None,
             }
         } else if year > 0 {
             types::Year {
                 era: types::Era(tinystr!(16, "incarnation")),
                 number: year,
-                related_iso: year + 8,
+                related_iso: None,
             }
         } else {
             types::Year {
                 era: types::Era(tinystr!(16, "before-incar")),
                 number: 1 - year,
-                related_iso: year + 8,
+                related_iso: None,
             }
         }
     }

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -90,7 +90,7 @@ impl Calendar for Gregorian {
     }
 
     /// The calendar-specific month represented by `date`
-    fn month(&self, date: &Self::DateInner) -> types::Month {
+    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         Iso.month(&date.0)
     }
 

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -185,13 +185,13 @@ pub fn year_as_gregorian(year: i32) -> types::Year {
         types::Year {
             era: types::Era(tinystr!(16, "ad")),
             number: year,
-            related_iso: year,
+            related_iso: None,
         }
     } else {
         types::Year {
             era: types::Era(tinystr!(16, "bc")),
             number: 1 - year,
-            related_iso: year,
+            related_iso: None,
         }
     }
 }

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -85,7 +85,7 @@ impl Calendar for Gregorian {
     }
 
     /// The calendar-specific year represented by `date`
-    fn year(&self, date: &Self::DateInner) -> types::Year {
+    fn year(&self, date: &Self::DateInner) -> types::FormattableYear {
         year_as_gregorian(date.0 .0.year)
     }
 
@@ -180,15 +180,15 @@ impl DateTime<Gregorian> {
     }
 }
 
-pub fn year_as_gregorian(year: i32) -> types::Year {
+pub fn year_as_gregorian(year: i32) -> types::FormattableYear {
     if year > 0 {
-        types::Year {
+        types::FormattableYear {
             era: types::Era(tinystr!(16, "ad")),
             number: year,
             related_iso: None,
         }
     } else {
-        types::Year {
+        types::FormattableYear {
             era: types::Era(tinystr!(16, "bc")),
             number: 1 - year,
             related_iso: None,

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -125,7 +125,7 @@ impl Calendar for Indian {
         types::Year {
             era: types::Era(tinystr!(16, "saka")),
             number: date.0.year,
-            related_iso: date.0.year + 78,
+            related_iso: None,
         }
     }
 
@@ -141,12 +141,12 @@ impl Calendar for Indian {
         let prev_year = types::Year {
             era: types::Era(tinystr!(16, "saka")),
             number: date.0.year - 1,
-            related_iso: date.0.year + 77,
+            related_iso: None,
         };
         let next_year = types::Year {
             era: types::Era(tinystr!(16, "saka")),
             number: date.0.year + 1,
-            related_iso: date.0.year + 79,
+            related_iso: None,
         };
         types::DayOfYearInfo {
             day_of_year: date.0.day_of_year(),

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -121,8 +121,8 @@ impl Calendar for Indian {
         date1.0.until(date2.0, _largest_unit, _smallest_unit)
     }
 
-    fn year(&self, date: &Self::DateInner) -> types::Year {
-        types::Year {
+    fn year(&self, date: &Self::DateInner) -> types::FormattableYear {
+        types::FormattableYear {
             era: types::Era(tinystr!(16, "saka")),
             number: date.0.year,
             related_iso: None,
@@ -138,12 +138,12 @@ impl Calendar for Indian {
     }
 
     fn day_of_year_info(&self, date: &Self::DateInner) -> types::DayOfYearInfo {
-        let prev_year = types::Year {
+        let prev_year = types::FormattableYear {
             era: types::Era(tinystr!(16, "saka")),
             number: date.0.year - 1,
             related_iso: None,
         };
-        let next_year = types::Year {
+        let next_year = types::FormattableYear {
             era: types::Era(tinystr!(16, "saka")),
             number: date.0.year + 1,
             related_iso: None,

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -129,7 +129,7 @@ impl Calendar for Indian {
         }
     }
 
-    fn month(&self, date: &Self::DateInner) -> types::Month {
+    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         date.0.solar_month()
     }
 

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -190,7 +190,7 @@ impl Calendar for Iso {
     }
 
     /// The calendar-specific month represented by `date`
-    fn month(&self, date: &Self::DateInner) -> types::Month {
+    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         date.0.solar_month()
     }
 

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -490,7 +490,7 @@ impl Iso {
         types::Year {
             era: types::Era(tinystr!(16, "default")),
             number: year,
-            related_iso: year,
+            related_iso: None,
         }
     }
 }

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -185,7 +185,7 @@ impl Calendar for Iso {
     }
 
     /// The calendar-specific year represented by `date`
-    fn year(&self, date: &Self::DateInner) -> types::Year {
+    fn year(&self, date: &Self::DateInner) -> types::FormattableYear {
         Self::year_as_iso(date.0.year)
     }
 
@@ -486,8 +486,8 @@ impl Iso {
     }
 
     /// Wrap the year in the appropriate era code
-    fn year_as_iso(year: i32) -> types::Year {
-        types::Year {
+    fn year_as_iso(year: i32) -> types::FormattableYear {
+        types::FormattableYear {
             era: types::Era(tinystr!(16, "default")),
             number: year,
             related_iso: None,

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -130,7 +130,7 @@ impl Calendar for Japanese {
         types::Year {
             era: types::Era(date.era),
             number: date.adjusted_year(),
-            related_iso: date.inner.0.year,
+            related_iso: None,
         }
     }
 

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -126,8 +126,8 @@ impl Calendar for Japanese {
     }
 
     /// The calendar-specific year represented by `date`
-    fn year(&self, date: &Self::DateInner) -> types::Year {
-        types::Year {
+    fn year(&self, date: &Self::DateInner) -> types::FormattableYear {
+        types::FormattableYear {
             era: types::Era(date.era),
             number: date.adjusted_year(),
             related_iso: None,

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -135,7 +135,7 @@ impl Calendar for Japanese {
     }
 
     /// The calendar-specific month represented by `date`
-    fn month(&self, date: &Self::DateInner) -> types::Month {
+    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         Iso.month(&date.inner)
     }
 

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -119,7 +119,7 @@ impl Calendar for Julian {
 
     /// The calendar-specific year represented by `date`
     /// Julian has the same era scheme as Georgian
-    fn year(&self, date: &Self::DateInner) -> types::Year {
+    fn year(&self, date: &Self::DateInner) -> types::FormattableYear {
         crate::gregorian::year_as_gregorian(date.0.year)
     }
 

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -124,7 +124,7 @@ impl Calendar for Julian {
     }
 
     /// The calendar-specific month represented by `date`
-    fn month(&self, date: &Self::DateInner) -> types::Month {
+    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         date.0.solar_month()
     }
 

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -23,7 +23,7 @@ pub struct Era(pub TinyStr16);
 /// More fields may be added in the future
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[non_exhaustive]
-pub struct Year {
+pub struct FormattableYear {
     /// The era containing the year.
     pub era: Era,
 
@@ -38,7 +38,7 @@ pub struct Year {
     pub related_iso: Option<i32>,
 }
 
-impl Year {
+impl FormattableYear {
     /// Construct a new Year given an era and number
     ///
     /// Other fields can be set mutably after construction
@@ -108,11 +108,11 @@ pub struct DayOfYearInfo {
     /// The number of days in a year.
     pub days_in_year: u32,
     /// The previous year.
-    pub prev_year: Year,
+    pub prev_year: FormattableYear,
     /// The number of days in the previous year.
     pub days_in_prev_year: u32,
     /// The next year.
-    pub next_year: Year,
+    pub next_year: FormattableYear,
 }
 
 /// A day number in a month. Usually 1-based.

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -20,7 +20,8 @@ pub struct Era(pub TinyStr16);
 
 /// Representation of a formattable year.
 ///
-/// More fields may be added in the future
+/// More fields may be added in the future, for things like
+/// the cyclic or extended year
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub struct FormattableYear {

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -86,7 +86,7 @@ impl fmt::Display for MonthCode {
 /// Representation of a formattable month.
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
-pub struct Month {
+pub struct FormattableMonth {
     /// The month number in this given year. For calendars with leap months, all months after
     /// the leap month will end up with an incremented number.
     ///

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -19,8 +19,10 @@ use zerovec::ule::AsULE;
 pub struct Era(pub TinyStr16);
 
 /// Representation of a formattable year.
+///
+/// More fields may be added in the future
 #[derive(Copy, Clone, Debug, PartialEq)]
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[non_exhaustive]
 pub struct Year {
     /// The era containing the year.
     pub era: Era,
@@ -30,9 +32,25 @@ pub struct Year {
 
     /// The related ISO year. This is normally the ISO (proleptic Gregorian) year having the greatest
     /// overlap with the calendar year. It is used in certain date formatting patterns.
-    pub related_iso: i32,
+    ///
+    /// Can be None if the calendar does not typically use related_iso (and CLDR does not contain patterns
+    /// using it)
+    pub related_iso: Option<i32>,
 }
 
+impl Year {
+    /// Construct a new Year given an era and number
+    ///
+    /// Other fields can be set mutably after construction
+    /// as needed
+    pub fn new(era: Era, number: i32) -> Self {
+        Self {
+            era,
+            number,
+            related_iso: None,
+        }
+    }
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(clippy::exhaustive_structs)] // this is a newtype
 #[cfg_attr(

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -27,7 +27,7 @@ pub trait DateInput {
     /// The calendar this date relates to
     type Calendar: Calendar;
     /// Gets the era and year input.
-    fn year(&self) -> Option<Year>;
+    fn year(&self) -> Option<FormattableYear>;
 
     /// Gets the month input.
     fn month(&self) -> Option<Month>;
@@ -106,7 +106,7 @@ pub trait LocalizedDateTimeInput<T: DateTimeInput> {
     /// The year number according to week numbering.
     ///
     /// For example, December 31, 2020 is part of the first week of 2021.
-    fn year_week(&self) -> Result<Year, DateTimeError>;
+    fn year_week(&self) -> Result<FormattableYear, DateTimeError>;
 
     /// The week of the month.
     ///
@@ -136,7 +136,7 @@ pub(crate) struct DateTimeInputWithLocale<'data, T: DateTimeInput> {
 ///
 /// See [`DateTimeInput`] for documentation on individual fields
 pub(crate) struct ExtractedDateTimeInput {
-    year: Option<Year>,
+    year: Option<FormattableYear>,
     month: Option<Month>,
     day_of_month: Option<DayOfMonth>,
     iso_weekday: Option<IsoWeekday>,
@@ -194,7 +194,7 @@ impl DateInput for ExtractedDateTimeInput {
     /// This actually doesn't matter, by the time we use this
     /// it's purely internal raw code where calendars are irrelevant
     type Calendar = icu_calendar::any_calendar::AnyCalendar;
-    fn year(&self) -> Option<Year> {
+    fn year(&self) -> Option<FormattableYear> {
         self.year
     }
     fn month(&self) -> Option<Month> {
@@ -236,7 +236,7 @@ impl DateInput for ExtractedZonedDateTimeInput {
     /// This actually doesn't matter, by the time we use this
     /// it's purely internal raw code where calendars are irrelevant
     type Calendar = icu_calendar::any_calendar::AnyCalendar;
-    fn year(&self) -> Option<Year> {
+    fn year(&self) -> Option<FormattableYear> {
         self.date_time_input.year
     }
     fn month(&self) -> Option<Month> {
@@ -315,7 +315,7 @@ fn compute_week_of_year<T: DateInput>(
 fn year_week<T: DateInput>(
     datetime: &T,
     calendar: &week_of::CalendarInfo,
-) -> Result<Year, DateTimeError> {
+) -> Result<FormattableYear, DateTimeError> {
     let (doy_info, week) = compute_week_of_year(datetime, calendar)?;
     Ok(match week.unit {
         week_of::RelativeUnit::Previous => doy_info.prev_year,
@@ -397,7 +397,7 @@ impl<'data, T: DateTimeInput> LocalizedDateTimeInput<T> for DateTimeInputWithLoc
         self.data
     }
 
-    fn year_week(&self) -> Result<Year, DateTimeError> {
+    fn year_week(&self) -> Result<FormattableYear, DateTimeError> {
         year_week(
             self.data,
             #[allow(clippy::expect_used)]
@@ -443,7 +443,7 @@ impl<'data, T: ZonedDateTimeInput> LocalizedDateTimeInput<T>
         self.data
     }
 
-    fn year_week(&self) -> Result<Year, DateTimeError> {
+    fn year_week(&self) -> Result<FormattableYear, DateTimeError> {
         year_week(
             self.data,
             #[allow(clippy::expect_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
@@ -483,7 +483,7 @@ impl<'data, T: ZonedDateTimeInput> LocalizedDateTimeInput<T>
 impl<C: Calendar, A: AsCalendar<Calendar = C>> DateInput for Date<A> {
     type Calendar = C;
     /// Gets the era and year input.
-    fn year(&self) -> Option<Year> {
+    fn year(&self) -> Option<FormattableYear> {
         Some(self.year())
     }
 
@@ -519,7 +519,7 @@ impl<C: Calendar, A: AsCalendar<Calendar = C>> DateInput for Date<A> {
 impl<C: Calendar, A: AsCalendar<Calendar = C>> DateInput for DateTime<A> {
     type Calendar = C;
     /// Gets the era and year input.
-    fn year(&self) -> Option<Year> {
+    fn year(&self) -> Option<FormattableYear> {
         Some(self.date.year())
     }
 

--- a/components/datetime/src/date.rs
+++ b/components/datetime/src/date.rs
@@ -30,7 +30,7 @@ pub trait DateInput {
     fn year(&self) -> Option<FormattableYear>;
 
     /// Gets the month input.
-    fn month(&self) -> Option<Month>;
+    fn month(&self) -> Option<FormattableMonth>;
 
     /// Gets the day input.
     fn day_of_month(&self) -> Option<DayOfMonth>;
@@ -137,7 +137,7 @@ pub(crate) struct DateTimeInputWithLocale<'data, T: DateTimeInput> {
 /// See [`DateTimeInput`] for documentation on individual fields
 pub(crate) struct ExtractedDateTimeInput {
     year: Option<FormattableYear>,
-    month: Option<Month>,
+    month: Option<FormattableMonth>,
     day_of_month: Option<DayOfMonth>,
     iso_weekday: Option<IsoWeekday>,
     day_of_year_info: Option<DayOfYearInfo>,
@@ -197,7 +197,7 @@ impl DateInput for ExtractedDateTimeInput {
     fn year(&self) -> Option<FormattableYear> {
         self.year
     }
-    fn month(&self) -> Option<Month> {
+    fn month(&self) -> Option<FormattableMonth> {
         self.month
     }
     fn day_of_month(&self) -> Option<DayOfMonth> {
@@ -239,7 +239,7 @@ impl DateInput for ExtractedZonedDateTimeInput {
     fn year(&self) -> Option<FormattableYear> {
         self.date_time_input.year
     }
-    fn month(&self) -> Option<Month> {
+    fn month(&self) -> Option<FormattableMonth> {
         self.date_time_input.month
     }
     fn day_of_month(&self) -> Option<DayOfMonth> {
@@ -488,7 +488,7 @@ impl<C: Calendar, A: AsCalendar<Calendar = C>> DateInput for Date<A> {
     }
 
     /// Gets the month input.
-    fn month(&self) -> Option<Month> {
+    fn month(&self) -> Option<FormattableMonth> {
         Some(self.month())
     }
 
@@ -524,7 +524,7 @@ impl<C: Calendar, A: AsCalendar<Calendar = C>> DateInput for DateTime<A> {
     }
 
     /// Gets the month input.
-    fn month(&self) -> Option<Month> {
+    fn month(&self) -> Option<FormattableMonth> {
         Some(self.date.month())
     }
 

--- a/components/datetime/src/mock/zoned_datetime.rs
+++ b/components/datetime/src/mock/zoned_datetime.rs
@@ -105,7 +105,7 @@ impl DateInput for MockZonedDateTime {
         self.datetime.year()
     }
 
-    fn month(&self) -> Option<Month> {
+    fn month(&self) -> Option<FormattableMonth> {
         self.datetime.month()
     }
 

--- a/components/datetime/src/mock/zoned_datetime.rs
+++ b/components/datetime/src/mock/zoned_datetime.rs
@@ -101,7 +101,7 @@ impl FromStr for MockZonedDateTime {
 
 impl DateInput for MockZonedDateTime {
     type Calendar = Gregorian;
-    fn year(&self) -> Option<Year> {
+    fn year(&self) -> Option<FormattableYear> {
         self.datetime.year()
     }
 


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/2156

 - Names these types FormattableYear etc to make it clear that they contain formatting info
 - Turns `related_iso` to an Option since most calendars don't need it
 - Makes FormattableYear `non_exhaustive` so cyclic/extended may be added in the future.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->