### PR TITLE
Add Date::new_from_codes, also document and fix up per-calendar constructor functions

### DIFF
--- a/components/calendar/benches/date.rs
+++ b/components/calendar/benches/date.rs
@@ -89,7 +89,15 @@ fn date_benches(c: &mut Criterion) {
         "calendar/ethiopic",
         &fxs,
         icu::calendar::ethiopic::Ethiopic::new(),
-        |y, m, d| Date::new_ethiopic_date(y, m, d).unwrap(),
+        |y, m, d| {
+            Date::new_ethiopic_date(
+                icu::calendar::ethiopic::EthiopicEraStyle::AmeteMihret,
+                y,
+                m,
+                d,
+            )
+            .unwrap()
+        },
     );
 
     #[cfg(feature = "bench")]

--- a/components/calendar/benches/datetime.rs
+++ b/components/calendar/benches/datetime.rs
@@ -100,7 +100,18 @@ fn datetime_benches(c: &mut Criterion) {
         "calendar/ethiopic",
         &fxs,
         icu::calendar::ethiopic::Ethiopic::new(),
-        |y, m, d, h, min, s| DateTime::new_ethiopic_datetime(y, m, d, h, min, s).unwrap(),
+        |y, m, d, h, min, s| {
+            DateTime::new_ethiopic_datetime(
+                icu::calendar::ethiopic::EthiopicEraStyle::AmeteMihret,
+                y,
+                m,
+                d,
+                h,
+                min,
+                s,
+            )
+            .unwrap()
+        },
     );
 
     #[cfg(feature = "bench")]

