### PR TITLE
fixed_decimal::Sign should be exhaustive

### DIFF
--- a/components/decimal/src/format.rs
+++ b/components/decimal/src/format.rs
@@ -26,7 +26,6 @@ impl<'l> FormattedFixedDecimal<'l> {
             Sign::None => None,
             Sign::Negative => Some(&self.symbols.minus_sign_affixes),
             Sign::Positive => Some(&self.symbols.plus_sign_affixes),
-            _ => unreachable!("This should not happen, because all the cases are covered."),
         }
     }
 }

--- a/ffi/diplomat/src/fixed_decimal.rs
+++ b/ffi/diplomat/src/fixed_decimal.rs
@@ -319,7 +319,6 @@ impl From<Sign> for ffi::ICU4XFixedDecimalSign {
             Sign::None => Self::None,
             Sign::Negative => Self::Negative,
             Sign::Positive => Self::Positive,
-            _ => unreachable!("This should not happen, because all the cases are covered."),
         }
     }
 }

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -119,8 +119,9 @@ pub struct FixedDecimal {
 }
 
 /// A specification of the sign used when formatting a number.
-#[non_exhaustive]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[allow(clippy::exhaustive_enums)]
+// There are only 3 sign values, and they correspond to the low-level data model of FixedDecimal and UTS 35.
 pub enum Sign {
     /// No sign (implicitly positive, e.g., 1729).
     None,


### PR DESCRIPTION
Fixes: https://github.com/unicode-org/icu4x/issues/2486

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->