### PR TITLE
Passing `Locale`s by reference

### DIFF
--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -95,8 +95,8 @@ impl Japanese {
     ) -> Result<Self, DataError> {
         let japanext = era_style == JapaneseEraStyle::All;
 
-        let mut locale = DataLocale::default();
-        locale.set_unicode_ext(
+        let mut locale = icu_locid::Locale::default();
+        locale.extensions.unicode.keywords.set(
             key!("ca"),
             if japanext {
                 value!("japanext")
@@ -107,7 +107,7 @@ impl Japanese {
 
         let eras = data_provider
             .load(DataRequest {
-                locale: &locale,
+                locale: (&locale).into(),
                 metadata: Default::default(),
             })?
             .take_payload()?;

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -123,9 +123,8 @@ impl Collator {
             }
             filtered_locale
         };
-        let locale = locale.into();
         let req = DataRequest {
-            locale: &locale,
+            locale: (&locale).into(),
             metadata: Default::default(),
         };
 

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -533,9 +533,9 @@ mod tests {
         use icu_provider::prelude::*;
 
         let provider = icu_testdata::get_provider();
-        let locale = "en-u-ca-gregory".parse::<Locale>().unwrap().into();
+        let locale = "en-u-ca-gregory".parse::<Locale>().unwrap();
         let req = DataRequest {
-            locale: &locale,
+            locale: (&locale).into(),
             metadata: Default::default(),
         };
         let date_data: DataPayload<DateSymbolsV1Marker> =
@@ -545,7 +545,7 @@ mod tests {
         let pattern = "MMM".parse().unwrap();
         let datetime = DateTime::new_gregorian_datetime(2020, 8, 1, 12, 34, 28).unwrap();
         let fixed_decimal_format = FixedDecimalFormatter::try_new(
-            locale.get_langid().language,
+            req.locale.get_langid().language,
             &provider,
             Default::default(),
         )

--- a/components/datetime/src/provider/date_time.rs
+++ b/components/datetime/src/provider/date_time.rs
@@ -63,7 +63,7 @@ where
 {
     let data = data_provider
         .load(DataRequest {
-            locale: &DataLocale::from(locale),
+            locale: locale.into(),
             metadata: Default::default(),
         })?
         .take_payload()?;
@@ -108,7 +108,7 @@ where
 {
     let data = data_provider
         .load(DataRequest {
-            locale: &DataLocale::from(locale),
+            locale: locale.into(),
             metadata: Default::default(),
         })?
         .take_payload()?;
@@ -277,7 +277,7 @@ where
         let data = self
             .data_provider
             .load(DataRequest {
-                locale: &DataLocale::from(self.locale),
+                locale: self.locale.into(),
                 metadata: Default::default(),
             })?
             .take_payload()?;

--- a/components/datetime/src/raw/datetime.rs
+++ b/components/datetime/src/raw/datetime.rs
@@ -69,7 +69,7 @@ impl TimeFormatter {
             Some(
                 data_provider
                     .load(DataRequest {
-                        locale: &DataLocale::from(&locale),
+                        locale: (&locale).into(),
                         metadata: Default::default(),
                     })?
                     .take_payload()?,
@@ -207,9 +207,8 @@ impl DateFormatter {
         let required = datetime::analyze_patterns(&patterns.get().0, false)
             .map_err(|field| DateTimeFormatterError::UnsupportedField(field.symbol))?;
 
-        let data_locale = DataLocale::from(&locale);
         let req = DataRequest {
-            locale: &data_locale,
+            locale: (&locale).into(),
             metadata: Default::default(),
         };
 
@@ -418,9 +417,8 @@ impl DateTimeFormatter {
         let required = datetime::analyze_patterns(&patterns.get().0, false)
             .map_err(|field| DateTimeFormatterError::UnsupportedField(field.symbol))?;
 
-        let data_locale = DataLocale::from(&locale);
         let req = DataRequest {
-            locale: &data_locale,
+            locale: (&locale).into(),
             metadata: Default::default(),
         };
 

--- a/components/datetime/src/raw/zoned_datetime.rs
+++ b/components/datetime/src/raw/zoned_datetime.rs
@@ -91,10 +91,8 @@ impl ZonedDateTimeFormatter {
         let required = datetime::analyze_patterns(&patterns.get().0, true)
             .map_err(|field| DateTimeFormatterError::UnsupportedField(field.symbol))?;
 
-        // TODO(#2136): Don't use expensive from
-        let data_locale = DataLocale::from(&locale);
         let req = DataRequest {
-            locale: &data_locale,
+            locale: (&locale).into(),
             metadata: Default::default(),
         };
 

--- a/components/datetime/src/skeleton/mod.rs
+++ b/components/datetime/src/skeleton/mod.rs
@@ -42,9 +42,9 @@ mod test {
         DataPayload<DateSkeletonPatternsV1Marker>,
     ) {
         let provider = icu_testdata::get_provider();
-        let locale = "en-u-ca-gregory".parse::<Locale>().unwrap().into();
+        let locale = "en-u-ca-gregory".parse::<Locale>().unwrap();
         let req = DataRequest {
-            locale: &locale,
+            locale: (&locale).into(),
             metadata: Default::default(),
         };
         let patterns = provider

--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -24,7 +24,7 @@ use writeable::Writeable;
 
 /// Loads a resource into its destination if the destination has not already been filled.
 fn load<D, P>(
-    locale: &DataLocale,
+    locale: &Locale,
     destination: &mut Option<DataPayload<D>>,
     provider: &P,
 ) -> Result<(), DateTimeFormatterError>
@@ -36,7 +36,7 @@ where
         *destination = Some(
             provider
                 .load(DataRequest {
-                    locale,
+                    locale: locale.into(),
                     metadata: Default::default(),
                 })?
                 .take_payload()?,
@@ -81,7 +81,7 @@ where
 ///
 /// [data provider]: icu_provider
 pub struct TimeZoneFormatter {
-    pub(super) locale: DataLocale,
+    pub(super) locale: Locale,
     pub(super) data_payloads: TimeZoneDataPayloads,
     pub(super) format_units: SmallVec<[TimeZoneFormatterUnit; 3]>,
     pub(super) fallback_unit: TimeZoneFormatterUnit,
@@ -126,12 +126,12 @@ impl TimeZoneFormatter {
             + DataProvider<provider::time_zones::MetaZoneSpecificNamesShortV1Marker>
             + ?Sized,
     {
-        let locale = DataLocale::from(locale.into());
+        let locale = locale.into();
         let format_units = SmallVec::<[TimeZoneFormatterUnit; 3]>::new();
         let data_payloads = TimeZoneDataPayloads {
             zone_formats: zone_provider
                 .load(DataRequest {
-                    locale: &locale,
+                    locale: (&locale).into(),
                     metadata: Default::default(),
                 })?
                 .take_payload()?,
@@ -377,12 +377,12 @@ impl TimeZoneFormatter {
             + DataProvider<provider::time_zones::MetaZoneSpecificNamesShortV1Marker>
             + ?Sized,
     {
-        let locale = DataLocale::from(locale.into());
+        let locale = locale.into();
         let format_units = SmallVec::<[TimeZoneFormatterUnit; 3]>::new();
         let data_payloads = TimeZoneDataPayloads {
             zone_formats: zone_provider
                 .load(DataRequest {
-                    locale: &locale,
+                    locale: (&locale).into(),
                     metadata: Default::default(),
                 })?
                 .take_payload()?,

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -369,9 +369,8 @@ fn test_dayperiod_patterns() {
             .unicode
             .keywords
             .set(key!("ca"), value!("gregory"));
-        let mut data_locale = DataLocale::from(&locale);
         let req = DataRequest {
-            locale: &data_locale,
+            locale: (&locale).into(),
             metadata: Default::default(),
         };
         let mut date_patterns_data: DataPayload<DatePatternsV1Marker> =
@@ -392,10 +391,9 @@ fn test_dayperiod_patterns() {
             provider.load(req).unwrap().take_payload().unwrap();
         let week_data: DataPayload<WeekDataV1Marker> =
             provider.load(req).unwrap().take_payload().unwrap();
-        data_locale.retain_unicode_ext(|_| false);
         let decimal_data: DataPayload<DecimalSymbolsV1Marker> = provider
             .load(DataRequest {
-                locale: &data_locale,
+                locale: (&locale.id).into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -532,9 +530,8 @@ fn test_time_zone_patterns() {
             .unicode
             .keywords
             .set(key!("ca"), value!("gregory"));
-        let data_locale = DataLocale::from(&locale);
         let req = DataRequest {
-            locale: &data_locale,
+            locale: (&locale).into(),
             metadata: Default::default(),
         };
         let mut config = test.config;

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -106,9 +106,10 @@ impl FixedDecimalFormatter {
         data_provider: &D,
         options: options::FixedDecimalFormatterOptions,
     ) -> Result<Self, FixedDecimalFormatterError> {
+        let locale = locale.into();
         let symbols = data_provider
             .load(DataRequest {
-                locale: &locale.into().into(),
+                locale: (&locale).into(),
                 metadata: Default::default(),
             })?
             .take_payload()?;

--- a/components/list/Cargo.toml
+++ b/components/list/Cargo.toml
@@ -21,7 +21,6 @@ include = [
 
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
-icu_locid = { version = "0.6", path = "../../components/locid" }
 icu_provider = { version = "0.6", path = "../../provider/core", features = ["macros"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 zerovec = { version = "0.7", path = "../../utils/zerovec", features = ["yoke"] }
@@ -36,12 +35,13 @@ serde_json = "1"
 postcard = { version = "1.0.0-alpha.4", features = ["use-std"] }
 icu_testdata = { version = "0.6", path = "../../provider/testdata", features = ["baked"] }
 icu_benchmark_macros = { version = "0.6", path = "../../tools/benchmark/macros" }
+icu_locid = { version = "0.6", path = "../../components/locid" }
 
 [lib]
 path = "src/lib.rs"
 
 [features]
-std = ["icu_provider/std", "icu_locid/std", "regex-automata/std", "regex-automata/alloc"]
+std = ["icu_provider/std", "regex-automata/std", "regex-automata/alloc"]
 serde = ["dep:serde", "icu_provider/serde", "zerovec/serde", "deduplicating_array"]
 serde_human = ["serde", "regex-automata/alloc"]
 datagen = ["serde", "std", "databake"]

--- a/components/list/examples/and_list.rs
+++ b/components/list/examples/and_list.rs
@@ -15,7 +15,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
     icu_benchmark_macros::main_setup!();
 
     let list_formatter = ListFormatter::try_new_and(
-        locale!("es"),
+        &locale!("es"),
         &icu_testdata::get_baked_provider(),
         ListStyle::Wide,
     )

--- a/components/list/src/list_formatter.rs
+++ b/components/list/src/list_formatter.rs
@@ -5,7 +5,6 @@
 use crate::provider::{AndListV1Marker, ErasedListV1Marker, OrListV1Marker, UnitListV1Marker};
 use crate::ListStyle;
 use core::fmt::{self, Write};
-use icu_locid::Locale;
 use icu_provider::prelude::*;
 use writeable::*;
 
@@ -20,14 +19,14 @@ macro_rules! constructor {
     ($name: ident, $marker: ty, $doc: literal) => {
         #[doc = concat!("Creates a new [`ListFormatter`] that produces a ", $doc, "-type list. See the [CLDR spec]",
             "(https://unicode.org/reports/tr35/tr35-general.html#ListPatterns) for an explanation of the different types.")]
-        pub fn $name<T: Into<Locale>, D: DataProvider<$marker> + ?Sized>(
-            locale: T,
+        pub fn $name<'a, L: Into<DataLocale<'a>>, D: DataProvider<$marker> + ?Sized>(
+            locale: L,
             data_provider: &D,
             style: ListStyle,
         ) -> Result<Self, DataError> {
             let data = data_provider
                 .load(DataRequest {
-                    locale: &locale.into().into(),
+                    locale: locale.into(),
                     metadata: Default::default(),
                 })?
                 .take_payload()?.cast();

--- a/components/plurals/benches/parser.rs
+++ b/components/plurals/benches/parser.rs
@@ -21,7 +21,7 @@ fn parser(c: &mut Criterion) {
     for langid in fixture_data.langs {
         let data_payload: DataPayload<icu_plurals::provider::CardinalV1Marker> = provider
             .load(DataRequest {
-                locale: &langid.into(),
+                locale: (&langid).into(),
                 metadata: Default::default(),
             })
             .unwrap()

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -344,10 +344,11 @@ impl PluralRules {
     where
         D: DataProvider<CardinalV1Marker> + ?Sized,
     {
+        let locale = locale.into();
         Ok(Self(
             data_provider
                 .load(DataRequest {
-                    locale: &locale.into().into(),
+                    locale: (&locale).into(),
                     metadata: Default::default(),
                 })?
                 .take_payload()?
@@ -390,10 +391,11 @@ impl PluralRules {
     where
         D: DataProvider<OrdinalV1Marker> + ?Sized,
     {
+        let locale = locale.into();
         Ok(Self(
             data_provider
                 .load(DataRequest {
-                    locale: &locale.into().into(),
+                    locale: (&locale).into(),
                     metadata: Default::default(),
                 })?
                 .take_payload()?

--- a/components/plurals/tests/plurals.rs
+++ b/components/plurals/tests/plurals.rs
@@ -21,7 +21,7 @@ fn test_static_load_works() {
 
     let _rules: DataPayload<CardinalV1Marker> = provider
         .load(DataRequest {
-            locale: &locale!("en").into(),
+            locale: (&locale!("en")).into(),
             metadata: Default::default(),
         })
         .expect("Failed to load payload")

--- a/docs/tutorials/data_provider.md
+++ b/docs/tutorials/data_provider.md
@@ -22,12 +22,12 @@ Each component should use `DataProvider` only to construct the instance of each 
 pub struct AdditiveIdentity(char);
 
 impl AdditiveIdentity {
-    pub fn try_new<L: Into<Locale>, P: DataProvider<DecimalSymbolsV1Marker>>(
-        locale: L,
-        provider: &D,
+    pub fn try_new(
+        locale: impl Into<DataLocale>,
+        provider: &(impl DataProvider<DecimalSymbolsV1Marker>),
     ) -> Result<Self, MyError> {
         let response = data_provider.load(DataRequest {
-            locale: &locale.into().into(),
+            locale: locale.into(),
             metadata: Default::default(),
         })?.take_payload()?;
 

--- a/docs/tutorials/writing_a_new_data_struct.md
+++ b/docs/tutorials/writing_a_new_data_struct.md
@@ -224,7 +224,7 @@ impl DataProvider<FooV1Marker> for FooProvider {
 impl IterableDataProvider<FooV1Marker> for FooProvider {
     fn supported_locales(
         &self,
-    ) -> Result<Vec<DataLocale>, DataError> {
+    ) -> Result<Vec<Locale>, DataError> {
         // This should list all supported locales, for example.
     }
 }

--- a/experimental/segmenter/src/complex.rs
+++ b/experimental/segmenter/src/complex.rs
@@ -95,7 +95,7 @@ pub fn complex_language_segment_str(
 mod tests {
     use super::*;
     use icu_locid::locale;
-    use icu_provider::{DataLocale, DataProvider, DataRequest};
+    use icu_provider::prelude::*;
 
     #[test]
     fn thai_word_break() {
@@ -104,7 +104,7 @@ mod tests {
         let locale = locale!("th");
         let payload = provider
             .load(DataRequest {
-                locale: &DataLocale::from(locale),
+                locale: (&locale).into(),
                 metadata: Default::default(),
             })
             .expect("Loading should succeed!")

--- a/experimental/segmenter/src/dictionary.rs
+++ b/experimental/segmenter/src/dictionary.rs
@@ -170,12 +170,12 @@ mod tests {
     use zerovec::ZeroSlice;
 
     fn get_payload(
-        locale: Locale,
+        locale: &Locale,
     ) -> Result<DataPayload<UCharDictionaryBreakDataV1Marker>, DataError> {
         let provider = icu_testdata::get_provider();
         provider
             .load(DataRequest {
-                locale: &DataLocale::from(locale),
+                locale: locale.into(),
                 metadata: Default::default(),
             })?
             .take_payload()
@@ -213,7 +213,7 @@ mod tests {
 
     #[test]
     fn cj_dictionary_test() {
-        let payload = get_payload(locale!("ja")).unwrap();
+        let payload = get_payload(&locale!("ja")).unwrap();
         let segmenter = DictionarySegmenter::try_new(&payload).expect("Data exists");
 
         // Match case

--- a/experimental/segmenter/src/line.rs
+++ b/experimental/segmenter/src/line.rs
@@ -126,7 +126,7 @@ impl LineBreakSegmenter {
         let locale = locale!("th");
         let dictionary_payload = provider
             .load(DataRequest {
-                locale: &DataLocale::from(locale),
+                locale: (&locale).into(),
                 metadata: Default::default(),
             })?
             .take_payload()?;

--- a/experimental/segmenter/src/lstm.rs
+++ b/experimental/segmenter/src/lstm.rs
@@ -151,7 +151,7 @@ mod tests {
         let provider = icu_testdata::get_provider();
         let payload = provider
             .load(DataRequest {
-                locale: &DataLocale::from(locale!("th")),
+                locale: (&locale!("th")).into(),
                 metadata: Default::default(),
             })
             .expect("Loading should succeed!")

--- a/experimental/segmenter/src/word.rs
+++ b/experimental/segmenter/src/word.rs
@@ -42,7 +42,7 @@ impl WordBreakSegmenter {
         let locale = locale!("th");
         let dictionary_payload = provider
             .load(DataRequest {
-                locale: &DataLocale::from(locale),
+                locale: (&locale).into(),
                 metadata: Default::default(),
             })?
             .take_payload()?;

--- a/provider/adapters/src/either.rs
+++ b/provider/adapters/src/either.rs
@@ -82,7 +82,7 @@ impl<
     fn supported_locales_for_key(
         &self,
         key: DataKey,
-    ) -> Result<alloc::vec::Vec<DataLocale>, DataError> {
+    ) -> Result<alloc::vec::Vec<icu_locid::Locale>, DataError> {
         use EitherProvider::*;
         match self {
             A(p) => p.supported_locales_for_key(key),
@@ -99,7 +99,7 @@ impl<
     > datagen::IterableDataProvider<M> for EitherProvider<P0, P1>
 {
     #[inline]
-    fn supported_locales(&self) -> Result<alloc::vec::Vec<DataLocale>, DataError> {
+    fn supported_locales(&self) -> Result<alloc::vec::Vec<icu_locid::Locale>, DataError> {
         use EitherProvider::*;
         match self {
             A(p) => p.supported_locales(),

--- a/provider/adapters/src/fallback/adapter.rs
+++ b/provider/adapters/src/fallback/adapter.rs
@@ -20,8 +20,9 @@ use crate::helpers::result_is_err_missing_data_options;
 /// // so we need to use icu_testdata::get_postcard_provider() instead.
 /// let provider = icu_testdata::get_postcard_provider();
 ///
+/// let locale = locale!("ja-JP");
 /// let req = DataRequest {
-///     locale: &locale!("ja-JP").into(),
+///     locale: (&locale).into(),
 ///     metadata: Default::default(),
 /// };
 ///
@@ -88,8 +89,9 @@ impl<P> LocaleFallbackProvider<P> {
     ///
     /// let provider = HelloWorldProvider;
     ///
+    /// let locale = locale!("de-CH");
     /// let req = DataRequest {
-    ///     locale: &locale!("de-CH").into(),
+    ///     locale: (&locale).into(),
     ///     metadata: Default::default(),
     /// };
     ///
@@ -140,10 +142,10 @@ impl<P> LocaleFallbackProvider<P> {
         F2: FnMut(&mut R) -> &mut DataResponseMetadata,
     {
         let key_fallbacker = self.fallbacker.for_key(key);
-        let mut fallback_iterator = key_fallbacker.fallback_for(base_req.locale.clone());
+        let mut fallback_iterator = key_fallbacker.fallback_for(base_req.locale.into());
         loop {
             let result = f1(DataRequest {
-                locale: fallback_iterator.get(),
+                locale: fallback_iterator.get().into(),
                 metadata: Default::default(),
             });
             if !result_is_err_missing_data_options(&result) {
@@ -156,7 +158,7 @@ impl<P> LocaleFallbackProvider<P> {
                     .map_err(|e| e.with_req(key, base_req));
             }
             // If we just checked und, break out of the loop.
-            if fallback_iterator.get().is_empty() {
+            if fallback_iterator.get() == &Locale::UND {
                 break;
             }
             fallback_iterator.step();

--- a/provider/adapters/src/fallback/mod.rs
+++ b/provider/adapters/src/fallback/mod.rs
@@ -22,7 +22,7 @@
 //! let key_fallbacker = fallbacker.for_config(Default::default());
 //!
 //! // Set up the fallback iterator.
-//! let mut fallback_iterator = key_fallbacker.fallback_for(icu_locid::locale!("hi-Latn-IN").into());
+//! let mut fallback_iterator = key_fallbacker.fallback_for((&icu_locid::locale!("hi-Latn-IN")).into());
 //!
 //! // Run the algorithm and check the results.
 //! assert_eq!(fallback_iterator.get().to_string(), "hi-Latn-IN");
@@ -40,6 +40,7 @@
 
 use icu_locid::extensions::unicode::{Key, Value};
 use icu_locid::subtags::Variants;
+use icu_locid::Locale;
 use icu_provider::prelude::*;
 use icu_provider::{DataKeyMetadata, FallbackPriority};
 
@@ -74,9 +75,7 @@ pub struct LocaleFallbackConfig {
     /// config.priority = FallbackPriority::Language;
     /// let key_fallbacker = fallbacker.for_config(config);
     /// let mut fallback_iterator = key_fallbacker.fallback_for(
-    ///     icu_locid::Locale::from_bytes(b"ca-ES-valencia")
-    ///         .unwrap()
-    ///         .into(),
+    ///     (&icu_locid::Locale::from_bytes(b"ca-ES-valencia").unwrap()).into(),
     /// );
     ///
     /// // Run the algorithm and check the results.
@@ -104,9 +103,7 @@ pub struct LocaleFallbackConfig {
     /// config.priority = FallbackPriority::Region;
     /// let key_fallbacker = fallbacker.for_config(config);
     /// let mut fallback_iterator = key_fallbacker.fallback_for(
-    ///     icu_locid::Locale::from_bytes(b"ca-ES-valencia")
-    ///         .unwrap()
-    ///         .into(),
+    ///     (&icu_locid::Locale::from_bytes(b"ca-ES-valencia").unwrap()).into(),
     /// );
     ///
     /// // Run the algorithm and check the results.
@@ -137,9 +134,7 @@ pub struct LocaleFallbackConfig {
     /// config.extension_key = Some(icu_locid::extensions_unicode_key!("nu"));
     /// let key_fallbacker = fallbacker.for_config(config);
     /// let mut fallback_iterator = key_fallbacker.fallback_for(
-    ///     icu_locid::Locale::from_bytes(b"ar-EG-u-nu-latn")
-    ///         .unwrap()
-    ///         .into(),
+    ///     (&icu_locid::Locale::from_bytes(b"ar-EG-u-nu-latn").unwrap()).into(),
     /// );
     ///
     /// // Run the algorithm and check the results.
@@ -195,7 +190,7 @@ struct LocaleFallbackIteratorInner<'a, 'b> {
 /// Because the `Iterator` trait does not allow items to borrow from the iterator, this class does
 /// not implement that trait. Instead, use `.step()` and `.get()`.
 pub struct LocaleFallbackIterator<'a, 'b> {
-    current: DataLocale,
+    current: Locale,
     inner: LocaleFallbackIteratorInner<'a, 'b>,
 }
 
@@ -256,8 +251,9 @@ impl LocaleFallbacker {
     /// let provider = icu_testdata::get_provider();
     /// let fallbacker = LocaleFallbacker::try_new(&provider).expect("data");
     /// let key_fallbacker = fallbacker.for_key(FooV1Marker::KEY);
-    /// let mut fallback_iterator = key_fallbacker
-    ///     .fallback_for(icu_locid::Locale::from_bytes(b"en-GB").unwrap().into());
+    /// let mut fallback_iterator = key_fallbacker.fallback_for(
+    ///     (&icu_locid::Locale::from_bytes(b"en-GB").unwrap()).into(),
+    /// );
     ///
     /// // Run the algorithm and check the results.
     /// assert_eq!(fallback_iterator.get().to_string(), "en-GB");
@@ -277,7 +273,7 @@ impl<'a> LocaleFallbackerWithConfig<'a> {
     /// When first initialized, the locale is normalized according to the fallback algorithm.
     ///
     /// [`Locale`]: icu_locid::Locale
-    pub fn fallback_for<'b>(&'b self, mut locale: DataLocale) -> LocaleFallbackIterator<'a, 'b> {
+    pub fn fallback_for<'b>(&'b self, mut locale: Locale) -> LocaleFallbackIterator<'a, 'b> {
         self.normalize(&mut locale);
         LocaleFallbackIterator {
             current: locale,
@@ -294,19 +290,19 @@ impl<'a> LocaleFallbackerWithConfig<'a> {
 }
 
 impl LocaleFallbackIterator<'_, '_> {
-    /// Borrows the current [`DataLocale`] under fallback.
-    pub fn get(&self) -> &DataLocale {
+    /// Borrows the current [`Locale`] under fallback.
+    pub fn get(&self) -> &Locale {
         &self.current
     }
 
-    /// Takes the current [`DataLocale`] under fallback.
-    pub fn take(self) -> DataLocale {
+    /// Takes the current [`Locale`] under fallback.
+    pub fn take(self) -> Locale {
         self.current
     }
 
     /// Performs one step of the locale fallback algorithm.
     ///
-    /// The fallback is completed once the inner [`DataLocale`] becomes `und`.
+    /// The fallback is completed once the inner locale becomes `und`.
     pub fn step(&mut self) -> &mut Self {
         self.inner.step(&mut self.current);
         self

--- a/provider/adapters/src/filter/impls.rs
+++ b/provider/adapters/src/filter/impls.rs
@@ -33,8 +33,9 @@ where
     ///     .filter_by_langid(|langid| langid.language != language!("en"));
     ///
     /// // German requests should succeed:
+    /// let de = locale!("de");
     /// let req_de = DataRequest {
-    ///     locale: &locale!("de").into(),
+    ///     locale: (&de).into(),
     ///     metadata: Default::default(),
     /// };
     /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
@@ -42,8 +43,9 @@ where
     /// assert!(matches!(response, Ok(_)));
     ///
     /// // English requests should fail:
+    /// let en = locale!("en-US");
     /// let req_en = DataRequest {
-    ///     locale: &locale!("en-US").into(),
+    ///     locale: (&en).into(),
     ///     metadata: Default::default(),
     /// };
     /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
@@ -57,14 +59,11 @@ where
     /// ));
     ///
     /// // English should not appear in the iterator result:
-    /// let supported_langids = provider
+    /// let supported_locales = provider
     ///     .supported_locales()
-    ///     .expect("Should successfully make an iterator of supported locales")
-    ///     .into_iter()
-    ///     .map(|options| options.get_langid())
-    ///     .collect::<Vec<LanguageIdentifier>>();
-    /// assert!(supported_langids.contains(&langid!("de")));
-    /// assert!(!supported_langids.contains(&langid!("en")));
+    ///     .expect("Should successfully make an iterator of supported locales");
+    /// assert!(supported_locales.contains(&locale!("de")));
+    /// assert!(!supported_locales.contains(&locale!("en")));
     /// ```
     pub fn filter_by_langid<'a>(
         self,
@@ -80,7 +79,7 @@ where
                 if !(old_predicate)(request) {
                     return false;
                 }
-                predicate(&request.locale.get_langid())
+                predicate(request.locale.get_langid())
             }),
             filter_name: self.filter_name,
         }
@@ -109,8 +108,9 @@ where
     ///     .filter_by_langid_allowlist_strict(&allowlist);
     ///
     /// // German requests should succeed:
+    /// let de = locale!("de");
     /// let req_de = DataRequest {
-    ///     locale: &locale!("de").into(),
+    ///     locale: (&de).into(),
     ///     metadata: Default::default(),
     /// };
     /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
@@ -118,8 +118,9 @@ where
     /// assert!(matches!(response, Ok(_)));
     ///
     /// // English requests should fail:
+    /// let en = locale!("en");
     /// let req_en = DataRequest {
-    ///     locale: &locale!("en-US").into(),
+    ///     locale: (&en).into(),
     ///     metadata: Default::default(),
     /// };
     /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
@@ -150,7 +151,8 @@ where
                 if !(old_predicate)(request) {
                     return false;
                 }
-                request.locale.is_langid_und() || allowlist.contains(&request.locale.get_langid())
+                LanguageIdentifier::UND == *request.locale.get_langid()
+                    || allowlist.contains(request.locale.get_langid())
             }),
             filter_name: self.filter_name,
         }
@@ -171,8 +173,9 @@ where
     ///     .require_langid();
     ///
     /// // Requests with a langid should succeed:
+    /// let de = locale!("de");
     /// let req_with_langid = DataRequest {
-    ///     locale: &locale!("de").into(),
+    ///     locale: (&de).into(),
     ///     metadata: Default::default(),
     /// };
     /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
@@ -207,7 +210,7 @@ where
                 if !(old_predicate)(request) {
                     return false;
                 }
-                !request.locale.is_langid_und()
+                LanguageIdentifier::UND != *request.locale.get_langid()
             }),
             filter_name: self.filter_name,
         }

--- a/provider/adapters/src/filter/mod.rs
+++ b/provider/adapters/src/filter/mod.rs
@@ -146,13 +146,13 @@ where
     fn supported_locales_for_key(
         &self,
         key: DataKey,
-    ) -> Result<alloc::vec::Vec<DataLocale>, DataError> {
+    ) -> Result<alloc::vec::Vec<icu_locid::Locale>, DataError> {
         self.inner.supported_locales_for_key(key).map(|vec| {
             // Use filter_map instead of filter to avoid cloning the locale
             vec.into_iter()
                 .filter_map(|locale| {
                     if (self.predicate)(DataRequest {
-                        locale: &locale,
+                        locale: (&locale).into(),
                         metadata: Default::default(),
                     }) {
                         Some(locale)
@@ -172,13 +172,13 @@ where
     F: Fn(DataRequest) -> bool,
     D: datagen::IterableDataProvider<M>,
 {
-    fn supported_locales(&self) -> Result<alloc::vec::Vec<DataLocale>, DataError> {
+    fn supported_locales(&self) -> Result<alloc::vec::Vec<icu_locid::Locale>, DataError> {
         self.inner.supported_locales().map(|vec| {
             // Use filter_map instead of filter to avoid cloning the locale
             vec.into_iter()
                 .filter_map(|locale| {
                     if (self.predicate)(DataRequest {
-                        locale: &locale,
+                        locale: (&locale).into(),
                         metadata: Default::default(),
                     }) {
                         Some(locale)

--- a/provider/adapters/src/fork/by_key.rs
+++ b/provider/adapters/src/fork/by_key.rs
@@ -166,7 +166,7 @@ where
     P0: datagen::IterableDynamicDataProvider<M>,
     P1: datagen::IterableDynamicDataProvider<M>,
 {
-    fn supported_locales_for_key(&self, key: DataKey) -> Result<Vec<DataLocale>, DataError> {
+    fn supported_locales_for_key(&self, key: DataKey) -> Result<Vec<icu_locid::Locale>, DataError> {
         let result = self.0.supported_locales_for_key(key);
         if !result_is_err_missing_data_key(&result) {
             return result;
@@ -293,7 +293,7 @@ where
     M: DataMarker,
     P: datagen::IterableDynamicDataProvider<M>,
 {
-    fn supported_locales_for_key(&self, key: DataKey) -> Result<Vec<DataLocale>, DataError> {
+    fn supported_locales_for_key(&self, key: DataKey) -> Result<Vec<icu_locid::Locale>, DataError> {
         for provider in self.providers.iter() {
             let result = provider.supported_locales_for_key(key);
             if !result_is_err_missing_data_key(&result) {

--- a/provider/blob/examples/simple_static.rs
+++ b/provider/blob/examples/simple_static.rs
@@ -14,7 +14,7 @@ fn main() {
 
     let hello: DataPayload<HelloWorldV1Marker> = dp
         .load(DataRequest {
-            locale: &locale!("zh").into(),
+            locale: (&locale!("zh")).into(),
             metadata: Default::default(),
         })
         .unwrap()

--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -43,7 +43,7 @@ use yoke::*;
 /// // Check that it works:
 /// let response: DataPayload<HelloWorldV1Marker> = provider
 ///     .load(DataRequest {
-///         locale: &locale!("la").into(),
+///         locale: (&locale!("la")).into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect("Data should be valid")

--- a/provider/blob/src/export/blob_exporter.rs
+++ b/provider/blob/src/export/blob_exporter.rs
@@ -42,7 +42,7 @@ impl DataExporter for BlobExporter<'_> {
     fn put_payload(
         &self,
         key: DataKey,
-        locale: &DataLocale,
+        locale: DataLocale,
         payload: &DataPayload<ExportMarker>,
     ) -> Result<(), DataError> {
         log::trace!("Adding: {}/{}", key, locale);

--- a/provider/blob/src/export/mod.rs
+++ b/provider/blob/src/export/mod.rs
@@ -34,7 +34,7 @@
 //!     exporter
 //!         .put_payload(
 //!             HelloWorldV1Marker::KEY,
-//!             &Default::default(),
+//!             Default::default(),
 //!             &UpcastDataPayload::upcast(payload.clone()),
 //!         )
 //!         .expect("Should successfully export");

--- a/provider/blob/src/static_data_provider.rs
+++ b/provider/blob/src/static_data_provider.rs
@@ -35,7 +35,7 @@ use serde::de::Deserialize;
 ///
 /// let response: DataPayload<HelloWorldV1Marker> = provider
 ///     .load(DataRequest {
-///         locale: &locale!("la").into(),
+///         locale: (&locale!("la")).into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect("Data should be valid")
@@ -82,7 +82,7 @@ impl StaticDataProvider {
     /// DataProvider::<HelloWorldV1Marker>::load(
     ///     &stub_provider,
     ///     DataRequest {
-    ///         locale: &locale!("la").into(),
+    ///         locale: (&locale!("la")).into(),
     ///         metadata: Default::default(),
     ///     },
     /// )

--- a/provider/core/src/any.rs
+++ b/provider/core/src/any.rs
@@ -259,7 +259,7 @@ impl AnyResponse {
 ///     .load_any(
 ///         HelloWorldV1Marker::KEY,
 ///         DataRequest {
-///             locale: &icu_locid::locale!("de").into(),
+///             locale: (&icu_locid::locale!("de")).into(),
 ///             metadata: Default::default(),
 ///         },
 ///     )

--- a/provider/core/src/buf.rs
+++ b/provider/core/src/buf.rs
@@ -37,7 +37,7 @@ impl DataMarker for BufferMarker {
 ///
 /// let german_hello_world: DataPayload<HelloWorldV1Marker> = data_provider
 ///     .load(DataRequest {
-///         locale: &locale!("de").into(),
+///         locale: (&locale!("de")).into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect("Loading should succeed")

--- a/provider/core/src/datagen/iter.rs
+++ b/provider/core/src/datagen/iter.rs
@@ -5,23 +5,24 @@
 //! Collection of iteration APIs for data providers.
 
 use crate::prelude::*;
+use icu_locid::Locale;
 
-/// A [`DynamicDataProvider`] that can iterate over all supported [`DataLocale`] for a certain key.
+/// A [`DynamicDataProvider`] that can iterate over all supported [`Locale`] for a certain key.
 ///
 /// Implementing this trait means that a data provider knows all of the data it can successfully
 /// return from a load request.
 pub trait IterableDynamicDataProvider<M: DataMarker>: DynamicDataProvider<M> {
-    /// Given a [`DataKey`], returns a list of [`DataLocale`].
-    fn supported_locales_for_key(&self, key: DataKey) -> Result<Vec<DataLocale>, DataError>;
+    /// Given a [`DataKey`], returns a list of [`Locale`].
+    fn supported_locales_for_key(&self, key: DataKey) -> Result<Vec<Locale>, DataError>;
 }
 
-/// A [`DataProvider`] that can iterate over all supported [`DataLocale`] for a certain key.
+/// A [`DataProvider`] that can iterate over all supported [`Locale`] for a certain key.
 ///
 /// Implementing this trait means that a data provider knows all of the data it can successfully
 /// return from a load request.
 pub trait IterableDataProvider<M: KeyedDataMarker>: DataProvider<M> {
-    /// Returns a list of [`DataLocale`].
-    fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError>;
+    /// Returns a list of [`Locale`].
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError>;
 }
 
 impl<M, P> IterableDynamicDataProvider<M> for Box<P>
@@ -29,7 +30,7 @@ where
     M: DataMarker,
     P: IterableDynamicDataProvider<M> + ?Sized,
 {
-    fn supported_locales_for_key(&self, key: DataKey) -> Result<Vec<DataLocale>, DataError> {
+    fn supported_locales_for_key(&self, key: DataKey) -> Result<Vec<Locale>, DataError> {
         (**self).supported_locales_for_key(key)
     }
 }

--- a/provider/core/src/datagen/mod.rs
+++ b/provider/core/src/datagen/mod.rs
@@ -30,7 +30,7 @@ pub trait DataExporter: Sync {
     fn put_payload(
         &self,
         key: DataKey,
-        locale: &DataLocale,
+        locale: DataLocale,
         payload: &DataPayload<ExportMarker>,
     ) -> Result<(), DataError>;
 
@@ -76,7 +76,7 @@ macro_rules! make_exportable_provider {
         );
 
         impl $crate::datagen::IterableDynamicDataProvider<$crate::datagen::ExportMarker> for $provider {
-            fn supported_locales_for_key(&self, key: $crate::DataKey) -> Result<Vec<$crate::DataLocale>, $crate::DataError> {
+            fn supported_locales_for_key(&self, key: $crate::DataKey) -> Result<Vec<icu_locid::Locale>, $crate::DataError> {
                 #![allow(non_upper_case_globals)]
                 // Reusing the struct names as identifiers
                 $(

--- a/provider/core/src/dynutil.rs
+++ b/provider/core/src/dynutil.rs
@@ -69,8 +69,9 @@ where
 /// // Implement DynamicDataProvider<AnyMarker> on HelloWorldProvider: DataProvider<HelloWorldV1Marker>
 /// icu_provider::impl_dynamic_data_provider!(HelloWorldProvider, [HelloWorldV1Marker,], AnyMarker);
 ///
+/// let locale = icu_locid::locale!("de");
 /// let req = DataRequest {
-///     locale: &icu_locid::locale!("de").into(),
+///     locale: (&locale).into(),
 ///     metadata: Default::default(),
 /// };
 ///
@@ -109,8 +110,9 @@ where
 ///     _ => HelloWorldV1Marker,
 /// }, AnyMarker);
 ///
+/// let locale = icu_locid::locale!("de");
 /// let req = DataRequest {
-///     locale: &icu_locid::locale!("de").into(),
+///     locale: (&locale).into(),
 ///     metadata: Default::default(),
 /// };
 ///

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -61,7 +61,7 @@ impl KeyedDataMarker for HelloWorldV1Marker {
 ///
 /// let german_hello_world: DataPayload<HelloWorldV1Marker> = HelloWorldProvider
 ///     .load(DataRequest {
-///         locale: &locale!("de").into(),
+///         locale: (&locale!("de")).into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect("Loading should succeed")
@@ -158,12 +158,11 @@ impl BufferProvider for HelloWorldJsonProvider {
 
 #[cfg(feature = "datagen")]
 impl IterableDataProvider<HelloWorldV1Marker> for HelloWorldProvider {
-    fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<icu_locid::Locale>, DataError> {
         #[allow(clippy::unwrap_used)] // datagen
         Ok(Self::DATA
             .iter()
-            .map(|(s, _)| s.parse::<icu_locid::LanguageIdentifier>().unwrap())
-            .map(DataLocale::from)
+            .map(|(s, _)| s.parse::<icu_locid::Locale>().unwrap())
             .collect())
     }
 }
@@ -175,22 +174,22 @@ fn test_iter() {
     assert_eq!(
         HelloWorldProvider.supported_locales().unwrap(),
         vec![
-            locale!("bn").into(),
-            locale!("cs").into(),
-            locale!("de").into(),
-            locale!("el").into(),
-            locale!("en").into(),
-            locale!("eo").into(),
-            locale!("fa").into(),
-            locale!("fi").into(),
-            locale!("is").into(),
-            locale!("ja").into(),
-            locale!("la").into(),
-            locale!("pt").into(),
-            locale!("ro").into(),
-            locale!("ru").into(),
-            locale!("vi").into(),
-            locale!("zh").into()
+            locale!("bn"),
+            locale!("cs"),
+            locale!("de"),
+            locale!("el"),
+            locale!("en"),
+            locale!("eo"),
+            locale!("fa"),
+            locale!("fi"),
+            locale!("is"),
+            locale!("ja"),
+            locale!("la"),
+            locale!("pt"),
+            locale!("ro"),
+            locale!("ru"),
+            locale!("vi"),
+            locale!("zh")
         ]
     );
 }

--- a/provider/core/src/request.rs
+++ b/provider/core/src/request.rs
@@ -8,7 +8,6 @@ use core::fmt;
 use core::fmt::Debug;
 use icu_locid::extensions::unicode as unicode_ext;
 use icu_locid::ordering::SubtagOrderingResult;
-use icu_locid::subtags::{Language, Region, Script, Variants};
 use icu_locid::{LanguageIdentifier, Locale};
 use writeable::{LengthHint, Writeable};
 
@@ -18,7 +17,7 @@ use icu_locid::subtags::Variant;
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct DataRequest<'a> {
-    pub locale: &'a DataLocale,
+    pub locale: DataLocale<'a>,
     pub metadata: DataRequestMetadata,
 }
 
@@ -28,42 +27,41 @@ impl fmt::Display for DataRequest<'_> {
     }
 }
 
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct DataRequestMetadata;
 
-/// A variant and language identifier, used for requesting data from a data provider.
-///
-/// The fields in a [`DataLocale`] are not generally known until runtime.
-#[derive(PartialEq, Clone, Default, Eq, Hash)]
-pub struct DataLocale {
-    langid: LanguageIdentifier,
-    keywords: unicode_ext::Keywords,
+#[derive(PartialEq, Clone, Copy, Eq, Hash)]
+pub struct DataLocale<'a> {
+    langid: &'a LanguageIdentifier,
+    keywords: &'a unicode_ext::Keywords,
 }
 
-impl<'a> Default for &'a DataLocale {
+impl<'a> Default for DataLocale<'a> {
     fn default() -> Self {
-        static DEFAULT: DataLocale = DataLocale {
-            langid: LanguageIdentifier::UND,
-            keywords: unicode_ext::Keywords::new(),
-        };
-        &DEFAULT
+        // We need static homes for the default values.
+        static LANGID: LanguageIdentifier = LanguageIdentifier::UND;
+        static KEYWORDS: unicode_ext::Keywords = unicode_ext::Keywords::new();
+        Self {
+            langid: &LANGID,
+            keywords: &KEYWORDS,
+        }
     }
 }
 
-impl fmt::Debug for DataLocale {
+impl fmt::Debug for DataLocale<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "DataLocale{{{}}}", self)
     }
 }
 
-impl fmt::Display for DataLocale {
+impl fmt::Display for DataLocale<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeable::Writeable::write_to(self, f)
     }
 }
 
-impl Writeable for DataLocale {
+impl Writeable for DataLocale<'_> {
     fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
         self.langid.write_to(sink)?;
         if !self.keywords.is_empty() {
@@ -83,34 +81,34 @@ impl Writeable for DataLocale {
     }
 }
 
-impl From<LanguageIdentifier> for DataLocale {
-    fn from(langid: LanguageIdentifier) -> Self {
+impl<'a> From<&'a LanguageIdentifier> for DataLocale<'a> {
+    fn from(langid: &'a LanguageIdentifier) -> Self {
         Self {
             langid,
-            keywords: unicode_ext::Keywords::new(),
+            ..Default::default()
         }
     }
 }
 
-impl From<Locale> for DataLocale {
-    fn from(locale: Locale) -> Self {
+impl<'a> From<&'a Locale> for DataLocale<'a> {
+    fn from(locale: &'a Locale) -> Self {
         Self {
-            langid: locale.id,
-            keywords: locale.extensions.unicode.keywords,
+            langid: &locale.id,
+            keywords: &locale.extensions.unicode.keywords,
         }
     }
 }
 
-impl From<&Locale> for DataLocale {
-    fn from(locale: &Locale) -> Self {
-        Self {
-            langid: locale.id.clone(),
-            keywords: locale.extensions.unicode.keywords.clone(),
-        }
+impl Into<Locale> for DataLocale<'_> {
+    /// Expensive
+    fn into(self) -> Locale {
+        let mut locale = Locale::from(self.langid.clone());
+        locale.extensions.unicode.keywords = self.keywords.clone();
+        locale
     }
 }
 
-impl DataLocale {
+impl DataLocale<'_> {
     /// Compare this [`DataLocale`] with BCP-47 bytes.
     ///
     /// The return value is equivalent to what would happen if you first converted this
@@ -142,20 +140,20 @@ impl DataLocale {
     ///     let a = ab[0];
     ///     let b = ab[1];
     ///     assert!(a.cmp(b) == Ordering::Less);
-    ///     let a_loc: DataLocale = a.parse::<Locale>().unwrap().into();
-    ///     assert_eq!(a, a_loc.to_string());
-    ///     assert!(a_loc.strict_cmp(a.as_bytes()) == Ordering::Equal, "{} == {}", a, a);
-    ///     assert!(a_loc.strict_cmp(b.as_bytes()) == Ordering::Less, "{} < {}", a, b);
-    ///     let b_loc: DataLocale = b.parse::<Locale>().unwrap().into();
-    ///     assert_eq!(b, b_loc.to_string());
-    ///     assert!(b_loc.strict_cmp(b.as_bytes()) == Ordering::Equal, "{} == {}", b, b);
-    ///     assert!(b_loc.strict_cmp(a.as_bytes()) == Ordering::Greater, "{} > {}", b, a);
+    ///     let a_loc = a.parse::<Locale>().unwrap();
+    ///     assert_eq!(a, DataLocale::from(&a_loc).to_string());
+    ///     assert!(DataLocale::from(&a_loc).strict_cmp(a.as_bytes()) == Ordering::Equal, "{} == {}", a, a);
+    ///     assert!(DataLocale::from(&a_loc).strict_cmp(b.as_bytes()) == Ordering::Less, "{} < {}", a, b);
+    ///     let b_loc = b.parse::<Locale>().unwrap();
+    ///     assert_eq!(b, DataLocale::from(&b_loc).to_string());
+    ///     assert!(DataLocale::from(&b_loc).strict_cmp(b.as_bytes()) == Ordering::Equal, "{} == {}", b, b);
+    ///     assert!(DataLocale::from(&b_loc).strict_cmp(a.as_bytes()) == Ordering::Greater, "{} > {}", b, a);
     /// }
     /// ```
     pub fn strict_cmp(&self, other: &[u8]) -> Ordering {
         let subtags = other.split(|b| *b == b'-');
         let mut subtag_result = self.langid.strict_cmp_iter(subtags);
-        if self.has_unicode_ext() {
+        if !self.keywords.is_empty() {
             let mut subtags = match subtag_result {
                 SubtagOrderingResult::Subtags(s) => s,
                 SubtagOrderingResult::Ordering(o) => return o,
@@ -169,33 +167,13 @@ impl DataLocale {
         }
         subtag_result.end()
     }
-}
 
-impl DataLocale {
     /// Returns whether this [`DataLocale`] has all empty fields (no components).
     pub fn is_empty(&self) -> bool {
-        self == <&DataLocale>::default()
-    }
-
-    /// Returns whether the [`LanguageIdentifier`] associated with this request is `und`.
-    ///
-    /// Note that this only checks the language identifier; extension keywords may also be set.
-    /// To check the entire `DataLocale`, use [`DataLocale::is_empty()`].
-    pub fn is_langid_und(&self) -> bool {
-        self.langid == LanguageIdentifier::UND
+        self == &Self::default()
     }
 
     /// Gets the [`LanguageIdentifier`] for this [`DataLocale`].
-    ///
-    /// This may allocate memory if there are variant subtags. If you need only the language,
-    /// script, and/or region subtag, use the specific getters for those subtags:
-    ///
-    /// - [`DataLocale::language()`]
-    /// - [`DataLocale::script()`]
-    /// - [`DataLocale::region()`]
-    ///
-    /// If you have ownership over the `DataLocale`, use [`DataLocale::into_locale()`]
-    /// and then access the `id` field.
     ///
     /// # Examples
     ///
@@ -206,203 +184,50 @@ impl DataLocale {
     /// const FOO_BAR: DataKey = icu_provider::data_key!("foo/bar@1");
     ///
     /// let req_no_langid = DataRequest {
-    ///     locale: &Default::default(),
+    ///     locale: Default::default(),
     ///     metadata: Default::default(),
     /// };
     ///
+    /// let lang_id = langid!("ar-EG");
     /// let req_with_langid = DataRequest {
-    ///     locale: &langid!("ar-EG").into(),
+    ///     locale: (&lang_id).into(),
     ///     metadata: Default::default(),
     /// };
     ///
-    /// assert_eq!(req_no_langid.locale.get_langid(), langid!("und"));
-    /// assert_eq!(req_with_langid.locale.get_langid(), langid!("ar-EG"));
+    /// assert_eq!(req_no_langid.locale.get_langid(), &langid!("und"));
+    /// assert_eq!(req_with_langid.locale.get_langid(), &lang_id);
     /// ```
-    pub fn get_langid(&self) -> LanguageIdentifier {
-        self.langid.clone()
+    pub fn get_langid(&self) -> &LanguageIdentifier {
+        &self.langid
     }
 
-    /// Overrides the entire [`LanguageIdentifier`] portion of this [`DataLocale`].
-    #[inline]
-    pub fn set_langid(&mut self, lid: LanguageIdentifier) {
-        self.langid = lid;
-    }
-
-    /// Converts this [`DataLocale`] into a [`Locale`].
-    ///
-    /// See also [`DataLocale::get_langid()`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use icu_locid::{langid, subtags_language as language, subtags_region as region, Locale};
-    /// use icu_provider::prelude::*;
-    ///
-    /// let locale: Locale = "it-IT-u-ca-coptic".parse().expect("Valid BCP-47");
-    /// let locale: DataLocale = locale.into();
-    ///
-    /// assert_eq!(locale.to_string(), "it-IT-u-ca-coptic");
-    /// assert_eq!(locale.get_langid(), langid!("it-IT"));
-    /// assert_eq!(locale.language(), language!("it"));
-    /// assert_eq!(locale.script(), None);
-    /// assert_eq!(locale.region(), Some(region!("IT")));
-    ///
-    /// let locale = locale.into_locale();
-    /// assert_eq!(locale.to_string(), "it-IT-u-ca-coptic");
-    /// ```
-    pub fn into_locale(self) -> Locale {
-        let mut loc = Locale {
-            id: self.langid,
-            ..Default::default()
-        };
-        loc.extensions.unicode.keywords = self.keywords;
-        loc
-    }
-
-    /// Returns the [`Language`] for this [`DataLocale`].
-    #[inline]
-    pub fn language(&self) -> Language {
-        self.langid.language
-    }
-
-    /// Returns the [`Language`] for this [`DataLocale`].
-    #[inline]
-    pub fn set_language(&mut self, language: Language) {
-        self.langid.language = language;
-    }
-
-    /// Returns the [`Script`] for this [`DataLocale`].
-    #[inline]
-    pub fn script(&self) -> Option<Script> {
-        self.langid.script
-    }
-
-    /// Sets the [`Script`] for this [`DataLocale`].
-    #[inline]
-    pub fn set_script(&mut self, script: Option<Script>) {
-        self.langid.script = script;
-    }
-
-    /// Returns the [`Region`] for this [`DataLocale`].
-    #[inline]
-    pub fn region(&self) -> Option<Region> {
-        self.langid.region
-    }
-
-    /// Sets the [`Region`] for this [`DataLocale`].
-    #[inline]
-    pub fn set_region(&mut self, region: Option<Region>) {
-        self.langid.region = region;
-    }
-
-    /// Returns whether there are any [`Variant`] subtags in this [`DataLocale`].
-    #[inline]
-    pub fn has_variants(&self) -> bool {
-        !self.langid.variants.is_empty()
-    }
-
-    #[inline]
-    pub fn set_variants(&mut self, variants: Variants) {
-        self.langid.variants = variants;
-    }
-
-    /// Removes all [`Variant`] subtags in this [`DataLocale`].
-    #[inline]
-    pub fn clear_variants(&mut self) -> Variants {
-        self.langid.variants.clear()
-    }
-
-    /// Gets the value of the specified Unicode extension keyword for this [`DataLocale`].
-    #[inline]
-    pub fn get_unicode_ext(&self, key: &unicode_ext::Key) -> Option<unicode_ext::Value> {
-        self.keywords.get(key).cloned()
-    }
-
-    /// Returns whether there are any Unicode extension keywords in this [`DataLocale`].
-    #[inline]
-    pub fn has_unicode_ext(&self) -> bool {
-        !self.keywords.is_empty()
-    }
-
-    /// Returns whether a specific Unicode extension keyword is present in this [`DataLocale`].
-    #[inline]
-    pub fn contains_unicode_ext(&self, key: &unicode_ext::Key) -> bool {
-        self.keywords.contains_key(key)
-    }
-
-    /// Returns whether this [`DataLocale`] contains a Unicode extension keyword
-    /// with the specified key and value.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use icu_locid::{extensions_unicode_key as key, extensions_unicode_value as value, Locale};
-    /// use icu_provider::prelude::*;
-    ///
-    /// let locale: Locale = "it-IT-u-ca-coptic".parse().expect("Valid BCP-47");
-    /// let locale: DataLocale = locale.into();
-    ///
-    /// assert_eq!(locale.get_unicode_ext(&key!("hc")), None);
-    /// assert_eq!(
-    ///     locale.get_unicode_ext(&key!("ca")),
-    ///     Some(value!("coptic"))
-    /// );
-    /// assert!(locale.matches_unicode_ext(&key!("ca"), &value!("coptic"),));
-    /// ```
-    #[inline]
-    pub fn matches_unicode_ext(&self, key: &unicode_ext::Key, value: &unicode_ext::Value) -> bool {
-        self.keywords.get(key) == Some(value)
-    }
-
-    /// Sets the value for a specific Unicode extension keyword on this [`DataLocale`].
-    #[inline]
-    pub fn set_unicode_ext(
-        &mut self,
-        key: unicode_ext::Key,
-        value: unicode_ext::Value,
-    ) -> Option<unicode_ext::Value> {
-        self.keywords.set(key, value)
-    }
-
-    /// Removes a specific Unicode extension keyword from this [`DataLocale`], returning
-    /// the value if it was present.
-    #[inline]
-    pub fn remove_unicode_ext(&mut self, key: &unicode_ext::Key) -> Option<unicode_ext::Value> {
-        self.keywords.remove(key)
-    }
-
-    /// Retains a subset of keywords as specified by the predicate function.
-    #[inline]
-    pub fn retain_unicode_ext<F>(&mut self, predicate: F)
-    where
-        F: FnMut(&unicode_ext::Key) -> bool,
-    {
-        self.keywords.retain_by_key(predicate)
+    pub fn get_unicode_keyword(&self, key: unicode_ext::Key) -> Option<&unicode_ext::Value> {
+        self.keywords.get(&key)
     }
 }
 
 #[test]
 fn test_data_locale_to_string() {
     struct TestCase {
-        pub locale: DataLocale,
+        pub locale: Locale,
         pub expected: &'static str,
     }
 
     for cas in [
         TestCase {
-            locale: Locale::UND.into(),
+            locale: Locale::UND,
             expected: "und",
         },
         TestCase {
-            locale: "und-u-cu-gbp".parse::<Locale>().unwrap().into(),
+            locale: "und-u-cu-gbp".parse::<Locale>().unwrap(),
             expected: "und-u-cu-gbp",
         },
         TestCase {
-            locale: "en-ZA-u-cu-gbp".parse::<Locale>().unwrap().into(),
+            locale: "en-ZA-u-cu-gbp".parse::<Locale>().unwrap(),
             expected: "en-ZA-u-cu-gbp",
         },
     ] {
-        assert_eq!(cas.expected, cas.locale.to_string());
+        assert_eq!(cas.expected, DataLocale::from(&cas.locale).to_string());
         writeable::assert_writeable_eq!(&cas.locale, cas.expected);
     }
 }

--- a/provider/core/src/response.rs
+++ b/provider/core/src/response.rs
@@ -5,7 +5,6 @@
 use crate::buf::BufferMarker;
 use crate::error::{DataError, DataErrorKind};
 use crate::marker::DataMarker;
-use crate::request::DataLocale;
 use crate::yoke::trait_hack::YokeTraitHack;
 use crate::yoke::*;
 use core::convert::TryFrom;
@@ -17,7 +16,7 @@ use core::marker::PhantomData;
 #[non_exhaustive]
 pub struct DataResponseMetadata {
     /// The resolved locale of the returned data, if locale fallbacking was performed.
-    pub locale: Option<DataLocale>,
+    pub locale: Option<icu_locid::Locale>,
     /// The format of the buffer for buffer-backed data, if known (for example, JSON).
     pub buffer_format: Option<crate::buf::BufferFormat>,
 }

--- a/provider/datagen/src/databake.rs
+++ b/provider/datagen/src/databake.rs
@@ -112,7 +112,7 @@ impl DataExporter for BakedDataExporter {
     fn put_payload(
         &self,
         key: DataKey,
-        locale: &DataLocale,
+        locale: DataLocale,
         payload: &DataPayload<ExportMarker>,
     ) -> Result<(), DataError> {
         let (payload, marker_type) = payload.tokenize(&self.dependencies);

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -285,7 +285,7 @@ pub fn datagen(
             .map_err(|e| e.with_key(key))?;
         let res = locales.into_par_iter().try_for_each(|locale| {
             let req = DataRequest {
-                locale: &locale,
+                locale: (&locale).into(),
                 metadata: Default::default(),
             };
             let payload = provider
@@ -293,7 +293,7 @@ pub fn datagen(
                 .and_then(DataResponse::take_payload)
                 .map_err(|e| e.with_req(key, req))?;
             exporters.par_iter().try_for_each(|e| {
-                e.put_payload(key, &locale, &payload)
+                e.put_payload(key, (&locale).into(), &payload)
                     .map_err(|e| e.with_req(key, req))
             })
         });

--- a/provider/datagen/src/transform/cldr/calendar/japanese.rs
+++ b/provider/datagen/src/transform/cldr/calendar/japanese.rs
@@ -34,7 +34,7 @@ impl From<&SourceData> for JapaneseErasProvider {
 
 impl DataProvider<JapaneseErasV1Marker> for JapaneseErasProvider {
     fn load(&self, req: DataRequest) -> Result<DataResponse<JapaneseErasV1Marker>, DataError> {
-        let japanext = req.locale.get_unicode_ext(&key!("ca")) == Some(value!("japanext"));
+        let japanext = req.locale.get_unicode_keyword(key!("ca")) == Some(&value!("japanext"));
         // The era codes depend on the Latin romanizations of the eras, found
         // in the `en` locale. We load this data to construct era codes but
         // actual user code only needs to load the data for the locales it cares about.
@@ -183,10 +183,10 @@ fn era_to_code(original: &str, year: i32) -> Result<TinyStr16, String> {
 icu_provider::make_exportable_provider!(JapaneseErasProvider, [JapaneseErasV1Marker,]);
 
 impl IterableDataProvider<JapaneseErasV1Marker> for JapaneseErasProvider {
-    fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![
-            DataLocale::from(Locale::from_str("und-u-ca-japanese").unwrap()),
-            DataLocale::from(Locale::from_str("und-u-ca-japanext").unwrap()),
+            Locale::from_str("und-u-ca-japanese").unwrap(),
+            Locale::from_str("und-u-ca-japanext").unwrap(),
         ])
     }
 }

--- a/provider/datagen/src/transform/cldr/datetime/mod.rs
+++ b/provider/datagen/src/transform/cldr/datetime/mod.rs
@@ -62,7 +62,7 @@ macro_rules! impl_data_provider {
                     let langid = req.locale.get_langid();
                     let calendar = req
                         .locale
-                        .get_unicode_ext(&key!("ca"))
+                        .get_unicode_keyword(key!("ca"))
                         .ok_or_else(|| DataErrorKind::MissingLocale.into_error())?;
 
                     let cldr_cal = self
@@ -73,7 +73,7 @@ macro_rules! impl_data_provider {
                     let resource: &cldr_serde::ca::Resource = self
                         .source
                         .cldr()?
-                        .dates(cldr_cal).read_and_parse(&langid, &format!("ca-{}.json", cldr_cal))?;
+                        .dates(cldr_cal).read_and_parse(langid, &format!("ca-{}.json", cldr_cal))?;
 
                     let mut data =
                         resource
@@ -90,8 +90,8 @@ macro_rules! impl_data_provider {
                     // CLDR treats ethiopic and ethioaa as separate calendars; however we treat them as a single resource key that
                     // supports symbols for both era patterns based on the settings on the date. Load in ethioaa data as well when dealing with
                     // ethiopic.
-                    if calendar == value!("ethiopic") {
-                        let ethioaa: &cldr_serde::ca::Resource = self.source.cldr()?.dates("ethiopic").read_and_parse(&langid, "ca-ethiopic-amete-alem.json")?;
+                    if calendar == &value!("ethiopic") {
+                        let ethioaa: &cldr_serde::ca::Resource = self.source.cldr()?.dates("ethiopic").read_and_parse(langid, "ca-ethiopic-amete-alem.json")?;
 
                         let ethioaa_data = ethioaa
                             .main
@@ -113,7 +113,7 @@ macro_rules! impl_data_provider {
                         data.eras.narrow.insert("2".to_string(), mundi_narrow.clone());
                     }
 
-                    if calendar == value!("japanese") {
+                    if calendar == &value!("japanese") {
                         if self.modern_japanese_eras.read().expect("poison").is_none() {
                                 let era_dates: &cldr_serde::japanese::Resource = self
                                     .source
@@ -142,13 +142,13 @@ macro_rules! impl_data_provider {
                         data.eras.abbr.retain(|e, _| set.contains(e));
                         data.eras.narrow.retain(|e, _| set.contains(e));
                     }
-                    if calendar == value!("japanese") || calendar == value!("japanext") {
+                    if calendar == &value!("japanese") || calendar == &value!("japanext") {
 
                         // Splice in gregorian data for pre-meiji
                         let greg_resource: &cldr_serde::ca::Resource = self
                             .source
                             .cldr()?
-                            .dates("gregorian").read_and_parse(&langid, "ca-gregorian.json")?;
+                            .dates("gregorian").read_and_parse(langid, "ca-gregorian.json")?;
 
                         let greg =
                             greg_resource
@@ -181,7 +181,7 @@ macro_rules! impl_data_provider {
             }
 
             impl IterableDataProvider<$marker> for CommonDateProvider {
-                fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
+                fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
                     let mut r = Vec::new();
                     for (cal_value, cldr_cal) in self.supported_cals.iter() {
                         r.extend(self
@@ -195,7 +195,7 @@ macro_rules! impl_data_provider {
                                     .unicode
                                     .keywords
                                     .set(key!("ca"), cal_value.clone());
-                                DataLocale::from(locale)
+                                locale
                             }));
                     }
                     Ok(r)
@@ -232,7 +232,7 @@ mod test {
         let locale: Locale = "cs-u-ca-gregory".parse().unwrap();
         let cs_dates: DataPayload<DatePatternsV1Marker> = provider
             .load(DataRequest {
-                locale: &locale.into(),
+                locale: (&locale).into(),
                 metadata: Default::default(),
             })
             .expect("Failed to load payload")
@@ -249,7 +249,7 @@ mod test {
         let locale: Locale = "haw-u-ca-gregory".parse().unwrap();
         let cs_dates: DataPayload<DatePatternsV1Marker> = provider
             .load(DataRequest {
-                locale: &locale.into(),
+                locale: (&locale).into(),
                 metadata: Default::default(),
             })
             .expect("Failed to load payload")
@@ -270,7 +270,7 @@ mod test {
         let locale: Locale = "fil-u-ca-gregory".parse().unwrap();
         let skeletons: DataPayload<DateSkeletonPatternsV1Marker> = provider
             .load(DataRequest {
-                locale: &locale.into(),
+                locale: (&locale).into(),
                 metadata: Default::default(),
             })
             .expect("Failed to load payload")
@@ -314,7 +314,7 @@ mod test {
         let locale: Locale = "cs-u-ca-gregory".parse().unwrap();
         let cs_dates: DataPayload<DateSymbolsV1Marker> = provider
             .load(DataRequest {
-                locale: &locale.into(),
+                locale: (&locale).into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -345,7 +345,7 @@ mod test {
         let locale: Locale = "cs-u-ca-gregory".parse().unwrap();
         let cs_dates: DataPayload<DateSymbolsV1Marker> = provider
             .load(DataRequest {
-                locale: &locale.into(),
+                locale: (&locale).into(),
                 metadata: Default::default(),
             })
             .unwrap()

--- a/provider/datagen/src/transform/cldr/decimal/mod.rs
+++ b/provider/datagen/src/transform/cldr/decimal/mod.rs
@@ -5,6 +5,7 @@
 use crate::transform::cldr::cldr_serde;
 use crate::SourceData;
 use icu_decimal::provider::*;
+use icu_locid::Locale;
 use icu_provider::datagen::IterableDataProvider;
 use icu_provider::prelude::*;
 use std::borrow::Cow;
@@ -70,13 +71,13 @@ impl DataProvider<DecimalSymbolsV1Marker> for NumbersProvider {
             .source
             .cldr()?
             .numbers()
-            .read_and_parse(&langid, "numbers.json")?;
+            .read_and_parse(langid, "numbers.json")?;
 
         #[allow(clippy::expect_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
         let numbers = &resource
             .main
             .0
-            .get(&langid)
+            .get(langid)
             .expect("CLDR file contains the expected language")
             .numbers;
 
@@ -96,14 +97,8 @@ impl DataProvider<DecimalSymbolsV1Marker> for NumbersProvider {
 icu_provider::make_exportable_provider!(NumbersProvider, [DecimalSymbolsV1Marker,]);
 
 impl IterableDataProvider<DecimalSymbolsV1Marker> for NumbersProvider {
-    fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
-        Ok(self
-            .source
-            .cldr()?
-            .numbers()
-            .list_langs()?
-            .map(DataLocale::from)
-            .collect())
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
+        Ok(self.source.cldr()?.numbers().list_langs()?.collect())
     }
 }
 
@@ -150,7 +145,7 @@ fn test_basic() {
 
     let ar_decimal: DataPayload<DecimalSymbolsV1Marker> = provider
         .load(DataRequest {
-            locale: &locale!("ar-EG").into(),
+            locale: (&locale!("ar-EG")).into(),
             metadata: Default::default(),
         })
         .unwrap()

--- a/provider/datagen/src/transform/cldr/fallback/mod.rs
+++ b/provider/datagen/src/transform/cldr/fallback/mod.rs
@@ -5,7 +5,7 @@
 use crate::transform::cldr::cldr_serde;
 use crate::SourceData;
 
-use icu_locid::LanguageIdentifier;
+use icu_locid::{LanguageIdentifier, Locale};
 use icu_provider::datagen::IterableDataProvider;
 use icu_provider::prelude::*;
 use icu_provider_adapters::fallback::provider::*;
@@ -86,13 +86,13 @@ icu_provider::make_exportable_provider!(
 );
 
 impl IterableDataProvider<LocaleFallbackLikelySubtagsV1Marker> for FallbackRulesProvider {
-    fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }
 
 impl IterableDataProvider<LocaleFallbackParentsV1Marker> for FallbackRulesProvider {
-    fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }

--- a/provider/datagen/src/transform/cldr/list/mod.rs
+++ b/provider/datagen/src/transform/cldr/list/mod.rs
@@ -6,7 +6,7 @@ use crate::transform::cldr::cldr_serde;
 use crate::transform::icuexport::uprops::EnumeratedPropertyCodePointTrieProvider;
 use crate::SourceData;
 use icu_list::provider::*;
-use icu_locid::subtags_language as language;
+use icu_locid::{subtags_language as language, Locale};
 use icu_provider::datagen::IterableDataProvider;
 use icu_provider::prelude::*;
 use lazy_static::lazy_static;
@@ -35,12 +35,12 @@ impl<M: KeyedDataMarker<Yokeable = ListFormatterPatternsV1<'static>>> DataProvid
             .source
             .cldr()?
             .misc()
-            .read_and_parse(&langid, "listPatterns.json")?;
+            .read_and_parse(langid, "listPatterns.json")?;
 
         let data = &resource
             .main
             .0
-            .get(&langid)
+            .get(langid)
             .expect("CLDR file contains the expected language")
             .list_patterns;
 
@@ -139,14 +139,8 @@ icu_provider::make_exportable_provider!(
 impl<M: KeyedDataMarker<Yokeable = ListFormatterPatternsV1<'static>>> IterableDataProvider<M>
     for ListProvider
 {
-    fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
-        Ok(self
-            .source
-            .cldr()?
-            .misc()
-            .list_langs()?
-            .map(DataLocale::from)
-            .collect())
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
+        Ok(self.source.cldr()?.misc().list_langs()?.collect())
     }
 }
 

--- a/provider/datagen/src/transform/cldr/locale_canonicalizer/aliases.rs
+++ b/provider/datagen/src/transform/cldr/locale_canonicalizer/aliases.rs
@@ -5,7 +5,7 @@
 use crate::transform::cldr::cldr_serde;
 use crate::SourceData;
 use icu_locale_canonicalizer::provider::*;
-use icu_locid::{subtags, subtags_language as language, LanguageIdentifier};
+use icu_locid::{subtags, subtags_language as language, LanguageIdentifier, Locale};
 use icu_provider::datagen::IterableDataProvider;
 use icu_provider::prelude::*;
 use tinystr::TinyAsciiStr;
@@ -48,7 +48,7 @@ impl DataProvider<AliasesV1Marker> for AliasesProvider {
 icu_provider::make_exportable_provider!(AliasesProvider, [AliasesV1Marker,]);
 
 impl IterableDataProvider<AliasesV1Marker> for AliasesProvider {
-    fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }

--- a/provider/datagen/src/transform/cldr/locale_canonicalizer/likely_subtags.rs
+++ b/provider/datagen/src/transform/cldr/locale_canonicalizer/likely_subtags.rs
@@ -5,6 +5,7 @@
 use crate::transform::cldr::cldr_serde;
 use crate::SourceData;
 use icu_locale_canonicalizer::provider::*;
+use icu_locid::Locale;
 use icu_provider::datagen::IterableDataProvider;
 use icu_provider::prelude::*;
 use zerovec::ZeroMap;
@@ -47,7 +48,7 @@ impl DataProvider<LikelySubtagsV1Marker> for LikelySubtagsProvider {
 icu_provider::make_exportable_provider!(LikelySubtagsProvider, [LikelySubtagsV1Marker,]);
 
 impl IterableDataProvider<LikelySubtagsV1Marker> for LikelySubtagsProvider {
-    fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }

--- a/provider/datagen/src/transform/cldr/source.rs
+++ b/provider/datagen/src/transform/cldr/source.rs
@@ -4,7 +4,7 @@
 
 use crate::source::AbstractFs;
 use elsa::sync::FrozenMap;
-use icu_locid::LanguageIdentifier;
+use icu_locid::{LanguageIdentifier, Locale};
 use icu_provider::DataError;
 use std::any::Any;
 use std::fmt::Debug;
@@ -112,10 +112,13 @@ impl<'a> CldrDirLang<'a> {
         read_and_parse_json(self.0, &format!("{}/{}/{}", self.1, lang, file_name))
     }
 
-    pub(crate) fn list_langs(&self) -> Result<impl Iterator<Item = LanguageIdentifier>, DataError> {
-        Ok(self.0.root.list(&self.1)?.into_iter().map(|path| {
-            LanguageIdentifier::from_str(&path.file_name().unwrap().to_string_lossy()).unwrap()
-        }))
+    pub(crate) fn list_langs(&self) -> Result<impl Iterator<Item = Locale>, DataError> {
+        Ok(self
+            .0
+            .root
+            .list(&self.1)?
+            .into_iter()
+            .map(|path| Locale::from_str(&path.file_name().unwrap().to_string_lossy()).unwrap()))
     }
 }
 

--- a/provider/datagen/src/transform/cldr/time_zones/mod.rs
+++ b/provider/datagen/src/transform/cldr/time_zones/mod.rs
@@ -6,6 +6,7 @@ use crate::transform::cldr::cldr_serde;
 use crate::transform::cldr::cldr_serde::time_zones::CldrTimeZonesData;
 use crate::SourceData;
 use icu_datetime::provider::time_zones::*;
+use icu_locid::Locale;
 use icu_provider::datagen::IterableDataProvider;
 use icu_provider::prelude::*;
 use std::collections::HashMap;
@@ -37,7 +38,7 @@ macro_rules! impl_data_provider {
                         .source
                         .cldr()?
                         .dates("gregorian")
-                        .read_and_parse(&langid, "timeZoneNames.json")?;
+                        .read_and_parse(langid, "timeZoneNames.json")?;
                     let time_zone_names = resource
                         .main
                         .0
@@ -91,13 +92,12 @@ macro_rules! impl_data_provider {
             }
 
             impl IterableDataProvider<$marker> for TimeZonesProvider {
-                fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
+                fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
                     Ok(self
                         .source
                         .cldr()?
                         .dates("gregorian")
                         .list_langs()?
-                        .map(DataLocale::from)
                         .collect())
                 }
             }
@@ -131,7 +131,7 @@ mod tests {
 
         let time_zone_formats: DataPayload<TimeZoneFormatsV1Marker> = provider
             .load(DataRequest {
-                locale: &langid!("en").into(),
+                locale: (&langid!("en")).into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -141,7 +141,7 @@ mod tests {
 
         let exemplar_cities: DataPayload<ExemplarCitiesV1Marker> = provider
             .load(DataRequest {
-                locale: &langid!("en").into(),
+                locale: (&langid!("en")).into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -158,7 +158,7 @@ mod tests {
 
         let generic_names_long: DataPayload<MetaZoneGenericNamesLongV1Marker> = provider
             .load(DataRequest {
-                locale: &langid!("en").into(),
+                locale: (&langid!("en")).into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -183,7 +183,7 @@ mod tests {
 
         let specific_names_long: DataPayload<MetaZoneSpecificNamesLongV1Marker> = provider
             .load(DataRequest {
-                locale: &langid!("en").into(),
+                locale: (&langid!("en")).into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -211,7 +211,7 @@ mod tests {
 
         let generic_names_short: DataPayload<MetaZoneGenericNamesShortV1Marker> = provider
             .load(DataRequest {
-                locale: &langid!("en").into(),
+                locale: (&langid!("en")).into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -236,7 +236,7 @@ mod tests {
 
         let specific_names_short: DataPayload<MetaZoneSpecificNamesShortV1Marker> = provider
             .load(DataRequest {
-                locale: &langid!("en").into(),
+                locale: (&langid!("en")).into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -264,7 +264,7 @@ mod tests {
 
         let metazone_period: DataPayload<MetaZonePeriodV1Marker> = provider
             .load(DataRequest {
-                locale: &langid!("en").into(),
+                locale: (&langid!("en")).into(),
                 metadata: Default::default(),
             })
             .unwrap()

--- a/provider/datagen/src/transform/icuexport/collator/mod.rs
+++ b/provider/datagen/src/transform/icuexport/collator/mod.rs
@@ -34,7 +34,7 @@ pub const ALL_KEYS: [DataKey; 6] = [
 ];
 
 fn locale_to_file_name(locale: &DataLocale) -> String {
-    let mut s = if locale.get_langid() == LanguageIdentifier::UND {
+    let mut s = if locale.get_langid() == &LanguageIdentifier::UND {
         String::from("root")
     } else {
         locale
@@ -43,7 +43,7 @@ fn locale_to_file_name(locale: &DataLocale) -> String {
             .replace('-', "_")
             .replace("posix", "POSIX")
     };
-    if let Some(extension) = &locale.get_unicode_ext(&key!("co")) {
+    if let Some(extension) = &locale.get_unicode_keyword(key!("co")) {
         s.push('_');
         s.push_str(match extension.to_string().as_str() {
             "trad" => "traditional",
@@ -138,7 +138,7 @@ macro_rules! collation_provider {
             }
 
             impl IterableDataProvider<$marker> for CollationProvider {
-                fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
+                fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
                     Ok(self
                         .source
                         .icuexport()?
@@ -153,7 +153,6 @@ macro_rules! collation_provider {
                                 .map(ToString::to_string)
                         )
                         .filter_map(|s|file_name_to_locale(&s))
-                        .map(DataLocale::from)
                         .collect()
                     )
                 }

--- a/provider/datagen/src/transform/icuexport/normalizer/mod.rs
+++ b/provider/datagen/src/transform/icuexport/normalizer/mod.rs
@@ -8,6 +8,7 @@
 use crate::SourceData;
 use icu_char16trie::char16trie::Char16Trie;
 use icu_codepointtrie::CodePointTrie;
+use icu_locid::Locale;
 use icu_normalizer::provider::*;
 use icu_normalizer::u24::U24;
 use icu_provider::datagen::IterableDataProvider;
@@ -51,8 +52,8 @@ macro_rules! normalization_provider {
         icu_provider::make_exportable_provider!($provider, [$marker,]);
 
         impl IterableDataProvider<$marker> for $provider {
-            fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
-                Ok(vec![DataLocale::default()])
+            fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
+                Ok(vec![Default::default()])
             }
         }
     };

--- a/provider/datagen/src/transform/icuexport/ucase/mod.rs
+++ b/provider/datagen/src/transform/icuexport/ucase/mod.rs
@@ -10,6 +10,7 @@ use icu_casemapping::provider::{CaseMappingV1, CaseMappingV1Marker};
 use icu_casemapping::CaseMappingInternals;
 use icu_codepointtrie::toml::CodePointDataSlice;
 use icu_codepointtrie::CodePointTrieHeader;
+use icu_locid::Locale;
 use icu_provider::prelude::*;
 use std::convert::TryFrom;
 
@@ -74,7 +75,7 @@ impl DataProvider<CaseMappingV1Marker> for CaseMappingDataProvider {
 }
 
 impl icu_provider::datagen::IterableDataProvider<CaseMappingV1Marker> for CaseMappingDataProvider {
-    fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }

--- a/provider/datagen/src/transform/icuexport/uprops/bin_uniset.rs
+++ b/provider/datagen/src/transform/icuexport/uprops/bin_uniset.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::SourceData;
+use icu_locid::Locale;
 use icu_properties::provider::*;
 use icu_provider::datagen::*;
 use icu_provider::prelude::*;
@@ -65,7 +66,7 @@ macro_rules! expand {
             impl IterableDataProvider<$marker> for BinaryPropertyUnicodeSetDataProvider {
                 fn supported_locales(
                     &self,
-                ) -> Result<Vec<DataLocale>, DataError> {
+                ) -> Result<Vec<Locale>, DataError> {
                     get_binary(&self.source, $prop_name)?;
 
                     Ok(vec![Default::default()])

--- a/provider/datagen/src/transform/icuexport/uprops/enum_codepointtrie.rs
+++ b/provider/datagen/src/transform/icuexport/uprops/enum_codepointtrie.rs
@@ -4,6 +4,7 @@
 
 use crate::SourceData;
 use icu_codepointtrie::CodePointTrie;
+use icu_locid::Locale;
 use icu_properties::provider::*;
 use icu_provider::datagen::*;
 use icu_provider::prelude::*;
@@ -62,7 +63,7 @@ macro_rules! expand {
             impl IterableDataProvider<$marker> for EnumeratedPropertyCodePointTrieProvider {
                 fn supported_locales(
                     &self,
-                ) -> Result<Vec<DataLocale>, DataError> {
+                ) -> Result<Vec<Locale>, DataError> {
                     get_enumerated(&self.source, $prop_name)?;
                     Ok(vec![Default::default()])
                 }

--- a/provider/datagen/src/transform/icuexport/uprops/script.rs
+++ b/provider/datagen/src/transform/icuexport/uprops/script.rs
@@ -4,6 +4,7 @@
 
 use crate::SourceData;
 use icu_codepointtrie::CodePointTrie;
+use icu_locid::Locale;
 use icu_properties::provider::{
     ScriptWithExtensionsPropertyV1, ScriptWithExtensionsPropertyV1Marker,
 };
@@ -82,7 +83,7 @@ impl DataProvider<ScriptWithExtensionsPropertyV1Marker> for ScriptWithExtensions
 impl IterableDataProvider<ScriptWithExtensionsPropertyV1Marker>
     for ScriptWithExtensionsPropertyProvider
 {
-    fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }

--- a/provider/datagen/src/transform/segmenter/lstm.rs
+++ b/provider/datagen/src/transform/segmenter/lstm.rs
@@ -6,7 +6,7 @@
 
 use crate::transform::cldr::source::read_and_parse_json;
 use crate::SourceData;
-use icu_locid::{langid, locale};
+use icu_locid::{langid, locale, Locale};
 use icu_provider::datagen::IterableDataProvider;
 use icu_provider::prelude::*;
 use icu_segmenter::*;
@@ -66,7 +66,7 @@ impl From<&SourceData> for SegmenterLstmProvider {
 
 impl SegmenterLstmProvider {
     // Generate LSTM Data for DataProvider from LSTM JSON.
-    fn generate_data(&self, locale: &DataLocale) -> Result<LstmDataV1<'static>, DataError> {
+    fn generate_data(&self, locale: DataLocale) -> Result<LstmDataV1<'static>, DataError> {
         let lstm_data: &RawLstmData = read_and_parse_json::<RawLstmData>(
             self.source.segmenter_lstm()?,
             &format!(
@@ -105,14 +105,14 @@ impl SegmenterLstmProvider {
         })
     }
 
-    fn get_json_filename(locale: &DataLocale) -> Option<&'static str> {
-        if locale.get_langid() == langid!("km") {
+    fn get_json_filename(locale: DataLocale) -> Option<&'static str> {
+        if locale.get_langid() == &langid!("km") {
             Some("lstm_km.json")
-        } else if locale.get_langid() == langid!("lo") {
+        } else if locale.get_langid() == &langid!("lo") {
             Some("lstm_lo.json")
-        } else if locale.get_langid() == langid!("my") {
+        } else if locale.get_langid() == &langid!("my") {
             Some("lstm_my.json")
-        } else if locale.get_langid() == langid!("th") {
+        } else if locale.get_langid() == &langid!("th") {
             Some("lstm_th.json")
         } else {
             None
@@ -133,12 +133,12 @@ impl DataProvider<LstmDataV1Marker> for SegmenterLstmProvider {
 icu_provider::make_exportable_provider!(SegmenterLstmProvider, [LstmDataV1Marker,]);
 
 impl IterableDataProvider<LstmDataV1Marker> for SegmenterLstmProvider {
-    fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![
-            locale!("km").into(),
-            locale!("lo").into(),
-            locale!("my").into(),
-            locale!("th").into(),
+            locale!("km"),
+            locale!("lo"),
+            locale!("my"),
+            locale!("th"),
         ])
     }
 }

--- a/provider/datagen/src/transform/segmenter/mod.rs
+++ b/provider/datagen/src/transform/segmenter/mod.rs
@@ -10,7 +10,7 @@ use crate::transform::icuexport::uprops::{
 use crate::SourceData;
 use icu_codepointtrie::CodePointTrie;
 use icu_codepointtrie_builder::{CodePointTrieBuilder, CodePointTrieBuilderData};
-use icu_locid::{langid, locale};
+use icu_locid::{langid, locale, Locale};
 use icu_properties::{
     maps, sets, EastAsianWidth, GeneralCategory, GraphemeClusterBreak, LineBreak, SentenceBreak,
     WordBreak,
@@ -694,25 +694,25 @@ icu_provider::make_exportable_provider!(
 );
 
 impl IterableDataProvider<LineBreakDataV1Marker> for SegmenterRuleProvider {
-    fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }
 
 impl IterableDataProvider<GraphemeClusterBreakDataV1Marker> for SegmenterRuleProvider {
-    fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }
 
 impl IterableDataProvider<WordBreakDataV1Marker> for SegmenterRuleProvider {
-    fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }
 
 impl IterableDataProvider<SentenceBreakDataV1Marker> for SegmenterRuleProvider {
-    fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![Default::default()])
     }
 }
@@ -729,16 +729,16 @@ pub struct SegmenterDictionaryProvider {
 }
 
 impl SegmenterDictionaryProvider {
-    fn get_toml_filename(locale: &DataLocale) -> Option<&'static str> {
-        if locale.get_langid() == langid!("km") {
+    fn get_toml_filename(locale: DataLocale) -> Option<&'static str> {
+        if locale.get_langid() == &langid!("km") {
             Some("dictionary_km.toml")
-        } else if locale.get_langid() == langid!("ja") {
+        } else if locale.get_langid() == &langid!("ja") {
             Some("dictionary_cj.toml")
-        } else if locale.get_langid() == langid!("lo") {
+        } else if locale.get_langid() == &langid!("lo") {
             Some("dictionary_lo.toml")
-        } else if locale.get_langid() == langid!("my") {
+        } else if locale.get_langid() == &langid!("my") {
             Some("dictionary_my.toml")
-        } else if locale.get_langid() == langid!("th") {
+        } else if locale.get_langid() == &langid!("th") {
             Some("dictionary_th.toml")
         } else {
             None
@@ -782,13 +782,13 @@ icu_provider::make_exportable_provider!(
 );
 
 impl IterableDataProvider<UCharDictionaryBreakDataV1Marker> for SegmenterDictionaryProvider {
-    fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
+    fn supported_locales(&self) -> Result<Vec<Locale>, DataError> {
         Ok(vec![
-            locale!("th").into(),
-            locale!("km").into(),
-            locale!("lo").into(),
-            locale!("my").into(),
-            locale!("ja").into(),
+            locale!("th"),
+            locale!("km"),
+            locale!("lo"),
+            locale!("my"),
+            locale!("ja"),
         ])
     }
 }

--- a/provider/datagen/tests/verify-zero-copy.rs
+++ b/provider/datagen/tests/verify-zero-copy.rs
@@ -84,7 +84,7 @@ fn main() {
             let payload = provider.load_buffer(
                 key,
                 DataRequest {
-                    locale: &locale,
+                    locale: (&locale).into(),
                     metadata: Default::default(),
                 },
             ).unwrap().take_payload().unwrap();

--- a/provider/fs/benches/provider_fs.rs
+++ b/provider/fs/benches/provider_fs.rs
@@ -17,7 +17,7 @@ fn overview_bench(c: &mut Criterion) {
                 .expect("Loading file from testdata directory");
             let _: DataPayload<HelloWorldV1Marker> = black_box(&provider)
                 .load(DataRequest {
-                    locale: &langid!("ru").into(),
+                    locale: (&langid!("ru")).into(),
                     metadata: Default::default(),
                 })
                 .and_then(DataResponse::take_payload)
@@ -44,7 +44,7 @@ fn json_bench(c: &mut Criterion) {
         b.iter(|| {
             let _: DataPayload<HelloWorldV1Marker> = black_box(&provider)
                 .load(DataRequest {
-                    locale: &langid!("ru").into(),
+                    locale: (&langid!("ru")).into(),
                     metadata: Default::default(),
                 })
                 .and_then(DataResponse::take_payload)
@@ -57,7 +57,7 @@ fn json_bench(c: &mut Criterion) {
             let _: DataPayload<HelloWorldV1Marker> = black_box(&provider as &dyn BufferProvider)
                 .as_deserializing()
                 .load(DataRequest {
-                    locale: &langid!("ru").into(),
+                    locale: (&langid!("ru")).into(),
                     metadata: Default::default(),
                 })
                 .and_then(DataResponse::take_payload)
@@ -75,7 +75,7 @@ fn bincode_bench(c: &mut Criterion) {
         b.iter(|| {
             let _: DataPayload<HelloWorldV1Marker> = black_box(&provider)
                 .load(DataRequest {
-                    locale: &langid!("ru").into(),
+                    locale: (&langid!("ru")).into(),
                     metadata: Default::default(),
                 })
                 .and_then(DataResponse::take_payload)
@@ -88,7 +88,7 @@ fn bincode_bench(c: &mut Criterion) {
             let _: DataPayload<HelloWorldV1Marker> = black_box(&provider as &dyn BufferProvider)
                 .as_deserializing()
                 .load(DataRequest {
-                    locale: &langid!("ru").into(),
+                    locale: (&langid!("ru")).into(),
                     metadata: Default::default(),
                 })
                 .expect("The data should be valid")
@@ -107,7 +107,7 @@ fn postcard_bench(c: &mut Criterion) {
         b.iter(|| {
             let _: DataPayload<HelloWorldV1Marker> = black_box(&provider)
                 .load(DataRequest {
-                    locale: &langid!("ru").into(),
+                    locale: (&langid!("ru")).into(),
                     metadata: Default::default(),
                 })
                 .expect("The data should be valid")
@@ -121,7 +121,7 @@ fn postcard_bench(c: &mut Criterion) {
             let _: DataPayload<HelloWorldV1Marker> = black_box(&provider as &dyn BufferProvider)
                 .as_deserializing()
                 .load(DataRequest {
-                    locale: &langid!("ru").into(),
+                    locale: (&langid!("ru")).into(),
                     metadata: Default::default(),
                 })
                 .and_then(DataResponse::take_payload)

--- a/provider/fs/src/export/fs_exporter.rs
+++ b/provider/fs/src/export/fs_exporter.rs
@@ -90,7 +90,7 @@ impl DataExporter for FilesystemExporter {
     fn put_payload(
         &self,
         key: DataKey,
-        locale: &DataLocale,
+        locale: DataLocale,
         obj: &DataPayload<ExportMarker>,
     ) -> Result<(), DataError> {
         log::trace!("Writing: {}/{}", key, locale);

--- a/provider/fs/src/export/mod.rs
+++ b/provider/fs/src/export/mod.rs
@@ -39,7 +39,7 @@
 //! let result = exporter
 //!     .put_payload(
 //!         HelloWorldV1Marker::KEY,
-//!         &Default::default(),
+//!         Default::default(),
 //!         &UpcastDataPayload::upcast(payload.clone()),
 //!     )
 //!     .expect("Should successfully export");

--- a/provider/fs/tests/test_file_io.rs
+++ b/provider/fs/tests/test_file_io.rs
@@ -18,9 +18,9 @@ const PATHS: &[&str] = &[JSON_PATH, BINCODE_PATH, POSTCARD_PATH];
 fn test_provider() {
     for path in PATHS {
         let provider = FsDataProvider::try_new(path).unwrap();
-        for locale in HelloWorldProvider.supported_locales().unwrap() {
+        for locale in &HelloWorldProvider.supported_locales().unwrap() {
             let req = DataRequest {
-                locale: &locale,
+                locale: locale.into(),
                 metadata: Default::default(),
             };
 
@@ -51,7 +51,7 @@ fn test_errors() {
         let provider = FsDataProvider::try_new(path).unwrap();
 
         let err: Result<DataResponse<HelloWorldV1Marker>, DataError> = provider.load(DataRequest {
-            locale: &langid!("zh-DE").into(),
+            locale: (&langid!("zh-DE")).into(),
             metadata: Default::default(),
         });
 

--- a/provider/testdata/src/lib.rs
+++ b/provider/testdata/src/lib.rs
@@ -42,7 +42,7 @@
 //!
 //! let data: DataPayload<icu_plurals::provider::CardinalV1Marker> = data_provider
 //!     .load(DataRequest {
-//!         locale: &locale!("ru").into(),
+//!         locale: (&locale!("ru")).into(),
 //!         metadata: Default::default(),
 //!     })
 //!     .unwrap()


### PR DESCRIPTION
This replaces `DataLocale`s owned fields by a reference to either a `Locale` or a `LanguageIdentifier`. This will allow our component constructors to work on `&Locale` and `&LanguageIdentifier` (aka `Into<DataLocale>`), which is nice as these are quite big structs that you don't want to be passing around and cloning all the time.

Vertical fallback constructs an owned `Locale` from the reference and works on that. This could be optimized to use a `(LanguageIdentifier, unicode::Keywords)` (aka old `DataLocale`) if needed, however this would only slightly reduce stack usage, otherwise it's equivalent.