### PR TITLE
Nightly cronjob CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -729,6 +729,8 @@ jobs:
 
     # We don't expect to keep being clippy-clean on nightly Rust,
     # so the "toolchain boilerplate" is deliberately omitted
+    # This just means we end up testing on the pinned stable even in the cronjob
+    # CI, which isn't that useful but specially omitting that task is more work than it's worth
 
     # Clippy job > Install and run clippy steps
     - name: Install clippy

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,6 +46,7 @@ jobs:
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -92,6 +93,7 @@ jobs:
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Get cargo-make version
@@ -134,6 +136,7 @@ jobs:
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Get cargo-make version
@@ -186,6 +189,7 @@ jobs:
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Get cargo-make version
@@ -225,6 +229,7 @@ jobs:
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Attempt to load cached CLDR source data
@@ -282,6 +287,7 @@ jobs:
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -353,6 +359,7 @@ jobs:
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Load nightly for rustdoc-json
@@ -432,6 +439,7 @@ jobs:
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -500,6 +508,7 @@ jobs:
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Install cargo-all-features
@@ -548,6 +557,7 @@ jobs:
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
     - name: Load nightly Rust toolchain for WASM.
       run: |
         rustup install $INSTALLED_NIGHTLY_VERSION
@@ -604,6 +614,7 @@ jobs:
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -651,6 +662,7 @@ jobs:
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -759,6 +771,7 @@ jobs:
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
 
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
@@ -885,6 +898,7 @@ jobs:
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
     - name: echo
       run: echo "toolchain is $INSTALLED_NIGHTLY_VERSION"
     # Nightly is only needed for the `--profile bench` line. Once that is stabilized,

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,6 +18,19 @@ on:
     branches: [ main ]
   pull_request:
     branches: '*'
+  workflow_dispatch:
+    inputs:
+      nightly:
+        description: "Test on latest nightly"
+        required: true
+        default: false
+        type: boolean
+  schedule:
+    # Run nightly cronjob CI every day at 14 UTC / 6AM PST / 3PM CET
+    - cron:  '0 14 * * *'
+
+env:
+  INSTALLED_NIGHTLY_VERSION: nightly-2022-04-05
 
 jobs:
 
@@ -26,6 +39,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Potentially override rust version with nightly
+      # pull_request is a fake for me to be able to test this for now
+      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -65,6 +85,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Potentially override rust version with nightly
+      # pull_request is a fake for me to be able to test this for now
+      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Get cargo-make version
@@ -100,6 +127,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Potentially override rust version with nightly
+      # pull_request is a fake for me to be able to test this for now
+      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Get cargo-make version
@@ -145,6 +179,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Potentially override rust version with nightly
+      # pull_request is a fake for me to be able to test this for now
+      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Get cargo-make version
@@ -177,6 +218,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Potentially override rust version with nightly
+      # pull_request is a fake for me to be able to test this for now
+      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Attempt to load cached CLDR source data
@@ -227,17 +275,24 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Potentially override rust version with nightly
+      # pull_request is a fake for me to be able to test this for now
+      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
     - name: Load cortex target for no_std build.
       run: |
-        rustup install nightly-2022-04-05
-        rustup component add --toolchain nightly-2022-04-05 rust-src
-        rustup target add thumbv7m-none-eabi --toolchain nightly-2022-04-05
-        rustup target add thumbv8m.main-none-eabihf --toolchain nightly-2022-04-05
-        rustup target add x86_64-unknown-linux-gnu --toolchain nightly-2022-04-05
-        rustup target add wasm32-unknown-unknown --toolchain nightly-2022-04-05
+        rustup install $INSTALLED_NIGHTLY_VERSION
+        rustup component add --toolchain $INSTALLED_NIGHTLY_VERSION rust-src
+        rustup target add thumbv7m-none-eabi --toolchain $INSTALLED_NIGHTLY_VERSION
+        rustup target add thumbv8m.main-none-eabihf --toolchain $INSTALLED_NIGHTLY_VERSION
+        rustup target add x86_64-unknown-linux-gnu --toolchain $INSTALLED_NIGHTLY_VERSION
+        rustup target add wasm32-unknown-unknown --toolchain $INSTALLED_NIGHTLY_VERSION
 
     - name: Set up Clang-14
       run: |
@@ -291,6 +346,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Potentially override rust version with nightly
+      # pull_request is a fake for me to be able to test this for now
+      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Load nightly for rustdoc-json
@@ -363,6 +425,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Potentially override rust version with nightly
+      # pull_request is a fake for me to be able to test this for now
+      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -388,9 +457,9 @@ jobs:
 
     - name: Load wasi for gn.
       run: |
-        rustup install nightly-2022-04-05
-        rustup component add --toolchain nightly-2022-04-05 rust-src
-        rustup target add wasm32-wasi --toolchain nightly-2022-04-05
+        rustup install $INSTALLED_NIGHTLY_VERSION
+        rustup component add --toolchain $INSTALLED_NIGHTLY_VERSION rust-src
+        rustup target add wasm32-wasi --toolchain $INSTALLED_NIGHTLY_VERSION
 
     - name: Attempt to load cached GN Third-Party Tools
       uses: actions/cache@v3
@@ -424,6 +493,13 @@ jobs:
     needs: [check]
     steps:
     - uses: actions/checkout@v2
+    - name: Potentially override rust version with nightly
+      # pull_request is a fake for me to be able to test this for now
+      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Install cargo-all-features
@@ -465,12 +541,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Potentially override rust version with nightly
+      # pull_request is a fake for me to be able to test this for now
+      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
     - name: Load nightly Rust toolchain for WASM.
       run: |
-        rustup install nightly-2022-04-05
-        rustup target add wasm32-unknown-unknown --toolchain nightly-2022-04-05
-        rustup target add wasm32-unknown-emscripten --toolchain nightly-2022-04-05
-        rustup component add rust-src --toolchain nightly-2022-04-05
+        rustup install $INSTALLED_NIGHTLY_VERSION
+        rustup target add wasm32-unknown-unknown --toolchain $INSTALLED_NIGHTLY_VERSION
+        rustup target add wasm32-unknown-emscripten --toolchain $INSTALLED_NIGHTLY_VERSION
+        rustup component add rust-src --toolchain $INSTALLED_NIGHTLY_VERSION
 
     - name: Get cargo-make version
       id: cargo-make-version
@@ -514,7 +597,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-
+    - name: Potentially override rust version with nightly
+      # pull_request is a fake for me to be able to test this for now
+      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -555,7 +644,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-
+    - name: Potentially override rust version with nightly
+      # pull_request is a fake for me to be able to test this for now
+      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -610,10 +705,11 @@ jobs:
   # Clippy job (cargo-clippy) - completes and puts warnings inline in PR
   clippy:
     runs-on: ubuntu-latest
-
+    # We don't expect to keep being clippy-clean on nightly Rust
+    if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
     steps:
-    - uses: actions/checkout@v2
 
+    - uses: actions/checkout@v2
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -631,6 +727,7 @@ jobs:
   # Benchmarking & dashboards job
 
   benchmark:
+    # We don't expect to keep being clippy-clean on nightly Rust
     strategy:
       # max-parallel: 1
       fail-fast: false
@@ -655,6 +752,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Potentially override rust version with nightly
+      # pull_request is a fake for me to be able to test this for now
+      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
 
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
@@ -774,17 +878,23 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
+    - name: Potentially override rust version with nightly
+      # pull_request is a fake for me to be able to test this for now
+      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
     # Nightly is only needed for the `--profile bench` line. Once that is stabilized,
     # then this line is no longer needed.
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly-2022-04-05
+        toolchain: ${{ env.INSTALLED_NIGHTLY_VERSION }}
         override: true
 
     - name: Run the example with dhat-rs to collect memory information
       run: |
-        cargo run --package icu_benchmark_memory -- --os ${{ matrix.os }} ${{ matrix.examples }} --toolchain nightly-2022-04-05
+        cargo run --package icu_benchmark_memory -- --os ${{ matrix.os }} ${{ matrix.examples }} --toolchain $INSTALLED_NIGHTLY_VERSION
 
     # Benchmarking & dashboards job > (unmerged PR only) Convert benchmark output into
     # dashboard HTML in a commit of a branch of the local repo.
