### PR TITLE
Add missing doc for segmenter, and turn on the missing_docs warning

### DIFF
--- a/experimental/segmenter/README.md
+++ b/experimental/segmenter/README.md
@@ -30,59 +30,11 @@ let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
 assert_eq!(&breakpoints, &[6, 11]);
 ```
 
-Segment a string with CSS option overrides:
-
-```rust
-use icu_segmenter::{LineBreakOptions, LineBreakRule, LineBreakSegmenter, WordBreakRule};
-
-let mut options = LineBreakOptions::default();
-options.line_break_rule = LineBreakRule::Strict;
-options.word_break_rule = WordBreakRule::BreakAll;
-options.ja_zh = false;
-let provider = icu_testdata::get_provider();
-let segmenter =
-    LineBreakSegmenter::try_new_with_options(&provider, options).expect("Data exists");
-
-let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
-assert_eq!(&breakpoints, &[1, 2, 3, 4, 6, 7, 8, 9, 10, 11]);
-```
-
-Segment a Latin1 byte string:
-
-```rust
-use icu_segmenter::LineBreakSegmenter;
-
-let provider = icu_testdata::get_provider();
-let segmenter = LineBreakSegmenter::try_new(&provider).expect("Data exists");
-
-let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
-assert_eq!(&breakpoints, &[6, 11]);
-```
+See [`LineBreakSegmenter`] for more examples.
 
 ### Grapheme Cluster Break
 
-Segment a string:
-
-```rust
-use icu_segmenter::GraphemeClusterBreakSegmenter;
-let provider = icu_testdata::get_provider();
-let segmenter = GraphemeClusterBreakSegmenter::try_new(&provider).expect("Data exists");
-
-let breakpoints: Vec<usize> = segmenter.segment_str("Hello 🗺").collect();
-// World Map (U+1F5FA) is encoded in four bytes in UTF-8.
-assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 10]);
-```
-
-Segment a Latin1 byte string:
-
-```rust
-use icu_segmenter::GraphemeClusterBreakSegmenter;
-let provider = icu_testdata::get_provider();
-let segmenter = GraphemeClusterBreakSegmenter::try_new(&provider).expect("Data exists");
-
-let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
-assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
-```
+See [`GraphemeClusterBreakSegmenter`] for examples.
 
 ### Word Break
 
@@ -97,40 +49,11 @@ let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
 assert_eq!(&breakpoints, &[0, 5, 6, 11]);
 ```
 
-Segment a Latin1 byte string:
-
-```rust
-use icu_segmenter::WordBreakSegmenter;
-let provider = icu_testdata::get_provider();
-let segmenter = WordBreakSegmenter::try_new(&provider).expect("Data exists");
-
-let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
-assert_eq!(&breakpoints, &[0, 5, 6, 11]);
-```
+See [`WordBreakSegmenter`] for more examples.
 
 ### Sentence Break
 
-Segment a string:
-
-```rust
-use icu_segmenter::SentenceBreakSegmenter;
-let provider = icu_testdata::get_provider();
-let segmenter = SentenceBreakSegmenter::try_new(&provider).expect("Data exists");
-
-let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
-assert_eq!(&breakpoints, &[0, 11]);
-```
-
-Segment a Latin1 byte string:
-
-```rust
-use icu_segmenter::SentenceBreakSegmenter;
-let provider = icu_testdata::get_provider();
-let segmenter = SentenceBreakSegmenter::try_new(&provider).expect("Data exists");
-
-let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
-assert_eq!(&breakpoints, &[0, 11]);
-```
+See [`SentenceBreakSegmenter`] for examples.
 
 ## More Information
 

--- a/experimental/segmenter/src/grapheme.rs
+++ b/experimental/segmenter/src/grapheme.rs
@@ -24,7 +24,32 @@ pub type GraphemeClusterBreakIteratorUtf16<'l, 's> =
     RuleBreakIterator<'l, 's, GraphemeClusterBreakTypeUtf16>;
 
 /// Supports loading grapheme cluster break data, and creating grapheme cluster break iterators for
