### PR TITLE
Add ExactSizeIterator 

### DIFF
--- a/utils/zerovec/src/flexzerovec/slice.rs
+++ b/utils/zerovec/src/flexzerovec/slice.rs
@@ -256,7 +256,9 @@ impl FlexZeroSlice {
 
     /// Gets an iterator over the elements of the slice as `usize`.
     #[inline]
-    pub fn iter(&self) -> impl DoubleEndedIterator<Item = usize> + '_ {
+    pub fn iter(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = usize> + '_ + ExactSizeIterator<Item = usize> {
         let w = self.get_width();
         self.data
             .chunks_exact(w)

--- a/utils/zerovec/src/map/map.rs
+++ b/utils/zerovec/src/map/map.rs
@@ -287,12 +287,7 @@ where
     /// Produce an ordered iterator over key-value pairs
     pub fn iter<'b>(
         &'b self,
-    ) -> impl Iterator<
-        Item = (
-            &'b <K as ZeroMapKV<'a>>::GetType,
-            &'b <V as ZeroMapKV<'a>>::GetType,
-        ),
-    > + ExactSizeIterator<
+    ) -> impl ExactSizeIterator<
         Item = (
             &'b <K as ZeroMapKV<'a>>::GetType,
             &'b <V as ZeroMapKV<'a>>::GetType,
@@ -311,8 +306,7 @@ where
     /// Produce an ordered iterator over keys
     pub fn iter_keys<'b>(
         &'b self,
-    ) -> impl Iterator<Item = &'b <K as ZeroMapKV<'a>>::GetType>
-           + ExactSizeIterator<Item = &'b <K as ZeroMapKV<'a>>::GetType> {
+    ) -> impl ExactSizeIterator<Item = &'b <K as ZeroMapKV<'a>>::GetType> {
         #[allow(clippy::unwrap_used)] // idx is in-range
         (0..self.keys.zvl_len()).map(move |idx| self.keys.zvl_get(idx).unwrap())
     }
@@ -320,8 +314,7 @@ where
     /// Produce an iterator over values, ordered by keys
     pub fn iter_values<'b>(
         &'b self,
-    ) -> impl Iterator<Item = &'b <V as ZeroMapKV<'a>>::GetType>
-           + ExactSizeIterator<Item = &'b <V as ZeroMapKV<'a>>::GetType> {
+    ) -> impl ExactSizeIterator<Item = &'b <V as ZeroMapKV<'a>>::GetType> {
         #[allow(clippy::unwrap_used)] // idx is in-range
         (0..self.values.zvl_len()).map(move |idx| self.values.zvl_get(idx).unwrap())
     }

--- a/utils/zerovec/src/map/map.rs
+++ b/utils/zerovec/src/map/map.rs
@@ -292,6 +292,11 @@ where
             &'b <K as ZeroMapKV<'a>>::GetType,
             &'b <V as ZeroMapKV<'a>>::GetType,
         ),
+    > + ExactSizeIterator<
+        Item = (
+            &'b <K as ZeroMapKV<'a>>::GetType,
+            &'b <V as ZeroMapKV<'a>>::GetType,
+        ),
     > {
         (0..self.keys.zvl_len()).map(move |idx| {
             (
@@ -304,13 +309,19 @@ where
     }
 
     /// Produce an ordered iterator over keys
-    pub fn iter_keys<'b>(&'b self) -> impl Iterator<Item = &'b <K as ZeroMapKV<'a>>::GetType> {
+    pub fn iter_keys<'b>(
+        &'b self,
+    ) -> impl Iterator<Item = &'b <K as ZeroMapKV<'a>>::GetType>
+           + ExactSizeIterator<Item = &'b <K as ZeroMapKV<'a>>::GetType> {
         #[allow(clippy::unwrap_used)] // idx is in-range
         (0..self.keys.zvl_len()).map(move |idx| self.keys.zvl_get(idx).unwrap())
     }
 
     /// Produce an iterator over values, ordered by keys
-    pub fn iter_values<'b>(&'b self) -> impl Iterator<Item = &'b <V as ZeroMapKV<'a>>::GetType> {
+    pub fn iter_values<'b>(
+        &'b self,
+    ) -> impl Iterator<Item = &'b <V as ZeroMapKV<'a>>::GetType>
+           + ExactSizeIterator<Item = &'b <V as ZeroMapKV<'a>>::GetType> {
         #[allow(clippy::unwrap_used)] // idx is in-range
         (0..self.values.zvl_len()).map(move |idx| self.values.zvl_get(idx).unwrap())
     }


### PR DESCRIPTION
This PR adds `ExactSizeIterator` to `FlexZeroVec`, `ZeroMap`.
ESI cannot be added to `VarZeroSlice` as `core::iter::Chain` does not have an impl for ESI. 