### PR TITLE
Adding `missing_debug_implementations` lint or todo

### DIFF
--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -142,7 +142,8 @@
         clippy::expect_used,
         clippy::panic,
         clippy::exhaustive_structs,
-        clippy::exhaustive_enums
+        clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 

--- a/components/collator/src/lib.rs
+++ b/components/collator/src/lib.rs
@@ -14,7 +14,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        // TODO(#1668): enable clippy::exhaustive_structs,
+        // TODO(#1668): enable clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 #![warn(missing_docs)]

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -75,7 +75,8 @@
         clippy::expect_used,
         clippy::panic,
         clippy::exhaustive_structs,
-        clippy::exhaustive_enums
+        clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 #![warn(missing_docs)]

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -85,7 +85,8 @@
         clippy::expect_used,
         clippy::panic,
         clippy::exhaustive_structs,
-        clippy::exhaustive_enums
+        clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 #![warn(missing_docs)]

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -95,7 +95,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 #![warn(missing_docs)]

--- a/components/list/src/lib.rs
+++ b/components/list/src/lib.rs
@@ -87,7 +87,8 @@
         clippy::expect_used,
         clippy::panic,
         clippy::exhaustive_structs,
-        clippy::exhaustive_enums
+        clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 #![warn(missing_docs)]

--- a/components/locale_canonicalizer/src/lib.rs
+++ b/components/locale_canonicalizer/src/lib.rs
@@ -85,7 +85,8 @@
         clippy::expect_used,
         clippy::panic,
         clippy::exhaustive_structs,
-        clippy::exhaustive_enums
+        clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 #![warn(missing_docs)]

--- a/components/locid/src/lib.rs
+++ b/components/locid/src/lib.rs
@@ -69,7 +69,8 @@
         clippy::expect_used,
         clippy::panic,
         clippy::exhaustive_structs,
-        clippy::exhaustive_enums
+        clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 #![warn(missing_docs)]

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -10,7 +10,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        // TODO(#1668): enable clippy::exhaustive_structs,
+        // TODO(#1668): enable clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 #![warn(missing_docs)]

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -73,7 +73,8 @@
         clippy::expect_used,
         clippy::panic,
         clippy::exhaustive_structs,
-        clippy::exhaustive_enums
+        clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 #![warn(missing_docs)]

--- a/components/properties/src/lib.rs
+++ b/components/properties/src/lib.rs
@@ -71,7 +71,8 @@
         clippy::expect_used,
         clippy::panic,
         clippy::exhaustive_structs,
-        clippy::exhaustive_enums
+        clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 #![warn(missing_docs)]

--- a/docs/process/style_guide.md
+++ b/docs/process/style_guide.md
@@ -906,6 +906,10 @@ In general, non-panicky APIs that return `Result`s or `Option`s should be prefer
 
 `#[allow()]`s should be documented with a comment.
 
+## Debug :: required
+
+Crates should deny the `missing_debug_implementations` lint at the top-level so that our types all have `Debug` implementations.
+
 # Imports and Configurations
 
 ## Features

--- a/ffi/capi_cdylib/src/lib.rs
+++ b/ffi/capi_cdylib/src/lib.rs
@@ -18,7 +18,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        clippy::exhaustive_enums,
+        missing_debug_implementations,
     )
 )]
 

--- a/ffi/capi_staticlib/src/lib.rs
+++ b/ffi/capi_staticlib/src/lib.rs
@@ -18,7 +18,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        clippy::exhaustive_enums,
+        missing_debug_implementations,
     )
 )]
 #![cfg_attr(

--- a/ffi/diplomat/src/lib.rs
+++ b/ffi/diplomat/src/lib.rs
@@ -10,7 +10,8 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        // Exhaustiveness and Debug is not required for Diplomat types
     )
 )]
 #![allow(clippy::upper_case_acronyms)]

--- a/ffi/ecma402/src/lib.rs
+++ b/ffi/ecma402/src/lib.rs
@@ -11,7 +11,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        // TODO(#1668): enable clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 

--- a/ffi/freertos/src/lib.rs
+++ b/ffi/freertos/src/lib.rs
@@ -10,7 +10,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        clippy::exhaustive_enums,
+        missing_debug_implementations,
     )
 )]
 #![allow(clippy::upper_case_acronyms)]

