### PR TITLE
Logging in FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
+name = "colored"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,6 +1403,7 @@ dependencies = [
  "log",
  "rustdoc-types",
  "serde_json",
+ "simple_logger",
  "syn-inline-mod",
  "tinystr 0.6.1",
  "unicode-bidi",
@@ -3059,6 +3071,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7de33c687404ec3045d4a0d437580455257c0436f858d702f244e7d652f9f07"
 dependencies = [
  "atty",
+ "chrono",
+ "colored",
  "log",
  "winapi",
 ]

--- a/ffi/capi_cdylib/Cargo.toml
+++ b/ffi/capi_cdylib/Cargo.toml
@@ -44,6 +44,12 @@ smaller_test = ["icu_capi/smaller_test"]
 deserialize_json = ["icu_capi/deserialize_json"]
 deserialize_postcard_07 = ["icu_capi/deserialize_postcard_07"]
 deserialize_bincode_1 = ["icu_capi/deserialize_bincode_1"]
+logging = ["icu_capi/logging"]
+simple_logger = ["icu_capi/simple_logger"]
+
+# meta feature for things we enable by default in wasm
+# do not sync with other crates
+wasm_default = ["provider_test", "logging"]
 
 [package.metadata.cargo-all-features]
 # Omit most optional dependency features from permutation testing
@@ -51,4 +57,6 @@ skip_optional_dependencies = true
 # Bench feature gets tested separately and is only relevant for CI.
 # x86tiny is not relevant in normal environments,
 # smaller_test gets tested on the FFI job anyway
-denylist = ["bench", "smaller_test"]
+# logging enables a feature of a dependency that has no externally visible API changes'
+# wasm_default is a metafeature
+denylist = ["bench", "smaller_test", "logging", "wasm_default"]

--- a/ffi/capi_staticlib/Cargo.toml
+++ b/ffi/capi_staticlib/Cargo.toml
@@ -46,6 +46,10 @@ deserialize_bincode_1 = ["icu_capi/deserialize_bincode_1"]
 logging = ["icu_capi/logging"]
 simple_logger = ["icu_capi/simple_logger"]
 
+# meta feature for things we enable by default in C and C++
+# do not sync with other crates
+cpp_default = ["provider_test", "logging", "simple_logger"]
+
 # Enables size-optimized builds on x86_64
 x86tiny = ["dlmalloc"]
 
@@ -59,7 +63,8 @@ skip_optional_dependencies = true
 # x86tiny is not relevant in normal environments,
 # smaller_test gets tested on the FFI job anyway
 # logging enables a feature of a dependency that has no externally visible API changes
-denylist = ["bench", "x86tiny", "smaller_test", "internal_all_features_hack", "logging"]
+# cpp_default is a meta-feature
+denylist = ["bench", "x86tiny", "smaller_test", "internal_all_features_hack", "logging", "cpp_default"]
 
 # This cfg originates in dlmalloc/lib.rs
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_arch = "wasm32"))'.dependencies]

--- a/ffi/capi_staticlib/Cargo.toml
+++ b/ffi/capi_staticlib/Cargo.toml
@@ -43,6 +43,8 @@ smaller_test = ["icu_capi/smaller_test"]
 deserialize_json = ["icu_capi/deserialize_json"]
 deserialize_postcard_07 = ["icu_capi/deserialize_postcard_07"]
 deserialize_bincode_1 = ["icu_capi/deserialize_bincode_1"]
+logging = ["icu_capi/logging"]
+simple_logger = ["icu_capi/simple_logger"]
 
 # Enables size-optimized builds on x86_64
 x86tiny = ["dlmalloc"]
@@ -56,7 +58,8 @@ skip_optional_dependencies = true
 # Bench feature gets tested separately and is only relevant for CI.
 # x86tiny is not relevant in normal environments,
 # smaller_test gets tested on the FFI job anyway
-denylist = ["bench", "x86tiny", "smaller_test", "internal_all_features_hack"]
+# logging enables a feature of a dependency that has no externally visible API changes
+denylist = ["bench", "x86tiny", "smaller_test", "internal_all_features_hack", "logging"]
 
 # This cfg originates in dlmalloc/lib.rs
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_arch = "wasm32"))'.dependencies]

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -44,7 +44,7 @@ smaller_test = ["provider_test"]
 deserialize_json = ["icu_provider/deserialize_json"]
 deserialize_postcard_07 = ["icu_provider/deserialize_postcard_07"]
 deserialize_bincode_1 = ["icu_provider/deserialize_bincode_1"]
-logging = ["icu_provider/log_error_context"]
+logging = ["icu_provider/log_error_context", "log"]
 # Use the env_logger functionality to log based on environment variables
 simple_logger = ["dep:simple_logger"]
 