@@ -881,8 +991,8 @@ jobs:
     - name: Install prerequisites for wasm build
       run: |
         rustup toolchain list
-        rustup toolchain install nightly-2022-04-05
-        rustup component add --toolchain nightly-2022-04-05 rust-src
+        rustup toolchain install $INSTALLED_NIGHTLY_VERSION
+        rustup component add --toolchain $INSTALLED_NIGHTLY_VERSION rust-src
 
     - name: Install Node.js v16.18.0
       uses: actions/setup-node@v3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -53,13 +53,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
       # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
         echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
+    - name: Potentially override rust version with nightly (Windows version)
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
+      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -101,13 +110,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
       # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
         echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
+    - name: Potentially override rust version with nightly (Windows version)
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
+      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Get cargo-make version
@@ -145,13 +163,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
       # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
         echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
+    - name: Potentially override rust version with nightly (Windows version)
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
+      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Get cargo-make version
@@ -199,13 +226,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
       # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
         echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
+    - name: Potentially override rust version with nightly (Windows version)
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
+      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Get cargo-make version
@@ -240,13 +276,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
       # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
         echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
+    - name: Potentially override rust version with nightly (Windows version)
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
+      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Attempt to load cached CLDR source data
@@ -299,13 +344,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
       # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
         echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
+    - name: Potentially override rust version with nightly (Windows version)
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
+      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -372,13 +426,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
       # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
         echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
+    - name: Potentially override rust version with nightly (Windows version)
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
+      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Load nightly for rustdoc-json
@@ -453,13 +516,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
       # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
         echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
+    - name: Potentially override rust version with nightly (Windows version)
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
+      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -523,13 +595,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
       # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
         echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
+    - name: Potentially override rust version with nightly (Windows version)
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
+      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Install cargo-all-features
@@ -573,13 +654,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
       # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
         echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
+    - name: Potentially override rust version with nightly (Windows version)
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
+      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
     - name: Load nightly Rust toolchain for WASM.
       run: |
         rustup install $INSTALLED_NIGHTLY_VERSION
@@ -631,13 +721,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
       # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
         echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
+    - name: Potentially override rust version with nightly (Windows version)
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
+      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -680,13 +779,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
       # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
         echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
+    - name: Potentially override rust version with nightly (Windows version)
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
+      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -790,13 +898,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
       # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
         echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
+    - name: Potentially override rust version with nightly (Windows version)
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
+      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
 
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
@@ -918,13 +1035,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
       # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
+      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
         echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
+    - name: Potentially override rust version with nightly (Windows version)
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
+      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
+      run: |
+        rustup override set nightly
+        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
+        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
+        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
     - name: echo
       run: echo "toolchain is $INSTALLED_NIGHTLY_VERSION"
     # Nightly is only needed for the `--profile bench` line. Once that is stabilized,

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -885,6 +885,8 @@ jobs:
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
+    - name: echo
+      run: echo "toolchain is $INSTALLED_NIGHTLY_VERSION"
     # Nightly is only needed for the `--profile bench` line. Once that is stabilized,
     # then this line is no longer needed.
     - uses: actions-rs/toolchain@v1
@@ -894,7 +896,8 @@ jobs:
 
     - name: Run the example with dhat-rs to collect memory information
       run: |
-        cargo run --package icu_benchmark_memory -- --os ${{ matrix.os }} ${{ matrix.examples }} --toolchain $INSTALLED_NIGHTLY_VERSION
+        # we use the env. syntax instead of the $ENV syntax because $ENV doesn't work on windows
+        cargo run --package icu_benchmark_memory -- --os ${{ matrix.os }} ${{ matrix.examples }} --toolchain ${{ env.INSTALLED_NIGHTLY_VERSION }}
 
     # Benchmarking & dashboards job > (unmerged PR only) Convert benchmark output into
     # dashboard HTML in a commit of a branch of the local repo.

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,6 +29,18 @@ on:
     # Run nightly cronjob CI every day at 14 UTC / 6AM PST / 3PM CET
     - cron:  '0 14 * * *'
 
+# For the nightly CI, we set four environment variables, and set a rustup override to nightly.
+# Each env var has a different purpose:
+# - ICU4X_NIGHTLY_TOOLCHAIN: This overrides the nightly used by ICU4X FFI/etc tasks
+# - INSTALLED_NIGHTLY_VERSION: This overrides the nightly used in this build-test.yml file when installing components
+#                              We do not reuse ICU4X_NIGHTLY_TOOLCHAIN because we want the *default* CI experience to be
+#                              as close to running locally as possible, and we want to avoid there being a bug that only occurs
+#                              on pull request CI because it is always run with ICU4X_NIGHTLY_TOOLCHAIN=... . Basically, 
+#                              ICU4X_NIGHTLY_TOOLCHAIN affects the makefile, and INSTALLED_NIGHTLY_VERSION affects this Actions file only
+# - ICU4X_BUILDING_WITH_FORCED_NIGHTLY: This lets tests know that we're building with forced nightly, in case of tests testing the behavior of specific Rust versions.
+# - `RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY`: Same as previously, but works for disabling doctests. Use ICU4X_BUILDING_WITH_FORCED_NIGHTLY where possible.
+#
+# When updating the CI stable version, please audit all cases of ICU4X_BUILDING_WITH_FORCED_NIGHTLY and remove cfgs where necessary.
 env:
   INSTALLED_NIGHTLY_VERSION: nightly-2022-04-05
 
@@ -40,13 +52,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
-      # pull_request is a fake for me to be able to test this for now
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
       if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -87,13 +100,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
-      # pull_request is a fake for me to be able to test this for now
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
       if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Get cargo-make version
@@ -130,13 +144,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
-      # pull_request is a fake for me to be able to test this for now
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
       if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Get cargo-make version
@@ -183,13 +198,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
-      # pull_request is a fake for me to be able to test this for now
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
       if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Get cargo-make version
@@ -223,13 +239,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
-      # pull_request is a fake for me to be able to test this for now
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
       if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Attempt to load cached CLDR source data
@@ -281,13 +298,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
-      # pull_request is a fake for me to be able to test this for now
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
       if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -353,13 +371,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
-      # pull_request is a fake for me to be able to test this for now
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
       if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Load nightly for rustdoc-json
@@ -433,13 +452,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
-      # pull_request is a fake for me to be able to test this for now
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
       if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -502,13 +522,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
-      # pull_request is a fake for me to be able to test this for now
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
       if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Install cargo-all-features
@@ -551,13 +572,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
-      # pull_request is a fake for me to be able to test this for now
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
       if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
     - name: Load nightly Rust toolchain for WASM.
       run: |
         rustup install $INSTALLED_NIGHTLY_VERSION
@@ -608,13 +630,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
-      # pull_request is a fake for me to be able to test this for now
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
       if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -656,13 +679,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
-      # pull_request is a fake for me to be able to test this for now
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
       if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
@@ -765,13 +789,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
-      # pull_request is a fake for me to be able to test this for now
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
       if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
 
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
@@ -892,13 +917,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Potentially override rust version with nightly
-      # pull_request is a fake for me to be able to test this for now
+      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
       if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
       run: |
         rustup override set nightly
         echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
         echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
         echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
+        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
     - name: echo
       run: echo "toolchain is $INSTALLED_NIGHTLY_VERSION"
     # Nightly is only needed for the `--profile bench` line. Once that is stabilized,

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -945,6 +945,14 @@ jobs:
     - name: Show the selected Rust toolchain
       run: rustup show
 
