### PR TITLE
Allow clippy::forget_copy in derive(Yokeable) impl

### DIFF
--- a/utils/yoke/derive/src/lib.rs
+++ b/utils/yoke/derive/src/lib.rs
@@ -206,6 +206,7 @@ fn yokeable_derive_impl(input: &DeriveInput) -> TokenStream2 {
                     // are the same
                     debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
                     let ptr: *const Self = (&this as *const Self::Output).cast();
+                    #[allow(clippy::forget_copy)] // This is a noop if the struct is copy, which Clippy doesn't like
                     mem::forget(this);
                     ptr::read(ptr)
                 }


### PR DESCRIPTION
The attribute was already emitted when proving covariance manually, but not in the normal case.

Maybe closes #2774 -- this allows the deny-by-default lint in the case that it wasn't, but still allows `clippy::forget_non_drop` to fire.

This is imho a clear, noncontroversial, and basically objective fix (since the allow is already present in the other case), thus filing this PR with this fix. However, I still maintain what I said in #2774 -- it's probably both reasonable and desirable to just `#[allow(clippy::all)]` on any derive-emitted `impl` to avoid triggering any clippy lint (perhaps even `#[allow(warnings, clippy::all)]`), even future ones.