### PR TITLE
Use rustup run instead of +nightly in ffi-coverage

### DIFF
--- a/ffi/diplomat/ffi_coverage/src/main.rs
+++ b/ffi/diplomat/ffi_coverage/src/main.rs
@@ -489,9 +489,11 @@ fn collect_public_types(krate: &str) -> impl Iterator<Item = (Vec<String>, ast::
 
         if CRATES.get(krate).is_none() {
             eprintln!("Parsing crate {krate}");
-            let output = std::process::Command::new("cargo")
+            let output = std::process::Command::new("rustup")
                 .args(&[
-                    "+nightly-2022-08-25",
+                    "run",
+                    "nightly-2022-08-25",
+                    "cargo",
                     "rustdoc",
                     "-p",
                     krate,


### PR DESCRIPTION
For whatever reason this doesn't work well on Windows. I think `cargo` is resolving to Actually Cargo (rather than the rustup shim) at least on @eggrobin's system





<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->