--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -687,3 +687,242 @@ impl IncludedInAnyCalendar for Iso {
         AnyDateInner::Iso(*d)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Ref;
+    use core::convert::TryInto;
+
+    fn single_test_roundtrip(
+        calendar: Ref<AnyCalendar>,
+        era: &str,
+        year: i32,
+        month_code: &str,
+        day: u8,
+    ) {
+        let era = types::Era(era.parse().expect("era must parse"));
+        let month = types::MonthCode(month_code.parse().expect("month code must parse"));
+
+        let date = Date::new_from_codes(era, year, month, day, calendar).unwrap_or_else(|e| {
+            panic!(
+                "Failed to construct date for {} with {:?}, {}, {}, {}: {}",
+                calendar.debug_name(),
+                era,
+                year,
+                month,
+                day,
+                e,
+            )
+        });
+
+        let roundtrip_year = date.year();
+        let roundtrip_era = roundtrip_year.era;
+        let roundtrip_year = roundtrip_year.number;
+        let roundtrip_month = date.month().code;
+        let roundtrip_day = date.day_of_month().0.try_into().expect("Must fit in u8");
+
+        assert_eq!(
+            (era, year, month, day),
+            (
+                roundtrip_era,
+                roundtrip_year,
+                roundtrip_month,
+                roundtrip_day
+            ),
+            "Failed to roundtrip for calendar {}",
+            calendar.debug_name()
+        );
+
+        let iso = date.to_iso();
+        let reconstructed = Date::new_from_iso(iso, calendar);
+        assert_eq!(
+            date, reconstructed,
+            "Failed to roundtrip via iso with {era:?}, {year}, {month}, {day}"
+        )
+    }
+
+    fn single_test_error(
+        calendar: Ref<AnyCalendar>,
+        era: &str,
+        year: i32,
+        month_code: &str,
+        day: u8,
+        error: DateTimeError,
+    ) {
+        let era = types::Era(era.parse().expect("era must parse"));
+        let month = types::MonthCode(month_code.parse().expect("month code must parse"));
+
+        let date = Date::new_from_codes(era, year, month, day, calendar);
+        assert_eq!(
+            date,
+            Err(error),
+            "Construction with {era:?}, {year}, {month}, {day} did not return {error:?}"
+        )
+    }
+
+    #[test]
+    fn test_any_construction() {
+        let provider = icu_testdata::get_provider();
+
+        let buddhist =
+            AnyCalendar::try_new_with_buffer_provider(AnyCalendarKind::Buddhist, &provider)
+                .expect("Calendar construction must succeed");
+        let coptic = AnyCalendar::try_new_with_buffer_provider(AnyCalendarKind::Coptic, &provider)
+            .expect("Calendar construction must succeed");
+        let ethiopic =
+            AnyCalendar::try_new_with_buffer_provider(AnyCalendarKind::Ethiopic, &provider)
+                .expect("Calendar construction must succeed");
+        let ethioaa =
+            AnyCalendar::try_new_with_buffer_provider(AnyCalendarKind::Ethioaa, &provider)
+                .expect("Calendar construction must succeed");
+        let gregorian =
+            AnyCalendar::try_new_with_buffer_provider(AnyCalendarKind::Gregorian, &provider)
+                .expect("Calendar construction must succeed");
+        let indian = AnyCalendar::try_new_with_buffer_provider(AnyCalendarKind::Indian, &provider)
+            .expect("Calendar construction must succeed");
+        let japanese =
+            AnyCalendar::try_new_with_buffer_provider(AnyCalendarKind::Japanese, &provider)
+                .expect("Calendar construction must succeed");
+        let japanext =
+            AnyCalendar::try_new_with_buffer_provider(AnyCalendarKind::Japanext, &provider)
+                .expect("Calendar construction must succeed");
+        let buddhist = Ref(&buddhist);
+        let coptic = Ref(&coptic);
+        let ethiopic = Ref(&ethiopic);
+        let ethioaa = Ref(&ethioaa);
+        let gregorian = Ref(&gregorian);
+        let indian = Ref(&indian);
+        let japanese = Ref(&japanese);
+        let japanext = Ref(&japanext);
+
+        single_test_roundtrip(buddhist, "be", 100, "M03", 1);
+        single_test_roundtrip(buddhist, "be", 2000, "M03", 1);
+        single_test_roundtrip(buddhist, "be", -100, "M03", 1);
+        single_test_error(
+            buddhist,
+            "be",
+            100,
+            "M13",
+            1,
+            DateTimeError::UnknownMonthCode("M13".parse().unwrap(), "Buddhist"),
+        );
+
+        single_test_roundtrip(coptic, "ad", 100, "M03", 1);
+        single_test_roundtrip(coptic, "ad", 2000, "M03", 1);
+        // fails ISO roundtrip
+        // single_test_roundtrip(coptic, "bd", 100, "M03", 1);
+        single_test_roundtrip(coptic, "ad", 100, "M13", 1);
+        single_test_error(
+            coptic,
+            "ad",
+            100,
+            "M14",
+            1,
+            DateTimeError::UnknownMonthCode("M14".parse().unwrap(), "Coptic"),
+        );
+        single_test_error(coptic, "ad", 0, "M03", 1, DateTimeError::OutOfRange);
+        single_test_error(coptic, "bd", 0, "M03", 1, DateTimeError::OutOfRange);
+
+        single_test_roundtrip(ethiopic, "incar", 100, "M03", 1);
+        single_test_roundtrip(ethiopic, "incar", 2000, "M03", 1);
+        single_test_roundtrip(ethiopic, "incar", 2000, "M13", 1);
+        // Fails ISO roundtrip due to https://github.com/unicode-org/icu4x/issues/2254
+        // single_test_roundtrip(ethiopic, "pre-incar", 100, "M03", 1);
+        single_test_error(ethiopic, "incar", 0, "M03", 1, DateTimeError::OutOfRange);
+        single_test_error(
+            ethiopic,
+            "pre-incar",
+            0,
+            "M03",
+            1,
+            DateTimeError::OutOfRange,
+        );
+        single_test_error(
+            ethiopic,
+            "incar",
+            100,
+            "M14",
+            1,
+            DateTimeError::UnknownMonthCode("M14".parse().unwrap(), "Ethiopic"),
+        );
+
+        single_test_roundtrip(ethioaa, "mundi", 7000, "M13", 1);
+        single_test_roundtrip(ethioaa, "mundi", 7000, "M13", 1);
+        // Fails ISO roundtrip due to https://github.com/unicode-org/icu4x/issues/2254
+        // single_test_roundtrip(ethioaa, "mundi", 100, "M03", 1);
+        single_test_error(
+            ethiopic,
+            "mundi",
+            100,
+            "M14",
+            1,
+            DateTimeError::UnknownMonthCode("M14".parse().unwrap(), "Ethiopic"),
+        );
+
+        single_test_roundtrip(gregorian, "ce", 100, "M03", 1);
+        single_test_roundtrip(gregorian, "ce", 2000, "M03", 1);
+        single_test_roundtrip(gregorian, "bce", 100, "M03", 1);
+        single_test_error(gregorian, "ce", 0, "M03", 1, DateTimeError::OutOfRange);
+        single_test_error(gregorian, "bce", 0, "M03", 1, DateTimeError::OutOfRange);
+
+        single_test_error(
+            gregorian,
+            "bce",
+            100,
+            "M13",
+            1,
+            DateTimeError::UnknownMonthCode("M13".parse().unwrap(), "Gregorian"),
+        );
+
+        single_test_roundtrip(indian, "saka", 100, "M03", 1);
+        single_test_roundtrip(indian, "saka", 2000, "M12", 1);
+        single_test_roundtrip(indian, "saka", -100, "M03", 1);
+        single_test_roundtrip(indian, "saka", 0, "M03", 1);
+        single_test_error(
+            indian,
+            "saka",
+            100,
+            "M13",
+            1,
+            DateTimeError::UnknownMonthCode("M13".parse().unwrap(), "Indian"),
+        );
+        single_test_roundtrip(japanese, "reiwa", 3, "M03", 1);
+        single_test_roundtrip(japanese, "heisei", 6, "M12", 1);
+        single_test_roundtrip(japanese, "meiji", 10, "M03", 1);
+        single_test_roundtrip(japanese, "ce", 1000, "M03", 1);
+        single_test_roundtrip(japanese, "bce", 10, "M03", 1);
+        single_test_error(japanese, "ce", 0, "M03", 1, DateTimeError::OutOfRange);
+        single_test_error(japanese, "bce", 0, "M03", 1, DateTimeError::OutOfRange);
+
+        single_test_error(
+            japanese,
+            "reiwa",
+            2,
+            "M13",
+            1,
+            DateTimeError::UnknownMonthCode("M13".parse().unwrap(), "Japanese (Modern eras only)"),
+        );
+
+        single_test_roundtrip(japanext, "reiwa", 3, "M03", 1);
+        single_test_roundtrip(japanext, "heisei", 6, "M12", 1);
+        single_test_roundtrip(japanext, "meiji", 10, "M03", 1);
+        single_test_roundtrip(japanext, "tenpyokampo-749", 1, "M04", 20);
+        single_test_roundtrip(japanext, "ce", 100, "M03", 1);
+        single_test_roundtrip(japanext, "bce", 10, "M03", 1);
+        single_test_error(japanext, "ce", 0, "M03", 1, DateTimeError::OutOfRange);
+        single_test_error(japanext, "bce", 0, "M03", 1, DateTimeError::OutOfRange);
+
+        single_test_error(
+            japanext,
+            "reiwa",
+            2,
+            "M13",
+            1,
+            DateTimeError::UnknownMonthCode(
+                "M13".parse().unwrap(),
+                "Japanese (With historical eras)",
+            ),
+        );
+    }
+}

--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -11,7 +11,9 @@ use crate::gregorian::Gregorian;
 use crate::indian::Indian;
 use crate::iso::Iso;
 use crate::japanese::{Japanese, JapaneseEraStyle};
