### PR TITLE
Fix root Readme example to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,39 +24,45 @@ More information about the project can be found in [the docs subdirectory](docs/
 
 ## Quick Start
 
-An example `ICU4X` powered application in Rust may look like this:
+An example `ICU4X` powered application in Rust may look like below...
+
+`Cargo.toml`:
 
 ```toml
-icu = "0.2"
-icu_provider_fs = "0.2"
+[dependencies]
+icu = "1.0.0-beta1"
+icu_provider_fs = "1.0.0-beta1"
+icu_testdata = "1.0.0-beta1"
+icu_datetime = "1.0.0-beta1"
+
+[features]
+serde = ["icu_datetime/serde"]
 ```
 
+`src/main.rs`:
+
 ```rust
+use icu::datetime::{mock::parse_gregorian_from_str, options::length, TypedDateTimeFormatter};
 use icu::locid::locale;
-use icu::datetime::{DateTimeFormat, mock::datetime::MockDateTime, options::length};
-use icu_provider_fs::FsDataProvider;
 
 fn main() {
-    let date: MockDateTime = "2020-10-14T13:21:00".parse()
-        .expect("Failed to parse a datetime.");
+    let provider = icu_testdata::get_provider();
 
-    let provider = FsDataProvider::try_new("/home/{USER}/projects/icu/icu4x-data")
-        .expect("Failed to initialize Data Provider.");
+    let options =
+        length::Bag::from_date_time_style(length::Date::Long, length::Time::Medium).into();
 
-    let options = length::Bag {
-        time: Some(length::Time::Medium),
-        date: Some(length::Date::Long),
-        ..Default::default()
-    }.into();
+    let dtf = TypedDateTimeFormatter::try_new_with_buffer_provider(&provider, &locale!("es").into(), options)
+        .expect("Failed to create TypedDateTimeFormatter instance.");
 
-    let dtf = DateTimeFormat::try_new(locale!("pl"), &provider, &options)
-        .expect("Failed to initialize DateTimeFormat");
+    let date = parse_gregorian_from_str("2020-09-12T12:35:00").expect("Failed to parse date.");
 
     let formatted_date = dtf.format(&date);
 
     println!("📅: {}", formatted_date);
 }
 ```
+
+...which can be run by `cargo run --all-features`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ fn main() {
 }
 ```
 
-...which can be run by `cargo run --all-features`.
-
 ## Development
 
 `ICU4X` is developed by the `ICU4X-SC`. We are a subcommittee of ICU-TC in the Unicode Consortium focused on providing solutions for client-side internationalization.  See [unicode.org](https://www.unicode.org/consortium/techchairs.html) for more information on our governance.

--- a/README.md
+++ b/README.md
@@ -32,9 +32,6 @@ An example `ICU4X` powered application in Rust may look like below...
 [dependencies]
 icu = { version = "1.0.0-beta1", features = ["serde"] }
 icu_testdata = "1.0.0-beta1"
-
-[features]
-serde = ["icu_datetime/serde"]
 ```
 
 `src/main.rs`:

--- a/README.md
+++ b/README.md
@@ -30,10 +30,8 @@ An example `ICU4X` powered application in Rust may look like below...
 
 ```toml
 [dependencies]
-icu = "1.0.0-beta1"
-icu_provider_fs = "1.0.0-beta1"
+icu = { version = "1.0.0-beta1", features = ["serde"] }
 icu_testdata = "1.0.0-beta1"
-icu_datetime = "1.0.0-beta1"
 
 [features]
 serde = ["icu_datetime/serde"]


### PR DESCRIPTION
Fixes #2352 

Does:
- update version from `0.2` to `1.0.0-beta1`
- updates code most based on what is in the example at the root of the `icu` component
- does best guess effort of how to get it to work

I tested using a local throwaway local Cargo project.

FYI @sven-oly 