### PR TITLE
Enable missing docs lint in timezone

### DIFF
--- a/components/timezone/src/lib.rs
+++ b/components/timezone/src/lib.rs
@@ -17,6 +17,7 @@
         clippy::exhaustive_enums
     )
 )]
+#![warn(missing_docs)]
 
 extern crate alloc;
 


### PR DESCRIPTION
Part of https://github.com/unicode-org/icu4x/issues/2109