--- a/provider/adapters/src/lib.rs
+++ b/provider/adapters/src/lib.rs
@@ -19,7 +19,8 @@
         clippy::expect_used,
         clippy::panic,
         clippy::exhaustive_structs,
-        clippy::exhaustive_enums
+        clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 

--- a/provider/blob/src/lib.rs
+++ b/provider/blob/src/lib.rs
@@ -37,7 +37,8 @@
         clippy::expect_used,
         clippy::panic,
         clippy::exhaustive_structs,
-        clippy::exhaustive_enums
+        clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -117,7 +117,8 @@
         clippy::expect_used,
         clippy::panic,
         clippy::exhaustive_structs,
-        clippy::exhaustive_enums
+        clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -51,7 +51,8 @@
         // clippy::expect_used,
         // clippy::panic,
         clippy::exhaustive_structs,
-        clippy::exhaustive_enums
+        clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 #![warn(missing_docs)]

--- a/provider/datagen/src/transform/cldr/calendar/japanese.rs
+++ b/provider/datagen/src/transform/cldr/calendar/japanese.rs
@@ -90,7 +90,6 @@ impl DataProvider<JapaneseErasV1Marker> for crate::DatagenProvider {
         // to catch such cases. It is relatively rare for a new era to be added, and in those cases the integrity check can
         // be disabled when generating new data.
         if japanext && env::var("ICU4X_SKIP_JAPANESE_INTEGRITY_CHECK").is_err() {
-            #[allow(clippy::expect_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
             let snapshot: JapaneseErasV1 = serde_json::from_str(JAPANESE_FILE)
                 .expect("Failed to parse the precached snapshot-japanese@1.json. This is a bug.");
 

--- a/provider/datagen/src/transform/cldr/cldr_serde/time_zones/meta_zones.rs
+++ b/provider/datagen/src/transform/cldr/cldr_serde/time_zones/meta_zones.rs
@@ -40,7 +40,6 @@ pub struct MetaZoneForPeriod {
 
 #[derive(PartialEq, Debug, Clone, Deserialize)]
 #[serde(untagged)]
-#[allow(clippy::enum_variant_names)]
 pub enum MetaLocationOrSubRegion {
     Location(Vec<MetaZoneForPeriod>),
     SubRegion(HashMap<String, Vec<MetaZoneForPeriod>>),
@@ -48,7 +47,6 @@ pub enum MetaLocationOrSubRegion {
 
 #[derive(PartialEq, Debug, Clone, Deserialize)]
 #[serde(untagged)]
-#[allow(clippy::enum_variant_names)]
 pub enum ZonePeriod {
     Region(Vec<MetaZoneForPeriod>),
     LocationOrSubRegion(HashMap<String, MetaLocationOrSubRegion>),

--- a/provider/datagen/src/transform/cldr/cldr_serde/time_zones/time_zone_names.rs
+++ b/provider/datagen/src/transform/cldr/cldr_serde/time_zones/time_zone_names.rs
@@ -52,11 +52,10 @@ pub struct LocationWithLong {
 
 #[derive(PartialEq, Debug, Clone, Deserialize)]
 #[serde(untagged)]
-#[allow(clippy::enum_variant_names)]
 pub enum Location {
-    LocationWithCity(LocationWithExemplarCity),
-    LocationWithLong(LocationWithLong),
-    LocationWithShort(LocationWithShort),
+    City(LocationWithExemplarCity),
+    Long(LocationWithLong),
+    Short(LocationWithShort),
 }
 
 #[derive(PartialEq, Debug, Clone, Deserialize)]
@@ -116,8 +115,6 @@ impl<'de> Visitor<'de> for TimeZoneNamesVisitor {
                 let value = map.next_value::<String>()?;
                 if key.contains('-') {
                     // key is of the form: "regionFormat-type-variant"
-                    #[allow(clippy::unwrap_used)]
-                    // TODO(#1668) Clippy exceptions need docs or fixing.
                     let variant = key.split('-').last().unwrap();
                     time_zone_names
                         .region_format_variants

--- a/provider/datagen/src/transform/cldr/datetime/patterns.rs
+++ b/provider/datagen/src/transform/cldr/datetime/patterns.rs
@@ -156,7 +156,7 @@ impl From<&cldr_serde::ca::Dates> for TimePatternsV1<'_> {
 
         let (time_h11_h12, time_h23_h24) = {
             let time = (&other.time_formats).into();
-                let alt_time = patterns::LengthPatternsV1 {
+            let alt_time = patterns::LengthPatternsV1 {
                 full: alt_hour_cycle
                     .apply_on_pattern(
                         &length_combinations_v1,

--- a/provider/datagen/src/transform/cldr/datetime/patterns.rs
+++ b/provider/datagen/src/transform/cldr/datetime/patterns.rs
@@ -10,7 +10,6 @@ use icu_datetime::provider::calendar::*;
 impl From<&cldr_serde::ca::LengthPatterns> for patterns::LengthPatternsV1<'_> {
     fn from(other: &cldr_serde::ca::LengthPatterns) -> Self {
         // TODO(#308): Support numbering system variations. We currently throw them away.
-        #[allow(clippy::expect_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
         Self {
             full: other
                 .full
@@ -39,7 +38,6 @@ impl From<&cldr_serde::ca::LengthPatterns> for patterns::LengthPatternsV1<'_> {
 impl From<&cldr_serde::ca::DateTimeFormats> for patterns::LengthPatternsV1<'_> {
     fn from(other: &cldr_serde::ca::DateTimeFormats) -> Self {
         // TODO(#308): Support numbering system variations. We currently throw them away.
-        #[allow(clippy::expect_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
         Self {
             full: other
                 .full
@@ -68,7 +66,6 @@ impl From<&cldr_serde::ca::DateTimeFormats> for patterns::LengthPatternsV1<'_> {
 impl From<&cldr_serde::ca::DateTimeFormats> for patterns::GenericLengthPatternsV1<'_> {
     fn from(other: &cldr_serde::ca::DateTimeFormats) -> Self {
         // TODO(#308): Support numbering system variations. We currently throw them away.
-        #[allow(clippy::expect_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
         Self {
             full: other
                 .full
@@ -117,19 +114,15 @@ impl From<&cldr_serde::ca::Dates> for TimePatternsV1<'_> {
         let pattern_str_medium = other.time_formats.medium.get_pattern();
         let pattern_str_short = other.time_formats.short.get_pattern();
 
-        #[allow(clippy::expect_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
         let pattern_full = pattern_str_full
             .parse()
             .expect("Failed to create a full Pattern from bytes.");
-        #[allow(clippy::expect_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
         let pattern_long = pattern_str_long
             .parse()
             .expect("Failed to create a long Pattern from bytes.");
-        #[allow(clippy::expect_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
         let pattern_medium = pattern_str_medium
             .parse()
             .expect("Failed to create a medium Pattern from bytes.");
-        #[allow(clippy::expect_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
         let pattern_short = pattern_str_short
             .parse()
             .expect("Failed to create a short Pattern from bytes.");
@@ -153,7 +146,6 @@ impl From<&cldr_serde::ca::Dates> for TimePatternsV1<'_> {
             }
         }
 
-        #[allow(clippy::expect_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
         let preferred_hour_cycle =
             preferred_hour_cycle.expect("Could not find a preferred hour cycle.");
         let alt_hour_cycle = if preferred_hour_cycle == CoarseHourCycle::H11H12 {
@@ -164,8 +156,7 @@ impl From<&cldr_serde::ca::Dates> for TimePatternsV1<'_> {
 
         let (time_h11_h12, time_h23_h24) = {
             let time = (&other.time_formats).into();
-            #[allow(clippy::expect_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
-            let alt_time = patterns::LengthPatternsV1 {
+                let alt_time = patterns::LengthPatternsV1 {
                 full: alt_hour_cycle
                     .apply_on_pattern(
                         &length_combinations_v1,

--- a/provider/datagen/src/transform/cldr/datetime/skeletons.rs
+++ b/provider/datagen/src/transform/cldr/datetime/skeletons.rs
@@ -36,23 +36,17 @@ impl From<&cldr_serde::ca::Dates> for DateSkeletonPatternsV1<'_> {
                     Ok(s) => s,
                     Err(SkeletonError::SymbolUnimplemented(_)) => return None,
                     Err(SkeletonError::SkeletonHasVariant) => return None,
-                    #[allow(clippy::panic)]
-                    // TODO(#1668) Clippy exceptions need docs or fixing.
                     Err(err) => panic!(
                         "Unexpected skeleton error while parsing skeleton {:?} {}",
                         skeleton_str, err
                     ),
                 };
-                #[allow(clippy::expect_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
                 let pattern_str = patterns.get("other").expect("Other variant must exist");
-                #[allow(clippy::expect_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
                 let pattern = pattern_str.parse().expect("Unable to parse a pattern");
 
                 let mut pattern_plurals = if patterns.len() == 1 {
                     PatternPlurals::SinglePattern(pattern)
                 } else {
-                    #[allow(clippy::expect_used)]
-                    // TODO(#1668) Clippy exceptions need docs or fixing.
                     let mut plural_pattern =
                         PluralPattern::new(pattern).expect("Unable to construct PluralPattern");
 
@@ -60,12 +54,8 @@ impl From<&cldr_serde::ca::Dates> for DateSkeletonPatternsV1<'_> {
                         if key == "other" {
                             continue;
                         }
-                        #[allow(clippy::expect_used)]
-                        // TODO(#1668) Clippy exceptions need docs or fixing.
                         let cat = PluralCategory::from_tr35_string(key)
                             .expect("Failed to retrieve plural category");
-                        #[allow(clippy::expect_used)]
-                        // TODO(#1668) Clippy exceptions need docs or fixing.
                         let pattern = pattern_str.parse().expect("Unable to parse a pattern");
                         plural_pattern.maybe_set_variant(cat, pattern);
                     }

--- a/provider/datagen/src/transform/cldr/datetime/week_data.rs
+++ b/provider/datagen/src/transform/cldr/datetime/week_data.rs
@@ -14,7 +14,6 @@ use icu_provider::prelude::*;
 use std::collections::HashSet;
 
 impl IterableDataProvider<WeekDataV1Marker> for crate::DatagenProvider {
-    #[allow(clippy::needless_collect)] // https://github.com/rust-lang/rust-clippy/issues/7526
     fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
         let week_data: &cldr_serde::week_data::Resource = self
             .source

--- a/provider/datagen/src/transform/cldr/decimal/decimal_pattern.rs
+++ b/provider/datagen/src/transform/cldr/decimal/decimal_pattern.rs
@@ -47,16 +47,12 @@ impl FromStr for DecimalSubPattern {
             Some(i) => i,
             None => return Err(Error::NoBodyInSubpattern),
         };
-        #[allow(clippy::indexing_slicing)] // TODO(#1668) Clippy exceptions need docs or fixing.
         let j = subpattern[i..]
             .find(|c: char| !matches!(c, '#' | '0' | ',' | '.'))
             .unwrap_or(subpattern.len() - i)
             + i;
-        #[allow(clippy::indexing_slicing)] // TODO(#1668) Clippy exceptions need docs or fixing.
         let prefix = &subpattern[..i];
-        #[allow(clippy::indexing_slicing)] // TODO(#1668) Clippy exceptions need docs or fixing.
         let body = &subpattern[i..j];
-        #[allow(clippy::indexing_slicing)] // TODO(#1668) Clippy exceptions need docs or fixing.
         let suffix = &subpattern[j..];
 
         // For now, we expect one of a handful of pattern bodies.

--- a/provider/datagen/src/transform/cldr/decimal/mod.rs
+++ b/provider/datagen/src/transform/cldr/decimal/mod.rs
@@ -2,9 +2,6 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-// All expects in this file have appropriate messages
-#![allow(clippy::expect_used)]
-
 use crate::transform::cldr::cldr_serde;
 use icu_decimal::provider::*;
 use icu_locid::extensions::unicode::Value;

--- a/provider/datagen/src/transform/cldr/plurals/mod.rs
+++ b/provider/datagen/src/transform/cldr/plurals/mod.rs
@@ -40,8 +40,6 @@ macro_rules! implement {
                 Ok(DataResponse {
                     metadata: Default::default(),
                     payload: Some(DataPayload::from_owned(PluralRulesV1::from(
-                        #[allow(clippy::unwrap_used)]
-                        // TODO(#1668) Clippy exceptions need docs or fixing.
                         self.get_rules_for(<$marker>::KEY)?
                             .0
                             .get(&req.locale.get_langid())
@@ -73,17 +71,15 @@ impl From<&cldr_serde::plurals::LocalePluralRules> for PluralRulesV1<'static> {
     fn from(other: &cldr_serde::plurals::LocalePluralRules) -> Self {
         /// Removes samples from plural rule strings. Takes an owned [`String`] reference and
         /// returns a new [`String`] in a [`Cow::Owned`].
-        #[allow(clippy::ptr_arg)]
-        fn convert(s: &String) -> Rule<'static> {
-            #[allow(clippy::expect_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
+        fn convert(s: &str) -> Rule<'static> {
             s.parse().expect("Rule parsing failed.")
         }
         Self {
-            zero: other.zero.as_ref().map(convert),
-            one: other.one.as_ref().map(convert),
-            two: other.two.as_ref().map(convert),
-            few: other.few.as_ref().map(convert),
-            many: other.many.as_ref().map(convert),
+            zero: other.zero.as_deref().map(convert),
+            one: other.one.as_deref().map(convert),
+            two: other.two.as_deref().map(convert),
+            few: other.few.as_deref().map(convert),
+            many: other.many.as_deref().map(convert),
         }
     }
 }

--- a/provider/datagen/src/transform/cldr/time_zones/convert.rs
+++ b/provider/datagen/src/transform/cldr/time_zones/convert.rs
@@ -35,11 +35,8 @@ fn type_fallback(zone_format: &ZoneFormat) -> Option<&String> {
 
 fn parse_hour_format(hour_format: &str) -> (Cow<'static, str>, Cow<'static, str>) {
     // e.g. "+HH:mm;-HH:mm" -> ("+HH:mm", "-HH:mm")
-    #[allow(clippy::unwrap_used)] // TODO(#1668) Clippy exceptions need docs or fixing.
     let index = hour_format.rfind(';').unwrap();
-    #[allow(clippy::indexing_slicing)] // TODO(#1668) Clippy exceptions need docs or fixing.
     let positive = String::from(&hour_format[0..index]);
-    #[allow(clippy::indexing_slicing)] // TODO(#1668) Clippy exceptions need docs or fixing.
     let negative = String::from(&hour_format[index + 1..]);
     (Cow::Owned(positive), Cow::Owned(negative))
 }
@@ -80,8 +77,6 @@ impl From<CldrTimeZonesData<'_>> for TimeZoneFormatsV1<'static> {
                 .region_format_variants
                 .iter()
                 .map(|(key, value)| {
-                    #[allow(clippy::expect_used)]
-                    // TODO(#1668) Clippy exceptions need docs or fixing.
                     (
                         key.parse::<TinyStr8>()
                             .expect("Time-zone variant was not compatible with TinyStr8"),
@@ -99,25 +94,25 @@ impl From<CldrTimeZonesData<'_>> for TimeZoneFormatsV1<'static> {
 impl Location {
     fn exemplar_city(&self) -> Option<String> {
         match self {
-            Self::LocationWithCity(place) => Some(place.exemplar_city.clone()),
-            Self::LocationWithLong(place) => place.exemplar_city.clone(),
-            Self::LocationWithShort(place) => place.exemplar_city.clone(),
+            Self::City(place) => Some(place.exemplar_city.clone()),
+            Self::Long(place) => place.exemplar_city.clone(),
+            Self::Short(place) => place.exemplar_city.clone(),
         }
     }
 
     fn long_metazone_names(&self) -> Option<ZoneFormat> {
         match self {
-            Self::LocationWithCity(place) => place.long.clone(),
-            Self::LocationWithLong(place) => Some(place.long.clone()),
-            Self::LocationWithShort(place) => place.long.clone(),
+            Self::City(place) => place.long.clone(),
+            Self::Long(place) => Some(place.long.clone()),
+            Self::Short(place) => place.long.clone(),
         }
     }
 
     fn short_metazone_names(&self) -> Option<ZoneFormat> {
         match self {
-            Self::LocationWithCity(place) => place.short.clone(),
-            Self::LocationWithLong(place) => place.short.clone(),
-            Self::LocationWithShort(place) => Some(place.short.clone()),
+            Self::City(place) => place.short.clone(),
+            Self::Long(place) => place.short.clone(),
+            Self::Short(place) => Some(place.short.clone()),
         }
     }
 }
@@ -439,8 +434,6 @@ fn iterate_zone_format_for_meta_zone_id(
         .map(move |(key, value)| {
             (
                 key1,
-                #[allow(clippy::expect_used)]
-                // TODO(#1668) Clippy exceptions need docs or fixing.
                 key.parse::<TinyStr8>()
                     .expect("Time-zone variant was not compatible with TinyStr8"),
                 value,
@@ -457,8 +450,6 @@ fn iterate_zone_format_for_time_zone_id(
         .map(move |(key, value)| {
             (
                 key1,
-                #[allow(clippy::expect_used)]
-                // TODO(#1668) Clippy exceptions need docs or fixing.
                 key.parse::<TinyStr8>()
                     .expect("Time-zone variant was not compatible with TinyStr8"),
                 value,

--- a/provider/fs/src/lib.rs
+++ b/provider/fs/src/lib.rs
@@ -98,7 +98,8 @@
         clippy::expect_used,
         clippy::panic,
         clippy::exhaustive_structs,
-        clippy::exhaustive_enums
+        clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 

--- a/provider/macros/src/lib.rs
+++ b/provider/macros/src/lib.rs
@@ -9,7 +9,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        clippy::exhaustive_enums,
+        missing_debug_implementations,
     )
 )]
 // Panics are OK in proc macros

--- a/tools/benchmark/macros/src/lib.rs
+++ b/tools/benchmark/macros/src/lib.rs
@@ -9,7 +9,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        clippy::exhaustive_enums,
+        missing_debug_implementations,
     )
 )]
 

--- a/utils/codepointtrie/builder/src/lib.rs
+++ b/utils/codepointtrie/builder/src/lib.rs
@@ -51,7 +51,8 @@
         clippy::expect_used,
         clippy::panic,
         clippy::exhaustive_structs,
-        clippy::exhaustive_enums
+        clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 // This is a build tool with many invariants being enforced

--- a/utils/codepointtrie/src/lib.rs
+++ b/utils/codepointtrie/src/lib.rs
@@ -39,7 +39,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        // TODO(#1668): enable clippy::exhaustive_structs,
+        // TODO(#1668): enable clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 

--- a/utils/deduplicating_array/src/lib.rs
+++ b/utils/deduplicating_array/src/lib.rs
@@ -36,7 +36,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        // TODO(#1668): enable clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 

--- a/utils/fixed_decimal/src/lib.rs
+++ b/utils/fixed_decimal/src/lib.rs
@@ -46,7 +46,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        // TODO(#1668): enable clippy::exhaustive_enums,
+        missing_debug_implementations,
     )
 )]
 

--- a/utils/litemap/src/lib.rs
+++ b/utils/litemap/src/lib.rs
@@ -31,7 +31,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        clippy::exhaustive_enums,
+        missing_debug_implementations,
     )
 )]
 

--- a/utils/pattern/src/lib.rs
+++ b/utils/pattern/src/lib.rs
@@ -108,7 +108,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        // TODO(#1668): enable clippy::exhaustive_structs,
+        // TODO(#1668): enable clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 

--- a/utils/tinystr/src/lib.rs
+++ b/utils/tinystr/src/lib.rs
@@ -58,7 +58,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        // TODO(#1668): enable clippy::exhaustive_enums,
+        missing_debug_implementations,
     )
 )]
 

--- a/utils/uniset/src/lib.rs
+++ b/utils/uniset/src/lib.rs
@@ -56,7 +56,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        // TODO(#1668): enable clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 #![warn(missing_docs)]

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -10,7 +10,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        // TODO(#1668): enable clippy::exhaustive_structs,
+        clippy::exhaustive_enums,
+        missing_debug_implementations,
     )
 )]
 

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -32,7 +32,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        // TODO(#1668): enable clippy::exhaustive_structs,
+        // TODO(#1668): enable clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 // The lifetimes here are important for safety and explicitly writing

--- a/utils/zerofrom/derive/src/lib.rs
+++ b/utils/zerofrom/derive/src/lib.rs
@@ -11,7 +11,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        clippy::exhaustive_enums,
+        missing_debug_implementations,
     )
 )]
 

--- a/utils/zerofrom/src/lib.rs
+++ b/utils/zerofrom/src/lib.rs
@@ -14,7 +14,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        clippy::exhaustive_structs,
+        clippy::exhaustive_enums,
+        missing_debug_implementations,
     )
 )]
 // The lifetimes here are important for safety and explicitly writing

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -200,7 +200,10 @@
         clippy::indexing_slicing,
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::panic
+        clippy::panic,
+        // TODO(#1668): enable clippy::exhaustive_structs,
+        // TODO(#1668): enable clippy::exhaustive_enums,
+        // TODO(#2266): enable missing_debug_implementations,
     )
 )]
 // this crate does a lot of nuanced lifetime manipulation, being explicit


### PR DESCRIPTION
Also added exhaustiveness lints (or TODOs) where they hadn't been added.

Also cleaned up `allow`s without denies in datagen.

#2266
#1668 