### PR TITLE
Update ICU tag for icuexportdata

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -208,8 +208,8 @@ jobs:
       uses: robinraju/release-downloader@v1.3
       with: 
         repository: "unicode-org/icu"
-        tag: "icu4x/2022-07-18/71.x"
-        fileName: "icuexportdata_icu4x-2022-07-18-71.x.zip"
+        tag: "icu4x/2022-07-25/71.x"
+        fileName: "icuexportdata_icu4x-2022-07-25-71.x.zip"
         out-file-path: "data/source/"
     - name: Run datagen
       uses: actions-rs/cargo@v1.0.1
@@ -217,7 +217,7 @@ jobs:
         command: run
         args: > 
           -p icu_datagen --features bin --release --
-          --icuexport-root data/source/icuexportdata_icu4x-2022-07-18-71.x.zip
+          --icuexport-root data/source/icuexportdata_icu4x-2022-07-25-71.x.zip
           --cldr-root data/source/cldr-41.0.0-json-full.zip
           --all-locales
           --all-keys

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -194,7 +194,7 @@ jobs:
       id: source-data-cache
       with:
         path: data/source
-        key: source-data-41-71c
+        key: source-data/41/icu4x-2022-07-25-71.x
     - name: Download CLDR source data
       if: steps.source-data-cache.outputs.cache-hit != 'true'
       uses: robinraju/release-downloader@v1.3

--- a/provider/datagen/src/source.rs
+++ b/provider/datagen/src/source.rs
@@ -98,7 +98,7 @@ impl SourceData {
     /// using the given tag. (see [GitHub releases](https://github.com/unicode-org/icu/releases)).
     pub fn with_icuexport_for_tag(self, mut tag: &str) -> Result<Self, DataError> {
         if tag == "release-71-1" {
-            tag = "icu4x/2022-07-18/71.x";
+            tag = "icu4x/2022-07-25/71.x";
         }
         self.with_icuexport(
             cached_path::CacheBuilder::new().freshness_lifetime(u64::MAX).build().and_then(|cache| cache

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -200,6 +200,7 @@ icuexportdata_glob = [
     "norm/small/nfkc.toml",
     "norm/small/nfkd.toml",
     "norm/small/nfkdex.toml",
+    "norm/small/passthroughnop.toml",
     "norm/small/uts46.toml",
     "norm/small/uts46d.toml",
     "ucase/small/ucase.toml",
@@ -264,7 +265,7 @@ icuexportdata_glob = [
     "uprops/small/XIDS.toml",
 ]
 
-icuexportdata_gitref = "icu4x/2022-07-18/71.x"
+icuexportdata_gitref = "icu4x/2022-07-25/71.x"
 
 [package.metadata.cargo-all-features]
 # Omit most optional dependency features from permutation testing


### PR DESCRIPTION
This should fix the `full-datagen` test