### PR TITLE
Don't save the locale in the DateTimeFormatter

### DIFF
--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -5,7 +5,7 @@
 use crate::error::DateTimeFormatterError as Error;
 use crate::fields::{self, Field, FieldLength, FieldSymbol, Second, Week, Year};
 use crate::input::{
-    DateTimeInput, DateTimeInputWithLocale, ExtractedDateTimeInput, LocalizedDateTimeInput,
+    DateTimeInput, DateTimeInputWithCalendar, ExtractedDateTimeInput, LocalizedDateTimeInput,
 };
 use crate::pattern::{
     runtime::{Pattern, PatternPlurals},
@@ -167,7 +167,7 @@ where
     T: DateTimeInput,
     W: fmt::Write + ?Sized,
 {
-    let loc_datetime = DateTimeInputWithLocale::new(datetime, week_data.map(|d| &d.0));
+    let loc_datetime = DateTimeInputWithCalendar::new(datetime, week_data.map(|d| &d.0));
     let pattern = patterns.select(&loc_datetime, ordinal_rules)?;
     write_pattern(
         pattern,
@@ -550,7 +550,7 @@ mod tests {
                 .unwrap();
 
         let mut sink = String::new();
-        let loc_datetime = DateTimeInputWithLocale::new(&datetime, None);
+        let loc_datetime = DateTimeInputWithCalendar::new(&datetime, None);
         write_pattern(
             &pattern,
             Some(date_data.get()),

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -20,7 +20,6 @@ use core::fmt;
 use fixed_decimal::FixedDecimal;
 use icu_decimal::FixedDecimalFormatter;
 use icu_plurals::PluralRules;
-use icu_provider::DataLocale;
 use icu_provider::DataPayload;
 use writeable::Writeable;
 
@@ -55,7 +54,6 @@ pub struct FormattedDateTime<'l> {
     pub(crate) time_symbols: Option<&'l provider::calendar::TimeSymbolsV1<'l>>,
     pub(crate) datetime: ExtractedDateTimeInput,
     pub(crate) week_data: Option<&'l WeekDataV1>,
-    pub(crate) locale: &'l DataLocale,
     pub(crate) ordinal_rules: Option<&'l PluralRules>,
     pub(crate) fixed_decimal_format: &'l FixedDecimalFormatter,
 }
@@ -70,7 +68,6 @@ impl<'l> Writeable for FormattedDateTime<'l> {
             self.week_data,
             self.ordinal_rules,
             self.fixed_decimal_format,
-            self.locale,
             sink,
         )
         .map_err(|_| core::fmt::Error)
@@ -164,14 +161,13 @@ pub fn write_pattern_plurals<T, W>(
     week_data: Option<&WeekDataV1>,
     ordinal_rules: Option<&PluralRules>,
     fixed_decimal_format: &FixedDecimalFormatter,
-    locale: &DataLocale,
     w: &mut W,
 ) -> Result<(), Error>
 where
     T: DateTimeInput,
     W: fmt::Write + ?Sized,
 {
-    let loc_datetime = DateTimeInputWithLocale::new(datetime, week_data.map(|d| &d.0), locale);
+    let loc_datetime = DateTimeInputWithLocale::new(datetime, week_data.map(|d| &d.0));
     let pattern = patterns.select(&loc_datetime, ordinal_rules)?;
     write_pattern(
         pattern,
@@ -554,7 +550,7 @@ mod tests {
                 .unwrap();
 
         let mut sink = String::new();
-        let loc_datetime = DateTimeInputWithLocale::new(&datetime, None, &Locale::UND.into());
+        let loc_datetime = DateTimeInputWithLocale::new(&datetime, None);
         write_pattern(
             &pattern,
             Some(date_data.get()),

--- a/components/datetime/src/format/zoned_datetime.rs
+++ b/components/datetime/src/format/zoned_datetime.rs
@@ -7,7 +7,7 @@
 use crate::error::DateTimeFormatterError as Error;
 use crate::fields::{self, FieldSymbol};
 use crate::input::{
-    DateTimeInput, DateTimeInputWithLocale, ExtractedDateTimeInput, ExtractedTimeZoneInput,
+    DateTimeInput, DateTimeInputWithCalendar, ExtractedDateTimeInput, ExtractedTimeZoneInput,
     LocalizedDateTimeInput, TimeZoneInput,
 };
 use crate::pattern::{runtime, PatternItem};
@@ -62,7 +62,7 @@ where
     W: fmt::Write + ?Sized,
 {
     let patterns = &zoned_datetime_format.datetime_format.patterns;
-    let loc_datetime = DateTimeInputWithLocale::new(
+    let loc_datetime = DateTimeInputWithCalendar::new(
         datetime,
         zoned_datetime_format
             .datetime_format

--- a/components/datetime/src/format/zoned_datetime.rs
+++ b/components/datetime/src/format/zoned_datetime.rs
@@ -61,7 +61,6 @@ where
     Z: TimeZoneInput,
     W: fmt::Write + ?Sized,
 {
-    let locale = &zoned_datetime_format.datetime_format.locale;
     let patterns = &zoned_datetime_format.datetime_format.patterns;
     let loc_datetime = DateTimeInputWithLocale::new(
         datetime,
@@ -70,7 +69,6 @@ where
             .week_data
             .as_ref()
             .map(|d| &d.get().0),
-        locale,
     );
 
     let pattern = patterns.get().0.select(

--- a/components/datetime/src/input.rs
+++ b/components/datetime/src/input.rs
@@ -9,7 +9,6 @@ use crate::provider::time_zones::{MetaZoneId, TimeZoneBcp47Id};
 use icu_calendar::any_calendar::AnyCalendarKind;
 use icu_calendar::Calendar;
 use icu_calendar::{arithmetic::week_of, AsCalendar, Date, DateTime, Iso};
-use icu_provider::DataLocale;
 use icu_timezone::{CustomTimeZone, GmtOffset, TimeVariant};
 
 // TODO (Manishearth) fix up imports to directly import from icu_calendar
@@ -344,11 +343,7 @@ fn day_of_week_in_month<T: DateInput>(datetime: &T) -> Result<DayOfWeekInMonth, 
 }
 
 impl<'data, T: DateTimeInput> DateTimeInputWithLocale<'data, T> {
-    pub fn new(
-        data: &'data T,
-        calendar: Option<&'data week_of::CalendarInfo>,
-        _locale: &DataLocale,
-    ) -> Self {
+    pub(crate) fn new(data: &'data T, calendar: Option<&'data week_of::CalendarInfo>) -> Self {
         Self { data, calendar }
     }
 }

--- a/components/datetime/src/input.rs
+++ b/components/datetime/src/input.rs
@@ -125,7 +125,7 @@ pub trait LocalizedDateTimeInput<T: DateTimeInput> {
     fn flexible_day_period(&self);
 }
 
-pub(crate) struct DateTimeInputWithLocale<'data, T: DateTimeInput> {
+pub(crate) struct DateTimeInputWithCalendar<'data, T: DateTimeInput> {
     data: &'data T,
     calendar: Option<&'data week_of::CalendarInfo>,
 }
@@ -342,13 +342,13 @@ fn day_of_week_in_month<T: DateInput>(datetime: &T) -> Result<DayOfWeekInMonth, 
     Ok(day_of_month.into())
 }
 
-impl<'data, T: DateTimeInput> DateTimeInputWithLocale<'data, T> {
+impl<'data, T: DateTimeInput> DateTimeInputWithCalendar<'data, T> {
     pub(crate) fn new(data: &'data T, calendar: Option<&'data week_of::CalendarInfo>) -> Self {
         Self { data, calendar }
     }
 }
 
-impl<'data, T: DateTimeInput> LocalizedDateTimeInput<T> for DateTimeInputWithLocale<'data, T> {
+impl<'data, T: DateTimeInput> LocalizedDateTimeInput<T> for DateTimeInputWithCalendar<'data, T> {
     fn datetime(&self) -> &T {
         self.data
     }

--- a/components/datetime/src/raw/datetime.rs
+++ b/components/datetime/src/raw/datetime.rs
@@ -34,7 +34,6 @@ use icu_plurals::{provider::OrdinalV1Marker, PluralRules};
 use icu_provider::prelude::*;
 
 pub(crate) struct TimeFormatter {
-    pub locale: DataLocale,
     pub patterns: DataPayload<PatternPluralsFromPatternsV1Marker>,
     pub symbols: Option<DataPayload<TimeSymbolsV1Marker>>,
     pub fixed_decimal_format: FixedDecimalFormatter,
@@ -90,23 +89,16 @@ impl TimeFormatter {
         )
         .map_err(DateTimeFormatterError::FixedDecimalFormatter)?;
 
-        Ok(Self::new(
-            locale,
-            patterns,
-            symbols_data,
-            fixed_decimal_format,
-        ))
+        Ok(Self::new(patterns, symbols_data, fixed_decimal_format))
     }
 
     /// Creates a new [`TimeFormatter`] regardless of whether there are time-zone symbols in the pattern.
     pub fn new(
-        locale: DataLocale,
         patterns: DataPayload<PatternPluralsFromPatternsV1Marker>,
         symbols: Option<DataPayload<TimeSymbolsV1Marker>>,
         fixed_decimal_format: FixedDecimalFormatter,
     ) -> Self {
         Self {
-            locale,
             patterns,
             symbols,
             fixed_decimal_format,
@@ -126,7 +118,6 @@ impl TimeFormatter {
             time_symbols: self.symbols.as_ref().map(|s| s.get()),
             datetime: ExtractedDateTimeInput::extract_from_time(value),
             week_data: None,
-            locale: &self.locale,
             ordinal_rules: None,
             fixed_decimal_format: &self.fixed_decimal_format,
         }
@@ -149,7 +140,6 @@ impl TimeFormatter {
             None,
             None,
             &self.fixed_decimal_format,
-            &self.locale,
             w,
         )
         .map_err(|_| core::fmt::Error)
@@ -167,7 +157,6 @@ impl TimeFormatter {
 }
 
 pub(crate) struct DateFormatter {
-    pub locale: DataLocale,
     pub generic_pattern: DataPayload<GenericPatternV1Marker>,
     pub patterns: DataPayload<PatternPluralsFromPatternsV1Marker>,
     pub symbols: Option<DataPayload<ErasedDateSymbolsV1Marker>>,
@@ -238,7 +227,6 @@ impl DateFormatter {
         .map_err(DateTimeFormatterError::FixedDecimalFormatter)?;
 
         Ok(Self::new(
-            locale,
             generic_pattern,
             patterns,
             symbols_data,
@@ -250,7 +238,6 @@ impl DateFormatter {
 
     /// Creates a new [`DateTimeFormatter`] regardless of whether there are time-zone symbols in the pattern.
     pub fn new(
-        locale: DataLocale,
         generic_pattern: DataPayload<GenericPatternV1Marker>,
         patterns: DataPayload<PatternPluralsFromPatternsV1Marker>,
         symbols: Option<DataPayload<ErasedDateSymbolsV1Marker>>,
@@ -259,7 +246,6 @@ impl DateFormatter {
         fixed_decimal_format: FixedDecimalFormatter,
     ) -> Self {
         Self {
-            locale,
             generic_pattern,
             patterns,
             symbols,
@@ -282,7 +268,6 @@ impl DateFormatter {
             time_symbols: None,
             datetime: ExtractedDateTimeInput::extract_from_date(value),
             week_data: None,
-            locale: &self.locale,
             ordinal_rules: None,
             fixed_decimal_format: &self.fixed_decimal_format,
         }
@@ -305,7 +290,6 @@ impl DateFormatter {
             None,
             None,
             &self.fixed_decimal_format,
-            &self.locale,
             w,
         )
         .map_err(|_| core::fmt::Error)
@@ -325,7 +309,6 @@ impl DateFormatter {
 /// This is the internal "raw" version of [crate::DateTimeFormatter], i.e. a version of DateTimeFormatter
 /// without the generic parameter. The actual implementation of [crate::DateTimeFormatter] should live here.
 pub(crate) struct DateTimeFormatter {
-    pub locale: DataLocale,
     pub patterns: DataPayload<PatternPluralsFromPatternsV1Marker>,
     pub date_symbols: Option<DataPayload<ErasedDateSymbolsV1Marker>>,
     pub time_symbols: Option<DataPayload<TimeSymbolsV1Marker>>,
@@ -367,7 +350,6 @@ impl DateTimeFormatter {
             )?;
 
         Ok(Self {
-            locale: date.locale,
             patterns,
             date_symbols: date.symbols,
             time_symbols: time.symbols,
@@ -440,7 +422,6 @@ impl DateTimeFormatter {
         .map_err(DateTimeFormatterError::FixedDecimalFormatter)?;
 
         Ok(Self::new(
-            locale,
             patterns,
             date_symbols_data,
             time_symbols_data,
@@ -452,7 +433,6 @@ impl DateTimeFormatter {
 
     /// Creates a new [`DateTimeFormatter`] regardless of whether there are time-zone symbols in the pattern.
     pub fn new(
-        locale: DataLocale,
         patterns: DataPayload<PatternPluralsFromPatternsV1Marker>,
         date_symbols: Option<DataPayload<ErasedDateSymbolsV1Marker>>,
         time_symbols: Option<DataPayload<TimeSymbolsV1Marker>>,
@@ -461,7 +441,6 @@ impl DateTimeFormatter {
         fixed_decimal_format: FixedDecimalFormatter,
     ) -> Self {
         Self {
-            locale,
             patterns,
             date_symbols,
             time_symbols,
@@ -485,7 +464,6 @@ impl DateTimeFormatter {
             time_symbols: self.time_symbols.as_ref().map(|s| s.get()),
             datetime: ExtractedDateTimeInput::extract_from(value),
             week_data: self.week_data.as_ref().map(|s| s.get()),
-            locale: &self.locale,
             ordinal_rules: self.ordinal_rules.as_ref(),
             fixed_decimal_format: &self.fixed_decimal_format,
         }
@@ -507,7 +485,6 @@ impl DateTimeFormatter {
             self.week_data.as_ref().map(|s| s.get()),
             self.ordinal_rules.as_ref(),
             &self.fixed_decimal_format,
-            &self.locale,
             w,
         )
         .map_err(|_| core::fmt::Error)

--- a/components/datetime/src/raw/zoned_datetime.rs
+++ b/components/datetime/src/raw/zoned_datetime.rs
@@ -110,7 +110,6 @@ impl ZonedDateTimeFormatter {
         .map_err(DateTimeFormatterError::FixedDecimalFormatter)?;
 
         let datetime_format = raw::DateTimeFormatter::new(
-            locale,
             patterns,
             date_symbols_data,
             time_symbols_data,
@@ -121,7 +120,7 @@ impl ZonedDateTimeFormatter {
 
         let time_zone_format = TimeZoneFormatter::try_new(
             provider,
-            &datetime_format.locale,
+            &locale,
             datetime_format
                 // Only dates have plural variants so we can use any of the patterns for the time segment.
                 .patterns


### PR DESCRIPTION
Part of #2188

It looks like we were saving the locale in order to feed it to the internal type `DateTimeInputWithLocale`, but we haven't been using it anywhere. I think I had thought that we would be using the locale to resolve either week-of-year or flexible day periods, but it's 1.0 time and we aren't doing that; instead, we now have a calendar field that's been added. So, I removed the locale field and renamed the type to `DateTimeInputWithCalendar`.

If we find that we actually need the locale, we can add it back later, maybe in a more efficient way.

The next step of #2188 will be to remove the need to clone the `DataLocale` for all requests except skeletons.