### PR TITLE
Static blob constructor over FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,9 +735,9 @@ dependencies = [
 [[package]]
 name = "diplomat"
 version = "0.4.0"
-source = "git+https://github.com/rust-diplomat/diplomat#f59ef837eb3941e97503b6e615a590cbaa8c5a0f"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=f4e3b07f57554782854809c40ee2e5a8e9d14773#f4e3b07f57554782854809c40ee2e5a8e9d14773"
 dependencies = [
- "diplomat_core",
+ "diplomat_core 0.4.0 (git+https://github.com/rust-diplomat/diplomat?rev=f4e3b07f57554782854809c40ee2e5a8e9d14773)",
  "proc-macro2",
  "quote",
  "syn",
@@ -746,7 +746,23 @@ dependencies = [
 [[package]]
 name = "diplomat-runtime"
 version = "0.4.0"
-source = "git+https://github.com/rust-diplomat/diplomat#f59ef837eb3941e97503b6e615a590cbaa8c5a0f"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=f4e3b07f57554782854809c40ee2e5a8e9d14773#f4e3b07f57554782854809c40ee2e5a8e9d14773"
+
+[[package]]
+name = "diplomat_core"
+version = "0.4.0"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=f4e3b07f57554782854809c40ee2e5a8e9d14773#f4e3b07f57554782854809c40ee2e5a8e9d14773"
+dependencies = [
+ "impls",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "rustdoc-types 0.11.0",
+ "serde",
+ "smallvec",
+ "strck_ident",
+ "syn",
+]
 
 [[package]]
 name = "diplomat_core"
@@ -1615,7 +1631,7 @@ dependencies = [
 name = "icu_ffi_coverage"
 version = "0.0.1"
 dependencies = [
- "diplomat_core",
+ "diplomat_core 0.4.0 (git+https://github.com/rust-diplomat/diplomat)",
  "elsa",
  "lazy_static",
  "rustdoc-types 0.14.0",

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -87,8 +87,8 @@ writeable = { version = "0.5", path = "../../utils/writeable/" }
 # The version here can either be a `version = ".."` spec or `git = "https://github.com/rust-diplomat/diplomat", rev = ".."`
 # Since this crate is published, Diplomat must be published preceding a new ICU4X release but may use git versions in between
 # ALSO MAKE SURE TO UPDATE ffi_coverage/Cargo.toml!
-diplomat = { git = "https://github.com/rust-diplomat/diplomat", version = "0.4.0" }
-diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", version = "0.4.0" }
+diplomat = { git = "https://github.com/rust-diplomat/diplomat", rev = "f4e3b07f57554782854809c40ee2e5a8e9d14773" }
+diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", rev = "f4e3b07f57554782854809c40ee2e5a8e9d14773" }
 icu_testdata = { version = "1.0.0", path = "../../provider/testdata", optional = true, features = ["icu_segmenter"] }
 
 

--- a/ffi/diplomat/cpp/docs/source/bidi_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/bidi_ffi.rst
@@ -23,8 +23,8 @@
 
         See the `Rust documentation for new_with_data_source <https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html#method.new_with_data_source>`__ for more information.
 
-
         Lifetimes: ``text`` must live at least as long as the output.
+
 
     .. cpp:function:: static bool level_is_rtl(uint8_t level)
 
@@ -82,8 +82,8 @@
 
         Get the nth paragraph, returning None if out of bounds
 
-
         Lifetimes: ``this`` must live at least as long as the output.
+
 
     .. cpp:function:: size_t size() const
 

--- a/ffi/diplomat/cpp/docs/source/fallbacker_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/fallbacker_ffi.rst
@@ -79,8 +79,8 @@
 
         See the `Rust documentation for for_config <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_adapters/fallback/struct.LocaleFallbacker.html#method.for_config>`__ for more information.
 
-
         Lifetimes: ``this`` must live at least as long as the output.
+
 
 .. cpp:class:: ICU4XLocaleFallbackerWithConfig
 
@@ -95,5 +95,5 @@
 
         See the `Rust documentation for fallback_for <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_adapters/fallback/struct.LocaleFallbackerWithConfig.html#method.fallback_for>`__ for more information.
 
-
         Lifetimes: ``this`` must live at least as long as the output.
+

--- a/ffi/diplomat/cpp/docs/source/provider_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/provider_ffi.rst
@@ -40,6 +40,8 @@
 
         See the `Rust documentation for BlobDataProvider <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.BlobDataProvider.html>`__ for more information.
 
+        Lifetimes: ``blob`` must live for the duration of the program.
+
 
     .. cpp:function:: static ICU4XDataProvider create_empty()
 

--- a/ffi/diplomat/cpp/docs/source/script_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/script_ffi.rst
@@ -61,8 +61,8 @@
 
         See the `Rust documentation for as_borrowed <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/script/struct.ScriptWithExtensions.html#method.as_borrowed>`__ for more information.
 
-
         Lifetimes: ``this`` must live at least as long as the output.
+
 
 .. cpp:class:: ICU4XScriptWithExtensionsBorrowed
 
@@ -84,8 +84,8 @@
 
         See the `Rust documentation for get_script_extensions_val <https://unicode-org.github.io/icu4x-docs/doc/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_extensions_val>`__ for more information.
 
-
         Lifetimes: ``this`` must live at least as long as the output.
+
 
     .. cpp:function:: bool has_script(uint32_t code_point, uint16_t script) const
 

--- a/ffi/diplomat/cpp/docs/source/segmenter_grapheme_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/segmenter_grapheme_ffi.rst
@@ -42,8 +42,8 @@
 
         See the `Rust documentation for segment_utf8 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.segment_utf8>`__ for more information.
 
-
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
+
 
     .. cpp:function:: ICU4XGraphemeClusterBreakIteratorUtf16 segment_utf16(const diplomat::span<uint16_t> input) const
 
@@ -51,8 +51,8 @@
 
         See the `Rust documentation for segment_utf16 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.segment_utf16>`__ for more information.
 
-
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
+
 
     .. cpp:function:: ICU4XGraphemeClusterBreakIteratorLatin1 segment_latin1(const diplomat::span<uint8_t> input) const
 
@@ -60,5 +60,5 @@
 
         See the `Rust documentation for segment_latin1 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.segment_latin1>`__ for more information.
 
-
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
+

--- a/ffi/diplomat/cpp/docs/source/segmenter_line_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/segmenter_line_ffi.rst
@@ -73,8 +73,8 @@
 
         See the `Rust documentation for segment_utf8 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineSegmenter.html#method.segment_utf8>`__ for more information.
 
-
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
+
 
     .. cpp:function:: ICU4XLineBreakIteratorUtf16 segment_utf16(const diplomat::span<uint16_t> input) const
 
@@ -82,8 +82,8 @@
 
         See the `Rust documentation for segment_utf16 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineSegmenter.html#method.segment_utf16>`__ for more information.
 
-
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
+
 
     .. cpp:function:: ICU4XLineBreakIteratorLatin1 segment_latin1(const diplomat::span<uint8_t> input) const
 
@@ -91,8 +91,8 @@
 
         See the `Rust documentation for segment_latin1 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineSegmenter.html#method.segment_latin1>`__ for more information.
 
-
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
+
 
 .. cpp:enum-struct:: ICU4XWordBreakRule
 

--- a/ffi/diplomat/cpp/docs/source/segmenter_sentence_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/segmenter_sentence_ffi.rst
@@ -42,8 +42,8 @@
 
         See the `Rust documentation for segment_utf8 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceSegmenter.html#method.segment_utf8>`__ for more information.
 
-
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
+
 
     .. cpp:function:: ICU4XSentenceBreakIteratorUtf16 segment_utf16(const diplomat::span<uint16_t> input) const
 
@@ -51,8 +51,8 @@
 
         See the `Rust documentation for segment_utf16 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceSegmenter.html#method.segment_utf16>`__ for more information.
 
-
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
+
 
     .. cpp:function:: ICU4XSentenceBreakIteratorLatin1 segment_latin1(const diplomat::span<uint8_t> input) const
 
@@ -60,5 +60,5 @@
 
         See the `Rust documentation for segment_latin1 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceSegmenter.html#method.segment_latin1>`__ for more information.
 
-
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
+

--- a/ffi/diplomat/cpp/docs/source/segmenter_word_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/segmenter_word_ffi.rst
@@ -42,8 +42,8 @@
 
         See the `Rust documentation for segment_utf8 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordSegmenter.html#method.segment_utf8>`__ for more information.
 
-
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
+
 
     .. cpp:function:: ICU4XWordBreakIteratorUtf16 segment_utf16(const diplomat::span<uint16_t> input) const
 
@@ -51,8 +51,8 @@
 
         See the `Rust documentation for segment_utf16 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordSegmenter.html#method.segment_utf16>`__ for more information.
 
-
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
+
 
     .. cpp:function:: ICU4XWordBreakIteratorLatin1 segment_latin1(const diplomat::span<uint8_t> input) const
 
@@ -60,5 +60,5 @@
 
         See the `Rust documentation for segment_latin1 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordSegmenter.html#method.segment_latin1>`__ for more information.
 
-
         Lifetimes: ``this``, ``input`` must live at least as long as the output.
+

--- a/ffi/diplomat/cpp/include/ICU4XBidi.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XBidi.hpp
@@ -46,6 +46,8 @@ class ICU4XBidi {
    * Takes in a Level for the default level, if it is an invalid value it will default to LTR
    * 
    * See the [Rust documentation for `new_with_data_source`](https://unicode-org.github.io/icu4x-docs/doc/unicode_bidi/struct.BidiInfo.html#method.new_with_data_source) for more information.
+   * 
+   * Lifetimes: `text` must live at least as long as the output.
    */
   ICU4XBidiInfo for_text(const std::string_view text, uint8_t default_level) const;
 

--- a/ffi/diplomat/cpp/include/ICU4XBidiInfo.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XBidiInfo.hpp
@@ -37,6 +37,8 @@ class ICU4XBidiInfo {
 
   /**
    * Get the nth paragraph, returning None if out of bounds
+   * 
+   * Lifetimes: `this` must live at least as long as the output.
    */
   std::optional<ICU4XBidiParagraph> paragraph_at(size_t n) const;
 

--- a/ffi/diplomat/cpp/include/ICU4XDataProvider.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XDataProvider.hpp
@@ -53,6 +53,8 @@ class ICU4XDataProvider {
    * Constructs a `BlobDataProvider` and returns it as an [`ICU4XDataProvider`].
    * 
    * See the [Rust documentation for `BlobDataProvider`](https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.BlobDataProvider.html) for more information.
+   * 
+   * Lifetimes: `blob` must live for the duration of the program.
    */
   static diplomat::result<ICU4XDataProvider, ICU4XError> create_from_byte_slice(const diplomat::span<uint8_t> blob);
 

--- a/ffi/diplomat/cpp/include/ICU4XGraphemeClusterSegmenter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XGraphemeClusterSegmenter.hpp
@@ -47,6 +47,8 @@ class ICU4XGraphemeClusterSegmenter {
    * Segments a (potentially ill-formed) UTF-8 string.
    * 
    * See the [Rust documentation for `segment_utf8`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.segment_utf8) for more information.
+   * 
+   * Lifetimes: `this`, `input` must live at least as long as the output.
    */
   ICU4XGraphemeClusterBreakIteratorUtf8 segment_utf8(const std::string_view input) const;
 
@@ -54,6 +56,8 @@ class ICU4XGraphemeClusterSegmenter {
    * Segments a UTF-16 string.
    * 
    * See the [Rust documentation for `segment_utf16`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.segment_utf16) for more information.
+   * 
+   * Lifetimes: `this`, `input` must live at least as long as the output.
    */
   ICU4XGraphemeClusterBreakIteratorUtf16 segment_utf16(const diplomat::span<uint16_t> input) const;
 
@@ -61,6 +65,8 @@ class ICU4XGraphemeClusterSegmenter {
    * Segments a Latin-1 string.
    * 
    * See the [Rust documentation for `segment_latin1`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.segment_latin1) for more information.
+   * 
+   * Lifetimes: `this`, `input` must live at least as long as the output.
    */
   ICU4XGraphemeClusterBreakIteratorLatin1 segment_latin1(const diplomat::span<uint8_t> input) const;
   inline const capi::ICU4XGraphemeClusterSegmenter* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XLineSegmenter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XLineSegmenter.hpp
@@ -54,6 +54,8 @@ class ICU4XLineSegmenter {
    * Segments a (potentially ill-formed) UTF-8 string.
    * 
    * See the [Rust documentation for `segment_utf8`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineSegmenter.html#method.segment_utf8) for more information.
+   * 
+   * Lifetimes: `this`, `input` must live at least as long as the output.
    */
   ICU4XLineBreakIteratorUtf8 segment_utf8(const std::string_view input) const;
 
@@ -61,6 +63,8 @@ class ICU4XLineSegmenter {
    * Segments a UTF-16 string.
    * 
    * See the [Rust documentation for `segment_utf16`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineSegmenter.html#method.segment_utf16) for more information.
+   * 
+   * Lifetimes: `this`, `input` must live at least as long as the output.
    */
   ICU4XLineBreakIteratorUtf16 segment_utf16(const diplomat::span<uint16_t> input) const;
 
@@ -68,6 +72,8 @@ class ICU4XLineSegmenter {
    * Segments a Latin-1 string.
    * 
    * See the [Rust documentation for `segment_latin1`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineSegmenter.html#method.segment_latin1) for more information.
+   * 
+   * Lifetimes: `this`, `input` must live at least as long as the output.
    */
   ICU4XLineBreakIteratorLatin1 segment_latin1(const diplomat::span<uint8_t> input) const;
   inline const capi::ICU4XLineSegmenter* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XLocaleFallbacker.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XLocaleFallbacker.hpp
@@ -52,6 +52,8 @@ class ICU4XLocaleFallbacker {
    * Associates this `ICU4XLocaleFallbacker` with configuration options.
    * 
    * See the [Rust documentation for `for_config`](https://unicode-org.github.io/icu4x-docs/doc/icu_provider_adapters/fallback/struct.LocaleFallbacker.html#method.for_config) for more information.
+   * 
+   * Lifetimes: `this` must live at least as long as the output.
    */
   diplomat::result<ICU4XLocaleFallbackerWithConfig, ICU4XError> for_config(ICU4XLocaleFallbackConfig config) const;
   inline const capi::ICU4XLocaleFallbacker* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XLocaleFallbackerWithConfig.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XLocaleFallbackerWithConfig.hpp
@@ -35,6 +35,8 @@ class ICU4XLocaleFallbackerWithConfig {
    * Creates an iterator from a locale with each step of fallback.
    * 
    * See the [Rust documentation for `fallback_for`](https://unicode-org.github.io/icu4x-docs/doc/icu_provider_adapters/fallback/struct.LocaleFallbackerWithConfig.html#method.fallback_for) for more information.
+   * 
+   * Lifetimes: `this` must live at least as long as the output.
    */
   ICU4XLocaleFallbackIterator fallback_for_locale(const ICU4XLocale& locale) const;
   inline const capi::ICU4XLocaleFallbackerWithConfig* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XScriptWithExtensions.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XScriptWithExtensions.hpp
@@ -58,6 +58,8 @@ class ICU4XScriptWithExtensions {
    * Borrow this object for a slightly faster variant with more operations
    * 
    * See the [Rust documentation for `as_borrowed`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/script/struct.ScriptWithExtensions.html#method.as_borrowed) for more information.
+   * 
+   * Lifetimes: `this` must live at least as long as the output.
    */
   ICU4XScriptWithExtensionsBorrowed as_borrowed() const;
   inline const capi::ICU4XScriptWithExtensions* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XScriptWithExtensionsBorrowed.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XScriptWithExtensionsBorrowed.hpp
@@ -41,6 +41,8 @@ class ICU4XScriptWithExtensionsBorrowed {
    * Get the Script property value for a code point
    * 
    * See the [Rust documentation for `get_script_extensions_val`](https://unicode-org.github.io/icu4x-docs/doc/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_extensions_val) for more information.
+   * 
+   * Lifetimes: `this` must live at least as long as the output.
    */
   ICU4XScriptExtensionsSet get_script_extensions_val(uint32_t code_point) const;
 

--- a/ffi/diplomat/cpp/include/ICU4XSentenceSegmenter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XSentenceSegmenter.hpp
@@ -46,6 +46,8 @@ class ICU4XSentenceSegmenter {
    * Segments a (potentially ill-formed) UTF-8 string.
    * 
    * See the [Rust documentation for `segment_utf8`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceSegmenter.html#method.segment_utf8) for more information.
+   * 
+   * Lifetimes: `this`, `input` must live at least as long as the output.
    */
   ICU4XSentenceBreakIteratorUtf8 segment_utf8(const std::string_view input) const;
 
@@ -53,6 +55,8 @@ class ICU4XSentenceSegmenter {
    * Segments a UTF-16 string.
    * 
    * See the [Rust documentation for `segment_utf16`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceSegmenter.html#method.segment_utf16) for more information.
+   * 
+   * Lifetimes: `this`, `input` must live at least as long as the output.
    */
   ICU4XSentenceBreakIteratorUtf16 segment_utf16(const diplomat::span<uint16_t> input) const;
 
@@ -60,6 +64,8 @@ class ICU4XSentenceSegmenter {
    * Segments a Latin-1 string.
    * 
    * See the [Rust documentation for `segment_latin1`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceSegmenter.html#method.segment_latin1) for more information.
+   * 
+   * Lifetimes: `this`, `input` must live at least as long as the output.
    */
   ICU4XSentenceBreakIteratorLatin1 segment_latin1(const diplomat::span<uint8_t> input) const;
   inline const capi::ICU4XSentenceSegmenter* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/cpp/include/ICU4XWordSegmenter.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XWordSegmenter.hpp
@@ -46,6 +46,8 @@ class ICU4XWordSegmenter {
    * Segments a (potentially ill-formed) UTF-8 string.
    * 
    * See the [Rust documentation for `segment_utf8`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordSegmenter.html#method.segment_utf8) for more information.
+   * 
+   * Lifetimes: `this`, `input` must live at least as long as the output.
    */
   ICU4XWordBreakIteratorUtf8 segment_utf8(const std::string_view input) const;
 
@@ -53,6 +55,8 @@ class ICU4XWordSegmenter {
    * Segments a UTF-16 string.
    * 
    * See the [Rust documentation for `segment_utf16`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordSegmenter.html#method.segment_utf16) for more information.
+   * 
+   * Lifetimes: `this`, `input` must live at least as long as the output.
    */
   ICU4XWordBreakIteratorUtf16 segment_utf16(const diplomat::span<uint16_t> input) const;
 
@@ -60,6 +64,8 @@ class ICU4XWordSegmenter {
    * Segments a Latin-1 string.
    * 
    * See the [Rust documentation for `segment_latin1`](https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordSegmenter.html#method.segment_latin1) for more information.
+   * 
+   * Lifetimes: `this`, `input` must live at least as long as the output.
    */
   ICU4XWordBreakIteratorLatin1 segment_latin1(const diplomat::span<uint8_t> input) const;
   inline const capi::ICU4XWordSegmenter* AsFFI() const { return this->inner.get(); }

--- a/ffi/diplomat/src/provider.rs
+++ b/ffi/diplomat/src/provider.rs
@@ -130,13 +130,13 @@ pub mod ffi {
         #[diplomat::rust_link(icu_provider_blob::BlobDataProvider, Struct)]
         #[allow(unused_variables)] // conditional on features
         pub fn create_from_byte_slice(
-            blob: &[u8],
+            blob: &'static [u8],
         ) -> DiplomatResult<Box<ICU4XDataProvider>, ICU4XError> {
             #[cfg(not(feature = "buffer_provider"))]
             panic!("Requires feature 'buffer_provider'");
 
             #[cfg(feature = "buffer_provider")]
-            icu_provider_blob::BlobDataProvider::try_new_from_blob(Box::from(blob)) // allocates
+            icu_provider_blob::BlobDataProvider::try_new_from_static_blob(blob)
                 .map_err(Into::into)
                 .map(convert_buffer_provider)
                 .into()

--- a/ffi/diplomat/src/wasm_glue.rs
+++ b/ffi/diplomat/src/wasm_glue.rs
@@ -15,9 +15,9 @@ impl log::Log for ConsoleLogger {
 
     fn log(&self, record: &Record) {
         if record.level() <= Level::Warn {
-            console_warn(format!("[{}] {}", record.level(), record.args()).as_str()).unwrap();
+            console_warn(format!("[{}] {}", record.level(), record.args()).as_str());
         } else {
-            console_log(format!("[{}] {}", record.level(), record.args()).as_str()).unwrap();
+            console_log(format!("[{}] {}", record.level(), record.args()).as_str());
         }
     }
 

--- a/ffi/diplomat/wasm/icu4x/docs/collator_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/collator_ffi.rst
@@ -37,10 +37,10 @@
 
         See the `Rust documentation for compare_utf16 <https://unicode-org.github.io/icu4x-docs/doc/icu/collator/struct.Collator.html#method.compare_utf16>`__ for more information.
 
-
         - Note: ``left`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
 
         - Note: ``right`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
+
 
 .. js:class:: ICU4XCollatorAlternateHandling
 

--- a/ffi/diplomat/wasm/icu4x/docs/data_struct_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/data_struct_ffi.rst
@@ -16,5 +16,5 @@
 
         See the `Rust documentation for DecimalSymbolsV1 <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/provider/struct.DecimalSymbolsV1.html>`__ for more information.
 
-
         - Note: ``digits`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
+

--- a/ffi/diplomat/wasm/icu4x/docs/provider_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/provider_ffi.rst
@@ -40,8 +40,8 @@
 
         See the `Rust documentation for BlobDataProvider <https://unicode-org.github.io/icu4x-docs/doc/icu_provider_blob/struct.BlobDataProvider.html>`__ for more information.
 
-
         - Note: ``blob`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
+
 
     .. js:staticfunction:: create_empty()
 

--- a/ffi/diplomat/wasm/icu4x/docs/provider_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/provider_ffi.rst
@@ -42,6 +42,8 @@
 
         - Note: ``blob`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
 
+        - Warning: This method leaks memory. The parameter `blob` will not be freed as it is required to live for the duration of the program.
+
 
     .. js:staticfunction:: create_empty()
 

--- a/ffi/diplomat/wasm/icu4x/docs/segmenter_grapheme_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/segmenter_grapheme_ffi.rst
@@ -49,8 +49,8 @@
 
         See the `Rust documentation for segment_utf16 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.segment_utf16>`__ for more information.
 
-
         - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
+
 
     .. js:function:: segment_latin1(input)
 
@@ -58,5 +58,5 @@
 
         See the `Rust documentation for segment_latin1 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.segment_latin1>`__ for more information.
 
-
         - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
+

--- a/ffi/diplomat/wasm/icu4x/docs/segmenter_line_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/segmenter_line_ffi.rst
@@ -72,8 +72,8 @@
 
         See the `Rust documentation for segment_utf16 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineSegmenter.html#method.segment_utf16>`__ for more information.
 
-
         - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
+
 
     .. js:function:: segment_latin1(input)
 
@@ -81,8 +81,8 @@
 
         See the `Rust documentation for segment_latin1 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.LineSegmenter.html#method.segment_latin1>`__ for more information.
 
-
         - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
+
 
 .. js:class:: ICU4XWordBreakRule
 

--- a/ffi/diplomat/wasm/icu4x/docs/segmenter_sentence_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/segmenter_sentence_ffi.rst
@@ -49,8 +49,8 @@
 
         See the `Rust documentation for segment_utf16 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceSegmenter.html#method.segment_utf16>`__ for more information.
 
-
         - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
+
 
     .. js:function:: segment_latin1(input)
 
@@ -58,5 +58,5 @@
 
         See the `Rust documentation for segment_latin1 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.SentenceSegmenter.html#method.segment_latin1>`__ for more information.
 
-
         - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
+

--- a/ffi/diplomat/wasm/icu4x/docs/segmenter_word_ffi.rst
+++ b/ffi/diplomat/wasm/icu4x/docs/segmenter_word_ffi.rst
@@ -49,8 +49,8 @@
 
         See the `Rust documentation for segment_utf16 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordSegmenter.html#method.segment_utf16>`__ for more information.
 
-
         - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
+
 
     .. js:function:: segment_latin1(input)
 
@@ -58,5 +58,5 @@
 
         See the `Rust documentation for segment_latin1 <https://unicode-org.github.io/icu4x-docs/doc/icu/segmenter/struct.WordSegmenter.html#method.segment_latin1>`__ for more information.
 
-
         - Note: ``input`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
+

--- a/ffi/diplomat/wasm/icu4x/lib/ICU4XDataProvider.js
+++ b/ffi/diplomat/wasm/icu4x/lib/ICU4XDataProvider.js
@@ -56,7 +56,7 @@ export class ICU4XDataProvider {
         throw new diplomatRuntime.FFIError(throw_value);
       }
     })();
-    buf_arg_blob.free();
+    buf_arg_blob.leak();
     return diplomat_out;
   }
 

--- a/ffi/diplomat/wasm/icu4x/lib/diplomat-wasm.mjs
+++ b/ffi/diplomat/wasm/icu4x/lib/diplomat-wasm.mjs
@@ -2,23 +2,16 @@ import cfg from '../diplomat.config.js';
 
 let wasm;
 
-function readString(ptr) {
-  const view = new Uint8Array(wasm.memory.buffer);
-  let end = ptr;
-  while (view[end]) end++;
-  return (new TextDecoder("utf-8")).decode(view.subarray(ptr, end));
-}
-
 const imports = {
   env: {
-    log_js(ptr) {
-      console.log(readString(ptr));
+    log_js(ptr, len) {
+      console.log(readString(wasm, ptr, len));
     },
-    warn_js(ptr) {
-      console.warn(readString(ptr));
+    warn_js(ptr, len) {
+      console.warn(readString(wasm, ptr, len));
     },
-    trace_js(ptr) {
-      throw new Error(readString(ptr));
+    trace_js(ptr, len) {
+      throw new Error(readString(wasm, ptr, len));
     }
   }
 }


### PR DESCRIPTION
This avoids cloning the blob. The target language has to assure its lifetime, which diplomat now supports.