### PR TITLE
Add validate_with to derive(ULE) and derive(VarULE)

### DIFF
--- a/utils/yoke/derive/src/lib.rs
+++ b/utils/yoke/derive/src/lib.rs
@@ -8,7 +8,9 @@ use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
 use syn::spanned::Spanned;
-use syn::{parse_macro_input, parse_quote, DeriveInput, Ident, Lifetime, Type, WherePredicate};
+use syn::{
+    parse_macro_input, parse_quote, DeriveInput, Ident, Lifetime, Path, Type, WherePredicate,
+};
 use synstructure::Structure;
 
 mod visitor;
@@ -93,7 +95,11 @@ fn yokeable_derive_impl(input: &DeriveInput) -> TokenStream2 {
             .to_compile_error();
         }
         let name = &input.ident;
+        let attr_path: Path = syn::parse_str("yoke").unwrap();
         let manual_covariance = input.attrs.iter().any(|a| {
+            if a.path != attr_path {
+                return false;
+            }
             if let Ok(i) = a.parse_args::<Ident>() {
                 if i == "prove_covariance_manually" {
                     return true;

--- a/utils/zerovec/derive/src/lib.rs
+++ b/utils/zerovec/derive/src/lib.rs
@@ -14,14 +14,14 @@ mod utils;
 mod varule;
 
 /// Full docs for this proc macro can be found on the [`zerovec`](docs.rs/zerovec) crate.
-#[proc_macro_derive(ULE)]
+#[proc_macro_derive(ULE, attributes(ule))]
 pub fn ule_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     TokenStream::from(ule::derive_impl(&input))
 }
 
 /// Full docs for this proc macro can be found on the [`zerovec`](docs.rs/zerovec) crate.
-#[proc_macro_derive(VarULE)]
+#[proc_macro_derive(VarULE, attributes(varule))]
 pub fn varule_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     TokenStream::from(varule::derive_impl(&input, None))

--- a/utils/zerovec/derive/src/utils.rs
+++ b/utils/zerovec/derive/src/utils.rs
@@ -9,7 +9,10 @@ use proc_macro2::TokenStream as TokenStream2;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::{parenthesized, parse2, Attribute, Error, Field, Fields, Ident, Index, Result, Token};
+use syn::{
+    parenthesized, parse2, Attribute, Error, Field, Fields, Ident, Index, Lit, Meta, MetaNameValue,
+    Path, Result, Token,
+};
 
 // Check that there are repr attributes satisfying the given predicate
 pub fn has_valid_repr(attrs: &[Attribute], predicate: impl Fn(&Ident) -> bool + Copy) -> bool {
@@ -274,4 +277,44 @@ pub fn extract_attributes_common(
     }
 
     Ok(attrs)
+}
+
+pub(crate) fn find_validate_with_path(
+    attrs: &[Attribute],
+    attr_path: &Path,
+) -> Result<Option<Path>> {
+    let mut validate_with: Option<Path> = None;
+    let validate_with_path: Path = syn::parse_str("validate_with").unwrap();
+    for attr in attrs.iter() {
+        if &attr.path != attr_path {
+            continue;
+        }
+        match attr.parse_args::<Meta>() {
+            Ok(Meta::NameValue(MetaNameValue {
+                path,
+                lit: Lit::Str(lit_str),
+                ..
+            })) if path == validate_with_path => {
+                if validate_with.is_some() {
+                    return Err(Error::new(attr.span(), "multiple varule are not allowed"));
+                }
+                validate_with = match syn::parse_str(&lit_str.value()) {
+                    Ok(p) => Some(p),
+                    Err(_) => {
+                        return Err(Error::new(
+                            attr.span(),
+                            "varule value must be a path to a function",
+                        ));
+                    }
+                }
+            }
+            _ => {
+                return Err(Error::new(
+                    attr.span(),
+                    "varule takes a single name value, validate_with = \"fn_path\"",
+                ));
+            }
+        }
+    }
+    Ok(validate_with)
 }


### PR DESCRIPTION
Note that Serde does this differently using `serde(try_from)` (see https://github.com/serde-rs/serde/issues/939). However, since ULE types are dealt with by reference, and there isn't a safe way to transmute `&A` to `&Transparent<A>`, the try_from thing doesn't make sense for ULE. So, I made it a `validate_with` function instead.

If we add a better way to go from `&A` to `&Transparent<A>`, then we could use the `try_from` thing.