### PR TITLE
Make expect_pattern GIGO

### DIFF
--- a/components/datetime/src/pattern/runtime/plural.rs
+++ b/components/datetime/src/pattern/runtime/plural.rs
@@ -204,8 +204,16 @@ impl<'data> PatternPlurals<'data> {
     pub fn expect_pattern(self, msg: &str) -> Pattern<'data> {
         match self {
             Self::SinglePattern(pattern) => pattern,
-            #[allow(clippy::panic)] // TODO(#1668) Clippy exceptions need docs or fixing.
-            _ => panic!("expect_pattern failed: {}", msg),
+
+            Self::MultipleVariants(patterns) => {
+                // Potentially change to log::warn! in #2648
+                debug_assert!(
+                    false,
+                    "expect_pattern called with bad data (falling back to `other` pattern): {}",
+                    msg
+                );
+                patterns.other
+            }
         }
     }
 


### PR DESCRIPTION
Still panics in debug mode; we should figure out a better strategy here with https://github.com/unicode-org/icu4x/issues/2648

Fixes #2627

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->