### PR TITLE
Remove more for push usages in favor of extend

### DIFF
--- a/components/datetime/src/pattern/reference/parser.rs
+++ b/components/datetime/src/pattern/reference/parser.rs
@@ -128,9 +128,11 @@ impl<'p> Parser<'p> {
                 return Err(PatternError::UnclosedLiteral);
             }
             Segment::Literal { literal, .. } => {
-                for ch in literal.chars() {
-                    result.push(ch.into());
-                }
+                let items = literal
+                    .chars()
+                    .map(|ch| ch.into())
+                    .collect::<Vec<PatternItem>>();
+                result.extend(items);
             }
         }
         Ok(())
@@ -146,9 +148,11 @@ impl<'p> Parser<'p> {
             }
             Segment::Literal { literal, .. } => {
                 if !literal.is_empty() {
-                    for ch in literal.chars() {
-                        result.push(ch.into());
-                    }
+                    let items = literal
+                        .chars()
+                        .map(|ch| ch.into())
+                        .collect::<Vec<GenericPatternItem>>();
+                    result.extend(items);
                 }
             }
             #[allow(clippy::panic)] // TODO(#1668) Clippy exceptions need docs or fixing.

--- a/components/datetime/src/pattern/reference/parser.rs
+++ b/components/datetime/src/pattern/reference/parser.rs
@@ -128,11 +128,7 @@ impl<'p> Parser<'p> {
                 return Err(PatternError::UnclosedLiteral);
             }
             Segment::Literal { literal, .. } => {
-                let items = literal
-                    .chars()
-                    .map(|ch| ch.into())
-                    .collect::<Vec<PatternItem>>();
-                result.extend(items);
+                result.extend(literal.chars().map(PatternItem::from));
             }
         }
         Ok(())
@@ -148,11 +144,7 @@ impl<'p> Parser<'p> {
             }
             Segment::Literal { literal, .. } => {
                 if !literal.is_empty() {
-                    let items = literal
-                        .chars()
-                        .map(|ch| ch.into())
-                        .collect::<Vec<GenericPatternItem>>();
-                    result.extend(items);
+                    result.extend(literal.chars().map(GenericPatternItem::from))
                 }
             }
             #[allow(clippy::panic)] // TODO(#1668) Clippy exceptions need docs or fixing.

--- a/components/locid/benches/helpers/macros.rs
+++ b/components/locid/benches/helpers/macros.rs
@@ -17,10 +17,7 @@ macro_rules! overview {
                     .filter(|&v| v.normalizing_eq($compare))
                     .count();
 
-                let mut strings = vec![];
-                for value in &values {
-                    strings.push(value.to_string());
-                }
+                &values.iter().map(|v| v.to_string()).collect<Vec<String>>()
             })
         });
     };

--- a/components/locid/benches/helpers/macros.rs
+++ b/components/locid/benches/helpers/macros.rs
@@ -17,7 +17,7 @@ macro_rules! overview {
                     .filter(|&v| v.normalizing_eq($compare))
                     .count();
 
-                &values.iter().map(|v| v.to_string()).collect<Vec<String>>()
+                values.iter().map(|v| v.to_string()).collect::<Vec<String>>()
             })
         });
     };

--- a/components/locid/benches/helpers/macros.rs
+++ b/components/locid/benches/helpers/macros.rs
@@ -17,7 +17,10 @@ macro_rules! overview {
                     .filter(|&v| v.normalizing_eq($compare))
                     .count();
 
-                values.iter().map(|v| v.to_string()).collect::<Vec<String>>()
+                values
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<String>>()
             })
         });
     };

--- a/components/locid_transform/src/canonicalizer.rs
+++ b/components/locid_transform/src/canonicalizer.rs
@@ -411,9 +411,7 @@ impl LocaleCanonicalizer {
                 }
 
                 if !modified.is_empty() {
-                    for variant in unmodified {
-                        modified.push(variant);
-                    }
+                    modified.extend(unmodified);
                     modified.sort();
                     modified.dedup();
                     locale.id.variants = Variants::from_vec_unchecked(modified);

--- a/provider/datagen/src/transform/icuexport/normalizer/mod.rs
+++ b/provider/datagen/src/transform/icuexport/normalizer/mod.rs
@@ -97,9 +97,8 @@ macro_rules! normalization_tables_provider {
                     .map(|&u| {
                         u.try_into()
                             .map_err(|_| DataError::custom("scalars24 conversion"))
-                            .unwrap()
                     })
-                    .collect::<Vec<char>>();
+                    .collect::<Result<Vec<char>, DataError>>()?;
                 Ok(DataResponse {
                     metadata: DataResponseMetadata::default(),
                     payload: Some(DataPayload::from_owned(DecompositionTablesV1 {
@@ -149,9 +148,8 @@ macro_rules! normalization_non_recursive_decomposition_supplement_provider {
                     .map(|&u| {
                         u.try_into()
                             .map_err(|_| DataError::custom("scalars24 conversion"))
-                            .unwrap()
                     })
-                    .collect::<Vec<char>>();
+                    .collect::<Result<Vec<char>, DataError>>()?;
 
                 Ok(DataResponse {
                     metadata: DataResponseMetadata::default(),

--- a/provider/datagen/src/transform/icuexport/normalizer/mod.rs
+++ b/provider/datagen/src/transform/icuexport/normalizer/mod.rs
@@ -92,12 +92,15 @@ macro_rules! normalization_tables_provider {
             $file_name,
             {
                 let mut scalars24: Vec<char> = Vec::new();
-                for &u in toml_data.scalars32.iter() {
-                    scalars24.push(
+                let scalars24 = toml_data
+                    .scalars32
+                    .iter()
+                    .map(|&u| {
                         u.try_into()
-                            .map_err(|_| DataError::custom("scalars24 conversion"))?,
-                    );
-                }
+                            .map_err(|_| DataError::custom("scalars24 conversion"))
+                            .unwrap()
+                    })
+                    .collect::<Vec<char>>();
                 Ok(DataResponse {
                     metadata: DataResponseMetadata::default(),
                     payload: Some(DataPayload::from_owned(DecompositionTablesV1 {
@@ -141,13 +144,15 @@ macro_rules! normalization_non_recursive_decomposition_supplement_provider {
             {
                 let trie = CodePointTrie::<u32>::try_from(&toml_data.trie)
                     .map_err(|e| DataError::custom("trie conversion").with_display_context(&e))?;
-                let mut scalars24: Vec<char> = Vec::new();
-                for &u in toml_data.scalars32.iter() {
-                    scalars24.push(
+                let scalars24 = toml_data
+                    .scalars32
+                    .iter()
+                    .map(|&u| {
                         u.try_into()
-                            .map_err(|_| DataError::custom("scalars24 conversion"))?,
-                    );
-                }
+                            .map_err(|_| DataError::custom("scalars24 conversion"))
+                            .unwrap()
+                    })
+                    .collect::<Vec<char>>();
 
                 Ok(DataResponse {
                     metadata: DataResponseMetadata::default(),

--- a/provider/datagen/src/transform/icuexport/normalizer/mod.rs
+++ b/provider/datagen/src/transform/icuexport/normalizer/mod.rs
@@ -91,7 +91,6 @@ macro_rules! normalization_tables_provider {
             DecompositionTables,
             $file_name,
             {
-                let mut scalars24: Vec<char> = Vec::new();
                 let scalars24 = toml_data
                     .scalars32
                     .iter()


### PR DESCRIPTION
Continuation of fix for #2482. Removed trivial `for { vec.push }` usages in favor of `vec.extend`.