### PR TITLE
Add tests for zh fallback

### DIFF
--- a/provider/adapters/src/fallback/algorithms.rs
+++ b/provider/adapters/src/fallback/algorithms.rs
@@ -356,6 +356,22 @@ mod tests {
             expected_region_chain: &["hi-Latn-IN", "und-IN"],
         },
         TestCase {
+            input: "zh-CN",
+            requires_data: true,
+            extension_key: None,
+            fallback_supplement: None,
+            expected_language_chain: &["zh-CN", "zh"],
+            expected_region_chain: &["zh-CN", "und-CN"],
+        },
+        TestCase {
+            input: "zh-TW",
+            requires_data: true,
+            extension_key: None,
+            fallback_supplement: None,
+            expected_language_chain: &["zh-TW", "zh-Hant-TW", "zh-Hant"],
+            expected_region_chain: &["zh-TW", "und-TW"],
+        },
+        TestCase {
             input: "yue-HK",
             requires_data: true,
             extension_key: None,

--- a/provider/adapters/src/fallback/algorithms.rs
+++ b/provider/adapters/src/fallback/algorithms.rs
@@ -360,6 +360,9 @@ mod tests {
             requires_data: true,
             extension_key: None,
             fallback_supplement: None,
+            // Note: "zh-Hans" is not reachable because it is the default script for "zh".
+            // The fallback algorithm does not visit the language-script bundle when the
+            // script is the default for the language
             expected_language_chain: &["zh-CN", "zh"],
             expected_region_chain: &["zh-CN", "und-CN"],
         },


### PR DESCRIPTION
The base languages are `zh` and `zh-Hant`.