### PR TITLE
Enable `locale` macro to support single unicode key value pair extension

### DIFF
--- a/components/locid/src/extensions/mod.rs
+++ b/components/locid/src/extensions/mod.rs
@@ -73,7 +73,7 @@ pub enum ExtensionType {
 }
 
 impl ExtensionType {
-    pub(crate) fn from_byte(key: u8) -> Result<Self, ParserError> {
+    pub(crate) const fn from_byte(key: u8) -> Result<Self, ParserError> {
         let key = key.to_ascii_lowercase();
         match key {
             b'u' => Ok(Self::Unicode),
@@ -82,6 +82,18 @@ impl ExtensionType {
             b'a'..=b'z' => Ok(Self::Other(key)),
             _ => Err(ParserError::InvalidExtension),
         }
+    }
+
+    pub(crate) const fn from_bytes_manual_slice(
+        bytes: &[u8],
+        start: usize,
+        end: usize,
+    ) -> Result<Self, ParserError> {
+        if end - start != 1 {
+            return Err(ParserError::InvalidExtension);
+        }
+        #[allow(clippy::indexing_slicing)]
+        Self::from_byte(bytes[start])
     }
 }
 
@@ -115,6 +127,18 @@ impl Extensions {
     pub const fn new() -> Self {
         Self {
             unicode: Unicode::new(),
+            transform: Transform::new(),
+            private: Private::new(),
+            other: Vec::new(),
+        }
+    }
+
+    /// Function to create a new map of extensions containing exactly one unicode extension, callable in `const`
+    /// context.
+    #[inline]
+    pub const fn single_unicode(unicode: Unicode) -> Self {
+        Self {
+            unicode,
             transform: Transform::new(),
             private: Private::new(),
             other: Vec::new(),

--- a/components/locid/src/extensions/mod.rs
+++ b/components/locid/src/extensions/mod.rs
@@ -136,7 +136,7 @@ impl Extensions {
     /// Function to create a new map of extensions containing exactly one unicode extension, callable in `const`
     /// context.
     #[inline]
-    pub const fn single_unicode(unicode: Unicode) -> Self {
+    pub const fn from_unicode(unicode: Unicode) -> Self {
         Self {
             unicode,
             transform: Transform::new(),

--- a/components/locid/src/extensions/unicode/key.rs
+++ b/components/locid/src/extensions/unicode/key.rs
@@ -41,15 +41,25 @@ impl Key {
     /// assert_eq!(key.as_str(), "ca");
     /// ```
     pub const fn from_bytes(key: &[u8]) -> Result<Self, ParserError> {
+        Self::from_bytes_manual_slice(key, 0, key.len())
+    }
+
+    /// Equivalent to [`from_bytes(bytes[start..end])`](Self::from_bytes) but callable in `const`
+    /// context.
+    pub const fn from_bytes_manual_slice(
+        bytes: &[u8],
+        start: usize,
+        end: usize,
+    ) -> Result<Self, ParserError> {
         #[allow(clippy::indexing_slicing)] // TODO(#1668) Clippy exceptions need docs or fixing.
-        if key.len() != KEY_LENGTH
-            || !key[0].is_ascii_alphanumeric()
-            || !key[1].is_ascii_alphabetic()
+        if end - start != KEY_LENGTH
+            || !bytes[start].is_ascii_alphanumeric()
+            || !bytes[start + 1].is_ascii_alphabetic()
         {
             return Err(ParserError::InvalidExtension);
         }
 
-        let key = match TinyAsciiStr::from_bytes(key) {
+        let key = match TinyAsciiStr::from_bytes_manual_slice(bytes, start, end) {
             Ok(k) => k,
             Err(_) => return Err(ParserError::InvalidSubtag),
         };

--- a/components/locid/src/extensions/unicode/keywords.rs
+++ b/components/locid/src/extensions/unicode/keywords.rs
@@ -82,7 +82,7 @@ impl Keywords {
 
     /// Create a new list of key-value pairs having exactly one pair, callable in a `const` context.
     #[inline]
-    pub const fn single(key: Key, value: Value) -> Self {
+    pub const fn new_single(key: Key, value: Value) -> Self {
         Self(LiteMap::from_store_unchecked(ShortVec::new_single((
             key, value,
         ))))

--- a/components/locid/src/extensions/unicode/keywords.rs
+++ b/components/locid/src/extensions/unicode/keywords.rs
@@ -80,6 +80,14 @@ impl Keywords {
         Self(LiteMap::new())
     }
 
+    /// Create a new list of key-value pairs having exactly one pair, callable in a `const` context.
+    #[inline]
+    pub const fn single(key: Key, value: Value) -> Self {
+        Self(LiteMap::from_store_unchecked(ShortVec::new_single((
+            key, value,
+        ))))
+    }
+
     /// Returns `true` if there are no keywords.
     ///
     /// # Examples

--- a/components/locid/src/extensions/unicode/keywords.rs
+++ b/components/locid/src/extensions/unicode/keywords.rs
@@ -83,9 +83,9 @@ impl Keywords {
     /// Create a new list of key-value pairs having exactly one pair, callable in a `const` context.
     #[inline]
     pub const fn new_single(key: Key, value: Value) -> Self {
-        Self(LiteMap::from_store_unchecked(ShortVec::new_single((
-            key, value,
-        ))))
+        Self(LiteMap::from_sorted_store_unchecked(ShortVec::new_single(
+            (key, value),
+        )))
     }
 
     /// Returns `true` if there are no keywords.

--- a/components/locid/src/extensions/unicode/mod.rs
+++ b/components/locid/src/extensions/unicode/mod.rs
@@ -95,6 +95,16 @@ impl Unicode {
         }
     }
 
+    /// Create a new map of Unicode extensions containing exactly one key-value pair, callable in
+    /// `const` context.
+    #[inline]
+    pub const fn single_keyword(key: Key, value: Value) -> Self {
+        Self {
+            keywords: Keywords::single(key, value),
+            attributes: Attributes::new(),
+        }
+    }
+
     /// Returns [`true`] if there list of keywords and attributes is empty.
     ///
     /// # Examples

--- a/components/locid/src/extensions/unicode/mod.rs
+++ b/components/locid/src/extensions/unicode/mod.rs
@@ -95,16 +95,6 @@ impl Unicode {
         }
     }
 
-    /// Create a new map of Unicode extensions containing exactly one key-value pair, callable in
-    /// `const` context.
-    #[inline]
-    pub const fn single_keyword(key: Key, value: Value) -> Self {
-        Self {
-            keywords: Keywords::single(key, value),
-            attributes: Attributes::new(),
-        }
-    }
-
     /// Returns [`true`] if there list of keywords and attributes is empty.
     ///
     /// # Examples

--- a/components/locid/src/extensions/unicode/value.rs
+++ b/components/locid/src/extensions/unicode/value.rs
@@ -111,29 +111,11 @@ impl Value {
 
     #[doc(hidden)]
     pub const fn subtag_from_bytes(bytes: &[u8]) -> Result<Option<TinyAsciiStr<8>>, ParserError> {
-        if *VALUE_LENGTH.start() > bytes.len() || *VALUE_LENGTH.end() < bytes.len() {
-            return Err(ParserError::InvalidExtension);
-        };
-        match TinyAsciiStr::from_bytes(bytes) {
-            Ok(TRUE_VALUE) => Ok(None),
-            Ok(val) if val.is_ascii_alphanumeric() => Ok(Some(val)),
-            _ => Err(ParserError::InvalidExtension),
-        }
+        Self::parse_subtag_from_bytes_manual_slice(bytes, 0, bytes.len())
     }
 
     pub(crate) fn parse_subtag(t: &[u8]) -> Result<Option<TinyAsciiStr<8>>, ParserError> {
-        let s = TinyAsciiStr::from_bytes(t).map_err(|_| ParserError::InvalidSubtag)?;
-        if !VALUE_LENGTH.contains(&t.len()) || !s.is_ascii_alphanumeric() {
-            return Err(ParserError::InvalidExtension);
-        }
-
-        let s = s.to_ascii_lowercase();
-
-        if s == TRUE_VALUE {
-            Ok(None)
-        } else {
-            Ok(Some(s))
-        }
+        Self::parse_subtag_from_bytes_manual_slice(t, 0, t.len())
     }
 
     pub(crate) const fn parse_subtag_from_bytes_manual_slice(

--- a/components/locid/src/extensions/unicode/value.rs
+++ b/components/locid/src/extensions/unicode/value.rs
@@ -136,6 +136,24 @@ impl Value {
         }
     }
 
+    pub(crate) const fn parse_subtag_from_bytes_manual_slice(
+        bytes: &[u8],
+        start: usize,
+        end: usize,
+    ) -> Result<Option<TinyAsciiStr<8>>, ParserError> {
+        let slice_len = end - start;
+        if slice_len > *VALUE_LENGTH.end() || slice_len < *VALUE_LENGTH.start() {
+            return Err(ParserError::InvalidExtension);
+        }
+
+        match TinyAsciiStr::from_bytes_manual_slice(bytes, start, end) {
+            Ok(TRUE_VALUE) => Ok(None),
+            Ok(s) if s.is_ascii_alphanumeric() => Ok(Some(s.to_ascii_lowercase())),
+            Ok(_) => Err(ParserError::InvalidExtension),
+            Err(_) => Err(ParserError::InvalidSubtag),
+        }
+    }
+
     pub(crate) fn for_each_subtag_str<E, F>(&self, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&str) -> Result<(), E>,

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -3,12 +3,17 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::ordering::SubtagOrderingResult;
-use crate::parser::{get_subtag_iterator, parse_locale, ParserError};
+use crate::parser::{
+    get_subtag_iterator, parse_locale,
+    parse_locale_with_single_variant_single_keyword_unicode_keyword_extension, ParserError,
+    ParserMode,
+};
 use crate::{extensions, subtags, LanguageIdentifier};
 use alloc::string::String;
 use alloc::string::ToString;
 use core::cmp::Ordering;
 use core::str::FromStr;
+use tinystr::TinyAsciiStr;
 
 /// A core struct representing a [`Unicode Locale Identifier`].
 ///
@@ -308,6 +313,26 @@ impl Locale {
             }
         }
         iter.next() == None
+    }
+
+    #[doc(hidden)]
+    #[allow(clippy::type_complexity)]
+    pub const fn from_bytes_with_single_variant_single_keyword_unicode_extension(
+        v: &[u8],
+    ) -> Result<
+        (
+            subtags::Language,
+            Option<subtags::Script>,
+            Option<subtags::Region>,
+            Option<subtags::Variant>,
+            Option<(extensions::unicode::Key, Option<TinyAsciiStr<8>>)>,
+        ),
+        ParserError,
+    > {
+        parse_locale_with_single_variant_single_keyword_unicode_keyword_extension(
+            v,
+            ParserMode::Locale,
+        )
     }
 
     pub(crate) fn for_each_subtag_str<E, F>(&self, f: &mut F) -> Result<(), E>

--- a/components/locid/src/macros.rs
+++ b/components/locid/src/macros.rs
@@ -196,13 +196,39 @@ macro_rules! langid {
 /// limitations (see [`Heap Allocations in Constants`]):
 ///
 /// ```compile_fail
-/// icu::locid::locale!("en-US-u-ca-ja");
+/// icu::locid::locale!("sl-IT-rozaj-biske-1994")
 /// ```
 /// Use runtime parsing instead:
 /// ```
-/// "en-US-u-ca-ja".parse::<icu::locid::Locale>().unwrap();
+/// "sl-IT-rozaj-biske-1994".parse::<icu::locid::Locale>().unwrap();
 /// ```
 ///
+/// Locales with multiple keys are not supported
+/// ```compile_fail
+/// icu::locid::locale!("en-US-u-ca-buddhist-ca-japanese");
+/// ```
+/// Use runtime parsing instead:
+/// ```
+/// "en-US-u-ca-buddhist-ca-japanese".parse::<icu::locid::Locale>().unwrap();
+/// ```
+///
+/// Locales with attributes are not supported
+/// ```compile_fail
+/// icu::locid::locale!("en-US-u-foobar-ca-buddhist");
+/// ```
+/// Use runtime parsing instead:
+/// ```
+/// "en-US-u-foobar-ca-buddhist".parse::<icu::locid::Locale>().unwrap();
+/// ```
+///
+/// Locales with single key but multiple types are not supported
+/// ```compile_fail
+/// icu::locid::locale!("en-US-u-ca-buddhist-japanese");
+/// ```
+/// Use runtime parsing instead:
+/// ```
+/// "en-US-u-ca-buddhist-japanese".parse::<icu::locid::Locale>().unwrap();
+/// ```
 /// [`Locale`]: crate::Locale
 /// [`Heap Allocations in Constants`]: https://github.com/rust-lang/const-eval/issues/20
 #[macro_export]
@@ -222,18 +248,19 @@ macro_rules! locale {
                             None => $crate::subtags::Variants::new(),
                         },
                     },
-                    extensions: $crate::extensions::Extensions::single_unicode(
-                        $crate::extensions::Unicode {
-                            keywords: match keyword {
-                                Some(k) => $crate::extensions::unicode::Keywords::new_single(
+                    extensions: match keyword {
+                        Some(k) => $crate::extensions::Extensions::single_unicode(
+                            $crate::extensions::Unicode {
+                                keywords: $crate::extensions::unicode::Keywords::new_single(
                                     k.0,
                                     $crate::extensions::unicode::Value::from_tinystr(k.1),
                                 ),
-                                None => $crate::extensions::unicode::Keywords::new(),
+
+                                attributes: $crate::extensions::unicode::Attributes::new(),
                             },
-                            attributes: $crate::extensions::unicode::Attributes::new(),
-                        },
-                    ),
+                        ),
+                        None => $crate::extensions::Extensions::new(),
+                    },
                 },
                 #[allow(clippy::panic)] // const context
                 _ => panic!(concat!(

--- a/components/locid/src/macros.rs
+++ b/components/locid/src/macros.rs
@@ -205,7 +205,7 @@ macro_rules! langid {
 ///
 /// Locales with multiple keys are not supported
 /// ```compile_fail
-/// icu::locid::locale!("en-US-u-ca-buddhist-ca-japanese");
+/// icu::locid::locale!("th-TH-u-ca-buddhist-nu-thai");
 /// ```
 /// Use runtime parsing instead:
 /// ```
@@ -223,7 +223,7 @@ macro_rules! langid {
 ///
 /// Locales with single key but multiple types are not supported
 /// ```compile_fail
-/// icu::locid::locale!("en-US-u-ca-buddhist-japanese");
+/// icu::locid::locale!("en-US-u-ca-islamic-umalqura");
 /// ```
 /// Use runtime parsing instead:
 /// ```

--- a/components/locid/src/macros.rs
+++ b/components/locid/src/macros.rs
@@ -209,7 +209,7 @@ macro_rules! langid {
 /// ```
 /// Use runtime parsing instead:
 /// ```
-/// "en-US-u-ca-buddhist-ca-japanese".parse::<icu::locid::Locale>().unwrap();
+/// "th-TH-u-ca-buddhist-nu-thai".parse::<icu::locid::Locale>().unwrap();
 /// ```
 ///
 /// Locales with attributes are not supported
@@ -227,7 +227,7 @@ macro_rules! langid {
 /// ```
 /// Use runtime parsing instead:
 /// ```
-/// "en-US-u-ca-buddhist-japanese".parse::<icu::locid::Locale>().unwrap();
+/// "en-US-u-ca-islamic-umalqura".parse::<icu::locid::Locale>().unwrap();
 /// ```
 /// [`Locale`]: crate::Locale
 /// [`Heap Allocations in Constants`]: https://github.com/rust-lang/const-eval/issues/20

--- a/components/locid/src/macros.rs
+++ b/components/locid/src/macros.rs
@@ -249,7 +249,7 @@ macro_rules! locale {
                         },
                     },
                     extensions: match keyword {
-                        Some(k) => $crate::extensions::Extensions::single_unicode(
+                        Some(k) => $crate::extensions::Extensions::from_unicode(
                             $crate::extensions::Unicode {
                                 keywords: $crate::extensions::unicode::Keywords::new_single(
                                     k.0,

--- a/components/locid/src/macros.rs
+++ b/components/locid/src/macros.rs
@@ -222,15 +222,18 @@ macro_rules! locale {
                             None => $crate::subtags::Variants::new(),
                         },
                     },
-                    extensions: match keyword {
-                        Some(k) => $crate::extensions::Extensions::single_unicode(
-                            $crate::extensions::Unicode::single_keyword(
-                                k.0,
-                                $crate::extensions::unicode::Value::from_tinystr(k.1),
-                            ),
-                        ),
-                        None => $crate::extensions::Extensions::new(),
-                    },
+                    extensions: $crate::extensions::Extensions::single_unicode(
+                        $crate::extensions::Unicode {
+                            keywords: match keyword {
+                                Some(k) => $crate::extensions::unicode::Keywords::new_single(
+                                    k.0,
+                                    $crate::extensions::unicode::Value::from_tinystr(k.1),
+                                ),
+                                None => $crate::extensions::unicode::Keywords::new(),
+                            },
+                            attributes: $crate::extensions::unicode::Attributes::new(),
+                        },
+                    ),
                 },
                 #[allow(clippy::panic)] // const context
                 _ => panic!(concat!(

--- a/components/locid/src/parser/locale.rs
+++ b/components/locid/src/parser/locale.rs
@@ -2,10 +2,14 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::extensions::Extensions;
+use tinystr::TinyAsciiStr;
+
+use crate::extensions::{self, Extensions};
 use crate::parser::errors::ParserError;
 use crate::parser::{get_subtag_iterator, parse_language_identifier_from_iter, ParserMode};
-use crate::Locale;
+use crate::{subtags, Locale};
+
+use super::parse_locale_with_single_variant_single_keyword_unicode_extension_from_iter;
 
 pub fn parse_locale(t: &[u8]) -> Result<Locale, ParserError> {
     let mut iter = get_subtag_iterator(t);
@@ -17,4 +21,22 @@ pub fn parse_locale(t: &[u8]) -> Result<Locale, ParserError> {
         Extensions::default()
     };
     Ok(Locale { id, extensions })
+}
+
+#[allow(clippy::type_complexity)]
+pub const fn parse_locale_with_single_variant_single_keyword_unicode_keyword_extension(
+    t: &[u8],
+    mode: ParserMode,
+) -> Result<
+    (
+        subtags::Language,
+        Option<subtags::Script>,
+        Option<subtags::Region>,
+        Option<subtags::Variant>,
+        Option<(extensions::unicode::Key, Option<TinyAsciiStr<8>>)>,
+    ),
+    ParserError,
+> {
+    let iter = get_subtag_iterator(t);
+    parse_locale_with_single_variant_single_keyword_unicode_extension_from_iter(iter, mode)
 }

--- a/components/locid/src/parser/mod.rs
+++ b/components/locid/src/parser/mod.rs
@@ -9,9 +9,13 @@ mod locale;
 pub use errors::ParserError;
 pub use langid::{
     parse_language_identifier, parse_language_identifier_from_iter,
-    parse_language_identifier_with_single_variant, ParserMode,
+    parse_language_identifier_with_single_variant,
+    parse_locale_with_single_variant_single_keyword_unicode_extension_from_iter, ParserMode,
 };
-pub use locale::parse_locale;
+
+pub use locale::{
+    parse_locale, parse_locale_with_single_variant_single_keyword_unicode_keyword_extension,
+};
 
 pub const fn get_subtag_iterator(slice: &[u8]) -> SubtagIterator {
     let mut current_start = 0;

--- a/provider/datagen/src/databake.rs
+++ b/provider/datagen/src/databake.rs
@@ -236,7 +236,7 @@ impl DataExporter for BakedDataExporter {
                 type DataStruct = #struct_type;
 
                 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-                    litemap::LiteMap::from_sorted_slice_unchecked(&[#(#data),*]);
+                    litemap::LiteMap::from_sorted_store_unchecked(&[#(#data),*]);
 
                 #(#statics)*
             },

--- a/provider/testdata/data/baked/calendar/japanese_v1.rs
+++ b/provider/testdata/data/baked/calendar/japanese_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_calendar::provider::JapaneseErasV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_calendar::provider::JapaneseErasV1 {
     dates_to_eras: unsafe {
         ::zerovec::ZeroVec::from_bytes_unchecked(&[

--- a/provider/testdata/data/baked/calendar/japanext_v1.rs
+++ b/provider/testdata/data/baked/calendar/japanext_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_calendar :: provider :: JapaneseExtendedErasV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_calendar::provider::JapaneseErasV1 {
     dates_to_eras: unsafe {
         ::zerovec::ZeroVec::from_bytes_unchecked(&[

--- a/provider/testdata/data/baked/collator/data_v1.rs
+++ b/provider/testdata/data/baked/collator/data_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_collator::provider::CollationDataV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("bn", BN),
         ("es", ES),
         ("ja", JA),

--- a/provider/testdata/data/baked/collator/dia_v1.rs
+++ b/provider/testdata/data/baked/collator/dia_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_collator::provider::CollationDiacriticsV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_collator::provider::CollationDiacriticsV1 {
     secondaries: unsafe {
         ::zerovec::ZeroVec::from_bytes_unchecked(&[

--- a/provider/testdata/data/baked/collator/jamo_v1.rs
+++ b/provider/testdata/data/baked/collator/jamo_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_collator::provider::CollationJamoV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_collator::provider::CollationJamoV1 {
     ce32s: unsafe {
         ::zerovec::ZeroVec::from_bytes_unchecked(&[

--- a/provider/testdata/data/baked/collator/meta_v1.rs
+++ b/provider/testdata/data/baked/collator/meta_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_collator::provider::CollationMetadataV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("bn", BN_JA),
         ("es", ES_TR),
         ("ja", BN_JA),

--- a/provider/testdata/data/baked/collator/prim_v1.rs
+++ b/provider/testdata/data/baked/collator/prim_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_collator :: provider :: CollationSpecialPrimariesV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_collator::provider::CollationSpecialPrimariesV1 {
     last_primaries: unsafe {
         ::zerovec::ZeroVec::from_bytes_unchecked(&[6u8, 5u8, 0u8, 12u8, 137u8, 13u8, 0u8, 14u8])

--- a/provider/testdata/data/baked/collator/reord_v1.rs
+++ b/provider/testdata/data/baked/collator/reord_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_collator::provider::CollationReorderingV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("bn", BN), ("ja", JA), ("th", TH)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("bn", BN), ("ja", JA), ("th", TH)]);
 static BN: &DataStruct = &::icu_collator::provider::CollationReorderingV1 {
     min_high_no_reorder: 1906311168u32,
     reorder_table: unsafe {

--- a/provider/testdata/data/baked/core/helloworld_v1.rs
+++ b/provider/testdata/data/baked/core/helloworld_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_provider::hello_world::HelloWorldV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("bn", BN),
         ("en", EN),
         ("ja", JA),

--- a/provider/testdata/data/baked/datetime/buddhist/datelengths_v1.rs
+++ b/provider/testdata/data/baked/datetime/buddhist/datelengths_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: calendar :: BuddhistDateLengthsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN_CCP),

--- a/provider/testdata/data/baked/datetime/buddhist/datesymbols_v1.rs
+++ b/provider/testdata/data/baked/datetime/buddhist/datesymbols_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: calendar :: BuddhistDateSymbolsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN),

--- a/provider/testdata/data/baked/datetime/coptic/datelengths_v1.rs
+++ b/provider/testdata/data/baked/datetime/coptic/datelengths_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: calendar :: CopticDateLengthsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN_CCP),

--- a/provider/testdata/data/baked/datetime/coptic/datesymbols_v1.rs
+++ b/provider/testdata/data/baked/datetime/coptic/datesymbols_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: calendar :: CopticDateSymbolsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN),

--- a/provider/testdata/data/baked/datetime/ethiopic/datelengths_v1.rs
+++ b/provider/testdata/data/baked/datetime/ethiopic/datelengths_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: calendar :: EthiopicDateLengthsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN_CCP),

--- a/provider/testdata/data/baked/datetime/ethiopic/datesymbols_v1.rs
+++ b/provider/testdata/data/baked/datetime/ethiopic/datesymbols_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: calendar :: EthiopicDateSymbolsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN),

--- a/provider/testdata/data/baked/datetime/gregory/datelengths_v1.rs
+++ b/provider/testdata/data/baked/datetime/gregory/datelengths_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: calendar :: GregorianDateLengthsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN_CCP),

--- a/provider/testdata/data/baked/datetime/gregory/datesymbols_v1.rs
+++ b/provider/testdata/data/baked/datetime/gregory/datesymbols_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: calendar :: GregorianDateSymbolsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN),

--- a/provider/testdata/data/baked/datetime/indian/datelengths_v1.rs
+++ b/provider/testdata/data/baked/datetime/indian/datelengths_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: calendar :: IndianDateLengthsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN_CCP),

--- a/provider/testdata/data/baked/datetime/indian/datesymbols_v1.rs
+++ b/provider/testdata/data/baked/datetime/indian/datesymbols_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: calendar :: IndianDateSymbolsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN),

--- a/provider/testdata/data/baked/datetime/japanese/datelengths_v1.rs
+++ b/provider/testdata/data/baked/datetime/japanese/datelengths_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: calendar :: JapaneseDateLengthsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN_CCP),

--- a/provider/testdata/data/baked/datetime/japanese/datesymbols_v1.rs
+++ b/provider/testdata/data/baked/datetime/japanese/datesymbols_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: calendar :: JapaneseDateSymbolsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN),

--- a/provider/testdata/data/baked/datetime/japanext/datelengths_v1.rs
+++ b/provider/testdata/data/baked/datetime/japanext/datelengths_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: calendar :: JapaneseExtendedDateLengthsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN_CCP),

--- a/provider/testdata/data/baked/datetime/japanext/datesymbols_v1.rs
+++ b/provider/testdata/data/baked/datetime/japanext/datesymbols_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: calendar :: JapaneseExtendedDateSymbolsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN),

--- a/provider/testdata/data/baked/datetime/skeletons_v1_u_ca.rs
+++ b/provider/testdata/data/baked/datetime/skeletons_v1_u_ca.rs
@@ -4,7 +4,7 @@ type DataStruct = [(
     ::icu_datetime::pattern::runtime::PatternPlurals<'static>,
 )];
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar-EG-u-ca-buddhist", AR_EG_U_CA_BUDDHIST_AR_EG_U_CA_COPTIC),
         ("ar-EG-u-ca-coptic", AR_EG_U_CA_BUDDHIST_AR_EG_U_CA_COPTIC),
         ("ar-EG-u-ca-ethiopic", AR_EG_U_CA_BUDDHIST_AR_EG_U_CA_COPTIC),

--- a/provider/testdata/data/baked/datetime/timelengths_v1.rs
+++ b/provider/testdata/data/baked/datetime/timelengths_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: calendar :: TimeLengthsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG_BN_CCP_EN_EN_001_FIL),
         ("ar-EG", AR_AR_EG_BN_CCP_EN_EN_001_FIL),
         ("bn", AR_AR_EG_BN_CCP_EN_EN_001_FIL),

--- a/provider/testdata/data/baked/datetime/timesymbols_v1.rs
+++ b/provider/testdata/data/baked/datetime/timesymbols_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: calendar :: TimeSymbolsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN_CCP_UND),

--- a/provider/testdata/data/baked/datetime/week_data_v1_r.rs
+++ b/provider/testdata/data/baked/datetime/week_data_v1_r.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_datetime::provider::week_data::WeekDataV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("und", UND_UND_AI_UND_AL_UND_AM_UND_AR_UND_AU),
         ("und-AD", UND_AD_UND_AN_UND_AT_UND_AX_UND_BE_UND_BG),
         ("und-AE", UND_AE_UND_AF_UND_BH_UND_DJ_UND_DZ_UND_EG),

--- a/provider/testdata/data/baked/decimal/symbols_v1_u_nu.rs
+++ b/provider/testdata/data/baked/decimal/symbols_v1_u_nu.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_decimal::provider::DecimalSymbolsV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("ar-EG-u-nu-latn", AR_EG_U_NU_LATN_AR_U_NU_LATN),

--- a/provider/testdata/data/baked/fallback/likelysubtags_v1.rs
+++ b/provider/testdata/data/baked/fallback/likelysubtags_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_provider_adapters :: fallback :: provider :: LocaleFallbackLikelySubtagsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_provider_adapters::fallback::provider::LocaleFallbackLikelySubtagsV1 {
         l2s: unsafe {

--- a/provider/testdata/data/baked/fallback/parents_v1.rs
+++ b/provider/testdata/data/baked/fallback/parents_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_provider_adapters :: fallback :: provider :: LocaleFallbackParentsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_provider_adapters::fallback::provider::LocaleFallbackParentsV1 {
     parents: unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/list/and_v1.rs
+++ b/provider/testdata/data/baked/list/and_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = <::icu_list::provider::AndListV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN),

--- a/provider/testdata/data/baked/list/or_v1.rs
+++ b/provider/testdata/data/baked/list/or_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = <::icu_list::provider::OrListV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN),

--- a/provider/testdata/data/baked/list/unit_v1.rs
+++ b/provider/testdata/data/baked/list/unit_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = <::icu_list::provider::UnitListV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN_CCP_UND),

--- a/provider/testdata/data/baked/locid_transform/aliases_v1.rs
+++ b/provider/testdata/data/baked/locid_transform/aliases_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_locid_transform::provider::AliasesV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_locid_transform::provider::AliasesV1 {
     language_variants: unsafe {
         ::zerovec::VarZeroVec::from_bytes_unchecked(&[

--- a/provider/testdata/data/baked/locid_transform/likelysubtags_v1.rs
+++ b/provider/testdata/data/baked/locid_transform/likelysubtags_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_locid_transform :: provider :: LikelySubtagsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_locid_transform::provider::LikelySubtagsV1 {
     language_script: unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/normalizer/comp_v1.rs
+++ b/provider/testdata/data/baked/normalizer/comp_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_normalizer :: provider :: CanonicalCompositionsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_normalizer::provider::CanonicalCompositionsV1 {
     canonical_compositions: ::icu_collections::char16trie::Char16Trie {
         data: unsafe {

--- a/provider/testdata/data/baked/normalizer/decomp_v1.rs
+++ b/provider/testdata/data/baked/normalizer/decomp_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_normalizer :: provider :: NonRecursiveDecompositionSupplementV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_normalizer::provider::NonRecursiveDecompositionSupplementV1 {
     trie: ::icu_collections::codepointtrie::CodePointTrie::from_parts(
         ::icu_collections::codepointtrie::CodePointTrieHeader {

--- a/provider/testdata/data/baked/normalizer/nfc_v1.rs
+++ b/provider/testdata/data/baked/normalizer/nfc_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_normalizer :: provider :: CanonicalCompositionPassthroughV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_normalizer::provider::CompositionPassthroughV1 {
     first: 768u32,
     trie: ::icu_collections::codepointtrie::CodePointTrie::from_parts(

--- a/provider/testdata/data/baked/normalizer/nfd_v1.rs
+++ b/provider/testdata/data/baked/normalizer/nfd_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_normalizer :: provider :: CanonicalDecompositionDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_normalizer::provider::DecompositionDataV1 {
     trie: ::icu_collections::codepointtrie::CodePointTrie::from_parts(
         ::icu_collections::codepointtrie::CodePointTrieHeader {

--- a/provider/testdata/data/baked/normalizer/nfdex_v1.rs
+++ b/provider/testdata/data/baked/normalizer/nfdex_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_normalizer :: provider :: CanonicalDecompositionTablesV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_normalizer::provider::DecompositionTablesV1 {
     scalars16: unsafe {
         ::zerovec::ZeroVec::from_bytes_unchecked(&[

--- a/provider/testdata/data/baked/normalizer/nfkc_v1.rs
+++ b/provider/testdata/data/baked/normalizer/nfkc_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_normalizer :: provider :: CompatibilityCompositionPassthroughV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_normalizer::provider::CompositionPassthroughV1 {
     first: 160u32,
     trie: ::icu_collections::codepointtrie::CodePointTrie::from_parts(

--- a/provider/testdata/data/baked/normalizer/nfkd_v1.rs
+++ b/provider/testdata/data/baked/normalizer/nfkd_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_normalizer :: provider :: CompatibilityDecompositionSupplementV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_normalizer::provider::DecompositionSupplementV1 {
     trie: ::icu_collections::codepointtrie::CodePointTrie::from_parts(
         ::icu_collections::codepointtrie::CodePointTrieHeader {

--- a/provider/testdata/data/baked/normalizer/nfkdex_v1.rs
+++ b/provider/testdata/data/baked/normalizer/nfkdex_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_normalizer :: provider :: CompatibilityDecompositionTablesV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_normalizer::provider::DecompositionTablesV1 {
     scalars16: unsafe {
         ::zerovec::ZeroVec::from_bytes_unchecked(&[

--- a/provider/testdata/data/baked/normalizer/uts46_v1.rs
+++ b/provider/testdata/data/baked/normalizer/uts46_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_normalizer :: provider :: Uts46CompositionPassthroughV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_normalizer::provider::CompositionPassthroughV1 {
     first: 65u32,
     trie: ::icu_collections::codepointtrie::CodePointTrie::from_parts(

--- a/provider/testdata/data/baked/normalizer/uts46d_v1.rs
+++ b/provider/testdata/data/baked/normalizer/uts46d_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_normalizer :: provider :: Uts46DecompositionSupplementV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_normalizer::provider::DecompositionSupplementV1 {
     trie: ::icu_collections::codepointtrie::CodePointTrie::from_parts(
         ::icu_collections::codepointtrie::CodePointTrieHeader {

--- a/provider/testdata/data/baked/plurals/cardinal_v1.rs
+++ b/provider/testdata/data/baked/plurals/cardinal_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_plurals::provider::CardinalV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR),
         ("bn", BN),
         ("en", EN),

--- a/provider/testdata/data/baked/plurals/ordinal_v1.rs
+++ b/provider/testdata/data/baked/plurals/ordinal_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_plurals::provider::OrdinalV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_ES_JA_RU_SR_TH_TR_UND),
         ("bn", BN),
         ("en", EN),

--- a/provider/testdata/data/baked/props/ahex_v1.rs
+++ b/provider/testdata/data/baked/props/ahex_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::AsciiHexDigitV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/alpha_v1.rs
+++ b/provider/testdata/data/baked/props/alpha_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::AlphabeticV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/bc_v1.rs
+++ b/provider/testdata/data/baked/props/bc_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::BidiClassV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_properties::provider::PropertyCodePointMapV1::CodePointTrie(
     ::icu_collections::codepointtrie::CodePointTrie::from_parts(
         ::icu_collections::codepointtrie::CodePointTrieHeader {

--- a/provider/testdata/data/baked/props/bidi_c_v1.rs
+++ b/provider/testdata/data/baked/props/bidi_c_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::BidiControlV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/bidi_m_v1.rs
+++ b/provider/testdata/data/baked/props/bidi_m_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::BidiMirroredV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/cased_v1.rs
+++ b/provider/testdata/data/baked/props/cased_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::CasedV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/casemap_v1.rs
+++ b/provider/testdata/data/baked/props/casemap_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_casemapping::provider::CaseMappingV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_casemapping::provider::CaseMappingV1 {
     casemap: ::icu_casemapping::provider::CaseMappingInternals {
         trie: ::icu_collections::codepointtrie::CodePointTrie::from_parts(

--- a/provider/testdata/data/baked/props/ccc_v1.rs
+++ b/provider/testdata/data/baked/props/ccc_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_properties :: provider :: CanonicalCombiningClassV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_properties::provider::PropertyCodePointMapV1::CodePointTrie(
     ::icu_collections::codepointtrie::CodePointTrie::from_parts(
         ::icu_collections::codepointtrie::CodePointTrieHeader {

--- a/provider/testdata/data/baked/props/ci_v1.rs
+++ b/provider/testdata/data/baked/props/ci_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::CaseIgnorableV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/cwcf_v1.rs
+++ b/provider/testdata/data/baked/props/cwcf_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_properties :: provider :: ChangesWhenCasefoldedV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/cwkcf_v1.rs
+++ b/provider/testdata/data/baked/props/cwkcf_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_properties :: provider :: ChangesWhenNfkcCasefoldedV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/cwl_v1.rs
+++ b/provider/testdata/data/baked/props/cwl_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_properties :: provider :: ChangesWhenLowercasedV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/cwt_v1.rs
+++ b/provider/testdata/data/baked/props/cwt_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_properties :: provider :: ChangesWhenTitlecasedV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/cwu_v1.rs
+++ b/provider/testdata/data/baked/props/cwu_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_properties :: provider :: ChangesWhenUppercasedV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/dash_v1.rs
+++ b/provider/testdata/data/baked/props/dash_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::DashV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/dep_v1.rs
+++ b/provider/testdata/data/baked/props/dep_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::DeprecatedV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/di_v1.rs
+++ b/provider/testdata/data/baked/props/di_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_properties :: provider :: DefaultIgnorableCodePointV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/dia_v1.rs
+++ b/provider/testdata/data/baked/props/dia_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::DiacriticV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/ea_v1.rs
+++ b/provider/testdata/data/baked/props/ea_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::EastAsianWidthV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_properties::provider::PropertyCodePointMapV1::CodePointTrie(
     ::icu_collections::codepointtrie::CodePointTrie::from_parts(
         ::icu_collections::codepointtrie::CodePointTrieHeader {

--- a/provider/testdata/data/baked/props/ebase_v1.rs
+++ b/provider/testdata/data/baked/props/ebase_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::EmojiModifierBaseV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/ecomp_v1.rs
+++ b/provider/testdata/data/baked/props/ecomp_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::EmojiComponentV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/emod_v1.rs
+++ b/provider/testdata/data/baked/props/emod_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::EmojiModifierV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/emoji_v1.rs
+++ b/provider/testdata/data/baked/props/emoji_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::EmojiV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/epres_v1.rs
+++ b/provider/testdata/data/baked/props/epres_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::EmojiPresentationV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/ext_v1.rs
+++ b/provider/testdata/data/baked/props/ext_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::ExtenderV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/extpict_v1.rs
+++ b/provider/testdata/data/baked/props/extpict_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_properties :: provider :: ExtendedPictographicV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/gc_v1.rs
+++ b/provider/testdata/data/baked/props/gc_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::GeneralCategoryV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_properties::provider::PropertyCodePointMapV1::CodePointTrie(
     ::icu_collections::codepointtrie::CodePointTrie::from_parts(
         ::icu_collections::codepointtrie::CodePointTrieHeader {

--- a/provider/testdata/data/baked/props/gcb_v1.rs
+++ b/provider/testdata/data/baked/props/gcb_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_properties :: provider :: GraphemeClusterBreakV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_properties::provider::PropertyCodePointMapV1::CodePointTrie(
     ::icu_collections::codepointtrie::CodePointTrie::from_parts(
         ::icu_collections::codepointtrie::CodePointTrieHeader {

--- a/provider/testdata/data/baked/props/gr_base_v1.rs
+++ b/provider/testdata/data/baked/props/gr_base_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::GraphemeBaseV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/gr_ext_v1.rs
+++ b/provider/testdata/data/baked/props/gr_ext_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::GraphemeExtendV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/hex_v1.rs
+++ b/provider/testdata/data/baked/props/hex_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::HexDigitV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/idc_v1.rs
+++ b/provider/testdata/data/baked/props/idc_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::IdContinueV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/ideo_v1.rs
+++ b/provider/testdata/data/baked/props/ideo_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::IdeographicV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/ids_v1.rs
+++ b/provider/testdata/data/baked/props/ids_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::IdStartV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/idsb_v1.rs
+++ b/provider/testdata/data/baked/props/idsb_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::IdsBinaryOperatorV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/idst_v1.rs
+++ b/provider/testdata/data/baked/props/idst_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_properties :: provider :: IdsTrinaryOperatorV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/join_c_v1.rs
+++ b/provider/testdata/data/baked/props/join_c_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::JoinControlV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/lb_v1.rs
+++ b/provider/testdata/data/baked/props/lb_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::LineBreakV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_properties::provider::PropertyCodePointMapV1::CodePointTrie(
     ::icu_collections::codepointtrie::CodePointTrie::from_parts(
         ::icu_collections::codepointtrie::CodePointTrieHeader {

--- a/provider/testdata/data/baked/props/loe_v1.rs
+++ b/provider/testdata/data/baked/props/loe_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_properties :: provider :: LogicalOrderExceptionV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/lower_v1.rs
+++ b/provider/testdata/data/baked/props/lower_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::LowercaseV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/math_v1.rs
+++ b/provider/testdata/data/baked/props/math_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::MathV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/nchar_v1.rs
+++ b/provider/testdata/data/baked/props/nchar_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_properties :: provider :: NoncharacterCodePointV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/pat_syn_v1.rs
+++ b/provider/testdata/data/baked/props/pat_syn_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::PatternSyntaxV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/pat_ws_v1.rs
+++ b/provider/testdata/data/baked/props/pat_ws_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::PatternWhiteSpaceV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/qmark_v1.rs
+++ b/provider/testdata/data/baked/props/qmark_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::QuotationMarkV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/radical_v1.rs
+++ b/provider/testdata/data/baked/props/radical_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::RadicalV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/ri_v1.rs
+++ b/provider/testdata/data/baked/props/ri_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::RegionalIndicatorV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/sb_v1.rs
+++ b/provider/testdata/data/baked/props/sb_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::SentenceBreakV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_properties::provider::PropertyCodePointMapV1::CodePointTrie(
     ::icu_collections::codepointtrie::CodePointTrie::from_parts(
         ::icu_collections::codepointtrie::CodePointTrieHeader {

--- a/provider/testdata/data/baked/props/sc_v1.rs
+++ b/provider/testdata/data/baked/props/sc_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::ScriptV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_properties::provider::PropertyCodePointMapV1::CodePointTrie(
     ::icu_collections::codepointtrie::CodePointTrie::from_parts(
         ::icu_collections::codepointtrie::CodePointTrieHeader {

--- a/provider/testdata/data/baked/props/scx_v1.rs
+++ b/provider/testdata/data/baked/props/scx_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_properties :: provider :: ScriptWithExtensionsPropertyV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_properties::provider::ScriptWithExtensionsPropertyV1 {
     data: ::icu_properties::script::ScriptWithExtensions {
         trie: ::icu_collections::codepointtrie::CodePointTrie::from_parts(

--- a/provider/testdata/data/baked/props/sd_v1.rs
+++ b/provider/testdata/data/baked/props/sd_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::SoftDottedV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/sterm_v1.rs
+++ b/provider/testdata/data/baked/props/sterm_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::SentenceTerminalV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/term_v1.rs
+++ b/provider/testdata/data/baked/props/term_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_properties :: provider :: TerminalPunctuationV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/uideo_v1.rs
+++ b/provider/testdata/data/baked/props/uideo_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::UnifiedIdeographV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/upper_v1.rs
+++ b/provider/testdata/data/baked/props/upper_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::UppercaseV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/vs_v1.rs
+++ b/provider/testdata/data/baked/props/vs_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::VariationSelectorV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/wb_v1.rs
+++ b/provider/testdata/data/baked/props/wb_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::WordBreakV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_properties::provider::PropertyCodePointMapV1::CodePointTrie(
     ::icu_collections::codepointtrie::CodePointTrie::from_parts(
         ::icu_collections::codepointtrie::CodePointTrieHeader {

--- a/provider/testdata/data/baked/props/wspace_v1.rs
+++ b/provider/testdata/data/baked/props/wspace_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::WhiteSpaceV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/xidc_v1.rs
+++ b/provider/testdata/data/baked/props/xidc_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::XidContinueV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/props/xids_v1.rs
+++ b/provider/testdata/data/baked/props/xids_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_properties::provider::XidStartV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct =
     &::icu_properties::provider::PropertyCodePointSetV1::InversionList(unsafe {
         #[allow(unused_unsafe)]

--- a/provider/testdata/data/baked/segmenter/grapheme_v1.rs
+++ b/provider/testdata/data/baked/segmenter/grapheme_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_segmenter :: provider :: GraphemeClusterBreakDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_segmenter::provider::RuleBreakDataV1 {
     property_table: ::icu_segmenter::provider::RuleBreakPropertyTable(
         ::icu_collections::codepointtrie::CodePointTrie::from_parts(

--- a/provider/testdata/data/baked/segmenter/line_v1.rs
+++ b/provider/testdata/data/baked/segmenter/line_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_segmenter::provider::LineBreakDataV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_segmenter::provider::RuleBreakDataV1 {
     property_table: ::icu_segmenter::provider::RuleBreakPropertyTable(
         ::icu_collections::codepointtrie::CodePointTrie::from_parts(

--- a/provider/testdata/data/baked/segmenter/lstm_v1.rs
+++ b/provider/testdata/data/baked/segmenter/lstm_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_segmenter::provider::LstmDataV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("th", TH)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("th", TH)]);
 static TH: &DataStruct = &::icu_segmenter::provider::LstmDataV1 {
     model: alloc::borrow::Cow::Borrowed("Thai_codepoints_exclusive_model4_heavy"),
     dic: unsafe {

--- a/provider/testdata/data/baked/segmenter/sentence_v1.rs
+++ b/provider/testdata/data/baked/segmenter/sentence_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_segmenter::provider::SentenceBreakDataV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_segmenter::provider::RuleBreakDataV1 {
     property_table: ::icu_segmenter::provider::RuleBreakPropertyTable(
         ::icu_collections::codepointtrie::CodePointTrie::from_parts(

--- a/provider/testdata/data/baked/segmenter/word_v1.rs
+++ b/provider/testdata/data/baked/segmenter/word_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_segmenter::provider::WordBreakDataV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_segmenter::provider::RuleBreakDataV1 {
     property_table: ::icu_segmenter::provider::RuleBreakPropertyTable(
         ::icu_collections::codepointtrie::CodePointTrie::from_parts(

--- a/provider/testdata/data/baked/time_zone/exemplar_cities_v1.rs
+++ b/provider/testdata/data/baked/time_zone/exemplar_cities_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: time_zones :: ExemplarCitiesV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN),

--- a/provider/testdata/data/baked/time_zone/formats_v1.rs
+++ b/provider/testdata/data/baked/time_zone/formats_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: time_zones :: TimeZoneFormatsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN),

--- a/provider/testdata/data/baked/time_zone/generic_long_v1.rs
+++ b/provider/testdata/data/baked/time_zone/generic_long_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: time_zones :: MetaZoneGenericNamesLongV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN),

--- a/provider/testdata/data/baked/time_zone/generic_short_v1.rs
+++ b/provider/testdata/data/baked/time_zone/generic_short_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: time_zones :: MetaZoneGenericNamesShortV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN_CCP),

--- a/provider/testdata/data/baked/time_zone/metazone_period_v1.rs
+++ b/provider/testdata/data/baked/time_zone/metazone_period_v1.rs
@@ -2,7 +2,7 @@
 type DataStruct =
     <::icu_timezone::provider::MetaZonePeriodV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[("und", UND)]);
+    litemap::LiteMap::from_sorted_store_unchecked(&[("und", UND)]);
 static UND: &DataStruct = &::icu_timezone::provider::MetaZonePeriodV1(unsafe {
     #[allow(unused_unsafe)]
     ::zerovec::ZeroMap2d::from_parts_unchecked(

--- a/provider/testdata/data/baked/time_zone/specific_long_v1.rs
+++ b/provider/testdata/data/baked/time_zone/specific_long_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: time_zones :: MetaZoneSpecificNamesLongV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN),

--- a/provider/testdata/data/baked/time_zone/specific_short_v1.rs
+++ b/provider/testdata/data/baked/time_zone/specific_short_v1.rs
@@ -1,7 +1,7 @@
 // @generated
 type DataStruct = < :: icu_datetime :: provider :: time_zones :: MetaZoneSpecificNamesShortV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
-    litemap::LiteMap::from_sorted_slice_unchecked(&[
+    litemap::LiteMap::from_sorted_store_unchecked(&[
         ("ar", AR_AR_EG),
         ("ar-EG", AR_AR_EG),
         ("bn", BN_CCP),

--- a/utils/litemap/src/map.rs
+++ b/utils/litemap/src/map.rs
@@ -37,11 +37,7 @@ impl<K, V> LiteMap<K, V> {
 
 impl<K, V, S> LiteMap<K, V, S> {
     /// Construct a new [`LiteMap`] using the given values
-    ///
-    /// # Safety
-    ///
-    /// The store must be sorted and have no duplicate keys.
-    pub const fn from_store_unchecked(values: S) -> Self {
+    pub const fn from_sorted_store_unchecked(values: S) -> Self {
         Self {
             values,
             _key_type: PhantomData,

--- a/utils/litemap/src/map.rs
+++ b/utils/litemap/src/map.rs
@@ -47,38 +47,10 @@ impl<K, V, S> LiteMap<K, V, S> {
 }
 
 impl<K, V> LiteMap<K, V, Vec<(K, V)>> {
-    /// Convert a `Vec<(K, V)>` into a [`LiteMap`].
-    ///
-    /// # Safety
-    ///
-    /// The vec must be sorted and have no duplicate keys.
-    #[inline]
-    pub unsafe fn from_tuple_vec_unchecked(values: Vec<(K, V)>) -> Self {
-        Self {
-            values,
-            _key_type: PhantomData,
-            _value_type: PhantomData,
-        }
-    }
-
     /// Convert a [`LiteMap`] into a sorted `Vec<(K, V)>`.
     #[inline]
     pub fn into_tuple_vec(self) -> Vec<(K, V)> {
         self.values
-    }
-}
-
-impl<'a, K, V> LiteMap<K, V, &'a [(K, V)]> {
-    /// Convert a `&'a [(K, V)]` into a [`LiteMap`].
-    ///
-    /// The slice must be sorted and have no duplicate keys.
-    #[inline]
-    pub const fn from_sorted_slice_unchecked(values: &'a [(K, V)]) -> Self {
-        Self {
-            values,
-            _key_type: PhantomData,
-            _value_type: PhantomData,
-        }
     }
 }
 

--- a/utils/litemap/src/map.rs
+++ b/utils/litemap/src/map.rs
@@ -37,6 +37,8 @@ impl<K, V> LiteMap<K, V> {
 
 impl<K, V, S> LiteMap<K, V, S> {
     /// Construct a new [`LiteMap`] using the given values
+    ///
+    /// The store must be sorted and have no duplicate keys.
     pub const fn from_sorted_store_unchecked(values: S) -> Self {
         Self {
             values,

--- a/utils/litemap/src/map.rs
+++ b/utils/litemap/src/map.rs
@@ -35,6 +35,21 @@ impl<K, V> LiteMap<K, V> {
     }
 }
 
+impl<K, V, S> LiteMap<K, V, S> {
+    /// Construct a new [`LiteMap`] using the given values
+    ///
+    /// # Safety
+    ///
+    /// The store must be sorted and have no duplicate keys.
+    pub const fn from_store_unchecked(values: S) -> Self {
+        Self {
+            values,
+            _key_type: PhantomData,
+            _value_type: PhantomData,
+        }
+    }
+}
+
 impl<K, V> LiteMap<K, V, Vec<(K, V)>> {
     /// Convert a `Vec<(K, V)>` into a [`LiteMap`].
     ///

--- a/utils/litemap/tests/rkyv.rs
+++ b/utils/litemap/tests/rkyv.rs
@@ -81,6 +81,6 @@ fn rkyv_deserialize() {
     let archived = unsafe { archived_root::<TupleVecOfStrings>(&RKYV.0) };
     let deserialized = archived.deserialize(&mut Infallible).unwrap();
     // Safe because we are deserializing a buffer from a trusted source
-    let deserialized: LiteMapOfStrings = unsafe { LiteMap::from_tuple_vec_unchecked(deserialized) };
+    let deserialized: LiteMapOfStrings = LiteMap::from_sorted_store_unchecked(deserialized);
     assert_eq!(deserialized.get("tr"), Some(&"Turkish".to_string()));
 }


### PR DESCRIPTION
PR 2/2 to fix #2191 