### PR TITLE
Invalid usage of string_view in FFI C++ example

### DIFF
--- a/ffi/diplomat/cpp/examples/locale/test.cpp
+++ b/ffi/diplomat/cpp/examples/locale/test.cpp
@@ -9,7 +9,7 @@
 
 static bool test_locale(ICU4XLocale &locale, std::string_view expectedString,
                         const char *message) {
-  std::string_view actualString = locale.to_string().ok().value();
+  std::string actualString = locale.to_string().ok().value();
   std::cout << message << ": \"" << actualString << "\"" << std::endl;
   if (actualString != expectedString) {
     std::cout << "Locale did not match expected: \"" << expectedString << "\""


### PR DESCRIPTION
Related to #2780 point 1.