### PR TITLE
Create data provider for an ideal components bag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,7 +1569,9 @@ dependencies = [
 name = "icu_datetime_bag_v2"
 version = "0.1.0"
 dependencies = [
+ "bitflags",
  "databake",
+ "displaydoc",
  "icu_datetime",
  "icu_provider",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,6 +691,8 @@ dependencies = [
  "icu_datetime",
  "icu_provider",
  "serde",
+ "yoke",
+ "zerovec 0.8.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,18 +684,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "datetime_bag_v2"
-version = "0.1.0"
-dependencies = [
- "databake",
- "icu_datetime",
- "icu_provider",
- "serde",
- "yoke",
- "zerovec 0.8.1",
-]
-
-[[package]]
 name = "deduplicating_array"
 version = "0.1.2"
 dependencies = [
@@ -1513,6 +1501,7 @@ dependencies = [
  "icu_collator",
  "icu_collections",
  "icu_datetime",
+ "icu_datetime_bag_v2",
  "icu_decimal",
  "icu_list",
  "icu_locid",
@@ -1573,6 +1562,18 @@ dependencies = [
  "smallvec",
  "tinystr 0.6.2",
  "writeable",
+ "zerovec 0.8.1",
+]
+
+[[package]]
+name = "icu_datetime_bag_v2"
+version = "0.1.0"
+dependencies = [
+ "databake",
+ "icu_datetime",
+ "icu_provider",
+ "serde",
+ "yoke",
  "zerovec 0.8.1",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "datetime_bag_v2"
+version = "0.1.0"
+dependencies = [
+ "databake",
+ "icu_datetime",
+ "icu_provider",
+ "serde",
+]
+
+[[package]]
 name = "deduplicating_array"
 version = "0.1.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "utils/databake",
     "utils/databake/derive",
     "experimental/segmenter",
+    "experimental/datetime_bag_v2",
     "ffi/capi_cdylib",
     "ffi/diplomat",
     "ffi/diplomat/ffi_coverage",

--- a/components/datetime/src/pattern/error.rs
+++ b/components/datetime/src/pattern/error.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use core::convert::Infallible;
+
 use crate::fields;
 use displaydoc::Display;
 
@@ -25,6 +27,10 @@ pub enum PatternError {
     UnclosedPlaceholder,
     #[displaydoc("plural pattern variants are only supported for week-of-month and week-of-year")]
     UnsupportedPluralPivot,
+    #[displaydoc("placeholders are only supported in generic and mixed patterns")]
+    UnsupportedPlaceholder,
+    #[displaydoc("fields are only supported in plain and mixed patterns")]
+    UnsupportedFields,
 }
 
 #[cfg(feature = "std")]
@@ -35,5 +41,11 @@ impl From<fields::Error> for PatternError {
         match input {
             fields::Error::InvalidLength(symbol) => Self::FieldLengthInvalid(symbol),
         }
+    }
+}
+
+impl From<Infallible> for PatternError {
+    fn from(x: Infallible) -> Self {
+        match x {}
     }
 }

--- a/components/datetime/src/pattern/item/mixed.rs
+++ b/components/datetime/src/pattern/item/mixed.rs
@@ -7,9 +7,12 @@ use core::convert::TryFrom;
 use crate::fields::{Field, FieldLength, FieldSymbol};
 use crate::pattern::PatternError;
 
+use super::{GenericPatternItem, PatternItem};
+
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[allow(clippy::exhaustive_enums)]
 pub enum MixedPatternItem {
     Field(Field),
     // A single digit, 0..=9
@@ -17,48 +20,65 @@ pub enum MixedPatternItem {
     Literal(char),
 }
 
+impl TryFrom<MixedPatternItem> for PatternItem {
+    type Error = PatternError;
+
+    fn try_from(value: MixedPatternItem) -> Result<Self, Self::Error> {
+        match value {
+            MixedPatternItem::Field(f) => Ok(Self::Field(f)),
+            MixedPatternItem::Literal(l) => Ok(Self::Literal(l)),
+            MixedPatternItem::Placeholder(_) => Err(PatternError::UnsupportedPlaceholder),
+        }
+    }
+}
+
+impl TryFrom<MixedPatternItem> for GenericPatternItem {
+    type Error = PatternError;
+
+    fn try_from(value: MixedPatternItem) -> Result<Self, Self::Error> {
+        match value {
+            MixedPatternItem::Placeholder(p) => Ok(Self::Placeholder(p)),
+            MixedPatternItem::Literal(l) => Ok(Self::Literal(l)),
+            MixedPatternItem::Field(_) => Err(PatternError::UnsupportedFields),
+        }
+    }
+}
+
+impl From<PatternItem> for MixedPatternItem {
+    fn from(item: PatternItem) -> Self {
+        match item {
+            PatternItem::Field(f) => Self::Field(f),
+            PatternItem::Literal(l) => Self::Literal(l),
+        }
+    }
+}
+
+impl From<GenericPatternItem> for MixedPatternItem {
+    fn from(item: GenericPatternItem) -> Self {
+        match item {
+            GenericPatternItem::Placeholder(p) => Self::Placeholder(p),
+            GenericPatternItem::Literal(l) => Self::Literal(l),
+        }
+    }
+}
+
 impl From<(FieldSymbol, FieldLength)> for MixedPatternItem {
     fn from(input: (FieldSymbol, FieldLength)) -> Self {
-        Self::Field(Field {
-            symbol: input.0,
-            length: input.1,
-        })
+        Self::from(PatternItem::from(input))
     }
 }
 
 impl TryFrom<(FieldSymbol, u8)> for MixedPatternItem {
     type Error = PatternError;
     fn try_from(input: (FieldSymbol, u8)) -> Result<Self, Self::Error> {
-        let length = if input.0 != FieldSymbol::Second(crate::fields::Second::FractionalSecond) {
-            FieldLength::from_idx(input.1).map_err(|_| PatternError::FieldLengthInvalid(input.0))?
-        } else if input.1 <= 127 {
-            FieldLength::from_idx(128 + input.1)
-                .map_err(|_| PatternError::FieldLengthInvalid(input.0))?
-        } else {
-            return Err(PatternError::FieldLengthInvalid(input.0));
-        };
-        Ok(Self::Field(Field {
-            symbol: input.0,
-            length,
-        }))
+        PatternItem::try_from(input).map(Self::from)
     }
 }
 
 impl TryFrom<(char, u8)> for MixedPatternItem {
     type Error = PatternError;
     fn try_from(input: (char, u8)) -> Result<Self, Self::Error> {
-        let symbol =
-            FieldSymbol::try_from(input.0).map_err(|_| PatternError::InvalidSymbol(input.0))?;
-
-        let length = if symbol != FieldSymbol::Second(crate::fields::Second::FractionalSecond) {
-            FieldLength::from_idx(input.1).map_err(|_| PatternError::FieldLengthInvalid(symbol))?
-        } else if input.1 <= 127 {
-            FieldLength::from_idx(128 + input.1)
-                .map_err(|_| PatternError::FieldLengthInvalid(symbol))?
-        } else {
-            return Err(PatternError::FieldLengthInvalid(symbol));
-        };
-        Ok(Self::Field(Field { symbol, length }))
+        PatternItem::try_from(input).map(Self::from)
     }
 }
 

--- a/components/datetime/src/pattern/item/mixed.rs
+++ b/components/datetime/src/pattern/item/mixed.rs
@@ -2,33 +2,22 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-mod generic;
-#[cfg(feature = "experimental")]
-mod mixed;
-mod ule;
+use core::convert::TryFrom;
 
 use crate::fields::{Field, FieldLength, FieldSymbol};
 use crate::pattern::PatternError;
-use core::convert::TryFrom;
-pub use generic::GenericPatternItem;
-
-#[cfg(feature = "experimental")]
-pub use mixed::MixedPatternItem;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
-#[cfg_attr(
-    feature = "datagen",
-    derive(serde::Serialize, databake::Bake),
-    databake(path = icu_datetime::pattern::item),
-)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-#[allow(clippy::exhaustive_enums)] // this type is stable
-pub enum PatternItem {
+pub enum MixedPatternItem {
     Field(Field),
+    // A single digit, 0..=9
+    Placeholder(u8),
     Literal(char),
 }
 
-impl From<(FieldSymbol, FieldLength)> for PatternItem {
+impl From<(FieldSymbol, FieldLength)> for MixedPatternItem {
     fn from(input: (FieldSymbol, FieldLength)) -> Self {
         Self::Field(Field {
             symbol: input.0,
@@ -37,7 +26,7 @@ impl From<(FieldSymbol, FieldLength)> for PatternItem {
     }
 }
 
-impl TryFrom<(FieldSymbol, u8)> for PatternItem {
+impl TryFrom<(FieldSymbol, u8)> for MixedPatternItem {
     type Error = PatternError;
     fn try_from(input: (FieldSymbol, u8)) -> Result<Self, Self::Error> {
         let length = if input.0 != FieldSymbol::Second(crate::fields::Second::FractionalSecond) {
@@ -55,7 +44,7 @@ impl TryFrom<(FieldSymbol, u8)> for PatternItem {
     }
 }
 
-impl TryFrom<(char, u8)> for PatternItem {
+impl TryFrom<(char, u8)> for MixedPatternItem {
     type Error = PatternError;
     fn try_from(input: (char, u8)) -> Result<Self, Self::Error> {
         let symbol =
@@ -73,8 +62,14 @@ impl TryFrom<(char, u8)> for PatternItem {
     }
 }
 
-impl From<char> for PatternItem {
+impl From<char> for MixedPatternItem {
     fn from(input: char) -> Self {
         Self::Literal(input)
+    }
+}
+
+impl From<u8> for MixedPatternItem {
+    fn from(input: u8) -> Self {
+        Self::Placeholder(input)
     }
 }

--- a/components/datetime/src/pattern/item/mod.rs
+++ b/components/datetime/src/pattern/item/mod.rs
@@ -3,7 +3,6 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 mod generic;
-#[cfg(feature = "experimental")]
 mod mixed;
 mod ule;
 
@@ -11,8 +10,6 @@ use crate::fields::{Field, FieldLength, FieldSymbol};
 use crate::pattern::PatternError;
 use core::convert::TryFrom;
 pub use generic::GenericPatternItem;
-
-#[cfg(feature = "experimental")]
 pub use mixed::MixedPatternItem;
 
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/components/datetime/src/pattern/item/ule.rs
+++ b/components/datetime/src/pattern/item/ule.rs
@@ -7,6 +7,9 @@ use crate::fields;
 use core::convert::TryFrom;
 use zerovec::ule::{AsULE, ZeroVecError, ULE};
 
+#[cfg(feature = "experimental")]
+mod mixed;
+
 /// `PatternItemULE` is a type optimized for efficent storing and
 /// deserialization of `TypedDateTimeFormatter` `PatternItem` elements using
 /// `ZeroVec` model.

--- a/components/datetime/src/pattern/item/ule/mixed.rs
+++ b/components/datetime/src/pattern/item/ule/mixed.rs
@@ -57,7 +57,7 @@ impl MixedPatternItemULE {
                     && value.0 == 0b0100_0000
             }
             Some(Tag::Placeholder) => value.0 == 0b1000_0000 && value.1 == 0 && value.2 < 10,
-            None => false
+            None => false,
         }
     }
 }

--- a/components/datetime/src/pattern/item/ule/mixed.rs
+++ b/components/datetime/src/pattern/item/ule/mixed.rs
@@ -1,0 +1,155 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use super::super::MixedPatternItem;
+use crate::fields;
+use core::convert::TryFrom;
+use zerovec::ule::{AsULE, ZeroVecError, ULE};
+
+/// # Diagram
+///
+/// ```text
+/// ┌───────────────┬───────────────┬───────────────┐
+/// │       u8      │       u8      │       u8      │
+/// ├─┬─┬─┬─┬─┬─┬─┬─┼─┬─┬─┬─┬─┬─┬─┬─┼─┬─┬─┬─┬─┬─┬─┬─┤
+/// ├─┴─┴─┼─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┤
+/// │     │          Unicode Code Point             │ Literal
+/// ├─┬─┬─┴─────────┬───────────────┬───────────────┤
+/// │0│1│           │  FieldSymbol  │  FieldLength  │ Field
+/// ├─┼─┼───────────┴───────────────┼───────────────┤
+/// │1│0│                           │  Placeholder  │ Placeholder
+/// └─┴─┴───────────────────────────┴───────────────┘
+///  ▲▲▲
+///  │││
+///  Variant Discriminant
+/// ```
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(transparent)]
+pub struct MixedPatternItemULE([u8; 3]);
+
+#[repr(u8)]
+enum Tag {
+    Literal,
+    Field,
+    Placeholder,
+}
+
+impl MixedPatternItemULE {
+    #[inline]
+    fn tag_from_byte(byte: u8) -> Tag {
+        match (byte & 0b1100_0000) >> 6 {
+            0 => Tag::Literal,
+            1 => Tag::Field,
+            2 => Tag::Placeholder,
+            _ => unreachable!(),
+        }
+    }
+
+    fn bytes_in_range(value: (u8, u8, u8)) -> bool {
+        match Self::tag_from_byte(value.0) {
+            Tag::Literal => {
+                char::try_from(u32::from_be_bytes([0x00, value.0, value.1, value.2])).is_ok()
+            }
+            Tag::Field => {
+                fields::FieldULE::validate_bytes((value.1, value.2)).is_ok()
+                    && value.0 == 0b0100_0000
+            }
+            Tag::Placeholder => value.0 == 0b1000_0000 && value.1 == 0 && value.2 < 10,
+        }
+    }
+}
+
+unsafe impl ULE for MixedPatternItemULE {
+    fn validate_byte_slice(bytes: &[u8]) -> Result<(), ZeroVecError> {
+        if bytes.len() % 3 != 0 {
+            return Err(ZeroVecError::length::<Self>(bytes.len()));
+        }
+
+        #[allow(clippy::indexing_slicing)] // chunks
+        if !bytes
+            .chunks(3)
+            .all(|c| Self::bytes_in_range((c[0], c[1], c[2])))
+        {
+            return Err(ZeroVecError::parse::<Self>());
+        }
+        Ok(())
+    }
+}
+
+impl AsULE for MixedPatternItem {
+    type ULE = MixedPatternItemULE;
+
+    fn to_unaligned(self) -> Self::ULE {
+        match self {
+            Self::Literal(ch) => {
+                let u = ch as u32;
+                let bytes = u.to_be_bytes();
+                MixedPatternItemULE([bytes[1], bytes[2], bytes[3]])
+            }
+            Self::Field(field) => {
+                MixedPatternItemULE([0b0100_0000, field.symbol.idx(), field.length.idx()])
+            }
+            Self::Placeholder(idx) => MixedPatternItemULE([0b1000_0000, 0x00, idx]),
+        }
+    }
+
+    fn from_unaligned(unaligned: Self::ULE) -> Self {
+        let value = unaligned.0;
+        #[allow(clippy::unwrap_used)] // validated
+        match MixedPatternItemULE::tag_from_byte(value[0]) {
+            Tag::Literal => Self::Literal(
+                char::try_from(u32::from_be_bytes([0x00, value[0], value[1], value[2]])).unwrap(),
+            ),
+            Tag::Field => {
+                let symbol = fields::FieldSymbol::from_idx(value[1]).unwrap();
+                let length = fields::FieldLength::from_idx(value[2]).unwrap();
+                Self::Field(fields::Field { symbol, length })
+            }
+            Tag::Placeholder => Self::Placeholder(value[2]),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::fields::{FieldLength, FieldSymbol, Second, Year};
+    use zerovec::ule::{AsULE, ULE};
+
+    #[test]
+    fn test_mixed_pattern_item_as_ule() {
+        let samples = &[
+            (MixedPatternItem::Placeholder(4), &[0x80, 0x00, 4]),
+            (MixedPatternItem::from('z'), &[0x00, 0x00, 0x7a]),
+            (MixedPatternItem::Placeholder(0), &[0x80, 0x00, 0]),
+            (
+                MixedPatternItem::from((FieldSymbol::Year(Year::Calendar), FieldLength::Wide)),
+                &[
+                    0x40,
+                    FieldSymbol::Year(Year::Calendar).idx(),
+                    FieldLength::Wide.idx(),
+                ],
+            ),
+            (MixedPatternItem::from('秒'), &[0, 0x79, 0xd2]),
+            (
+                MixedPatternItem::from((
+                    FieldSymbol::Second(Second::Millisecond),
+                    FieldLength::One,
+                )),
+                &[
+                    0x40,
+                    FieldSymbol::Second(Second::Millisecond).idx(),
+                    FieldLength::One.idx(),
+                ],
+            ),
+        ];
+
+        for (ref_pattern, ref_bytes) in samples {
+            let ule = ref_pattern.to_unaligned();
+            assert_eq!(ULE::as_byte_slice(&[ule]), *ref_bytes);
+            let pattern = MixedPatternItem::from_unaligned(ule);
+            assert_eq!(pattern, *ref_pattern);
+        }
+    }
+}

--- a/components/datetime/src/pattern/mod.rs
+++ b/components/datetime/src/pattern/mod.rs
@@ -15,6 +15,9 @@ pub use hour_cycle::CoarseHourCycle;
 use icu_provider::{yoke, zerofrom};
 pub use item::{GenericPatternItem, PatternItem};
 
+#[cfg(feature = "experimental")]
+pub use item::MixedPatternItem;
+
 /// The granularity of time represented in a pattern item.
 /// Ordered from least granular to most granular for comparsion.
 #[derive(

--- a/components/datetime/src/pattern/mod.rs
+++ b/components/datetime/src/pattern/mod.rs
@@ -15,6 +15,9 @@ pub use hour_cycle::CoarseHourCycle;
 use icu_provider::{yoke, zerofrom};
 pub use item::{GenericPatternItem, PatternItem};
 
+#[cfg(not(feature = "experimental"))]
+pub(crate) use item::MixedPatternItem;
+
 #[cfg(feature = "experimental")]
 pub use item::MixedPatternItem;
 

--- a/components/datetime/src/pattern/reference/display.rs
+++ b/components/datetime/src/pattern/reference/display.rs
@@ -8,6 +8,9 @@ use super::{
     super::{GenericPatternItem, PatternItem},
     GenericPattern, Pattern,
 };
+
+#[cfg(feature = "experimental")]
+use super::{super::MixedPatternItem, MixedPattern};
 use alloc::string::String;
 use core::fmt::{self, Write};
 
@@ -109,6 +112,36 @@ impl fmt::Display for GenericPattern {
                 }
                 GenericPatternItem::Literal(ch) => {
                     buffer.push(*ch);
+                }
+            }
+        }
+        dump_buffer_into_formatter(&buffer, formatter)?;
+        buffer.clear();
+        Ok(())
+    }
+}
+
+#[cfg(feature = "experimental")]
+impl fmt::Display for MixedPattern {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut buffer = alloc::string::String::new();
+        for pattern_item in self.items.iter() {
+            match pattern_item {
+                MixedPatternItem::Placeholder(idx) => {
+                    dump_buffer_into_formatter(&buffer, formatter)?;
+                    buffer.clear();
+                    write!(formatter, "{{{idx}}}")?;
+                }
+                MixedPatternItem::Literal(ch) => {
+                    buffer.push(*ch);
+                }
+                MixedPatternItem::Field(field) => {
+                    dump_buffer_into_formatter(&buffer, formatter)?;
+                    buffer.clear();
+                    let ch: char = field.symbol.into();
+                    for _ in 0..field.length.to_len() {
+                        formatter.write_char(ch)?;
+                    }
                 }
             }
         }

--- a/components/datetime/src/pattern/reference/mixed.rs
+++ b/components/datetime/src/pattern/reference/mixed.rs
@@ -1,0 +1,26 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use super::{super::MixedPatternItem, super::PatternError, Parser};
+use alloc::vec::Vec;
+use core::str::FromStr;
+
+#[allow(clippy::exhaustive_structs)] // this type is stable
+pub struct MixedPattern {
+    pub items: Vec<MixedPatternItem>,
+}
+
+impl From<Vec<MixedPatternItem>> for MixedPattern {
+    fn from(items: Vec<MixedPatternItem>) -> Self {
+        Self { items }
+    }
+}
+
+impl FromStr for MixedPattern {
+    type Err = PatternError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Parser::new(s).parse_mixed().map(Self::from)
+    }
+}

--- a/components/datetime/src/pattern/reference/mod.rs
+++ b/components/datetime/src/pattern/reference/mod.rs
@@ -12,6 +12,12 @@ mod generic;
 mod parser;
 pub(crate) mod pattern;
 
+#[cfg(feature = "experimental")]
+mod mixed;
+
 pub use generic::GenericPattern;
 pub use parser::Parser;
 pub use pattern::Pattern;
+
+#[cfg(feature = "experimental")]
+pub use mixed::MixedPattern;

--- a/components/datetime/src/pattern/runtime/mixed.rs
+++ b/components/datetime/src/pattern/runtime/mixed.rs
@@ -17,6 +17,7 @@ use zerovec::ZeroVec;
     derive(databake::Bake),
     databake(path = icu_datetime::pattern::runtime),
 )]
+#[allow(clippy::exhaustive_structs)]
 pub struct MixedPattern<'data> {
     pub items: ZeroVec<'data, MixedPatternItem>,
 }

--- a/components/datetime/src/pattern/runtime/mixed.rs
+++ b/components/datetime/src/pattern/runtime/mixed.rs
@@ -1,0 +1,62 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use core::{fmt, str::FromStr};
+
+use super::{
+    super::MixedPatternItem,
+    super::{reference, PatternError},
+};
+use icu_provider::{yoke, zerofrom};
+use zerovec::ZeroVec;
+
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[cfg_attr(
+    feature = "datagen",
+    derive(databake::Bake),
+    databake(path = icu_datetime::pattern::runtime),
+)]
+pub struct MixedPattern<'data> {
+    pub items: ZeroVec<'data, MixedPatternItem>,
+}
+
+impl Default for MixedPattern<'_> {
+    fn default() -> Self {
+        Self {
+            items: ZeroVec::new(),
+        }
+    }
+}
+
+impl From<&reference::MixedPattern> for MixedPattern<'_> {
+    fn from(input: &reference::MixedPattern) -> Self {
+        Self {
+            items: ZeroVec::alloc_from_slice(&input.items),
+        }
+    }
+}
+
+impl From<&MixedPattern<'_>> for reference::MixedPattern {
+    fn from(input: &MixedPattern<'_>) -> Self {
+        Self {
+            items: input.items.to_vec(),
+        }
+    }
+}
+
+impl fmt::Display for MixedPattern<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let reference = reference::MixedPattern::from(self);
+        reference.fmt(formatter)
+    }
+}
+
+impl FromStr for MixedPattern<'_> {
+    type Err = PatternError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let reference = reference::MixedPattern::from_str(s)?;
+        Ok(Self::from(&reference))
+    }
+}

