### PR TITLE
Improve performance of VarZeroVec::deserialize and add provider benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,6 +1839,7 @@ dependencies = [
  "bytes",
  "cargo_metadata",
  "clap",
+ "criterion",
  "displaydoc",
  "eyre",
  "futures",

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -325,6 +325,7 @@ icu_timezone = { version = "1.0.0-beta1", path = "../../components/timezone", de
 
 [dev-dependencies]
 icu = { path = "../../components/icu" }
+criterion = "0.3"
 
 [features]
 default = [
@@ -380,3 +381,7 @@ required-features = ["bin"]
 name = "icu4x-testdata-datagen"
 path = "src/bin/datagen.rs"
 required-features = ["bin"]
+
+[[bench]]
+name = "providers"
+harness = false

--- a/provider/testdata/benches/providers.rs
+++ b/provider/testdata/benches/providers.rs
@@ -1,0 +1,93 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+extern crate alloc;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use icu_locid::locale;
+use icu_provider::hello_world::HelloWorldV1Marker;
+use icu_provider::prelude::*;
+use icu_provider::AsDeserializingBufferProvider;
+use icu_provider_blob::BlobDataProvider;
+use icu_provider_blob::StaticDataProvider;
+
+static POSTCARD_BYTES: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/data/testdata.postcard"
+));
+
+mod baked {
+    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/data/baked/mod.rs"));
+    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/data/baked/any.rs"));
+}
+
+#[inline(never)]
+fn create_static_data_provider() -> StaticDataProvider {
+    icu_provider_blob::StaticDataProvider::try_new_from_static_blob(black_box(POSTCARD_BYTES))
+        .unwrap()
+}
+
+#[inline(never)]
+fn create_blob_data_provider() -> BlobDataProvider {
+    icu_provider_blob::BlobDataProvider::try_new_from_blob(black_box(POSTCARD_BYTES)).unwrap()
+}
+
+#[inline(never)]
+fn create_baked_data_provider() -> baked::BakedDataProvider {
+    baked::BakedDataProvider
+}
+
+fn providers_bench(c: &mut Criterion) {
+    c.bench_function("provider/construct/static", |b| {
+        b.iter(|| create_static_data_provider());
+    });
+    c.bench_function("provider/construct/blob", |b| {
+        b.iter(|| create_blob_data_provider());
+    });
+    c.bench_function("provider/construct/baked", |b| {
+        b.iter(|| create_baked_data_provider());
+    });
+
+    c.bench_function("provider/load/static", |b| {
+        let provider = create_static_data_provider();
+        b.iter(|| {
+            let result: DataResponse<HelloWorldV1Marker> = provider
+                .as_deserializing()
+                .load(DataRequest {
+                    locale: &locale!("ja").into(),
+                    metadata: Default::default(),
+                })
+                .unwrap();
+            result
+        });
+    });
+    c.bench_function("provider/load/blob", |b| {
+        let provider = create_blob_data_provider();
+        b.iter(|| {
+            let result: DataResponse<HelloWorldV1Marker> = provider
+                .as_deserializing()
+                .load(DataRequest {
+                    locale: &locale!("ja").into(),
+                    metadata: Default::default(),
+                })
+                .unwrap();
+            result
+        });
+    });
+    c.bench_function("provider/load/baked", |b| {
+        let provider = create_baked_data_provider();
+        b.iter(|| {
+            let result: DataResponse<HelloWorldV1Marker> = provider
+                .load(DataRequest {
+                    locale: &locale!("ja").into(),
+                    metadata: Default::default(),
+                })
+                .unwrap();
+            result
+        });
+    });
+}
+
+criterion_group!(benches, providers_bench,);
+criterion_main!(benches);

--- a/provider/testdata/benches/providers.rs
+++ b/provider/testdata/benches/providers.rs
@@ -40,13 +40,13 @@ fn create_baked_data_provider() -> baked::BakedDataProvider {
 
 fn providers_bench(c: &mut Criterion) {
     c.bench_function("provider/construct/static", |b| {
-        b.iter(|| create_static_data_provider());
+        b.iter(create_static_data_provider);
     });
     c.bench_function("provider/construct/blob", |b| {
-        b.iter(|| create_blob_data_provider());
+        b.iter(create_blob_data_provider);
     });
     c.bench_function("provider/construct/baked", |b| {
-        b.iter(|| create_baked_data_provider());
+        b.iter(create_baked_data_provider);
     });
 
     c.bench_function("provider/load/static", |b| {

--- a/utils/zerovec/src/varzerovec/components.rs
+++ b/utils/zerovec/src/varzerovec/components.rs
@@ -322,7 +322,13 @@ impl<'a, T: VarULE + ?Sized, F: VarZeroVecFormat> VarZeroVecComponents<'a, T, F>
     #[allow(clippy::len_zero)] // more explicit to enforce safety invariants
     fn check_indices_and_things(self) -> Result<(), ZeroVecError> {
         assert_eq!(self.len(), self.indices_slice().len());
-        assert!(self.len() > 0);
+        if self.len() == 0 {
+            if self.things.len() > 0 {
+                return Err(ZeroVecError::VarZeroVecFormatError);
+            } else {
+                return Ok(());
+            }
+        }
         // Safety: i is in bounds (assertion above)
         let mut start = F::rawbytes_to_usize(unsafe { *self.indices_slice().get_unchecked(0) });
         if start != 0 {

--- a/utils/zerovec/src/varzerovec/components.rs
+++ b/utils/zerovec/src/varzerovec/components.rs
@@ -319,6 +319,7 @@ impl<'a, T: VarULE + ?Sized, F: VarZeroVecFormat> VarZeroVecComponents<'a, T, F>
     /// This method is NOT allowed to call any other methods on VarZeroVecComponents since all other methods
     /// assume that the slice has been passed through check_indices_and_things
     #[inline]
+    #[allow(clippy::len_zero)] // more explicit to enforce safety invariants
     fn check_indices_and_things(self) -> Result<(), ZeroVecError> {
         assert_eq!(self.len(), self.indices_slice().len());
         assert!(self.len() > 0);


### PR DESCRIPTION
Fixes #2600

After @zbraniecki noticed a performance issue with StaticDataProvider's constructor, I looked into the code with @Manishearth  and found some low-hanging fruit to optimize. I managed to get a 63% improvement, as shown below with the new benches run across the second commit in this PR:

```
Benchmarking provider/construct/static: Collecting 100 samples in estimated 5.0030 s (5.2M iterati                                                                                                  provider/construct/static                        
                        time:   [951.26 ns 952.42 ns 953.85 ns]
                        change: [-63.724% -63.601% -63.474%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe

Benchmarking provider/construct/blob: Collecting 100 samples in estimated 5.4580 s (25k iterations                                                                                                  provider/construct/blob time:   [214.57 us 214.85 us 215.23 us]
                        change: [-0.7276% -0.5377% -0.3567%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe

Benchmarking provider/construct/baked: Collecting 100 samples in estimated 5.0000 s (18446744074B                                                                                                   provider/construct/baked                        
                        time:   [0.0000 ps 0.0000 ps 0.0000 ps]
                        change: [-45.396% -1.3066% +75.734%] (p = 0.98 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe

provider/load/static    time:   [117.46 ns 117.92 ns 118.47 ns]                                 
                        change: [-0.8186% +1.4342% +4.4178%] (p = 0.35 > 0.05)
                        No change in performance detected.
Found 17 outliers among 100 measurements (17.00%)
  2 (2.00%) high mild
  15 (15.00%) high severe

provider/load/blob      time:   [114.53 ns 114.67 ns 114.83 ns]                               
                        change: [-3.5102% -3.2867% -3.0490%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high severe

provider/load/baked     time:   [39.669 ns 39.951 ns 40.354 ns]                                 
                        change: [+7.0914% +7.7782% +8.7248%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe
```