### PR TITLE
Add a remark about inversion list worst-case performance

### DIFF
--- a/components/collections/src/codepointinvlist/cpinvlist.rs
+++ b/components/collections/src/codepointinvlist/cpinvlist.rs
@@ -374,7 +374,9 @@ impl<'data> CodePointInversionList<'data> {
     /// Checks to see the query is in the [`CodePointInversionList`]
     ///
     /// Runs a binary search in `O(log(n))` where `n` is the number of start and end points
-    /// in the set using [`core`] implementation
+    /// in the set using [`core`] implementation. Note that due to the nature of binary search,
+    /// the extremes of the Unicode range have worst-case performance, and ASCII is at the low
+    /// extreme end of the Unicode range.
     ///
     /// # Examples
     ///
@@ -397,7 +399,9 @@ impl<'data> CodePointInversionList<'data> {
     /// the range from 0 to the maximum valid Unicode Scalar Value.
     ///
     /// Runs a binary search in `O(log(n))` where `n` is the number of start and end points
-    /// in the set using [`core`] implementation
+    /// in the set using [`core`] implementation. Note that due to the nature of binary search,
+    /// the extremes of the Unicode range have worst-case performance, and ASCII is at the low
+    /// extreme end of the Unicode range.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Explicitly note the implications of ASCII being at the start of the Unicode range and the extremes being the worst cases for binary search.