--- a/components/datetime/src/pattern/runtime/mod.rs
+++ b/components/datetime/src/pattern/runtime/mod.rs
@@ -14,6 +14,12 @@ pub(crate) mod helpers;
 mod pattern;
 mod plural;
 
+#[cfg(feature = "experimental")]
+mod mixed;
+
 pub use generic::GenericPattern;
 pub use pattern::Pattern;
 pub use plural::{PatternPlurals, PluralPattern};
+
+#[cfg(feature = "experimental")]
+pub use mixed::MixedPattern;

--- a/components/datetime/src/provider/calendar/mod.rs
+++ b/components/datetime/src/provider/calendar/mod.rs
@@ -83,6 +83,9 @@ pub mod patterns {
     use crate::pattern::runtime::{self, GenericPattern, PatternPlurals};
     use icu_provider::{yoke, zerofrom};
 
+    #[cfg(feature = "experimental")]
+    use crate::pattern::runtime::MixedPattern;
+
     /// Data struct for date/time patterns broken down by pattern length.
     #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
     #[cfg_attr(
@@ -164,4 +167,12 @@ pub mod patterns {
             Self(pattern)
         }
     }
+
+    #[icu_provider::data_struct]
+    #[derive(Debug, PartialEq, Clone, Default)]
+    #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+    pub struct MixedPatternV1<'data>(
+        #[cfg_attr(feature = "serde", serde(borrow))] pub MixedPattern<'data>,
+    );
 }

