### PR TITLE
Avoid testdata dependency from icu_capi

### DIFF
--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -54,7 +54,7 @@ serde = [
     "icu_provider/serde",
     "icu_segmenter/serde",
 ]
-buffer_provider = ["serde", "icu_testdata/buffer"]
+buffer_provider = ["serde", "icu_provider_adapters/serde"]
 provider_fs = ["icu_provider_fs", "buffer_provider"]
 provider_test = ["icu_testdata"]
 smaller_test = ["provider_test", "buffer_provider"]

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -57,7 +57,7 @@ serde = [
 buffer_provider = ["serde", "icu_provider_adapters/serde"]
 provider_fs = ["icu_provider_fs", "buffer_provider"]
 provider_test = ["icu_testdata"]
-smaller_test = ["provider_test", "buffer_provider"]
+smaller_test = ["provider_test", "buffer_provider", "icu_testdata/buffer"]
 logging = ["icu_provider/log_error_context", "log"]
 # Use the env_logger functionality to log based on environment variables
 simple_logger = ["dep:simple_logger"]

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -56,8 +56,8 @@ serde = [
 ]
 buffer_provider = ["serde", "icu_provider_adapters/serde"]
 provider_fs = ["icu_provider_fs", "buffer_provider"]
-provider_test = ["icu_testdata"]
-smaller_test = ["provider_test", "buffer_provider", "icu_testdata/buffer"]
+provider_test = ["icu_testdata/buffer"]
+smaller_test = ["provider_test", "buffer_provider"]
 logging = ["icu_provider/log_error_context", "log"]
 # Use the env_logger functionality to log based on environment variables
 simple_logger = ["dep:simple_logger"]

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -54,9 +54,9 @@ serde = [
     "icu_provider/serde",
     "icu_segmenter/serde",
 ]
-buffer_provider = ["serde", "icu_provider_adapters/serde"]
+buffer_provider = ["serde", "icu_provider_adapters/serde", "icu_testdata?/buffer"]
 provider_fs = ["icu_provider_fs", "buffer_provider"]
-provider_test = ["icu_testdata/buffer"]
+provider_test = ["icu_testdata"]
 smaller_test = ["provider_test", "buffer_provider"]
 logging = ["icu_provider/log_error_context", "log"]
 # Use the env_logger functionality to log based on environment variables


### PR DESCRIPTION
To use blob provider (via `buffer_provider` feature) from `icu_capi`, I would like to remove `testdata` dependency from `icu_capi` when using `buffer_provider`. Although original discussion was https://github.com/unicode-org/icu4x/issues/849, icu_capi has testdata dependency now unfortunately.