### PR TITLE
Make sink-writing normalization methods non-experimental

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "atoi"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1647,6 +1653,7 @@ name = "icu_normalizer"
 version = "0.6.0"
 dependencies = [
  "arraystring",
+ "arrayvec",
  "atoi",
  "databake",
  "displaydoc",
@@ -1660,6 +1667,7 @@ dependencies = [
  "smallvec",
  "utf16_iter",
  "utf8_iter",
+ "write16",
  "zerofrom",
  "zerovec",
 ]
@@ -4037,6 +4045,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]

--- a/components/normalizer/Cargo.toml
+++ b/components/normalizer/Cargo.toml
@@ -52,7 +52,7 @@ icu_testdata = { version = "0.6", path = "../../provider/testdata" }
 atoi = "1.0.0"
 arraystring = "0.3.0"
 arrayvec = "0.7.2"
-write16 = { versean = "1.0", features = ["arrayvec"] }
+write16 = { version = "1.0", features = ["arrayvec"] }
 
 [lib]
 path = "src/lib.rs"

--- a/components/normalizer/Cargo.toml
+++ b/components/normalizer/Cargo.toml
@@ -42,6 +42,7 @@ icu_uniset = { version = "0.5", path = "../../utils/uniset" }
 icu_properties = { version = "0.6", path = "../../components/properties" }
 utf8_iter = "1.0"
 utf16_iter = "1.0"
+write16 = "1.0"
 databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../../utils/zerofrom" }
 icu_char16trie = { version = "0.1", path = "../../experimental/char16trie" }
@@ -50,6 +51,8 @@ icu_char16trie = { version = "0.1", path = "../../experimental/char16trie" }
 icu_testdata = { version = "0.6", path = "../../provider/testdata" }
 atoi = "1.0.0"
 arraystring = "0.3.0"
+arrayvec = "0.7.2"
+write16 = { versean = "1.0", features = ["arrayvec"] }
 
 [lib]
 path = "src/lib.rs"

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -1130,7 +1130,6 @@ macro_rules! normalizer_methods {
         }
 
         /// Normalize a string slice into a `Write` sink.