--- a/components/datetime/src/provider/calendar/mod.rs
+++ b/components/datetime/src/provider/calendar/mod.rs
@@ -168,6 +168,7 @@ pub mod patterns {
         }
     }
 
+    #[cfg(feature = "experimental")]
     #[icu_provider::data_struct]
     #[derive(Debug, PartialEq, Clone, Default)]
     #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
@@ -175,4 +176,19 @@ pub mod patterns {
     pub struct MixedPatternV1<'data>(
         #[cfg_attr(feature = "serde", serde(borrow))] pub MixedPattern<'data>,
     );
+
+    #[cfg(feature = "experimental")]
+    pub(crate) struct MixedPatternV1Marker;
+
+    #[cfg(feature = "experimental")]
+    impl DataMarker for MixedPatternV1Marker {
+        type Yokeable = MixedPatternV1<'static>;
+    }
+
+    #[cfg(feature = "experimental")]
+    impl<'data> From<MixedPattern<'data>> for MixedPatternV1<'data> {
+        fn from(pattern: MixedPattern<'data>) -> Self {
+            Self(pattern)
+        }
+    }
 }

--- a/experimental/datetime_bag_v2/Cargo.toml
+++ b/experimental/datetime_bag_v2/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "datetime_bag_v2"
+name = "icu_datetime_bag_v2"
 description = "New components bag API for DateTimeFormatter"
 version = "0.1.0"
 authors = ["The ICU4X Project Developers"]

