### PR TITLE
Use open_enum for enumerated properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,6 +1764,7 @@ dependencies = [
  "icu_collections",
  "icu_provider",
  "icu_testdata",
+ "open-enum",
  "serde",
  "unicode-bidi",
  "zerovec",
@@ -2400,6 +2401,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "open-enum"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9807f1199cf84ec7cc801a79e5ee9aa5178e4762c6b9c7066c30b3cabdcd911e"
+dependencies = [
+ "open-enum-derive",
+]
+
+[[package]]
+name = "open-enum-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "894ae443e59fecf7173ab3b963473f44193fa71b3c8953c61a5bd5f30880bb88"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2596,11 +2617,11 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/components/properties/Cargo.toml
+++ b/components/properties/Cargo.toml
@@ -39,6 +39,7 @@ serde = { version = "1.0", default-features = false, features = ["derive", "allo
 zerovec = { version = "0.9", path = "../../utils/zerovec", features = ["derive"] }
 unicode-bidi = { version = "0.3.8", optional = true, default-features = false }
 databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"]}
+open-enum = { version = "0.3" }
 
 [dev-dependencies]
 icu = { path = "../icu", default-features = false }

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -4,6 +4,8 @@
 
 //! A collection of enums for enumerated properties.
 
+use open_enum::open_enum;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -46,63 +48,60 @@ enum EnumeratedProperty {
 /// These are the categories required by the Unicode Bidirectional Algorithm.
 /// For the property values, see [Bidirectional Class Values](https://unicode.org/reports/tr44/#Bidi_Class_Values).
 /// For more information, see [Unicode Standard Annex #9](https://unicode.org/reports/tr41/tr41-28.html#UAX9).
+#[open_enum]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "datagen", derive(databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_properties))]
-#[allow(clippy::exhaustive_structs)] // newtype
-#[repr(transparent)]
+#[repr(u8)]
 #[zerovec::make_ule(BidiClassULE)]
-pub struct BidiClass(pub u8);
-
-#[allow(non_upper_case_globals)]
-impl BidiClass {
+pub enum BidiClass {
     /// (`L`) any strong left-to-right character
-    pub const LeftToRight: BidiClass = BidiClass(0);
+    LeftToRight,
     /// (`R`) any strong right-to-left (non-Arabic-type) character
-    pub const RightToLeft: BidiClass = BidiClass(1);
+    RightToLeft,
     /// (`EN`) any ASCII digit or Eastern Arabic-Indic digit
-    pub const EuropeanNumber: BidiClass = BidiClass(2);
+    EuropeanNumber,
     /// (`ES`) plus and minus signs
-    pub const EuropeanSeparator: BidiClass = BidiClass(3);
+    EuropeanSeparator,
     /// (`ET`) a terminator in a numeric format context, includes currency signs
-    pub const EuropeanTerminator: BidiClass = BidiClass(4);
+    EuropeanTerminator,
     /// (`AN`) any Arabic-Indic digit
-    pub const ArabicNumber: BidiClass = BidiClass(5);
+    ArabicNumber,
     /// (`CS`) commas, colons, and slashes
-    pub const CommonSeparator: BidiClass = BidiClass(6);
+    CommonSeparator,
     /// (`B`) various newline characters
-    pub const ParagraphSeparator: BidiClass = BidiClass(7);
+    ParagraphSeparator,
     /// (`S`) various segment-related control codes
-    pub const SegmentSeparator: BidiClass = BidiClass(8);
+    SegmentSeparator,
     /// (`WS`) spaces
-    pub const WhiteSpace: BidiClass = BidiClass(9);
+    WhiteSpace,
     /// (`ON`) most other symbols and punctuation marks
-    pub const OtherNeutral: BidiClass = BidiClass(10);
+    OtherNeutral,
     /// (`LRE`) U+202A: the LR embedding control
-    pub const LeftToRightEmbedding: BidiClass = BidiClass(11);
+    LeftToRightEmbedding,
     /// (`LRO`) U+202D: the LR override control
-    pub const LeftToRightOverride: BidiClass = BidiClass(12);
+    LeftToRightOverride,
     /// (`AL`) any strong right-to-left (Arabic-type) character
-    pub const ArabicLetter: BidiClass = BidiClass(13);
+    ArabicLetter,
     /// (`RLE`) U+202B: the RL embedding control
-    pub const RightToLeftEmbedding: BidiClass = BidiClass(14);
+    RightToLeftEmbedding,
     /// (`RLO`) U+202E: the RL override control
-    pub const RightToLeftOverride: BidiClass = BidiClass(15);
+    RightToLeftOverride,
     /// (`PDF`) U+202C: terminates an embedding or override control
-    pub const PopDirectionalFormat: BidiClass = BidiClass(16);
+    PopDirectionalFormat,
     /// (`NSM`) any nonspacing mark
-    pub const NonspacingMark: BidiClass = BidiClass(17);
+    NonspacingMark,
     /// (`BN`) most format characters, control codes, or noncharacters
-    pub const BoundaryNeutral: BidiClass = BidiClass(18);
+    BoundaryNeutral,
     /// (`FSI`) U+2068: the first strong isolate control
-    pub const FirstStrongIsolate: BidiClass = BidiClass(19);
+    FirstStrongIsolate,
     /// (`LRI`) U+2066: the LR isolate control
-    pub const LeftToRightIsolate: BidiClass = BidiClass(20);
+    LeftToRightIsolate,
     /// (`RLI`) U+2067: the RL isolate control
-    pub const RightToLeftIsolate: BidiClass = BidiClass(21);
+    RightToLeftIsolate,
     /// (`PDI`) U+2069: terminates an isolate control
-    pub const PopDirectionalIsolate: BidiClass = BidiClass(22);
+    PopDirectionalIsolate,
 }
 
 /// Enumerated property General_Category.
@@ -190,6 +189,8 @@ pub enum GeneralCategory {
     OtherSymbol = 27,
 }
 
+use GeneralCategory as GC;
+
 /// Groupings of multiple General_Category property values.
 ///
 /// Instances of `GeneralCategoryGroup` represent the defined multi-category
@@ -205,125 +206,120 @@ pub enum GeneralCategory {
 /// is the union of `UppercaseLetter`, `LowercaseLetter`, etc.
 ///
 /// See `UCharCategory` and `U_GET_GC_MASK` in ICU4C.
+#[open_enum(inner_vis = pub(crate))]
 #[derive(Copy, Clone, PartialEq, Debug, Eq)]
-#[allow(clippy::exhaustive_structs)] // newtype
-#[repr(transparent)]
-pub struct GeneralCategoryGroup(pub(crate) u32);
-
-use GeneralCategory as GC;
-use GeneralCategoryGroup as GCG;
-
-#[allow(non_upper_case_globals)]
-impl GeneralCategoryGroup {
+#[repr(u32)]
+pub enum GeneralCategoryGroup {
     /// (`Lu`) An uppercase letter
-    pub const UppercaseLetter: GeneralCategoryGroup = GCG(1 << (GC::UppercaseLetter as u32));
+    UppercaseLetter = 1 << (GC::UppercaseLetter as u32),
     /// (`Ll`) A lowercase letter
-    pub const LowercaseLetter: GeneralCategoryGroup = GCG(1 << (GC::LowercaseLetter as u32));
+    LowercaseLetter = 1 << (GC::LowercaseLetter as u32),
     /// (`Lt`) A digraphic letter, with first part uppercase
-    pub const TitlecaseLetter: GeneralCategoryGroup = GCG(1 << (GC::TitlecaseLetter as u32));
+    TitlecaseLetter = 1 << (GC::TitlecaseLetter as u32),
     /// (`Lm`) A modifier letter
-    pub const ModifierLetter: GeneralCategoryGroup = GCG(1 << (GC::ModifierLetter as u32));
+    ModifierLetter = 1 << (GC::ModifierLetter as u32),
     /// (`Lo`) Other letters, including syllables and ideographs
-    pub const OtherLetter: GeneralCategoryGroup = GCG(1 << (GC::OtherLetter as u32));
+    OtherLetter = 1 << (GC::OtherLetter as u32),
     /// (`LC`) The union of UppercaseLetter, LowercaseLetter, and TitlecaseLetter
-    pub const CasedLetter: GeneralCategoryGroup = GCG(1 << (GC::UppercaseLetter as u32)
+    CasedLetter = 1 << (GC::UppercaseLetter as u32)
         | 1 << (GC::LowercaseLetter as u32)
-        | 1 << (GC::TitlecaseLetter as u32));
+        | 1 << (GC::TitlecaseLetter as u32),
     /// (`L`) The union of all letter categories
-    pub const Letter: GeneralCategoryGroup = GCG(1 << (GC::UppercaseLetter as u32)
+    Letter = 1 << (GC::UppercaseLetter as u32)
         | 1 << (GC::LowercaseLetter as u32)
         | 1 << (GC::TitlecaseLetter as u32)
         | 1 << (GC::ModifierLetter as u32)
-        | 1 << (GC::OtherLetter as u32));
+        | 1 << (GC::OtherLetter as u32),
 
     /// (`Mn`) A nonspacing combining mark (zero advance width)
-    pub const NonspacingMark: GeneralCategoryGroup = GCG(1 << (GC::NonspacingMark as u32));
+    NonspacingMark = 1 << (GC::NonspacingMark as u32),
     /// (`Mc`) A spacing combining mark (positive advance width)
-    pub const EnclosingMark: GeneralCategoryGroup = GCG(1 << (GC::EnclosingMark as u32));
+    EnclosingMark = 1 << (GC::EnclosingMark as u32),
     /// (`Me`) An enclosing combining mark
-    pub const SpacingMark: GeneralCategoryGroup = GCG(1 << (GC::SpacingMark as u32));
+    SpacingMark = 1 << (GC::SpacingMark as u32),
     /// (`M`) The union of all mark categories
-    pub const Mark: GeneralCategoryGroup = GCG(1 << (GC::NonspacingMark as u32)
+    Mark = 1 << (GC::NonspacingMark as u32)
         | 1 << (GC::EnclosingMark as u32)
-        | 1 << (GC::SpacingMark as u32));
+        | 1 << (GC::SpacingMark as u32),
 
     /// (`Nd`) A decimal digit
-    pub const DecimalNumber: GeneralCategoryGroup = GCG(1 << (GC::DecimalNumber as u32));
+    DecimalNumber = 1 << (GC::DecimalNumber as u32),
     /// (`Nl`) A letterlike numeric character
-    pub const LetterNumber: GeneralCategoryGroup = GCG(1 << (GC::LetterNumber as u32));
+    LetterNumber = 1 << (GC::LetterNumber as u32),
     /// (`No`) A numeric character of other type
-    pub const OtherNumber: GeneralCategoryGroup = GCG(1 << (GC::OtherNumber as u32));
+    OtherNumber = 1 << (GC::OtherNumber as u32),
     /// (`N`) The union of all number categories
-    pub const Number: GeneralCategoryGroup = GCG(1 << (GC::DecimalNumber as u32)
+    Number = 1 << (GC::DecimalNumber as u32)
         | 1 << (GC::LetterNumber as u32)
-        | 1 << (GC::OtherNumber as u32));
+        | 1 << (GC::OtherNumber as u32),
 
     /// (`Zs`) A space character (of various non-zero widths)
-    pub const SpaceSeparator: GeneralCategoryGroup = GCG(1 << (GC::SpaceSeparator as u32));
+    SpaceSeparator = 1 << (GC::SpaceSeparator as u32),
     /// (`Zl`) U+2028 LINE SEPARATOR only
-    pub const LineSeparator: GeneralCategoryGroup = GCG(1 << (GC::LineSeparator as u32));
+    LineSeparator = 1 << (GC::LineSeparator as u32),
     /// (`Zp`) U+2029 PARAGRAPH SEPARATOR only
-    pub const ParagraphSeparator: GeneralCategoryGroup = GCG(1 << (GC::ParagraphSeparator as u32));
+    ParagraphSeparator = 1 << (GC::ParagraphSeparator as u32),
     /// (`Z`) The union of all separator categories
-    pub const Separator: GeneralCategoryGroup = GCG(1 << (GC::SpaceSeparator as u32)
+    Separator = 1 << (GC::SpaceSeparator as u32)
         | 1 << (GC::LineSeparator as u32)
-        | 1 << (GC::ParagraphSeparator as u32));
+        | 1 << (GC::ParagraphSeparator as u32),
 
     /// (`Cc`) A C0 or C1 control code
-    pub const Control: GeneralCategoryGroup = GCG(1 << (GC::Control as u32));
+    Control = 1 << (GC::Control as u32),
     /// (`Cf`) A format control character
-    pub const Format: GeneralCategoryGroup = GCG(1 << (GC::Format as u32));
+    Format = 1 << (GC::Format as u32),
     /// (`Co`) A private-use character
-    pub const PrivateUse: GeneralCategoryGroup = GCG(1 << (GC::PrivateUse as u32));
+    PrivateUse = 1 << (GC::PrivateUse as u32),
     /// (`Cs`) A surrogate code point
-    pub const Surrogate: GeneralCategoryGroup = GCG(1 << (GC::Surrogate as u32));
+    Surrogate = 1 << (GC::Surrogate as u32),
     /// (`Cn`) A reserved unassigned code point or a noncharacter
-    pub const Unassigned: GeneralCategoryGroup = GCG(1 << (GC::Unassigned as u32));
+    Unassigned = 1 << (GC::Unassigned as u32),
     /// (`C`) The union of all control code, reserved, and unassigned categories
-    pub const Other: GeneralCategoryGroup = GCG(1 << (GC::Control as u32)
+    Other = 1 << (GC::Control as u32)
         | 1 << (GC::Format as u32)
         | 1 << (GC::PrivateUse as u32)
         | 1 << (GC::Surrogate as u32)
-        | 1 << (GC::Unassigned as u32));
+        | 1 << (GC::Unassigned as u32),
 
     /// (`Pd`) A dash or hyphen punctuation mark
-    pub const DashPunctuation: GeneralCategoryGroup = GCG(1 << (GC::DashPunctuation as u32));
+    DashPunctuation = 1 << (GC::DashPunctuation as u32),
     /// (`Ps`) An opening punctuation mark (of a pair)
-    pub const OpenPunctuation: GeneralCategoryGroup = GCG(1 << (GC::OpenPunctuation as u32));
+    OpenPunctuation = 1 << (GC::OpenPunctuation as u32),
     /// (`Pe`) A closing punctuation mark (of a pair)
-    pub const ClosePunctuation: GeneralCategoryGroup = GCG(1 << (GC::ClosePunctuation as u32));
+    ClosePunctuation = 1 << (GC::ClosePunctuation as u32),
     /// (`Pc`) A connecting punctuation mark, like a tie
-    pub const ConnectorPunctuation: GeneralCategoryGroup =
-        GCG(1 << (GC::ConnectorPunctuation as u32));
+    ConnectorPunctuation = 1 << (GC::ConnectorPunctuation as u32),
     /// (`Pi`) An initial quotation mark
-    pub const InitialPunctuation: GeneralCategoryGroup = GCG(1 << (GC::InitialPunctuation as u32));
+    InitialPunctuation = 1 << (GC::InitialPunctuation as u32),
     /// (`Pf`) A final quotation mark
-    pub const FinalPunctuation: GeneralCategoryGroup = GCG(1 << (GC::FinalPunctuation as u32));
+    FinalPunctuation = 1 << (GC::FinalPunctuation as u32),
     /// (`Po`) A punctuation mark of other type
-    pub const OtherPunctuation: GeneralCategoryGroup = GCG(1 << (GC::OtherPunctuation as u32));
+    OtherPunctuation = 1 << (GC::OtherPunctuation as u32),
     /// (`P`) The union of all punctuation categories
-    pub const Punctuation: GeneralCategoryGroup = GCG(1 << (GC::DashPunctuation as u32)
+    Punctuation = 1 << (GC::DashPunctuation as u32)
         | 1 << (GC::OpenPunctuation as u32)
         | 1 << (GC::ClosePunctuation as u32)
         | 1 << (GC::ConnectorPunctuation as u32)
         | 1 << (GC::OtherPunctuation as u32)
         | 1 << (GC::InitialPunctuation as u32)
-        | 1 << (GC::FinalPunctuation as u32));
+        | 1 << (GC::FinalPunctuation as u32),
 
     /// (`Sm`) A symbol of mathematical use
-    pub const MathSymbol: GeneralCategoryGroup = GCG(1 << (GC::MathSymbol as u32));
+    MathSymbol = 1 << (GC::MathSymbol as u32),
     /// (`Sc`) A currency sign
-    pub const CurrencySymbol: GeneralCategoryGroup = GCG(1 << (GC::CurrencySymbol as u32));
+    CurrencySymbol = 1 << (GC::CurrencySymbol as u32),
     /// (`Sk`) A non-letterlike modifier symbol
-    pub const ModifierSymbol: GeneralCategoryGroup = GCG(1 << (GC::ModifierSymbol as u32));
+    ModifierSymbol = 1 << (GC::ModifierSymbol as u32),
     /// (`So`) A symbol of other type
-    pub const OtherSymbol: GeneralCategoryGroup = GCG(1 << (GC::OtherSymbol as u32));
+    OtherSymbol = 1 << (GC::OtherSymbol as u32),
     /// (`S`) The union of all symbol categories
-    pub const Symbol: GeneralCategoryGroup = GCG(1 << (GC::MathSymbol as u32)
+    Symbol = 1 << (GC::MathSymbol as u32)
         | 1 << (GC::CurrencySymbol as u32)
         | 1 << (GC::ModifierSymbol as u32)
-        | 1 << (GC::OtherSymbol as u32));
+        | 1 << (GC::OtherSymbol as u32),
+}
 
+impl GeneralCategoryGroup {
     /// Return whether the code point belongs in the provided multi-value category.
     ///
     /// ```
@@ -394,180 +390,177 @@ impl From<u32> for GeneralCategoryGroup {
 ///
 /// For more information, see UAX #24: <http://www.unicode.org/reports/tr24/>.
 /// See `UScriptCode` in ICU4C.
+#[open_enum]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "datagen", derive(databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_properties))]
-#[allow(clippy::exhaustive_structs)] // newtype
-#[repr(transparent)]
-#[zerovec::make_ule(ScriptULE)]
-pub struct Script(pub u16);
-
 #[allow(missing_docs)] // These constants don't need individual documentation.
-#[allow(non_upper_case_globals)]
-impl Script {
-    pub const Adlam: Script = Script(167);
-    pub const Ahom: Script = Script(161);
-    pub const AnatolianHieroglyphs: Script = Script(156);
-    pub const Arabic: Script = Script(2);
-    pub const Armenian: Script = Script(3);
-    pub const Avestan: Script = Script(117);
-    pub const Balinese: Script = Script(62);
-    pub const Bamum: Script = Script(130);
-    pub const BassaVah: Script = Script(134);
-    pub const Batak: Script = Script(63);
-    pub const Bengali: Script = Script(4);
-    pub const Bhaiksuki: Script = Script(168);
-    pub const Bopomofo: Script = Script(5);
-    pub const Brahmi: Script = Script(65);
-    pub const Braille: Script = Script(46);
-    pub const Buginese: Script = Script(55);
-    pub const Buhid: Script = Script(44);
-    pub const CanadianAboriginal: Script = Script(40);
-    pub const Carian: Script = Script(104);
-    pub const CaucasianAlbanian: Script = Script(159);
-    pub const Chakma: Script = Script(118);
-    pub const Cham: Script = Script(66);
-    pub const Cherokee: Script = Script(6);
-    pub const Chorasmian: Script = Script(189);
-    pub const Common: Script = Script(0);
-    pub const Coptic: Script = Script(7);
-    pub const Cuneiform: Script = Script(101);
-    pub const Cypriot: Script = Script(47);
-    pub const CyproMinoan: Script = Script(193);
-    pub const Cyrillic: Script = Script(8);
-    pub const Deseret: Script = Script(9);
-    pub const Devanagari: Script = Script(10);
-    pub const DivesAkuru: Script = Script(190);
-    pub const Dogra: Script = Script(178);
-    pub const Duployan: Script = Script(135);
-    pub const EgyptianHieroglyphs: Script = Script(71);
-    pub const Elbasan: Script = Script(136);
-    pub const Elymaic: Script = Script(185);
-    pub const Ethiopian: Script = Script(11);
-    pub const Georgian: Script = Script(12);
-    pub const Glagolitic: Script = Script(56);
-    pub const Gothic: Script = Script(13);
-    pub const Grantha: Script = Script(137);
-    pub const Greek: Script = Script(14);
-    pub const Gujarati: Script = Script(15);
-    pub const GunjalaGondi: Script = Script(179);
-    pub const Gurmukhi: Script = Script(16);
-    pub const Han: Script = Script(17);
-    pub const Hangul: Script = Script(18);
-    pub const HanifiRohingya: Script = Script(182);
-    pub const Hanunoo: Script = Script(43);
-    pub const Hatran: Script = Script(162);
-    pub const Hebrew: Script = Script(19);
-    pub const Hiragana: Script = Script(20);
-    pub const ImperialAramaic: Script = Script(116);
-    pub const Inherited: Script = Script(1);
-    pub const InscriptionalPahlavi: Script = Script(122);
-    pub const InscriptionalParthian: Script = Script(125);
-    pub const Javanese: Script = Script(78);
-    pub const Kaithi: Script = Script(120);
-    pub const Kannada: Script = Script(21);
-    pub const Katakana: Script = Script(22);
-    pub const KayahLi: Script = Script(79);
-    pub const Kharoshthi: Script = Script(57);
-    pub const KhitanSmallScript: Script = Script(191);
-    pub const Khmer: Script = Script(23);
-    pub const Khojki: Script = Script(157);
-    pub const Khudawadi: Script = Script(145);
-    pub const Lao: Script = Script(24);
-    pub const Latin: Script = Script(25);
-    pub const Lepcha: Script = Script(82);
-    pub const Limbu: Script = Script(48);
-    pub const LinearA: Script = Script(83);
-    pub const LinearB: Script = Script(49);
-    pub const Lisu: Script = Script(131);
-    pub const Lycian: Script = Script(107);
-    pub const Lydian: Script = Script(108);
-    pub const Mahajani: Script = Script(160);
-    pub const Makasar: Script = Script(180);
-    pub const Malayalam: Script = Script(26);
-    pub const Mandaic: Script = Script(84);
-    pub const Manichaean: Script = Script(121);
-    pub const Marchen: Script = Script(169);
-    pub const MasaramGondi: Script = Script(175);
-    pub const Medefaidrin: Script = Script(181);
-    pub const MeeteiMayek: Script = Script(115);
-    pub const MendeKikakui: Script = Script(140);
-    pub const MeroiticCursive: Script = Script(141);
-    pub const MeroiticHieroglyphs: Script = Script(86);
-    pub const Miao: Script = Script(92);
-    pub const Modi: Script = Script(163);
-    pub const Mongolian: Script = Script(27);
-    pub const Mro: Script = Script(149);
-    pub const Multani: Script = Script(164);
-    pub const Myanmar: Script = Script(28);
-    pub const Nabataean: Script = Script(143);
-    pub const Nandinagari: Script = Script(187);
-    pub const NewTaiLue: Script = Script(59);
-    pub const Newa: Script = Script(170);
-    pub const Nko: Script = Script(87);
-    pub const Nushu: Script = Script(150);
-    pub const NyiakengPuachueHmong: Script = Script(186);
-    pub const Ogham: Script = Script(29);
-    pub const OlChiki: Script = Script(109);
-    pub const OldHungarian: Script = Script(76);
-    pub const OldItalic: Script = Script(30);
-    pub const OldNorthArabian: Script = Script(142);
-    pub const OldPermic: Script = Script(89);
-    pub const OldPersian: Script = Script(61);
-    pub const OldSogdian: Script = Script(184);
-    pub const OldSouthArabian: Script = Script(133);
-    pub const OldTurkic: Script = Script(88);
-    pub const OldUyghur: Script = Script(194);
-    pub const Oriya: Script = Script(31);
-    pub const Osage: Script = Script(171);
-    pub const Osmanya: Script = Script(50);
-    pub const PahawhHmong: Script = Script(75);
-    pub const Palmyrene: Script = Script(144);
-    pub const PauCinHau: Script = Script(165);
-    pub const PhagsPa: Script = Script(90);
-    pub const Phoenician: Script = Script(91);
-    pub const PsalterPahlavi: Script = Script(123);
-    pub const Rejang: Script = Script(110);
-    pub const Runic: Script = Script(32);
-    pub const Samaritan: Script = Script(126);
-    pub const Saurashtra: Script = Script(111);
-    pub const Sharada: Script = Script(151);
-    pub const Shavian: Script = Script(51);
-    pub const Siddham: Script = Script(166);
-    pub const SignWriting: Script = Script(112);
-    pub const Sinhala: Script = Script(33);
-    pub const Sogdian: Script = Script(183);
-    pub const SoraSompeng: Script = Script(152);
-    pub const Soyombo: Script = Script(176);
-    pub const Sundanese: Script = Script(113);
-    pub const SylotiNagri: Script = Script(58);
-    pub const Syriac: Script = Script(34);
-    pub const Tagalog: Script = Script(42);
-    pub const Tagbanwa: Script = Script(45);
-    pub const TaiLe: Script = Script(52);
-    pub const TaiTham: Script = Script(106);
-    pub const TaiViet: Script = Script(127);
-    pub const Takri: Script = Script(153);
-    pub const Tamil: Script = Script(35);
-    pub const Tangsa: Script = Script(195);
-    pub const Tangut: Script = Script(154);
-    pub const Telugu: Script = Script(36);
-    pub const Thaana: Script = Script(37);
-    pub const Thai: Script = Script(38);
-    pub const Tibetan: Script = Script(39);
-    pub const Tifinagh: Script = Script(60);
-    pub const Tirhuta: Script = Script(158);
-    pub const Toto: Script = Script(196);
-    pub const Ugaritic: Script = Script(53);
-    pub const Unknown: Script = Script(103);
-    pub const Vai: Script = Script(99);
-    pub const Vithkuqi: Script = Script(197);
-    pub const Wancho: Script = Script(188);
-    pub const WarangCiti: Script = Script(146);
-    pub const Yezidi: Script = Script(192);
-    pub const Yi: Script = Script(41);
-    pub const ZanabazarSquare: Script = Script(177);
+#[repr(u16)]
+#[zerovec::make_ule(ScriptULE)]
+pub enum Script {
+    Adlam = 167,
+    Ahom = 161,
+    AnatolianHieroglyphs = 156,
+    Arabic = 2,
+    Armenian = 3,
+    Avestan = 117,
+    Balinese = 62,
+    Bamum = 130,
+    BassaVah = 134,
+    Batak = 63,
+    Bengali = 4,
+    Bhaiksuki = 168,
+    Bopomofo = 5,
+    Brahmi = 65,
+    Braille = 46,
+    Buginese = 55,
+    Buhid = 44,
+    CanadianAboriginal = 40,
+    Carian = 104,
+    CaucasianAlbanian = 159,
+    Chakma = 118,
+    Cham = 66,
+    Cherokee = 6,
+    Chorasmian = 189,
+    Common = 0,
+    Coptic = 7,
+    Cuneiform = 101,
+    Cypriot = 47,
+    CyproMinoan = 193,
+    Cyrillic = 8,
+    Deseret = 9,
+    Devanagari = 10,
+    DivesAkuru = 190,
+    Dogra = 178,
+    Duployan = 135,
+    EgyptianHieroglyphs = 71,
+    Elbasan = 136,
+    Elymaic = 185,
+    Ethiopian = 11,
+    Georgian = 12,
+    Glagolitic = 56,
+    Gothic = 13,
+    Grantha = 137,
+    Greek = 14,
+    Gujarati = 15,
+    GunjalaGondi = 179,
+    Gurmukhi = 16,
+    Han = 17,
+    Hangul = 18,
+    HanifiRohingya = 182,
+    Hanunoo = 43,
+    Hatran = 162,
+    Hebrew = 19,
+    Hiragana = 20,
+    ImperialAramaic = 116,
+    Inherited = 1,
+    InscriptionalPahlavi = 122,
+    InscriptionalParthian = 125,
+    Javanese = 78,
+    Kaithi = 120,
+    Kannada = 21,
+    Katakana = 22,
+    KayahLi = 79,
+    Kharoshthi = 57,
+    KhitanSmallScript = 191,
+    Khmer = 23,
+    Khojki = 157,
+    Khudawadi = 145,
+    Lao = 24,
+    Latin = 25,
+    Lepcha = 82,
+    Limbu = 48,
+    LinearA = 83,
+    LinearB = 49,
+    Lisu = 131,
+    Lycian = 107,
+    Lydian = 108,
+    Mahajani = 160,
+    Makasar = 180,
+    Malayalam = 26,
+    Mandaic = 84,
+    Manichaean = 121,
+    Marchen = 169,
+    MasaramGondi = 175,
+    Medefaidrin = 181,
+    MeeteiMayek = 115,
+    MendeKikakui = 140,
+    MeroiticCursive = 141,
+    MeroiticHieroglyphs = 86,
+    Miao = 92,
+    Modi = 163,
+    Mongolian = 27,
+    Mro = 149,
+    Multani = 164,
+    Myanmar = 28,
+    Nabataean = 143,
+    Nandinagari = 187,
+    NewTaiLue = 59,
+    Newa = 170,
+    Nko = 87,
+    Nushu = 150,
+    NyiakengPuachueHmong = 186,
+    Ogham = 29,
+    OlChiki = 109,
+    OldHungarian = 76,
+    OldItalic = 30,
+    OldNorthArabian = 142,
+    OldPermic = 89,
+    OldPersian = 61,
+    OldSogdian = 184,
+    OldSouthArabian = 133,
+    OldTurkic = 88,
+    OldUyghur = 194,
+    Oriya = 31,
+    Osage = 171,
+    Osmanya = 50,
+    PahawhHmong = 75,
+    Palmyrene = 144,
+    PauCinHau = 165,
+    PhagsPa = 90,
+    Phoenician = 91,
+    PsalterPahlavi = 123,
+    Rejang = 110,
+    Runic = 32,
+    Samaritan = 126,
+    Saurashtra = 111,
+    Sharada = 151,
+    Shavian = 51,
+    Siddham = 166,
+    SignWriting = 112,
+    Sinhala = 33,
+    Sogdian = 183,
+    SoraSompeng = 152,
+    Soyombo = 176,
+    Sundanese = 113,
+    SylotiNagri = 58,
+    Syriac = 34,
+    Tagalog = 42,
+    Tagbanwa = 45,
+    TaiLe = 52,
+    TaiTham = 106,
+    TaiViet = 127,
+    Takri = 153,
+    Tamil = 35,
+    Tangsa = 195,
+    Tangut = 154,
+    Telugu = 36,
+    Thaana = 37,
+    Thai = 38,
+    Tibetan = 39,
+    Tifinagh = 60,
+    Tirhuta = 158,
+    Toto = 196,
+    Ugaritic = 53,
+    Unknown = 103,
+    Vai = 99,
+    Vithkuqi = 197,
+    Wancho = 188,
+    WarangCiti = 146,
+    Yezidi = 192,
+    Yi = 41,
+    ZanabazarSquare = 177,
 }
 
 /// Enumerated property East_Asian_Width.
@@ -576,24 +569,26 @@ impl Script {
 /// <https://www.unicode.org/reports/tr11/#Definitions>
 ///
 /// The numeric value is compatible with `UEastAsianWidth` in ICU4C.
+#[open_enum]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "datagen", derive(databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_properties))]
-#[allow(clippy::exhaustive_structs)] // newtype
-#[repr(transparent)]
+#[repr(u8)]
 #[zerovec::make_ule(EastAsianWidthULE)]
-pub struct EastAsianWidth(pub u8);
-
-#[allow(missing_docs)] // These constants don't need individual documentation.
-#[allow(non_upper_case_globals)]
-impl EastAsianWidth {
-    pub const Neutral: EastAsianWidth = EastAsianWidth(0); //name="N"
-    pub const Ambiguous: EastAsianWidth = EastAsianWidth(1); //name="A"
-    pub const Halfwidth: EastAsianWidth = EastAsianWidth(2); //name="H"
-    pub const Fullwidth: EastAsianWidth = EastAsianWidth(3); //name="F"
-    pub const Narrow: EastAsianWidth = EastAsianWidth(4); //name="Na"
-    pub const Wide: EastAsianWidth = EastAsianWidth(5); //name="W"
+pub enum EastAsianWidth {
+    /// name="N"
+    Neutral,
+    /// name="A"
+    Ambiguous,
+    /// name="H"
+    Halfwidth,
+    /// name="F"
+    Fullwidth,
+    /// name="Na"
+    Narrow,
+    /// name="W"
+    Wide,
 }
 
 /// Enumerated property Line_Break.
@@ -602,61 +597,100 @@ impl EastAsianWidth {
 /// value: <https://www.unicode.org/reports/tr14/#Properties>
 ///
 /// The numeric value is compatible with `ULineBreak` in ICU4C.
+#[open_enum]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "datagen", derive(databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_properties))]
-#[allow(clippy::exhaustive_structs)] // newtype
-#[repr(transparent)]
+#[repr(u8)]
 #[zerovec::make_ule(LineBreakULE)]
-pub struct LineBreak(pub u8);
-
-#[allow(missing_docs)] // These constants don't need individual documentation.
-#[allow(non_upper_case_globals)]
-impl LineBreak {
-    pub const Unknown: LineBreak = LineBreak(0); // name="XX"
-    pub const Ambiguous: LineBreak = LineBreak(1); // name="AI"
-    pub const Alphabetic: LineBreak = LineBreak(2); // name="AL"
-    pub const BreakBoth: LineBreak = LineBreak(3); // name="B2"
-    pub const BreakAfter: LineBreak = LineBreak(4); // name="BA"
-    pub const BreakBefore: LineBreak = LineBreak(5); // name="BB"
-    pub const MandatoryBreak: LineBreak = LineBreak(6); // name="BK"
-    pub const ContingentBreak: LineBreak = LineBreak(7); // name="CB"
-    pub const ClosePunctuation: LineBreak = LineBreak(8); // name="CL"
-    pub const CombiningMark: LineBreak = LineBreak(9); // name="CM"
-    pub const CarriageReturn: LineBreak = LineBreak(10); // name="CR"
-    pub const Exclamation: LineBreak = LineBreak(11); // name="EX"
-    pub const Glue: LineBreak = LineBreak(12); // name="GL"
-    pub const Hyphen: LineBreak = LineBreak(13); // name="HY"
-    pub const Ideographic: LineBreak = LineBreak(14); // name="ID"
-    pub const Inseparable: LineBreak = LineBreak(15); // name="IN"
-    pub const InfixNumeric: LineBreak = LineBreak(16); // name="IS"
-    pub const LineFeed: LineBreak = LineBreak(17); // name="LF"
-    pub const Nonstarter: LineBreak = LineBreak(18); // name="NS"
-    pub const Numeric: LineBreak = LineBreak(19); // name="NU"
-    pub const OpenPunctuation: LineBreak = LineBreak(20); // name="OP"
-    pub const PostfixNumeric: LineBreak = LineBreak(21); // name="PO"
-    pub const PrefixNumeric: LineBreak = LineBreak(22); // name="PR"
-    pub const Quotation: LineBreak = LineBreak(23); // name="QU"
-    pub const ComplexContext: LineBreak = LineBreak(24); // name="SA"
-    pub const Surrogate: LineBreak = LineBreak(25); // name="SG"
-    pub const Space: LineBreak = LineBreak(26); // name="SP"
-    pub const BreakSymbols: LineBreak = LineBreak(27); // name="SY"
-    pub const ZWSpace: LineBreak = LineBreak(28); // name="ZW"
-    pub const NextLine: LineBreak = LineBreak(29); // name="NL"
-    pub const WordJoiner: LineBreak = LineBreak(30); // name="WJ"
-    pub const H2: LineBreak = LineBreak(31); // name="H2"
-    pub const H3: LineBreak = LineBreak(32); // name="H3"
-    pub const JL: LineBreak = LineBreak(33); // name="JL"
-    pub const JT: LineBreak = LineBreak(34); // name="JT"
-    pub const JV: LineBreak = LineBreak(35); // name="JV"
-    pub const CloseParenthesis: LineBreak = LineBreak(36); // name="CP"
-    pub const ConditionalJapaneseStarter: LineBreak = LineBreak(37); // name="CJ"
-    pub const HebrewLetter: LineBreak = LineBreak(38); // name="HL"
-    pub const RegionalIndicator: LineBreak = LineBreak(39); // name="RI"
-    pub const EBase: LineBreak = LineBreak(40); // name="EB"
-    pub const EModifier: LineBreak = LineBreak(41); // name="EM"
-    pub const ZWJ: LineBreak = LineBreak(42); // name="ZWJ"
+pub enum LineBreak {
+    /// name="XX"
+    Unknown,
+    /// name="AI"
+    Ambiguous,
+    /// name="AL"
+    Alphabetic,
+    /// name="B2"
+    BreakBoth,
+    /// name="BA"
+    BreakAfter,
+    /// name="BB"
+    BreakBefore,
+    /// name="BK"
+    MandatoryBreak,
+    /// name="CB"
+    ContingentBreak,
+    /// name="CL"
+    ClosePunctuation,
+    /// name="CM"
+    CombiningMark,
+    /// name="CR"
+    CarriageReturn,
+    /// name="EX"
+    Exclamation,
+    /// name="GL"
+    Glue,
+    /// name="HY"
+    Hyphen,
+    /// name="ID"
+    Ideographic,
+    /// name="IN"
+    Inseparable,
+    /// name="IS"
+    InfixNumeric,
+    /// name="LF"
+    LineFeed,
+    /// name="NS"
+    Nonstarter,
+    /// name="NU"
+    Numeric,
+    /// name="OP"
+    OpenPunctuation,
+    /// name="PO"
+    PostfixNumeric,
+    /// name="PR"
+    PrefixNumeric,
+    /// name="QU"
+    Quotation,
+    /// name="SA"
+    ComplexContext,
+    /// name="SG"
+    Surrogate,
+    /// name="SP"
+    Space,
+    /// name="SY"
+    BreakSymbols,
+    /// name="ZW"
+    ZWSpace,
+    /// name="NL"
+    NextLine,
+    /// name="WJ"
+    WordJoiner,
+    /// name="H2"
+    H2,
+    /// name="H3"
+    H3,
+    /// name="JL"
+    JL,
+    /// name="JT"
+    JT,
+    /// name="JV"
+    JV,
+    /// name="CP"
+    CloseParenthesis,
+    /// name="CJ"
+    ConditionalJapaneseStarter,
+    /// name="HL"
+    HebrewLetter,
+    /// name="RI"
+    RegionalIndicator,
+    /// name="EB"
+    EBase,
+    /// name="EM"
+    EModifier,
+    /// name="ZWJ"
+    ZWJ,
 }
 
 /// Enumerated property Grapheme_Cluster_Break.
@@ -666,40 +700,54 @@ impl LineBreak {
 /// <https://www.unicode.org/reports/tr29/#Default_Grapheme_Cluster_Table>
 ///
 /// The numeric value is compatible with `UGraphemeClusterBreak` in ICU4C.
+#[open_enum]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "datagen", derive(databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_properties))]
-#[allow(clippy::exhaustive_structs)] // this type is stable
-#[repr(transparent)]
+#[repr(u8)]
 #[zerovec::make_ule(GraphemeClusterBreakULE)]
-pub struct GraphemeClusterBreak(pub u8);
-
-#[allow(missing_docs)] // These constants don't need individual documentation.
-#[allow(non_upper_case_globals)]
-impl GraphemeClusterBreak {
-    pub const Other: GraphemeClusterBreak = GraphemeClusterBreak(0); // name="XX"
-    pub const Control: GraphemeClusterBreak = GraphemeClusterBreak(1); // name="CN"
-    pub const CR: GraphemeClusterBreak = GraphemeClusterBreak(2); // name="CR"
-    pub const Extend: GraphemeClusterBreak = GraphemeClusterBreak(3); // name="EX"
-    pub const L: GraphemeClusterBreak = GraphemeClusterBreak(4); // name="L"
-    pub const LF: GraphemeClusterBreak = GraphemeClusterBreak(5); // name="LF"
-    pub const LV: GraphemeClusterBreak = GraphemeClusterBreak(6); // name="LV"
-    pub const LVT: GraphemeClusterBreak = GraphemeClusterBreak(7); // name="LVT"
-    pub const T: GraphemeClusterBreak = GraphemeClusterBreak(8); // name="T"
-    pub const V: GraphemeClusterBreak = GraphemeClusterBreak(9); // name="V"
-    pub const SpacingMark: GraphemeClusterBreak = GraphemeClusterBreak(10); // name="SM"
-    pub const Prepend: GraphemeClusterBreak = GraphemeClusterBreak(11); // name="PP"
-    pub const RegionalIndicator: GraphemeClusterBreak = GraphemeClusterBreak(12); // name="RI"
+pub enum GraphemeClusterBreak {
+    /// name="XX"
+    Other,
+    /// name="CN"
+    Control,
+    /// name="CR"
+    CR,
+    /// name="EX"
+    Extend,
+    /// name="L"
+    L,
+    /// name="LF"
+    LF,
+    /// name="LV"
+    LV,
+    /// name="LVT"
+    LVT,
+    /// name="T"
+    T,
+    /// name="V"
+    V,
+    /// name="SM"
+    SpacingMark,
+    /// name="PP"
+    Prepend,
+    /// name="RI"
+    RegionalIndicator,
     /// This value is obsolete and unused.
-    pub const EBase: GraphemeClusterBreak = GraphemeClusterBreak(13); // name="EB"
+    /// name="EB"
+    EBase,
     /// This value is obsolete and unused.
-    pub const EBaseGAZ: GraphemeClusterBreak = GraphemeClusterBreak(14); // name="EBG"
+    /// name="EBG"
+    EBaseGAZ,
     /// This value is obsolete and unused.
-    pub const EModifier: GraphemeClusterBreak = GraphemeClusterBreak(15); // name="EM"
+    /// name="EM"
+    EModifier,
     /// This value is obsolete and unused.
-    pub const GlueAfterZwj: GraphemeClusterBreak = GraphemeClusterBreak(16); // name="GAZ"
-    pub const ZWJ: GraphemeClusterBreak = GraphemeClusterBreak(17); // name="ZWJ"
+    /// name="GAZ"
+    GlueAfterZwj,
+    /// name="ZWJ"
+    ZWJ,
 }
 
 /// Enumerated property Word_Break.
@@ -709,45 +757,64 @@ impl GraphemeClusterBreak {
 /// <https://www.unicode.org/reports/tr29/#Default_Word_Boundaries>.
 ///
 /// The numeric value is compatible with `UWordBreakValues` in ICU4C.
+#[open_enum]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "datagen", derive(databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_properties))]
-#[allow(clippy::exhaustive_structs)] // newtype
-#[repr(transparent)]
+#[repr(u8)]
 #[zerovec::make_ule(WordBreakULE)]
-pub struct WordBreak(pub u8);
-
-#[allow(missing_docs)] // These constants don't need individual documentation.
-#[allow(non_upper_case_globals)]
-impl WordBreak {
-    pub const Other: WordBreak = WordBreak(0); // name="XX"
-    pub const ALetter: WordBreak = WordBreak(1); // name="LE"
-    pub const Format: WordBreak = WordBreak(2); // name="FO"
-    pub const Katakana: WordBreak = WordBreak(3); // name="KA"
-    pub const MidLetter: WordBreak = WordBreak(4); // name="ML"
-    pub const MidNum: WordBreak = WordBreak(5); // name="MN"
-    pub const Numeric: WordBreak = WordBreak(6); // name="NU"
-    pub const ExtendNumLet: WordBreak = WordBreak(7); // name="EX"
-    pub const CR: WordBreak = WordBreak(8); // name="CR"
-    pub const Extend: WordBreak = WordBreak(9); // name="Extend"
-    pub const LF: WordBreak = WordBreak(10); // name="LF"
-    pub const MidNumLet: WordBreak = WordBreak(11); // name="MB"
-    pub const Newline: WordBreak = WordBreak(12); // name="NL"
-    pub const RegionalIndicator: WordBreak = WordBreak(13); // name="RI"
-    pub const HebrewLetter: WordBreak = WordBreak(14); // name="HL"
-    pub const SingleQuote: WordBreak = WordBreak(15); // name="SQ"
-    pub const DoubleQuote: WordBreak = WordBreak(16); // name=DQ
+pub enum WordBreak {
+    /// name="XX"
+    Other,
+    /// name="LE"
+    ALetter,
+    /// name="FO"
+    Format,
+    /// name="KA"
+    Katakana,
+    /// name="ML"
+    MidLetter,
+    /// name="MN"
+    MidNum,
+    /// name="NU"
+    Numeric,
+    /// name="EX"
+    ExtendNumLet,
+    /// name="CR"
+    CR,
+    /// name="Extend"
+    Extend,
+    /// name="LF"
+    LF,
+    /// name="MB"
+    MidNumLet,
+    /// name="NL"
+    Newline,
+    /// name="RI"
+    RegionalIndicator,
+    /// name="HL"
+    HebrewLetter,
+    /// name="SQ"
+    SingleQuote,
+    /// name=DQ
+    DoubleQuote,
     /// This value is obsolete and unused.
-    pub const EBase: WordBreak = WordBreak(17); // name="EB"
+    /// name="EB"
+    EBase,
     /// This value is obsolete and unused.
-    pub const EBaseGAZ: WordBreak = WordBreak(18); // name="EBG"
+    /// name="EBG"
+    EBaseGAZ,
     /// This value is obsolete and unused.
-    pub const EModifier: WordBreak = WordBreak(19); // name="EM"
+    /// name="EM"
+    EModifier,
     /// This value is obsolete and unused.
-    pub const GlueAfterZwj: WordBreak = WordBreak(20); // name="GAZ"
-    pub const ZWJ: WordBreak = WordBreak(21); // name="ZWJ"
-    pub const WSegSpace: WordBreak = WordBreak(22); // name="WSegSpace"
+    /// name="GAZ"
+    GlueAfterZwj,
+    /// name="ZWJ"
+    ZWJ,
+    /// name="WSegSpace"
+    WSegSpace,
 }
 
 /// Enumerated property Sentence_Break.
@@ -756,33 +823,44 @@ impl WordBreak {
 /// <https://www.unicode.org/reports/tr29/#Default_Word_Boundaries>.
 ///
 /// The numeric value is compatible with `USentenceBreak` in ICU4C.
+#[open_enum]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "datagen", derive(databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_properties))]
-#[allow(clippy::exhaustive_structs)] // newtype
-#[repr(transparent)]
+#[repr(u8)]
 #[zerovec::make_ule(SentenceBreakULE)]
-pub struct SentenceBreak(pub u8);
-
-#[allow(missing_docs)] // These constants don't need individual documentation.
-#[allow(non_upper_case_globals)]
-impl SentenceBreak {
-    pub const Other: SentenceBreak = SentenceBreak(0); // name="XX"
-    pub const ATerm: SentenceBreak = SentenceBreak(1); // name="AT"
-    pub const Close: SentenceBreak = SentenceBreak(2); // name="CL"
-    pub const Format: SentenceBreak = SentenceBreak(3); // name="FO"
-    pub const Lower: SentenceBreak = SentenceBreak(4); // name="LO"
-    pub const Numeric: SentenceBreak = SentenceBreak(5); // name="NU"
-    pub const OLetter: SentenceBreak = SentenceBreak(6); // name="LE"
-    pub const Sep: SentenceBreak = SentenceBreak(7); // name="SE"
-    pub const Sp: SentenceBreak = SentenceBreak(8); // name="SP"
-    pub const STerm: SentenceBreak = SentenceBreak(9); // name="ST"
-    pub const Upper: SentenceBreak = SentenceBreak(10); // name="UP"
-    pub const CR: SentenceBreak = SentenceBreak(11); // name="CR"
-    pub const Extend: SentenceBreak = SentenceBreak(12); // name="EX"
-    pub const LF: SentenceBreak = SentenceBreak(13); // name="LF"
-    pub const SContinue: SentenceBreak = SentenceBreak(14); // name="SC"
+pub enum SentenceBreak {
+    /// name="XX"
+    Other,
+    /// name="AT"
+    ATerm,
+    /// name="CL"
+    Close,
+    /// name="FO"
+    Format,
+    /// name="LO"
+    Lower,
+    /// name="NU"
+    Numeric,
+    /// name="LE"
+    OLetter,
+    /// name="SE"
+    Sep,
+    /// name="SP"
+    Sp,
+    /// name="ST"
+    STerm,
+    /// name="UP"
+    Upper,
+    /// name="CR"
+    CR,
+    /// name="EX"
+    Extend,
+    /// name="LF"
+    LF,
+    /// name="SC"
+    SContinue,
 }
 
 /// Property Canonical_Combining_Class.
@@ -793,78 +871,132 @@ impl SentenceBreak {
 /// to look up the Canonical_Combining_Class property by scalar value.
 //
 // NOTE: The Pernosco debugger has special knowledge
-// of this struct. Please do not change the bit layout
-// or the crate-module-qualified name of this struct
+// of this type. Please do not change the bit layout
+// or the crate-module-qualified name of this type
 // without coordination.
+#[open_enum]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "datagen", derive(databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_properties))]
-#[allow(clippy::exhaustive_structs)] // newtype
-#[repr(transparent)]
+#[repr(u8)]
 #[zerovec::make_ule(CanonicalCombiningClassULE)]
-pub struct CanonicalCombiningClass(pub u8);
-
-// These constant names come from PropertyValueAliases.txt
-#[allow(missing_docs)] // These constants don't need individual documentation.
-#[allow(non_upper_case_globals)]
-impl CanonicalCombiningClass {
-    pub const NotReordered: CanonicalCombiningClass = CanonicalCombiningClass(0); // name="NR"
-    pub const Overlay: CanonicalCombiningClass = CanonicalCombiningClass(1); // name="OV"
-    pub const HanReading: CanonicalCombiningClass = CanonicalCombiningClass(6); // name="HANR"
-    pub const Nukta: CanonicalCombiningClass = CanonicalCombiningClass(7); // name="NK"
-    pub const KanaVoicing: CanonicalCombiningClass = CanonicalCombiningClass(8); // name="KV"
-    pub const Virama: CanonicalCombiningClass = CanonicalCombiningClass(9); // name="VR"
-    pub const CCC10: CanonicalCombiningClass = CanonicalCombiningClass(10); // name="CCC10"
-    pub const CCC11: CanonicalCombiningClass = CanonicalCombiningClass(11); // name="CCC11"
-    pub const CCC12: CanonicalCombiningClass = CanonicalCombiningClass(12); // name="CCC12"
-    pub const CCC13: CanonicalCombiningClass = CanonicalCombiningClass(13); // name="CCC13"
-    pub const CCC14: CanonicalCombiningClass = CanonicalCombiningClass(14); // name="CCC14"
-    pub const CCC15: CanonicalCombiningClass = CanonicalCombiningClass(15); // name="CCC15"
-    pub const CCC16: CanonicalCombiningClass = CanonicalCombiningClass(16); // name="CCC16"
-    pub const CCC17: CanonicalCombiningClass = CanonicalCombiningClass(17); // name="CCC17"
-    pub const CCC18: CanonicalCombiningClass = CanonicalCombiningClass(18); // name="CCC18"
-    pub const CCC19: CanonicalCombiningClass = CanonicalCombiningClass(19); // name="CCC19"
-    pub const CCC20: CanonicalCombiningClass = CanonicalCombiningClass(20); // name="CCC20"
-    pub const CCC21: CanonicalCombiningClass = CanonicalCombiningClass(21); // name="CCC21"
-    pub const CCC22: CanonicalCombiningClass = CanonicalCombiningClass(22); // name="CCC22"
-    pub const CCC23: CanonicalCombiningClass = CanonicalCombiningClass(23); // name="CCC23"
-    pub const CCC24: CanonicalCombiningClass = CanonicalCombiningClass(24); // name="CCC24"
-    pub const CCC25: CanonicalCombiningClass = CanonicalCombiningClass(25); // name="CCC25"
-    pub const CCC26: CanonicalCombiningClass = CanonicalCombiningClass(26); // name="CCC26"
-    pub const CCC27: CanonicalCombiningClass = CanonicalCombiningClass(27); // name="CCC27"
-    pub const CCC28: CanonicalCombiningClass = CanonicalCombiningClass(28); // name="CCC28"
-    pub const CCC29: CanonicalCombiningClass = CanonicalCombiningClass(29); // name="CCC29"
-    pub const CCC30: CanonicalCombiningClass = CanonicalCombiningClass(30); // name="CCC30"
-    pub const CCC31: CanonicalCombiningClass = CanonicalCombiningClass(31); // name="CCC31"
-    pub const CCC32: CanonicalCombiningClass = CanonicalCombiningClass(32); // name="CCC32"
-    pub const CCC33: CanonicalCombiningClass = CanonicalCombiningClass(33); // name="CCC33"
-    pub const CCC34: CanonicalCombiningClass = CanonicalCombiningClass(34); // name="CCC34"
-    pub const CCC35: CanonicalCombiningClass = CanonicalCombiningClass(35); // name="CCC35"
-    pub const CCC36: CanonicalCombiningClass = CanonicalCombiningClass(36); // name="CCC36"
-    pub const CCC84: CanonicalCombiningClass = CanonicalCombiningClass(84); // name="CCC84"
-    pub const CCC91: CanonicalCombiningClass = CanonicalCombiningClass(91); // name="CCC91"
-    pub const CCC103: CanonicalCombiningClass = CanonicalCombiningClass(103); // name="CCC103"
-    pub const CCC107: CanonicalCombiningClass = CanonicalCombiningClass(107); // name="CCC107"
-    pub const CCC118: CanonicalCombiningClass = CanonicalCombiningClass(118); // name="CCC118"
-    pub const CCC122: CanonicalCombiningClass = CanonicalCombiningClass(122); // name="CCC122"
-    pub const CCC129: CanonicalCombiningClass = CanonicalCombiningClass(129); // name="CCC129"
-    pub const CCC130: CanonicalCombiningClass = CanonicalCombiningClass(130); // name="CCC130"
-    pub const CCC132: CanonicalCombiningClass = CanonicalCombiningClass(132); // name="CCC132"
-    pub const CCC133: CanonicalCombiningClass = CanonicalCombiningClass(133); // name="CCC133" // RESERVED
-    pub const AttachedBelowLeft: CanonicalCombiningClass = CanonicalCombiningClass(200); // name="ATBL"
-    pub const AttachedBelow: CanonicalCombiningClass = CanonicalCombiningClass(202); // name="ATB"
-    pub const AttachedAbove: CanonicalCombiningClass = CanonicalCombiningClass(214); // name="ATA"
-    pub const AttachedAboveRight: CanonicalCombiningClass = CanonicalCombiningClass(216); // name="ATAR"
-    pub const BelowLeft: CanonicalCombiningClass = CanonicalCombiningClass(218); // name="BL"
-    pub const Below: CanonicalCombiningClass = CanonicalCombiningClass(220); // name="B"
-    pub const BelowRight: CanonicalCombiningClass = CanonicalCombiningClass(222); // name="BR"
-    pub const Left: CanonicalCombiningClass = CanonicalCombiningClass(224); // name="L"
-    pub const Right: CanonicalCombiningClass = CanonicalCombiningClass(226); // name="R"
-    pub const AboveLeft: CanonicalCombiningClass = CanonicalCombiningClass(228); // name="AL"
-    pub const Above: CanonicalCombiningClass = CanonicalCombiningClass(230); // name="A"
-    pub const AboveRight: CanonicalCombiningClass = CanonicalCombiningClass(232); // name="AR"
-    pub const DoubleBelow: CanonicalCombiningClass = CanonicalCombiningClass(233); // name="DB"
-    pub const DoubleAbove: CanonicalCombiningClass = CanonicalCombiningClass(234); // name="DA"
-    pub const IotaSubscript: CanonicalCombiningClass = CanonicalCombiningClass(240); // name="IS"
+pub enum CanonicalCombiningClass {
+    // These constant names come from PropertyValueAliases.txt
+    /// name="NR"
+    NotReordered = 0,
+    /// name="OV"
+    Overlay = 1,
+    /// name="HANR"
+    HanReading = 6,
+    /// name="NK"
+    Nukta = 7,
+    /// name="KV"
+    KanaVoicing = 8,
+    /// name="VR"
+    Virama = 9,
+    /// name="CCC10"
+    CCC10 = 10,
+    /// name="CCC11"
+    CCC11 = 11,
+    /// name="CCC12"
+    CCC12 = 12,
+    /// name="CCC13"
+    CCC13 = 13,
+    /// name="CCC14"
+    CCC14 = 14,
+    /// name="CCC15"
+    CCC15 = 15,
+    /// name="CCC16"
+    CCC16 = 16,
+    /// name="CCC17"
+    CCC17 = 17,
+    /// name="CCC18"
+    CCC18 = 18,
+    /// name="CCC19"
+    CCC19 = 19,
+    /// name="CCC20"
+    CCC20 = 20,
+    /// name="CCC21"
+    CCC21 = 21,
+    /// name="CCC22"
+    CCC22 = 22,
+    /// name="CCC23"
+    CCC23 = 23,
+    /// name="CCC24"
+    CCC24 = 24,
+    /// name="CCC25"
+    CCC25 = 25,
+    /// name="CCC26"
+    CCC26 = 26,
+    /// name="CCC27"
+    CCC27 = 27,
+    /// name="CCC28"
+    CCC28 = 28,
+    /// name="CCC29"
+    CCC29 = 29,
+    /// name="CCC30"
+    CCC30 = 30,
+    /// name="CCC31"
+    CCC31 = 31,
+    /// name="CCC32"
+    CCC32 = 32,
+    /// name="CCC33"
+    CCC33 = 33,
+    /// name="CCC34"
+    CCC34 = 34,
+    /// name="CCC35"
+    CCC35 = 35,
+    /// name="CCC36"
+    CCC36 = 36,
+    /// name="CCC84"
+    CCC84 = 84,
+    /// name="CCC91"
+    CCC91 = 91,
+    /// name="CCC103"
+    CCC103 = 103,
+    /// name="CCC107"
+    CCC107 = 107,
+    /// name="CCC118"
+    CCC118 = 118,
+    /// name="CCC122"
+    CCC122 = 122,
+    /// name="CCC129"
+    CCC129 = 129,
+    /// name="CCC130"
+    CCC130 = 130,
+    /// name="CCC132"
+    CCC132 = 132,
+    /// name="CCC133" (RESERVED)
+    CCC133 = 133,
+    /// name="ATBL"
+    AttachedBelowLeft = 200,
+    /// name="ATB"
+    AttachedBelow = 202,
+    /// name="ATA"
+    AttachedAbove = 214,
+    /// name="ATAR"
+    AttachedAboveRight = 216,
+    /// name="BL"
+    BelowLeft = 218,
+    /// name="B"
+    Below = 220,
+    /// name="BR"
+    BelowRight = 222,
+    /// name="L"
+    Left = 224,
+    /// name="R"
+    Right = 226,
+    /// name="AL"
+    AboveLeft = 228,
+    /// name="A"
+    Above = 230,
+    /// name="AR"
+    AboveRight = 232,
+    /// name="DB"
+    DoubleBelow = 233,
+    /// name="DA"
+    DoubleAbove = 234,
+    /// name="IS"
+    IotaSubscript = 240,
 }


### PR DESCRIPTION
The pattern of using an integer newtype with named associated constants is exactly what the [open_enum macro](https://docs.rs/open-enum/0.3.0/open_enum/) aims to make cleaner. This pull should result in no semantic change. All values have stayed the same; the syntax has just changed. I've also moved some comments to docstrings.

I think it looks cleaner and I aimed to make open-enum a small dependency appropriate for icu4x - what are your thoughts?