### PR TITLE
Enable experimental feature in icu in segmenter's Cargo.toml

### DIFF
--- a/experimental/segmenter/Cargo.toml
+++ b/experimental/segmenter/Cargo.toml
@@ -44,7 +44,7 @@ displaydoc = { version = "0.2.3", default-features = false }
 criterion = "0.3"
 icu_testdata = { path = "../../provider/testdata", default-features = false, features = ["buffer", "icu_segmenter"] }
 serde-json-core = { version = "0.4", features = ["std"] }
-icu = { path = "../../components/icu" }
+icu = { path = "../../components/icu", features = ["experimental"]}
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
This patch fixed the following doc test error when running `cargo test --all-features` under `experimental/segmenter`.

```
---- src/lib.rs - (line 54) stdout ----
error[E0432]: unresolved import `icu::segmenter`
 --> src/lib.rs:55:10
  |
3 | use icu::segmenter::WordSegmenter;
  |          ^^^^^^^^^ could not find `segmenter` in `icu`
```