+    # Job-specific dependencies
+    # Nightly is only needed for the `--profile bench` line. Once that is stabilized,
+    # then this line is no longer needed.
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ env.INSTALLED_NIGHTLY_VERSION }}
+        override: true
+
     ## Actual job
     ##
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -464,50 +464,50 @@ jobs:
     needs: [check]
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Load nightly Rust toolchain for WASM.
-        run: |
-          rustup install nightly-2022-04-05
-          rustup target add wasm32-unknown-unknown --toolchain nightly-2022-04-05
-          rustup target add wasm32-unknown-emscripten --toolchain nightly-2022-04-05
-          rustup component add rust-src --toolchain nightly-2022-04-05
+    - uses: actions/checkout@v2
+    - name: Load nightly Rust toolchain for WASM.
+      run: |
+        rustup install nightly-2022-04-05
+        rustup target add wasm32-unknown-unknown --toolchain nightly-2022-04-05
+        rustup target add wasm32-unknown-emscripten --toolchain nightly-2022-04-05
+        rustup component add rust-src --toolchain nightly-2022-04-05
 
-      - name: Get cargo-make version
-        id: cargo-make-version
-        run: |
-          echo "::set-output name=hash::$(cargo search cargo-make | grep '^cargo-make =' | md5sum)"
-        shell: bash
-      - name: Attempt to load cached cargo-make
-        uses: actions/cache@v2
-        id: cargo-make-cache
-        with:
-          path: |
-            ~/.cargo/bin/cargo-make
-            ~/.cargo/bin/cargo-make.exe
-          key: ${{ runner.os }}-make-${{ steps.cargo-make-version.outputs.hash }}
-      - name: Install cargo-make
-        if: steps.cargo-make-cache.outputs.cache-hit != 'true'
-        uses: actions-rs/install@v0.1.2
-        with:
-          crate: cargo-make
-          version: latest
-      - name: Install emsdk
-        run: |
-          cd ~
-          git clone https://github.com/emscripten-core/emsdk.git --branch 2.0.27
-          cd emsdk
-          ./emsdk install latest
-          ./emsdk activate latest
-      - name: Install Node.js v16.18.0
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.18.0
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-      - name: Run emscripten test
-        run: |
-          . ~/emsdk/emsdk_env.sh
-          cargo make ci-job-wasm
+    - name: Get cargo-make version
+      id: cargo-make-version
+      run: |
+        echo "::set-output name=hash::$(cargo search cargo-make | grep '^cargo-make =' | md5sum)"
+      shell: bash
+    - name: Attempt to load cached cargo-make
+      uses: actions/cache@v2
+      id: cargo-make-cache
+      with:
+        path: |
+          ~/.cargo/bin/cargo-make
+          ~/.cargo/bin/cargo-make.exe
+        key: ${{ runner.os }}-make-${{ steps.cargo-make-version.outputs.hash }}
+    - name: Install cargo-make
+      if: steps.cargo-make-cache.outputs.cache-hit != 'true'
+      uses: actions-rs/install@v0.1.2
+      with:
+        crate: cargo-make
+        version: latest
+    - name: Install emsdk
+      run: |
+        cd ~
+        git clone https://github.com/emscripten-core/emsdk.git --branch 2.0.27
+        cd emsdk
+        ./emsdk install latest
+        ./emsdk activate latest
+    - name: Install Node.js v16.18.0
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.18.0
+        cache: 'npm'
+        cache-dependency-path: '**/package-lock.json'
+    - name: Run emscripten test
+      run: |
+        . ~/emsdk/emsdk_env.sh
+        cargo make ci-job-wasm
 
   # Fmt job - runs cargo fmt
   fmt:
@@ -654,73 +654,73 @@ jobs:
     needs: [check]
 
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
-      - name: Load the default Rust toolchain via the rust-toolchain file.
-        run: rustup show
+    - name: Load the default Rust toolchain via the rust-toolchain file.
+      run: rustup show
 
-      - name: Create output dir
-        run: mkdir -p ./benchmarks/perf/${{ matrix.component }}
+    - name: Create output dir
+      run: mkdir -p ./benchmarks/perf/${{ matrix.component }}
 
-      # Benchmarking & dashboards job > Run benchmark.
+    # Benchmarking & dashboards job > Run benchmark.
 
-      - name: Run benchmark
-        run: |
-          pushd $PWD && cd ${{ matrix.component }};
-          export REL_OUTPUT_PATH="`dirs +1`/benchmarks/perf/${{ matrix.component }}";
-          mkdir -p $REL_OUTPUT_PATH;
-          export OUTPUT_PATH_CMD="ls -d $REL_OUTPUT_PATH";
-          export OUTPUT_PATH=$(echo $OUTPUT_PATH_CMD | sh);
-          cargo bench --features bench -- --output-format bencher | tee $OUTPUT_PATH/output.txt;
-          popd
+    - name: Run benchmark
+      run: |
+        pushd $PWD && cd ${{ matrix.component }};
+        export REL_OUTPUT_PATH="`dirs +1`/benchmarks/perf/${{ matrix.component }}";
+        mkdir -p $REL_OUTPUT_PATH;
+        export OUTPUT_PATH_CMD="ls -d $REL_OUTPUT_PATH";
+        export OUTPUT_PATH=$(echo $OUTPUT_PATH_CMD | sh);
+        cargo bench --features bench -- --output-format bencher | tee $OUTPUT_PATH/output.txt;
+        popd
 
-      # In the following step(s) regarding converting benchmark output to dashboards, the branch in `gh-pages-branch` needs to exist.
-      # If it doesn't already exist, it should be created by someone with push permissions, like so:
-      #   # Create a local branch
-      #   $ git checkout --orphan <newbranch>
-      #   $ git commit --allow-empty -m "root commit"
-      #   # Push it to create a remote branch
-      #   $ git push origin <newbranch>:<newbranch>
+    # In the following step(s) regarding converting benchmark output to dashboards, the branch in `gh-pages-branch` needs to exist.
+    # If it doesn't already exist, it should be created by someone with push permissions, like so:
+    #   # Create a local branch
+    #   $ git checkout --orphan <newbranch>
+    #   $ git commit --allow-empty -m "root commit"
+    #   # Push it to create a remote branch
+    #   $ git push origin <newbranch>:<newbranch>
 
-      # Benchmarking & dashboards job > (unmerged PR only) Convert benchmark output into dashboard HTML in a commit of a branch of the local repo.
+    # Benchmarking & dashboards job > (unmerged PR only) Convert benchmark output into dashboard HTML in a commit of a branch of the local repo.
 
-      - name: Store benchmark result & create dashboard (unmerged PR only)
-        # any action that is not a merge to main implies unfinished PR
-        if: github.event_name != 'push' || github.ref != 'refs/heads/main'
-        uses: rhysd/github-action-benchmark@v1.8.1
-        with:
-          name: Rust Benchmark
-          tool: 'cargo'
-          output-file-path: ./benchmarks/perf/${{ matrix.component }}/output.txt
-          benchmark-data-dir-path: ./benchmarks/perf/${{ matrix.component }}
-          # Show alert with commit comment on detecting possible performance regression
-          alert-threshold: '200%'  # If for nothing else, enabling the possibility of alerts with meaningful thresholds requires this job to be done per-component
-          fail-on-alert: true
-          gh-pages-branch: unmerged-pr-bench-data  # Requires one-time-only creation of this branch on remote repo.
-          auto-push: false  # Do not store historical benchmark info of unfinished PRs. Commits seem to get made anyways, so make sure
-                            # that the branch in `gh-pages-branch` is different from the branch used for merges to main branch.
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-on-alert: true
+    - name: Store benchmark result & create dashboard (unmerged PR only)
+      # any action that is not a merge to main implies unfinished PR
+      if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+      uses: rhysd/github-action-benchmark@v1.8.1
+      with:
+        name: Rust Benchmark
+        tool: 'cargo'
+        output-file-path: ./benchmarks/perf/${{ matrix.component }}/output.txt
+        benchmark-data-dir-path: ./benchmarks/perf/${{ matrix.component }}
+        # Show alert with commit comment on detecting possible performance regression
+        alert-threshold: '200%'  # If for nothing else, enabling the possibility of alerts with meaningful thresholds requires this job to be done per-component
+        fail-on-alert: true
+        gh-pages-branch: unmerged-pr-bench-data  # Requires one-time-only creation of this branch on remote repo.
+        auto-push: false  # Do not store historical benchmark info of unfinished PRs. Commits seem to get made anyways, so make sure
+                          # that the branch in `gh-pages-branch` is different from the branch used for merges to main branch.
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        comment-on-alert: true
 
