### PR TITLE
Adding CNAME in docs CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1133,6 +1133,10 @@ jobs:
           </body>
         </html>
         EOL
+        
+    - name: Create doc CNAME
+      run: |
+        echo "icu4x.unicode.org" > CNAME
 
     # Doc-GH-Pages job > Copy docs (+ bench dashboard HTML) to remote docs repo's GH pages branch step
 


### PR DESCRIPTION
Without this, every docs push will wipe the doc repo's CNAME, breaking the site.