### PR TITLE
Warn against breaking the Pernosco integration of CharacterAndClass

### DIFF
--- a/components/collator/src/elements.rs
+++ b/components/collator/src/elements.rs
@@ -716,6 +716,11 @@ impl CharacterAndClassAndTrieValue {
 /// Note that 0xFF is won't be assigned to an actual
 /// canonical combining class per definition D104
 /// in The Unicode Standard.
+//
+// NOTE: The Pernosco debugger has special knowledge
+// of this struct. Please do not change the bit layout
+// or the crate-module-qualified name of this struct
+// without coordination.
 #[derive(Debug, Clone)]
 struct CharacterAndClass(u32);
 

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -438,6 +438,11 @@ impl CharacterAndTrieValue {
 /// Note that 0xFF is won't be assigned to an actual
 /// canonical combining class per definition D104
 /// in The Unicode Standard.
+//
+// NOTE: The Pernosco debugger has special knowledge
+// of this struct. Please do not change the bit layout
+// or the crate-module-qualified name of this struct
+// without coordination.
 #[derive(Debug)]
 struct CharacterAndClass(u32);
 

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -791,6 +791,11 @@ impl SentenceBreak {
 ///
 /// See `icu_normalizer::properties::CanonicalCombiningClassMap` for the API
 /// to look up the Canonical_Combining_Class property by scalar value.
+//
+// NOTE: The Pernosco debugger has special knowledge
+// of this struct. Please do not change the bit layout
+// or the crate-module-qualified name of this struct
+// without coordination.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "datagen", derive(databake::Bake))]


### PR DESCRIPTION
Pernosco helpfully has special knowledge to render `CharacterAndClass` in a more usable way that generic DWARF would allow. Adding comments to warn against breaking this integration.