### PR TITLE
Remove heapless feature from serde-json-core.

### DIFF
--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -36,7 +36,7 @@ all-features = true
 icu_provider = { version = "1.0.0-beta1", path = "../core", features = ["serde", "std"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 displaydoc = { version = "0.2.3", default-features = false }
-serde-json-core = { version = "0.4", features = ["std"] }
+serde-json-core = { version = "0.4", default-features = false, features = ["std"] }
 writeable = { version = "0.4", path = "../../utils/writeable" }
 
 # Dependencies for the export feature


### PR DESCRIPTION
provider_fs has serde-json-core crate dependency and it has heapless crate dependency as default if using default feature.

When using cargo vendor (we use it in Gecko), a lot of unnecessary crates are copied since heapless has a lot of dependencies. So I would like to avoid it.