### PR TITLE
Passing `DataLocale` by reference

### DIFF
--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -31,10 +31,7 @@ use icu_normalizer::Decomposition;
 use icu_properties::maps::CodePointMapData;
 use icu_properties::provider::CanonicalCombiningClassV1Marker;
 use icu_properties::CanonicalCombiningClass;
-use icu_provider::DataLocale;
-use icu_provider::DataPayload;
-use icu_provider::DataProvider;
-use icu_provider::DataRequest;
+use icu_provider::prelude::*;
 use smallvec::SmallVec;
 use utf16_iter::Utf16CharsEx;
 use utf8_iter::Utf8CharsEx;
@@ -126,42 +123,27 @@ impl Collator {
             }
             filtered_locale
         };
-        let locale: DataLocale = locale.into();
+        let locale = locale.into();
+        let req = DataRequest {
+            locale: &locale,
+            metadata: Default::default(),
+        };
 
         let metadata_payload: DataPayload<crate::provider::CollationMetadataV1Marker> =
-            data_provider
-                .load(&DataRequest {
-                    locale: locale.clone(),
-                    metadata: Default::default(),
-                })?
-                .take_payload()?;
+            data_provider.load(req)?.take_payload()?;
 
         let metadata = metadata_payload.get();
 
         let tailoring: Option<DataPayload<crate::provider::CollationDataV1Marker>> =
             if metadata.tailored() {
-                Some(
-                    data_provider
-                        .load(&DataRequest {
-                            locale: locale.clone(),
-                            metadata: Default::default(),
-                        })?
-                        .take_payload()?,
-                )
+                Some(data_provider.load(req)?.take_payload()?)
             } else {
                 None
             };
 
         let reordering: Option<DataPayload<crate::provider::CollationReorderingV1Marker>> =
             if metadata.reordering() {
-                Some(
-                    data_provider
-                        .load(&DataRequest {
-                            locale: locale.clone(),
-                            metadata: Default::default(),
-                        })?
-                        .take_payload()?,
-                )
+                Some(data_provider.load(req)?.take_payload()?)
             } else {
                 None
             };
@@ -172,19 +154,15 @@ impl Collator {
             }
         }
 
-        let root: DataPayload<CollationDataV1Marker> = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
+        let root: DataPayload<CollationDataV1Marker> =
+            data_provider.load(Default::default())?.take_payload()?;
 
         let tailored_diacritics = metadata.tailored_diacritics();
         let diacritics: DataPayload<CollationDiacriticsV1Marker> = data_provider
