### PR TITLE
Better rust_link handling; add module-based allowlist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,9 +735,9 @@ dependencies = [
 [[package]]
 name = "diplomat"
 version = "0.3.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=d49289af387b9803c90e46139fe95dd0d6f324ae#d49289af387b9803c90e46139fe95dd0d6f324ae"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=373d7d5e157ce5c4beff4779658813d456387b35#373d7d5e157ce5c4beff4779658813d456387b35"
 dependencies = [
- "diplomat_core 0.3.0 (git+https://github.com/rust-diplomat/diplomat?rev=d49289af387b9803c90e46139fe95dd0d6f324ae)",
+ "diplomat_core",
  "proc-macro2",
  "quote",
  "syn",
@@ -746,12 +746,12 @@ dependencies = [
 [[package]]
 name = "diplomat-runtime"
 version = "0.3.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=d49289af387b9803c90e46139fe95dd0d6f324ae#d49289af387b9803c90e46139fe95dd0d6f324ae"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=373d7d5e157ce5c4beff4779658813d456387b35#373d7d5e157ce5c4beff4779658813d456387b35"
 
 [[package]]
 name = "diplomat_core"
 version = "0.3.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=be4f3aa9da018b05296f0d3b1777e1f3806054fa#be4f3aa9da018b05296f0d3b1777e1f3806054fa"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=373d7d5e157ce5c4beff4779658813d456387b35#373d7d5e157ce5c4beff4779658813d456387b35"
 dependencies = [
  "impls",
  "lazy_static",
@@ -759,20 +759,8 @@ dependencies = [
  "quote",
  "rustdoc-types",
  "serde",
- "syn",
-]
-
-[[package]]
-name = "diplomat_core"
-version = "0.3.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=d49289af387b9803c90e46139fe95dd0d6f324ae#d49289af387b9803c90e46139fe95dd0d6f324ae"
-dependencies = [
- "impls",
- "lazy_static",
- "proc-macro2",
- "quote",
- "rustdoc-types",
- "serde",
+ "smallvec",
+ "strck_ident",
  "syn",
 ]
 
@@ -1383,7 +1371,7 @@ version = "1.0.0-alpha1"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
- "diplomat_core 0.3.0 (git+https://github.com/rust-diplomat/diplomat?rev=be4f3aa9da018b05296f0d3b1777e1f3806054fa)",
+ "diplomat_core",
  "elsa",
  "fixed_decimal",
  "icu_calendar",
@@ -3085,9 +3073,9 @@ checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 dependencies = [
  "serde",
 ]
@@ -3186,6 +3174,20 @@ name = "stdweb-internal-runtime"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
+
+[[package]]
+name = "strck"
+version = "0.1.0"
+source = "git+https://github.com/QnnOkabayashi/strck?rev=a57d391d8f028cca28fb51d1dd8cf49578fb6cd5#a57d391d8f028cca28fb51d1dd8cf49578fb6cd5"
+
+[[package]]
+name = "strck_ident"
+version = "0.1.0"
+source = "git+https://github.com/QnnOkabayashi/strck?rev=a57d391d8f028cca28fb51d1dd8cf49578fb6cd5#a57d391d8f028cca28fb51d1dd8cf49578fb6cd5"
+dependencies = [
+ "strck",
+ "unicode-ident",
+]
 
 [[package]]
 name = "strsim"
@@ -3594,6 +3596,12 @@ name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 [[package]]
 name = "diplomat"
 version = "0.3.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=373d7d5e157ce5c4beff4779658813d456387b35#373d7d5e157ce5c4beff4779658813d456387b35"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=3fe1337b940a6940bf0bd79899ef431cfbc73356#3fe1337b940a6940bf0bd79899ef431cfbc73356"
 dependencies = [
  "diplomat_core",
  "proc-macro2",
@@ -746,12 +746,12 @@ dependencies = [
 [[package]]
 name = "diplomat-runtime"
 version = "0.3.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=373d7d5e157ce5c4beff4779658813d456387b35#373d7d5e157ce5c4beff4779658813d456387b35"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=3fe1337b940a6940bf0bd79899ef431cfbc73356#3fe1337b940a6940bf0bd79899ef431cfbc73356"
 
 [[package]]
 name = "diplomat_core"
 version = "0.3.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=373d7d5e157ce5c4beff4779658813d456387b35#373d7d5e157ce5c4beff4779658813d456387b35"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=3fe1337b940a6940bf0bd79899ef431cfbc73356#3fe1337b940a6940bf0bd79899ef431cfbc73356"
 dependencies = [
  "impls",
  "lazy_static",
@@ -3177,13 +3177,15 @@ checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strck"
-version = "0.1.0"
-source = "git+https://github.com/QnnOkabayashi/strck?rev=a57d391d8f028cca28fb51d1dd8cf49578fb6cd5#a57d391d8f028cca28fb51d1dd8cf49578fb6cd5"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b99bb054f5dcde86a98558e47aeeaa334cedc523728dff80a4c2824a5a54ad"
 
 [[package]]
 name = "strck_ident"
-version = "0.1.0"
-source = "git+https://github.com/QnnOkabayashi/strck?rev=a57d391d8f028cca28fb51d1dd8cf49578fb6cd5#a57d391d8f028cca28fb51d1dd8cf49578fb6cd5"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af2d128f1161e1356e1f9a5cc32e58c62ccbdb79287a2269fc2aaaacf8ff27b"
 dependencies = [
  "strck",
  "unicode-ident",

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -71,15 +71,15 @@ writeable = { version = "0.4", path = "../../utils/writeable/" }
 # Run `cargo make diplomat-install` to get the right diplomat binary installed
 # The version here can either be a `version = ".."` spec or `git = "https://github.com/rust-diplomat/diplomat", rev = ".."`
 # Since this crate is published, Diplomat must be published preceding a new ICU4X release but may use git versions in between
-diplomat = { git = "https://github.com/rust-diplomat/diplomat", rev = "d49289af387b9803c90e46139fe95dd0d6f324ae" }
-diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", rev = "d49289af387b9803c90e46139fe95dd0d6f324ae" }
+diplomat = { git = "https://github.com/rust-diplomat/diplomat", rev = "373d7d5e157ce5c4beff4779658813d456387b35" }
+diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", rev = "373d7d5e157ce5c4beff4779658813d456387b35" }
 icu_testdata = { version = "1.0.0-beta1", path = "../../provider/testdata", optional = true }
 
 # completeness feature
 syn-inline-mod = { version =  "0.4.0", optional = true }
 serde_json = { version =  "1", optional = true }
 rustdoc-types = { version =  "0.11", optional = true }
-diplomat_core = { git = "https://github.com/rust-diplomat/diplomat", rev = "be4f3aa9da018b05296f0d3b1777e1f3806054fa", optional = true }
+diplomat_core = { git = "https://github.com/rust-diplomat/diplomat", rev = "373d7d5e157ce5c4beff4779658813d456387b35", optional = true }
 lazy_static = { version =  "1", optional = true }
 elsa = { version = "1", optional = true }
 

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -71,15 +71,15 @@ writeable = { version = "0.4", path = "../../utils/writeable/" }
 # Run `cargo make diplomat-install` to get the right diplomat binary installed
 # The version here can either be a `version = ".."` spec or `git = "https://github.com/rust-diplomat/diplomat", rev = ".."`
 # Since this crate is published, Diplomat must be published preceding a new ICU4X release but may use git versions in between
-diplomat = { git = "https://github.com/rust-diplomat/diplomat", rev = "373d7d5e157ce5c4beff4779658813d456387b35" }
-diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", rev = "373d7d5e157ce5c4beff4779658813d456387b35" }
+diplomat = { git = "https://github.com/rust-diplomat/diplomat", rev = "3fe1337b940a6940bf0bd79899ef431cfbc73356" }
+diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", rev = "3fe1337b940a6940bf0bd79899ef431cfbc73356" }
 icu_testdata = { version = "1.0.0-beta1", path = "../../provider/testdata", optional = true }
 
 # completeness feature
 syn-inline-mod = { version =  "0.4.0", optional = true }
 serde_json = { version =  "1", optional = true }
 rustdoc-types = { version =  "0.11", optional = true }
-diplomat_core = { git = "https://github.com/rust-diplomat/diplomat", rev = "373d7d5e157ce5c4beff4779658813d456387b35", optional = true }
+diplomat_core = { git = "https://github.com/rust-diplomat/diplomat", rev = "3fe1337b940a6940bf0bd79899ef431cfbc73356", optional = true }
 lazy_static = { version =  "1", optional = true }
 elsa = { version = "1", optional = true }
 

--- a/ffi/diplomat/cpp/docs/source/bidi_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/bidi_ffi.rst
@@ -5,14 +5,14 @@
 
     An ICU4X Bidi object, containing loaded bidi data
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/bidi/struct.BidiClassAdapter.html>`__ for more information.
+    See the `Rust documentation for BidiClassAdapter <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/bidi/struct.BidiClassAdapter.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XBidi, ICU4XError> try_new(const ICU4XDataProvider& provider)
 
         Creates a new :cpp:class:`ICU4XBidi` from locale data.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/bidi/struct.BidiClassAdapter.html#method.new>`__ for more information.
+        See the `Rust documentation for new <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/bidi/struct.BidiClassAdapter.html#method.new>`__ for more information.
 
 
     .. cpp:function:: ICU4XBidiInfo for_text(const std::string_view text, uint8_t default_level) const
@@ -21,7 +21,7 @@
 
         Takes in a Level for the default level, if it is an invalid value it will default to LTR
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html#method.new_with_data_source>`__ for more information.
+        See the `Rust documentation for new_with_data_source <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html#method.new_with_data_source>`__ for more information.
 
 
         Lifetimes: ``text`` must live at least as long as the output.
@@ -32,7 +32,7 @@
 
         Invalid levels (numbers greater than 125) will be assumed LTR
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_rtl>`__ for more information.
+        See the `Rust documentation for is_rtl <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_rtl>`__ for more information.
 
 
     .. cpp:function:: static bool level_is_ltr(uint8_t level)
@@ -41,21 +41,21 @@
 
         Invalid levels (numbers greater than 125) will be assumed LTR
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_ltr>`__ for more information.
+        See the `Rust documentation for is_ltr <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_ltr>`__ for more information.
 
 
     .. cpp:function:: static uint8_t level_rtl()
 
         Get a basic RTL Level value
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.rtl>`__ for more information.
+        See the `Rust documentation for rtl <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.rtl>`__ for more information.
 
 
     .. cpp:function:: static uint8_t level_ltr()
 
         Get a simple LTR Level value
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.ltr>`__ for more information.
+        See the `Rust documentation for ltr <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.ltr>`__ for more information.
 
 
 .. cpp:enum-struct:: ICU4XBidiDirection
@@ -70,7 +70,7 @@
 
     An object containing bidi information for a given string, produced by ``for_text()`` on ``ICU4XBidi``
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html>`__ for more information.
+    See the `Rust documentation for BidiInfo <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html>`__ for more information.
 
 
     .. cpp:function:: size_t paragraph_count() const
@@ -113,14 +113,14 @@
 
         The primary direction of this paragraph
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at>`__ for more information.
+        See the `Rust documentation for level_at <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at>`__ for more information.
 
 
     .. cpp:function:: size_t size() const
 
         The number of bytes in this paragraph
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.ParagraphInfo.html#method.len>`__ for more information.
+        See the `Rust documentation for len <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.ParagraphInfo.html#method.len>`__ for more information.
 
 
     .. cpp:function:: size_t range_start() const
@@ -137,14 +137,14 @@
 
         Reorder a line based on display order. The ranges are specified relative to the source text and must be contained within this paragraph's range.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at>`__ for more information.
+        See the `Rust documentation for level_at <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at>`__ for more information.
 
 
     .. cpp:function:: diplomat::result<std::string, ICU4XError> reorder_line(size_t range_start, size_t range_end) const
 
         Reorder a line based on display order. The ranges are specified relative to the source text and must be contained within this paragraph's range.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at>`__ for more information.
+        See the `Rust documentation for level_at <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at>`__ for more information.
 
 
     .. cpp:function:: uint8_t level_at(size_t pos) const
@@ -153,5 +153,5 @@
 
         Returns 0 (equivalent to ``Level::ltr()``) on error
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at>`__ for more information.
+        See the `Rust documentation for level_at <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at>`__ for more information.
 

--- a/ffi/diplomat/cpp/docs/source/calendar_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/calendar_ffi.rst
@@ -3,47 +3,47 @@
 
 .. cpp:class:: ICU4XCalendar
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/enum.AnyCalendar.html>`__ for more information.
+    See the `Rust documentation for AnyCalendar <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/enum.AnyCalendar.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XCalendar, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale)
 
         Creates a new :cpp:class:`ICU4XCalendar` from the specified date and time.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.AnyCalendar.html#method.try_new_unstable>`__ for more information.
+        See the `Rust documentation for try_new_unstable <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.AnyCalendar.html#method.try_new_unstable>`__ for more information.
 
 
 .. cpp:class:: ICU4XDateTime
 
     An ICU4X DateTime object capable of containing a date and time for any calendar.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html>`__ for more information.
+    See the `Rust documentation for DateTime <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XDateTime, ICU4XError> try_new_from_iso_in_calendar(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, const ICU4XCalendar& calendar)
 
         Creates a new :cpp:class:`ICU4XDateTime` representing the ISO date and time given but in a given calendar
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html#method.new_iso_datetime>`__ for more information.
+        See the `Rust documentation for new_iso_datetime <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html#method.new_iso_datetime>`__ for more information.
 
 
     .. cpp:function:: diplomat::result<std::monostate, ICU4XError> set_ns(uint32_t ns)
 
         Sets the fractional seconds field of this datetime, in nanoseconds
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/types/struct.Time.html#structfield.nanosecond>`__ for more information.
+        See the `Rust documentation for nanosecond <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/types/struct.Time.html#structfield.nanosecond>`__ for more information.
 
 
 .. cpp:class:: ICU4XGregorianDateTime
 
     An ICU4X DateTime object capable of containing a Gregorian date and time.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html>`__ for more information.
+    See the `Rust documentation for DateTime <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XGregorianDateTime, ICU4XError> try_new(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second)
 
         Creates a new :cpp:class:`ICU4XGregorianDateTime` from the specified date and time.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html#method.new_gregorian_datetime>`__ for more information.
+        See the `Rust documentation for new_gregorian_datetime <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html#method.new_gregorian_datetime>`__ for more information.
 

--- a/ffi/diplomat/cpp/docs/source/data_struct_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/data_struct_ffi.rst
@@ -12,5 +12,5 @@
 
         Construct a new DecimalSymbolsV1 data struct.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/provider/struct.DecimalSymbolsV1.html>`__ for more information.
+        See the `Rust documentation for DecimalSymbolsV1 <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/provider/struct.DecimalSymbolsV1.html>`__ for more information.
 

--- a/ffi/diplomat/cpp/docs/source/datetime_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/datetime_ffi.rst
@@ -15,112 +15,112 @@
 
     An ICU4X DateFormatter object capable of formatting a :cpp:class:`ICU4XDateTime` as a string, using some calendar specified at runtime in the locale.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html>`__ for more information.
+    See the `Rust documentation for DateTimeFormatter <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XDateTimeFormatter, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XDateLength date_length, ICU4XTimeLength time_length)
 
         Creates a new :cpp:class:`ICU4XDateTimeFormatter` from locale data.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.try_new_unstable>`__ for more information.
+        See the `Rust documentation for try_new_unstable <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.try_new_unstable>`__ for more information.
 
 
     .. cpp:function:: template<typename W> diplomat::result<std::monostate, ICU4XError> format_datetime_to_writeable(const ICU4XDateTime& value, W& write) const
 
         Formats a :cpp:class:`ICU4XDateTime` to a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.format_to_write>`__ for more information.
+        See the `Rust documentation for format_to_write <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.format_to_write>`__ for more information.
 
 
     .. cpp:function:: diplomat::result<std::string, ICU4XError> format_datetime(const ICU4XDateTime& value) const
 
         Formats a :cpp:class:`ICU4XDateTime` to a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.format_to_write>`__ for more information.
+        See the `Rust documentation for format_to_write <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.format_to_write>`__ for more information.
 
 
 .. cpp:class:: ICU4XGregorianDateFormatter
 
     An ICU4X TypedDateFormatter object capable of formatting a :cpp:class:`ICU4XGregorianDateTime` as a string, using the Gregorian Calendar.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html>`__ for more information.
+    See the `Rust documentation for TypedDateFormatter <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XGregorianDateFormatter, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XDateLength length)
 
         Creates a new :cpp:class:`ICU4XGregorianDateFormatter` from locale data.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.TypedDateFormatter.html#method.try_new_unstable>`__ for more information.
+        See the `Rust documentation for try_new_unstable <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.TypedDateFormatter.html#method.try_new_unstable>`__ for more information.
 
 
     .. cpp:function:: template<typename W> diplomat::result<std::monostate, ICU4XError> format_datetime_to_writeable(const ICU4XGregorianDateTime& value, W& write) const
 
         Formats a :cpp:class:`ICU4XGregorianDateTime` to a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html#method.format_to_write>`__ for more information.
+        See the `Rust documentation for format_to_write <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html#method.format_to_write>`__ for more information.
 
 
     .. cpp:function:: diplomat::result<std::string, ICU4XError> format_datetime(const ICU4XGregorianDateTime& value) const
 
         Formats a :cpp:class:`ICU4XGregorianDateTime` to a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html#method.format_to_write>`__ for more information.
+        See the `Rust documentation for format_to_write <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html#method.format_to_write>`__ for more information.
 
 
 .. cpp:class:: ICU4XGregorianDateTimeFormatter
 
     An ICU4X TypedDateFormatter object capable of formatting a :cpp:class:`ICU4XGregorianDateTime` as a string, using the Gregorian Calendar.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html>`__ for more information.
+    See the `Rust documentation for TypedDateTimeFormatter <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XGregorianDateTimeFormatter, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XDateLength date_length, ICU4XTimeLength time_length)
 
         Creates a new :cpp:class:`ICU4XGregorianDateFormatter` from locale data.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.try_new_unstable>`__ for more information.
+        See the `Rust documentation for try_new_unstable <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.try_new_unstable>`__ for more information.
 
 
     .. cpp:function:: template<typename W> diplomat::result<std::monostate, ICU4XError> format_datetime_to_writeable(const ICU4XGregorianDateTime& value, W& write) const
 
         Formats a :cpp:class:`ICU4XGregorianDateTime` to a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.format_to_write>`__ for more information.
+        See the `Rust documentation for format_to_write <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.format_to_write>`__ for more information.
 
 
     .. cpp:function:: diplomat::result<std::string, ICU4XError> format_datetime(const ICU4XGregorianDateTime& value) const
 
         Formats a :cpp:class:`ICU4XGregorianDateTime` to a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.format_to_write>`__ for more information.
+        See the `Rust documentation for format_to_write <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.format_to_write>`__ for more information.
 
 
 .. cpp:class:: ICU4XTimeFormatter
 
     An ICU4X TimeFormatter object capable of formatting a :cpp:class:`ICU4XGregorianDateTime` as a string
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html>`__ for more information.
+    See the `Rust documentation for TimeFormatter <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XTimeFormatter, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XTimeLength length)
 
         Creates a new :cpp:class:`ICU4XTimeFormatter` from locale data.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.TypedDateFormatter.html#method.try_new_unstable>`__ for more information.
+        See the `Rust documentation for try_new_unstable <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.TypedDateFormatter.html#method.try_new_unstable>`__ for more information.
 
 
     .. cpp:function:: template<typename W> diplomat::result<std::monostate, ICU4XError> format_gregorian_datetime_to_writeable(const ICU4XGregorianDateTime& value, W& write) const
 
         Formats a :cpp:class:`ICU4XGregorianDateTime` to a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html#method.format_to_write>`__ for more information.
+        See the `Rust documentation for format_to_write <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html#method.format_to_write>`__ for more information.
 
 
     .. cpp:function:: diplomat::result<std::string, ICU4XError> format_gregorian_datetime(const ICU4XGregorianDateTime& value) const
 
         Formats a :cpp:class:`ICU4XGregorianDateTime` to a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html#method.format_to_write>`__ for more information.
+        See the `Rust documentation for format_to_write <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html#method.format_to_write>`__ for more information.
 
 
 .. cpp:enum-struct:: ICU4XTimeLength

--- a/ffi/diplomat/cpp/docs/source/decimal_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/decimal_ffi.rst
@@ -5,14 +5,14 @@
 
     An ICU4X Fixed Decimal Format object, capable of formatting a :cpp:class:`ICU4XFixedDecimal` as a string.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html>`__ for more information.
+    See the `Rust documentation for FixedDecimalFormatter <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XFixedDecimalFormatter, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XFixedDecimalGroupingStrategy grouping_strategy)
 
         Creates a new :cpp:class:`ICU4XFixedDecimalFormatter` from locale data.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.try_new>`__ for more information.
+        See the `Rust documentation for try_new <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.try_new>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XFixedDecimalFormatter, ICU4XError> try_new_from_decimal_symbols_v1(const ICU4XDataStruct& data_struct, ICU4XFixedDecimalGroupingStrategy grouping_strategy)
@@ -26,14 +26,14 @@
 
         Formats a :cpp:class:`ICU4XFixedDecimal` to a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.format>`__ for more information.
+        See the `Rust documentation for format <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.format>`__ for more information.
 
 
     .. cpp:function:: diplomat::result<std::string, ICU4XError> format(const ICU4XFixedDecimal& value) const
 
         Formats a :cpp:class:`ICU4XFixedDecimal` to a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.format>`__ for more information.
+        See the `Rust documentation for format <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.format>`__ for more information.
 
 
 .. cpp:enum-struct:: ICU4XFixedDecimalGroupingStrategy

--- a/ffi/diplomat/cpp/docs/source/fixed_decimal_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/fixed_decimal_ffi.rst
@@ -3,98 +3,98 @@
 
 .. cpp:class:: ICU4XFixedDecimal
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html>`__ for more information.
+    See the `Rust documentation for FixedDecimal <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html>`__ for more information.
 
 
     .. cpp:function:: static ICU4XFixedDecimal create(int32_t v)
 
         Construct an :cpp:class:`ICU4XFixedDecimal` from an integer.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html>`__ for more information.
+        See the `Rust documentation for FixedDecimal <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XFixedDecimal, ICU4XError> create_from_f64_with_max_precision(double f)
 
         Construct an :cpp:class:`ICU4XFixedDecimal` from an float, with enough digits to recover the original floating point in IEEE 754 without needing trailing zeros
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64>`__ for more information.
+        See the `Rust documentation for try_from_f64 <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XFixedDecimal, ICU4XError> create_from_f64_with_lower_magnitude(double f, int16_t precision)
 
         Construct an :cpp:class:`ICU4XFixedDecimal` from an float, with a given power of 10 for the lower magnitude
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64>`__ for more information.
+        See the `Rust documentation for try_from_f64 <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XFixedDecimal, ICU4XError> create_from_f64_with_significant_digits(double f, uint8_t digits)
 
         Construct an :cpp:class:`ICU4XFixedDecimal` from an float, for a given number of significant digits
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64>`__ for more information.
+        See the `Rust documentation for try_from_f64 <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XFixedDecimal, ICU4XError> create_fromstr(const std::string_view v)
 
         Construct an :cpp:class:`ICU4XFixedDecimal` from a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html>`__ for more information.
+        See the `Rust documentation for FixedDecimal <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html>`__ for more information.
 
 
     .. cpp:function:: void multiply_pow10(int16_t power)
 
         Multiply the :cpp:class:`ICU4XFixedDecimal` by a given power of ten.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.multiply_pow10>`__ for more information.
+        See the `Rust documentation for multiply_pow10 <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.multiply_pow10>`__ for more information.
 
 
     .. cpp:function:: void set_sign(ICU4XFixedDecimalSign sign)
 
         Set the sign of the :cpp:class:`ICU4XFixedDecimal`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.set_sign>`__ for more information.
+        See the `Rust documentation for set_sign <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.set_sign>`__ for more information.
 
 
     .. cpp:function:: void pad_start(int16_t position)
 
         Zero-pad the :cpp:class:`ICU4XFixedDecimal` on the left to a particular position
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_start>`__ for more information.
+        See the `Rust documentation for pad_start <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_start>`__ for more information.
 
 
     .. cpp:function:: void set_max_position(int16_t position)
 
         Truncate the :cpp:class:`ICU4XFixedDecimal` on the left to a particular position, deleting digits if necessary. This is useful for, e.g. abbreviating years ("2022" -> "22")
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.set_max_position>`__ for more information.
+        See the `Rust documentation for set_max_position <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.set_max_position>`__ for more information.
 
 
     .. cpp:function:: void pad_end(int16_t position)
 
         Zero-pad the :cpp:class:`ICU4XFixedDecimal` on the right to a particular position
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_end>`__ for more information.
+        See the `Rust documentation for pad_end <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_end>`__ for more information.
 
 
     .. cpp:function:: template<typename W> void to_string_to_writeable(W& to) const
 
         Format the :cpp:class:`ICU4XFixedDecimal` as a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.write_to>`__ for more information.
+        See the `Rust documentation for write_to <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.write_to>`__ for more information.
 
 
     .. cpp:function:: std::string to_string() const
 
         Format the :cpp:class:`ICU4XFixedDecimal` as a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.write_to>`__ for more information.
+        See the `Rust documentation for write_to <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.write_to>`__ for more information.
 
 
 .. cpp:enum-struct:: ICU4XFixedDecimalSign
 
     The sign of a FixedDecimal, as shown in formatting.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/enum.Sign.html>`__ for more information.
+    See the `Rust documentation for Sign <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/enum.Sign.html>`__ for more information.
 
 
     .. cpp:enumerator:: None

--- a/ffi/diplomat/cpp/docs/source/locale_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/locale_ffi.rst
@@ -5,14 +5,14 @@
 
     An ICU4X Locale, capable of representing strings like ``"en-US"``.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html>`__ for more information.
+    See the `Rust documentation for Locale <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XLocale, ICU4XError> create(const std::string_view name)
 
         Construct an :cpp:class:`ICU4XLocale` from an locale identifier.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes>`__ for more information.
+        See the `Rust documentation for from_bytes <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes>`__ for more information.
 
 
     .. cpp:function:: static ICU4XLocale create_en()
@@ -34,110 +34,110 @@
 
         Clones the :cpp:class:`ICU4XLocale`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html>`__ for more information.
+        See the `Rust documentation for Locale <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html>`__ for more information.
 
 
     .. cpp:function:: template<typename W> diplomat::result<std::monostate, ICU4XError> basename_to_writeable(W& write) const
 
         Write a string representation of the ``LanguageIdentifier`` part of :cpp:class:`ICU4XLocale` to ``write``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
+        See the `Rust documentation for id <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
 
 
     .. cpp:function:: diplomat::result<std::string, ICU4XError> basename() const
 
         Write a string representation of the ``LanguageIdentifier`` part of :cpp:class:`ICU4XLocale` to ``write``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
+        See the `Rust documentation for id <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
 
 
     .. cpp:function:: template<typename W> diplomat::result<std::monostate, ICU4XError> get_unicode_extension_to_writeable(const std::string_view bytes, W& write) const
 
         Write a string representation of the unicode extension to ``write``
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.extensions>`__ for more information.
+        See the `Rust documentation for extensions <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.extensions>`__ for more information.
 
 
     .. cpp:function:: diplomat::result<std::string, ICU4XError> get_unicode_extension(const std::string_view bytes) const
 
         Write a string representation of the unicode extension to ``write``
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.extensions>`__ for more information.
+        See the `Rust documentation for extensions <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.extensions>`__ for more information.
 
 
     .. cpp:function:: template<typename W> diplomat::result<std::monostate, ICU4XError> language_to_writeable(W& write) const
 
         Write a string representation of :cpp:class:`ICU4XLocale` language to ``write``
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
+        See the `Rust documentation for id <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
 
 
     .. cpp:function:: diplomat::result<std::string, ICU4XError> language() const
 
         Write a string representation of :cpp:class:`ICU4XLocale` language to ``write``
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
+        See the `Rust documentation for id <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
 
 
     .. cpp:function:: diplomat::result<std::monostate, ICU4XError> set_language(const std::string_view bytes)
 
         Set the language part of the :cpp:class:`ICU4XLocale`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes>`__ for more information.
+        See the `Rust documentation for from_bytes <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes>`__ for more information.
 
 
     .. cpp:function:: template<typename W> diplomat::result<std::monostate, ICU4XError> region_to_writeable(W& write) const
 
         Write a string representation of :cpp:class:`ICU4XLocale` region to ``write``
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
+        See the `Rust documentation for id <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
 
 
     .. cpp:function:: diplomat::result<std::string, ICU4XError> region() const
 
         Write a string representation of :cpp:class:`ICU4XLocale` region to ``write``
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
+        See the `Rust documentation for id <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
 
 
     .. cpp:function:: diplomat::result<std::monostate, ICU4XError> set_region(const std::string_view bytes)
 
         Set the region part of the :cpp:class:`ICU4XLocale`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes>`__ for more information.
+        See the `Rust documentation for from_bytes <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes>`__ for more information.
 
 
     .. cpp:function:: template<typename W> diplomat::result<std::monostate, ICU4XError> script_to_writeable(W& write) const
 
         Write a string representation of :cpp:class:`ICU4XLocale` script to ``write``
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
+        See the `Rust documentation for id <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
 
 
     .. cpp:function:: diplomat::result<std::string, ICU4XError> script() const
 
         Write a string representation of :cpp:class:`ICU4XLocale` script to ``write``
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
+        See the `Rust documentation for id <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
 
 
     .. cpp:function:: diplomat::result<std::monostate, ICU4XError> set_script(const std::string_view bytes)
 
         Set the script part of the :cpp:class:`ICU4XLocale`. Pass an empty string to remove the script.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes>`__ for more information.
+        See the `Rust documentation for from_bytes <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes>`__ for more information.
 
 
     .. cpp:function:: template<typename W> diplomat::result<std::monostate, ICU4XError> tostring_to_writeable(W& write) const
 
         Write a string representation of :cpp:class:`ICU4XLocale` to ``write``
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html>`__ for more information.
+        See the `Rust documentation for Locale <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html>`__ for more information.
 
 
     .. cpp:function:: diplomat::result<std::string, ICU4XError> tostring() const
 
         Write a string representation of :cpp:class:`ICU4XLocale` to ``write``
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html>`__ for more information.
+        See the `Rust documentation for Locale <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html>`__ for more information.
 

--- a/ffi/diplomat/cpp/docs/source/locid_transform_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/locid_transform_ffi.rst
@@ -5,56 +5,56 @@
 
     A locale canonicalizer.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html>`__ for more information.
+    See the `Rust documentation for LocaleCanonicalizer <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XLocaleCanonicalizer, ICU4XError> create(const ICU4XDataProvider& provider)
 
         Create a new :cpp:class:`ICU4XLocaleCanonicalizer`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html#method.new>`__ for more information.
+        See the `Rust documentation for new <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html#method.new>`__ for more information.
 
 
     .. cpp:function:: ICU4XTransformResult canonicalize(ICU4XLocale& locale) const
 
         FFI version of ``LocaleCanonicalizer::canonicalize()``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html#method.canonicalize>`__ for more information.
+        See the `Rust documentation for canonicalize <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html#method.canonicalize>`__ for more information.
 
 
 .. cpp:class:: ICU4XLocaleExpander
 
     A locale expander.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html>`__ for more information.
+    See the `Rust documentation for LocaleExpander <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XLocaleExpander, ICU4XError> create(const ICU4XDataProvider& provider)
 
         Create a new :cpp:class:`ICU4XLocaleExpander`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.new>`__ for more information.
+        See the `Rust documentation for new <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.new>`__ for more information.
 
 
     .. cpp:function:: ICU4XTransformResult maximize(ICU4XLocale& locale) const
 
         FFI version of ``LocaleExpander::maximize()``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.maximize>`__ for more information.
+        See the `Rust documentation for maximize <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.maximize>`__ for more information.
 
 
     .. cpp:function:: ICU4XTransformResult minimize(ICU4XLocale& locale) const
 
         FFI version of ``LocaleExpander::minimize()``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.minimize>`__ for more information.
+        See the `Rust documentation for minimize <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.minimize>`__ for more information.
 
 
 .. cpp:enum-struct:: ICU4XTransformResult
 
     FFI version of ``TransformResult``.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/enum.TransformResult.html>`__ for more information.
+    See the `Rust documentation for TransformResult <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/enum.TransformResult.html>`__ for more information.
 
 
     .. cpp:enumerator:: Modified

--- a/ffi/diplomat/cpp/docs/source/pluralrules_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/pluralrules_ffi.rst
@@ -22,7 +22,7 @@
 
     FFI version of ``PluralCategory``.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/enum.PluralCategory.html>`__ for more information.
+    See the `Rust documentation for PluralCategory <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/enum.PluralCategory.html>`__ for more information.
 
 
     .. cpp:enumerator:: Zero
@@ -41,7 +41,7 @@
 
     FFI version of ``PluralOperands``.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralOperands.html>`__ for more information.
+    See the `Rust documentation for PluralOperands <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralOperands.html>`__ for more information.
 
 
     .. cpp:member:: uint64_t i
@@ -60,40 +60,40 @@
 
         FFI version of ``PluralOperands::from_str()``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralOperands.html#method.from_str>`__ for more information.
+        See the `Rust documentation for from_str <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralOperands.html#method.from_str>`__ for more information.
 
 
 .. cpp:class:: ICU4XPluralRules
 
     FFI version of ``PluralRules``.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html>`__ for more information.
+    See the `Rust documentation for PluralRules <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XPluralRules, ICU4XError> try_new_cardinal(const ICU4XDataProvider& provider, const ICU4XLocale& locale)
 
         FFI version of ``PluralRules::try_new_cardinal()``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.try_new_unstable>`__ for more information.
+        See the `Rust documentation for try_new_unstable <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.try_new_unstable>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XPluralRules, ICU4XError> try_new_ordinal(const ICU4XDataProvider& provider, const ICU4XLocale& locale)
 
         FFI version of ``PluralRules::try_new_ordinal()``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.try_new_unstable>`__ for more information.
+        See the `Rust documentation for try_new_unstable <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.try_new_unstable>`__ for more information.
 
 
     .. cpp:function:: ICU4XPluralCategory select(ICU4XPluralOperands op) const
 
         FFI version of ``PluralRules::select()``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.select>`__ for more information.
+        See the `Rust documentation for select <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.select>`__ for more information.
 
 
     .. cpp:function:: ICU4XPluralCategories categories() const
 
         FFI version of ``PluralRules::categories()``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.categories>`__ for more information.
+        See the `Rust documentation for categories <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.categories>`__ for more information.
 

--- a/ffi/diplomat/cpp/docs/source/properties_maps_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/properties_maps_ffi.rst
@@ -7,21 +7,25 @@
 
     For properties whose values fit into 16 bits.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html>`__ for more information.
+    See the `Rust documentation for properties <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html>`__ for more information.
+
+    See the `Rust documentation for CodePointMapData <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapData.html>`__ for more information.
+
+    See the `Rust documentation for CodePointMapDataBorrowed <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XCodePointMapData16, ICU4XError> try_get_script(const ICU4XDataProvider& provider)
 
         Gets a map for Unicode property Script from a :cpp:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_script.html>`__ for more information.
+        See the `Rust documentation for load_script <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_script.html>`__ for more information.
 
 
     .. cpp:function:: uint16_t get(char32_t cp) const
 
         Gets the value for a code point.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html#method.get>`__ for more information.
+        See the `Rust documentation for get <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html#method.get>`__ for more information.
 
 
 .. cpp:class:: ICU4XCodePointMapData8
@@ -30,61 +34,65 @@
 
     For properties whose values fit into 8 bits.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html>`__ for more information.
+    See the `Rust documentation for properties <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html>`__ for more information.
+
+    See the `Rust documentation for CodePointMapData <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapData.html>`__ for more information.
+
+    See the `Rust documentation for CodePointMapDataBorrowed <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XCodePointMapData8, ICU4XError> try_get_general_category(const ICU4XDataProvider& provider)
 
         Gets a map for Unicode property General_Category from a :cpp:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_general_category.html>`__ for more information.
+        See the `Rust documentation for load_general_category <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_general_category.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XCodePointMapData8, ICU4XError> try_get_bidi_class(const ICU4XDataProvider& provider)
 
         Gets a map for Unicode property Bidi_Class from a :cpp:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_bidi_class.html>`__ for more information.
+        See the `Rust documentation for load_bidi_class <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_bidi_class.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XCodePointMapData8, ICU4XError> try_get_east_asian_width(const ICU4XDataProvider& provider)
 
         Gets a map for Unicode property East_Asian_Width from a :cpp:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_east_asian_width.html>`__ for more information.
+        See the `Rust documentation for load_east_asian_width <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_east_asian_width.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XCodePointMapData8, ICU4XError> try_get_line_break(const ICU4XDataProvider& provider)
 
         Gets a map for Unicode property Line_Break from a :cpp:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_line_break.html>`__ for more information.
+        See the `Rust documentation for load_line_break <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_line_break.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XCodePointMapData8, ICU4XError> try_grapheme_cluster_break(const ICU4XDataProvider& provider)
 
         Gets a map for Unicode property Grapheme_Cluster_Break from a :cpp:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_grapheme_cluster_break.html>`__ for more information.
+        See the `Rust documentation for load_grapheme_cluster_break <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_grapheme_cluster_break.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XCodePointMapData8, ICU4XError> try_get_word_break(const ICU4XDataProvider& provider)
 
         Gets a map for Unicode property Word_Break from a :cpp:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_word_break.html>`__ for more information.
+        See the `Rust documentation for load_word_break <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_word_break.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XCodePointMapData8, ICU4XError> try_get_sentence_break(const ICU4XDataProvider& provider)
 
         Gets a map for Unicode property Sentence_Break from a :cpp:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_sentence_break.html>`__ for more information.
+        See the `Rust documentation for load_sentence_break <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_sentence_break.html>`__ for more information.
 
 
     .. cpp:function:: uint8_t get(char32_t cp) const
 
         Gets the value for a code point.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html#method.get>`__ for more information.
+        See the `Rust documentation for get <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html#method.get>`__ for more information.
 

--- a/ffi/diplomat/cpp/docs/source/properties_sets_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/properties_sets_ffi.rst
@@ -5,19 +5,23 @@
 
     An ICU4X Unicode Set Property object, capable of querying whether a code point is contained in a set based on a Unicode property.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html>`__ for more information.
+    See the `Rust documentation for properties <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html>`__ for more information.
+
+    See the `Rust documentation for CodePointSetData <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/struct.CodePointSetData.html>`__ for more information.
+
+    See the `Rust documentation for CodePointSetDataBorrowed <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/struct.CodePointSetDataBorrowed.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XCodePointSetData, ICU4XError> try_get_ascii_hex_digit(const ICU4XDataProvider& provider)
 
         Gets a set for Unicode property ascii_hex_digit from a :cpp:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/fn.load_ascii_hex_digit.html>`__ for more information.
+        See the `Rust documentation for load_ascii_hex_digit <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/fn.load_ascii_hex_digit.html>`__ for more information.
 
 
     .. cpp:function:: bool contains(char32_t cp) const
 
         Checks whether the code point is in the set.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/struct.CodePointSetDataBorrowed.html#method.contains>`__ for more information.
+        See the `Rust documentation for contains <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/struct.CodePointSetDataBorrowed.html#method.contains>`__ for more information.
 

--- a/ffi/diplomat/cpp/docs/source/provider_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/provider_ffi.rst
@@ -17,33 +17,33 @@
 
     An ICU4X data provider, capable of loading ICU4X data keys from some source.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_provider/index.html>`__ for more information.
+    See the `Rust documentation for icu_provider <https://unicode-org.github.io/icu4x-docs/doc/icu_provider/index.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XDataProvider, ICU4XError> create_fs(const std::string_view path)
 
         Constructs an ``FsDataProvider`` and returns it as an :cpp:class:`ICU4XDataProvider`. Requires the ``provider_fs`` feature. Not supported in WASM.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_fs/struct.FsDataProvider.html>`__ for more information.
+        See the `Rust documentation for FsDataProvider <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_fs/struct.FsDataProvider.html>`__ for more information.
 
 
     .. cpp:function:: static ICU4XDataProvider create_test()
 
         Constructs a testdata provider and returns it as an :cpp:class:`ICU4XDataProvider`. Requires the ``provider_test`` feature.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_testdata/index.html>`__ for more information.
+        See the `Rust documentation for icu_testdata <https://unicode-org.github.io/icu4x-docs/doc/icu_testdata/index.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XDataProvider, ICU4XError> create_from_byte_slice(const diplomat::span<uint8_t> blob)
 
         Constructs a ``BlobDataProvider`` and returns it as an :cpp:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.BlobDataProvider.html>`__ for more information.
+        See the `Rust documentation for BlobDataProvider <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.BlobDataProvider.html>`__ for more information.
 
 
     .. cpp:function:: static ICU4XDataProvider create_empty()
 
         Constructs an empty ``StaticDataProvider`` and returns it as an :cpp:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.StaticDataProvider.html>`__ for more information.
+        See the `Rust documentation for StaticDataProvider <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.StaticDataProvider.html>`__ for more information.
 

--- a/ffi/diplomat/cpp/docs/source/segmenter_grapheme_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/segmenter_grapheme_ffi.rst
@@ -26,21 +26,21 @@
 
     An ICU4X grapheme-cluster-break segmenter, capable of finding grapheme cluster breakpoints in strings.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterBreakSegmenter.html>`__ for more information.
+    See the `Rust documentation for GraphemeClusterBreakSegmenter <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterBreakSegmenter.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XGraphemeClusterBreakSegmenter, ICU4XError> try_new(const ICU4XDataProvider& provider)
 
         Construct an :cpp:class:`ICU4XGraphemeClusterBreakSegmenter`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterBreakSegmenter.html#method.try_new>`__ for more information.
+        See the `Rust documentation for try_new <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterBreakSegmenter.html#method.try_new>`__ for more information.
 
 
     .. cpp:function:: ICU4XGraphemeClusterBreakIteratorUtf8 segment_utf8(const std::string_view input) const
 
         Segments a UTF-8 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_str>`__ for more information.
+        See the `Rust documentation for segment_str <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_str>`__ for more information.
 
 
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
@@ -49,7 +49,7 @@
 
         Segments a UTF-16 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_utf16>`__ for more information.
+        See the `Rust documentation for segment_utf16 <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_utf16>`__ for more information.
 
 
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
@@ -58,7 +58,7 @@
 
         Segments a Latin-1 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_latin1>`__ for more information.
+        See the `Rust documentation for segment_latin1 <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_latin1>`__ for more information.
 
 
         Lifetimes: ``this``, ``input`` must live at least as long as the output.

--- a/ffi/diplomat/cpp/docs/source/segmenter_line_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/segmenter_line_ffi.rst
@@ -24,7 +24,7 @@
 
 .. cpp:struct:: ICU4XLineBreakOptions
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakOptions.html>`__ for more information.
+    See the `Rust documentation for LineBreakOptions <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakOptions.html>`__ for more information.
 
 
     .. cpp:member:: ICU4XLineBreakRule line_break_rule
@@ -35,7 +35,7 @@
 
 .. cpp:enum-struct:: ICU4XLineBreakRule
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/enum.LineBreakRule.html>`__ for more information.
+    See the `Rust documentation for LineBreakRule <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/enum.LineBreakRule.html>`__ for more information.
 
 
     .. cpp:enumerator:: Loose
@@ -50,28 +50,28 @@
 
     An ICU4X line-break segmenter, capable of finding breakpoints in strings.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html>`__ for more information.
+    See the `Rust documentation for LineBreakSegmenter <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XLineBreakSegmenter, ICU4XError> try_new(const ICU4XDataProvider& provider)
 
         Construct a :cpp:class:`ICU4XLineBreakSegmenter` with default options.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.try_new>`__ for more information.
+        See the `Rust documentation for try_new <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.try_new>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XLineBreakSegmenter, ICU4XError> try_new_with_options(const ICU4XDataProvider& provider, ICU4XLineBreakOptions options)
 
         Construct a :cpp:class:`ICU4XLineBreakSegmenter` with custom options.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.try_new_with_options>`__ for more information.
+        See the `Rust documentation for try_new_with_options <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.try_new_with_options>`__ for more information.
 
 
     .. cpp:function:: ICU4XLineBreakIteratorUtf8 segment_utf8(const std::string_view input) const
 
         Segments a UTF-8 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_str>`__ for more information.
+        See the `Rust documentation for segment_str <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_str>`__ for more information.
 
 
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
@@ -80,7 +80,7 @@
 
         Segments a UTF-16 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_utf16>`__ for more information.
+        See the `Rust documentation for segment_utf16 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_utf16>`__ for more information.
 
 
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
@@ -89,14 +89,14 @@
 
         Segments a Latin-1 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_latin1>`__ for more information.
+        See the `Rust documentation for segment_latin1 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_latin1>`__ for more information.
 
 
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
 
 .. cpp:enum-struct:: ICU4XWordBreakRule
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/enum.WordBreakRule.html>`__ for more information.
+    See the `Rust documentation for WordBreakRule <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/enum.WordBreakRule.html>`__ for more information.
 
 
     .. cpp:enumerator:: Normal

--- a/ffi/diplomat/cpp/docs/source/segmenter_sentence_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/segmenter_sentence_ffi.rst
@@ -26,21 +26,21 @@
 
     An ICU4X sentence-break segmenter, capable of finding sentence breakpoints in strings.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html>`__ for more information.
+    See the `Rust documentation for SentenceBreakSegmenter <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XSentenceBreakSegmenter, ICU4XError> try_new(const ICU4XDataProvider& provider)
 
         Construct an :cpp:class:`ICU4XSentenceBreakSegmenter`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.try_new>`__ for more information.
+        See the `Rust documentation for try_new <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.try_new>`__ for more information.
 
 
     .. cpp:function:: ICU4XSentenceBreakIteratorUtf8 segment_utf8(const std::string_view input) const
 
         Segments a UTF-8 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_str>`__ for more information.
+        See the `Rust documentation for segment_str <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_str>`__ for more information.
 
 
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
@@ -49,7 +49,7 @@
 
         Segments a UTF-16 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_utf16>`__ for more information.
+        See the `Rust documentation for segment_utf16 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_utf16>`__ for more information.
 
 
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
@@ -58,7 +58,7 @@
 
         Segments a Latin-1 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_latin1>`__ for more information.
+        See the `Rust documentation for segment_latin1 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_latin1>`__ for more information.
 
 
         Lifetimes: ``this``, ``input`` must live at least as long as the output.

--- a/ffi/diplomat/cpp/docs/source/segmenter_word_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/segmenter_word_ffi.rst
@@ -26,21 +26,21 @@
 
     An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html>`__ for more information.
+    See the `Rust documentation for WordBreakSegmenter <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html>`__ for more information.
 
 
     .. cpp:function:: static diplomat::result<ICU4XWordBreakSegmenter, ICU4XError> try_new(const ICU4XDataProvider& provider)
 
         Construct an :cpp:class:`ICU4XWordBreakSegmenter`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.try_new>`__ for more information.
+        See the `Rust documentation for try_new <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.try_new>`__ for more information.
 
 
     .. cpp:function:: ICU4XWordBreakIteratorUtf8 segment_utf8(const std::string_view input) const
 
         Segments a UTF-8 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_str>`__ for more information.
+        See the `Rust documentation for segment_str <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_str>`__ for more information.
 
 
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
@@ -49,7 +49,7 @@
 
         Segments a UTF-16 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_utf16>`__ for more information.
+        See the `Rust documentation for segment_utf16 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_utf16>`__ for more information.
 
 
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
@@ -58,7 +58,7 @@
 
         Segments a Latin-1 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_latin1>`__ for more information.
+        See the `Rust documentation for segment_latin1 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_latin1>`__ for more information.
 
 
         Lifetimes: ``this``, ``input`` must live at least as long as the output.

--- a/ffi/diplomat/cpp/include/ICU4XBidi.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XBidi.hpp
@@ -28,7 +28,7 @@ struct ICU4XBidiDeleter {
 /**
  * An ICU4X Bidi object, containing loaded bidi data
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/bidi/struct.BidiClassAdapter.html) for more information.
+ * See the [Rust documentation for `BidiClassAdapter`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/bidi/struct.BidiClassAdapter.html) for more information.
  */
 class ICU4XBidi {
  public:
@@ -36,7 +36,7 @@ class ICU4XBidi {
   /**
    * Creates a new [`ICU4XBidi`] from locale data.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/bidi/struct.BidiClassAdapter.html#method.new) for more information.
+   * See the [Rust documentation for `new`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/bidi/struct.BidiClassAdapter.html#method.new) for more information.
    */
   static diplomat::result<ICU4XBidi, ICU4XError> try_new(const ICU4XDataProvider& provider);
 
@@ -45,7 +45,7 @@ class ICU4XBidi {
    * 
    * Takes in a Level for the default level, if it is an invalid value it will default to LTR
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html#method.new_with_data_source) for more information.
+   * See the [Rust documentation for `new_with_data_source`](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html#method.new_with_data_source) for more information.
    */
   ICU4XBidiInfo for_text(const std::string_view text, uint8_t default_level) const;
 
@@ -54,7 +54,7 @@ class ICU4XBidi {
    * 
    * Invalid levels (numbers greater than 125) will be assumed LTR
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_rtl) for more information.
+   * See the [Rust documentation for `is_rtl`](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_rtl) for more information.
    */
   static bool level_is_rtl(uint8_t level);
 
@@ -63,21 +63,21 @@ class ICU4XBidi {
    * 
    * Invalid levels (numbers greater than 125) will be assumed LTR
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_ltr) for more information.
+   * See the [Rust documentation for `is_ltr`](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_ltr) for more information.
    */
   static bool level_is_ltr(uint8_t level);
 
   /**
    * Get a basic RTL Level value
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.rtl) for more information.
+   * See the [Rust documentation for `rtl`](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.rtl) for more information.
    */
   static uint8_t level_rtl();
 
   /**
    * Get a simple LTR Level value
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.ltr) for more information.
+   * See the [Rust documentation for `ltr`](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.ltr) for more information.
    */
   static uint8_t level_ltr();
   inline const capi::ICU4XBidi* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XBidiInfo.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XBidiInfo.hpp
@@ -25,7 +25,7 @@ struct ICU4XBidiInfoDeleter {
 /**
  * An object containing bidi information for a given string, produced by `for_text()` on `ICU4XBidi`
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html) for more information.
+ * See the [Rust documentation for `BidiInfo`](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html) for more information.
  */
 class ICU4XBidiInfo {
  public:

--- a/ffi/diplomat/cpp/include/ICU4XBidiParagraph.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XBidiParagraph.hpp
@@ -41,14 +41,14 @@ class ICU4XBidiParagraph {
   /**
    * The primary direction of this paragraph
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at) for more information.
+   * See the [Rust documentation for `level_at`](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at) for more information.
    */
   ICU4XBidiDirection direction() const;
 
   /**
    * The number of bytes in this paragraph
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.ParagraphInfo.html#method.len) for more information.
+   * See the [Rust documentation for `len`](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.ParagraphInfo.html#method.len) for more information.
    */
   size_t size() const;
 
@@ -66,7 +66,7 @@ class ICU4XBidiParagraph {
    * Reorder a line based on display order. The ranges are specified relative to the source text and must be contained
    * within this paragraph's range.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at) for more information.
+   * See the [Rust documentation for `level_at`](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at) for more information.
    */
   template<typename W> diplomat::result<std::monostate, ICU4XError> reorder_line_to_writeable(size_t range_start, size_t range_end, W& out) const;
 
@@ -74,7 +74,7 @@ class ICU4XBidiParagraph {
    * Reorder a line based on display order. The ranges are specified relative to the source text and must be contained
    * within this paragraph's range.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at) for more information.
+   * See the [Rust documentation for `level_at`](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at) for more information.
    */
   diplomat::result<std::string, ICU4XError> reorder_line(size_t range_start, size_t range_end) const;
 
@@ -85,7 +85,7 @@ class ICU4XBidiParagraph {
    * 
    * Returns 0 (equivalent to `Level::ltr()`) on error
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at) for more information.
+   * See the [Rust documentation for `level_at`](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at) for more information.
    */
   uint8_t level_at(size_t pos) const;
   inline const capi::ICU4XBidiParagraph* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XCalendar.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XCalendar.hpp
@@ -28,7 +28,7 @@ struct ICU4XCalendarDeleter {
 /**
  * 
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/enum.AnyCalendar.html) for more information.
+ * See the [Rust documentation for `AnyCalendar`](https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/enum.AnyCalendar.html) for more information.
  */
 class ICU4XCalendar {
  public:
@@ -36,7 +36,7 @@ class ICU4XCalendar {
   /**
    * Creates a new [`ICU4XCalendar`] from the specified date and time.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.AnyCalendar.html#method.try_new_unstable) for more information.
+   * See the [Rust documentation for `try_new_unstable`](https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.AnyCalendar.html#method.try_new_unstable) for more information.
    */
   static diplomat::result<ICU4XCalendar, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale);
   inline const capi::ICU4XCalendar* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XCodePointMapData16.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XCodePointMapData16.hpp
@@ -29,7 +29,11 @@ struct ICU4XCodePointMapData16Deleter {
  * 
  * For properties whose values fit into 16 bits.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html) for more information.
+ * See the [Rust documentation for `properties`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html) for more information.
+ * 
+ * See the [Rust documentation for `CodePointMapData`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapData.html) for more information.
+ * 
+ * See the [Rust documentation for `CodePointMapDataBorrowed`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html) for more information.
  */
 class ICU4XCodePointMapData16 {
  public:
@@ -37,14 +41,14 @@ class ICU4XCodePointMapData16 {
   /**
    * Gets a map for Unicode property Script from a [`ICU4XDataProvider`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_script.html) for more information.
+   * See the [Rust documentation for `load_script`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_script.html) for more information.
    */
   static diplomat::result<ICU4XCodePointMapData16, ICU4XError> try_get_script(const ICU4XDataProvider& provider);
 
   /**
    * Gets the value for a code point.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html#method.get) for more information.
+   * See the [Rust documentation for `get`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html#method.get) for more information.
    */
   uint16_t get(char32_t cp) const;
   inline const capi::ICU4XCodePointMapData16* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XCodePointMapData8.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XCodePointMapData8.hpp
@@ -29,7 +29,11 @@ struct ICU4XCodePointMapData8Deleter {
  * 
  * For properties whose values fit into 8 bits.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html) for more information.
+ * See the [Rust documentation for `properties`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html) for more information.
+ * 
+ * See the [Rust documentation for `CodePointMapData`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapData.html) for more information.
+ * 
+ * See the [Rust documentation for `CodePointMapDataBorrowed`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html) for more information.
  */
 class ICU4XCodePointMapData8 {
  public:
@@ -37,56 +41,56 @@ class ICU4XCodePointMapData8 {
   /**
    * Gets a map for Unicode property General_Category from a [`ICU4XDataProvider`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_general_category.html) for more information.
+   * See the [Rust documentation for `load_general_category`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_general_category.html) for more information.
    */
   static diplomat::result<ICU4XCodePointMapData8, ICU4XError> try_get_general_category(const ICU4XDataProvider& provider);
 
   /**
    * Gets a map for Unicode property Bidi_Class from a [`ICU4XDataProvider`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_bidi_class.html) for more information.
+   * See the [Rust documentation for `load_bidi_class`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_bidi_class.html) for more information.
    */
   static diplomat::result<ICU4XCodePointMapData8, ICU4XError> try_get_bidi_class(const ICU4XDataProvider& provider);
 
   /**
    * Gets a map for Unicode property East_Asian_Width from a [`ICU4XDataProvider`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_east_asian_width.html) for more information.
+   * See the [Rust documentation for `load_east_asian_width`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_east_asian_width.html) for more information.
    */
   static diplomat::result<ICU4XCodePointMapData8, ICU4XError> try_get_east_asian_width(const ICU4XDataProvider& provider);
 
   /**
    * Gets a map for Unicode property Line_Break from a [`ICU4XDataProvider`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_line_break.html) for more information.
+   * See the [Rust documentation for `load_line_break`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_line_break.html) for more information.
    */
   static diplomat::result<ICU4XCodePointMapData8, ICU4XError> try_get_line_break(const ICU4XDataProvider& provider);
 
   /**
    * Gets a map for Unicode property Grapheme_Cluster_Break from a [`ICU4XDataProvider`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_grapheme_cluster_break.html) for more information.
+   * See the [Rust documentation for `load_grapheme_cluster_break`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_grapheme_cluster_break.html) for more information.
    */
   static diplomat::result<ICU4XCodePointMapData8, ICU4XError> try_grapheme_cluster_break(const ICU4XDataProvider& provider);
 
   /**
    * Gets a map for Unicode property Word_Break from a [`ICU4XDataProvider`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_word_break.html) for more information.
+   * See the [Rust documentation for `load_word_break`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_word_break.html) for more information.
    */
   static diplomat::result<ICU4XCodePointMapData8, ICU4XError> try_get_word_break(const ICU4XDataProvider& provider);
 
   /**
    * Gets a map for Unicode property Sentence_Break from a [`ICU4XDataProvider`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_sentence_break.html) for more information.
+   * See the [Rust documentation for `load_sentence_break`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_sentence_break.html) for more information.
    */
   static diplomat::result<ICU4XCodePointMapData8, ICU4XError> try_get_sentence_break(const ICU4XDataProvider& provider);
 
   /**
    * Gets the value for a code point.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html#method.get) for more information.
+   * See the [Rust documentation for `get`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html#method.get) for more information.
    */
   uint8_t get(char32_t cp) const;
   inline const capi::ICU4XCodePointMapData8* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XCodePointSetData.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XCodePointSetData.hpp
@@ -27,7 +27,11 @@ struct ICU4XCodePointSetDataDeleter {
 /**
  * An ICU4X Unicode Set Property object, capable of querying whether a code point is contained in a set based on a Unicode property.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html) for more information.
+ * See the [Rust documentation for `properties`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html) for more information.
+ * 
+ * See the [Rust documentation for `CodePointSetData`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/struct.CodePointSetData.html) for more information.
+ * 
+ * See the [Rust documentation for `CodePointSetDataBorrowed`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/struct.CodePointSetDataBorrowed.html) for more information.
  */
 class ICU4XCodePointSetData {
  public:
@@ -35,14 +39,14 @@ class ICU4XCodePointSetData {
   /**
    * Gets a set for Unicode property ascii_hex_digit from a [`ICU4XDataProvider`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/fn.load_ascii_hex_digit.html) for more information.
+   * See the [Rust documentation for `load_ascii_hex_digit`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/fn.load_ascii_hex_digit.html) for more information.
    */
   static diplomat::result<ICU4XCodePointSetData, ICU4XError> try_get_ascii_hex_digit(const ICU4XDataProvider& provider);
 
   /**
    * Checks whether the code point is in the set.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/struct.CodePointSetDataBorrowed.html#method.contains) for more information.
+   * See the [Rust documentation for `contains`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/struct.CodePointSetDataBorrowed.html#method.contains) for more information.
    */
   bool contains(char32_t cp) const;
   inline const capi::ICU4XCodePointSetData* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XDataProvider.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XDataProvider.hpp
@@ -26,7 +26,7 @@ struct ICU4XDataProviderDeleter {
 /**
  * An ICU4X data provider, capable of loading ICU4X data keys from some source.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_provider/index.html) for more information.
+ * See the [Rust documentation for `icu_provider`](https://unicode-org.github.io/icu4x-docs/doc/icu_provider/index.html) for more information.
  */
 class ICU4XDataProvider {
  public:
@@ -36,7 +36,7 @@ class ICU4XDataProvider {
    * Requires the `provider_fs` feature.
    * Not supported in WASM.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_provider_fs/struct.FsDataProvider.html) for more information.
+   * See the [Rust documentation for `FsDataProvider`](https://unicode-org.github.io/icu4x-docs/doc/icu_provider_fs/struct.FsDataProvider.html) for more information.
    */
   static diplomat::result<ICU4XDataProvider, ICU4XError> create_fs(const std::string_view path);
 
@@ -44,21 +44,21 @@ class ICU4XDataProvider {
    * Constructs a testdata provider and returns it as an [`ICU4XDataProvider`].
    * Requires the `provider_test` feature.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_testdata/index.html) for more information.
+   * See the [Rust documentation for `icu_testdata`](https://unicode-org.github.io/icu4x-docs/doc/icu_testdata/index.html) for more information.
    */
   static ICU4XDataProvider create_test();
 
   /**
    * Constructs a `BlobDataProvider` and returns it as an [`ICU4XDataProvider`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.BlobDataProvider.html) for more information.
+   * See the [Rust documentation for `BlobDataProvider`](https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.BlobDataProvider.html) for more information.
    */
   static diplomat::result<ICU4XDataProvider, ICU4XError> create_from_byte_slice(const diplomat::span<uint8_t> blob);
 
   /**
    * Constructs an empty `StaticDataProvider` and returns it as an [`ICU4XDataProvider`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.StaticDataProvider.html) for more information.
+   * See the [Rust documentation for `StaticDataProvider`](https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.StaticDataProvider.html) for more information.
    */
   static ICU4XDataProvider create_empty();
   inline const capi::ICU4XDataProvider* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XDataStruct.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XDataStruct.hpp
@@ -34,7 +34,7 @@ class ICU4XDataStruct {
   /**
    * Construct a new DecimalSymbolsV1 data struct.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/provider/struct.DecimalSymbolsV1.html) for more information.
+   * See the [Rust documentation for `DecimalSymbolsV1`](https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/provider/struct.DecimalSymbolsV1.html) for more information.
    */
   static diplomat::result<ICU4XDataStruct, ICU4XError> create_decimal_symbols_v1(const std::string_view plus_sign_prefix, const std::string_view plus_sign_suffix, const std::string_view minus_sign_prefix, const std::string_view minus_sign_suffix, const std::string_view decimal_separator, const std::string_view grouping_separator, uint8_t primary_group_size, uint8_t secondary_group_size, uint8_t min_group_size, const diplomat::span<char32_t> digits);
   inline const capi::ICU4XDataStruct* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XDateTime.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XDateTime.hpp
@@ -27,7 +27,7 @@ struct ICU4XDateTimeDeleter {
 /**
  * An ICU4X DateTime object capable of containing a date and time for any calendar.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html) for more information.
+ * See the [Rust documentation for `DateTime`](https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html) for more information.
  */
 class ICU4XDateTime {
  public:
@@ -36,14 +36,14 @@ class ICU4XDateTime {
    * Creates a new [`ICU4XDateTime`] representing the ISO date and time
    * given but in a given calendar
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html#method.new_iso_datetime) for more information.
+   * See the [Rust documentation for `new_iso_datetime`](https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html#method.new_iso_datetime) for more information.
    */
   static diplomat::result<ICU4XDateTime, ICU4XError> try_new_from_iso_in_calendar(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, const ICU4XCalendar& calendar);
 
   /**
    * Sets the fractional seconds field of this datetime, in nanoseconds
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/types/struct.Time.html#structfield.nanosecond) for more information.
+   * See the [Rust documentation for `nanosecond`](https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/types/struct.Time.html#structfield.nanosecond) for more information.
    */
   diplomat::result<std::monostate, ICU4XError> set_ns(uint32_t ns);
   inline const capi::ICU4XDateTime* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XDateTimeFormatter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XDateTimeFormatter.hpp
@@ -32,7 +32,7 @@ struct ICU4XDateTimeFormatterDeleter {
  * An ICU4X DateFormatter object capable of formatting a [`ICU4XDateTime`] as a string,
  * using some calendar specified at runtime in the locale.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html) for more information.
+ * See the [Rust documentation for `DateTimeFormatter`](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html) for more information.
  */
 class ICU4XDateTimeFormatter {
  public:
@@ -40,21 +40,21 @@ class ICU4XDateTimeFormatter {
   /**
    * Creates a new [`ICU4XDateTimeFormatter`] from locale data.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.try_new_unstable) for more information.
+   * See the [Rust documentation for `try_new_unstable`](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.try_new_unstable) for more information.
    */
   static diplomat::result<ICU4XDateTimeFormatter, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XDateLength date_length, ICU4XTimeLength time_length);
 
   /**
    * Formats a [`ICU4XDateTime`] to a string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.format_to_write) for more information.
+   * See the [Rust documentation for `format_to_write`](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.format_to_write) for more information.
    */
   template<typename W> diplomat::result<std::monostate, ICU4XError> format_datetime_to_writeable(const ICU4XDateTime& value, W& write) const;
 
   /**
    * Formats a [`ICU4XDateTime`] to a string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.format_to_write) for more information.
+   * See the [Rust documentation for `format_to_write`](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.format_to_write) for more information.
    */
   diplomat::result<std::string, ICU4XError> format_datetime(const ICU4XDateTime& value) const;
   inline const capi::ICU4XDateTimeFormatter* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XFixedDecimal.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XFixedDecimal.hpp
@@ -27,7 +27,7 @@ struct ICU4XFixedDecimalDeleter {
 /**
  * 
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html) for more information.
+ * See the [Rust documentation for `FixedDecimal`](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html) for more information.
  */
 class ICU4XFixedDecimal {
  public:
@@ -35,7 +35,7 @@ class ICU4XFixedDecimal {
   /**
    * Construct an [`ICU4XFixedDecimal`] from an integer.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html) for more information.
+   * See the [Rust documentation for `FixedDecimal`](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html) for more information.
    */
   static ICU4XFixedDecimal create(int32_t v);
 
@@ -43,49 +43,49 @@ class ICU4XFixedDecimal {
    * Construct an [`ICU4XFixedDecimal`] from an float, with enough digits to recover
    * the original floating point in IEEE 754 without needing trailing zeros
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64) for more information.
+   * See the [Rust documentation for `try_from_f64`](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64) for more information.
    */
   static diplomat::result<ICU4XFixedDecimal, ICU4XError> create_from_f64_with_max_precision(double f);
 
   /**
    * Construct an [`ICU4XFixedDecimal`] from an float, with a given power of 10 for the lower magnitude
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64) for more information.
+   * See the [Rust documentation for `try_from_f64`](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64) for more information.
    */
   static diplomat::result<ICU4XFixedDecimal, ICU4XError> create_from_f64_with_lower_magnitude(double f, int16_t precision);
 
   /**
    * Construct an [`ICU4XFixedDecimal`] from an float, for a given number of significant digits
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64) for more information.
+   * See the [Rust documentation for `try_from_f64`](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64) for more information.
    */
   static diplomat::result<ICU4XFixedDecimal, ICU4XError> create_from_f64_with_significant_digits(double f, uint8_t digits);
 
   /**
    * Construct an [`ICU4XFixedDecimal`] from a string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html) for more information.
+   * See the [Rust documentation for `FixedDecimal`](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html) for more information.
    */
   static diplomat::result<ICU4XFixedDecimal, ICU4XError> create_fromstr(const std::string_view v);
 
   /**
    * Multiply the [`ICU4XFixedDecimal`] by a given power of ten.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.multiply_pow10) for more information.
+   * See the [Rust documentation for `multiply_pow10`](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.multiply_pow10) for more information.
    */
   void multiply_pow10(int16_t power);
 
   /**
    * Set the sign of the [`ICU4XFixedDecimal`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.set_sign) for more information.
+   * See the [Rust documentation for `set_sign`](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.set_sign) for more information.
    */
   void set_sign(ICU4XFixedDecimalSign sign);
 
   /**
    * Zero-pad the [`ICU4XFixedDecimal`] on the left to a particular position
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_start) for more information.
+   * See the [Rust documentation for `pad_start`](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_start) for more information.
    */
   void pad_start(int16_t position);
 
@@ -93,28 +93,28 @@ class ICU4XFixedDecimal {
    * Truncate the [`ICU4XFixedDecimal`] on the left to a particular position, deleting digits if necessary. This is useful for, e.g. abbreviating years
    * ("2022" -> "22")
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.set_max_position) for more information.
+   * See the [Rust documentation for `set_max_position`](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.set_max_position) for more information.
    */
   void set_max_position(int16_t position);
 
   /**
    * Zero-pad the [`ICU4XFixedDecimal`] on the right to a particular position
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_end) for more information.
+   * See the [Rust documentation for `pad_end`](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_end) for more information.
    */
   void pad_end(int16_t position);
 
   /**
    * Format the [`ICU4XFixedDecimal`] as a string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.write_to) for more information.
+   * See the [Rust documentation for `write_to`](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.write_to) for more information.
    */
   template<typename W> void to_string_to_writeable(W& to) const;
 
   /**
    * Format the [`ICU4XFixedDecimal`] as a string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.write_to) for more information.
+   * See the [Rust documentation for `write_to`](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.write_to) for more information.
    */
   std::string to_string() const;
   inline const capi::ICU4XFixedDecimal* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XFixedDecimalFormatter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XFixedDecimalFormatter.hpp
@@ -31,7 +31,7 @@ struct ICU4XFixedDecimalFormatterDeleter {
 /**
  * An ICU4X Fixed Decimal Format object, capable of formatting a [`ICU4XFixedDecimal`] as a string.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html) for more information.
+ * See the [Rust documentation for `FixedDecimalFormatter`](https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html) for more information.
  */
 class ICU4XFixedDecimalFormatter {
  public:
@@ -39,7 +39,7 @@ class ICU4XFixedDecimalFormatter {
   /**
    * Creates a new [`ICU4XFixedDecimalFormatter`] from locale data.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.try_new) for more information.
+   * See the [Rust documentation for `try_new`](https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.try_new) for more information.
    */
   static diplomat::result<ICU4XFixedDecimalFormatter, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XFixedDecimalGroupingStrategy grouping_strategy);
 
@@ -55,14 +55,14 @@ class ICU4XFixedDecimalFormatter {
   /**
    * Formats a [`ICU4XFixedDecimal`] to a string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.format) for more information.
+   * See the [Rust documentation for `format`](https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.format) for more information.
    */
   template<typename W> diplomat::result<std::monostate, ICU4XError> format_to_writeable(const ICU4XFixedDecimal& value, W& write) const;
 
   /**
    * Formats a [`ICU4XFixedDecimal`] to a string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.format) for more information.
+   * See the [Rust documentation for `format`](https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.format) for more information.
    */
   diplomat::result<std::string, ICU4XError> format(const ICU4XFixedDecimal& value) const;
   inline const capi::ICU4XFixedDecimalFormatter* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XFixedDecimalSign.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XFixedDecimalSign.hpp
@@ -16,7 +16,7 @@
 /**
  * The sign of a FixedDecimal, as shown in formatting.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/enum.Sign.html) for more information.
+ * See the [Rust documentation for `Sign`](https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/enum.Sign.html) for more information.
  */
 enum struct ICU4XFixedDecimalSign {
 

--- a/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakSegmenter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XGraphemeClusterBreakSegmenter.hpp
@@ -31,7 +31,7 @@ struct ICU4XGraphemeClusterBreakSegmenterDeleter {
  * An ICU4X grapheme-cluster-break segmenter, capable of finding grapheme cluster breakpoints
  * in strings.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterBreakSegmenter.html) for more information.
+ * See the [Rust documentation for `GraphemeClusterBreakSegmenter`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterBreakSegmenter.html) for more information.
  */
 class ICU4XGraphemeClusterBreakSegmenter {
  public:
@@ -39,28 +39,28 @@ class ICU4XGraphemeClusterBreakSegmenter {
   /**
    * Construct an [`ICU4XGraphemeClusterBreakSegmenter`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterBreakSegmenter.html#method.try_new) for more information.
+   * See the [Rust documentation for `try_new`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterBreakSegmenter.html#method.try_new) for more information.
    */
   static diplomat::result<ICU4XGraphemeClusterBreakSegmenter, ICU4XError> try_new(const ICU4XDataProvider& provider);
 
   /**
    * Segments a UTF-8 string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_str) for more information.
+   * See the [Rust documentation for `segment_str`](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_str) for more information.
    */
   ICU4XGraphemeClusterBreakIteratorUtf8 segment_utf8(const std::string_view input) const;
 
   /**
    * Segments a UTF-16 string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_utf16) for more information.
+   * See the [Rust documentation for `segment_utf16`](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_utf16) for more information.
    */
   ICU4XGraphemeClusterBreakIteratorUtf16 segment_utf16(const diplomat::span<uint16_t> input) const;
 
   /**
    * Segments a Latin-1 string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_latin1) for more information.
+   * See the [Rust documentation for `segment_latin1`](https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_latin1) for more information.
    */
   ICU4XGraphemeClusterBreakIteratorLatin1 segment_latin1(const diplomat::span<uint8_t> input) const;
   inline const capi::ICU4XGraphemeClusterBreakSegmenter* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XGregorianDateFormatter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XGregorianDateFormatter.hpp
@@ -31,7 +31,7 @@ struct ICU4XGregorianDateFormatterDeleter {
  * An ICU4X TypedDateFormatter object capable of formatting a [`ICU4XGregorianDateTime`] as a string,
  * using the Gregorian Calendar.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html) for more information.
+ * See the [Rust documentation for `TypedDateFormatter`](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html) for more information.
  */
 class ICU4XGregorianDateFormatter {
  public:
@@ -39,21 +39,21 @@ class ICU4XGregorianDateFormatter {
   /**
    * Creates a new [`ICU4XGregorianDateFormatter`] from locale data.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.TypedDateFormatter.html#method.try_new_unstable) for more information.
+   * See the [Rust documentation for `try_new_unstable`](https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.TypedDateFormatter.html#method.try_new_unstable) for more information.
    */
   static diplomat::result<ICU4XGregorianDateFormatter, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XDateLength length);
 
   /**
    * Formats a [`ICU4XGregorianDateTime`] to a string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html#method.format_to_write) for more information.
+   * See the [Rust documentation for `format_to_write`](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html#method.format_to_write) for more information.
    */
   template<typename W> diplomat::result<std::monostate, ICU4XError> format_datetime_to_writeable(const ICU4XGregorianDateTime& value, W& write) const;
 
   /**
    * Formats a [`ICU4XGregorianDateTime`] to a string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html#method.format_to_write) for more information.
+   * See the [Rust documentation for `format_to_write`](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html#method.format_to_write) for more information.
    */
   diplomat::result<std::string, ICU4XError> format_datetime(const ICU4XGregorianDateTime& value) const;
   inline const capi::ICU4XGregorianDateFormatter* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XGregorianDateTime.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XGregorianDateTime.hpp
@@ -26,7 +26,7 @@ struct ICU4XGregorianDateTimeDeleter {
 /**
  * An ICU4X DateTime object capable of containing a Gregorian date and time.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html) for more information.
+ * See the [Rust documentation for `DateTime`](https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html) for more information.
  */
 class ICU4XGregorianDateTime {
  public:
@@ -34,7 +34,7 @@ class ICU4XGregorianDateTime {
   /**
    * Creates a new [`ICU4XGregorianDateTime`] from the specified date and time.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html#method.new_gregorian_datetime) for more information.
+   * See the [Rust documentation for `new_gregorian_datetime`](https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html#method.new_gregorian_datetime) for more information.
    */
   static diplomat::result<ICU4XGregorianDateTime, ICU4XError> try_new(int32_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second);
   inline const capi::ICU4XGregorianDateTime* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XGregorianDateTimeFormatter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XGregorianDateTimeFormatter.hpp
@@ -32,7 +32,7 @@ struct ICU4XGregorianDateTimeFormatterDeleter {
  * An ICU4X TypedDateFormatter object capable of formatting a [`ICU4XGregorianDateTime`] as a string,
  * using the Gregorian Calendar.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html) for more information.
+ * See the [Rust documentation for `TypedDateTimeFormatter`](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html) for more information.
  */
 class ICU4XGregorianDateTimeFormatter {
  public:
@@ -40,21 +40,21 @@ class ICU4XGregorianDateTimeFormatter {
   /**
    * Creates a new [`ICU4XGregorianDateFormatter`] from locale data.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.try_new_unstable) for more information.
+   * See the [Rust documentation for `try_new_unstable`](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.try_new_unstable) for more information.
    */
   static diplomat::result<ICU4XGregorianDateTimeFormatter, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XDateLength date_length, ICU4XTimeLength time_length);
 
   /**
    * Formats a [`ICU4XGregorianDateTime`] to a string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.format_to_write) for more information.
+   * See the [Rust documentation for `format_to_write`](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.format_to_write) for more information.
    */
   template<typename W> diplomat::result<std::monostate, ICU4XError> format_datetime_to_writeable(const ICU4XGregorianDateTime& value, W& write) const;
 
   /**
    * Formats a [`ICU4XGregorianDateTime`] to a string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.format_to_write) for more information.
+   * See the [Rust documentation for `format_to_write`](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.format_to_write) for more information.
    */
   diplomat::result<std::string, ICU4XError> format_datetime(const ICU4XGregorianDateTime& value) const;
   inline const capi::ICU4XGregorianDateTimeFormatter* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XLineBreakOptions.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XLineBreakOptions.hpp
@@ -26,7 +26,7 @@ struct ICU4XLineBreakOptionsDeleter {
 /**
  * 
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakOptions.html) for more information.
+ * See the [Rust documentation for `LineBreakOptions`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakOptions.html) for more information.
  */
 struct ICU4XLineBreakOptions {
  public:

--- a/ffi/diplomat/cpp/include/ICU4XLineBreakRule.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XLineBreakRule.hpp
@@ -16,7 +16,7 @@
 /**
  * 
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/enum.LineBreakRule.html) for more information.
+ * See the [Rust documentation for `LineBreakRule`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/enum.LineBreakRule.html) for more information.
  */
 enum struct ICU4XLineBreakRule {
   Loose = 0,

--- a/ffi/diplomat/cpp/include/ICU4XLineBreakSegmenter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XLineBreakSegmenter.hpp
@@ -31,7 +31,7 @@ struct ICU4XLineBreakSegmenterDeleter {
 /**
  * An ICU4X line-break segmenter, capable of finding breakpoints in strings.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html) for more information.
+ * See the [Rust documentation for `LineBreakSegmenter`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html) for more information.
  */
 class ICU4XLineBreakSegmenter {
  public:
@@ -39,35 +39,35 @@ class ICU4XLineBreakSegmenter {
   /**
    * Construct a [`ICU4XLineBreakSegmenter`] with default options.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.try_new) for more information.
+   * See the [Rust documentation for `try_new`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.try_new) for more information.
    */
   static diplomat::result<ICU4XLineBreakSegmenter, ICU4XError> try_new(const ICU4XDataProvider& provider);
 
   /**
    * Construct a [`ICU4XLineBreakSegmenter`] with custom options.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.try_new_with_options) for more information.
+   * See the [Rust documentation for `try_new_with_options`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.try_new_with_options) for more information.
    */
   static diplomat::result<ICU4XLineBreakSegmenter, ICU4XError> try_new_with_options(const ICU4XDataProvider& provider, ICU4XLineBreakOptions options);
 
   /**
    * Segments a UTF-8 string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_str) for more information.
+   * See the [Rust documentation for `segment_str`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_str) for more information.
    */
   ICU4XLineBreakIteratorUtf8 segment_utf8(const std::string_view input) const;
 
   /**
    * Segments a UTF-16 string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_utf16) for more information.
+   * See the [Rust documentation for `segment_utf16`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_utf16) for more information.
    */
   ICU4XLineBreakIteratorUtf16 segment_utf16(const diplomat::span<uint16_t> input) const;
 
   /**
    * Segments a Latin-1 string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_latin1) for more information.
+   * See the [Rust documentation for `segment_latin1`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_latin1) for more information.
    */
   ICU4XLineBreakIteratorLatin1 segment_latin1(const diplomat::span<uint8_t> input) const;
   inline const capi::ICU4XLineBreakSegmenter* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XLocale.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XLocale.hpp
@@ -26,7 +26,7 @@ struct ICU4XLocaleDeleter {
 /**
  * An ICU4X Locale, capable of representing strings like `"en-US"`.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html) for more information.
+ * See the [Rust documentation for `Locale`](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html) for more information.
  */
 class ICU4XLocale {
  public:
@@ -34,7 +34,7 @@ class ICU4XLocale {
   /**
    * Construct an [`ICU4XLocale`] from an locale identifier.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes) for more information.
+   * See the [Rust documentation for `from_bytes`](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes) for more information.
    */
   static diplomat::result<ICU4XLocale, ICU4XError> create(const std::string_view name);
 
@@ -56,7 +56,7 @@ class ICU4XLocale {
   /**
    * Clones the [`ICU4XLocale`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html) for more information.
+   * See the [Rust documentation for `Locale`](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html) for more information.
    */
   ICU4XLocale clone() const;
 
@@ -64,7 +64,7 @@ class ICU4XLocale {
    * Write a string representation of the `LanguageIdentifier` part of
    * [`ICU4XLocale`] to `write`.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id) for more information.
+   * See the [Rust documentation for `id`](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id) for more information.
    */
   template<typename W> diplomat::result<std::monostate, ICU4XError> basename_to_writeable(W& write) const;
 
@@ -72,98 +72,98 @@ class ICU4XLocale {
    * Write a string representation of the `LanguageIdentifier` part of
    * [`ICU4XLocale`] to `write`.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id) for more information.
+   * See the [Rust documentation for `id`](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id) for more information.
    */
   diplomat::result<std::string, ICU4XError> basename() const;
 
   /**
    * Write a string representation of the unicode extension to `write`
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.extensions) for more information.
+   * See the [Rust documentation for `extensions`](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.extensions) for more information.
    */
   template<typename W> diplomat::result<std::monostate, ICU4XError> get_unicode_extension_to_writeable(const std::string_view bytes, W& write) const;
 
   /**
    * Write a string representation of the unicode extension to `write`
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.extensions) for more information.
+   * See the [Rust documentation for `extensions`](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.extensions) for more information.
    */
   diplomat::result<std::string, ICU4XError> get_unicode_extension(const std::string_view bytes) const;
 
   /**
    * Write a string representation of [`ICU4XLocale`] language to `write`
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id) for more information.
+   * See the [Rust documentation for `id`](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id) for more information.
    */
   template<typename W> diplomat::result<std::monostate, ICU4XError> language_to_writeable(W& write) const;
 
   /**
    * Write a string representation of [`ICU4XLocale`] language to `write`
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id) for more information.
+   * See the [Rust documentation for `id`](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id) for more information.
    */
   diplomat::result<std::string, ICU4XError> language() const;
 
   /**
    * Set the language part of the [`ICU4XLocale`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes) for more information.
+   * See the [Rust documentation for `from_bytes`](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes) for more information.
    */
   diplomat::result<std::monostate, ICU4XError> set_language(const std::string_view bytes);
 
   /**
    * Write a string representation of [`ICU4XLocale`] region to `write`
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id) for more information.
+   * See the [Rust documentation for `id`](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id) for more information.
    */
   template<typename W> diplomat::result<std::monostate, ICU4XError> region_to_writeable(W& write) const;
 
   /**
    * Write a string representation of [`ICU4XLocale`] region to `write`
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id) for more information.
+   * See the [Rust documentation for `id`](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id) for more information.
    */
   diplomat::result<std::string, ICU4XError> region() const;
 
   /**
    * Set the region part of the [`ICU4XLocale`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes) for more information.
+   * See the [Rust documentation for `from_bytes`](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes) for more information.
    */
   diplomat::result<std::monostate, ICU4XError> set_region(const std::string_view bytes);
 
   /**
    * Write a string representation of [`ICU4XLocale`] script to `write`
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id) for more information.
+   * See the [Rust documentation for `id`](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id) for more information.
    */
   template<typename W> diplomat::result<std::monostate, ICU4XError> script_to_writeable(W& write) const;
 
   /**
    * Write a string representation of [`ICU4XLocale`] script to `write`
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id) for more information.
+   * See the [Rust documentation for `id`](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id) for more information.
    */
   diplomat::result<std::string, ICU4XError> script() const;
 
   /**
    * Set the script part of the [`ICU4XLocale`]. Pass an empty string to remove the script.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes) for more information.
+   * See the [Rust documentation for `from_bytes`](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes) for more information.
    */
   diplomat::result<std::monostate, ICU4XError> set_script(const std::string_view bytes);
 
   /**
    * Write a string representation of [`ICU4XLocale`] to `write`
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html) for more information.
+   * See the [Rust documentation for `Locale`](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html) for more information.
    */
   template<typename W> diplomat::result<std::monostate, ICU4XError> tostring_to_writeable(W& write) const;
 
   /**
    * Write a string representation of [`ICU4XLocale`] to `write`
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html) for more information.
+   * See the [Rust documentation for `Locale`](https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html) for more information.
    */
   diplomat::result<std::string, ICU4XError> tostring() const;
   inline const capi::ICU4XLocale* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XLocaleCanonicalizer.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XLocaleCanonicalizer.hpp
@@ -29,7 +29,7 @@ struct ICU4XLocaleCanonicalizerDeleter {
 /**
  * A locale canonicalizer.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html) for more information.
+ * See the [Rust documentation for `LocaleCanonicalizer`](https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html) for more information.
  */
 class ICU4XLocaleCanonicalizer {
  public:
@@ -37,14 +37,14 @@ class ICU4XLocaleCanonicalizer {
   /**
    * Create a new [`ICU4XLocaleCanonicalizer`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html#method.new) for more information.
+   * See the [Rust documentation for `new`](https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html#method.new) for more information.
    */
   static diplomat::result<ICU4XLocaleCanonicalizer, ICU4XError> create(const ICU4XDataProvider& provider);
 
   /**
    * FFI version of `LocaleCanonicalizer::canonicalize()`.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html#method.canonicalize) for more information.
+   * See the [Rust documentation for `canonicalize`](https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html#method.canonicalize) for more information.
    */
   ICU4XTransformResult canonicalize(ICU4XLocale& locale) const;
   inline const capi::ICU4XLocaleCanonicalizer* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XLocaleExpander.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XLocaleExpander.hpp
@@ -29,7 +29,7 @@ struct ICU4XLocaleExpanderDeleter {
 /**
  * A locale expander.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html) for more information.
+ * See the [Rust documentation for `LocaleExpander`](https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html) for more information.
  */
 class ICU4XLocaleExpander {
  public:
@@ -37,21 +37,21 @@ class ICU4XLocaleExpander {
   /**
    * Create a new [`ICU4XLocaleExpander`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.new) for more information.
+   * See the [Rust documentation for `new`](https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.new) for more information.
    */
   static diplomat::result<ICU4XLocaleExpander, ICU4XError> create(const ICU4XDataProvider& provider);
 
   /**
    * FFI version of `LocaleExpander::maximize()`.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.maximize) for more information.
+   * See the [Rust documentation for `maximize`](https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.maximize) for more information.
    */
   ICU4XTransformResult maximize(ICU4XLocale& locale) const;
 
   /**
    * FFI version of `LocaleExpander::minimize()`.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.minimize) for more information.
+   * See the [Rust documentation for `minimize`](https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.minimize) for more information.
    */
   ICU4XTransformResult minimize(ICU4XLocale& locale) const;
   inline const capi::ICU4XLocaleExpander* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XPluralCategory.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XPluralCategory.hpp
@@ -16,7 +16,7 @@
 /**
  * FFI version of `PluralCategory`.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/enum.PluralCategory.html) for more information.
+ * See the [Rust documentation for `PluralCategory`](https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/enum.PluralCategory.html) for more information.
  */
 enum struct ICU4XPluralCategory {
   Zero = 0,

--- a/ffi/diplomat/cpp/include/ICU4XPluralOperands.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XPluralOperands.hpp
@@ -26,7 +26,7 @@ struct ICU4XPluralOperandsDeleter {
 /**
  * FFI version of `PluralOperands`.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralOperands.html) for more information.
+ * See the [Rust documentation for `PluralOperands`](https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralOperands.html) for more information.
  */
 struct ICU4XPluralOperands {
  public:
@@ -40,7 +40,7 @@ struct ICU4XPluralOperands {
   /**
    * FFI version of `PluralOperands::from_str()`.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralOperands.html#method.from_str) for more information.
+   * See the [Rust documentation for `from_str`](https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralOperands.html#method.from_str) for more information.
    */
   static diplomat::result<ICU4XPluralOperands, ICU4XError> create(const std::string_view s);
 };

--- a/ffi/diplomat/cpp/include/ICU4XPluralRules.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XPluralRules.hpp
@@ -31,7 +31,7 @@ struct ICU4XPluralRulesDeleter {
 /**
  * FFI version of `PluralRules`.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html) for more information.
+ * See the [Rust documentation for `PluralRules`](https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html) for more information.
  */
 class ICU4XPluralRules {
  public:
@@ -39,28 +39,28 @@ class ICU4XPluralRules {
   /**
    * FFI version of `PluralRules::try_new_cardinal()`.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.try_new_unstable) for more information.
+   * See the [Rust documentation for `try_new_unstable`](https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.try_new_unstable) for more information.
    */
   static diplomat::result<ICU4XPluralRules, ICU4XError> try_new_cardinal(const ICU4XDataProvider& provider, const ICU4XLocale& locale);
 
   /**
    * FFI version of `PluralRules::try_new_ordinal()`.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.try_new_unstable) for more information.
+   * See the [Rust documentation for `try_new_unstable`](https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.try_new_unstable) for more information.
    */
   static diplomat::result<ICU4XPluralRules, ICU4XError> try_new_ordinal(const ICU4XDataProvider& provider, const ICU4XLocale& locale);
 
   /**
    * FFI version of `PluralRules::select()`.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.select) for more information.
+   * See the [Rust documentation for `select`](https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.select) for more information.
    */
   ICU4XPluralCategory select(ICU4XPluralOperands op) const;
 
   /**
    * FFI version of `PluralRules::categories()`.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.categories) for more information.
+   * See the [Rust documentation for `categories`](https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.categories) for more information.
    */
   ICU4XPluralCategories categories() const;
   inline const capi::ICU4XPluralRules* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XSentenceBreakSegmenter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XSentenceBreakSegmenter.hpp
@@ -30,7 +30,7 @@ struct ICU4XSentenceBreakSegmenterDeleter {
 /**
  * An ICU4X sentence-break segmenter, capable of finding sentence breakpoints in strings.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html) for more information.
+ * See the [Rust documentation for `SentenceBreakSegmenter`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html) for more information.
  */
 class ICU4XSentenceBreakSegmenter {
  public:
@@ -38,28 +38,28 @@ class ICU4XSentenceBreakSegmenter {
   /**
    * Construct an [`ICU4XSentenceBreakSegmenter`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.try_new) for more information.
+   * See the [Rust documentation for `try_new`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.try_new) for more information.
    */
   static diplomat::result<ICU4XSentenceBreakSegmenter, ICU4XError> try_new(const ICU4XDataProvider& provider);
 
   /**
    * Segments a UTF-8 string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_str) for more information.
+   * See the [Rust documentation for `segment_str`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_str) for more information.
    */
   ICU4XSentenceBreakIteratorUtf8 segment_utf8(const std::string_view input) const;
 
   /**
    * Segments a UTF-16 string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_utf16) for more information.
+   * See the [Rust documentation for `segment_utf16`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_utf16) for more information.
    */
   ICU4XSentenceBreakIteratorUtf16 segment_utf16(const diplomat::span<uint16_t> input) const;
 
   /**
    * Segments a Latin-1 string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_latin1) for more information.
+   * See the [Rust documentation for `segment_latin1`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_latin1) for more information.
    */
   ICU4XSentenceBreakIteratorLatin1 segment_latin1(const diplomat::span<uint8_t> input) const;
   inline const capi::ICU4XSentenceBreakSegmenter* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XTimeFormatter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XTimeFormatter.hpp
@@ -30,7 +30,7 @@ struct ICU4XTimeFormatterDeleter {
 /**
  * An ICU4X TimeFormatter object capable of formatting a [`ICU4XGregorianDateTime`] as a string
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html) for more information.
+ * See the [Rust documentation for `TimeFormatter`](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html) for more information.
  */
 class ICU4XTimeFormatter {
  public:
@@ -38,21 +38,21 @@ class ICU4XTimeFormatter {
   /**
    * Creates a new [`ICU4XTimeFormatter`] from locale data.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.TypedDateFormatter.html#method.try_new_unstable) for more information.
+   * See the [Rust documentation for `try_new_unstable`](https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.TypedDateFormatter.html#method.try_new_unstable) for more information.
    */
   static diplomat::result<ICU4XTimeFormatter, ICU4XError> try_new(const ICU4XDataProvider& provider, const ICU4XLocale& locale, ICU4XTimeLength length);
 
   /**
    * Formats a [`ICU4XGregorianDateTime`] to a string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html#method.format_to_write) for more information.
+   * See the [Rust documentation for `format_to_write`](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html#method.format_to_write) for more information.
    */
   template<typename W> diplomat::result<std::monostate, ICU4XError> format_gregorian_datetime_to_writeable(const ICU4XGregorianDateTime& value, W& write) const;
 
   /**
    * Formats a [`ICU4XGregorianDateTime`] to a string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html#method.format_to_write) for more information.
+   * See the [Rust documentation for `format_to_write`](https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html#method.format_to_write) for more information.
    */
   diplomat::result<std::string, ICU4XError> format_gregorian_datetime(const ICU4XGregorianDateTime& value) const;
   inline const capi::ICU4XTimeFormatter* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XTransformResult.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XTransformResult.hpp
@@ -16,7 +16,7 @@
 /**
  * FFI version of `TransformResult`.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/enum.TransformResult.html) for more information.
+ * See the [Rust documentation for `TransformResult`](https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/enum.TransformResult.html) for more information.
  */
 enum struct ICU4XTransformResult {
   Modified = 0,

--- a/ffi/diplomat/cpp/include/ICU4XWordBreakRule.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XWordBreakRule.hpp
@@ -16,7 +16,7 @@
 /**
  * 
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/enum.WordBreakRule.html) for more information.
+ * See the [Rust documentation for `WordBreakRule`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/enum.WordBreakRule.html) for more information.
  */
 enum struct ICU4XWordBreakRule {
   Normal = 0,

--- a/ffi/diplomat/cpp/include/ICU4XWordBreakSegmenter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XWordBreakSegmenter.hpp
@@ -30,7 +30,7 @@ struct ICU4XWordBreakSegmenterDeleter {
 /**
  * An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
  * 
- * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html) for more information.
+ * See the [Rust documentation for `WordBreakSegmenter`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html) for more information.
  */
 class ICU4XWordBreakSegmenter {
  public:
@@ -38,28 +38,28 @@ class ICU4XWordBreakSegmenter {
   /**
    * Construct an [`ICU4XWordBreakSegmenter`].
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.try_new) for more information.
+   * See the [Rust documentation for `try_new`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.try_new) for more information.
    */
   static diplomat::result<ICU4XWordBreakSegmenter, ICU4XError> try_new(const ICU4XDataProvider& provider);
 
   /**
    * Segments a UTF-8 string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_str) for more information.
+   * See the [Rust documentation for `segment_str`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_str) for more information.
    */
   ICU4XWordBreakIteratorUtf8 segment_utf8(const std::string_view input) const;
 
   /**
    * Segments a UTF-16 string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_utf16) for more information.
+   * See the [Rust documentation for `segment_utf16`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_utf16) for more information.
    */
   ICU4XWordBreakIteratorUtf16 segment_utf16(const diplomat::span<uint16_t> input) const;
 
   /**
    * Segments a Latin-1 string.
    * 
-   * See the [Rust documentation](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_latin1) for more information.
+   * See the [Rust documentation for `segment_latin1`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_latin1) for more information.
    */
   ICU4XWordBreakIteratorLatin1 segment_latin1(const diplomat::span<uint8_t> input) const;
   inline const capi::ICU4XWordBreakSegmenter* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/src/bin/completeness.rs
+++ b/ffi/diplomat/src/bin/completeness.rs
@@ -109,7 +109,9 @@ lazy_static::lazy_static! {
         "ZeroFrom",
     ].into_iter().collect();
 
-    static ref ALLOWLISTED_PATHS: HashSet<Vec<String>> = [
+    // Paths which are not checked for FFI coverage. Naming a type or module here
+    // will include all type methods and module contents.
+    static ref IGNORED_PATHS: HashSet<Vec<String>> = [
         // Stuff that could be exposed over FFI but is not currently planned
         // =========================
         // Largely for use by datetimeformat, not super public (#2421)
@@ -201,7 +203,7 @@ fn collect_public_types(krate: &str) -> impl Iterator<Item = (Vec<String>, ast::
         path_already_extended: bool,
         inside: Option<In>,
     ) {
-        /// Helper function that ensures that ALLOWLISTED_PATHS
+        /// Helper function that ensures that IGNORED_PATHS
         /// is respected for every type inserted
         ///
         /// (We have a check at the beginning of recurse() but that won't catch leaf nodes)
@@ -210,11 +212,11 @@ fn collect_public_types(krate: &str) -> impl Iterator<Item = (Vec<String>, ast::
             path: Vec<String>,
             ty: ast::DocType,
         ) {
-            if !ALLOWLISTED_PATHS.contains(&path) {
+            if !IGNORED_PATHS.contains(&path) {
                 types.insert((path, ty));
             }
         }
-        if ALLOWLISTED_PATHS.contains(&path) {
+        if IGNORED_PATHS.contains(&path) {
             return;
         }
         match &item.inner {

--- a/ffi/diplomat/src/bin/completeness.rs
+++ b/ffi/diplomat/src/bin/completeness.rs
@@ -5,14 +5,27 @@
 use diplomat_core::*;
 use rustdoc_types::{Crate, Item, ItemEnum, Type};
 use std::collections::{BTreeSet, HashSet};
+use std::fmt;
 use std::fs::File;
 use std::path::PathBuf;
+/// RustLink but without display information
+#[derive(PartialEq, Eq, Debug, Clone, PartialOrd, Ord, Hash)]
+struct RustLinkInfo {
+    path: ast::Path,
+    typ: ast::DocType,
+}
+
+impl fmt::Display for RustLinkInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}#{:?}", self.path, self.typ)
+    }
+}
 
 fn main() {
     let doc_types = ["icu", "fixed_decimal"]
         .into_iter()
         .flat_map(collect_public_types)
-        .map(|(path, typ)| ast::RustLink {
+        .map(|(path, typ)| RustLinkInfo {
             path: ast::Path {
                 elements: path
                     .into_iter()
@@ -37,6 +50,10 @@ fn main() {
     .all_rust_links()
     .into_iter()
     .cloned()
+    .map(|rl| RustLinkInfo {
+        path: rl.path,
+        typ: rl.typ,
+    })
     .collect::<BTreeSet<_>>();
 
     doc_types

--- a/ffi/diplomat/src/bin/completeness.rs
+++ b/ffi/diplomat/src/bin/completeness.rs
@@ -112,19 +112,18 @@ lazy_static::lazy_static! {
     static ref ALLOWLISTED_PATHS: HashSet<Vec<String>> = [
         // Stuff that could be exposed over FFI but is not currently planned
         // =========================
-        // Largely for use by datetimeformat, not super public
+        // Largely for use by datetimeformat, not super public (#2421)
         "icu::calendar::week_of",
 
 
         // Individual calendars: Currently the main entry point is AnyCalendar
-        "icu::calendar::iso",
         "icu::calendar::buddhist",
         "icu::calendar::coptic",
         "icu::calendar::ethiopian",
         "icu::calendar::indian",
         "icu::calendar::japanese",
         "icu::calendar::julian",
-        "icu::calendar::any_calendar::IncludedInAnyCalendar",
+        "icu::calendar::any_calendar::IntoAnyCalendar",
 
 
         // Stuff that does not need to be exposed over FFI

--- a/ffi/diplomat/src/bin/completeness.rs
+++ b/ffi/diplomat/src/bin/completeness.rs
@@ -109,8 +109,43 @@ lazy_static::lazy_static! {
         "ZeroFrom",
     ].into_iter().collect();
 
-    static ref ALLOWLISTED_MODULES: HashSet<Vec<String>> = [
-        "icu::calendar::week_of"
+    static ref ALLOWLISTED_PATHS: HashSet<Vec<String>> = [
+        // Stuff that could be exposed over FFI but is not currently planned
+        // =========================
+        // Largely for use by datetimeformat, not super public
+        "icu::calendar::week_of",
+
+
+        // Individual calendars: Currently the main entry point is AnyCalendar
+        "icu::calendar::iso",
+        "icu::calendar::buddhist",
+        "icu::calendar::coptic",
+        "icu::calendar::ethiopian",
+        "icu::calendar::indian",
+        "icu::calendar::japanese",
+        "icu::calendar::julian",
+        "icu::calendar::any_calendar::IncludedInAnyCalendar",
+
+
+        // Stuff that does not need to be exposed over FFI
+        // Especially for stuff that are Rust specific like conversion traits
+        // and markers and newtypes
+        // =========================
+
+        // "Internal" trait that should never be called directly
+        "icu::calendar::Calendar",
+        // Used for rust-specific type transforms
+        "icu::calendar::AsCalendar",
+
+        // FFI largely deals with primitives rather than Rust's nice wrapper types
+        // (which are hard to do in a zero-cost way over FFI)
+        "icu::calendar::types",
+
+        // Provider modules
+        // We could potentially expose them later, but it's hard to expose them
+        // uniformly especially for complex types
+        "icu::calendar::provider",
+        "icu::datetime::provider",
     ].iter().map(|s| s.split("::").map(|x| x.to_string()).collect()).collect();
 }
 
@@ -167,7 +202,7 @@ fn collect_public_types(krate: &str) -> impl Iterator<Item = (Vec<String>, ast::
         path_already_extended: bool,
         inside: Option<In>,
     ) {
-        /// Helper function that ensures that ALLOWLISTED_MODULES
+        /// Helper function that ensures that ALLOWLISTED_PATHS
         /// is respected for every type inserted
         ///
         /// (We have a check at the beginning of recurse() but that won't catch leaf nodes)
@@ -176,11 +211,11 @@ fn collect_public_types(krate: &str) -> impl Iterator<Item = (Vec<String>, ast::
             path: Vec<String>,
             ty: ast::DocType,
         ) {
-            if !ALLOWLISTED_MODULES.contains(&path) {
+            if !ALLOWLISTED_PATHS.contains(&path) {
                 types.insert((path, ty));
             }
         }
-        if ALLOWLISTED_MODULES.contains(&path) {
+        if ALLOWLISTED_PATHS.contains(&path) {
             return;
         }
         match &item.inner {

--- a/ffi/diplomat/wasm/icu4x/docs/bidi_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/bidi_ffi.rst
@@ -5,14 +5,14 @@
 
     An ICU4X Bidi object, containing loaded bidi data
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/bidi/struct.BidiClassAdapter.html>`__ for more information.
+    See the `Rust documentation for BidiClassAdapter <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/bidi/struct.BidiClassAdapter.html>`__ for more information.
 
 
     .. js:staticfunction:: try_new(provider)
 
         Creates a new :js:class:`ICU4XBidi` from locale data.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/bidi/struct.BidiClassAdapter.html#method.new>`__ for more information.
+        See the `Rust documentation for new <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/bidi/struct.BidiClassAdapter.html#method.new>`__ for more information.
 
 
     .. js:function:: for_text(text, default_level)
@@ -21,7 +21,7 @@
 
         Takes in a Level for the default level, if it is an invalid value it will default to LTR
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html#method.new_with_data_source>`__ for more information.
+        See the `Rust documentation for new_with_data_source <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html#method.new_with_data_source>`__ for more information.
 
 
     .. js:staticfunction:: level_is_rtl(level)
@@ -30,7 +30,7 @@
 
         Invalid levels (numbers greater than 125) will be assumed LTR
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_rtl>`__ for more information.
+        See the `Rust documentation for is_rtl <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_rtl>`__ for more information.
 
 
     .. js:staticfunction:: level_is_ltr(level)
@@ -39,21 +39,21 @@
 
         Invalid levels (numbers greater than 125) will be assumed LTR
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_ltr>`__ for more information.
+        See the `Rust documentation for is_ltr <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_ltr>`__ for more information.
 
 
     .. js:staticfunction:: level_rtl()
 
         Get a basic RTL Level value
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.rtl>`__ for more information.
+        See the `Rust documentation for rtl <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.rtl>`__ for more information.
 
 
     .. js:staticfunction:: level_ltr()
 
         Get a simple LTR Level value
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.ltr>`__ for more information.
+        See the `Rust documentation for ltr <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.ltr>`__ for more information.
 
 
 .. js:class:: ICU4XBidiDirection
@@ -62,7 +62,7 @@
 
     An object containing bidi information for a given string, produced by ``for_text()`` on ``ICU4XBidi``
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html>`__ for more information.
+    See the `Rust documentation for BidiInfo <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html>`__ for more information.
 
 
     .. js:function:: paragraph_count()
@@ -103,14 +103,14 @@
 
         The primary direction of this paragraph
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at>`__ for more information.
+        See the `Rust documentation for level_at <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at>`__ for more information.
 
 
     .. js:function:: size()
 
         The number of bytes in this paragraph
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.ParagraphInfo.html#method.len>`__ for more information.
+        See the `Rust documentation for len <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.ParagraphInfo.html#method.len>`__ for more information.
 
 
     .. js:function:: range_start()
@@ -127,7 +127,7 @@
 
         Reorder a line based on display order. The ranges are specified relative to the source text and must be contained within this paragraph's range.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at>`__ for more information.
+        See the `Rust documentation for level_at <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at>`__ for more information.
 
 
     .. js:function:: level_at(pos)
@@ -136,5 +136,5 @@
 
         Returns 0 (equivalent to ``Level::ltr()``) on error
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at>`__ for more information.
+        See the `Rust documentation for level_at <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at>`__ for more information.
 

--- a/ffi/diplomat/wasm/icu4x/docs/calendar_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/calendar_ffi.rst
@@ -3,47 +3,47 @@
 
 .. js:class:: ICU4XCalendar
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/enum.AnyCalendar.html>`__ for more information.
+    See the `Rust documentation for AnyCalendar <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/enum.AnyCalendar.html>`__ for more information.
 
 
     .. js:staticfunction:: try_new(provider, locale)
 
         Creates a new :js:class:`ICU4XCalendar` from the specified date and time.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.AnyCalendar.html#method.try_new_unstable>`__ for more information.
+        See the `Rust documentation for try_new_unstable <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.AnyCalendar.html#method.try_new_unstable>`__ for more information.
 
 
 .. js:class:: ICU4XDateTime
 
     An ICU4X DateTime object capable of containing a date and time for any calendar.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html>`__ for more information.
+    See the `Rust documentation for DateTime <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html>`__ for more information.
 
 
     .. js:staticfunction:: try_new_from_iso_in_calendar(year, month, day, hour, minute, second, calendar)
 
         Creates a new :js:class:`ICU4XDateTime` representing the ISO date and time given but in a given calendar
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html#method.new_iso_datetime>`__ for more information.
+        See the `Rust documentation for new_iso_datetime <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html#method.new_iso_datetime>`__ for more information.
 
 
     .. js:function:: set_ns(ns)
 
         Sets the fractional seconds field of this datetime, in nanoseconds
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/types/struct.Time.html#structfield.nanosecond>`__ for more information.
+        See the `Rust documentation for nanosecond <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/types/struct.Time.html#structfield.nanosecond>`__ for more information.
 
 
 .. js:class:: ICU4XGregorianDateTime
 
     An ICU4X DateTime object capable of containing a Gregorian date and time.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html>`__ for more information.
+    See the `Rust documentation for DateTime <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html>`__ for more information.
 
 
     .. js:staticfunction:: try_new(year, month, day, hour, minute, second)
 
         Creates a new :js:class:`ICU4XGregorianDateTime` from the specified date and time.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html#method.new_gregorian_datetime>`__ for more information.
+        See the `Rust documentation for new_gregorian_datetime <https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html#method.new_gregorian_datetime>`__ for more information.
 

--- a/ffi/diplomat/wasm/icu4x/docs/data_struct_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/data_struct_ffi.rst
@@ -12,7 +12,7 @@
 
         Construct a new DecimalSymbolsV1 data struct.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/provider/struct.DecimalSymbolsV1.html>`__ for more information.
+        See the `Rust documentation for DecimalSymbolsV1 <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/provider/struct.DecimalSymbolsV1.html>`__ for more information.
 
 
         - Note: ``digits`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.

--- a/ffi/diplomat/wasm/icu4x/docs/datetime_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/datetime_ffi.rst
@@ -7,84 +7,84 @@
 
     An ICU4X DateFormatter object capable of formatting a :js:class:`ICU4XDateTime` as a string, using some calendar specified at runtime in the locale.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html>`__ for more information.
+    See the `Rust documentation for DateTimeFormatter <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html>`__ for more information.
 
 
     .. js:staticfunction:: try_new(provider, locale, date_length, time_length)
 
         Creates a new :js:class:`ICU4XDateTimeFormatter` from locale data.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.try_new_unstable>`__ for more information.
+        See the `Rust documentation for try_new_unstable <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.try_new_unstable>`__ for more information.
 
 
     .. js:function:: format_datetime(value)
 
         Formats a :js:class:`ICU4XDateTime` to a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.format_to_write>`__ for more information.
+        See the `Rust documentation for format_to_write <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.format_to_write>`__ for more information.
 
 
 .. js:class:: ICU4XGregorianDateFormatter
 
     An ICU4X TypedDateFormatter object capable of formatting a :js:class:`ICU4XGregorianDateTime` as a string, using the Gregorian Calendar.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html>`__ for more information.
+    See the `Rust documentation for TypedDateFormatter <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html>`__ for more information.
 
 
     .. js:staticfunction:: try_new(provider, locale, length)
 
         Creates a new :js:class:`ICU4XGregorianDateFormatter` from locale data.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.TypedDateFormatter.html#method.try_new_unstable>`__ for more information.
+        See the `Rust documentation for try_new_unstable <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.TypedDateFormatter.html#method.try_new_unstable>`__ for more information.
 
 
     .. js:function:: format_datetime(value)
 
         Formats a :js:class:`ICU4XGregorianDateTime` to a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html#method.format_to_write>`__ for more information.
+        See the `Rust documentation for format_to_write <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html#method.format_to_write>`__ for more information.
 
 
 .. js:class:: ICU4XGregorianDateTimeFormatter
 
     An ICU4X TypedDateFormatter object capable of formatting a :js:class:`ICU4XGregorianDateTime` as a string, using the Gregorian Calendar.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html>`__ for more information.
+    See the `Rust documentation for TypedDateTimeFormatter <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html>`__ for more information.
 
 
     .. js:staticfunction:: try_new(provider, locale, date_length, time_length)
 
         Creates a new :js:class:`ICU4XGregorianDateFormatter` from locale data.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.try_new_unstable>`__ for more information.
+        See the `Rust documentation for try_new_unstable <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.try_new_unstable>`__ for more information.
 
 
     .. js:function:: format_datetime(value)
 
         Formats a :js:class:`ICU4XGregorianDateTime` to a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.format_to_write>`__ for more information.
+        See the `Rust documentation for format_to_write <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.format_to_write>`__ for more information.
 
 
 .. js:class:: ICU4XTimeFormatter
 
     An ICU4X TimeFormatter object capable of formatting a :js:class:`ICU4XGregorianDateTime` as a string
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html>`__ for more information.
+    See the `Rust documentation for TimeFormatter <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html>`__ for more information.
 
 
     .. js:staticfunction:: try_new(provider, locale, length)
 
         Creates a new :js:class:`ICU4XTimeFormatter` from locale data.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.TypedDateFormatter.html#method.try_new_unstable>`__ for more information.
+        See the `Rust documentation for try_new_unstable <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.TypedDateFormatter.html#method.try_new_unstable>`__ for more information.
 
 
     .. js:function:: format_gregorian_datetime(value)
 
         Formats a :js:class:`ICU4XGregorianDateTime` to a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html#method.format_to_write>`__ for more information.
+        See the `Rust documentation for format_to_write <https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html#method.format_to_write>`__ for more information.
 
 
 .. js:class:: ICU4XTimeLength

--- a/ffi/diplomat/wasm/icu4x/docs/decimal_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/decimal_ffi.rst
@@ -5,14 +5,14 @@
 
     An ICU4X Fixed Decimal Format object, capable of formatting a :js:class:`ICU4XFixedDecimal` as a string.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html>`__ for more information.
+    See the `Rust documentation for FixedDecimalFormatter <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html>`__ for more information.
 
 
     .. js:staticfunction:: try_new(provider, locale, grouping_strategy)
 
         Creates a new :js:class:`ICU4XFixedDecimalFormatter` from locale data.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.try_new>`__ for more information.
+        See the `Rust documentation for try_new <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.try_new>`__ for more information.
 
 
     .. js:staticfunction:: try_new_from_decimal_symbols_v1(data_struct, grouping_strategy)
@@ -26,7 +26,7 @@
 
         Formats a :js:class:`ICU4XFixedDecimal` to a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.format>`__ for more information.
+        See the `Rust documentation for format <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.format>`__ for more information.
 
 
 .. js:class:: ICU4XFixedDecimalGroupingStrategy

--- a/ffi/diplomat/wasm/icu4x/docs/fixed_decimal_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/fixed_decimal_ffi.rst
@@ -3,89 +3,89 @@
 
 .. js:class:: ICU4XFixedDecimal
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html>`__ for more information.
+    See the `Rust documentation for FixedDecimal <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html>`__ for more information.
 
 
     .. js:staticfunction:: create(v)
 
         Construct an :js:class:`ICU4XFixedDecimal` from an integer.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html>`__ for more information.
+        See the `Rust documentation for FixedDecimal <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html>`__ for more information.
 
 
     .. js:staticfunction:: create_from_f64_with_max_precision(f)
 
         Construct an :js:class:`ICU4XFixedDecimal` from an float, with enough digits to recover the original floating point in IEEE 754 without needing trailing zeros
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64>`__ for more information.
+        See the `Rust documentation for try_from_f64 <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64>`__ for more information.
 
 
     .. js:staticfunction:: create_from_f64_with_lower_magnitude(f, precision)
 
         Construct an :js:class:`ICU4XFixedDecimal` from an float, with a given power of 10 for the lower magnitude
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64>`__ for more information.
+        See the `Rust documentation for try_from_f64 <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64>`__ for more information.
 
 
     .. js:staticfunction:: create_from_f64_with_significant_digits(f, digits)
 
         Construct an :js:class:`ICU4XFixedDecimal` from an float, for a given number of significant digits
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64>`__ for more information.
+        See the `Rust documentation for try_from_f64 <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64>`__ for more information.
 
 
     .. js:staticfunction:: create_fromstr(v)
 
         Construct an :js:class:`ICU4XFixedDecimal` from a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html>`__ for more information.
+        See the `Rust documentation for FixedDecimal <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html>`__ for more information.
 
 
     .. js:function:: multiply_pow10(power)
 
         Multiply the :js:class:`ICU4XFixedDecimal` by a given power of ten.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.multiply_pow10>`__ for more information.
+        See the `Rust documentation for multiply_pow10 <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.multiply_pow10>`__ for more information.
 
 
     .. js:function:: set_sign(sign)
 
         Set the sign of the :js:class:`ICU4XFixedDecimal`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.set_sign>`__ for more information.
+        See the `Rust documentation for set_sign <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.set_sign>`__ for more information.
 
 
     .. js:function:: pad_start(position)
 
         Zero-pad the :js:class:`ICU4XFixedDecimal` on the left to a particular position
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_start>`__ for more information.
+        See the `Rust documentation for pad_start <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_start>`__ for more information.
 
 
     .. js:function:: set_max_position(position)
 
         Truncate the :js:class:`ICU4XFixedDecimal` on the left to a particular position, deleting digits if necessary. This is useful for, e.g. abbreviating years ("2022" -> "22")
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.set_max_position>`__ for more information.
+        See the `Rust documentation for set_max_position <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.set_max_position>`__ for more information.
 
 
     .. js:function:: pad_end(position)
 
         Zero-pad the :js:class:`ICU4XFixedDecimal` on the right to a particular position
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_end>`__ for more information.
+        See the `Rust documentation for pad_end <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_end>`__ for more information.
 
 
     .. js:function:: to_string()
 
         Format the :js:class:`ICU4XFixedDecimal` as a string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.write_to>`__ for more information.
+        See the `Rust documentation for write_to <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.write_to>`__ for more information.
 
 
 .. js:class:: ICU4XFixedDecimalSign
 
     The sign of a FixedDecimal, as shown in formatting.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/enum.Sign.html>`__ for more information.
+    See the `Rust documentation for Sign <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/enum.Sign.html>`__ for more information.
 

--- a/ffi/diplomat/wasm/icu4x/docs/locale_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/locale_ffi.rst
@@ -5,14 +5,14 @@
 
     An ICU4X Locale, capable of representing strings like ``"en-US"``.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html>`__ for more information.
+    See the `Rust documentation for Locale <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html>`__ for more information.
 
 
     .. js:staticfunction:: create(name)
 
         Construct an :js:class:`ICU4XLocale` from an locale identifier.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes>`__ for more information.
+        See the `Rust documentation for from_bytes <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes>`__ for more information.
 
 
     .. js:staticfunction:: create_en()
@@ -34,68 +34,68 @@
 
         Clones the :js:class:`ICU4XLocale`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html>`__ for more information.
+        See the `Rust documentation for Locale <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html>`__ for more information.
 
 
     .. js:function:: basename()
 
         Write a string representation of the ``LanguageIdentifier`` part of :js:class:`ICU4XLocale` to ``write``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
+        See the `Rust documentation for id <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
 
 
     .. js:function:: get_unicode_extension(bytes)
 
         Write a string representation of the unicode extension to ``write``
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.extensions>`__ for more information.
+        See the `Rust documentation for extensions <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.extensions>`__ for more information.
 
 
     .. js:function:: language()
 
         Write a string representation of :js:class:`ICU4XLocale` language to ``write``
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
+        See the `Rust documentation for id <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
 
 
     .. js:function:: set_language(bytes)
 
         Set the language part of the :js:class:`ICU4XLocale`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes>`__ for more information.
+        See the `Rust documentation for from_bytes <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes>`__ for more information.
 
 
     .. js:function:: region()
 
         Write a string representation of :js:class:`ICU4XLocale` region to ``write``
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
+        See the `Rust documentation for id <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
 
 
     .. js:function:: set_region(bytes)
 
         Set the region part of the :js:class:`ICU4XLocale`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes>`__ for more information.
+        See the `Rust documentation for from_bytes <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes>`__ for more information.
 
 
     .. js:function:: script()
 
         Write a string representation of :js:class:`ICU4XLocale` script to ``write``
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
+        See the `Rust documentation for id <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id>`__ for more information.
 
 
     .. js:function:: set_script(bytes)
 
         Set the script part of the :js:class:`ICU4XLocale`. Pass an empty string to remove the script.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes>`__ for more information.
+        See the `Rust documentation for from_bytes <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes>`__ for more information.
 
 
     .. js:function:: tostring()
 
         Write a string representation of :js:class:`ICU4XLocale` to ``write``
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html>`__ for more information.
+        See the `Rust documentation for Locale <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html>`__ for more information.
 

--- a/ffi/diplomat/wasm/icu4x/docs/locid_transform_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/locid_transform_ffi.rst
@@ -5,54 +5,54 @@
 
     A locale canonicalizer.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html>`__ for more information.
+    See the `Rust documentation for LocaleCanonicalizer <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html>`__ for more information.
 
 
     .. js:staticfunction:: create(provider)
 
         Create a new :js:class:`ICU4XLocaleCanonicalizer`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html#method.new>`__ for more information.
+        See the `Rust documentation for new <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html#method.new>`__ for more information.
 
 
     .. js:function:: canonicalize(locale)
 
         FFI version of ``LocaleCanonicalizer::canonicalize()``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html#method.canonicalize>`__ for more information.
+        See the `Rust documentation for canonicalize <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html#method.canonicalize>`__ for more information.
 
 
 .. js:class:: ICU4XLocaleExpander
 
     A locale expander.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html>`__ for more information.
+    See the `Rust documentation for LocaleExpander <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html>`__ for more information.
 
 
     .. js:staticfunction:: create(provider)
 
         Create a new :js:class:`ICU4XLocaleExpander`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.new>`__ for more information.
+        See the `Rust documentation for new <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.new>`__ for more information.
 
 
     .. js:function:: maximize(locale)
 
         FFI version of ``LocaleExpander::maximize()``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.maximize>`__ for more information.
+        See the `Rust documentation for maximize <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.maximize>`__ for more information.
 
 
     .. js:function:: minimize(locale)
 
         FFI version of ``LocaleExpander::minimize()``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.minimize>`__ for more information.
+        See the `Rust documentation for minimize <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.minimize>`__ for more information.
 
 
 .. js:class:: ICU4XTransformResult
 
     FFI version of ``TransformResult``.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/enum.TransformResult.html>`__ for more information.
+    See the `Rust documentation for TransformResult <https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/enum.TransformResult.html>`__ for more information.
 

--- a/ffi/diplomat/wasm/icu4x/docs/pluralrules_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/pluralrules_ffi.rst
@@ -22,14 +22,14 @@
 
     FFI version of ``PluralCategory``.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/enum.PluralCategory.html>`__ for more information.
+    See the `Rust documentation for PluralCategory <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/enum.PluralCategory.html>`__ for more information.
 
 
 .. js:class:: ICU4XPluralOperands
 
     FFI version of ``PluralOperands``.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralOperands.html>`__ for more information.
+    See the `Rust documentation for PluralOperands <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralOperands.html>`__ for more information.
 
 
     .. js:attribute:: i
@@ -48,40 +48,40 @@
 
         FFI version of ``PluralOperands::from_str()``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralOperands.html#method.from_str>`__ for more information.
+        See the `Rust documentation for from_str <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralOperands.html#method.from_str>`__ for more information.
 
 
 .. js:class:: ICU4XPluralRules
 
     FFI version of ``PluralRules``.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html>`__ for more information.
+    See the `Rust documentation for PluralRules <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html>`__ for more information.
 
 
     .. js:staticfunction:: try_new_cardinal(provider, locale)
 
         FFI version of ``PluralRules::try_new_cardinal()``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.try_new_unstable>`__ for more information.
+        See the `Rust documentation for try_new_unstable <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.try_new_unstable>`__ for more information.
 
 
     .. js:staticfunction:: try_new_ordinal(provider, locale)
 
         FFI version of ``PluralRules::try_new_ordinal()``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.try_new_unstable>`__ for more information.
+        See the `Rust documentation for try_new_unstable <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.try_new_unstable>`__ for more information.
 
 
     .. js:function:: select(op)
 
         FFI version of ``PluralRules::select()``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.select>`__ for more information.
+        See the `Rust documentation for select <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.select>`__ for more information.
 
 
     .. js:function:: categories()
 
         FFI version of ``PluralRules::categories()``.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.categories>`__ for more information.
+        See the `Rust documentation for categories <https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.categories>`__ for more information.
 

--- a/ffi/diplomat/wasm/icu4x/docs/properties_maps_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/properties_maps_ffi.rst
@@ -7,21 +7,25 @@
 
     For properties whose values fit into 16 bits.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html>`__ for more information.
+    See the `Rust documentation for properties <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html>`__ for more information.
+
+    See the `Rust documentation for CodePointMapData <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapData.html>`__ for more information.
+
+    See the `Rust documentation for CodePointMapDataBorrowed <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html>`__ for more information.
 
 
     .. js:staticfunction:: try_get_script(provider)
 
         Gets a map for Unicode property Script from a :js:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_script.html>`__ for more information.
+        See the `Rust documentation for load_script <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_script.html>`__ for more information.
 
 
     .. js:function:: get(cp)
 
         Gets the value for a code point.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html#method.get>`__ for more information.
+        See the `Rust documentation for get <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html#method.get>`__ for more information.
 
 
 .. js:class:: ICU4XCodePointMapData8
@@ -30,61 +34,65 @@
 
     For properties whose values fit into 8 bits.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html>`__ for more information.
+    See the `Rust documentation for properties <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html>`__ for more information.
+
+    See the `Rust documentation for CodePointMapData <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapData.html>`__ for more information.
+
+    See the `Rust documentation for CodePointMapDataBorrowed <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html>`__ for more information.
 
 
     .. js:staticfunction:: try_get_general_category(provider)
 
         Gets a map for Unicode property General_Category from a :js:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_general_category.html>`__ for more information.
+        See the `Rust documentation for load_general_category <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_general_category.html>`__ for more information.
 
 
     .. js:staticfunction:: try_get_bidi_class(provider)
 
         Gets a map for Unicode property Bidi_Class from a :js:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_bidi_class.html>`__ for more information.
+        See the `Rust documentation for load_bidi_class <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_bidi_class.html>`__ for more information.
 
 
     .. js:staticfunction:: try_get_east_asian_width(provider)
 
         Gets a map for Unicode property East_Asian_Width from a :js:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_east_asian_width.html>`__ for more information.
+        See the `Rust documentation for load_east_asian_width <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_east_asian_width.html>`__ for more information.
 
 
     .. js:staticfunction:: try_get_line_break(provider)
 
         Gets a map for Unicode property Line_Break from a :js:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_line_break.html>`__ for more information.
+        See the `Rust documentation for load_line_break <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_line_break.html>`__ for more information.
 
 
     .. js:staticfunction:: try_grapheme_cluster_break(provider)
 
         Gets a map for Unicode property Grapheme_Cluster_Break from a :js:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_grapheme_cluster_break.html>`__ for more information.
+        See the `Rust documentation for load_grapheme_cluster_break <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_grapheme_cluster_break.html>`__ for more information.
 
 
     .. js:staticfunction:: try_get_word_break(provider)
 
         Gets a map for Unicode property Word_Break from a :js:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_word_break.html>`__ for more information.
+        See the `Rust documentation for load_word_break <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_word_break.html>`__ for more information.
 
 
     .. js:staticfunction:: try_get_sentence_break(provider)
 
         Gets a map for Unicode property Sentence_Break from a :js:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_sentence_break.html>`__ for more information.
+        See the `Rust documentation for load_sentence_break <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_sentence_break.html>`__ for more information.
 
 
     .. js:function:: get(cp)
 
         Gets the value for a code point.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html#method.get>`__ for more information.
+        See the `Rust documentation for get <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html#method.get>`__ for more information.
 

--- a/ffi/diplomat/wasm/icu4x/docs/properties_sets_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/properties_sets_ffi.rst
@@ -5,19 +5,23 @@
 
     An ICU4X Unicode Set Property object, capable of querying whether a code point is contained in a set based on a Unicode property.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html>`__ for more information.
+    See the `Rust documentation for properties <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html>`__ for more information.
+
+    See the `Rust documentation for CodePointSetData <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/struct.CodePointSetData.html>`__ for more information.
+
+    See the `Rust documentation for CodePointSetDataBorrowed <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/struct.CodePointSetDataBorrowed.html>`__ for more information.
 
 
     .. js:staticfunction:: try_get_ascii_hex_digit(provider)
 
         Gets a set for Unicode property ascii_hex_digit from a :js:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/fn.load_ascii_hex_digit.html>`__ for more information.
+        See the `Rust documentation for load_ascii_hex_digit <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/fn.load_ascii_hex_digit.html>`__ for more information.
 
 
     .. js:function:: contains(cp)
 
         Checks whether the code point is in the set.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/struct.CodePointSetDataBorrowed.html#method.contains>`__ for more information.
+        See the `Rust documentation for contains <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/struct.CodePointSetDataBorrowed.html#method.contains>`__ for more information.
 

--- a/ffi/diplomat/wasm/icu4x/docs/provider_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/provider_ffi.rst
@@ -17,28 +17,28 @@
 
     An ICU4X data provider, capable of loading ICU4X data keys from some source.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_provider/index.html>`__ for more information.
+    See the `Rust documentation for icu_provider <https://unicode-org.github.io/icu4x-docs/doc/icu_provider/index.html>`__ for more information.
 
 
     .. js:staticfunction:: create_fs(path)
 
         Constructs an ``FsDataProvider`` and returns it as an :js:class:`ICU4XDataProvider`. Requires the ``provider_fs`` feature. Not supported in WASM.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_fs/struct.FsDataProvider.html>`__ for more information.
+        See the `Rust documentation for FsDataProvider <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_fs/struct.FsDataProvider.html>`__ for more information.
 
 
     .. js:staticfunction:: create_test()
 
         Constructs a testdata provider and returns it as an :js:class:`ICU4XDataProvider`. Requires the ``provider_test`` feature.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_testdata/index.html>`__ for more information.
+        See the `Rust documentation for icu_testdata <https://unicode-org.github.io/icu4x-docs/doc/icu_testdata/index.html>`__ for more information.
 
 
     .. js:staticfunction:: create_from_byte_slice(blob)
 
         Constructs a ``BlobDataProvider`` and returns it as an :js:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.BlobDataProvider.html>`__ for more information.
+        See the `Rust documentation for BlobDataProvider <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.BlobDataProvider.html>`__ for more information.
 
 
         - Note: ``blob`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
@@ -47,5 +47,5 @@
 
         Constructs an empty ``StaticDataProvider`` and returns it as an :js:class:`ICU4XDataProvider`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.StaticDataProvider.html>`__ for more information.
+        See the `Rust documentation for StaticDataProvider <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.StaticDataProvider.html>`__ for more information.
 

--- a/ffi/diplomat/wasm/icu4x/docs/segmenter_grapheme_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/segmenter_grapheme_ffi.rst
@@ -26,28 +26,28 @@
 
     An ICU4X grapheme-cluster-break segmenter, capable of finding grapheme cluster breakpoints in strings.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterBreakSegmenter.html>`__ for more information.
+    See the `Rust documentation for GraphemeClusterBreakSegmenter <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterBreakSegmenter.html>`__ for more information.
 
 
     .. js:staticfunction:: try_new(provider)
 
         Construct an :js:class:`ICU4XGraphemeClusterBreakSegmenter`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterBreakSegmenter.html#method.try_new>`__ for more information.
+        See the `Rust documentation for try_new <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterBreakSegmenter.html#method.try_new>`__ for more information.
 
 
     .. js:function:: segment_utf8(input)
 
         Segments a UTF-8 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_str>`__ for more information.
+        See the `Rust documentation for segment_str <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_str>`__ for more information.
 
 
     .. js:function:: segment_utf16(input)
 
         Segments a UTF-16 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_utf16>`__ for more information.
+        See the `Rust documentation for segment_utf16 <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_utf16>`__ for more information.
 
 
         - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
@@ -56,7 +56,7 @@
 
         Segments a Latin-1 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_latin1>`__ for more information.
+        See the `Rust documentation for segment_latin1 <https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_latin1>`__ for more information.
 
 
         - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.

--- a/ffi/diplomat/wasm/icu4x/docs/segmenter_line_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/segmenter_line_ffi.rst
@@ -24,7 +24,7 @@
 
 .. js:class:: ICU4XLineBreakOptions
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakOptions.html>`__ for more information.
+    See the `Rust documentation for LineBreakOptions <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakOptions.html>`__ for more information.
 
 
     .. js:attribute:: line_break_rule
@@ -35,42 +35,42 @@
 
 .. js:class:: ICU4XLineBreakRule
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/enum.LineBreakRule.html>`__ for more information.
+    See the `Rust documentation for LineBreakRule <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/enum.LineBreakRule.html>`__ for more information.
 
 
 .. js:class:: ICU4XLineBreakSegmenter
 
     An ICU4X line-break segmenter, capable of finding breakpoints in strings.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html>`__ for more information.
+    See the `Rust documentation for LineBreakSegmenter <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html>`__ for more information.
 
 
     .. js:staticfunction:: try_new(provider)
 
         Construct a :js:class:`ICU4XLineBreakSegmenter` with default options.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.try_new>`__ for more information.
+        See the `Rust documentation for try_new <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.try_new>`__ for more information.
 
 
     .. js:staticfunction:: try_new_with_options(provider, options)
 
         Construct a :js:class:`ICU4XLineBreakSegmenter` with custom options.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.try_new_with_options>`__ for more information.
+        See the `Rust documentation for try_new_with_options <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.try_new_with_options>`__ for more information.
 
 
     .. js:function:: segment_utf8(input)
 
         Segments a UTF-8 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_str>`__ for more information.
+        See the `Rust documentation for segment_str <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_str>`__ for more information.
 
 
     .. js:function:: segment_utf16(input)
 
         Segments a UTF-16 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_utf16>`__ for more information.
+        See the `Rust documentation for segment_utf16 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_utf16>`__ for more information.
 
 
         - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
@@ -79,12 +79,12 @@
 
         Segments a Latin-1 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_latin1>`__ for more information.
+        See the `Rust documentation for segment_latin1 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_latin1>`__ for more information.
 
 
         - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
 
 .. js:class:: ICU4XWordBreakRule
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/enum.WordBreakRule.html>`__ for more information.
+    See the `Rust documentation for WordBreakRule <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/enum.WordBreakRule.html>`__ for more information.
 

--- a/ffi/diplomat/wasm/icu4x/docs/segmenter_sentence_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/segmenter_sentence_ffi.rst
@@ -26,28 +26,28 @@
 
     An ICU4X sentence-break segmenter, capable of finding sentence breakpoints in strings.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html>`__ for more information.
+    See the `Rust documentation for SentenceBreakSegmenter <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html>`__ for more information.
 
 
     .. js:staticfunction:: try_new(provider)
 
         Construct an :js:class:`ICU4XSentenceBreakSegmenter`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.try_new>`__ for more information.
+        See the `Rust documentation for try_new <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.try_new>`__ for more information.
 
 
     .. js:function:: segment_utf8(input)
 
         Segments a UTF-8 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_str>`__ for more information.
+        See the `Rust documentation for segment_str <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_str>`__ for more information.
 
 
     .. js:function:: segment_utf16(input)
 
         Segments a UTF-16 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_utf16>`__ for more information.
+        See the `Rust documentation for segment_utf16 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_utf16>`__ for more information.
 
 
         - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
@@ -56,7 +56,7 @@
 
         Segments a Latin-1 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_latin1>`__ for more information.
+        See the `Rust documentation for segment_latin1 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_latin1>`__ for more information.
 
 
         - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.

--- a/ffi/diplomat/wasm/icu4x/docs/segmenter_word_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/segmenter_word_ffi.rst
@@ -26,28 +26,28 @@
 
     An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
 
-    See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html>`__ for more information.
+    See the `Rust documentation for WordBreakSegmenter <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html>`__ for more information.
 
 
     .. js:staticfunction:: try_new(provider)
 
         Construct an :js:class:`ICU4XWordBreakSegmenter`.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.try_new>`__ for more information.
+        See the `Rust documentation for try_new <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.try_new>`__ for more information.
 
 
     .. js:function:: segment_utf8(input)
 
         Segments a UTF-8 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_str>`__ for more information.
+        See the `Rust documentation for segment_str <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_str>`__ for more information.
 
 
     .. js:function:: segment_utf16(input)
 
         Segments a UTF-16 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_utf16>`__ for more information.
+        See the `Rust documentation for segment_utf16 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_utf16>`__ for more information.
 
 
         - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
@@ -56,7 +56,7 @@
 
         Segments a Latin-1 string.
 
-        See the `Rust documentation <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_latin1>`__ for more information.
+        See the `Rust documentation for segment_latin1 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_latin1>`__ for more information.
 
 
         - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XBidi.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XBidi.d.ts
@@ -8,7 +8,7 @@ import { ICU4XError } from "./ICU4XError";
 
  * An ICU4X Bidi object, containing loaded bidi data
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/bidi/struct.BidiClassAdapter.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/bidi/struct.BidiClassAdapter.html Rust documentation for `BidiClassAdapter`} for more information.
  */
 export class ICU4XBidi {
 
@@ -16,7 +16,7 @@ export class ICU4XBidi {
 
    * Creates a new {@link ICU4XBidi `ICU4XBidi`} from locale data.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/bidi/struct.BidiClassAdapter.html#method.new Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/bidi/struct.BidiClassAdapter.html#method.new Rust documentation for `new`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_new(provider: ICU4XDataProvider): ICU4XBidi | never;
@@ -27,7 +27,7 @@ export class ICU4XBidi {
 
    * Takes in a Level for the default level, if it is an invalid value it will default to LTR
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html#method.new_with_data_source Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html#method.new_with_data_source Rust documentation for `new_with_data_source`} for more information.
    */
   for_text(text: string, default_level: u8): ICU4XBidiInfo;
 
@@ -37,7 +37,7 @@ export class ICU4XBidi {
 
    * Invalid levels (numbers greater than 125) will be assumed LTR
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_rtl Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_rtl Rust documentation for `is_rtl`} for more information.
    */
   static level_is_rtl(level: u8): boolean;
 
@@ -47,7 +47,7 @@ export class ICU4XBidi {
 
    * Invalid levels (numbers greater than 125) will be assumed LTR
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_ltr Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.is_ltr Rust documentation for `is_ltr`} for more information.
    */
   static level_is_ltr(level: u8): boolean;
 
@@ -55,7 +55,7 @@ export class ICU4XBidi {
 
    * Get a basic RTL Level value
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.rtl Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.rtl Rust documentation for `rtl`} for more information.
    */
   static level_rtl(): u8;
 
@@ -63,7 +63,7 @@ export class ICU4XBidi {
 
    * Get a simple LTR Level value
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.ltr Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Level.html#method.ltr Rust documentation for `ltr`} for more information.
    */
   static level_ltr(): u8;
 }

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XBidiInfo.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XBidiInfo.d.ts
@@ -5,7 +5,7 @@ import { ICU4XBidiParagraph } from "./ICU4XBidiParagraph";
 
  * An object containing bidi information for a given string, produced by `for_text()` on `ICU4XBidi`
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html Rust documentation for `BidiInfo`} for more information.
  */
 export class ICU4XBidiInfo {
 

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XBidiParagraph.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XBidiParagraph.d.ts
@@ -22,7 +22,7 @@ export class ICU4XBidiParagraph {
 
    * The primary direction of this paragraph
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at Rust documentation for `level_at`} for more information.
    */
   direction(): ICU4XBidiDirection;
 
@@ -30,7 +30,7 @@ export class ICU4XBidiParagraph {
 
    * The number of bytes in this paragraph
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.ParagraphInfo.html#method.len Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.ParagraphInfo.html#method.len Rust documentation for `len`} for more information.
    */
   size(): usize;
 
@@ -50,7 +50,7 @@ export class ICU4XBidiParagraph {
 
    * Reorder a line based on display order. The ranges are specified relative to the source text and must be contained within this paragraph's range.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at Rust documentation for `level_at`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   reorder_line(range_start: usize, range_end: usize): string | never;
@@ -61,7 +61,7 @@ export class ICU4XBidiParagraph {
 
    * Returns 0 (equivalent to `Level::ltr()`) on error
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.Paragraph.html#method.level_at Rust documentation for `level_at`} for more information.
    */
   level_at(pos: usize): u8;
 }

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XCalendar.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XCalendar.d.ts
@@ -5,7 +5,7 @@ import { ICU4XLocale } from "./ICU4XLocale";
 
 /**
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/enum.AnyCalendar.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/enum.AnyCalendar.html Rust documentation for `AnyCalendar`} for more information.
  */
 export class ICU4XCalendar {
 
@@ -13,7 +13,7 @@ export class ICU4XCalendar {
 
    * Creates a new {@link ICU4XCalendar `ICU4XCalendar`} from the specified date and time.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.AnyCalendar.html#method.try_new_unstable Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.AnyCalendar.html#method.try_new_unstable Rust documentation for `try_new_unstable`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_new(provider: ICU4XDataProvider, locale: ICU4XLocale): ICU4XCalendar | never;

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XCodePointMapData16.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XCodePointMapData16.d.ts
@@ -9,7 +9,11 @@ import { ICU4XError } from "./ICU4XError";
 
  * For properties whose values fit into 16 bits.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html Rust documentation for `properties`} for more information.
+
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapData.html Rust documentation for `CodePointMapData`} for more information.
+
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html Rust documentation for `CodePointMapDataBorrowed`} for more information.
  */
 export class ICU4XCodePointMapData16 {
 
@@ -17,7 +21,7 @@ export class ICU4XCodePointMapData16 {
 
    * Gets a map for Unicode property Script from a {@link ICU4XDataProvider `ICU4XDataProvider`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_script.html Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_script.html Rust documentation for `load_script`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_get_script(provider: ICU4XDataProvider): ICU4XCodePointMapData16 | never;
@@ -26,7 +30,7 @@ export class ICU4XCodePointMapData16 {
 
    * Gets the value for a code point.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html#method.get Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html#method.get Rust documentation for `get`} for more information.
    */
   get(cp: char): u16;
 }

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XCodePointMapData8.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XCodePointMapData8.d.ts
@@ -9,7 +9,11 @@ import { ICU4XError } from "./ICU4XError";
 
  * For properties whose values fit into 8 bits.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html Rust documentation for `properties`} for more information.
+
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapData.html Rust documentation for `CodePointMapData`} for more information.
+
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html Rust documentation for `CodePointMapDataBorrowed`} for more information.
  */
 export class ICU4XCodePointMapData8 {
 
@@ -17,7 +21,7 @@ export class ICU4XCodePointMapData8 {
 
    * Gets a map for Unicode property General_Category from a {@link ICU4XDataProvider `ICU4XDataProvider`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_general_category.html Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_general_category.html Rust documentation for `load_general_category`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_get_general_category(provider: ICU4XDataProvider): ICU4XCodePointMapData8 | never;
@@ -26,7 +30,7 @@ export class ICU4XCodePointMapData8 {
 
    * Gets a map for Unicode property Bidi_Class from a {@link ICU4XDataProvider `ICU4XDataProvider`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_bidi_class.html Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_bidi_class.html Rust documentation for `load_bidi_class`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_get_bidi_class(provider: ICU4XDataProvider): ICU4XCodePointMapData8 | never;
@@ -35,7 +39,7 @@ export class ICU4XCodePointMapData8 {
 
    * Gets a map for Unicode property East_Asian_Width from a {@link ICU4XDataProvider `ICU4XDataProvider`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_east_asian_width.html Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_east_asian_width.html Rust documentation for `load_east_asian_width`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_get_east_asian_width(provider: ICU4XDataProvider): ICU4XCodePointMapData8 | never;
@@ -44,7 +48,7 @@ export class ICU4XCodePointMapData8 {
 
    * Gets a map for Unicode property Line_Break from a {@link ICU4XDataProvider `ICU4XDataProvider`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_line_break.html Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_line_break.html Rust documentation for `load_line_break`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_get_line_break(provider: ICU4XDataProvider): ICU4XCodePointMapData8 | never;
@@ -53,7 +57,7 @@ export class ICU4XCodePointMapData8 {
 
    * Gets a map for Unicode property Grapheme_Cluster_Break from a {@link ICU4XDataProvider `ICU4XDataProvider`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_grapheme_cluster_break.html Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_grapheme_cluster_break.html Rust documentation for `load_grapheme_cluster_break`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_grapheme_cluster_break(provider: ICU4XDataProvider): ICU4XCodePointMapData8 | never;
@@ -62,7 +66,7 @@ export class ICU4XCodePointMapData8 {
 
    * Gets a map for Unicode property Word_Break from a {@link ICU4XDataProvider `ICU4XDataProvider`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_word_break.html Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_word_break.html Rust documentation for `load_word_break`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_get_word_break(provider: ICU4XDataProvider): ICU4XCodePointMapData8 | never;
@@ -71,7 +75,7 @@ export class ICU4XCodePointMapData8 {
 
    * Gets a map for Unicode property Sentence_Break from a {@link ICU4XDataProvider `ICU4XDataProvider`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_sentence_break.html Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/fn.load_sentence_break.html Rust documentation for `load_sentence_break`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_get_sentence_break(provider: ICU4XDataProvider): ICU4XCodePointMapData8 | never;
@@ -80,7 +84,7 @@ export class ICU4XCodePointMapData8 {
 
    * Gets the value for a code point.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html#method.get Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/maps/struct.CodePointMapDataBorrowed.html#method.get Rust documentation for `get`} for more information.
    */
   get(cp: char): u8;
 }

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XCodePointSetData.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XCodePointSetData.d.ts
@@ -7,7 +7,11 @@ import { ICU4XError } from "./ICU4XError";
 
  * An ICU4X Unicode Set Property object, capable of querying whether a code point is contained in a set based on a Unicode property.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/index.html Rust documentation for `properties`} for more information.
+
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/struct.CodePointSetData.html Rust documentation for `CodePointSetData`} for more information.
+
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/struct.CodePointSetDataBorrowed.html Rust documentation for `CodePointSetDataBorrowed`} for more information.
  */
 export class ICU4XCodePointSetData {
 
@@ -15,7 +19,7 @@ export class ICU4XCodePointSetData {
 
    * Gets a set for Unicode property ascii_hex_digit from a {@link ICU4XDataProvider `ICU4XDataProvider`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/fn.load_ascii_hex_digit.html Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/fn.load_ascii_hex_digit.html Rust documentation for `load_ascii_hex_digit`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_get_ascii_hex_digit(provider: ICU4XDataProvider): ICU4XCodePointSetData | never;
@@ -24,7 +28,7 @@ export class ICU4XCodePointSetData {
 
    * Checks whether the code point is in the set.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/struct.CodePointSetDataBorrowed.html#method.contains Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/properties/sets/struct.CodePointSetDataBorrowed.html#method.contains Rust documentation for `contains`} for more information.
    */
   contains(cp: char): boolean;
 }

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XDataProvider.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XDataProvider.d.ts
@@ -5,7 +5,7 @@ import { ICU4XError } from "./ICU4XError";
 
  * An ICU4X data provider, capable of loading ICU4X data keys from some source.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu_provider/index.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu_provider/index.html Rust documentation for `icu_provider`} for more information.
  */
 export class ICU4XDataProvider {
 
@@ -13,7 +13,7 @@ export class ICU4XDataProvider {
 
    * Constructs an `FsDataProvider` and returns it as an {@link ICU4XDataProvider `ICU4XDataProvider`}. Requires the `provider_fs` feature. Not supported in WASM.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu_provider_fs/struct.FsDataProvider.html Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu_provider_fs/struct.FsDataProvider.html Rust documentation for `FsDataProvider`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static create_fs(path: string): ICU4XDataProvider | never;
@@ -22,7 +22,7 @@ export class ICU4XDataProvider {
 
    * Constructs a testdata provider and returns it as an {@link ICU4XDataProvider `ICU4XDataProvider`}. Requires the `provider_test` feature.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu_testdata/index.html Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu_testdata/index.html Rust documentation for `icu_testdata`} for more information.
    */
   static create_test(): ICU4XDataProvider;
 
@@ -30,7 +30,7 @@ export class ICU4XDataProvider {
 
    * Constructs a `BlobDataProvider` and returns it as an {@link ICU4XDataProvider `ICU4XDataProvider`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.BlobDataProvider.html Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.BlobDataProvider.html Rust documentation for `BlobDataProvider`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static create_from_byte_slice(blob: Uint8Array): ICU4XDataProvider | never;
@@ -39,7 +39,7 @@ export class ICU4XDataProvider {
 
    * Constructs an empty `StaticDataProvider` and returns it as an {@link ICU4XDataProvider `ICU4XDataProvider`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.StaticDataProvider.html Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.StaticDataProvider.html Rust documentation for `StaticDataProvider`} for more information.
    */
   static create_empty(): ICU4XDataProvider;
 }

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XDataStruct.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XDataStruct.d.ts
@@ -14,7 +14,7 @@ export class ICU4XDataStruct {
 
    * Construct a new DecimalSymbolsV1 data struct.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/provider/struct.DecimalSymbolsV1.html Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/provider/struct.DecimalSymbolsV1.html Rust documentation for `DecimalSymbolsV1`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static create_decimal_symbols_v1(plus_sign_prefix: string, plus_sign_suffix: string, minus_sign_prefix: string, minus_sign_suffix: string, decimal_separator: string, grouping_separator: string, primary_group_size: u8, secondary_group_size: u8, min_group_size: u8, digits: Uint32Array): ICU4XDataStruct | never;

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XDateTime.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XDateTime.d.ts
@@ -7,7 +7,7 @@ import { ICU4XError } from "./ICU4XError";
 
  * An ICU4X DateTime object capable of containing a date and time for any calendar.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html Rust documentation for `DateTime`} for more information.
  */
 export class ICU4XDateTime {
 
@@ -15,7 +15,7 @@ export class ICU4XDateTime {
 
    * Creates a new {@link ICU4XDateTime `ICU4XDateTime`} representing the ISO date and time given but in a given calendar
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html#method.new_iso_datetime Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html#method.new_iso_datetime Rust documentation for `new_iso_datetime`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_new_from_iso_in_calendar(year: i32, month: u8, day: u8, hour: u8, minute: u8, second: u8, calendar: ICU4XCalendar): ICU4XDateTime | never;
@@ -24,7 +24,7 @@ export class ICU4XDateTime {
 
    * Sets the fractional seconds field of this datetime, in nanoseconds
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/types/struct.Time.html#structfield.nanosecond Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/types/struct.Time.html#structfield.nanosecond Rust documentation for `nanosecond`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   set_ns(ns: u32): void | never;

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XDateTimeFormatter.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XDateTimeFormatter.d.ts
@@ -10,7 +10,7 @@ import { ICU4XTimeLength } from "./ICU4XTimeLength";
 
  * An ICU4X DateFormatter object capable of formatting a {@link ICU4XDateTime `ICU4XDateTime`} as a string, using some calendar specified at runtime in the locale.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html Rust documentation for `DateTimeFormatter`} for more information.
  */
 export class ICU4XDateTimeFormatter {
 
@@ -18,7 +18,7 @@ export class ICU4XDateTimeFormatter {
 
    * Creates a new {@link ICU4XDateTimeFormatter `ICU4XDateTimeFormatter`} from locale data.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.try_new_unstable Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.try_new_unstable Rust documentation for `try_new_unstable`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_new(provider: ICU4XDataProvider, locale: ICU4XLocale, date_length: ICU4XDateLength, time_length: ICU4XTimeLength): ICU4XDateTimeFormatter | never;
@@ -27,7 +27,7 @@ export class ICU4XDateTimeFormatter {
 
    * Formats a {@link ICU4XDateTime `ICU4XDateTime`} to a string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.format_to_write Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.DateTimeFormatter.html#method.format_to_write Rust documentation for `format_to_write`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   format_datetime(value: ICU4XDateTime): string | never;

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XFixedDecimal.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XFixedDecimal.d.ts
@@ -5,7 +5,7 @@ import { ICU4XFixedDecimalSign } from "./ICU4XFixedDecimalSign";
 
 /**
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html Rust documentation for `FixedDecimal`} for more information.
  */
 export class ICU4XFixedDecimal {
 
@@ -13,7 +13,7 @@ export class ICU4XFixedDecimal {
 
    * Construct an {@link ICU4XFixedDecimal `ICU4XFixedDecimal`} from an integer.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html Rust documentation for `FixedDecimal`} for more information.
    */
   static create(v: i32): ICU4XFixedDecimal;
 
@@ -21,7 +21,7 @@ export class ICU4XFixedDecimal {
 
    * Construct an {@link ICU4XFixedDecimal `ICU4XFixedDecimal`} from an float, with enough digits to recover the original floating point in IEEE 754 without needing trailing zeros
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64 Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64 Rust documentation for `try_from_f64`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static create_from_f64_with_max_precision(f: f64): ICU4XFixedDecimal | never;
@@ -30,7 +30,7 @@ export class ICU4XFixedDecimal {
 
    * Construct an {@link ICU4XFixedDecimal `ICU4XFixedDecimal`} from an float, with a given power of 10 for the lower magnitude
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64 Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64 Rust documentation for `try_from_f64`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static create_from_f64_with_lower_magnitude(f: f64, precision: i16): ICU4XFixedDecimal | never;
@@ -39,7 +39,7 @@ export class ICU4XFixedDecimal {
 
    * Construct an {@link ICU4XFixedDecimal `ICU4XFixedDecimal`} from an float, for a given number of significant digits
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64 Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.try_from_f64 Rust documentation for `try_from_f64`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static create_from_f64_with_significant_digits(f: f64, digits: u8): ICU4XFixedDecimal | never;
@@ -48,7 +48,7 @@ export class ICU4XFixedDecimal {
 
    * Construct an {@link ICU4XFixedDecimal `ICU4XFixedDecimal`} from a string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html Rust documentation for `FixedDecimal`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static create_fromstr(v: string): ICU4XFixedDecimal | never;
@@ -57,7 +57,7 @@ export class ICU4XFixedDecimal {
 
    * Multiply the {@link ICU4XFixedDecimal `ICU4XFixedDecimal`} by a given power of ten.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.multiply_pow10 Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.multiply_pow10 Rust documentation for `multiply_pow10`} for more information.
    */
   multiply_pow10(power: i16): void;
 
@@ -65,7 +65,7 @@ export class ICU4XFixedDecimal {
 
    * Set the sign of the {@link ICU4XFixedDecimal `ICU4XFixedDecimal`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.set_sign Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.set_sign Rust documentation for `set_sign`} for more information.
    */
   set_sign(sign: ICU4XFixedDecimalSign): void;
 
@@ -73,7 +73,7 @@ export class ICU4XFixedDecimal {
 
    * Zero-pad the {@link ICU4XFixedDecimal `ICU4XFixedDecimal`} on the left to a particular position
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_start Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_start Rust documentation for `pad_start`} for more information.
    */
   pad_start(position: i16): void;
 
@@ -81,7 +81,7 @@ export class ICU4XFixedDecimal {
 
    * Truncate the {@link ICU4XFixedDecimal `ICU4XFixedDecimal`} on the left to a particular position, deleting digits if necessary. This is useful for, e.g. abbreviating years ("2022" -> "22")
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.set_max_position Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.set_max_position Rust documentation for `set_max_position`} for more information.
    */
   set_max_position(position: i16): void;
 
@@ -89,7 +89,7 @@ export class ICU4XFixedDecimal {
 
    * Zero-pad the {@link ICU4XFixedDecimal `ICU4XFixedDecimal`} on the right to a particular position
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_end Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.pad_end Rust documentation for `pad_end`} for more information.
    */
   pad_end(position: i16): void;
 
@@ -97,7 +97,7 @@ export class ICU4XFixedDecimal {
 
    * Format the {@link ICU4XFixedDecimal `ICU4XFixedDecimal`} as a string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.write_to Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/struct.FixedDecimal.html#method.write_to Rust documentation for `write_to`} for more information.
    */
   to_string(): string;
 }

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XFixedDecimalFormatter.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XFixedDecimalFormatter.d.ts
@@ -10,7 +10,7 @@ import { ICU4XLocale } from "./ICU4XLocale";
 
  * An ICU4X Fixed Decimal Format object, capable of formatting a {@link ICU4XFixedDecimal `ICU4XFixedDecimal`} as a string.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html Rust documentation for `FixedDecimalFormatter`} for more information.
  */
 export class ICU4XFixedDecimalFormatter {
 
@@ -18,7 +18,7 @@ export class ICU4XFixedDecimalFormatter {
 
    * Creates a new {@link ICU4XFixedDecimalFormatter `ICU4XFixedDecimalFormatter`} from locale data.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.try_new Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.try_new Rust documentation for `try_new`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_new(provider: ICU4XDataProvider, locale: ICU4XLocale, grouping_strategy: ICU4XFixedDecimalGroupingStrategy): ICU4XFixedDecimalFormatter | never;
@@ -36,7 +36,7 @@ export class ICU4XFixedDecimalFormatter {
 
    * Formats a {@link ICU4XFixedDecimal `ICU4XFixedDecimal`} to a string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.format Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.format Rust documentation for `format`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   format(value: ICU4XFixedDecimal): string | never;

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XFixedDecimalSign.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XFixedDecimalSign.d.ts
@@ -3,7 +3,7 @@
 
  * The sign of a FixedDecimal, as shown in formatting.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/enum.Sign.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/decimal/enum.Sign.html Rust documentation for `Sign`} for more information.
  */
 export enum ICU4XFixedDecimalSign {
   /**

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XGraphemeClusterBreakSegmenter.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XGraphemeClusterBreakSegmenter.d.ts
@@ -9,7 +9,7 @@ import { ICU4XGraphemeClusterBreakIteratorUtf8 } from "./ICU4XGraphemeClusterBre
 
  * An ICU4X grapheme-cluster-break segmenter, capable of finding grapheme cluster breakpoints in strings.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterBreakSegmenter.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterBreakSegmenter.html Rust documentation for `GraphemeClusterBreakSegmenter`} for more information.
  */
 export class ICU4XGraphemeClusterBreakSegmenter {
 
@@ -17,7 +17,7 @@ export class ICU4XGraphemeClusterBreakSegmenter {
 
    * Construct an {@link ICU4XGraphemeClusterBreakSegmenter `ICU4XGraphemeClusterBreakSegmenter`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterBreakSegmenter.html#method.try_new Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterBreakSegmenter.html#method.try_new Rust documentation for `try_new`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_new(provider: ICU4XDataProvider): ICU4XGraphemeClusterBreakSegmenter | never;
@@ -26,7 +26,7 @@ export class ICU4XGraphemeClusterBreakSegmenter {
 
    * Segments a UTF-8 string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_str Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_str Rust documentation for `segment_str`} for more information.
    */
   segment_utf8(input: string): ICU4XGraphemeClusterBreakIteratorUtf8;
 
@@ -34,7 +34,7 @@ export class ICU4XGraphemeClusterBreakSegmenter {
 
    * Segments a UTF-16 string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_utf16 Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_utf16 Rust documentation for `segment_utf16`} for more information.
    */
   segment_utf16(input: Uint16Array): ICU4XGraphemeClusterBreakIteratorUtf16;
 
@@ -42,7 +42,7 @@ export class ICU4XGraphemeClusterBreakSegmenter {
 
    * Segments a Latin-1 string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_latin1 Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu_segmenter/struct.GraphemeClusterBreakSegmenter.html#method.segment_latin1 Rust documentation for `segment_latin1`} for more information.
    */
   segment_latin1(input: Uint8Array): ICU4XGraphemeClusterBreakIteratorLatin1;
 }

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XGregorianDateFormatter.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XGregorianDateFormatter.d.ts
@@ -9,7 +9,7 @@ import { ICU4XLocale } from "./ICU4XLocale";
 
  * An ICU4X TypedDateFormatter object capable of formatting a {@link ICU4XGregorianDateTime `ICU4XGregorianDateTime`} as a string, using the Gregorian Calendar.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html Rust documentation for `TypedDateFormatter`} for more information.
  */
 export class ICU4XGregorianDateFormatter {
 
@@ -17,7 +17,7 @@ export class ICU4XGregorianDateFormatter {
 
    * Creates a new {@link ICU4XGregorianDateFormatter `ICU4XGregorianDateFormatter`} from locale data.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.TypedDateFormatter.html#method.try_new_unstable Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.TypedDateFormatter.html#method.try_new_unstable Rust documentation for `try_new_unstable`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_new(provider: ICU4XDataProvider, locale: ICU4XLocale, length: ICU4XDateLength): ICU4XGregorianDateFormatter | never;
@@ -26,7 +26,7 @@ export class ICU4XGregorianDateFormatter {
 
    * Formats a {@link ICU4XGregorianDateTime `ICU4XGregorianDateTime`} to a string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html#method.format_to_write Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateFormatter.html#method.format_to_write Rust documentation for `format_to_write`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   format_datetime(value: ICU4XGregorianDateTime): string | never;

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XGregorianDateTime.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XGregorianDateTime.d.ts
@@ -6,7 +6,7 @@ import { ICU4XError } from "./ICU4XError";
 
  * An ICU4X DateTime object capable of containing a Gregorian date and time.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html Rust documentation for `DateTime`} for more information.
  */
 export class ICU4XGregorianDateTime {
 
@@ -14,7 +14,7 @@ export class ICU4XGregorianDateTime {
 
    * Creates a new {@link ICU4XGregorianDateTime `ICU4XGregorianDateTime`} from the specified date and time.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html#method.new_gregorian_datetime Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/calendar/struct.DateTime.html#method.new_gregorian_datetime Rust documentation for `new_gregorian_datetime`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_new(year: i32, month: u8, day: u8, hour: u8, minute: u8, second: u8): ICU4XGregorianDateTime | never;

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XGregorianDateTimeFormatter.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XGregorianDateTimeFormatter.d.ts
@@ -10,7 +10,7 @@ import { ICU4XTimeLength } from "./ICU4XTimeLength";
 
  * An ICU4X TypedDateFormatter object capable of formatting a {@link ICU4XGregorianDateTime `ICU4XGregorianDateTime`} as a string, using the Gregorian Calendar.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html Rust documentation for `TypedDateTimeFormatter`} for more information.
  */
 export class ICU4XGregorianDateTimeFormatter {
 
@@ -18,7 +18,7 @@ export class ICU4XGregorianDateTimeFormatter {
 
    * Creates a new {@link ICU4XGregorianDateFormatter `ICU4XGregorianDateFormatter`} from locale data.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.try_new_unstable Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.try_new_unstable Rust documentation for `try_new_unstable`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_new(provider: ICU4XDataProvider, locale: ICU4XLocale, date_length: ICU4XDateLength, time_length: ICU4XTimeLength): ICU4XGregorianDateTimeFormatter | never;
@@ -27,7 +27,7 @@ export class ICU4XGregorianDateTimeFormatter {
 
    * Formats a {@link ICU4XGregorianDateTime `ICU4XGregorianDateTime`} to a string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.format_to_write Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TypedDateTimeFormatter.html#method.format_to_write Rust documentation for `format_to_write`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   format_datetime(value: ICU4XGregorianDateTime): string | never;

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XLineBreakOptions.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XLineBreakOptions.d.ts
@@ -3,7 +3,7 @@ import { ICU4XWordBreakRule } from "./ICU4XWordBreakRule";
 
 /**
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakOptions.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakOptions.html Rust documentation for `LineBreakOptions`} for more information.
  */
 export class ICU4XLineBreakOptions {
   line_break_rule: ICU4XLineBreakRule;

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XLineBreakRule.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XLineBreakRule.d.ts
@@ -1,7 +1,7 @@
 
 /**
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/enum.LineBreakRule.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/enum.LineBreakRule.html Rust documentation for `LineBreakRule`} for more information.
  */
 export enum ICU4XLineBreakRule {
   /**

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XLineBreakSegmenter.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XLineBreakSegmenter.d.ts
@@ -10,7 +10,7 @@ import { ICU4XLineBreakOptions } from "./ICU4XLineBreakOptions";
 
  * An ICU4X line-break segmenter, capable of finding breakpoints in strings.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html Rust documentation for `LineBreakSegmenter`} for more information.
  */
 export class ICU4XLineBreakSegmenter {
 
@@ -18,7 +18,7 @@ export class ICU4XLineBreakSegmenter {
 
    * Construct a {@link ICU4XLineBreakSegmenter `ICU4XLineBreakSegmenter`} with default options.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.try_new Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.try_new Rust documentation for `try_new`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_new(provider: ICU4XDataProvider): ICU4XLineBreakSegmenter | never;
@@ -27,7 +27,7 @@ export class ICU4XLineBreakSegmenter {
 
    * Construct a {@link ICU4XLineBreakSegmenter `ICU4XLineBreakSegmenter`} with custom options.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.try_new_with_options Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.try_new_with_options Rust documentation for `try_new_with_options`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_new_with_options(provider: ICU4XDataProvider, options: ICU4XLineBreakOptions): ICU4XLineBreakSegmenter | never;
@@ -36,7 +36,7 @@ export class ICU4XLineBreakSegmenter {
 
    * Segments a UTF-8 string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_str Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_str Rust documentation for `segment_str`} for more information.
    */
   segment_utf8(input: string): ICU4XLineBreakIteratorUtf8;
 
@@ -44,7 +44,7 @@ export class ICU4XLineBreakSegmenter {
 
    * Segments a UTF-16 string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_utf16 Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_utf16 Rust documentation for `segment_utf16`} for more information.
    */
   segment_utf16(input: Uint16Array): ICU4XLineBreakIteratorUtf16;
 
@@ -52,7 +52,7 @@ export class ICU4XLineBreakSegmenter {
 
    * Segments a Latin-1 string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_latin1 Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineBreakSegmenter.html#method.segment_latin1 Rust documentation for `segment_latin1`} for more information.
    */
   segment_latin1(input: Uint8Array): ICU4XLineBreakIteratorLatin1;
 }

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XLocale.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XLocale.d.ts
@@ -5,7 +5,7 @@ import { ICU4XError } from "./ICU4XError";
 
  * An ICU4X Locale, capable of representing strings like `"en-US"`.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html Rust documentation for `Locale`} for more information.
  */
 export class ICU4XLocale {
 
@@ -13,7 +13,7 @@ export class ICU4XLocale {
 
    * Construct an {@link ICU4XLocale `ICU4XLocale`} from an locale identifier.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes Rust documentation for `from_bytes`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static create(name: string): ICU4XLocale | never;
@@ -40,7 +40,7 @@ export class ICU4XLocale {
 
    * Clones the {@link ICU4XLocale `ICU4XLocale`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html Rust documentation for `Locale`} for more information.
    */
   clone(): ICU4XLocale;
 
@@ -48,7 +48,7 @@ export class ICU4XLocale {
 
    * Write a string representation of the `LanguageIdentifier` part of {@link ICU4XLocale `ICU4XLocale`} to `write`.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id Rust documentation for `id`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   basename(): string | never;
@@ -57,7 +57,7 @@ export class ICU4XLocale {
 
    * Write a string representation of the unicode extension to `write`
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.extensions Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.extensions Rust documentation for `extensions`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   get_unicode_extension(bytes: string): string | never;
@@ -66,7 +66,7 @@ export class ICU4XLocale {
 
    * Write a string representation of {@link ICU4XLocale `ICU4XLocale`} language to `write`
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id Rust documentation for `id`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   language(): string | never;
@@ -75,7 +75,7 @@ export class ICU4XLocale {
 
    * Set the language part of the {@link ICU4XLocale `ICU4XLocale`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes Rust documentation for `from_bytes`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   set_language(bytes: string): void | never;
@@ -84,7 +84,7 @@ export class ICU4XLocale {
 
    * Write a string representation of {@link ICU4XLocale `ICU4XLocale`} region to `write`
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id Rust documentation for `id`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   region(): string | never;
@@ -93,7 +93,7 @@ export class ICU4XLocale {
 
    * Set the region part of the {@link ICU4XLocale `ICU4XLocale`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes Rust documentation for `from_bytes`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   set_region(bytes: string): void | never;
@@ -102,7 +102,7 @@ export class ICU4XLocale {
 
    * Write a string representation of {@link ICU4XLocale `ICU4XLocale`} script to `write`
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#structfield.id Rust documentation for `id`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   script(): string | never;
@@ -111,7 +111,7 @@ export class ICU4XLocale {
 
    * Set the script part of the {@link ICU4XLocale `ICU4XLocale`}. Pass an empty string to remove the script.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html#method.from_bytes Rust documentation for `from_bytes`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   set_script(bytes: string): void | never;
@@ -120,7 +120,7 @@ export class ICU4XLocale {
 
    * Write a string representation of {@link ICU4XLocale `ICU4XLocale`} to `write`
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html Rust documentation for `Locale`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   tostring(): string | never;

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XLocaleCanonicalizer.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XLocaleCanonicalizer.d.ts
@@ -8,7 +8,7 @@ import { ICU4XTransformResult } from "./ICU4XTransformResult";
 
  * A locale canonicalizer.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html Rust documentation for `LocaleCanonicalizer`} for more information.
  */
 export class ICU4XLocaleCanonicalizer {
 
@@ -16,7 +16,7 @@ export class ICU4XLocaleCanonicalizer {
 
    * Create a new {@link ICU4XLocaleCanonicalizer `ICU4XLocaleCanonicalizer`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html#method.new Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html#method.new Rust documentation for `new`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static create(provider: ICU4XDataProvider): ICU4XLocaleCanonicalizer | never;
@@ -25,7 +25,7 @@ export class ICU4XLocaleCanonicalizer {
 
    * FFI version of `LocaleCanonicalizer::canonicalize()`.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html#method.canonicalize Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleCanonicalizer.html#method.canonicalize Rust documentation for `canonicalize`} for more information.
    */
   canonicalize(locale: ICU4XLocale): ICU4XTransformResult;
 }

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XLocaleExpander.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XLocaleExpander.d.ts
@@ -8,7 +8,7 @@ import { ICU4XTransformResult } from "./ICU4XTransformResult";
 
  * A locale expander.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html Rust documentation for `LocaleExpander`} for more information.
  */
 export class ICU4XLocaleExpander {
 
@@ -16,7 +16,7 @@ export class ICU4XLocaleExpander {
 
    * Create a new {@link ICU4XLocaleExpander `ICU4XLocaleExpander`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.new Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.new Rust documentation for `new`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static create(provider: ICU4XDataProvider): ICU4XLocaleExpander | never;
@@ -25,7 +25,7 @@ export class ICU4XLocaleExpander {
 
    * FFI version of `LocaleExpander::maximize()`.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.maximize Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.maximize Rust documentation for `maximize`} for more information.
    */
   maximize(locale: ICU4XLocale): ICU4XTransformResult;
 
@@ -33,7 +33,7 @@ export class ICU4XLocaleExpander {
 
    * FFI version of `LocaleExpander::minimize()`.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.minimize Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/struct.LocaleExpander.html#method.minimize Rust documentation for `minimize`} for more information.
    */
   minimize(locale: ICU4XLocale): ICU4XTransformResult;
 }

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XPluralCategory.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XPluralCategory.d.ts
@@ -3,7 +3,7 @@
 
  * FFI version of `PluralCategory`.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/enum.PluralCategory.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/enum.PluralCategory.html Rust documentation for `PluralCategory`} for more information.
  */
 export enum ICU4XPluralCategory {
   /**

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XPluralOperands.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XPluralOperands.d.ts
@@ -6,7 +6,7 @@ import { ICU4XError } from "./ICU4XError";
 
  * FFI version of `PluralOperands`.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralOperands.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralOperands.html Rust documentation for `PluralOperands`} for more information.
  */
 export class ICU4XPluralOperands {
   i: u64;
@@ -20,7 +20,7 @@ export class ICU4XPluralOperands {
 
    * FFI version of `PluralOperands::from_str()`.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralOperands.html#method.from_str Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralOperands.html#method.from_str Rust documentation for `from_str`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static create(s: string): ICU4XPluralOperands | never;

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XPluralRules.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XPluralRules.d.ts
@@ -10,7 +10,7 @@ import { ICU4XPluralOperands } from "./ICU4XPluralOperands";
 
  * FFI version of `PluralRules`.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html Rust documentation for `PluralRules`} for more information.
  */
 export class ICU4XPluralRules {
 
@@ -18,7 +18,7 @@ export class ICU4XPluralRules {
 
    * FFI version of `PluralRules::try_new_cardinal()`.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.try_new_unstable Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.try_new_unstable Rust documentation for `try_new_unstable`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_new_cardinal(provider: ICU4XDataProvider, locale: ICU4XLocale): ICU4XPluralRules | never;
@@ -27,7 +27,7 @@ export class ICU4XPluralRules {
 
    * FFI version of `PluralRules::try_new_ordinal()`.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.try_new_unstable Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.try_new_unstable Rust documentation for `try_new_unstable`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_new_ordinal(provider: ICU4XDataProvider, locale: ICU4XLocale): ICU4XPluralRules | never;
@@ -36,7 +36,7 @@ export class ICU4XPluralRules {
 
    * FFI version of `PluralRules::select()`.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.select Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.select Rust documentation for `select`} for more information.
    */
   select(op: ICU4XPluralOperands): ICU4XPluralCategory;
 
@@ -44,7 +44,7 @@ export class ICU4XPluralRules {
 
    * FFI version of `PluralRules::categories()`.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.categories Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/plurals/struct.PluralRules.html#method.categories Rust documentation for `categories`} for more information.
    */
   categories(): ICU4XPluralCategories;
 }

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XSentenceBreakSegmenter.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XSentenceBreakSegmenter.d.ts
@@ -9,7 +9,7 @@ import { ICU4XSentenceBreakIteratorUtf8 } from "./ICU4XSentenceBreakIteratorUtf8
 
  * An ICU4X sentence-break segmenter, capable of finding sentence breakpoints in strings.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html Rust documentation for `SentenceBreakSegmenter`} for more information.
  */
 export class ICU4XSentenceBreakSegmenter {
 
@@ -17,7 +17,7 @@ export class ICU4XSentenceBreakSegmenter {
 
    * Construct an {@link ICU4XSentenceBreakSegmenter `ICU4XSentenceBreakSegmenter`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.try_new Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.try_new Rust documentation for `try_new`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_new(provider: ICU4XDataProvider): ICU4XSentenceBreakSegmenter | never;
@@ -26,7 +26,7 @@ export class ICU4XSentenceBreakSegmenter {
 
    * Segments a UTF-8 string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_str Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_str Rust documentation for `segment_str`} for more information.
    */
   segment_utf8(input: string): ICU4XSentenceBreakIteratorUtf8;
 
@@ -34,7 +34,7 @@ export class ICU4XSentenceBreakSegmenter {
 
    * Segments a UTF-16 string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_utf16 Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_utf16 Rust documentation for `segment_utf16`} for more information.
    */
   segment_utf16(input: Uint16Array): ICU4XSentenceBreakIteratorUtf16;
 
@@ -42,7 +42,7 @@ export class ICU4XSentenceBreakSegmenter {
 
    * Segments a Latin-1 string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_latin1 Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceBreakSegmenter.html#method.segment_latin1 Rust documentation for `segment_latin1`} for more information.
    */
   segment_latin1(input: Uint8Array): ICU4XSentenceBreakIteratorLatin1;
 }

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XTimeFormatter.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XTimeFormatter.d.ts
@@ -9,7 +9,7 @@ import { ICU4XTimeLength } from "./ICU4XTimeLength";
 
  * An ICU4X TimeFormatter object capable of formatting a {@link ICU4XGregorianDateTime `ICU4XGregorianDateTime`} as a string
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html Rust documentation for `TimeFormatter`} for more information.
  */
 export class ICU4XTimeFormatter {
 
@@ -17,7 +17,7 @@ export class ICU4XTimeFormatter {
 
    * Creates a new {@link ICU4XTimeFormatter `ICU4XTimeFormatter`} from locale data.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.TypedDateFormatter.html#method.try_new_unstable Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.TypedDateFormatter.html#method.try_new_unstable Rust documentation for `try_new_unstable`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_new(provider: ICU4XDataProvider, locale: ICU4XLocale, length: ICU4XTimeLength): ICU4XTimeFormatter | never;
@@ -26,7 +26,7 @@ export class ICU4XTimeFormatter {
 
    * Formats a {@link ICU4XGregorianDateTime `ICU4XGregorianDateTime`} to a string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html#method.format_to_write Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/datetime/struct.TimeFormatter.html#method.format_to_write Rust documentation for `format_to_write`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   format_gregorian_datetime(value: ICU4XGregorianDateTime): string | never;

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XTransformResult.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XTransformResult.d.ts
@@ -3,7 +3,7 @@
 
  * FFI version of `TransformResult`.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/enum.TransformResult.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/locale_canonicalizer/enum.TransformResult.html Rust documentation for `TransformResult`} for more information.
  */
 export enum ICU4XTransformResult {
   /**

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XWordBreakRule.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XWordBreakRule.d.ts
@@ -1,7 +1,7 @@
 
 /**
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/enum.WordBreakRule.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/enum.WordBreakRule.html Rust documentation for `WordBreakRule`} for more information.
  */
 export enum ICU4XWordBreakRule {
   /**

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XWordBreakSegmenter.d.ts
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XWordBreakSegmenter.d.ts
@@ -9,7 +9,7 @@ import { ICU4XWordBreakIteratorUtf8 } from "./ICU4XWordBreakIteratorUtf8";
 
  * An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
 
- * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html Rust documentation} for more information.
+ * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html Rust documentation for `WordBreakSegmenter`} for more information.
  */
 export class ICU4XWordBreakSegmenter {
 
@@ -17,7 +17,7 @@ export class ICU4XWordBreakSegmenter {
 
    * Construct an {@link ICU4XWordBreakSegmenter `ICU4XWordBreakSegmenter`}.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.try_new Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.try_new Rust documentation for `try_new`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
   static try_new(provider: ICU4XDataProvider): ICU4XWordBreakSegmenter | never;
@@ -26,7 +26,7 @@ export class ICU4XWordBreakSegmenter {
 
    * Segments a UTF-8 string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_str Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_str Rust documentation for `segment_str`} for more information.
    */
   segment_utf8(input: string): ICU4XWordBreakIteratorUtf8;
 
@@ -34,7 +34,7 @@ export class ICU4XWordBreakSegmenter {
 
    * Segments a UTF-16 string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_utf16 Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_utf16 Rust documentation for `segment_utf16`} for more information.
    */
   segment_utf16(input: Uint16Array): ICU4XWordBreakIteratorUtf16;
 
@@ -42,7 +42,7 @@ export class ICU4XWordBreakSegmenter {
 
    * Segments a Latin-1 string.
 
-   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_latin1 Rust documentation} for more information.
+   * See the {@link https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordBreakSegmenter.html#method.segment_latin1 Rust documentation for `segment_latin1`} for more information.
    */
   segment_latin1(input: Uint8Array): ICU4XWordBreakIteratorLatin1;
 }

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -27,7 +27,7 @@ include = [
 all-features = true
 
 [dependencies]
-smallvec = "1.6"
+smallvec = "1.9"
 static_assertions = "1.1"
 writeable = { version = "0.4", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }


### PR DESCRIPTION
Blocked on https://github.com/rust-diplomat/diplomat/pull/224

Can't actually be run until https://github.com/unicode-org/icu4x/pull/2403


This updates to a Diplomat with more `rust_link` options; but does not yet use them. I'll do a pass once the rest of this merges.

It also adds an initial allowlist, split into two sections: one section for things that don't need to be exposed over FFI (because they are rust-specific) and one for things which coudl be but aren't currently planned.

The hope is that the latter section of the allowlist can be pared down over time. The nice thing is that by keeping it in source rather than completely in `missing_keys` we can comment it, and hopefulyl we can get to a point where `missing_keys` is empty.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->