### PR TITLE
Derive `Clone` for `LocaleFallbackProvider`

### DIFF
--- a/provider/adapters/src/fallback/adapter.rs
+++ b/provider/adapters/src/fallback/adapter.rs
@@ -43,6 +43,7 @@ use crate::helpers::result_is_err_missing_data_options;
 ///     "こんにちは世界",
 /// );
 /// ```
+#[derive(Clone)]
 pub struct LocaleFallbackProvider<P> {
     inner: P,
     fallbacker: LocaleFallbacker,


### PR DESCRIPTION
Just a simple change to allow cloning `LocaleFallbackProvider`s wrapping data providers that are `Clone` (mainly `BlobDataProvider`).