### PR TITLE
fixes in execution/paths to smooth the tutorial experience. (differen…

### DIFF
--- a/docs/tutorials/data_management.md
+++ b/docs/tutorials/data_management.md
@@ -194,9 +194,13 @@ let _any_provider = BakedDataProvider;
 
 The `dir` format will generate a directory tree of data files in JSON (although the `--syntax` option can be used to generate `postcard` or `bincode` files, which doesn't have many practical uses).
 
-This directory can be read by the `FsDataProvider` from the `icu_provider_fs` crate. You will also need to activate the feature for the chosen syntax on the `icu_provider` crate.
-
 Let's give it a try:
+
+```console
+$ icu4x-datagen --cldr-tag latest --icuexport-tag latest --out my-data-dir --format dir --keys-for-bin target/debug/myapp --locales ja
+```
+
+This directory can be read by the `FsDataProvider` from the `icu_provider_fs` crate. You will also need to activate the feature for the chosen syntax on the `icu_provider` crate.
 
 Same as `BlobDataProvider`, this also a buffer provider, so you will need to activate `icu`'s `serde` feature and use the `with_buffer_provider` constructors.
 
@@ -231,12 +235,6 @@ fn main() {
 
     println!("📅: {}", formatted_date);
 }
-```
-
-Then, run the following command.
-
-```console
-$ icu4x-datagen --cldr-tag latest --icuexport-tag latest --out my-data-dir --format dir --keys-for-bin target/debug/myapp --locales ja
 ```
 
 # 6. Summary

--- a/docs/tutorials/data_management.md
+++ b/docs/tutorials/data_management.md
@@ -86,7 +86,6 @@ fn main() {
 You might have noticed that the blob we generated is a hefty 13MB. This is no surprise, as we included `--all-keys` `--all-locales`. However, our binary only uses date formatting data in Japanese. There's room for optimization:
 
 ```console
-$ cargo build
 $ icu4x-datagen --overwrite --cldr-tag latest --icuexport-tag latest --out my-data-blob --format blob --keys-for-bin target/debug/myapp --locales ja
 ```
 
@@ -139,6 +138,17 @@ So far we've used `--format blob` and `BlobDataProvider`. This is useful if we w
 The `mod` format will generate a Rust module that defines a data provider. This format naturally has no deserialization overhead, and allows for compile-time optimizations (data slicing isn't really necessary, as the compiler will do it for us), but cannot be dynamically loaded at runtime.
 
 Let's give it a try:
+
+For the mod generation to work, you need an actual application that compiles. You can keep the existing app if you have been following this tutorial from the start.
+
+```rust
+// Initial application that compiles so that icu4x-datagen can run against the binary.
+fn main() {
+    println!("Hello !");
+}
+```
+
+Then we can run:
 
 ```console
 $ icu4x-datagen --cldr-tag latest --icuexport-tag latest --out my-data-mod --format mod --keys-for-bin target/debug/myapp --locales ja
@@ -195,6 +205,8 @@ let _any_provider = BakedDataProvider;
 
 The `dir` format will generate a directory tree of data files in JSON (although the `--syntax` option can be used to generate `postcard` or `bincode` files, which doesn't have many practical uses).
 
+This directory can be read by the `FsDataProvider` from the `icu_provider_fs` crate. You will also need to activate the feature for the chosen syntax on the `icu_provider` crate.
+
 Let's give it a try:
 
 Same as `BlobDataProvider`, this also a buffer provider, so you will need to activate `icu`'s `serde` feature and use the `with_buffer_provider` constructors.
@@ -235,11 +247,8 @@ fn main() {
 Then, run the following command.
 
 ```console
-$ cargo build && icu4x-datagen --cldr-tag latest --icuexport-tag latest --out my-data-dir --format dir --keys-for-bin target/debug/myapp --locales ja
+$ icu4x-datagen --cldr-tag latest --icuexport-tag latest --out my-data-dir --format dir --keys-for-bin target/debug/myapp --locales ja
 ```
-
-This directory can be read by the `FsDataProvider` from the `icu_provider_fs` crate. You will also need to activate the feature for the chosen syntax on the `icu_provider` crate.
-
 
 # 6. Summary
 

--- a/docs/tutorials/data_management.md
+++ b/docs/tutorials/data_management.md
@@ -139,15 +139,6 @@ The `mod` format will generate a Rust module that defines a data provider. This 
 
 Let's give it a try:
 
-```rust
-// Initial application that compiles so that icu4x-datagen can run against the binary.
-fn main() {
-    println!("Hello !");
-}
-```
-
-Then we can run:
-
 ```console
 $ icu4x-datagen --cldr-tag latest --icuexport-tag latest --out my-data-mod --format mod --keys-for-bin target/debug/myapp --locales ja
 ```

--- a/docs/tutorials/data_management.md
+++ b/docs/tutorials/data_management.md
@@ -139,8 +139,6 @@ The `mod` format will generate a Rust module that defines a data provider. This 
 
 Let's give it a try:
 
-For the mod generation to work, you need an actual application that compiles. You can keep the existing app if you have been following this tutorial from the start.
-
 ```rust
 // Initial application that compiles so that icu4x-datagen can run against the binary.
 fn main() {

--- a/docs/tutorials/data_management.md
+++ b/docs/tutorials/data_management.md
@@ -219,7 +219,6 @@ use icu_provider_fs::FsDataProvider;
 const LOCALE: Locale = locale!("ja");
 
 fn main() {
-    // we will ask icu4x-datagen to generate everything in "my-data-dir"
     let buffer_provider = FsDataProvider::try_new("my-data-dir")
            .expect("Failed to initialize Data Provider");
 


### PR DESCRIPTION
doc fixes to make the tutorial more smooth.

- renamed each type in their own file (no need to issues a bunch of `rm` commands)
- added overwrite for blob generation, it would be stuck at 13m otherwise.
- moved the generation for the `dir` output *after* rust code modification. (we want to be sure it's building, before running `icu4x-datagen` as it requires the binary to be built)

#2281