### PR TITLE
Remove static_assertions dep from fixed-decimal, bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,7 +953,6 @@ dependencies = [
  "rand_pcg",
  "ryu",
  "smallvec",
- "static_assertions",
  "writeable",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "fixed_decimal"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "criterion",
  "displaydoc",
@@ -1771,7 +1771,6 @@ dependencies = [
  "serde",
  "serde_json",
  "stable_deref_trait",
- "static_assertions",
  "writeable",
  "yoke",
  "zerofrom",
@@ -3201,12 +3200,6 @@ checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
 dependencies = [
  "version_check",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdweb"

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -79,5 +79,4 @@ databake = { version = "0.1.0", path = "../../utils/databake", optional = true, 
 
 [dev-dependencies]
 serde_json = "1.0"
-static_assertions = "1.1"
 icu_provider_adapters = { path = "../../provider/adapters" }

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -28,7 +28,6 @@ all-features = true
 
 [dependencies]
 smallvec = "1.9"
-static_assertions = "1.1"
 writeable = { version = "0.5", path = "../../utils/writeable" }
 displaydoc = { version = "0.2.3", default-features = false }
 ryu = { version = "1.0.5", optional = true, features = ["small"] }

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "fixed_decimal"
 description = "An API for representing numbers in a human-readable form"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -12,14 +12,13 @@ use core::ops::RangeInclusive;
 
 use core::str::FromStr;
 
-use static_assertions::const_assert;
-
 use crate::uint_iterator::IntIterator;
 
 use crate::Error;
 
 // FixedDecimal assumes usize (digits.len()) is at least as big as a u16
-const_assert!(core::mem::size_of::<usize>() >= core::mem::size_of::<u16>());
+#[cfg(not(any(target_pointer_width = "16", target_pointer_width = "32", target_pointer_width = "64")))]
+compile_error!("The fixed_decimal crate only works if usizes are at least the size of a u16");
 
 /// A struct containing decimal digits with efficient iteration and manipulation by magnitude
 /// (power of 10). Supports a mantissa of non-zero digits and a number of leading and trailing

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -17,7 +17,11 @@ use crate::uint_iterator::IntIterator;
 use crate::Error;
 
 // FixedDecimal assumes usize (digits.len()) is at least as big as a u16
-#[cfg(not(any(target_pointer_width = "16", target_pointer_width = "32", target_pointer_width = "64")))]
+#[cfg(not(any(
+    target_pointer_width = "16",
+    target_pointer_width = "32",
+    target_pointer_width = "64"
+)))]
 compile_error!("The fixed_decimal crate only works if usizes are at least the size of a u16");
 
 /// A struct containing decimal digits with efficient iteration and manipulation by magnitude


### PR DESCRIPTION
We don't really need this dep; let's prune it.