### PR TITLE
Hide fields of certain non-provider library structs

### DIFF
--- a/components/collections/src/char16trie/trie.rs
+++ b/components/collections/src/char16trie/trie.rs
@@ -82,6 +82,7 @@ fn skip_node_value(pos: usize, lead: u16) -> usize {
 pub struct Char16Trie<'data> {
     /// An array of u16 containing the trie data.
     #[cfg_attr(feature = "serde", serde(borrow))]
+    #[doc(hidden)] // #2417
     pub data: ZeroVec<'data, u16>,
 }
 

--- a/components/properties/src/script.rs
+++ b/components/properties/src/script.rs
@@ -253,6 +253,7 @@ pub struct ScriptWithExtensions<'data> {
     /// When the lower 10 bits of the value are used as an index, that index is
     /// used for the outer-level vector of the nested `extensions` structure.
     #[cfg_attr(feature = "serde", serde(borrow))]
+    #[doc(hidden)] // #2417
     pub trie: CodePointTrie<'data, ScriptWithExt>,
 
     /// This companion structure stores Script_Extensions values, which are
@@ -261,6 +262,7 @@ pub struct ScriptWithExtensions<'data> {
     /// sub-vector represents the Script_Extensions array value for a code point,
     /// and may also indicate Script value, as described for the `trie` field.
     #[cfg_attr(feature = "serde", serde(borrow))]
+    #[doc(hidden)] // #2417
     pub extensions: VarZeroVec<'data, ZeroSlice<Script>>,
 }
 


### PR DESCRIPTION
Fixes #2417

I scrubbed the library code. The two structs mentioned in the issue were the only ones that seemed good for making this change. There are a lot of other structs I analyzed, but I excluded them if they were:

- In a `provider` or `serde` module
- `#[doc(hidden)]`, private, experimental, or test code
- Newtypes
- Enums
- Things that appeared to be intended for public manipulation, like CodePointTrieHeader
- Things that are in low-level modules, like `datetime::fields` and `plurals::ast`