### PR TITLE
Move map_project to closures

### DIFF
--- a/components/datetime/src/raw/datetime.rs
+++ b/components/datetime/src/raw/datetime.rs
@@ -358,14 +358,12 @@ impl DateTimeFormat {
         date: DateFormat,
         time: TimeFormat,
     ) -> Result<Self, DateTimeFormatError> {
+        let generic_pattern = &date.generic_pattern;
+        let time_patterns = &time.patterns;
         let patterns = date
             .patterns
-            .try_map_project_with_capture::<PatternPluralsFromPatternsV1Marker, (
-                DataPayload<GenericPatternV1Marker>,
-                DataPayload<PatternPluralsFromPatternsV1Marker>,
-            ), DateTimeFormatError>(
-                (date.generic_pattern, time.patterns),
-                |data, (generic_pattern, time_patterns), _| {
+            .try_map_project::<PatternPluralsFromPatternsV1Marker, _, DateTimeFormatError>(
+                |data, _| {
                     let date_pattern = data.0.expect_pattern("Lengths are single patterns");
                     let time_pattern: crate::pattern::runtime::Pattern = time_patterns
                         .get()

--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -89,24 +89,21 @@ impl BufferProvider for BlobDataProvider {
         Ok(DataResponse {
             metadata,
             payload: Some(DataPayload::from_yoked_buffer(
-                self.data.try_map_project_cloned_with_capture(
-                    (key, req),
-                    |blob, (key, req), _| {
-                        let idx = blob
-                            .keys
-                            .get0(&key.get_hash())
-                            .ok_or(DataErrorKind::MissingResourceKey)
-                            .and_then(|cursor| {
-                                cursor
-                                    .get1_copied_by(|bytes| req.options.strict_cmp(bytes).reverse())
-                                    .ok_or(DataErrorKind::MissingResourceOptions)
-                            })
-                            .map_err(|kind| kind.with_req(key, req))?;
-                        blob.buffers.get(idx).ok_or_else(|| {
-                            DataError::custom("Invalid blob bytes").with_req(key, req)
+                self.data.try_map_project_cloned(|blob, _| {
+                    let idx = blob
+                        .keys
+                        .get0(&key.get_hash())
+                        .ok_or(DataErrorKind::MissingResourceKey)
+                        .and_then(|cursor| {
+                            cursor
+                                .get1_copied_by(|bytes| req.options.strict_cmp(bytes).reverse())
+                                .ok_or(DataErrorKind::MissingResourceOptions)
                         })
-                    },
-                )?,
+                        .map_err(|kind| kind.with_req(key, req))?;
+                    blob.buffers
+                        .get(idx)
+                        .ok_or_else(|| DataError::custom("Invalid blob bytes").with_req(key, req))
+                })?,
             )),
         })
     }

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -260,6 +260,11 @@ where
     /// This function is similar to [`DataPayload::try_from_rc_buffer`], but it accepts a buffer
     /// that is already yoked.
     ///
+    /// The callback takes an additional `PhantomData<&()>` parameter to anchor lifetimes
+    /// (see [#86702](https://github.com/rust-lang/rust/issues/86702)) This parameter
+    /// should just be ignored in the callback.
+    ///
+    ///
     /// # Examples
     ///
     /// ```
@@ -270,8 +275,7 @@ where
     ///
     /// let payload = DataPayload::<HelloWorldV1Marker>::try_from_yoked_buffer(
     ///     Yoke::attach_to_cart("{\"message\":\"Hello World\"}".as_bytes().into(), |b| b),
-    ///     (),
-    ///     |bytes, _, _| serde_json::from_slice(bytes),
+    ///     |bytes, _| serde_json::from_slice(bytes),
     /// )
     /// .expect("JSON is valid");
     ///
@@ -279,18 +283,17 @@ where
     /// # } // feature = "serde_json"
     /// ```
     #[allow(clippy::type_complexity)]
-    pub fn try_from_yoked_buffer<T, E>(
+    pub fn try_from_yoked_buffer<F, E>(
         yoked_buffer: Yoke<&'static [u8], RcWrap>,
-        capture: T,
-        f: for<'de> fn(
+        f: F,
+    ) -> Result<Self, E>
+    where
+        F: for<'de> FnOnce(
             <&'static [u8] as yoke::Yokeable<'de>>::Output,
-            T,
             PhantomData<&'de ()>,
         ) -> Result<<M::Yokeable as Yokeable<'de>>::Output, E>,
-    ) -> Result<Self, E> {
-        let yoke = yoked_buffer
-            .wrap_cart_in_option()
-            .try_map_project_with_capture(capture, f)?;
+    {
+        let yoke = yoked_buffer.wrap_cart_in_option().try_map_project(f)?;
         Ok(Self { yoke })
     }
 
@@ -431,15 +434,13 @@ where
     /// assert_eq!("Hello World", p2.get());
     /// ```
     #[allow(clippy::type_complexity)]
-    pub fn map_project<M2>(
-        self,
-        f: for<'a> fn(
+    pub fn map_project<M2, F>(self, f: F) -> DataPayload<M2>
+    where
+        M2: DataMarker,
+        F: for<'a> FnOnce(
             <M::Yokeable as Yokeable<'a>>::Output,
             PhantomData<&'a ()>,
         ) -> <M2::Yokeable as Yokeable<'a>>::Output,
-    ) -> DataPayload<M2>
-    where
-        M2: DataMarker,
     {
         DataPayload {
             yoke: self.yoke.map_project(f),
@@ -475,124 +476,20 @@ where
     /// assert_eq!(p1.get().message, *p2.get());
     /// ```
     #[allow(clippy::type_complexity)]
-    pub fn map_project_cloned<'this, M2>(
-        &'this self,
-        f: for<'a> fn(
+    pub fn map_project_cloned<'this, M2, F>(&'this self, f: F) -> DataPayload<M2>
+    where
+        M2: DataMarker,
+        F: for<'a> FnOnce(
             &'this <M::Yokeable as Yokeable<'a>>::Output,
             PhantomData<&'a ()>,
         ) -> <M2::Yokeable as Yokeable<'a>>::Output,
-    ) -> DataPayload<M2>
-    where
-        M2: DataMarker,
     {
         DataPayload {
             yoke: self.yoke.map_project_cloned(f),
         }
     }
 
-    /// Version of [`DataPayload::map_project()`] that moves `self` and takes a `capture`
-    /// parameter to pass additional data to `f`.
-    ///
-    /// # Examples
-    ///
-    /// Capture a string from the context and append it to the message:
-    ///
-    /// ```
-    /// // Same imports and definitions as above
-    /// # use icu_provider::hello_world::*;
-    /// # use icu_provider::prelude::*;
-    /// # use std::borrow::Cow;
-    /// # struct HelloWorldV1MessageMarker;
-    /// # impl DataMarker for HelloWorldV1MessageMarker {
-    /// #     type Yokeable = Cow<'static, str>;
-    /// # }
-    ///
-    /// let p1: DataPayload<HelloWorldV1Marker> = DataPayload::from_owned(HelloWorldV1 {
-    ///     message: Cow::Borrowed("Hello World"),
-    /// });
-    ///
-    /// assert_eq!("Hello World", p1.get().message);
-    ///
-    /// let p2: DataPayload<HelloWorldV1MessageMarker> =
-    ///     p1.map_project_with_capture("Extra", |mut obj, capture, _| {
-    ///         obj.message.to_mut().push_str(capture);
-    ///         obj.message
-    ///     });
-    ///
-    /// assert_eq!("Hello WorldExtra", p2.get());
-    /// ```
-    #[allow(clippy::type_complexity)]
-    pub fn map_project_with_capture<M2, T>(
-        self,
-        capture: T,
-        f: for<'a> fn(
-            <M::Yokeable as Yokeable<'a>>::Output,
-            capture: T,
-            PhantomData<&'a ()>,
-        ) -> <M2::Yokeable as Yokeable<'a>>::Output,
-    ) -> DataPayload<M2>
-    where
-        M2: DataMarker,
-    {
-        DataPayload {
-            yoke: self.yoke.map_project_with_capture(capture, f),
-        }
-    }
-
-    /// Version of [`DataPayload::map_project()`] that borrows `self` and takes a `capture`
-    /// parameter to pass additional data to `f`.
-    ///
-    /// # Examples
-    ///
-    /// Same example as above, but this time, do not move out of `p1`:
-    ///
-    /// ```
-    /// // Same imports and definitions as above
-    /// # use icu_provider::hello_world::*;
-    /// # use icu_provider::prelude::*;
-    /// # use std::borrow::Cow;
-    /// # struct HelloWorldV1MessageMarker;
-    /// # impl DataMarker for HelloWorldV1MessageMarker {
-    /// #     type Yokeable = Cow<'static, str>;
-    /// # }
-    ///
-    /// let p1: DataPayload<HelloWorldV1Marker> = DataPayload::from_owned(HelloWorldV1 {
-    ///     message: Cow::Borrowed("Hello World"),
-    /// });
-    ///
-    /// assert_eq!("Hello World", p1.get().message);
-    ///
-    /// let p2: DataPayload<HelloWorldV1MessageMarker> =
-    ///     p1.map_project_cloned_with_capture("Extra", |obj, capture, _| {
-    ///         let mut message = obj.message.clone();
-    ///         message.to_mut().push_str(capture);
-    ///         message
-    ///     });
-    ///
-    /// // Note: p1 is still valid, but the values no longer equal.
-    /// assert_ne!(p1.get().message, *p2.get());
-    /// assert_eq!("Hello WorldExtra", p2.get());
-    /// ```
-    #[allow(clippy::type_complexity)]
-    pub fn map_project_cloned_with_capture<'this, M2, T>(
-        &'this self,
-        capture: T,
-        f: for<'a> fn(
-            &'this <M::Yokeable as Yokeable<'a>>::Output,
-            capture: T,
-            PhantomData<&'a ()>,
-        ) -> <M2::Yokeable as Yokeable<'a>>::Output,
-    ) -> DataPayload<M2>
-    where
-        M2: DataMarker,
-    {
-        DataPayload {
-            yoke: self.yoke.map_project_cloned_with_capture(capture, f),
-        }
-    }
-
-    /// Version of [`DataPayload::map_project()`] that moves `self`, takes a `capture`
-    /// parameter to pass additional data to `f`, and bubbles up an error from `f`.
+    /// Version of [`DataPayload::map_project()`] that bubbles up an error from `f`.
     ///
     /// # Examples
     ///
@@ -614,12 +511,13 @@ where
     ///
     /// assert_eq!("Hello World", p1.get().message);
     ///
+    /// let string_to_append = "Extra";
     /// let p2: DataPayload<HelloWorldV1MessageMarker> =
-    ///     p1.try_map_project_with_capture("Extra", |mut obj, capture, _| {
+    ///     p1.try_map_project(|mut obj, _| {
     ///         if obj.message.is_empty() {
     ///             return Err("Example error");
     ///         }
-    ///         obj.message.to_mut().push_str(&capture);
+    ///         obj.message.to_mut().push_str(string_to_append);
     ///         Ok(obj.message)
     ///     })?;
     ///
@@ -627,25 +525,20 @@ where
     /// # Ok::<(), &'static str>(())
     /// ```
     #[allow(clippy::type_complexity)]
-    pub fn try_map_project_with_capture<M2, T, E>(
-        self,
-        capture: T,
-        f: for<'a> fn(
-            <M::Yokeable as Yokeable<'a>>::Output,
-            capture: T,
-            PhantomData<&'a ()>,
-        ) -> Result<<M2::Yokeable as Yokeable<'a>>::Output, E>,
-    ) -> Result<DataPayload<M2>, E>
+    pub fn try_map_project<M2, F, E>(self, f: F) -> Result<DataPayload<M2>, E>
     where
         M2: DataMarker,
+        F: for<'a> FnOnce(
+            <M::Yokeable as Yokeable<'a>>::Output,
+            PhantomData<&'a ()>,
+        ) -> Result<<M2::Yokeable as Yokeable<'a>>::Output, E>,
     {
         Ok(DataPayload {
-            yoke: self.yoke.try_map_project_with_capture(capture, f)?,
+            yoke: self.yoke.try_map_project(f)?,
         })
     }
 