@@ -83,9 +83,12 @@ diplomat_core = { git = "https://github.com/rust-diplomat/diplomat", rev = "be4f
 lazy_static = { version =  "1", optional = true }
 elsa = { version = "1", optional = true }
 
+
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Logging is automagical in wasm, we only need this for native
 simple_logger = { version = "1.12", optional = true }
+log = { version = "0.4" , optional = true}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 log = { version = "0.4" }

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -32,7 +32,8 @@ all-features = true
 skip_optional_dependencies = true
 # Bench feature gets tested separately and is only relevant for CI.
 # smaller_test gets tested on the FFI job anyway
-denylist = ["bench", "smaller_test"]
+# logging enables a feature of a dependency that has no externally visible API changes
+denylist = ["bench", "smaller_test", "logging"]
 
 # Please keep the features list in sync with the icu_capi_staticlib crate
 [features]
@@ -43,6 +44,9 @@ smaller_test = ["provider_test"]
 deserialize_json = ["icu_provider/deserialize_json"]
 deserialize_postcard_07 = ["icu_provider/deserialize_postcard_07"]
 deserialize_bincode_1 = ["icu_provider/deserialize_bincode_1"]
+logging = ["icu_provider/log_error_context"]
+# Use the env_logger functionality to log based on environment variables
+simple_logger = ["dep:simple_logger"]
 
 completeness = ["syn-inline-mod", "serde_json", "rustdoc-types", "diplomat_core", "lazy_static", "elsa"]
 
@@ -78,6 +82,10 @@ rustdoc-types = { version =  "0.11", optional = true }
 diplomat_core = { git = "https://github.com/rust-diplomat/diplomat", rev = "be4f3aa9da018b05296f0d3b1777e1f3806054fa", optional = true }
 lazy_static = { version =  "1", optional = true }
 elsa = { version = "1", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# Logging is automagical in wasm, we only need this for native
+simple_logger = { version = "1.12", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 log = { version = "0.4" }

--- a/ffi/diplomat/c/examples/fixeddecimal/Makefile
+++ b/ffi/diplomat/c/examples/fixeddecimal/Makefile
@@ -14,7 +14,7 @@ $(ALL_HEADERS):
 
 
 ../../../../../target/debug/libicu_capi_staticlib_test.a: $(ALL_RUST)
-	cargo build -p icu_capi_staticlib --features provider_test
+	cargo build -p icu_capi_staticlib --features cpp_default
 	mv ../../../../../target/debug/libicu_capi_staticlib.a ../../../../../target/debug/libicu_capi_staticlib_test.a
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib_test.a $(ALL_HEADERS) test.c

--- a/ffi/diplomat/c/examples/fixeddecimal/test.c
+++ b/ffi/diplomat/c/examples/fixeddecimal/test.c
@@ -3,10 +3,12 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 #include "../../include/ICU4XFixedDecimalFormatter.h"
+#include "../../include/ICU4XLogger.h"
 #include <string.h>
 #include <stdio.h>
 
 int main() {
+    ICU4XLogger_init_simple_logger();
     diplomat_result_box_ICU4XLocale_ICU4XError locale_result = ICU4XLocale_create("bn", 2);
     if (!locale_result.is_ok) {
         return 1;

--- a/ffi/diplomat/c/examples/locale/Makefile
+++ b/ffi/diplomat/c/examples/locale/Makefile
@@ -14,7 +14,7 @@ $(ALL_HEADERS):
 
 
 ../../../../../target/debug/libicu_capi_staticlib_test.a: $(ALL_RUST)
-	cargo build -p icu_capi_staticlib --features provider_test
+	cargo build -p icu_capi_staticlib --features cpp_default
 	mv ../../../../../target/debug/libicu_capi_staticlib.a ../../../../../target/debug/libicu_capi_staticlib_test.a
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib_test.a $(ALL_HEADERS) test.c

--- a/ffi/diplomat/c/examples/locale/test.c
+++ b/ffi/diplomat/c/examples/locale/test.c
@@ -4,6 +4,7 @@
 
 #include "../../include/ICU4XLocaleCanonicalizer.h"
 #include "../../include/ICU4XLocaleExpander.h"
+#include "../../include/ICU4XLogger.h"
 #include <string.h>
 #include <stdio.h>
 
@@ -37,6 +38,7 @@ ICU4XLocale* get_locale(const char* localeText) {
 
 
 int main() {
+    ICU4XLogger_init_simple_logger();
     char output[40];
 
     // Test creating a locale.

--- a/ffi/diplomat/c/examples/pluralrules/Makefile
+++ b/ffi/diplomat/c/examples/pluralrules/Makefile
@@ -14,7 +14,7 @@ $(ALL_HEADERS):
 
 
 ../../../../../target/debug/libicu_capi_staticlib_test.a: $(ALL_RUST)
-	cargo build -p icu_capi_staticlib --features provider_test
+	cargo build -p icu_capi_staticlib --features cpp_default
 	mv ../../../../../target/debug/libicu_capi_staticlib.a ../../../../../target/debug/libicu_capi_staticlib_test.a
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib_test.a $(ALL_HEADERS) test.c

--- a/ffi/diplomat/c/examples/pluralrules/test.c
+++ b/ffi/diplomat/c/examples/pluralrules/test.c
@@ -3,10 +3,12 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 #include "../../include/ICU4XPluralRules.h"
+#include "../../include/ICU4XLogger.h"
 #include <string.h>
 #include <stdio.h>
 
 int main() {
+    ICU4XLogger_init_simple_logger();
     diplomat_result_box_ICU4XLocale_ICU4XError locale_result = ICU4XLocale_create("ar", 2);
     if (!locale_result.is_ok) {
         return 1;

--- a/ffi/diplomat/c/include/ICU4XLogger.h
+++ b/ffi/diplomat/c/include/ICU4XLogger.h
@@ -1,0 +1,29 @@
+#ifndef ICU4XLogger_H
+#define ICU4XLogger_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+namespace capi {
+#endif
+
+typedef struct ICU4XLogger ICU4XLogger;
+#ifdef __cplusplus
+} // namespace capi
+#endif
+#ifdef __cplusplus
+namespace capi {
+extern "C" {
+#endif
+
+bool ICU4XLogger_init_simple_logger();
+void ICU4XLogger_destroy(ICU4XLogger* self);
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace capi
+#endif
+#endif

--- a/ffi/diplomat/cpp/docs/source/index.rst
+++ b/ffi/diplomat/cpp/docs/source/index.rst
@@ -14,6 +14,7 @@ Documentation
    fixed_decimal_ffi
    locale_ffi
    locid_transform_ffi
+   logging_ffi
    pluralrules_ffi
    properties_maps_ffi
    properties_sets_ffi

--- a/ffi/diplomat/cpp/docs/source/logging_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/logging_ffi.rst
@@ -1,0 +1,12 @@
+``logging::ffi``
+================
+
+.. cpp:class:: ICU4XLogger
+
+    An object allowing control over the logging used
+
+
+    .. cpp:function:: static bool init_simple_logger()
+
+        Initialize the logger from the ``simple_logger`` crate, which simply logs to stdout. Returns ``false`` if there was already a logger set.
+

--- a/ffi/diplomat/cpp/docs/source/logging_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/logging_ffi.rst
@@ -8,5 +8,5 @@
 
     .. cpp:function:: static bool init_simple_logger()
 
-        Initialize the logger from the ``simple_logger`` crate, which simply logs to stdout. Returns ``false`` if there was already a logger set.
+        Initialize the logger from the ``simple_logger`` crate, which simply logs to stdout. Returns ``false`` if there was already a logger set, or if logging has not been compiled into the platform
 

--- a/ffi/diplomat/cpp/examples/bidi/test.cpp
+++ b/ffi/diplomat/cpp/examples/bidi/test.cpp
@@ -4,6 +4,7 @@
 
 #include "../../include/ICU4XDataProvider.hpp"
 #include "../../include/ICU4XBidi.hpp"
+#include "../../include/ICU4XLogger.hpp"
 
 #include <iostream>
 

--- a/ffi/diplomat/cpp/examples/datetime/Makefile
+++ b/ffi/diplomat/cpp/examples/datetime/Makefile
@@ -16,7 +16,7 @@ $(ALL_HEADERS):
 
 
 ../../../../../target/debug/libicu_capi_staticlib_test.a: $(ALL_RUST)
-	cargo build -p icu_capi_staticlib --features provider_test
+	cargo build -p icu_capi_staticlib --features cpp_default
 	mv ../../../../../target/debug/libicu_capi_staticlib.a ../../../../../target/debug/libicu_capi_staticlib_test.a
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib_test.a $(ALL_HEADERS) test.cpp

--- a/ffi/diplomat/cpp/examples/datetime/test.cpp
+++ b/ffi/diplomat/cpp/examples/datetime/test.cpp
@@ -7,12 +7,14 @@
 #include "../../include/ICU4XDateTimeFormatter.hpp"
 #include "../../include/ICU4XTimeFormatter.hpp"
 #include "../../include/ICU4XDataStruct.hpp"
+#include "../../include/ICU4XLogger.hpp"
 
 #include <atomic>
 #include <iostream>
 #include <array>
 
 int main() {
+    ICU4XLogger::init_simple_logger();
     ICU4XLocale locale = ICU4XLocale::create("es").ok().value();
     std::cout << "Running test for locale " << locale.tostring().ok().value() << std::endl;
     ICU4XDataProvider dp = ICU4XDataProvider::create_test();

--- a/ffi/diplomat/cpp/examples/fixeddecimal/Makefile
+++ b/ffi/diplomat/cpp/examples/fixeddecimal/Makefile
@@ -16,7 +16,7 @@ $(ALL_HEADERS):
 
 
 ../../../../../target/debug/libicu_capi_staticlib_test.a: $(ALL_RUST)
-	cargo build -p icu_capi_staticlib --features provider_test
+	cargo build -p icu_capi_staticlib --features cpp_default
 	mv ../../../../../target/debug/libicu_capi_staticlib.a ../../../../../target/debug/libicu_capi_staticlib_test.a
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib_test.a $(ALL_HEADERS) test.cpp

--- a/ffi/diplomat/cpp/examples/fixeddecimal/test.cpp
+++ b/ffi/diplomat/cpp/examples/fixeddecimal/test.cpp
@@ -4,11 +4,13 @@
 
 #include "../../include/ICU4XFixedDecimalFormatter.hpp"
 #include "../../include/ICU4XDataStruct.hpp"
+#include "../../include/ICU4XLogger.hpp"
 
 #include <iostream>
 #include <array>
 
 int main() {
+    ICU4XLogger::init_simple_logger();
     ICU4XLocale locale = ICU4XLocale::create_bn();
     std::cout << "Running test for locale " << locale.tostring().ok().value() << std::endl;
     ICU4XDataProvider dp = ICU4XDataProvider::create_test();

--- a/ffi/diplomat/cpp/examples/fixeddecimal_wasm/Makefile
+++ b/ffi/diplomat/cpp/examples/fixeddecimal_wasm/Makefile
@@ -16,7 +16,7 @@ $(ALL_RUST):
 $(ALL_HEADERS):
 
 ../../../../../target/debug/libicu_capi_staticlib_test.a: $(ALL_RUST)
-	cargo build -p icu_capi_staticlib -p icu_capi_staticlib --features cpp_default
+	cargo build -p icu_capi_staticlib -p icu_capi_staticlib --features provider_test
 	mv ../../../../../target/debug/libicu_capi_staticlib.a ../../../../../target/debug/libicu_capi_staticlib_test.a
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib_test.a $(ALL_HEADERS) test.cpp

--- a/ffi/diplomat/cpp/examples/fixeddecimal_wasm/Makefile
+++ b/ffi/diplomat/cpp/examples/fixeddecimal_wasm/Makefile
@@ -16,7 +16,7 @@ $(ALL_RUST):
 $(ALL_HEADERS):
 
 ../../../../../target/debug/libicu_capi_staticlib_test.a: $(ALL_RUST)
-	cargo build -p icu_capi_staticlib -p icu_capi_staticlib --features provider_test
+	cargo build -p icu_capi_staticlib -p icu_capi_staticlib --features cpp_default
 	mv ../../../../../target/debug/libicu_capi_staticlib.a ../../../../../target/debug/libicu_capi_staticlib_test.a
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib_test.a $(ALL_HEADERS) test.cpp

--- a/ffi/diplomat/cpp/examples/locale/Makefile
+++ b/ffi/diplomat/cpp/examples/locale/Makefile
@@ -16,7 +16,7 @@ $(ALL_HEADERS):
 
 
 ../../../../../target/debug/libicu_capi_staticlib.a: $(ALL_RUST)
-	cargo build -p icu_capi_staticlib -p icu_capi_staticlib
+	cargo build -p icu_capi_staticlib -p icu_capi_staticlib --features cpp_default
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib.a $(ALL_HEADERS) test.cpp
 	$(CXX) -std=c++17 test.cpp ../../../../../target/debug/libicu_capi_staticlib.a -ldl -lpthread -lm -g

--- a/ffi/diplomat/cpp/examples/locale/test.cpp
+++ b/ffi/diplomat/cpp/examples/locale/test.cpp
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 #include "../../include/ICU4XLocale.hpp"
+#include "../../include/ICU4XLogger.hpp"
 
 #include <iostream>
 
@@ -30,6 +31,7 @@ static bool test_string(std::string_view actualString,
 }
 
 int main() {
+  ICU4XLogger::init_simple_logger();
   ICU4XLocale locale = ICU4XLocale::create("es-ES").ok().value();
   if (!test_locale(locale, "es-ES", "Created a locale")) {
     return 1;

--- a/ffi/diplomat/cpp/examples/pluralrules/Makefile
+++ b/ffi/diplomat/cpp/examples/pluralrules/Makefile
@@ -16,7 +16,7 @@ $(ALL_HEADERS):
 
 
 ../../../../../target/debug/libicu_capi_staticlib_test.a: $(ALL_RUST)
-	cargo build -p icu_capi_staticlib --features provider_test
+	cargo build -p icu_capi_staticlib --features cpp_default
 	mv ../../../../../target/debug/libicu_capi_staticlib.a ../../../../../target/debug/libicu_capi_staticlib_test.a
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib_test.a $(ALL_HEADERS) test.cpp

--- a/ffi/diplomat/cpp/examples/pluralrules/test.cpp
+++ b/ffi/diplomat/cpp/examples/pluralrules/test.cpp
@@ -3,12 +3,14 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 #include "../../include/ICU4XPluralRules.hpp"
+#include "../../include/ICU4XLogger.hpp"
 
 #include <iostream>
 
 const std::string_view path = "../../../../../provider/testdata/data/json/";
 
 int main() {
+    ICU4XLogger::init_simple_logger();
     ICU4XLocale locale = ICU4XLocale::create("ar").ok().value();
     std::cout << "Running test for locale " << locale.tostring().ok().value() << std::endl;
     ICU4XDataProvider dp = ICU4XDataProvider::create_fs(path).ok().value();

--- a/ffi/diplomat/cpp/examples/properties/Makefile
+++ b/ffi/diplomat/cpp/examples/properties/Makefile
@@ -16,7 +16,7 @@ $(ALL_HEADERS):
 
 
 ../../../../../target/debug/libicu_capi_staticlib_test.a: $(ALL_RUST)
-	cargo build -p icu_capi_staticlib --features provider_test
+	cargo build -p icu_capi_staticlib --features cpp_default
 	mv ../../../../../target/debug/libicu_capi_staticlib.a ../../../../../target/debug/libicu_capi_staticlib_test.a
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib_test.a $(ALL_HEADERS) test.cpp

--- a/ffi/diplomat/cpp/examples/properties/test.cpp
+++ b/ffi/diplomat/cpp/examples/properties/test.cpp
@@ -4,6 +4,7 @@
 
 #include "../../include/ICU4XCodePointSetData.hpp"
 #include "../../include/ICU4XCodePointMapData16.hpp"
+#include "../../include/ICU4XLogger.hpp"
 
 #include <iostream>
 
@@ -33,6 +34,7 @@ int test_map_16_property(ICU4XCodePointMapData16 data, char32_t sample, uint32_t
 }
 
 int main() {
+    ICU4XLogger::init_simple_logger();
     ICU4XDataProvider dp = ICU4XDataProvider::create_test();
     int result;
 

--- a/ffi/diplomat/cpp/examples/segmenter/Makefile
+++ b/ffi/diplomat/cpp/examples/segmenter/Makefile
@@ -16,7 +16,7 @@ $(ALL_HEADERS):
 
 
 ../../../../../target/debug/libicu_capi_staticlib_test.a: $(ALL_RUST)
-	cargo build -p icu_capi_staticlib --features provider_test
+	cargo build -p icu_capi_staticlib --features cpp_default
 	mv ../../../../../target/debug/libicu_capi_staticlib.a ../../../../../target/debug/libicu_capi_staticlib_test.a
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib_test.a $(ALL_HEADERS) test.cpp

--- a/ffi/diplomat/cpp/examples/segmenter/test.cpp
+++ b/ffi/diplomat/cpp/examples/segmenter/test.cpp
@@ -7,6 +7,7 @@
 #include "../../include/ICU4XLineBreakSegmenter.hpp"
 #include "../../include/ICU4XSentenceBreakSegmenter.hpp"
 #include "../../include/ICU4XWordBreakSegmenter.hpp"
+#include "../../include/ICU4XLogger.hpp"
 
 #include <iostream>
 #include <string_view>
@@ -88,6 +89,7 @@ void test_sentence(const std::string_view& str) {
 }
 
 int main(int argc, char* argv[]) {
+    ICU4XLogger::init_simple_logger();
     std::string_view str;
     if (argc >= 2) {
         str = argv[1];

--- a/ffi/diplomat/cpp/include/ICU4XLogger.h
+++ b/ffi/diplomat/cpp/include/ICU4XLogger.h
@@ -1,0 +1,29 @@
+#ifndef ICU4XLogger_H
+#define ICU4XLogger_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+namespace capi {
+#endif
+
+typedef struct ICU4XLogger ICU4XLogger;
+#ifdef __cplusplus
+} // namespace capi
+#endif
+#ifdef __cplusplus
+namespace capi {
+extern "C" {
+#endif
+
+bool ICU4XLogger_init_simple_logger();
+void ICU4XLogger_destroy(ICU4XLogger* self);
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace capi
+#endif
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XLogger.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XLogger.hpp
@@ -1,0 +1,49 @@
+#ifndef ICU4XLogger_HPP
+#define ICU4XLogger_HPP
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <algorithm>
+#include <memory>
+#include <variant>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+#include "ICU4XLogger.h"
+
+
+/**
+ * A destruction policy for using ICU4XLogger with std::unique_ptr.
+ */
+struct ICU4XLoggerDeleter {
+  void operator()(capi::ICU4XLogger* l) const noexcept {
+    capi::ICU4XLogger_destroy(l);
+  }
+};
+
+/**
+ * An object allowing control over the logging used
+ */
+class ICU4XLogger {
+ public:
+
+  /**
+   * Initialize the logger from the `simple_logger` crate, which simply logs to
+   * stdout. Returns `false` if there was already a logger set.
+   */
+  static bool init_simple_logger();
+  inline const capi::ICU4XLogger* AsFFI() const { return this->inner.get(); }
+  inline capi::ICU4XLogger* AsFFIMut() { return this->inner.get(); }
+  inline ICU4XLogger(capi::ICU4XLogger* i) : inner(i) {}
+  ICU4XLogger() = default;
+  ICU4XLogger(ICU4XLogger&&) noexcept = default;
+  ICU4XLogger& operator=(ICU4XLogger&& other) noexcept = default;
+ private:
+  std::unique_ptr<capi::ICU4XLogger, ICU4XLoggerDeleter> inner;
+};
+
+
+inline bool ICU4XLogger::init_simple_logger() {
+  return capi::ICU4XLogger_init_simple_logger();
+}
+#endif

--- a/ffi/diplomat/cpp/include/ICU4XLogger.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XLogger.hpp
@@ -29,7 +29,8 @@ class ICU4XLogger {
 
   /**
    * Initialize the logger from the `simple_logger` crate, which simply logs to
-   * stdout. Returns `false` if there was already a logger set.
+   * stdout. Returns `false` if there was already a logger set, or if logging has not been
+   * compiled into the platform
    */
   static bool init_simple_logger();
   inline const capi::ICU4XLogger* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/src/errors.rs
+++ b/ffi/diplomat/src/errors.rs
@@ -112,7 +112,7 @@ fn log_conversion<T: core::fmt::Display>(e: &T, ffi_error: ICU4XError) {
 
 #[cfg(not(feature = "logging"))]
 #[inline]
-fn log_conversion<T: Display>(_e: &T, _ffi_error: ICU4XError) {}
+fn log_conversion<T: core::fmt::Display>(_e: &T, _ffi_error: ICU4XError) {}
 
 impl From<fmt::Error> for ICU4XError {
     fn from(e: fmt::Error) -> Self {

--- a/ffi/diplomat/src/errors.rs
+++ b/ffi/diplomat/src/errors.rs
@@ -17,6 +17,7 @@ use icu_provider::{DataError, DataErrorKind};
 pub mod ffi {
     use alloc::boxed::Box;
 
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     #[repr(C)]
     /// A common enum for errors that ICU4X may return, organized by API
     ///
@@ -97,15 +98,32 @@ pub mod ffi {
     }
 }
 
+#[cfg(feature = "logging")]
+#[inline]
+fn log_conversion<T: core::fmt::Display>(e: &T, ffi_error: ICU4XError) {
+    use core::any;
+    log::warn!(
+        "Returning ICU4XError::{:?} based on original {}: {}",
+        ffi_error,
+        any::type_name::<T>(),
+        e
+    );
+}
+
+#[cfg(not(feature = "logging"))]
+#[inline]
+fn log_conversion<T: Display>(_e: &T, _ffi_error: ICU4XError) {}
+
 impl From<fmt::Error> for ICU4XError {
-    fn from(_: fmt::Error) -> Self {
+    fn from(e: fmt::Error) -> Self {
+        log_conversion(&e, ICU4XError::WriteableError);
         ICU4XError::WriteableError
     }
 }
 
 impl From<DataError> for ICU4XError {
     fn from(e: DataError) -> Self {
-        match e.kind {
+        let ret = match e.kind {
             DataErrorKind::MissingDataKey => ICU4XError::DataMissingDataKeyError,
             DataErrorKind::MissingLocale => ICU4XError::DataMissingLocaleError,
             DataErrorKind::NeedsLocale => ICU4XError::DataNeedsLocaleError,
@@ -126,26 +144,30 @@ impl From<DataError> for ICU4XError {
                 ICU4XError::DataUnavailableBufferFormatError
             }
             _ => ICU4XError::UnknownError,
-        }
+        };
+        log_conversion(&e, ret);
+        ret
     }
 }
 
 impl From<PropertiesError> for ICU4XError {
     fn from(e: PropertiesError) -> Self {
-        match e {
+        let ret = match e {
             PropertiesError::PropDataLoad(e) => e.into(),
             PropertiesError::UnknownScriptId(..) => ICU4XError::PropertyUnknownScriptIdError,
             PropertiesError::UnknownGeneralCategoryGroup(..) => {
                 ICU4XError::PropertyUnknownGeneralCategoryGroupError
             }
             _ => ICU4XError::UnknownError,
-        }
+        };
+        log_conversion(&e, ret);
+        ret
     }
 }
 
 impl From<DateTimeError> for ICU4XError {
     fn from(e: DateTimeError) -> Self {
-        match e {
+        let ret = match e {
             DateTimeError::Parse => ICU4XError::DateTimeParseError,
             DateTimeError::Overflow { field: _, max: _ } => ICU4XError::DateTimeOverflowError,
             DateTimeError::Underflow { field: _, min: _ } => ICU4XError::DateTimeUnderflowError,
@@ -157,13 +179,15 @@ impl From<DateTimeError> for ICU4XError {
                 ICU4XError::DateTimeUnknownAnyCalendarKindError
             }
             _ => ICU4XError::UnknownError,
-        }
+        };
+        log_conversion(&e, ret);
+        ret
     }
 }
 
 impl From<DateTimeFormatterError> for ICU4XError {
     fn from(e: DateTimeFormatterError) -> Self {
-        match e {
+        let ret = match e {
             DateTimeFormatterError::Pattern(_) => ICU4XError::DateTimeFormatPatternError,
             DateTimeFormatterError::Format(err) => err.into(),
             DateTimeFormatterError::DataProvider(err) => err.into(),
@@ -194,45 +218,55 @@ impl From<DateTimeFormatterError> for ICU4XError {
                 ICU4XError::DateTimeFormatMismatchedCalendarLocaleError
             }
             _ => ICU4XError::UnknownError,
-        }
+        };
+        log_conversion(&e, ret);
+        ret
     }
 }
 
 impl From<DecimalError> for ICU4XError {
     fn from(e: DecimalError) -> Self {
-        match e {
+        let ret = match e {
             DecimalError::Limit => ICU4XError::DecimalLimitError,
             DecimalError::Syntax => ICU4XError::DecimalSyntaxError,
-        }
+        };
+        log_conversion(&e, ret);
+        ret
     }
 }
 
 impl From<PluralRulesError> for ICU4XError {
     fn from(e: PluralRulesError) -> Self {
-        match e {
+        let ret = match e {
             PluralRulesError::DataProvider(e) => e.into(),
             PluralRulesError::Parser(..) => ICU4XError::PluralParserError,
             _ => ICU4XError::UnknownError,
-        }
+        };
+        log_conversion(&e, ret);
+        ret
     }
 }
 
 impl From<FixedDecimalFormatterError> for ICU4XError {
     fn from(e: FixedDecimalFormatterError) -> Self {
-        match e {
+        let ret = match e {
             FixedDecimalFormatterError::Data(e) => e.into(),
             _ => ICU4XError::UnknownError,
-        }
+        };
+        log_conversion(&e, ret);
+        ret
     }
 }
 
 impl From<ParserError> for ICU4XError {
     fn from(e: ParserError) -> Self {
-        match e {
+        let ret = match e {
             ParserError::InvalidLanguage => ICU4XError::LocaleParserLanguageError,
             ParserError::InvalidSubtag => ICU4XError::LocaleParserSubtagError,
             ParserError::InvalidExtension => ICU4XError::LocaleParserExtensionError,
             _ => ICU4XError::UnknownError,
-        }
+        };
+        log_conversion(&e, ret);
+        ret
     }
 }

--- a/ffi/diplomat/src/lib.rs
+++ b/ffi/diplomat/src/lib.rs
@@ -42,6 +42,7 @@ pub mod errors;
 pub mod fixed_decimal;
 pub mod locale;
 pub mod locid_transform;
+pub mod logging;
 pub mod pluralrules;
 pub mod properties_maps;
 pub mod properties_sets;

--- a/ffi/diplomat/src/logging.rs
+++ b/ffi/diplomat/src/logging.rs
@@ -1,0 +1,24 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+#[diplomat::bridge]
+pub mod ffi {
+    use alloc::boxed::Box;
+
+    #[diplomat::opaque]
+    /// An object allowing control over the logging used
+    pub struct ICU4XLogger;
+
+    impl ICU4XLogger {
+        /// Initialize the logger from the `simple_logger` crate, which simply logs to
+        /// stdout. Returns `false` if there was already a logger set, or if logging has not been
+        /// compiled into the platform
+        pub fn init_simple_logger() -> bool {
+            #[cfg(not(all(not(target_arch = "wasm32"), feature = "simple_logger")))]
+            unimplemented!("ICU4X binary not compiled with simple_logger support");
+            #[cfg(all(not(target_arch = "wasm32"), feature = "simple_logger"))]
+            simple_logger::init().is_ok()
+        }
+    }
+}

--- a/ffi/diplomat/wasm/icu4x/docs/index.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/index.rst
@@ -14,6 +14,7 @@ Documentation
    fixed_decimal_ffi
    locale_ffi
    locid_transform_ffi
+   logging_ffi
    pluralrules_ffi
    properties_maps_ffi
    properties_sets_ffi

--- a/ffi/diplomat/wasm/icu4x/docs/logging_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/logging_ffi.rst
@@ -8,5 +8,5 @@
 
     .. js:staticfunction:: init_simple_logger()
 
-        Initialize the logger from the ``simple_logger`` crate, which simply logs to stdout. Returns ``false`` if there was already a logger set.
+        Initialize the logger from the ``simple_logger`` crate, which simply logs to stdout. Returns ``false`` if there was already a logger set, or if logging has not been compiled into the platform
 

--- a/ffi/diplomat/wasm/icu4x/docs/logging_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/logging_ffi.rst
@@ -1,0 +1,12 @@
+``logging::ffi``
+================
+
+.. js:class:: ICU4XLogger
+
+    An object allowing control over the logging used
+
+
+    .. js:staticfunction:: init_simple_logger()
+
+        Initialize the logger from the ``simple_logger`` crate, which simply logs to stdout. Returns ``false`` if there was already a logger set.
+

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XLogger.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XLogger.d.ts
@@ -1,0 +1,13 @@
+
+/**
+
+ * An object allowing control over the logging used
+ */
+export class ICU4XLogger {
+
+  /**
+
+   * Initialize the logger from the `simple_logger` crate, which simply logs to stdout. Returns `false` if there was already a logger set.
+   */
+  static init_simple_logger(): boolean;
+}

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XLogger.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XLogger.d.ts
@@ -7,7 +7,7 @@ export class ICU4XLogger {
 
   /**
 
-   * Initialize the logger from the `simple_logger` crate, which simply logs to stdout. Returns `false` if there was already a logger set.
+   * Initialize the logger from the `simple_logger` crate, which simply logs to stdout. Returns `false` if there was already a logger set, or if logging has not been compiled into the platform
    */
   static init_simple_logger(): boolean;
 }

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XLogger.js
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XLogger.js
@@ -1,0 +1,21 @@
+import wasm from "./diplomat-wasm.mjs"
+import * as diplomatRuntime from "./diplomat-runtime.js"
+
+const ICU4XLogger_box_destroy_registry = new FinalizationRegistry(underlying => {
+  wasm.ICU4XLogger_destroy(underlying);
+});
+
+export class ICU4XLogger {
+  #lifetimeEdges = [];
+  constructor(underlying, owned, edges) {
+    this.underlying = underlying;
+    this.#lifetimeEdges.push(...edges);
+    if (owned) {
+      ICU4XLogger_box_destroy_registry.register(this, underlying);
+    }
+  }
+
+  static init_simple_logger() {
+    return wasm.ICU4XLogger_init_simple_logger();
+  }
+}

--- a/ffi/diplomat/wasm/icu4x/lib/index.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/index.d.ts
@@ -34,6 +34,7 @@ export { ICU4XLineBreakSegmenter } from './ICU4XLineBreakSegmenter.js';
 export { ICU4XLocale } from './ICU4XLocale.js';
 export { ICU4XLocaleCanonicalizer } from './ICU4XLocaleCanonicalizer.js';
 export { ICU4XLocaleExpander } from './ICU4XLocaleExpander.js';
+export { ICU4XLogger } from './ICU4XLogger.js';
 export { ICU4XPluralCategories } from './ICU4XPluralCategories.js';
 export { ICU4XPluralCategory } from './ICU4XPluralCategory.js';
 export { ICU4XPluralOperands } from './ICU4XPluralOperands.js';

--- a/ffi/diplomat/wasm/icu4x/lib/index.js
+++ b/ffi/diplomat/wasm/icu4x/lib/index.js
@@ -34,6 +34,7 @@ export { ICU4XLineBreakSegmenter } from './ICU4XLineBreakSegmenter.js';
 export { ICU4XLocale } from './ICU4XLocale.js';
 export { ICU4XLocaleCanonicalizer } from './ICU4XLocaleCanonicalizer.js';
 export { ICU4XLocaleExpander } from './ICU4XLocaleExpander.js';
+export { ICU4XLogger } from './ICU4XLogger.js';
 export { ICU4XPluralCategories } from './ICU4XPluralCategories.js';
 export { ICU4XPluralCategory } from './ICU4XPluralCategory.js';
 export { ICU4XPluralOperands } from './ICU4XPluralOperands.js';

--- a/tools/scripts/wasm.toml
+++ b/tools/scripts/wasm.toml
@@ -10,7 +10,7 @@ category = "ICU4X WASM"
 install_crate = { rustup_component_name = "rust-src" }
 toolchain = "nightly-2022-04-05"
 command = "cargo"
-args = ["wasm-build-dev", "--package", "icu_capi_cdylib", "--features", "provider_test"]
+args = ["wasm-build-dev", "--package", "icu_capi_cdylib", "--features", "wasm_default"]
 
 [tasks.wasm-build-release]
 description = "Build WASM FFI into the target directory (release mode)"
@@ -20,7 +20,7 @@ toolchain = "nightly-2022-04-05"
 # We don't care about panics in release mode because most incorrect inputs are handled by result types.
 env = { "RUSTFLAGS" = "-C panic=abort -C opt-level=s" }
 command = "cargo"
-args = ["wasm-build-release", "--package", "icu_capi_cdylib", "--features", "provider_test"]
+args = ["wasm-build-release", "--package", "icu_capi_cdylib", "--features", "wasm_default"]
 
 [tasks.wasm-build-examples]
 description = "Build WASM examples into the target directory"


### PR DESCRIPTION
Fixes #2051

We already have decent logging for WASM, this hooks up logging for C++ (opt in via `simple_logger`, more loggers and custom loggers can be added in the future).

This adds two FFI features:
 - `"logging"` enables logging of both FFI and Data error conversions. This is `no_std`, and is all you need to get error logging on WASM
 - `"simple_logger"` enables the ability to call `ICU4XLogger::init_simple_logger()`, which does simple stdout logging.

This also adds `default_wasm` and `default_cpp` features so that we can better control the default experience people get when building ICU4X, and add more features to the "default" in the future.






<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->