### PR TITLE
Singleton testdata providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32",
  "serde",
- "spin",
+ "spin 0.9.2",
  "stable_deref_trait",
 ]
 
@@ -1822,6 +1822,7 @@ dependencies = [
  "icu_provider_fs",
  "icu_segmenter",
  "icu_timezone",
+ "lazy_static",
  "litemap",
  "log",
  "reqwest",
@@ -1962,6 +1963,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "leb128"
@@ -3063,6 +3067,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"

--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -54,8 +54,8 @@ use yoke::*;
 /// ```
 ///
 /// [`StaticDataProvider`]: crate::StaticDataProvider
+#[derive(Clone)]
 pub struct BlobDataProvider {
-    #[allow(clippy::type_complexity)]
     data: Yoke<BlobSchemaV1<'static>, RcWrap<[u8]>>,
 }
 

--- a/provider/blob/src/blob_schema.rs
+++ b/provider/blob/src/blob_schema.rs
@@ -15,7 +15,7 @@ pub(crate) enum BlobSchema<'data> {
 }
 
 /// Version 1 of the ICU4X data blob schema.
-#[derive(serde::Deserialize, yoke::Yokeable)]
+#[derive(Clone, Copy, serde::Deserialize, yoke::Yokeable)]
 #[yoke(prove_covariance_manually)]
 #[cfg_attr(feature = "export", derive(serde::Serialize))]
 pub(crate) struct BlobSchemaV1<'data> {

--- a/provider/blob/src/static_data_provider.rs
+++ b/provider/blob/src/static_data_provider.rs
@@ -46,6 +46,7 @@ use serde::de::Deserialize;
 /// ```
 ///
 /// [`BlobDataProvider`]: crate::BlobDataProvider
+#[derive(Clone, Copy)]
 pub struct StaticDataProvider {
     data: BlobSchemaV1<'static>,
 }

--- a/provider/fs/src/fs_data_provider.rs
+++ b/provider/fs/src/fs_data_provider.rs
@@ -19,7 +19,7 @@ use writeable::Writeable;
 /// let provider = FsDataProvider::try_new("/path/to/data/directory")
 ///     .expect_err("Specify a real directory in the line above");
 /// ```
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct FsDataProvider {
     root: PathBuf,
     manifest: Manifest,

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -280,6 +280,7 @@ icu_provider = { version = "1.0.0-beta1", path = "../core" }
 icu_provider_adapters = { version = "1.0.0-beta1", path = "../adapters", optional = true }
 icu_provider_blob = { version = "1.0.0-beta1", path = "../blob", optional = true }
 icu_provider_fs = { version = "1.0.0-beta1", path = "../fs", optional = true }
+lazy_static = { version = "1", features = ["spin_no_std"], optional = true }
 
 # bin feature
 bytes = {version = "1.1.0", optional = true }
@@ -334,11 +335,12 @@ metadata = [
     "writeable",
     "std"
 ]
-fs = ["icu_provider/deserialize_json", "icu_provider_fs", "std"]
+fs = ["icu_provider/deserialize_json", "icu_provider_fs", "std", "lazy_static"]
 static = [
     "icu_provider_blob",
     "icu_provider_adapters",
     "icu_provider_adapters/serde",
+    "lazy_static",
 ]
 baked = [
     "icu_list",

--- a/provider/testdata/src/lib.rs
+++ b/provider/testdata/src/lib.rs
@@ -98,41 +98,60 @@ use icu_provider_fs::FsDataProvider;
 #[allow(clippy::panic)]
 #[cfg(feature = "fs")]
 pub fn get_json_provider() -> FsDataProvider {
-    let path = match std::env::var_os("ICU4X_TESTDATA_DIR") {
-        Some(val) => val.into(),
-        None => paths::data_root().join("json"),
+    lazy_static::lazy_static! {
+        static ref JSON: FsDataProvider = {
+            let path = match std::env::var_os("ICU4X_TESTDATA_DIR") {
+                Some(val) => val.into(),
+                None => paths::data_root().join("json"),
+            };
+            // The statically compiled data file is valid.
+            #[allow(clippy::unwrap_used)]
+            FsDataProvider::try_new(&path).unwrap_or_else(|err| {
+                panic!(
+                    "The test data directory was unable to be opened: {}: {:?}",
+                    err, path
+                )
+            })
+        };
+    }
+    (*JSON).clone()
+}
+
+#[cfg(feature = "static")]
+lazy_static::lazy_static! {
+    static ref POSTCARD: StaticDataProvider = {
+        // The statically compiled data file is valid.
+        #[allow(clippy::unwrap_used)]
+        StaticDataProvider::try_new_from_static_blob(include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/data/testdata.postcard"
+        )))
+        .unwrap()
     };
-    FsDataProvider::try_new(&path).unwrap_or_else(|err| {
-        panic!(
-            "The test data directory was unable to be opened: {}: {:?}",
-            err, path
-        )
-    })
 }
 
 /// Get a data provider, loading from the statically initialized postcard blob.
 #[cfg(feature = "static")]
 pub fn get_postcard_provider() -> StaticDataProvider {
-    // The statically compiled data file is valid.
-    #[allow(clippy::unwrap_used)]
-    StaticDataProvider::try_new_from_static_blob(include_bytes!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/data/testdata.postcard"
-    )))
-    .unwrap()
+    *POSTCARD
 }
 
 /// Get a small data provider that only contains the `decimal/symbols@1[u-nu]` key
 /// for `en` and `bn`.
 #[cfg(feature = "static")]
 pub fn get_smaller_postcard_provider() -> StaticDataProvider {
-    // The statically compiled data file is valid.
-    #[allow(clippy::unwrap_used)]
-    StaticDataProvider::try_new_from_static_blob(include_bytes!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/data/decimal-bn-en.postcard"
-    )))
-    .unwrap()
+    lazy_static::lazy_static! {
+        static ref SMALLER_POSTCARD: StaticDataProvider = {
+            // The statically compiled data file is valid.
+            #[allow(clippy::unwrap_used)]
+            StaticDataProvider::try_new_from_static_blob(include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/data/decimal-bn-en.postcard"
+            )))
+            .unwrap()
+        };
+    }
+    *SMALLER_POSTCARD
 }
 
 #[cfg(feature = "baked")]
@@ -153,5 +172,5 @@ pub fn get_baked_provider() -> BakedDataProvider {
 pub fn get_provider() -> LocaleFallbackProvider<StaticDataProvider> {
     // The statically compiled data file is valid.
     #[allow(clippy::unwrap_used)]
-    LocaleFallbackProvider::try_new_unstable(get_postcard_provider()).unwrap()
+    LocaleFallbackProvider::try_new_unstable(*POSTCARD).unwrap()
 }

--- a/utils/yoke/derive/src/lib.rs
+++ b/utils/yoke/derive/src/lib.rs
@@ -167,6 +167,7 @@ fn yokeable_derive_impl(input: &DeriveInput) -> TokenStream2 {
                         // are the same
                         debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
                         let ptr: *const Self = (&this as *const Self::Output).cast();
+                        #[allow(clippy::forget_copy)] // This is a noop if the struct is copy, which Clippy doesn't like
                         mem::forget(this);
                         ptr::read(ptr)
                     }


### PR DESCRIPTION
This saves some deserialization overhead during testing and allows returning `DeserializingBufferProvider` (#2364)