-/// different string encodings. Please see the [module-level documentation](crate) for its usages.
+/// different string encodings.
+///
+/// # Examples
+///
+/// Segment a string:
+///
+/// ```rust
+/// use icu_segmenter::GraphemeClusterBreakSegmenter;
+/// let provider = icu_testdata::get_provider();
+/// let segmenter = GraphemeClusterBreakSegmenter::try_new(&provider).expect("Data exists");
+///
+/// let breakpoints: Vec<usize> = segmenter.segment_str("Hello 🗺").collect();
+/// // World Map (U+1F5FA) is encoded in four bytes in UTF-8.
+/// assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 10]);
+/// ```
+///
+/// Segment a Latin1 byte string:
+///
+/// ```rust
+/// use icu_segmenter::GraphemeClusterBreakSegmenter;
+/// let provider = icu_testdata::get_provider();
+/// let segmenter = GraphemeClusterBreakSegmenter::try_new(&provider).expect("Data exists");
+///
+/// let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
+/// assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+/// ```
 pub struct GraphemeClusterBreakSegmenter {
     payload: DataPayload<GraphemeClusterBreakDataV1Marker>,
     dictionary: Dictionary,

--- a/experimental/segmenter/src/grapheme.rs
+++ b/experimental/segmenter/src/grapheme.rs
@@ -32,6 +32,7 @@ pub struct GraphemeClusterBreakSegmenter {
 }
 
 impl GraphemeClusterBreakSegmenter {
+    /// Construct a [`GraphemeClusterBreakSegmenter`].
     pub fn try_new<D>(provider: &D) -> Result<Self, DataError>
     where
         D: DataProvider<GraphemeClusterBreakDataV1Marker> + ?Sized,

--- a/experimental/segmenter/src/lib.rs
+++ b/experimental/segmenter/src/lib.rs
@@ -138,6 +138,7 @@
 //! ```
 
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![warn(missing_docs)]
 
 extern crate alloc;
 
@@ -152,6 +153,8 @@ mod line;
 mod sentence;
 mod word;
 
+// icu_datagen uses provider, but we don't want to expose this implementation detail to the users.
+#[doc(hidden)]
 pub mod provider;
 
 // icu_datagen uses symbols, but we don't want to expose this implementation detail to the users.

--- a/experimental/segmenter/src/lib.rs
+++ b/experimental/segmenter/src/lib.rs
@@ -32,59 +32,11 @@
 //! assert_eq!(&breakpoints, &[6, 11]);
 //! ```
 //!
-//! Segment a string with CSS option overrides:
-//!
-//! ```rust
-//! use icu_segmenter::{LineBreakOptions, LineBreakRule, LineBreakSegmenter, WordBreakRule};
-//!
-//! let mut options = LineBreakOptions::default();
-//! options.line_break_rule = LineBreakRule::Strict;
-//! options.word_break_rule = WordBreakRule::BreakAll;
-//! options.ja_zh = false;
-//! let provider = icu_testdata::get_provider();
-//! let segmenter =
-//!     LineBreakSegmenter::try_new_with_options(&provider, options).expect("Data exists");
-//!
-//! let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
-//! assert_eq!(&breakpoints, &[1, 2, 3, 4, 6, 7, 8, 9, 10, 11]);
-//! ```
-//!
-//! Segment a Latin1 byte string:
-//!
-//! ```rust
-//! use icu_segmenter::LineBreakSegmenter;
-//!
-//! let provider = icu_testdata::get_provider();
-//! let segmenter = LineBreakSegmenter::try_new(&provider).expect("Data exists");
-//!
-//! let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
-//! assert_eq!(&breakpoints, &[6, 11]);
-//! ```
+//! See [`LineBreakSegmenter`] for more examples.
 //!
 //! ## Grapheme Cluster Break
 //!
-//! Segment a string:
-//!
-//!```rust
-//! use icu_segmenter::GraphemeClusterBreakSegmenter;
-//! let provider = icu_testdata::get_provider();
-//! let segmenter = GraphemeClusterBreakSegmenter::try_new(&provider).expect("Data exists");
-//!
-//! let breakpoints: Vec<usize> = segmenter.segment_str("Hello 🗺").collect();
-//! // World Map (U+1F5FA) is encoded in four bytes in UTF-8.
-//! assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 10]);
-//! ```
-//!
-//! Segment a Latin1 byte string:
-//!
-//! ```rust
-//! use icu_segmenter::GraphemeClusterBreakSegmenter;
-//! let provider = icu_testdata::get_provider();
-//! let segmenter = GraphemeClusterBreakSegmenter::try_new(&provider).expect("Data exists");
-//!
-//! let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
-//! assert_eq!(&breakpoints, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
-//! ```
+//! See [`GraphemeClusterBreakSegmenter`] for examples.
 //!
 //! ## Word Break
 //!
@@ -99,40 +51,11 @@
 //! assert_eq!(&breakpoints, &[0, 5, 6, 11]);
 //! ```
 //!
-//! Segment a Latin1 byte string:
-//!
-//! ```rust
-//! use icu_segmenter::WordBreakSegmenter;
-//! let provider = icu_testdata::get_provider();
-//! let segmenter = WordBreakSegmenter::try_new(&provider).expect("Data exists");
-//!
-//! let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
-//! assert_eq!(&breakpoints, &[0, 5, 6, 11]);
-//! ```
+//! See [`WordBreakSegmenter`] for more examples.
 //!
 //! ## Sentence Break
 //!
-//! Segment a string:
-//!
-//!```rust
-//! use icu_segmenter::SentenceBreakSegmenter;
-//! let provider = icu_testdata::get_provider();
-//! let segmenter = SentenceBreakSegmenter::try_new(&provider).expect("Data exists");
-//!
-//! let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
-//! assert_eq!(&breakpoints, &[0, 11]);
-//! ```
-//!
-//! Segment a Latin1 byte string:
-//!
-//! ```rust
-//! use icu_segmenter::SentenceBreakSegmenter;
-//! let provider = icu_testdata::get_provider();
-//! let segmenter = SentenceBreakSegmenter::try_new(&provider).expect("Data exists");
-//!
-//! let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
-//! assert_eq!(&breakpoints, &[0, 11]);
-//! ```
+//! See [`SentenceBreakSegmenter`] for examples.
 
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![warn(missing_docs)]

--- a/experimental/segmenter/src/lib.rs
+++ b/experimental/segmenter/src/lib.rs
@@ -2,9 +2,6 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-// TODO: Document all exported types in this module
-// #![warn(missing_docs)]
-
 //! \[Experimental\] Segment strings by lines, graphemes, word, and sentences.
 //!
 //! This module is published as its own crate ([`icu_segmenter`](https://docs.rs/icu_segmenter/latest/icu_segmenter/))
@@ -153,8 +150,6 @@ mod line;
 mod sentence;
 mod word;
 
-// icu_datagen uses provider, but we don't want to expose this implementation detail to the users.
-#[doc(hidden)]
 pub mod provider;
 
 // icu_datagen uses symbols, but we don't want to expose this implementation detail to the users.

--- a/experimental/segmenter/src/line.rs
+++ b/experimental/segmenter/src/line.rs
@@ -113,6 +113,7 @@ pub struct LineBreakSegmenter {
 }
 
 impl LineBreakSegmenter {
+    /// Construct a [`LineBreakSegmenter`] with default [`LineBreakOptions`].
     #[cfg(feature = "lstm")]
     pub fn try_new<D>(provider: &D) -> Result<Self, DataError>
     where
@@ -121,6 +122,7 @@ impl LineBreakSegmenter {
         Self::try_new_with_options(provider, Default::default())
     }
 
+    /// Construct a [`LineBreakSegmenter`] with default [`LineBreakOptions`].
     #[cfg(not(feature = "lstm"))]
     pub fn try_new<D>(provider: &D) -> Result<Self, DataError>
     where
@@ -131,6 +133,7 @@ impl LineBreakSegmenter {
         Self::try_new_with_options(provider, Default::default())
     }
 
+    /// Construct a [`LineBreakSegmenter`] with custom [`LineBreakOptions`].
     #[cfg(feature = "lstm")]
     pub fn try_new_with_options<D>(
         provider: &D,
@@ -159,6 +162,7 @@ impl LineBreakSegmenter {
         })
     }
 
+    /// Construct a [`LineBreakSegmenter`] with custom [`LineBreakOptions`].
     #[cfg(not(feature = "lstm"))]
     pub fn try_new_with_options<D>(
         provider: &D,

--- a/experimental/segmenter/src/line.rs
+++ b/experimental/segmenter/src/line.rs
@@ -104,7 +104,50 @@ pub type LineBreakIteratorLatin1<'l, 's> = LineBreakIterator<'l, 's, LineBreakTy
 pub type LineBreakIteratorUtf16<'l, 's> = LineBreakIterator<'l, 's, LineBreakTypeUtf16>;
 
 /// Supports loading line break data, and creating line break iterators for different string
-/// encodings. Please see the [module-level documentation](crate) for its usages.
+/// encodings.
+///
+/// # Examples
+///
+/// Segment a string with default options:
+///
+/// ```rust
+/// use icu_segmenter::LineBreakSegmenter;
+///
+/// let provider = icu_testdata::get_provider();
+/// let segmenter = LineBreakSegmenter::try_new(&provider).expect("Data exists");
+///
+/// let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
+/// assert_eq!(&breakpoints, &[6, 11]);
+/// ```
+///
+/// Segment a string with CSS option overrides:
+///
+/// ```rust
+/// use icu_segmenter::{LineBreakOptions, LineBreakRule, LineBreakSegmenter, WordBreakRule};
+///
+/// let mut options = LineBreakOptions::default();
+/// options.line_break_rule = LineBreakRule::Strict;
+/// options.word_break_rule = WordBreakRule::BreakAll;
+/// options.ja_zh = false;
+/// let provider = icu_testdata::get_provider();
+/// let segmenter =
+///     LineBreakSegmenter::try_new_with_options(&provider, options).expect("Data exists");
+///
+/// let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
+/// assert_eq!(&breakpoints, &[1, 2, 3, 4, 6, 7, 8, 9, 10, 11]);
+/// ```
+///
+/// Segment a Latin1 byte string:
+///
+/// ```rust
+/// use icu_segmenter::LineBreakSegmenter;
+///
+/// let provider = icu_testdata::get_provider();
+/// let segmenter = LineBreakSegmenter::try_new(&provider).expect("Data exists");
+///
+/// let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
+/// assert_eq!(&breakpoints, &[6, 11]);
+/// ```
 pub struct LineBreakSegmenter {
     options: LineBreakOptions,
     payload: DataPayload<LineBreakDataV1Marker>,
@@ -483,14 +526,12 @@ pub trait LineBreakType<'l, 's> {
 }
 
 /// Implements the [`Iterator`] trait over the line break opportunities of the given string. Please
-/// see the [module-level documentation](crate) for its usages.
+/// see the examples in [`LineBreakSegmenter`] for its usages.
 ///
 /// Lifetimes:
 ///
 /// - `'l` = lifetime of the [`LineBreakSegmenter`] object from which this iterator was created
 /// - `'s` = lifetime of the string being segmented
-///
-/// [`Iterator`]: core::iter::Iterator
 pub struct LineBreakIterator<'l, 's, Y: LineBreakType<'l, 's> + ?Sized> {
     iter: Y::IterAttr,
     len: usize,

--- a/experimental/segmenter/src/provider.rs
+++ b/experimental/segmenter/src/provider.rs
@@ -42,9 +42,18 @@ pub struct RuleBreakDataV1<'data> {
     /// Number of properties; should be the square root of the length of [`Self::break_state_table`].
     pub property_count: u8,
 
+    /// The index of the last simple state for [`Self::break_state_table`]. (A simple state has no
+    /// `left` nor `right` in SegmenterProperty).
     pub last_codepoint_property: i8,
+
+    /// The index of SOT (start of text) state for [`Self::break_state_table`].
     pub sot_property: u8,
+
+    /// The index of EOT (end of text) state [`Self::break_state_table`].
     pub eot_property: u8,
+
+    /// The index of "SA" state (or 127 if the complex language isn't handled) for
+    /// [`Self::break_state_table`].
     pub complex_property: u8,
 }
 
@@ -97,15 +106,17 @@ pub struct UCharDictionaryBreakDataV1<'data> {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[yoke(prove_covariance_manually)]
 pub struct LstmMatrix<'data> {
+    #[allow(missing_docs)]
     #[cfg_attr(feature = "serde", serde(borrow))]
     pub dim: ZeroVec<'data, i16>,
+    #[allow(missing_docs)]
     #[cfg_attr(feature = "serde", serde(borrow))]
     pub data: ZeroVec<'data, f32>,
 }
 
 #[cfg(feature = "lstm")]
 impl<'data> LstmMatrix<'data> {
-    pub fn as_ndarray1(&self) -> Result<Array1<f32>, Error> {
+    pub(crate) fn as_ndarray1(&self) -> Result<Array1<f32>, Error> {
         if self.dim.len() == 1 {
             Ok(Array::from_vec(self.data.to_vec()))
         } else {
@@ -113,7 +124,7 @@ impl<'data> LstmMatrix<'data> {
         }
     }
 
-    pub fn as_ndarray2(&self) -> Result<Array2<f32>, Error> {
+    pub(crate) fn as_ndarray2(&self) -> Result<Array2<f32>, Error> {
         if self.dim.len() == 2 {
             Array::from_shape_vec(
                 (

--- a/experimental/segmenter/src/rule_segmenter.rs
+++ b/experimental/segmenter/src/rule_segmenter.rs
@@ -24,14 +24,11 @@ pub trait RuleBreakType<'l, 's> {
 }
 
 /// Implements the [`Iterator`] trait over the segmenter break opportunities of the given string.
-/// Please see the [module-level documentation](crate) for its usages.
 ///
 /// Lifetimes:
 ///
 /// - `'l` = lifetime of the segmenter object from which this iterator was created
 /// - `'s` = lifetime of the string being segmented
-///
-/// [`Iterator`]: core::iter::Iterator
 pub struct RuleBreakIterator<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> {
     pub(crate) iter: Y::IterAttr,
     pub(crate) len: usize,

--- a/experimental/segmenter/src/sentence.rs
+++ b/experimental/segmenter/src/sentence.rs
@@ -21,7 +21,31 @@ pub type SentenceBreakIteratorLatin1<'l, 's> = RuleBreakIterator<'l, 's, Sentenc
 pub type SentenceBreakIteratorUtf16<'l, 's> = RuleBreakIterator<'l, 's, SentenceBreakTypeUtf16>;
 
 /// Supports loading sentence break data, and creating sentence break iterators for different string
-/// encodings. Please see the [module-level documentation](crate) for its usages.
+/// encodings.
+///
+/// # Examples
+///
+/// Segment a string:
+///
+/// ```rust
+/// use icu_segmenter::SentenceBreakSegmenter;
+/// let provider = icu_testdata::get_provider();
+/// let segmenter = SentenceBreakSegmenter::try_new(&provider).expect("Data exists");
+///
+/// let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
+/// assert_eq!(&breakpoints, &[0, 11]);
+/// ```
+///
+/// Segment a Latin1 byte string:
+///
+/// ```rust
+/// use icu_segmenter::SentenceBreakSegmenter;
+/// let provider = icu_testdata::get_provider();
+/// let segmenter = SentenceBreakSegmenter::try_new(&provider).expect("Data exists");
+///
+/// let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
+/// assert_eq!(&breakpoints, &[0, 11]);
+/// ```
 pub struct SentenceBreakSegmenter {
     payload: DataPayload<SentenceBreakDataV1Marker>,
     dictionary: Dictionary,

--- a/experimental/segmenter/src/sentence.rs
+++ b/experimental/segmenter/src/sentence.rs
@@ -29,6 +29,7 @@ pub struct SentenceBreakSegmenter {
 }
 
 impl SentenceBreakSegmenter {
+    /// Construct a [`SentenceBreakSegmenter`].
     pub fn try_new<D>(provider: &D) -> Result<Self, DataError>
     where
         D: DataProvider<SentenceBreakDataV1Marker> + ?Sized,

--- a/experimental/segmenter/src/word.rs
+++ b/experimental/segmenter/src/word.rs
@@ -32,6 +32,7 @@ pub struct WordBreakSegmenter {
 }
 
 impl WordBreakSegmenter {
+    /// Construct a [`WordBreakSegmenter`].
     #[cfg(feature = "lstm")]
     pub fn try_new<D>(provider: &D) -> Result<Self, DataError>
     where
@@ -72,6 +73,7 @@ impl WordBreakSegmenter {
         })
     }
 
+    /// Construct a [`WordBreakSegmenter`].
     #[cfg(not(feature = "lstm"))]
     pub fn try_new<D>(provider: &D) -> Result<Self, DataError>
     where

--- a/experimental/segmenter/src/word.rs
+++ b/experimental/segmenter/src/word.rs
@@ -24,7 +24,31 @@ pub type WordBreakIteratorLatin1<'l, 's> = RuleBreakIterator<'l, 's, WordBreakTy
 pub type WordBreakIteratorUtf16<'l, 's> = RuleBreakIterator<'l, 's, WordBreakTypeUtf16>;
 
 /// Supports loading word break data, and creating word break iterators for different string
-/// encodings. Please see the [module-level documentation](crate) for its usages.
+/// encodings.
+///
+/// # Examples
+///
+/// Segment a string:
+///
+/// ```rust
+/// use icu_segmenter::WordBreakSegmenter;
+/// let provider = icu_testdata::get_provider();
+/// let segmenter = WordBreakSegmenter::try_new(&provider).expect("Data exists");
+///
+/// let breakpoints: Vec<usize> = segmenter.segment_str("Hello World").collect();
+/// assert_eq!(&breakpoints, &[0, 5, 6, 11]);
+/// ```
+///
+/// Segment a Latin1 byte string:
+///
+/// ```rust
+/// use icu_segmenter::WordBreakSegmenter;
+/// let provider = icu_testdata::get_provider();
+/// let segmenter = WordBreakSegmenter::try_new(&provider).expect("Data exists");
+///
+/// let breakpoints: Vec<usize> = segmenter.segment_latin1(b"Hello World").collect();
+/// assert_eq!(&breakpoints, &[0, 5, 6, 11]);
+/// ```
 pub struct WordBreakSegmenter {
     payload: DataPayload<WordBreakDataV1Marker>,
     dictionary: Dictionary,

--- a/provider/datagen/src/transform/segmenter/mod.rs
+++ b/provider/datagen/src/transform/segmenter/mod.rs
@@ -48,7 +48,7 @@ struct SegmenterProperty {
 
 // state machine break result define
 // The follow is "Double_Quote x Double_Quote".
-// [[tables]]
+// [[rules]]
 // left = [ "Double_Qoute" ]
 // right = [ "Double_Qoute" ]
 // break_state = true # true if break opportunity.


### PR DESCRIPTION
I follow the wording of `try_new` in FFI.
https://github.com/unicode-org/icu4x/blob/d0cb377b5a49274d043d1823f806b0c145657ce1/ffi/diplomat/src/segmenter_grapheme.rs#L39