### PR TITLE
Change argument order in constructors for plurals, datetime, and decimal

### DIFF
--- a/components/datetime/README.md
+++ b/components/datetime/README.md
@@ -26,7 +26,7 @@ let options = DateTimeFormatterOptions::Length(length::Bag::from_date_time_style
     length::Time::Short,
 ));
 
-let dtf = DateTimeFormatter::<Gregorian>::try_new(&locale!("en").into(), &provider, &options)
+let dtf = DateTimeFormatter::<Gregorian>::try_new(&provider, &locale!("en").into(), &options)
     .expect("Failed to create DateTimeFormatter instance.");
 
 let date = parse_gregorian_from_str("2020-09-12T12:35:00").expect("Failed to parse date.");
@@ -44,7 +44,7 @@ use icu::datetime::{options::length, DateTimeFormatter, DateTimeFormatterOptions
 let options =
     length::Bag::from_date_time_style(length::Date::Medium, length::Time::Short).into();
 
-let dtf = DateTimeFormatter::<Gregorian>::try_new(&locale.into(), &provider, &options);
+let dtf = DateTimeFormatter::<Gregorian>::try_new(&provider, &locale.into(), &options);
 ```
 
 At the moment, the crate provides only options using the [`Length`] bag, but in the future,

--- a/components/datetime/benches/datetime.rs
+++ b/components/datetime/benches/datetime.rs
@@ -37,8 +37,8 @@ fn datetime_benches(c: &mut Criterion) {
                         let locale: Locale = setup.locale.parse().expect("Failed to parse locale.");
                         let options = fixtures::get_options(&setup.options);
                         let dtf = DateTimeFormatter::<Gregorian>::try_new(
-                            &locale.into(),
                             &provider,
+                            &locale.into(),
                             &options,
                         )
                         .expect("Failed to create DateTimeFormatter.");
@@ -115,8 +115,8 @@ fn datetime_benches(c: &mut Criterion) {
                         let locale: Locale = setup.locale.parse().unwrap();
                         let options = fixtures::get_options(&setup.options);
                         let dtf = DateTimeFormatter::<Gregorian>::try_new(
-                            &locale.into(),
                             &provider,
+                            &locale.into(),
                             &options,
                         )
                         .unwrap();
@@ -145,8 +145,8 @@ fn datetime_benches(c: &mut Criterion) {
                         let locale: Locale = setup.locale.parse().unwrap();
                         let options = fixtures::get_options(&setup.options);
                         let dtf = DateTimeFormatter::<Gregorian>::try_new(
-                            &locale.into(),
                             &provider,
+                            &locale.into(),
                             &options,
                         )
                         .unwrap();
@@ -172,8 +172,8 @@ fn datetime_benches(c: &mut Criterion) {
                         let locale: Locale = setup.locale.parse().unwrap();
                         let options = fixtures::get_options(&setup.options);
                         let dtf = DateTimeFormatter::<Gregorian>::try_new(
-                            &locale.into(),
                             &provider,
+                            &locale.into(),
                             &options,
                         )
                         .unwrap();
@@ -203,8 +203,8 @@ fn datetime_benches(c: &mut Criterion) {
                         let locale: Locale = setup.locale.parse().unwrap();
                         let options = fixtures::get_options(&setup.options);
                         let dtf = DateTimeFormatter::<Gregorian>::try_new(
-                            &locale.into(),
                             &provider,
+                            &locale.into(),
                             &options,
                         )
                         .unwrap();

--- a/components/datetime/examples/work_log.rs
+++ b/components/datetime/examples/work_log.rs
@@ -55,7 +55,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
     options.time = Some(length::Time::Short);
 
     let dtf =
-        DateTimeFormatter::<Gregorian>::try_new(&locale!("en").into(), &provider, &options.into())
+        DateTimeFormatter::<Gregorian>::try_new(&provider, &locale!("en").into(), &options.into())
             .expect("Failed to create DateTimeFormatter instance.");
     {
         print("\n====== Work Log (en) example ============", None);

--- a/components/datetime/src/any/datetime.rs
+++ b/components/datetime/src/any/datetime.rs
@@ -50,7 +50,7 @@ use icu_provider::DataLocale;
 ///
 /// let mut options = length::Bag::from_date_time_style(length::Date::Medium, length::Time::Short);
 ///
-/// let dtf = AnyDateTimeFormatter::try_new_with_buffer_provider(&Locale::from_str("en-u-ca-gregory").unwrap().into(), &provider, &options.into())
+/// let dtf = AnyDateTimeFormatter::try_new_with_buffer_provider(&provider, &Locale::from_str("en-u-ca-gregory").unwrap().into(), &options.into())
 ///     .expect("Failed to create DateTimeFormatter instance.");
 ///
 /// let datetime = DateTime::new_gregorian_datetime(2020, 9, 1, 12, 34, 28)
@@ -79,15 +79,15 @@ impl AnyDateTimeFormatter {
     /// - `u-ca-japanese` (Japanese calendar): `calendar/japanese@1`
     #[inline]
     pub fn try_new_with_any_provider<P>(
-        locale: &DataLocale,
         data_provider: &P,
+        locale: &DataLocale,
         options: &DateTimeFormatterOptions,
     ) -> Result<Self, DateTimeFormatterError>
     where
         P: AnyProvider,
     {
         let downcasting = data_provider.as_downcasting();
-        Self::try_new_unstable(locale, &downcasting, options)
+        Self::try_new_unstable(&downcasting, locale, options)
     }
 
     /// Construct a new [`AnyDateTimeFormatter`] from a data provider that implements
@@ -114,7 +114,7 @@ impl AnyDateTimeFormatter {
     /// let mut options = length::Bag::from_date_time_style(length::Date::Medium, length::Time::Short);
     /// let locale = Locale::from_str("en-u-ca-gregory").unwrap();
     ///
-    /// let dtf = AnyDateTimeFormatter::try_new_with_buffer_provider(&locale.into(), &provider, &options.into())
+    /// let dtf = AnyDateTimeFormatter::try_new_with_buffer_provider(&provider, &locale.into(), &options.into())
     ///     .expect("Failed to create DateTimeFormatter instance.");
     ///
     /// let datetime = DateTime::new_gregorian_datetime(2020, 9, 1, 12, 34, 28)
@@ -127,15 +127,15 @@ impl AnyDateTimeFormatter {
     #[inline]
     #[cfg(feature = "serde")]
     pub fn try_new_with_buffer_provider<P>(
-        locale: &DataLocale,
         data_provider: &P,
+        locale: &DataLocale,
         options: &DateTimeFormatterOptions,
     ) -> Result<Self, DateTimeFormatterError>
     where
         P: BufferProvider,
     {
         let deserializing = data_provider.as_deserializing();
-        Self::try_new_unstable(locale, &deserializing, options)
+        Self::try_new_unstable(&deserializing, locale, options)
     }
 
     /// Construct a new [`AnyDateTimeFormatter`] from a data provider that can provide all of the requested data.
@@ -159,7 +159,7 @@ impl AnyDateTimeFormatter {
     /// let mut options = length::Bag::from_date_time_style(length::Date::Medium, length::Time::Short);
     /// let locale = Locale::from_str("en-u-ca-gregory").unwrap();
     ///
-    /// let dtf = AnyDateTimeFormatter::try_new_unstable(&locale.into(), &provider, &options.into())
+    /// let dtf = AnyDateTimeFormatter::try_new_unstable(&provider, &locale.into(), &options.into())
     ///     .expect("Failed to create DateTimeFormatter instance.");
     ///
     /// let datetime = DateTime::new_gregorian_datetime(2020, 9, 1, 12, 34, 28)
@@ -171,8 +171,8 @@ impl AnyDateTimeFormatter {
     /// ```
     #[inline(never)]
     pub fn try_new_unstable<P>(
-        locale: &DataLocale,
         data_provider: &P,
+        locale: &DataLocale,
         options: &DateTimeFormatterOptions,
     ) -> Result<Self, DateTimeFormatterError>
     where
@@ -207,7 +207,7 @@ impl AnyDateTimeFormatter {
         let calendar = AnyCalendar::try_new_unstable(kind, data_provider)?;
 
         Ok(Self(
-            raw::DateTimeFormatter::try_new(locale, data_provider, options)?,
+            raw::DateTimeFormatter::try_new(data_provider, locale, options)?,
             calendar,
         ))
     }
@@ -288,9 +288,12 @@ impl AnyDateTimeFormatter {
     /// let options = length::Bag::from_date_style(length::Date::Medium).into();
     ///
     /// let provider = icu_testdata::get_provider();
-    /// let dtf = AnyDateTimeFormatter::try_new_with_buffer_provider(&Locale::from_str("en-u-ca-gregory").unwrap().into(),
-    ///                                                           &provider, &options)
-    ///     .expect("Failed to create DateTimeFormatter instance.");
+    /// let dtf = AnyDateTimeFormatter::try_new_with_buffer_provider(
+    ///     &provider,
+    ///     &Locale::from_str("en-u-ca-gregory").unwrap().into(),
+    ///     &options
+    /// )
+    /// .expect("Failed to create DateTimeFormatter instance.");
     ///
     /// let mut expected_components_bag = components::Bag::default();
     /// expected_components_bag.year = Some(components::Year::Numeric);

--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -46,8 +46,8 @@ use crate::{
 /// let provider = icu_testdata::get_provider();
 ///
 /// let tf = TimeFormatter::try_new(
-///     &locale!("en").into(),
 ///     &provider,
+///     &locale!("en").into(),
 ///     Time::Short,
 ///     None,
 /// )
@@ -78,8 +78,8 @@ impl TimeFormatter {
     /// let provider = icu_testdata::get_provider();
     ///
     /// TimeFormatter::try_new(
-    ///     &locale!("en").into(),
     ///     &provider,
+    ///     &locale!("en").into(),
     ///     Time::Short,
     ///     None,
     /// )
@@ -89,8 +89,8 @@ impl TimeFormatter {
     /// [data provider]: icu_provider
     #[inline]
     pub fn try_new<D>(
-        locale: &DataLocale,
         data_provider: &D,
+        locale: &DataLocale,
         length: length::Time,
         preferences: Option<preferences::Bag>,
     ) -> Result<Self, DateTimeFormatterError>
@@ -103,8 +103,8 @@ impl TimeFormatter {
         let locale = locale.clone();
 
         Ok(Self(raw::TimeFormatter::try_new(
-            locale,
             data_provider,
+            locale,
             length,
             preferences,
         )?))
@@ -122,7 +122,7 @@ impl TimeFormatter {
     /// # let locale = icu::locid::locale!("en");
     /// # let provider = icu_testdata::get_provider();
     /// let tf =
-    ///     TimeFormatter::try_new(&locale.into(), &provider, Time::Short, None)
+    ///     TimeFormatter::try_new(&provider, &locale.into(), Time::Short, None)
     ///         .expect("Failed to create TimeFormatter instance.");
     ///
     /// let datetime = DateTime::new_gregorian_datetime(2020, 9, 1, 12, 34, 28)
@@ -153,7 +153,7 @@ impl TimeFormatter {
     /// # let locale = icu::locid::locale!("en");
     /// # let provider = icu_testdata::get_provider();
     /// let tf =
-    ///     TimeFormatter::try_new(&locale.into(), &provider, Time::Short, None)
+    ///     TimeFormatter::try_new(&provider, &locale.into(), Time::Short, None)
     ///         .expect("Failed to create TimeFormatter instance.");
     ///
     /// let datetime = DateTime::new_gregorian_datetime(2020, 9, 1, 12, 34, 28)
@@ -184,7 +184,7 @@ impl TimeFormatter {
     /// # let locale = icu::locid::locale!("en");
     /// # let provider = icu_testdata::get_provider();
     /// let tf =
-    ///     TimeFormatter::try_new(&locale.into(), &provider, Time::Short, None)
+    ///     TimeFormatter::try_new(&provider, &locale.into(), Time::Short, None)
     ///         .expect("Failed to create TimeFormatter instance.");
     ///
     /// let datetime = DateTime::new_gregorian_datetime(2020, 9, 1, 12, 34, 28)
@@ -217,7 +217,7 @@ impl TimeFormatter {
 ///
 /// let provider = icu_testdata::get_provider();
 ///
-/// let df = DateFormatter::<Gregorian>::try_new(&locale!("en").into(), &provider, Date::Full)
+/// let df = DateFormatter::<Gregorian>::try_new(&provider, &locale!("en").into(), Date::Full)
 ///     .expect("Failed to create DateFormatter instance.");
 ///
 /// let datetime = DateTime::new_gregorian_datetime(2020, 9, 1, 12, 34, 28)
@@ -244,15 +244,15 @@ impl<C: CldrCalendar> DateFormatter<C> {
     ///
     /// let provider = icu_testdata::get_provider();
     ///
-    /// DateFormatter::<Gregorian>::try_new(&locale!("en").into(), &provider, Date::Full)
+    /// DateFormatter::<Gregorian>::try_new(&provider, &locale!("en").into(), Date::Full)
     ///     .unwrap();
     /// ```
     ///
     /// [data provider]: icu_provider
     #[inline]
     pub fn try_new<D>(
-        locale: &DataLocale,
         data_provider: &D,
+        locale: &DataLocale,
         length: length::Date,
     ) -> Result<Self, DateTimeFormatterError>
     where
@@ -269,7 +269,7 @@ impl<C: CldrCalendar> DateFormatter<C> {
 
         calendar::potentially_fixup_calendar::<C>(&mut locale)?;
         Ok(Self(
-            raw::DateFormatter::try_new(locale, data_provider, length)?,
+            raw::DateFormatter::try_new(data_provider, locale, length)?,
             PhantomData,
         ))
     }
@@ -285,7 +285,7 @@ impl<C: CldrCalendar> DateFormatter<C> {
     /// use writeable::assert_writeable_eq;
     /// # let locale = icu::locid::locale!("en");
     /// # let provider = icu_testdata::get_provider();
-    /// let df = DateFormatter::<Gregorian>::try_new(&locale.into(), &provider, Date::Full)
+    /// let df = DateFormatter::<Gregorian>::try_new(&provider, &locale.into(), Date::Full)
     ///     .expect("Failed to create DateFormatter instance.");
     ///
     /// let datetime = DateTime::new_gregorian_datetime(2020, 9, 1, 12, 34, 28)
@@ -315,7 +315,7 @@ impl<C: CldrCalendar> DateFormatter<C> {
     /// use icu::datetime::{options::length::Date, DateFormatter};
     /// # let locale = icu::locid::locale!("en");
     /// # let provider = icu_testdata::get_provider();
-    /// let df = DateFormatter::<Gregorian>::try_new(&locale.into(), &provider, Date::Short)
+    /// let df = DateFormatter::<Gregorian>::try_new(&provider, &locale.into(), Date::Short)
     ///     .expect("Failed to create DateFormatter instance.");
     ///
     /// let datetime = DateTime::new_gregorian_datetime(2020, 9, 1, 12, 34, 28)
@@ -345,7 +345,7 @@ impl<C: CldrCalendar> DateFormatter<C> {
     /// use icu::datetime::{options::length::Date, DateFormatter};
     /// # let locale = icu::locid::locale!("en");
     /// # let provider = icu_testdata::get_provider();
-    /// let df = DateFormatter::<Gregorian>::try_new(&locale.into(), &provider, Date::Short)
+    /// let df = DateFormatter::<Gregorian>::try_new(&provider, &locale.into(), Date::Short)
     ///     .expect("Failed to create DateTimeFormatter instance.");
     ///
     /// let datetime = DateTime::new_gregorian_datetime(2020, 9, 1, 12, 34, 28)
@@ -384,8 +384,8 @@ impl<C: CldrCalendar> DateFormatter<C> {
 /// );
 ///
 /// let dtf = DateTimeFormatter::<Gregorian>::try_new(
-///     &locale!("en").into(),
 ///     &provider,
+///     &locale!("en").into(),
 ///     &options.into(),
 /// )
 /// .expect("Failed to create DateTimeFormatter instance.");
@@ -416,15 +416,15 @@ impl<C: CldrCalendar> DateTimeFormatter<C> {
     /// let provider = icu_testdata::get_provider();
     ///
     /// let tf = TimeFormatter::try_new(
-    ///     &locale!("en").into(),
     ///     &provider,
+    ///     &locale!("en").into(),
     ///     length::Time::Short,
     ///     None,
     /// )
     /// .expect("Failed to create TimeFormatter instance.");
     /// let df = DateFormatter::<Gregorian>::try_new(
-    ///     &locale!("en").into(),
     ///     &provider,
+    ///     &locale!("en").into(),
     ///     length::Date::Short,
     /// )
     /// .expect("Failed to create DateFormatter instance.");
@@ -460,8 +460,8 @@ where {
     /// let options = length::Bag::from_time_style(length::Time::Medium);
     ///
     /// DateTimeFormatter::<Gregorian>::try_new(
-    ///     &locale!("en").into(),
     ///     &provider,
+    ///     &locale!("en").into(),
     ///     &options.into(),
     /// )
     /// .unwrap();
@@ -470,8 +470,8 @@ where {
     /// [data provider]: icu_provider
     #[inline]
     pub fn try_new<D>(
-        locale: &DataLocale,
         data_provider: &D,
+        locale: &DataLocale,
         options: &DateTimeFormatterOptions,
     ) -> Result<Self, DateTimeFormatterError>
     where
@@ -491,7 +491,7 @@ where {
 
         calendar::potentially_fixup_calendar::<C>(&mut locale)?;
         Ok(Self(
-            raw::DateTimeFormatter::try_new(locale, data_provider, options)?,
+            raw::DateTimeFormatter::try_new(data_provider, locale, options)?,
             PhantomData,
         ))
     }
@@ -508,7 +508,7 @@ where {
     /// # let locale = icu::locid::locale!("en");
     /// # let provider = icu_testdata::get_provider();
     /// # let options = icu::datetime::options::length::Bag::from_time_style(icu::datetime::options::length::Time::Medium);
-    /// let dtf = DateTimeFormatter::<Gregorian>::try_new(&locale.into(), &provider, &options.into())
+    /// let dtf = DateTimeFormatter::<Gregorian>::try_new(&provider, &locale.into(), &options.into())
     ///     .expect("Failed to create DateTimeFormatter instance.");
     ///
     /// let datetime = DateTime::new_gregorian_datetime(2020, 9, 1, 12, 34, 28)
@@ -539,7 +539,7 @@ where {
     /// # let locale = icu::locid::locale!("en");
     /// # let provider = icu_testdata::get_provider();
     /// # let options = icu::datetime::options::length::Bag::from_time_style(icu::datetime::options::length::Time::Medium);
-    /// let dtf = DateTimeFormatter::<Gregorian>::try_new(&locale.into(), &provider, &options.into())
+    /// let dtf = DateTimeFormatter::<Gregorian>::try_new(&provider, &locale.into(), &options.into())
     ///     .expect("Failed to create DateTimeFormatter instance.");
     ///
     /// let datetime = DateTime::new_gregorian_datetime(2020, 9, 1, 12, 34, 28)
@@ -570,7 +570,7 @@ where {
     /// # let locale = icu::locid::locale!("en");
     /// # let provider = icu_testdata::get_provider();
     /// # let options = icu::datetime::options::length::Bag::from_time_style(icu::datetime::options::length::Time::Medium);
-    /// let dtf = DateTimeFormatter::<Gregorian>::try_new(&locale.into(), &provider, &options.into())
+    /// let dtf = DateTimeFormatter::<Gregorian>::try_new(&provider, &locale.into(), &options.into())
     ///     .expect("Failed to create DateTimeFormatter instance.");
     ///
     /// let datetime = DateTime::new_gregorian_datetime(2020, 9, 1, 12, 34, 28)
@@ -602,8 +602,8 @@ where {
     ///
     /// let provider = icu_testdata::get_provider();
     /// let dtf = DateTimeFormatter::<Gregorian>::try_new(
-    ///     &locale!("en").into(),
     ///     &provider,
+    ///     &locale!("en").into(),
     ///     &options,
     /// )
     /// .expect("Failed to create DateTimeFormatter instance.");

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -39,7 +39,7 @@ use writeable::Writeable;
 /// use icu::locid::locale;
 /// # let provider = icu_testdata::get_provider();
 /// # let options = icu::datetime::DateTimeFormatterOptions::default();
-/// let dtf = DateTimeFormatter::<Gregorian>::try_new(&locale!("en").into(), &provider, &options)
+/// let dtf = DateTimeFormatter::<Gregorian>::try_new(&provider, &locale!("en").into(), &options)
 ///     .expect("Failed to create DateTimeFormatter instance.");
 ///
 /// let datetime = DateTime::new_gregorian_datetime(2020, 9, 1, 12, 34, 28)
@@ -520,7 +520,7 @@ mod tests {
         let locale: Locale = "en-u-ca-japanese".parse().unwrap();
         let options =
             length::Bag::from_date_time_style(length::Date::Medium, length::Time::Short).into();
-        let dtf = DateTimeFormatter::<Japanese>::try_new(&locale.into(), &provider, &options)
+        let dtf = DateTimeFormatter::<Japanese>::try_new(&provider, &locale.into(), &options)
             .expect("DateTimeFormat construction succeeds");
 
         let japanext =
@@ -553,7 +553,7 @@ mod tests {
         let pattern = "MMM".parse().unwrap();
         let datetime = DateTime::new_gregorian_datetime(2020, 8, 1, 12, 34, 28).unwrap();
         let fixed_decimal_format =
-            FixedDecimalFormatter::try_new(&locale, &provider, Default::default()).unwrap();
+            FixedDecimalFormatter::try_new(&provider, &locale, Default::default()).unwrap();
 
         let mut sink = String::new();
         let loc_datetime = DateTimeInputWithLocale::new(&datetime, None, &Locale::UND.into());
@@ -587,8 +587,8 @@ mod tests {
         let mut fixed_decimal_format_options = FixedDecimalFormatterOptions::default();
         fixed_decimal_format_options.grouping_strategy = GroupingStrategy::Never;
         let fixed_decimal_format = FixedDecimalFormatter::try_new(
-            &icu_locid::locale!("en").into(),
             &provider,
+            &icu_locid::locale!("en").into(),
             fixed_decimal_format_options,
         )
         .unwrap();

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -28,7 +28,7 @@
 //!     length::Time::Short,
 //! ));
 //!
-//! let dtf = DateTimeFormatter::<Gregorian>::try_new(&locale!("en").into(), &provider, &options)
+//! let dtf = DateTimeFormatter::<Gregorian>::try_new(&provider, &locale!("en").into(), &options)
 //!     .expect("Failed to create DateTimeFormatter instance.");
 //!
 //! let date = parse_gregorian_from_str("2020-09-12T12:35:00").expect("Failed to parse date.");
@@ -48,7 +48,7 @@
 //! let options =
 //!     length::Bag::from_date_time_style(length::Date::Medium, length::Time::Short).into();
 //!
-//! let dtf = DateTimeFormatter::<Gregorian>::try_new(&locale.into(), &provider, &options);
+//! let dtf = DateTimeFormatter::<Gregorian>::try_new(&provider, &locale.into(), &options);
 //! ```
 //!
 //! At the moment, the crate provides only options using the [`Length`] bag, but in the future,

--- a/components/datetime/src/raw/datetime.rs
+++ b/components/datetime/src/raw/datetime.rs
@@ -44,8 +44,8 @@ impl TimeFormatter {
     /// using the short style.
     #[inline(never)]
     pub fn try_new<D>(
-        locale: DataLocale,
         data_provider: &D,
+        locale: DataLocale,
         length: length::Time,
         preferences: Option<preferences::Bag>,
     ) -> Result<Self, DateTimeFormatterError>
@@ -82,7 +82,7 @@ impl TimeFormatter {
         fixed_decimal_format_options.grouping_strategy = GroupingStrategy::Never;
 
         let fixed_decimal_format =
-            FixedDecimalFormatter::try_new(&locale, data_provider, fixed_decimal_format_options)
+            FixedDecimalFormatter::try_new(data_provider, &locale, fixed_decimal_format_options)
                 .map_err(DateTimeFormatterError::FixedDecimalFormatter)?;
 
         Ok(Self::new(
@@ -176,8 +176,8 @@ impl DateFormatter {
     /// a list of options, then collects all data necessary to format date values into the given locale.
     #[inline(never)]
     pub fn try_new<D>(
-        mut locale: DataLocale,
         data_provider: &D,
+        mut locale: DataLocale,
         length: length::Date,
     ) -> Result<Self, DateTimeFormatterError>
     where
@@ -212,7 +212,7 @@ impl DateFormatter {
         };
 
         let ordinal_rules = if let PatternPlurals::MultipleVariants(_) = &patterns.get().0 {
-            Some(PluralRules::try_new_ordinal(&locale, data_provider)?)
+            Some(PluralRules::try_new_ordinal(data_provider, &locale)?)
         } else {
             None
         };
@@ -227,7 +227,7 @@ impl DateFormatter {
         fixed_decimal_format_options.grouping_strategy = GroupingStrategy::Never;
 
         let fixed_decimal_format =
-            FixedDecimalFormatter::try_new(&locale, data_provider, fixed_decimal_format_options)
+            FixedDecimalFormatter::try_new(data_provider, &locale, fixed_decimal_format_options)
                 .map_err(DateTimeFormatterError::FixedDecimalFormatter)?;
 
         Ok(Self::new(
@@ -373,8 +373,8 @@ impl DateTimeFormatter {
     /// a list of options, then collects all data necessary to format date and time values into the given locale.
     #[inline(never)]
     pub fn try_new<D>(
-        mut locale: DataLocale,
         data_provider: &D,
+        mut locale: DataLocale,
         options: &DateTimeFormatterOptions,
     ) -> Result<Self, DateTimeFormatterError>
     where
@@ -410,7 +410,7 @@ impl DateTimeFormatter {
         };
 
         let ordinal_rules = if let PatternPlurals::MultipleVariants(_) = &patterns.get().0 {
-            Some(PluralRules::try_new_ordinal(&locale, data_provider)?)
+            Some(PluralRules::try_new_ordinal(data_provider, &locale)?)
         } else {
             None
         };
@@ -431,7 +431,7 @@ impl DateTimeFormatter {
         fixed_decimal_format_options.grouping_strategy = GroupingStrategy::Never;
 
         let fixed_decimal_format =
-            FixedDecimalFormatter::try_new(&locale, data_provider, fixed_decimal_format_options)
+            FixedDecimalFormatter::try_new(data_provider, &locale, fixed_decimal_format_options)
                 .map_err(DateTimeFormatterError::FixedDecimalFormatter)?;
 
         Ok(Self::new(

--- a/components/datetime/src/raw/zoned_datetime.rs
+++ b/components/datetime/src/raw/zoned_datetime.rs
@@ -99,7 +99,7 @@ impl ZonedDateTimeFormatter {
         };
 
         let ordinal_rules = if let PatternPlurals::MultipleVariants(_) = &patterns.get().0 {
-            Some(PluralRules::try_new_ordinal(&locale, plural_provider)?)
+            Some(PluralRules::try_new_ordinal(plural_provider, &locale)?)
         } else {
             None
         };
@@ -120,7 +120,7 @@ impl ZonedDateTimeFormatter {
         fixed_decimal_format_options.grouping_strategy = GroupingStrategy::Never;
 
         let fixed_decimal_format =
-            FixedDecimalFormatter::try_new(&locale, decimal_provider, fixed_decimal_format_options)
+            FixedDecimalFormatter::try_new(decimal_provider, &locale, fixed_decimal_format_options)
                 .map_err(DateTimeFormatterError::FixedDecimalFormatter)?;
 
         let datetime_format = raw::DateTimeFormatter::new(

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -194,13 +194,13 @@ fn assert_fixture_element<A, D>(
 {
     let any_input = input_value.to_any();
     let iso_any_input = input_iso.to_any();
-    let dtf = DateTimeFormatter::<A::Calendar>::try_new(&locale.into(), provider, options).unwrap();
+    let dtf = DateTimeFormatter::<A::Calendar>::try_new(provider, &locale.into(), options).unwrap();
     let result = dtf.format_to_string(input_value);
 
     assert_eq!(result, output_value, "{}", description);
 
     let any_dtf =
-        AnyDateTimeFormatter::try_new_unstable(&locale.into(), provider, options).unwrap();
+        AnyDateTimeFormatter::try_new_unstable(provider, &locale.into(), options).unwrap();
     let result = any_dtf.format_to_string(&any_input).unwrap();
 
     assert_eq!(
@@ -232,11 +232,11 @@ fn assert_fixture_element<A, D>(
     if let DateTimeFormatterOptions::Length(bag) = options {
         if bag.date.is_some() && bag.time.is_some() {
             let df =
-                DateFormatter::<A::Calendar>::try_new(&locale.into(), provider, bag.date.unwrap())
+                DateFormatter::<A::Calendar>::try_new(provider, &locale.into(), bag.date.unwrap())
                     .unwrap();
             let tf = TimeFormatter::try_new(
-                &locale.into(),
                 provider,
+                &locale.into(),
                 bag.time.unwrap(),
                 bag.preferences,
             )
@@ -260,7 +260,7 @@ fn assert_fixture_element<A, D>(
             assert_eq!(s, output_value, "{}", description);
         } else if bag.date.is_some() {
             let df =
-                DateFormatter::<A::Calendar>::try_new(&locale.into(), provider, bag.date.unwrap())
+                DateFormatter::<A::Calendar>::try_new(provider, &locale.into(), bag.date.unwrap())
                     .unwrap();
             let result = df.format_to_string(input_value);
 
@@ -279,8 +279,8 @@ fn assert_fixture_element<A, D>(
             assert_eq!(s, output_value, "{}", description);
         } else if bag.time.is_some() {
             let tf = TimeFormatter::try_new(
-                &locale.into(),
                 provider,
+                &locale.into(),
                 bag.time.unwrap(),
                 bag.preferences,
             )
@@ -445,8 +445,8 @@ fn test_dayperiod_patterns() {
                             },
                         ]);
                         let dtf = DateTimeFormatter::<Gregorian>::try_new(
-                            &data_locale,
                             &local_provider.as_downcasting(),
+                            &data_locale,
                             &format_options,
                         )
                         .unwrap();
@@ -761,7 +761,7 @@ fn constructing_datetime_format_with_time_zone_pattern_symbols_is_err() {
 
     let provider = icu_testdata::get_provider();
     let result =
-        DateTimeFormatter::<Gregorian>::try_new(&locale!("en").into(), &provider, &options);
+        DateTimeFormatter::<Gregorian>::try_new(&provider, &locale!("en").into(), &options);
 
     assert!(result.is_err());
 }

--- a/components/datetime/tests/resolved_components.rs
+++ b/components/datetime/tests/resolved_components.rs
@@ -11,7 +11,7 @@ use icu_locid::locale;
 
 fn assert_resolved_components(options: &DateTimeFormatterOptions, bag: &components::Bag) {
     let provider = icu_testdata::get_provider();
-    let dtf = DateTimeFormatter::<Gregorian>::try_new(&locale!("en").into(), &provider, options)
+    let dtf = DateTimeFormatter::<Gregorian>::try_new(&provider, &locale!("en").into(), options)
         .expect("Failed to create a DateTimeFormatter.");
 
     assert_eq!(dtf.resolve_components(), *bag);

--- a/components/decimal/README.md
+++ b/components/decimal/README.md
@@ -18,7 +18,7 @@ use icu::locid::locale;
 use writeable::Writeable;
 
 let provider = icu_testdata::get_provider();
-let fdf = FixedDecimalFormatter::try_new(&locale!("bn").into(), &provider, Default::default())
+let fdf = FixedDecimalFormatter::try_new(&provider, &locale!("bn").into(), Default::default())
     .expect("Data should load successfully");
 
 let fixed_decimal = 1000007.into();
@@ -37,7 +37,7 @@ use icu::locid::Locale;
 use writeable::Writeable;
 
 let provider = icu_testdata::get_provider();
-let fdf = FixedDecimalFormatter::try_new(&Locale::UND.into(), &provider, Default::default())
+let fdf = FixedDecimalFormatter::try_new(&provider, &Locale::UND.into(), Default::default())
     .expect("Data should load successfully");
 
 let fixed_decimal = FixedDecimal::from(200050)
@@ -59,7 +59,7 @@ use writeable::Writeable;
 
 let provider = icu_testdata::get_provider();
 let locale = "th-u-nu-thai".parse::<Locale>().unwrap();
-let fdf = FixedDecimalFormatter::try_new(&locale.into(), &provider, Default::default())
+let fdf = FixedDecimalFormatter::try_new(&provider, &locale.into(), Default::default())
     .expect("Data should load successfully");
 
 let fixed_decimal = 1000007.into();

--- a/components/decimal/benches/fixed_decimal_format.rs
+++ b/components/decimal/benches/fixed_decimal_format.rs
@@ -34,7 +34,7 @@ fn overview_bench(c: &mut Criterion) {
             // This benchmark demonstrates the performance of the format function on 1000 numbers
             // ranging from -1e9 to 1e9.
             let fdf =
-                FixedDecimalFormatter::try_new(&Locale::UND.into(), &provider, Default::default())
+                FixedDecimalFormatter::try_new(&provider, &Locale::UND.into(), Default::default())
                     .unwrap();
             for &num in &nums {
                 let fd = FixedDecimal::from(black_box(num));

--- a/components/decimal/examples/code_line_diff.rs
+++ b/components/decimal/examples/code_line_diff.rs
@@ -28,7 +28,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
 
     let provider = icu_testdata::get_provider();
 
-    let fdf = FixedDecimalFormatter::try_new(&locale!("bn").into(), &provider, Default::default())
+    let fdf = FixedDecimalFormatter::try_new(&provider, &locale!("bn").into(), Default::default())
         .expect("Failed to create FixedDecimalFormatter instance.");
 
     for line in LINES_REMOVED_ADDED.iter() {

--- a/components/decimal/src/grouper.rs
+++ b/components/decimal/src/grouper.rs
@@ -168,8 +168,8 @@ fn test_grouper() {
                 ..Default::default()
             };
             let fdf = FixedDecimalFormatter::try_new(
-                &LanguageIdentifier::UND.into(),
                 &provider.as_downcasting(),
+                &LanguageIdentifier::UND.into(),
                 options,
             )
             .unwrap();

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -22,7 +22,7 @@
 //! use writeable::Writeable;
 //!
 //! let provider = icu_testdata::get_provider();
-//! let fdf = FixedDecimalFormatter::try_new(&locale!("bn").into(), &provider, Default::default())
+//! let fdf = FixedDecimalFormatter::try_new(&provider, &locale!("bn").into(), Default::default())
 //!     .expect("Data should load successfully");
 //!
 //! let fixed_decimal = 1000007.into();
@@ -41,7 +41,7 @@
 //! use writeable::Writeable;
 //!
 //! let provider = icu_testdata::get_provider();
-//! let fdf = FixedDecimalFormatter::try_new(&Locale::UND.into(), &provider, Default::default())
+//! let fdf = FixedDecimalFormatter::try_new(&provider, &Locale::UND.into(), Default::default())
 //!     .expect("Data should load successfully");
 //!
 //! let fixed_decimal = FixedDecimal::from(200050)
@@ -63,7 +63,7 @@
 //!
 //! let provider = icu_testdata::get_provider();
 //! let locale = "th-u-nu-thai".parse::<Locale>().unwrap();
-//! let fdf = FixedDecimalFormatter::try_new(&locale.into(), &provider, Default::default())
+//! let fdf = FixedDecimalFormatter::try_new(&provider, &locale.into(), Default::default())
 //!     .expect("Data should load successfully");
 //!
 //! let fixed_decimal = 1000007.into();
@@ -124,8 +124,8 @@ pub struct FixedDecimalFormatter {
 impl FixedDecimalFormatter {
     /// Creates a new [`FixedDecimalFormatter`] from locale data and an options bag.
     pub fn try_new<D: DataProvider<provider::DecimalSymbolsV1Marker> + ?Sized>(
-        locale: &DataLocale,
         data_provider: &D,
+        locale: &DataLocale,
         options: options::FixedDecimalFormatterOptions,
     ) -> Result<Self, FixedDecimalFormatterError> {
         let symbols = data_provider

--- a/components/decimal/src/options.rs
+++ b/components/decimal/src/options.rs
@@ -28,7 +28,7 @@ pub struct FixedDecimalFormatterOptions {
 /// let provider = icu_testdata::get_provider();
 /// let mut options: options::FixedDecimalFormatterOptions = Default::default();
 /// options.grouping_strategy = options::GroupingStrategy::Min2;
-/// let fdf = FixedDecimalFormatter::try_new(&locale.into(), &provider, options)
+/// let fdf = FixedDecimalFormatter::try_new(&provider, &locale.into(), options)
 ///     .expect("Data should load successfully");
 ///
 /// let one_thousand = 1000.into();

--- a/components/icu/README.md
+++ b/components/icu/README.md
@@ -43,7 +43,7 @@ let provider = icu_testdata::get_provider();
 let options =
     length::Bag::from_date_time_style(length::Date::Long, length::Time::Medium).into();
 
-let dtf = DateTimeFormatter::try_new(&locale!("en").into(), &provider, &options)
+let dtf = DateTimeFormatter::try_new(&provider, &locale!("en").into(), &options)
     .expect("Failed to create DateTimeFormatter instance.");
 
 let date = parse_gregorian_from_str("2020-09-12T12:35:00").expect("Failed to parse date.");

--- a/components/icu/examples/tui.rs
+++ b/components/icu/examples/tui.rs
@@ -80,7 +80,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
     }
 
     {
-        let pr = PluralRules::try_new_cardinal(&locale!("en").into(), &provider)
+        let pr = PluralRules::try_new_cardinal(&provider, &locale!("en").into())
             .expect("Failed to create PluralRules.");
 
         match pr.select(email_count) {

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -45,7 +45,7 @@
 //! let options =
 //!     length::Bag::from_date_time_style(length::Date::Long, length::Time::Medium).into();
 //!
-//! let dtf = DateTimeFormatter::try_new(&locale!("en").into(), &provider, &options)
+//! let dtf = DateTimeFormatter::try_new(&provider, &locale!("en").into(), &options)
 //!     .expect("Failed to create DateTimeFormatter instance.");
 //!
 //! let date = parse_gregorian_from_str("2020-09-12T12:35:00").expect("Failed to parse date.");

--- a/components/plurals/README.md
+++ b/components/plurals/README.md
@@ -27,7 +27,7 @@ use icu::plurals::{PluralCategory, PluralRuleType, PluralRules};
 
 let provider = icu_testdata::get_provider();
 
-let pr = PluralRules::try_new(&locale!("en").into(), &provider, PluralRuleType::Cardinal)
+let pr = PluralRules::try_new(&provider, &locale!("en").into(), PluralRuleType::Cardinal)
     .expect("Failed to construct a PluralRules struct.");
 
 assert_eq!(pr.select(5_usize), PluralCategory::Other);

--- a/components/plurals/benches/pluralrules.rs
+++ b/components/plurals/benches/pluralrules.rs
@@ -18,7 +18,7 @@ fn pluralrules(c: &mut Criterion) {
     c.bench_function("plurals/pluralrules/overview", |b| {
         b.iter(|| {
             for lang in &plurals_data.langs {
-                let pr = PluralRules::try_new(&lang.into(), &provider, PluralRuleType::Cardinal)
+                let pr = PluralRules::try_new(&provider, &lang.into(), PluralRuleType::Cardinal)
                     .unwrap();
                 for s in &numbers_data.usize {
                     let _ = pr.select(*s);
@@ -35,14 +35,14 @@ fn pluralrules(c: &mut Criterion) {
         c.bench_function("plurals/pluralrules/construct/fs", |b| {
             b.iter(|| {
                 for lang in &plurals_data.langs {
-                    PluralRules::try_new(&lang.into(), &provider, PluralRuleType::Ordinal).unwrap();
-                    PluralRules::try_new(&lang.into(), &provider, PluralRuleType::Cardinal)
+                    PluralRules::try_new(&provider, &lang.into(), PluralRuleType::Ordinal).unwrap();
+                    PluralRules::try_new(&provider, &lang.into(), PluralRuleType::Cardinal)
                         .unwrap();
                 }
             });
         });
 
-        let pr = PluralRules::try_new(&locale!("ru").into(), &provider, PluralRuleType::Cardinal)
+        let pr = PluralRules::try_new(&provider, &locale!("ru").into(), PluralRuleType::Cardinal)
             .unwrap();
         c.bench_function("plurals/pluralrules/select/fs", |b| {
             b.iter(|| {

--- a/components/plurals/examples/elevator_floors.rs
+++ b/components/plurals/examples/elevator_floors.rs
@@ -31,7 +31,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
 
     {
         print("\n====== Elevator Floor (en) example ============", None);
-        let pr = PluralRules::try_new_ordinal(&locale!("en").into(), &provider)
+        let pr = PluralRules::try_new_ordinal(&provider, &locale!("en").into())
             .expect("Failed to create a PluralRules instance.");
 
         for value in VALUES {

--- a/components/plurals/examples/unread_emails.rs
+++ b/components/plurals/examples/unread_emails.rs
@@ -30,7 +30,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
 
     {
         print("\n====== Unread Emails (en) example ============", None);
-        let pr = PluralRules::try_new_cardinal(&locale!("en").into(), &provider)
+        let pr = PluralRules::try_new_cardinal(&provider, &locale!("en").into())
             .expect("Failed to create a PluralRules instance.");
 
         for value in VALUES {

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! let provider = icu_testdata::get_provider();
 //!
-//! let pr = PluralRules::try_new(&locale!("en").into(), &provider, PluralRuleType::Cardinal)
+//! let pr = PluralRules::try_new(&provider, &locale!("en").into(), PluralRuleType::Cardinal)
 //!     .expect("Failed to construct a PluralRules struct.");
 //!
 //! assert_eq!(pr.select(5_usize), PluralCategory::Other);
@@ -141,7 +141,7 @@ pub enum PluralRuleType {
 ///
 /// let dp = icu_testdata::get_provider();
 ///
-/// let pr = PluralRules::try_new(&locale!("en").into(), &dp, PluralRuleType::Cardinal)
+/// let pr = PluralRules::try_new(&dp, &locale!("en").into(), PluralRuleType::Cardinal)
 ///     .expect("Failed to construct a PluralRules struct.");
 ///
 /// assert_eq!(pr.select(5_usize), PluralCategory::Other);
@@ -267,7 +267,7 @@ impl PluralCategory {
 ///
 /// let dp = icu_testdata::get_provider();
 ///
-/// let pr = PluralRules::try_new(&locale!("en").into(), &dp, PluralRuleType::Cardinal)
+/// let pr = PluralRules::try_new(&dp, &locale!("en").into(), PluralRuleType::Cardinal)
 ///     .expect("Failed to construct a PluralRules struct.");
 ///
 /// assert_eq!(pr.select(5_usize), PluralCategory::Other);
@@ -293,22 +293,22 @@ impl PluralRules {
     ///
     /// let dp = icu_testdata::get_provider();
     ///
-    /// let _ = PluralRules::try_new(&lid.into(), &dp, PluralRuleType::Cardinal);
+    /// let _ = PluralRules::try_new(&dp, &lid.into(), PluralRuleType::Cardinal);
     /// ```
     ///
     /// [`type`]: PluralRuleType
     /// [`data provider`]: icu_provider
     pub fn try_new<D>(
-        locale: &DataLocale,
         data_provider: &D,
+        locale: &DataLocale,
         rule_type: PluralRuleType,
     ) -> Result<Self, PluralRulesError>
     where
         D: DataProvider<CardinalV1Marker> + DataProvider<OrdinalV1Marker> + ?Sized,
     {
         match rule_type {
-            PluralRuleType::Cardinal => Self::try_new_cardinal(locale, data_provider),
-            PluralRuleType::Ordinal => Self::try_new_ordinal(locale, data_provider),
+            PluralRuleType::Cardinal => Self::try_new_cardinal(data_provider, locale),
+            PluralRuleType::Ordinal => Self::try_new_ordinal(data_provider, locale),
         }
     }
 
@@ -330,7 +330,7 @@ impl PluralRules {
     ///
     /// let dp = icu_testdata::get_provider();
     ///
-    /// let rules = PluralRules::try_new_cardinal(&locale!("ru").into(), &dp).expect("Data should be present");
+    /// let rules = PluralRules::try_new_cardinal(&dp, &locale!("ru").into()).expect("Data should be present");
     ///
     /// assert_eq!(rules.select(2_usize), PluralCategory::Few);
     /// ```
@@ -338,8 +338,8 @@ impl PluralRules {
     /// [`One`]: PluralCategory::One
     /// [`Other`]: PluralCategory::Other
     pub fn try_new_cardinal<D>(
-        locale: &DataLocale,
         data_provider: &D,
+        locale: &DataLocale,
     ) -> Result<Self, PluralRulesError>
     where
         D: DataProvider<CardinalV1Marker> + ?Sized,
@@ -374,7 +374,7 @@ impl PluralRules {
     ///
     /// let dp = icu_testdata::get_provider();
     ///
-    /// let rules = PluralRules::try_new_ordinal(&locale!("ru").into(), &dp).expect("Data should be present");
+    /// let rules = PluralRules::try_new_ordinal(&dp, &locale!("ru").into()).expect("Data should be present");
     ///
     /// assert_eq!(rules.select(2_usize), PluralCategory::Other);
     /// ```
@@ -384,8 +384,8 @@ impl PluralRules {
     /// [`Few`]: PluralCategory::Few
     /// [`Other`]: PluralCategory::Other
     pub fn try_new_ordinal<D>(
-        locale: &DataLocale,
         data_provider: &D,
+        locale: &DataLocale,
     ) -> Result<Self, PluralRulesError>
     where
         D: DataProvider<OrdinalV1Marker> + ?Sized,
@@ -411,7 +411,7 @@ impl PluralRules {
     ///
     /// let dp = icu_testdata::get_provider();
     ///
-    /// let pr = PluralRules::try_new(&locale!("en").into(), &dp, PluralRuleType::Cardinal)
+    /// let pr = PluralRules::try_new(&dp, &locale!("en").into(), PluralRuleType::Cardinal)
     ///     .expect("Failed to construct a PluralRules struct.");
     ///
     /// match pr.select(1_usize) {
@@ -439,7 +439,7 @@ impl PluralRules {
     /// #
     /// # let dp = icu_testdata::get_provider();
     /// #
-    /// # let pr = PluralRules::try_new(&locale!("en").into(), &dp, PluralRuleType::Cardinal)
+    /// # let pr = PluralRules::try_new(&dp, &locale!("en").into(), PluralRuleType::Cardinal)
     /// #     .expect("Failed to construct a PluralRules struct.");
     ///
     /// let operands = PluralOperands::try_from(-5).expect("Failed to parse to operands.");
@@ -487,7 +487,7 @@ impl PluralRules {
     ///
     /// let dp = icu_testdata::get_provider();
     ///
-    /// let pr = PluralRules::try_new(&locale!("fr").into(), &dp, PluralRuleType::Cardinal)
+    /// let pr = PluralRules::try_new(&dp, &locale!("fr").into(), PluralRuleType::Cardinal)
     ///     .expect("Failed to construct a PluralRules struct.");
     ///
     /// let mut categories = pr.categories();

--- a/components/plurals/tests/categories.rs
+++ b/components/plurals/tests/categories.rs
@@ -19,8 +19,8 @@ fn test_categories() {
 
     for test in test_set {
         let pr = PluralRules::try_new(
-            &LanguageIdentifier::from_str(&test.langid).unwrap().into(),
             &provider,
+            &LanguageIdentifier::from_str(&test.langid).unwrap().into(),
             test.plural_type.into(),
         )
         .unwrap();

--- a/components/plurals/tests/plurals.rs
+++ b/components/plurals/tests/plurals.rs
@@ -11,7 +11,7 @@ fn test_plural_rules() {
     let provider = icu_testdata::get_provider();
 
     let pr =
-        PluralRules::try_new(&locale!("en").into(), &provider, PluralRuleType::Cardinal).unwrap();
+        PluralRules::try_new(&provider, &locale!("en").into(), PluralRuleType::Cardinal).unwrap();
 
     assert_eq!(pr.select(5_usize), PluralCategory::Other);
 }
@@ -35,7 +35,7 @@ fn test_plural_rules_missing() {
     // Use get_postcard_provider to skip vertical fallback
     let provider = icu_testdata::get_postcard_provider();
 
-    let pr = PluralRules::try_new(&locale!("xx").into(), &provider, PluralRuleType::Cardinal);
+    let pr = PluralRules::try_new(&provider, &locale!("xx").into(), PluralRuleType::Cardinal);
 
     assert!(pr.is_err());
 }

--- a/ffi/diplomat/c/examples/fixeddecimal/test.c
+++ b/ffi/diplomat/c/examples/fixeddecimal/test.c
@@ -13,7 +13,7 @@ int main() {
     ICU4XFixedDecimal* decimal = ICU4XFixedDecimal_create(1000007);
 
     diplomat_result_box_ICU4XFixedDecimalFormatter_ICU4XError fdf_result =
-        ICU4XFixedDecimalFormatter_try_new(locale, provider, ICU4XFixedDecimalGroupingStrategy_Auto);
+        ICU4XFixedDecimalFormatter_try_new(provider, locale, ICU4XFixedDecimalGroupingStrategy_Auto);
     if (!fdf_result.is_ok)  {
         printf("Failed to create FixedDecimalFormatter\n");
         return 1;

--- a/ffi/diplomat/c/examples/fixeddecimal_tiny/test.c
+++ b/ffi/diplomat/c/examples/fixeddecimal_tiny/test.c
@@ -12,7 +12,7 @@ int main() {
     ICU4XFixedDecimal* decimal = ICU4XFixedDecimal_create(1000007);
 
     diplomat_result_box_ICU4XFixedDecimalFormatter_ICU4XError fdf_result =
-        ICU4XFixedDecimalFormatter_try_new(locale, provider, ICU4XFixedDecimalGroupingStrategy_Auto);
+        ICU4XFixedDecimalFormatter_try_new(provider, locale, ICU4XFixedDecimalGroupingStrategy_Auto);
     if (!fdf_result.is_ok)  {
         printf("Failed to create FixedDecimalFormatter\n");
         return 1;

--- a/ffi/diplomat/c/examples/pluralrules/test.c
+++ b/ffi/diplomat/c/examples/pluralrules/test.c
@@ -9,7 +9,7 @@
 int main() {
     ICU4XLocale* locale = ICU4XLocale_create("ar", 2);
     ICU4XDataProvider* provider = ICU4XDataProvider_create_test();
-    diplomat_result_box_ICU4XPluralRules_ICU4XError plural_result = ICU4XPluralRules_try_new_cardinal(locale, provider);
+    diplomat_result_box_ICU4XPluralRules_ICU4XError plural_result = ICU4XPluralRules_try_new_cardinal(provider, locale);
     if (!plural_result.is_ok) {
         printf("Failed to create PluralRules\n");
         return 1;

--- a/ffi/diplomat/c/include/ICU4XFixedDecimalFormatter.h
+++ b/ffi/diplomat/c/include/ICU4XFixedDecimalFormatter.h
@@ -14,8 +14,8 @@ typedef struct ICU4XFixedDecimalFormatter ICU4XFixedDecimalFormatter;
 #ifdef __cplusplus
 } // namespace capi
 #endif
-#include "ICU4XLocale.h"
 #include "ICU4XDataProvider.h"
+#include "ICU4XLocale.h"
 #include "ICU4XFixedDecimalGroupingStrategy.h"
 #include "diplomat_result_box_ICU4XFixedDecimalFormatter_ICU4XError.h"
 #include "ICU4XDataStruct.h"
@@ -26,7 +26,7 @@ namespace capi {
 extern "C" {
 #endif
 
-diplomat_result_box_ICU4XFixedDecimalFormatter_ICU4XError ICU4XFixedDecimalFormatter_try_new(const ICU4XLocale* locale, const ICU4XDataProvider* provider, ICU4XFixedDecimalGroupingStrategy grouping_strategy);
+diplomat_result_box_ICU4XFixedDecimalFormatter_ICU4XError ICU4XFixedDecimalFormatter_try_new(const ICU4XDataProvider* provider, const ICU4XLocale* locale, ICU4XFixedDecimalGroupingStrategy grouping_strategy);
 
 diplomat_result_box_ICU4XFixedDecimalFormatter_ICU4XError ICU4XFixedDecimalFormatter_try_new_from_decimal_symbols_v1(const ICU4XDataStruct* data_struct, ICU4XFixedDecimalGroupingStrategy grouping_strategy);
 

--- a/ffi/diplomat/c/include/ICU4XGregorianDateFormatter.h
+++ b/ffi/diplomat/c/include/ICU4XGregorianDateFormatter.h
@@ -14,8 +14,8 @@ typedef struct ICU4XGregorianDateFormatter ICU4XGregorianDateFormatter;
 #ifdef __cplusplus
 } // namespace capi
 #endif
-#include "ICU4XLocale.h"
 #include "ICU4XDataProvider.h"
+#include "ICU4XLocale.h"
 #include "ICU4XDateLength.h"
 #include "diplomat_result_box_ICU4XGregorianDateFormatter_ICU4XError.h"
 #include "ICU4XGregorianDateTime.h"
@@ -25,7 +25,7 @@ namespace capi {
 extern "C" {
 #endif
 
-diplomat_result_box_ICU4XGregorianDateFormatter_ICU4XError ICU4XGregorianDateFormatter_try_new(const ICU4XLocale* locale, const ICU4XDataProvider* provider, ICU4XDateLength length);
+diplomat_result_box_ICU4XGregorianDateFormatter_ICU4XError ICU4XGregorianDateFormatter_try_new(const ICU4XDataProvider* provider, const ICU4XLocale* locale, ICU4XDateLength length);
 
 diplomat_result_void_ICU4XError ICU4XGregorianDateFormatter_format_datetime(const ICU4XGregorianDateFormatter* self, const ICU4XGregorianDateTime* value, DiplomatWriteable* write);
 void ICU4XGregorianDateFormatter_destroy(ICU4XGregorianDateFormatter* self);

--- a/ffi/diplomat/c/include/ICU4XGregorianDateTimeFormatter.h
+++ b/ffi/diplomat/c/include/ICU4XGregorianDateTimeFormatter.h
@@ -14,8 +14,8 @@ typedef struct ICU4XGregorianDateTimeFormatter ICU4XGregorianDateTimeFormatter;
 #ifdef __cplusplus
 } // namespace capi
 #endif
-#include "ICU4XLocale.h"
 #include "ICU4XDataProvider.h"
+#include "ICU4XLocale.h"
 #include "ICU4XDateLength.h"
 #include "ICU4XTimeLength.h"
 #include "ICU4XHourCyclePreference.h"
@@ -27,7 +27,7 @@ namespace capi {
 extern "C" {
 #endif
 
-diplomat_result_box_ICU4XGregorianDateTimeFormatter_ICU4XError ICU4XGregorianDateTimeFormatter_try_new(const ICU4XLocale* locale, const ICU4XDataProvider* provider, ICU4XDateLength date_length, ICU4XTimeLength time_length, ICU4XHourCyclePreference time_preferences);
+diplomat_result_box_ICU4XGregorianDateTimeFormatter_ICU4XError ICU4XGregorianDateTimeFormatter_try_new(const ICU4XDataProvider* provider, const ICU4XLocale* locale, ICU4XDateLength date_length, ICU4XTimeLength time_length, ICU4XHourCyclePreference time_preferences);
 
 diplomat_result_void_ICU4XError ICU4XGregorianDateTimeFormatter_format_datetime(const ICU4XGregorianDateTimeFormatter* self, const ICU4XGregorianDateTime* value, DiplomatWriteable* write);
 void ICU4XGregorianDateTimeFormatter_destroy(ICU4XGregorianDateTimeFormatter* self);

--- a/ffi/diplomat/c/include/ICU4XPluralRules.h
+++ b/ffi/diplomat/c/include/ICU4XPluralRules.h
@@ -14,8 +14,8 @@ typedef struct ICU4XPluralRules ICU4XPluralRules;
 #ifdef __cplusplus
 } // namespace capi
 #endif
-#include "ICU4XLocale.h"
 #include "ICU4XDataProvider.h"
+#include "ICU4XLocale.h"
 #include "diplomat_result_box_ICU4XPluralRules_ICU4XError.h"
 #include "ICU4XPluralOperands.h"
 #include "ICU4XPluralCategory.h"
@@ -25,9 +25,9 @@ namespace capi {
 extern "C" {
 #endif
 
-diplomat_result_box_ICU4XPluralRules_ICU4XError ICU4XPluralRules_try_new_cardinal(const ICU4XLocale* locale, const ICU4XDataProvider* provider);
+diplomat_result_box_ICU4XPluralRules_ICU4XError ICU4XPluralRules_try_new_cardinal(const ICU4XDataProvider* provider, const ICU4XLocale* locale);
 
-diplomat_result_box_ICU4XPluralRules_ICU4XError ICU4XPluralRules_try_new_ordinal(const ICU4XLocale* locale, const ICU4XDataProvider* provider);
+diplomat_result_box_ICU4XPluralRules_ICU4XError ICU4XPluralRules_try_new_ordinal(const ICU4XDataProvider* provider, const ICU4XLocale* locale);
 
 ICU4XPluralCategory ICU4XPluralRules_select(const ICU4XPluralRules* self, ICU4XPluralOperands op);
 

--- a/ffi/diplomat/c/include/ICU4XTimeFormatter.h
+++ b/ffi/diplomat/c/include/ICU4XTimeFormatter.h
@@ -14,8 +14,8 @@ typedef struct ICU4XTimeFormatter ICU4XTimeFormatter;
 #ifdef __cplusplus
 } // namespace capi
 #endif
-#include "ICU4XLocale.h"
 #include "ICU4XDataProvider.h"
+#include "ICU4XLocale.h"
 #include "ICU4XTimeLength.h"
 #include "ICU4XHourCyclePreference.h"
 #include "diplomat_result_box_ICU4XTimeFormatter_ICU4XError.h"
@@ -26,7 +26,7 @@ namespace capi {
 extern "C" {
 #endif
 
-diplomat_result_box_ICU4XTimeFormatter_ICU4XError ICU4XTimeFormatter_try_new(const ICU4XLocale* locale, const ICU4XDataProvider* provider, ICU4XTimeLength length, ICU4XHourCyclePreference preferences);
+diplomat_result_box_ICU4XTimeFormatter_ICU4XError ICU4XTimeFormatter_try_new(const ICU4XDataProvider* provider, const ICU4XLocale* locale, ICU4XTimeLength length, ICU4XHourCyclePreference preferences);
 
 diplomat_result_void_ICU4XError ICU4XTimeFormatter_format_gregorian_datetime(const ICU4XTimeFormatter* self, const ICU4XGregorianDateTime* value, DiplomatWriteable* write);
 void ICU4XTimeFormatter_destroy(ICU4XTimeFormatter* self);

--- a/ffi/diplomat/cpp/docs/source/datetime_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/datetime_ffi.rst
@@ -18,7 +18,7 @@
     See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateFormatter.html>`__ for more information.
 
 
-    .. cpp:function:: static diplomat::result<ICU4XGregorianDateFormatter, ICU4XError> try_new(const ICU4XLocale& locale, const ICU4XDataProvider& provider, ICU4XDateLength length)
+    .. cpp:function:: static diplomat::result<ICU4XGregorianDateFormatter, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XDateLength length)
 
         Creates a new :cpp:class:`ICU4XGregorianDateFormatter` from locale data.
 
@@ -46,7 +46,7 @@
     See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html>`__ for more information.
 
 
-    .. cpp:function:: static diplomat::result<ICU4XGregorianDateTimeFormatter, ICU4XError> try_new(const ICU4XLocale& locale, const ICU4XDataProvider& provider, ICU4XDateLength date_length, ICU4XTimeLength time_length, ICU4XHourCyclePreference time_preferences)
+    .. cpp:function:: static diplomat::result<ICU4XGregorianDateTimeFormatter, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XDateLength date_length, ICU4XTimeLength time_length, ICU4XHourCyclePreference time_preferences)
 
         Creates a new :cpp:class:`ICU4XGregorianDateFormatter` from locale data.
 
@@ -86,7 +86,7 @@
     See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html>`__ for more information.
 
 
-    .. cpp:function:: static diplomat::result<ICU4XTimeFormatter, ICU4XError> try_new(const ICU4XLocale& locale, const ICU4XDataProvider& provider, ICU4XTimeLength length, ICU4XHourCyclePreference preferences)
+    .. cpp:function:: static diplomat::result<ICU4XTimeFormatter, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XTimeLength length, ICU4XHourCyclePreference preferences)
 
         Creates a new :cpp:class:`ICU4XTimeFormatter` from locale data.
 

--- a/ffi/diplomat/cpp/docs/source/decimal_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/decimal_ffi.rst
@@ -8,7 +8,7 @@
     See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html>`__ for more information.
 
 
-    .. cpp:function:: static diplomat::result<ICU4XFixedDecimalFormatter, ICU4XError> try_new(const ICU4XLocale& locale, const ICU4XDataProvider& provider, ICU4XFixedDecimalGroupingStrategy grouping_strategy)
+    .. cpp:function:: static diplomat::result<ICU4XFixedDecimalFormatter, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XFixedDecimalGroupingStrategy grouping_strategy)
 
         Creates a new :cpp:class:`ICU4XFixedDecimalFormatter` from locale data.
 

--- a/ffi/diplomat/cpp/docs/source/pluralrules_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/pluralrules_ffi.rst
@@ -70,14 +70,14 @@
     See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_plurals/struct.PluralRules.html>`__ for more information.
 
 
-    .. cpp:function:: static diplomat::result<ICU4XPluralRules, ICU4XError> try_new_cardinal(const ICU4XLocale& locale, const ICU4XDataProvider& provider)
+    .. cpp:function:: static diplomat::result<ICU4XPluralRules, ICU4XError> try_new_cardinal(const ICU4XDataProvider& provider, const ICU4XLocale& locale)
 
         FFI version of ``PluralRules::try_new_cardinal()``.
 
         See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_plurals/struct.PluralRules.html#method.try_new>`__ for more information.
 
 
-    .. cpp:function:: static diplomat::result<ICU4XPluralRules, ICU4XError> try_new_ordinal(const ICU4XLocale& locale, const ICU4XDataProvider& provider)
+    .. cpp:function:: static diplomat::result<ICU4XPluralRules, ICU4XError> try_new_ordinal(const ICU4XDataProvider& provider, const ICU4XLocale& locale)
 
         FFI version of ``PluralRules::try_new_ordinal()``.
 

--- a/ffi/diplomat/cpp/examples/datetime/test.cpp
+++ b/ffi/diplomat/cpp/examples/datetime/test.cpp
@@ -18,7 +18,7 @@ int main() {
 
     ICU4XGregorianDateTime date = ICU4XGregorianDateTime::try_new(2022, 07, 11, 13, 06, 42).ok().value();
 
-    ICU4XTimeFormatter tf = ICU4XTimeFormatter::try_new(locale, dp, ICU4XTimeLength::Short, ICU4XHourCyclePreference::None).ok().value();
+    ICU4XTimeFormatter tf = ICU4XTimeFormatter::try_new(dp, locale, ICU4XTimeLength::Short, ICU4XHourCyclePreference::None).ok().value();
     std::string out = tf.format_gregorian_datetime(date).ok().value();
     std::cout << "Formatted value is " << out << std::endl;
     if (out != "13:06") {
@@ -26,7 +26,7 @@ int main() {
         return 1;
     }
 
-    ICU4XGregorianDateFormatter df = ICU4XGregorianDateFormatter::try_new(locale, dp, ICU4XDateLength::Full).ok().value();
+    ICU4XGregorianDateFormatter df = ICU4XGregorianDateFormatter::try_new(dp, locale, ICU4XDateLength::Full).ok().value();
     out = df.format_datetime(date).ok().value();
     std::cout << "Formatted value is " << out << std::endl;
     if (out != "lunes, 11 de julio de 2022") {
@@ -34,7 +34,7 @@ int main() {
         return 1;
     }
 
-    ICU4XGregorianDateTimeFormatter dtf = ICU4XGregorianDateTimeFormatter::try_new(locale, dp, ICU4XDateLength::Medium, ICU4XTimeLength::Short, ICU4XHourCyclePreference::None).ok().value();
+    ICU4XGregorianDateTimeFormatter dtf = ICU4XGregorianDateTimeFormatter::try_new(dp, locale, ICU4XDateLength::Medium, ICU4XTimeLength::Short, ICU4XHourCyclePreference::None).ok().value();
     out = dtf.format_datetime(date).ok().value();
     std::cout << "Formatted value is " << out << std::endl;
     if (out != "11 jul 2022, 13:06") {

--- a/ffi/diplomat/cpp/examples/fixeddecimal/test.cpp
+++ b/ffi/diplomat/cpp/examples/fixeddecimal/test.cpp
@@ -13,7 +13,7 @@ int main() {
     std::cout << "Running test for locale " << locale.tostring().ok().value() << std::endl;
     ICU4XDataProvider dp = ICU4XDataProvider::create_test();
     ICU4XFixedDecimalFormatter fdf = ICU4XFixedDecimalFormatter::try_new(
-        locale, dp, ICU4XFixedDecimalGroupingStrategy::Auto).ok().value();
+        dp, locale, ICU4XFixedDecimalGroupingStrategy::Auto).ok().value();
 
     ICU4XFixedDecimal decimal = ICU4XFixedDecimal::create(1000007);
     std::string out = fdf.format(decimal).ok().value();

--- a/ffi/diplomat/cpp/examples/fixeddecimal_wasm/test.cpp
+++ b/ffi/diplomat/cpp/examples/fixeddecimal_wasm/test.cpp
@@ -23,7 +23,7 @@ int runFixedDecimal() {
     std::cout << "Running test for locale " << locale.tostring().ok().value() << std::endl;
     ICU4XDataProvider dp = ICU4XDataProvider::create_test();
     ICU4XFixedDecimalFormatter fdf = ICU4XFixedDecimalFormatter::try_new(
-        locale, dp, ICU4XFixedDecimalGroupingStrategy::Auto).ok().value();
+        dp, locale, ICU4XFixedDecimalGroupingStrategy::Auto).ok().value();
 
     ICU4XFixedDecimal decimal = ICU4XFixedDecimal::create(1000007);
     std::string out = fdf.format(decimal).ok().value();

--- a/ffi/diplomat/cpp/examples/pluralrules/test.cpp
+++ b/ffi/diplomat/cpp/examples/pluralrules/test.cpp
@@ -12,7 +12,7 @@ int main() {
     ICU4XLocale locale = ICU4XLocale::create("ar").value();
     std::cout << "Running test for locale " << locale.tostring().ok().value() << std::endl;
     ICU4XDataProvider dp = ICU4XDataProvider::create_fs(path).ok().value();
-    ICU4XPluralRules pr = ICU4XPluralRules::try_new_cardinal(locale, dp).ok().value();
+    ICU4XPluralRules pr = ICU4XPluralRules::try_new_cardinal(dp, locale).ok().value();
 
     ICU4XPluralOperands op = { .i = 3 };
     ICU4XPluralCategory cat = pr.select(op);

--- a/ffi/diplomat/cpp/include/ICU4XFixedDecimalFormatter.h
+++ b/ffi/diplomat/cpp/include/ICU4XFixedDecimalFormatter.h
@@ -14,8 +14,8 @@ typedef struct ICU4XFixedDecimalFormatter ICU4XFixedDecimalFormatter;
 #ifdef __cplusplus
 } // namespace capi
 #endif
-#include "ICU4XLocale.h"
 #include "ICU4XDataProvider.h"
+#include "ICU4XLocale.h"
 #include "ICU4XFixedDecimalGroupingStrategy.h"
 #include "diplomat_result_box_ICU4XFixedDecimalFormatter_ICU4XError.h"
 #include "ICU4XDataStruct.h"
@@ -26,7 +26,7 @@ namespace capi {
 extern "C" {
 #endif
 
-diplomat_result_box_ICU4XFixedDecimalFormatter_ICU4XError ICU4XFixedDecimalFormatter_try_new(const ICU4XLocale* locale, const ICU4XDataProvider* provider, ICU4XFixedDecimalGroupingStrategy grouping_strategy);
+diplomat_result_box_ICU4XFixedDecimalFormatter_ICU4XError ICU4XFixedDecimalFormatter_try_new(const ICU4XDataProvider* provider, const ICU4XLocale* locale, ICU4XFixedDecimalGroupingStrategy grouping_strategy);
 
 diplomat_result_box_ICU4XFixedDecimalFormatter_ICU4XError ICU4XFixedDecimalFormatter_try_new_from_decimal_symbols_v1(const ICU4XDataStruct* data_struct, ICU4XFixedDecimalGroupingStrategy grouping_strategy);
 

--- a/ffi/diplomat/cpp/include/ICU4XFixedDecimalFormatter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XFixedDecimalFormatter.hpp
@@ -11,8 +11,8 @@
 
 #include "ICU4XFixedDecimalFormatter.h"
 
-class ICU4XLocale;
 class ICU4XDataProvider;
+class ICU4XLocale;
 #include "ICU4XFixedDecimalGroupingStrategy.hpp"
 class ICU4XFixedDecimalFormatter;
 #include "ICU4XError.hpp"
@@ -41,7 +41,7 @@ class ICU4XFixedDecimalFormatter {
    * 
    * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.try_new) for more information.
    */
-  static diplomat::result<ICU4XFixedDecimalFormatter, ICU4XError> try_new(const ICU4XLocale& locale, const ICU4XDataProvider& provider, ICU4XFixedDecimalGroupingStrategy grouping_strategy);
+  static diplomat::result<ICU4XFixedDecimalFormatter, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XFixedDecimalGroupingStrategy grouping_strategy);
 
   /**
    * Creates a new [`ICU4XFixedDecimalFormatter`] from preconstructed locale data in the form of an [`ICU4XDataStruct`]
@@ -75,13 +75,13 @@ class ICU4XFixedDecimalFormatter {
   std::unique_ptr<capi::ICU4XFixedDecimalFormatter, ICU4XFixedDecimalFormatterDeleter> inner;
 };
 
-#include "ICU4XLocale.hpp"
 #include "ICU4XDataProvider.hpp"
+#include "ICU4XLocale.hpp"
 #include "ICU4XDataStruct.hpp"
 #include "ICU4XFixedDecimal.hpp"
 
-inline diplomat::result<ICU4XFixedDecimalFormatter, ICU4XError> ICU4XFixedDecimalFormatter::try_new(const ICU4XLocale& locale, const ICU4XDataProvider& provider, ICU4XFixedDecimalGroupingStrategy grouping_strategy) {
-  auto diplomat_result_raw_out_value = capi::ICU4XFixedDecimalFormatter_try_new(locale.AsFFI(), provider.AsFFI(), static_cast<capi::ICU4XFixedDecimalGroupingStrategy>(grouping_strategy));
+inline diplomat::result<ICU4XFixedDecimalFormatter, ICU4XError> ICU4XFixedDecimalFormatter::try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XFixedDecimalGroupingStrategy grouping_strategy) {
+  auto diplomat_result_raw_out_value = capi::ICU4XFixedDecimalFormatter_try_new(provider.AsFFI(), locale.AsFFI(), static_cast<capi::ICU4XFixedDecimalGroupingStrategy>(grouping_strategy));
   diplomat::result<ICU4XFixedDecimalFormatter, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
     diplomat_result_out_value = diplomat::Ok<ICU4XFixedDecimalFormatter>(std::move(ICU4XFixedDecimalFormatter(diplomat_result_raw_out_value.ok)));

--- a/ffi/diplomat/cpp/include/ICU4XGregorianDateFormatter.h
+++ b/ffi/diplomat/cpp/include/ICU4XGregorianDateFormatter.h
@@ -14,8 +14,8 @@ typedef struct ICU4XGregorianDateFormatter ICU4XGregorianDateFormatter;
 #ifdef __cplusplus
 } // namespace capi
 #endif
-#include "ICU4XLocale.h"
 #include "ICU4XDataProvider.h"
+#include "ICU4XLocale.h"
 #include "ICU4XDateLength.h"
 #include "diplomat_result_box_ICU4XGregorianDateFormatter_ICU4XError.h"
 #include "ICU4XGregorianDateTime.h"
@@ -25,7 +25,7 @@ namespace capi {
 extern "C" {
 #endif
 
-diplomat_result_box_ICU4XGregorianDateFormatter_ICU4XError ICU4XGregorianDateFormatter_try_new(const ICU4XLocale* locale, const ICU4XDataProvider* provider, ICU4XDateLength length);
+diplomat_result_box_ICU4XGregorianDateFormatter_ICU4XError ICU4XGregorianDateFormatter_try_new(const ICU4XDataProvider* provider, const ICU4XLocale* locale, ICU4XDateLength length);
 
 diplomat_result_void_ICU4XError ICU4XGregorianDateFormatter_format_datetime(const ICU4XGregorianDateFormatter* self, const ICU4XGregorianDateTime* value, DiplomatWriteable* write);
 void ICU4XGregorianDateFormatter_destroy(ICU4XGregorianDateFormatter* self);

--- a/ffi/diplomat/cpp/include/ICU4XGregorianDateFormatter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XGregorianDateFormatter.hpp
@@ -11,8 +11,8 @@
 
 #include "ICU4XGregorianDateFormatter.h"
 
-class ICU4XLocale;
 class ICU4XDataProvider;
+class ICU4XLocale;
 #include "ICU4XDateLength.hpp"
 class ICU4XGregorianDateFormatter;
 #include "ICU4XError.hpp"
@@ -41,7 +41,7 @@ class ICU4XGregorianDateFormatter {
    * 
    * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.DateFormatter.html#method.try_new) for more information.
    */
-  static diplomat::result<ICU4XGregorianDateFormatter, ICU4XError> try_new(const ICU4XLocale& locale, const ICU4XDataProvider& provider, ICU4XDateLength length);
+  static diplomat::result<ICU4XGregorianDateFormatter, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XDateLength length);
 
   /**
    * Formats a [`ICU4XGregorianDateTime`] to a string.
@@ -66,12 +66,12 @@ class ICU4XGregorianDateFormatter {
   std::unique_ptr<capi::ICU4XGregorianDateFormatter, ICU4XGregorianDateFormatterDeleter> inner;
 };
 
-#include "ICU4XLocale.hpp"
 #include "ICU4XDataProvider.hpp"
+#include "ICU4XLocale.hpp"
 #include "ICU4XGregorianDateTime.hpp"
 
-inline diplomat::result<ICU4XGregorianDateFormatter, ICU4XError> ICU4XGregorianDateFormatter::try_new(const ICU4XLocale& locale, const ICU4XDataProvider& provider, ICU4XDateLength length) {
-  auto diplomat_result_raw_out_value = capi::ICU4XGregorianDateFormatter_try_new(locale.AsFFI(), provider.AsFFI(), static_cast<capi::ICU4XDateLength>(length));
+inline diplomat::result<ICU4XGregorianDateFormatter, ICU4XError> ICU4XGregorianDateFormatter::try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XDateLength length) {
+  auto diplomat_result_raw_out_value = capi::ICU4XGregorianDateFormatter_try_new(provider.AsFFI(), locale.AsFFI(), static_cast<capi::ICU4XDateLength>(length));
   diplomat::result<ICU4XGregorianDateFormatter, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
     diplomat_result_out_value = diplomat::Ok<ICU4XGregorianDateFormatter>(std::move(ICU4XGregorianDateFormatter(diplomat_result_raw_out_value.ok)));

--- a/ffi/diplomat/cpp/include/ICU4XGregorianDateTimeFormatter.h
+++ b/ffi/diplomat/cpp/include/ICU4XGregorianDateTimeFormatter.h
@@ -14,8 +14,8 @@ typedef struct ICU4XGregorianDateTimeFormatter ICU4XGregorianDateTimeFormatter;
 #ifdef __cplusplus
 } // namespace capi
 #endif
-#include "ICU4XLocale.h"
 #include "ICU4XDataProvider.h"
+#include "ICU4XLocale.h"
 #include "ICU4XDateLength.h"
 #include "ICU4XTimeLength.h"
 #include "ICU4XHourCyclePreference.h"
@@ -27,7 +27,7 @@ namespace capi {
 extern "C" {
 #endif
 
-diplomat_result_box_ICU4XGregorianDateTimeFormatter_ICU4XError ICU4XGregorianDateTimeFormatter_try_new(const ICU4XLocale* locale, const ICU4XDataProvider* provider, ICU4XDateLength date_length, ICU4XTimeLength time_length, ICU4XHourCyclePreference time_preferences);
+diplomat_result_box_ICU4XGregorianDateTimeFormatter_ICU4XError ICU4XGregorianDateTimeFormatter_try_new(const ICU4XDataProvider* provider, const ICU4XLocale* locale, ICU4XDateLength date_length, ICU4XTimeLength time_length, ICU4XHourCyclePreference time_preferences);
 
 diplomat_result_void_ICU4XError ICU4XGregorianDateTimeFormatter_format_datetime(const ICU4XGregorianDateTimeFormatter* self, const ICU4XGregorianDateTime* value, DiplomatWriteable* write);
 void ICU4XGregorianDateTimeFormatter_destroy(ICU4XGregorianDateTimeFormatter* self);

--- a/ffi/diplomat/cpp/include/ICU4XGregorianDateTimeFormatter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XGregorianDateTimeFormatter.hpp
@@ -11,8 +11,8 @@
 
 #include "ICU4XGregorianDateTimeFormatter.h"
 
-class ICU4XLocale;
 class ICU4XDataProvider;
+class ICU4XLocale;
 #include "ICU4XDateLength.hpp"
 #include "ICU4XTimeLength.hpp"
 #include "ICU4XHourCyclePreference.hpp"
@@ -43,7 +43,7 @@ class ICU4XGregorianDateTimeFormatter {
    * 
    * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
    */
-  static diplomat::result<ICU4XGregorianDateTimeFormatter, ICU4XError> try_new(const ICU4XLocale& locale, const ICU4XDataProvider& provider, ICU4XDateLength date_length, ICU4XTimeLength time_length, ICU4XHourCyclePreference time_preferences);
+  static diplomat::result<ICU4XGregorianDateTimeFormatter, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XDateLength date_length, ICU4XTimeLength time_length, ICU4XHourCyclePreference time_preferences);
 
   /**
    * Formats a [`ICU4XGregorianDateTime`] to a string.
@@ -68,12 +68,12 @@ class ICU4XGregorianDateTimeFormatter {
   std::unique_ptr<capi::ICU4XGregorianDateTimeFormatter, ICU4XGregorianDateTimeFormatterDeleter> inner;
 };
 
-#include "ICU4XLocale.hpp"
 #include "ICU4XDataProvider.hpp"
+#include "ICU4XLocale.hpp"
 #include "ICU4XGregorianDateTime.hpp"
 
-inline diplomat::result<ICU4XGregorianDateTimeFormatter, ICU4XError> ICU4XGregorianDateTimeFormatter::try_new(const ICU4XLocale& locale, const ICU4XDataProvider& provider, ICU4XDateLength date_length, ICU4XTimeLength time_length, ICU4XHourCyclePreference time_preferences) {
-  auto diplomat_result_raw_out_value = capi::ICU4XGregorianDateTimeFormatter_try_new(locale.AsFFI(), provider.AsFFI(), static_cast<capi::ICU4XDateLength>(date_length), static_cast<capi::ICU4XTimeLength>(time_length), static_cast<capi::ICU4XHourCyclePreference>(time_preferences));
+inline diplomat::result<ICU4XGregorianDateTimeFormatter, ICU4XError> ICU4XGregorianDateTimeFormatter::try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XDateLength date_length, ICU4XTimeLength time_length, ICU4XHourCyclePreference time_preferences) {
+  auto diplomat_result_raw_out_value = capi::ICU4XGregorianDateTimeFormatter_try_new(provider.AsFFI(), locale.AsFFI(), static_cast<capi::ICU4XDateLength>(date_length), static_cast<capi::ICU4XTimeLength>(time_length), static_cast<capi::ICU4XHourCyclePreference>(time_preferences));
   diplomat::result<ICU4XGregorianDateTimeFormatter, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
     diplomat_result_out_value = diplomat::Ok<ICU4XGregorianDateTimeFormatter>(std::move(ICU4XGregorianDateTimeFormatter(diplomat_result_raw_out_value.ok)));

--- a/ffi/diplomat/cpp/include/ICU4XPluralRules.h
+++ b/ffi/diplomat/cpp/include/ICU4XPluralRules.h
@@ -14,8 +14,8 @@ typedef struct ICU4XPluralRules ICU4XPluralRules;
 #ifdef __cplusplus
 } // namespace capi
 #endif
-#include "ICU4XLocale.h"
 #include "ICU4XDataProvider.h"
+#include "ICU4XLocale.h"
 #include "diplomat_result_box_ICU4XPluralRules_ICU4XError.h"
 #include "ICU4XPluralOperands.h"
 #include "ICU4XPluralCategory.h"
@@ -25,9 +25,9 @@ namespace capi {
 extern "C" {
 #endif
 
-diplomat_result_box_ICU4XPluralRules_ICU4XError ICU4XPluralRules_try_new_cardinal(const ICU4XLocale* locale, const ICU4XDataProvider* provider);
+diplomat_result_box_ICU4XPluralRules_ICU4XError ICU4XPluralRules_try_new_cardinal(const ICU4XDataProvider* provider, const ICU4XLocale* locale);
 
-diplomat_result_box_ICU4XPluralRules_ICU4XError ICU4XPluralRules_try_new_ordinal(const ICU4XLocale* locale, const ICU4XDataProvider* provider);
+diplomat_result_box_ICU4XPluralRules_ICU4XError ICU4XPluralRules_try_new_ordinal(const ICU4XDataProvider* provider, const ICU4XLocale* locale);
 
 ICU4XPluralCategory ICU4XPluralRules_select(const ICU4XPluralRules* self, ICU4XPluralOperands op);
 

--- a/ffi/diplomat/cpp/include/ICU4XPluralRules.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XPluralRules.hpp
@@ -11,8 +11,8 @@
 
 #include "ICU4XPluralRules.h"
 
-class ICU4XLocale;
 class ICU4XDataProvider;
+class ICU4XLocale;
 class ICU4XPluralRules;
 #include "ICU4XError.hpp"
 struct ICU4XPluralOperands;
@@ -41,14 +41,14 @@ class ICU4XPluralRules {
    * 
    * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_plurals/struct.PluralRules.html#method.try_new) for more information.
    */
-  static diplomat::result<ICU4XPluralRules, ICU4XError> try_new_cardinal(const ICU4XLocale& locale, const ICU4XDataProvider& provider);
+  static diplomat::result<ICU4XPluralRules, ICU4XError> try_new_cardinal(const ICU4XDataProvider& provider, const ICU4XLocale& locale);
 
   /**
    * FFI version of `PluralRules::try_new_ordinal()`.
    * 
    * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_plurals/struct.PluralRules.html#method.try_new) for more information.
    */
-  static diplomat::result<ICU4XPluralRules, ICU4XError> try_new_ordinal(const ICU4XLocale& locale, const ICU4XDataProvider& provider);
+  static diplomat::result<ICU4XPluralRules, ICU4XError> try_new_ordinal(const ICU4XDataProvider& provider, const ICU4XLocale& locale);
 
   /**
    * FFI version of `PluralRules::select()`.
@@ -73,13 +73,13 @@ class ICU4XPluralRules {
   std::unique_ptr<capi::ICU4XPluralRules, ICU4XPluralRulesDeleter> inner;
 };
 
-#include "ICU4XLocale.hpp"
 #include "ICU4XDataProvider.hpp"
+#include "ICU4XLocale.hpp"
 #include "ICU4XPluralOperands.hpp"
 #include "ICU4XPluralCategories.hpp"
 
-inline diplomat::result<ICU4XPluralRules, ICU4XError> ICU4XPluralRules::try_new_cardinal(const ICU4XLocale& locale, const ICU4XDataProvider& provider) {
-  auto diplomat_result_raw_out_value = capi::ICU4XPluralRules_try_new_cardinal(locale.AsFFI(), provider.AsFFI());
+inline diplomat::result<ICU4XPluralRules, ICU4XError> ICU4XPluralRules::try_new_cardinal(const ICU4XDataProvider& provider, const ICU4XLocale& locale) {
+  auto diplomat_result_raw_out_value = capi::ICU4XPluralRules_try_new_cardinal(provider.AsFFI(), locale.AsFFI());
   diplomat::result<ICU4XPluralRules, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
     diplomat_result_out_value = diplomat::Ok<ICU4XPluralRules>(std::move(ICU4XPluralRules(diplomat_result_raw_out_value.ok)));
@@ -88,8 +88,8 @@ inline diplomat::result<ICU4XPluralRules, ICU4XError> ICU4XPluralRules::try_new_
   }
   return diplomat_result_out_value;
 }
-inline diplomat::result<ICU4XPluralRules, ICU4XError> ICU4XPluralRules::try_new_ordinal(const ICU4XLocale& locale, const ICU4XDataProvider& provider) {
-  auto diplomat_result_raw_out_value = capi::ICU4XPluralRules_try_new_ordinal(locale.AsFFI(), provider.AsFFI());
+inline diplomat::result<ICU4XPluralRules, ICU4XError> ICU4XPluralRules::try_new_ordinal(const ICU4XDataProvider& provider, const ICU4XLocale& locale) {
+  auto diplomat_result_raw_out_value = capi::ICU4XPluralRules_try_new_ordinal(provider.AsFFI(), locale.AsFFI());
   diplomat::result<ICU4XPluralRules, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
     diplomat_result_out_value = diplomat::Ok<ICU4XPluralRules>(std::move(ICU4XPluralRules(diplomat_result_raw_out_value.ok)));

--- a/ffi/diplomat/cpp/include/ICU4XTimeFormatter.h
+++ b/ffi/diplomat/cpp/include/ICU4XTimeFormatter.h
@@ -14,8 +14,8 @@ typedef struct ICU4XTimeFormatter ICU4XTimeFormatter;
 #ifdef __cplusplus
 } // namespace capi
 #endif
-#include "ICU4XLocale.h"
 #include "ICU4XDataProvider.h"
+#include "ICU4XLocale.h"
 #include "ICU4XTimeLength.h"
 #include "ICU4XHourCyclePreference.h"
 #include "diplomat_result_box_ICU4XTimeFormatter_ICU4XError.h"
@@ -26,7 +26,7 @@ namespace capi {
 extern "C" {
 #endif
 
-diplomat_result_box_ICU4XTimeFormatter_ICU4XError ICU4XTimeFormatter_try_new(const ICU4XLocale* locale, const ICU4XDataProvider* provider, ICU4XTimeLength length, ICU4XHourCyclePreference preferences);
+diplomat_result_box_ICU4XTimeFormatter_ICU4XError ICU4XTimeFormatter_try_new(const ICU4XDataProvider* provider, const ICU4XLocale* locale, ICU4XTimeLength length, ICU4XHourCyclePreference preferences);
 
 diplomat_result_void_ICU4XError ICU4XTimeFormatter_format_gregorian_datetime(const ICU4XTimeFormatter* self, const ICU4XGregorianDateTime* value, DiplomatWriteable* write);
 void ICU4XTimeFormatter_destroy(ICU4XTimeFormatter* self);

--- a/ffi/diplomat/cpp/include/ICU4XTimeFormatter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XTimeFormatter.hpp
@@ -11,8 +11,8 @@
 
 #include "ICU4XTimeFormatter.h"
 
-class ICU4XLocale;
 class ICU4XDataProvider;
+class ICU4XLocale;
 #include "ICU4XTimeLength.hpp"
 #include "ICU4XHourCyclePreference.hpp"
 class ICU4XTimeFormatter;
@@ -41,7 +41,7 @@ class ICU4XTimeFormatter {
    * 
    * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.DateFormatter.html#method.try_new) for more information.
    */
-  static diplomat::result<ICU4XTimeFormatter, ICU4XError> try_new(const ICU4XLocale& locale, const ICU4XDataProvider& provider, ICU4XTimeLength length, ICU4XHourCyclePreference preferences);
+  static diplomat::result<ICU4XTimeFormatter, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XTimeLength length, ICU4XHourCyclePreference preferences);
 
   /**
    * Formats a [`ICU4XGregorianDateTime`] to a string.
@@ -66,12 +66,12 @@ class ICU4XTimeFormatter {
   std::unique_ptr<capi::ICU4XTimeFormatter, ICU4XTimeFormatterDeleter> inner;
 };
 
-#include "ICU4XLocale.hpp"
 #include "ICU4XDataProvider.hpp"
+#include "ICU4XLocale.hpp"
 #include "ICU4XGregorianDateTime.hpp"
 
-inline diplomat::result<ICU4XTimeFormatter, ICU4XError> ICU4XTimeFormatter::try_new(const ICU4XLocale& locale, const ICU4XDataProvider& provider, ICU4XTimeLength length, ICU4XHourCyclePreference preferences) {
-  auto diplomat_result_raw_out_value = capi::ICU4XTimeFormatter_try_new(locale.AsFFI(), provider.AsFFI(), static_cast<capi::ICU4XTimeLength>(length), static_cast<capi::ICU4XHourCyclePreference>(preferences));
+inline diplomat::result<ICU4XTimeFormatter, ICU4XError> ICU4XTimeFormatter::try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XTimeLength length, ICU4XHourCyclePreference preferences) {
+  auto diplomat_result_raw_out_value = capi::ICU4XTimeFormatter_try_new(provider.AsFFI(), locale.AsFFI(), static_cast<capi::ICU4XTimeLength>(length), static_cast<capi::ICU4XHourCyclePreference>(preferences));
   diplomat::result<ICU4XTimeFormatter, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
     diplomat_result_out_value = diplomat::Ok<ICU4XTimeFormatter>(std::move(ICU4XTimeFormatter(diplomat_result_raw_out_value.ok)));

--- a/ffi/diplomat/src/datetime.rs
+++ b/ffi/diplomat/src/datetime.rs
@@ -43,8 +43,8 @@ pub mod ffi {
         /// Creates a new [`ICU4XTimeFormatter`] from locale data.
         #[diplomat::rust_link(icu::decimal::DateFormatter::try_new, FnInStruct)]
         pub fn try_new(
-            locale: &ICU4XLocale,
             provider: &ICU4XDataProvider,
+            locale: &ICU4XLocale,
             length: ICU4XTimeLength,
             preferences: ICU4XHourCyclePreference,
         ) -> DiplomatResult<Box<ICU4XTimeFormatter>, ICU4XError> {
@@ -74,7 +74,7 @@ pub mod ffi {
                 ICU4XHourCyclePreference::None => None,
             };
 
-            TimeFormatter::try_new(locale, &provider, length, preferences)
+            TimeFormatter::try_new(&provider, locale, length, preferences)
                 .map(|tf| Box::new(ICU4XTimeFormatter(tf)))
                 .map_err(Into::into)
                 .into()
@@ -115,8 +115,8 @@ pub mod ffi {
         /// Creates a new [`ICU4XGregorianDateFormatter`] from locale data.
         #[diplomat::rust_link(icu::decimal::DateFormatter::try_new, FnInStruct)]
         pub fn try_new(
-            locale: &ICU4XLocale,
             provider: &ICU4XDataProvider,
+            locale: &ICU4XLocale,
             length: ICU4XDateLength,
         ) -> DiplomatResult<Box<ICU4XGregorianDateFormatter>, ICU4XError> {
             use icu_provider::serde::AsDeserializingBufferProvider;
@@ -130,7 +130,7 @@ pub mod ffi {
                 ICU4XDateLength::Short => length::Date::Short,
             };
 
-            DateFormatter::try_new(locale, &provider, length)
+            DateFormatter::try_new(&provider, locale, length)
                 .map(|df| Box::new(ICU4XGregorianDateFormatter(df)))
                 .map_err(Into::into)
                 .into()
@@ -164,8 +164,8 @@ pub mod ffi {
         /// Creates a new [`ICU4XGregorianDateFormatter`] from locale data.
         #[diplomat::rust_link(icu::datetime::DateTimeFormatter::try_new, FnInStruct)]
         pub fn try_new(
-            locale: &ICU4XLocale,
             provider: &ICU4XDataProvider,
+            locale: &ICU4XLocale,
             date_length: ICU4XDateLength,
             time_length: ICU4XTimeLength,
             time_preferences: ICU4XHourCyclePreference,
@@ -204,7 +204,7 @@ pub mod ffi {
                 ICU4XHourCyclePreference::None => None,
             };
 
-            DateTimeFormatter::try_new(locale, &provider, &options.into())
+            DateTimeFormatter::try_new(&provider, locale, &options.into())
                 .map(|dtf| Box::new(ICU4XGregorianDateTimeFormatter(dtf)))
                 .map_err(Into::into)
                 .into()

--- a/ffi/diplomat/src/decimal.rs
+++ b/ffi/diplomat/src/decimal.rs
@@ -39,13 +39,13 @@ pub mod ffi {
         /// Creates a new [`ICU4XFixedDecimalFormatter`] from locale data.
         #[diplomat::rust_link(icu::decimal::FixedDecimalFormatter::try_new, FnInStruct)]
         pub fn try_new(
-            locale: &ICU4XLocale,
             provider: &ICU4XDataProvider,
+            locale: &ICU4XLocale,
             grouping_strategy: ICU4XFixedDecimalGroupingStrategy,
         ) -> DiplomatResult<Box<ICU4XFixedDecimalFormatter>, ICU4XError> {
             use icu_provider::serde::AsDeserializingBufferProvider;
             let provider = provider.0.as_deserializing();
-            Self::try_new_impl(locale, &provider, grouping_strategy)
+            Self::try_new_impl(&provider, locale, grouping_strategy)
         }
 
         /// Creates a new [`ICU4XFixedDecimalFormatter`] from preconstructed locale data in the form of an [`ICU4XDataStruct`]
@@ -64,15 +64,15 @@ pub mod ffi {
                 data: data_struct.0.clone(),
             };
             Self::try_new_impl(
-                &ICU4XLocale(Locale::UND),
                 &provider.as_downcasting(),
+                &ICU4XLocale(Locale::UND),
                 grouping_strategy,
             )
         }
 
         fn try_new_impl<D>(
-            locale: &ICU4XLocale,
             provider: &D,
+            locale: &ICU4XLocale,
             grouping_strategy: ICU4XFixedDecimalGroupingStrategy,
         ) -> DiplomatResult<Box<ICU4XFixedDecimalFormatter>, ICU4XError>
         where
@@ -88,7 +88,7 @@ pub mod ffi {
             };
             let mut options = FixedDecimalFormatterOptions::default();
             options.grouping_strategy = grouping_strategy;
-            FixedDecimalFormatter::try_new(locale, provider, options)
+            FixedDecimalFormatter::try_new(provider, locale, options)
                 .map(|fdf| Box::new(ICU4XFixedDecimalFormatter(fdf)))
                 .map_err(Into::into)
                 .into()

--- a/ffi/diplomat/src/pluralrules.rs
+++ b/ffi/diplomat/src/pluralrules.rs
@@ -35,13 +35,13 @@ pub mod ffi {
         /// FFI version of `PluralRules::try_new_cardinal()`.
         #[diplomat::rust_link(icu_plurals::PluralRules::try_new, FnInStruct)]
         pub fn try_new_cardinal(
-            locale: &ICU4XLocale,
             provider: &ICU4XDataProvider,
+            locale: &ICU4XLocale,
         ) -> DiplomatResult<Box<ICU4XPluralRules>, ICU4XError> {
             use icu_provider::serde::AsDeserializingBufferProvider;
             let locale = &locale.0.as_ref().into();
             let provider = provider.0.as_deserializing();
-            PluralRules::try_new_cardinal(locale, &provider)
+            PluralRules::try_new_cardinal(&provider, locale)
                 .map(|r| Box::new(ICU4XPluralRules(r)))
                 .map_err(Into::into)
                 .into()
@@ -50,13 +50,13 @@ pub mod ffi {
         /// FFI version of `PluralRules::try_new_ordinal()`.
         #[diplomat::rust_link(icu_plurals::PluralRules::try_new, FnInStruct)]
         pub fn try_new_ordinal(
-            locale: &ICU4XLocale,
             provider: &ICU4XDataProvider,
+            locale: &ICU4XLocale,
         ) -> DiplomatResult<Box<ICU4XPluralRules>, ICU4XError> {
             use icu_provider::serde::AsDeserializingBufferProvider;
             let locale = &locale.0.as_ref().into();
             let provider = provider.0.as_deserializing();
-            PluralRules::try_new_ordinal(locale, &provider)
+            PluralRules::try_new_ordinal(&provider, locale)
                 .map(|r| Box::new(ICU4XPluralRules(r)))
                 .map_err(Into::into)
                 .into()

--- a/ffi/diplomat/wasm/docs/datetime_ffi.rst
+++ b/ffi/diplomat/wasm/docs/datetime_ffi.rst
@@ -10,7 +10,7 @@
     See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateFormatter.html>`__ for more information.
 
 
-    .. js:staticfunction:: try_new(locale, provider, length)
+    .. js:staticfunction:: try_new(provider, locale, length)
 
         Creates a new :js:class:`ICU4XGregorianDateFormatter` from locale data.
 
@@ -31,7 +31,7 @@
     See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html>`__ for more information.
 
 
-    .. js:staticfunction:: try_new(locale, provider, date_length, time_length, time_preferences)
+    .. js:staticfunction:: try_new(provider, locale, date_length, time_length, time_preferences)
 
         Creates a new :js:class:`ICU4XGregorianDateFormatter` from locale data.
 
@@ -54,7 +54,7 @@
     See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html>`__ for more information.
 
 
-    .. js:staticfunction:: try_new(locale, provider, length, preferences)
+    .. js:staticfunction:: try_new(provider, locale, length, preferences)
 
         Creates a new :js:class:`ICU4XTimeFormatter` from locale data.
 

--- a/ffi/diplomat/wasm/docs/decimal_ffi.rst
+++ b/ffi/diplomat/wasm/docs/decimal_ffi.rst
@@ -8,7 +8,7 @@
     See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html>`__ for more information.
 
 
-    .. js:staticfunction:: try_new(locale, provider, grouping_strategy)
+    .. js:staticfunction:: try_new(provider, locale, grouping_strategy)
 
         Creates a new :js:class:`ICU4XFixedDecimalFormatter` from locale data.
 

--- a/ffi/diplomat/wasm/docs/pluralrules_ffi.rst
+++ b/ffi/diplomat/wasm/docs/pluralrules_ffi.rst
@@ -58,14 +58,14 @@
     See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_plurals/struct.PluralRules.html>`__ for more information.
 
 
-    .. js:staticfunction:: try_new_cardinal(locale, provider)
+    .. js:staticfunction:: try_new_cardinal(provider, locale)
 
         FFI version of ``PluralRules::try_new_cardinal()``.
 
         See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_plurals/struct.PluralRules.html#method.try_new>`__ for more information.
 
 
-    .. js:staticfunction:: try_new_ordinal(locale, provider)
+    .. js:staticfunction:: try_new_ordinal(provider, locale)
 
         FFI version of ``PluralRules::try_new_ordinal()``.
 

--- a/ffi/diplomat/wasm/example/main.mjs
+++ b/ffi/diplomat/wasm/example/main.mjs
@@ -9,5 +9,5 @@ const dataProvider = ICU4XDataProvider.create_test();
 
 const locale = ICU4XLocale.create("bn");
 
-const fdf = ICU4XFixedDecimalFormatter.try_new(locale, dataProvider, "Auto");
+const fdf = ICU4XFixedDecimalFormatter.try_new(dataProvider, locale, "Auto");
 console.log(fdf.format(decimal));

--- a/ffi/diplomat/wasm/lib/ICU4XFixedDecimalFormatter.d.ts
+++ b/ffi/diplomat/wasm/lib/ICU4XFixedDecimalFormatter.d.ts
@@ -21,7 +21,7 @@ export class ICU4XFixedDecimalFormatter {
    * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.try_new Rust documentation} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
-  static try_new(locale: ICU4XLocale, provider: ICU4XDataProvider, grouping_strategy: ICU4XFixedDecimalGroupingStrategy): ICU4XFixedDecimalFormatter | never;
+  static try_new(provider: ICU4XDataProvider, locale: ICU4XLocale, grouping_strategy: ICU4XFixedDecimalGroupingStrategy): ICU4XFixedDecimalFormatter | never;
 
   /**
 

--- a/ffi/diplomat/wasm/lib/ICU4XFixedDecimalFormatter.js
+++ b/ffi/diplomat/wasm/lib/ICU4XFixedDecimalFormatter.js
@@ -17,10 +17,10 @@ export class ICU4XFixedDecimalFormatter {
     }
   }
 
-  static try_new(arg_locale, arg_provider, arg_grouping_strategy) {
+  static try_new(arg_provider, arg_locale, arg_grouping_strategy) {
     return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
-      wasm.ICU4XFixedDecimalFormatter_try_new(diplomat_receive_buffer, arg_locale.underlying, arg_provider.underlying, ICU4XFixedDecimalGroupingStrategy_js_to_rust[arg_grouping_strategy]);
+      wasm.ICU4XFixedDecimalFormatter_try_new(diplomat_receive_buffer, arg_provider.underlying, arg_locale.underlying, ICU4XFixedDecimalGroupingStrategy_js_to_rust[arg_grouping_strategy]);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
         const ok_value = new ICU4XFixedDecimalFormatter(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true, []);

--- a/ffi/diplomat/wasm/lib/ICU4XGregorianDateFormatter.d.ts
+++ b/ffi/diplomat/wasm/lib/ICU4XGregorianDateFormatter.d.ts
@@ -20,7 +20,7 @@ export class ICU4XGregorianDateFormatter {
    * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.DateFormatter.html#method.try_new Rust documentation} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
-  static try_new(locale: ICU4XLocale, provider: ICU4XDataProvider, length: ICU4XDateLength): ICU4XGregorianDateFormatter | never;
+  static try_new(provider: ICU4XDataProvider, locale: ICU4XLocale, length: ICU4XDateLength): ICU4XGregorianDateFormatter | never;
 
   /**
 

--- a/ffi/diplomat/wasm/lib/ICU4XGregorianDateFormatter.js
+++ b/ffi/diplomat/wasm/lib/ICU4XGregorianDateFormatter.js
@@ -17,10 +17,10 @@ export class ICU4XGregorianDateFormatter {
     }
   }
 
-  static try_new(arg_locale, arg_provider, arg_length) {
+  static try_new(arg_provider, arg_locale, arg_length) {
     return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
-      wasm.ICU4XGregorianDateFormatter_try_new(diplomat_receive_buffer, arg_locale.underlying, arg_provider.underlying, ICU4XDateLength_js_to_rust[arg_length]);
+      wasm.ICU4XGregorianDateFormatter_try_new(diplomat_receive_buffer, arg_provider.underlying, arg_locale.underlying, ICU4XDateLength_js_to_rust[arg_length]);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
         const ok_value = new ICU4XGregorianDateFormatter(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true, []);

--- a/ffi/diplomat/wasm/lib/ICU4XGregorianDateTimeFormatter.d.ts
+++ b/ffi/diplomat/wasm/lib/ICU4XGregorianDateTimeFormatter.d.ts
@@ -22,7 +22,7 @@ export class ICU4XGregorianDateTimeFormatter {
    * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.try_new Rust documentation} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
-  static try_new(locale: ICU4XLocale, provider: ICU4XDataProvider, date_length: ICU4XDateLength, time_length: ICU4XTimeLength, time_preferences: ICU4XHourCyclePreference): ICU4XGregorianDateTimeFormatter | never;
+  static try_new(provider: ICU4XDataProvider, locale: ICU4XLocale, date_length: ICU4XDateLength, time_length: ICU4XTimeLength, time_preferences: ICU4XHourCyclePreference): ICU4XGregorianDateTimeFormatter | never;
 
   /**
 

--- a/ffi/diplomat/wasm/lib/ICU4XGregorianDateTimeFormatter.js
+++ b/ffi/diplomat/wasm/lib/ICU4XGregorianDateTimeFormatter.js
@@ -19,10 +19,10 @@ export class ICU4XGregorianDateTimeFormatter {
     }
   }
 
-  static try_new(arg_locale, arg_provider, arg_date_length, arg_time_length, arg_time_preferences) {
+  static try_new(arg_provider, arg_locale, arg_date_length, arg_time_length, arg_time_preferences) {
     return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
-      wasm.ICU4XGregorianDateTimeFormatter_try_new(diplomat_receive_buffer, arg_locale.underlying, arg_provider.underlying, ICU4XDateLength_js_to_rust[arg_date_length], ICU4XTimeLength_js_to_rust[arg_time_length], ICU4XHourCyclePreference_js_to_rust[arg_time_preferences]);
+      wasm.ICU4XGregorianDateTimeFormatter_try_new(diplomat_receive_buffer, arg_provider.underlying, arg_locale.underlying, ICU4XDateLength_js_to_rust[arg_date_length], ICU4XTimeLength_js_to_rust[arg_time_length], ICU4XHourCyclePreference_js_to_rust[arg_time_preferences]);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
         const ok_value = new ICU4XGregorianDateTimeFormatter(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true, []);

--- a/ffi/diplomat/wasm/lib/ICU4XPluralRules.d.ts
+++ b/ffi/diplomat/wasm/lib/ICU4XPluralRules.d.ts
@@ -21,7 +21,7 @@ export class ICU4XPluralRules {
    * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu_plurals/struct.PluralRules.html#method.try_new Rust documentation} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
-  static try_new_cardinal(locale: ICU4XLocale, provider: ICU4XDataProvider): ICU4XPluralRules | never;
+  static try_new_cardinal(provider: ICU4XDataProvider, locale: ICU4XLocale): ICU4XPluralRules | never;
 
   /**
 
@@ -30,7 +30,7 @@ export class ICU4XPluralRules {
    * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu_plurals/struct.PluralRules.html#method.try_new Rust documentation} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
-  static try_new_ordinal(locale: ICU4XLocale, provider: ICU4XDataProvider): ICU4XPluralRules | never;
+  static try_new_ordinal(provider: ICU4XDataProvider, locale: ICU4XLocale): ICU4XPluralRules | never;
 
   /**
 

--- a/ffi/diplomat/wasm/lib/ICU4XPluralRules.js
+++ b/ffi/diplomat/wasm/lib/ICU4XPluralRules.js
@@ -18,10 +18,10 @@ export class ICU4XPluralRules {
     }
   }
 
-  static try_new_cardinal(arg_locale, arg_provider) {
+  static try_new_cardinal(arg_provider, arg_locale) {
     return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
-      wasm.ICU4XPluralRules_try_new_cardinal(diplomat_receive_buffer, arg_locale.underlying, arg_provider.underlying);
+      wasm.ICU4XPluralRules_try_new_cardinal(diplomat_receive_buffer, arg_provider.underlying, arg_locale.underlying);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
         const ok_value = new ICU4XPluralRules(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true, []);
@@ -35,10 +35,10 @@ export class ICU4XPluralRules {
     })();
   }
 
-  static try_new_ordinal(arg_locale, arg_provider) {
+  static try_new_ordinal(arg_provider, arg_locale) {
     return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
-      wasm.ICU4XPluralRules_try_new_ordinal(diplomat_receive_buffer, arg_locale.underlying, arg_provider.underlying);
+      wasm.ICU4XPluralRules_try_new_ordinal(diplomat_receive_buffer, arg_provider.underlying, arg_locale.underlying);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
         const ok_value = new ICU4XPluralRules(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true, []);

--- a/ffi/diplomat/wasm/lib/ICU4XTimeFormatter.d.ts
+++ b/ffi/diplomat/wasm/lib/ICU4XTimeFormatter.d.ts
@@ -21,7 +21,7 @@ export class ICU4XTimeFormatter {
    * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.DateFormatter.html#method.try_new Rust documentation} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
-  static try_new(locale: ICU4XLocale, provider: ICU4XDataProvider, length: ICU4XTimeLength, preferences: ICU4XHourCyclePreference): ICU4XTimeFormatter | never;
+  static try_new(provider: ICU4XDataProvider, locale: ICU4XLocale, length: ICU4XTimeLength, preferences: ICU4XHourCyclePreference): ICU4XTimeFormatter | never;
 
   /**
 

--- a/ffi/diplomat/wasm/lib/ICU4XTimeFormatter.js
+++ b/ffi/diplomat/wasm/lib/ICU4XTimeFormatter.js
@@ -18,10 +18,10 @@ export class ICU4XTimeFormatter {
     }
   }
 
-  static try_new(arg_locale, arg_provider, arg_length, arg_preferences) {
+  static try_new(arg_provider, arg_locale, arg_length, arg_preferences) {
     return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
-      wasm.ICU4XTimeFormatter_try_new(diplomat_receive_buffer, arg_locale.underlying, arg_provider.underlying, ICU4XTimeLength_js_to_rust[arg_length], ICU4XHourCyclePreference_js_to_rust[arg_preferences]);
+      wasm.ICU4XTimeFormatter_try_new(diplomat_receive_buffer, arg_provider.underlying, arg_locale.underlying, ICU4XTimeLength_js_to_rust[arg_length], ICU4XHourCyclePreference_js_to_rust[arg_preferences]);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
         const ok_value = new ICU4XTimeFormatter(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true, []);

--- a/ffi/diplomat/wasm/test/data-providers.mjs
+++ b/ffi/diplomat/wasm/test/data-providers.mjs
@@ -15,7 +15,7 @@ test("use create_from_byte_slice to format a simple decimal", async t => {
   const bytes = new Uint8Array(nodeBuffer.buffer, nodeBuffer.byteOffset, nodeBuffer.length);
   const provider = ICU4XDataProvider.create_from_byte_slice(bytes);
 
-  const format = ICU4XFixedDecimalFormatter.try_new(locale, provider, "Auto");
+  const format = ICU4XFixedDecimalFormatter.try_new(provider, locale, "Auto");
 
   const decimal = ICU4XFixedDecimal.create(1234);
   decimal.multiply_pow10(-2);

--- a/ffi/diplomat/wasm/test/fixed-decimal-format.mjs
+++ b/ffi/diplomat/wasm/test/fixed-decimal-format.mjs
@@ -8,7 +8,7 @@ import { ICU4XFixedDecimal, ICU4XLocale, ICU4XDataProvider, ICU4XFixedDecimalFor
 
 const locale = ICU4XLocale.create("bn");
 const dataProvider = ICU4XDataProvider.create_test();
-const format = ICU4XFixedDecimalFormatter.try_new(locale, dataProvider, "Auto");
+const format = ICU4XFixedDecimalFormatter.try_new(dataProvider, locale, "Auto");
 
 test("format a simple decimal", t => {
   const decimal = ICU4XFixedDecimal.create(1234);


### PR DESCRIPTION
Progress on #2136 

This does not do ZonedDateTimeFormat because that one's complicated with multiple types of providers and I'd rather do that one in its own PR.