-      # Benchmarking & dashboards job > (PR merge to main only) Convert benchmark output into dashboard HTML in a commit of a branch of the local repo.
+    # Benchmarking & dashboards job > (PR merge to main only) Convert benchmark output into dashboard HTML in a commit of a branch of the local repo.
 
-      - name: Store benchmark result & create dashboard (merge to main only)
-        # only merges to main (implies PR is finished and approved by this point)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
-        uses: rhysd/github-action-benchmark@v1.8.1
-        with:
-          name: Rust Benchmark
-          tool: 'cargo'
-          output-file-path: ./benchmarks/perf/${{ matrix.component }}/output.txt
-          benchmark-data-dir-path: ./benchmarks/perf/${{ matrix.component }}
-          # Show alert with commit comment on detecting possible performance regression
-          alert-threshold: '200%'  # If for nothing else, enabling the possibility of alerts with meaningful thresholds requires this job to be done per-component
-          fail-on-alert: true
-          gh-pages-branch: merged-bench-data  # Requires one-time-only creation of this branch on remote repo.
-          auto-push: true  # Use the branch at `gh-pages-branch` to store historical info of benchmark data.
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-on-alert: true
-          alert-comment-cc-users: '@sffc,@zbraniecki,@echeran'
+    - name: Store benchmark result & create dashboard (merge to main only)
+      # only merges to main (implies PR is finished and approved by this point)
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
+      uses: rhysd/github-action-benchmark@v1.8.1
+      with:
+        name: Rust Benchmark
+        tool: 'cargo'
+        output-file-path: ./benchmarks/perf/${{ matrix.component }}/output.txt
+        benchmark-data-dir-path: ./benchmarks/perf/${{ matrix.component }}
+        # Show alert with commit comment on detecting possible performance regression
+        alert-threshold: '200%'  # If for nothing else, enabling the possibility of alerts with meaningful thresholds requires this job to be done per-component
+        fail-on-alert: true
+        gh-pages-branch: merged-bench-data  # Requires one-time-only creation of this branch on remote repo.
+        auto-push: true  # Use the branch at `gh-pages-branch` to store historical info of benchmark data.
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        comment-on-alert: true
+        alert-comment-cc-users: '@sffc,@zbraniecki,@echeran'
 
   # Run examples with dhat-rs in order to collect memory heap size metrics. These
   # metrics will then be charted over time. See tools/benchmark/memory/README.md for
@@ -773,77 +773,77 @@ jobs:
     needs: [check]
 
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
-      # Nightly is only needed for the `--profile bench` line. Once that is stabilized,
-      # then this line is no longer needed.
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2022-04-05
-          override: true
+    # Nightly is only needed for the `--profile bench` line. Once that is stabilized,
+    # then this line is no longer needed.
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly-2022-04-05
+        override: true
 
-      - name: Run the example with dhat-rs to collect memory information
-        run: |
-          cargo run --package icu_benchmark_memory -- --os ${{ matrix.os }} ${{ matrix.examples }} --toolchain nightly-2022-04-05
+    - name: Run the example with dhat-rs to collect memory information
+      run: |
+        cargo run --package icu_benchmark_memory -- --os ${{ matrix.os }} ${{ matrix.examples }} --toolchain nightly-2022-04-05
 
-      # Benchmarking & dashboards job > (unmerged PR only) Convert benchmark output into
-      # dashboard HTML in a commit of a branch of the local repo.
+    # Benchmarking & dashboards job > (unmerged PR only) Convert benchmark output into
+    # dashboard HTML in a commit of a branch of the local repo.
 
-      - name: Store benchmark result & create dashboard (unmerged PR only)
-        # any action that is not a merge to main implies unfinished PR
-        if: github.event_name != 'push' || github.ref != 'refs/heads/main'
-        # The gregtatum fork of rhysd/github-action-benchmark contains support for ndjson.
-        # If the PR gets merged, this can be switched back to the main project.
-        # https://github.com/rhysd/github-action-benchmark/pull/54
-        uses: gregtatum/github-action-benchmark@d3f06f738e9612988d575db23fae5ca0008d3d12
-        with:
-          name: Heap – ${{ matrix.os }}
-          # The ndjson tool is only supported by the gregtatum fork of github-action-benchmark.
-          tool: 'ndjson'
-          benchmark-data-dir-path: ./benchmarks/memory/${{ matrix.os }}
-          output-file-path: ./benchmarks/memory/${{ matrix.os }}/output.ndjson
-          # Show alert with commit comment on detecting possible memory regression
-          alert-threshold: '200%'
-          fail-on-alert: true
-          # Requires one-time-only creation of this branch on remote repo. This will
-          # store the generated information.
-          gh-pages-branch: unmerged-pr-bench-data
+    - name: Store benchmark result & create dashboard (unmerged PR only)
+      # any action that is not a merge to main implies unfinished PR
+      if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+      # The gregtatum fork of rhysd/github-action-benchmark contains support for ndjson.
+      # If the PR gets merged, this can be switched back to the main project.
+      # https://github.com/rhysd/github-action-benchmark/pull/54
+      uses: gregtatum/github-action-benchmark@d3f06f738e9612988d575db23fae5ca0008d3d12
+      with:
+        name: Heap – ${{ matrix.os }}
+        # The ndjson tool is only supported by the gregtatum fork of github-action-benchmark.
+        tool: 'ndjson'
+        benchmark-data-dir-path: ./benchmarks/memory/${{ matrix.os }}
+        output-file-path: ./benchmarks/memory/${{ matrix.os }}/output.ndjson
+        # Show alert with commit comment on detecting possible memory regression
+        alert-threshold: '200%'
+        fail-on-alert: true
+        # Requires one-time-only creation of this branch on remote repo. This will
+        # store the generated information.
+        gh-pages-branch: unmerged-pr-bench-data
 
-          # Do not store historical benchmark info of unfinished PRs. Commits seem to get
-          # made anyways, so make sure that the branch in `gh-pages-branch` is
-          # different from the branch used for merges to main branch.
-          auto-push: false
+        # Do not store historical benchmark info of unfinished PRs. Commits seem to get
+        # made anyways, so make sure that the branch in `gh-pages-branch` is
+        # different from the branch used for merges to main branch.
+        auto-push: false
 
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-on-alert: true
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        comment-on-alert: true
 
-      # Benchmarking & dashboards job > (PR merge to main only) Convert benchmark output
-      # into dashboard HTML in a commit of a branch of the local repo.
+    # Benchmarking & dashboards job > (PR merge to main only) Convert benchmark output
+    # into dashboard HTML in a commit of a branch of the local repo.
 
