### PR TITLE
Don't upload stuff on schedule/triggered tasks

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -829,8 +829,7 @@ jobs:
     # Benchmarking & dashboards job > (unmerged PR only) Convert benchmark output into dashboard HTML in a commit of a branch of the local repo.
 
     - name: Store benchmark result & create dashboard (unmerged PR only)
-      # any action that is not a merge to main implies unfinished PR
-      if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+      if: github.event_name == 'pull_request'
       uses: rhysd/github-action-benchmark@v1.8.1
       with:
         name: Rust Benchmark
@@ -965,8 +964,8 @@ jobs:
     # dashboard HTML in a commit of a branch of the local repo.
 
     - name: Store benchmark result & create dashboard (unmerged PR only)
-      # any action that is not a merge to main implies unfinished PR
-      if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+      # Unfinished PRs only
+      if: github.event_name == 'pull_request'
       # The gregtatum fork of rhysd/github-action-benchmark contains support for ndjson.
       # If the PR gets merged, this can be switched back to the main project.
       # https://github.com/rhysd/github-action-benchmark/pull/54
@@ -1109,8 +1108,8 @@ jobs:
         cargo run --package icu_benchmark_binsize  -- wasmpkg/wasm-opt ${{ matrix.type }} | tee benchmarks/binsize/${{ matrix.type }}/output.txt
 
     - name: Store benchmark result (non-merge action only)
-      # Data from anything that is not a merge to mainline goes to a preliminary branch
-      if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+      # PRs go to a preliminary branch
+      if: github.event_name == 'pull_request'
       # Use gregtatum special feature to process ndjson-formatted benchmark data
       uses: gregtatum/github-action-benchmark@d3f06f738e9612988d575db23fae5ca0008d3d12
       with:
@@ -1160,7 +1159,7 @@ jobs:
 
     - name: Store benchmark result (non-merge action only)
       # Data from anything that is not a merge to mainline goes to a preliminary branch
-      if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+      if: github.event_name == 'pull_request'
       # Use gregtatum special feature to process ndjson-formatted benchmark data
       uses: gregtatum/github-action-benchmark@d3f06f738e9612988d575db23fae5ca0008d3d12
       with:


### PR DESCRIPTION
I recently added `schedule` and `workflow_dispatch` triggers to our CI

However, they fail these tasks since there is no commit information attached (`Error: No commit information is found in payload:`)

https://github.com/unicode-org/icu4x/actions/runs/3526067248/jobs/5913655023


My understanding is that these subtasks should only be run for PRs, so I tweaked them to do exactly that.

In the future we may want the nightly task to also upload to these dashboards, but I'll let Greg figure that out eventually.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->