### PR TITLE
`icu_datagen@1.0.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "icu_datagen"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cached-path",
  "clap",

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_datagen"
 description = "Generate data for ICU4X DataProvider"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
@@ -14,6 +14,7 @@ license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions
 include = [
+    "data/**/*",
     "src/**/*",
     "examples/**/*",
     "benches/**/*",

--- a/provider/datagen/README.md
+++ b/provider/datagen/README.md
@@ -27,14 +27,14 @@ fn main() {
 ```
 
 ### Command line
-The command line interface is available with the `bin` feature.
+The command line interface can be installed with the `bin` feature.
 ```bash
-cargo run --features bin -- \
-    --icu_exports-root /path/to/icu_exports/root \
-    --all-keys \
-    --locales de,en-AU \
-    --format blob \
-    --out data.postcard
+$ cargo install icu_datagen --features bin
+$ icu4x-datagen \
+>    --all-keys \
+>    --locales de,en-AU \
+>    --format blob \
+>    --out data.postcard
 ```
 More details can be found by running `--help`.
 

--- a/provider/datagen/src/bin/datagen.rs
+++ b/provider/datagen/src/bin/datagen.rs
@@ -155,6 +155,14 @@ fn main() -> eyre::Result<()> {
                 ),
         )
         .arg(
+            Arg::with_name("KEYS_FOR_BIN")
+                .long("keys-for-bin")
+                .takes_value(true)
+                .help(
+                    "Analyzes the binary and only includes keys that are used by the binary."
+                ),
+        )
+        .arg(
             Arg::with_name("HELLO_WORLD")
                 .long("hello-world-key")
                 .help("Whether to include the 'hello world' key."),
@@ -170,6 +178,7 @@ fn main() -> eyre::Result<()> {
                 .arg("KEY_FILE")
                 .arg("HELLO_WORLD")
                 .arg("ALL_KEYS")
+                .arg("KEYS_FOR_BIN")
                 .required(true),
         )
         .arg(
@@ -245,6 +254,9 @@ fn main() -> eyre::Result<()> {
     } else if let Some(key_file_path) = matches.value_of_os("KEY_FILE") {
         icu_datagen::keys_from_file(key_file_path)
             .with_context(|| key_file_path.to_string_lossy().into_owned())?
+    } else if let Some(bin_path) = matches.value_of_os("KEYS_FOR_BIN") {
+        icu_datagen::keys_from_bin(bin_path)
+            .with_context(|| bin_path.to_string_lossy().into_owned())?
     } else {
         unreachable!();
     };

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -30,14 +30,14 @@
 //! ```
 //!
 //! ## Command line
-//! The command line interface is available with the `bin` feature.
+//! The command line interface can be installed with the `bin` feature.
 //! ```bash
-//! cargo run --features bin -- \
-//!     --icu_exports-root /path/to/icu_exports/root \
-//!     --all-keys \
-//!     --locales de,en-AU \
-//!     --format blob \
-//!     --out data.postcard
+//! $ cargo install icu_datagen --features bin
+//! $ icu4x-datagen \
+//! >    --all-keys \
+//! >    --locales de,en-AU \
+//! >    --format blob \
+//! >    --out data.postcard
 //! ```
 
 //! More details can be found by running `--help`.


### PR DESCRIPTION
This includes segmenter data, whose absence currently makes the binary on crates.io crash. Whoops.

Also added the binary analysis tool to the CLI as I need that for the tutorial, and fixed the doc as `cargo run -p icu_datagen` only works in the workspace.