-      - name: Store benchmark result & create dashboard (merge to main only)
-        # only merges to main (implies PR is finished and approved by this point)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
-        # The gregtatum fork of rhysd/github-action-benchmark contains support for ndjson.
-        # If the PR gets merged, this can be switched back to the main project.
-        # https://github.com/rhysd/github-action-benchmark/pull/54
-        uses: gregtatum/github-action-benchmark@d3f06f738e9612988d575db23fae5ca0008d3d12
-        with:
-          name: Heap – ${{ matrix.os }}
-          # The ndjson tool is only supported by the gregtatum fork of github-action-benchmark.
-          tool: 'ndjson'
-          benchmark-data-dir-path: ./benchmarks/memory/${{ matrix.os }}
-          output-file-path: ./benchmarks/memory/${{ matrix.os }}/output.ndjson
-          alert-threshold: '200%'
-          fail-on-alert: true
-          # The historical run information will be stored in this branch. This is the same
-          # branch that is being used by the performance benchmark. The information is
-          # computed by gregtatum/github-action-benchmark, and is added to a .js file in
-          # the branch, e.g. benchmarks/memory/{os}/data.js
-          gh-pages-branch: merged-bench-data
-          auto-push: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-on-alert: true
-          alert-comment-cc-users: '@sffc,@zbraniecki,@echeran'
+    - name: Store benchmark result & create dashboard (merge to main only)
+      # only merges to main (implies PR is finished and approved by this point)
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
+      # The gregtatum fork of rhysd/github-action-benchmark contains support for ndjson.
+      # If the PR gets merged, this can be switched back to the main project.
+      # https://github.com/rhysd/github-action-benchmark/pull/54
+      uses: gregtatum/github-action-benchmark@d3f06f738e9612988d575db23fae5ca0008d3d12
+      with:
+        name: Heap – ${{ matrix.os }}
+        # The ndjson tool is only supported by the gregtatum fork of github-action-benchmark.
+        tool: 'ndjson'
+        benchmark-data-dir-path: ./benchmarks/memory/${{ matrix.os }}
+        output-file-path: ./benchmarks/memory/${{ matrix.os }}/output.ndjson
+        alert-threshold: '200%'
+        fail-on-alert: true
+        # The historical run information will be stored in this branch. This is the same
+        # branch that is being used by the performance benchmark. The information is
+        # computed by gregtatum/github-action-benchmark, and is added to a .js file in
+        # the branch, e.g. benchmarks/memory/{os}/data.js
+        gh-pages-branch: merged-bench-data
+        auto-push: true
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        comment-on-alert: true
+        alert-comment-cc-users: '@sffc,@zbraniecki,@echeran'
 
   # Binary size benchmark: build and size wasm binaries; creates ndjson output data format
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -51,27 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Potentially override rust version with nightly
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
-    - name: Potentially override rust version with nightly (Windows version)
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
-    - name: Load the default Rust toolchain via the rust-toolchain file.
-      run: rustup show
 
+    # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
       run: |
@@ -92,6 +73,13 @@ jobs:
         crate: cargo-make
         version: latest
 
+    # Toolchain boilerplate
+    - name: Potentially override rust version with nightly
+      run: cargo make set-nightly-version-for-ci
+    - name: Show the selected Rust toolchain
+      run: rustup show
+
+    # Actual job
     - name: Check
       uses: actions-rs/cargo@v1.0.1
       with:
@@ -108,26 +96,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Potentially override rust version with nightly
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
-    - name: Potentially override rust version with nightly (Windows version)
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
-    - name: Load the default Rust toolchain via the rust-toolchain file.
-      run: rustup show
+
+    # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
       run: |
@@ -147,6 +117,14 @@ jobs:
       with:
         crate: cargo-make
         version: latest
+
+    # Toolchain boilerplate
+    - name: Potentially override rust version with nightly
+      run: cargo make set-nightly-version-for-ci
+    - name: Show the selected Rust toolchain
+      run: rustup show
+
+    # Actual job
     - name: Run `cargo make ci-job-test`
       uses: actions-rs/cargo@v1.0.1
       with:
@@ -161,26 +139,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Potentially override rust version with nightly
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
-    - name: Potentially override rust version with nightly (Windows version)
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
-    - name: Load the default Rust toolchain via the rust-toolchain file.
-      run: rustup show
+
+    # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
       run: |
@@ -200,7 +160,14 @@ jobs:
       with:
         crate: cargo-make
         version: latest
-    # Note: rustfmt is required for databake formatting
+
+    # Toolchain boilerplate
+    - name: Potentially override rust version with nightly
+      run: cargo make set-nightly-version-for-ci
+    - name: Show the selected Rust toolchain
+      run: rustup show
+
+    # Job specific dependencies
     - name: Install rustfmt
       run: rustup component add rustfmt
     - name: Build icu4x-testdata-datagen
@@ -213,6 +180,8 @@ jobs:
       with:
         command: build
         args: --bin=icu4x-datagen --features=experimental,bin
+
+    # Actual job
     - name: Run `cargo make ci-job-testdata`
       uses: actions-rs/cargo@v1.0.1
       with:
@@ -224,26 +193,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Potentially override rust version with nightly
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
-    - name: Potentially override rust version with nightly (Windows version)
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
-    - name: Load the default Rust toolchain via the rust-toolchain file.
-      run: rustup show
+    # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
       run: |
@@ -263,6 +213,14 @@ jobs:
       with:
         crate: cargo-make
         version: latest
+
+    # Toolchain boilerplate
+    - name: Potentially override rust version with nightly
+      run: cargo make set-nightly-version-for-ci
+    - name: Show the selected Rust toolchain
+      run: rustup show
+
+    # Actual job
     - name: Run `cargo make ci-job-test-docs`
       uses: actions-rs/cargo@v1.0.1
       with:
@@ -274,26 +232,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
+    # Cargo-make boilerplate
+    - name: Get cargo-make version
+      id: cargo-make-version
+      run: |
+        echo "::set-output name=hash::$(cargo search cargo-make | grep '^cargo-make =' | md5sum)"
+      shell: bash
+    - name: Attempt to load cached cargo-make
+      uses: actions/cache@v2
+      id: cargo-make-cache
+      with:
+        path: |
+          ~/.cargo/bin/cargo-make
+          ~/.cargo/bin/cargo-make.exe
+        key: ${{ runner.os }}-make-${{ steps.cargo-make-version.outputs.hash }}
+    - name: Install cargo-make
+      if: steps.cargo-make-cache.outputs.cache-hit != 'true'
+      uses: actions-rs/install@v0.1.2
+      with:
+        crate: cargo-make
+        version: latest
+
+    # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
-    - name: Potentially override rust version with nightly (Windows version)
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
-    - name: Load the default Rust toolchain via the rust-toolchain file.
+      run: cargo make set-nightly-version-for-ci
+    - name: Show the selected Rust toolchain
       run: rustup show
+
+
+    # Job-specific dependencies
     - name: Attempt to load cached CLDR source data
       uses: actions/cache@v2
       id: source-data-cache
@@ -317,6 +285,8 @@ jobs:
         tag: "release-72-1"
         fileName: "icuexportdata_release-72-1.zip"
         out-file-path: "data/source/"
+
+    # Actual job
     - name: Run datagen
       uses: actions-rs/cargo@v1.0.1
       # cargo make ci-job-full-datagen replicates this
@@ -342,49 +312,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Potentially override rust version with nightly
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
-    - name: Potentially override rust version with nightly (Windows version)
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
-    - name: Load the default Rust toolchain via the rust-toolchain file.
-      run: rustup show
 
-    - name: Load cortex target for no_std build.
-      run: |
-        rustup install $INSTALLED_NIGHTLY_VERSION
-        rustup component add --toolchain $INSTALLED_NIGHTLY_VERSION rust-src
-        rustup target add thumbv7m-none-eabi --toolchain $INSTALLED_NIGHTLY_VERSION
-        rustup target add thumbv8m.main-none-eabihf --toolchain $INSTALLED_NIGHTLY_VERSION
-        rustup target add x86_64-unknown-linux-gnu --toolchain $INSTALLED_NIGHTLY_VERSION
-        rustup target add wasm32-unknown-unknown --toolchain $INSTALLED_NIGHTLY_VERSION
-
-    - name: Set up Clang-14
-      run: |
-        wget https://apt.llvm.org/llvm.sh
-        chmod +x llvm.sh
-        sudo ./llvm.sh 14
-
-    - name: Install Node.js v16.18.0
-      uses: actions/setup-node@v3
-      with:
-        node-version: 16.18.0
-        cache: 'npm'
-        cache-dependency-path: '**/package-lock.json'
-
+    # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
       run: |
@@ -405,6 +334,34 @@ jobs:
         crate: cargo-make
         version: latest
 
+    # Toolchain boilerplate
+    - name: Potentially override rust version with nightly
+      run: cargo make set-nightly-version-for-ci
+    - name: Show the selected Rust toolchain
+      run: rustup show
+
+    # Job-specific dependencies
+    - name: Load cortex target for no_std build.
+      run: |
+        rustup install $INSTALLED_NIGHTLY_VERSION
+        rustup component add --toolchain $INSTALLED_NIGHTLY_VERSION rust-src
+        rustup target add thumbv7m-none-eabi --toolchain $INSTALLED_NIGHTLY_VERSION
+        rustup target add thumbv8m.main-none-eabihf --toolchain $INSTALLED_NIGHTLY_VERSION
+        rustup target add x86_64-unknown-linux-gnu --toolchain $INSTALLED_NIGHTLY_VERSION
+        rustup target add wasm32-unknown-unknown --toolchain $INSTALLED_NIGHTLY_VERSION
+    - name: Set up Clang-14
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 14
+    - name: Install Node.js v16.18.0
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.18.0
+        cache: 'npm'
+        cache-dependency-path: '**/package-lock.json'
+
+    # Actual job
     - name: Run `cargo make ci-job-ffi`
       uses: actions-rs/cargo@v1.0.1
       with:
