### PR TITLE
week_of refactoring

### DIFF
--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::any_calendar::{AnyCalendar, IntoAnyCalendar};
-use crate::week_of::{self, CalendarInfo, WeekOf};
+use crate::week_of::{self, WeekOfYearConfigV1, WeekOf};
 use crate::{types, Calendar, DateDuration, DateDurationUnit, DateTimeError, Iso};
 use alloc::rc::Rc;
 use alloc::sync::Arc;
@@ -279,7 +279,7 @@ impl<A: AsCalendar> Date<A> {
     ///     })
     /// );
     /// ```
-    pub fn week_of_year(&self, calendar_info: &CalendarInfo) -> Result<WeekOf, DateTimeError> {
+    pub fn week_of_year(&self, calendar_info: &WeekOfYearConfigV1) -> Result<WeekOf, DateTimeError> {
         let doy_info = self.day_of_year_info();
         week_of::week_of(
             calendar_info,

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::any_calendar::{AnyCalendar, IntoAnyCalendar};
-use crate::week::{WeekOf, WeekCalculator};
+use crate::week::{WeekCalculator, WeekOf};
 use crate::{types, Calendar, DateDuration, DateDurationUnit, DateTimeError, Iso};
 use alloc::rc::Rc;
 use alloc::sync::Arc;

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -247,7 +247,7 @@ impl<A: AsCalendar> Date<A> {
     ///
     /// assert_eq!(date.week_of_month(first_weekday), 2);
     /// ```
-    pub fn week_of_month(&self, first_weekday: types::IsoWeekday) -> u16 {
+    pub fn week_of_month(&self, first_weekday: types::IsoWeekday) -> types::WeekOfMonth {
         let config = WeekOfYearConfig {
             first_weekday,
             min_week_days: 0, // ignored

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::any_calendar::{AnyCalendar, IntoAnyCalendar};
-use crate::week_of::{self, WeekOf, WeekOfYearConfig};
+use crate::week_of::{self, WeekOf, WeekCalculator};
 use crate::{types, Calendar, DateDuration, DateDurationUnit, DateTimeError, Iso};
 use alloc::rc::Rc;
 use alloc::sync::Arc;
@@ -248,7 +248,7 @@ impl<A: AsCalendar> Date<A> {
     /// assert_eq!(date.week_of_month(first_weekday), 2);
     /// ```
     pub fn week_of_month(&self, first_weekday: types::IsoWeekday) -> types::WeekOfMonth {
-        let config = WeekOfYearConfig {
+        let config = WeekCalculator {
             first_weekday,
             min_week_days: 0, // ignored
         };
@@ -282,7 +282,7 @@ impl<A: AsCalendar> Date<A> {
     ///     })
     /// );
     /// ```
-    pub fn week_of_year(&self, config: &WeekOfYearConfig) -> Result<WeekOf, DateTimeError> {
+    pub fn week_of_year(&self, config: &WeekCalculator) -> Result<WeekOf, DateTimeError> {
         config.week_of_year(self.day_of_year_info(), self.day_of_week())
     }
 

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -248,8 +248,11 @@ impl<A: AsCalendar> Date<A> {
     /// assert_eq!(date.week_of_month(first_weekday), 2);
     /// ```
     pub fn week_of_month(&self, first_weekday: types::IsoWeekday) -> u16 {
-        let day_of_month = self.day_of_month();
-        week_of::simple_week_of(first_weekday, day_of_month.0 as u16, self.day_of_week())
+        let config = WeekOfYearConfig {
+            first_weekday,
+            min_week_days: 0, // ignored
+        };
+        config.week_of_month(self.day_of_month(), self.day_of_week())
     }
 
     /// The week of the year containing this date.
@@ -280,14 +283,7 @@ impl<A: AsCalendar> Date<A> {
     /// );
     /// ```
     pub fn week_of_year(&self, config: &WeekOfYearConfig) -> Result<WeekOf, DateTimeError> {
-        let doy_info = self.day_of_year_info();
-        week_of::week_of(
-            config,
-            doy_info.days_in_prev_year as u16,
-            doy_info.days_in_year as u16,
-            doy_info.day_of_year as u16,
-            self.day_of_week(),
-        )
+        config.week_of_year(self.day_of_year_info(), self.day_of_week())
     }
 
     /// Construct a date from raw values for a given calendar. This does not check any

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::any_calendar::{AnyCalendar, IntoAnyCalendar};
-use crate::week_of::{self, WeekOfYearConfigV1, WeekOf};
+use crate::week_of::{self, WeekOf, WeekOfYearConfig};
 use crate::{types, Calendar, DateDuration, DateDurationUnit, DateTimeError, Iso};
 use alloc::rc::Rc;
 use alloc::sync::Arc;
@@ -279,10 +279,10 @@ impl<A: AsCalendar> Date<A> {
     ///     })
     /// );
     /// ```
-    pub fn week_of_year(&self, calendar_info: &WeekOfYearConfigV1) -> Result<WeekOf, DateTimeError> {
+    pub fn week_of_year(&self, config: &WeekOfYearConfig) -> Result<WeekOf, DateTimeError> {
         let doy_info = self.day_of_year_info();
         week_of::week_of(
-            calendar_info,
+            config,
             doy_info.days_in_prev_year as u16,
             doy_info.days_in_year as u16,
             doy_info.day_of_year as u16,

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::any_calendar::{AnyCalendar, IntoAnyCalendar};
-use crate::week_of::{self, WeekOf, WeekCalculator};
+use crate::week::{WeekOf, WeekCalculator};
 use crate::{types, Calendar, DateDuration, DateDurationUnit, DateTimeError, Iso};
 use alloc::rc::Rc;
 use alloc::sync::Arc;
@@ -238,6 +238,7 @@ impl<A: AsCalendar> Date<A> {
     ///
     /// ```
     /// use icu::calendar::Date;
+    /// use icu::calendar::types::WeekOfMonth;
     /// use icu::calendar::types::IsoWeekday;
     ///
     /// let date = Date::new_iso_date(2022, 8, 10).unwrap(); // second Wednesday
@@ -245,7 +246,10 @@ impl<A: AsCalendar> Date<A> {
     /// // The following info is usually locale-specific
     /// let first_weekday = IsoWeekday::Sunday;
     ///
-    /// assert_eq!(date.week_of_month(first_weekday), 2);
+    /// assert_eq!(
+    ///     date.week_of_month(first_weekday),
+    ///     WeekOfMonth(2)
+    /// );
     /// ```
     pub fn week_of_month(&self, first_weekday: types::IsoWeekday) -> types::WeekOfMonth {
         let config = WeekCalculator {
@@ -262,22 +266,19 @@ impl<A: AsCalendar> Date<A> {
     /// ```
     /// use icu::calendar::Date;
     /// use icu::calendar::types::IsoWeekday;
-    /// use icu::calendar::week_of::CalendarInfo;
-    /// use icu::calendar::week_of::RelativeUnit;
-    /// use icu::calendar::week_of::WeekOf;
+    /// use icu::calendar::week::WeekCalculator;
+    /// use icu::calendar::week::RelativeUnit;
+    /// use icu::calendar::week::WeekOf;
     ///
     /// let date = Date::new_iso_date(2022, 8, 26).unwrap();
     ///
     /// // The following info is usually locale-specific
-    /// let calendar_info = CalendarInfo {
-    ///     first_weekday: IsoWeekday::Sunday,
-    ///     min_week_days: 4
-    /// };
+    /// let week_calculator = WeekCalculator::default();
     ///
     /// assert_eq!(
-    ///     date.week_of_year(&calendar_info),
+    ///     date.week_of_year(&week_calculator),
     ///     Ok(WeekOf {
-    ///         week: 34,
+    ///         week: 35,
     ///         unit: RelativeUnit::Current
     ///     })
     /// );

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -131,7 +131,15 @@ pub mod japanese;
 pub mod julian;
 pub mod provider;
 pub mod types;
-pub mod week_of;
+mod week_of;
+
+pub mod week {
+    //! Functions for week-of-month and week-of-year arithmetic.
+    use crate::week_of;
+    pub use week_of::WeekCalculator;
+    pub use week_of::RelativeUnit;
+    pub use week_of::WeekOf;
+}
 
 pub use any_calendar::{AnyCalendar, AnyCalendarKind};
 pub use calendar::Calendar;

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -136,8 +136,8 @@ mod week_of;
 pub mod week {
     //! Functions for week-of-month and week-of-year arithmetic.
     use crate::week_of;
-    pub use week_of::WeekCalculator;
     pub use week_of::RelativeUnit;
+    pub use week_of::WeekCalculator;
     pub use week_of::WeekOf;
 }
 

--- a/components/calendar/src/provider.rs
+++ b/components/calendar/src/provider.rs
@@ -86,7 +86,7 @@ impl FromStr for EraStartDate {
 #[cfg_attr(
     feature = "datagen",
     derive(serde::Serialize, databake::Bake),
-    databake(path = icu_calendar::week_of),
+    databake(path = icu_calendar::provider),
 )]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[allow(clippy::exhaustive_structs)] // used in data provider

--- a/components/calendar/src/provider.rs
+++ b/components/calendar/src/provider.rs
@@ -9,11 +9,11 @@
 // Provider structs must be stable
 #![allow(clippy::exhaustive_structs, clippy::exhaustive_enums)]
 
+use crate::types::IsoWeekday;
 use core::str::FromStr;
 use icu_provider::{yoke, zerofrom};
 use tinystr::TinyStr16;
 use zerovec::ZeroVec;
-use crate::types::IsoWeekday;
 
 /// The date at which an era started
 ///

--- a/components/calendar/src/provider.rs
+++ b/components/calendar/src/provider.rs
@@ -13,6 +13,7 @@ use core::str::FromStr;
 use icu_provider::{yoke, zerofrom};
 use tinystr::TinyStr16;
 use zerovec::ZeroVec;
+use crate::types::IsoWeekday;
 
 /// The date at which an era started
 ///
@@ -72,4 +73,26 @@ impl FromStr for EraStartDate {
 
         Ok(EraStartDate { year, month, day })
     }
+}
+
+/// An ICU4X mapping to a subset of CLDR weekData.
+/// See CLDR-JSON's weekData.json for more context.
+#[icu_provider::data_struct(marker(
+    WeekDataV1Marker,
+    "datetime/week_data@1",
+    fallback_by = "region"
+))]
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(
+    feature = "datagen",
+    derive(serde::Serialize, databake::Bake),
+    databake(path = icu_calendar::week_of),
+)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[allow(clippy::exhaustive_structs)] // used in data provider
+pub struct WeekDataV1 {
+    /// The first day of a week.
+    pub first_weekday: IsoWeekday,
+    /// For a given week, the minimum number of that week's days present in a given month or year for the week to be considered part of that month or year.
+    pub min_week_days: u8,
 }

--- a/components/calendar/src/week_of.rs
+++ b/components/calendar/src/week_of.rs
@@ -40,6 +40,14 @@ impl WeekOfYearConfig {
         (7 + (weekday as i8) - (self.first_weekday as i8)) % 7
     }
 
+    /// Returns the week of month according to a calendar with min_week_days = 1.
+    ///
+    /// This is different from what the UTS35 spec describes [1] but the latter is
+    /// missing a month of week-of-month field so following the spec would result
+    /// in inconsistencies (e.g. in the ISO calendar 2021-01-01 is the last week
+    /// of December but 'MMMMW' would have it formatted as 'week 5 of January').
+    ///
+    /// 1: https://www.unicode.org/reports/tr35/tr35-55/tr35-dates.html#Date_Patterns_Week_Of_Year
     pub fn week_of_month(&self, day_of_month: DayOfMonth, iso_weekday: IsoWeekday) -> WeekOfMonth {
         WeekOfMonth(simple_week_of(self.first_weekday, day_of_month.0 as u16, iso_weekday) as u32)
     }

--- a/components/calendar/src/week_of.rs
+++ b/components/calendar/src/week_of.rs
@@ -7,7 +7,7 @@
 //! The main functionality of this module is found in the [`week_of()`] (and [`simple_week_of()`])
 //! functions.
 
-use crate::{error::DateTimeError, types::IsoWeekday, provider::WeekDataV1};
+use crate::{error::DateTimeError, provider::WeekDataV1, types::{IsoWeekday, DayOfYearInfo, DayOfMonth}};
 
 /// Minimum number of days in a month unit required for using this module
 pub const MIN_UNIT_DAYS: u16 = 14;
@@ -38,6 +38,20 @@ impl WeekOfYearConfig {
     /// Returns the zero based index of `weekday` vs this calendar's start of week.
     fn weekday_index(&self, weekday: IsoWeekday) -> i8 {
         (7 + (weekday as i8) - (self.first_weekday as i8)) % 7
+    }
+
+    pub fn week_of_month(&self, day_of_month: DayOfMonth, weekday: IsoWeekday) -> u16 {
+        simple_week_of(self.first_weekday, day_of_month.0 as u16, weekday)
+    }
+
+    pub fn week_of_year(&self, day_of_year_info: DayOfYearInfo, weekday: IsoWeekday) -> Result<WeekOf, DateTimeError> {
+        week_of(
+            self,
+            day_of_year_info.days_in_prev_year as u16,
+            day_of_year_info.days_in_year as u16,
+            day_of_year_info.day_of_year as u16,
+            weekday,
+        )
     }
 }
 

--- a/components/calendar/src/week_of.rs
+++ b/components/calendar/src/week_of.rs
@@ -7,35 +7,41 @@
 //! The main functionality of this module is found in the [`week_of()`] (and [`simple_week_of()`])
 //! functions.
 
-use crate::{error::DateTimeError, types::IsoWeekday};
+use crate::{error::DateTimeError, types::IsoWeekday, provider::WeekDataV1};
 
 /// Minimum number of days in a month unit required for using this module
 pub const MIN_UNIT_DAYS: u16 = 14;
 
 /// Information about how a given calendar assigns weeks to a year or month.
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(
-    feature = "datagen",
-    derive(serde::Serialize, databake::Bake),
-    databake(path = icu_calendar::week_of),
-)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-#[allow(clippy::exhaustive_structs)] // used in data provider
-pub struct WeekOfYearConfigV1 {
+#[non_exhaustive]
+pub struct WeekOfYearConfig {
     /// The first day of a week.
     pub first_weekday: IsoWeekday,
     /// For a given week, the minimum number of that week's days present in a given month or year for the week to be considered part of that month or year.
     pub min_week_days: u8,
 }
 
-impl WeekOfYearConfigV1 {
+impl From<WeekDataV1> for WeekOfYearConfig {
+    fn from(other: WeekDataV1) -> Self {
+        Self { first_weekday: other.first_weekday, min_week_days: other.min_week_days }
+    }
+}
+
+impl From<&WeekDataV1> for WeekOfYearConfig {
+    fn from(other: &WeekDataV1) -> Self {
+        Self { first_weekday: other.first_weekday, min_week_days: other.min_week_days }
+    }
+}
+
+impl WeekOfYearConfig {
     /// Returns the zero based index of `weekday` vs this calendar's start of week.
     fn weekday_index(&self, weekday: IsoWeekday) -> i8 {
         (7 + (weekday as i8) - (self.first_weekday as i8)) % 7
     }
 }
 
-impl Default for WeekOfYearConfigV1 {
+impl Default for WeekOfYearConfig {
     fn default() -> Self {
         Self {
             first_weekday: IsoWeekday::Monday,
@@ -90,7 +96,7 @@ impl UnitInfo {
     ///
     /// The returned value can be negative if this unit's first week started during the previous
     /// unit.
-    fn first_week_offset(&self, calendar: &WeekOfYearConfigV1) -> i8 {
+    fn first_week_offset(&self, calendar: &WeekOfYearConfig) -> i8 {
         let first_day_index = calendar.weekday_index(self.first_day);
         if 7 - first_day_index >= calendar.min_week_days as i8 {
             -first_day_index
@@ -100,7 +106,7 @@ impl UnitInfo {
     }
 
     /// Returns the number of weeks in this unit according to `calendar`.
-    fn num_weeks(&self, calendar: &WeekOfYearConfigV1) -> u16 {
+    fn num_weeks(&self, calendar: &WeekOfYearConfig) -> u16 {
         let first_week_offset = self.first_week_offset(calendar);
         let num_days_including_first_week =
             (self.duration_days as i32) - (first_week_offset as i32);
@@ -112,7 +118,7 @@ impl UnitInfo {
     }
 
     /// Returns the week number for the given day in this unit.
-    fn relative_week(&self, calendar: &WeekOfYearConfigV1, day: u16) -> RelativeWeek {
+    fn relative_week(&self, calendar: &WeekOfYearConfig, day: u16) -> RelativeWeek {
         let days_since_first_week =
             i32::from(day) - i32::from(self.first_week_offset(calendar)) - 1;
         if days_since_first_week < 0 {
@@ -158,7 +164,7 @@ pub struct WeekOf {
 ///  - day: 1-based day of month/year.
 ///  - week_day: The weekday of `day`..
 pub fn week_of(
-    calendar: &WeekOfYearConfigV1,
+    calendar: &WeekOfYearConfig,
     num_days_in_previous_unit: u16,
     num_days_in_unit: u16,
     day: u16,
@@ -200,7 +206,7 @@ pub fn week_of(
 ///  - day: 1-based day of the month or year.
 ///  - week_day: The weekday of `day`.
 pub fn simple_week_of(first_weekday: IsoWeekday, day: u16, week_day: IsoWeekday) -> u16 {
-    let calendar = WeekOfYearConfigV1 {
+    let calendar = WeekOfYearConfig {
         first_weekday,
         min_week_days: 1,
     };
@@ -221,20 +227,20 @@ pub fn simple_week_of(first_weekday: IsoWeekday, day: u16, week_day: IsoWeekday)
 
 #[cfg(test)]
 mod tests {
-    use super::{week_of, WeekOfYearConfigV1, RelativeUnit, RelativeWeek, UnitInfo, WeekOf};
+    use super::{week_of, WeekOfYearConfig, RelativeUnit, RelativeWeek, UnitInfo, WeekOf};
     use crate::{error::DateTimeError, types::IsoWeekday, Date, DateDuration};
 
-    static ISO_CALENDAR: WeekOfYearConfigV1 = WeekOfYearConfigV1 {
+    static ISO_CALENDAR: WeekOfYearConfig = WeekOfYearConfig {
         first_weekday: IsoWeekday::Monday,
         min_week_days: 4,
     };
 
-    static AE_CALENDAR: WeekOfYearConfigV1 = WeekOfYearConfigV1 {
+    static AE_CALENDAR: WeekOfYearConfig = WeekOfYearConfig {
         first_weekday: IsoWeekday::Saturday,
         min_week_days: 4,
     };
 
-    static US_CALENDAR: WeekOfYearConfigV1 = WeekOfYearConfigV1 {
+    static US_CALENDAR: WeekOfYearConfig = WeekOfYearConfig {
         first_weekday: IsoWeekday::Sunday,
         min_week_days: 1,
     };
@@ -308,7 +314,7 @@ mod tests {
     /// This alternative implementation serves as an exhaustive safety check
     /// of relative_week() (in addition to the manual test points used
     /// for testing week_of()).
-    fn classify_days_of_unit(calendar: &WeekOfYearConfigV1, unit: &UnitInfo) -> Vec<RelativeWeek> {
+    fn classify_days_of_unit(calendar: &WeekOfYearConfig, unit: &UnitInfo) -> Vec<RelativeWeek> {
         let mut weeks: Vec<Vec<IsoWeekday>> = Vec::new();
         for day_index in 0..unit.duration_days {
             let day = super::add_to_weekday(unit.first_day, i32::from(day_index));
@@ -341,7 +347,7 @@ mod tests {
     fn test_relative_week_of_month() -> Result<(), DateTimeError> {
         for min_week_days in 1..7 {
             for start_of_week in 1..7 {
-                let calendar = WeekOfYearConfigV1 {
+                let calendar = WeekOfYearConfig {
                     first_weekday: IsoWeekday::from(start_of_week),
                     min_week_days,
                 };
@@ -370,7 +376,7 @@ mod tests {
     }
 
     fn week_of_month_from_iso_date(
-        calendar: &WeekOfYearConfigV1,
+        calendar: &WeekOfYearConfig,
         yyyymmdd: u32,
     ) -> Result<WeekOf, DateTimeError> {
         let year = (yyyymmdd / 10000) as i32;

--- a/components/calendar/src/week_of.rs
+++ b/components/calendar/src/week_of.rs
@@ -7,7 +7,7 @@
 //! The main functionality of this module is found in the [`week_of()`] (and [`simple_week_of()`])
 //! functions.
 
-use crate::{error::DateTimeError, provider::WeekDataV1, types::{IsoWeekday, DayOfYearInfo, DayOfMonth}};
+use crate::{error::DateTimeError, provider::WeekDataV1, types::{IsoWeekday, DayOfYearInfo, DayOfMonth, WeekOfMonth, WeekOfYear}};
 
 /// Minimum number of days in a month unit required for using this module
 pub const MIN_UNIT_DAYS: u16 = 14;
@@ -40,17 +40,17 @@ impl WeekOfYearConfig {
         (7 + (weekday as i8) - (self.first_weekday as i8)) % 7
     }
 
-    pub fn week_of_month(&self, day_of_month: DayOfMonth, weekday: IsoWeekday) -> u16 {
-        simple_week_of(self.first_weekday, day_of_month.0 as u16, weekday)
+    pub fn week_of_month(&self, day_of_month: DayOfMonth, iso_weekday: IsoWeekday) -> WeekOfMonth {
+        WeekOfMonth(simple_week_of(self.first_weekday, day_of_month.0 as u16, iso_weekday) as u32)
     }
 
-    pub fn week_of_year(&self, day_of_year_info: DayOfYearInfo, weekday: IsoWeekday) -> Result<WeekOf, DateTimeError> {
+    pub fn week_of_year(&self, day_of_year_info: DayOfYearInfo, iso_weekday: IsoWeekday) -> Result<WeekOf, DateTimeError> {
         week_of(
             self,
             day_of_year_info.days_in_prev_year as u16,
             day_of_year_info.days_in_year as u16,
             day_of_year_info.day_of_year as u16,
-            weekday,
+            iso_weekday,
         )
     }
 }

--- a/components/calendar/src/week_of.rs
+++ b/components/calendar/src/week_of.rs
@@ -65,8 +65,6 @@ impl WeekCalculator {
     /// in inconsistencies (e.g. in the ISO calendar 2021-01-01 is the last week
     /// of December but 'MMMMW' would have it formatted as 'week 5 of January').
     ///
-    /// 1: https://www.unicode.org/reports/tr35/tr35-55/tr35-dates.html#Date_Patterns_Week_Of_Year
-    ///
     /// # Examples
     ///
     /// ```
@@ -88,6 +86,8 @@ impl WeekCalculator {
     ///     )
     /// );
     /// ```
+    ///
+    /// [1]: https://www.unicode.org/reports/tr35/tr35-55/tr35-dates.html#Date_Patterns_Week_Of_Year
     pub fn week_of_month(&self, day_of_month: DayOfMonth, iso_weekday: IsoWeekday) -> WeekOfMonth {
         WeekOfMonth(simple_week_of(self.first_weekday, day_of_month.0 as u16, iso_weekday) as u32)
     }
@@ -251,7 +251,7 @@ pub enum RelativeUnit {
 pub struct WeekOf {
     /// Week of month/year. 1 based.
     pub week: u16,
-    /// The month/year that this week is in, relative to the month/unit for which [`week_of`] was called.
+    /// The month/year that this week is in, relative to the month/year of the input date.
     pub unit: RelativeUnit,
 }
 

--- a/components/calendar/src/week_of.rs
+++ b/components/calendar/src/week_of.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::{error::DateTimeError, provider::WeekDataV1, types::{IsoWeekday, DayOfYearInfo, DayOfMonth, WeekOfMonth, WeekOfYear}};
+use crate::{error::DateTimeError, provider::WeekDataV1, types::{IsoWeekday, DayOfYearInfo, DayOfMonth, WeekOfMonth}};
 use icu_provider::prelude::*;
 
 /// Minimum number of days in a month unit required for using this module

--- a/components/calendar/src/week_of.rs
+++ b/components/calendar/src/week_of.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-//! Week-of-year calculations.
+//! Week-of-year and week-of-month calculations.
 //!
 //! The main functionality of this module is found in the [`week_of()`] (and [`simple_week_of()`])
 //! functions.
@@ -13,6 +13,7 @@ use crate::{error::DateTimeError, types::IsoWeekday};
 pub const MIN_UNIT_DAYS: u16 = 14;
 
 /// Information about how a given calendar assigns weeks to a year or month.
+// FIXME: Rename this type
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(
     feature = "datagen",
@@ -483,4 +484,11 @@ fn test_simple_week_of() {
         simple_week_of(IsoWeekday::Tuesday, 7, IsoWeekday::Tuesday),
         2
     );
+
+    // The 1st is a Monday and the week starts on Sundays.
+    // TODO(#2461): Enable this test
+    // assert_eq!(
+    //     simple_week_of(IsoWeekday::Sunday, 26, IsoWeekday::Friday),
+    //     4
+    // );
 }

--- a/components/calendar/src/week_of.rs
+++ b/components/calendar/src/week_of.rs
@@ -2,7 +2,11 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::{error::DateTimeError, provider::WeekDataV1, types::{IsoWeekday, DayOfYearInfo, DayOfMonth, WeekOfMonth}};
+use crate::{
+    error::DateTimeError,
+    provider::WeekDataV1,
+    types::{DayOfMonth, DayOfYearInfo, IsoWeekday, WeekOfMonth},
+};
 use icu_provider::prelude::*;
 
 /// Minimum number of days in a month unit required for using this module
@@ -21,13 +25,19 @@ pub struct WeekCalculator {
 
 impl From<WeekDataV1> for WeekCalculator {
     fn from(other: WeekDataV1) -> Self {
-        Self { first_weekday: other.first_weekday, min_week_days: other.min_week_days }
+        Self {
+            first_weekday: other.first_weekday,
+            min_week_days: other.min_week_days,
+        }
     }
 }
 
 impl From<&WeekDataV1> for WeekCalculator {
     fn from(other: &WeekDataV1) -> Self {
-        Self { first_weekday: other.first_weekday, min_week_days: other.min_week_days }
+        Self {
+            first_weekday: other.first_weekday,
+            min_week_days: other.min_week_days,
+        }
     }
 }
 
@@ -35,16 +45,18 @@ impl WeekCalculator {
     /// Creates a new [`WeekCalculator`] from locale data.
     pub fn try_new_unstable<P>(provider: &P, locale: &DataLocale) -> Result<Self, DataError>
     where
-        P: DataProvider<crate::provider::WeekDataV1Marker>
+        P: DataProvider<crate::provider::WeekDataV1Marker>,
     {
-        provider.load(DataRequest {locale, metadata: Default::default()}).and_then(DataResponse::take_payload).map(|payload| payload.get().into())
+        provider
+            .load(DataRequest {
+                locale,
+                metadata: Default::default(),
+            })
+            .and_then(DataResponse::take_payload)
+            .map(|payload| payload.get().into())
     }
 
-    icu_provider::gen_any_buffer_constructors!(
-        locale: include,
-        options: skip,
-        error: DataError
-    );
+    icu_provider::gen_any_buffer_constructors!(locale: include, options: skip, error: DataError);
 
     /// Returns the week of month according to a calendar with min_week_days = 1.
     ///
@@ -54,19 +66,19 @@ impl WeekCalculator {
     /// of December but 'MMMMW' would have it formatted as 'week 5 of January').
     ///
     /// 1: https://www.unicode.org/reports/tr35/tr35-55/tr35-dates.html#Date_Patterns_Week_Of_Year
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use icu_calendar::week::WeekCalculator;
     /// use icu_calendar::types::{IsoWeekday, DayOfMonth, WeekOfMonth};
-    /// 
+    ///
     /// let week_calculator = WeekCalculator::try_new_with_buffer_provider(
     ///     &icu_testdata::get_provider(),
     ///     &icu_locid::locale!("en-GB").into()
     /// )
     /// .expect("Data exists");
-    /// 
+    ///
     /// // Wednesday the 10th is in week 2:
     /// assert_eq!(
     ///     WeekOfMonth(2),
@@ -81,22 +93,22 @@ impl WeekCalculator {
     }
 
     /// Returns the week of year according to the weekday and [`DayOfYearInfo`].
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use icu_calendar::week::{WeekCalculator, WeekOf, RelativeUnit};
     /// use icu_calendar::types::{IsoWeekday, DayOfMonth};
     /// use icu_calendar::Date;
-    /// 
+    ///
     /// let week_calculator = WeekCalculator::try_new_with_buffer_provider(
     ///     &icu_testdata::get_provider(),
     ///     &icu_locid::locale!("en-GB").into()
     /// )
     /// .expect("Data exists");
-    /// 
+    ///
     /// let iso_date = Date::new_iso_date(2022, 8, 26).unwrap();
-    /// 
+    ///
     /// // Friday August 26 is in week 34 of year 2022:
     /// assert_eq!(
     ///     WeekOf {
@@ -109,7 +121,11 @@ impl WeekCalculator {
     ///     ).unwrap()
     /// );
     /// ```
-    pub fn week_of_year(&self, day_of_year_info: DayOfYearInfo, iso_weekday: IsoWeekday) -> Result<WeekOf, DateTimeError> {
+    pub fn week_of_year(
+        &self,
+        day_of_year_info: DayOfYearInfo,
+        iso_weekday: IsoWeekday,
+    ) -> Result<WeekOf, DateTimeError> {
         week_of(
             self,
             day_of_year_info.days_in_prev_year as u16,
@@ -311,7 +327,7 @@ pub fn simple_week_of(first_weekday: IsoWeekday, day: u16, week_day: IsoWeekday)
 
 #[cfg(test)]
 mod tests {
-    use super::{week_of, WeekCalculator, RelativeUnit, RelativeWeek, UnitInfo, WeekOf};
+    use super::{week_of, RelativeUnit, RelativeWeek, UnitInfo, WeekCalculator, WeekOf};
     use crate::{error::DateTimeError, types::IsoWeekday, Date, DateDuration};
 
     static ISO_CALENDAR: WeekCalculator = WeekCalculator {

--- a/components/datetime/src/any/date.rs
+++ b/components/datetime/src/any/date.rs
@@ -7,10 +7,10 @@ use alloc::string::String;
 
 use icu_provider::prelude::*;
 
-use crate::provider::{calendar::*, week_data::WeekDataV1Marker};
+use crate::provider::{calendar::*};
 use crate::{input::DateInput, DateTimeFormatterError, FormattedDateTime};
 use icu_calendar::any_calendar::{AnyCalendar, AnyCalendarKind};
-use icu_calendar::provider::{JapaneseErasV1Marker, JapaneseExtendedErasV1Marker};
+use icu_calendar::provider::{JapaneseErasV1Marker, JapaneseExtendedErasV1Marker, WeekDataV1Marker};
 use icu_calendar::Date;
 use icu_decimal::provider::DecimalSymbolsV1Marker;
 use icu_plurals::provider::OrdinalV1Marker;

--- a/components/datetime/src/any/date.rs
+++ b/components/datetime/src/any/date.rs
@@ -7,10 +7,12 @@ use alloc::string::String;
 
 use icu_provider::prelude::*;
 
-use crate::provider::{calendar::*};
+use crate::provider::calendar::*;
 use crate::{input::DateInput, DateTimeFormatterError, FormattedDateTime};
 use icu_calendar::any_calendar::{AnyCalendar, AnyCalendarKind};
-use icu_calendar::provider::{JapaneseErasV1Marker, JapaneseExtendedErasV1Marker, WeekDataV1Marker};
+use icu_calendar::provider::{
+    JapaneseErasV1Marker, JapaneseExtendedErasV1Marker, WeekDataV1Marker,
+};
 use icu_calendar::Date;
 use icu_decimal::provider::DecimalSymbolsV1Marker;
 use icu_plurals::provider::OrdinalV1Marker;

--- a/components/datetime/src/any/datetime.rs
+++ b/components/datetime/src/any/datetime.rs
@@ -9,10 +9,10 @@ use icu_provider::prelude::*;
 
 #[cfg(feature = "experimental")]
 use crate::options::components;
-use crate::provider::{calendar::*, date_time::PatternSelector, week_data::WeekDataV1Marker};
+use crate::provider::{calendar::*, date_time::PatternSelector};
 use crate::{input::DateTimeInput, DateTimeFormatterError, FormattedDateTime};
 use icu_calendar::any_calendar::{AnyCalendar, AnyCalendarKind};
-use icu_calendar::provider::{JapaneseErasV1Marker, JapaneseExtendedErasV1Marker};
+use icu_calendar::provider::{JapaneseErasV1Marker, JapaneseExtendedErasV1Marker, WeekDataV1Marker};
 use icu_calendar::{types::Time, DateTime};
 use icu_decimal::provider::DecimalSymbolsV1Marker;
 use icu_plurals::provider::OrdinalV1Marker;

--- a/components/datetime/src/any/datetime.rs
+++ b/components/datetime/src/any/datetime.rs
@@ -12,7 +12,9 @@ use crate::options::components;
 use crate::provider::{calendar::*, date_time::PatternSelector};
 use crate::{input::DateTimeInput, DateTimeFormatterError, FormattedDateTime};
 use icu_calendar::any_calendar::{AnyCalendar, AnyCalendarKind};
-use icu_calendar::provider::{JapaneseErasV1Marker, JapaneseExtendedErasV1Marker, WeekDataV1Marker};
+use icu_calendar::provider::{
+    JapaneseErasV1Marker, JapaneseExtendedErasV1Marker, WeekDataV1Marker,
+};
 use icu_calendar::{types::Time, DateTime};
 use icu_decimal::provider::DecimalSymbolsV1Marker;
 use icu_plurals::provider::OrdinalV1Marker;

--- a/components/datetime/src/any/zoned_datetime.rs
+++ b/components/datetime/src/any/zoned_datetime.rs
@@ -8,11 +8,11 @@ use alloc::string::String;
 use icu_provider::prelude::*;
 
 use crate::input::{DateTimeInput, ExtractedDateTimeInput, TimeZoneInput};
-use crate::provider::{self, calendar::*, date_time::PatternSelector, week_data::WeekDataV1Marker};
+use crate::provider::{self, calendar::*, date_time::PatternSelector};
 use crate::time_zone::TimeZoneFormatterOptions;
 use crate::{DateTimeFormatterError, FormattedZonedDateTime};
 use icu_calendar::any_calendar::{AnyCalendar, AnyCalendarKind};
-use icu_calendar::provider::{JapaneseErasV1Marker, JapaneseExtendedErasV1Marker};
+use icu_calendar::provider::{JapaneseErasV1Marker, JapaneseExtendedErasV1Marker, WeekDataV1Marker};
 use icu_calendar::{types::Time, DateTime};
 use icu_decimal::provider::DecimalSymbolsV1Marker;
 use icu_plurals::provider::OrdinalV1Marker;

--- a/components/datetime/src/any/zoned_datetime.rs
+++ b/components/datetime/src/any/zoned_datetime.rs
@@ -12,7 +12,9 @@ use crate::provider::{self, calendar::*, date_time::PatternSelector};
 use crate::time_zone::TimeZoneFormatterOptions;
 use crate::{DateTimeFormatterError, FormattedZonedDateTime};
 use icu_calendar::any_calendar::{AnyCalendar, AnyCalendarKind};
-use icu_calendar::provider::{JapaneseErasV1Marker, JapaneseExtendedErasV1Marker, WeekDataV1Marker};
+use icu_calendar::provider::{
+    JapaneseErasV1Marker, JapaneseExtendedErasV1Marker, WeekDataV1Marker,
+};
 use icu_calendar::{types::Time, DateTime};
 use icu_decimal::provider::DecimalSymbolsV1Marker;
 use icu_plurals::provider::OrdinalV1Marker;

--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -16,7 +16,7 @@ use core::marker::PhantomData;
 use icu_decimal::provider::DecimalSymbolsV1Marker;
 use icu_plurals::provider::OrdinalV1Marker;
 use icu_provider::prelude::*;
-use icu_calendar::provider::{WeekDataV1, WeekDataV1Marker};
+use icu_calendar::provider::WeekDataV1Marker;
 
 use crate::{
     calendar, input::DateInput, input::DateTimeInput, input::IsoTimeInput, CldrCalendar,

--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -9,7 +9,6 @@ use crate::{
     options::{length, preferences, DateTimeFormatterOptions},
     provider::calendar::{TimeLengthsV1Marker, TimeSymbolsV1Marker},
     provider::date_time::PatternSelector,
-    provider::week_data::WeekDataV1Marker,
     raw,
 };
 use alloc::string::String;
@@ -17,6 +16,7 @@ use core::marker::PhantomData;
 use icu_decimal::provider::DecimalSymbolsV1Marker;
 use icu_plurals::provider::OrdinalV1Marker;
 use icu_provider::prelude::*;
+use icu_calendar::provider::{WeekDataV1, WeekDataV1Marker};
 
 use crate::{
     calendar, input::DateInput, input::DateTimeInput, input::IsoTimeInput, CldrCalendar,

--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -13,10 +13,10 @@ use crate::{
 };
 use alloc::string::String;
 use core::marker::PhantomData;
+use icu_calendar::provider::WeekDataV1Marker;
 use icu_decimal::provider::DecimalSymbolsV1Marker;
 use icu_plurals::provider::OrdinalV1Marker;
 use icu_provider::prelude::*;
-use icu_calendar::provider::WeekDataV1Marker;
 
 use crate::{
     calendar, input::DateInput, input::DateTimeInput, input::IsoTimeInput, CldrCalendar,

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -5,7 +5,7 @@
 use crate::error::DateTimeFormatterError as Error;
 use crate::fields::{self, Field, FieldLength, FieldSymbol, Second, Week, Year};
 use crate::input::{
-    DateTimeInput, DateTimeInputWithCalendar, ExtractedDateTimeInput, LocalizedDateTimeInput,
+    DateTimeInput, DateTimeInputWithWeekConfig, ExtractedDateTimeInput, LocalizedDateTimeInput,
 };
 use crate::pattern::{
     runtime::{Pattern, PatternPlurals},
@@ -167,7 +167,7 @@ where
     T: DateTimeInput,
     W: fmt::Write + ?Sized,
 {
-    let loc_datetime = DateTimeInputWithCalendar::new(datetime, week_data.map(|v| v.into()));
+    let loc_datetime = DateTimeInputWithWeekConfig::new(datetime, week_data.map(|v| v.into()));
     let pattern = patterns.select(&loc_datetime, ordinal_rules)?;
     write_pattern(
         pattern,
@@ -546,7 +546,7 @@ mod tests {
                 .unwrap();
 
         let mut sink = String::new();
-        let loc_datetime = DateTimeInputWithCalendar::new(&datetime, None);
+        let loc_datetime = DateTimeInputWithWeekConfig::new(&datetime, None);
         write_pattern(
             &pattern,
             Some(date_data.get()),

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -18,7 +18,7 @@ use crate::provider::date_time::{DateSymbols, TimeSymbols};
 use core::fmt;
 use fixed_decimal::FixedDecimal;
 use icu_decimal::FixedDecimalFormatter;
-use icu_calendar::provider::{WeekDataV1, WeekDataV1Marker};
+use icu_calendar::provider::WeekDataV1;
 use icu_plurals::PluralRules;
 use icu_provider::DataPayload;
 use writeable::Writeable;

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -14,11 +14,11 @@ use crate::pattern::{
 use crate::provider;
 use crate::provider::calendar::patterns::PatternPluralsFromPatternsV1Marker;
 use crate::provider::date_time::{DateSymbols, TimeSymbols};
-use crate::provider::week_data::WeekDataV1;
 
 use core::fmt;
 use fixed_decimal::FixedDecimal;
 use icu_decimal::FixedDecimalFormatter;
+use icu_calendar::provider::{WeekDataV1, WeekDataV1Marker};
 use icu_plurals::PluralRules;
 use icu_provider::DataPayload;
 use writeable::Writeable;
@@ -167,7 +167,7 @@ where
     T: DateTimeInput,
     W: fmt::Write + ?Sized,
 {
-    let loc_datetime = DateTimeInputWithCalendar::new(datetime, week_data.map(|d| &d.0));
+    let loc_datetime = DateTimeInputWithCalendar::new(datetime, week_data.map(|v| v.into()));
     let pattern = patterns.select(&loc_datetime, ordinal_rules)?;
     write_pattern(
         pattern,

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -17,8 +17,8 @@ use crate::provider::date_time::{DateSymbols, TimeSymbols};
 
 use core::fmt;
 use fixed_decimal::FixedDecimal;
-use icu_decimal::FixedDecimalFormatter;
 use icu_calendar::provider::WeekDataV1;
+use icu_decimal::FixedDecimalFormatter;
 use icu_plurals::PluralRules;
 use icu_provider::DataPayload;
 use writeable::Writeable;
@@ -263,7 +263,7 @@ where
             Week::WeekOfYear => format_number(
                 w,
                 fixed_decimal_format,
-                FixedDecimal::from(datetime.week_of_year()?.1.0),
+                FixedDecimal::from(datetime.week_of_year()?.1 .0),
                 field.length,
             )?,
             Week::WeekOfMonth => format_number(

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -227,7 +227,7 @@ where
             Year::WeekOf => format_number(
                 w,
                 fixed_decimal_format,
-                FixedDecimal::from(datetime.year_week()?.number),
+                FixedDecimal::from(datetime.week_of_year()?.0.number),
                 field.length,
             )?,
         },
@@ -263,7 +263,7 @@ where
             Week::WeekOfYear => format_number(
                 w,
                 fixed_decimal_format,
-                FixedDecimal::from(datetime.week_of_year()?.0),
+                FixedDecimal::from(datetime.week_of_year()?.1.0),
                 field.length,
             )?,
             Week::WeekOfMonth => format_number(

--- a/components/datetime/src/format/zoned_datetime.rs
+++ b/components/datetime/src/format/zoned_datetime.rs
@@ -68,7 +68,7 @@ where
             .datetime_format
             .week_data
             .as_ref()
-            .map(|d| &d.get().0),
+            .map(|d| d.get().into()),
     );
 
     let pattern = patterns.get().0.select(

--- a/components/datetime/src/format/zoned_datetime.rs
+++ b/components/datetime/src/format/zoned_datetime.rs
@@ -7,7 +7,7 @@
 use crate::error::DateTimeFormatterError as Error;
 use crate::fields::{self, FieldSymbol};
 use crate::input::{
-    DateTimeInput, DateTimeInputWithCalendar, ExtractedDateTimeInput, ExtractedTimeZoneInput,
+    DateTimeInput, DateTimeInputWithWeekConfig, ExtractedDateTimeInput, ExtractedTimeZoneInput,
     LocalizedDateTimeInput, TimeZoneInput,
 };
 use crate::pattern::{runtime, PatternItem};
@@ -62,7 +62,7 @@ where
     W: fmt::Write + ?Sized,
 {
     let patterns = &zoned_datetime_format.datetime_format.patterns;
-    let loc_datetime = DateTimeInputWithCalendar::new(
+    let loc_datetime = DateTimeInputWithWeekConfig::new(
         datetime,
         zoned_datetime_format
             .datetime_format

--- a/components/datetime/src/input.rs
+++ b/components/datetime/src/input.rs
@@ -361,12 +361,14 @@ impl<'data, T: DateTimeInput> LocalizedDateTimeInput<T> for DateTimeInputWithWee
     }
 
     fn week_of_month(&self) -> Result<WeekOfMonth, DateTimeError> {
-        week_of_month(
-            self.data,
-            self.calendar
-                .ok_or(DateTimeError::MissingCalendar)?
-                .first_weekday,
-        )
+        let config = self.calendar.ok_or(DateTimeError::MissingCalendar)?;
+        let day_of_month = self.data
+            .day_of_month()
+            .ok_or(DateTimeError::MissingInput("DateTimeInput::day_of_month"))?;
+        let iso_weekday = self.data
+            .iso_weekday()
+            .ok_or(DateTimeError::MissingInput("DateTimeInput::iso_weekday"))?;
+        Ok(config.week_of_month(day_of_month, iso_weekday))
     }
 
     fn week_of_year(&self) -> Result<WeekOfYear, DateTimeError> {

--- a/components/datetime/src/input.rs
+++ b/components/datetime/src/input.rs
@@ -127,7 +127,7 @@ pub trait LocalizedDateTimeInput<T: DateTimeInput> {
 
 pub(crate) struct DateTimeInputWithCalendar<'data, T: DateTimeInput> {
     data: &'data T,
-    calendar: Option<&'data week_of::WeekOfYearConfigV1>,
+    calendar: Option<week_of::WeekOfYearConfig>,
 }
 
 /// A [`DateTimeInput`] type with all of the fields pre-extracted
@@ -268,7 +268,7 @@ impl TimeZoneInput for ExtractedTimeZoneInput {
 
 fn compute_week_of_year<T: DateInput>(
     datetime: &T,
-    calendar: &week_of::WeekOfYearConfigV1,
+    calendar: &week_of::WeekOfYearConfig,
 ) -> Result<(DayOfYearInfo, week_of::WeekOf), DateTimeError> {
     let doy_info = datetime
         .day_of_year_info()
@@ -289,7 +289,7 @@ fn compute_week_of_year<T: DateInput>(
 
 fn year_week<T: DateInput>(
     datetime: &T,
-    calendar: &week_of::WeekOfYearConfigV1,
+    calendar: &week_of::WeekOfYearConfig,
 ) -> Result<FormattableYear, DateTimeError> {
     let (doy_info, week) = compute_week_of_year(datetime, calendar)?;
     Ok(match week.unit {
@@ -303,7 +303,7 @@ fn year_week<T: DateInput>(
 
 fn week_of_year<T: DateInput>(
     datetime: &T,
-    calendar: &week_of::WeekOfYearConfigV1,
+    calendar: &week_of::WeekOfYearConfig,
 ) -> Result<WeekOfYear, DateTimeError> {
     let (_, week) = compute_week_of_year(datetime, calendar)?;
     Ok(WeekOfYear(u32::from(week.week)))
@@ -343,7 +343,7 @@ fn day_of_week_in_month<T: DateInput>(datetime: &T) -> Result<DayOfWeekInMonth, 
 }
 
 impl<'data, T: DateTimeInput> DateTimeInputWithCalendar<'data, T> {
-    pub(crate) fn new(data: &'data T, calendar: Option<&'data week_of::WeekOfYearConfigV1>) -> Self {
+    pub(crate) fn new(data: &'data T, calendar: Option<week_of::WeekOfYearConfig>) -> Self {
         Self { data, calendar }
     }
 }
@@ -356,7 +356,7 @@ impl<'data, T: DateTimeInput> LocalizedDateTimeInput<T> for DateTimeInputWithCal
     fn year_week(&self) -> Result<FormattableYear, DateTimeError> {
         year_week(
             self.data,
-            self.calendar.ok_or(DateTimeError::MissingCalendar)?,
+            self.calendar.as_ref().ok_or(DateTimeError::MissingCalendar)?,
         )
     }
 
@@ -372,7 +372,7 @@ impl<'data, T: DateTimeInput> LocalizedDateTimeInput<T> for DateTimeInputWithCal
     fn week_of_year(&self) -> Result<WeekOfYear, DateTimeError> {
         week_of_year(
             self.data,
-            self.calendar.ok_or(DateTimeError::MissingCalendar)?,
+            self.calendar.as_ref().ok_or(DateTimeError::MissingCalendar)?,
         )
     }
 

--- a/components/datetime/src/input.rs
+++ b/components/datetime/src/input.rs
@@ -125,7 +125,7 @@ pub trait LocalizedDateTimeInput<T: DateTimeInput> {
     fn flexible_day_period(&self);
 }
 
-pub(crate) struct DateTimeInputWithCalendar<'data, T: DateTimeInput> {
+pub(crate) struct DateTimeInputWithWeekConfig<'data, T: DateTimeInput> {
     data: &'data T,
     calendar: Option<week_of::WeekOfYearConfig>,
 }
@@ -342,13 +342,13 @@ fn day_of_week_in_month<T: DateInput>(datetime: &T) -> Result<DayOfWeekInMonth, 
     Ok(day_of_month.into())
 }
 
-impl<'data, T: DateTimeInput> DateTimeInputWithCalendar<'data, T> {
+impl<'data, T: DateTimeInput> DateTimeInputWithWeekConfig<'data, T> {
     pub(crate) fn new(data: &'data T, calendar: Option<week_of::WeekOfYearConfig>) -> Self {
         Self { data, calendar }
     }
 }
 
-impl<'data, T: DateTimeInput> LocalizedDateTimeInput<T> for DateTimeInputWithCalendar<'data, T> {
+impl<'data, T: DateTimeInput> LocalizedDateTimeInput<T> for DateTimeInputWithWeekConfig<'data, T> {
     fn datetime(&self) -> &T {
         self.data
     }

--- a/components/datetime/src/input.rs
+++ b/components/datetime/src/input.rs
@@ -7,9 +7,9 @@
 
 use crate::provider::time_zones::{MetaZoneId, TimeZoneBcp47Id};
 use icu_calendar::any_calendar::AnyCalendarKind;
+use icu_calendar::week::{RelativeUnit, WeekCalculator};
 use icu_calendar::Calendar;
 use icu_calendar::{AsCalendar, Date, DateTime, Iso};
-use icu_calendar::week::{WeekCalculator, RelativeUnit};
 use icu_timezone::{CustomTimeZone, GmtOffset, ZoneVariant};
 
 // TODO (Manishearth) fix up imports to directly import from icu_calendar
@@ -275,10 +275,12 @@ impl<'data, T: DateTimeInput> LocalizedDateTimeInput<T> for DateTimeInputWithWee
 
     fn week_of_month(&self) -> Result<WeekOfMonth, DateTimeError> {
         let config = self.calendar.ok_or(DateTimeError::MissingCalendar)?;
-        let day_of_month = self.data
+        let day_of_month = self
+            .data
             .day_of_month()
             .ok_or(DateTimeError::MissingInput("DateTimeInput::day_of_month"))?;
-        let iso_weekday = self.data
+        let iso_weekday = self
+            .data
             .iso_weekday()
             .ok_or(DateTimeError::MissingInput("DateTimeInput::iso_weekday"))?;
         Ok(config.week_of_month(day_of_month, iso_weekday))
@@ -286,16 +288,21 @@ impl<'data, T: DateTimeInput> LocalizedDateTimeInput<T> for DateTimeInputWithWee
 
     fn week_of_year(&self) -> Result<(FormattableYear, WeekOfYear), DateTimeError> {
         let config = self.calendar.ok_or(DateTimeError::MissingCalendar)?;
-        let day_of_year_info = self.data
+        let day_of_year_info = self
+            .data
             .day_of_year_info()
-            .ok_or(DateTimeError::MissingInput("DateTimeInput::day_of_year_info"))?;
-        let iso_weekday = self.data
+            .ok_or(DateTimeError::MissingInput(
+                "DateTimeInput::day_of_year_info",
+            ))?;
+        let iso_weekday = self
+            .data
             .iso_weekday()
             .ok_or(DateTimeError::MissingInput("DateTimeInput::iso_weekday"))?;
         let week_of = config.week_of_year(day_of_year_info, iso_weekday)?;
         let year = match week_of.unit {
             RelativeUnit::Previous => day_of_year_info.prev_year,
-            RelativeUnit::Current => self.data
+            RelativeUnit::Current => self
+                .data
                 .year()
                 .ok_or(DateTimeError::MissingInput("DateTimeInput::year"))?,
             RelativeUnit::Next => day_of_year_info.next_year,
@@ -304,7 +311,8 @@ impl<'data, T: DateTimeInput> LocalizedDateTimeInput<T> for DateTimeInputWithWee
     }
 
     fn day_of_week_in_month(&self) -> Result<DayOfWeekInMonth, DateTimeError> {
-        let day_of_month = self.data
+        let day_of_month = self
+            .data
             .day_of_month()
             .ok_or(DateTimeError::MissingInput("DateTimeInput::day_of_month"))?;
         Ok(day_of_month.into())

--- a/components/datetime/src/input.rs
+++ b/components/datetime/src/input.rs
@@ -127,7 +127,7 @@ pub trait LocalizedDateTimeInput<T: DateTimeInput> {
 
 pub(crate) struct DateTimeInputWithCalendar<'data, T: DateTimeInput> {
     data: &'data T,
-    calendar: Option<&'data week_of::CalendarInfo>,
+    calendar: Option<&'data week_of::WeekOfYearConfigV1>,
 }
 
 /// A [`DateTimeInput`] type with all of the fields pre-extracted
@@ -268,7 +268,7 @@ impl TimeZoneInput for ExtractedTimeZoneInput {
 
 fn compute_week_of_year<T: DateInput>(
     datetime: &T,
-    calendar: &week_of::CalendarInfo,
+    calendar: &week_of::WeekOfYearConfigV1,
 ) -> Result<(DayOfYearInfo, week_of::WeekOf), DateTimeError> {
     let doy_info = datetime
         .day_of_year_info()
@@ -289,7 +289,7 @@ fn compute_week_of_year<T: DateInput>(
 
 fn year_week<T: DateInput>(
     datetime: &T,
-    calendar: &week_of::CalendarInfo,
+    calendar: &week_of::WeekOfYearConfigV1,
 ) -> Result<FormattableYear, DateTimeError> {
     let (doy_info, week) = compute_week_of_year(datetime, calendar)?;
     Ok(match week.unit {
@@ -303,7 +303,7 @@ fn year_week<T: DateInput>(
 
 fn week_of_year<T: DateInput>(
     datetime: &T,
-    calendar: &week_of::CalendarInfo,
+    calendar: &week_of::WeekOfYearConfigV1,
 ) -> Result<WeekOfYear, DateTimeError> {
     let (_, week) = compute_week_of_year(datetime, calendar)?;
     Ok(WeekOfYear(u32::from(week.week)))
@@ -343,7 +343,7 @@ fn day_of_week_in_month<T: DateInput>(datetime: &T) -> Result<DayOfWeekInMonth, 
 }
 
 impl<'data, T: DateTimeInput> DateTimeInputWithCalendar<'data, T> {
-    pub(crate) fn new(data: &'data T, calendar: Option<&'data week_of::CalendarInfo>) -> Self {
+    pub(crate) fn new(data: &'data T, calendar: Option<&'data week_of::WeekOfYearConfigV1>) -> Self {
         Self { data, calendar }
     }
 }

--- a/components/datetime/src/pattern/runtime/plural.rs
+++ b/components/datetime/src/pattern/runtime/plural.rs
@@ -165,7 +165,7 @@ impl<'data> PatternPlurals<'data> {
             Self::MultipleVariants(plural_pattern) => {
                 let week_number = match plural_pattern.pivot_field() {
                     Week::WeekOfMonth => loc_datetime.week_of_month()?.0,
-                    Week::WeekOfYear => loc_datetime.week_of_year()?.1.0,
+                    Week::WeekOfYear => loc_datetime.week_of_year()?.1 .0,
                 };
                 let category = ordinal_rules
                     .ok_or(DateTimeFormatterError::MissingOrdinalRules)?

--- a/components/datetime/src/pattern/runtime/plural.rs
+++ b/components/datetime/src/pattern/runtime/plural.rs
@@ -165,7 +165,7 @@ impl<'data> PatternPlurals<'data> {
             Self::MultipleVariants(plural_pattern) => {
                 let week_number = match plural_pattern.pivot_field() {
                     Week::WeekOfMonth => loc_datetime.week_of_month()?.0,
-                    Week::WeekOfYear => loc_datetime.week_of_year()?.0,
+                    Week::WeekOfYear => loc_datetime.week_of_year()?.1.0,
                 };
                 let category = ordinal_rules
                     .ok_or(DateTimeFormatterError::MissingOrdinalRules)?

--- a/components/datetime/src/provider/mod.rs
+++ b/components/datetime/src/provider/mod.rs
@@ -15,8 +15,5 @@ pub mod calendar;
 /// Data providers for time zones.
 pub mod time_zones;
 
-/// Provider for week data.
-pub mod week_data;
-
 /// Traits for managing data needed by [`TypedDateTimeFormatter`](crate::TypedDateTimeFormatter).
 pub(crate) mod date_time;

--- a/components/datetime/src/provider/week_data.rs
+++ b/components/datetime/src/provider/week_data.rs
@@ -3,19 +3,3 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use icu_provider::prelude::*;
-
-/// An ICU4X mapping to a subset of CLDR weekData.
-/// See CLDR-JSON's weekData.json for more context.
-#[icu_provider::data_struct(marker(
-    WeekDataV1Marker,
-    "datetime/week_data@1",
-    fallback_by = "region"
-))]
-#[derive(Clone, Copy, Default)]
-#[cfg_attr(
-    feature = "datagen",
-    derive(serde::Serialize, databake::Bake),
-    databake(path = icu_datetime::provider::week_data),
-)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-pub struct WeekDataV1(pub icu_calendar::week_of::WeekOfYearConfigV1);

--- a/components/datetime/src/provider/week_data.rs
+++ b/components/datetime/src/provider/week_data.rs
@@ -1,5 +1,0 @@
-// This file is part of ICU4X. For terms of use, please see the file
-// called LICENSE at the top level of the ICU4X source tree
-// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
-
-use icu_provider::prelude::*;

--- a/components/datetime/src/provider/week_data.rs
+++ b/components/datetime/src/provider/week_data.rs
@@ -18,4 +18,4 @@ use icu_provider::prelude::*;
     databake(path = icu_datetime::provider::week_data),
 )]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-pub struct WeekDataV1(pub icu_calendar::week_of::CalendarInfo);
+pub struct WeekDataV1(pub icu_calendar::week_of::WeekOfYearConfigV1);

--- a/components/datetime/src/raw/datetime.rs
+++ b/components/datetime/src/raw/datetime.rs
@@ -19,7 +19,6 @@ use crate::{
             ErasedDateLengthsV1Marker, ErasedDateSymbolsV1Marker, TimeLengthsV1Marker,
             TimeSymbolsV1Marker,
         },
-        week_data::WeekDataV1Marker,
     },
     DateTimeFormatterError, FormattedDateTime,
 };
@@ -32,6 +31,7 @@ use icu_decimal::{
 };
 use icu_plurals::{provider::OrdinalV1Marker, PluralRules};
 use icu_provider::prelude::*;
+use icu_calendar::provider::WeekDataV1Marker;
 
 pub(crate) struct TimeFormatter {
     pub patterns: DataPayload<PatternPluralsFromPatternsV1Marker>,

--- a/components/datetime/src/raw/datetime.rs
+++ b/components/datetime/src/raw/datetime.rs
@@ -24,6 +24,7 @@ use crate::{
 };
 use alloc::string::String;
 
+use icu_calendar::provider::WeekDataV1Marker;
 use icu_decimal::{
     options::{FixedDecimalFormatterOptions, GroupingStrategy},
     provider::DecimalSymbolsV1Marker,
@@ -31,7 +32,6 @@ use icu_decimal::{
 };
 use icu_plurals::{provider::OrdinalV1Marker, PluralRules};
 use icu_provider::prelude::*;
-use icu_calendar::provider::WeekDataV1Marker;
 
 pub(crate) struct TimeFormatter {
     pub patterns: DataPayload<PatternPluralsFromPatternsV1Marker>,

--- a/components/datetime/src/raw/zoned_datetime.rs
+++ b/components/datetime/src/raw/zoned_datetime.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use alloc::string::String;
+use icu_calendar::provider::WeekDataV1Marker;
 use icu_decimal::{
     options::{FixedDecimalFormatterOptions, GroupingStrategy},
     provider::DecimalSymbolsV1Marker,
@@ -10,7 +11,6 @@ use icu_decimal::{
 };
 use icu_plurals::{provider::OrdinalV1Marker, PluralRules};
 use icu_provider::prelude::*;
-use icu_calendar::provider::WeekDataV1Marker;
 
 use crate::{
     format::{

--- a/components/datetime/src/raw/zoned_datetime.rs
+++ b/components/datetime/src/raw/zoned_datetime.rs
@@ -10,6 +10,7 @@ use icu_decimal::{
 };
 use icu_plurals::{provider::OrdinalV1Marker, PluralRules};
 use icu_provider::prelude::*;
+use icu_calendar::provider::WeekDataV1Marker;
 
 use crate::{
     format::{
@@ -25,7 +26,6 @@ use crate::{
             patterns::PatternPluralsFromPatternsV1Marker, ErasedDateSymbolsV1Marker,
             TimeLengthsV1Marker, TimeSymbolsV1Marker,
         },
-        week_data::WeekDataV1Marker,
     },
     raw,
     time_zone::{TimeZoneFormatter, TimeZoneFormatterOptions},

--- a/components/datetime/src/zoned_datetime.rs
+++ b/components/datetime/src/zoned_datetime.rs
@@ -4,7 +4,7 @@
 
 use alloc::string::String;
 use core::marker::PhantomData;
-use icu_calendar::provider::JapaneseErasV1Marker;
+use icu_calendar::provider::{JapaneseErasV1Marker, WeekDataV1Marker};
 use icu_decimal::provider::DecimalSymbolsV1Marker;
 use icu_plurals::provider::OrdinalV1Marker;
 use icu_provider::prelude::*;
@@ -18,7 +18,6 @@ use crate::{
         self,
         calendar::{TimeLengthsV1Marker, TimeSymbolsV1Marker},
         date_time::PatternSelector,
-        week_data::WeekDataV1Marker,
     },
     raw,
     time_zone::TimeZoneFormatterOptions,

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -14,8 +14,8 @@ use icu_calendar::{
     ethiopian::{Ethiopian, EthiopianEraStyle},
     indian::Indian,
     japanese::{Japanese, JapaneseExtended},
+    provider::WeekDataV1Marker,
     AsCalendar, DateTime, Gregorian, Iso,
-    provider::WeekDataV1Marker
 };
 use icu_datetime::provider::time_zones::{
     ExemplarCitiesV1Marker, MetaZoneGenericNamesLongV1Marker, MetaZoneGenericNamesShortV1Marker,
@@ -25,7 +25,7 @@ use icu_datetime::provider::time_zones::{
 use icu_datetime::time_zone::TimeZoneFormatterConfig;
 use icu_datetime::{
     pattern::runtime,
-    provider::{calendar::*},
+    provider::calendar::*,
     time_zone::{TimeZoneFormatter, TimeZoneFormatterOptions},
     CldrCalendar, DateTimeFormatter, DateTimeFormatterOptions, TimeFormatter, TypedDateFormatter,
     TypedDateTimeFormatter, TypedZonedDateTimeFormatter,

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -15,6 +15,7 @@ use icu_calendar::{
     indian::Indian,
     japanese::{Japanese, JapaneseExtended},
     AsCalendar, DateTime, Gregorian, Iso,
+    provider::WeekDataV1Marker
 };
 use icu_datetime::provider::time_zones::{
     ExemplarCitiesV1Marker, MetaZoneGenericNamesLongV1Marker, MetaZoneGenericNamesShortV1Marker,
@@ -24,7 +25,7 @@ use icu_datetime::provider::time_zones::{
 use icu_datetime::time_zone::TimeZoneFormatterConfig;
 use icu_datetime::{
     pattern::runtime,
-    provider::{calendar::*, week_data::WeekDataV1Marker},
+    provider::{calendar::*},
     time_zone::{TimeZoneFormatter, TimeZoneFormatterOptions},
     CldrCalendar, DateTimeFormatter, DateTimeFormatterOptions, TimeFormatter, TypedDateFormatter,
     TypedDateTimeFormatter, TypedZonedDateTimeFormatter,

--- a/ffi/diplomat/ffi_coverage/tests/missing_apis.txt
+++ b/ffi/diplomat/ffi_coverage/tests/missing_apis.txt
@@ -33,6 +33,8 @@ icu::calendar::Date::new_julian_date#FnInStruct
 icu::calendar::Date::to_any#FnInStruct
 icu::calendar::Date::to_calendar#FnInStruct
 icu::calendar::Date::to_iso#FnInStruct
+icu::calendar::Date::week_of_month#FnInStruct
+icu::calendar::Date::week_of_year#FnInStruct
 icu::calendar::Date::wrap_calendar_in_rc#FnInStruct
 icu::calendar::Date::year#FnInStruct
 icu::calendar::DateTime::from_minutes_since_local_unix_epoch#FnInStruct
@@ -91,6 +93,14 @@ icu::calendar::iso::Iso::new#FnInStruct
 icu::calendar::iso::Iso::to_any#FnInStruct
 icu::calendar::iso::Iso::to_any_cloned#FnInStruct
 icu::calendar::iso::IsoDateInner#Struct
+icu::calendar::week::RelativeUnit#Enum
+icu::calendar::week::WeekCalculator#Struct
+icu::calendar::week::WeekCalculator::try_new_unstable#FnInStruct
+icu::calendar::week::WeekCalculator::try_new_with_any_provider#FnInStruct
+icu::calendar::week::WeekCalculator::try_new_with_buffer_provider#FnInStruct
+icu::calendar::week::WeekCalculator::week_of_month#FnInStruct
+icu::calendar::week::WeekCalculator::week_of_year#FnInStruct
+icu::calendar::week::WeekOf#Struct
 icu::casemapping::CaseMapping#Struct
 icu::casemapping::CaseMapping::fold#FnInStruct
 icu::casemapping::CaseMapping::fold_turkic#FnInStruct
@@ -392,7 +402,6 @@ icu::datetime::input::LocalizedDateTimeInput::day_of_week_in_month#FnInTrait
 icu::datetime::input::LocalizedDateTimeInput::flexible_day_period#FnInTrait
 icu::datetime::input::LocalizedDateTimeInput::week_of_month#FnInTrait
 icu::datetime::input::LocalizedDateTimeInput::week_of_year#FnInTrait
-icu::datetime::input::LocalizedDateTimeInput::year_week#FnInTrait
 icu::datetime::input::MonthCode#Struct
 icu::datetime::input::MonthCode::Err#AssociatedTypeInStruct
 icu::datetime::input::MonthCode::from_str#FnInStruct

--- a/provider/core/src/helpers.rs
+++ b/provider/core/src/helpers.rs
@@ -230,6 +230,18 @@ macro_rules! gen_any_buffer_constructors {
         }
     };
 
+    (locale: include, options: skip, error: $error_ty:path) => {
+        $crate::gen_any_buffer_constructors!(
+            locale: include,
+            options: skip,
+            error: $error_ty,
+            functions: [
+                Self::try_new_unstable,
+                try_new_with_any_provider,
+                try_new_with_buffer_provider
+            ]
+        );
+    };
     (locale: include, options: skip, error: $error_ty:path, functions: [$f1:path, $f2:ident, $f3:ident]) => {
         #[doc = concat!("Create a new instance using an [`AnyProvider`](icu_provider::AnyProvider).\n\nSee also: [`", stringify!($f1), "`]")]
         pub fn $f2(provider: &(impl $crate::AnyProvider + ?Sized), locale: &$crate::DataLocale) -> Result<Self, $error_ty> {

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -383,7 +383,7 @@ fn test_keys_from_file() {
             icu_datetime::provider::calendar::GregorianDateSymbolsV1Marker::KEY,
             icu_plurals::provider::OrdinalV1Marker::KEY,
             icu_datetime::provider::calendar::TimeSymbolsV1Marker::KEY,
-            icu_datetime::provider::week_data::WeekDataV1Marker::KEY,
+            icu_calendar::provider::WeekDataV1Marker::KEY,
         ]
     );
 }
@@ -403,7 +403,7 @@ fn test_keys_from_bin() {
             icu_plurals::provider::OrdinalV1Marker::KEY,
             icu_datetime::provider::calendar::TimeLengthsV1Marker::KEY,
             icu_datetime::provider::calendar::TimeSymbolsV1Marker::KEY,
-            icu_datetime::provider::week_data::WeekDataV1Marker::KEY,
+            icu_calendar::provider::WeekDataV1Marker::KEY,
         ]
     );
 }

--- a/provider/datagen/src/registry.rs
+++ b/provider/datagen/src/registry.rs
@@ -8,7 +8,6 @@ use icu_calendar::provider::*;
 use icu_collator::provider::*;
 use icu_datetime::provider::calendar::*;
 use icu_datetime::provider::time_zones::*;
-use icu_datetime::provider::week_data::*;
 use icu_decimal::provider::*;
 use icu_list::provider::*;
 use icu_locid_transform::provider::*;

--- a/provider/datagen/src/transform/cldr/datetime/week_data.rs
+++ b/provider/datagen/src/transform/cldr/datetime/week_data.rs
@@ -6,7 +6,7 @@ use crate::transform::cldr::cldr_serde::{
     self,
     week_data::{Territory, DEFAULT_TERRITORY},
 };
-use icu_calendar::week_of::CalendarInfo;
+use icu_calendar::week_of::WeekOfYearConfigV1;
 use icu_datetime::provider::week_data::*;
 use icu_locid::LanguageIdentifier;
 use icu_provider::datagen::IterableDataProvider;
@@ -55,7 +55,7 @@ impl DataProvider<WeekDataV1Marker> for crate::DatagenProvider {
 
         Ok(DataResponse {
             metadata: Default::default(),
-            payload: Some(DataPayload::from_owned(WeekDataV1(CalendarInfo {
+            payload: Some(DataPayload::from_owned(WeekDataV1(WeekOfYearConfigV1 {
                 first_weekday: week_data
                     .first_day
                     .get(&territory)

--- a/provider/datagen/src/transform/cldr/datetime/week_data.rs
+++ b/provider/datagen/src/transform/cldr/datetime/week_data.rs
@@ -6,7 +6,7 @@ use crate::transform::cldr::cldr_serde::{
     self,
     week_data::{Territory, DEFAULT_TERRITORY},
 };
-use icu_calendar::week_of::WeekOfYearConfig;
+use icu_calendar::week_of::WeekCalculator;
 use icu_calendar::provider::{WeekDataV1, WeekDataV1Marker};
 use icu_locid::LanguageIdentifier;
 use icu_provider::datagen::IterableDataProvider;
@@ -55,7 +55,7 @@ impl DataProvider<WeekDataV1Marker> for crate::DatagenProvider {
 
         Ok(DataResponse {
             metadata: Default::default(),
-            payload: Some(DataPayload::from_owned(WeekDataV1(WeekOfYearConfig {
+            payload: Some(DataPayload::from_owned(WeekDataV1(WeekCalculator {
                 first_weekday: week_data
                     .first_day
                     .get(&territory)

--- a/provider/datagen/src/transform/cldr/datetime/week_data.rs
+++ b/provider/datagen/src/transform/cldr/datetime/week_data.rs
@@ -7,7 +7,6 @@ use crate::transform::cldr::cldr_serde::{
     week_data::{Territory, DEFAULT_TERRITORY},
 };
 use icu_calendar::provider::{WeekDataV1, WeekDataV1Marker};
-use icu_calendar::week_of::WeekCalculator;
 use icu_locid::LanguageIdentifier;
 use icu_provider::datagen::IterableDataProvider;
 use icu_provider::prelude::*;
@@ -55,7 +54,7 @@ impl DataProvider<WeekDataV1Marker> for crate::DatagenProvider {
 
         Ok(DataResponse {
             metadata: Default::default(),
-            payload: Some(DataPayload::from_owned(WeekDataV1(WeekCalculator {
+            payload: Some(DataPayload::from_owned(WeekDataV1 {
                 first_weekday: week_data
                     .first_day
                     .get(&territory)
@@ -72,7 +71,7 @@ impl DataProvider<WeekDataV1Marker> for crate::DatagenProvider {
                         "Missing default entry for minDays in weekData.json",
                     ))?
                     .0,
-            }))),
+            })),
         })
     }
 }

--- a/provider/datagen/src/transform/cldr/datetime/week_data.rs
+++ b/provider/datagen/src/transform/cldr/datetime/week_data.rs
@@ -6,8 +6,8 @@ use crate::transform::cldr::cldr_serde::{
     self,
     week_data::{Territory, DEFAULT_TERRITORY},
 };
-use icu_calendar::week_of::WeekOfYearConfigV1;
-use icu_datetime::provider::week_data::*;
+use icu_calendar::week_of::WeekOfYearConfig;
+use icu_calendar::provider::{WeekDataV1, WeekDataV1Marker};
 use icu_locid::LanguageIdentifier;
 use icu_provider::datagen::IterableDataProvider;
 use icu_provider::prelude::*;
@@ -55,7 +55,7 @@ impl DataProvider<WeekDataV1Marker> for crate::DatagenProvider {
 
         Ok(DataResponse {
             metadata: Default::default(),
-            payload: Some(DataPayload::from_owned(WeekDataV1(WeekOfYearConfigV1 {
+            payload: Some(DataPayload::from_owned(WeekDataV1(WeekOfYearConfig {
                 first_weekday: week_data
                     .first_day
                     .get(&territory)

--- a/provider/datagen/src/transform/cldr/datetime/week_data.rs
+++ b/provider/datagen/src/transform/cldr/datetime/week_data.rs
@@ -6,8 +6,8 @@ use crate::transform::cldr::cldr_serde::{
     self,
     week_data::{Territory, DEFAULT_TERRITORY},
 };
-use icu_calendar::week_of::WeekCalculator;
 use icu_calendar::provider::{WeekDataV1, WeekDataV1Marker};
+use icu_calendar::week_of::WeekCalculator;
 use icu_locid::LanguageIdentifier;
 use icu_provider::datagen::IterableDataProvider;
 use icu_provider::prelude::*;

--- a/provider/datagen/src/transform/cldr/datetime/week_data.rs
+++ b/provider/datagen/src/transform/cldr/datetime/week_data.rs
@@ -88,8 +88,8 @@ fn basic_cldr_week_data() {
         .unwrap()
         .take_payload()
         .unwrap();
-    assert_eq!(1, default_week_data.get().0.min_week_days);
-    assert_eq!(IsoWeekday::Monday, default_week_data.get().0.first_weekday);
+    assert_eq!(1, default_week_data.get().min_week_days);
+    assert_eq!(IsoWeekday::Monday, default_week_data.get().first_weekday);
 
     let fr_week_data: DataPayload<WeekDataV1Marker> = provider
         .load(DataRequest {
@@ -99,8 +99,8 @@ fn basic_cldr_week_data() {
         .unwrap()
         .take_payload()
         .unwrap();
-    assert_eq!(4, fr_week_data.get().0.min_week_days);
-    assert_eq!(IsoWeekday::Monday, fr_week_data.get().0.first_weekday);
+    assert_eq!(4, fr_week_data.get().min_week_days);
+    assert_eq!(IsoWeekday::Monday, fr_week_data.get().first_weekday);
 
     let iq_week_data: DataPayload<WeekDataV1Marker> = provider
         .load(DataRequest {
@@ -112,10 +112,10 @@ fn basic_cldr_week_data() {
         .unwrap();
     // Only first_weekday is defined for IQ, min_week_days uses the default.
     assert_eq!(
-        default_week_data.get().0.min_week_days,
-        iq_week_data.get().0.min_week_days
+        default_week_data.get().min_week_days,
+        iq_week_data.get().min_week_days
     );
-    assert_eq!(IsoWeekday::Saturday, iq_week_data.get().0.first_weekday);
+    assert_eq!(IsoWeekday::Saturday, iq_week_data.get().first_weekday);
 
     let gg_week_data: DataPayload<WeekDataV1Marker> = provider
         .load(DataRequest {
@@ -125,10 +125,10 @@ fn basic_cldr_week_data() {
         .unwrap()
         .take_payload()
         .unwrap();
-    assert_eq!(4, gg_week_data.get().0.min_week_days);
+    assert_eq!(4, gg_week_data.get().min_week_days);
     // Only min_week_days is defined for GG, first_weekday uses the default.
     assert_eq!(
-        default_week_data.get().0.first_weekday,
-        gg_week_data.get().0.first_weekday
+        default_week_data.get().first_weekday,
+        gg_week_data.get().first_weekday
     );
 }

--- a/provider/testdata/data/baked/any.rs
+++ b/provider/testdata/data/baked/any.rs
@@ -67,7 +67,7 @@ impl AnyProvider for BakedDataProvider {
         const TIMEZONEFORMATSV1MARKER: ::icu_provider::DataKeyHash =
             ::icu_datetime::provider::time_zones::TimeZoneFormatsV1Marker::KEY.get_hash();
         const WEEKDATAV1MARKER: ::icu_provider::DataKeyHash =
-            ::icu_datetime::provider::week_data::WeekDataV1Marker::KEY.get_hash();
+            ::icu_calendar::provider::WeekDataV1Marker::KEY.get_hash();
         const DECIMALSYMBOLSV1MARKER: ::icu_provider::DataKeyHash =
             ::icu_decimal::provider::DecimalSymbolsV1Marker::KEY.get_hash();
         const ANDLISTV1MARKER: ::icu_provider::DataKeyHash =

--- a/provider/testdata/data/baked/any.rs
+++ b/provider/testdata/data/baked/any.rs
@@ -6,7 +6,7 @@ impl AnyProvider for BakedDataProvider {
         const JAPANESEEXTENDEDERASV1MARKER: ::icu_provider::DataKeyHash =
             ::icu_calendar::provider::JapaneseExtendedErasV1Marker::KEY.get_hash();
         const WEEKDATAV1MARKER: ::icu_provider::DataKeyHash =
-            ::icu_calendar::week_of::WeekDataV1Marker::KEY.get_hash();
+            ::icu_calendar::provider::WeekDataV1Marker::KEY.get_hash();
         const CASEMAPPINGV1MARKER: ::icu_provider::DataKeyHash =
             ::icu_casemapping::provider::CaseMappingV1Marker::KEY.get_hash();
         const COLLATIONDATAV1MARKER: ::icu_provider::DataKeyHash =

--- a/provider/testdata/data/baked/any.rs
+++ b/provider/testdata/data/baked/any.rs
@@ -5,6 +5,8 @@ impl AnyProvider for BakedDataProvider {
             ::icu_calendar::provider::JapaneseErasV1Marker::KEY.get_hash();
         const JAPANESEEXTENDEDERASV1MARKER: ::icu_provider::DataKeyHash =
             ::icu_calendar::provider::JapaneseExtendedErasV1Marker::KEY.get_hash();
+        const WEEKDATAV1MARKER: ::icu_provider::DataKeyHash =
+            ::icu_calendar::week_of::WeekDataV1Marker::KEY.get_hash();
         const CASEMAPPINGV1MARKER: ::icu_provider::DataKeyHash =
             ::icu_casemapping::provider::CaseMappingV1Marker::KEY.get_hash();
         const COLLATIONDATAV1MARKER: ::icu_provider::DataKeyHash =
@@ -66,8 +68,6 @@ impl AnyProvider for BakedDataProvider {
                 .get_hash();
         const TIMEZONEFORMATSV1MARKER: ::icu_provider::DataKeyHash =
             ::icu_datetime::provider::time_zones::TimeZoneFormatsV1Marker::KEY.get_hash();
-        const WEEKDATAV1MARKER: ::icu_provider::DataKeyHash =
-            ::icu_calendar::provider::WeekDataV1Marker::KEY.get_hash();
         const DECIMALSYMBOLSV1MARKER: ::icu_provider::DataKeyHash =
             ::icu_decimal::provider::DecimalSymbolsV1Marker::KEY.get_hash();
         const ANDLISTV1MARKER: ::icu_provider::DataKeyHash =
@@ -247,6 +247,9 @@ impl AnyProvider for BakedDataProvider {
                 JAPANESEEXTENDEDERASV1MARKER => calendar::japanext_v1::DATA
                     .get_by(|k| req.locale.strict_cmp(k.as_bytes()).reverse())
                     .map(AnyPayload::from_static_ref),
+                WEEKDATAV1MARKER => datetime::week_data_v1_r::DATA
+                    .get_by(|k| req.locale.strict_cmp(k.as_bytes()).reverse())
+                    .map(AnyPayload::from_static_ref),
                 CASEMAPPINGV1MARKER => props::casemap_v1::DATA
                     .get_by(|k| req.locale.strict_cmp(k.as_bytes()).reverse())
                     .map(AnyPayload::from_static_ref),
@@ -341,9 +344,6 @@ impl AnyProvider for BakedDataProvider {
                     .get_by(|k| req.locale.strict_cmp(k.as_bytes()).reverse())
                     .map(AnyPayload::from_static_ref),
                 TIMEZONEFORMATSV1MARKER => time_zone::formats_v1::DATA
-                    .get_by(|k| req.locale.strict_cmp(k.as_bytes()).reverse())
-                    .map(AnyPayload::from_static_ref),
-                WEEKDATAV1MARKER => datetime::week_data_v1_r::DATA
                     .get_by(|k| req.locale.strict_cmp(k.as_bytes()).reverse())
                     .map(AnyPayload::from_static_ref),
                 DECIMALSYMBOLSV1MARKER => decimal::symbols_v1_u_nu::DATA

--- a/provider/testdata/data/baked/datetime/week_data_v1_r.rs
+++ b/provider/testdata/data/baked/datetime/week_data_v1_r.rs
@@ -1,6 +1,6 @@
 // @generated
 type DataStruct =
-    <::icu_calendar::week_of::WeekDataV1Marker as ::icu_provider::DataMarker>::Yokeable;
+    <::icu_calendar::provider::WeekDataV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
     litemap::LiteMap::from_sorted_store_unchecked(&[
         ("und", UND_UND_AI_UND_AL_UND_AM_UND_AR_UND_AU),
@@ -160,29 +160,30 @@ pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
         ("und-ZW", UND_AG_UND_AS_UND_BD_UND_BR_UND_BS_UND_BT),
     ]);
 static UND_AD_UND_AN_UND_AT_UND_AX_UND_BE_UND_BG: &DataStruct =
-    &::icu_calendar::week_of::WeekDataV1 {
+    &::icu_calendar::provider::WeekDataV1 {
         first_weekday: ::icu_calendar::types::IsoWeekday::Monday,
         min_week_days: 4u8,
     };
 static UND_AE_UND_AF_UND_BH_UND_DJ_UND_DZ_UND_EG: &DataStruct =
-    &::icu_calendar::week_of::WeekDataV1 {
+    &::icu_calendar::provider::WeekDataV1 {
         first_weekday: ::icu_calendar::types::IsoWeekday::Saturday,
         min_week_days: 1u8,
     };
 static UND_AG_UND_AS_UND_BD_UND_BR_UND_BS_UND_BT: &DataStruct =
-    &::icu_calendar::week_of::WeekDataV1 {
+    &::icu_calendar::provider::WeekDataV1 {
         first_weekday: ::icu_calendar::types::IsoWeekday::Sunday,
         min_week_days: 1u8,
     };
-static UND_MV: &DataStruct = &::icu_calendar::week_of::WeekDataV1 {
+static UND_MV: &DataStruct = &::icu_calendar::provider::WeekDataV1 {
     first_weekday: ::icu_calendar::types::IsoWeekday::Friday,
     min_week_days: 1u8,
 };
-static UND_PT: &DataStruct = &::icu_calendar::week_of::WeekDataV1 {
+static UND_PT: &DataStruct = &::icu_calendar::provider::WeekDataV1 {
     first_weekday: ::icu_calendar::types::IsoWeekday::Sunday,
     min_week_days: 4u8,
 };
-static UND_UND_AI_UND_AL_UND_AM_UND_AR_UND_AU: &DataStruct = &::icu_calendar::week_of::WeekDataV1 {
-    first_weekday: ::icu_calendar::types::IsoWeekday::Monday,
-    min_week_days: 1u8,
-};
+static UND_UND_AI_UND_AL_UND_AM_UND_AR_UND_AU: &DataStruct =
+    &::icu_calendar::provider::WeekDataV1 {
+        first_weekday: ::icu_calendar::types::IsoWeekday::Monday,
+        min_week_days: 1u8,
+    };

--- a/provider/testdata/data/baked/datetime/week_data_v1_r.rs
+++ b/provider/testdata/data/baked/datetime/week_data_v1_r.rs
@@ -1,6 +1,6 @@
 // @generated
 type DataStruct =
-    <::icu_calendar::provider::WeekDataV1Marker as ::icu_provider::DataMarker>::Yokeable;
+    <::icu_calendar::week_of::WeekDataV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
     litemap::LiteMap::from_sorted_store_unchecked(&[
         ("und", UND_UND_AI_UND_AL_UND_AM_UND_AR_UND_AU),
@@ -160,32 +160,29 @@ pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
         ("und-ZW", UND_AG_UND_AS_UND_BD_UND_BR_UND_BS_UND_BT),
     ]);
 static UND_AD_UND_AN_UND_AT_UND_AX_UND_BE_UND_BG: &DataStruct =
-    &::icu_datetime::provider::week_data::WeekDataV1(::icu_calendar::week_of::CalendarInfo {
+    &::icu_calendar::week_of::WeekDataV1 {
         first_weekday: ::icu_calendar::types::IsoWeekday::Monday,
         min_week_days: 4u8,
-    });
+    };
 static UND_AE_UND_AF_UND_BH_UND_DJ_UND_DZ_UND_EG: &DataStruct =
-    &::icu_datetime::provider::week_data::WeekDataV1(::icu_calendar::week_of::CalendarInfo {
+    &::icu_calendar::week_of::WeekDataV1 {
         first_weekday: ::icu_calendar::types::IsoWeekday::Saturday,
         min_week_days: 1u8,
-    });
+    };
 static UND_AG_UND_AS_UND_BD_UND_BR_UND_BS_UND_BT: &DataStruct =
-    &::icu_datetime::provider::week_data::WeekDataV1(::icu_calendar::week_of::CalendarInfo {
+    &::icu_calendar::week_of::WeekDataV1 {
         first_weekday: ::icu_calendar::types::IsoWeekday::Sunday,
         min_week_days: 1u8,
-    });
-static UND_MV: &DataStruct =
-    &::icu_datetime::provider::week_data::WeekDataV1(::icu_calendar::week_of::CalendarInfo {
-        first_weekday: ::icu_calendar::types::IsoWeekday::Friday,
-        min_week_days: 1u8,
-    });
-static UND_PT: &DataStruct =
-    &::icu_datetime::provider::week_data::WeekDataV1(::icu_calendar::week_of::CalendarInfo {
-        first_weekday: ::icu_calendar::types::IsoWeekday::Sunday,
-        min_week_days: 4u8,
-    });
-static UND_UND_AI_UND_AL_UND_AM_UND_AR_UND_AU: &DataStruct =
-    &::icu_datetime::provider::week_data::WeekDataV1(::icu_calendar::week_of::CalendarInfo {
-        first_weekday: ::icu_calendar::types::IsoWeekday::Monday,
-        min_week_days: 1u8,
-    });
+    };
+static UND_MV: &DataStruct = &::icu_calendar::week_of::WeekDataV1 {
+    first_weekday: ::icu_calendar::types::IsoWeekday::Friday,
+    min_week_days: 1u8,
+};
+static UND_PT: &DataStruct = &::icu_calendar::week_of::WeekDataV1 {
+    first_weekday: ::icu_calendar::types::IsoWeekday::Sunday,
+    min_week_days: 4u8,
+};
+static UND_UND_AI_UND_AL_UND_AM_UND_AR_UND_AU: &DataStruct = &::icu_calendar::week_of::WeekDataV1 {
+    first_weekday: ::icu_calendar::types::IsoWeekday::Monday,
+    min_week_days: 1u8,
+};

--- a/provider/testdata/data/baked/datetime/week_data_v1_r.rs
+++ b/provider/testdata/data/baked/datetime/week_data_v1_r.rs
@@ -1,6 +1,6 @@
 // @generated
 type DataStruct =
-    <::icu_datetime::provider::week_data::WeekDataV1Marker as ::icu_provider::DataMarker>::Yokeable;
+    <::icu_calendar::provider::WeekDataV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub static DATA: litemap::LiteMap<&str, &DataStruct, &[(&str, &DataStruct)]> =
     litemap::LiteMap::from_sorted_store_unchecked(&[
         ("und", UND_UND_AI_UND_AL_UND_AM_UND_AR_UND_AU),

--- a/provider/testdata/data/baked/mod.rs
+++ b/provider/testdata/data/baked/mod.rs
@@ -41,14 +41,14 @@ impl DataProvider<::icu_calendar::provider::JapaneseExtendedErasV1Marker> for Ba
         })
     }
 }
-impl DataProvider<::icu_calendar::week_of::WeekDataV1Marker> for BakedDataProvider {
-    fn load(&self, req: DataRequest) -> Result<DataResponse<::icu_calendar::week_of::WeekDataV1Marker>, DataError> {
+impl DataProvider<::icu_calendar::provider::WeekDataV1Marker> for BakedDataProvider {
+    fn load(&self, req: DataRequest) -> Result<DataResponse<::icu_calendar::provider::WeekDataV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),
             payload: Some(DataPayload::from_owned(zerofrom::ZeroFrom::zero_from(
                 *datetime::week_data_v1_r::DATA
                     .get_by(|k| req.locale.strict_cmp(k.as_bytes()).reverse())
-                    .ok_or_else(|| DataErrorKind::MissingLocale.with_req(::icu_calendar::week_of::WeekDataV1Marker::KEY, req))?,
+                    .ok_or_else(|| DataErrorKind::MissingLocale.with_req(::icu_calendar::provider::WeekDataV1Marker::KEY, req))?,
             ))),
         })
     }

--- a/provider/testdata/data/baked/mod.rs
+++ b/provider/testdata/data/baked/mod.rs
@@ -41,6 +41,18 @@ impl DataProvider<::icu_calendar::provider::JapaneseExtendedErasV1Marker> for Ba
         })
     }
 }
+impl DataProvider<::icu_calendar::week_of::WeekDataV1Marker> for BakedDataProvider {
+    fn load(&self, req: DataRequest) -> Result<DataResponse<::icu_calendar::week_of::WeekDataV1Marker>, DataError> {
+        Ok(DataResponse {
+            metadata: Default::default(),
+            payload: Some(DataPayload::from_owned(zerofrom::ZeroFrom::zero_from(
+                *datetime::week_data_v1_r::DATA
+                    .get_by(|k| req.locale.strict_cmp(k.as_bytes()).reverse())
+                    .ok_or_else(|| DataErrorKind::MissingLocale.with_req(::icu_calendar::week_of::WeekDataV1Marker::KEY, req))?,
+            ))),
+        })
+    }
+}
 impl DataProvider<::icu_casemapping::provider::CaseMappingV1Marker> for BakedDataProvider {
     fn load(&self, req: DataRequest) -> Result<DataResponse<::icu_casemapping::provider::CaseMappingV1Marker>, DataError> {
         Ok(DataResponse {
@@ -427,18 +439,6 @@ impl DataProvider<::icu_datetime::provider::time_zones::TimeZoneFormatsV1Marker>
                 *time_zone::formats_v1::DATA
                     .get_by(|k| req.locale.strict_cmp(k.as_bytes()).reverse())
                     .ok_or_else(|| DataErrorKind::MissingLocale.with_req(::icu_datetime::provider::time_zones::TimeZoneFormatsV1Marker::KEY, req))?,
-            ))),
-        })
-    }
-}
-impl DataProvider<::icu_calendar::provider::WeekDataV1Marker> for BakedDataProvider {
-    fn load(&self, req: DataRequest) -> Result<DataResponse<::icu_datetime::provider::week_data::WeekDataV1Marker>, DataError> {
-        Ok(DataResponse {
-            metadata: Default::default(),
-            payload: Some(DataPayload::from_owned(zerofrom::ZeroFrom::zero_from(
-                *datetime::week_data_v1_r::DATA
-                    .get_by(|k| req.locale.strict_cmp(k.as_bytes()).reverse())
-                    .ok_or_else(|| DataErrorKind::MissingLocale.with_req(::icu_datetime::provider::week_data::WeekDataV1Marker::KEY, req))?,
             ))),
         })
     }

--- a/provider/testdata/data/baked/mod.rs
+++ b/provider/testdata/data/baked/mod.rs
@@ -431,7 +431,7 @@ impl DataProvider<::icu_datetime::provider::time_zones::TimeZoneFormatsV1Marker>
         })
     }
 }
-impl DataProvider<::icu_datetime::provider::week_data::WeekDataV1Marker> for BakedDataProvider {
+impl DataProvider<::icu_calendar::provider::WeekDataV1Marker> for BakedDataProvider {
     fn load(&self, req: DataRequest) -> Result<DataResponse<::icu_datetime::provider::week_data::WeekDataV1Marker>, DataError> {
         Ok(DataResponse {
             metadata: Default::default(),


### PR DESCRIPTION
Fixes #2421 (except FFI which I'll do later)

This makes the `week_of` module private and instead exports only select parts of it, as well as exposing the functionality via `Date`. It also moves the WeekDataV1 data struct into the icu_calendar crate.