### PR TITLE
Add binary search and other utilities to FlexZeroVec

### DIFF
--- a/utils/zerovec/src/flexzerovec/slice.rs
+++ b/utils/zerovec/src/flexzerovec/slice.rs
@@ -395,7 +395,7 @@ impl FlexZeroSlice {
     ) -> Option<Result<usize, usize>> {
         // Note: We need to check bounds separately, since `self.data.get(range)` does not return
         // bounds errors, since it is indexing directly into the upscaled data array
-        if range.start >= self.len() || range.end > self.len() {
+        if range.start > self.len() || range.end > self.len() {
             return None;
         }
         let scaled_slice = self.data.get(range)?;
@@ -430,7 +430,7 @@ impl FlexZeroSlice {
     ) -> Option<Result<usize, usize>> {
         // Note: We need to check bounds separately, since `self.data.get(range)` does not return
         // bounds errors, since it is indexing directly into the upscaled data array
-        if range.start >= self.len() || range.end > self.len() {
+        if range.start > self.len() || range.end > self.len() {
             return None;
         }
         let scaled_slice = self.data.get(range)?;


### PR DESCRIPTION
Please spent time making sure these are correct. I had to chase down some off-by-1 errors when integrating this into VZV.