### PR TITLE
Expand i18n in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The design goals of `ICU4X` are:
 * Small and modular code
 * Pluggable locale data
 * Availability and ease of use in multiple programming languages
-* Written by i18n experts to encourage best practices
+* Written by internationalization experts to encourage best practices
 
 ***Stay informed!*** Join our public, low-traffic mailing list: [icu4x-announce@unicode.org](https://groups.google.com/u/1/a/unicode.org/g/icu4x-announce).  *Note: After subscribing, check your spam folder for a confirmation.*
 
@@ -67,14 +67,14 @@ Please subscribe to this repository to participate in discussions.  If you want 
 
 *For the full charter, including answers to frequently asked questions, see [charter.md](docs/process/charter.md).*
 
-ICU4X is a new project whose objective is to solve the needs of clients who wish to provide client-side i18n for their products in resource-constrained environments.
+ICU4X is a new project whose objective is to solve the needs of clients who wish to provide client-side internationalization for their products in resource-constrained environments.
 
 ICU4X, or "ICU for X", will be built from the start with several key design constraints:
 
 1. Small and modular code.
 2. Pluggable locale data.
 3. Availability and ease of use in multiple programming languages.
-4. Written by i18n experts to encourage best practices.
+4. Written by internationalization experts to encourage best practices.
 
 ICU4X will provide an ECMA-402-compatible API surface in the target client-side platforms, including the web platform, iOS, Android, WearOS, WatchOS, Flutter, and Fuchsia, supported in programming languages including Rust, JavaScript, Objective-C, Java, Dart, and C++.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ Document | Summary
 [roadmap.md](process/roadmap.md) | ICU4X 1.0 Roadmap
 [benchmarking.md](process/benchmarking.md) | Description of the model and facets of performance benchmarking that ICU4X is using.
 [bylaws.md](process/bylaws.md) | ICU4X-SC abides by the bylaws listed in this document.
-[charter.md](process/charter.md) | ICU4X is a new project whose objective is to solve the needs of clients who wish to provide client-side i18n for their products in resource-constrained environments.
+[charter.md](process/charter.md) | ICU4X is a new project whose objective is to solve the needs of clients who wish to provide client-side internationalization for their products in resource-constrained environments.
 [crate_ownership.md](process/crate_ownership.md) | Describes ownership rules for public crates (on crates.io).
 [release.md](process/release.md) | Documentation on release process.
 [style_guide.md](process/style_guide.md) | A guide to best practices for writing Rust code in ICU4x.

--- a/docs/design/principles.md
+++ b/docs/design/principles.md
@@ -2,9 +2,9 @@
 
 These principles are not cast in stone, but are strong guidelines for developers.
 
-## i18n Best Practices
+## Internationalization Best Practices
 
-Above all, ICU4X must provide modern, standards-compliant APIs that encourage best i18n practices and produce correct results for all languages and locales. No language or locale should be at a structural disadvantage.
+Above all, ICU4X must provide modern, standards-compliant APIs that encourage best internationalization practices and produce correct results for all languages and locales. No language or locale should be at a structural disadvantage.
 
 ## Code Style
 

--- a/docs/process/charter.md
+++ b/docs/process/charter.md
@@ -12,7 +12,7 @@ ICU4X is being built from the start with several key design constraints:
 1. Small, modular, fast, low-memory code.
 2. Pluggable locale data.
 3. Availability and ease of use in multiple programming languages.
-4. Written by i18n experts to encourage best practices.
+4. Written by internationalization experts to encourage best practices.
 
 Above all, ICU4X code will produce correct results for all languages and locales. No language or locale should be at a structural disadvantage.
 
@@ -64,7 +64,7 @@ ICU4X will have an independent code base from ICU, and will operate independentl
 
 ### Is ICU4X going to replace ICU?
 
-ICU4X is a new library to fill the growing need for on-device i18n across a variety of client-side platforms, including IoT, mobile, and web environments.  We hope ICU4X will eventually replace client-side solutions such as Closure i18n (goog.i18n) and Dart Intl.  [ICU4C] and [ICU4J] will continue to be the gold standard for internationalization on servers and higher-resource environments.
+ICU4X is a new library to fill the growing need for on-device internationalization across a variety of client-side platforms, including IoT, mobile, and web environments.  We hope ICU4X will eventually replace client-side solutions such as Closure i18n (goog.i18n) and Dart Intl.  [ICU4C] and [ICU4J] will continue to be the gold standard for internationalization on servers and higher-resource environments.
 
 ### Why make a new project instead of improving ICU?
 
@@ -90,7 +90,7 @@ A transpiler can be written in any language, but Lisp has a history of being use
 
 ### Won't this increase the maintenance burden?
 
-I18n engineers currently need to maintain several half-baked client-side i18n solutions including Closure i18n and Dart Intl.  We hope ICU4X will be able to eventually replace those libraries, and it will also allow us to fulfill the needs of new clients that we are currently unable to support.
+Internationalization engineers currently need to maintain several half-baked client-side internationalization solutions including Closure i18n and Dart Intl.  We hope ICU4X will be able to eventually replace those libraries, and it will also allow us to fulfill the needs of new clients that we are currently unable to support.
 
 ### Will ICU4C, ICU4J, and ICU4X share any code?
 

--- a/provider/core/README.md
+++ b/provider/core/README.md
@@ -3,7 +3,7 @@
 `icu_provider` is one of the [`ICU4X`] components.
 
 Unicode's experience with ICU4X's parent projects, ICU4C and ICU4J, led the team to realize
-that data management is the most critical aspect of deploying i18n, and that it requires
+that data management is the most critical aspect of deploying internationalization, and that it requires
 a high level of customization for the needs of the platform it is embedded in. As a result
 ICU4X comes with a selection of providers that should allow for ICU4X to naturally fit into
 different business and technological needs of customers.

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -5,7 +5,7 @@
 //! `icu_provider` is one of the [`ICU4X`] components.
 //!
 //! Unicode's experience with ICU4X's parent projects, ICU4C and ICU4J, led the team to realize
-//! that data management is the most critical aspect of deploying i18n, and that it requires
+//! that data management is the most critical aspect of deploying internationalization, and that it requires
 //! a high level of customization for the needs of the platform it is embedded in. As a result
 //! ICU4X comes with a selection of providers that should allow for ICU4X to naturally fit into
 //! different business and technological needs of customers.


### PR DESCRIPTION
I received a feedback on our README that it implies knowledge of the `i18n` term.

I think we can afford to expand it in official writing more often to lower the entry barrier and reduce sense of jargon required to read through.