@@ -424,29 +381,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Potentially override rust version with nightly
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
-    - name: Potentially override rust version with nightly (Windows version)
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
-    - name: Load the default Rust toolchain via the rust-toolchain file.
-      run: rustup show
-    - name: Load nightly for rustdoc-json
-      run: |
-        rustup install nightly-2022-08-25
+    # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
       run: |
@@ -467,6 +402,16 @@ jobs:
         crate: cargo-make
         version: latest
 
+    # Toolchain boilerplate
+    - name: Potentially override rust version with nightly
+      run: cargo make set-nightly-version-for-ci
+    - name: Show the selected Rust toolchain
+      run: rustup show
+
+    # Job-specific dependencies
+    - name: Load nightly for rustdoc-json
+      run: |
+        rustup install nightly-2022-08-25
     - name: Run diplomat-get-rev to ensure it works
       id: diplomat-getrev-check
       run: cargo make --loglevel error diplomat-get-rev
@@ -498,6 +443,7 @@ jobs:
         command: install
         args: --git https://github.com/rust-diplomat/diplomat.git --version ${{ steps.diplomat-version.outputs.rev }} diplomat-tool
 
+    # Actual job
     - name: Run `cargo make ci-job-verify-ffi`
       uses: actions-rs/cargo@v1.0.1
       with:
@@ -514,27 +460,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Potentially override rust version with nightly
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
-    - name: Potentially override rust version with nightly (Windows version)
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
-    - name: Load the default Rust toolchain via the rust-toolchain file.
-      run: rustup show
 
+    # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
       run: |
@@ -555,6 +482,13 @@ jobs:
         crate: cargo-make
         version: latest
 
+    # Toolchain boilerplate
+    - name: Potentially override rust version with nightly
+      run: cargo make set-nightly-version-for-ci
+    - name: Show the selected Rust toolchain
+      run: rustup show
+
+    # Job-specific dependencies
     - name: Load wasi for gn.
       run: |
         rustup install $INSTALLED_NIGHTLY_VERSION
@@ -575,12 +509,12 @@ jobs:
         command: make
         args: gn-install
 
+    # Actual job
     - name: Run `cargo make ci-job-verify-gn`
       uses: actions-rs/cargo@v1.0.1
       with:
         command: make
         args: ci-job-verify-gn
-
     - name: Run `cargo make ci-job-gn`
       uses: actions-rs/cargo@v1.0.1
       with:
@@ -593,32 +527,7 @@ jobs:
     needs: [check]
     steps:
     - uses: actions/checkout@v2
-    - name: Potentially override rust version with nightly
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
-    - name: Potentially override rust version with nightly (Windows version)
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
-    - name: Load the default Rust toolchain via the rust-toolchain file.
-      run: rustup show
-    - name: Install cargo-all-features
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: install
-        args: cargo-all-features --version "^1.6"
-
+    # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
       run: |
@@ -639,6 +548,13 @@ jobs:
         crate: cargo-make
         version: latest
 
+    # Toolchain boilerplate
+    - name: Potentially override rust version with nightly
+      run: cargo make set-nightly-version-for-ci
+    - name: Show the selected Rust toolchain
+      run: rustup show
+
+    # Actual job
     - name: Build All Feature Permutations
       uses: actions-rs/cargo@v1.0.1
       with:
@@ -652,31 +568,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Potentially override rust version with nightly
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
-    - name: Potentially override rust version with nightly (Windows version)
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
-    - name: Load nightly Rust toolchain for WASM.
-      run: |
-        rustup install $INSTALLED_NIGHTLY_VERSION
-        rustup target add wasm32-unknown-unknown --toolchain $INSTALLED_NIGHTLY_VERSION
-        rustup target add wasm32-unknown-emscripten --toolchain $INSTALLED_NIGHTLY_VERSION
-        rustup component add rust-src --toolchain $INSTALLED_NIGHTLY_VERSION
-
+    # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
       run: |
@@ -696,6 +588,14 @@ jobs:
       with:
         crate: cargo-make
         version: latest
+
+    # Toolchain boilerplate
+    - name: Potentially override rust version with nightly
+      run: cargo make set-nightly-version-for-ci
+    - name: Show the selected Rust toolchain
+      run: rustup show
+
+    # Job-specific dependencies
     - name: Install emsdk
       run: |
         cd ~
@@ -709,7 +609,8 @@ jobs:
         node-version: 16.18.0
         cache: 'npm'
         cache-dependency-path: '**/package-lock.json'
-    - name: Run emscripten test
+    # Actual job
+    - name: Run emscripten/wasm test
       run: |
         . ~/emsdk/emsdk_env.sh
         cargo make ci-job-wasm
@@ -719,31 +620,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Potentially override rust version with nightly
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
-    - name: Potentially override rust version with nightly (Windows version)
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
-    - name: Load the default Rust toolchain via the rust-toolchain file.
-      run: rustup show
-
-    - name: Install rustfmt
-      run: rustup component add rustfmt
-
-
+    # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
       run: |
@@ -764,7 +641,17 @@ jobs:
         crate: cargo-make
         version: latest
 
+    # Toolchain boilerplate
+    - name: Potentially override rust version with nightly
+      run: cargo make set-nightly-version-for-ci
+    - name: Show the selected Rust toolchain
+      run: rustup show
 
+    # Job-specific dependencies
+    - name: Install rustfmt
+      run: rustup component add rustfmt
+
+    # Actual job
     - name: Check Format
       uses: actions-rs/cargo@v1.0.1
       with:
@@ -777,27 +664,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Potentially override rust version with nightly
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
-    - name: Potentially override rust version with nightly (Windows version)
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
-    - name: Load the default Rust toolchain via the rust-toolchain file.
-      run: rustup show
-
+    # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
       run: |
@@ -818,6 +685,13 @@ jobs:
         crate: cargo-make
         version: latest
 
+    # Toolchain boilerplate
+    - name: Potentially override rust version with nightly
+      run: cargo make set-nightly-version-for-ci
+    - name: Show the selected Rust toolchain
+      run: rustup show
+
+    # Job-specific dependencies
     - name: Get cargo-readme version
       id: cargo-readme-version
       run: |
@@ -840,6 +714,7 @@ jobs:
 
     # TODO(#234) re-include cache steps, also using Rust version in cache key
 
+    # Actual job
     - name: Tidy
       uses: actions-rs/cargo@v1.0.1
       with:
@@ -849,16 +724,13 @@ jobs:
   # Clippy job (cargo-clippy) - completes and puts warnings inline in PR
   clippy:
     runs-on: ubuntu-latest
-    # We don't expect to keep being clippy-clean on nightly Rust
-    if: "github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly)"
     steps:
-
     - uses: actions/checkout@v2
-    - name: Load the default Rust toolchain via the rust-toolchain file.
-      run: rustup show
+
+    # We don't expect to keep being clippy-clean on nightly Rust,
+    # so the "toolchain boilerplate" is deliberately omitted
 
     # Clippy job > Install and run clippy steps
-
     - name: Install clippy
       run: rustup component add clippy
 
