### PR TITLE
Make multiply_pow10 be infallible

### DIFF
--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -379,9 +379,7 @@ where
                     };
 
                     // We store fractional seconds as nanoseconds, convert to seconds.
-                    fraction
-                        .multiply_pow10(-9)
-                        .map_err(|_| Error::FixedDecimal)?;
+                    fraction.multiply_pow10(-9);
 
                     seconds
                         .concatenate_right(fraction)

--- a/components/decimal/README.md
+++ b/components/decimal/README.md
@@ -41,8 +41,7 @@ let fdf = FixedDecimalFormatter::try_new(&provider, &Locale::UND.into(), Default
     .expect("Data should load successfully");
 
 let fixed_decimal = FixedDecimal::from(200050)
-    .multiplied_pow10(-2)
-    .expect("Operation is fully in range");
+    .multiplied_pow10(-2);
 
 assert_eq!("2,000.50", fdf.format(&fixed_decimal).write_to_string());
 ```

--- a/components/decimal/src/grouper.rs
+++ b/components/decimal/src/grouper.rs
@@ -154,9 +154,7 @@ fn test_grouper() {
     ];
     for cas in &cases {
         for i in 0..4 {
-            let dec = FixedDecimal::from(1)
-                .multiplied_pow10((i as i16) + 3)
-                .unwrap();
+            let dec = FixedDecimal::from(1).multiplied_pow10((i as i16) + 3);
             let provider = AnyPayloadProvider::new_owned::<DecimalSymbolsV1Marker>(
                 crate::provider::DecimalSymbolsV1 {
                     grouping_sizes: cas.sizes,

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -45,8 +45,7 @@
 //!     .expect("Data should load successfully");
 //!
 //! let fixed_decimal = FixedDecimal::from(200050)
-//!     .multiplied_pow10(-2)
-//!     .expect("Operation is fully in range");
+//!     .multiplied_pow10(-2);
 //!
 //! assert_eq!("2,000.50", fdf.format(&fixed_decimal).write_to_string());
 //! ```

--- a/components/plurals/benches/operands.rs
+++ b/components/plurals/benches/operands.rs
@@ -29,9 +29,7 @@ fn operands(c: &mut Criterion) {
                     .expect("Failed to parse a number into an operands.");
             }
             for s in &data.fixed_decimals {
-                let f: FixedDecimal = FixedDecimal::from(s.value)
-                    .multiplied_pow10(s.exponent)
-                    .unwrap();
+                let f: FixedDecimal = FixedDecimal::from(s.value).multiplied_pow10(s.exponent);
                 let _: PluralOperands = PluralOperands::from(black_box(&f));
             }
         })