-    /// Version of [`DataPayload::map_project()`] that borrows `self`, takes a `capture`
-    /// parameter to pass additional data to `f`, and bubbles up an error from `f`.
+    /// Version of [`DataPayload::map_project_cloned()`] that  bubbles up an error from `f`.
     ///
     /// # Examples
     ///
@@ -667,13 +560,14 @@ where
     ///
     /// assert_eq!("Hello World", p1.get().message);
     ///
+    /// let string_to_append = "Extra";
     /// let p2: DataPayload<HelloWorldV1MessageMarker> =
-    ///     p1.try_map_project_cloned_with_capture("Extra", |obj, capture, _| {
+    ///     p1.try_map_project_cloned(|obj, _| {
     ///         if obj.message.is_empty() {
     ///             return Err("Example error");
     ///         }
     ///         let mut message = obj.message.clone();
-    ///         message.to_mut().push_str(capture);
+    ///         message.to_mut().push_str(string_to_append);
     ///         Ok(message)
     ///     })?;
     ///
@@ -683,20 +577,16 @@ where
     /// # Ok::<(), &'static str>(())
     /// ```
     #[allow(clippy::type_complexity)]
-    pub fn try_map_project_cloned_with_capture<'this, M2, T, E>(
-        &'this self,
-        capture: T,
-        f: for<'a> fn(
-            &'this <M::Yokeable as Yokeable<'a>>::Output,
-            capture: T,
-            PhantomData<&'a ()>,
-        ) -> Result<<M2::Yokeable as Yokeable<'a>>::Output, E>,
-    ) -> Result<DataPayload<M2>, E>
+    pub fn try_map_project_cloned<'this, M2, F, E>(&'this self, f: F) -> Result<DataPayload<M2>, E>
     where
         M2: DataMarker,
