### PR TITLE
Mark generated files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,8 @@
 *.postcard  binary
-provider/testdata/data/baked linguist-generated=true
-provider/testdata/data/json linguist-generated=true
-provider/testdata/data/cldr linguist-generated=true
-provider/testdata/data/icuexport linguist-generated=true
+provider/testdata/data/baked/** linguist-generated=true
+provider/testdata/data/json/** linguist-generated=true
+provider/testdata/data/cldr/** linguist-generated=true
+provider/testdata/data/icuexport/** linguist-generated=true
 ffi/diplomat/c/include/** linguist-generated=true
 ffi/diplomat/cpp/include/** linguist-generated=true
 ffi/diplomat/cpp/docs/** linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,7 @@
 *.postcard  binary
+provider/testdata/data/** linguist-generated=true
+ffi/diplomat/c/include/** linguist-generated=true
+ffi/diplomat/cpp/include/** linguist-generated=true
+ffi/diplomat/cpp/docs/** linguist-generated=true
+ffi/diplomat/wasm/icu4x/lib/** linguist-generated=true
+ffi/diplomat/wasm/icu4x/docs/** linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
 *.postcard  binary
-provider/testdata/data/** linguist-generated=true
+provider/testdata/data/baked linguist-generated=true
+provider/testdata/data/json linguist-generated=true
+provider/testdata/data/cldr linguist-generated=true
+provider/testdata/data/icuexport linguist-generated=true
 ffi/diplomat/c/include/** linguist-generated=true
 ffi/diplomat/cpp/include/** linguist-generated=true
 ffi/diplomat/cpp/docs/** linguist-generated=true


### PR DESCRIPTION
This ought to collapse them by default in PR view (though you can still expand them, and it will still show folders which is part of what makes things slow)

Ought to be a little bit nicer for reviewing.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->