### PR TITLE
Fix clippy for the non_exhaustive enums.

### DIFF
--- a/components/decimal/src/format.rs
+++ b/components/decimal/src/format.rs
@@ -26,7 +26,7 @@ impl<'l> FormattedFixedDecimal<'l> {
             Sign::None => None,
             Sign::Negative => Some(&self.symbols.minus_sign_affixes),
             Sign::Positive => Some(&self.symbols.plus_sign_affixes),
-            _ => None, // This should not happen, because all the cases are covered.
+            _ => unreachable!("This should not happen, because all the cases are covered."),
         }
     }
 }

--- a/components/decimal/src/format.rs
+++ b/components/decimal/src/format.rs
@@ -23,9 +23,10 @@ pub struct FormattedFixedDecimal<'l> {
 impl<'l> FormattedFixedDecimal<'l> {
     fn get_affixes(&self) -> Option<&AffixesV1> {
         match self.value.sign() {
-            Sign::Negative => Some(&self.symbols.minus_sign_affixes),
             Sign::None => None,
+            Sign::Negative => Some(&self.symbols.minus_sign_affixes),
             Sign::Positive => Some(&self.symbols.plus_sign_affixes),
+            _ => None, // This should not happen, because all the cases are covered.
         }
     }
 }

--- a/ffi/diplomat/src/fixed_decimal.rs
+++ b/ffi/diplomat/src/fixed_decimal.rs
@@ -318,7 +318,7 @@ impl From<Sign> for ffi::ICU4XFixedDecimalSign {
             Sign::None => Self::None,
             Sign::Negative => Self::Negative,
             Sign::Positive => Self::Positive,
-            _ => Self::None, // This should not happen, because all the cases are covered.
+            _ => unreachable!("This should not happen, because all the cases are covered."),
         }
     }
 }

--- a/ffi/diplomat/src/fixed_decimal.rs
+++ b/ffi/diplomat/src/fixed_decimal.rs
@@ -318,6 +318,7 @@ impl From<Sign> for ffi::ICU4XFixedDecimalSign {
             Sign::None => Self::None,
             Sign::Negative => Self::Negative,
             Sign::Positive => Self::Positive,
+            _ => Self::None, // This should not happen, because all the cases are covered.
         }
     }
 }

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -118,8 +118,8 @@ pub struct FixedDecimal {
 }
 
 /// A specification of the sign used when formatting a number.
+#[non_exhaustive]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-#[allow(clippy::exhaustive_enums)] // TODO(#1668)
 pub enum Sign {
     /// No sign (implicitly positive, e.g., 1729).
     None,
@@ -1945,9 +1945,9 @@ impl FromStr for FixedDecimal {
 /// specifies not only the point on the number line but also the precision of the number to a
 /// specific power of 10. This enum augments a floating-point value with the additional
 /// information required by FixedDecimal.
+#[non_exhaustive]
 #[cfg(feature = "ryu")]
 #[derive(Debug, Clone, Copy)]
-#[allow(clippy::exhaustive_enums)] // TODO(#1668)
 pub enum DoublePrecision {
     /// Specify that the floating point number is integer-valued.
     ///


### PR DESCRIPTION
part of: https://github.com/unicode-org/icu4x/issues/1668
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->