### PR TITLE
Move ICU4XOrdering to its own module

### DIFF
--- a/ffi/diplomat/cpp/docs/source/collator_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/collator_ffi.rst
@@ -145,14 +145,3 @@
     .. cpp:enumerator:: Quaternary
 
     .. cpp:enumerator:: Identical
-
-.. cpp:enum-struct:: ICU4XOrdering
-
-    See the `Rust documentation for Ordering <https://unicode-org.github.io/icu4x-docs/doc/core/cmp/enum.Ordering.html>`__ for more information.
-
-
-    .. cpp:enumerator:: Less
-
-    .. cpp:enumerator:: Equal
-
-    .. cpp:enumerator:: Greater

--- a/ffi/diplomat/cpp/docs/source/common_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/common_ffi.rst
@@ -1,0 +1,13 @@
+``common::ffi``
+===============
+
+.. cpp:enum-struct:: ICU4XOrdering
+
+    See the `Rust documentation for Ordering <https://unicode-org.github.io/icu4x-docs/doc/core/cmp/enum.Ordering.html>`__ for more information.
+
+
+    .. cpp:enumerator:: Less
+
+    .. cpp:enumerator:: Equal
+
+    .. cpp:enumerator:: Greater

--- a/ffi/diplomat/cpp/docs/source/index.rst
+++ b/ffi/diplomat/cpp/docs/source/index.rst
@@ -8,6 +8,7 @@ Documentation
    bidi_ffi
    calendar_ffi
    collator_ffi
+   common_ffi
    data_struct_ffi
    date_ffi
    datetime_ffi

--- a/ffi/diplomat/js/docs/source/collator_ffi.rst
+++ b/ffi/diplomat/js/docs/source/collator_ffi.rst
@@ -95,8 +95,3 @@
 
     See the `Rust documentation for Strength <https://unicode-org.github.io/icu4x-docs/doc/icu/collator/enum.Strength.html>`__ for more information.
 
-
-.. js:class:: ICU4XOrdering
-
-    See the `Rust documentation for Ordering <https://unicode-org.github.io/icu4x-docs/doc/core/cmp/enum.Ordering.html>`__ for more information.
-

--- a/ffi/diplomat/js/docs/source/common_ffi.rst
+++ b/ffi/diplomat/js/docs/source/common_ffi.rst
@@ -1,0 +1,7 @@
+``common::ffi``
+===============
+
+.. js:class:: ICU4XOrdering
+
+    See the `Rust documentation for Ordering <https://unicode-org.github.io/icu4x-docs/doc/core/cmp/enum.Ordering.html>`__ for more information.
+

--- a/ffi/diplomat/js/docs/source/index.rst
+++ b/ffi/diplomat/js/docs/source/index.rst
@@ -8,6 +8,7 @@ Documentation
    bidi_ffi
    calendar_ffi
    collator_ffi
+   common_ffi
    data_struct_ffi
    date_ffi
    datetime_ffi

--- a/ffi/diplomat/src/collator.rs
+++ b/ffi/diplomat/src/collator.rs
@@ -9,8 +9,8 @@ pub mod ffi {
     use icu_collator::{Collator, CollatorOptions};
 
     use crate::{
-        errors::ffi::ICU4XError, locale::ffi::ICU4XLocale, provider::ffi::ICU4XDataProvider,
-        common::ffi::ICU4XOrdering
+        common::ffi::ICU4XOrdering, errors::ffi::ICU4XError, locale::ffi::ICU4XLocale,
+        provider::ffi::ICU4XDataProvider,
     };
 
     #[diplomat::opaque]

--- a/ffi/diplomat/src/collator.rs
+++ b/ffi/diplomat/src/collator.rs
@@ -10,19 +10,12 @@ pub mod ffi {
 
     use crate::{
         errors::ffi::ICU4XError, locale::ffi::ICU4XLocale, provider::ffi::ICU4XDataProvider,
+        common::ffi::ICU4XOrdering
     };
 
     #[diplomat::opaque]
     #[diplomat::rust_link(icu::collator::Collator, Struct)]
     pub struct ICU4XCollator(pub Collator);
-
-    #[diplomat::enum_convert(core::cmp::Ordering)]
-    #[diplomat::rust_link(core::cmp::Ordering, Enum)]
-    pub enum ICU4XOrdering {
-        Less = -1,
-        Equal = 0,
-        Greater = 1,
-    }
 
     #[diplomat::rust_link(icu::collator::CollatorOptions, Struct)]
     #[diplomat::rust_link(icu::collator::CollatorOptions::new, FnInStruct, hidden)]

--- a/ffi/diplomat/src/common.rs
+++ b/ffi/diplomat/src/common.rs
@@ -1,0 +1,16 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+#[diplomat::bridge]
+pub mod ffi {
+    use alloc::boxed::Box;
+
+    #[diplomat::enum_convert(core::cmp::Ordering)]
+    #[diplomat::rust_link(core::cmp::Ordering, Enum)]
+    pub enum ICU4XOrdering {
+        Less = -1,
+        Equal = 0,
+        Greater = 1,
+    }
+}

--- a/ffi/diplomat/src/lib.rs
+++ b/ffi/diplomat/src/lib.rs
@@ -49,6 +49,7 @@ mod utils;
 pub mod bidi;
 pub mod calendar;
 pub mod collator;
+pub mod common;
 pub mod data_struct;
 pub mod date;
 pub mod datetime;

--- a/ffi/diplomat/src/locale.rs
+++ b/ffi/diplomat/src/locale.rs
@@ -13,7 +13,7 @@ pub mod ffi {
     use icu_locid::Locale;
     use writeable::Writeable;
 
-    use crate::collator::ffi::ICU4XOrdering;
+    use crate::common::ffi::ICU4XOrdering;
 
     #[diplomat::opaque]
     /// An ICU4X Locale, capable of representing strings like `"en-US"`.


### PR DESCRIPTION
Currently the `locale` module depends on the `collator` module because they both use `ICU4XOrdering`. When we start disabling whole modules (#2602), this will need to be fixed, so I'll just fix it now.