### PR TITLE
chore(license): fix license in collections/Cargo.toml, others

### DIFF
--- a/components/collator/fuzz/Cargo.toml
+++ b/components/collator/fuzz/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"
+license = "Unicode-DFS-2016"
 
 [package.metadata]
 cargo-fuzz = true

--- a/components/collections/Cargo.toml
+++ b/components/collections/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
-license-file = "LICENSE"
+license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions
 include = [
@@ -65,7 +65,7 @@ databake = ["dep:databake", "zerovec/databake"]
 name = "codepointtrie"
 harness = false
 path = "src/codepointtrie/benches/codepointtrie.rs"
- 
+
 [[bench]]
 name = "iai_cpt"
 harness = false

--- a/components/normalizer/fuzz/Cargo.toml
+++ b/components/normalizer/fuzz/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"
+license = "Unicode-DFS-2016"
 
 [package.metadata]
 cargo-fuzz = true


### PR DESCRIPTION
- also the two fuzz components didn’t have a license

Fixes #2559

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->