### PR TITLE
Don't use std postcard in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "deduplicating_array"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "postcard",
  "serde",

--- a/utils/deduplicating_array/Cargo.toml
+++ b/utils/deduplicating_array/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 
 [dev-dependencies]
 serde_json = "1.0"
-postcard = { version = "1.0.0", features = ["use-std"] }
+postcard = { version = "1.0.0", features = ["alloc"], default_features = false }
 
 [features]
 bench = []

--- a/utils/deduplicating_array/Cargo.toml
+++ b/utils/deduplicating_array/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "deduplicating_array"
 description = "A serde serialization strategy that uses PartialEq to reduce serialized size."
-version = "0.1.2"
+version = "0.1.3"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"

--- a/utils/deduplicating_array/examples/postcard.rs
+++ b/utils/deduplicating_array/examples/postcard.rs
@@ -27,12 +27,12 @@ const COORDINATES: [(f64, f64); 5] = [
 
 #[no_mangle]
 fn main(_argc: isize, _argv: *const *const u8) -> isize {
-    let bytes = postcard::to_stdvec(&DataStruct {
+    let bytes = postcard::to_allocvec(&DataStruct {
         coordinates: COORDINATES,
     })
     .expect("Serialization should be successful");
 
-    let duplicating_bytes = postcard::to_stdvec(&DuplicatingDataStruct {
+    let duplicating_bytes = postcard::to_allocvec(&DuplicatingDataStruct {
         coordinates: COORDINATES,
     })
     .expect("Serialization should be successful");

--- a/utils/deduplicating_array/src/lib.rs
+++ b/utils/deduplicating_array/src/lib.rs
@@ -286,7 +286,7 @@ mod test {
             1, // [2] => [0]
         ];
 
-        assert_eq!(postcard::to_stdvec(&STRUCT).unwrap(), bytes);
+        assert_eq!(postcard::to_allocvec(&STRUCT).unwrap(), bytes);
 
         let de_struct = postcard::from_bytes::<TestStruct>(bytes).unwrap();
 


### PR DESCRIPTION
This doesn't really change much from the ICU4X side, but it means that deduplicating_array's tests can still be run when postcard has been built in no_std mode.

In general we should always be requesting the minimal feature set where possible, even in tests.

Included a bump so I can use this


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->