-            .load(&DataRequest {
-                locale: if tailored_diacritics {
-                    locale
-                } else {
-                    DataLocale::default()
-                },
-                metadata: Default::default(),
+            .load(if tailored_diacritics {
+                req
+            } else {
+                Default::default()
             })?
             .take_payload()?;
 
@@ -202,20 +180,18 @@ impl Collator {
         }
 
         let jamo: DataPayload<CollationJamoV1Marker> = data_provider
-            .load(&DataRequest::default())? // TODO: redesign Korean search collation handling
+            .load(Default::default())? // TODO: redesign Korean search collation handling
             .take_payload()?;
 
         if jamo.get().ce32s.len() != JAMO_COUNT {
             return Err(CollatorError::MalformedData);
         }
 
-        let decompositions: DataPayload<CanonicalDecompositionDataV1Marker> = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
+        let decompositions: DataPayload<CanonicalDecompositionDataV1Marker> =
+            data_provider.load(Default::default())?.take_payload()?;
 
-        let tables: DataPayload<CanonicalDecompositionTablesV1Marker> = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
+        let tables: DataPayload<CanonicalDecompositionTablesV1Marker> =
+            data_provider.load(Default::default())?.take_payload()?;
 
         let ccc = icu_properties::maps::get_canonical_combining_class(data_provider)?;
 
@@ -237,9 +213,8 @@ impl Collator {
         let special_primaries = if merged_options.alternate_handling() == AlternateHandling::Shifted
             || merged_options.numeric()
         {
-            let special_primaries: DataPayload<CollationSpecialPrimariesV1Marker> = data_provider
-                .load(&DataRequest::default())?
-                .take_payload()?;
+            let special_primaries: DataPayload<CollationSpecialPrimariesV1Marker> =
+                data_provider.load(Default::default())?.take_payload()?;
             // `variant_count` isn't stable yet:
             // https://github.com/rust-lang/rust/issues/73662
             if special_primaries.get().last_primaries.len() <= (MaxVariable::Currency as usize) {

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -533,28 +533,23 @@ mod tests {
         use icu_provider::prelude::*;
 
         let provider = icu_testdata::get_provider();
-        let locale: Locale = "en-u-ca-gregory".parse().unwrap();
-        let date_data: DataPayload<DateSymbolsV1Marker> = provider
-            .load(&DataRequest {
-                locale: locale.clone().into(),
-                metadata: Default::default(),
-            })
-            .unwrap()
-            .take_payload()
-            .unwrap();
-        let time_data: DataPayload<TimeSymbolsV1Marker> = provider
-            .load(&DataRequest {
-                locale: locale.clone().into(),
-                metadata: Default::default(),
-            })
-            .unwrap()
-            .take_payload()
-            .unwrap();
+        let locale = "en-u-ca-gregory".parse::<Locale>().unwrap().into();
+        let req = DataRequest {
+            locale: &locale,
+            metadata: Default::default(),
+        };
+        let date_data: DataPayload<DateSymbolsV1Marker> =
+            provider.load(req).unwrap().take_payload().unwrap();
+        let time_data: DataPayload<TimeSymbolsV1Marker> =
+            provider.load(req).unwrap().take_payload().unwrap();
         let pattern = "MMM".parse().unwrap();
         let datetime = DateTime::new_gregorian_datetime(2020, 8, 1, 12, 34, 28).unwrap();
-        let fixed_decimal_format =
-            FixedDecimalFormatter::try_new(locale.id.language, &provider, Default::default())
-                .unwrap();
+        let fixed_decimal_format = FixedDecimalFormatter::try_new(
+            locale.get_langid().language,
+            &provider,
+            Default::default(),
+        )
+        .unwrap();
 
         let mut sink = String::new();
         let loc_datetime = DateTimeInputWithLocale::new(&datetime, None, &"und".parse().unwrap());

--- a/components/datetime/src/provider/date_time.rs
+++ b/components/datetime/src/provider/date_time.rs
@@ -62,8 +62,8 @@ where
     D: DataProvider<TimePatternsV1Marker> + ?Sized,
 {
     let data = data_provider
-        .load(&DataRequest {
-            locale: DataLocale::from(locale),
+        .load(DataRequest {
+            locale: &DataLocale::from(locale),
             metadata: Default::default(),
         })?
         .take_payload()?;
@@ -107,8 +107,8 @@ where
     D: DataProvider<DatePatternsV1Marker> + ?Sized,
 {
     let data = data_provider
-        .load(&DataRequest {
-            locale: DataLocale::from(locale),
+        .load(DataRequest {
+            locale: &DataLocale::from(locale),
             metadata: Default::default(),
         })?
         .take_payload()?;
@@ -276,8 +276,8 @@ where
     fn skeleton_data_payload(self) -> Result<DataPayload<DateSkeletonPatternsV1Marker>> {
         let data = self
             .data_provider
-            .load(&DataRequest {
-                locale: DataLocale::from(self.locale),
+            .load(DataRequest {
+                locale: &DataLocale::from(self.locale),
                 metadata: Default::default(),
             })?
             .take_payload()?;

--- a/components/datetime/src/raw/datetime.rs
+++ b/components/datetime/src/raw/datetime.rs
@@ -68,8 +68,8 @@ impl TimeFormatter {
         let symbols_data = if required.time_symbols_data {
             Some(
                 data_provider
-                    .load(&DataRequest {
-                        locale: DataLocale::from(&locale),
+                    .load(DataRequest {
+                        locale: &DataLocale::from(&locale),
                         metadata: Default::default(),
                     })?
                     .take_payload()?,
@@ -191,8 +191,7 @@ impl DateFormatter {
             + DataProvider<WeekDataV1Marker>
             + ?Sized,
     {
-        let cal = locale.extensions.unicode.keywords.get(&key!("ca"));
-        if cal == Some(&value!("ethioaa")) {
+        if locale.extensions.unicode.keywords.get(&key!("ca")) == Some(&value!("ethioaa")) {
             locale
                 .extensions
                 .unicode
@@ -208,15 +207,14 @@ impl DateFormatter {
         let required = datetime::analyze_patterns(&patterns.get().0, false)
             .map_err(|field| DateTimeFormatterError::UnsupportedField(field.symbol))?;
 
+        let data_locale = DataLocale::from(&locale);
+        let req = DataRequest {
+            locale: &data_locale,
+            metadata: Default::default(),
+        };
+
         let week_data = if required.week_data {
-            Some(
-                data_provider
-                    .load(&DataRequest {
-                        locale: DataLocale::from(&locale),
-                        metadata: Default::default(),
-                    })?
-                    .take_payload()?,
-            )
+            Some(data_provider.load(req)?.take_payload()?)
         } else {
             None
         };
@@ -232,14 +230,7 @@ impl DateFormatter {
         };
 
         let symbols_data = if required.date_symbols_data {
-            Some(
-                data_provider
-                    .load(&DataRequest {
-                        locale: DataLocale::from(&locale),
-                        metadata: Default::default(),
-                    })?
-                    .take_payload()?,
-            )
+            Some(data_provider.load(req)?.take_payload()?)
         } else {
             None
         };
@@ -427,15 +418,14 @@ impl DateTimeFormatter {
         let required = datetime::analyze_patterns(&patterns.get().0, false)
             .map_err(|field| DateTimeFormatterError::UnsupportedField(field.symbol))?;
 
+        let data_locale = DataLocale::from(&locale);
+        let req = DataRequest {
+            locale: &data_locale,
+            metadata: Default::default(),
+        };
+
         let week_data = if required.week_data {
-            Some(
-                data_provider
-                    .load(&DataRequest {
-                        locale: DataLocale::from(&locale),
-                        metadata: Default::default(),
-                    })?
-                    .take_payload()?,
-            )
+            Some(data_provider.load(req)?.take_payload()?)
         } else {
             None
         };
@@ -451,27 +441,13 @@ impl DateTimeFormatter {
         };
 
         let date_symbols_data = if required.date_symbols_data {
-            Some(
-                data_provider
-                    .load(&DataRequest {
-                        locale: DataLocale::from(&locale),
-                        metadata: Default::default(),
-                    })?
-                    .take_payload()?,
-            )
+            Some(data_provider.load(req)?.take_payload()?)
         } else {
             None
         };
 
         let time_symbols_data = if required.time_symbols_data {
-            Some(
-                data_provider
-                    .load(&DataRequest {
-                        locale: DataLocale::from(&locale),
-                        metadata: Default::default(),
-                    })?
-                    .take_payload()?,
-            )
+            Some(data_provider.load(req)?.take_payload()?)
         } else {
             None
         };

--- a/components/datetime/src/raw/zoned_datetime.rs
+++ b/components/datetime/src/raw/zoned_datetime.rs
@@ -75,14 +75,14 @@ impl ZonedDateTimeFormatter {
         PP: DataProvider<OrdinalV1Marker> + ?Sized,
         DEP: DataProvider<DecimalSymbolsV1Marker> + ?Sized,
     {
-        let cal = locale.extensions.unicode.keywords.get(&key!("ca"));
-        if cal == Some(&value!("ethioaa")) {
+        if locale.extensions.unicode.keywords.get(&key!("ca")) == Some(&value!("ethioaa")) {
             locale
                 .extensions
                 .unicode
                 .keywords
                 .set(key!("ca"), value!("ethiopic"));
         }
+
         let patterns = provider::date_time::PatternSelector::for_options(
             date_provider,
             &locale,
@@ -91,15 +91,15 @@ impl ZonedDateTimeFormatter {
         let required = datetime::analyze_patterns(&patterns.get().0, true)
             .map_err(|field| DateTimeFormatterError::UnsupportedField(field.symbol))?;
 
+        // TODO(#2136): Don't use expensive from
+        let data_locale = DataLocale::from(&locale);
+        let req = DataRequest {
+            locale: &data_locale,
+            metadata: Default::default(),
+        };
+
         let week_data = if required.week_data {
-            Some(
-                date_provider
-                    .load(&DataRequest {
-                        locale: DataLocale::from(&locale),
-                        metadata: Default::default(),
-                    })?
-                    .take_payload()?,
-            )
+            Some(date_provider.load(req)?.take_payload()?)
         } else {
             None
         };
@@ -115,27 +115,13 @@ impl ZonedDateTimeFormatter {
         };
 
         let date_symbols_data = if required.date_symbols_data {
-            Some(
-                date_provider
-                    .load(&DataRequest {
-                        locale: DataLocale::from(&locale),
-                        metadata: Default::default(),
-                    })?
-                    .take_payload()?,
-            )
+            Some(date_provider.load(req)?.take_payload()?)
         } else {
             None
         };
 
         let time_symbols_data = if required.time_symbols_data {
-            Some(
-                date_provider
-                    .load(&DataRequest {
-                        locale: DataLocale::from(&locale),
-                        metadata: Default::default(),
-                    })?
-                    .take_payload()?,
-            )
+            Some(date_provider.load(req)?.take_payload()?)
         } else {
             None
         };

--- a/components/datetime/src/skeleton/mod.rs
+++ b/components/datetime/src/skeleton/mod.rs
@@ -42,20 +42,18 @@ mod test {
         DataPayload<DateSkeletonPatternsV1Marker>,
     ) {
         let provider = icu_testdata::get_provider();
-        let locale: Locale = "en-u-ca-gregory".parse().unwrap();
+        let locale = "en-u-ca-gregory".parse::<Locale>().unwrap().into();
+        let req = DataRequest {
+            locale: &locale,
+            metadata: Default::default(),
+        };
         let patterns = provider
-            .load(&DataRequest {
-                locale: DataLocale::from(&locale),
-                metadata: Default::default(),
-            })
+            .load(req)
             .expect("Failed to load payload")
             .take_payload()
             .expect("Failed to retrieve payload");
         let skeletons = provider
-            .load(&DataRequest {
-                locale: locale.into(),
-                metadata: Default::default(),
-            })
+            .load(req)
             .expect("Failed to load payload")
             .take_payload()
             .expect("Failed to retrieve payload");

--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -18,27 +18,25 @@ use crate::{
     pattern::{PatternError, PatternItem},
     provider::{self, calendar::patterns::PatternPluralsFromPatternsV1Marker},
 };
-use icu_locid::{LanguageIdentifier, Locale};
+use icu_locid::Locale;
 use icu_provider::prelude::*;
 use writeable::Writeable;
 
 /// Loads a resource into its destination if the destination has not already been filled.
-fn load<D, L, P>(
-    locale: &L,
+fn load<D, P>(
+    locale: &DataLocale,
     destination: &mut Option<DataPayload<D>>,
     provider: &P,
 ) -> Result<(), DateTimeFormatterError>
 where
     D: KeyedDataMarker,
-    L: Clone + Into<LanguageIdentifier>,
     P: DataProvider<D> + ?Sized,
 {
-    let langid: LanguageIdentifier = locale.clone().into();
     if destination.is_none() {
         *destination = Some(
             provider
-                .load(&DataRequest {
-                    locale: langid.into(),
+                .load(DataRequest {
+                    locale,
                     metadata: Default::default(),
                 })?
                 .take_payload()?,
@@ -83,7 +81,7 @@ where
 ///
 /// [data provider]: icu_provider
 pub struct TimeZoneFormatter {
-    pub(super) locale: Locale,
+    pub(super) locale: DataLocale,
     pub(super) data_payloads: TimeZoneDataPayloads,
     pub(super) format_units: SmallVec<[TimeZoneFormatterUnit; 3]>,
     pub(super) fallback_unit: TimeZoneFormatterUnit,
@@ -128,12 +126,12 @@ impl TimeZoneFormatter {
             + DataProvider<provider::time_zones::MetaZoneSpecificNamesShortV1Marker>
             + ?Sized,
     {
-        let locale = locale.into();
+        let locale = DataLocale::from(locale.into());
         let format_units = SmallVec::<[TimeZoneFormatterUnit; 3]>::new();
         let data_payloads = TimeZoneDataPayloads {
             zone_formats: zone_provider
-                .load(&DataRequest {
-                    locale: DataLocale::from(&locale),
+                .load(DataRequest {
+                    locale: &locale,
                     metadata: Default::default(),
                 })?
                 .take_payload()?,
@@ -379,12 +377,12 @@ impl TimeZoneFormatter {
             + DataProvider<provider::time_zones::MetaZoneSpecificNamesShortV1Marker>
             + ?Sized,
     {
-        let locale = locale.into();
+        let locale = DataLocale::from(locale.into());
         let format_units = SmallVec::<[TimeZoneFormatterUnit; 3]>::new();
         let data_payloads = TimeZoneDataPayloads {
             zone_formats: zone_provider
-                .load(&DataRequest {
-                    locale: DataLocale::from(&locale),
+                .load(DataRequest {
+                    locale: &locale,
                     metadata: Default::default(),
                 })?
                 .take_payload()?,

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -369,63 +369,33 @@ fn test_dayperiod_patterns() {
             .unicode
             .keywords
             .set(key!("ca"), value!("gregory"));
-        let mut date_patterns_data: DataPayload<DatePatternsV1Marker> = provider
-            .load(&DataRequest {
-                locale: DataLocale::from(&locale),
-                metadata: Default::default(),
-            })
-            .unwrap()
-            .take_payload()
-            .unwrap();
+        let mut data_locale = DataLocale::from(&locale);
+        let req = DataRequest {
+            locale: &data_locale,
+            metadata: Default::default(),
+        };
+        let mut date_patterns_data: DataPayload<DatePatternsV1Marker> =
+            provider.load(req).unwrap().take_payload().unwrap();
         date_patterns_data.with_mut(|data| {
             data.length_combinations.long = "{0}".parse().unwrap();
         });
-        let mut time_patterns_data: DataPayload<TimePatternsV1Marker> = provider
-            .load(&DataRequest {
-                locale: DataLocale::from(&locale),
-                metadata: Default::default(),
-            })
-            .unwrap()
-            .take_payload()
-            .unwrap();
+        let mut time_patterns_data: DataPayload<TimePatternsV1Marker> =
+            provider.load(req).unwrap().take_payload().unwrap();
         date_patterns_data.with_mut(|data| {
             data.length_combinations.long = "{0}".parse().unwrap();
         });
-        let date_symbols_data: DataPayload<DateSymbolsV1Marker> = provider
-            .load(&DataRequest {
-                locale: DataLocale::from(&locale),
-                metadata: Default::default(),
-            })
-            .unwrap()
-            .take_payload()
-            .unwrap();
-        let time_symbols_data: DataPayload<TimeSymbolsV1Marker> = provider
-            .load(&DataRequest {
-                locale: DataLocale::from(&locale),
-                metadata: Default::default(),
-            })
-            .unwrap()
-            .take_payload()
-            .unwrap();
-        let skeleton_data: DataPayload<DateSkeletonPatternsV1Marker> = provider
-            .load(&DataRequest {
-                locale: DataLocale::from(&locale),
-                metadata: Default::default(),
-            })
-            .unwrap()
-            .take_payload()
-            .unwrap();
-        let week_data: DataPayload<WeekDataV1Marker> = provider
-            .load(&DataRequest {
-                locale: DataLocale::from(&locale),
-                metadata: Default::default(),
-            })
-            .unwrap()
-            .take_payload()
-            .unwrap();
+        let date_symbols_data: DataPayload<DateSymbolsV1Marker> =
+            provider.load(req).unwrap().take_payload().unwrap();
+        let time_symbols_data: DataPayload<TimeSymbolsV1Marker> =
+            provider.load(req).unwrap().take_payload().unwrap();
+        let skeleton_data: DataPayload<DateSkeletonPatternsV1Marker> =
+            provider.load(req).unwrap().take_payload().unwrap();
+        let week_data: DataPayload<WeekDataV1Marker> =
+            provider.load(req).unwrap().take_payload().unwrap();
+        data_locale.retain_unicode_ext(|_| false);
         let decimal_data: DataPayload<DecimalSymbolsV1Marker> = provider
-            .load(&DataRequest {
-                locale: DataLocale::from(locale.id.clone()),
+            .load(DataRequest {
+                locale: &data_locale,
                 metadata: Default::default(),
             })
             .unwrap()
@@ -562,6 +532,11 @@ fn test_time_zone_patterns() {
             .unicode
             .keywords
             .set(key!("ca"), value!("gregory"));
+        let data_locale = DataLocale::from(&locale);
+        let req = DataRequest {
+            locale: &data_locale,
+            metadata: Default::default(),
+        };
         let mut config = test.config;
         let zoned: MockZonedDateTime = test.datetime.parse().unwrap();
         let datetime = zoned.datetime;
@@ -570,46 +545,16 @@ fn test_time_zone_patterns() {
         time_zone.metazone_id = config.metazone_id.take().map(MetaZoneId);
         time_zone.time_variant = config.time_variant.take();
 
-        let mut date_patterns_data: DataPayload<DatePatternsV1Marker> = date_provider
-            .load(&DataRequest {
-                locale: DataLocale::from(&locale),
-                metadata: Default::default(),
-            })
-            .unwrap()
-            .take_payload()
-            .unwrap();
-        let mut time_patterns_data: DataPayload<TimePatternsV1Marker> = date_provider
-            .load(&DataRequest {
-                locale: DataLocale::from(&locale),
-                metadata: Default::default(),
-            })
-            .unwrap()
-            .take_payload()
-            .unwrap();
-        let skeleton_data: DataPayload<DateSkeletonPatternsV1Marker> = date_provider
-            .load(&DataRequest {
-                locale: DataLocale::from(&locale),
-                metadata: Default::default(),
-            })
-            .unwrap()
-            .take_payload()
-            .unwrap();
-        let symbols_data: DataPayload<DateSymbolsV1Marker> = date_provider
-            .load(&DataRequest {
-                locale: DataLocale::from(&locale),
-                metadata: Default::default(),
-            })
-            .unwrap()
-            .take_payload()
-            .unwrap();
-        let week_data: DataPayload<WeekDataV1Marker> = date_provider
-            .load(&DataRequest {
-                locale: DataLocale::from(&locale),
-                metadata: Default::default(),
-            })
-            .unwrap()
-            .take_payload()
-            .unwrap();
+        let mut date_patterns_data: DataPayload<DatePatternsV1Marker> =
+            date_provider.load(req).unwrap().take_payload().unwrap();
+        let mut time_patterns_data: DataPayload<TimePatternsV1Marker> =
+            date_provider.load(req).unwrap().take_payload().unwrap();
+        let skeleton_data: DataPayload<DateSkeletonPatternsV1Marker> =
+            date_provider.load(req).unwrap().take_payload().unwrap();
+        let symbols_data: DataPayload<DateSymbolsV1Marker> =
+            date_provider.load(req).unwrap().take_payload().unwrap();
+        let week_data: DataPayload<WeekDataV1Marker> =
+            date_provider.load(req).unwrap().take_payload().unwrap();
 
         date_patterns_data.with_mut(|data| {
             data.length_combinations.long = "{0}".parse().unwrap();

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -107,8 +107,8 @@ impl FixedDecimalFormatter {
         options: options::FixedDecimalFormatterOptions,
     ) -> Result<Self, FixedDecimalFormatterError> {
         let symbols = data_provider
-            .load(&DataRequest {
-                locale: locale.into().into(),
+            .load(DataRequest {
+                locale: &locale.into().into(),
                 metadata: Default::default(),
             })?
             .take_payload()?;

--- a/components/list/src/list_formatter.rs
+++ b/components/list/src/list_formatter.rs
@@ -26,8 +26,8 @@ macro_rules! constructor {
             style: ListStyle,
         ) -> Result<Self, DataError> {
             let data = data_provider
-                .load(&DataRequest {
-                    locale: locale.into().into(),
+                .load(DataRequest {
+                    locale: &locale.into().into(),
                     metadata: Default::default(),
                 })?
                 .take_payload()?.cast();

--- a/components/locale_canonicalizer/src/locale_canonicalizer.rs
+++ b/components/locale_canonicalizer/src/locale_canonicalizer.rs
@@ -309,10 +309,10 @@ impl LocaleCanonicalizer {
             Key::from_tinystr_unchecked(tinystr!(2, "sd")),
         ];
         let aliases: DataPayload<AliasesV1Marker> =
-            provider.load(&DataRequest::default())?.take_payload()?;
+            provider.load(Default::default())?.take_payload()?;
 
         let likely_subtags: DataPayload<LikelySubtagsV1Marker> =
-            provider.load(&DataRequest::default())?.take_payload()?;
+            provider.load(Default::default())?.take_payload()?;
 
         Ok(LocaleCanonicalizer {
             aliases,

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -83,9 +83,7 @@ use icu_char16trie::char16trie::TrieResult;
 use icu_codepointtrie::CodePointTrie;
 use icu_properties::maps::{CodePointMapData, CodePointMapDataBorrowed};
 use icu_properties::CanonicalCombiningClass;
-use icu_provider::DataPayload;
-use icu_provider::DataProvider;
-use icu_provider::DataRequest;
+use icu_provider::prelude::*;
 use icu_uniset::UnicodeSet;
 use provider::CanonicalCompositionPassthroughV1Marker;
 use provider::CanonicalCompositionsV1Marker;
@@ -1218,12 +1216,10 @@ impl DecomposingNormalizer {
             + DataProvider<icu_properties::provider::CanonicalCombiningClassV1Marker>
             + ?Sized,
     {
-        let decompositions: DataPayload<CanonicalDecompositionDataV1Marker> = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
-        let tables: DataPayload<CanonicalDecompositionTablesV1Marker> = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
+        let decompositions: DataPayload<CanonicalDecompositionDataV1Marker> =
+            data_provider.load(Default::default())?.take_payload()?;
+        let tables: DataPayload<CanonicalDecompositionTablesV1Marker> =
+            data_provider.load(Default::default())?.take_payload()?;
 
         if tables.get().scalars16.len() + tables.get().scalars24.len() > 0xFFF {
             // The data is from a future where there exists a normalization flavor whose
@@ -1256,21 +1252,15 @@ impl DecomposingNormalizer {
             + DataProvider<icu_properties::provider::CanonicalCombiningClassV1Marker>
             + ?Sized,
     {
-        let decompositions: DataPayload<CanonicalDecompositionDataV1Marker> = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
+        let decompositions: DataPayload<CanonicalDecompositionDataV1Marker> =
+            data_provider.load(Default::default())?.take_payload()?;
         let supplementary_decompositions: DataPayload<
             CompatibilityDecompositionSupplementV1Marker,
-        > = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
-        let tables: DataPayload<CanonicalDecompositionTablesV1Marker> = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
+        > = data_provider.load(Default::default())?.take_payload()?;
+        let tables: DataPayload<CanonicalDecompositionTablesV1Marker> =
+            data_provider.load(Default::default())?.take_payload()?;
         let supplementary_tables: DataPayload<CompatibilityDecompositionTablesV1Marker> =
-            data_provider
-                .load(&DataRequest::default())?
-                .take_payload()?;
+            data_provider.load(Default::default())?.take_payload()?;
 
         if tables.get().scalars16.len()
             + tables.get().scalars24.len()
@@ -1332,20 +1322,14 @@ impl DecomposingNormalizer {
             + DataProvider<icu_properties::provider::CanonicalCombiningClassV1Marker>
             + ?Sized,
     {
-        let decompositions: DataPayload<CanonicalDecompositionDataV1Marker> = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
+        let decompositions: DataPayload<CanonicalDecompositionDataV1Marker> =
+            data_provider.load(Default::default())?.take_payload()?;
         let supplementary_decompositions: DataPayload<Uts46DecompositionSupplementV1Marker> =
-            data_provider
-                .load(&DataRequest::default())?
-                .take_payload()?;
-        let tables: DataPayload<CanonicalDecompositionTablesV1Marker> = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
+            data_provider.load(Default::default())?.take_payload()?;
+        let tables: DataPayload<CanonicalDecompositionTablesV1Marker> =
+            data_provider.load(Default::default())?.take_payload()?;
         let supplementary_tables: DataPayload<CompatibilityDecompositionTablesV1Marker> =
-            data_provider
-                .load(&DataRequest::default())?
-                .take_payload()?;
+            data_provider.load(Default::default())?.take_payload()?;
 
         if tables.get().scalars16.len()
             + tables.get().scalars24.len()
@@ -1412,14 +1396,11 @@ impl ComposingNormalizer {
     {
         let decomposing_normalizer = DecomposingNormalizer::try_new_nfd(data_provider)?;
 
-        let canonical_compositions: DataPayload<CanonicalCompositionsV1Marker> = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
+        let canonical_compositions: DataPayload<CanonicalCompositionsV1Marker> =
+            data_provider.load(Default::default())?.take_payload()?;
         let potential_passthrough_and_not_backward_combining: DataPayload<
             CanonicalCompositionPassthroughV1Marker,
-        > = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
+        > = data_provider.load(Default::default())?.take_payload()?;
 
         Ok(ComposingNormalizer {
             decomposing_normalizer,
@@ -1444,14 +1425,11 @@ impl ComposingNormalizer {
     {
         let decomposing_normalizer = DecomposingNormalizer::try_new_nfkd(data_provider)?;
 
-        let canonical_compositions: DataPayload<CanonicalCompositionsV1Marker> = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
+        let canonical_compositions: DataPayload<CanonicalCompositionsV1Marker> =
+            data_provider.load(Default::default())?.take_payload()?;
         let potential_passthrough_and_not_backward_combining: DataPayload<
             CompatibilityCompositionPassthroughV1Marker,
-        > = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
+        > = data_provider.load(Default::default())?.take_payload()?;
 
         Ok(ComposingNormalizer {
             decomposing_normalizer,
@@ -1506,14 +1484,11 @@ impl ComposingNormalizer {
                 data_provider,
             )?;
 
-        let canonical_compositions: DataPayload<CanonicalCompositionsV1Marker> = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
+        let canonical_compositions: DataPayload<CanonicalCompositionsV1Marker> =
+            data_provider.load(Default::default())?.take_payload()?;
         let potential_passthrough_and_not_backward_combining: DataPayload<
             Uts46CompositionPassthroughV1Marker,
-        > = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
+        > = data_provider.load(Default::default())?.take_payload()?;
 
         Ok(ComposingNormalizer {
             decomposing_normalizer,
@@ -1599,9 +1574,8 @@ impl CanonicalComposition {
     where
         D: DataProvider<CanonicalCompositionsV1Marker> + ?Sized,
     {
-        let canonical_compositions: DataPayload<CanonicalCompositionsV1Marker> = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
+        let canonical_compositions: DataPayload<CanonicalCompositionsV1Marker> =
+            data_provider.load(Default::default())?.take_payload()?;
         Ok(CanonicalComposition {
             canonical_compositions,
         })
@@ -1793,12 +1767,10 @@ impl CanonicalDecomposition {
             + DataProvider<NonRecursiveDecompositionSupplementV1Marker>
             + ?Sized,
     {
-        let decompositions: DataPayload<CanonicalDecompositionDataV1Marker> = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
-        let tables: DataPayload<CanonicalDecompositionTablesV1Marker> = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
+        let decompositions: DataPayload<CanonicalDecompositionDataV1Marker> =
+            data_provider.load(Default::default())?.take_payload()?;
+        let tables: DataPayload<CanonicalDecompositionTablesV1Marker> =
+            data_provider.load(Default::default())?.take_payload()?;
 
         if tables.get().scalars16.len() + tables.get().scalars24.len() > 0xFFF {
             // The data is from a future where there exists a normalization flavor whose
@@ -1810,9 +1782,8 @@ impl CanonicalDecomposition {
             return Err(NormalizerError::FutureExtension);
         }
 
-        let non_recursive: DataPayload<NonRecursiveDecompositionSupplementV1Marker> = data_provider
-            .load(&DataRequest::default())?
-            .take_payload()?;
+        let non_recursive: DataPayload<NonRecursiveDecompositionSupplementV1Marker> =
+            data_provider.load(Default::default())?.take_payload()?;
 
         Ok(CanonicalDecomposition {
             decompositions,

--- a/components/plurals/benches/parser.rs
+++ b/components/plurals/benches/parser.rs
@@ -20,8 +20,8 @@ fn parser(c: &mut Criterion) {
 
     for langid in fixture_data.langs {
         let data_payload: DataPayload<icu_plurals::provider::CardinalV1Marker> = provider
-            .load(&DataRequest {
-                locale: langid.into(),
+            .load(DataRequest {
+                locale: &langid.into(),
                 metadata: Default::default(),
             })
             .unwrap()

--- a/components/plurals/tests/plurals.rs
+++ b/components/plurals/tests/plurals.rs
@@ -20,8 +20,8 @@ fn test_static_load_works() {
     let provider = icu_testdata::get_provider();
 
     let _rules: DataPayload<CardinalV1Marker> = provider
-        .load(&DataRequest {
-            locale: locale!("en").into(),
+        .load(DataRequest {
+            locale: &locale!("en").into(),
             metadata: Default::default(),
         })
         .expect("Failed to load payload")

--- a/components/properties/src/maps.rs
+++ b/components/properties/src/maps.rs
@@ -253,7 +253,7 @@ macro_rules! make_map_property {
         $vis fn $name(
             provider: &(impl DataProvider<$keyed_data_marker> + ?Sized)
         ) -> Result<CodePointMapData<$value_ty>, PropertiesError> {
-            Ok(provider.load(&Default::default()).and_then(DataResponse::take_payload).map(CodePointMapData::from_data)?)
+            Ok(provider.load(Default::default()).and_then(DataResponse::take_payload).map(CodePointMapData::from_data)?)
         }
     }
 }

--- a/components/properties/src/script.rs
+++ b/components/properties/src/script.rs
@@ -643,6 +643,6 @@ pub fn get_script_with_extensions(
     provider: &(impl DataProvider<ScriptWithExtensionsPropertyV1Marker> + ?Sized),
 ) -> ScriptWithExtensionsResult {
     Ok(provider
-        .load(&Default::default())
+        .load(Default::default())
         .and_then(DataResponse::take_payload)?)
 }

--- a/components/properties/src/sets.rs
+++ b/components/properties/src/sets.rs
@@ -205,7 +205,7 @@ macro_rules! make_set_property {
         $vis fn $funcname(
             provider: &(impl DataProvider<$keyed_data_marker> + ?Sized)
         ) -> Result<CodePointSetData, PropertiesError> {
-            Ok(provider.load(&Default::default()).and_then(DataResponse::take_payload).map(CodePointSetData::from_data)?)
+            Ok(provider.load(Default::default()).and_then(DataResponse::take_payload).map(CodePointSetData::from_data)?)
         }
     }
 }

--- a/docs/tutorials/data_provider.md
+++ b/docs/tutorials/data_provider.md
@@ -26,8 +26,8 @@ impl AdditiveIdentity {
         locale: L,
         provider: &D,
     ) -> Result<Self, MyError> {
-        let response = data_provider.load(&DataRequest {
-            locale: locale.into().into(),
+        let response = data_provider.load(DataRequest {
+            locale: &locale.into().into(),
             metadata: Default::default(),
         })?.take_payload()?;
 

--- a/docs/tutorials/writing_a_new_data_struct.md
+++ b/docs/tutorials/writing_a_new_data_struct.md
@@ -211,7 +211,7 @@ impl From<&SourceData> for FooProvider {
 impl DataProvider<FooV1Marker> for FooProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<FooV1Marker>, DataError> {
         // Load the data from CLDR JSON and emit it as an ICU4X data struct.
         // This is the core transform operation. This step could take a lot of

--- a/experimental/casemapping/src/casemapping.rs
+++ b/experimental/casemapping/src/casemapping.rs
@@ -37,7 +37,7 @@ impl CaseMapping {
     where
         P: DataProvider<CaseMappingV1Marker> + ?Sized,
     {
-        let internals = provider.load(&DataRequest::default())?.take_payload()?;
+        let internals = provider.load(Default::default())?.take_payload()?;
         debug_assert!(internals.get().casemap.validate().is_ok());
         let locale = CaseMapLocale::from(locale);
         Ok(Self { internals, locale })

--- a/experimental/segmenter/src/complex.rs
+++ b/experimental/segmenter/src/complex.rs
@@ -103,8 +103,8 @@ mod tests {
         let provider = icu_testdata::get_provider();
         let locale = locale!("th");
         let payload = provider
-            .load(&DataRequest {
-                locale: DataLocale::from(locale),
+            .load(DataRequest {
+                locale: &DataLocale::from(locale),
                 metadata: Default::default(),
             })
             .expect("Loading should succeed!")

--- a/experimental/segmenter/src/dictionary.rs
+++ b/experimental/segmenter/src/dictionary.rs
@@ -174,8 +174,8 @@ mod tests {
     ) -> Result<DataPayload<UCharDictionaryBreakDataV1Marker>, DataError> {
         let provider = icu_testdata::get_provider();
         provider
-            .load(&DataRequest {
-                locale: DataLocale::from(locale),
+            .load(DataRequest {
+                locale: &DataLocale::from(locale),
                 metadata: Default::default(),
             })?
             .take_payload()

--- a/experimental/segmenter/src/grapheme.rs
+++ b/experimental/segmenter/src/grapheme.rs
@@ -32,7 +32,7 @@ impl GraphemeClusterBreakSegmenter {
     where
         D: DataProvider<GraphemeClusterBreakDataV1Marker> + ?Sized,
     {
-        let payload = provider.load(&DataRequest::default())?.take_payload()?;
+        let payload = provider.load(Default::default())?.take_payload()?;
         Ok(Self { payload })
     }
 

--- a/experimental/segmenter/src/line.rs
+++ b/experimental/segmenter/src/line.rs
@@ -121,12 +121,12 @@ impl LineBreakSegmenter {
             + DataProvider<UCharDictionaryBreakDataV1Marker>
             + ?Sized,
     {
-        let payload = provider.load(&DataRequest::default())?.take_payload()?;
+        let payload = provider.load(Default::default())?.take_payload()?;
 
         let locale = locale!("th");
         let dictionary_payload = provider
-            .load(&DataRequest {
-                locale: DataLocale::from(locale),
+            .load(DataRequest {
+                locale: &DataLocale::from(locale),
                 metadata: Default::default(),
             })?
             .take_payload()?;
@@ -777,7 +777,7 @@ mod tests {
     fn linebreak_propery() {
         let provider = icu_testdata::get_provider();
         let payload: DataPayload<LineBreakDataV1Marker> = provider
-            .load(&DataRequest::default())
+            .load(Default::default())
             .expect("Loading should succeed!")
             .take_payload()
             .expect("Data should be present!");
@@ -813,7 +813,7 @@ mod tests {
     fn break_rule() {
         let provider = icu_testdata::get_provider();
         let payload: DataPayload<LineBreakDataV1Marker> = provider
-            .load(&DataRequest::default())
+            .load(Default::default())
             .expect("Loading should succeed!")
             .take_payload()
             .expect("Data should be present!");

--- a/experimental/segmenter/src/lstm.rs
+++ b/experimental/segmenter/src/lstm.rs
@@ -150,8 +150,8 @@ mod tests {
 
         let provider = icu_testdata::get_provider();
         let payload = provider
-            .load(&DataRequest {
-                locale: DataLocale::from(locale!("th")),
+            .load(DataRequest {
+                locale: &DataLocale::from(locale!("th")),
                 metadata: Default::default(),
             })
             .expect("Loading should succeed!")

--- a/experimental/segmenter/src/sentence.rs
+++ b/experimental/segmenter/src/sentence.rs
@@ -30,7 +30,7 @@ impl SentenceBreakSegmenter {
     where
         D: DataProvider<SentenceBreakDataV1Marker> + ?Sized,
     {
-        let payload = provider.load(&DataRequest::default())?.take_payload()?;
+        let payload = provider.load(Default::default())?.take_payload()?;
         Ok(Self { payload })
     }
 

--- a/experimental/segmenter/src/word.rs
+++ b/experimental/segmenter/src/word.rs
@@ -37,12 +37,12 @@ impl WordBreakSegmenter {
             + DataProvider<UCharDictionaryBreakDataV1Marker>
             + ?Sized,
     {
-        let payload = provider.load(&DataRequest::default())?.take_payload()?;
+        let payload = provider.load(Default::default())?.take_payload()?;
 
         let locale = locale!("th");
         let dictionary_payload = provider
-            .load(&DataRequest {
-                locale: DataLocale::from(locale),
+            .load(DataRequest {
+                locale: &DataLocale::from(locale),
                 metadata: Default::default(),
             })?
             .take_payload()?;

--- a/provider/adapters/src/any_payload.rs
+++ b/provider/adapters/src/any_payload.rs
@@ -19,13 +19,13 @@ use zerofrom::ZeroFrom;
 /// use icu_provider_adapters::any_payload::AnyPayloadProvider;
 /// use std::borrow::Cow;
 ///
-/// let provider = AnyPayloadProvider::new_static::<HelloWorldV1Marker>(
-///     &HelloWorldV1 {
+/// let provider =
+///     AnyPayloadProvider::new_static::<HelloWorldV1Marker>(&HelloWorldV1 {
 ///         message: Cow::Borrowed("hello world"),
-/// });
+///     });
 ///
 /// let payload: DataPayload<HelloWorldV1Marker> = provider
-///     .load_any(HelloWorldV1Marker::KEY, &Default::default())
+///     .load_any(HelloWorldV1Marker::KEY, Default::default())
 ///     .expect("Load should succeed")
 ///     .downcast()
 ///     .expect("Types should match")
@@ -69,7 +69,7 @@ impl AnyPayloadProvider {
 }
 
 impl AnyProvider for AnyPayloadProvider {
-    fn load_any(&self, key: DataKey, _: &DataRequest) -> Result<AnyResponse, DataError> {
+    fn load_any(&self, key: DataKey, _: DataRequest) -> Result<AnyResponse, DataError> {
         key.match_key(self.key)?;
         Ok(AnyResponse {
             metadata: DataResponseMetadata::default(),
@@ -84,7 +84,7 @@ where
     for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
     M::Yokeable: ZeroFrom<'static, M::Yokeable>,
 {
-    fn load(&self, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
+    fn load(&self, req: DataRequest) -> Result<DataResponse<M>, DataError> {
         self.as_downcasting().load(req)
     }
 }

--- a/provider/adapters/src/either.rs
+++ b/provider/adapters/src/either.rs
@@ -21,7 +21,7 @@ pub enum EitherProvider<P0, P1> {
 
 impl<P0: AnyProvider, P1: AnyProvider> AnyProvider for EitherProvider<P0, P1> {
     #[inline]
-    fn load_any(&self, key: DataKey, req: &DataRequest) -> Result<AnyResponse, DataError> {
+    fn load_any(&self, key: DataKey, req: DataRequest) -> Result<AnyResponse, DataError> {
         use EitherProvider::*;
         match self {
             A(p) => p.load_any(key, req),
@@ -35,7 +35,7 @@ impl<P0: BufferProvider, P1: BufferProvider> BufferProvider for EitherProvider<P
     fn load_buffer(
         &self,
         key: DataKey,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<BufferMarker>, DataError> {
         use EitherProvider::*;
         match self {
@@ -49,7 +49,7 @@ impl<M: DataMarker, P0: DynamicDataProvider<M>, P1: DynamicDataProvider<M>> Dyna
     for EitherProvider<P0, P1>
 {
     #[inline]
-    fn load_data(&self, key: DataKey, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
+    fn load_data(&self, key: DataKey, req: DataRequest) -> Result<DataResponse<M>, DataError> {
         use EitherProvider::*;
         match self {
             A(p) => p.load_data(key, req),
@@ -62,7 +62,7 @@ impl<M: KeyedDataMarker, P0: DataProvider<M>, P1: DataProvider<M>> DataProvider<
     for EitherProvider<P0, P1>
 {
     #[inline]
-    fn load(&self, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
+    fn load(&self, req: DataRequest) -> Result<DataResponse<M>, DataError> {
         use EitherProvider::*;
         match self {
             A(p) => p.load(req),

--- a/provider/adapters/src/fallback/adapter.rs
+++ b/provider/adapters/src/fallback/adapter.rs
@@ -140,7 +140,7 @@ impl<P> LocaleFallbackProvider<P> {
         F2: FnMut(&mut R) -> &mut DataResponseMetadata,
     {
         let key_fallbacker = self.fallbacker.for_key(key);
-        let mut fallback_iterator = key_fallbacker.fallback_for(base_req);
+        let mut fallback_iterator = key_fallbacker.fallback_for(base_req.locale.clone());
         loop {
             let result = f1(DataRequest {
                 locale: fallback_iterator.get(),

--- a/provider/adapters/src/fallback/adapter.rs
+++ b/provider/adapters/src/fallback/adapter.rs
@@ -21,13 +21,13 @@ use crate::helpers::result_is_err_missing_data_options;
 /// let provider = icu_testdata::get_postcard_provider();
 ///
 /// let req = DataRequest {
-///     locale: locale!("ja-JP").into(),
+///     locale: &locale!("ja-JP").into(),
 ///     metadata: Default::default(),
 /// };
 ///
 /// // The provider does not have data for "ja-JP":
 /// let result: Result<DataResponse<HelloWorldV1Marker>, DataError> =
-///     provider.load(&req);
+///     provider.load(req);
 /// assert!(matches!(result, Err(_)));
 ///
 /// // But if we wrap the provider in a fallback provider...
@@ -36,7 +36,7 @@ use crate::helpers::result_is_err_missing_data_options;
 ///
 /// // ...then we can load "ja-JP" based on "ja" data
 /// let response: DataResponse<HelloWorldV1Marker> =
-///     provider.load(&req).expect("successful with vertical fallback");
+///     provider.load(req).expect("successful with vertical fallback");
 ///
 /// assert_eq!(
 ///     "ja",
@@ -82,17 +82,19 @@ impl<P> LocaleFallbackProvider<P> {
     /// use icu_locid::locale;
     /// use icu_provider::hello_world::*;
     /// use icu_provider::prelude::*;
-    /// use icu_provider_adapters::fallback::{LocaleFallbacker, LocaleFallbackProvider};
+    /// use icu_provider_adapters::fallback::{
+    ///     LocaleFallbackProvider, LocaleFallbacker,
+    /// };
     ///
     /// let provider = HelloWorldProvider;
     ///
     /// let req = DataRequest {
-    ///     locale: locale!("de-CH").into(),
+    ///     locale: &locale!("de-CH").into(),
     ///     metadata: Default::default(),
     /// };
     ///
     /// // There is no "de-CH" data in the `HelloWorldProvider`
-    /// DataProvider::<HelloWorldV1Marker>::load(&provider, &req)
+    /// DataProvider::<HelloWorldV1Marker>::load(&provider, req)
     ///     .expect_err("No data for de-CH");
     ///
     /// // `HelloWorldProvider` does not contain fallback data,
@@ -100,11 +102,12 @@ impl<P> LocaleFallbackProvider<P> {
     /// // use it to create the fallbacking data provider.
     /// let fallbacker = LocaleFallbacker::try_new(&icu_testdata::get_provider())
     ///     .expect("Fallback data present");
-    /// let provider = LocaleFallbackProvider::new_with_fallbacker(provider, fallbacker);
+    /// let provider =
+    ///     LocaleFallbackProvider::new_with_fallbacker(provider, fallbacker);
     ///
     /// // Now we can load the "de-CH" data via fallback to "de".
     /// let german_hello_world: DataPayload<HelloWorldV1Marker> = provider
-    ///     .load(&req)
+    ///     .load(req)
     ///     .expect("Loading should succeed")
     ///     .take_payload()
     ///     .expect("Data should be present");
@@ -128,29 +131,32 @@ impl<P> LocaleFallbackProvider<P> {
     fn run_fallback<F1, F2, R>(
         &self,
         key: DataKey,
-        base_req: &DataRequest,
+        base_req: DataRequest,
         mut f1: F1,
         mut f2: F2,
     ) -> Result<R, DataError>
     where
-        F1: FnMut(&DataRequest) -> Result<R, DataError>,
+        F1: FnMut(DataRequest) -> Result<R, DataError>,
         F2: FnMut(&mut R) -> &mut DataResponseMetadata,
     {
         let key_fallbacker = self.fallbacker.for_key(key);
-        let mut fallback_iterator = key_fallbacker.fallback_for(base_req.clone());
+        let mut fallback_iterator = key_fallbacker.fallback_for(base_req);
         loop {
-            let result = f1(fallback_iterator.get());
+            let result = f1(DataRequest {
+                locale: fallback_iterator.get(),
+                metadata: Default::default(),
+            });
             if !result_is_err_missing_data_options(&result) {
                 return result
                     .map(|mut res| {
-                        f2(&mut res).locale = Some(fallback_iterator.take().locale);
+                        f2(&mut res).locale = Some(fallback_iterator.take());
                         res
                     })
                     // Log the original request rather than the fallback request
                     .map_err(|e| e.with_req(key, base_req));
             }
             // If we just checked und, break out of the loop.
-            if fallback_iterator.get().locale.is_empty() {
+            if fallback_iterator.get().is_empty() {
                 break;
             }
             fallback_iterator.step();
@@ -163,7 +169,7 @@ impl<P> AnyProvider for LocaleFallbackProvider<P>
 where
     P: AnyProvider,
 {
-    fn load_any(&self, key: DataKey, base_req: &DataRequest) -> Result<AnyResponse, DataError> {
+    fn load_any(&self, key: DataKey, base_req: DataRequest) -> Result<AnyResponse, DataError> {
         self.run_fallback(
             key,
             base_req,
@@ -180,7 +186,7 @@ where
     fn load_buffer(
         &self,
         key: DataKey,
-        base_req: &DataRequest,
+        base_req: DataRequest,
     ) -> Result<DataResponse<BufferMarker>, DataError> {
         self.run_fallback(
             key,
@@ -196,11 +202,7 @@ where
     P: DynamicDataProvider<M>,
     M: KeyedDataMarker,
 {
-    fn load_data(
-        &self,
-        key: DataKey,
-        base_req: &DataRequest,
-    ) -> Result<DataResponse<M>, DataError> {
+    fn load_data(&self, key: DataKey, base_req: DataRequest) -> Result<DataResponse<M>, DataError> {
         self.run_fallback(
             key,
             base_req,
@@ -215,7 +217,7 @@ where
     P: DataProvider<M>,
     M: KeyedDataMarker,
 {
-    fn load(&self, base_req: &DataRequest) -> Result<DataResponse<M>, DataError> {
+    fn load(&self, base_req: DataRequest) -> Result<DataResponse<M>, DataError> {
         self.run_fallback(
             M::KEY,
             base_req,

--- a/provider/adapters/src/fallback/algorithms.rs
+++ b/provider/adapters/src/fallback/algorithms.rs
@@ -341,8 +341,11 @@ mod tests {
                 } else {
                     fallbacker_no_data.for_config(config)
                 };
-                let mut locale = DataLocale::from(Locale::from_str(cas.input).unwrap());
-                let mut it = key_fallbacker.fallback_for(&mut locale);
+                let locale = DataLocale::from(Locale::from_str(cas.input).unwrap());
+                let mut it = key_fallbacker.fallback_for(DataRequest {
+                    locale: &locale,
+                    metadata: Default::default(),
+                });
                 for expected in expected_chain {
                     assert_eq!(
                         expected,

--- a/provider/adapters/src/fallback/algorithms.rs
+++ b/provider/adapters/src/fallback/algorithms.rs
@@ -342,10 +342,7 @@ mod tests {
                     fallbacker_no_data.for_config(config)
                 };
                 let locale = DataLocale::from(Locale::from_str(cas.input).unwrap());
-                let mut it = key_fallbacker.fallback_for(DataRequest {
-                    locale: &locale,
-                    metadata: Default::default(),
-                });
+                let mut it = key_fallbacker.fallback_for(locale);
                 for expected in expected_chain {
                     assert_eq!(
                         expected,

--- a/provider/adapters/src/fallback/mod.rs
+++ b/provider/adapters/src/fallback/mod.rs
@@ -22,10 +22,7 @@
 //! let key_fallbacker = fallbacker.for_config(Default::default());
 //!
 //! // Set up the fallback iterator.
-//! let mut fallback_iterator = key_fallbacker.fallback_for(DataRequest {
-//!       locale: &icu_locid::locale!("hi-Latn-IN").into(),
-//!     metadata: Default::default(),
-//! });
+//! let mut fallback_iterator = key_fallbacker.fallback_for(icu_locid::locale!("hi-Latn-IN").into());
 //!
 //! // Run the algorithm and check the results.
 //! assert_eq!(fallback_iterator.get().to_string(), "hi-Latn-IN");
@@ -76,12 +73,11 @@ pub struct LocaleFallbackConfig {
     /// let mut config = LocaleFallbackConfig::default();
     /// config.priority = FallbackPriority::Language;
     /// let key_fallbacker = fallbacker.for_config(config);
-    /// let mut fallback_iterator = key_fallbacker.fallback_for(DataRequest {
-    ///     locale: &icu_locid::Locale::from_bytes(b"ca-ES-valencia")
+    /// let mut fallback_iterator = key_fallbacker.fallback_for(
+    ///     icu_locid::Locale::from_bytes(b"ca-ES-valencia")
     ///         .unwrap()
     ///         .into(),
-    ///     metadata: Default::default(),
-    /// });
+    /// );
     ///
     /// // Run the algorithm and check the results.
     /// assert_eq!(fallback_iterator.get().to_string(), "ca-ES-valencia");
@@ -107,12 +103,11 @@ pub struct LocaleFallbackConfig {
     /// let mut config = LocaleFallbackConfig::default();
     /// config.priority = FallbackPriority::Region;
     /// let key_fallbacker = fallbacker.for_config(config);
-    /// let mut fallback_iterator = key_fallbacker.fallback_for(DataRequest {
-    ///     locale: &icu_locid::Locale::from_bytes(b"ca-ES-valencia")
+    /// let mut fallback_iterator = key_fallbacker.fallback_for(
+    ///     icu_locid::Locale::from_bytes(b"ca-ES-valencia")
     ///         .unwrap()
     ///         .into(),
-    ///     metadata: Default::default(),
-    /// });
+    /// );
     ///
     /// // Run the algorithm and check the results.
     /// assert_eq!(fallback_iterator.get().to_string(), "ca-ES-valencia");
@@ -141,12 +136,11 @@ pub struct LocaleFallbackConfig {
     /// let mut config = LocaleFallbackConfig::default();
     /// config.extension_key = Some(icu_locid::extensions_unicode_key!("nu"));
     /// let key_fallbacker = fallbacker.for_config(config);
-    /// let mut fallback_iterator = key_fallbacker.fallback_for(DataRequest {
-    ///     locale: &icu_locid::Locale::from_bytes(b"ar-EG-u-nu-latn")
+    /// let mut fallback_iterator = key_fallbacker.fallback_for(
+    ///     icu_locid::Locale::from_bytes(b"ar-EG-u-nu-latn")
     ///         .unwrap()
     ///         .into(),
-    ///     metadata: Default::default(),
-    /// });
+    /// );
     ///
     /// // Run the algorithm and check the results.
     /// assert_eq!(fallback_iterator.get().to_string(), "ar-EG-u-nu-latn");
@@ -262,10 +256,8 @@ impl LocaleFallbacker {
     /// let provider = icu_testdata::get_provider();
     /// let fallbacker = LocaleFallbacker::try_new(&provider).expect("data");
     /// let key_fallbacker = fallbacker.for_key(FooV1Marker::KEY);
-    /// let mut fallback_iterator = key_fallbacker.fallback_for(DataRequest {
-    ///     locale: &icu_locid::Locale::from_bytes(b"en-GB").unwrap().into(),
-    ///     metadata: Default::default(),
-    /// });
+    /// let mut fallback_iterator = key_fallbacker
+    ///     .fallback_for(icu_locid::Locale::from_bytes(b"en-GB").unwrap().into());
     ///
     /// // Run the algorithm and check the results.
     /// assert_eq!(fallback_iterator.get().to_string(), "en-GB");
@@ -285,8 +277,7 @@ impl<'a> LocaleFallbackerWithConfig<'a> {
     /// When first initialized, the locale is normalized according to the fallback algorithm.
     ///
     /// [`Locale`]: icu_locid::Locale
-    pub fn fallback_for<'b>(&'b self, req: DataRequest) -> LocaleFallbackIterator<'a, 'b> {
-        let mut locale = req.locale.clone();
+    pub fn fallback_for<'b>(&'b self, mut locale: DataLocale) -> LocaleFallbackIterator<'a, 'b> {
         self.normalize(&mut locale);
         LocaleFallbackIterator {
             current: locale,

--- a/provider/adapters/src/filter/impls.rs
+++ b/provider/adapters/src/filter/impls.rs
@@ -10,7 +10,7 @@ use icu_locid::LanguageIdentifier;
 
 impl<D, F> RequestFilterDataProvider<D, F>
 where
-    F: Fn(&DataRequest) -> bool + Sync,
+    F: Fn(DataRequest) -> bool + Sync,
 {
     /// Filter out data requests with certain langids according to the predicate function. The
     /// predicate should return `true` to allow a langid and `false` to reject a langid.
@@ -22,7 +22,7 @@ where
     ///
     /// ```
     /// use icu_locid::LanguageIdentifier;
-    /// use icu_locid::{langid, subtags_language as language, locale};
+    /// use icu_locid::{langid, locale, subtags_language as language};
     /// use icu_provider::datagen::*;
     /// use icu_provider::hello_world::*;
     /// use icu_provider::prelude::*;
@@ -34,18 +34,20 @@ where
     ///
     /// // German requests should succeed:
     /// let req_de = DataRequest {
-    ///     locale: locale!("de").into(),
+    ///     locale: &locale!("de").into(),
     ///     metadata: Default::default(),
     /// };
-    /// let response: Result<DataResponse<HelloWorldV1Marker>, _> = provider.load(&req_de);
+    /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
+    ///     provider.load(req_de);
     /// assert!(matches!(response, Ok(_)));
     ///
     /// // English requests should fail:
     /// let req_en = DataRequest {
-    ///     locale: locale!("en-US").into(),
+    ///     locale: &locale!("en-US").into(),
     ///     metadata: Default::default(),
     /// };
-    /// let response: Result<DataResponse<HelloWorldV1Marker>, _> = provider.load(&req_en);
+    /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
+    ///     provider.load(req_en);
     /// assert!(matches!(
     ///     response,
     ///     Err(DataError {
@@ -67,7 +69,7 @@ where
     pub fn filter_by_langid<'a>(
         self,
         predicate: impl Fn(&LanguageIdentifier) -> bool + Sync + 'a,
-    ) -> RequestFilterDataProvider<D, Box<dyn Fn(&DataRequest) -> bool + Sync + 'a>>
+    ) -> RequestFilterDataProvider<D, Box<dyn Fn(DataRequest) -> bool + Sync + 'a>>
     where
         F: 'a,
     {
@@ -108,18 +110,20 @@ where
     ///
     /// // German requests should succeed:
     /// let req_de = DataRequest {
-    ///     locale: locale!("de").into(),
+    ///     locale: &locale!("de").into(),
     ///     metadata: Default::default(),
     /// };
-    /// let response: Result<DataResponse<HelloWorldV1Marker>, _> = provider.load(&req_de);
+    /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
+    ///     provider.load(req_de);
     /// assert!(matches!(response, Ok(_)));
     ///
     /// // English requests should fail:
     /// let req_en = DataRequest {
-    ///     locale: locale!("en-US").into(),
+    ///     locale: &locale!("en-US").into(),
     ///     metadata: Default::default(),
     /// };
-    /// let response: Result<DataResponse<HelloWorldV1Marker>, _> = provider.load(&req_en);
+    /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
+    ///     provider.load(req_en);
     /// assert!(matches!(
     ///     response,
     ///     Err(DataError {
@@ -135,7 +139,7 @@ where
     pub fn filter_by_langid_allowlist_strict<'a>(
         self,
         allowlist: &'a [LanguageIdentifier],
-    ) -> RequestFilterDataProvider<D, Box<dyn Fn(&DataRequest) -> bool + Sync + 'a>>
+    ) -> RequestFilterDataProvider<D, Box<dyn Fn(DataRequest) -> bool + Sync + 'a>>
     where
         F: 'a,
     {
@@ -168,11 +172,11 @@ where
     ///
     /// // Requests with a langid should succeed:
     /// let req_with_langid = DataRequest {
-    ///     locale: locale!("de").into(),
+    ///     locale: &locale!("de").into(),
     ///     metadata: Default::default(),
     /// };
     /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
-    ///     provider.load(&req_with_langid);
+    ///     provider.load(req_with_langid);
     /// assert!(matches!(response, Ok(_)));
     ///
     /// // Requests without a langid should fail:
@@ -181,7 +185,7 @@ where
     ///     metadata: Default::default(),
     /// };
     /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
-    ///     provider.load(&req_no_langid);
+    ///     provider.load(req_no_langid);
     /// assert!(matches!(
     ///     response,
     ///     Err(DataError {
@@ -192,7 +196,7 @@ where
     /// ```
     pub fn require_langid<'a>(
         self,
-    ) -> RequestFilterDataProvider<D, Box<dyn Fn(&DataRequest) -> bool + Sync + 'a>>
+    ) -> RequestFilterDataProvider<D, Box<dyn Fn(DataRequest) -> bool + Sync + 'a>>
     where
         F: 'a,
     {

--- a/provider/adapters/src/filter/mod.rs
+++ b/provider/adapters/src/filter/mod.rs
@@ -53,7 +53,7 @@ use icu_provider::prelude::*;
 #[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct RequestFilterDataProvider<D, F>
 where
-    F: Fn(&DataRequest) -> bool,
+    F: Fn(DataRequest) -> bool,
 {
     /// The data provider to which we delegate requests.
     pub inner: D,
@@ -68,11 +68,11 @@ where
 
 impl<D, F, M> DynamicDataProvider<M> for RequestFilterDataProvider<D, F>
 where
-    F: Fn(&DataRequest) -> bool,
+    F: Fn(DataRequest) -> bool,
     M: DataMarker,
     D: DynamicDataProvider<M>,
 {
-    fn load_data(&self, key: DataKey, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
+    fn load_data(&self, key: DataKey, req: DataRequest) -> Result<DataResponse<M>, DataError> {
         if (self.predicate)(req) {
             self.inner.load_data(key, req)
         } else {
@@ -85,11 +85,11 @@ where
 
 impl<D, F, M> DataProvider<M> for RequestFilterDataProvider<D, F>
 where
-    F: Fn(&DataRequest) -> bool,
+    F: Fn(DataRequest) -> bool,
     M: KeyedDataMarker,
     D: DataProvider<M>,
 {
-    fn load(&self, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
+    fn load(&self, req: DataRequest) -> Result<DataResponse<M>, DataError> {
         if (self.predicate)(req) {
             self.inner.load(req)
         } else {
@@ -102,13 +102,13 @@ where
 
 impl<D, F> BufferProvider for RequestFilterDataProvider<D, F>
 where
-    F: Fn(&DataRequest) -> bool,
+    F: Fn(DataRequest) -> bool,
     D: BufferProvider,
 {
     fn load_buffer(
         &self,
         key: DataKey,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<BufferMarker>, DataError> {
         if (self.predicate)(req) {
             self.inner.load_buffer(key, req)
@@ -122,10 +122,10 @@ where
 
 impl<D, F> AnyProvider for RequestFilterDataProvider<D, F>
 where
-    F: Fn(&DataRequest) -> bool,
+    F: Fn(DataRequest) -> bool,
     D: AnyProvider,
 {
-    fn load_any(&self, key: DataKey, req: &DataRequest) -> Result<AnyResponse, DataError> {
+    fn load_any(&self, key: DataKey, req: DataRequest) -> Result<AnyResponse, DataError> {
         if (self.predicate)(req) {
             self.inner.load_any(key, req)
         } else {
@@ -140,7 +140,7 @@ where
 impl<M, D, F> datagen::IterableDynamicDataProvider<M> for RequestFilterDataProvider<D, F>
 where
     M: DataMarker,
-    F: Fn(&DataRequest) -> bool,
+    F: Fn(DataRequest) -> bool,
     D: datagen::IterableDynamicDataProvider<M>,
 {
     fn supported_locales_for_key(
@@ -150,13 +150,12 @@ where
         self.inner.supported_locales_for_key(key).map(|vec| {
             // Use filter_map instead of filter to avoid cloning the locale
             vec.into_iter()
-                .filter_map(move |locale| {
-                    let request = DataRequest {
-                        locale,
+                .filter_map(|locale| {
+                    if (self.predicate)(DataRequest {
+                        locale: &locale,
                         metadata: Default::default(),
-                    };
-                    if (self.predicate)(&request) {
-                        Some(request.locale)
+                    }) {
+                        Some(locale)
                     } else {
                         None
                     }
@@ -170,20 +169,19 @@ where
 impl<M, D, F> datagen::IterableDataProvider<M> for RequestFilterDataProvider<D, F>
 where
     M: KeyedDataMarker,
-    F: Fn(&DataRequest) -> bool,
+    F: Fn(DataRequest) -> bool,
     D: datagen::IterableDataProvider<M>,
 {
     fn supported_locales(&self) -> Result<alloc::vec::Vec<DataLocale>, DataError> {
         self.inner.supported_locales().map(|vec| {
             // Use filter_map instead of filter to avoid cloning the locale
             vec.into_iter()
-                .filter_map(move |locale| {
-                    let request = DataRequest {
-                        locale,
+                .filter_map(|locale| {
+                    if (self.predicate)(DataRequest {
+                        locale: &locale,
                         metadata: Default::default(),
-                    };
-                    if (self.predicate)(&request) {
-                        Some(request.locale)
+                    }) {
+                        Some(locale)
                     } else {
                         None
                     }
@@ -199,7 +197,7 @@ where
     D: datagen::DataConverter<MFrom, MTo>,
     MFrom: DataMarker,
     MTo: DataMarker,
-    F: Fn(&DataRequest) -> bool,
+    F: Fn(DataRequest) -> bool,
 {
     fn convert(
         &self,
@@ -218,7 +216,7 @@ pub trait Filterable: Sized {
     fn filterable(
         self,
         filter_name: &'static str,
-    ) -> RequestFilterDataProvider<Self, fn(&DataRequest) -> bool>;
+    ) -> RequestFilterDataProvider<Self, fn(DataRequest) -> bool>;
 }
 
 impl<T> Filterable for T
@@ -228,8 +226,8 @@ where
     fn filterable(
         self,
         filter_name: &'static str,
-    ) -> RequestFilterDataProvider<Self, fn(&DataRequest) -> bool> {
-        fn noop(_: &DataRequest) -> bool {
+    ) -> RequestFilterDataProvider<Self, fn(DataRequest) -> bool> {
+        fn noop(_: DataRequest) -> bool {
             true
         }
         RequestFilterDataProvider {

--- a/provider/adapters/src/fork/by_key.rs
+++ b/provider/adapters/src/fork/by_key.rs
@@ -37,7 +37,7 @@ use crate::helpers::result_is_err_missing_data_key;
 ///     fn load_buffer(
 ///         &self,
 ///         key: DataKey,
-///         req: &DataRequest,
+///         req: DataRequest,
 ///     ) -> Result<DataResponse<BufferMarker>, DataError> {
 ///         Err(DataErrorKind::MissingDataKey.with_req(key, req))
 ///     }
@@ -51,8 +51,8 @@ use crate::helpers::result_is_err_missing_data_key;
 /// let data_provider = forking_provider.as_deserializing();
 ///
 /// let german_hello_world: DataPayload<HelloWorldV1Marker> = data_provider
-///     .load(&DataRequest {
-///         locale: locale!("de").into(),
+///     .load(DataRequest {
+///         locale: &locale!("de").into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect("Loading should succeed")
@@ -89,8 +89,8 @@ use crate::helpers::result_is_err_missing_data_key;
 ///
 /// // Chinese is the first provider, so this succeeds
 /// let chinese_hello_world = data_provider
-///     .load(&DataRequest {
-///         locale: locale!("zh").into(),
+///     .load(DataRequest {
+///         locale: &locale!("zh").into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect("Loading should succeed")
@@ -101,8 +101,8 @@ use crate::helpers::result_is_err_missing_data_key;
 ///
 /// // German is shadowed by Chinese, so this fails
 /// data_provider
-///     .load(&DataRequest {
-///         locale: locale!("de").into(),
+///     .load(DataRequest {
+///         locale: &locale!("de").into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect_err("Should stop at the first provider, even though the second has data");
@@ -120,7 +120,7 @@ where
     fn load_buffer(
         &self,
         key: DataKey,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<BufferMarker>, DataError> {
         let result = self.0.load_buffer(key, req);
         if !result_is_err_missing_data_key(&result) {
@@ -135,7 +135,7 @@ where
     P0: AnyProvider,
     P1: AnyProvider,
 {
-    fn load_any(&self, key: DataKey, req: &DataRequest) -> Result<AnyResponse, DataError> {
+    fn load_any(&self, key: DataKey, req: DataRequest) -> Result<AnyResponse, DataError> {
         let result = self.0.load_any(key, req);
         if !result_is_err_missing_data_key(&result) {
             return result;
@@ -150,7 +150,7 @@ where
     P0: DynamicDataProvider<M>,
     P1: DynamicDataProvider<M>,
 {
-    fn load_data(&self, key: DataKey, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
+    fn load_data(&self, key: DataKey, req: DataRequest) -> Result<DataResponse<M>, DataError> {
         let result = self.0.load_data(key, req);
         if !result_is_err_missing_data_key(&result) {
             return result;
@@ -213,8 +213,8 @@ where
 ///
 /// // Chinese is the first provider, so this succeeds
 /// let chinese_hello_world = data_provider
-///     .load(&DataRequest {
-///         locale: locale!("zh").into(),
+///     .load(DataRequest {
+///         locale: &locale!("zh").into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect("Loading should succeed")
@@ -225,8 +225,8 @@ where
 ///
 /// // German is shadowed by Chinese, so this fails
 /// data_provider
-///     .load(&DataRequest {
-///         locale: locale!("de").into(),
+///     .load(DataRequest {
+///         locale: &locale!("de").into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect_err("Should stop at the first provider, even though the second has data");
@@ -244,7 +244,7 @@ where
     fn load_buffer(
         &self,
         key: DataKey,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<BufferMarker>, DataError> {
         for provider in self.providers.iter() {
             let result = provider.load_buffer(key, req);
@@ -260,7 +260,7 @@ impl<P> AnyProvider for MultiForkByKeyProvider<P>
 where
     P: AnyProvider,
 {
-    fn load_any(&self, key: DataKey, req: &DataRequest) -> Result<AnyResponse, DataError> {
+    fn load_any(&self, key: DataKey, req: DataRequest) -> Result<AnyResponse, DataError> {
         for provider in self.providers.iter() {
             let result = provider.load_any(key, req);
             if !result_is_err_missing_data_key(&result) {
@@ -276,7 +276,7 @@ where
     M: DataMarker,
     P: DynamicDataProvider<M>,
 {
-    fn load_data(&self, key: DataKey, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
+    fn load_data(&self, key: DataKey, req: DataRequest) -> Result<DataResponse<M>, DataError> {
         for provider in self.providers.iter() {
             let result = provider.load_data(key, req);
             if !result_is_err_missing_data_key(&result) {

--- a/provider/blob/examples/simple_static.rs
+++ b/provider/blob/examples/simple_static.rs
@@ -13,8 +13,8 @@ fn main() {
     .unwrap();
 
     let hello: DataPayload<HelloWorldV1Marker> = dp
-        .load(&DataRequest {
-            locale: locale!("zh").into(),
+        .load(DataRequest {
+            locale: &locale!("zh").into(),
             metadata: Default::default(),
         })
         .unwrap()

--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -42,8 +42,8 @@ use yoke::*;
 ///
 /// // Check that it works:
 /// let response: DataPayload<HelloWorldV1Marker> = provider
-///     .load(&DataRequest {
-///         locale: locale!("la").into(),
+///     .load(DataRequest {
+///         locale: &locale!("la").into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect("Data should be valid")
@@ -81,7 +81,7 @@ impl BufferProvider for BlobDataProvider {
     fn load_buffer(
         &self,
         key: DataKey,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<BufferMarker>, DataError> {
         let mut metadata = DataResponseMetadata::default();
         metadata.buffer_format = Some(BufferFormat::Postcard1);

--- a/provider/blob/src/export/mod.rs
+++ b/provider/blob/src/export/mod.rs
@@ -53,7 +53,7 @@
 //!     metadata: Default::default(),
 //! };
 //! let response: DataPayload<HelloWorldV1Marker> = provider
-//!     .load(&req)
+//!     .load(req)
 //!     .unwrap()
 //!     .take_payload()
 //!     .unwrap();

--- a/provider/blob/src/static_data_provider.rs
+++ b/provider/blob/src/static_data_provider.rs
@@ -34,8 +34,8 @@ use serde::de::Deserialize;
 ///     .expect("Deserialization should succeed");
 ///
 /// let response: DataPayload<HelloWorldV1Marker> = provider
-///     .load(&DataRequest {
-///         locale: locale!("la").into(),
+///     .load(DataRequest {
+///         locale: &locale!("la").into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect("Data should be valid")
@@ -81,8 +81,8 @@ impl StaticDataProvider {
     ///
     /// DataProvider::<HelloWorldV1Marker>::load(
     ///     &stub_provider,
-    ///     &DataRequest {
-    ///         locale: locale!("la").into(),
+    ///     DataRequest {
+    ///         locale: &locale!("la").into(),
     ///         metadata: Default::default(),
     ///     },
     /// )
@@ -99,7 +99,7 @@ impl BufferProvider for StaticDataProvider {
     fn load_buffer(
         &self,
         key: DataKey,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<BufferMarker>, DataError> {
         let mut metadata = DataResponseMetadata::default();
         metadata.buffer_format = Some(BufferFormat::Postcard1);

--- a/provider/core/src/any.rs
+++ b/provider/core/src/any.rs
@@ -258,8 +258,8 @@ impl AnyResponse {
 ///     .as_any_provider()
 ///     .load_any(
 ///         HelloWorldV1Marker::KEY,
-///         &DataRequest {
-///             locale: icu_locid::locale!("de").into(),
+///         DataRequest {
+///             locale: &icu_locid::locale!("de").into(),
 ///             metadata: Default::default(),
 ///         },
 ///     )
@@ -274,7 +274,7 @@ impl AnyResponse {
 /// assert_eq!(payload.get().message, "Hallo Welt");
 /// ```
 pub trait AnyProvider {
-    fn load_any(&self, key: DataKey, req: &DataRequest) -> Result<AnyResponse, DataError>;
+    fn load_any(&self, key: DataKey, req: DataRequest) -> Result<AnyResponse, DataError>;
 }
 
 /// A wrapper over `DynamicDataProvider<AnyMarker>` that implements `AnyProvider`
@@ -301,7 +301,7 @@ where
     P: DynamicDataProvider<AnyMarker> + ?Sized,
 {
     #[inline]
-    fn load_any(&self, key: DataKey, req: &DataRequest) -> Result<AnyResponse, DataError> {
+    fn load_any(&self, key: DataKey, req: DataRequest) -> Result<AnyResponse, DataError> {
         self.0.load_data(key, req)?.try_into()
     }
 }
@@ -333,7 +333,7 @@ where
     M::Yokeable: ZeroFrom<'static, M::Yokeable>,
 {
     #[inline]
-    fn load(&self, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
+    fn load(&self, req: DataRequest) -> Result<DataResponse<M>, DataError> {
         self.0.load_any(M::KEY, req)?.downcast()
     }
 }

--- a/provider/core/src/buf.rs
+++ b/provider/core/src/buf.rs
@@ -36,8 +36,8 @@ impl DataMarker for BufferMarker {
 /// let data_provider = buffer_provider.as_deserializing();
 ///
 /// let german_hello_world: DataPayload<HelloWorldV1Marker> = data_provider
-///     .load(&DataRequest {
-///         locale: locale!("de").into(),
+///     .load(DataRequest {
+///         locale: &locale!("de").into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect("Loading should succeed")
@@ -53,7 +53,7 @@ pub trait BufferProvider {
     fn load_buffer(
         &self,
         key: DataKey,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<BufferMarker>, DataError>;
 }
 

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -22,7 +22,7 @@ where
     ///
     /// Returns [`Ok`] if the request successfully loaded data. If data failed to load, returns an
     /// Error with more information.
-    fn load_data(&self, key: DataKey, req: &DataRequest) -> Result<DataResponse<M>, DataError>;
+    fn load_data(&self, key: DataKey, req: DataRequest) -> Result<DataResponse<M>, DataError>;
 }
 
 /// A data provider that loads data for a specific [`DataKey`].
@@ -34,7 +34,7 @@ where
     ///
     /// Returns [`Ok`] if the request successfully loaded data. If data failed to load, returns an
     /// Error with more information.
-    fn load(&self, req: &DataRequest) -> Result<DataResponse<M>, DataError>;
+    fn load(&self, req: DataRequest) -> Result<DataResponse<M>, DataError>;
 }
 
 impl<M, P> DynamicDataProvider<M> for alloc::boxed::Box<P>
@@ -42,7 +42,7 @@ where
     M: DataMarker,
     P: DynamicDataProvider<M> + ?Sized,
 {
-    fn load_data(&self, key: DataKey, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
+    fn load_data(&self, key: DataKey, req: DataRequest) -> Result<DataResponse<M>, DataError> {
         (**self).load_data(key, req)
     }
 }
@@ -102,7 +102,7 @@ mod test {
     }
 
     impl DataProvider<HelloWorldV1Marker> for DataWarehouse {
-        fn load(&self, _: &DataRequest) -> Result<DataResponse<HelloWorldV1Marker>, DataError> {
+        fn load(&self, _: DataRequest) -> Result<DataResponse<HelloWorldV1Marker>, DataError> {
             Ok(DataResponse {
                 metadata: DataResponseMetadata::default(),
                 payload: Some(DataPayload::from_owned(self.hello_v1.clone())),
@@ -125,7 +125,7 @@ mod test {
     }
 
     impl DataProvider<HelloWorldV1Marker> for DataProvider2 {
-        fn load(&self, _: &DataRequest) -> Result<DataResponse<HelloWorldV1Marker>, DataError> {
+        fn load(&self, _: DataRequest) -> Result<DataResponse<HelloWorldV1Marker>, DataError> {
             Ok(DataResponse {
                 metadata: DataResponseMetadata::default(),
                 payload: Some(DataPayload::from_owned(self.data.hello_v1.clone())),
@@ -134,7 +134,7 @@ mod test {
     }
 
     impl DataProvider<HelloAltMarker> for DataProvider2 {
-        fn load(&self, _: &DataRequest) -> Result<DataResponse<HelloAltMarker>, DataError> {
+        fn load(&self, _: DataRequest) -> Result<DataResponse<HelloAltMarker>, DataError> {
             Ok(DataResponse {
                 metadata: DataResponseMetadata::default(),
                 payload: Some(DataPayload::from_owned(self.data.hello_alt.clone())),
@@ -168,13 +168,13 @@ mod test {
     fn get_payload_v1<P: DataProvider<HelloWorldV1Marker> + ?Sized>(
         provider: &P,
     ) -> Result<DataPayload<HelloWorldV1Marker>, DataError> {
-        provider.load(&Default::default())?.take_payload()
+        provider.load(Default::default())?.take_payload()
     }
 
     fn get_payload_alt<P: DataProvider<HelloAltMarker> + ?Sized>(
         provider: &P,
     ) -> Result<DataPayload<HelloAltMarker>, DataError> {
-        provider.load(&Default::default())?.take_payload()
+        provider.load(Default::default())?.take_payload()
     }
 
     #[test]
@@ -291,7 +291,7 @@ mod test {
         let response: Result<DataResponse<HelloWorldV1Marker>, DataError> = AnyProvider::load_any(
             &provider.as_any_provider(),
             HELLO_ALT_KEY,
-            &Default::default(),
+            Default::default(),
         )
         .unwrap()
         .downcast();
@@ -309,9 +309,9 @@ mod test {
         P: DataProvider<HelloWorldV1Marker> + DataProvider<HelloAltMarker> + ?Sized,
     {
         let v1: DataPayload<HelloWorldV1Marker> =
-            d.load(&Default::default()).unwrap().take_payload().unwrap();
+            d.load(Default::default()).unwrap().take_payload().unwrap();
         let v2: DataPayload<HelloAltMarker> =
-            d.load(&Default::default()).unwrap().take_payload().unwrap();
+            d.load(Default::default()).unwrap().take_payload().unwrap();
         if v1.get().message == v2.get().message {
             panic!()
         }

--- a/provider/core/src/dynutil.rs
+++ b/provider/core/src/dynutil.rs
@@ -60,7 +60,7 @@ where
 /// # impl DataProvider<HelloWorldV1Marker> for HelloWorldProvider {
 /// #     fn load(
 /// #         &self,
-/// #         req: &DataRequest,
+/// #         req: DataRequest,
 /// #     ) -> Result<DataResponse<HelloWorldV1Marker>, DataError> {
 /// #         icu_provider::hello_world::HelloWorldProvider.load(req)
 /// #     }
@@ -70,16 +70,16 @@ where
 /// icu_provider::impl_dynamic_data_provider!(HelloWorldProvider, [HelloWorldV1Marker,], AnyMarker);
 ///
 /// let req = DataRequest {
-///     locale: icu_locid::locale!("de").into(),
+///     locale: &icu_locid::locale!("de").into(),
 ///     metadata: Default::default(),
 /// };
 ///
 /// // Successful because the key matches:
-/// HelloWorldProvider.load_data(HelloWorldV1Marker::KEY, &req).unwrap();
+/// HelloWorldProvider.load_data(HelloWorldV1Marker::KEY, req).unwrap();
 ///
 /// // MissingDataKey error as the key does not match:
 /// assert_eq!(
-///     HelloWorldProvider.load_data(icu_provider::data_key!("dummy@1"), &req).unwrap_err().kind,
+///     HelloWorldProvider.load_data(icu_provider::data_key!("dummy@1"), req).unwrap_err().kind,
 ///     DataErrorKind::MissingDataKey,
 /// );
 /// ```
@@ -95,7 +95,7 @@ where
 /// #
 /// # struct HelloWorldProvider;
 /// # impl DynamicDataProvider<HelloWorldV1Marker> for HelloWorldProvider {
-/// #     fn load_data(&self, key: DataKey, req: &DataRequest)
+/// #     fn load_data(&self, key: DataKey, req: DataRequest)
 /// #             -> Result<DataResponse<HelloWorldV1Marker>, DataError> {
 /// #         icu_provider::hello_world::HelloWorldProvider.load(req)
 /// #     }
@@ -110,15 +110,15 @@ where
 /// }, AnyMarker);
 ///
 /// let req = DataRequest {
-///     locale: icu_locid::locale!("de").into(),
+///     locale: &icu_locid::locale!("de").into(),
 ///     metadata: Default::default(),
 /// };
 ///
 /// // Successful because the key matches:
-/// HelloWorldProvider.as_any_provider().load_any(HelloWorldV1Marker::KEY, &req).unwrap();
+/// HelloWorldProvider.as_any_provider().load_any(HelloWorldV1Marker::KEY, req).unwrap();
 ///
 /// // Because of the wildcard, any key actually works:
-/// HelloWorldProvider.as_any_provider().load_any(icu_provider::data_key!("dummy@1"), &req).unwrap();
+/// HelloWorldProvider.as_any_provider().load_any(icu_provider::data_key!("dummy@1"), req).unwrap();
 /// ```
 ///
 /// [`DynamicDataProvider`]: crate::DynamicDataProvider
@@ -149,7 +149,7 @@ macro_rules! impl_dynamic_data_provider {
             fn load_data(
                 &self,
                 key: $crate::DataKey,
-                req: &$crate::DataRequest,
+                req: $crate::DataRequest,
             ) -> Result<
                 $crate::DataResponse<$dyn_m>,
                 $crate::DataError,
@@ -194,7 +194,7 @@ macro_rules! impl_dynamic_data_provider {
             fn load_data(
                 &self,
                 key: $crate::DataKey,
-                req: &$crate::DataRequest,
+                req: $crate::DataRequest,
             ) -> Result<
                 $crate::DataResponse<$dyn_m>,
                 $crate::DataError,

--- a/provider/core/src/error.rs
+++ b/provider/core/src/error.rs
@@ -78,7 +78,7 @@ pub enum DataErrorKind {
 /// ```no_run
 /// # use icu_provider::prelude::*;
 /// let key: DataKey = unimplemented!();
-/// let req: &DataRequest = unimplemented!();
+/// let req: DataRequest = unimplemented!();
 /// DataErrorKind::NeedsLocale.with_req(key, req);
 /// ```
 ///
@@ -150,7 +150,7 @@ impl DataErrorKind {
 
     /// Creates a DataError with a request context.
     #[inline]
-    pub fn with_req(self, key: DataKey, req: &DataRequest) -> DataError {
+    pub fn with_req(self, key: DataKey, req: DataRequest) -> DataError {
         self.into_error().with_req(key, req)
     }
 }
@@ -197,7 +197,7 @@ impl DataError {
     /// If the "log_error_context" feature is enabled, this logs the whole request. Either way,
     /// it returns an error with the resource key portion of the request as context.
     #[cfg_attr(not(feature = "log_error_context"), allow(unused_variables))]
-    pub fn with_req(self, key: DataKey, req: &DataRequest) -> Self {
+    pub fn with_req(self, key: DataKey, req: DataRequest) -> Self {
         // Don't write out a log for MissingDataKey since there is no context to add
         #[cfg(feature = "log_error_context")]
         if self.kind != DataErrorKind::MissingDataKey {

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -60,8 +60,8 @@ impl KeyedDataMarker for HelloWorldV1Marker {
 /// use icu_provider::prelude::*;
 ///
 /// let german_hello_world: DataPayload<HelloWorldV1Marker> = HelloWorldProvider
-///     .load(&DataRequest {
-///         locale: locale!("de").into(),
+///     .load(DataRequest {
+///         locale: &locale!("de").into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect("Loading should succeed")
@@ -102,7 +102,7 @@ impl HelloWorldProvider {
 }
 
 impl DataProvider<HelloWorldV1Marker> for HelloWorldProvider {
-    fn load(&self, req: &DataRequest) -> Result<DataResponse<HelloWorldV1Marker>, DataError> {
+    fn load(&self, req: DataRequest) -> Result<DataResponse<HelloWorldV1Marker>, DataError> {
         #[allow(clippy::indexing_slicing)] // binary_search
         let data = Self::DATA
             .binary_search_by(|(k, _)| req.locale.strict_cmp(k.as_bytes()).reverse())
@@ -138,7 +138,7 @@ impl BufferProvider for HelloWorldJsonProvider {
     fn load_buffer(
         &self,
         key: DataKey,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<BufferMarker>, DataError> {
         key.match_key(HelloWorldV1Marker::KEY)?;
         let result = self.0.load(req)?;
@@ -171,10 +171,9 @@ impl IterableDataProvider<HelloWorldV1Marker> for HelloWorldProvider {
 #[test]
 fn test_iter() {
     use icu_locid::locale;
-    let supported_langids: Vec<DataLocale> = HelloWorldProvider.supported_locales().unwrap();
 
     assert_eq!(
-        supported_langids,
+        HelloWorldProvider.supported_locales().unwrap(),
         vec![
             locale!("bn").into(),
             locale!("cs").into(),

--- a/provider/core/src/serde/mod.rs
+++ b/provider/core/src/serde/mod.rs
@@ -107,7 +107,7 @@ where
     // Necessary workaround bound (see `yoke::trait_hack` docs):
     for<'de> YokeTraitHack<<M::Yokeable as Yokeable<'de>>::Output>: Deserialize<'de>,
 {
-    fn load_data(&self, key: DataKey, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
+    fn load_data(&self, key: DataKey, req: DataRequest) -> Result<DataResponse<M>, DataError> {
         let buffer_response = BufferProvider::load_buffer(self.0, key, req)?;
         let buffer_format = buffer_response
             .metadata
@@ -133,7 +133,7 @@ where
     for<'de> YokeTraitHack<<M::Yokeable as Yokeable<'de>>::Output>: Deserialize<'de>,
 {
     /// Converts a buffer into a concrete type by deserializing from a supported buffer format.
-    fn load(&self, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
+    fn load(&self, req: DataRequest) -> Result<DataResponse<M>, DataError> {
         self.load_data(M::KEY, req)
     }
 }
@@ -152,7 +152,7 @@ macro_rules! impl_auto_deserializing {
             for<'de> yoke::trait_hack::YokeTraitHack<<M::Yokeable as yoke::Yokeable<'de>>::Output>:
                 serde::de::Deserialize<'de>,
         {
-            fn load(&self, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
+            fn load(&self, req: DataRequest) -> Result<DataResponse<M>, DataError> {
                 self.as_deserializing().load(req)
             }
         }
@@ -169,7 +169,7 @@ macro_rules! impl_auto_deserializing {
             fn load_data(
                 &self,
                 key: DataKey,
-                req: &DataRequest,
+                req: DataRequest,
             ) -> Result<DataResponse<M>, DataError> {
                 self.as_deserializing().load_data(key, req)
             }

--- a/provider/datagen/src/databake.rs
+++ b/provider/datagen/src/databake.rs
@@ -303,7 +303,7 @@ impl DataExporter for BakedDataExporter {
                 impl DataProvider<#marker> for BakedDataProvider {
                     fn load(
                         &self,
-                        req: &DataRequest,
+                        req: DataRequest,
                     ) -> Result<DataResponse<#marker>, DataError> {
                         Ok(DataResponse {
                             metadata: Default::default(),
@@ -334,7 +334,7 @@ impl DataExporter for BakedDataExporter {
                 fn litemap_slice_get<T: ?Sized>(
                     values: &'static [(&'static str, &'static T)],
                     key: DataKey,
-                    req: &DataRequest,
+                    req: DataRequest,
                 ) -> Result<&'static T, DataError> {
                     #[allow(clippy::unwrap_used)]
                     values
@@ -383,7 +383,7 @@ impl DataExporter for BakedDataExporter {
             PathBuf::from("any"),
             quote! {
                 impl AnyProvider for BakedDataProvider {
-                    fn load_any(&self, key: DataKey, req: &DataRequest) -> Result<AnyResponse, DataError> {
+                    fn load_any(&self, key: DataKey, req: DataRequest) -> Result<AnyResponse, DataError> {
                         #(#any_consts)*
                         Ok(AnyResponse {
                             payload: Some(match key.get_hash() {

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -285,16 +285,16 @@ pub fn datagen(
             .map_err(|e| e.with_key(key))?;
         let res = locales.into_par_iter().try_for_each(|locale| {
             let req = DataRequest {
-                locale: locale.clone(),
+                locale: &locale,
                 metadata: Default::default(),
             };
             let payload = provider
-                .load_data(key, &req)
+                .load_data(key, req)
                 .and_then(DataResponse::take_payload)
-                .map_err(|e| e.with_req(key, &req))?;
+                .map_err(|e| e.with_req(key, req))?;
             exporters.par_iter().try_for_each(|e| {
                 e.put_payload(key, &locale, &payload)
-                    .map_err(|e| e.with_req(key, &req))
+                    .map_err(|e| e.with_req(key, req))
             })
         });
 

--- a/provider/datagen/src/transform/cldr/calendar/japanese.rs
+++ b/provider/datagen/src/transform/cldr/calendar/japanese.rs
@@ -33,7 +33,7 @@ impl From<&SourceData> for JapaneseErasProvider {
 }
 
 impl DataProvider<JapaneseErasV1Marker> for JapaneseErasProvider {
-    fn load(&self, req: &DataRequest) -> Result<DataResponse<JapaneseErasV1Marker>, DataError> {
+    fn load(&self, req: DataRequest) -> Result<DataResponse<JapaneseErasV1Marker>, DataError> {
         let japanext = req.locale.get_unicode_ext(&key!("ca")) == Some(value!("japanext"));
         // The era codes depend on the Latin romanizations of the eras, found
         // in the `en` locale. We load this data to construct era codes but

--- a/provider/datagen/src/transform/cldr/datetime/mod.rs
+++ b/provider/datagen/src/transform/cldr/datetime/mod.rs
@@ -53,7 +53,7 @@ macro_rules! impl_data_provider {
             impl DataProvider<$marker> for CommonDateProvider {
                 fn load(
                     &self,
-                    req: &DataRequest,
+                    req: DataRequest,
                 ) -> Result<DataResponse<$marker>, DataError> {
                     if req.locale.is_empty() {
                         return Err(DataErrorKind::NeedsLocale.into_error());
@@ -231,8 +231,8 @@ mod test {
 
         let locale: Locale = "cs-u-ca-gregory".parse().unwrap();
         let cs_dates: DataPayload<DatePatternsV1Marker> = provider
-            .load(&DataRequest {
-                locale: locale.into(),
+            .load(DataRequest {
+                locale: &locale.into(),
                 metadata: Default::default(),
             })
             .expect("Failed to load payload")
@@ -248,8 +248,8 @@ mod test {
 
         let locale: Locale = "haw-u-ca-gregory".parse().unwrap();
         let cs_dates: DataPayload<DatePatternsV1Marker> = provider
-            .load(&DataRequest {
-                locale: locale.into(),
+            .load(DataRequest {
+                locale: &locale.into(),
                 metadata: Default::default(),
             })
             .expect("Failed to load payload")
@@ -269,8 +269,8 @@ mod test {
 
         let locale: Locale = "fil-u-ca-gregory".parse().unwrap();
         let skeletons: DataPayload<DateSkeletonPatternsV1Marker> = provider
-            .load(&DataRequest {
-                locale: locale.into(),
+            .load(DataRequest {
+                locale: &locale.into(),
                 metadata: Default::default(),
             })
             .expect("Failed to load payload")
@@ -313,8 +313,8 @@ mod test {
 
         let locale: Locale = "cs-u-ca-gregory".parse().unwrap();
         let cs_dates: DataPayload<DateSymbolsV1Marker> = provider
-            .load(&DataRequest {
-                locale: locale.into(),
+            .load(DataRequest {
+                locale: &locale.into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -344,8 +344,8 @@ mod test {
 
         let locale: Locale = "cs-u-ca-gregory".parse().unwrap();
         let cs_dates: DataPayload<DateSymbolsV1Marker> = provider
-            .load(&DataRequest {
-                locale: locale.into(),
+            .load(DataRequest {
+                locale: &locale.into(),
                 metadata: Default::default(),
             })
             .unwrap()

--- a/provider/datagen/src/transform/cldr/datetime/week_data.rs
+++ b/provider/datagen/src/transform/cldr/datetime/week_data.rs
@@ -54,7 +54,7 @@ impl IterableDataProvider<WeekDataV1Marker> for WeekDataProvider {
 }
 
 impl DataProvider<WeekDataV1Marker> for WeekDataProvider {
-    fn load(&self, req: &DataRequest) -> Result<DataResponse<WeekDataV1Marker>, DataError> {
+    fn load(&self, req: DataRequest) -> Result<DataResponse<WeekDataV1Marker>, DataError> {
         let territory = req
             .locale
             .region()
@@ -103,10 +103,7 @@ fn basic_cldr_week_data() {
     let provider = WeekDataProvider::from(&SourceData::for_test());
 
     let default_week_data: DataPayload<WeekDataV1Marker> = provider
-        .load(&DataRequest {
-            locale: DataLocale::default(),
-            metadata: Default::default(),
-        })
+        .load(Default::default())
         .unwrap()
         .take_payload()
         .unwrap();
@@ -114,8 +111,8 @@ fn basic_cldr_week_data() {
     assert_eq!(IsoWeekday::Monday, default_week_data.get().0.first_weekday);
 
     let fr_week_data: DataPayload<WeekDataV1Marker> = provider
-        .load(&DataRequest {
-            locale: DataLocale::from(langid!("und-FR")),
+        .load(DataRequest {
+            locale: &DataLocale::from(langid!("und-FR")),
             metadata: Default::default(),
         })
         .unwrap()
@@ -125,8 +122,8 @@ fn basic_cldr_week_data() {
     assert_eq!(IsoWeekday::Monday, fr_week_data.get().0.first_weekday);
 
     let iq_week_data: DataPayload<WeekDataV1Marker> = provider
-        .load(&DataRequest {
-            locale: DataLocale::from(langid!("und-IQ")),
+        .load(DataRequest {
+            locale: &DataLocale::from(langid!("und-IQ")),
             metadata: Default::default(),
         })
         .unwrap()
@@ -140,8 +137,8 @@ fn basic_cldr_week_data() {
     assert_eq!(IsoWeekday::Saturday, iq_week_data.get().0.first_weekday);
 
     let gg_week_data: DataPayload<WeekDataV1Marker> = provider
-        .load(&DataRequest {
-            locale: DataLocale::from(langid!("und-GG")),
+        .load(DataRequest {
+            locale: &DataLocale::from(langid!("und-GG")),
             metadata: Default::default(),
         })
         .unwrap()

--- a/provider/datagen/src/transform/cldr/decimal/mod.rs
+++ b/provider/datagen/src/transform/cldr/decimal/mod.rs
@@ -63,7 +63,7 @@ impl NumbersProvider {
 }
 
 impl DataProvider<DecimalSymbolsV1Marker> for NumbersProvider {
-    fn load(&self, req: &DataRequest) -> Result<DataResponse<DecimalSymbolsV1Marker>, DataError> {
+    fn load(&self, req: DataRequest) -> Result<DataResponse<DecimalSymbolsV1Marker>, DataError> {
         let langid = req.locale.get_langid();
 
         let resource: &cldr_serde::numbers::Resource = self
@@ -149,8 +149,8 @@ fn test_basic() {
     let provider = NumbersProvider::from(&SourceData::for_test());
 
     let ar_decimal: DataPayload<DecimalSymbolsV1Marker> = provider
-        .load(&DataRequest {
-            locale: locale!("ar-EG").into(),
+        .load(DataRequest {
+            locale: &locale!("ar-EG").into(),
             metadata: Default::default(),
         })
         .unwrap()

--- a/provider/datagen/src/transform/cldr/fallback/mod.rs
+++ b/provider/datagen/src/transform/cldr/fallback/mod.rs
@@ -30,7 +30,7 @@ impl From<&SourceData> for FallbackRulesProvider {
 impl DataProvider<LocaleFallbackLikelySubtagsV1Marker> for FallbackRulesProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<LocaleFallbackLikelySubtagsV1Marker>, DataError> {
         // We treat searching for `und` as a request for all data. Other requests
         // are not currently supported.
@@ -55,7 +55,7 @@ impl DataProvider<LocaleFallbackLikelySubtagsV1Marker> for FallbackRulesProvider
 impl DataProvider<LocaleFallbackParentsV1Marker> for FallbackRulesProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<LocaleFallbackParentsV1Marker>, DataError> {
         // We treat searching for `und` as a request for all data. Other requests
         // are not currently supported.
@@ -193,7 +193,7 @@ fn test_basic() {
 
     let provider = FallbackRulesProvider::from(&SourceData::for_test());
     let likely_subtags: DataPayload<LocaleFallbackLikelySubtagsV1Marker> = provider
-        .load(&DataRequest::default())
+        .load(Default::default())
         .unwrap()
         .take_payload()
         .unwrap();
@@ -222,7 +222,7 @@ fn test_basic() {
     );
 
     let parents: DataPayload<LocaleFallbackParentsV1Marker> = provider
-        .load(&DataRequest::default())
+        .load(Default::default())
         .unwrap()
         .take_payload()
         .unwrap();

--- a/provider/datagen/src/transform/cldr/list/mod.rs
+++ b/provider/datagen/src/transform/cldr/list/mod.rs
@@ -28,7 +28,7 @@ impl From<&SourceData> for ListProvider {
 impl<M: KeyedDataMarker<Yokeable = ListFormatterPatternsV1<'static>>> DataProvider<M>
     for ListProvider
 {
-    fn load(&self, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
+    fn load(&self, req: DataRequest) -> Result<DataResponse<M>, DataError> {
         let langid = req.locale.get_langid();
 
         let resource: &cldr_serde::list_patterns::Resource = self

--- a/provider/datagen/src/transform/cldr/locale_canonicalizer/aliases.rs
+++ b/provider/datagen/src/transform/cldr/locale_canonicalizer/aliases.rs
@@ -26,7 +26,7 @@ impl From<&SourceData> for AliasesProvider {
 }
 
 impl DataProvider<AliasesV1Marker> for AliasesProvider {
-    fn load(&self, req: &DataRequest) -> Result<DataResponse<AliasesV1Marker>, DataError> {
+    fn load(&self, req: DataRequest) -> Result<DataResponse<AliasesV1Marker>, DataError> {
         // We treat searching for `und` as a request for all data. Other requests
         // are not currently supported.
         if !req.locale.is_empty() {
@@ -285,7 +285,7 @@ fn test_basic() {
 
     let provider = AliasesProvider::from(&SourceData::for_test());
     let data: DataPayload<AliasesV1Marker> = provider
-        .load(&DataRequest::default())
+        .load(Default::default())
         .unwrap()
         .take_payload()
         .unwrap();

--- a/provider/datagen/src/transform/cldr/locale_canonicalizer/likely_subtags.rs
+++ b/provider/datagen/src/transform/cldr/locale_canonicalizer/likely_subtags.rs
@@ -24,7 +24,7 @@ impl From<&SourceData> for LikelySubtagsProvider {
 }
 
 impl DataProvider<LikelySubtagsV1Marker> for LikelySubtagsProvider {
-    fn load(&self, req: &DataRequest) -> Result<DataResponse<LikelySubtagsV1Marker>, DataError> {
+    fn load(&self, req: DataRequest) -> Result<DataResponse<LikelySubtagsV1Marker>, DataError> {
         // We treat searching for und as a request for all data. Other requests
         // are not currently supported.
         if !req.locale.is_empty() {
@@ -146,7 +146,7 @@ fn test_basic() {
 
     let provider = LikelySubtagsProvider::from(&SourceData::for_test());
     let result: DataPayload<LikelySubtagsV1Marker> = provider
-        .load(&Default::default())
+        .load(Default::default())
         .unwrap()
         .take_payload()
         .unwrap();

--- a/provider/datagen/src/transform/cldr/plurals/mod.rs
+++ b/provider/datagen/src/transform/cldr/plurals/mod.rs
@@ -49,7 +49,7 @@ impl PluralsProvider {
 }
 
 impl<M: KeyedDataMarker<Yokeable = PluralRulesV1<'static>>> DataProvider<M> for PluralsProvider {
-    fn load(&self, req: &DataRequest) -> Result<DataResponse<M>, DataError> {
+    fn load(&self, req: DataRequest) -> Result<DataResponse<M>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
             payload: Some(DataPayload::from_owned(PluralRulesV1::from(
@@ -107,8 +107,8 @@ fn test_basic() {
 
     // Spot-check locale 'cs' since it has some interesting entries
     let cs_rules: DataPayload<CardinalV1Marker> = provider
-        .load(&DataRequest {
-            locale: langid!("cs").into(),
+        .load(DataRequest {
+            locale: &langid!("cs").into(),
             metadata: Default::default(),
         })
         .unwrap()

--- a/provider/datagen/src/transform/cldr/time_zones/mod.rs
+++ b/provider/datagen/src/transform/cldr/time_zones/mod.rs
@@ -30,7 +30,7 @@ macro_rules! impl_data_provider {
     ($($marker:ident),+) => {
         $(
             impl DataProvider<$marker> for TimeZonesProvider {
-                fn load(&self, req: &DataRequest) -> Result<DataResponse<$marker>, DataError> {
+                fn load(&self, req: DataRequest) -> Result<DataResponse<$marker>, DataError> {
                     let langid = req.locale.get_langid();
 
                     let resource: &cldr_serde::time_zones::time_zone_names::Resource = self
@@ -130,8 +130,8 @@ mod tests {
         let provider = TimeZonesProvider::from(&SourceData::for_test());
 
         let time_zone_formats: DataPayload<TimeZoneFormatsV1Marker> = provider
-            .load(&DataRequest {
-                locale: langid!("en").into(),
+            .load(DataRequest {
+                locale: &langid!("en").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -140,8 +140,8 @@ mod tests {
         assert_eq!("GMT", time_zone_formats.get().gmt_zero_format);
 
         let exemplar_cities: DataPayload<ExemplarCitiesV1Marker> = provider
-            .load(&DataRequest {
-                locale: langid!("en").into(),
+            .load(DataRequest {
+                locale: &langid!("en").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -157,8 +157,8 @@ mod tests {
         );
 
         let generic_names_long: DataPayload<MetaZoneGenericNamesLongV1Marker> = provider
-            .load(&DataRequest {
-                locale: langid!("en").into(),
+            .load(DataRequest {
+                locale: &langid!("en").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -182,8 +182,8 @@ mod tests {
         );
 
         let specific_names_long: DataPayload<MetaZoneSpecificNamesLongV1Marker> = provider
-            .load(&DataRequest {
-                locale: langid!("en").into(),
+            .load(DataRequest {
+                locale: &langid!("en").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -210,8 +210,8 @@ mod tests {
         );
 
         let generic_names_short: DataPayload<MetaZoneGenericNamesShortV1Marker> = provider
-            .load(&DataRequest {
-                locale: langid!("en").into(),
+            .load(DataRequest {
+                locale: &langid!("en").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -235,8 +235,8 @@ mod tests {
         );
 
         let specific_names_short: DataPayload<MetaZoneSpecificNamesShortV1Marker> = provider
-            .load(&DataRequest {
-                locale: langid!("en").into(),
+            .load(DataRequest {
+                locale: &langid!("en").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -263,8 +263,8 @@ mod tests {
         );
 
         let metazone_period: DataPayload<MetaZonePeriodV1Marker> = provider
-            .load(&DataRequest {
-                locale: langid!("en").into(),
+            .load(DataRequest {
+                locale: &langid!("en").into(),
                 metadata: Default::default(),
             })
             .unwrap()

--- a/provider/datagen/src/transform/icuexport/collator/mod.rs
+++ b/provider/datagen/src/transform/icuexport/collator/mod.rs
@@ -115,7 +115,7 @@ macro_rules! collation_provider {
     ($(($marker:ident, $serde_struct:ident, $suffix:literal, $conversion:expr)),+, $toml_data:ident) => {
         $(
             impl DataProvider<$marker> for CollationProvider {
-                fn load(&self, req: &DataRequest) -> Result<DataResponse<$marker>, DataError> {
+                fn load(&self, req: DataRequest) -> Result<DataResponse<$marker>, DataError> {
                     let $toml_data: &collator_serde::$serde_struct = self
                         .source
                         .icuexport()?

--- a/provider/datagen/src/transform/icuexport/normalizer/mod.rs
+++ b/provider/datagen/src/transform/icuexport/normalizer/mod.rs
@@ -36,7 +36,7 @@ macro_rules! normalization_provider {
         }
 
         impl DataProvider<$marker> for $provider {
-            fn load(&self, _req: &DataRequest) -> Result<DataResponse<$marker>, DataError> {
+            fn load(&self, _req: DataRequest) -> Result<DataResponse<$marker>, DataError> {
                 let $toml_data: &normalizer_serde::$serde_struct =
                     self.source.icuexport()?.read_and_parse_toml(&format!(
                         "norm/{}/{}.toml",

--- a/provider/datagen/src/transform/icuexport/ucase/mod.rs
+++ b/provider/datagen/src/transform/icuexport/ucase/mod.rs
@@ -29,7 +29,7 @@ impl From<&SourceData> for CaseMappingDataProvider {
 }
 
 impl DataProvider<CaseMappingV1Marker> for CaseMappingDataProvider {
-    fn load(&self, _req: &DataRequest) -> Result<DataResponse<CaseMappingV1Marker>, DataError> {
+    fn load(&self, _req: DataRequest) -> Result<DataResponse<CaseMappingV1Marker>, DataError> {
         let toml = &self
             .source
             .icuexport()?

--- a/provider/datagen/src/transform/icuexport/uprops/bin_uniset.rs
+++ b/provider/datagen/src/transform/icuexport/uprops/bin_uniset.rs
@@ -43,7 +43,7 @@ macro_rules! expand {
             impl DataProvider<$marker> for BinaryPropertyUnicodeSetDataProvider {
                 fn load(
                     &self,
-                    _: &DataRequest,
+                    _: DataRequest,
                 ) -> Result<DataResponse<$marker>, DataError> {
                     let data = get_binary(&self.source, $prop_name)?;
 
@@ -154,7 +154,7 @@ fn test_basic() {
     let provider = BinaryPropertyUnicodeSetDataProvider::from(&SourceData::for_test());
 
     let payload: DataPayload<WhiteSpaceV1Marker> = provider
-        .load(&DataRequest::default())
+        .load(Default::default())
         .and_then(DataResponse::take_payload)
         .expect("Loading was successful");
 

--- a/provider/datagen/src/transform/icuexport/uprops/enum_codepointtrie.rs
+++ b/provider/datagen/src/transform/icuexport/uprops/enum_codepointtrie.rs
@@ -45,7 +45,7 @@ macro_rules! expand {
         $(
             impl DataProvider<$marker> for EnumeratedPropertyCodePointTrieProvider
             {
-                fn load(&self, _: &DataRequest) -> Result<DataResponse<$marker>, DataError> {
+                fn load(&self, _: DataRequest) -> Result<DataResponse<$marker>, DataError> {
                     let source_cpt_data = &get_enumerated(&self.source, $prop_name)?.code_point_trie;
 
                     let code_point_trie = CodePointTrie::try_from(source_cpt_data).map_err(|e| {
@@ -101,7 +101,7 @@ mod tests {
         let provider = EnumeratedPropertyCodePointTrieProvider::from(&SourceData::for_test());
 
         let payload: DataPayload<GeneralCategoryV1Marker> = provider
-            .load(&DataRequest::default())
+            .load(Default::default())
             .and_then(DataResponse::take_payload)
             .expect("Loading was successful");
 
@@ -119,7 +119,7 @@ mod tests {
         let provider = EnumeratedPropertyCodePointTrieProvider::from(&SourceData::for_test());
 
         let payload: DataPayload<ScriptV1Marker> = provider
-            .load(&DataRequest::default())
+            .load(Default::default())
             .and_then(DataResponse::take_payload)
             .expect("Loading was successful");
 

--- a/provider/datagen/src/transform/icuexport/uprops/script.rs
+++ b/provider/datagen/src/transform/icuexport/uprops/script.rs
@@ -35,7 +35,7 @@ impl From<&SourceData> for ScriptWithExtensionsPropertyProvider {
 impl DataProvider<ScriptWithExtensionsPropertyV1Marker> for ScriptWithExtensionsPropertyProvider {
     fn load(
         &self,
-        _: &DataRequest,
+        _: DataRequest,
     ) -> Result<DataResponse<ScriptWithExtensionsPropertyV1Marker>, DataError> {
         let scx_data = self
             .source
@@ -101,7 +101,7 @@ mod tests {
         let provider = ScriptWithExtensionsPropertyProvider::from(&SourceData::for_test());
 
         let payload: DataPayload<ScriptWithExtensionsPropertyV1Marker> = provider
-            .load(&Default::default())
+            .load(Default::default())
             .and_then(DataResponse::take_payload)
             .expect("Loading was successful");
 
@@ -120,10 +120,7 @@ mod tests {
         let provider = ScriptWithExtensionsPropertyProvider::from(&SourceData::for_test());
 
         let payload: DataPayload<ScriptWithExtensionsPropertyV1Marker> = provider
-            .load(&DataRequest {
-                locale: DataLocale::default(),
-                metadata: Default::default(),
-            })
+            .load(Default::default())
             .expect("The data should be valid")
             .take_payload()
             .expect("Loading was successful");
@@ -196,7 +193,7 @@ mod tests {
         let provider = ScriptWithExtensionsPropertyProvider::from(&SourceData::for_test());
 
         let payload: DataPayload<ScriptWithExtensionsPropertyV1Marker> = provider
-            .load(&DataRequest::default())
+            .load(Default::default())
             .expect("The data should be valid")
             .take_payload()
             .expect("Loading was successful");
@@ -275,7 +272,7 @@ mod tests {
         let provider = ScriptWithExtensionsPropertyProvider::from(&SourceData::for_test());
 
         let payload: DataPayload<ScriptWithExtensionsPropertyV1Marker> = provider
-            .load(&DataRequest::default())
+            .load(Default::default())
             .expect("The data should be valid")
             .take_payload()
             .expect("Loading was successful");

--- a/provider/datagen/src/transform/segmenter/lstm.rs
+++ b/provider/datagen/src/transform/segmenter/lstm.rs
@@ -121,8 +121,8 @@ impl SegmenterLstmProvider {
 }
 
 impl DataProvider<LstmDataV1Marker> for SegmenterLstmProvider {
-    fn load(&self, req: &DataRequest) -> Result<DataResponse<LstmDataV1Marker>, DataError> {
-        let lstm_data = self.generate_data(&req.locale)?;
+    fn load(&self, req: DataRequest) -> Result<DataResponse<LstmDataV1Marker>, DataError> {
+        let lstm_data = self.generate_data(req.locale)?;
         Ok(DataResponse {
             metadata: DataResponseMetadata::default(),
             payload: Some(DataPayload::from_owned(lstm_data)),

--- a/provider/datagen/src/transform/segmenter/mod.rs
+++ b/provider/datagen/src/transform/segmenter/mod.rs
@@ -634,7 +634,7 @@ impl SegmenterRuleProvider {
 }
 
 impl DataProvider<LineBreakDataV1Marker> for SegmenterRuleProvider {
-    fn load(&self, _req: &DataRequest) -> Result<DataResponse<LineBreakDataV1Marker>, DataError> {
+    fn load(&self, _req: DataRequest) -> Result<DataResponse<LineBreakDataV1Marker>, DataError> {
         let break_data = self.generate_rule_break_data(LineBreakDataV1Marker::KEY)?;
 
         Ok(DataResponse {
@@ -647,7 +647,7 @@ impl DataProvider<LineBreakDataV1Marker> for SegmenterRuleProvider {
 impl DataProvider<GraphemeClusterBreakDataV1Marker> for SegmenterRuleProvider {
     fn load(
         &self,
-        _req: &DataRequest,
+        _req: DataRequest,
     ) -> Result<DataResponse<GraphemeClusterBreakDataV1Marker>, DataError> {
         let break_data = self.generate_rule_break_data(GraphemeClusterBreakDataV1Marker::KEY)?;
 
@@ -659,7 +659,7 @@ impl DataProvider<GraphemeClusterBreakDataV1Marker> for SegmenterRuleProvider {
 }
 
 impl DataProvider<WordBreakDataV1Marker> for SegmenterRuleProvider {
-    fn load(&self, _req: &DataRequest) -> Result<DataResponse<WordBreakDataV1Marker>, DataError> {
+    fn load(&self, _req: DataRequest) -> Result<DataResponse<WordBreakDataV1Marker>, DataError> {
         let break_data = self.generate_rule_break_data(WordBreakDataV1Marker::KEY)?;
 
         Ok(DataResponse {
@@ -672,7 +672,7 @@ impl DataProvider<WordBreakDataV1Marker> for SegmenterRuleProvider {
 impl DataProvider<SentenceBreakDataV1Marker> for SegmenterRuleProvider {
     fn load(
         &self,
-        _req: &DataRequest,
+        _req: DataRequest,
     ) -> Result<DataResponse<SentenceBreakDataV1Marker>, DataError> {
         let break_data = self.generate_rule_break_data(SentenceBreakDataV1Marker::KEY)?;
 
@@ -757,13 +757,13 @@ impl From<&SourceData> for SegmenterDictionaryProvider {
 impl DataProvider<UCharDictionaryBreakDataV1Marker> for SegmenterDictionaryProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<UCharDictionaryBreakDataV1Marker>, DataError> {
         let toml_data = self
             .source
             .segmenter()?
             .read_and_parse_toml::<SegmenterDictionaryData>(
-                Self::get_toml_filename(&req.locale)
+                Self::get_toml_filename(req.locale)
                     .ok_or_else(|| DataErrorKind::MissingLocale.into_error())?,
             )?;
         let data = UCharDictionaryBreakDataV1 {
@@ -801,7 +801,7 @@ mod tests {
     fn load_grapheme_cluster_data() {
         let provider = SegmenterRuleProvider::from(&SourceData::for_test());
         let payload: DataPayload<GraphemeClusterBreakDataV1Marker> = provider
-            .load(&DataRequest::default())
+            .load(Default::default())
             .expect("Loading should succeed!")
             .take_payload()
             .expect("Data should be present!");

--- a/provider/datagen/tests/verify-zero-copy.rs
+++ b/provider/datagen/tests/verify-zero-copy.rs
@@ -83,8 +83,8 @@ fn main() {
         {
             let payload = provider.load_buffer(
                 key,
-                &DataRequest {
-                    locale: locale.clone(),
+                DataRequest {
+                    locale: &locale,
                     metadata: Default::default(),
                 },
             ).unwrap().take_payload().unwrap();

--- a/provider/fs/benches/provider_fs.rs
+++ b/provider/fs/benches/provider_fs.rs
@@ -16,8 +16,8 @@ fn overview_bench(c: &mut Criterion) {
             let provider = FsDataProvider::try_new("./tests/data/json")
                 .expect("Loading file from testdata directory");
             let _: DataPayload<HelloWorldV1Marker> = black_box(&provider)
-                .load(&DataRequest {
-                    locale: langid!("ru").into(),
+                .load(DataRequest {
+                    locale: &langid!("ru").into(),
                     metadata: Default::default(),
                 })
                 .and_then(DataResponse::take_payload)
@@ -43,8 +43,8 @@ fn json_bench(c: &mut Criterion) {
     c.bench_function("json/generic", |b| {
         b.iter(|| {
             let _: DataPayload<HelloWorldV1Marker> = black_box(&provider)
-                .load(&DataRequest {
-                    locale: langid!("ru").into(),
+                .load(DataRequest {
+                    locale: &langid!("ru").into(),
                     metadata: Default::default(),
                 })
                 .and_then(DataResponse::take_payload)
@@ -56,8 +56,8 @@ fn json_bench(c: &mut Criterion) {
         b.iter(|| {
             let _: DataPayload<HelloWorldV1Marker> = black_box(&provider as &dyn BufferProvider)
                 .as_deserializing()
-                .load(&DataRequest {
-                    locale: langid!("ru").into(),
+                .load(DataRequest {
+                    locale: &langid!("ru").into(),
                     metadata: Default::default(),
                 })
                 .and_then(DataResponse::take_payload)
@@ -74,8 +74,8 @@ fn bincode_bench(c: &mut Criterion) {
     c.bench_function("bincode/generic", |b| {
         b.iter(|| {
             let _: DataPayload<HelloWorldV1Marker> = black_box(&provider)
-                .load(&DataRequest {
-                    locale: langid!("ru").into(),
+                .load(DataRequest {
+                    locale: &langid!("ru").into(),
                     metadata: Default::default(),
                 })
                 .and_then(DataResponse::take_payload)
@@ -87,8 +87,8 @@ fn bincode_bench(c: &mut Criterion) {
         b.iter(|| {
             let _: DataPayload<HelloWorldV1Marker> = black_box(&provider as &dyn BufferProvider)
                 .as_deserializing()
-                .load(&DataRequest {
-                    locale: langid!("ru").into(),
+                .load(DataRequest {
+                    locale: &langid!("ru").into(),
                     metadata: Default::default(),
                 })
                 .expect("The data should be valid")
@@ -106,8 +106,8 @@ fn postcard_bench(c: &mut Criterion) {
     c.bench_function("postcard/generic", |b| {
         b.iter(|| {
             let _: DataPayload<HelloWorldV1Marker> = black_box(&provider)
-                .load(&DataRequest {
-                    locale: langid!("ru").into(),
+                .load(DataRequest {
+                    locale: &langid!("ru").into(),
                     metadata: Default::default(),
                 })
                 .expect("The data should be valid")
@@ -120,8 +120,8 @@ fn postcard_bench(c: &mut Criterion) {
         b.iter(|| {
             let _: DataPayload<HelloWorldV1Marker> = black_box(&provider as &dyn BufferProvider)
                 .as_deserializing()
-                .load(&DataRequest {
-                    locale: langid!("ru").into(),
+                .load(DataRequest {
+                    locale: &langid!("ru").into(),
                     metadata: Default::default(),
                 })
                 .and_then(DataResponse::take_payload)

--- a/provider/fs/src/export/mod.rs
+++ b/provider/fs/src/export/mod.rs
@@ -54,7 +54,7 @@
 //!     metadata: Default::default(),
 //! };
 //! let response: DataPayload<HelloWorldV1Marker> = provider
-//!     .load(&req)
+//!     .load(req)
 //!     .unwrap()
 //!     .take_payload()
 //!     .unwrap();

--- a/provider/fs/src/fs_data_provider.rs
+++ b/provider/fs/src/fs_data_provider.rs
@@ -49,7 +49,7 @@ impl BufferProvider for FsDataProvider {
     fn load_buffer(
         &self,
         key: DataKey,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<BufferMarker>, DataError> {
         let mut path_buf = self.root.join(&*key.write_to_string());
         if !path_buf.exists() {

--- a/provider/fs/tests/test_file_io.rs
+++ b/provider/fs/tests/test_file_io.rs
@@ -20,23 +20,23 @@ fn test_provider() {
         let provider = FsDataProvider::try_new(path).unwrap();
         for locale in HelloWorldProvider.supported_locales().unwrap() {
             let req = DataRequest {
-                locale,
+                locale: &locale,
                 metadata: Default::default(),
             };
 
             let expected = HelloWorldProvider
-                .load(&req)
+                .load(req)
                 .unwrap()
                 .take_payload()
                 .unwrap();
 
             let actual: DataPayload<HelloWorldV1Marker> =
-                provider.load(&req).unwrap().take_payload().unwrap();
+                provider.load(req).unwrap().take_payload().unwrap();
             assert_eq!(actual.get(), expected.get());
 
             let actual: DataPayload<HelloWorldV1Marker> = (&provider as &dyn BufferProvider)
                 .as_deserializing()
-                .load(&req)
+                .load(req)
                 .unwrap()
                 .take_payload()
                 .unwrap();
@@ -50,11 +50,10 @@ fn test_errors() {
     for path in PATHS {
         let provider = FsDataProvider::try_new(path).unwrap();
 
-        let err: Result<DataResponse<HelloWorldV1Marker>, DataError> =
-            provider.load(&DataRequest {
-                locale: langid!("zh-DE").into(),
-                metadata: Default::default(),
-            });
+        let err: Result<DataResponse<HelloWorldV1Marker>, DataError> = provider.load(DataRequest {
+            locale: &langid!("zh-DE").into(),
+            metadata: Default::default(),
+        });
 
         assert!(
             matches!(
@@ -76,8 +75,7 @@ fn test_errors() {
             const KEY: DataKey = data_key!("nope@1");
         }
 
-        let err: Result<DataResponse<WrongV1Marker>, DataError> =
-            provider.load(&Default::default());
+        let err: Result<DataResponse<WrongV1Marker>, DataError> = provider.load(Default::default());
 
         assert!(
             matches!(

--- a/provider/testdata/README.md
+++ b/provider/testdata/README.md
@@ -39,8 +39,8 @@ use std::borrow::Cow;
 let data_provider = icu_testdata::get_provider();
 
 let data: DataPayload<icu_plurals::provider::CardinalV1Marker> = data_provider
-    .load(&DataRequest {
-        locale: locale!("ru").into(),
+    .load(DataRequest {
+        locale: &locale!("ru").into(),
         metadata: Default::default(),
     })
     .unwrap()

--- a/provider/testdata/data/baked/any.rs
+++ b/provider/testdata/data/baked/any.rs
@@ -1,6 +1,6 @@
 // @generated
 impl AnyProvider for BakedDataProvider {
-    fn load_any(&self, key: DataKey, req: &DataRequest) -> Result<AnyResponse, DataError> {
+    fn load_any(&self, key: DataKey, req: DataRequest) -> Result<AnyResponse, DataError> {
         const JAPANESEERASV1MARKER: ::icu_provider::DataKeyHash = ::icu_calendar::provider::JapaneseErasV1Marker::KEY.get_hash();
         const CASEMAPPINGV1MARKER: ::icu_provider::DataKeyHash = ::icu_casemapping::provider::CaseMappingV1Marker::KEY.get_hash();
         const COLLATIONDATAV1MARKER: ::icu_provider::DataKeyHash = ::icu_collator::provider::CollationDataV1Marker::KEY.get_hash();

--- a/provider/testdata/data/baked/mod.rs
+++ b/provider/testdata/data/baked/mod.rs
@@ -20,7 +20,7 @@ use ::icu_provider::prelude::*;
 impl DataProvider<::icu_calendar::provider::JapaneseErasV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_calendar::provider::JapaneseErasV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -37,7 +37,7 @@ impl DataProvider<::icu_calendar::provider::JapaneseErasV1Marker> for BakedDataP
 impl DataProvider<::icu_casemapping::provider::CaseMappingV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_casemapping::provider::CaseMappingV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -54,7 +54,7 @@ impl DataProvider<::icu_casemapping::provider::CaseMappingV1Marker> for BakedDat
 impl DataProvider<::icu_collator::provider::CollationDataV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_collator::provider::CollationDataV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -71,7 +71,7 @@ impl DataProvider<::icu_collator::provider::CollationDataV1Marker> for BakedData
 impl DataProvider<::icu_collator::provider::CollationDiacriticsV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_collator::provider::CollationDiacriticsV1Marker>, DataError>
     {
         Ok(DataResponse {
@@ -89,7 +89,7 @@ impl DataProvider<::icu_collator::provider::CollationDiacriticsV1Marker> for Bak
 impl DataProvider<::icu_collator::provider::CollationJamoV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_collator::provider::CollationJamoV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -106,7 +106,7 @@ impl DataProvider<::icu_collator::provider::CollationJamoV1Marker> for BakedData
 impl DataProvider<::icu_collator::provider::CollationMetadataV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_collator::provider::CollationMetadataV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -123,7 +123,7 @@ impl DataProvider<::icu_collator::provider::CollationMetadataV1Marker> for Baked
 impl DataProvider<::icu_collator::provider::CollationReorderingV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_collator::provider::CollationReorderingV1Marker>, DataError>
     {
         Ok(DataResponse {
@@ -143,7 +143,7 @@ impl DataProvider<::icu_collator::provider::CollationSpecialPrimariesV1Marker>
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_collator::provider::CollationSpecialPrimariesV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (collator :: prim_v1 :: DATA , < :: icu_collator :: provider :: CollationSpecialPrimariesV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -152,7 +152,7 @@ impl DataProvider<::icu_collator::provider::CollationSpecialPrimariesV1Marker>
 impl DataProvider<::icu_datetime::provider::calendar::DatePatternsV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_datetime::provider::calendar::DatePatternsV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (datetime :: datelengths_v1_u_ca :: DATA , < :: icu_datetime :: provider :: calendar :: DatePatternsV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -163,7 +163,7 @@ impl DataProvider<::icu_datetime::provider::calendar::DateSkeletonPatternsV1Mark
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_datetime::provider::calendar::DateSkeletonPatternsV1Marker>,
         DataError,
@@ -174,7 +174,7 @@ impl DataProvider<::icu_datetime::provider::calendar::DateSkeletonPatternsV1Mark
 impl DataProvider<::icu_datetime::provider::calendar::DateSymbolsV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_datetime::provider::calendar::DateSymbolsV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (datetime :: datesymbols_v1_u_ca :: DATA , < :: icu_datetime :: provider :: calendar :: DateSymbolsV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -183,7 +183,7 @@ impl DataProvider<::icu_datetime::provider::calendar::DateSymbolsV1Marker> for B
 impl DataProvider<::icu_datetime::provider::calendar::TimePatternsV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_datetime::provider::calendar::TimePatternsV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (datetime :: timelengths_v1_u_ca :: DATA , < :: icu_datetime :: provider :: calendar :: TimePatternsV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -192,7 +192,7 @@ impl DataProvider<::icu_datetime::provider::calendar::TimePatternsV1Marker> for 
 impl DataProvider<::icu_datetime::provider::calendar::TimeSymbolsV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_datetime::provider::calendar::TimeSymbolsV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (datetime :: timesymbols_v1_u_ca :: DATA , < :: icu_datetime :: provider :: calendar :: TimeSymbolsV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -203,7 +203,7 @@ impl DataProvider<::icu_datetime::provider::time_zones::ExemplarCitiesV1Marker>
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_datetime::provider::time_zones::ExemplarCitiesV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (time_zone :: exemplar_cities_v1 :: DATA , < :: icu_datetime :: provider :: time_zones :: ExemplarCitiesV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -214,7 +214,7 @@ impl DataProvider<::icu_datetime::provider::time_zones::MetaZoneGenericNamesLong
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_datetime::provider::time_zones::MetaZoneGenericNamesLongV1Marker>,
         DataError,
@@ -227,7 +227,7 @@ impl DataProvider<::icu_datetime::provider::time_zones::MetaZoneGenericNamesShor
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_datetime::provider::time_zones::MetaZoneGenericNamesShortV1Marker>,
         DataError,
@@ -240,7 +240,7 @@ impl DataProvider<::icu_datetime::provider::time_zones::MetaZonePeriodV1Marker>
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_datetime::provider::time_zones::MetaZonePeriodV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (time_zone :: metazone_period_v1 :: DATA , < :: icu_datetime :: provider :: time_zones :: MetaZonePeriodV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -251,7 +251,7 @@ impl DataProvider<::icu_datetime::provider::time_zones::MetaZoneSpecificNamesLon
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_datetime::provider::time_zones::MetaZoneSpecificNamesLongV1Marker>,
         DataError,
@@ -264,7 +264,7 @@ impl DataProvider<::icu_datetime::provider::time_zones::MetaZoneSpecificNamesSho
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_datetime::provider::time_zones::MetaZoneSpecificNamesShortV1Marker>,
         DataError,
@@ -277,7 +277,7 @@ impl DataProvider<::icu_datetime::provider::time_zones::TimeZoneFormatsV1Marker>
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_datetime::provider::time_zones::TimeZoneFormatsV1Marker>,
         DataError,
@@ -288,7 +288,7 @@ impl DataProvider<::icu_datetime::provider::time_zones::TimeZoneFormatsV1Marker>
 impl DataProvider<::icu_datetime::provider::week_data::WeekDataV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_datetime::provider::week_data::WeekDataV1Marker>, DataError>
     {
         Ok(DataResponse {
@@ -306,7 +306,7 @@ impl DataProvider<::icu_datetime::provider::week_data::WeekDataV1Marker> for Bak
 impl DataProvider<::icu_decimal::provider::DecimalSymbolsV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_decimal::provider::DecimalSymbolsV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -323,7 +323,7 @@ impl DataProvider<::icu_decimal::provider::DecimalSymbolsV1Marker> for BakedData
 impl DataProvider<::icu_list::provider::AndListV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_list::provider::AndListV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -340,7 +340,7 @@ impl DataProvider<::icu_list::provider::AndListV1Marker> for BakedDataProvider {
 impl DataProvider<::icu_list::provider::OrListV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_list::provider::OrListV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -357,7 +357,7 @@ impl DataProvider<::icu_list::provider::OrListV1Marker> for BakedDataProvider {
 impl DataProvider<::icu_list::provider::UnitListV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_list::provider::UnitListV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -374,7 +374,7 @@ impl DataProvider<::icu_list::provider::UnitListV1Marker> for BakedDataProvider 
 impl DataProvider<::icu_locale_canonicalizer::provider::AliasesV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_locale_canonicalizer::provider::AliasesV1Marker>, DataError>
     {
         Ok(DataResponse {
@@ -394,7 +394,7 @@ impl DataProvider<::icu_locale_canonicalizer::provider::LikelySubtagsV1Marker>
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_locale_canonicalizer::provider::LikelySubtagsV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (locale_canonicalizer :: likelysubtags_v1 :: DATA , < :: icu_locale_canonicalizer :: provider :: LikelySubtagsV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -405,7 +405,7 @@ impl DataProvider<::icu_normalizer::provider::CanonicalCompositionPassthroughV1M
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_normalizer::provider::CanonicalCompositionPassthroughV1Marker>,
         DataError,
@@ -416,7 +416,7 @@ impl DataProvider<::icu_normalizer::provider::CanonicalCompositionPassthroughV1M
 impl DataProvider<::icu_normalizer::provider::CanonicalCompositionsV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_normalizer::provider::CanonicalCompositionsV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (normalizer :: comp_v1 :: DATA , < :: icu_normalizer :: provider :: CanonicalCompositionsV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -427,7 +427,7 @@ impl DataProvider<::icu_normalizer::provider::CanonicalDecompositionDataV1Marker
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_normalizer::provider::CanonicalDecompositionDataV1Marker>,
         DataError,
@@ -440,7 +440,7 @@ impl DataProvider<::icu_normalizer::provider::CanonicalDecompositionTablesV1Mark
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_normalizer::provider::CanonicalDecompositionTablesV1Marker>,
         DataError,
@@ -453,7 +453,7 @@ impl DataProvider<::icu_normalizer::provider::CompatibilityCompositionPassthroug
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_normalizer::provider::CompatibilityCompositionPassthroughV1Marker>,
         DataError,
@@ -466,7 +466,7 @@ impl DataProvider<::icu_normalizer::provider::CompatibilityDecompositionSuppleme
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_normalizer::provider::CompatibilityDecompositionSupplementV1Marker>,
         DataError,
@@ -479,7 +479,7 @@ impl DataProvider<::icu_normalizer::provider::CompatibilityDecompositionTablesV1
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_normalizer::provider::CompatibilityDecompositionTablesV1Marker>,
         DataError,
@@ -492,7 +492,7 @@ impl DataProvider<::icu_normalizer::provider::NonRecursiveDecompositionSupplemen
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_normalizer::provider::NonRecursiveDecompositionSupplementV1Marker>,
         DataError,
@@ -505,7 +505,7 @@ impl DataProvider<::icu_normalizer::provider::Uts46CompositionPassthroughV1Marke
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_normalizer::provider::Uts46CompositionPassthroughV1Marker>,
         DataError,
@@ -518,7 +518,7 @@ impl DataProvider<::icu_normalizer::provider::Uts46DecompositionSupplementV1Mark
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_normalizer::provider::Uts46DecompositionSupplementV1Marker>,
         DataError,
@@ -529,7 +529,7 @@ impl DataProvider<::icu_normalizer::provider::Uts46DecompositionSupplementV1Mark
 impl DataProvider<::icu_plurals::provider::CardinalV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_plurals::provider::CardinalV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -546,7 +546,7 @@ impl DataProvider<::icu_plurals::provider::CardinalV1Marker> for BakedDataProvid
 impl DataProvider<::icu_plurals::provider::OrdinalV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_plurals::provider::OrdinalV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -563,7 +563,7 @@ impl DataProvider<::icu_plurals::provider::OrdinalV1Marker> for BakedDataProvide
 impl DataProvider<::icu_properties::provider::AlphabeticV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::AlphabeticV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -580,7 +580,7 @@ impl DataProvider<::icu_properties::provider::AlphabeticV1Marker> for BakedDataP
 impl DataProvider<::icu_properties::provider::AsciiHexDigitV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::AsciiHexDigitV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -597,7 +597,7 @@ impl DataProvider<::icu_properties::provider::AsciiHexDigitV1Marker> for BakedDa
 impl DataProvider<::icu_properties::provider::BidiClassV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::BidiClassV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -614,7 +614,7 @@ impl DataProvider<::icu_properties::provider::BidiClassV1Marker> for BakedDataPr
 impl DataProvider<::icu_properties::provider::BidiControlV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::BidiControlV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -631,7 +631,7 @@ impl DataProvider<::icu_properties::provider::BidiControlV1Marker> for BakedData
 impl DataProvider<::icu_properties::provider::BidiMirroredV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::BidiMirroredV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -650,7 +650,7 @@ impl DataProvider<::icu_properties::provider::CanonicalCombiningClassV1Marker>
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::CanonicalCombiningClassV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (props :: ccc_v1 :: DATA , < :: icu_properties :: provider :: CanonicalCombiningClassV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -659,7 +659,7 @@ impl DataProvider<::icu_properties::provider::CanonicalCombiningClassV1Marker>
 impl DataProvider<::icu_properties::provider::CaseIgnorableV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::CaseIgnorableV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -676,7 +676,7 @@ impl DataProvider<::icu_properties::provider::CaseIgnorableV1Marker> for BakedDa
 impl DataProvider<::icu_properties::provider::CasedV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::CasedV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -693,7 +693,7 @@ impl DataProvider<::icu_properties::provider::CasedV1Marker> for BakedDataProvid
 impl DataProvider<::icu_properties::provider::ChangesWhenCasefoldedV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::ChangesWhenCasefoldedV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (props :: cwcf_v1 :: DATA , < :: icu_properties :: provider :: ChangesWhenCasefoldedV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -702,7 +702,7 @@ impl DataProvider<::icu_properties::provider::ChangesWhenCasefoldedV1Marker> for
 impl DataProvider<::icu_properties::provider::ChangesWhenLowercasedV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::ChangesWhenLowercasedV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (props :: cwl_v1 :: DATA , < :: icu_properties :: provider :: ChangesWhenLowercasedV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -713,7 +713,7 @@ impl DataProvider<::icu_properties::provider::ChangesWhenNfkcCasefoldedV1Marker>
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_properties::provider::ChangesWhenNfkcCasefoldedV1Marker>,
         DataError,
@@ -724,7 +724,7 @@ impl DataProvider<::icu_properties::provider::ChangesWhenNfkcCasefoldedV1Marker>
 impl DataProvider<::icu_properties::provider::ChangesWhenTitlecasedV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::ChangesWhenTitlecasedV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (props :: cwt_v1 :: DATA , < :: icu_properties :: provider :: ChangesWhenTitlecasedV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -733,7 +733,7 @@ impl DataProvider<::icu_properties::provider::ChangesWhenTitlecasedV1Marker> for
 impl DataProvider<::icu_properties::provider::ChangesWhenUppercasedV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::ChangesWhenUppercasedV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (props :: cwu_v1 :: DATA , < :: icu_properties :: provider :: ChangesWhenUppercasedV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -742,7 +742,7 @@ impl DataProvider<::icu_properties::provider::ChangesWhenUppercasedV1Marker> for
 impl DataProvider<::icu_properties::provider::DashV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::DashV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -761,7 +761,7 @@ impl DataProvider<::icu_properties::provider::DefaultIgnorableCodePointV1Marker>
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_properties::provider::DefaultIgnorableCodePointV1Marker>,
         DataError,
@@ -772,7 +772,7 @@ impl DataProvider<::icu_properties::provider::DefaultIgnorableCodePointV1Marker>
 impl DataProvider<::icu_properties::provider::DeprecatedV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::DeprecatedV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -789,7 +789,7 @@ impl DataProvider<::icu_properties::provider::DeprecatedV1Marker> for BakedDataP
 impl DataProvider<::icu_properties::provider::DiacriticV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::DiacriticV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -806,7 +806,7 @@ impl DataProvider<::icu_properties::provider::DiacriticV1Marker> for BakedDataPr
 impl DataProvider<::icu_properties::provider::EastAsianWidthV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::EastAsianWidthV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -823,7 +823,7 @@ impl DataProvider<::icu_properties::provider::EastAsianWidthV1Marker> for BakedD
 impl DataProvider<::icu_properties::provider::EmojiComponentV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::EmojiComponentV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -840,7 +840,7 @@ impl DataProvider<::icu_properties::provider::EmojiComponentV1Marker> for BakedD
 impl DataProvider<::icu_properties::provider::EmojiModifierBaseV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::EmojiModifierBaseV1Marker>, DataError>
     {
         Ok(DataResponse {
@@ -858,7 +858,7 @@ impl DataProvider<::icu_properties::provider::EmojiModifierBaseV1Marker> for Bak
 impl DataProvider<::icu_properties::provider::EmojiModifierV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::EmojiModifierV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -875,7 +875,7 @@ impl DataProvider<::icu_properties::provider::EmojiModifierV1Marker> for BakedDa
 impl DataProvider<::icu_properties::provider::EmojiPresentationV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::EmojiPresentationV1Marker>, DataError>
     {
         Ok(DataResponse {
@@ -893,7 +893,7 @@ impl DataProvider<::icu_properties::provider::EmojiPresentationV1Marker> for Bak
 impl DataProvider<::icu_properties::provider::EmojiV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::EmojiV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -910,7 +910,7 @@ impl DataProvider<::icu_properties::provider::EmojiV1Marker> for BakedDataProvid
 impl DataProvider<::icu_properties::provider::ExtendedPictographicV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::ExtendedPictographicV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (props :: extpict_v1 :: DATA , < :: icu_properties :: provider :: ExtendedPictographicV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -919,7 +919,7 @@ impl DataProvider<::icu_properties::provider::ExtendedPictographicV1Marker> for 
 impl DataProvider<::icu_properties::provider::ExtenderV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::ExtenderV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -936,7 +936,7 @@ impl DataProvider<::icu_properties::provider::ExtenderV1Marker> for BakedDataPro
 impl DataProvider<::icu_properties::provider::GeneralCategoryV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::GeneralCategoryV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -953,7 +953,7 @@ impl DataProvider<::icu_properties::provider::GeneralCategoryV1Marker> for Baked
 impl DataProvider<::icu_properties::provider::GraphemeBaseV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::GraphemeBaseV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -970,7 +970,7 @@ impl DataProvider<::icu_properties::provider::GraphemeBaseV1Marker> for BakedDat
 impl DataProvider<::icu_properties::provider::GraphemeClusterBreakV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::GraphemeClusterBreakV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (props :: gcb_v1 :: DATA , < :: icu_properties :: provider :: GraphemeClusterBreakV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -979,7 +979,7 @@ impl DataProvider<::icu_properties::provider::GraphemeClusterBreakV1Marker> for 
 impl DataProvider<::icu_properties::provider::GraphemeExtendV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::GraphemeExtendV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -996,7 +996,7 @@ impl DataProvider<::icu_properties::provider::GraphemeExtendV1Marker> for BakedD
 impl DataProvider<::icu_properties::provider::HexDigitV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::HexDigitV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1013,7 +1013,7 @@ impl DataProvider<::icu_properties::provider::HexDigitV1Marker> for BakedDataPro
 impl DataProvider<::icu_properties::provider::IdContinueV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::IdContinueV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1030,7 +1030,7 @@ impl DataProvider<::icu_properties::provider::IdContinueV1Marker> for BakedDataP
 impl DataProvider<::icu_properties::provider::IdStartV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::IdStartV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1047,7 +1047,7 @@ impl DataProvider<::icu_properties::provider::IdStartV1Marker> for BakedDataProv
 impl DataProvider<::icu_properties::provider::IdeographicV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::IdeographicV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1064,7 +1064,7 @@ impl DataProvider<::icu_properties::provider::IdeographicV1Marker> for BakedData
 impl DataProvider<::icu_properties::provider::IdsBinaryOperatorV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::IdsBinaryOperatorV1Marker>, DataError>
     {
         Ok(DataResponse {
@@ -1082,7 +1082,7 @@ impl DataProvider<::icu_properties::provider::IdsBinaryOperatorV1Marker> for Bak
 impl DataProvider<::icu_properties::provider::IdsTrinaryOperatorV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::IdsTrinaryOperatorV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (props :: idst_v1 :: DATA , < :: icu_properties :: provider :: IdsTrinaryOperatorV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -1091,7 +1091,7 @@ impl DataProvider<::icu_properties::provider::IdsTrinaryOperatorV1Marker> for Ba
 impl DataProvider<::icu_properties::provider::JoinControlV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::JoinControlV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1108,7 +1108,7 @@ impl DataProvider<::icu_properties::provider::JoinControlV1Marker> for BakedData
 impl DataProvider<::icu_properties::provider::LineBreakV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::LineBreakV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1125,7 +1125,7 @@ impl DataProvider<::icu_properties::provider::LineBreakV1Marker> for BakedDataPr
 impl DataProvider<::icu_properties::provider::LogicalOrderExceptionV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::LogicalOrderExceptionV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (props :: loe_v1 :: DATA , < :: icu_properties :: provider :: LogicalOrderExceptionV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -1134,7 +1134,7 @@ impl DataProvider<::icu_properties::provider::LogicalOrderExceptionV1Marker> for
 impl DataProvider<::icu_properties::provider::LowercaseV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::LowercaseV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1151,7 +1151,7 @@ impl DataProvider<::icu_properties::provider::LowercaseV1Marker> for BakedDataPr
 impl DataProvider<::icu_properties::provider::MathV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::MathV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1168,7 +1168,7 @@ impl DataProvider<::icu_properties::provider::MathV1Marker> for BakedDataProvide
 impl DataProvider<::icu_properties::provider::NoncharacterCodePointV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::NoncharacterCodePointV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (props :: nchar_v1 :: DATA , < :: icu_properties :: provider :: NoncharacterCodePointV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -1177,7 +1177,7 @@ impl DataProvider<::icu_properties::provider::NoncharacterCodePointV1Marker> for
 impl DataProvider<::icu_properties::provider::PatternSyntaxV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::PatternSyntaxV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1194,7 +1194,7 @@ impl DataProvider<::icu_properties::provider::PatternSyntaxV1Marker> for BakedDa
 impl DataProvider<::icu_properties::provider::PatternWhiteSpaceV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::PatternWhiteSpaceV1Marker>, DataError>
     {
         Ok(DataResponse {
@@ -1212,7 +1212,7 @@ impl DataProvider<::icu_properties::provider::PatternWhiteSpaceV1Marker> for Bak
 impl DataProvider<::icu_properties::provider::QuotationMarkV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::QuotationMarkV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1229,7 +1229,7 @@ impl DataProvider<::icu_properties::provider::QuotationMarkV1Marker> for BakedDa
 impl DataProvider<::icu_properties::provider::RadicalV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::RadicalV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1246,7 +1246,7 @@ impl DataProvider<::icu_properties::provider::RadicalV1Marker> for BakedDataProv
 impl DataProvider<::icu_properties::provider::RegionalIndicatorV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::RegionalIndicatorV1Marker>, DataError>
     {
         Ok(DataResponse {
@@ -1264,7 +1264,7 @@ impl DataProvider<::icu_properties::provider::RegionalIndicatorV1Marker> for Bak
 impl DataProvider<::icu_properties::provider::ScriptV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::ScriptV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1283,7 +1283,7 @@ impl DataProvider<::icu_properties::provider::ScriptWithExtensionsPropertyV1Mark
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_properties::provider::ScriptWithExtensionsPropertyV1Marker>,
         DataError,
@@ -1294,7 +1294,7 @@ impl DataProvider<::icu_properties::provider::ScriptWithExtensionsPropertyV1Mark
 impl DataProvider<::icu_properties::provider::SentenceBreakV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::SentenceBreakV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1311,7 +1311,7 @@ impl DataProvider<::icu_properties::provider::SentenceBreakV1Marker> for BakedDa
 impl DataProvider<::icu_properties::provider::SentenceTerminalV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::SentenceTerminalV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1328,7 +1328,7 @@ impl DataProvider<::icu_properties::provider::SentenceTerminalV1Marker> for Bake
 impl DataProvider<::icu_properties::provider::SoftDottedV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::SoftDottedV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1345,7 +1345,7 @@ impl DataProvider<::icu_properties::provider::SoftDottedV1Marker> for BakedDataP
 impl DataProvider<::icu_properties::provider::TerminalPunctuationV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::TerminalPunctuationV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (props :: term_v1 :: DATA , < :: icu_properties :: provider :: TerminalPunctuationV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -1354,7 +1354,7 @@ impl DataProvider<::icu_properties::provider::TerminalPunctuationV1Marker> for B
 impl DataProvider<::icu_properties::provider::UnifiedIdeographV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::UnifiedIdeographV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1371,7 +1371,7 @@ impl DataProvider<::icu_properties::provider::UnifiedIdeographV1Marker> for Bake
 impl DataProvider<::icu_properties::provider::UppercaseV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::UppercaseV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1388,7 +1388,7 @@ impl DataProvider<::icu_properties::provider::UppercaseV1Marker> for BakedDataPr
 impl DataProvider<::icu_properties::provider::VariationSelectorV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::VariationSelectorV1Marker>, DataError>
     {
         Ok(DataResponse {
@@ -1406,7 +1406,7 @@ impl DataProvider<::icu_properties::provider::VariationSelectorV1Marker> for Bak
 impl DataProvider<::icu_properties::provider::WhiteSpaceV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::WhiteSpaceV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1423,7 +1423,7 @@ impl DataProvider<::icu_properties::provider::WhiteSpaceV1Marker> for BakedDataP
 impl DataProvider<::icu_properties::provider::WordBreakV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::WordBreakV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1440,7 +1440,7 @@ impl DataProvider<::icu_properties::provider::WordBreakV1Marker> for BakedDataPr
 impl DataProvider<::icu_properties::provider::XidContinueV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::XidContinueV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1457,7 +1457,7 @@ impl DataProvider<::icu_properties::provider::XidContinueV1Marker> for BakedData
 impl DataProvider<::icu_properties::provider::XidStartV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_properties::provider::XidStartV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1474,7 +1474,7 @@ impl DataProvider<::icu_properties::provider::XidStartV1Marker> for BakedDataPro
 impl DataProvider<::icu_provider::hello_world::HelloWorldV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_provider::hello_world::HelloWorldV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1493,7 +1493,7 @@ impl DataProvider<::icu_provider_adapters::fallback::provider::LocaleFallbackLik
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<
             ::icu_provider_adapters::fallback::provider::LocaleFallbackLikelySubtagsV1Marker,
@@ -1508,7 +1508,7 @@ impl DataProvider<::icu_provider_adapters::fallback::provider::LocaleFallbackPar
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<
         DataResponse<::icu_provider_adapters::fallback::provider::LocaleFallbackParentsV1Marker>,
         DataError,
@@ -1519,7 +1519,7 @@ impl DataProvider<::icu_provider_adapters::fallback::provider::LocaleFallbackPar
 impl DataProvider<::icu_segmenter::LstmDataV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_segmenter::LstmDataV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1538,7 +1538,7 @@ impl DataProvider<::icu_segmenter::provider::GraphemeClusterBreakDataV1Marker>
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_segmenter::provider::GraphemeClusterBreakDataV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (segmenter :: grapheme_v1 :: DATA , < :: icu_segmenter :: provider :: GraphemeClusterBreakDataV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -1547,7 +1547,7 @@ impl DataProvider<::icu_segmenter::provider::GraphemeClusterBreakDataV1Marker>
 impl DataProvider<::icu_segmenter::provider::LineBreakDataV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_segmenter::provider::LineBreakDataV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1564,7 +1564,7 @@ impl DataProvider<::icu_segmenter::provider::LineBreakDataV1Marker> for BakedDat
 impl DataProvider<::icu_segmenter::provider::SentenceBreakDataV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_segmenter::provider::SentenceBreakDataV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1583,7 +1583,7 @@ impl DataProvider<::icu_segmenter::provider::UCharDictionaryBreakDataV1Marker>
 {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_segmenter::provider::UCharDictionaryBreakDataV1Marker>, DataError>
     {
         Ok (DataResponse { metadata : Default :: default () , payload : Some (DataPayload :: from_owned (zerofrom :: ZeroFrom :: zero_from (litemap_slice_get (segmenter :: dictionary_v1 :: DATA , < :: icu_segmenter :: provider :: UCharDictionaryBreakDataV1Marker as KeyedDataMarker > :: KEY , req) ? ,))) , })
@@ -1592,7 +1592,7 @@ impl DataProvider<::icu_segmenter::provider::UCharDictionaryBreakDataV1Marker>
 impl DataProvider<::icu_segmenter::provider::WordBreakDataV1Marker> for BakedDataProvider {
     fn load(
         &self,
-        req: &DataRequest,
+        req: DataRequest,
     ) -> Result<DataResponse<::icu_segmenter::provider::WordBreakDataV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
@@ -1609,7 +1609,7 @@ impl DataProvider<::icu_segmenter::provider::WordBreakDataV1Marker> for BakedDat
 fn litemap_slice_get<T: ?Sized>(
     values: &'static [(&'static str, &'static T)],
     key: DataKey,
-    req: &DataRequest,
+    req: DataRequest,
 ) -> Result<&'static T, DataError> {
     #[allow(clippy::unwrap_used)]
     values

--- a/provider/testdata/src/lib.rs
+++ b/provider/testdata/src/lib.rs
@@ -41,8 +41,8 @@
 //! let data_provider = icu_testdata::get_provider();
 //!
 //! let data: DataPayload<icu_plurals::provider::CardinalV1Marker> = data_provider
-//!     .load(&DataRequest {
-//!         locale: locale!("ru").into(),
+//!     .load(DataRequest {
+//!         locale: &locale!("ru").into(),
 //!         metadata: Default::default(),
 //!     })
 //!     .unwrap()


### PR DESCRIPTION
Before:
```rust
provider.load(&DataRequest {
  locale: DataLocale::from(locale),
  metadata: Default::default(),
};
```

Now:

```rust
provider.load(DataRequest {
  locale: &DataLocale::from(locale),
  metadata: Default::default(),
};
```

This allows reusing `DataLocales` for multiple requests.