### PR TITLE
`LiteMap` of `&'a [(K, V)]`

### DIFF
--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -48,7 +48,7 @@ default = ["alloc"]
 alloc = []
 
 # Enables the `testing` module with tools for testing custom stores.
-testing = []
+testing = ["alloc"]
 
 [[test]]
 name = "serde"

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -42,6 +42,14 @@ icu_locid = { version = "0.6", path = "../../components/locid" }
 icu_benchmark_macros = { version = "0.6", path = "../../tools/benchmark/macros" }
 criterion = "0.3.4"
 
+[features]
+bench = []
+default = ["alloc"]
+alloc = []
+
+# Enables the `testing` module with tools for testing custom stores.
+testing = []
+
 [[test]]
 name = "serde"
 required-features = ["serde"]
@@ -59,12 +67,6 @@ required-features = ["serde"]
 name = "litemap_postcard"
 path = "benches/bin/litemap_postcard.rs"
 required-features = ["serde"]
-
-[features]
-bench = []
-
-# Enables the `testing` module with tools for testing custom stores.
-testing = []
 
 [[bench]]
 name = "litemap"

--- a/utils/litemap/src/map.rs
+++ b/utils/litemap/src/map.rs
@@ -2,14 +2,14 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::store::*;
 use alloc::borrow::Borrow;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
 use core::iter::FromIterator;
 use core::marker::PhantomData;
 use core::mem;
 use core::ops::{Index, IndexMut};
-use alloc::vec::Vec;
-use crate::store::*;
-use core::cmp::Ordering;
 
 /// A simple "flat" map based on a sorted vector
 ///
@@ -57,14 +57,14 @@ impl<K, V> LiteMap<K, V, Vec<(K, V)>> {
     }
 }
 