@@ -896,30 +768,41 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    # Cargo-make boilerplate
+    - name: Get cargo-make version
+      id: cargo-make-version
+      run: |
+        echo "::set-output name=hash::$(cargo search cargo-make | grep '^cargo-make =' | md5sum)"
+      shell: bash
+    - name: Attempt to load cached cargo-make
+      uses: actions/cache@v2
+      id: cargo-make-cache
+      with:
+        path: |
+          ~/.cargo/bin/cargo-make
+          ~/.cargo/bin/cargo-make.exe
+        key: ${{ runner.os }}-make-${{ steps.cargo-make-version.outputs.hash }}
+    - name: Install cargo-make
+      if: steps.cargo-make-cache.outputs.cache-hit != 'true'
+      uses: actions-rs/install@v0.1.2
+      with:
+        crate: cargo-make
+        version: latest
+
+    # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
-    - name: Potentially override rust version with nightly (Windows version)
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
+      run: cargo make set-nightly-version-for-ci
+    - name: Show the selected Rust toolchain
+      run: rustup show
 
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
 
     - name: Create output dir
       run: mkdir -p ./benchmarks/perf/${{ matrix.component }}
+
+    ## Actual job
+    ##
 
     # Benchmarking & dashboards job > Run benchmark.
 
@@ -1033,32 +916,35 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Potentially override rust version with nightly
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os != 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
+    # Cargo-make boilerplate
+    - name: Get cargo-make version
+      id: cargo-make-version
       run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $GITHUB_ENV
-    - name: Potentially override rust version with nightly (Windows version)
-      # DO NOT LAND with the pull_request entry, that's purely for testing on PR CI
-      if: "(runner.os == 'Windows') && (github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.nightly))"
-      run: |
-        rustup override set nightly
-        echo "ICU4X_NIGHTLY_TOOLCHAIN=nightly" >> $env:GITHUB_ENV
-        echo "INSTALLED_NIGHTLY_VERSION=nightly" >> $env:GITHUB_ENV
-        echo "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1" >> $env:GITHUB_ENV
-        echo "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY" >> $env:GITHUB_ENV
-    - name: echo
-      run: echo "toolchain is $INSTALLED_NIGHTLY_VERSION"
-    # Nightly is only needed for the `--profile bench` line. Once that is stabilized,
-    # then this line is no longer needed.
-    - uses: actions-rs/toolchain@v1
+        echo "::set-output name=hash::$(cargo search cargo-make | grep '^cargo-make =' | md5sum)"
+      shell: bash
+    - name: Attempt to load cached cargo-make
+      uses: actions/cache@v2
+      id: cargo-make-cache
       with:
-        toolchain: ${{ env.INSTALLED_NIGHTLY_VERSION }}
-        override: true
+        path: |
+          ~/.cargo/bin/cargo-make
+          ~/.cargo/bin/cargo-make.exe
+        key: ${{ runner.os }}-make-${{ steps.cargo-make-version.outputs.hash }}
+    - name: Install cargo-make
+      if: steps.cargo-make-cache.outputs.cache-hit != 'true'
+      uses: actions-rs/install@v0.1.2
+      with:
+        crate: cargo-make
+        version: latest
+
+    # Toolchain boilerplate
+    - name: Potentially override rust version with nightly
+      run: cargo make set-nightly-version-for-ci
+    - name: Show the selected Rust toolchain
+      run: rustup show
+
+    ## Actual job
+    ##
 
     - name: Run the example with dhat-rs to collect memory information
       run: |
@@ -1134,13 +1020,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      
+    # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
       run: |
         echo "::set-output name=hash::$(cargo search cargo-make | grep '^cargo-make =' | md5sum)"
       shell: bash
-
     - name: Attempt to load cached cargo-make
       uses: actions/cache@v2
       id: cargo-make-cache
@@ -1149,7 +1034,6 @@ jobs:
           ~/.cargo/bin/cargo-make
           ~/.cargo/bin/cargo-make.exe
         key: ${{ runner.os }}-make-${{ steps.cargo-make-version.outputs.hash }}
-
     - name: Install cargo-make
       if: steps.cargo-make-cache.outputs.cache-hit != 'true'
       uses: actions-rs/install@v0.1.2
@@ -1157,6 +1041,13 @@ jobs:
         crate: cargo-make
         version: latest
 
+    # Toolchain boilerplate
+    - name: Potentially override rust version with nightly
+      run: cargo make set-nightly-version-for-ci
+    - name: Show the selected Rust toolchain
+      run: rustup show
+
+    # Job-specific dependencies
     - name: Install prerequisites for wasm build
       run: |
         rustup toolchain list
@@ -1190,6 +1081,8 @@ jobs:
         command: install
         args: twiggy --version 0.7.0
 
+    ## Actual job
+    ##
     - name: Setup output data directory
       run: |
         mkdir -p benchmarks/binsize/${{ matrix.type }}

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -194,7 +194,6 @@ if not ${event_name}
 end
 
 is_schedule = eq "${event_name}" "schedule"
-is_pr = eq "${event_name}" "pull_request"
 is_dispatch = eq "${event_name}" "workflow_dispatch"
 dispatch_needs_nightly = set false
 
@@ -207,7 +206,7 @@ if is_dispatch
     end
 end
 
