### PR TITLE
Fix feature specification in provider/fs

### DIFF
--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -54,8 +54,6 @@ icu_provider = { version = "1.0.0-beta1", path = "../core", features = ["deseria
 criterion = "0.3.3"
 
 [features]
-deserialize_bincode_1 = ["icu_provider/deserialize_bincode_1"]
-deserialize_postcard_07 = ["icu_provider/deserialize_postcard_07"]
 # Enables the "export" module and FilesystemExporter
 export = [
     "log",
@@ -66,8 +64,6 @@ export = [
     "sha2",
     "icu_provider/datagen",
     "icu_provider/deserialize_json",
-    "deserialize_bincode_1",
-    "deserialize_postcard_07",
 ]
 bench = []
 

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -64,6 +64,8 @@ export = [
     "sha2",
     "icu_provider/datagen",
     "icu_provider/deserialize_json",
+    "icu_provider/deserialize_bincode_1",
+    "icu_provider/deserialize_postcard_07",
 ]
 bench = []
 

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -54,6 +54,8 @@ icu_provider = { version = "1.0.0-beta1", path = "../core", features = ["deseria
 criterion = "0.3.3"
 
 [features]
+deserialize_bincode_1 = ["icu_provider/deserialize_bincode_1"]
+deserialize_postcard_07 = ["icu_provider/deserialize_postcard_07"]
 # Enables the "export" module and FilesystemExporter
 export = [
     "log",
@@ -64,8 +66,8 @@ export = [
     "sha2",
     "icu_provider/datagen",
     "icu_provider/deserialize_json",
-    "icu_provider/deserialize_bincode_1",
-    "icu_provider/deserialize_postcard_07",
+    "deserialize_bincode_1",
+    "deserialize_postcard_07",
 ]
 bench = []
 

--- a/provider/fs/benches/provider_fs.rs
+++ b/provider/fs/benches/provider_fs.rs
@@ -66,6 +66,7 @@ fn json_bench(c: &mut Criterion) {
     });
 }
 
+#[cfg(all(feature = "bench"))]
 fn bincode_bench(c: &mut Criterion) {
     let provider = FsDataProvider::try_new("./tests/data/bincode")
         .expect("Loading file from testdata directory");
@@ -98,6 +99,7 @@ fn bincode_bench(c: &mut Criterion) {
     });
 }
 
+#[cfg(all(feature = "bench"))]
 fn postcard_bench(c: &mut Criterion) {
     let provider = FsDataProvider::try_new("./tests/data/postcard")
         .expect("Loading file from testdata directory");

--- a/provider/fs/benches/provider_fs.rs
+++ b/provider/fs/benches/provider_fs.rs
@@ -29,9 +29,7 @@ fn overview_bench(c: &mut Criterion) {
     #[cfg(feature = "bench")]
     {
         json_bench(c);
-        #[cfg(feature = "deserialize_bincode_1")]
         bincode_bench(c);
-        #[cfg(feature = "deserialize_postcard_07")]
         postcard_bench(c);
     }
 }
@@ -68,7 +66,6 @@ fn json_bench(c: &mut Criterion) {
     });
 }
 
-#[cfg(all(feature = "bench", feature = "deserialize_bincode_1"))]
 fn bincode_bench(c: &mut Criterion) {
     let provider = FsDataProvider::try_new("./tests/data/bincode")
         .expect("Loading file from testdata directory");
@@ -101,7 +98,6 @@ fn bincode_bench(c: &mut Criterion) {
     });
 }
 
-#[cfg(all(feature = "bench", feature = "deserialize_postcard_07"))]
 fn postcard_bench(c: &mut Criterion) {
     let provider = FsDataProvider::try_new("./tests/data/postcard")
         .expect("Loading file from testdata directory");


### PR DESCRIPTION
Fixed `feature` references in `provider/fs` modules that are used in benchmarks by creating `feature`s that are named the same following the examples in `ffi` crate.

This should fix issue #2525 