### PR TITLE
More borrowing in locid's `write_to_string`

### DIFF
--- a/components/locid/src/extensions/mod.rs
+++ b/components/locid/src/extensions/mod.rs
@@ -283,7 +283,7 @@ impl_writeable_for_each_subtag_str_no_test!(Extensions);
 fn test_writeable() {
     use crate::Locale;
     use writeable::assert_writeable_eq;
-    assert_writeable_eq!(Extensions::new(), "",);
+    assert_writeable_eq!(Extensions::new(), "");
     assert_writeable_eq!(
         "my-t-my-d0-zawgyi".parse::<Locale>().unwrap().extensions,
         "t-my-d0-zawgyi",

--- a/components/locid/src/extensions/other/mod.rs
+++ b/components/locid/src/extensions/other/mod.rs
@@ -47,7 +47,10 @@ pub use subtag::Subtag;
 /// [`Other Use Extensions`]: https://unicode.org/reports/tr35/#other_extensions
 /// [`Unicode Locale Identifier`]: https://unicode.org/reports/tr35/#Unicode_locale_identifier
 #[derive(Clone, PartialEq, Eq, Debug, Default, Hash, PartialOrd, Ord)]
-pub struct Other((u8, Vec<Subtag>));
+pub struct Other {
+    ext: u8,
+    keys: Vec<Subtag>,
+}
 
 impl Other {
     /// A constructor which takes a pre-sorted list of [`Subtag`].
@@ -67,9 +70,9 @@ impl Other {
     /// let other = Other::from_vec_unchecked(b'a', vec![subtag1, subtag2]);
     /// assert_eq!(&other.to_string(), "-a-foo-bar");
     /// ```
-    pub fn from_vec_unchecked(ext: u8, input: Vec<Subtag>) -> Self {
+    pub fn from_vec_unchecked(ext: u8, keys: Vec<Subtag>) -> Self {
         assert!(ext.is_ascii_alphabetic());
-        Self((ext, input))
+        Self { ext, keys }
     }
 
     pub(crate) fn try_from_iter(ext: u8, iter: &mut SubtagIterator) -> Result<Self, ParserError> {
@@ -89,6 +92,22 @@ impl Other {
         Ok(Self::from_vec_unchecked(ext, keys))
     }
 
+    /// Gets the tag character for this extension as a &str.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::locid::Locale;
+    ///
+    /// let loc: Locale = "und-a-hello-world".parse().unwrap();
+    /// let other_ext = &loc.extensions.other[0];
+    /// assert_eq!(other_ext.get_ext_str(), "a");
+    /// ```
+    pub fn get_ext_str(&self) -> &str {
+        debug_assert!(self.ext.is_ascii_alphabetic());
+        unsafe { core::str::from_utf8_unchecked(core::slice::from_ref(&self.ext)) }
+    }
+
     /// Gets the tag character for this extension as a char.
     ///
     /// # Examples
@@ -101,7 +120,7 @@ impl Other {
     /// assert_eq!(other_ext.get_ext(), 'a');
     /// ```
     pub fn get_ext(&self) -> char {
-        self.get_ext_byte() as char
+        self.ext as char
     }
 
     /// Gets the tag character for this extension as a byte.
@@ -116,19 +135,15 @@ impl Other {
     /// assert_eq!(other_ext.get_ext_byte(), b'a');
     /// ```
     pub fn get_ext_byte(&self) -> u8 {
-        self.0 .0
+        self.ext
     }
 
     pub(crate) fn for_each_subtag_str<E, F>(&self, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&str) -> Result<(), E>,
     {
-        let (ext, keys) = &self.0;
-        debug_assert!(ext.is_ascii_alphabetic());
-        // Safety: ext is ascii_alphabetic, so it is valid UTF-8
-        let ext_str = unsafe { core::str::from_utf8_unchecked(core::slice::from_ref(ext)) };
-        f(ext_str)?;
-        keys.iter().map(|t| t.as_str()).try_for_each(f)
+        f(self.get_ext_str())?;
+        self.keys.iter().map(|t| t.as_str()).try_for_each(f)
     }
 }
 
@@ -136,10 +151,9 @@ writeable::impl_display_with_writeable!(Other);
 
 impl writeable::Writeable for Other {
     fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
-        let (ext, keys) = &self.0;
         sink.write_char('-')?;
-        sink.write_char(*ext as char)?;
-        for key in keys.iter() {
+        sink.write_str(self.get_ext_str())?;
+        for key in self.keys.iter() {
             sink.write_char('-')?;
             writeable::Writeable::write_to(key, sink)?;
         }
@@ -149,7 +163,7 @@ impl writeable::Writeable for Other {
 
     fn writeable_length_hint(&self) -> writeable::LengthHint {
         let mut result = writeable::LengthHint::exact(2);
-        for key in self.0 .1.iter() {
+        for key in self.keys.iter() {
             result += writeable::Writeable::writeable_length_hint(key) + 1;
         }
         result

--- a/components/locid/src/extensions/private/mod.rs
+++ b/components/locid/src/extensions/private/mod.rs
@@ -50,7 +50,7 @@ use crate::parser::SubtagIterator;
 /// let subtag2: Subtag = "bar".parse().expect("Failed to parse a Subtag.");
 ///
 /// let private = Private::from_vec_unchecked(vec![subtag1, subtag2]);
-/// assert_eq!(&private.to_string(), "-x-foo-bar");
+/// assert_eq!(&private.to_string(), "x-foo-bar");
 /// ```
 ///
 /// [`Private Use Extensions`]: https://unicode.org/reports/tr35/#pu_extensions
@@ -84,7 +84,7 @@ impl Private {
     /// let subtag2: Subtag = "bar".parse().expect("Failed to parse a Subtag.");
     ///
     /// let private = Private::from_vec_unchecked(vec![subtag1, subtag2]);
-    /// assert_eq!(&private.to_string(), "-x-foo-bar");
+    /// assert_eq!(&private.to_string(), "x-foo-bar");
     /// ```
     pub fn from_vec_unchecked(input: Vec<Subtag>) -> Self {
         Self(input)
@@ -101,7 +101,7 @@ impl Private {
     /// let subtag2: Subtag = "bar".parse().expect("Failed to parse a Subtag.");
     /// let mut private = Private::from_vec_unchecked(vec![subtag1, subtag2]);
     ///
-    /// assert_eq!(&private.to_string(), "-x-foo-bar");
+    /// assert_eq!(&private.to_string(), "x-foo-bar");
     ///
     /// private.clear();
     ///
@@ -138,7 +138,7 @@ impl writeable::Writeable for Private {
         if self.is_empty() {
             return Ok(());
         }
-        sink.write_str("-x")?;
+        sink.write_str("x")?;
         for key in self.iter() {
             sink.write_char('-')?;
             writeable::Writeable::write_to(key, sink)?;
@@ -150,7 +150,7 @@ impl writeable::Writeable for Private {
         if self.is_empty() {
             return writeable::LengthHint::exact(0);
         }
-        let mut result = writeable::LengthHint::exact(2);
+        let mut result = writeable::LengthHint::exact(1);
         for key in self.iter() {
             result += writeable::Writeable::writeable_length_hint(key) + 1;
         }

--- a/components/locid/src/extensions/transform/mod.rs
+++ b/components/locid/src/extensions/transform/mod.rs
@@ -28,7 +28,7 @@
 //! assert!(loc.extensions.transform.fields.contains_key(&key));
 //! assert_eq!(loc.extensions.transform.fields.get(&key), Some(&value));
 //!
-//! assert_eq!(&loc.extensions.transform.to_string(), "-t-es-AR-h0-hybrid");
+//! assert_eq!(&loc.extensions.transform.to_string(), "t-es-AR-h0-hybrid");
 //! ```
 mod fields;
 mod key;
@@ -208,7 +208,7 @@ impl writeable::Writeable for Transform {
         if self.is_empty() {
             return Ok(());
         }
-        sink.write_str("-t")?;
+        sink.write_str("t")?;
         if let Some(lang) = &self.lang {
             sink.write_char('-')?;
             writeable::Writeable::write_to(lang, sink)?;
@@ -224,7 +224,7 @@ impl writeable::Writeable for Transform {
         if self.is_empty() {
             return writeable::LengthHint::exact(0);
         }
-        let mut result = writeable::LengthHint::exact(2);
+        let mut result = writeable::LengthHint::exact(1);
         if let Some(lang) = &self.lang {
             result += writeable::Writeable::writeable_length_hint(lang) + 1;
         }

--- a/components/locid/src/extensions/transform/value.rs
+++ b/components/locid/src/extensions/transform/value.rs
@@ -123,12 +123,12 @@ fn test_writeable() {
     use writeable::assert_writeable_eq;
 
     let hybrid = "hybrid".parse().unwrap();
-    let foo = "foobar".parse().unwrap();
+    let foobar = "barbar".parse().unwrap();
 
     assert_writeable_eq!(Value::default(), "true");
     assert_writeable_eq!(Value::from_vec_unchecked(vec![hybrid]), "hybrid");
     assert_writeable_eq!(
-        Value::from_vec_unchecked(vec![hybrid, foo]),
+        Value::from_vec_unchecked(vec![hybrid, foobar]),
         "hybrid-foobar"
     );
 }

--- a/components/locid/src/extensions/transform/value.rs
+++ b/components/locid/src/extensions/transform/value.rs
@@ -123,7 +123,7 @@ fn test_writeable() {
     use writeable::assert_writeable_eq;
 
     let hybrid = "hybrid".parse().unwrap();
-    let foobar = "barbar".parse().unwrap();
+    let foobar = "foobar".parse().unwrap();
 
     assert_writeable_eq!(Value::default(), "true");
     assert_writeable_eq!(Value::from_vec_unchecked(vec![hybrid]), "hybrid");

--- a/components/locid/src/extensions/transform/value.rs
+++ b/components/locid/src/extensions/transform/value.rs
@@ -29,7 +29,7 @@ use tinystr::TinyAsciiStr;
 /// assert_eq!(&value1.to_string(), "hybrid");
 /// assert_eq!(&value2.to_string(), "hybrid-foobar");
 /// ```
-#[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord, Default)]
 pub struct Value(Vec<TinyAsciiStr<{ *TYPE_LENGTH.end() }>>);
 
 const TYPE_LENGTH: RangeInclusive<usize> = 3..=8;
@@ -116,4 +116,19 @@ impl FromStr for Value {
     }
 }
 
-impl_writeable_for_tinystr_list!(Value, "true", "hybrid", "foobar");
+impl_writeable_for_each_subtag_str_no_test!(Value, selff, selff.0.is_empty() => alloc::borrow::Cow::Borrowed("true"));
+
+#[test]
+fn test_writeable() {
+    use writeable::assert_writeable_eq;
+
+    let hybrid = "hybrid".parse().unwrap();
+    let foo = "foobar".parse().unwrap();
+
+    assert_writeable_eq!(Value::default(), "true");
+    assert_writeable_eq!(Value::from_vec_unchecked(vec![hybrid]), "hybrid");
+    assert_writeable_eq!(
+        Value::from_vec_unchecked(vec![hybrid, foo]),
+        "hybrid-foobar"
+    );
+}

--- a/components/locid/src/extensions/unicode/mod.rs
+++ b/components/locid/src/extensions/unicode/mod.rs
@@ -25,7 +25,7 @@
 //! assert_eq!(loc.extensions.unicode.keywords.get(&key), Some(&value));
 //! assert!(loc.extensions.unicode.attributes.contains(&attribute));
 //!
-//! assert_eq!(&loc.extensions.unicode.to_string(), "-u-foobar-hc-h12");
+//! assert_eq!(&loc.extensions.unicode.to_string(), "u-foobar-hc-h12");
 //! ```
 mod attribute;
 mod attributes;
@@ -205,7 +205,7 @@ impl writeable::Writeable for Unicode {
         if self.is_empty() {
             return Ok(());
         }
-        sink.write_str("-u")?;
+        sink.write_str("u")?;
         if !self.attributes.is_empty() {
             sink.write_char('-')?;
             writeable::Writeable::write_to(&self.attributes, sink)?;
@@ -221,7 +221,7 @@ impl writeable::Writeable for Unicode {
         if self.is_empty() {
             return writeable::LengthHint::exact(0);
         }
-        let mut result = writeable::LengthHint::exact(2);
+        let mut result = writeable::LengthHint::exact(1);
         if !self.attributes.is_empty() {
             result += writeable::Writeable::writeable_length_hint(&self.attributes) + 1;
         }

--- a/components/locid/src/extensions/unicode/value.rs
+++ b/components/locid/src/extensions/unicode/value.rs
@@ -33,7 +33,7 @@ use tinystr::TinyAsciiStr;
 /// // The value "true" is special-cased to an empty value
 /// assert_eq!(&value3.to_string(), "");
 /// ```
-#[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord, Default)]
 pub struct Value(ShortVec<TinyAsciiStr<{ *VALUE_LENGTH.end() }>>);
 
 const VALUE_LENGTH: RangeInclusive<usize> = 3..=8;
@@ -153,7 +153,7 @@ impl FromStr for Value {
     }
 }
 
-impl_writeable_for_tinystr_list!(Value, "", "islamic", "civil");
+impl_writeable_for_subtag_list!(Value, "islamic", "civil");
 
 /// A macro allowing for compile-time construction of valid Unicode [`Value`] subtag.
 ///

--- a/components/locid/src/langid.rs
+++ b/components/locid/src/langid.rs
@@ -359,7 +359,7 @@ impl FromStr for LanguageIdentifier {
     }
 }
 
-impl_writeable_for_each_subtag_str_no_test!(LanguageIdentifier);
+impl_writeable_for_each_subtag_str_no_test!(LanguageIdentifier, selff, selff.script.is_none() && selff.region.is_none() && selff.variants.is_empty() => selff.language.write_to_string());
 
 #[test]
 fn test_writeable() {

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -391,7 +391,7 @@ impl core::fmt::Debug for Locale {
     }
 }
 
-impl_writeable_for_each_subtag_str_no_test!(Locale);
+impl_writeable_for_each_subtag_str_no_test!(Locale, selff, selff.extensions.is_empty() => selff.id.write_to_string());
 
 #[test]
 fn test_writeable() {

--- a/provider/core/src/request.rs
+++ b/provider/core/src/request.rs
@@ -142,6 +142,16 @@ impl Writeable for DataLocale {
                 LengthHint::exact(0)
             }
     }
+
+    fn write_to_string(&self) -> alloc::borrow::Cow<str> {
+        if self.keywords.is_empty() {
+            return self.langid.write_to_string();
+        }
+        let mut string =
+            alloc::string::String::with_capacity(self.writeable_length_hint().capacity());
+        let _ = self.write_to(&mut string);
+        alloc::borrow::Cow::Owned(string)
+    }
 }
 
 writeable::impl_display_with_writeable!(DataLocale);

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -240,7 +240,11 @@ pub trait Writeable {
     /// }
     /// ```
     fn write_to_string(&self) -> Cow<str> {
-        let mut output = String::with_capacity(self.writeable_length_hint().capacity());
+        let hint = self.writeable_length_hint();
+        if hint.is_zero() {
+            return Cow::Borrowed("");
+        }
+        let mut output = String::with_capacity(hint.capacity());
         let _ = self.write_to(&mut output);
         Cow::Owned(output)
     }


### PR DESCRIPTION
We hadn't made use of `Writeable`'s borrowing capability in this crate. When a `Locale`/`LanguageIdentifier` is only a language code (which I guess happens quite a lot), we don't have to allocate. Subtags can now also be borrowed, as well as empty extension structs and `Value`s.

The second commit is a "breaking" change which I would consider a bug fix. The extension structs (`Private`, `Other`, `Transform`, `Unicode`) would generate strings with leading dashes. This is unlike all other types in the crate. I think this has flown under the radar because the stringification of the wrapper `Extensions` struct doesn't delegate to these but has custom logic.