### PR TITLE
Add C/C++ headers in the package

### DIFF
--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -18,7 +18,7 @@ include = [
     "examples/**/*",
     "benches/**/*",
     "tests/**/*",
-    "include/**/*",
+    "**/include/**/*",
     "Cargo.toml",
     "LICENSE",
     "README.md"


### PR DESCRIPTION
When using `icu_capi` crate, C/C++ headers are missing in this package. It seems that headers path is changed.