--- a/experimental/datetime_bag_v2/Cargo.toml
+++ b/experimental/datetime_bag_v2/Cargo.toml
@@ -1,3 +1,8 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+
 [package]
 name = "icu_datetime_bag_v2"
 description = "New components bag API for DateTimeFormatter"
@@ -27,6 +32,8 @@ path = "src/lib.rs"
 [dependencies]
 icu_provider = { version = "1.0.0-beta1", path = "../../provider/core", features = ["macros"] }
 icu_datetime = { version = "1.0.0-beta1", path = "../../components/datetime", features = ["datagen", "experimental"] }
+bitflags = "1.3"
+displaydoc = { version = "0.2.3", default-features = false }
 yoke = { version = "0.6.0", path = "../../utils/yoke", features = ["derive"] }
 zerovec = { version = "0.8", path = "../../utils/zerovec", features = ["yoke"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/experimental/datetime_bag_v2/Cargo.toml
+++ b/experimental/datetime_bag_v2/Cargo.toml
@@ -26,7 +26,9 @@ path = "src/lib.rs"
 
 [dependencies]
 icu_provider = { version = "1.0.0-beta1", path = "../../provider/core", features = ["macros"] }
-icu_datetime = { version = "1.0.0-beta1", path = "../../components/datetime", features = ["datagen"] }
+icu_datetime = { version = "1.0.0-beta1", path = "../../components/datetime", features = ["datagen", "experimental"] }
+yoke = { version = "0.6.0", path = "../../utils/yoke", features = ["derive"] }
+zerovec = { version = "0.8", path = "../../utils/zerovec", features = ["yoke"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"] }
 

--- a/experimental/datetime_bag_v2/Cargo.toml
+++ b/experimental/datetime_bag_v2/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "datetime_bag_v2"
+description = "New components bag API for DateTimeFormatter"
+version = "0.1.0"
+authors = ["The ICU4X Project Developers"]
+edition = "2018"
+readme = "README.md"
+repository = "https://github.com/unicode-org/icu4x"
+license = "Unicode-DFS-2016"
+# Keep this in sync with other crates unless there are exceptions
+include = [
+    "src/**/*",
+    "examples/**/*",
+    "benches/**/*",
+    "tests/**/*",
+    "Cargo.toml",
+    "LICENSE",
+    "README.md",
+]
+
+[lib]
+bench = false       # This option is required for Benchmark CI
+path = "src/lib.rs"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+icu_provider = { version = "1.0.0-beta1", path = "../../provider/core", features = ["macros"] }
+icu_datetime = { version = "1.0.0-beta1", path = "../../components/datetime", features = ["datagen"] }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
+databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"] }
+
+[features]
+std = ["icu_provider/std"]
+default = []
+serde = ["dep:serde", "icu_provider/serde"]
+datagen = ["serde", "databake"]

--- a/experimental/datetime_bag_v2/LICENSE
+++ b/experimental/datetime_bag_v2/LICENSE
@@ -1,0 +1,51 @@
+UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE
+
+See Terms of Use <https://www.unicode.org/copyright.html>
+for definitions of Unicode Inc.’s Data Files and Software.
+
+NOTICE TO USER: Carefully read the following legal agreement.
+BY DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.'S
+DATA FILES ("DATA FILES"), AND/OR SOFTWARE ("SOFTWARE"),
+YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT.
+IF YOU DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE
+THE DATA FILES OR SOFTWARE.
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 1991-2022 Unicode, Inc. All rights reserved.
+Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Unicode data files and any associated documentation
+(the "Data Files") or Unicode software and any associated documentation
+(the "Software") to deal in the Data Files or Software
+without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, and/or sell copies of
+the Data Files or Software, and to permit persons to whom the Data Files
+or Software are furnished to do so, provided that either
+(a) this copyright and permission notice appear with all copies
+of the Data Files or Software, or
+(b) this copyright and permission notice appear in associated
+Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in these Data Files or Software without prior
+written authorization of the copyright holder.
+
+—
+
+Portions of ICU4X may have been adapted from ICU4C and/or ICU4J.
+ICU 1.8.1 to ICU 57.1 © 1995-2016 International Business Machines Corporation and others.

--- a/experimental/datetime_bag_v2/src/lib.rs
+++ b/experimental/datetime_bag_v2/src/lib.rs
@@ -1,0 +1,5 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+pub mod provider;

--- a/experimental/datetime_bag_v2/src/lib.rs
+++ b/experimental/datetime_bag_v2/src/lib.rs
@@ -2,4 +2,144 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use std::convert::TryFrom;
+
+use icu_datetime::{fields::FieldSymbol, provider::calendar::SkeletonV1};
+
+use bitflags::bitflags;
+use displaydoc::Display;
+
 pub mod provider;
+
+#[derive(Display, Debug, Copy, Clone)]
+#[non_exhaustive]
+pub enum Error {
+    #[displaydoc("invalid field symbol `{0:?}` for component")]
+    InvalidFieldSymbol(FieldSymbol),
+    #[displaydoc("missing required fields for component")]
+    MissingFieldSymbols,
+}
+
+pub enum DateFormatKind {
+    EraYearMonthDay,
+    EraYearMonth,
+    EraYear,
+    Era,
+    YearMonthDay,
+    YearMonth,
+    Year,
+    MonthDay,
+    Month,
+    Day,
+}
+
+pub struct DateFormat {
+    pub kind: DateFormatKind,
+    pub with_weekday: bool,
+}
+
+impl TryFrom<&SkeletonV1> for DateFormat {
+    type Error = Error;
+    fn try_from(skeleton: &SkeletonV1) -> Result<Self, Self::Error> {
+        bitflags! {
+            struct DateFlags: u8 {
+                const ERA = 0b0000_0001;
+                const YEAR = 0b0000_0010;
+                const MONTH = 0b0000_0100;
+                const DAY = 0b0000_1000;
+                const ERA_YEAR_MONTH_DAY = Self::ERA.bits | Self::YEAR_MONTH_DAY.bits;
+                const ERA_YEAR_MONTH = Self::ERA.bits | Self::YEAR_MONTH.bits;
+                const ERA_YEAR = Self::ERA.bits | Self::YEAR.bits;
+                const YEAR_MONTH_DAY = Self::YEAR_MONTH.bits | Self::DAY.bits;
+                const YEAR_MONTH = Self::YEAR.bits | Self::MONTH.bits;
+                const MONTH_DAY = Self::MONTH.bits | Self::DAY.bits;
+            }
+        }
+
+        let mut flags = DateFlags::empty();
+        let mut with_weekday = false;
+
+        for symbol in skeleton.0.as_slice().iter().map(|field| field.symbol) {
+            match symbol {
+                FieldSymbol::Era => flags |= DateFlags::ERA,
+                FieldSymbol::Year(_) => flags |= DateFlags::YEAR,
+                FieldSymbol::Month(_) => flags |= DateFlags::MONTH,
+                FieldSymbol::Day(_) => flags |= DateFlags::DAY,
+                FieldSymbol::Weekday(_) => with_weekday = true,
+                sym => return Err(Error::InvalidFieldSymbol(sym)),
+            }
+        }
+
+        let kind = match flags {
+            DateFlags::ERA_YEAR_MONTH_DAY => DateFormatKind::EraYearMonthDay,
+            DateFlags::ERA_YEAR_MONTH => DateFormatKind::EraYearMonth,
+            DateFlags::ERA_YEAR => DateFormatKind::EraYear,
+            DateFlags::ERA => DateFormatKind::Era,
+            DateFlags::YEAR_MONTH_DAY => DateFormatKind::YearMonthDay,
+            DateFlags::YEAR_MONTH => DateFormatKind::YearMonth,
+            DateFlags::YEAR => DateFormatKind::Year,
+            DateFlags::MONTH_DAY => DateFormatKind::MonthDay,
+            DateFlags::MONTH => DateFormatKind::Month,
+            DateFlags::DAY => DateFormatKind::Day,
+            _ => return Err(Error::MissingFieldSymbols),
+        };
+
+        Ok(Self { kind, with_weekday })
+    }
+}
+
+pub enum TimeFormatKind {
+    HourMinuteSecondFractionalSecond,
+    HourMinuteSecond,
+    HourMinute,
+    Hour,
+}
+
+pub struct TimeFormat {
+    pub kind: TimeFormatKind,
+    pub with_weekday: bool,
+}
+
+impl TryFrom<&SkeletonV1> for TimeFormat {
+    type Error = Error;
+
+    fn try_from(skeleton: &SkeletonV1) -> Result<Self, Self::Error> {
+        bitflags! {
+            struct TimeFlags: u8 {
+                const HOUR = 0b0000_0001;
+                const MINUTE = 0b0000_0010;
+                const SECOND = 0b0000_0100;
+                const FRACTIONAL_SECOND = 0b0000_1000;
+                const HOUR_MINUTE_SECOND_FRACTIONAL_SECOND = Self::HOUR_MINUTE_SECOND.bits | Self::FRACTIONAL_SECOND.bits;
+                const HOUR_MINUTE_SECOND = Self::HOUR_MINUTE.bits | Self::SECOND.bits;
+                const HOUR_MINUTE = Self::HOUR.bits | Self::MINUTE.bits;
+            }
+        }
+
+        let mut flags = TimeFlags::empty();
+        let mut with_weekday = false;
+
+        for symbol in skeleton.0.as_slice().iter().map(|field| field.symbol) {
+            match symbol {
+                FieldSymbol::Hour(_) => flags |= TimeFlags::HOUR,
+                FieldSymbol::Minute => flags |= TimeFlags::MINUTE,
+                FieldSymbol::Second(_) => flags |= TimeFlags::SECOND,
+                // TODO: CLDR doesn't define a fractional second symbol independent of second
+                FieldSymbol::Weekday(_) => with_weekday = true,
+                sym => return Err(Error::InvalidFieldSymbol(sym)),
+            }
+        }
+
+        let kind = match flags {
+            TimeFlags::HOUR_MINUTE_SECOND_FRACTIONAL_SECOND => {
+                TimeFormatKind::HourMinuteSecondFractionalSecond
+            }
+            TimeFlags::HOUR_MINUTE_SECOND => TimeFormatKind::HourMinuteSecond,
+            TimeFlags::HOUR_MINUTE => TimeFormatKind::HourMinute,
+            TimeFlags::HOUR => TimeFormatKind::Hour,
+            _ => return Err(Error::MissingFieldSymbols),
+        };
+
+        Ok(Self { kind, with_weekday })
+    }
+}

--- a/experimental/datetime_bag_v2/src/provider.rs
+++ b/experimental/datetime_bag_v2/src/provider.rs
@@ -11,84 +11,148 @@ use icu_provider::{yoke, zerofrom};
 // TODO: must definitely wrap all `Pattern`s into a `PatternV1` struct,
 // or should those allow plural alternatives?
 
-// won't implement this for now
-// #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
-// #[cfg_attr(
-//         feature = "datagen",
-//         derive(serde::Serialize, databake::Bake),
-//         // databake(path = icu_datetime::provider::calendar::patterns),
-//     )]
-// #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-pub struct DateTimeFormatLengthsV1<'data> {
+#[icu_provider::data_struct(FormatLengthsV1Marker = "datetime/formatlengths@1")]
+#[derive(Debug, PartialEq, Clone, Default)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+pub struct FormatLengthsV1<'data> {
     // Isn't this already provided in datetime/timelengths?
     // pub preferred_hour_cycle: pattern::CoarseHourCycle
-    pub long: DateTimeFormatV1<'data>,
-    pub medium: DateTimeFormatV1<'data>,
-    pub short: DateTimeFormatV1<'data>,
-    pub short_lossy: DateTimeFormatV1<'data>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
+    pub long: FormatPatternsV1<'data>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
+    pub medium: FormatPatternsV1<'data>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
+    pub short: FormatPatternsV1<'data>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
+    pub short_lossy: FormatPatternsV1<'data>,
 }
 
-pub struct DateTimeFormatV1<'data> {
+#[icu_provider::data_struct]
+#[derive(Debug, PartialEq, Clone, Default)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+pub struct FormatPatternsV1<'data> {
     pub glue: DateTimeFormatGlueV1<'data>,
     pub date: DateFormatV1<'data>,
     pub date_weekday: DateWeekdayFormatV1<'data>,
     pub time: TimeFormatV1<'data>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub weekday: Pattern<'data>,
     pub time_zone: (), // TODO
 }
+
+#[icu_provider::data_struct]
+#[derive(Debug, PartialEq, Clone, Default)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub struct DateTimeFormatGlueV1<'data> {
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub datetime: GenericPatternV1<'data>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub time_zone: GenericPatternV1<'data>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub weekday: MixedPatternV1<'data>,
 }
 
+#[icu_provider::data_struct]
+#[derive(Debug, PartialEq, Clone, Default)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub struct DateFormatV1<'data> {
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub glue_era: MixedPatternV1<'data>,
     pub components: DateFormatComponentsV1<'data>,
 }
 
