### PR TITLE
Fix link generated in CI

### DIFF
--- a/.github/workflows/artifacts-info.yml
+++ b/.github/workflows/artifacts-info.yml
@@ -32,5 +32,5 @@ jobs:
         echo "${{ github.event.pull_request.head.repo.html_url }}/actions/workflows/artifacts-build.yml"
         echo "::endgroup::"
         echo "::group::Wasm Demo Preview"
-        echo "https://storage.googleapis.com/icu4x-pr-artifacts/gha/${{ github.sha }}/wasm-demo/index.html"
+        echo "http://${{ env.GCP_BUCKET_ID }}.storage.googleapis.com/gha/${{ github.event.pull_request.head.sha }}/wasm-demo/index.html"
         echo "::endgroup::"


### PR DESCRIPTION
Fixes the links printed in the "Uploaded Artifacts" CI step so that it correctly gives the link to the wasm demo corresponding to the PR the CI is running in.