### PR TITLE
Add link to vertical fallback algorithm

### DIFF
--- a/provider/adapters/src/fallback/mod.rs
+++ b/provider/adapters/src/fallback/mod.rs
@@ -4,6 +4,11 @@
 
 //! Tools for locale fallback, enabling arbitrary input locales to be mapped into the nearest
 //! locale with data.
+//! 
+//! The algorithm implemented in this module is called [Flexible Vertical Fallback](
+//! https://docs.google.com/document/d/1Mp7EUyl-sFh_HZYgyeVwj88vJGpCBIWxzlCwGgLCDwM/edit).
+//! Watch [#2243](https://github.com/unicode-org/icu4x/issues/2243) to track improvements to
+//! this algorithm and steps to enshrine the algorithm in CLDR.
 //!
 //! # Examples
 //!

--- a/provider/adapters/src/fallback/mod.rs
+++ b/provider/adapters/src/fallback/mod.rs
@@ -4,7 +4,7 @@
 
 //! Tools for locale fallback, enabling arbitrary input locales to be mapped into the nearest
 //! locale with data.
-//! 
+//!
 //! The algorithm implemented in this module is called [Flexible Vertical Fallback](
 //! https://docs.google.com/document/d/1Mp7EUyl-sFh_HZYgyeVwj88vJGpCBIWxzlCwGgLCDwM/edit).
 //! Watch [#2243](https://github.com/unicode-org/icu4x/issues/2243) to track improvements to


### PR DESCRIPTION
Fixes #1203

Since this algorithm is eventually destined for CLDR, I decided not to spend time migrating it to a markdown doc in this repo. For the sake of closing this 1.0 issue, I'll link to my Google Doc, and I filed #2243 to track the migration of the algorithm to CLDR.