### PR TITLE
Less building in CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -86,11 +86,6 @@ jobs:
       with:
         crate: cargo-make
         version: latest
-    - name: Build
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: build
-        args: --all-targets --all-features
     - name: Run `cargo make ci-job-test`
       uses: actions-rs/cargo@v1.0.1
       with:
@@ -171,11 +166,6 @@ jobs:
       with:
         crate: cargo-make
         version: latest
-    - name: Build
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: build
-        args: --all-targets --all-features
     - name: Run `cargo make ci-job-test-docs`
       uses: actions-rs/cargo@v1.0.1
       with:
@@ -269,11 +259,6 @@ jobs:
       with:
         crate: cargo-make
         version: latest
-    - name: Build
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: build
-        args: --all-targets --all-features
     - name: Run `cargo make ci-job-ffi`
       uses: actions-rs/cargo@v1.0.1
       with:


### PR DESCRIPTION
Building `--all-targets --all-features` takes about 15 minutes on CI and builds too many targets, or targets with the wrong features that cannot be reused. It also weird if the ffi test fails because of a bug in some benchmark. Let's let cargo figure out what needs to be built.