### PR TITLE
doc-hidden CaseMappingData field

### DIFF
--- a/experimental/casemapping/src/internals.rs
+++ b/experimental/casemapping/src/internals.rs
@@ -100,7 +100,9 @@ impl DotType {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_casemapping::provider))]
-pub struct CaseMappingData(pub u16);
+// field is doc(hidden) so that databake can work, though it's unclear if
+// this field has invariants
+pub struct CaseMappingData(#[doc(hidden)] pub u16);
 
 impl CaseMappingData {
     // Sequences of case-ignorable characters are skipped when determining


### PR DESCRIPTION
This is a followup from https://github.com/unicode-org/icu4x/pull/2301. I added a public field there so that `databake` could work, noting that CaseMappingData doesn't apprear to have any invariants.

cc @iainireland can you verify that that is the case re: invariants?

Either way, it's probably nicer for this to be doc(hidden) until we know for sure. We can also write a nicer manual databake impl that uses a constructor function if preferred.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->