-use crate::{types, AsCalendar, Calendar, Date, DateDuration, DateDurationUnit, DateTime, Ref};
+use crate::{
+    types, AsCalendar, Calendar, Date, DateDuration, DateDurationUnit, DateTime, DateTimeError, Ref,
+};
 
 use icu_locid::{
     extensions::unicode::Value, extensions_unicode_key as key, extensions_unicode_value as value,
@@ -80,6 +82,39 @@ macro_rules! match_cal_and_date {
 
 impl Calendar for AnyCalendar {
     type DateInner = AnyDateInner;
+    fn date_from_codes(
+        &self,
+        era: types::Era,
+        year: i32,
+        month_code: types::MonthCode,
+        day: u8,
+    ) -> Result<Self::DateInner, DateTimeError> {
+        let ret = match *self {
+            Self::Gregorian(ref c) => {
+                AnyDateInner::Gregorian(c.date_from_codes(era, year, month_code, day)?)
+            }
+            Self::Buddhist(ref c) => {
+                AnyDateInner::Buddhist(c.date_from_codes(era, year, month_code, day)?)
+            }
+            Self::Japanese(ref c) => {
+                AnyDateInner::Japanese(c.date_from_codes(era, year, month_code, day)?)
+            }
+            Self::Japanext(ref c) => {
+                AnyDateInner::Japanext(c.date_from_codes(era, year, month_code, day)?)
+            }
+            Self::Ethiopic(ref c) => {
+                AnyDateInner::Ethiopic(c.date_from_codes(era, year, month_code, day)?)
+            }
+            Self::Indian(ref c) => {
+                AnyDateInner::Indian(c.date_from_codes(era, year, month_code, day)?)
+            }
+            Self::Coptic(ref c) => {
+                AnyDateInner::Coptic(c.date_from_codes(era, year, month_code, day)?)
+            }
+            Self::Iso(ref c) => AnyDateInner::Iso(c.date_from_codes(era, year, month_code, day)?),
+        };
+        Ok(ret)
+    }
     fn date_from_iso(&self, iso: Date<Iso>) -> AnyDateInner {
         match *self {
             Self::Gregorian(ref c) => AnyDateInner::Gregorian(c.date_from_iso(iso)),

--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -6,7 +6,7 @@
 
 use crate::buddhist::Buddhist;
 use crate::coptic::Coptic;
-use crate::ethiopic::Ethiopic;
+use crate::ethiopic::{Ethiopic, EthiopicEraStyle};
 use crate::gregorian::Gregorian;
 use crate::indian::Indian;
 use crate::iso::Iso;
@@ -299,9 +299,11 @@ impl AnyCalendar {
             AnyCalendarKind::Coptic => AnyCalendar::Coptic(Coptic),
             AnyCalendarKind::Iso => AnyCalendar::Iso(Iso),
             AnyCalendarKind::Ethiopic => {
-                AnyCalendar::Ethiopic(Ethiopic::new_with_amete_alem(false))
+                AnyCalendar::Ethiopic(Ethiopic::new_with_era_style(EthiopicEraStyle::AmeteMihret))
             }
-            AnyCalendarKind::Ethioaa => AnyCalendar::Ethiopic(Ethiopic::new_with_amete_alem(true)),
+            AnyCalendarKind::Ethioaa => {
+                AnyCalendar::Ethiopic(Ethiopic::new_with_era_style(EthiopicEraStyle::AmeteAlem))
+            }
         })
     }
 
@@ -335,9 +337,11 @@ impl AnyCalendar {
             AnyCalendarKind::Coptic => AnyCalendar::Coptic(Coptic),
             AnyCalendarKind::Iso => AnyCalendar::Iso(Iso),
             AnyCalendarKind::Ethiopic => {
-                AnyCalendar::Ethiopic(Ethiopic::new_with_amete_alem(false))
+                AnyCalendar::Ethiopic(Ethiopic::new_with_era_style(EthiopicEraStyle::AmeteMihret))
             }
-            AnyCalendarKind::Ethioaa => AnyCalendar::Ethiopic(Ethiopic::new_with_amete_alem(true)),
+            AnyCalendarKind::Ethioaa => {
+                AnyCalendar::Ethiopic(Ethiopic::new_with_era_style(EthiopicEraStyle::AmeteAlem))
+            }
         })
     }
 
@@ -363,9 +367,11 @@ impl AnyCalendar {
             AnyCalendarKind::Coptic => AnyCalendar::Coptic(Coptic),
             AnyCalendarKind::Iso => AnyCalendar::Iso(Iso),
             AnyCalendarKind::Ethiopic => {
-                AnyCalendar::Ethiopic(Ethiopic::new_with_amete_alem(false))
+                AnyCalendar::Ethiopic(Ethiopic::new_with_era_style(EthiopicEraStyle::AmeteMihret))
             }
-            AnyCalendarKind::Ethioaa => AnyCalendar::Ethiopic(Ethiopic::new_with_amete_alem(true)),
+            AnyCalendarKind::Ethioaa => {
+                AnyCalendar::Ethiopic(Ethiopic::new_with_era_style(EthiopicEraStyle::AmeteAlem))
+            }
         })
     }
 

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -33,7 +33,9 @@
 
 use crate::any_calendar::AnyCalendarKind;
 use crate::iso::{Iso, IsoDateInner};
-use crate::{types, Calendar, Date, DateDuration, DateDurationUnit, DateTime, DateTimeError};
+use crate::{
+    types, ArithmeticDate, Calendar, Date, DateDuration, DateDurationUnit, DateTime, DateTimeError,
+};
 use tinystr::tinystr;
 
 /// The number of years the Buddhist Era is ahead of C.E. by
@@ -53,6 +55,21 @@ pub struct Buddhist;
 
 impl Calendar for Buddhist {
     type DateInner = IsoDateInner;
+
+    fn date_from_codes(
+        &self,
+        era: types::Era,
+        year: i32,
+        month_code: types::MonthCode,
+        day: u8,
+    ) -> Result<Self::DateInner, DateTimeError> {
+        if era.0 != tinystr!(16, "be") {
+            return Err(DateTimeError::UnknownEra(era.0, self.debug_name()));
+        }
+        let year = year - BUDDHIST_ERA_OFFSET;
+
+        ArithmeticDate::new_from_solar(self, year, month_code, day).map(IsoDateInner)
+    }
     fn date_from_iso(&self, iso: Date<Iso>) -> IsoDateInner {
         *iso.inner()
     }

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -26,9 +26,7 @@ pub trait Calendar {
         year: i32,
         month_code: types::MonthCode,
         day: u8,
-    ) -> Result<Self::DateInner, DateTimeError> {
-        Err(DateTimeError::OutOfRange)
-    }
+    ) -> Result<Self::DateInner, DateTimeError>;
     /// Construct the date from an ISO date
     fn date_from_iso(&self, iso: Date<Iso>) -> Self::DateInner;
     /// Obtain an ISO date from this date

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::any_calendar::AnyCalendarKind;
-use crate::{types, Date, DateDuration, DateDurationUnit, Iso};
+use crate::{types, Date, DateDuration, DateDurationUnit, DateTimeError, Iso};
 use core::fmt;
 
 /// A calendar implementation