+#[icu_provider::data_struct]
+#[derive(Debug, PartialEq, Clone, Default)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub struct DateFormatComponentsV1<'data> {
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub year_month_day: Pattern<'data>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub year_month: Pattern<'data>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub year: Pattern<'data>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub era: Pattern<'data>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub month_day: Pattern<'data>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub month: Pattern<'data>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub day: Pattern<'data>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub era_year_month_day: Option<Pattern<'data>>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub era_year_month: Option<Pattern<'data>>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub era_year: Option<Pattern<'data>>,
 }
 
+#[icu_provider::data_struct]
+#[derive(Debug, PartialEq, Clone, Default)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub struct DateWeekdayFormatV1<'data> {
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub year_month_day: Option<MixedPatternV1<'data>>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub year_month: Option<MixedPatternV1<'data>>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub year: Option<MixedPatternV1<'data>>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub era: Option<MixedPatternV1<'data>>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub month_day: Option<MixedPatternV1<'data>>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub month: Option<MixedPatternV1<'data>>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub day: Option<MixedPatternV1<'data>>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub era_year_month_day: Option<MixedPatternV1<'data>>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub era_year_month: Option<MixedPatternV1<'data>>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub era_year: Option<MixedPatternV1<'data>>,
 }
 
