### PR TITLE
Use ndarray 0.15 instead of a commit hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2221,8 +2221,9 @@ checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "ndarray"
-version = "0.15.4"
-source = "git+https://github.com/rust-ndarray/ndarray?rev=31244100631382bb8ee30721872a928bfdf07f44#31244100631382bb8ee30721872a928bfdf07f44"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
 dependencies = [
  "matrixmultiply",
  "num-complex",

--- a/experimental/segmenter/Cargo.toml
+++ b/experimental/segmenter/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "1.0", default-features = false, features = ["derive", "allo
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 zerovec = { version = "0.7", path = "../../utils/zerovec", features = ["yoke"] }
 databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"] }
-ndarray = { version = "0.15", default-features = false, optional = true, features = ["serde"] }
+ndarray = { version = "0.15.5", default-features = false, optional = true, features = ["serde"] }
 unicode-segmentation = { version = "1.3.0", optional = true }
 num-traits = { version = "0.2", optional = true }
 icu_locid = { version = "0.6", path = "../../components/locid" }

--- a/experimental/segmenter/Cargo.toml
+++ b/experimental/segmenter/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "1.0", default-features = false, features = ["derive", "allo
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 zerovec = { version = "0.7", path = "../../utils/zerovec", features = ["yoke"] }
 databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"] }
-ndarray = { git = "https://github.com/rust-ndarray/ndarray", rev = "31244100631382bb8ee30721872a928bfdf07f44", default-features = false, optional = true, features = ["serde"] }
+ndarray = { version = "0.15", default-features = false, optional = true, features = ["serde"] }
 unicode-segmentation = { version = "1.3.0", optional = true }
 num-traits = { version = "0.2", optional = true }
 icu_locid = { version = "0.6", path = "../../components/locid" }


### PR DESCRIPTION
As of this patch, the latest release version of ndarray 0.15 is 0.15.6.

Fixed #2280.
