### PR TITLE
Add div_rem_euclid and use it in icu_calendar

### DIFF
--- a/components/calendar/src/helpers.rs
+++ b/components/calendar/src/helpers.rs
@@ -1,0 +1,69 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+/// Calculate `(n / d, n % d)` such that the remainder is always positive.
+pub fn div_rem_euclid(n: i32, d: i32) -> (i32, i32) {
+    debug_assert!(d > 0);
+    let (a, b) = (n / d, n % d);
+    if n >= 0 || b == 0 {
+        (a, b)
+    } else {
+        (a - 1, d + b)
+    }
+}
+
+#[test]
+fn test_div_rem_euclid() {
+    assert_eq!(div_rem_euclid(i32::MIN, 1), (-2147483648, 0));
+    assert_eq!(div_rem_euclid(i32::MIN, 2), (-1073741824, 0));
+    assert_eq!(div_rem_euclid(i32::MIN, 3), (-715827883, 1));
+
+    assert_eq!(div_rem_euclid(-10, 1), (-10, 0));
+    assert_eq!(div_rem_euclid(-10, 2), (-5, 0));
+    assert_eq!(div_rem_euclid(-10, 3), (-4, 2));
+
+    assert_eq!(div_rem_euclid(-9, 1), (-9, 0));
+    assert_eq!(div_rem_euclid(-9, 2), (-5, 1));
+    assert_eq!(div_rem_euclid(-9, 3), (-3, 0));
+
+    assert_eq!(div_rem_euclid(-8, 1), (-8, 0));
+    assert_eq!(div_rem_euclid(-8, 2), (-4, 0));
+    assert_eq!(div_rem_euclid(-8, 3), (-3, 1));
+
+    assert_eq!(div_rem_euclid(-2, 1), (-2, 0));
+    assert_eq!(div_rem_euclid(-2, 2), (-1, 0));
+    assert_eq!(div_rem_euclid(-2, 3), (-1, 1));
+
+    assert_eq!(div_rem_euclid(-1, 1), (-1, 0));
+    assert_eq!(div_rem_euclid(-1, 2), (-1, 1));
+    assert_eq!(div_rem_euclid(-1, 3), (-1, 2));
+
+    assert_eq!(div_rem_euclid(0, 1), (0, 0));
+    assert_eq!(div_rem_euclid(0, 2), (0, 0));
+    assert_eq!(div_rem_euclid(0, 3), (0, 0));
+
+    assert_eq!(div_rem_euclid(1, 1), (1, 0));
+    assert_eq!(div_rem_euclid(1, 2), (0, 1));
+    assert_eq!(div_rem_euclid(1, 3), (0, 1));
+
+    assert_eq!(div_rem_euclid(2, 1), (2, 0));
+    assert_eq!(div_rem_euclid(2, 2), (1, 0));
+    assert_eq!(div_rem_euclid(2, 3), (0, 2));
+
+    assert_eq!(div_rem_euclid(8, 1), (8, 0));
+    assert_eq!(div_rem_euclid(8, 2), (4, 0));
+    assert_eq!(div_rem_euclid(8, 3), (2, 2));
+
+    assert_eq!(div_rem_euclid(9, 1), (9, 0));
+    assert_eq!(div_rem_euclid(9, 2), (4, 1));
+    assert_eq!(div_rem_euclid(9, 3), (3, 0));
+
+    assert_eq!(div_rem_euclid(10, 1), (10, 0));
+    assert_eq!(div_rem_euclid(10, 2), (5, 0));
+    assert_eq!(div_rem_euclid(10, 3), (3, 1));
+
+    assert_eq!(div_rem_euclid(i32::MAX, 1), (2147483647, 0));
+    assert_eq!(div_rem_euclid(i32::MAX, 2), (1073741823, 1));
+    assert_eq!(div_rem_euclid(i32::MAX, 3), (715827882, 1));
+}

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -124,6 +124,7 @@ mod duration;
 mod error;
 pub mod ethiopian;
 pub mod gregorian;
+mod helpers;
 pub mod indian;
 pub mod iso;
 pub mod japanese;

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -481,7 +481,7 @@ impl Time {
     /// and the day number, which could be positive or negative.
     pub(crate) fn from_minute_with_remainder_days(minute: i32) -> (Time, i32) {
         let (extra_days, minute_in_day) = helpers::div_rem_euclid(minute, 1440);
-        let (hours, minutes) = helpers::div_rem_euclid(minute_in_day, 60);
+        let (hours, minutes) = (minute_in_day / 60, minute_in_day % 60);
         #[allow(clippy::unwrap_used)] // values are moduloed to be in range
         (
             Self {

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -5,6 +5,7 @@
 //! This module contains various types used by `icu_calendar` and `icu_datetime`
 
 use crate::error::CalendarError;
+use crate::helpers;
 use core::convert::TryFrom;
 use core::convert::TryInto;
 use core::fmt;
@@ -479,23 +480,8 @@ impl Time {
     /// Takes a number of minutes, which could be positive or negative, and returns the Time
     /// and the day number, which could be positive or negative.
     pub(crate) fn from_minute_with_remainder_days(minute: i32) -> (Time, i32) {
-        let minutes_a_hour = 60;
-        let hours_a_day = 24;
-        let minutes_a_day = minutes_a_hour * hours_a_day;
-        let extra_days = if minute.is_negative() {
-            // TODO: migrate to div_floor
-            (minute + 1) / minutes_a_day - 1
-        } else {
-            minute / minutes_a_day
-        };
-
-        let minutes = (minutes_a_hour + minute % minutes_a_hour) % minutes_a_hour;
-        let hours = if minute.is_negative() {
-            ((minutes_a_day - minutes - (minute % minutes_a_day).abs()) / minutes_a_hour)
-                % hours_a_day
-        } else {
-            (minute / minutes_a_hour) % hours_a_day
-        };
+        let (extra_days, minute_in_day) = helpers::div_rem_euclid(minute, 1440);
+        let (hours, minutes) = helpers::div_rem_euclid(minute_in_day, 60);
         #[allow(clippy::unwrap_used)] // values are moduloed to be in range
         (
             Self {


### PR DESCRIPTION
It turns out that there are a whole lot of other cases where we fail with negative numbers in icu_calendar. I'm adding a helper function and migrating from_minute_with_remainder_days to use it.

CC @pt2121