+#[icu_provider::data_struct]
+#[derive(Debug, PartialEq, Clone, Default)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub struct TimeFormatV1<'data> {
     // TODO: is `glue` used in time formats?
     // pub glue: (),
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub h11_h12: TimeFormatComponentsV1<'data>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub h23_h24: TimeFormatComponentsV1<'data>,
 }
 
+#[icu_provider::data_struct]
+#[derive(Debug, PartialEq, Clone, Default)]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub struct TimeFormatComponentsV1<'data> {
     // TODO: is `glue` used in time formats?
     // pub glue: (),
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub hour_minute_second_fractional_second: Option<Pattern<'data>>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub hour_minute_second: Pattern<'data>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub hour_minute: Pattern<'data>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub hour: Pattern<'data>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub weekday_hour_minute_second_fractional_second: Option<Pattern<'data>>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub weekday_hour_minute_second: Option<Pattern<'data>>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub weekday_hour_minute: Option<Pattern<'data>>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub weekday_hour: Option<Pattern<'data>>,
 }

--- a/experimental/datetime_bag_v2/src/provider.rs
+++ b/experimental/datetime_bag_v2/src/provider.rs
@@ -1,5 +1,15 @@
-use icu_datetime::{pattern::runtime::Pattern, provider::calendar::patterns::GenericPatternV1};
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use icu_datetime::{
+    pattern::runtime::Pattern,
+    provider::calendar::patterns::{GenericPatternV1, MixedPatternV1},
+};
 use icu_provider::{yoke, zerofrom};
+
+// TODO: must definitely wrap all `Pattern`s into a `PatternV1` struct,
+// or should those allow plural alternatives?
 
 // won't implement this for now
 // #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
@@ -29,20 +39,15 @@ pub struct DateTimeFormatV1<'data> {
 pub struct DateTimeFormatGlueV1<'data> {
     pub datetime: GenericPatternV1<'data>,
     pub time_zone: GenericPatternV1<'data>,
-    // TODO: Several fields use a single `FieldSymbol` and a `GenericPattern`
-    // or a single `FieldSymbol`, so they should be defined with a custom struct
-    pub weekday: GenericPatternV1<'data>,
+    pub weekday: MixedPatternV1<'data>,
 }
 
 pub struct DateFormatV1<'data> {