@@ -108,9 +106,7 @@ fn operands(c: &mut Criterion) {
         c.bench_function("plurals/operands/create/from_fixed_decimal", |b| {
             b.iter(|| {
                 for s in &data.fixed_decimals {
-                    let f: FixedDecimal = FixedDecimal::from(s.value)
-                        .multiplied_pow10(s.exponent)
-                        .unwrap();
+                    let f: FixedDecimal = FixedDecimal::from(s.value).multiplied_pow10(s.exponent);
                     let _: PluralOperands = PluralOperands::from(black_box(&f));
                 }
             });
@@ -118,9 +114,9 @@ fn operands(c: &mut Criterion) {
 
         {
             let samples = [
-                FixedDecimal::from(1).multiplied_pow10(0).unwrap(),
-                FixedDecimal::from(123450).multiplied_pow10(-4).unwrap(),
-                FixedDecimal::from(2500).multiplied_pow10(-2).unwrap(),
+                FixedDecimal::from(1 as i128).multiplied_pow10(0),
+                FixedDecimal::from(123450 as i128).multiplied_pow10(-4),
+                FixedDecimal::from(2500 as i128).multiplied_pow10(-2),
             ];
             let mut group = c.benchmark_group("plurals/operands/create/from_fixed_decimal/samples");
             for s in samples.iter() {

--- a/components/plurals/benches/operands.rs
+++ b/components/plurals/benches/operands.rs
@@ -114,9 +114,9 @@ fn operands(c: &mut Criterion) {
 
         {
             let samples = [
-                FixedDecimal::from(1 as i128).multiplied_pow10(0),
-                FixedDecimal::from(123450 as i128).multiplied_pow10(-4),
-                FixedDecimal::from(2500 as i128).multiplied_pow10(-2),
+                FixedDecimal::from(1_i128).multiplied_pow10(0),
+                FixedDecimal::from(123450_i128).multiplied_pow10(-4),
+                FixedDecimal::from(2500_i128).multiplied_pow10(-2),
             ];
             let mut group = c.benchmark_group("plurals/operands/create/from_fixed_decimal/samples");
             for s in samples.iter() {

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -77,7 +77,7 @@ use fixed_decimal::FixedDecimal;
 ///         t: 45,
 ///         c: 0,
 ///     }),
-///     FixedDecimal::from(12345)
+///     FixedDecimal::from(12345_i128)
 ///         .multiplied_pow10(-2)
 ///         .to_string()
 ///         .parse()

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -69,18 +69,17 @@ use fixed_decimal::FixedDecimal;
 /// use fixed_decimal::FixedDecimal;
 /// use icu::plurals::PluralOperands;
 /// assert_eq!(
-///     Ok(PluralOperands {
+///     PluralOperands {
 ///         i: 123,
 ///         v: 2,
 ///         w: 2,
 ///         f: 45,
 ///         t: 45,
 ///         c: 0,
-///     }),
-///     FixedDecimal::from(12345_i128)
-///         .multiplied_pow10(-2)
-///         .to_string()
-///         .parse()
+///     },
+///     (&FixedDecimal::from(12345)
+///         .multiplied_pow10(-2))
+///         .into()
 /// )
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Default)]

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -79,7 +79,8 @@ use fixed_decimal::FixedDecimal;
 ///     }),
 ///     FixedDecimal::from(12345)
 ///         .multiplied_pow10(-2)
-///         .map(|d| (&d).into())
+///         .to_string()
+///         .parse()
 /// )
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Default)]

--- a/components/plurals/tests/fixtures/mod.rs
+++ b/components/plurals/tests/fixtures/mod.rs
@@ -39,9 +39,7 @@ pub struct FixedDecimalInput {
 
 impl From<&FixedDecimalInput> for FixedDecimal {
     fn from(f: &FixedDecimalInput) -> Self {
-        FixedDecimal::from(f.from)
-            .multiplied_pow10(f.pow10)
-            .unwrap()
+        FixedDecimal::from(f.from).multiplied_pow10(f.pow10)
     }
 }
 

--- a/ffi/diplomat/c/include/ICU4XFixedDecimal.h
+++ b/ffi/diplomat/c/include/ICU4XFixedDecimal.h
@@ -31,7 +31,7 @@ diplomat_result_box_ICU4XFixedDecimal_ICU4XError ICU4XFixedDecimal_create_from_f
 
 diplomat_result_box_ICU4XFixedDecimal_ICU4XError ICU4XFixedDecimal_create_fromstr(const char* v_data, size_t v_len);
 
-bool ICU4XFixedDecimal_multiply_pow10(ICU4XFixedDecimal* self, int16_t power);
+void ICU4XFixedDecimal_multiply_pow10(ICU4XFixedDecimal* self, int16_t power);
 
 void ICU4XFixedDecimal_set_sign(ICU4XFixedDecimal* self, ICU4XFixedDecimalSign sign);
 

--- a/ffi/diplomat/cpp/docs/source/fixed_decimal_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/fixed_decimal_ffi.rst
@@ -41,7 +41,7 @@
         See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html>`__ for more information.
 
 
-    .. cpp:function:: bool multiply_pow10(int16_t power)
+    .. cpp:function:: void multiply_pow10(int16_t power)
 
         Multiply the :cpp:class:`ICU4XFixedDecimal` by a given power of ten.
 

--- a/ffi/diplomat/cpp/include/ICU4XFixedDecimal.h
+++ b/ffi/diplomat/cpp/include/ICU4XFixedDecimal.h
@@ -31,7 +31,7 @@ diplomat_result_box_ICU4XFixedDecimal_ICU4XError ICU4XFixedDecimal_create_from_f
 
 diplomat_result_box_ICU4XFixedDecimal_ICU4XError ICU4XFixedDecimal_create_fromstr(const char* v_data, size_t v_len);
 
-bool ICU4XFixedDecimal_multiply_pow10(ICU4XFixedDecimal* self, int16_t power);
+void ICU4XFixedDecimal_multiply_pow10(ICU4XFixedDecimal* self, int16_t power);
 
 void ICU4XFixedDecimal_set_sign(ICU4XFixedDecimal* self, ICU4XFixedDecimalSign sign);
 

--- a/ffi/diplomat/cpp/include/ICU4XFixedDecimal.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XFixedDecimal.hpp
@@ -73,7 +73,7 @@ class ICU4XFixedDecimal {
    * 
    * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.multiply_pow10) for more information.
    */
-  bool multiply_pow10(int16_t power);
+  void multiply_pow10(int16_t power);
 
   /**
    * Set the sign of the [`ICU4XFixedDecimal`].
@@ -171,8 +171,8 @@ inline diplomat::result<ICU4XFixedDecimal, ICU4XError> ICU4XFixedDecimal::create
   }
   return diplomat_result_out_value;
 }
-inline bool ICU4XFixedDecimal::multiply_pow10(int16_t power) {
-  return capi::ICU4XFixedDecimal_multiply_pow10(this->inner.get(), power);
+inline void ICU4XFixedDecimal::multiply_pow10(int16_t power) {
+  capi::ICU4XFixedDecimal_multiply_pow10(this->inner.get(), power);
 }
 inline void ICU4XFixedDecimal::set_sign(ICU4XFixedDecimalSign sign) {
   capi::ICU4XFixedDecimal_set_sign(this->inner.get(), static_cast<capi::ICU4XFixedDecimalSign>(sign));

--- a/ffi/diplomat/src/fixed_decimal.rs
+++ b/ffi/diplomat/src/fixed_decimal.rs
@@ -89,8 +89,8 @@ pub mod ffi {
 
         /// Multiply the [`ICU4XFixedDecimal`] by a given power of ten.
         #[diplomat::rust_link(fixed_decimal::decimal::FixedDecimal::multiply_pow10, FnInStruct)]
-        pub fn multiply_pow10(&mut self, power: i16) -> bool {
-            self.0.multiply_pow10(power).is_ok()
+        pub fn multiply_pow10(&mut self, power: i16) {
+            self.0.multiply_pow10(power)
         }
 
         /// Set the sign of the [`ICU4XFixedDecimal`].

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XFixedDecimal.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XFixedDecimal.d.ts
@@ -59,7 +59,7 @@ export class ICU4XFixedDecimal {
 
    * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.multiply_pow10 Rust documentation} for more information.
    */
-  multiply_pow10(power: i16): boolean;
+  multiply_pow10(power: i16): void;
 
   /**
 

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XFixedDecimal.js
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XFixedDecimal.js
@@ -93,7 +93,7 @@ export class ICU4XFixedDecimal {
   }
 
   multiply_pow10(arg_power) {
-    return wasm.ICU4XFixedDecimal_multiply_pow10(this.underlying, arg_power);
+    void wasm.ICU4XFixedDecimal_multiply_pow10(this.underlying, arg_power);
   }
 
   set_sign(arg_sign) {

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XFixedDecimal.js
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XFixedDecimal.js
@@ -93,7 +93,7 @@ export class ICU4XFixedDecimal {
   }
 
   multiply_pow10(arg_power) {
-    void wasm.ICU4XFixedDecimal_multiply_pow10(this.underlying, arg_power);
+    wasm.ICU4XFixedDecimal_multiply_pow10(this.underlying, arg_power);
   }
 
   set_sign(arg_sign) {

--- a/utils/fixed_decimal/README.md
+++ b/utils/fixed_decimal/README.md
@@ -12,8 +12,7 @@ the individual digits of a number.
 use fixed_decimal::FixedDecimal;
 
 let dec = FixedDecimal::from(250)
-    .multiplied_pow10(-2)
-    .expect("Bounds are small");
+    .multiplied_pow10(-2);
 assert_eq!("2.50", format!("{}", dec));
 
 #[derive(Debug, PartialEq)]

--- a/utils/fixed_decimal/benches/fixed_decimal.rs
+++ b/utils/fixed_decimal/benches/fixed_decimal.rs
@@ -96,7 +96,7 @@ fn to_string_benches(c: &mut Criterion) {
     use writeable::Writeable;
 
     let objects = [
-        FixedDecimal::from(2250).multiplied_pow10(-2).unwrap(),
+        FixedDecimal::from(2250).multiplied_pow10(-2),
         FixedDecimal::from(908070605040302010u128),
     ];
 

--- a/utils/fixed_decimal/examples/permyriad.rs
+++ b/utils/fixed_decimal/examples/permyriad.rs
@@ -17,9 +17,7 @@ use writeable::Writeable;
 fn main(_argc: isize, _argv: *const *const u8) -> isize {
     icu_benchmark_macros::main_setup!();
     let monetary_int = 19_9500;
-    let fixed_decimal = FixedDecimal::from(monetary_int)
-        .multiplied_pow10(-4)
-        .expect("-4 is well in range");
+    let fixed_decimal = FixedDecimal::from(monetary_int).multiplied_pow10(-4);
 
     let mut output = String::with_capacity(fixed_decimal.write_len().capacity());
     fixed_decimal

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -378,7 +378,7 @@ impl FixedDecimal {
         self.lower_magnitude = 0;
         self.magnitude = 0;
         self.digits.clear();
-        self.sign = Sign::Positive;
+        self.sign = Sign::None;
 
         #[cfg(debug_assertions)]
         self.check_invariants();

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -389,8 +389,7 @@ impl FixedDecimal {
     /// Leading or trailing zeros may be added to keep the digit at magnitude 0 (the last digit
     /// before the decimal separator) visible.
     ///
-    /// Can fail if the change in magnitude pushes the digits out of bounds; the magnitudes of all
-    /// digits should fit in an i16.
+    /// NOTE: if the operation causes overflow, the number will be set to zero.
     ///
     /// # Examples
     ///
@@ -449,8 +448,7 @@ impl FixedDecimal {
     /// Leading or trailing zeros may be added to keep the digit at magnitude 0 (the last digit
     /// before the decimal separator) visible.
     ///
-    /// Can fail if the change in magnitude pushes the digits out of bounds; the magnitudes of all
-    /// digits should fit in an i16.
+    /// NOTE: if the operation causes overflow, the returned number will be zero.
     ///
     /// # Examples
     ///

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -372,6 +372,18 @@ impl FixedDecimal {
         self.digits.is_empty()
     }
 
+    /// Clears all the fields and sets the number to zero.
+    fn clear(&mut self) {
+        self.upper_magnitude = 0;
+        self.lower_magnitude = 0;
+        self.magnitude = 0;
+        self.digits.clear();
+        self.sign = Sign::Positive;
+
+        #[cfg(debug_assertions)]
+        self.check_invariants();
+    }
+
     /// Shift the digits by a power of 10, modifying self.
     ///
     /// Leading or trailing zeros may be added to keep the digit at magnitude 0 (the last digit
@@ -388,28 +400,40 @@ impl FixedDecimal {
     /// let mut dec = FixedDecimal::from(42);
     /// assert_eq!("42", dec.to_string());
     ///
-    /// dec.multiply_pow10(3).expect("Bounds are small");
+    /// dec.multiply_pow10(3);
     /// assert_eq!("42000", dec.to_string());
     /// ```
-    pub fn multiply_pow10(&mut self, delta: i16) -> Result<(), Error> {
+    pub fn multiply_pow10(&mut self, delta: i16) {
         match delta.cmp(&0) {
             Ordering::Greater => {
-                self.upper_magnitude = self
-                    .upper_magnitude
-                    .checked_add(delta)
-                    .ok_or(Error::Limit)?;
-                // If we get here, then the magnitude change is in-bounds.
-                let lower_magnitude = self.lower_magnitude + delta;
-                self.lower_magnitude = cmp::min(0, lower_magnitude);
+                let upper_magnitude = self.upper_magnitude.checked_add(delta);
+                match upper_magnitude {
+                    Some(upper_magnitude) => {
+                        self.upper_magnitude = upper_magnitude;
+                        // If we get here, then the magnitude change is in-bounds.
+                        let lower_magnitude = self.lower_magnitude + delta;
+                        self.lower_magnitude = cmp::min(0, lower_magnitude);
+                    }
+                    None => {
+                        // there is an overflow
+                        self.clear();
+                    }
+                }
             }
             Ordering::Less => {
-                self.lower_magnitude = self
-                    .lower_magnitude
-                    .checked_add(delta)
-                    .ok_or(Error::Limit)?;
-                // If we get here, then the magnitude change is in-bounds.
-                let upper_magnitude = self.upper_magnitude + delta;
-                self.upper_magnitude = cmp::max(0, upper_magnitude);
+                let lower_magnitude = self.lower_magnitude.checked_add(delta);
+                match lower_magnitude {
+                    Some(lower_magnitude) => {
+                        self.lower_magnitude = lower_magnitude;
+                        // If we get here, then the magnitude change is in-bounds.
+                        let upper_magnitude = self.upper_magnitude + delta;
+                        self.upper_magnitude = cmp::max(0, upper_magnitude);
+                    }
+                    None => {
+                        // there is an overflow
+                        self.clear();
+                    }
+                }
             }
             Ordering::Equal => {}
         };
@@ -418,7 +442,6 @@ impl FixedDecimal {
         }
         #[cfg(debug_assertions)]
         self.check_invariants();
-        Ok(())
     }
 
     /// Shift the digits by a power of 10, consuming self and returning a new object if successful.
@@ -435,15 +458,12 @@ impl FixedDecimal {
     /// use fixed_decimal::FixedDecimal;
     ///
     /// let dec = FixedDecimal::from(42)
-    ///     .multiplied_pow10(3)
-    ///     .expect("Bounds are small");
+    ///     .multiplied_pow10(3);
     /// assert_eq!("42000", dec.to_string());
     /// ```
-    pub fn multiplied_pow10(mut self, delta: i16) -> Result<Self, Error> {
-        match self.multiply_pow10(delta) {
-            Ok(()) => Ok(self),
-            Err(err) => Err(err),
-        }
+    pub fn multiplied_pow10(mut self, delta: i16) -> Self {
+        self.multiply_pow10(delta);
+        self
     }
 
     /// Returns the sign.
@@ -567,7 +587,6 @@ impl FixedDecimal {
     ///
     /// let dec = FixedDecimal::from(123400)
     ///     .multiplied_pow10(-4)
-    ///     .expect("in-bounds")
     ///     .padded_start(4);
     /// assert_eq!("0012.3400", dec.to_string());
     ///
@@ -587,7 +606,6 @@ impl FixedDecimal {
     ///
     /// let mut dec = FixedDecimal::from(123400)
     ///     .multiplied_pow10(-4)
-    ///     .expect("in-bounds")
     ///     .padded_start(4);
     /// assert_eq!("0012.3400", dec.to_string());
     ///
@@ -600,8 +618,7 @@ impl FixedDecimal {
     /// ```
     /// # use fixed_decimal::FixedDecimal;
     /// let mut dec = FixedDecimal::from(22)
-    ///     .multiplied_pow10(-4)
-    ///     .expect("in-bounds");
+    ///     .multiplied_pow10(-4);
     /// assert_eq!("0.0022", dec.to_string());
     ///
     /// dec.trim_start();
@@ -622,7 +639,6 @@ impl FixedDecimal {
     ///
     /// let dec = FixedDecimal::from(123400)
     ///     .multiplied_pow10(-4)
-    ///     .expect("in-bounds")
     ///     .padded_start(4);
     /// assert_eq!("0012.3400", dec.to_string());
     ///
@@ -642,7 +658,6 @@ impl FixedDecimal {
     ///
     /// let mut dec = FixedDecimal::from(123400)
     ///     .multiplied_pow10(-4)
-    ///     .expect("in-bounds")
     ///     .padded_start(4);
     /// assert_eq!("0012.3400", dec.to_string());
     ///
@@ -743,7 +758,7 @@ impl FixedDecimal {
     /// ```
     /// use fixed_decimal::FixedDecimal;
     ///
-    /// let mut dec = FixedDecimal::from(4235970).multiplied_pow10(-3).expect("in-bounds");
+    /// let mut dec = FixedDecimal::from(4235970).multiplied_pow10(-3);
     /// assert_eq!("4235.970", dec.to_string());
     ///
     /// assert_eq!("04235.970", dec.clone().with_max_position(5).to_string());
@@ -775,7 +790,7 @@ impl FixedDecimal {
     /// ```
     /// use fixed_decimal::FixedDecimal;
     ///
-    /// let mut dec = FixedDecimal::from(4235970).multiplied_pow10(-3).expect("in-bounds");
+    /// let mut dec = FixedDecimal::from(4235970).multiplied_pow10(-3);
     /// assert_eq!("4235.970", dec.to_string());
     ///
     /// dec.set_max_position(5);
@@ -1555,8 +1570,7 @@ impl FixedDecimal {
     ///
     /// let integer = FixedDecimal::from(123);
     /// let fraction = FixedDecimal::from(456)
-    ///     .multiplied_pow10(-3)
-    ///     .expect("in-range");
+    ///     .multiplied_pow10(-3);
     ///
     /// let result =  integer.concatenated_right(fraction).expect("nonoverlapping");
     ///
@@ -1584,8 +1598,7 @@ impl FixedDecimal {
     ///
     /// let mut integer = FixedDecimal::from(123);
     /// let fraction = FixedDecimal::from(456)
-    ///     .multiplied_pow10(-3)
-    ///     .expect("nonoverlapping");
+    ///     .multiplied_pow10(-3);
     ///
     /// integer.concatenate_right(fraction);
     ///
@@ -1712,8 +1725,7 @@ impl writeable::Writeable for FixedDecimal {
     /// use writeable::Writeable;
     ///
     /// let dec = FixedDecimal::from(-5000)
-    ///     .multiplied_pow10(-2)
-    ///     .expect("Bounds are small");
+    ///     .multiplied_pow10(-2);
     /// let result = dec.write_to_string();
     /// assert_eq!(LengthHint::exact(6), dec.write_len());
     /// ```
@@ -1912,7 +1924,7 @@ impl FromStr for FixedDecimal {
                 pow += (digit - b'0') as i16;
             }
 
-            dec.multiply_pow10(pos_neg * pow)?;
+            dec.multiply_pow10(pos_neg * pow);
 
             // Clean up magnitude after multiplication
             if dec.magnitude > 0 {
@@ -2339,7 +2351,7 @@ fn test_basic() {
     for cas in &cases {
         let mut dec: FixedDecimal = cas.input.into();
         // println!("{}", cas.input + 0.01);
-        dec.multiply_pow10(cas.delta).unwrap();
+        dec.multiply_pow10(cas.delta);
         writeable::assert_writeable_eq!(dec, cas.expected, "{:?}", cas);
     }
 }
@@ -2521,12 +2533,13 @@ fn test_ui128_limits() {
 fn test_upper_magnitude_bounds() {
     let mut dec: FixedDecimal = 98765.into();
     assert_eq!(dec.upper_magnitude, 4);
-    dec.multiply_pow10(32763).unwrap();
+    dec.multiply_pow10(32763);
     assert_eq!(dec.upper_magnitude, core::i16::MAX);
     assert_eq!(dec.nonzero_magnitude_left(), core::i16::MAX);
     let dec_backup = dec.clone();
-    assert_eq!(Error::Limit, dec.multiply_pow10(1).unwrap_err());
-    assert_eq!(dec, dec_backup, "Value should be unchanged on failure");
+    dec.multiply_pow10(1);
+    assert!(dec.is_zero());
+    assert_ne!(dec, dec_backup, "Value should be unchanged on failure");
 
     // Checking from_str for dec (which is valid)
     let dec_roundtrip = FixedDecimal::from_str(&dec.to_string()).unwrap();
@@ -2537,12 +2550,13 @@ fn test_upper_magnitude_bounds() {
 fn test_lower_magnitude_bounds() {
     let mut dec: FixedDecimal = 98765.into();
     assert_eq!(dec.lower_magnitude, 0);
-    dec.multiply_pow10(-32768).unwrap();
+    dec.multiply_pow10(-32768);
     assert_eq!(dec.lower_magnitude, core::i16::MIN);
     assert_eq!(dec.nonzero_magnitude_right(), core::i16::MIN);
     let dec_backup = dec.clone();
-    assert_eq!(Error::Limit, dec.multiply_pow10(-1).unwrap_err());
-    assert_eq!(dec, dec_backup, "Value should be unchanged on failure");
+    dec.multiply_pow10(-1);
+    assert!(dec.is_zero());
+    assert_ne!(dec, dec_backup);
 
     // Checking from_str for dec (which is valid)
     let dec_roundtrip = FixedDecimal::from_str(&dec.to_string()).unwrap();
@@ -3122,9 +3136,7 @@ fn test_rounding() {
     assert_eq!("-0.0", dec.to_string());
 
     // Test Truncate Right
-    let mut dec = FixedDecimal::from(4235970)
-        .multiplied_pow10(-3)
-        .expect("in-bounds");
+    let mut dec = FixedDecimal::from(4235970).multiplied_pow10(-3);
     assert_eq!("4235.970", dec.to_string());
 
     dec.trunc(-5);
@@ -3158,9 +3170,7 @@ fn test_rounding() {
     assert_eq!("0.0", dec.to_string());
 
     // Test trunced
-    let dec = FixedDecimal::from(4235970)
-        .multiplied_pow10(-3)
-        .expect("in-bounds");
+    let dec = FixedDecimal::from(4235970).multiplied_pow10(-3);
     assert_eq!("4235.970", dec.to_string());
 
     assert_eq!("4235.97000", dec.clone().trunced(-5).to_string());

--- a/utils/fixed_decimal/src/lib.rs
+++ b/utils/fixed_decimal/src/lib.rs
@@ -14,8 +14,7 @@
 //! use fixed_decimal::FixedDecimal;
 //!
 //! let dec = FixedDecimal::from(250)
-//!     .multiplied_pow10(-2)
-//!     .expect("Bounds are small");
+//!     .multiplied_pow10(-2);
 //! assert_eq!("2.50", format!("{}", dec));
 //!
 //! #[derive(Debug, PartialEq)]
@@ -78,10 +77,8 @@ pub enum Error {
     /// use fixed_decimal::FixedDecimal;
     ///
     /// let mut dec1 = FixedDecimal::from(123);
-    /// assert_eq!(
-    ///     Error::Limit,
-    ///     dec1.multiply_pow10(core::i16::MAX).unwrap_err()
-    /// );
+    /// dec1.multiply_pow10(core::i16::MAX);
+    /// assert!(dec1.is_zero());
     /// ```
     #[displaydoc("Magnitude or number of digits exceeded")]
     Limit,


### PR DESCRIPTION
closes: https://github.com/unicode-org/icu4x/issues/1985
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->