### PR TITLE
Clean up dependency specifications so serde isn't pulled in by default

### DIFF
--- a/components/collator/Cargo.toml
+++ b/components/collator/Cargo.toml
@@ -40,7 +40,7 @@ icu_locid = { version = "1.0.0", path = "../../components/locid" }
 icu_normalizer = { version = "1.0.0", path = "../../components/normalizer" }
 icu_properties = { version = "1.0.0", path = "../../components/properties" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
-zerovec = { version = "0.9", path = "../../utils/zerovec", features = ["serde"] }
+zerovec = { version = "0.9", path = "../../utils/zerovec" }
 utf8_iter = "1.0"
 utf16_iter = "1.0"
 databake = { version = "0.1.0", path = "../../utils/databake", optional = true, features = ["derive"] }

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -39,7 +39,7 @@ icu_provider = { version = "1.0.0", path = "../../provider/core", features = ["m
 icu_calendar = { version = "1.0.0", path = "../calendar" }
 icu_timezone = { version = "1.0.0", path = "../timezone" }
 writeable = { version = "0.5", path = "../../utils/writeable" }
-litemap = { version = "0.6", path = "../../utils/litemap" , optional = true}
+litemap = { version = "0.6", path = "../../utils/litemap" }
 tinystr = { version = "0.7", path = "../../utils/tinystr", features = ["alloc", "zerovec"], default-features = false }
 zerovec = { version = "0.9", path = "../../utils/zerovec", features = ["yoke"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
@@ -73,7 +73,7 @@ bench = ["serde"]
 # experimental_skeleton_matching is the minimal set of skeleton features required for datagen.
 experimental_skeleton_matching = []
 # experimental is the full set of skeleton and component APIs.
-experimental = ["experimental_skeleton_matching", "litemap"]
+experimental = ["experimental_skeleton_matching"]
 serde = ["dep:serde", "litemap/serde", "zerovec/serde", "tinystr/serde", "smallvec/serde", "icu_calendar/serde", "icu_decimal/serde", "icu_provider/serde", "icu_plurals/serde", "icu_timezone/serde"]
 datagen = ["serde", "experimental_skeleton_matching", "icu_calendar/datagen", "icu_timezone/datagen", "icu_provider/datagen", "std", "databake"]
 

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -39,7 +39,7 @@ icu_provider = { version = "1.0.0", path = "../../provider/core", features = ["m
 icu_calendar = { version = "1.0.0", path = "../calendar" }
 icu_timezone = { version = "1.0.0", path = "../timezone" }
 writeable = { version = "0.5", path = "../../utils/writeable" }
-litemap = { version = "0.6", path = "../../utils/litemap" }
+litemap = { version = "0.6", path = "../../utils/litemap" , optional = true}
 tinystr = { version = "0.7", path = "../../utils/tinystr", features = ["alloc", "zerovec"], default-features = false }
 zerovec = { version = "0.9", path = "../../utils/zerovec", features = ["yoke"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
@@ -73,7 +73,7 @@ bench = ["serde"]
 # experimental_skeleton_matching is the minimal set of skeleton features required for datagen.
 experimental_skeleton_matching = []
 # experimental is the full set of skeleton and component APIs.
-experimental = ["experimental_skeleton_matching"]
+experimental = ["experimental_skeleton_matching", "litemap"]
 serde = ["dep:serde", "litemap/serde", "zerovec/serde", "tinystr/serde", "smallvec/serde", "icu_calendar/serde", "icu_decimal/serde", "icu_provider/serde", "icu_plurals/serde", "icu_timezone/serde"]
 datagen = ["serde", "experimental_skeleton_matching", "icu_calendar/datagen", "icu_timezone/datagen", "icu_provider/datagen", "std", "databake"]
 

--- a/components/locid_transform/Cargo.toml
+++ b/components/locid_transform/Cargo.toml
@@ -31,7 +31,7 @@ denylist = ["bench"]
 all-features = true
 
 [dependencies]
-icu_locid = { version = "1.0.0", path = "../locid", features = ["serde", "zerovec"] }
+icu_locid = { version = "1.0.0", path = "../locid", features = ["zerovec"] }
 icu_provider = { version = "1.0.0", path = "../../provider/core", features = ["macros"] }
 serde = { version = "1.0", features = ["derive", "alloc"], optional = true, default-features = false }
 tinystr = { version = "0.7", path = "../../utils/tinystr", default-features = false, features = ["alloc", "zerovec"] }

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -43,6 +43,9 @@ macros = ["icu_provider_macros"]
 # Enable logging of additional context of data errors
 log_error_context = ["log"]
 
+# Enable BufferProvider and other deserialization infrastructure
+serde = ["dep:serde", "yoke/serde"]
+
 # Features for specific serde formats
 deserialize_json = ["serde", "serde_json"]
 deserialize_bincode_1 = ["serde", "bincode", "std"]

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -23,7 +23,7 @@ include = [
 
 [features]
 derive = ["yoke-derive", "zerofrom/derive"]
-alloc = ["stable_deref_trait/alloc", "serde/alloc", "zerofrom/alloc"]
+alloc = ["stable_deref_trait/alloc", "serde?/alloc", "zerofrom/alloc"]
 default = ["alloc", "zerofrom"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Fortunately `serde` is just a single dep (it doesn't depend on other things), but I noticed we were pulling it in by default as a runtime dep even when it's not being used.


Audited by running `cargo tree -p icu -e no-build,no-dev,no-proc-macro`

We probably should have a couple tests that run that command with:

 - Various `icu` packages incl `icu_provider_blob`
 - `--features serde`
 - (other deserialize features)
 - `--features experimental`

and check the list of pulled in crates against an allowlist. We can be more lenient about build/proc deps, and extremely lenient about datagen deps, but we should be auditing our runtime deps more.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->