-impl<K: ?Sized, V: ?Sized> LiteMap<K, V, &'static[(&'static K, &'static V)]> {
-    /// Convert a `&'static [(K, V)]` into a [`LiteMap`].
+impl<'a, K: ?Sized, V: ?Sized> LiteMap<K, V, &'a [(&'a K, &'a V)]> {
+    /// Convert a `&'a [(K, V)]` into a [`LiteMap`].
     ///
     /// # Safety
     ///
     /// The slice must be sorted and have no duplicate keys.
     #[inline]
-    pub const unsafe fn from_slice_unchecked(values: &'static [(&'static K, &'static V)]) -> Self {
+    pub const unsafe fn from_slice_unchecked(values: &'a [(&'a K, &'a V)]) -> Self {
         Self {
             values,
             _key_type: PhantomData,

--- a/utils/litemap/src/map.rs
+++ b/utils/litemap/src/map.rs
@@ -57,14 +57,14 @@ impl<K, V> LiteMap<K, V, Vec<(K, V)>> {
     }
 }
 
-impl<'a, K: ?Sized, V: ?Sized> LiteMap<K, V, &'a [(&'a K, &'a V)]> {
+impl<'a, K, V> LiteMap<K, V, &'a [(K, V)]> {
     /// Convert a `&'a [(K, V)]` into a [`LiteMap`].
     ///
     /// # Safety
     ///
     /// The slice must be sorted and have no duplicate keys.
     #[inline]
-    pub const unsafe fn from_slice_unchecked(values: &'a [(&'a K, &'a V)]) -> Self {
+    pub const unsafe fn from_slice_unchecked(values: &'a [(K, V)]) -> Self {
         Self {
             values,
             _key_type: PhantomData,

--- a/utils/litemap/src/serde.rs
+++ b/utils/litemap/src/serde.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use super::LiteMap;
-use crate::store::Store;
+use crate::store::*;
 use core::fmt;
 use core::marker::PhantomData;
 use serde::de::{MapAccess, SeqAccess, Visitor};
@@ -64,7 +64,7 @@ impl<'de, K, V, R> Visitor<'de> for LiteMapVisitor<K, V, R>
 where
     K: Deserialize<'de> + Ord,
     V: Deserialize<'de>,
-    R: Store<K, V>,
+    R: StoreMut<K, V>,
 {
     type Value = LiteMap<K, V, R>;
 
@@ -127,7 +127,7 @@ impl<'de, K, V, R> Deserialize<'de> for LiteMap<K, V, R>
 where
     K: Ord + Deserialize<'de>,
     V: Deserialize<'de>,
-    R: Store<K, V>,
+    R: StoreMut<K, V>,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/utils/litemap/src/store/mod.rs
+++ b/utils/litemap/src/store/mod.rs
@@ -23,7 +23,9 @@
 //!
 //! [`check_litemap()`]: crate::testing::check_litemap
 
+#[cfg(feature = "alloc")]
 mod vec_impl;
+mod slice_impl;
 
 use core::cmp::Ordering;
 use core::iter::DoubleEndedIterator;
@@ -34,19 +36,7 @@ use core::iter::Iterator;
 ///
 /// Some methods have default implementations provided for convenience; however, it is generally
 /// better to implement all methods that your data store supports.
-pub trait Store<K, V> {
-    type KeyValueIntoIter: Iterator<Item = (K, V)>;
-
-    /// Creates a new store with the specified capacity hint.
-    ///
-    /// Implementations may ignore the argument if they do not support pre-allocating capacity.
-    fn lm_with_capacity(capacity: usize) -> Self;
-
-    /// Reserves additional capacity in the store.
-    ///
-    /// Implementations may ignore the argument if they do not support pre-allocating capacity.
-    fn lm_reserve(&mut self, additional: usize);
-
+pub trait Store<K: ?Sized, V: ?Sized>: Sized {
     /// Returns the number of elements in the store.
     fn lm_len(&self) -> usize;
 
@@ -57,9 +47,6 @@ pub trait Store<K, V> {
 
     /// Gets a key/value pair at the specified index.
     fn lm_get(&self, index: usize) -> Option<(&K, &V)>;
-
-    /// Gets a key/value pair at the specified index, with a mutable value.
-    fn lm_get_mut(&mut self, index: usize) -> Option<(&K, &mut V)>;
 
     /// Gets the last element in the store, or None if the store is empty.
     fn lm_last(&self) -> Option<(&K, &V)> {
@@ -77,7 +64,23 @@ pub trait Store<K, V> {
     fn lm_binary_search_by<F>(&self, cmp: F) -> Result<usize, usize>
     where
         F: FnMut(&K) -> Ordering;
+}
 
+pub trait StoreMut<K, V>: Store<K, V> {
+    type KeyValueIntoIter: Iterator<Item = (K, V)>;
+
+    /// Creates a new store with the specified capacity hint.
+    ///
+    /// Implementations may ignore the argument if they do not support pre-allocating capacity.
+    fn lm_with_capacity(capacity: usize) -> Self;
+
+    /// Reserves additional capacity in the store.
+    ///
+    /// Implementations may ignore the argument if they do not support pre-allocating capacity.
+    fn lm_reserve(&mut self, additional: usize);
+
+    /// Gets a key/value pair at the specified index, with a mutable value.
+    fn lm_get_mut(&mut self, index: usize) -> Option<(&K, &mut V)>;
     /// Pushes one additional item onto the store.
     fn lm_push(&mut self, key: K, value: V);
 
@@ -137,15 +140,19 @@ pub trait Store<K, V> {
 
     /// Returns an iterator that moves every item from this store.
     fn lm_into_iter(self) -> Self::KeyValueIntoIter;
+
 }
 
 /// Iterator methods for the LiteMap store.
 pub trait StoreIterable<'a, K: 'a, V: 'a>: Store<K, V> {
     type KeyValueIter: Iterator<Item = (&'a K, &'a V)> + DoubleEndedIterator + 'a;
-    type KeyValueIterMut: Iterator<Item = (&'a K, &'a mut V)> + DoubleEndedIterator + 'a;
 
     /// Returns an iterator over key/value pairs.
     fn lm_iter(&'a self) -> Self::KeyValueIter;
+}
+
+pub trait StoreIterableMut<'a, K: 'a, V: 'a>: StoreMut<K, V> + StoreIterable<'a, K, V> {
+    type KeyValueIterMut: Iterator<Item = (&'a K, &'a mut V)> + DoubleEndedIterator + 'a;
 
     /// Returns an iterator over key/value pairs, with a mutable value.
     fn lm_iter_mut(&'a mut self) -> Self::KeyValueIterMut;

--- a/utils/litemap/src/store/slice_impl.rs
+++ b/utils/litemap/src/store/slice_impl.rs
@@ -4,11 +4,6 @@
 
 use super::*;
 
-#[inline]
-fn map_f<'a, K: ?Sized, V: ?Sized>(input: &(&'a K, &'a V)) -> (&'a K, &'a V) {
-    *input
-}
-
 impl<'a, K: 'a + ?Sized, V: 'a + ?Sized> Store<K, V> for &'a [(&'a K, &'a V)] {
     #[inline]
     fn lm_len(&self) -> usize {
@@ -22,12 +17,12 @@ impl<'a, K: 'a + ?Sized, V: 'a + ?Sized> Store<K, V> for &'a [(&'a K, &'a V)] {
 
     #[inline]
     fn lm_get(&self, index: usize) -> Option<(&K, &V)> {
-        self.get(index).map(map_f)
+        self.get(index).copied()
     }
 
     #[inline]
     fn lm_last(&self) -> Option<(&K, &V)> {
-        self.last().map(map_f)
+        self.last().copied()
     }
 
     #[inline]
@@ -39,11 +34,11 @@ impl<'a, K: 'a + ?Sized, V: 'a + ?Sized> Store<K, V> for &'a [(&'a K, &'a V)] {
     }
 }
 
-// impl<'a, K: 'a, V: 'a> StoreIterable<'a, K, V> for &'a [(K, V)] {
-//     type KeyValueIter = core::iter::Map<core::slice::Iter<'a, (K, V)>, MapF<K, V>>;
+impl<'a, K: 'a, V: 'a> StoreIterable<'a, K, V> for &'a [(&'a K, &'a V)] {
+    type KeyValueIter = core::iter::Copied<core::slice::Iter<'a, (&'a K, &'a V)>>;
 
-//     #[inline]
-//     fn lm_iter(&'a self) -> Self::KeyValueIter {
-//         self.iter().map(map_f)
-//     }
-// }
+    #[inline]
+    fn lm_iter(&'a self) -> Self::KeyValueIter {
+        self.iter().copied()
+    }
+}

--- a/utils/litemap/src/store/slice_impl.rs
+++ b/utils/litemap/src/store/slice_impl.rs
@@ -1,0 +1,49 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use super::*;
+
+#[inline]
+fn map_f<K: ?Sized, V: ?Sized>(input: &(&'static K, &'static V)) -> (&'static K, &'static V) {
+    *input
+}
+
+impl<K: 'static + ?Sized, V: 'static + ?Sized> Store<K, V> for &'static [(&'static K, &'static V)] {
+    #[inline]
+    fn lm_len(&self) -> usize {
+        self.len()
+    }
+
+    #[inline]
+    fn lm_is_empty(&self) -> bool {
+        self.is_empty()
+    }
+
+    #[inline]
+    fn lm_get(&self, index: usize) -> Option<(&K, &V)> {
+        self.get(index).map(map_f)
+    }
+
+    #[inline]
+    fn lm_last(&self) -> Option<(&K, &V)> {
+        self.last().map(map_f)
+    }
+
+    #[inline]
+    fn lm_binary_search_by<F>(&self, mut cmp: F) -> Result<usize, usize>
+    where
+        F: FnMut(&K) -> Ordering,
+    {
+        self.binary_search_by(|(k, _)| cmp(k))
+    }
+}
+
+// impl<'a, K: 'a, V: 'a> StoreIterable<'a, K, V> for &'a [(K, V)] {
+//     type KeyValueIter = core::iter::Map<core::slice::Iter<'a, (K, V)>, MapF<K, V>>;
+
+//     #[inline]
+//     fn lm_iter(&'a self) -> Self::KeyValueIter {
+//         self.iter().map(map_f)
+//     }
+// }

--- a/utils/litemap/src/store/slice_impl.rs
+++ b/utils/litemap/src/store/slice_impl.rs
@@ -4,7 +4,14 @@
 
 use super::*;
 
-impl<'a, K: 'a + ?Sized, V: 'a + ?Sized> Store<K, V> for &'a [(&'a K, &'a V)] {
+type MapF<K, V> = fn(&(K, V)) -> (&K, &V);
+
+#[inline]
+fn map_f<K, V>(input: &(K, V)) -> (&K, &V) {
+    (&input.0, &input.1)
+}
+
+impl<'a, K: 'a, V: 'a> Store<K, V> for &'a [(K, V)] {
     #[inline]
     fn lm_len(&self) -> usize {
         self.len()
@@ -17,12 +24,12 @@ impl<'a, K: 'a + ?Sized, V: 'a + ?Sized> Store<K, V> for &'a [(&'a K, &'a V)] {
 
     #[inline]
     fn lm_get(&self, index: usize) -> Option<(&K, &V)> {
-        self.get(index).copied()
+        self.get(index).map(map_f)
     }
 
     #[inline]
     fn lm_last(&self) -> Option<(&K, &V)> {
-        self.last().copied()
+        self.last().map(map_f)
     }
 
     #[inline]
@@ -34,11 +41,11 @@ impl<'a, K: 'a + ?Sized, V: 'a + ?Sized> Store<K, V> for &'a [(&'a K, &'a V)] {
     }
 }
 
-impl<'a, K: 'a, V: 'a> StoreIterable<'a, K, V> for &'a [(&'a K, &'a V)] {
-    type KeyValueIter = core::iter::Copied<core::slice::Iter<'a, (&'a K, &'a V)>>;
+impl<'a, K: 'a, V: 'a> StoreIterable<'a, K, V> for &'a [(K, V)] {
+    type KeyValueIter = core::iter::Map<core::slice::Iter<'a, (K, V)>, MapF<K, V>>;
 
     #[inline]
     fn lm_iter(&'a self) -> Self::KeyValueIter {
-        self.iter().copied()
+        self.iter().map(map_f)
     }
 }

--- a/utils/litemap/src/store/slice_impl.rs
+++ b/utils/litemap/src/store/slice_impl.rs
@@ -5,11 +5,11 @@
 use super::*;
 
 #[inline]
-fn map_f<K: ?Sized, V: ?Sized>(input: &(&'static K, &'static V)) -> (&'static K, &'static V) {
+fn map_f<'a, K: ?Sized, V: ?Sized>(input: &(&'a K, &'a V)) -> (&'a K, &'a V) {
     *input
 }
 
-impl<K: 'static + ?Sized, V: 'static + ?Sized> Store<K, V> for &'static [(&'static K, &'static V)] {
+impl<'a, K: 'a + ?Sized, V: 'a + ?Sized> Store<K, V> for &'a [(&'a K, &'a V)] {
     #[inline]
     fn lm_len(&self) -> usize {
         self.len()

--- a/utils/litemap/src/store/vec_impl.rs
+++ b/utils/litemap/src/store/vec_impl.rs
@@ -50,8 +50,6 @@ impl<K, V> Store<K, V> for Vec<(K, V)> {
 }
 
 impl<K, V> StoreMut<K, V> for Vec<(K, V)> {
-    type KeyValueIntoIter = alloc::vec::IntoIter<(K, V)>;
-
     #[inline]
     fn lm_with_capacity(capacity: usize) -> Self {
         Self::with_capacity(capacity)
@@ -83,16 +81,6 @@ impl<K, V> StoreMut<K, V> for Vec<(K, V)> {
     }
 
     #[inline]
-    fn lm_extend_end(&mut self, other: Self) {
-        self.extend(other)
-    }
-
-    #[inline]
-    fn lm_extend_start(&mut self, other: Self) {
-        self.splice(0..0, other);
-    }
-
-    #[inline]
     fn lm_clear(&mut self) {
         self.clear()
     }
@@ -103,11 +91,6 @@ impl<K, V> StoreMut<K, V> for Vec<(K, V)> {
         F: FnMut(&K, &V) -> bool,
     {
         self.retain(|(k, v)| predicate(k, v))
-    }
-
-    #[inline]
-    fn lm_into_iter(self) -> Self::KeyValueIntoIter {
-        IntoIterator::into_iter(self)
     }
 }
 
@@ -122,10 +105,26 @@ impl<'a, K: 'a, V: 'a> StoreIterable<'a, K, V> for Vec<(K, V)> {
 
 impl<'a, K: 'a, V: 'a> StoreIterableMut<'a, K, V> for Vec<(K, V)> {
     type KeyValueIterMut = core::iter::Map<core::slice::IterMut<'a, (K, V)>, MapFMut<K, V>>;
+    type KeyValueIntoIter = alloc::vec::IntoIter<(K, V)>;
 
     #[inline]
     fn lm_iter_mut(&'a mut self) -> Self::KeyValueIterMut {
         self.as_mut_slice().iter_mut().map(map_f_mut)
+    }
+
+    #[inline]
+    fn lm_into_iter(self) -> Self::KeyValueIntoIter {
+        IntoIterator::into_iter(self)
+    }
+
+    #[inline]
+    fn lm_extend_end(&mut self, other: Self) {
+        self.extend(other)
+    }
+
+    #[inline]
+    fn lm_extend_start(&mut self, other: Self) {
+        self.splice(0..0, other);
     }
 }
 

--- a/utils/litemap/src/store/vec_impl.rs
+++ b/utils/litemap/src/store/vec_impl.rs
@@ -20,18 +20,6 @@ fn map_f_mut<K, V>(input: &mut (K, V)) -> (&K, &mut V) {
 }
 
 impl<K, V> Store<K, V> for Vec<(K, V)> {
-    type KeyValueIntoIter = alloc::vec::IntoIter<(K, V)>;
-
-    #[inline]
-    fn lm_with_capacity(capacity: usize) -> Self {
-        Self::with_capacity(capacity)
-    }
-
-    #[inline]
-    fn lm_reserve(&mut self, additional: usize) {
-        self.reserve(additional)
-    }
-
     #[inline]
     fn lm_len(&self) -> usize {
         self.as_slice().len()
@@ -48,11 +36,6 @@ impl<K, V> Store<K, V> for Vec<(K, V)> {
     }
 
     #[inline]
-    fn lm_get_mut(&mut self, index: usize) -> Option<(&K, &mut V)> {
-        self.as_mut_slice().get_mut(index).map(map_f_mut)
-    }
-
-    #[inline]
     fn lm_last(&self) -> Option<(&K, &V)> {
         self.as_slice().last().map(map_f)
     }
@@ -63,6 +46,25 @@ impl<K, V> Store<K, V> for Vec<(K, V)> {
         F: FnMut(&K) -> Ordering,
     {
         self.as_slice().binary_search_by(|(k, _)| cmp(k))
+    }
+}
+
+impl<K, V> StoreMut<K, V> for Vec<(K, V)> {
+    type KeyValueIntoIter = alloc::vec::IntoIter<(K, V)>;
+
+    #[inline]
+    fn lm_with_capacity(capacity: usize) -> Self {
+        Self::with_capacity(capacity)
+    }
+
+    #[inline]
+    fn lm_reserve(&mut self, additional: usize) {
+        self.reserve(additional)
+    }
+
+    #[inline]
+    fn lm_get_mut(&mut self, index: usize) -> Option<(&K, &mut V)> {
+        self.as_mut_slice().get_mut(index).map(map_f_mut)
     }
 
     #[inline]
@@ -111,12 +113,15 @@ impl<K, V> Store<K, V> for Vec<(K, V)> {
 
 impl<'a, K: 'a, V: 'a> StoreIterable<'a, K, V> for Vec<(K, V)> {
     type KeyValueIter = core::iter::Map<core::slice::Iter<'a, (K, V)>, MapF<K, V>>;
-    type KeyValueIterMut = core::iter::Map<core::slice::IterMut<'a, (K, V)>, MapFMut<K, V>>;
 
     #[inline]
     fn lm_iter(&'a self) -> Self::KeyValueIter {
         self.as_slice().iter().map(map_f)
     }
+}
+
+impl<'a, K: 'a, V: 'a> StoreIterableMut<'a, K, V> for Vec<(K, V)> {
+    type KeyValueIterMut = core::iter::Map<core::slice::IterMut<'a, (K, V)>, MapFMut<K, V>>;
 
     #[inline]
     fn lm_iter_mut(&'a mut self) -> Self::KeyValueIterMut {

--- a/utils/litemap/src/testing.rs
+++ b/utils/litemap/src/testing.rs
@@ -4,7 +4,7 @@
 
 //! Test utilities, primarily targeted to custom LiteMap stores.
 
-use crate::store::{Store, StoreFromIterator, StoreIterable};
+use crate::store::*;
 use crate::LiteMap;
 use alloc::vec::Vec;
 use core::fmt::Debug;
@@ -15,8 +15,8 @@ fn check_equivalence<K, V, S0, S1>(mut a: S0, mut b: S1)
 where
     K: Ord + Debug + PartialEq,
     V: Debug + PartialEq,
-    S0: Store<K, V>,
-    S1: Store<K, V>,
+    S0: StoreMut<K, V>,
+    S1: StoreMut<K, V>,
 {
     let len = a.lm_len();
     assert_eq!(len, b.lm_len());
@@ -80,7 +80,7 @@ const RANDOM_DATA: &[(u32, u64)] = &[
 #[allow(clippy::panic)]
 fn populate_litemap<S>(map: &mut LiteMap<u32, u64, S>)
 where
-    S: Store<u32, u64> + Debug,
+    S: StoreMut<u32, u64> + Debug,
 {
     assert_eq!(0, map.len());
     assert!(map.is_empty());
@@ -111,15 +111,7 @@ where
 /// Call this function in a test and pass it an empty instance of a `LiteMap` with a custom store.
 // Test code
 #[allow(clippy::expect_used)]
-pub fn check_litemap<'a, S>(mut litemap_test: LiteMap<u32, u64, S>)
-where
-    S: Store<u32, u64>
-        + StoreIterable<'a, u32, u64>
-        + StoreFromIterator<u32, u64>
-        + Clone
-        + Debug
-        + PartialEq,
-{
+pub fn check_litemap<'a, S>(mut litemap_test: LiteMap<u32, u64, Vec<(u32, u64)>>) {
     assert!(litemap_test.is_empty());
     let mut litemap_std = LiteMap::<u32, u64>::new();
     populate_litemap(&mut litemap_test);

--- a/utils/litemap/src/testing.rs
+++ b/utils/litemap/src/testing.rs
@@ -108,7 +108,7 @@ where
 
 /// Tests that the given litemap instance has behavior consistent with the reference impl.
 ///
-/// Call this function in a test and pass it an instance of a `LiteMap` populated with the above data.
+/// Call this function in a test and pass it an empty instance of a `LiteMap` with a custom store.
 // Test code
 #[allow(clippy::expect_used)]
 pub fn check_litemap<'a, S>(mut litemap_test: LiteMap<u32, u64, S>)
@@ -169,5 +169,5 @@ where
 
     litemap_test.clear();
     litemap_std.clear();
-    check_equivalence(litemap_test.clone().values, litemap_std.clone().values);
+    check_equivalence(litemap_test.values, litemap_std.values);
 }

--- a/utils/litemap/tests/store.rs
+++ b/utils/litemap/tests/store.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use litemap::store::{Store, StoreFromIterator, StoreIterable};
+use litemap::store::*;
 use litemap::testing::check_litemap;
 use litemap::LiteMap;
 use std::cmp::Ordering;
@@ -26,18 +26,6 @@ fn map_f_mut<K, V>(input: &mut (K, V)) -> (&K, &mut V) {
 }
 
 impl<K, V> Store<K, V> for VecWithDefaults<(K, V)> {
-    type KeyValueIntoIter = std::vec::IntoIter<(K, V)>;
-
-    #[inline]
-    fn lm_with_capacity(capacity: usize) -> Self {
-        Self(Vec::with_capacity(capacity))
-    }
-
-    #[inline]
-    fn lm_reserve(&mut self, additional: usize) {
-        self.0.reserve(additional)
-    }
-
     #[inline]
     fn lm_len(&self) -> usize {
         self.0.as_slice().len()
@@ -50,11 +38,6 @@ impl<K, V> Store<K, V> for VecWithDefaults<(K, V)> {
         self.0.as_slice().get(index).map(map_f)
     }
 
-    #[inline]
-    fn lm_get_mut(&mut self, index: usize) -> Option<(&K, &mut V)> {
-        self.0.as_mut_slice().get_mut(index).map(map_f_mut)
-    }
-
     // leave lm_last as default
 
     #[inline]
@@ -63,6 +46,23 @@ impl<K, V> Store<K, V> for VecWithDefaults<(K, V)> {
         F: FnMut(&K) -> Ordering,
     {
         self.0.as_slice().binary_search_by(|(k, _)| cmp(k))
+    }
+}
+
+impl<K, V> StoreMut<K, V> for VecWithDefaults<(K, V)> {
+    #[inline]
+    fn lm_with_capacity(capacity: usize) -> Self {
+        Self(Vec::with_capacity(capacity))
+    }
+
+    #[inline]
+    fn lm_reserve(&mut self, additional: usize) {
+        self.0.reserve(additional)
+    }
+
+    #[inline]
+    fn lm_get_mut(&mut self, index: usize) -> Option<(&K, &mut V)> {
+        self.0.as_mut_slice().get_mut(index).map(map_f_mut)
     }
 
     #[inline]
@@ -79,37 +79,40 @@ impl<K, V> Store<K, V> for VecWithDefaults<(K, V)> {
     fn lm_remove(&mut self, index: usize) -> (K, V) {
         self.0.remove(index)
     }
-
-    // leave lm_extend_end as default
-
-    // leave lm_extend_start as default
-
     #[inline]
     fn lm_clear(&mut self) {
         self.0.clear()
     }
 
     // leave lm_retain as default
-
-    #[inline]
-    fn lm_into_iter(self) -> Self::KeyValueIntoIter {
-        IntoIterator::into_iter(self.0)
-    }
 }
 
 impl<'a, K: 'a, V: 'a> StoreIterable<'a, K, V> for VecWithDefaults<(K, V)> {
     type KeyValueIter = core::iter::Map<core::slice::Iter<'a, (K, V)>, MapF<K, V>>;
-    type KeyValueIterMut = core::iter::Map<core::slice::IterMut<'a, (K, V)>, MapFMut<K, V>>;
 
     #[inline]
     fn lm_iter(&'a self) -> Self::KeyValueIter {
         self.0.as_slice().iter().map(map_f)
     }
+}
+
+impl<'a, K: 'a, V: 'a> StoreIterableMut<'a, K, V> for VecWithDefaults<(K, V)> {
+    type KeyValueIterMut = core::iter::Map<core::slice::IterMut<'a, (K, V)>, MapFMut<K, V>>;
+    type KeyValueIntoIter = std::vec::IntoIter<(K, V)>;
 
     #[inline]
     fn lm_iter_mut(&'a mut self) -> Self::KeyValueIterMut {
         self.0.as_mut_slice().iter_mut().map(map_f_mut)
     }
+
+    #[inline]
+    fn lm_into_iter(self) -> Self::KeyValueIntoIter {
+        IntoIterator::into_iter(self.0)
+    }
+
+    // leave lm_extend_end as default
+
+    // leave lm_extend_start as default
 }
 
 impl<A> std::iter::FromIterator<A> for VecWithDefaults<A> {


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->