-    // TODO: Same as `DateTimeGlueV1::weekday`
-    pub glue_era: GenericPatternV1<'data>,
+    pub glue_era: MixedPatternV1<'data>,
     pub components: DateFormatComponentsV1<'data>,
 }
 
 pub struct DateFormatComponentsV1<'data> {
-    // TODO: must definitely wrap all `Pattern`s into a `PatternV1` struct,
-    // or should `components` also allow plural alternatives?
     pub year_month_day: Pattern<'data>,
     pub year_month: Pattern<'data>,
     pub year: Pattern<'data>,
@@ -56,18 +61,16 @@ pub struct DateFormatComponentsV1<'data> {
 }
 
 pub struct DateWeekdayFormatV1<'data> {
-    // TODO: This uses generic and regular patterns, so it should be
-    // its own custom struct
-    pub year_month_day: Option<GenericPatternV1<'data>>,
-    pub year_month: Option<GenericPatternV1<'data>>,
-    pub year: Option<GenericPatternV1<'data>>,
-    pub era: Option<GenericPatternV1<'data>>,
-    pub month_day: Option<GenericPatternV1<'data>>,
-    pub month: Option<GenericPatternV1<'data>>,
-    pub day: Option<GenericPatternV1<'data>>,
-    pub era_year_month_day: Option<GenericPatternV1<'data>>,
-    pub era_year_month: Option<GenericPatternV1<'data>>,
-    pub era_year: Option<GenericPatternV1<'data>>,
+    pub year_month_day: Option<MixedPatternV1<'data>>,
+    pub year_month: Option<MixedPatternV1<'data>>,
+    pub year: Option<MixedPatternV1<'data>>,
+    pub era: Option<MixedPatternV1<'data>>,
+    pub month_day: Option<MixedPatternV1<'data>>,
+    pub month: Option<MixedPatternV1<'data>>,
+    pub day: Option<MixedPatternV1<'data>>,
+    pub era_year_month_day: Option<MixedPatternV1<'data>>,
+    pub era_year_month: Option<MixedPatternV1<'data>>,
+    pub era_year: Option<MixedPatternV1<'data>>,
 }
 
 pub struct TimeFormatV1<'data> {

