### PR TITLE
Bump all crate versions to 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,7 +1299,7 @@ checksum = "71a816c97c42258aa5834d07590b718b4c9a598944cd39a52dc25b351185d678"
 
 [[package]]
 name = "icu"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "icu_calendar",
  "icu_casemapping",
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "criterion",
  "databake",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "icu_capi"
-version = "1.0.0-alpha1"
+version = "1.0.0"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "icu_capi_cdylib"
-version = "1.0.0-alpha1"
+version = "1.0.0"
 dependencies = [
  "icu_capi",
  "icu_provider",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "icu_capi_staticlib"
-version = "1.0.0-alpha1"
+version = "1.0.0"
 dependencies = [
  "dlmalloc",
  "icu_capi",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "icu_casemapping"
-version = "0.2.0"
+version = "0.7.0"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "icu_collator"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "arraystring",
  "atoi",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "criterion",
  "databake",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "icu_datagen"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "cached-path",
  "clap",
@@ -1538,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "icu_datetime"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "bincode",
  "criterion",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "icu_decimal"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "criterion",
  "databake",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "icu_freertos"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "cortex-m",
  "freertos-rust",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "icu_list"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "criterion",
  "databake",
@@ -1632,7 +1632,7 @@ dependencies = [
 
 [[package]]
 name = "icu_locid"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "criterion",
  "databake",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "criterion",
  "databake",
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "arraystring",
  "arrayvec",
@@ -1699,7 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "icu_plurals"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "criterion",
  "databake",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "icu_properties"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "bincode",
  "databake",
@@ -1756,7 +1756,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_adapters"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "databake",
  "icu_locid",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_blob"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "icu_locid",
  "icu_provider",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_fs"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "bincode",
  "criterion",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_macros"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "icu",
  "icu_provider",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "icu_segmenter"
-version = "1.0.0-alpha1"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "databake",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "icu_testdata"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "bytes",
  "cargo_metadata",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "icu_timezone"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "databake",
  "displaydoc",

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ An example `ICU4X` powered application in Rust may look like below...
 
 ```toml
 [dependencies]
-icu = { version = "1.0.0-beta1", features = ["serde"] }
-icu_testdata = "1.0.0-beta1"
+icu = { version = "1.0.0", features = ["serde"] }
+icu_testdata = "1.0.0"
 ```
 
 `src/main.rs`:

--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_calendar"
 description = "API for supporting various types of calendars"
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"
@@ -40,8 +40,8 @@ denylist = ["bench"]
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
 tinystr = { version = "0.7", path = "../../utils/tinystr", features = ["alloc", "zerovec"], default-features = false }
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core", features = ["macros"] }
-icu_locid = { version = "1.0.0-beta1", path = "../../components/locid" }
+icu_provider = { version = "1.0.0", path = "../../provider/core", features = ["macros"] }
+icu_locid = { version = "1.0.0", path = "../../components/locid" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 zerovec = { version = "0.9", path = "../../utils/zerovec", default-features = false, features = ["derive"] }
 databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"] }

--- a/components/collator/Cargo.toml
+++ b/components/collator/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_collator"
 description = "API for comparing strings according to language-dependent conventions"
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"
@@ -34,11 +34,11 @@ all-features = true
 [dependencies]
 smallvec = { version = "1.7", features = ["union", "const_generics", "const_new"] }
 displaydoc = { version = "0.2.3", default-features = false }
-icu_collections = { version = "1.0.0-beta1", path = "../../components/collections" }
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core", features = ["macros"] }
-icu_locid = { version = "1.0.0-beta1", path = "../../components/locid" }
-icu_normalizer = { version = "1.0.0-beta1", path = "../../components/normalizer" }
-icu_properties = { version = "1.0.0-beta1", path = "../../components/properties" }
+icu_collections = { version = "1.0.0", path = "../../components/collections" }
+icu_provider = { version = "1.0.0", path = "../../provider/core", features = ["macros"] }
+icu_locid = { version = "1.0.0", path = "../../components/locid" }
+icu_normalizer = { version = "1.0.0", path = "../../components/normalizer" }
+icu_properties = { version = "1.0.0", path = "../../components/properties" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 zerovec = { version = "0.9", path = "../../utils/zerovec", features = ["serde"] }
 utf8_iter = "1.0"

--- a/components/collator/fuzz/Cargo.toml
+++ b/components/collator/fuzz/Cargo.toml
@@ -20,8 +20,8 @@ rust_icu_ucol = { path = "../../../../rust_icu/rust_icu_ucol", features = ["use-
 rust_icu_sys = { path = "../../../../rust_icu/rust_icu_sys", features = ["use-bindgen", "icu_config"] }
 rust_icu_ustring = { path = "../../../../rust_icu/rust_icu_ustring", features = ["use-bindgen", "icu_config"] }
 encoding_rs = "0.8.31"
-icu_locid = { version = "1.0.0-beta1", path = "../../../components/locid" }
-icu_testdata = { version = "1.0.0-beta1", path = "../../../provider/testdata" }
+icu_locid = { version = "1.0.0", path = "../../../components/locid" }
+icu_testdata = { version = "1.0.0", path = "../../../provider/testdata" }
 icu_collator = { path = ".." }
 
 # Prevent this from interfering with workspaces

--- a/components/collections/Cargo.toml
+++ b/components/collections/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_collections"
 description = "Collection of API for use in ICU libraries."
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"

--- a/components/collections/codepointtrie_builder/Cargo.toml
+++ b/components/collections/codepointtrie_builder/Cargo.toml
@@ -25,7 +25,7 @@ include = [
 ]
 
 [dependencies]
-icu_collections = { version = "1.0.0-beta1", path = "..", features = ["serde"] }
+icu_collections = { version = "1.0.0", path = "..", features = ["serde"] }
 lazy_static = { version = "1.4.0" }
 toml = "0.5"
 

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_datetime"
 description = "API for formatting date and time to user readable textual representation"
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"
@@ -32,12 +32,12 @@ denylist = ["bench"]
 all-features = true
 
 [dependencies]
-icu_decimal = { version = "1.0.0-beta1", path = "../decimal" }
-icu_locid = { version = "1.0.0-beta1", path = "../locid" }
-icu_plurals = { version = "1.0.0-beta1", path = "../plurals" }
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core", features = ["macros"] }
-icu_calendar = { version = "1.0.0-beta1", path = "../calendar" }
-icu_timezone = { version = "1.0.0-beta1", path = "../timezone" }
+icu_decimal = { version = "1.0.0", path = "../decimal" }
+icu_locid = { version = "1.0.0", path = "../locid" }
+icu_plurals = { version = "1.0.0", path = "../plurals" }
+icu_provider = { version = "1.0.0", path = "../../provider/core", features = ["macros"] }
+icu_calendar = { version = "1.0.0", path = "../calendar" }
+icu_timezone = { version = "1.0.0", path = "../timezone" }
 writeable = { version = "0.5", path = "../../utils/writeable" }
 litemap = { version = "0.6", path = "../../utils/litemap" }
 tinystr = { version = "0.7", path = "../../utils/tinystr", features = ["alloc", "zerovec"], default-features = false }
@@ -54,7 +54,7 @@ fixed_decimal = { version = "0.5", path = "../../utils/fixed_decimal" }
 criterion = "0.3"
 icu = { path = "../icu", default-features = false }
 icu_benchmark_macros = { version = "0.7", path = "../../tools/benchmark/macros" }
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core" }
+icu_provider = { version = "1.0.0", path = "../../provider/core" }
 icu_provider_adapters = { path = "../../provider/adapters" }
 icu_testdata = { path = "../../provider/testdata", default-features = false, features = ["buffer", "icu_datetime", "icu_timezone", "icu_calendar", "icu_decimal", "icu_plurals"] }
 

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_decimal"
 description = "API for formatting basic decimal numbers in a locale-sensitive way"
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 repository = "https://github.com/unicode-org/icu4x"
@@ -31,8 +31,8 @@ denylist = ["bench"]
 all-features = true
 
 [dependencies]
-icu_locid = { version = "1.0.0-beta1", path = "../locid" }
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core", features = ["macros"] }
+icu_locid = { version = "1.0.0", path = "../locid" }
+icu_provider = { version = "1.0.0", path = "../../provider/core", features = ["macros"] }
 fixed_decimal = { version = "0.5", path = "../../utils/fixed_decimal" }
 writeable = { version = "0.5", path = "../../utils/writeable" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/components/icu/Cargo.toml
+++ b/components/icu/Cargo.toml
@@ -40,8 +40,8 @@ icu_plurals = { version = "1.0.0", path = "../plurals", default-features = false
 icu_properties = { version = "1.0.0", path = "../properties", default-features = false }
 icu_timezone = { version = "1.0.0", path = "../timezone", default-features = false }
 
-icu_casemapping = { version = "0.2", path = "../../experimental/casemapping", default-features = false, optional = true }
-icu_segmenter = { version = "1.0.0-alpha1", path = "../../experimental/segmenter", default-features = false, optional = true }
+icu_casemapping = { version = "0.7.0", path = "../../experimental/casemapping", default-features = false, optional = true }
+icu_segmenter = { version = "0.7.0", path = "../../experimental/segmenter", default-features = false, optional = true }
 
 # For docs links
 icu_provider = { version = "1.0.0", path = "../../provider/core", default-features = false }

--- a/components/icu/Cargo.toml
+++ b/components/icu/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu"
 description = "International Components for Unicode"
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"
@@ -27,24 +27,24 @@ include = [
 all-features = true
 
 [dependencies]
-icu_calendar = { version = "1.0.0-beta1", path = "../calendar", default-features = false }
-icu_collator = { version = "1.0.0-beta1", path = "../collator", default-features = false }
-icu_collections = { version = "1.0.0-beta1", path = "../collections", default-features = false }
-icu_datetime = { version = "1.0.0-beta1", path = "../datetime", default-features = false }
-icu_decimal = { version = "1.0.0-beta1", path = "../decimal", default-features = false }
-icu_list = { version = "1.0.0-beta1", path = "../list", default-features = false }
-icu_locid_transform = { version = "1.0.0-beta1", path = "../locid_transform", default-features = false }
-icu_locid = { version = "1.0.0-beta1", path = "../locid", default-features = false }
-icu_normalizer = { version = "1.0.0-beta1", path = "../normalizer", default-features = false }
-icu_plurals = { version = "1.0.0-beta1", path = "../plurals", default-features = false }
-icu_properties = { version = "1.0.0-beta1", path = "../properties", default-features = false }
-icu_timezone = { version = "1.0.0-beta1", path = "../timezone", default-features = false }
+icu_calendar = { version = "1.0.0", path = "../calendar", default-features = false }
+icu_collator = { version = "1.0.0", path = "../collator", default-features = false }
+icu_collections = { version = "1.0.0", path = "../collections", default-features = false }
+icu_datetime = { version = "1.0.0", path = "../datetime", default-features = false }
+icu_decimal = { version = "1.0.0", path = "../decimal", default-features = false }
+icu_list = { version = "1.0.0", path = "../list", default-features = false }
+icu_locid_transform = { version = "1.0.0", path = "../locid_transform", default-features = false }
+icu_locid = { version = "1.0.0", path = "../locid", default-features = false }
+icu_normalizer = { version = "1.0.0", path = "../normalizer", default-features = false }
+icu_plurals = { version = "1.0.0", path = "../plurals", default-features = false }
+icu_properties = { version = "1.0.0", path = "../properties", default-features = false }
+icu_timezone = { version = "1.0.0", path = "../timezone", default-features = false }
 
 icu_casemapping = { version = "0.2", path = "../../experimental/casemapping", default-features = false, optional = true }
 icu_segmenter = { version = "1.0.0-alpha1", path = "../../experimental/segmenter", default-features = false, optional = true }
 
 # For docs links
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core", default-features = false }
+icu_provider = { version = "1.0.0", path = "../../provider/core", default-features = false }
 
 [dev-dependencies]
 icu_testdata = { path = "../../provider/testdata" }

--- a/components/list/Cargo.toml
+++ b/components/list/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_list"
 description = "ECMA-402 ListFormatter"
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"
@@ -25,8 +25,8 @@ include = [
 
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
-icu_locid = { version = "1.0.0-beta1", path = "../../components/locid" }
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core", features = ["macros"] }
+icu_locid = { version = "1.0.0", path = "../../components/locid" }
+icu_provider = { version = "1.0.0", path = "../../provider/core", features = ["macros"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 zerovec = { version = "0.9", path = "../../utils/zerovec", features = ["yoke"] }
 deduplicating_array = { version = "0.1", path = "../../utils/deduplicating_array", optional = true }

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_locid"
 description = "API for managing Unicode Language and Locale Identifiers"
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"

--- a/components/locid_transform/Cargo.toml
+++ b/components/locid_transform/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_locid_transform"
 description = "API for Unicode Language and Locale Identifiers canonicalization"
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 repository = "https://github.com/unicode-org/icu4x"
@@ -31,8 +31,8 @@ denylist = ["bench"]
 all-features = true
 
 [dependencies]
-icu_locid = { version = "1.0.0-beta1", path = "../locid", features = ["serde", "zerovec"] }
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core", features = ["macros"] }
+icu_locid = { version = "1.0.0", path = "../locid", features = ["serde", "zerovec"] }
+icu_provider = { version = "1.0.0", path = "../../provider/core", features = ["macros"] }
 serde = { version = "1.0", features = ["derive", "alloc"], optional = true, default-features = false }
 tinystr = { version = "0.7", path = "../../utils/tinystr", default-features = false, features = ["alloc", "zerovec"] }
 zerovec = { version = "0.9", path = "../../utils/zerovec",  features = ["yoke"] }

--- a/components/normalizer/Cargo.toml
+++ b/components/normalizer/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_normalizer"
 description = "API for normalizing text into Unicode Normalization Forms"
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"
@@ -34,11 +34,11 @@ all-features = true
 [dependencies]
 smallvec = "1.6"
 displaydoc = { version = "0.2.3", default-features = false }
-icu_collections = { version = "1.0.0-beta1", path = "../../components/collections" }
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core", features = ["macros"] }
+icu_collections = { version = "1.0.0", path = "../../components/collections" }
+icu_provider = { version = "1.0.0", path = "../../provider/core", features = ["macros"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 zerovec = { version = "0.9", path = "../../utils/zerovec" }
-icu_properties = { version = "1.0.0-beta1", path = "../../components/properties" }
+icu_properties = { version = "1.0.0", path = "../../components/properties" }
 utf8_iter = "1.0.1"
 utf16_iter = "1.0.3"
 write16 = { version = "1.0", features = ["alloc"] }

--- a/components/normalizer/fuzz/Cargo.lock
+++ b/components/normalizer/fuzz/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "displaydoc",
  "serde",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "icu_locid"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "icu_properties"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "displaydoc",
  "icu_locid",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_adapters"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "icu_locid",
  "icu_provider",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_blob"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "icu_provider",
  "postcard",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_macros"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "icu_testdata"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "icu_provider",
  "icu_provider_adapters",

--- a/components/normalizer/fuzz/Cargo.toml
+++ b/components/normalizer/fuzz/Cargo.toml
@@ -19,7 +19,7 @@ rust_icu_unorm2 = { path = "../../../../rust_icu/rust_icu_unorm2", features = ["
 rust_icu_sys = { path = "../../../../rust_icu/rust_icu_sys", features = ["use-bindgen", "icu_config"] }
 rust_icu_ustring = { path = "../../../../rust_icu/rust_icu_ustring", features = ["use-bindgen", "icu_config"] }
 encoding_rs = "0.8.31"
-icu_testdata = { version = "1.0.0-beta1", path = "../../../provider/testdata" }
+icu_testdata = { version = "1.0.0", path = "../../../provider/testdata" }
 icu_normalizer = { path = "..", features = ["serde"] }
 utf8_iter = "1.0.1"
 utf16_iter = "1.0.3"

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_plurals"
 description = "Unicode Plural Rules categorizer for numeric input"
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"
@@ -33,8 +33,8 @@ all-features = true
 
 [dependencies]
 fixed_decimal = { version = "0.5", path = "../../utils/fixed_decimal" }
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core", features = ["macros"] }
-icu_locid = { version = "1.0.0-beta1", path = "../locid" }
+icu_provider = { version = "1.0.0", path = "../../provider/core", features = ["macros"] }
+icu_locid = { version = "1.0.0", path = "../locid" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 displaydoc = { version = "0.2.3", default-features = false }
 zerovec = { version = "0.9", path = "../../utils/zerovec", features = ["yoke"] }
@@ -43,7 +43,7 @@ databake = { version = "0.1.0", path = "../../utils/databake", optional = true, 
 [dev-dependencies]
 criterion = "0.3"
 icu_benchmark_macros = { version = "0.7", path = "../../tools/benchmark/macros" }
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core" }
+icu_provider = { version = "1.0.0", path = "../../provider/core" }
 icu_testdata = { path = "../../provider/testdata", default-features = false, features = ["icu_plurals"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }

--- a/components/properties/Cargo.toml
+++ b/components/properties/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_properties"
 description = "Definitions for Unicode properties"
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"
@@ -33,8 +33,8 @@ all-features = true
 
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
-icu_collections = { version = "1.0.0-beta1", path = "../../components/collections"}
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core", features = ["macros"] }
+icu_collections = { version = "1.0.0", path = "../../components/collections"}
+icu_provider = { version = "1.0.0", path = "../../provider/core", features = ["macros"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 zerovec = { version = "0.9", path = "../../utils/zerovec", features = ["derive"] }
 unicode-bidi = { version = "0.3.8", optional = true, default-features = false }

--- a/components/timezone/Cargo.toml
+++ b/components/timezone/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_timezone"
 description = "API for resolving and manipulating time zone information"
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"
@@ -40,9 +40,9 @@ denylist = ["bench"]
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
 tinystr = { version = "0.7", path = "../../utils/tinystr", features = ["alloc", "zerovec"], default-features = false }
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core", features = ["macros"] }
-icu_locid = { version = "1.0.0-beta1", path = "../../components/locid" }
-icu_calendar = { version = "1.0.0-beta1", path = "../../components/calendar" }
+icu_provider = { version = "1.0.0", path = "../../provider/core", features = ["macros"] }
+icu_locid = { version = "1.0.0", path = "../../components/locid" }
+icu_calendar = { version = "1.0.0", path = "../../components/calendar" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 zerovec = { version = "0.9", path = "../../utils/zerovec", default-features = false, features = ["derive", "yoke"] }
 databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"] }

--- a/docs/tutorials/intro.md
+++ b/docs/tutorials/intro.md
@@ -192,7 +192,7 @@ If you have ICU4X data on the file system in a JSON format, it can be loaded via
 ```toml
 [dependencies]
 icu = "0.6"
-icu_provider_fs = {version = "1.0.0-beta1" , features = ["deserialize_json"]}
+icu_provider_fs = {version = "1.0.0" , features = ["deserialize_json"]}
 ```
 
 ```rs

--- a/experimental/casemapping/Cargo.toml
+++ b/experimental/casemapping/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_casemapping"
 description = "Unicode case mapping algorithms"
-version = "0.2.0"
+version = "0.7.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"

--- a/experimental/casemapping/Cargo.toml
+++ b/experimental/casemapping/Cargo.toml
@@ -24,9 +24,9 @@ include = [
 
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
-icu_collections = { version = "1.0.0-beta1", path = "../../components/collections" }
-icu_locid = { version = "1.0.0-beta1", path = "../../components/locid" }
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core", features = ["macros"] }
+icu_collections = { version = "1.0.0", path = "../../components/collections" }
+icu_locid = { version = "1.0.0", path = "../../components/locid" }
+icu_provider = { version = "1.0.0", path = "../../provider/core", features = ["macros"] }
 yoke = { version = "0.6.0", path = "../../utils/yoke", features = ["derive"] }
 zerovec = { version = "0.9", path = "../../utils/zerovec", features = ["yoke"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/experimental/segmenter/Cargo.toml
+++ b/experimental/segmenter/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_segmenter"
 description = "Unicode line breaking and text segmentation algorithms for text boundaries analysis"
-version = "1.0.0-alpha1"
+version = "0.7.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"

--- a/experimental/segmenter/Cargo.toml
+++ b/experimental/segmenter/Cargo.toml
@@ -28,8 +28,8 @@ include = [
 skip_optional_dependencies = true
 
 [dependencies]
-icu_collections = { version = "1.0.0-beta1", path = "../../components/collections" }
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core", features = ["macros"] }
+icu_collections = { version = "1.0.0", path = "../../components/collections" }
+icu_provider = { version = "1.0.0", path = "../../provider/core", features = ["macros"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 zerovec = { version = "0.9", path = "../../utils/zerovec", features = ["yoke"] }
@@ -37,7 +37,7 @@ databake = { version = "0.1.0", path = "../../utils/databake", optional = true, 
 ndarray = { version = "0.15.5", default-features = false, optional = true, features = ["serde"] }
 unicode-segmentation = { version = "1.3.0", optional = true }
 num-traits = { version = "0.2", default-features = false, optional = true }
-icu_locid = { version = "1.0.0-beta1", path = "../../components/locid" }
+icu_locid = { version = "1.0.0", path = "../../components/locid" }
 utf8_iter = "1.0.3"
 displaydoc = { version = "0.2.3", default-features = false }
 

--- a/ffi/capi_cdylib/Cargo.toml
+++ b/ffi/capi_cdylib/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 
 [dependencies]
 icu_capi = { version = "1.0.0-alpha1", path = "../diplomat", default-features = false }
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core", default-features = false }
+icu_provider = { version = "1.0.0", path = "../../provider/core", default-features = false }
 
 # Please keep features/cargo-all-features lists in sync with the icu_capi crate
 [features]

--- a/ffi/capi_cdylib/Cargo.toml
+++ b/ffi/capi_cdylib/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_capi_cdylib"
 description = "C interface to ICU4X"
-version = "1.0.0-alpha1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 resolver = "2"
@@ -32,7 +32,7 @@ crate-type = ["cdylib", "rlib"]
 path = "src/lib.rs"
 
 [dependencies]
-icu_capi = { version = "1.0.0-alpha1", path = "../diplomat", default-features = false }
+icu_capi = { version = "1.0.0", path = "../diplomat", default-features = false }
 icu_provider = { version = "1.0.0", path = "../../provider/core", default-features = false }
 
 # Please keep features/cargo-all-features lists in sync with the icu_capi crate

--- a/ffi/capi_staticlib/Cargo.toml
+++ b/ffi/capi_staticlib/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 
 [dependencies]
 icu_capi = { version = "1.0.0-alpha1", path = "../diplomat", default-features = false }
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core", default-features = false }
+icu_provider = { version = "1.0.0", path = "../../provider/core", default-features = false }
 
 # Please keep features/cargo-all-features lists in sync with the icu_capi crate
 [features]

--- a/ffi/capi_staticlib/Cargo.toml
+++ b/ffi/capi_staticlib/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_capi_staticlib"
 description = "C interface to ICU4X"
-version = "1.0.0-alpha1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 resolver = "2"
@@ -32,7 +32,7 @@ crate-type = ["staticlib", "rlib"]
 path = "src/lib.rs"
 
 [dependencies]
-icu_capi = { version = "1.0.0-alpha1", path = "../diplomat", default-features = false }
+icu_capi = { version = "1.0.0", path = "../diplomat", default-features = false }
 icu_provider = { version = "1.0.0", path = "../../provider/core", default-features = false }
 
 # Please keep features/cargo-all-features lists in sync with the icu_capi crate

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_capi"
 description = "C interface to ICU4X"
-version = "1.0.0-alpha1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 resolver = "2"

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -76,7 +76,7 @@ icu_properties = { version = "1.0.0", path = "../../components/properties/", fea
 icu_provider = { version = "1.0.0", path = "../../provider/core" }
 icu_provider_adapters = { version = "1.0.0", path = "../../provider/adapters" }
 icu_provider_blob = { version = "1.0.0", path = "../../provider/blob" }
-icu_segmenter = { version = "1.0.0-alpha1", path = "../../experimental/segmenter" }
+icu_segmenter = { version = "0.7.0", path = "../../experimental/segmenter" }
 icu_timezone = { version = "1.0.0", path = "../../components/timezone" }
 serde = { version = "1.0", default-features = false, optional = true }
 tinystr = { version = "0.7", path = "../../utils/tinystr", features = ["alloc"], default-features = false }

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -62,22 +62,22 @@ simple_logger = ["dep:simple_logger"]
 
 [dependencies]
 fixed_decimal = { version = "0.5", path = "../../utils/fixed_decimal", features = ["ryu"] }
-icu_calendar = { version = "1.0.0-beta1", path = "../../components/calendar"}
-icu_collator = { version = "1.0.0-beta1", path = "../../components/collator" }
-icu_collections = { version = "1.0.0-beta1", path = "../../components/collections"}
-icu_datetime = { version = "1.0.0-beta1", path = "../../components/datetime/" }
-icu_decimal = { version = "1.0.0-beta1", path = "../../components/decimal/" }
-icu_list = { version = "1.0.0-beta1", path = "../../components/list" }
-icu_locid_transform = { version = "1.0.0-beta1", path = "../../components/locid_transform" }
-icu_locid = { version = "1.0.0-beta1", path = "../../components/locid" }
-icu_normalizer = { version = "1.0.0-beta1", path = "../../components/normalizer/" }
-icu_plurals = { version = "1.0.0-beta1", path = "../../components/plurals/" }
-icu_properties = { version = "1.0.0-beta1", path = "../../components/properties/", features = ["bidi"] }
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core" }
-icu_provider_adapters = { version = "1.0.0-beta1", path = "../../provider/adapters" }
-icu_provider_blob = { version = "1.0.0-beta1", path = "../../provider/blob" }
+icu_calendar = { version = "1.0.0", path = "../../components/calendar"}
+icu_collator = { version = "1.0.0", path = "../../components/collator" }
+icu_collections = { version = "1.0.0", path = "../../components/collections"}
+icu_datetime = { version = "1.0.0", path = "../../components/datetime/" }
+icu_decimal = { version = "1.0.0", path = "../../components/decimal/" }
+icu_list = { version = "1.0.0", path = "../../components/list" }
+icu_locid_transform = { version = "1.0.0", path = "../../components/locid_transform" }
+icu_locid = { version = "1.0.0", path = "../../components/locid" }
+icu_normalizer = { version = "1.0.0", path = "../../components/normalizer/" }
+icu_plurals = { version = "1.0.0", path = "../../components/plurals/" }
+icu_properties = { version = "1.0.0", path = "../../components/properties/", features = ["bidi"] }
+icu_provider = { version = "1.0.0", path = "../../provider/core" }
+icu_provider_adapters = { version = "1.0.0", path = "../../provider/adapters" }
+icu_provider_blob = { version = "1.0.0", path = "../../provider/blob" }
 icu_segmenter = { version = "1.0.0-alpha1", path = "../../experimental/segmenter" }
-icu_timezone = { version = "1.0.0-beta1", path = "../../components/timezone" }
+icu_timezone = { version = "1.0.0", path = "../../components/timezone" }
 serde = { version = "1.0", default-features = false, optional = true }
 tinystr = { version = "0.7", path = "../../utils/tinystr", features = ["alloc"], default-features = false }
 unicode-bidi = { version = "0.3.8", default-features = false }
@@ -89,7 +89,7 @@ writeable = { version = "0.5", path = "../../utils/writeable/" }
 # ALSO MAKE SURE TO UPDATE ffi_coverage/Cargo.toml!
 diplomat = { git = "https://github.com/rust-diplomat/diplomat", version = "0.4.0" }
 diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", version = "0.4.0" }
-icu_testdata = { version = "1.0.0-beta1", path = "../../provider/testdata", optional = true, features = ["icu_segmenter"] }
+icu_testdata = { version = "1.0.0", path = "../../provider/testdata", optional = true, features = ["icu_segmenter"] }
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -101,4 +101,4 @@ log = { version = "0.4", optional = true }
 log = { version = "0.4" }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "none")))'.dependencies]
-icu_provider_fs = { version = "1.0.0-beta1", path = "../../provider/fs/", optional = true }
+icu_provider_fs = { version = "1.0.0", path = "../../provider/fs/", optional = true }

--- a/ffi/ecma402/Cargo.lock
+++ b/ffi/ecma402/Cargo.lock
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "icu"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "icu_calendar",
  "icu_collator",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "icu_collator"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "icu_datagen"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "cached-path",
  "crlify",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "icu_datetime"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "icu_decimal"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "icu_list"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "databake",
  "deduplicating_array",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "icu_locid"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "icu_plurals"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "icu_properties"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "bincode",
  "databake",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_adapters"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "databake",
  "icu_locid",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_blob"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "icu_provider",
  "log",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_fs"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "bincode",
  "crlify",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_macros"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "icu_timezone"
-version = "1.0.0-beta1"
+version = "1.0.0"
 dependencies = [
  "databake",
  "displaydoc",

--- a/ffi/ecma402/Cargo.toml
+++ b/ffi/ecma402/Cargo.toml
@@ -28,16 +28,16 @@ all-features = true
 
 [dependencies]
 ecma402_traits = { version = "0.2.0" }
-icu = { version = "1.0.0-beta1", path = "../../components/icu", features = ["std"] }
-icu_provider = { version = "1.0.0-beta1", path = "../../provider/core" }
+icu = { version = "1.0.0", path = "../../components/icu", features = ["std"] }
+icu_provider = { version = "1.0.0", path = "../../provider/core" }
 writeable = { version = "0.5", path = "../../utils/writeable" }
 
 # Bake dependencies
-icu_plurals = { version = "1.0.0-beta1", path = "../../components/plurals" }
-icu_list = { version = "1.0.0-beta1", path = "../../components/list"}
+icu_plurals = { version = "1.0.0", path = "../../components/plurals" }
+icu_list = { version = "1.0.0", path = "../../components/list"}
 zerovec = { version = "0.9", path = "../../utils/zerovec" }
 litemap = { version = "0.6", path = "../../utils/litemap" }
 
 [build-dependencies]
-icu = { version = "1.0.0-beta1", path = "../../components/icu", features = ["std"] }
-icu_datagen = { version = "1.0.0-beta1", path = "../../provider/datagen" }
+icu = { version = "1.0.0", path = "../../components/icu", features = ["std"] }
+icu_datagen = { version = "1.0.0", path = "../../provider/datagen" }

--- a/ffi/freertos/Cargo.toml
+++ b/ffi/freertos/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_freertos"
 description = "C interface to ICU4X"
-version = "0.6.0"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 resolver = "2"
@@ -32,7 +32,7 @@ crate-type = ["staticlib", "rlib"]
 path = "src/lib.rs"
 
 [dependencies]
-icu_capi = { version = "1.0.0-alpha1", path = "../diplomat", default-features = false }
+icu_capi = { version = "1.0.0", path = "../diplomat", default-features = false }
 
 [target.'cfg(target_os = "none")'.dependencies]
 freertos-rust = { version = "0.1.2" }

--- a/provider/adapters/Cargo.toml
+++ b/provider/adapters/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_provider_adapters"
 description = "Adapters for composing and manipulating data providers."
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"
@@ -24,8 +24,8 @@ include = [
 ]
 
 [dependencies]
-icu_provider = { version = "1.0.0-beta1", path = "../core", features = ["macros"] }
-icu_locid = { version = "1.0.0-beta1", path = "../../components/locid", features = ["zerovec"] }
+icu_provider = { version = "1.0.0", path = "../core", features = ["macros"] }
+icu_locid = { version = "1.0.0", path = "../../components/locid", features = ["zerovec"] }
 yoke = { version = "0.6", path = "../../utils/yoke" }
 zerovec = { version = "0.9", path = "../../utils/zerovec", features = ["yoke"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
@@ -34,7 +34,7 @@ tinystr = { version = "0.7", path = "../../utils/tinystr", features = ["zerovec"
 
 [dev-dependencies]
 icu_testdata = { path = "../testdata", default-features = false, features = ["buffer"] }
-icu_provider = { version = "1.0.0-beta1", path = "../core", features = ["macros", "deserialize_json"] }
+icu_provider = { version = "1.0.0", path = "../core", features = ["macros", "deserialize_json"] }
 icu_provider_fs = { path = "../fs" }
 writeable = { path = "../../utils/writeable" }
 

--- a/provider/blob/Cargo.toml
+++ b/provider/blob/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_provider_blob"
 description = "ICU4X data provider that reads from blobs in memory"
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"
@@ -27,7 +27,7 @@ include = [
 all-features = true
 
 [dependencies]
-icu_provider = { version = "1.0.0-beta1", path = "../core", features = ["deserialize_postcard_1", "serde"] }
+icu_provider = { version = "1.0.0", path = "../core", features = ["deserialize_postcard_1", "serde"] }
 serde = { version = "1.0", default-features = false, features = ["alloc"] }
 postcard = { version = "1.0.0", default-features = false, features = ["alloc"] }
 writeable = { version = "0.5", path = "../../utils/writeable" }
@@ -38,7 +38,7 @@ zerovec = { version = "0.9", path = "../../utils/zerovec", features = ["serde", 
 log = { version = "0.4", optional = true }
 
 [dev-dependencies]
-icu_locid = { version = "1.0.0-beta1", path = "../../components/locid", features = ["serde"] }
+icu_locid = { version = "1.0.0", path = "../../components/locid", features = ["serde"] }
 
 [lib]
 path = "src/lib.rs"

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_provider"
 description = "Trait and struct definitions for the ICU data provider"
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
@@ -52,7 +52,7 @@ deserialize_postcard_1 = ["serde", "postcard"]
 datagen = ["dhat", "serde", "erased-serde", "databake", "std", "serde_json", "sync", "yoke/serde"]
 
 [dependencies]
-icu_locid = { version = "1.0.0-beta1", path = "../../components/locid" }
+icu_locid = { version = "1.0.0", path = "../../components/locid" }
 writeable = { version = "0.5", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
 yoke = { version = "0.6.2", path = "../../utils/yoke", features = ["derive"] }
@@ -61,7 +61,7 @@ zerovec = { version = "0.9", path = "../../utils/zerovec", features = ["derive"]
 stable_deref_trait = { version = "1.2.0", default-features = false }
 
 log = { version = "0.4", optional = true }
-icu_provider_macros = { version = "1.0.0-beta1", path = "../macros", optional = true }
+icu_provider_macros = { version = "1.0.0", path = "../macros", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 
 # Serde formats

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_datagen"
 description = "Generate data for ICU4X DataProvider"
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
@@ -34,33 +34,33 @@ all-features = true
 [dependencies]
 
 # ICU components
-icu_calendar = { version = "1.0.0-beta1", path = "../../components/calendar", features = ["datagen"] }
-icu_collator = { version = "1.0.0-beta1", path = "../../components/collator", features = ["datagen"] }
-icu_datetime = { version = "1.0.0-beta1", path = "../../components/datetime", features = ["datagen"] }
-icu_decimal = { version = "1.0.0-beta1", path = "../../components/decimal", features = ["datagen"] }
-icu_list = { version = "1.0.0-beta1", path = "../../components/list", features = ["datagen"]}
-icu_locid_transform = { version = "1.0.0-beta1", path = "../../components/locid_transform", features = ["datagen"] }
-icu_normalizer = { version = "1.0.0-beta1", path = "../../components/normalizer", features = ["datagen"] }
-icu_plurals = { version = "1.0.0-beta1", path = "../../components/plurals", features = ["datagen"] }
-icu_properties = { version = "1.0.0-beta1", path = "../../components/properties", features = ["datagen"]}
-icu_timezone = { version = "1.0.0-beta1", path = "../../components/timezone", features = ["datagen"] }
+icu_calendar = { version = "1.0.0", path = "../../components/calendar", features = ["datagen"] }
+icu_collator = { version = "1.0.0", path = "../../components/collator", features = ["datagen"] }
+icu_datetime = { version = "1.0.0", path = "../../components/datetime", features = ["datagen"] }
+icu_decimal = { version = "1.0.0", path = "../../components/decimal", features = ["datagen"] }
+icu_list = { version = "1.0.0", path = "../../components/list", features = ["datagen"]}
+icu_locid_transform = { version = "1.0.0", path = "../../components/locid_transform", features = ["datagen"] }
+icu_normalizer = { version = "1.0.0", path = "../../components/normalizer", features = ["datagen"] }
+icu_plurals = { version = "1.0.0", path = "../../components/plurals", features = ["datagen"] }
+icu_properties = { version = "1.0.0", path = "../../components/properties", features = ["datagen"]}
+icu_timezone = { version = "1.0.0", path = "../../components/timezone", features = ["datagen"] }
 
 # (experimental)
 icu_casemapping = { version = "0.2", path = "../../experimental/casemapping", features = ["datagen"], optional = true }
 icu_segmenter = { version = "1.0.0-alpha1", path = "../../experimental/segmenter", features = ["datagen", "lstm"], optional = true }
 
 # ICU provider infrastructure
-icu_provider = { version = "1.0.0-beta1", path = "../core", features = ["std", "log_error_context", "datagen"]}
-icu_provider_adapters = { version = "1.0.0-beta1", path = "../adapters", features = ["datagen"] }
-icu_provider_blob = { version = "1.0.0-beta1", path = "../blob", features = ["export"] }
-icu_provider_fs = { version = "1.0.0-beta1", path = "../fs", features = ["export"] }
+icu_provider = { version = "1.0.0", path = "../core", features = ["std", "log_error_context", "datagen"]}
+icu_provider_adapters = { version = "1.0.0", path = "../adapters", features = ["datagen"] }
+icu_provider_blob = { version = "1.0.0", path = "../blob", features = ["export"] }
+icu_provider_fs = { version = "1.0.0", path = "../fs", features = ["export"] }
 
 # Other
 displaydoc = { version = "0.2.3", default-features = false }
 elsa = "1.7"
-icu_collections = { version = "1.0.0-beta1", path = "../../components/collections", features = ["serde"] }
+icu_collections = { version = "1.0.0", path = "../../components/collections", features = ["serde"] }
 icu_codepointtrie_builder = { version = "0.3.3", path = "../../components/collections/codepointtrie_builder" }
-icu_locid = { version = "1.0.0-beta1", path = "../../components/locid", features = ["std"] }
+icu_locid = { version = "1.0.0", path = "../../components/locid", features = ["std"] }
 itertools = "0.10"
 log = "0.4"
 rayon = "1.5"

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -46,8 +46,8 @@ icu_properties = { version = "1.0.0", path = "../../components/properties", feat
 icu_timezone = { version = "1.0.0", path = "../../components/timezone", features = ["datagen"] }
 
 # (experimental)
-icu_casemapping = { version = "0.2", path = "../../experimental/casemapping", features = ["datagen"], optional = true }
-icu_segmenter = { version = "1.0.0-alpha1", path = "../../experimental/segmenter", features = ["datagen", "lstm"], optional = true }
+icu_casemapping = { version = "0.7.0", path = "../../experimental/casemapping", features = ["datagen"], optional = true }
+icu_segmenter = { version = "0.7.0", path = "../../experimental/segmenter", features = ["datagen", "lstm"], optional = true }
 
 # ICU provider infrastructure
 icu_provider = { version = "1.0.0", path = "../core", features = ["std", "log_error_context", "datagen"]}

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_provider_fs"
 description = "ICU4X data provider that reads from structured data files"
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"
@@ -33,7 +33,7 @@ denylist = ["bench"]
 all-features = true
 
 [dependencies]
-icu_provider = { version = "1.0.0-beta1", path = "../core", features = ["serde", "std"] }
+icu_provider = { version = "1.0.0", path = "../core", features = ["serde", "std"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 displaydoc = { version = "0.2.3", default-features = false }
 serde-json-core = { version = "0.4", default-features = false, features = ["std"] }
@@ -48,9 +48,9 @@ crlify = { version = "1", path = "../../utils/crlify", optional = true }
 sha2 = { version = "0.10.2", optional = true }
 
 [dev-dependencies]
-icu_locid = { version = "1.0.0-beta1", path = "../../components/locid", features = ["serde"] }
+icu_locid = { version = "1.0.0", path = "../../components/locid", features = ["serde"] }
 icu_benchmark_macros = { version = "0.7", path = "../../tools/benchmark/macros" }
-icu_provider = { version = "1.0.0-beta1", path = "../core", features = ["deserialize_json", "deserialize_bincode_1", "deserialize_postcard_1", "datagen"] }
+icu_provider = { version = "1.0.0", path = "../core", features = ["deserialize_json", "deserialize_bincode_1", "deserialize_postcard_1", "datagen"] }
 criterion = "0.3.3"
 
 [features]

--- a/provider/macros/Cargo.toml
+++ b/provider/macros/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_provider_macros"
 description = "Proc macros for ICU data providers"
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_testdata"
 description = "Pre-built test data for ICU4X"
-version = "1.0.0-beta1"
+version = "1.0.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"
@@ -275,11 +275,11 @@ extra_features = [
 ]
 
 [dependencies]
-icu_provider = { version = "1.0.0-beta1", path = "../core" }
-icu_provider_adapters = { version = "1.0.0-beta1", path = "../adapters" }
+icu_provider = { version = "1.0.0", path = "../core" }
+icu_provider_adapters = { version = "1.0.0", path = "../adapters" }
 
 # serde feature
-icu_provider_blob = { version = "1.0.0-beta1", path = "../blob", optional = true }
+icu_provider_blob = { version = "1.0.0", path = "../blob", optional = true }
 lazy_static = { version = "1", features = ["spin_no_std"], optional = true }
 
 # bin feature
@@ -287,8 +287,8 @@ bytes = {version = "1.1.0", optional = true }
 clap = { version = "2.33", optional = true }
 eyre = { version = "0.6", optional = true }
 futures = { version = "0.3", optional = true }
-icu_provider_fs = { version = "1.0.0-beta1", path = "../fs", optional = true }
-icu_datagen = { version = "1.0.0-beta1", path = "../datagen", features = ["experimental"], optional = true }
+icu_provider_fs = { version = "1.0.0", path = "../fs", optional = true }
+icu_datagen = { version = "1.0.0", path = "../datagen", features = ["experimental"], optional = true }
 log = { version = "0.4", optional = true }
 reqwest = { version = "0.11", features = ["stream"], optional = true }
 simple_logger = { version = "1.12", optional = true, default-features = false }
@@ -303,25 +303,25 @@ displaydoc = { version = "0.2.3", default-features = false, optional = true }
 writeable = { version = "0.5", path = "../../utils/writeable", optional = true }
 
 # databake deps
-icu_locid = { version = "1.0.0-beta1", path = "../../components/locid" }
-icu_collections = { version = "1.0.0-beta1", path = "../../components/collections" }
+icu_locid = { version = "1.0.0", path = "../../components/locid" }
+icu_collections = { version = "1.0.0", path = "../../components/collections" }
 litemap = { version = "0.6", path = "../../utils/litemap", default-features = false }
 tinystr = { version = "0.7", path = "../../utils/tinystr" }
 zerovec = { version = "0.9", path = "../../utils/zerovec" }
 
 # databake options
-icu_calendar = { version = "1.0.0-beta1", path = "../../components/calendar", default-features = false, optional = true }
+icu_calendar = { version = "1.0.0", path = "../../components/calendar", default-features = false, optional = true }
 icu_casemapping = { version = "0.2", path = "../../experimental/casemapping", default-features = false, optional = true }
-icu_collator = { version = "1.0.0-beta1", path = "../../components/collator", default-features = false, optional = true }
-icu_datetime = { version = "1.0.0-beta1", path = "../../components/datetime", default-features = false, optional = true }
-icu_decimal = { version = "1.0.0-beta1", path = "../../components/decimal", default-features = false, optional = true }
-icu_list = { version = "1.0.0-beta1", path = "../../components/list", default-features = false, optional = true }
-icu_locid_transform = { version = "1.0.0-beta1", path = "../../components/locid_transform", default-features = false, optional = true }
-icu_normalizer = { version = "1.0.0-beta1", path = "../../components/normalizer", default-features = false, optional = true }
-icu_plurals = { version = "1.0.0-beta1", path = "../../components/plurals", default-features = false, optional = true }
-icu_properties = { version = "1.0.0-beta1", path = "../../components/properties", default-features = false, optional = true }
+icu_collator = { version = "1.0.0", path = "../../components/collator", default-features = false, optional = true }
+icu_datetime = { version = "1.0.0", path = "../../components/datetime", default-features = false, optional = true }
+icu_decimal = { version = "1.0.0", path = "../../components/decimal", default-features = false, optional = true }
+icu_list = { version = "1.0.0", path = "../../components/list", default-features = false, optional = true }
+icu_locid_transform = { version = "1.0.0", path = "../../components/locid_transform", default-features = false, optional = true }
+icu_normalizer = { version = "1.0.0", path = "../../components/normalizer", default-features = false, optional = true }
+icu_plurals = { version = "1.0.0", path = "../../components/plurals", default-features = false, optional = true }
+icu_properties = { version = "1.0.0", path = "../../components/properties", default-features = false, optional = true }
 icu_segmenter = { version = "1.0.0-alpha1", path = "../../experimental/segmenter", default-features = false, optional = true }
-icu_timezone = { version = "1.0.0-beta1", path = "../../components/timezone", default-features = false, optional = true }
+icu_timezone = { version = "1.0.0", path = "../../components/timezone", default-features = false, optional = true }
 
 [dev-dependencies]
 icu = { path = "../../components/icu" }

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -311,7 +311,7 @@ zerovec = { version = "0.9", path = "../../utils/zerovec" }
 
 # databake options
 icu_calendar = { version = "1.0.0", path = "../../components/calendar", default-features = false, optional = true }
-icu_casemapping = { version = "0.2", path = "../../experimental/casemapping", default-features = false, optional = true }
+icu_casemapping = { version = "0.7.0", path = "../../experimental/casemapping", default-features = false, optional = true }
 icu_collator = { version = "1.0.0", path = "../../components/collator", default-features = false, optional = true }
 icu_datetime = { version = "1.0.0", path = "../../components/datetime", default-features = false, optional = true }
 icu_decimal = { version = "1.0.0", path = "../../components/decimal", default-features = false, optional = true }
@@ -320,7 +320,7 @@ icu_locid_transform = { version = "1.0.0", path = "../../components/locid_transf
 icu_normalizer = { version = "1.0.0", path = "../../components/normalizer", default-features = false, optional = true }
 icu_plurals = { version = "1.0.0", path = "../../components/plurals", default-features = false, optional = true }
 icu_properties = { version = "1.0.0", path = "../../components/properties", default-features = false, optional = true }
-icu_segmenter = { version = "1.0.0-alpha1", path = "../../experimental/segmenter", default-features = false, optional = true }
+icu_segmenter = { version = "0.7.0", path = "../../experimental/segmenter", default-features = false, optional = true }
 icu_timezone = { version = "1.0.0", path = "../../components/timezone", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -38,7 +38,7 @@ rkyv = { version = "0.7", features = ["validation"] }
 bytecheck = "0.6"
 bincode = "1"
 postcard = { version = "1.0.0", features = ["use-std"] }
-icu_locid = { version = "1.0.0-beta1", path = "../../components/locid" }
+icu_locid = { version = "1.0.0", path = "../../components/locid" }
 icu_benchmark_macros = { version = "0.7", path = "../../tools/benchmark/macros" }
 criterion = "0.3.4"
 


### PR DESCRIPTION
(except for segmenter and casemapping, they are 0.7)


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->