### PR TITLE
DTF options::length::Bag constructor from two options

### DIFF
--- a/components/datetime/README.md
+++ b/components/datetime/README.md
@@ -38,8 +38,8 @@ use std::str::FromStr;
 // See the next code example for a more ergonomic example with .into().
 let options =
     DateTimeFormatterOptions::Length(length::Bag::from_date_time_style(
-        length::Date::Medium,
-        length::Time::Short,
+        Some(length::Date::Medium),
+        Some(length::Time::Short),
     ));
 
 // You can work with a formatter that can select the calendar at runtime:
@@ -80,8 +80,8 @@ use icu::datetime::{
 };
 use icu::locid::locale;
 let options = length::Bag::from_date_time_style(
-    length::Date::Medium,
-    length::Time::Short,
+    Some(length::Date::Medium),
+    Some(length::Time::Short),
 )
 .into();
 

--- a/components/datetime/src/any/datetime.rs
+++ b/components/datetime/src/any/datetime.rs
@@ -488,12 +488,15 @@ where {
     /// use icu::locid::locale;
     /// use std::str::FromStr;
     ///
-    /// let options = length::Bag::from_date_style(length::Date::Medium).into();
+    /// let options = length::Bag::from_date_time_style(
+    ///     Some(length::Date::Medium),
+    ///     None
+    /// );
     ///
     /// let dtf = DateTimeFormatter::try_new_unstable(
     ///     &icu_testdata::unstable(),
     ///     &locale!("en-u-ca-gregory").into(),
-    ///     options,
+    ///     options.into(),
     /// )
     /// .expect("Failed to create TypedDateTimeFormatter instance.");
     ///

--- a/components/datetime/src/any/datetime.rs
+++ b/components/datetime/src/any/datetime.rs
@@ -41,8 +41,8 @@ use writeable::Writeable;
 /// use writeable::assert_writeable_eq;
 ///
 /// let mut options = length::Bag::from_date_time_style(
-///     length::Date::Medium,
-///     length::Time::Short,
+///     Some(length::Date::Medium),
+///     Some(length::Time::Short),
 /// );
 ///
 /// let dtf = DateTimeFormatter::try_new_unstable(
@@ -95,7 +95,10 @@ use writeable::Writeable;
 /// let iso_converted = iso_datetime.to_calendar(calendar);
 ///
 ///
-/// let options = length::Bag::from_date_time_style(length::Date::Medium, length::Time::Short);
+/// let options = length::Bag::from_date_time_style(
+///     Some(length::Date::Medium),
+///     Some(length::Time::Short)
+/// );
 ///
 /// let dtf = DateTimeFormatter::try_new_unstable(&icu_testdata::unstable(), &locale.into(), options.into())
 ///     .expect("Failed to create DateTimeFormatter instance.");
@@ -161,7 +164,10 @@ impl DateTimeFormatter {
     /// use std::str::FromStr;
     /// use writeable::assert_writeable_eq;
     ///
-    /// let mut options = length::Bag::from_date_time_style(length::Date::Medium, length::Time::Short);
+    /// let mut options = length::Bag::from_date_time_style(
+    ///     Some(length::Date::Medium),
+    ///     Some(length::Time::Short)
+    /// );
     /// let locale = locale!("en-u-ca-gregory");
     ///
     /// let dtf = DateTimeFormatter::try_new_with_buffer_provider(
@@ -304,7 +310,10 @@ impl DateTimeFormatter {
     /// use std::str::FromStr;
     /// use writeable::assert_writeable_eq;
     ///
-    /// let options = length::Bag::from_date_time_style(length::Date::Medium, length::Time::Short);
+    /// let options = length::Bag::from_date_time_style(
+    ///     Some(length::Date::Medium),
+    ///     Some(length::Time::Short)
+    /// );
     /// let locale = locale!("en-u-ca-gregory");
     ///
     /// let dtf = DateTimeFormatter::try_new_unstable(
@@ -541,7 +550,8 @@ mod tests {
     use icu::locid::{locale, Locale};
 
     fn test_format(datetime: &DateTime<AnyCalendar>, locale: Locale, expected: &str) {
-        let options = length::Bag::from_date_time_style(length::Date::Long, length::Time::Short);
+        let options =
+            length::Bag::from_date_time_style(Some(length::Date::Long), Some(length::Time::Short));
 
         let dtf = DateTimeFormatter::try_new_unstable(
             &icu_testdata::unstable(),

--- a/components/datetime/src/any/zoned_datetime.rs
+++ b/components/datetime/src/any/zoned_datetime.rs
@@ -50,8 +50,8 @@ use writeable::Writeable;
 /// use writeable::assert_writeable_eq;
 ///
 /// let options = length::Bag::from_date_time_style(
-///     length::Date::Medium,
-///     length::Time::Long,
+///     Some(length::Date::Medium),
+///     Some(length::Time::Long),
 /// );
 /// let zdtf = ZonedDateTimeFormatter::try_new_unstable(
 ///     &icu_testdata::unstable(),
@@ -85,8 +85,8 @@ use writeable::Writeable;
 /// use writeable::assert_writeable_eq;
 ///
 /// let options = length::Bag::from_date_time_style(
-///     length::Date::Medium,
-///     length::Time::Full,
+///     Some(length::Date::Medium),
+///     Some(length::Time::Full),
 /// );
 /// let zdtf = ZonedDateTimeFormatter::try_new_unstable(
 ///     &icu_testdata::unstable(),
@@ -265,7 +265,10 @@ impl ZonedDateTimeFormatter {
     /// use std::str::FromStr;
     /// use writeable::assert_writeable_eq;
     ///
-    /// let options = length::Bag::from_date_time_style(length::Date::Medium, length::Time::Long);
+    /// let options = length::Bag::from_date_time_style(
+    ///     Some(length::Date::Medium),
+    ///     Some(length::Time::Long)
+    /// );
     /// let locale = locale!("en-u-ca-gregory");
     ///
     /// let zdtf = ZonedDateTimeFormatter::try_new_unstable(
@@ -374,7 +377,10 @@ impl ZonedDateTimeFormatter {
     /// use std::str::FromStr;
     /// use writeable::assert_writeable_eq;
     ///
-    /// let options = length::Bag::from_date_time_style(length::Date::Medium, length::Time::Long).into();
+    /// let options = length::Bag::from_date_time_style(
+    ///     Some(length::Date::Medium),
+    ///     Some(length::Time::Long)
+    /// ).into();
     /// let locale = locale!("en-u-ca-gregory");
     ///
     /// let zdtf = ZonedDateTimeFormatter::try_new_with_any_provider(
@@ -432,7 +438,10 @@ impl ZonedDateTimeFormatter {
     /// use std::str::FromStr;
     /// use writeable::assert_writeable_eq;
     ///
-    /// let options = length::Bag::from_date_time_style(length::Date::Medium, length::Time::Long).into();
+    /// let options = length::Bag::from_date_time_style(
+    ///     Some(length::Date::Medium),
+    ///     Some(length::Time::Long)
+    /// ).into();
     /// let locale = locale!("en");
     ///
     /// let zdtf = ZonedDateTimeFormatter::try_new_with_buffer_provider(

--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -608,7 +608,7 @@ where {
     /// use icu::datetime::TypedDateTimeFormatter;
     /// use writeable::assert_writeable_eq;
     /// use icu::locid::locale;
-    /// # let options = icu::datetime::options::length::Bag::from_time_style(icu::datetime::options::length::Time::Medium);
+    /// # let options = icu::datetime::options::length::Bag::from_time_style(Some(icu::datetime::options::length::Time::Medium));
     /// let dtf = TypedDateTimeFormatter::<Gregorian>::try_new_unstable(&icu_testdata::unstable(), &locale!("en").into(), options.into())
     ///     .expect("Failed to create TypedDateTimeFormatter instance.");
     ///
@@ -633,7 +633,7 @@ where {
     /// use icu::calendar::{DateTime, Gregorian};
     /// use icu::datetime::TypedDateTimeFormatter;
     /// use icu::locid::locale;
-    /// # let options = icu::datetime::options::length::Bag::from_time_style(icu::datetime::options::length::Time::Medium);
+    /// # let options = icu::datetime::options::length::Bag::from_time_style(Some(icu::datetime::options::length::Time::Medium));
     /// let dtf = TypedDateTimeFormatter::<Gregorian>::try_new_unstable(&icu_testdata::unstable(), &locale!("en").into(), options.into())
     ///     .expect("Failed to create TypedDateTimeFormatter instance.");
     ///
@@ -662,11 +662,14 @@ where {
     /// };
     /// use icu::locid::locale;
     ///
-    /// let options = length::Bag::from_date_style(length::Date::Medium).into();
+    /// let options = length::Bag::from_date_time_style(
+    ///     Some(length::Date::Medium),
+    ///     None
+    /// );
     /// let dtf = TypedDateTimeFormatter::<Gregorian>::try_new_unstable(
     ///     &icu_testdata::unstable(),
     ///     &locale!("en").into(),
-    ///     options,
+    ///     options.into(),
     /// )
     /// .expect("Failed to create TypedDateTimeFormatter instance.");
     ///

--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -389,8 +389,8 @@ impl<C: CldrCalendar> TypedDateFormatter<C> {
 /// use writeable::assert_writeable_eq;
 ///
 /// let mut options = length::Bag::from_date_time_style(
-///     length::Date::Medium,
-///     length::Time::Short,
+///     Some(length::Date::Medium),
+///     Some(length::Time::Short),
 /// );
 ///
 /// let dtf = TypedDateTimeFormatter::<Gregorian>::try_new_unstable(
@@ -541,7 +541,10 @@ where {
     /// use icu::locid::locale;
     /// use writeable::assert_writeable_eq;
     ///
-    /// let options = length::Bag::from_date_time_style(length::Date::Medium, length::Time::Medium);
+    /// let options = length::Bag::from_date_time_style(
+    ///     Some(length::Date::Medium),
+    ///     Some(length::Time::Medium)
+    /// );
     ///
     /// let dtf = TypedDateTimeFormatter::<Gregorian>::try_new_unstable(
     ///     &icu_testdata::unstable(),

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -40,8 +40,8 @@
 //! // See the next code example for a more ergonomic example with .into().
 //! let options =
 //!     DateTimeFormatterOptions::Length(length::Bag::from_date_time_style(
-//!         length::Date::Medium,
-//!         length::Time::Short,
+//!         Some(length::Date::Medium),
+//!         Some(length::Time::Short),
 //!     ));
 //!
 //! // You can work with a formatter that can select the calendar at runtime:
@@ -82,8 +82,8 @@
 //! };
 //! use icu::locid::locale;
 //! let options = length::Bag::from_date_time_style(
-//!     length::Date::Medium,
-//!     length::Time::Short,
+//!     Some(length::Date::Medium),
+//!     Some(length::Time::Short),
 //! )
 //! .into();
 //!

--- a/components/datetime/src/options/length.rs
+++ b/components/datetime/src/options/length.rs
@@ -111,18 +111,18 @@ impl Bag {
     }
 
     /// Constructs a Bag given a date field (time set to None)
-    pub fn from_date_style(date: Date) -> Self {
+    pub fn from_date_style(date: Option<Date>) -> Self {
         Self {
-            date: Some(date),
+            date,
             time: None,
         }
     }
 
     /// Constructs a Bag given a time field (date set to None)
-    pub fn from_time_style(time: Time) -> Self {
+    pub fn from_time_style(time: Option<Time>) -> Self {
         Self {
             date: None,
-            time: Some(time),
+            time,
         }
     }
 }
@@ -136,7 +136,7 @@ impl Bag {
 /// ```
 /// use icu::datetime::options::length;
 ///
-/// let bag = length::Bag::from_date_style(length::Date::Long);
+/// let bag = length::Bag::from_date_style(Some(length::Date::Long));
 /// ```
 ///
 /// The available lengths correspond to [`UTS #35: Unicode LDML 4. Dates`], section 2.4 [`Element dateFormats`].
@@ -208,7 +208,7 @@ pub enum Date {
 /// ```
 /// use icu::datetime::options::length;
 ///
-/// let bag = length::Bag::from_time_style(length::Time::Medium);
+/// let bag = length::Bag::from_time_style(Some(length::Time::Medium));
 /// ```
 ///
 /// The available lengths correspond to [`UTS #35: Unicode LDML 4. Dates`], section 2.4 [`Element timeFormats`].

--- a/components/datetime/src/options/length.rs
+++ b/components/datetime/src/options/length.rs
@@ -112,18 +112,12 @@ impl Bag {
 
     /// Constructs a Bag given a date field (time set to None)
     pub fn from_date_style(date: Option<Date>) -> Self {
-        Self {
-            date,
-            time: None,
-        }
+        Self { date, time: None }
     }
 
     /// Constructs a Bag given a time field (date set to None)
     pub fn from_time_style(time: Option<Time>) -> Self {
-        Self {
-            date: None,
-            time,
-        }
+        Self { date: None, time }
     }
 }
 /// Represents different lengths a [`DateTimeInput`] implementer can be formatted into.

--- a/components/datetime/src/options/length.rs
+++ b/components/datetime/src/options/length.rs
@@ -22,8 +22,8 @@
 //! use icu::datetime::DateTimeFormatterOptions;
 //!
 //! let bag = length::Bag::from_date_time_style(
-//!     length::Date::Medium, // "medium" date connector will be used
-//!     length::Time::Short,
+//!     Some(length::Date::Medium), // "medium" date connector will be used
+//!     Some(length::Time::Short),
 //! );
 //!
 //! let options = DateTimeFormatterOptions::Length(bag);
@@ -56,7 +56,10 @@ use serde::{Deserialize, Serialize};
 /// use icu::datetime::options::length;
 /// use icu::datetime::DateTimeFormatterOptions;
 ///
-/// let bag = length::Bag::from_date_time_style(length::Date::Medium, length::Time::Short);
+/// let bag = length::Bag::from_date_time_style(
+///     Some(length::Date::Medium),
+///     Some(length::Time::Short)
+/// );
 ///
 /// let options = DateTimeFormatterOptions::Length(bag);
 /// ```
@@ -103,11 +106,8 @@ impl Bag {
     }
 
     /// Constructs a Bag given a date and time field
-    pub fn from_date_time_style(date: Date, time: Time) -> Self {
-        Self {
-            date: Some(date),
-            time: Some(time),
-        }
+    pub fn from_date_time_style(date: Option<Date>, time: Option<Time>) -> Self {
+        Self { date, time }
     }
 
     /// Constructs a Bag given a date field (time set to None)

--- a/components/datetime/src/options/mod.rs
+++ b/components/datetime/src/options/mod.rs
@@ -17,7 +17,10 @@
 //! ```
 //! use icu::datetime::{options::length, DateTimeFormatterOptions};
 //!
-//! let bag = length::Bag::from_date_time_style(length::Date::Medium, length::Time::Short);
+//! let bag = length::Bag::from_date_time_style(
+//!     Some(length::Date::Medium),
+//!     Some(length::Time::Short)
+//! );
 //! ```
 //!
 //! At the moment only the [`length::Bag`] works, and we plan to extend that to support
@@ -44,7 +47,10 @@ pub(crate) mod preferences;
 /// ```
 /// use icu::datetime::{options::length, DateTimeFormatterOptions};
 ///
-/// let bag = length::Bag::from_date_time_style(length::Date::Medium, length::Time::Short);
+/// let bag = length::Bag::from_date_time_style(
+///     Some(length::Date::Medium),
+///     Some(length::Time::Short)
+/// );
 /// ```
 ///
 /// At the moment only the [`length::Bag`] works, and we plan to extend that to support

--- a/components/datetime/src/zoned_datetime.rs
+++ b/components/datetime/src/zoned_datetime.rs
@@ -54,8 +54,8 @@ use crate::{
 /// use writeable::assert_writeable_eq;
 ///
 /// let options = length::Bag::from_date_time_style(
-///     length::Date::Medium,
-///     length::Time::Long,
+///     Some(length::Date::Medium),
+///     Some(length::Time::Long),
 /// );
 /// let zdtf = TypedZonedDateTimeFormatter::<Gregorian>::try_new_unstable(
 ///     &icu_testdata::unstable(),
@@ -186,7 +186,10 @@ impl<C: CldrCalendar> TypedZonedDateTimeFormatter<C> {
     /// use icu::timezone::CustomTimeZone;
     /// use writeable::assert_writeable_eq;
     ///
-    /// let options = length::Bag::from_date_time_style(length::Date::Medium, length::Time::Long);
+    /// let options = length::Bag::from_date_time_style(
+    ///     Some(length::Date::Medium),
+    ///     Some(length::Time::Long)
+    /// );
     ///
     /// let zdtf = TypedZonedDateTimeFormatter::<Gregorian>::try_new_unstable(
     ///     &icu_testdata::unstable(),
@@ -266,7 +269,10 @@ impl<C: CldrCalendar> TypedZonedDateTimeFormatter<C> {
     /// use std::str::FromStr;
     /// use writeable::assert_writeable_eq;
     ///
-    /// let options = length::Bag::from_date_time_style(length::Date::Medium, length::Time::Long);
+    /// let options = length::Bag::from_date_time_style(
+    ///     Some(length::Date::Medium),
+    ///     Some(length::Time::Long)
+    /// );
     ///
     /// let zdtf = TypedZonedDateTimeFormatter::<Gregorian>::try_new_unstable(
     ///     &icu_testdata::unstable(),
@@ -306,7 +312,10 @@ impl<C: CldrCalendar> TypedZonedDateTimeFormatter<C> {
     /// use icu::timezone::CustomTimeZone;
     /// use std::str::FromStr;
     ///
-    /// let options = length::Bag::from_date_time_style(length::Date::Medium, length::Time::Long);
+    /// let options = length::Bag::from_date_time_style(
+    ///     Some(length::Date::Medium),
+    ///     Some(length::Time::Long)
+    /// );
     ///
     /// let zdtf = TypedZonedDateTimeFormatter::<Gregorian>::try_new_unstable(
     ///     &icu_testdata::unstable(),

--- a/components/datetime/tests/resolved_components.rs
+++ b/components/datetime/tests/resolved_components.rs
@@ -28,7 +28,7 @@ fn assert_resolved_components(
 
 #[test]
 fn test_length_date() {
-    let length_bag = length::Bag::from_date_style(length::Date::Medium);
+    let length_bag = length::Bag::from_date_style(Some(length::Date::Medium));
 
     let mut components_bag = components::Bag::default();
     components_bag.year = Some(components::Year::Numeric);
@@ -43,7 +43,7 @@ fn test_length_date() {
 
 #[test]
 fn test_length_time() {
-    let length_bag = length::Bag::from_time_style(length::Time::Medium);
+    let length_bag = length::Bag::from_time_style(Some(length::Time::Medium));
     let mut components_bag = components::Bag::default();
     components_bag.hour = Some(components::Numeric::Numeric);
     components_bag.minute = Some(components::Numeric::TwoDigit);
@@ -60,7 +60,7 @@ fn test_length_time() {
 
 #[test]
 fn test_length_time_preferences() {
-    let length_bag = length::Bag::from_time_style(length::Time::Medium);
+    let length_bag = length::Bag::from_time_style(Some(length::Time::Medium));
 
     let mut components_bag = components::Bag::default();
     components_bag.hour = Some(components::Numeric::TwoDigit);


### PR DESCRIPTION
The current `options::length::Bag::from_date_time_style` currently requires both date and time lengths to be `Some`.

This is because we use `Option<Length>` rather than having `Length::None` variant. I chose the former because it allows the user to leverage all of the features that Rust provides for `Option` which otherwise would be lost or had to be reimplemented on `Length`.

But the downside is that it makes the APIs that accept `Length` a bit quirky. You can pass any length to it, except of `None`. If the value of your date/time length is `None` then you have to use different API.

I believe that instead, the API should accept `Option<Length>` therefore allowing for the value of `bag.date` and `bag.time` to be passed to a new bag as needed.

My argument is that most scenarios where the value is not provided by hand, it is provided as a variable and the type of that variable will be `Option<Length>` not `Length`.