+        F: for<'a> FnOnce(
+            &'this <M::Yokeable as Yokeable<'a>>::Output,
+            PhantomData<&'a ()>,
+        ) -> Result<<M2::Yokeable as Yokeable<'a>>::Output, E>,
     {
         Ok(DataPayload {
-            yoke: self.yoke.try_map_project_cloned_with_capture(capture, f)?,
+            yoke: self.yoke.try_map_project_cloned(f)?,
         })
     }
 

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -402,8 +402,8 @@ where
     /// data from its context. Use one of the sister methods if you need these capabilities:
     ///
     /// - [`DataPayload::map_project_cloned()`] if you don't have ownership of `self`
-    /// - [`DataPayload::map_project_with_capture()`] to pass context to the mapping function
-    /// - [`DataPayload::map_project_cloned_with_capture()`] to do both of these things
+    /// - [`DataPayload::try_map_project()`] to bubble up an error
+    /// - [`DataPayload::try_map_project_cloned()`] to do both of the above
     ///
     /// # Examples
     ///

--- a/provider/core/src/serde/mod.rs
+++ b/provider/core/src/serde/mod.rs
@@ -16,7 +16,6 @@ pub mod borrow_de_utils;
 use crate::buf::BufferFormat;
 use crate::buf::BufferProvider;
 use crate::prelude::*;