-        #[cfg(feature = "experimental")]
         pub fn normalize_to<W: core::fmt::Write + ?Sized>(
             &self,
             text: &str,
@@ -1165,8 +1164,7 @@ macro_rules! normalizer_methods {
         ///
         /// Unpaired surrogates are mapped to the REPLACEMENT CHARACTER
         /// before normalizing.
-        #[cfg(feature = "experimental")]
-        pub fn normalize_utf16_to<W: core::fmt::Write + ?Sized>(
+        pub fn normalize_utf16_to<W: write16::Write16 + ?Sized>(
             &self,
             text: &[u16],
             sink: &mut W,
@@ -1196,7 +1194,6 @@ macro_rules! normalizer_methods {
         ///
         /// Errors are mapped to the REPLACEMENT CHARACTER according
         /// to the WHATWG Encoding Standard.
-        #[cfg(feature = "experimental")]
         pub fn normalize_utf8_to<W: core::fmt::Write + ?Sized>(
             &self,
             text: &[u8],

--- a/components/normalizer/src/tests.rs
+++ b/components/normalizer/src/tests.rs
@@ -134,8 +134,122 @@ fn test_uts46_basic() {
     assert_eq!(normalizer.normalize("ς"), "ς");
 }
 
-use atoi::FromRadix16;
 type StackString = arraystring::ArrayString<arraystring::typenum::U48>;
+
+#[test]
+fn test_nfd_str_to() {
+    let data_provider = icu_testdata::get_provider();
+
+    let normalizer: DecomposingNormalizer =
+        DecomposingNormalizer::try_new_nfd(&data_provider).unwrap();
+
+    let mut buf = StackString::new();
+    assert!(normalizer.normalize_to("ä", &mut buf).is_ok());
+    assert_eq!(&buf, "a\u{0308}");
+
+    buf.clear();
+    assert!(normalizer.normalize_to("ệ", &mut buf).is_ok());
+    assert_eq!(&buf, "e\u{0323}\u{0302}");
+}
+
+#[test]
+fn test_nfd_utf8_to() {
+    let data_provider = icu_testdata::get_provider();
+
+    let normalizer: DecomposingNormalizer =
+        DecomposingNormalizer::try_new_nfd(&data_provider).unwrap();
+
+    let mut buf = StackString::new();
+    assert!(normalizer
+        .normalize_utf8_to("ä".as_bytes(), &mut buf)
+        .is_ok());
+    assert_eq!(&buf, "a\u{0308}");
+
+    buf.clear();
+    assert!(normalizer
+        .normalize_utf8_to("ệ".as_bytes(), &mut buf)
+        .is_ok());
+    assert_eq!(&buf, "e\u{0323}\u{0302}");
+}
+
+type StackVec = arrayvec::ArrayVec<u16, 32>;
+
+#[test]
+fn test_nfd_utf16_to() {
+    let data_provider = icu_testdata::get_provider();
+
+    let normalizer: DecomposingNormalizer =
+        DecomposingNormalizer::try_new_nfd(&data_provider).unwrap();
+
+    let mut buf = StackVec::new();
+    assert!(normalizer
+        .normalize_utf16_to([0x00E4u16].as_slice(), &mut buf)
+        .is_ok());
+    assert_eq!(&buf, [0x0061u16, 0x0308u16].as_slice());
+
+    buf.clear();
+    assert!(normalizer
+        .normalize_utf16_to([0x1EC7u16].as_slice(), &mut buf)
+        .is_ok());
+    assert_eq!(&buf, [0x0065u16, 0x0323u16, 0x0302u16].as_slice());
+}
+
+#[test]
+fn test_nfc_str_to() {
+    let data_provider = icu_testdata::get_provider();
+
+    let normalizer: ComposingNormalizer = ComposingNormalizer::try_new_nfc(&data_provider).unwrap();
+
+    let mut buf = StackString::new();
+    assert!(normalizer.normalize_to("a\u{0308}", &mut buf).is_ok());
+    assert_eq!(&buf, "ä");
+
+    buf.clear();
+    assert!(normalizer
+        .normalize_to("e\u{0323}\u{0302}", &mut buf)
+        .is_ok());
+    assert_eq!(&buf, "ệ");
+}
+
+#[test]
+fn test_nfc_utf8_to() {
+    let data_provider = icu_testdata::get_provider();
+
+    let normalizer: ComposingNormalizer = ComposingNormalizer::try_new_nfc(&data_provider).unwrap();
+
+    let mut buf = StackString::new();
+    assert!(normalizer
+        .normalize_utf8_to("a\u{0308}".as_bytes(), &mut buf)
+        .is_ok());
+    assert_eq!(&buf, "ä");
+
+    buf.clear();
+    assert!(normalizer
+        .normalize_utf8_to("e\u{0323}\u{0302}".as_bytes(), &mut buf)
+        .is_ok());
+    assert_eq!(&buf, "ệ");
+}
+
+#[test]
+fn test_nfc_utf16_to() {
+    let data_provider = icu_testdata::get_provider();
+
+    let normalizer: ComposingNormalizer = ComposingNormalizer::try_new_nfc(&data_provider).unwrap();
+
+    let mut buf = StackVec::new();
+    assert!(normalizer
+        .normalize_utf16_to([0x0061u16, 0x0308u16].as_slice(), &mut buf)
+        .is_ok());
+    assert_eq!(&buf, [0x00E4u16].as_slice());
+
+    buf.clear();
+    assert!(normalizer
+        .normalize_utf16_to([0x0065u16, 0x0323u16, 0x0302u16].as_slice(), &mut buf)
+        .is_ok());
+    assert_eq!(&buf, [0x1EC7u16].as_slice());
+}
+
+use atoi::FromRadix16;
 
 /// Parse five semicolon-terminated strings consisting of space-separated hexadecimal scalar values
 fn parse_hex(mut hexes: &[u8]) -> [StackString; 5] {


### PR DESCRIPTION
Use `Write16` for UTF-16.