-if ${is_schedule} or ${is_pr} or ${dispatch_needs_nightly}
+if ${is_schedule} or ${dispatch_needs_nightly}
     echo "Setting up CI environment for forced-nightly Rust build"
     appendfile ${env_file} "ICU4X_NIGHTLY_TOOLCHAIN=nightly\n"
     appendfile ${env_file} "INSTALLED_NIGHTLY_VERSION=nightly\n"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -21,6 +21,7 @@ ICU4X_NIGHTLY_TOOLCHAIN = { value = "nightly-2022-04-05", condition = { env_not_
 # https://chrome-infra-packages.appspot.com/p/gn/gn
 # TODO: Choose the correct distribution of GN automatically.
 ICU4X_GN_PACKAGE = { value = "gn/gn/linux-amd64", condition = { env_not_set = ["ICU4X_GN_PACKAGE"] } }
+ICU4X_BUILDING_WITH_FORCED_NIGHTLY = { value = "1", condition = { env_set = ["ICU4X_BUILDING_WITH_FORCED_NIGHTLY"] } }
 
 [tasks.quick]
 description = "Run quick version of all lints and builds (useful before pushing to GitHub)"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -173,3 +173,48 @@ dependencies = [
 
     # benchmarking and coverage jobs not included
 ]
+
+[tasks.set-nightly-version-for-ci]
+description = "Set all nightly version env vars for CI"
+category = "CI"
+script_runner = "@duckscript"
+script = '''
+exit_on_error true
+env_file = get_env GITHUB_ENV
+if not ${env_file}
+    echo "GITHUB_ENV not set!"
+    exit 1
+end
+
+event_name = get_env GITHUB_EVENT_NAME
+
+if not ${event_name}
+    echo "GITHUB_EVENT_NAME not set!"
+    exit 1
+end
+
+is_schedule = eq "${event_name}" "schedule"
+is_pr = eq "${event_name}" "pull_request"
+is_dispatch = eq "${event_name}" "workflow_dispatch"
+dispatch_needs_nightly = set false
+
+if is_dispatch
+    event_path = get_env GITHUB_EVENT_PATH
+    event_file = readfile ${event_path}
+    event_json = json_parse ${event_file}
+    if ${event_json.inputs.nightly}
+        dispatch_needs_nightly = set true
+    end
+end
+
+if ${is_schedule} or ${is_pr} or ${dispatch_needs_nightly}
+    echo "Setting up CI environment for forced-nightly Rust build"
+    appendfile ${env_file} "ICU4X_NIGHTLY_TOOLCHAIN=nightly\n"
+    appendfile ${env_file} "INSTALLED_NIGHTLY_VERSION=nightly\n"
+    appendfile ${env_file} "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1\n"
+    appendfile ${env_file} "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY\n"
+    exec rustup override set nightly
+else
+    echo "forced-nightly environment not required"
+end
+'''

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -88,6 +88,8 @@ pub struct Locale {
 
 #[test]
 fn test_sizes() {
+    // Remove when we upgrade to a compiler where the new sizes are default
+    let forced_nightly = std::env::var("ICU4X_BUILDING_WITH_FORCED_NIGHTLY").is_ok();
     assert_eq!(core::mem::size_of::<subtags::Language>(), 3);
     assert_eq!(core::mem::size_of::<subtags::Script>(), 4);
     assert_eq!(core::mem::size_of::<subtags::Region>(), 3);
@@ -100,12 +102,21 @@ fn test_sizes() {
     assert_eq!(core::mem::size_of::<extensions::transform::Fields>(), 24);
 
     assert_eq!(core::mem::size_of::<extensions::unicode::Attributes>(), 24);
-    assert_eq!(core::mem::size_of::<extensions::unicode::Keywords>(), 48);
+    assert_eq!(
+        core::mem::size_of::<extensions::unicode::Keywords>(),
+        if forced_nightly { 40 } else { 48 }
+    );
     assert_eq!(core::mem::size_of::<Vec<extensions::other::Other>>(), 24);
     assert_eq!(core::mem::size_of::<extensions::private::Private>(), 24);
-    assert_eq!(core::mem::size_of::<extensions::Extensions>(), 192);
+    assert_eq!(
+        core::mem::size_of::<extensions::Extensions>(),
+        if forced_nightly { 184 } else { 192 }
+    );
 
-    assert_eq!(core::mem::size_of::<Locale>(), 240);
+    assert_eq!(
+        core::mem::size_of::<Locale>(),
+        if forced_nightly { 232 } else { 240 }
+    );
 }
 
 impl Locale {

--- a/ffi/gn/.cargo/config
+++ b/ffi/gn/.cargo/config
@@ -3,7 +3,6 @@
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 # AUTO-GENERATED in ffi.toml
-
 [source.crates-io]
 replace-with = "vendored-sources"
 

--- a/provider/core/src/key.rs
+++ b/provider/core/src/key.rs
@@ -144,6 +144,7 @@ impl DataKeyPath {
         /// ```compile_fail
         /// const unsafe fn canary() { core::slice::from_raw_parts(0 as *const u8, 0); }
         /// ```
+        #[cfg(not(ICU4X_BUILDING_WITH_FORCED_NIGHTLY))]
         const _: () = ();
         unsafe {
             // Safe due to invariant that self.path is tagged correctly

--- a/tools/scripts/ffi.toml
+++ b/tools/scripts/ffi.toml
@@ -108,12 +108,16 @@ install_crate = { rustup_component_name = "rust-src" }
 script_runner = "@duckscript"
 script = '''
 exit_on_error true
-cd ffi/diplomat/c/examples/fixeddecimal_tiny
-rm -f ../../../../../target/debug/libicu_capi_staticlib.a
-rm -f ../../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi_staticlib.a
-rm -f ../../../../../target/x86_64-unknown-linux-gnu/release-opt-size/libicu_capi_staticlib.a
-exec --fail-on-error make
-exec ls -l
+if "${ICU4X_BUILDING_WITH_FORCED_NIGHTLY}"
+    echo "Skipping test-c-tiny since ICU4X_BUILDING_WITH_FORCED_NIGHTLY is set"
+else
+    cd ffi/diplomat/c/examples/fixeddecimal_tiny
+    rm -f ../../../../../target/debug/libicu_capi_staticlib.a
+    rm -f ../../../../../target/x86_64-unknown-linux-gnu/debug/libicu_capi_staticlib.a
+    rm -f ../../../../../target/x86_64-unknown-linux-gnu/release-opt-size/libicu_capi_staticlib.a
+    exec --fail-on-error make
+    exec ls -l
+end
 '''
 
 [tasks.test-cpp]
@@ -262,11 +266,15 @@ category = "ICU4X Development"
 script_runner = "@duckscript"
 script = '''
 exit_on_error true
-cd ffi/tinywasm
+if "${ICU4X_BUILDING_WITH_FORCED_NIGHTLY}"
+    echo "Skipping test-wasm since ICU4X_BUILDING_WITH_FORCED_NIGHTLY is set"
+else
+    cd ffi/tinywasm
 
-exec --fail-on-error ./build.sh
-exec --fail-on-error ls -l
-exec --fail-on-error node tiny.mjs
+    exec --fail-on-error ./build.sh
+    exec --fail-on-error ls -l
+    exec --fail-on-error node tiny.mjs
+end
 '''
 
 [tasks.diplomat-get-rev]

--- a/tools/scripts/gn.toml
+++ b/tools/scripts/gn.toml
@@ -60,11 +60,13 @@ cd ffi/gn
 
 rm -rf vendor
 output = exec --fail-on-error cargo vendor
+output_trimmed = trim_start ${output.stdout} # Needed since there are whitespace differences between cargo versions
+                                             # Probably can be removed when we update our CI stable
 writefile .cargo/config "# This file is part of ICU4X. For terms of use, please see the file\n"
 appendfile .cargo/config "# called LICENSE at the top level of the ICU4X source tree\n"
 appendfile .cargo/config "# (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).\n\n"
 appendfile .cargo/config "# AUTO-GENERATED in ffi.toml\n"
-appendfile .cargo/config ${output.stdout}
+appendfile .cargo/config ${output_trimmed}
 '''
 
 [tasks.gn-gen]

--- a/tools/scripts/wasm.toml
+++ b/tools/scripts/wasm.toml
@@ -20,7 +20,7 @@ exit_on_error true
 
 # Re-run the build command only to generate the JSON output (--message-format=json)
 set_env RUSTFLAGS "-C panic=abort -C opt-level=s"
-output = exec cargo +nightly-2022-04-05 wasm-build-release --message-format=json --examples --workspace --features serde --exclude icu_datagen
+output = exec cargo +${ICU4X_NIGHTLY_TOOLCHAIN} wasm-build-release --message-format=json --examples --workspace --features serde --exclude icu_datagen
 if ${output.code}
     echo ${output.stderr}
     trigger_error "Build failed! See output above."

--- a/utils/tinystr/src/ascii.rs
+++ b/utils/tinystr/src/ascii.rs
@@ -142,6 +142,7 @@ impl<const N: usize> TinyAsciiStr<N> {
         /// ```compile_fail
         /// const unsafe fn canary() { core::slice::from_raw_parts(0 as *const u8, 0); }
         /// ```
+        #[cfg(not(ICU4X_BUILDING_WITH_FORCED_NIGHTLY))]
         const _: () = ();
         // Safe because `self.bytes.as_slice()` pointer-casts to `&[u8]`,
         // and changing the length of that slice to self.len() < N is safe.

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -101,6 +101,7 @@ macro_rules! impl_const_constructors {
                 /// ```compile_fail
                 /// const unsafe fn canary() { core::slice::from_raw_parts(0 as *const u8, 0); }
                 /// ```
+                #[cfg(not(ICU4X_BUILDING_WITH_FORCED_NIGHTLY))]
                 const _: () = ();
                 let len = bytes.len();
                 #[allow(clippy::modulo_one)]

--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -356,6 +356,7 @@ where
         /// ```compile_fail
         /// const unsafe fn canary() { core::slice::from_raw_parts(0 as *const u8, 0); }
         /// ```
+        #[cfg(not(ICU4X_BUILDING_WITH_FORCED_NIGHTLY))]
         const _: () = ();
         Self::new_borrowed(core::mem::transmute((
             bytes.as_ptr(),

--- a/utils/zerovec/src/zerovec/slice.rs
+++ b/utils/zerovec/src/zerovec/slice.rs
@@ -69,6 +69,7 @@ where
         /// ```compile_fail
         /// const unsafe fn canary() { core::slice::from_raw_parts(0 as *const u8, 0); }
         /// ```
+        #[cfg(not(ICU4X_BUILDING_WITH_FORCED_NIGHTLY))]
         const _: () = ();
         core::mem::transmute((bytes.as_ptr(), bytes.len() / core::mem::size_of::<T::ULE>()))
     }


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/2718


This is reviewable now, but please do not merge yet, since for the purposes of testing I've made it so that the nightly CI is run for the pull_request task as well.

This adds a cronjob (and a manually-triggerable) CI task that runs everything[^1] under the latest nightly. It does this by conditionally setting env vars, so future changes to CI will automatically inherit this as long as new jobs use the same boilerplate. There are also env vars that allow us to skip or fixup tests that are testing things on specific compiler versions.

 [^1]: Except for the clippy build and the rustdoc-json using stuff