### PR TITLE
`icu_provider@1.0.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bincode",
  "databake",

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_provider"
 description = "Trait and struct definitions for the ICU data provider"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"


### PR DESCRIPTION
#2698 [changed](https://github.com/unicode-org/icu4x/pull/2698/files#diff-b8dc29c753e51c2cf91f3a9dc33bcf4e16cdb38a704f1a16a1c9d44ecf0ae080) the return type of `DataPayload<ExportMarker>::bake`. This is a breaking change, but behind the datagen feature which is currently only used by `icu_datagen`. We have decided that this breakage is fine, as the `datagen` feature is not necessarily covered by our semver guarantees, and it's unlikely anyone will have written their own data generation in the week since 1.0. We have also decided that this is naughty and will not become regular practice. @sffc, @Manishearth to confirm.