### PR TITLE
Some wasm demo fixes

### DIFF
--- a/ffi/diplomat/wasm/wasm-demo/index.html
+++ b/ffi/diplomat/wasm/wasm-demo/index.html
@@ -162,14 +162,14 @@
                                     <span class="input-group-text">Calendar</span>
                                   </div>
                                   <select name="dtf-calendar" class="form-select">
-                                      <option value="gregory" selected>Gregorian</option>
+                                      <option value="from-locale" selected>Default for locale</option>
+                                      <option value="gregory">Gregorian</option>
                                       <option value="japanese">Japanese</option>
                                       <option value="japanext">Japanese (historical eras)</option>
                                       <option value="buddhist">Buddhist</option>
                                       <option value="indian">Indian national</option>
                                       <option value="coptic">Coptic</option>
                                       <option value="ethiopic">Ethiopian</option>
-                                      <option value="from-locale">Use from locale</option>
                                     </select>
                             </div>
 

--- a/ffi/diplomat/wasm/wasm-demo/src/ts/date-time.ts
+++ b/ffi/diplomat/wasm/wasm-demo/src/ts/date-time.ts
@@ -44,9 +44,17 @@ export class DateTimeDemo {
     }
 
     #updateLocaleAndCalendar(): void {
-        const locid = (this.#calendarStr == "from-locale") ?
-            this.#localeStr :
-            `${this.#localeStr}-u-ca-${this.#calendarStr}`;
+        let locid = this.#localeStr;
+        if (this.#calendarStr != "from-locale") {
+            if (locid.indexOf("-u-") == -1) {
+                locid = `${locid}-u-ca-${this.#calendarStr}`;
+            } else {
+                // Don't bother trying to patch up the situation where a calendar
+                // is already specified; this is GIGO and the current locale parsing behavior
+                // will just default to the first one (#calendarStr)
+                locid = locid.replace("-u-", `-u-ca-${this.#calendarStr}-`);
+            }
+        }
         this.#locale = result(() => ICU4XLocale.create_from_string(locid));
         this.#calendar = result(() => ICU4XCalendar.create_for_locale(this.#dataProvider, unwrap(this.#locale) ));
         this.#updateDateTime();

--- a/ffi/diplomat/wasm/wasm-demo/src/ts/date-time.ts
+++ b/ffi/diplomat/wasm/wasm-demo/src/ts/date-time.ts
@@ -20,13 +20,13 @@ export class DateTimeDemo {
         this.#displayFn = displayFn;
         this.#dataProvider = dataProvider;
 
-        this.#locale = Ok(ICU4XLocale.create_from_string("en-u-ca-gregory"));
+        this.#locale = Ok(ICU4XLocale.create_from_string("en"));
         this.#calendar = Ok(ICU4XCalendar.create_for_locale(dataProvider, unwrap(this.#locale)));
         this.#dateLength = ICU4XDateLength.Short;
         this.#timeLength = ICU4XTimeLength.Short;
         this.#dateTime = null;
         this.#dateTimeStr = "";
-        this.#calendarStr = "gregory";
+        this.#calendarStr = "from-locale";
         this.#localeStr = "en";
         this.#updateFormatter();
     }


### PR DESCRIPTION
By default the demo was broken if you tried formatting with `hc`. This fixes it.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->