### PR TITLE
Making `IterableResourceProvider` return `Locale`s instead of `ResourceOptions`

### DIFF
--- a/docs/tutorials/writing_a_new_data_struct.md
+++ b/docs/tutorials/writing_a_new_data_struct.md
@@ -216,16 +216,16 @@ impl ResourceProvider<FooV1Marker> for FooProvider {
         // Load the data from CLDR JSON and emit it as an ICU4X data struct.
         // This is the core transform operation. This step could take a lot of
         // work, such as pre-parsing patterns, re-organizing the data, etc.
-        // This method will be called once per option returned by supported_options.
+        // This method will be called once per option returned by supported_locales.
         // Use internal mutability (RwLock) to avoid duplicating work.
     }
 }
 
 impl IterableResourceProvider<FooV1Marker> for FooProvider {
-    fn supported_options(
+    fn supported_locales(
         &self,
-    ) -> Result<Vec<ResourceOptions>, DataError> {
-        // This should list all supported locales, for example.
+    ) -> Result<Vec<Locale>, DataError> {
+        // This should list all supported locales.
     }
 }
 

--- a/provider/adapters/src/either.rs
+++ b/provider/adapters/src/either.rs
@@ -80,14 +80,14 @@ impl<M: DataMarker, P0: datagen::IterableDynProvider<M>, P1: datagen::IterableDy
     datagen::IterableDynProvider<M> for EitherProvider<P0, P1>
 {
     #[inline]
-    fn supported_options_for_key(
+    fn supported_locales_for_key(
         &self,
         key: ResourceKey,
-    ) -> Result<alloc::vec::Vec<ResourceOptions>, DataError> {
+    ) -> Result<alloc::vec::Vec<icu_locid::Locale>, DataError> {
         use EitherProvider::*;
         match self {
-            A(p) => p.supported_options_for_key(key),
-            B(p) => p.supported_options_for_key(key),
+            A(p) => p.supported_locales_for_key(key),
+            B(p) => p.supported_locales_for_key(key),
         }
     }
 }
@@ -100,11 +100,11 @@ impl<
     > datagen::IterableResourceProvider<M> for EitherProvider<P0, P1>
 {
     #[inline]
-    fn supported_options(&self) -> Result<alloc::vec::Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<alloc::vec::Vec<icu_locid::Locale>, DataError> {
         use EitherProvider::*;
         match self {
-            A(p) => p.supported_options(),
-            B(p) => p.supported_options(),
+            A(p) => p.supported_locales(),
+            B(p) => p.supported_locales(),
         }
     }
 }

--- a/provider/adapters/src/filter/impls.rs
+++ b/provider/adapters/src/filter/impls.rs
@@ -22,7 +22,7 @@ where
     ///
     /// ```
     /// use icu_locid::LanguageIdentifier;
-    /// use icu_locid::{langid, subtags_language as language, locale};
+    /// use icu_locid::{subtags_language as language, locale};
     /// use icu_provider::datagen::*;
     /// use icu_provider::hello_world::*;
     /// use icu_provider::prelude::*;
@@ -55,14 +55,9 @@ where
     /// ));
     ///
     /// // English should not appear in the iterator result:
-    /// let supported_langids = provider
-    ///     .supported_options()
-    ///     .expect("Should successfully make an iterator of supported locales")
-    ///     .into_iter()
-    ///     .map(|options| options.get_langid())
-    ///     .collect::<Vec<LanguageIdentifier>>();
-    /// assert!(supported_langids.contains(&langid!("de")));
-    /// assert!(!supported_langids.contains(&langid!("en")));
+    /// let locales = provider.supported_locales().expect("HelloWorldProvider infallible");
+    /// assert!(locales.contains(&locale!("de")));
+    /// assert!(!locales.contains(&locale!("en")));
     /// ```
     pub fn filter_by_langid<'a>(
         self,

--- a/provider/adapters/src/fork/by_key.rs
+++ b/provider/adapters/src/fork/by_key.rs
@@ -6,6 +6,8 @@
 
 use alloc::vec::Vec;
 #[cfg(feature = "datagen")]
+use icu_locid::Locale;
+#[cfg(feature = "datagen")]
 use icu_provider::datagen;
 use icu_provider::prelude::*;
 
@@ -170,15 +172,12 @@ where
     P0: datagen::IterableDynProvider<M>,
     P1: datagen::IterableDynProvider<M>,
 {
-    fn supported_options_for_key(
-        &self,
-        key: ResourceKey,
-    ) -> Result<Vec<ResourceOptions>, DataError> {
-        let result = self.0.supported_options_for_key(key);
+    fn supported_locales_for_key(&self, key: ResourceKey) -> Result<Vec<Locale>, DataError> {
+        let result = self.0.supported_locales_for_key(key);
         if !result_is_err_missing_resource_key(&result) {
             return result;
         }
-        self.1.supported_options_for_key(key)
+        self.1.supported_locales_for_key(key)
     }
 }
 
@@ -304,12 +303,9 @@ where
     M: DataMarker,
     P: datagen::IterableDynProvider<M>,
 {
-    fn supported_options_for_key(
-        &self,
-        key: ResourceKey,
-    ) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales_for_key(&self, key: ResourceKey) -> Result<Vec<Locale>, DataError> {
         for provider in self.providers.iter() {
-            let result = provider.supported_options_for_key(key);
+            let result = provider.supported_locales_for_key(key);
             if !result_is_err_missing_resource_key(&result) {
                 return result;
             }

--- a/provider/core/src/data_provider/test.rs
+++ b/provider/core/src/data_provider/test.rs
@@ -68,7 +68,7 @@ impl ResourceProvider<HelloWorldV1Marker> for DataWarehouse {
 }
 
 impl IterableResourceProvider<HelloWorldV1Marker> for DataWarehouse {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<icu_locid::Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }
@@ -100,7 +100,7 @@ impl ResourceProvider<HelloWorldV1Marker> for DataProvider2 {
 }
 
 impl IterableResourceProvider<HelloWorldV1Marker> for DataProvider2 {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<icu_locid::Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }
@@ -115,7 +115,7 @@ impl ResourceProvider<HelloAltMarker> for DataProvider2 {
 }
 
 impl IterableResourceProvider<HelloAltMarker> for DataProvider2 {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<icu_locid::Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }

--- a/provider/core/src/datagen/iter.rs
+++ b/provider/core/src/datagen/iter.rs
@@ -5,26 +5,24 @@
 //! Collection of iteration APIs for data providers.
 
 use crate::prelude::*;
+use icu_locid::Locale;
 
-/// A [`DynProvider`] that can iterate over all supported [`ResourceOptions`] for a certain key.
+/// A [`DynProvider`] that can iterate over all supported [`Locale`]s for a certain key.
 ///
 /// Implementing this trait means that a data provider knows all of the data it can successfully
 /// return from a load request.
 pub trait IterableDynProvider<M: DataMarker>: DynProvider<M> {
-    /// Given a [`ResourceKey`], returns a list of [`ResourceOptions`].
-    fn supported_options_for_key(
-        &self,
-        key: ResourceKey,
-    ) -> Result<Vec<ResourceOptions>, DataError>;
+    /// Given a [`ResourceKey`], returns a list of [`Locale`]s.
+    fn supported_locales_for_key(&self, key: ResourceKey) -> Result<Vec<Locale>, DataError>;
 }
 
-/// A [`ResourceProvider`] that can iterate over all supported [`ResourceOptions`] for a certain key.
+/// A [`ResourceProvider`] that can iterate over all supported [`Locale`]s for a certain key.
 ///
 /// Implementing this trait means that a data provider knows all of the data it can successfully
 /// return from a load request.
 pub trait IterableResourceProvider<M: ResourceMarker>: ResourceProvider<M> {
-    /// Returns a list of [`ResourceOptions`].
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError>;
+    /// Returns a list of [`Locale`]s.
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError>;
 }
 
 impl<M, P> IterableDynProvider<M> for Box<P>
@@ -32,10 +30,7 @@ where
     M: DataMarker,
     P: IterableDynProvider<M> + ?Sized,
 {
-    fn supported_options_for_key(
-        &self,
-        key: ResourceKey,
-    ) -> Result<Vec<ResourceOptions>, DataError> {
-        (**self).supported_options_for_key(key)
+    fn supported_locales_for_key(&self, key: ResourceKey) -> Result<Vec<Locale>, DataError> {
+        (**self).supported_locales_for_key(key)
     }
 }

--- a/provider/core/src/datagen/mod.rs
+++ b/provider/core/src/datagen/mod.rs
@@ -58,7 +58,7 @@ macro_rules! make_exportable_provider {
         );
 
         impl $crate::datagen::IterableDynProvider<$crate::datagen::ExportMarker> for $provider {
-            fn supported_options_for_key(&self, key: $crate::ResourceKey) -> Result<Vec<$crate::ResourceOptions>, $crate::DataError> {
+            fn supported_locales_for_key(&self, key: $crate::ResourceKey) -> Result<Vec<icu_locid::Locale>, $crate::DataError> {
                 #![allow(non_upper_case_globals)]
                 // Reusing the struct names as identifiers
                 $(
@@ -67,7 +67,7 @@ macro_rules! make_exportable_provider {
                 match key.get_hash() {
                     $(
                         $struct_m => {
-                            $crate::datagen::IterableResourceProvider::<$struct_m>::supported_options(self)
+                            $crate::datagen::IterableResourceProvider::<$struct_m>::supported_locales(self)
                         }
                     )+,
                     _ => Err($crate::DataErrorKind::MissingResourceKey.with_key(key))

--- a/provider/core/src/dynutil.rs
+++ b/provider/core/src/dynutil.rs
@@ -71,9 +71,9 @@ where
 /// }
 ///
 /// impl IterableResourceProvider<HelloWorldV1Marker> for MyProvider {
-///     fn supported_options(
+///     fn supported_locales(
 ///         &self,
-///     ) -> Result<Vec<ResourceOptions>, DataError> {
+///     ) -> Result<Vec<icu_locid::Locale>, DataError> {
 ///         Ok(vec![Default::default()])
 ///     }
 /// }
@@ -122,8 +122,8 @@ where
 /// }
 ///
 /// impl IterableDynProvider<HelloWorldV1Marker> for MyProvider {
-///     fn supported_options_for_key(&self, _: ResourceKey)
-///         -> Result<Vec<ResourceOptions>, DataError> {
+///     fn supported_locales_for_key(&self, _: ResourceKey)
+///         -> Result<Vec<icu_locid::Locale>, DataError> {
 ///         Ok(vec![Default::default()])
 ///     }
 /// }

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -156,40 +156,35 @@ impl BufferProvider for HelloWorldJsonProvider {
 
 #[cfg(feature = "datagen")]
 impl IterableResourceProvider<HelloWorldV1Marker> for HelloWorldProvider {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<icu_locid::Locale>, DataError> {
         #[allow(clippy::unwrap_used)] // datagen
-        Ok(Self::DATA
-            .iter()
-            .map(|(s, _)| s.parse::<icu_locid::LanguageIdentifier>().unwrap())
-            .map(ResourceOptions::from)
-            .collect())
+        Ok(Self::DATA.iter().map(|(s, _)| s.parse().unwrap()).collect())
     }
 }
 
 #[test]
 fn test_iter() {
     use icu_locid::locale;
-    let supported_langids: Vec<ResourceOptions> = HelloWorldProvider.supported_options().unwrap();
 
     assert_eq!(
-        supported_langids,
-        vec![
-            locale!("bn").into(),
-            locale!("cs").into(),
-            locale!("de").into(),
-            locale!("el").into(),
-            locale!("en").into(),
-            locale!("eo").into(),
-            locale!("fa").into(),
-            locale!("fi").into(),
-            locale!("is").into(),
-            locale!("ja").into(),
-            locale!("la").into(),
-            locale!("pt").into(),
-            locale!("ro").into(),
-            locale!("ru").into(),
-            locale!("vi").into(),
-            locale!("zh").into()
-        ]
+        HelloWorldProvider.supported_locales(),
+        Ok(vec![
+            locale!("bn"),
+            locale!("cs"),
+            locale!("de"),
+            locale!("el"),
+            locale!("en"),
+            locale!("eo"),
+            locale!("fa"),
+            locale!("fi"),
+            locale!("is"),
+            locale!("ja"),
+            locale!("la"),
+            locale!("pt"),
+            locale!("ro"),
+            locale!("ru"),
+            locale!("vi"),
+            locale!("zh"),
+        ]),
     );
 }

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -280,10 +280,11 @@ pub fn datagen(
 
     keys.into_par_iter().try_for_each(|&key| {
         log::info!("Writing key: {}", key);
-        let options = provider
-            .supported_options_for_key(key)
+        let locales = provider
+            .supported_locales_for_key(key)
             .map_err(|e| e.with_key(key))?;
-        let res = options.into_par_iter().try_for_each(|options| {
+        let res = locales.into_par_iter().try_for_each(|locale| {
+            let options = ResourceOptions::from(locale);
             let req = DataRequest {
                 options: options.clone(),
                 metadata: Default::default(),

--- a/provider/datagen/src/transform/cldr/calendar/japanese.rs
+++ b/provider/datagen/src/transform/cldr/calendar/japanese.rs
@@ -5,7 +5,7 @@
 use crate::transform::cldr::cldr_serde;
 use crate::SourceData;
 use icu_calendar::provider::*;
-use icu_locid::langid;
+use icu_locid::{langid, Locale};
 use icu_provider::datagen::IterableResourceProvider;
 use icu_provider::prelude::*;
 use std::collections::BTreeMap;
@@ -194,7 +194,7 @@ fn era_to_code(original: &str, year: i32) -> Result<TinyStr16, String> {
 icu_provider::make_exportable_provider!(JapaneseErasProvider, [JapaneseErasV1Marker,]);
 
 impl IterableResourceProvider<JapaneseErasV1Marker> for JapaneseErasProvider {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }

--- a/provider/datagen/src/transform/cldr/datetime/mod.rs
+++ b/provider/datagen/src/transform/cldr/datetime/mod.rs
@@ -114,7 +114,7 @@ macro_rules! impl_resource_provider {
             }
 
             impl IterableResourceProvider<$marker> for CommonDateProvider {
-                fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+                fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
                     let mut r = Vec::new();
                     for (cal_value, cldr_cal) in self.supported_cals.iter() {
                         r.extend(self
@@ -128,7 +128,7 @@ macro_rules! impl_resource_provider {
                                     .unicode
                                     .keywords
                                     .set(key!("ca"), cal_value.clone());
-                                ResourceOptions::from(locale)
+                                locale
                             }));
                     }
                     Ok(r)

--- a/provider/datagen/src/transform/cldr/datetime/week_data.rs
+++ b/provider/datagen/src/transform/cldr/datetime/week_data.rs
@@ -9,6 +9,7 @@ use crate::transform::cldr::cldr_serde::{
 use crate::SourceData;
 use icu_calendar::arithmetic::week_of::CalendarInfo;
 use icu_datetime::provider::week_data::*;
+use icu_locid::Locale;
 use icu_provider::datagen::IterableResourceProvider;
 use icu_provider::prelude::*;
 use std::collections::HashSet;
@@ -29,14 +30,14 @@ impl From<&SourceData> for WeekDataProvider {
 
 impl IterableResourceProvider<WeekDataV1Marker> for WeekDataProvider {
     #[allow(clippy::needless_collect)] // https://github.com/rust-lang/rust-clippy/issues/7526
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         let week_data: &cldr_serde::week_data::Resource = self
             .source
             .cldr()?
             .core()
             .read_and_parse("supplemental/weekData.json")?;
         let week_data = &week_data.supplemental.week_data;
-        let regions: HashSet<ResourceOptions> = week_data
+        let regions: HashSet<_> = week_data
             .min_days
             .keys()
             .chain(week_data.first_day.keys())
@@ -45,7 +46,7 @@ impl IterableResourceProvider<WeekDataV1Marker> for WeekDataProvider {
                 Territory::Region(r) => Some(Some(*r)),
                 _ => None,
             })
-            .map(ResourceOptions::temp_for_region)
+            .map(Locale::from)
             .collect();
         Ok(regions.into_iter().collect())
     }

--- a/provider/datagen/src/transform/cldr/decimal/mod.rs
+++ b/provider/datagen/src/transform/cldr/decimal/mod.rs
@@ -5,6 +5,7 @@
 use crate::transform::cldr::cldr_serde;
 use crate::SourceData;
 use icu_decimal::provider::*;
+use icu_locid::Locale;
 use icu_provider::datagen::IterableResourceProvider;
 use icu_provider::prelude::*;
 use std::borrow::Cow;
@@ -101,13 +102,13 @@ impl ResourceProvider<DecimalSymbolsV1Marker> for NumbersProvider {
 icu_provider::make_exportable_provider!(NumbersProvider, [DecimalSymbolsV1Marker,]);
 
 impl IterableResourceProvider<DecimalSymbolsV1Marker> for NumbersProvider {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(self
             .source
             .cldr()?
             .numbers()
             .list_langs()?
-            .map(Into::<ResourceOptions>::into)
+            .map(Locale::from)
             .collect())
     }
 }

--- a/provider/datagen/src/transform/cldr/fallback/mod.rs
+++ b/provider/datagen/src/transform/cldr/fallback/mod.rs
@@ -5,7 +5,7 @@
 use crate::transform::cldr::cldr_serde;
 use crate::SourceData;
 
-use icu_locid::LanguageIdentifier;
+use icu_locid::{LanguageIdentifier, Locale};
 use icu_provider::datagen::IterableResourceProvider;
 use icu_provider::prelude::*;
 use icu_provider_adapters::fallback::provider::*;
@@ -86,13 +86,13 @@ icu_provider::make_exportable_provider!(
 );
 
 impl IterableResourceProvider<LocaleFallbackLikelySubtagsV1Marker> for FallbackRulesProvider {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }
 
 impl IterableResourceProvider<LocaleFallbackParentsV1Marker> for FallbackRulesProvider {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }

--- a/provider/datagen/src/transform/cldr/list/mod.rs
+++ b/provider/datagen/src/transform/cldr/list/mod.rs
@@ -6,7 +6,7 @@ use crate::transform::cldr::cldr_serde;
 use crate::transform::icuexport::uprops::EnumeratedPropertyCodePointTrieProvider;
 use crate::SourceData;
 use icu_list::provider::*;
-use icu_locid::subtags_language as language;
+use icu_locid::{subtags_language as language, Locale};
 use icu_provider::datagen::IterableResourceProvider;
 use icu_provider::prelude::*;
 
@@ -137,13 +137,13 @@ icu_provider::make_exportable_provider!(
 impl<M: ResourceMarker<Yokeable = ListFormatterPatternsV1<'static>>> IterableResourceProvider<M>
     for ListProvider
 {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(self
             .source
             .cldr()?
             .misc()
             .list_langs()?
-            .map(Into::<ResourceOptions>::into)
+            .map(Locale::from)
             .collect())
     }
 }

--- a/provider/datagen/src/transform/cldr/locale_canonicalizer/aliases.rs
+++ b/provider/datagen/src/transform/cldr/locale_canonicalizer/aliases.rs
@@ -5,7 +5,7 @@
 use crate::transform::cldr::cldr_serde;
 use crate::SourceData;
 use icu_locale_canonicalizer::provider::*;
-use icu_locid::{subtags, subtags_language as language, LanguageIdentifier};
+use icu_locid::{subtags, subtags_language as language, LanguageIdentifier, Locale};
 use icu_provider::datagen::IterableResourceProvider;
 use icu_provider::prelude::*;
 use tinystr::TinyAsciiStr;
@@ -50,7 +50,7 @@ impl ResourceProvider<AliasesV1Marker> for AliasesProvider {
 icu_provider::make_exportable_provider!(AliasesProvider, [AliasesV1Marker,]);
 
 impl IterableResourceProvider<AliasesV1Marker> for AliasesProvider {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }

--- a/provider/datagen/src/transform/cldr/locale_canonicalizer/likely_subtags.rs
+++ b/provider/datagen/src/transform/cldr/locale_canonicalizer/likely_subtags.rs
@@ -5,6 +5,7 @@
 use crate::transform::cldr::cldr_serde;
 use crate::SourceData;
 use icu_locale_canonicalizer::provider::*;
+use icu_locid::Locale;
 use icu_provider::datagen::IterableResourceProvider;
 use icu_provider::prelude::*;
 use zerovec::ZeroMap;
@@ -52,7 +53,7 @@ impl ResourceProvider<LikelySubtagsV1Marker> for LikelySubtagsProvider {
 icu_provider::make_exportable_provider!(LikelySubtagsProvider, [LikelySubtagsV1Marker,]);
 
 impl IterableResourceProvider<LikelySubtagsV1Marker> for LikelySubtagsProvider {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }

--- a/provider/datagen/src/transform/cldr/plurals/mod.rs
+++ b/provider/datagen/src/transform/cldr/plurals/mod.rs
@@ -4,6 +4,7 @@
 
 use crate::transform::cldr::cldr_serde;
 use crate::SourceData;
+use icu_locid::Locale;
 use icu_plurals::provider::*;
 use icu_plurals::rules::runtime::ast::Rule;
 use icu_provider::datagen::IterableResourceProvider;
@@ -70,14 +71,14 @@ icu_provider::make_exportable_provider!(PluralsProvider, [OrdinalV1Marker, Cardi
 impl<M: ResourceMarker<Yokeable = PluralRulesV1<'static>>> IterableResourceProvider<M>
     for PluralsProvider
 {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(self
             .get_rules_for(M::KEY)?
             .0
             .keys()
             // TODO(#568): Avoid the clone
             .cloned()
-            .map(ResourceOptions::from)
+            .map(Locale::from)
             .collect())
     }
 }

--- a/provider/datagen/src/transform/cldr/time_zones/mod.rs
+++ b/provider/datagen/src/transform/cldr/time_zones/mod.rs
@@ -6,6 +6,7 @@ use crate::transform::cldr::cldr_serde;
 use crate::transform::cldr::cldr_serde::time_zones::CldrTimeZonesData;
 use crate::SourceData;
 use icu_datetime::provider::time_zones::*;
+use icu_locid::Locale;
 use icu_provider::datagen::IterableResourceProvider;
 use icu_provider::prelude::*;
 use std::collections::HashMap;
@@ -93,13 +94,13 @@ macro_rules! impl_resource_provider {
             }
 
             impl IterableResourceProvider<$marker> for TimeZonesProvider {
-                fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+                fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
                     Ok(self
                         .source
                         .cldr()?
                         .dates("gregorian")
                         .list_langs()?
-                        .map(Into::<ResourceOptions>::into)
+                        .map(Locale::from)
                         .collect())
                 }
             }

--- a/provider/datagen/src/transform/icuexport/collator/mod.rs
+++ b/provider/datagen/src/transform/icuexport/collator/mod.rs
@@ -137,7 +137,7 @@ macro_rules! collation_provider {
             }
 
             impl IterableResourceProvider<$marker> for CollationProvider {
-                fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+                fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
                     Ok(self
                         .source
                         .icuexport()?
@@ -152,7 +152,6 @@ macro_rules! collation_provider {
                                 .map(ToString::to_string)
                         )
                         .filter_map(|s|file_name_to_locale(&s))
-                        .map(ResourceOptions::from)
                         .collect()
                     )
                 }

--- a/provider/datagen/src/transform/icuexport/normalizer/mod.rs
+++ b/provider/datagen/src/transform/icuexport/normalizer/mod.rs
@@ -8,6 +8,7 @@
 use crate::SourceData;
 use icu_char16trie::char16trie::Char16Trie;
 use icu_codepointtrie::CodePointTrie;
+use icu_locid::Locale;
 use icu_normalizer::provider::*;
 use icu_normalizer::u24::U24;
 use icu_provider::datagen::IterableResourceProvider;
@@ -54,8 +55,8 @@ macro_rules! normalization_provider {
         icu_provider::make_exportable_provider!($provider, [$marker,]);
 
         impl IterableResourceProvider<$marker> for $provider {
-            fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
-                Ok(vec![ResourceOptions::default()])
+            fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
+                Ok(vec![Default::default()])
             }
         }
     };

--- a/provider/datagen/src/transform/icuexport/ucase/mod.rs
+++ b/provider/datagen/src/transform/icuexport/ucase/mod.rs
@@ -10,6 +10,7 @@ use icu_casemapping::provider::{CaseMappingV1, CaseMappingV1Marker};
 use icu_casemapping::CaseMappingInternals;
 use icu_codepointtrie::toml::CodePointDataSlice;
 use icu_codepointtrie::CodePointTrieHeader;
+use icu_locid::Locale;
 use icu_provider::prelude::*;
 use std::convert::TryFrom;
 
@@ -79,7 +80,7 @@ impl ResourceProvider<CaseMappingV1Marker> for CaseMappingDataProvider {
 impl icu_provider::datagen::IterableResourceProvider<CaseMappingV1Marker>
     for CaseMappingDataProvider
 {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }

--- a/provider/datagen/src/transform/icuexport/uprops/bin_uniset.rs
+++ b/provider/datagen/src/transform/icuexport/uprops/bin_uniset.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::SourceData;
+use icu_locid::Locale;
 use icu_properties::provider::*;
 use icu_provider::datagen::*;
 use icu_provider::prelude::*;
@@ -63,9 +64,9 @@ macro_rules! expand {
             }
 
             impl IterableResourceProvider<$marker> for BinaryPropertyUnicodeSetDataProvider {
-                fn supported_options(
+                fn supported_locales(
                     &self,
-                ) -> Result<Vec<ResourceOptions>, DataError> {
+                ) -> Result<Vec<Locale>, DataError> {
                     get_binary(&self.source, $prop_name)?;
 
                     Ok(vec![Default::default()])

--- a/provider/datagen/src/transform/icuexport/uprops/enum_codepointtrie.rs
+++ b/provider/datagen/src/transform/icuexport/uprops/enum_codepointtrie.rs
@@ -4,6 +4,7 @@
 
 use crate::SourceData;
 use icu_codepointtrie::CodePointTrie;
+use icu_locid::Locale;
 use icu_properties::provider::*;
 use icu_provider::datagen::*;
 use icu_provider::prelude::*;
@@ -60,9 +61,9 @@ macro_rules! expand {
             }
 
             impl IterableResourceProvider<$marker> for EnumeratedPropertyCodePointTrieProvider {
-                fn supported_options(
+                fn supported_locales(
                     &self,
-                ) -> Result<Vec<ResourceOptions>, DataError> {
+                ) -> Result<Vec<Locale>, DataError> {
                     get_enumerated(&self.source, $prop_name)?;
                     Ok(vec![Default::default()])
                 }

--- a/provider/datagen/src/transform/icuexport/uprops/script.rs
+++ b/provider/datagen/src/transform/icuexport/uprops/script.rs
@@ -4,6 +4,7 @@
 
 use crate::SourceData;
 use icu_codepointtrie::CodePointTrie;
+use icu_locid::Locale;
 use icu_properties::provider::{
     ScriptWithExtensionsPropertyV1, ScriptWithExtensionsPropertyV1Marker,
 };
@@ -84,7 +85,7 @@ impl ResourceProvider<ScriptWithExtensionsPropertyV1Marker>
 impl IterableResourceProvider<ScriptWithExtensionsPropertyV1Marker>
     for ScriptWithExtensionsPropertyProvider
 {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }

--- a/provider/datagen/src/transform/segmenter/mod.rs
+++ b/provider/datagen/src/transform/segmenter/mod.rs
@@ -10,7 +10,7 @@ use crate::transform::icuexport::uprops::{
 use crate::SourceData;
 use icu_codepointtrie::CodePointTrie;
 use icu_codepointtrie_builder::{CodePointTrieBuilder, CodePointTrieBuilderData};
-use icu_locid::{langid, locale};
+use icu_locid::{langid, locale, Locale};
 use icu_properties::{
     maps, sets, EastAsianWidth, GeneralCategory, GraphemeClusterBreak, LineBreak, SentenceBreak,
     WordBreak,
@@ -696,25 +696,25 @@ icu_provider::make_exportable_provider!(
 );
 
 impl IterableResourceProvider<LineBreakDataV1Marker> for SegmenterRuleProvider {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }
 
 impl IterableResourceProvider<GraphemeClusterBreakDataV1Marker> for SegmenterRuleProvider {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }
 
 impl IterableResourceProvider<WordBreakDataV1Marker> for SegmenterRuleProvider {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }
 
 impl IterableResourceProvider<SentenceBreakDataV1Marker> for SegmenterRuleProvider {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }
@@ -784,13 +784,13 @@ icu_provider::make_exportable_provider!(
 );
 
 impl IterableResourceProvider<UCharDictionaryBreakDataV1Marker> for SegmenterDictionaryProvider {
-    fn supported_options(&self) -> Result<Vec<ResourceOptions>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![
-            locale!("th").into(),
-            locale!("km").into(),
-            locale!("lo").into(),
-            locale!("my").into(),
-            locale!("ja").into(),
+            locale!("th"),
+            locale!("km"),
+            locale!("lo"),
+            locale!("my"),
+            locale!("ja"),
         ])
     }
 }

--- a/provider/datagen/tests/verify-zero-copy.rs
+++ b/provider/datagen/tests/verify-zero-copy.rs
@@ -70,8 +70,8 @@ fn main() {
         let mut max_total_violation = 0;
         let mut max_net_violation = 0;
 
-        for options in
-            match IterableDynProvider::<icu_provider::datagen::ExportMarker>::supported_options_for_key(
+        for locale in
+            match IterableDynProvider::<icu_provider::datagen::ExportMarker>::supported_locales_for_key(
                 &converter, key,
             ) {
                 Err(_) if key.get_path().starts_with("props/") => {
@@ -84,7 +84,7 @@ fn main() {
             let payload = provider.load_buffer(
                 key,
                 &DataRequest {
-                    options: options.clone(),
+                    options: locale.into(),
                     metadata: Default::default(),
                 },
             ).unwrap().take_payload().unwrap();

--- a/provider/fs/tests/test_file_io.rs
+++ b/provider/fs/tests/test_file_io.rs
@@ -18,9 +18,9 @@ const PATHS: &[&str] = &[JSON_PATH, BINCODE_PATH, POSTCARD_PATH];
 fn test_provider() {
     for path in PATHS {
         let provider = FsDataProvider::try_new(path).unwrap();
-        for options in HelloWorldProvider.supported_options().unwrap() {
+        for locale in HelloWorldProvider.supported_locales().unwrap() {
             let req = DataRequest {
-                options,
+                options: locale.into(),
                 metadata: Default::default(),
             };
 


### PR DESCRIPTION
Implementors usually have `Locale`s and should just be able to return those without depending on the representation inside `DataRequest`. This allows us to make `ResourceOptions` private (see discussion in #1995).