@@ -19,6 +19,16 @@ use core::fmt;
 pub trait Calendar {
     /// The internal type used to represent dates
     type DateInner: PartialEq + Eq + Clone + fmt::Debug;
+    /// Construct a date from era/month codes and fields
+    fn date_from_codes(
+        &self,
+        era: types::Era,
+        year: i32,
+        month_code: types::MonthCode,
+        day: u8,
+    ) -> Result<Self::DateInner, DateTimeError> {
+        Err(DateTimeError::OutOfRange)
+    }
     /// Construct the date from an ISO date
     fn date_from_iso(&self, iso: Date<Iso>) -> Self::DateInner;
     /// Obtain an ISO date from this date

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -223,10 +223,8 @@ pub fn ordinal_solar_month_from_code(code: types::MonthCode) -> Option<u8> {
         if bytes[2] >= b'1' && bytes[2] <= b'9' {
             return Some(bytes[2] - b'0');
         }
-    } else if bytes[1] == b'1' {
-        if bytes[2] >= b'1' && bytes[2] <= b'3' {
-            return Some(10 + bytes[2] - b'0');
-        }
+    } else if bytes[1] == b'1' && bytes[2] >= b'1' && bytes[2] <= b'3' {
+        return Some(10 + bytes[2] - b'0');
     }
     None
 }

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::{types, Calendar, DateDuration, DateDurationUnit};
+use crate::{types, Calendar, DateDuration, DateDurationUnit, DateTimeError};
 use core::convert::TryInto;
 use core::marker::PhantomData;
 use tinystr::tinystr;
@@ -173,4 +173,60 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
             code: types::MonthCode(code),
         }
     }
