### PR TITLE
Grey out unusable time styles in WASM demo

### DIFF
--- a/ffi/diplomat/wasm/wasm-demo/index.html
+++ b/ffi/diplomat/wasm/wasm-demo/index.html
@@ -194,11 +194,12 @@
 
                         Time length
                         <div class="btn-toolbar" role="toolbar" aria-label="DateTime Formatting options">
-                            <div class="btn-group" role="group" aria-label="DateTime Formatting Locale">
-                                <input type="radio" class="btn-check" name="dtf-time-length" id="dtf-time-length-full" value="Full">
+                            <div class="btn-group" role="group" aria-label="DateTime Formatting Locale"
+                                 title="Demo doesn't currently support full/long time styles as they need timezone support, which is available in ICU4X but not this demo">
+                                <input type="radio" class="btn-check" name="dtf-time-length" id="dtf-time-length-full" value="Full" disabled>
                                 <label class="btn btn-outline-primary" for="dtf-time-length-full">Full</label>
 
-                                <input type="radio" class="btn-check" name="dtf-time-length" id="dtf-time-length-long" value="Long">
+                                <input type="radio" class="btn-check" name="dtf-time-length" id="dtf-time-length-long" value="Long" disabled>
                                 <label class="btn btn-outline-primary" for="dtf-time-length-long">Long</label>
 
                                 <input type="radio" class="btn-check" name="dtf-time-length" id="dtf-time-length-medium" value="Medium">


### PR DESCRIPTION
We can turn these on when we switch over to ZonedDTF


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->