### PR TITLE
Expose RuleBreakIterator as a public interface

### DIFF
--- a/experimental/segmenter/src/lib.rs
+++ b/experimental/segmenter/src/lib.rs
@@ -104,3 +104,5 @@ pub use crate::sentence::{
 pub use crate::word::{
     WordBreakIteratorLatin1, WordBreakIteratorUtf16, WordBreakIteratorUtf8, WordBreakSegmenter,
 };
+
+pub use crate::rule_segmenter::RuleBreakIterator;


### PR DESCRIPTION
All the UAX 29 break iterators (grapheme cluster, sentence, and word) are type
defines of RuleBreakIterator. Expose RuleBreakIterator so that users can refer
to RuleBreakIterator's documentation for APIs.