### PR TITLE
Allow nightly to be overridden by an environment variable

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -9,6 +9,8 @@ extend = [{ path = "./tools/scripts/data.toml"}, { path = "./tools/scripts/valgr
 [config]
 default_to_workspace = false
 
+[env]
+MAKEFILE_NIGHTLY = { value = "nightly-2022-04-05", condition = { env_not_set = ["MAKEFILE_NIGHTLY"] } }
 
 [tasks.quick]
 description = "Run quick version of all lints and builds (useful before pushing to GitHub)"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -10,7 +10,7 @@ extend = [{ path = "./tools/scripts/data.toml"}, { path = "./tools/scripts/valgr
 default_to_workspace = false
 
 [env]
-MAKEFILE_NIGHTLY = { value = "nightly-2022-04-05", condition = { env_not_set = ["MAKEFILE_NIGHTLY"] } }
+ICU4X_NIGHTLY_TOOLCHAIN = { value = "nightly-2022-04-05", condition = { env_not_set = ["ICU4X_NIGHTLY_TOOLCHAIN"] } }
 
 [tasks.quick]
 description = "Run quick version of all lints and builds (useful before pushing to GitHub)"

--- a/ffi/diplomat/c/examples/fixeddecimal_tiny/Makefile
+++ b/ffi/diplomat/c/examples/fixeddecimal_tiny/Makefile
@@ -7,7 +7,7 @@
 
 ALL_HEADERS := $(wildcard ../../include/*.h)
 ALL_RUST := $(wildcard ../../../src/*.rs)
-MAKEFILE_NIGHTLY ?= "nightly-2022-04-05"
+ICU4X_NIGHTLY_TOOLCHAIN ?= "nightly-2022-04-05"
 
 $(ALL_RUST):
 
@@ -22,10 +22,10 @@ LLD := lld-14
 	cargo build -p icu_capi_staticlib --no-default-features --features buffer_provider
 
 ../../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi_staticlib.a: $(ALL_RUST)
-	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" cargo +${MAKEFILE_NIGHTLY} panic-abort-build -p icu_capi_staticlib --target x86_64-unknown-linux-gnu --no-default-features --features x86tiny,buffer_provider
+	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" cargo +${ICU4X_NIGHTLY_TOOLCHAIN} panic-abort-build -p icu_capi_staticlib --target x86_64-unknown-linux-gnu --no-default-features --features x86tiny,buffer_provider
 
 ../../../../../target/x86_64-unknown-linux-gnu/release-opt-size/libicu_capi_staticlib.a: $(ALL_RUST)
-	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" cargo +${MAKEFILE_NIGHTLY} panic-abort-build -p icu_capi_staticlib --target x86_64-unknown-linux-gnu --no-default-features --features x86tiny,buffer_provider --profile=release-opt-size
+	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" cargo +${ICU4X_NIGHTLY_TOOLCHAIN} panic-abort-build -p icu_capi_staticlib --target x86_64-unknown-linux-gnu --no-default-features --features x86tiny,buffer_provider --profile=release-opt-size
 
 decimal-bn-en.postcard:
 	cargo run -p icu_datagen --features bin -- --locales en bn --keys "decimal/symbols@1" --cldr-root ../../../../../provider/testdata/data/cldr/ --format blob --out decimal-bn-en.postcard

--- a/ffi/diplomat/c/examples/fixeddecimal_tiny/Makefile
+++ b/ffi/diplomat/c/examples/fixeddecimal_tiny/Makefile
@@ -7,6 +7,7 @@
 
 ALL_HEADERS := $(wildcard ../../include/*.h)
 ALL_RUST := $(wildcard ../../../src/*.rs)
+MAKEFILE_NIGHTLY ?= "nightly-2022-04-05"
 
 $(ALL_RUST):
 
@@ -21,10 +22,10 @@ LLD := lld-14
 	cargo build -p icu_capi_staticlib --no-default-features --features buffer_provider
 
 ../../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi_staticlib.a: $(ALL_RUST)
-	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" cargo +nightly-2022-04-05 panic-abort-build -p icu_capi_staticlib --target x86_64-unknown-linux-gnu --no-default-features --features x86tiny,buffer_provider
+	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" cargo +${MAKEFILE_NIGHTLY} panic-abort-build -p icu_capi_staticlib --target x86_64-unknown-linux-gnu --no-default-features --features x86tiny,buffer_provider
 
 ../../../../../target/x86_64-unknown-linux-gnu/release-opt-size/libicu_capi_staticlib.a: $(ALL_RUST)
-	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" cargo +nightly-2022-04-05 panic-abort-build -p icu_capi_staticlib --target x86_64-unknown-linux-gnu --no-default-features --features x86tiny,buffer_provider --profile=release-opt-size
+	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" cargo +${MAKEFILE_NIGHTLY} panic-abort-build -p icu_capi_staticlib --target x86_64-unknown-linux-gnu --no-default-features --features x86tiny,buffer_provider --profile=release-opt-size
 
 decimal-bn-en.postcard:
 	cargo run -p icu_datagen --features bin -- --locales en bn --keys "decimal/symbols@1" --cldr-root ../../../../../provider/testdata/data/cldr/ --format blob --out decimal-bn-en.postcard

--- a/ffi/diplomat/cpp/examples/fixeddecimal_wasm/Makefile
+++ b/ffi/diplomat/cpp/examples/fixeddecimal_wasm/Makefile
@@ -7,6 +7,7 @@
 
 ALL_HEADERS := $(wildcard ../../include/*.hpp) $(wildcard ../../../c/include/*.h)
 ALL_RUST := $(wildcard ../../../src/*.rs)
+MAKEFILE_NIGHTLY ?= "nightly-2022-04-05"
 
 CXX?=g++
 EMCC?=emcc
@@ -23,7 +24,7 @@ a.out: ../../../../../target/debug/libicu_capi_staticlib_test.a $(ALL_HEADERS) t
 	$(CXX) -std=c++17 test.cpp ../../../../../target/debug/libicu_capi_staticlib_test.a -ldl -lpthread -lm -g
 
 ../../../../../target/wasm32-unknown-emscripten/release-opt-size/libicu_capi_staticlib_test.a: $(ALL_RUST)
-	RUSTFLAGS="-Cpanic=abort" cargo +nightly-2022-04-05 build --profile=release-opt-size -p icu_capi_staticlib --features provider_test --target wasm32-unknown-emscripten -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
+	RUSTFLAGS="-Cpanic=abort" cargo +${MAKEFILE_NIGHTLY} build --profile=release-opt-size -p icu_capi_staticlib --features provider_test --target wasm32-unknown-emscripten -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 	mv ../../../../../target/wasm32-unknown-emscripten/release-opt-size/libicu_capi_staticlib.a ../../../../../target/wasm32-unknown-emscripten/release-opt-size/libicu_capi_staticlib_test.a
 
 web-version.html: ../../../../../target/wasm32-unknown-emscripten/release-opt-size/libicu_capi_staticlib_test.a $(ALL_HEADERS) test.cpp

--- a/ffi/diplomat/cpp/examples/fixeddecimal_wasm/Makefile
+++ b/ffi/diplomat/cpp/examples/fixeddecimal_wasm/Makefile
@@ -7,7 +7,7 @@
 
 ALL_HEADERS := $(wildcard ../../include/*.hpp) $(wildcard ../../../c/include/*.h)
 ALL_RUST := $(wildcard ../../../src/*.rs)
-MAKEFILE_NIGHTLY ?= "nightly-2022-04-05"
+ICU4X_NIGHTLY_TOOLCHAIN ?= "nightly-2022-04-05"
 
 CXX?=g++
 EMCC?=emcc
@@ -24,7 +24,7 @@ a.out: ../../../../../target/debug/libicu_capi_staticlib_test.a $(ALL_HEADERS) t
 	$(CXX) -std=c++17 test.cpp ../../../../../target/debug/libicu_capi_staticlib_test.a -ldl -lpthread -lm -g
 
 ../../../../../target/wasm32-unknown-emscripten/release-opt-size/libicu_capi_staticlib_test.a: $(ALL_RUST)
-	RUSTFLAGS="-Cpanic=abort" cargo +${MAKEFILE_NIGHTLY} build --profile=release-opt-size -p icu_capi_staticlib --features provider_test --target wasm32-unknown-emscripten -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
+	RUSTFLAGS="-Cpanic=abort" cargo +${ICU4X_NIGHTLY_TOOLCHAIN} build --profile=release-opt-size -p icu_capi_staticlib --features provider_test --target wasm32-unknown-emscripten -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 	mv ../../../../../target/wasm32-unknown-emscripten/release-opt-size/libicu_capi_staticlib.a ../../../../../target/wasm32-unknown-emscripten/release-opt-size/libicu_capi_staticlib_test.a
 
 web-version.html: ../../../../../target/wasm32-unknown-emscripten/release-opt-size/libicu_capi_staticlib_test.a $(ALL_HEADERS) test.cpp

--- a/ffi/diplomat/js/examples/node/build.sh
+++ b/ffi/diplomat/js/examples/node/build.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+MAKEFILE_NIGHTLY="${MAKEFILE_NIGHTLY:-nightly-2022-04-05}"
+
 if test -d "lib"; then
     exit 0
 fi
@@ -12,8 +14,8 @@ mkdir lib
 cp ../../include/* lib
 
 # Install Rust toolchains
-rustup toolchain install nightly-2022-04-05
-rustup +nightly-2022-04-05 component add rust-src
+rustup toolchain install ${MAKEFILE_NIGHTLY}
+rustup +${MAKEFILE_NIGHTLY} component add rust-src
 
 # 60 KiB, working around a bug in older rustc
 # https://github.com/unicode-org/icu4x/issues/2753
@@ -21,7 +23,7 @@ rustup +nightly-2022-04-05 component add rust-src
 WASM_STACK_SIZE=100000
 
 # Build the WASM library
-RUSTFLAGS="-Cpanic=abort -Copt-level=s -C link-args=-zstack-size=${WASM_STACK_SIZE}" cargo +nightly-2022-04-05 build \
+RUSTFLAGS="-Cpanic=abort -Copt-level=s -C link-args=-zstack-size=${WASM_STACK_SIZE}" cargo +${MAKEFILE_NIGHTLY} build \
     -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort \
     --target wasm32-unknown-unknown \
     --release \

--- a/ffi/diplomat/js/examples/node/build.sh
+++ b/ffi/diplomat/js/examples/node/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MAKEFILE_NIGHTLY="${MAKEFILE_NIGHTLY:-nightly-2022-04-05}"
+ICU4X_NIGHTLY_TOOLCHAIN="${ICU4X_NIGHTLY_TOOLCHAIN:-nightly-2022-04-05}"
 
 if test -d "lib"; then
     exit 0
@@ -14,8 +14,8 @@ mkdir lib
 cp ../../include/* lib
 
 # Install Rust toolchains
-rustup toolchain install ${MAKEFILE_NIGHTLY}
-rustup +${MAKEFILE_NIGHTLY} component add rust-src
+rustup toolchain install ${ICU4X_NIGHTLY_TOOLCHAIN}
+rustup +${ICU4X_NIGHTLY_TOOLCHAIN} component add rust-src
 
 # 60 KiB, working around a bug in older rustc
 # https://github.com/unicode-org/icu4x/issues/2753
@@ -23,7 +23,7 @@ rustup +${MAKEFILE_NIGHTLY} component add rust-src
 WASM_STACK_SIZE=100000
 
 # Build the WASM library
-RUSTFLAGS="-Cpanic=abort -Copt-level=s -C link-args=-zstack-size=${WASM_STACK_SIZE}" cargo +${MAKEFILE_NIGHTLY} build \
+RUSTFLAGS="-Cpanic=abort -Copt-level=s -C link-args=-zstack-size=${WASM_STACK_SIZE}" cargo +${ICU4X_NIGHTLY_TOOLCHAIN} build \
     -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort \
     --target wasm32-unknown-unknown \
     --release \

--- a/ffi/diplomat/js/examples/node/build.sh
+++ b/ffi/diplomat/js/examples/node/build.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+# Set toolchain variable to a default if not defined
 ICU4X_NIGHTLY_TOOLCHAIN="${ICU4X_NIGHTLY_TOOLCHAIN:-nightly-2022-04-05}"
 
 if test -d "lib"; then

--- a/ffi/diplomat/js/examples/node/build.sh
+++ b/ffi/diplomat/js/examples/node/build.sh
@@ -38,6 +38,6 @@ if test -f "full-data-cached.postcard"; then
     exit 0
 else
     # Regen all data
-    cargo run -p icu_datagen --features=bin,experimental -- --all-locales --all-keys --cldr-tag latest --icuexport-tag latest --format blob --out lib/full.postcard
+    cargo run -p icu_datagen --features=bin,experimental -- --all-locales --all-keys --cldr-tag latest --icuexport-tag release-72-1 --format blob --out lib/full.postcard
     cp lib/full.postcard full-data-cached.postcard
 fi

--- a/ffi/diplomat/js/examples/node/build.sh
+++ b/ffi/diplomat/js/examples/node/build.sh
@@ -38,6 +38,6 @@ if test -f "full-data-cached.postcard"; then
     exit 0
 else
     # Regen all data
-    cargo run -p icu_datagen --features=bin,experimental -- --all-locales --all-keys --cldr-tag latest --icuexport-tag release-72-1 --format blob --out lib/full.postcard
+    cargo run -p icu_datagen --features=bin,experimental -- --all-locales --all-keys --cldr-tag latest --icuexport-tag icu4x/2022-08-17/71.x --format blob --out lib/full.postcard
     cp lib/full.postcard full-data-cached.postcard
 fi

--- a/tools/benchmark/memory/src/main.rs
+++ b/tools/benchmark/memory/src/main.rs
@@ -74,7 +74,7 @@ fn process_cli_args() -> ProcessedArgs {
 
         toolchain: matches
             .value_of("TOOLCHAIN")
-            .or_else(|| env::var("MAKEFILE_NIGHTLY"))
+            .or_else(|| env::var("MAKEFILE_NIGHTLY").ok())
             .unwrap_or("nightly-2022-04-05")
             .to_string(),
     }

--- a/tools/benchmark/memory/src/main.rs
+++ b/tools/benchmark/memory/src/main.rs
@@ -45,6 +45,8 @@ fn process_cli_args() -> ProcessedArgs {
                     .help("The toolchain for cargo to use. Defaults to nightly.")
             ).get_matches();
 
+    let default_toolchain = env::var("MAKEFILE_NIGHTLY").unwrap_or("nightly-2022-04-05".into());
+
     ProcessedArgs {
         // Validate the OS, and copy into an owned String.
         os: matches.value_of("OS").map(|os| {
@@ -74,8 +76,7 @@ fn process_cli_args() -> ProcessedArgs {
 
         toolchain: matches
             .value_of("TOOLCHAIN")
-            .or_else(|| env::var("MAKEFILE_NIGHTLY").ok())
-            .unwrap_or("nightly-2022-04-05")
+            .unwrap_or(&default_toolchain)
             .to_string(),
     }
 }

--- a/tools/benchmark/memory/src/main.rs
+++ b/tools/benchmark/memory/src/main.rs
@@ -45,7 +45,7 @@ fn process_cli_args() -> ProcessedArgs {
                     .help("The toolchain for cargo to use. Defaults to nightly.")
             ).get_matches();
 
-    let default_toolchain = env::var("MAKEFILE_NIGHTLY").unwrap_or("nightly-2022-04-05".into());
+    let default_toolchain = env::var("ICU4X_NIGHTLY_TOOLCHAIN").unwrap_or("nightly-2022-04-05".into());
 
     ProcessedArgs {
         // Validate the OS, and copy into an owned String.

--- a/tools/benchmark/memory/src/main.rs
+++ b/tools/benchmark/memory/src/main.rs
@@ -74,6 +74,7 @@ fn process_cli_args() -> ProcessedArgs {
 
         toolchain: matches
             .value_of("TOOLCHAIN")
+            .or_else(|| env::var("MAKEFILE_NIGHTLY"))
             .unwrap_or("nightly-2022-04-05")
             .to_string(),
     }

--- a/tools/benchmark/memory/src/main.rs
+++ b/tools/benchmark/memory/src/main.rs
@@ -45,7 +45,8 @@ fn process_cli_args() -> ProcessedArgs {
                     .help("The toolchain for cargo to use. Defaults to nightly.")
             ).get_matches();
 
-    let default_toolchain = env::var("ICU4X_NIGHTLY_TOOLCHAIN").unwrap_or("nightly-2022-04-05".into());
+    let default_toolchain =
+        env::var("ICU4X_NIGHTLY_TOOLCHAIN").unwrap_or_else(|| "nightly-2022-04-05".into());
 
     ProcessedArgs {
         // Validate the OS, and copy into an owned String.

--- a/tools/benchmark/memory/src/main.rs
+++ b/tools/benchmark/memory/src/main.rs
@@ -46,7 +46,7 @@ fn process_cli_args() -> ProcessedArgs {
             ).get_matches();
 
     let default_toolchain =
-        env::var("ICU4X_NIGHTLY_TOOLCHAIN").unwrap_or_else(|| "nightly-2022-04-05".into());
+        env::var("ICU4X_NIGHTLY_TOOLCHAIN").unwrap_or_else(|_| "nightly-2022-04-05".into());
 
     ProcessedArgs {
         // Validate the OS, and copy into an owned String.

--- a/tools/scripts/ffi.toml
+++ b/tools/scripts/ffi.toml
@@ -34,7 +34,7 @@ dependencies = [
 [tasks.cargo-make-min-version]
 description = "Verify that the minimum version of cargo-make exists"
 category = "ICU4X Development"
-install_crate = { crate_name = "cargo-make", binary = "cargo", test_arg = ["make", "--version"], min_version = "0.35.0" }
+install_crate = { crate_name = "cargo-make", binary = "cargo", test_arg = ["make", "--version"], min_version = "0.36.2" }
 
 [tasks.diplomat-coverage]
 description = "Produces the list of ICU APIs that are not exported through Diplomat"

--- a/tools/scripts/ffi.toml
+++ b/tools/scripts/ffi.toml
@@ -236,7 +236,7 @@ find ./js/docs/source -type f -exec sed -i  {} -e 's/staticfunction/function/g' 
 [tasks.build-wearos-ffi]
 description = "Build ICU4X CAPI for Cortex"
 category = "ICU4X FFI"
-toolchain = "${MAKEFILE_NIGHTLY}"
+toolchain = "${ICU4X_NIGHTLY_TOOLCHAIN}"
 install_crate = { rustup_component_name = "rust-src" }
 env = { "RUSTFLAGS" = "-Ctarget-cpu=cortex-m33 -Cpanic=abort" }
 command = "cargo"
@@ -249,7 +249,7 @@ args = ["build", "--package", "icu_freertos",
 [tasks.test-nostd]
 description = "Ensure ICU4X core builds on no-std"
 category = "ICU4X FFI"
-toolchain = "${MAKEFILE_NIGHTLY}"
+toolchain = "${ICU4X_NIGHTLY_TOOLCHAIN}"
 install_crate = { rustup_component_name = "rust-src" }
 command = "cargo"
 args = ["build", "--package", "icu", "--target", "thumbv7m-none-eabi"]

--- a/tools/scripts/ffi.toml
+++ b/tools/scripts/ffi.toml
@@ -236,7 +236,7 @@ find ./js/docs/source -type f -exec sed -i  {} -e 's/staticfunction/function/g' 
 [tasks.build-wearos-ffi]
 description = "Build ICU4X CAPI for Cortex"
 category = "ICU4X FFI"
-toolchain = "nightly-2022-04-05"
+toolchain = "${MAKEFILE_NIGHTLY}"
 install_crate = { rustup_component_name = "rust-src" }
 env = { "RUSTFLAGS" = "-Ctarget-cpu=cortex-m33 -Cpanic=abort" }
 command = "cargo"
@@ -249,7 +249,7 @@ args = ["build", "--package", "icu_freertos",
 [tasks.test-nostd]
 description = "Ensure ICU4X core builds on no-std"
 category = "ICU4X FFI"
-toolchain = "nightly-2022-04-05"
+toolchain = "${MAKEFILE_NIGHTLY}"
 install_crate = { rustup_component_name = "rust-src" }
 command = "cargo"
 args = ["build", "--package", "icu", "--target", "thumbv7m-none-eabi"]

--- a/tools/scripts/valgrind.toml
+++ b/tools/scripts/valgrind.toml
@@ -8,7 +8,7 @@
 description = "Pre-build artifacts for use with the Valgrind task"
 category = "ICU4X Valgrind"
 command = "cargo"
-toolchain = "nightly-2022-04-05"
+toolchain = "${MAKEFILE_NIGHTLY}"
 # Add features here and below if a desired example is not being built
 args = [
     "build", "--examples",
@@ -34,7 +34,7 @@ mkdir benchmarks
 mkdir benchmarks/valgrind
 
 # Re-run the build command only to generate the JSON output (--message-format=json)
-output = exec cargo +nightly-2022-04-05 build --examples --message-format=json --features icu_benchmark_macros/rust_global_allocator --features zerovec/serde --profile bench -Z unstable-options
+output = exec cargo +${MAKEFILE_NIGHTLY} build --examples --message-format=json --features icu_benchmark_macros/rust_global_allocator --features zerovec/serde --profile bench -Z unstable-options
 if ${output.code}
     trigger_error "Build failed! To debug, build examples with `--features icu_benchmark_macros/rust_global_allocator`"
 end

--- a/tools/scripts/valgrind.toml
+++ b/tools/scripts/valgrind.toml
@@ -8,7 +8,7 @@
 description = "Pre-build artifacts for use with the Valgrind task"
 category = "ICU4X Valgrind"
 command = "cargo"
-toolchain = "${MAKEFILE_NIGHTLY}"
+toolchain = "${ICU4X_NIGHTLY_TOOLCHAIN}"
 # Add features here and below if a desired example is not being built
 args = [
     "build", "--examples",
@@ -34,7 +34,7 @@ mkdir benchmarks
 mkdir benchmarks/valgrind
 
 # Re-run the build command only to generate the JSON output (--message-format=json)
-output = exec cargo +${MAKEFILE_NIGHTLY} build --examples --message-format=json --features icu_benchmark_macros/rust_global_allocator --features zerovec/serde --profile bench -Z unstable-options
+output = exec cargo +${ICU4X_NIGHTLY_TOOLCHAIN} build --examples --message-format=json --features icu_benchmark_macros/rust_global_allocator --features zerovec/serde --profile bench -Z unstable-options
 if ${output.code}
     trigger_error "Build failed! To debug, build examples with `--features icu_benchmark_macros/rust_global_allocator`"
 end


### PR DESCRIPTION
This makes it easy to run CI with a different nightly.

Part of https://github.com/unicode-org/icu4x/issues/2718

currently relies on an unreleased cargo-make version, won't pass CI


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->