-use core::marker::PhantomData;
 use serde::de::Deserialize;
 use yoke::trait_hack::YokeTraitHack;
 use yoke::Yokeable;
@@ -43,7 +42,6 @@ fn deserialize_impl<'data, M>(
     // Allow `bytes` to be unused in case all buffer formats are disabled
     #[allow(unused_variables)] bytes: &'data [u8],
     buffer_format: BufferFormat,
-    _: PhantomData<&'data ()>,
 ) -> Result<<M::Yokeable as Yokeable<'data>>::Output, DataError>
 where
     M: DataMarker,
@@ -96,7 +94,7 @@ impl DataPayload<BufferMarker> {
         // Necessary workaround bound (see `yoke::trait_hack` docs):
         for<'de> YokeTraitHack<<M::Yokeable as Yokeable<'de>>::Output>: Deserialize<'de>,
     {
-        self.try_map_project_with_capture(buffer_format, deserialize_impl::<M>)
+        self.try_map_project(|bytes, _| deserialize_impl::<M>(bytes, buffer_format))
     }
 }
 

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -646,9 +646,6 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// This is similar to [`Yoke::map_project`], however it can also bubble up an error
     /// from the callback.
     ///
-    /// This is a bit more efficient than cloning the [`Yoke`] and then calling [`Yoke::map_project`]
-    /// because then it will not clone fields that are going to be discarded.
-    ///
     /// ```
     /// # use std::rc::Rc;
     /// # use yoke::Yoke;

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -652,9 +652,10 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// ```
     /// # use std::rc::Rc;
     /// # use yoke::Yoke;
+    /// # use std::str::{self, Utf8Error};
     /// #
-    /// fn slice(y: Yoke<&'static str, Rc<[u8]>>) -> Yoke<&'static [u8], Rc<[u8]>> {
-    ///     y.map_project(move |yk, _| yk.as_bytes())
+    /// fn slice(y: Yoke<&'static [u8], Rc<[u8]>>) -> Result<Yoke<&'static str, Rc<[u8]>>, Utf8Error> {
+    ///     y.try_map_project(move |bytes, _| str::from_utf8(bytes))
     /// }
     /// ```
     ///


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/1061

This moves the Yoke `map_project` functions all over to using closures, and also ensures that the closurefull functions have full functionality.

This does not remove the `_with_capture` functions from Yoke, however it renames them to `_with_explicit_capture`. As a util crate Yoke can always remove them in the future, but holding on to them gives us a wider range of Rust version support in Yoke.

ICU4X DataPayload does not do this: it only has the closure APIs. If something breaks in the compiler in the future it should not be hard for us to re-add `_with_explicit_capture` APIs as needed, but it's cleaner to not start with them. I'm also adding tests upstream (https://github.com/rust-lang/rust/pull/99257).




<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->