### PR TITLE
Add CodePointTrieBorrow as a borrowed counterpart of CodePointTrie

### DIFF
--- a/components/collator/src/elements.rs
+++ b/components/collator/src/elements.rs
@@ -20,7 +20,7 @@
 
 use core::char::REPLACEMENT_CHARACTER;
 use icu_collections::char16trie::TrieResult;
-use icu_collections::codepointtrie::CodePointTrieBorrow;
+use icu_collections::codepointtrie::CodePointTrieBorrowed;
 use icu_normalizer::provider::DecompositionDataV1;
 use icu_normalizer::provider::DecompositionTablesV1;
 use icu_properties::CanonicalCombiningClass;
@@ -742,7 +742,7 @@ impl CharacterAndClass {
         (self.character(), self.ccc())
     }
     #[inline(always)]
-    pub fn set_ccc_from_trie_if_not_already_set(&mut self, trie: &CodePointTrieBorrow<u32>) {
+    pub fn set_ccc_from_trie_if_not_already_set(&mut self, trie: &CodePointTrieBorrowed<u32>) {
         if self.0 >> 24 != 0xFF {
             return;
         }
@@ -800,7 +800,7 @@ where
     /// The `CollationElement32` mapping for the Combining Diacritical Marks block.
     diacritics: &'data ZeroSlice<u16>,
     /// NFD main trie.
-    trie: CodePointTrieBorrow<'data, u32>,
+    trie: CodePointTrieBorrowed<'data, u32>,
     /// NFD complex decompositions on the BMP
     scalars16: &'data ZeroSlice<u16>,
     /// NFD complex decompositions on supplementary planes

--- a/components/collections/src/codepointtrie/cptrie.rs
+++ b/components/collections/src/codepointtrie/cptrie.rs
@@ -117,7 +117,7 @@ pub struct CodePointTrie<'trie, T: TrieValue> {
 /// Borrowed version of `CodePointTrie`. It makes sense to hold this type
 /// by value instead of holding `CodePointTrie` by reference if the reference
 /// is held across multiple lookups.
-#[derive(Debug, Eq, PartialEq, Yokeable, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct CodePointTrieBorrow<'trie, T: TrieValue> {
     pub(crate) header: &'trie CodePointTrieHeader,
     pub(crate) index: &'trie ZeroSlice<u16>,
@@ -131,7 +131,7 @@ impl<'zf, T: TrieValue> ZeroFrom<'zf, CodePointTrie<'_, T>> for CodePointTrieBor
             header: &other.header,
             index: &other.index,
             data: &other.data,
-            error_value: other.error_value.clone(),
+            error_value: other.error_value,
         }
     }
 }

--- a/components/collections/src/codepointtrie/mod.rs
+++ b/components/collections/src/codepointtrie/mod.rs
@@ -45,7 +45,7 @@ mod serde;
 pub use cptrie::CodePointMapRange;
 pub use cptrie::CodePointMapRangeIterator;
 pub use cptrie::CodePointTrie;
-pub use cptrie::CodePointTrieBorrow;
+pub use cptrie::CodePointTrieBorrowed;
 pub use cptrie::CodePointTrieHeader;
 pub use cptrie::TrieType;
 pub use cptrie::TrieValue;

--- a/components/collections/src/codepointtrie/mod.rs
+++ b/components/collections/src/codepointtrie/mod.rs
@@ -45,6 +45,7 @@ mod serde;
 pub use cptrie::CodePointMapRange;
 pub use cptrie::CodePointMapRangeIterator;
 pub use cptrie::CodePointTrie;
+pub use cptrie::CodePointTrieBorrow;
 pub use cptrie::CodePointTrieHeader;
 pub use cptrie::TrieType;
 pub use cptrie::TrieValue;

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -85,7 +85,7 @@ use core::str::from_utf8_unchecked;
 use icu_collections::char16trie::Char16Trie;
 use icu_collections::char16trie::Char16TrieIterator;
 use icu_collections::char16trie::TrieResult;
-use icu_collections::codepointtrie::CodePointTrieBorrow;
+use icu_collections::codepointtrie::CodePointTrieBorrowed;
 use icu_properties::CanonicalCombiningClass;
 use icu_provider::prelude::*;
 use provider::CanonicalCompositionsV1Marker;
@@ -466,7 +466,7 @@ impl CharacterAndClass {
         (self.character(), self.ccc())
     }
     #[inline(always)]
-    pub fn set_ccc_from_trie_if_not_already_set(&mut self, trie: &CodePointTrieBorrow<u32>) {
+    pub fn set_ccc_from_trie_if_not_already_set(&mut self, trie: &CodePointTrieBorrowed<u32>) {
         if self.0 >> 24 != 0xFF {
             return;
         }
@@ -477,7 +477,7 @@ impl CharacterAndClass {
 
 // This function exists as a borrow check helper.
 #[inline(always)]
-fn sort_slice_by_ccc(slice: &mut [CharacterAndClass], trie: &CodePointTrieBorrow<u32>) {
+fn sort_slice_by_ccc(slice: &mut [CharacterAndClass], trie: &CodePointTrieBorrowed<u32>) {
     // We don't look up the canonical combining class for starters
     // of for single combining characters between starters. When
     // there's more than one combining character between starters,
@@ -509,8 +509,8 @@ where
     // However, when `Decomposition` appears inside a `Composition`, this
     // may become a non-starter before `decomposing_next()` is called.
     pending: Option<CharacterAndTrieValue>, // None at end of stream
-    trie: CodePointTrieBorrow<'data, u32>,
-    supplementary_trie: Option<CodePointTrieBorrow<'data, u32>>,
+    trie: CodePointTrieBorrowed<'data, u32>,
+    supplementary_trie: Option<CodePointTrieBorrowed<'data, u32>>,
     scalars16: &'data ZeroSlice<u16>,
     scalars24: &'data ZeroSlice<char>,
     supplementary_scalars16: &'data ZeroSlice<u16>,

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -689,6 +689,7 @@ where
     }
 
     #[inline(never)]
+    #[allow(clippy::unwrap_used)]
     fn attach_supplementary_trie_value(&self, c: char) -> Option<CharacterAndTrieValue> {
         let voicing_mark = u32::from(c).wrapping_sub(0xFF9E);
         if voicing_mark <= 1 && self.half_width_voicing_marks_become_non_starters {
@@ -701,6 +702,8 @@ where
                 0xD800 | u32::from(CanonicalCombiningClass::KanaVoicing.0),
             ));
         }
+        // unwrap OK, because this method is called only after checking that
+        // `self.supplementary_trie` is `Some`.
         let trie_value = self.supplementary_trie.unwrap().get(c);
         if trie_value != 0 {
             return Some(CharacterAndTrieValue::new_from_supplement(c, trie_value));


### PR DESCRIPTION
The purpose is to avoid checking the ZeroVec discriminants on each access when the borrow is held across multiple lookups.

Improves Japanese and Chinese NFC to NFC UTF-16 normalization throughput by 7.9% on Haswell.