--- a/experimental/datetime_bag_v2/src/provider.rs
+++ b/experimental/datetime_bag_v2/src/provider.rs
@@ -1,0 +1,91 @@
+use icu_datetime::{pattern::runtime::Pattern, provider::calendar::patterns::GenericPatternV1};
+use icu_provider::{yoke, zerofrom};
+
+// won't implement this for now
+// #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+// #[cfg_attr(
+//         feature = "datagen",
+//         derive(serde::Serialize, databake::Bake),
+//         // databake(path = icu_datetime::provider::calendar::patterns),
+//     )]
+// #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+pub struct DateTimeFormatLengthsV1<'data> {
+    // Isn't this already provided in datetime/timelengths?
+    // pub preferred_hour_cycle: pattern::CoarseHourCycle
+    pub long: DateTimeFormatV1<'data>,
+    pub medium: DateTimeFormatV1<'data>,
+    pub short: DateTimeFormatV1<'data>,
+    pub short_lossy: DateTimeFormatV1<'data>,
+}
+
+pub struct DateTimeFormatV1<'data> {
+    pub glue: DateTimeFormatGlueV1<'data>,
+    pub date: DateFormatV1<'data>,
+    pub date_weekday: DateWeekdayFormatV1<'data>,
+    pub time: TimeFormatV1<'data>,
+    pub weekday: Pattern<'data>,
+    pub time_zone: (), // TODO
+}
+pub struct DateTimeFormatGlueV1<'data> {
+    pub datetime: GenericPatternV1<'data>,
+    pub time_zone: GenericPatternV1<'data>,
+    // TODO: Several fields use a single `FieldSymbol` and a `GenericPattern`
+    // or a single `FieldSymbol`, so they should be defined with a custom struct
+    pub weekday: GenericPatternV1<'data>,
+}
+
+pub struct DateFormatV1<'data> {
+    // TODO: Same as `DateTimeGlueV1::weekday`
+    pub glue_era: GenericPatternV1<'data>,
+    pub components: DateFormatComponentsV1<'data>,
+}
+
+pub struct DateFormatComponentsV1<'data> {
+    // TODO: must definitely wrap all `Pattern`s into a `PatternV1` struct,
+    // or should `components` also allow plural alternatives?
+    pub year_month_day: Pattern<'data>,
+    pub year_month: Pattern<'data>,
+    pub year: Pattern<'data>,
+    pub era: Pattern<'data>,
+    pub month_day: Pattern<'data>,
+    pub month: Pattern<'data>,
+    pub day: Pattern<'data>,
+    pub era_year_month_day: Option<Pattern<'data>>,
+    pub era_year_month: Option<Pattern<'data>>,
+    pub era_year: Option<Pattern<'data>>,
+}
+
+pub struct DateWeekdayFormatV1<'data> {
+    // TODO: This uses generic and regular patterns, so it should be
+    // its own custom struct
+    pub year_month_day: Option<GenericPatternV1<'data>>,
+    pub year_month: Option<GenericPatternV1<'data>>,
+    pub year: Option<GenericPatternV1<'data>>,
+    pub era: Option<GenericPatternV1<'data>>,
+    pub month_day: Option<GenericPatternV1<'data>>,
+    pub month: Option<GenericPatternV1<'data>>,
+    pub day: Option<GenericPatternV1<'data>>,
+    pub era_year_month_day: Option<GenericPatternV1<'data>>,
+    pub era_year_month: Option<GenericPatternV1<'data>>,
+    pub era_year: Option<GenericPatternV1<'data>>,
+}
+
+pub struct TimeFormatV1<'data> {
+    // TODO: is `glue` used in time formats?
+    // pub glue: (),
+    pub h11_h12: TimeFormatComponentsV1<'data>,
+    pub h23_h24: TimeFormatComponentsV1<'data>,
+}
+
+pub struct TimeFormatComponentsV1<'data> {
+    // TODO: is `glue` used in time formats?
+    // pub glue: (),
+    pub hour_minute_second_fractional_second: Option<Pattern<'data>>,
+    pub hour_minute_second: Pattern<'data>,
+    pub hour_minute: Pattern<'data>,
+    pub hour: Pattern<'data>,
+    pub weekday_hour_minute_second_fractional_second: Option<Pattern<'data>>,
+    pub weekday_hour_minute_second: Option<Pattern<'data>>,
+    pub weekday_hour_minute: Option<Pattern<'data>>,
+    pub weekday_hour: Option<Pattern<'data>>,
+}

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -48,6 +48,8 @@ icu_timezone = { version = "1.0.0-beta1", path = "../../components/timezone", fe
 # (experimental)
 icu_casemapping = { version = "0.2", path = "../../experimental/casemapping", features = ["datagen"], optional = true }
 icu_segmenter = { version = "1.0.0-alpha1", path = "../../experimental/segmenter", features = ["datagen", "lstm"], optional = true }
+icu_datetime_bag_v2 = { version = "0.1", path = "../../experimental/datetime_bag_v2", features = ["datagen"], optional = true }
+
 
 # ICU provider infrastructure
 icu_provider = { version = "1.0.0-beta1", path = "../core", features = ["std", "log_error_context", "datagen"]}
@@ -93,7 +95,7 @@ icu = { path = "../../components/icu" }
 
 [features]
 default = []
-experimental = ["icu_casemapping", "icu_segmenter", "icu_datetime/experimental"]
+experimental = ["icu_casemapping", "icu_segmenter", "icu_datetime/experimental", "icu_datetime_bag_v2"]
 bin = ["clap", "eyre", "simple_logger"]
 
 [[bin]]

--- a/provider/datagen/src/transform/cldr/cldr_serde/ca.rs
+++ b/provider/datagen/src/transform/cldr/cldr_serde/ca.rs
@@ -119,6 +119,14 @@ pub struct LengthPatterns {
 }
 
 #[derive(PartialEq, Debug, Deserialize, Clone)]
+pub struct LengthSkeletons {
+    pub full: String,
+    pub long: String,
+    pub medium: String,
+    pub short: String,
+}
+
+#[derive(PartialEq, Debug, Deserialize, Clone)]
 pub struct DateTimeFormats {
     pub full: LengthPattern,
     pub long: LengthPattern,
@@ -145,8 +153,12 @@ pub struct Dates {
     pub day_periods: day_periods::Contexts,
     #[serde(rename = "dateFormats")]
     pub date_formats: LengthPatterns,
+    #[serde(rename = "dateSkeletons")]
+    pub date_skeletons: LengthSkeletons,
     #[serde(rename = "timeFormats")]
     pub time_formats: LengthPatterns,
+    #[serde(rename = "timeSkeletons")]
+    pub time_skeletons: LengthSkeletons,
     #[serde(rename = "dateTimeFormats")]
     pub datetime_formats: DateTimeFormats,
 }

--- a/provider/datagen/src/transform/cldr/datetime/format.rs
+++ b/provider/datagen/src/transform/cldr/datetime/format.rs
@@ -1,3 +1,7 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
 use icu_datetime::provider::calendar::{
     patterns::{GenericLengthPatternsV1, LengthPatternsV1},
     DateSkeletonPatternsV1,

--- a/provider/datagen/src/transform/cldr/datetime/format.rs
+++ b/provider/datagen/src/transform/cldr/datetime/format.rs
@@ -1,0 +1,15 @@
+use icu_datetime::provider::calendar::{
+    patterns::{GenericLengthPatternsV1, LengthPatternsV1},
+    DateSkeletonPatternsV1,
+};
+use icu_datetime_bag_v2::provider::FormatLengthsV1;
+
+use crate::transform::cldr::cldr_serde;
+
+impl From<&cldr_serde::ca::Dates> for FormatLengthsV1<'_> {
+    fn from(other: &cldr_serde::ca::Dates) -> Self {
+        let length_combinations = GenericLengthPatternsV1::from(&other.datetime_formats);
+        let patterns = DateSkeletonPatternsV1::from(other);
+        todo!()
+    }
+}

--- a/provider/datagen/src/transform/cldr/datetime/format.rs
+++ b/provider/datagen/src/transform/cldr/datetime/format.rs
@@ -2,9 +2,11 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use std::convert::TryFrom;
+
 use icu_datetime::provider::calendar::{
     patterns::{GenericLengthPatternsV1, LengthPatternsV1},
-    DateSkeletonPatternsV1,
+    DateSkeletonPatternsV1, SkeletonV1,
 };
 use icu_datetime_bag_v2::provider::FormatLengthsV1;
 
@@ -12,8 +14,42 @@ use crate::transform::cldr::cldr_serde;
 
 impl From<&cldr_serde::ca::Dates> for FormatLengthsV1<'_> {
     fn from(other: &cldr_serde::ca::Dates) -> Self {
+        struct Format<'data> {
+            patterns: LengthPatternsV1<'data>,
+            skeletons: LengthSkeletons,
+        }
+        struct LengthSkeletons {
+            full: SkeletonV1,
+            long: SkeletonV1,
+            medium: SkeletonV1,
+            short: SkeletonV1,
+        }
+
+        impl From<&cldr_serde::ca::LengthSkeletons> for LengthSkeletons {
+            fn from(skeletons: &cldr_serde::ca::LengthSkeletons) -> Self {
+                Self {
+                    full: SkeletonV1::try_from(&*skeletons.full)
+                        .expect("unable to parse a skeleton"),
+                    long: SkeletonV1::try_from(&*skeletons.long)
+                        .expect("unable to parse a skeleton"),
+                    medium: SkeletonV1::try_from(&*skeletons.medium)
+                        .expect("unable to parse a skeleton"),
+                    short: SkeletonV1::try_from(&*skeletons.short)
+                        .expect("unable to parse a skeleton"),
+                }
+            }
+        }
+
         let length_combinations = GenericLengthPatternsV1::from(&other.datetime_formats);
-        let patterns = DateSkeletonPatternsV1::from(other);
+        let skeleton_patterns = DateSkeletonPatternsV1::from(other);
+        let date_formats = Format {
+            patterns: LengthPatternsV1::from(&other.date_formats),
+            skeletons: LengthSkeletons::from(&other.date_skeletons),
+        };
+        let time_formats = Format {
+            patterns: LengthPatternsV1::from(&other.time_formats),
+            skeletons: LengthSkeletons::from(&other.time_skeletons),
+        };
         todo!()
     }
 }

--- a/provider/datagen/src/transform/cldr/datetime/mod.rs
+++ b/provider/datagen/src/transform/cldr/datetime/mod.rs
@@ -16,6 +16,9 @@ use std::str::FromStr;
 mod patterns;
 mod skeletons;
 mod symbols;
+
+#[cfg(feature = "experimental")]
+mod format;
 pub mod week_data;
 
 lazy_static! {


### PR DESCRIPTION
Closes #1318

This follows the [Provider data format](https://docs.google.com/document/d/18v9fQcDvHDkG_7Hx6rDt1r3Mq6_JMecgORgOH4yXAWU/edit#heading=h.yoca0tmipd40) JSON as closely as possible.

There's a lot of work to be done still, but I'm opening a draft to seek for some comments on the structure of the provider.

Some thoughts:

- Would be good to have a concept of a generic `Pattern` (not to be confused with `GenericPattern`) restricted to a subset of `FieldSymbol`s. That way, e.g. `year_month_day` could be restricted to a `Pattern` with only the `Year`, `Month` and `Day` symbols, which should make parsing a bit easier.
- `preferred_hour_cycle` is already provided by the current version of CLDR, right?
- `time_zone` is still a WIP, since I'm not sure what should be the underlying data needed for that.
- Is there a need for `glue` in time formats?
- Always open for better name proposals 😅
- The proposed JSON includes "mixed" patterns with format fields + placeholders. I'm creating an entirely new pattern struct to handle this, but there's a possibility of unifying `Pattern`, `GenericPattern` and this new `MixedPattern` in a single struct.