+
+    /// Construct a new arithmetic date from a year, month code, and day, bounds checking
+    /// the month
+    pub fn new_from_solar<C2: Calendar>(
+        // Separate type since the debug_name() impl may differ when DateInner types
+        // are nested (e.g. in GregorianDateInner)
+        cal: &C2,
+        year: i32,
+        month_code: types::MonthCode,
+        day: u8,
+    ) -> Result<Self, DateTimeError> {
+        let month = if let Some(ordinal) = ordinal_solar_month_from_code(month_code) {
+            ordinal
+        } else {
+            return Err(DateTimeError::UnknownMonthCode(
+                month_code.0,
+                cal.debug_name(),
+            ));
+        };
+
+        if month > C::months_for_every_year() {
+            return Err(DateTimeError::UnknownMonthCode(
+                month_code.0,
+                cal.debug_name(),
+            ));
+        }
+
+        if day > C::month_days(year, month) {
+            return Err(DateTimeError::OutOfRange);
+        }
+
+        Ok(Self::new(year, month, day))
+    }
+}
+
+/// For solar calendars, get the month number from the month code
+pub fn ordinal_solar_month_from_code(code: types::MonthCode) -> Option<u8> {
+    // Match statements on tinystrs are annoying so instead
+    // we calculate it from the bytes directly
+    if code.0.len() != 3 {
+        return None;
+    }
+    let bytes = code.0.all_bytes();
+    if bytes[0] != b'M' {
+        return None;
+    }
+    if bytes[1] == b'0' {
+        if bytes[2] >= b'1' && bytes[2] <= b'9' {
+            return Some(bytes[2] - b'0');
+        }
+    } else if bytes[1] == b'1' {
+        if bytes[2] >= b'1' && bytes[2] <= b'3' {
+            return Some(10 + bytes[2] - b'0');
+        }
+    }
+    None
 }

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -76,6 +76,29 @@ impl CalendarArithmetic for Coptic {
 
 impl Calendar for Coptic {
     type DateInner = CopticDateInner;
+    fn date_from_codes(
+        &self,
+        era: types::Era,
+        year: i32,
+        month_code: types::MonthCode,
+        day: u8,
+    ) -> Result<Self::DateInner, DateTimeError> {
+        let year = if era.0 == tinystr!(16, "ad") {
+            if year <= 0 {
+                return Err(DateTimeError::OutOfRange);
+            }
+            year
+        } else if era.0 == tinystr!(16, "bd") {
+            if year <= 0 {
+                return Err(DateTimeError::OutOfRange);
+            }
+            1 - year
+        } else {
+            return Err(DateTimeError::UnknownEra(era.0, self.debug_name()));
+        };
+
+        ArithmeticDate::new_from_solar(self, year, month_code, day).map(CopticDateInner)
+    }
     fn date_from_iso(&self, iso: Date<Iso>) -> CopticDateInner {
         let fixed_iso = Iso::fixed_from_iso(*iso.inner());
         Self::coptic_from_fixed(fixed_iso)

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -201,6 +201,8 @@ impl Coptic {
 impl Date<Coptic> {
     /// Construct new Coptic Date.
     ///
+    /// Negative years are in the B.D. era, starting with 0 = 1 B.D.
+    ///
     /// ```rust
     /// use icu::calendar::Date;
     ///
@@ -230,6 +232,8 @@ impl Date<Coptic> {
 
 impl DateTime<Coptic> {
     /// Construct a new Coptic datetime from integers.
+    ///
+    /// Negative years are in the B.D. era, starting with 0 = 1 B.D.
     ///
     /// ```rust
     /// use icu::calendar::DateTime;

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -43,7 +43,16 @@ impl<C: Calendar> AsCalendar for Rc<C> {
 ///
 /// Use `Date<Ref<'a, C>>` where you would use `Date<&'a C>`
 #[allow(clippy::exhaustive_structs)] // newtype
+#[derive(PartialEq, Eq, Debug)]
 pub struct Ref<'a, C>(pub &'a C);
+
+impl<C> Copy for Ref<'_, C> {}
+
+impl<C> Clone for Ref<'_, C> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 
 impl<C: Calendar> AsCalendar for Ref<'_, C> {
     type Calendar = C;

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::any_calendar::{AnyCalendar, IncludedInAnyCalendar};
-use crate::{types, Calendar, DateDuration, DateDurationUnit, Iso};
+use crate::{types, Calendar, DateDuration, DateDurationUnit, DateTimeError, Iso};
 use alloc::rc::Rc;
 use core::fmt;
 use core::ops::Deref;
@@ -91,6 +91,21 @@ pub struct Date<A: AsCalendar> {
 }
 
 impl<A: AsCalendar> Date<A> {
+    /// Construct a date from from era/month codes and fields, and some calendar representation
+    #[inline]
+    pub fn new_from_codes(
+        era: types::Era,
+        year: i32,
+        month_code: types::MonthCode,
+        day: u8,
+        calendar: A,
+    ) -> Result<Self, DateTimeError> {
+        let inner = calendar
+            .as_calendar()
+            .date_from_codes(era, year, month_code, day)?;
+        Ok(Date { inner, calendar })
+    }
+
     /// Construct a date from an ISO date and some calendar representation
     #[inline]
     pub fn new_from_iso(iso: Date<Iso>, calendar: A) -> Self {

--- a/components/calendar/src/datetime.rs
+++ b/components/calendar/src/datetime.rs
@@ -3,8 +3,8 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::any_calendar::{AnyCalendar, IncludedInAnyCalendar};
-use crate::types::Time;
-use crate::{AsCalendar, Calendar, Date, Iso};
+use crate::types::{self, Time};
+use crate::{AsCalendar, Calendar, Date, DateTimeError, Iso};
 
 /// A date+time for a given calendar.
 ///
@@ -36,6 +36,21 @@ pub struct DateTime<A: AsCalendar> {
 impl<A: AsCalendar> DateTime<A> {
     pub fn new(date: Date<A>, time: Time) -> Self {
         DateTime { date, time }
+    }
+
+    /// Construct a datetime from from era/month codes and fields,
+    /// and some calendar representation
+    #[inline]
+    pub fn new_from_codes(
+        era: types::Era,
+        year: i32,
+        month_code: types::MonthCode,
+        day: u8,
+        time: Time,
+        calendar: A,
+    ) -> Result<Self, DateTimeError> {
+        let date = Date::new_from_codes(era, year, month_code, day, calendar)?;
+        Ok(DateTime { date, time })
     }
 
     /// Construct a DateTime from an ISO datetime and some calendar representation

--- a/components/calendar/src/error.rs
+++ b/components/calendar/src/error.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use displaydoc::Display;
-use tinystr::TinyStr16;
+use tinystr::{TinyStr16, TinyStr4};
 
 #[cfg(feature = "std")]
 impl std::error::Error for DateTimeError {}
@@ -40,8 +40,10 @@ pub enum DateTimeError {
     OutOfRange,
     /// Unknown era
     #[displaydoc("No era named {0} for calendar {1}")]
-    /// An input was missing.
     UnknownEra(TinyStr16, &'static str),
+    /// Unknown month code for a given calendar
+    #[displaydoc("No month code named {0} for calendar {1}")]
+    UnknownMonthCode(TinyStr4, &'static str),
     #[displaydoc("No value for {0}")]
     MissingInput(&'static str),
 }

--- a/components/calendar/src/error.rs
+++ b/components/calendar/src/error.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use displaydoc::Display;
+use tinystr::TinyStr16;
 
 #[cfg(feature = "std")]
 impl std::error::Error for DateTimeError {}
@@ -37,7 +38,10 @@ pub enum DateTimeError {
     /// Out of range
     // TODO(Manishearth) turn this into a proper variant
     OutOfRange,
+    /// Unknown era
+    #[displaydoc("No era named {0} for calendar {1}")]
     /// An input was missing.
+    UnknownEra(TinyStr16, &'static str),
     #[displaydoc("No value for {0}")]
     MissingInput(&'static str),
 }

--- a/components/calendar/src/ethiopic.rs
+++ b/components/calendar/src/ethiopic.rs
@@ -42,6 +42,17 @@ use crate::{
 use core::marker::PhantomData;
 use tinystr::tinystr;
 
+/// Which era style the ethiopic calendar uses
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[non_exhaustive]
+pub enum EthiopicEraStyle {
+    /// Use an era scheme of pre- and post- Incarnation eras,
+    /// anchored at the date of the Incarnation of Jesus in this calendar
+    AmeteMihret,
+    /// Use an era scheme of the Anno Mundi era, anchored at the date of Creation
+    /// in this calendar
+    AmeteAlem,
+}
 /// The Ethiopic Calendar
 // The bool specifies whether dates should be in the Amete Alem era scheme
 #[derive(Copy, Clone, Debug, Hash, Default, Eq, PartialEq)]
@@ -161,17 +172,21 @@ impl Ethiopic {
         Self(false)
     }
     /// Construct a new Ethiopic Calendar with a value specifying whether or not it is Amete Alem
-    pub fn new_with_amete_alem(amete_alem: bool) -> Self {
-        Self(amete_alem)
+    pub fn new_with_era_style(era_style: EthiopicEraStyle) -> Self {
+        Self(era_style == EthiopicEraStyle::AmeteAlem)
     }
     /// Set whether or not this uses the Amete Alem era scheme
-    pub fn set_amete_alem(&mut self, value: bool) {
-        self.0 = value
+    pub fn set_era_style(&mut self, era_style: EthiopicEraStyle) {
+        self.0 = era_style == EthiopicEraStyle::AmeteAlem
     }
 
     /// Returns whether this has the Amete Alem era
-    pub fn is_amete_alem(&self) -> bool {
-        self.0
+    pub fn era_style(&self) -> EthiopicEraStyle {
+        if self.0 {
+            EthiopicEraStyle::AmeteAlem
+        } else {
+            EthiopicEraStyle::AmeteMihret
+        }
     }
 
     // "Fixed" is a day count representation of calendars staring from Jan 1st of year 1 of the Georgian Calendar.
@@ -193,9 +208,14 @@ impl Ethiopic {
         let coptic_date = Coptic::coptic_from_fixed(date + coptic_epoch - ethiopic_epoch);
 
         #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-        *Date::new_ethiopic_date(coptic_date.0.year, coptic_date.0.month, coptic_date.0.day)
-            .unwrap()
-            .inner()
+        *Date::new_ethiopic_date(
+            EthiopicEraStyle::AmeteMihret,
+            coptic_date.0.year,
+            coptic_date.0.month,
+            coptic_date.0.day,
+        )
+        .unwrap()
+        .inner()
     }
 
     fn days_in_year_direct(year: i32) -> u32 {
@@ -232,21 +252,31 @@ impl Ethiopic {
 impl Date<Ethiopic> {
     /// Construct new Ethiopic Date.
     ///
+    /// For the Amete Mihret era style, negative years work with
+    /// year 0 as 1 pre-Incarnation, year -1 as 2 pre-Incarnation,
+    /// and so on.
+    ///
     /// ```rust
     /// use icu::calendar::Date;
+    /// use icu::calendar::ethiopic::EthiopicEraStyle;
     ///
     /// let date_ethiopic =
-    ///     Date::new_ethiopic_date(2014, 8, 25).expect("Failed to initialize Ethopic Date instance.");
+    ///     Date::new_ethiopic_date(EthiopicEraStyle::AmeteMihret, 2014, 8, 25)
+    ///     .expect("Failed to initialize Ethopic Date instance.");
     ///
     /// assert_eq!(date_ethiopic.year().number, 2014);
     /// assert_eq!(date_ethiopic.month().ordinal, 8);
     /// assert_eq!(date_ethiopic.day_of_month().0, 25);
     /// ```
     pub fn new_ethiopic_date(
-        year: i32,
+        era_style: EthiopicEraStyle,
+        mut year: i32,
         month: u8,
         day: u8,
     ) -> Result<Date<Ethiopic>, DateTimeError> {
+        if era_style == EthiopicEraStyle::AmeteAlem {
+            year -= 5493;
+        }
         let inner = ArithmeticDate {
             year,
             month,
@@ -259,17 +289,25 @@ impl Date<Ethiopic> {
             return Err(DateTimeError::OutOfRange);
         }
 
-        Ok(Date::from_raw(EthiopicDateInner(inner), Ethiopic::new()))
+        Ok(Date::from_raw(
+            EthiopicDateInner(inner),
+            Ethiopic::new_with_era_style(era_style),
+        ))
     }
 }
 
 impl DateTime<Ethiopic> {
     /// Construct a new Ethiopic datetime from integers.
     ///
+    /// For the Amete Mihret era style, negative years work with
+    /// year 0 as 1 pre-Incarnation, year -1 as 2 pre-Incarnation,
+    /// and so on.
+    ///
     /// ```rust
     /// use icu::calendar::DateTime;
+    /// use icu::calendar::ethiopic::EthiopicEraStyle;
     ///
-    /// let datetime_ethiopic = DateTime::new_ethiopic_datetime(2014, 8, 25, 13, 1, 0)
+    /// let datetime_ethiopic = DateTime::new_ethiopic_datetime(EthiopicEraStyle::AmeteMihret, 2014, 8, 25, 13, 1, 0)
     ///     .expect("Failed to initialize Ethiopic DateTime instance.");
     ///
     /// assert_eq!(datetime_ethiopic.date.year().number, 2014);
@@ -280,6 +318,7 @@ impl DateTime<Ethiopic> {
     /// assert_eq!(datetime_ethiopic.time.second.number(), 0);
     /// ```
     pub fn new_ethiopic_datetime(
+        era_style: EthiopicEraStyle,
         year: i32,
         month: u8,
         day: u8,
@@ -288,7 +327,7 @@ impl DateTime<Ethiopic> {
         second: u8,
     ) -> Result<DateTime<Ethiopic>, DateTimeError> {
         Ok(DateTime {
-            date: Date::new_ethiopic_date(year, month, day)?,
+            date: Date::new_ethiopic_date(era_style, year, month, day)?,
             time: types::Time::try_new(hour, minute, second, 0)?,
         })
     }

--- a/components/calendar/src/ethiopic.rs
+++ b/components/calendar/src/ethiopic.rs
@@ -42,6 +42,9 @@ use crate::{
 use core::marker::PhantomData;
 use tinystr::tinystr;
 
+/// The number of years the Amete Alem epoch precedes the Amete Mihret epoch
+const AMETE_ALEM_OFFSET: i32 = 5500;
+
 /// Which era style the ethiopic calendar uses
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[non_exhaustive]
@@ -105,7 +108,7 @@ impl Calendar for Ethiopic {
             }
             1 - year
         } else if era.0 == tinystr!(16, "mundi") {
-            year - 5493
+            year - AMETE_ALEM_OFFSET
         } else {
             return Err(DateTimeError::UnknownEra(era.0, self.debug_name()));
         };
@@ -255,7 +258,7 @@ impl Ethiopic {
         if amete_alem {
             types::FormattableYear {
                 era: types::Era(tinystr!(16, "mundi")),
-                number: year + 5493,
+                number: year + AMETE_ALEM_OFFSET,
                 related_iso: None,
             }
         } else if year > 0 {
@@ -300,7 +303,7 @@ impl Date<Ethiopic> {
         day: u8,
     ) -> Result<Date<Ethiopic>, DateTimeError> {
         if era_style == EthiopicEraStyle::AmeteAlem {
-            year -= 5493;
+            year -= AMETE_ALEM_OFFSET;
         }
         let inner = ArithmeticDate {
             year,

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -70,9 +70,9 @@ impl Calendar for Gregorian {
             return Err(DateTimeError::UnknownEra(era.0, self.debug_name()));
         };
 
-        Ok(GregorianDateInner(IsoDateInner(
-            ArithmeticDate::new_from_solar(self, year, month_code, day)?,
-        )))
+        ArithmeticDate::new_from_solar(self, year, month_code, day)
+            .map(IsoDateInner)
+            .map(GregorianDateInner)
     }
 
     fn date_from_iso(&self, iso: Date<Iso>) -> GregorianDateInner {

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -33,7 +33,9 @@
 
 use crate::any_calendar::AnyCalendarKind;
 use crate::iso::{Iso, IsoDateInner};
-use crate::{types, Calendar, Date, DateDuration, DateDurationUnit, DateTime, DateTimeError};
+use crate::{
+    types, ArithmeticDate, Calendar, Date, DateDuration, DateDurationUnit, DateTime, DateTimeError,
+};
 use tinystr::tinystr;
 
 /// The Gregorian Calendar
@@ -47,6 +49,32 @@ pub struct GregorianDateInner(IsoDateInner);
 
 impl Calendar for Gregorian {
     type DateInner = GregorianDateInner;
+    fn date_from_codes(
+        &self,
+        era: types::Era,
+        year: i32,
+        month_code: types::MonthCode,
+        day: u8,
+    ) -> Result<Self::DateInner, DateTimeError> {
+        let year = if era.0 == tinystr!(16, "ce") {
+            if year <= 0 {
+                return Err(DateTimeError::OutOfRange);
+            }
+            year
+        } else if era.0 == tinystr!(16, "bce") {
+            if year <= 0 {
+                return Err(DateTimeError::OutOfRange);
+            }
+            1 - year
+        } else {
+            return Err(DateTimeError::UnknownEra(era.0, self.debug_name()));
+        };
+
+        Ok(GregorianDateInner(IsoDateInner(
+            ArithmeticDate::new_from_solar(self, year, month_code, day)?,
+        )))
+    }
+
     fn date_from_iso(&self, iso: Date<Iso>) -> GregorianDateInner {
         GregorianDateInner(*iso.inner())
     }

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -76,6 +76,19 @@ impl CalendarArithmetic for Indian {
 
 impl Calendar for Indian {
     type DateInner = IndianDateInner;
+    fn date_from_codes(
+        &self,
+        era: types::Era,
+        year: i32,
+        month_code: types::MonthCode,
+        day: u8,
+    ) -> Result<Self::DateInner, DateTimeError> {
+        if era.0 != tinystr!(16, "saka") {
+            return Err(DateTimeError::UnknownEra(era.0, self.debug_name()));
+        }
+
+        ArithmeticDate::new_from_solar(self, year, month_code, day).map(IndianDateInner)
+    }
     fn date_from_iso(&self, iso: Date<Iso>) -> IndianDateInner {
         let day_of_year = Iso::day_of_year(*iso.inner());
         IndianDateInner(ArithmeticDate::date_from_year_day(

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -182,7 +182,7 @@ impl Indian {
 }
 
 impl Date<Indian> {
-    /// Construct new Indian Date.
+    /// Construct new Indian Date, with year provided in the Śaka era.
     ///
     /// ```rust
     /// use icu::calendar::Date;
@@ -212,7 +212,7 @@ impl Date<Indian> {
 }
 
 impl DateTime<Indian> {
-    /// Construct a new Indian datetime from integers.
+    /// Construct a new Indian datetime from integers, with year provided in the Śaka era.
     ///
     /// ```rust
     /// use icu::calendar::DateTime;

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -69,6 +69,21 @@ impl CalendarArithmetic for Iso {
 
 impl Calendar for Iso {
     type DateInner = IsoDateInner;
+    /// Construct a date from era/month codes and fields
+    fn date_from_codes(
+        &self,
+        era: types::Era,
+        year: i32,
+        month_code: types::MonthCode,
+        day: u8,
+    ) -> Result<Self::DateInner, DateTimeError> {
+        if era.0 != tinystr!(16, "default") {
+            return Err(DateTimeError::UnknownEra(era.0, self.debug_name()));
+        }
+
+        ArithmeticDate::new_from_solar(self, year, month_code, day).map(IsoDateInner)
+    }
+
     fn date_from_iso(&self, iso: Date<Iso>) -> IsoDateInner {
         *iso.inner()
     }

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -269,7 +269,7 @@ impl Date<Japanese> {
     ///
     /// let era = types::Era(tinystr!(16, "heisei"));
     ///
-    /// let date = Date::new_japanese_date(japanese_calendar, era, 14, 1, 2)
+    /// let date = Date::new_japanese_date(era, 14, 1, 2, japanese_calendar)
     ///     .expect("Constructing a date should succeed");
     ///
     /// assert_eq!(date.year().era, era);
@@ -279,20 +279,20 @@ impl Date<Japanese> {
     ///
     /// // This function will error for eras that are out of bounds:
     /// // (Heisei was 32 years long, Heisei 33 is in Reiwa)
-    /// let oob_date = Date::new_japanese_date(japanese_calendar, era, 33, 1, 2);
+    /// let oob_date = Date::new_japanese_date(era, 33, 1, 2, japanese_calendar);
     /// assert!(oob_date.is_err());
     ///
     /// // and for unknown eras
     /// let fake_era = types::Era(tinystr!(16, "neko")); // 🐱
-    /// let fake_date = Date::new_japanese_date(japanese_calendar, fake_era, 10, 1, 2);
+    /// let fake_date = Date::new_japanese_date(fake_era, 10, 1, 2, japanese_calendar);
     /// assert!(fake_date.is_err());
     /// ```
     pub fn new_japanese_date<A: AsCalendar<Calendar = Japanese>>(
-        japanese_calendar: A,
         era: types::Era,
         year: i32,
         month: u8,
         day: u8,
+        japanese_calendar: A,
     ) -> Result<Date<A>, DateTimeError> {
         let inner = japanese_calendar
             .as_calendar()
@@ -316,7 +316,7 @@ impl DateTime<Japanese> {
     ///
     /// let era = types::Era(tinystr!(16, "heisei"));
     ///
-    /// let datetime = DateTime::new_japanese_datetime(japanese_calendar, era, 14, 1, 2, 13, 1, 0)
+    /// let datetime = DateTime::new_japanese_datetime(era, 14, 1, 2, 13, 1, 0, japanese_calendar)
     ///     .expect("Constructing a date should succeed");
     ///
     /// assert_eq!(datetime.date.year().era, era);
@@ -331,7 +331,6 @@ impl DateTime<Japanese> {
                                          // if people wish to construct this by parts they can use
                                          // Date::new_japanese_date() + DateTime::new(date, time)
     pub fn new_japanese_datetime<A: AsCalendar<Calendar = Japanese>>(
-        japanese_calendar: A,
         era: types::Era,
         year: i32,
         month: u8,
@@ -339,9 +338,10 @@ impl DateTime<Japanese> {
         hour: u8,
         minute: u8,
         second: u8,
+        japanese_calendar: A,
     ) -> Result<DateTime<A>, DateTimeError> {
         Ok(DateTime {
-            date: Date::new_japanese_date(japanese_calendar, era, year, month, day)?,
+            date: Date::new_japanese_date(era, year, month, day, japanese_calendar)?,
             time: types::Time::try_new(hour, minute, second, 0)?,
         })
     }
@@ -538,7 +538,7 @@ mod tests {
     fn single_test_roundtrip(calendar: Ref<Japanese>, era: &str, year: i32, month: u8, day: u8) {
         let era = types::Era(era.parse().expect("era must parse"));
 
-        let date = Date::new_japanese_date(calendar, era, year, month, day).unwrap_or_else(|e| {
+        let date = Date::new_japanese_date(era, year, month, day, calendar).unwrap_or_else(|e| {
             panic!(
                 "Failed to construct date with {:?}, {}, {}, {}: {}",
                 era, year, month, day, e
@@ -566,14 +566,14 @@ mod tests {
         let era2 = types::Era(era2.parse().expect("era must parse"));
 
         let expected =
-            Date::new_japanese_date(calendar, era2, year2, month, day).unwrap_or_else(|e| {
+            Date::new_japanese_date(era2, year2, month, day, calendar).unwrap_or_else(|e| {
                 panic!(
                     "Failed to construct expectation date with {:?}, {}, {}, {}: {}",
                     era2, year2, month, day, e
                 )
             });
 
-        let date = Date::new_japanese_date(calendar, era, year, month, day).unwrap_or_else(|e| {
+        let date = Date::new_japanese_date(era, year, month, day, calendar).unwrap_or_else(|e| {
             panic!(
                 "Failed to construct date with {:?}, {}, {}, {}: {}",
                 era, year, month, day, e
@@ -597,7 +597,7 @@ mod tests {
     ) {
         let era = types::Era(era.parse().expect("era must parse"));
 
-        let date = Date::new_japanese_date(calendar, era, year, month, day);
+        let date = Date::new_japanese_date(era, year, month, day, calendar);
         assert_eq!(
             date,
             Err(error),

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -39,6 +39,7 @@ use crate::{
 };
 use core::convert::TryInto;
 use core::marker::PhantomData;
+use tinystr::tinystr;
 
 // Julian epoch is equivalent to fixed_from_iso of December 30th of 0 year
 // 1st Jan of 1st year Julian is equivalent to December 30th of 0th year of ISO year
@@ -75,6 +76,29 @@ impl CalendarArithmetic for Julian {
 
 impl Calendar for Julian {
     type DateInner = JulianDateInner;
+    fn date_from_codes(
+        &self,
+        era: types::Era,
+        year: i32,
+        month_code: types::MonthCode,
+        day: u8,
+    ) -> Result<Self::DateInner, DateTimeError> {
+        let year = if era.0 == tinystr!(16, "ce") {
+            if year <= 0 {
+                return Err(DateTimeError::OutOfRange);
+            }
+            year
+        } else if era.0 == tinystr!(16, "bce") {
+            if year <= 0 {
+                return Err(DateTimeError::OutOfRange);
+            }
+            1 - year
+        } else {
+            return Err(DateTimeError::UnknownEra(era.0, self.debug_name()));
+        };
+
+        ArithmeticDate::new_from_solar(self, year, month_code, day).map(JulianDateInner)
+    }
     fn date_from_iso(&self, iso: Date<Iso>) -> JulianDateInner {
         let fixed_iso = Iso::fixed_from_iso(*iso.inner());
         Self::julian_from_fixed(fixed_iso)

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -229,6 +229,8 @@ impl Julian {
 impl Date<Julian> {
     /// Construct new Julian Date.
     ///
+    /// Zero and negative years are in BC, with year 0 = 1 BC
+    ///
     /// ```rust
     /// use icu::calendar::Date;
     ///
@@ -260,6 +262,8 @@ impl Date<Julian> {
 
 impl DateTime<Julian> {
     /// Construct a new Julian datetime from integers.
+    ///
+    /// Zero and negative years are in BC, with year 0 = 1 BC
     ///
     /// ```rust
     /// use icu::calendar::DateTime;

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -11,7 +11,7 @@ use icu_calendar::{
     any_calendar::{AnyCalendarKind, IncludedInAnyCalendar},
     buddhist::Buddhist,
     coptic::Coptic,
-    ethiopic::Ethiopic,
+    ethiopic::{Ethiopic, EthiopicEraStyle},
     indian::Indian,
     japanese::{Japanese, JapaneseEraStyle},
     provider::JapaneseErasV1Marker,
@@ -73,7 +73,8 @@ fn test_fixture(fixture_name: &str) {
         let input_indian = input_value.to_calendar(Indian);
         let input_ethiopic = input_value.to_calendar(Ethiopic::new());
 
-        let input_ethioaa = input_value.to_calendar(Ethiopic::new_with_amete_alem(true));
+        let input_ethioaa =
+            input_value.to_calendar(Ethiopic::new_with_era_style(EthiopicEraStyle::AmeteAlem));
         let description = match fx.description {
             Some(description) => {
                 format!(

--- a/components/datetime/tests/fixtures/tests/components-width-differences.json
+++ b/components/datetime/tests/fixtures/tests/components-width-differences.json
@@ -34,7 +34,7 @@
                 "fr-u-ca-coptic": "1736 ap. D.",
                 "en-u-ca-ethiopic" : "2012 ERA0",
                 "fr-u-ca-ethiopic" : "2012 av. Inc.",
-                "fr-u-ca-ethioaa" : "7505 ERA0"
+                "fr-u-ca-ethioaa" : "7512 ERA0"
             }
         }
     },

--- a/components/datetime/tests/fixtures/tests/components.json
+++ b/components/datetime/tests/fixtures/tests/components.json
@@ -26,7 +26,7 @@
                 "en-u-ca-indian": "Tuesday, Chaitra 21, 1942 Saka at 08:25:07",
                 "en-u-ca-ethiopic": "Tuesday, Ter 12, 2012 ERA0 at 08:25:07",
                 "fr-u-ca-ethiopic": "mardi 12 ter 2012 avant l’Incarnation à 08:25:07",
-                "fr-u-ca-ethioaa": "mardi 12 ter 7505 ERA0 à 08:25:07"
+                "fr-u-ca-ethioaa": "mardi 12 ter 7512 ERA0 à 08:25:07"
             }
         }
     },

--- a/utils/zerovec/src/zerovec/slice.rs
+++ b/utils/zerovec/src/zerovec/slice.rs
@@ -331,7 +331,7 @@ where
     /// assert_eq!(it.next(), None);
     /// ```
     #[inline]
-    pub fn iter(&self) -> impl DoubleEndedIterator<Item = T> + '_ {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = T> + ExactSizeIterator<Item = T> + '_ {
         self.as_ule_slice().iter().copied().map(T::from_unaligned)
     }
 }


### PR DESCRIPTION
This provides a convenient API to construct dates from month and era codes (and year/day information). This also documents all the remaining constructors and makes them uniform.




<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->