### PR TITLE
Add std feature to icu_collator

### DIFF
--- a/components/collator/Cargo.toml
+++ b/components/collator/Cargo.toml
@@ -59,3 +59,4 @@ bench = false  # This option is required for Benchmark CI
 default = []
 serde = ["dep:serde", "zerovec/serde", "icu_properties/serde", "icu_normalizer/serde", "icu_collections/serde", "icu_provider/serde"]
 datagen = ["serde", "databake", "zerovec/databake", "icu_properties/databake", "icu_normalizer/databake", "icu_collections/databake"]
+std = []

--- a/components/icu/Cargo.toml
+++ b/components/icu/Cargo.toml
@@ -49,6 +49,7 @@ icu_testdata = { path = "../../provider/testdata" }
 default = []
 std = [
     "icu_calendar/std",
+    "icu_collator/std",
     "icu_datetime/std",
     "icu_decimal/std",
     "icu_list/std",


### PR DESCRIPTION
Adds the missing `std` feature to `icu_collator` and also switches it on via the `std` feature in the `icu` package. As far as I can see, it doesn't look like the other dependencies of `icu_collator` need to have the `std` feature enabled, but please check this.

Resolves #2375