### PR TITLE
Use better branch setting for benchmarks CI job

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -733,7 +733,7 @@ jobs:
           # Show alert with commit comment on detecting possible performance regression
           alert-threshold: '200%'  # If for nothing else, enabling the possibility of alerts with meaningful thresholds requires this job to be done per-component
           fail-on-alert: true
-          gh-pages-branch: gh-pages  # Requires one-time-only creation of this branch on remote repo.
+          gh-pages-branch: merged-bench-data  # Requires one-time-only creation of this branch on remote repo.
                                      # We could use another branch besides `gh-pages` to store this historical benchmark info.
           auto-push: true  # Use the branch at `gh-pages-branch` to store historical info of benchmark data.
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -857,7 +857,7 @@ jobs:
           # branch that is being used by the performance benchmark. The information is
           # computed by gregtatum/github-action-benchmark, and is added to a .js file in
           # the branch, e.g. benchmarks/memory/{os}/data.js
-          gh-pages-branch: gh-pages
+          gh-pages-branch: merged-bench-data
           auto-push: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
@@ -999,7 +999,7 @@ jobs:
         # Tentative setting, optimized value to be determined
         alert-threshold: '200%'
         fail-on-alert: true
-        gh-pages-branch: gh-pages
+        gh-pages-branch: merged-bench-data
         auto-push: true
         github-token: ${{ secrets.GITHUB_TOKEN }}
         comment-on-alert: true
@@ -1049,7 +1049,7 @@ jobs:
         # Tentative setting, optimized value to be determined
         alert-threshold: '100%'
         fail-on-alert: true
-        gh-pages-branch: gh-pages
+        gh-pages-branch: merged-bench-data
         auto-push: true
         github-token: ${{ secrets.GITHUB_TOKEN }}
         comment-on-alert: true

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1105,7 +1105,7 @@ jobs:
     - name: Switch to benchmark data storage branch.
       run: |
         git fetch
-        git checkout gh-pages
+        git checkout merged-bench-data
 
     # TODO(#234) re-include cache steps, also using Rust version in cache key
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -693,10 +693,10 @@ jobs:
       # In the following step(s) regarding converting benchmark output to dashboards, the branch in `gh-pages-branch` needs to exist.
       # If it doesn't already exist, it should be created by someone with push permissions, like so:
       #   # Create a local branch
-      #   $ git checkout --orphan gh-pages
+      #   $ git checkout --orphan <newbranch>
       #   $ git commit --allow-empty -m "root commit"
       #   # Push it to create a remote branch
-      #   $ git push origin gh-pages:gh-pages
+      #   $ git push origin <newbranch>:<newbranch>
 
       # Benchmarking & dashboards job > (unmerged PR only) Convert benchmark output into dashboard HTML in a commit of a branch of the local repo.
 
@@ -713,7 +713,6 @@ jobs:
           alert-threshold: '200%'  # If for nothing else, enabling the possibility of alerts with meaningful thresholds requires this job to be done per-component
           fail-on-alert: true
           gh-pages-branch: unmerged-pr-bench-data  # Requires one-time-only creation of this branch on remote repo.
-                                                   # We could use another branch besides `gh-pages` to store this historical benchmark info.
           auto-push: false  # Do not store historical benchmark info of unfinished PRs. Commits seem to get made anyways, so make sure
                             # that the branch in `gh-pages-branch` is different from the branch used for merges to main branch.
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -734,7 +733,6 @@ jobs:
           alert-threshold: '200%'  # If for nothing else, enabling the possibility of alerts with meaningful thresholds requires this job to be done per-component
           fail-on-alert: true
           gh-pages-branch: merged-bench-data  # Requires one-time-only creation of this branch on remote repo.
-                                     # We could use another branch besides `gh-pages` to store this historical benchmark info.
           auto-push: true  # Use the branch at `gh-pages-branch` to store historical info of benchmark data.
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
@@ -1116,7 +1114,7 @@ jobs:
         path: doc
         name: doc
 
-    # Doc-GH-Pages job > Generate placeholder root index.html to redirect to `icu4x` crate
+    # Doc-GH-Pages job > Generate placeholder root index.html to redirect to `icu` crate
 
     - name: Create doc /index.html
       run: |


### PR DESCRIPTION
Fixes #2735 

If this looks good, then right before merging, I will checkout the current state of the `gh-pages` branch  as a new branch called `merged-bench-data` according to the PR and push it up.  Only afterwards should the merge of this PR happen.

I've already tested in my personal fork.  To test, first, I branched off of this PR's branch to create a "testing branch" with [testing-specific changes appended](https://github.com/echeran/icu4x/commits/better-benchmark-data-branch-test), created a [PR entirely within my fork](https://github.com/echeran/icu4x/pull/29), and merged that PR to also test the post-merge CI workflow behavior.

The [unmerged PR CI workflow run](https://github.com/echeran/icu4x/actions/runs/3222716568) and the [post-merge CI workflow run](https://github.com/echeran/icu4x/actions/runs/3222719131) both look good (except for me not configuring a Github token for my fork of `icu4x-docs`, which isn't relevant for the test).  The relevant thing is that I was able to see the [new commits that the CI benchmark job makes happen on the new branch](https://github.com/echeran/icu4x/commits/merged-bench-data), and that means we preserve existing CI behavior while leaving `gh-pages` to only be used for more appropriate things in the future, not bechmark data storage.