### PR TITLE
Rename select() to category_for() for PluralRules

### DIFF
--- a/components/datetime/src/pattern/runtime/plural.rs
+++ b/components/datetime/src/pattern/runtime/plural.rs
@@ -168,7 +168,7 @@ impl<'data> PatternPlurals<'data> {
                 // TODO(#1668) Clippy exceptions need docs or fixing.
                 let category = ordinal_rules
                     .expect("ordinal_rules must be set with PatternPlurals::MultipleVariants")
-                    .select(week_number);
+                    .category_for(week_number);
                 Ok(plural_pattern.variant(category))
             }
         }

--- a/components/icu/examples/tui.rs
+++ b/components/icu/examples/tui.rs
@@ -83,7 +83,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
         let pr = PluralRules::try_new_cardinal(&locale!("en").into(), &provider)
             .expect("Failed to create PluralRules.");
 
-        match pr.select(email_count) {
+        match pr.category_for(email_count) {
             PluralCategory::One => print("Note: You have one unread email."),
             _ => print(format!("Note: You have {} unread emails.", email_count)),
         }

--- a/components/plurals/README.md
+++ b/components/plurals/README.md
@@ -30,7 +30,7 @@ let provider = icu_testdata::get_provider();
 let pr = PluralRules::try_new(&locale!("en").into(), &provider, PluralRuleType::Cardinal)
     .expect("Failed to construct a PluralRules struct.");
 
-assert_eq!(pr.select(5_usize), PluralCategory::Other);
+assert_eq!(pr.category_for(5_usize), PluralCategory::Other);
 ```
 
 ### Plural Rules

--- a/components/plurals/benches/pluralrules.rs
+++ b/components/plurals/benches/pluralrules.rs
@@ -21,7 +21,7 @@ fn pluralrules(c: &mut Criterion) {
                 let pr = PluralRules::try_new(&lang.into(), &provider, PluralRuleType::Cardinal)
                     .unwrap();
                 for s in &numbers_data.usize {
-                    let _ = pr.select(*s);
+                    let _ = pr.category_for(*s);
                 }
             }
         })
@@ -47,7 +47,7 @@ fn pluralrules(c: &mut Criterion) {
         c.bench_function("plurals/pluralrules/select/fs", |b| {
             b.iter(|| {
                 for s in &numbers_data.usize {
-                    let _ = pr.select(black_box(*s));
+                    let _ = pr.category_for(black_box(*s));
                 }
             })
         });

--- a/components/plurals/examples/elevator_floors.rs
+++ b/components/plurals/examples/elevator_floors.rs
@@ -35,7 +35,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
             .expect("Failed to create a PluralRules instance.");
 
         for value in VALUES {
-            match pr.select(*value) {
+            match pr.category_for(*value) {
                 PluralCategory::One => print("You are on the {}st floor.", Some(*value)),
                 PluralCategory::Two => print("You are on the {}nd floor.", Some(*value)),
                 PluralCategory::Few => print("You are on the {}rd floor.", Some(*value)),

--- a/components/plurals/examples/unread_emails.rs
+++ b/components/plurals/examples/unread_emails.rs
@@ -34,7 +34,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
             .expect("Failed to create a PluralRules instance.");
 
         for value in VALUES {
-            match pr.select(*value) {
+            match pr.category_for(*value) {
                 PluralCategory::One => print("You have one unread email.", None),
                 _ => print("You have {} unread emails.", Some(*value)),
             }

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -32,7 +32,7 @@
 //! let pr = PluralRules::try_new(&locale!("en").into(), &provider, PluralRuleType::Cardinal)
 //!     .expect("Failed to construct a PluralRules struct.");
 //!
-//! assert_eq!(pr.select(5_usize), PluralCategory::Other);
+//! assert_eq!(pr.category_for(5_usize), PluralCategory::Other);
 //! ```
 //!
 //! ## Plural Rules
@@ -144,7 +144,7 @@ pub enum PluralRuleType {
 /// let pr = PluralRules::try_new(&locale!("en").into(), &dp, PluralRuleType::Cardinal)
 ///     .expect("Failed to construct a PluralRules struct.");
 ///
-/// assert_eq!(pr.select(5_usize), PluralCategory::Other);
+/// assert_eq!(pr.category_for(5_usize), PluralCategory::Other);
 /// ```
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Ord, PartialOrd)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
@@ -270,7 +270,7 @@ impl PluralCategory {
 /// let pr = PluralRules::try_new(&locale!("en").into(), &dp, PluralRuleType::Cardinal)
 ///     .expect("Failed to construct a PluralRules struct.");
 ///
-/// assert_eq!(pr.select(5_usize), PluralCategory::Other);
+/// assert_eq!(pr.category_for(5_usize), PluralCategory::Other);
 /// ```
 ///
 /// [`ICU4X`]: ../icu/index.html
@@ -332,7 +332,7 @@ impl PluralRules {
     ///
     /// let rules = PluralRules::try_new_cardinal(&locale!("ru").into(), &dp).expect("Data should be present");
     ///
-    /// assert_eq!(rules.select(2_usize), PluralCategory::Few);
+    /// assert_eq!(rules.category_for(2_usize), PluralCategory::Few);
     /// ```
     ///
     /// [`One`]: PluralCategory::One
@@ -376,7 +376,7 @@ impl PluralRules {
     ///
     /// let rules = PluralRules::try_new_ordinal(&locale!("ru").into(), &dp).expect("Data should be present");
     ///
-    /// assert_eq!(rules.select(2_usize), PluralCategory::Other);
+    /// assert_eq!(rules.category_for(2_usize), PluralCategory::Other);
     /// ```
     ///
     /// [`One`]: PluralCategory::One
@@ -414,7 +414,7 @@ impl PluralRules {
     /// let pr = PluralRules::try_new(&locale!("en").into(), &dp, PluralRuleType::Cardinal)
     ///     .expect("Failed to construct a PluralRules struct.");
     ///
-    /// match pr.select(1_usize) {
+    /// match pr.category_for(1_usize) {
     ///     PluralCategory::One => "One item",
     ///     PluralCategory::Other => "Many items",
     ///     _ => unreachable!(),
@@ -427,7 +427,7 @@ impl PluralRules {
     ///
     /// For signed numbers and strings, [`Plural Operands`] implement [`TryFrom`](std::convert::TryFrom)
     /// and [`FromStr`](std::str::FromStr), which should be used before passing the result to
-    /// [`select()`](PluralRules::select()).
+    /// [`category_for()`](PluralRules::category_for()).
     ///
     /// # Examples
     ///
@@ -445,13 +445,13 @@ impl PluralRules {
     /// let operands = PluralOperands::try_from(-5).expect("Failed to parse to operands.");
     /// let operands2: PluralOperands = "5.10".parse().expect("Failed to parse to operands.");
     ///
-    /// assert_eq!(pr.select(operands), PluralCategory::Other);
-    /// assert_eq!(pr.select(operands2), PluralCategory::Other);
+    /// assert_eq!(pr.category_for(operands), PluralCategory::Other);
+    /// assert_eq!(pr.category_for(operands2), PluralCategory::Other);
     /// ```
     ///
     /// [`Plural Category`]: PluralCategory
     /// [`Plural Operands`]: operands::PluralOperands
-    pub fn select<I: Into<PluralOperands>>(&self, input: I) -> PluralCategory {
+    pub fn category_for<I: Into<PluralOperands>>(&self, input: I) -> PluralCategory {
         let rules = self.0.get();
         let input = input.into();
 

--- a/components/plurals/tests/plurals.rs
+++ b/components/plurals/tests/plurals.rs
@@ -13,7 +13,7 @@ fn test_plural_rules() {
     let pr =
         PluralRules::try_new(&locale!("en").into(), &provider, PluralRuleType::Cardinal).unwrap();
 
-    assert_eq!(pr.select(5_usize), PluralCategory::Other);
+    assert_eq!(pr.category_for(5_usize), PluralCategory::Other);
 }
 
 #[test]

--- a/ffi/diplomat/src/pluralrules.rs
+++ b/ffi/diplomat/src/pluralrules.rs
@@ -65,7 +65,7 @@ pub mod ffi {
         /// FFI version of `PluralRules::select()`.
         #[diplomat::rust_link(icu_plurals::PluralRules::select, FnInStruct)]
         pub fn select(&self, op: ICU4XPluralOperands) -> ICU4XPluralCategory {
-            let res = self.0.select(PluralOperands {
+            let res = self.0.category_for(PluralOperands {
                 i: op.i,
                 v: op.v,
                 w: op.w,


### PR DESCRIPTION
Fixes #540 