### PR TITLE
Remove two char types in line segmenter and polish utf8 iterator naming

### DIFF
--- a/experimental/segmenter/src/grapheme.rs
+++ b/experimental/segmenter/src/grapheme.rs
@@ -12,7 +12,8 @@ use crate::provider::*;
 use crate::rule_segmenter::*;
 
 /// Grapheme cluster break iterator for an `str` (a UTF-8 string).
-pub type GraphemeClusterBreakIterator<'l, 's> = RuleBreakIterator<'l, 's, GraphemeClusterBreakType>;
+pub type GraphemeClusterBreakIteratorUtf8<'l, 's> =
+    RuleBreakIterator<'l, 's, GraphemeClusterBreakTypeUtf8>;
 
 /// Grapheme cluster break iterator for a Latin-1 (8-bit) string.
 pub type GraphemeClusterBreakIteratorLatin1<'l, 's> =
@@ -46,8 +47,11 @@ impl GraphemeClusterBreakSegmenter {
     }
 
     /// Create a grapheme cluster break iterator for an `str` (a UTF-8 string).
-    pub fn segment_str<'l, 's>(&'l self, input: &'s str) -> GraphemeClusterBreakIterator<'l, 's> {
-        GraphemeClusterBreakIterator {
+    pub fn segment_str<'l, 's>(
+        &'l self,
+        input: &'s str,
+    ) -> GraphemeClusterBreakIteratorUtf8<'l, 's> {
+        GraphemeClusterBreakIteratorUtf8 {
             iter: input.char_indices(),
             len: input.len(),
             current_pos_data: None,
@@ -91,9 +95,9 @@ impl GraphemeClusterBreakSegmenter {
     }
 }
 
-pub struct GraphemeClusterBreakType;
+pub struct GraphemeClusterBreakTypeUtf8;
 
-impl<'l, 's> RuleBreakType<'l, 's> for GraphemeClusterBreakType {
+impl<'l, 's> RuleBreakType<'l, 's> for GraphemeClusterBreakTypeUtf8 {
     type IterAttr = CharIndices<'s>;
     type CharType = char;
 

--- a/experimental/segmenter/src/grapheme.rs
+++ b/experimental/segmenter/src/grapheme.rs
@@ -113,7 +113,7 @@ pub struct GraphemeClusterBreakTypeLatin1;
 
 impl<'l, 's> RuleBreakType<'l, 's> for GraphemeClusterBreakTypeLatin1 {
     type IterAttr = Latin1Indices<'s>;
-    type CharType = u8; // TODO: Latin1Char
+    type CharType = u8;
 
     fn get_current_position_character_len(_: &RuleBreakIterator<Self>) -> usize {
         panic!("not reachable")

--- a/experimental/segmenter/src/lib.rs
+++ b/experimental/segmenter/src/lib.rs
@@ -168,8 +168,8 @@ mod math_helper;
 
 pub use crate::dictionary::{DictionaryBreakIterator, DictionarySegmenter};
 pub use crate::grapheme::{
-    GraphemeClusterBreakIterator, GraphemeClusterBreakIteratorLatin1,
-    GraphemeClusterBreakIteratorUtf16, GraphemeClusterBreakSegmenter,
+    GraphemeClusterBreakIteratorLatin1, GraphemeClusterBreakIteratorUtf16,
+    GraphemeClusterBreakIteratorUtf8, GraphemeClusterBreakSegmenter,
 };
 pub use crate::line::{
     LineBreakIterator, LineBreakIteratorLatin1, LineBreakIteratorUtf16, LineBreakIteratorUtf8,
@@ -182,9 +182,9 @@ pub use crate::provider::{
     UCharDictionaryBreakDataV1, UCharDictionaryBreakDataV1Marker, WordBreakDataV1Marker,
 };
 pub use crate::sentence::{
-    SentenceBreakIterator, SentenceBreakIteratorLatin1, SentenceBreakIteratorUtf16,
+    SentenceBreakIteratorLatin1, SentenceBreakIteratorUtf16, SentenceBreakIteratorUtf8,
     SentenceBreakSegmenter,
 };
 pub use crate::word::{
-    WordBreakIterator, WordBreakIteratorLatin1, WordBreakIteratorUtf16, WordBreakSegmenter,
+    WordBreakIteratorLatin1, WordBreakIteratorUtf16, WordBreakIteratorUtf8, WordBreakSegmenter,
 };

--- a/experimental/segmenter/src/lib.rs
+++ b/experimental/segmenter/src/lib.rs
@@ -172,8 +172,8 @@ pub use crate::grapheme::{
     GraphemeClusterBreakIteratorUtf16, GraphemeClusterBreakSegmenter,
 };
 pub use crate::line::{
-    Latin1Char, LineBreakIterator, LineBreakOptions, LineBreakRule, LineBreakSegmenter, Utf16Char,
-    WordBreakRule,
+    LineBreakIterator, LineBreakIteratorLatin1, LineBreakIteratorUtf16, LineBreakIteratorUtf8,
+    LineBreakOptions, LineBreakRule, LineBreakSegmenter, WordBreakRule,
 };
 pub use crate::lstm_structs::{LstmDataV1, LstmDataV1Marker, LstmMatrix};
 pub use crate::provider::{

--- a/experimental/segmenter/src/sentence.rs
+++ b/experimental/segmenter/src/sentence.rs
@@ -108,7 +108,7 @@ pub struct SentenceBreakTypeLatin1;
 
 impl<'l, 's> RuleBreakType<'l, 's> for SentenceBreakTypeLatin1 {
     type IterAttr = Latin1Indices<'s>;
-    type CharType = u8; // TODO: Latin1Char
+    type CharType = u8;
 
     fn get_current_position_character_len(_: &RuleBreakIterator<Self>) -> usize {
         panic!("not reachable")

--- a/experimental/segmenter/src/sentence.rs
+++ b/experimental/segmenter/src/sentence.rs
@@ -12,7 +12,7 @@ use crate::provider::*;
 use crate::rule_segmenter::*;
 
 /// Sentence break iterator for an `str` (a UTF-8 string).
-pub type SentenceBreakIterator<'l, 's> = RuleBreakIterator<'l, 's, SentenceBreakType>;
+pub type SentenceBreakIteratorUtf8<'l, 's> = RuleBreakIterator<'l, 's, SentenceBreakTypeUtf8>;
 
 /// Sentence break iterator for a Latin-1 (8-bit) string.
 pub type SentenceBreakIteratorLatin1<'l, 's> = RuleBreakIterator<'l, 's, SentenceBreakTypeLatin1>;
@@ -44,8 +44,8 @@ impl SentenceBreakSegmenter {
     }
 
     /// Create a sentence break iterator for an `str` (a UTF-8 string).
-    pub fn segment_str<'l, 's>(&'l self, input: &'s str) -> SentenceBreakIterator<'l, 's> {
-        SentenceBreakIterator {
+    pub fn segment_str<'l, 's>(&'l self, input: &'s str) -> SentenceBreakIteratorUtf8<'l, 's> {
+        SentenceBreakIteratorUtf8 {
             iter: input.char_indices(),
             len: input.len(),
             current_pos_data: None,
@@ -86,9 +86,9 @@ impl SentenceBreakSegmenter {
     }
 }
 
-pub struct SentenceBreakType;
+pub struct SentenceBreakTypeUtf8;
 
-impl<'l, 's> RuleBreakType<'l, 's> for SentenceBreakType {
+impl<'l, 's> RuleBreakType<'l, 's> for SentenceBreakTypeUtf8 {
     type IterAttr = CharIndices<'s>;
     type CharType = char;
 

--- a/experimental/segmenter/src/word.rs
+++ b/experimental/segmenter/src/word.rs
@@ -17,7 +17,7 @@ use crate::rule_segmenter::*;
 use crate::LstmDataV1Marker;
 
 /// Word break iterator for an `str` (a UTF-8 string).
-pub type WordBreakIterator<'l, 's> = RuleBreakIterator<'l, 's, WordBreakType>;
+pub type WordBreakIteratorUtf8<'l, 's> = RuleBreakIterator<'l, 's, WordBreakTypeUtf8>;
 
 /// Word break iterator for a Latin-1 (8-bit) string.
 pub type WordBreakIteratorLatin1<'l, 's> = RuleBreakIterator<'l, 's, WordBreakTypeLatin1>;
@@ -140,8 +140,8 @@ impl WordBreakSegmenter {
     }
 
     /// Create a word break iterator for an `str` (a UTF-8 string).
-    pub fn segment_str<'l, 's>(&'l self, input: &'s str) -> WordBreakIterator<'l, 's> {
-        WordBreakIterator {
+    pub fn segment_str<'l, 's>(&'l self, input: &'s str) -> WordBreakIteratorUtf8<'l, 's> {
+        WordBreakIteratorUtf8 {
             iter: input.char_indices(),
             len: input.len(),
             current_pos_data: None,
@@ -179,9 +179,9 @@ impl WordBreakSegmenter {
     }
 }
 
-pub struct WordBreakType;
+pub struct WordBreakTypeUtf8;
 
-impl<'l, 's> RuleBreakType<'l, 's> for WordBreakType {
+impl<'l, 's> RuleBreakType<'l, 's> for WordBreakTypeUtf8 {
     type IterAttr = CharIndices<'s>;
     type CharType = char;
 

--- a/experimental/segmenter/src/word.rs
+++ b/experimental/segmenter/src/word.rs
@@ -235,7 +235,7 @@ pub struct WordBreakTypeLatin1;
 
 impl<'l, 's> RuleBreakType<'l, 's> for WordBreakTypeLatin1 {
     type IterAttr = Latin1Indices<'s>;
-    type CharType = u8; // TODO: Latin1Char
+    type CharType = u8;
 
     fn get_current_position_character_len(_: &RuleBreakIterator<Self>) -> usize {
         panic!("not reachable")

--- a/ffi/diplomat/src/segmenter_grapheme.rs
+++ b/ffi/diplomat/src/segmenter_grapheme.rs
@@ -11,8 +11,8 @@ pub mod ffi {
     use diplomat_runtime::DiplomatResult;
     use icu_provider::DataProvider;
     use icu_segmenter::{
-        GraphemeClusterBreakDataV1Marker, GraphemeClusterBreakIterator,
-        GraphemeClusterBreakIteratorLatin1, GraphemeClusterBreakIteratorUtf16,
+        GraphemeClusterBreakDataV1Marker, GraphemeClusterBreakIteratorLatin1,
+        GraphemeClusterBreakIteratorUtf16, GraphemeClusterBreakIteratorUtf8,
         GraphemeClusterBreakSegmenter,
     };
 
@@ -23,7 +23,7 @@ pub mod ffi {
     pub struct ICU4XGraphemeClusterBreakSegmenter(GraphemeClusterBreakSegmenter);
 
     #[diplomat::opaque]
-    pub struct ICU4XGraphemeClusterBreakIteratorUtf8<'a>(GraphemeClusterBreakIterator<'a, 'a>);
+    pub struct ICU4XGraphemeClusterBreakIteratorUtf8<'a>(GraphemeClusterBreakIteratorUtf8<'a, 'a>);
 
     #[diplomat::opaque]
     pub struct ICU4XGraphemeClusterBreakIteratorUtf16<'a>(

--- a/ffi/diplomat/src/segmenter_line.rs
+++ b/ffi/diplomat/src/segmenter_line.rs
@@ -14,13 +14,11 @@ pub mod ffi {
     use core::convert::TryFrom;
     use diplomat_runtime::DiplomatResult;
     use icu_provider::DataProvider;
-    use icu_segmenter::Latin1Char;
     use icu_segmenter::LineBreakDataV1Marker;
-    use icu_segmenter::LineBreakIterator;
     use icu_segmenter::LineBreakSegmenter;
     use icu_segmenter::LstmDataV1Marker;
     use icu_segmenter::UCharDictionaryBreakDataV1Marker;
-    use icu_segmenter::Utf16Char;
+    use icu_segmenter::{LineBreakIteratorLatin1, LineBreakIteratorUtf16, LineBreakIteratorUtf8};
 
     #[diplomat::opaque]
     /// An ICU4X line-break segmenter, capable of finding breakpoints in strings.
@@ -50,13 +48,13 @@ pub mod ffi {
     }
 
     #[diplomat::opaque]
-    pub struct ICU4XLineBreakIteratorUtf8<'a>(LineBreakIterator<'a, 'a, char>);
+    pub struct ICU4XLineBreakIteratorUtf8<'a>(LineBreakIteratorUtf8<'a, 'a>);
 
     #[diplomat::opaque]
-    pub struct ICU4XLineBreakIteratorUtf16<'a>(LineBreakIterator<'a, 'a, Utf16Char>);
+    pub struct ICU4XLineBreakIteratorUtf16<'a>(LineBreakIteratorUtf16<'a, 'a>);
 
     #[diplomat::opaque]
-    pub struct ICU4XLineBreakIteratorLatin1<'a>(LineBreakIterator<'a, 'a, Latin1Char>);
+    pub struct ICU4XLineBreakIteratorLatin1<'a>(LineBreakIteratorLatin1<'a, 'a>);
 
     impl ICU4XLineBreakSegmenter {
         /// Construct a [`ICU4XLineBreakSegmenter`] with default options.

--- a/ffi/diplomat/src/segmenter_sentence.rs
+++ b/ffi/diplomat/src/segmenter_sentence.rs
@@ -11,8 +11,8 @@ pub mod ffi {
     use diplomat_runtime::DiplomatResult;
     use icu_provider::DataProvider;
     use icu_segmenter::{
-        SentenceBreakDataV1Marker, SentenceBreakIterator, SentenceBreakIteratorLatin1,
-        SentenceBreakIteratorUtf16, SentenceBreakSegmenter,
+        SentenceBreakDataV1Marker, SentenceBreakIteratorLatin1, SentenceBreakIteratorUtf16,
+        SentenceBreakIteratorUtf8, SentenceBreakSegmenter,
     };
 
     #[diplomat::opaque]
@@ -21,7 +21,7 @@ pub mod ffi {
     pub struct ICU4XSentenceBreakSegmenter(SentenceBreakSegmenter);
 
     #[diplomat::opaque]
-    pub struct ICU4XSentenceBreakIteratorUtf8<'a>(SentenceBreakIterator<'a, 'a>);
+    pub struct ICU4XSentenceBreakIteratorUtf8<'a>(SentenceBreakIteratorUtf8<'a, 'a>);
 
     #[diplomat::opaque]
     pub struct ICU4XSentenceBreakIteratorUtf16<'a>(SentenceBreakIteratorUtf16<'a, 'a>);

--- a/ffi/diplomat/src/segmenter_word.rs
+++ b/ffi/diplomat/src/segmenter_word.rs
@@ -12,7 +12,7 @@ pub mod ffi {
     use icu_provider::DataProvider;
     use icu_segmenter::{
         LstmDataV1Marker, UCharDictionaryBreakDataV1Marker, WordBreakDataV1Marker,
-        WordBreakIterator, WordBreakIteratorLatin1, WordBreakIteratorUtf16, WordBreakSegmenter,
+        WordBreakIteratorLatin1, WordBreakIteratorUtf16, WordBreakIteratorUtf8, WordBreakSegmenter,
     };
 
     #[diplomat::opaque]
@@ -21,7 +21,7 @@ pub mod ffi {
     pub struct ICU4XWordBreakSegmenter(WordBreakSegmenter);
 
     #[diplomat::opaque]
-    pub struct ICU4XWordBreakIteratorUtf8<'a>(WordBreakIterator<'a, 'a>);
+    pub struct ICU4XWordBreakIteratorUtf8<'a>(WordBreakIteratorUtf8<'a, 'a>);
 
     #[diplomat::opaque]
     pub struct ICU4XWordBreakIteratorUtf16<'a>(WordBreakIteratorUtf16<'a, 'a>);


### PR DESCRIPTION
- Remove Latin1Char and Utf16Char in line.rs
- Append 'Utf8' to UAX29 iterators iterating over str