### PR TITLE
Allow noncompact CompactDecimal

### DIFF
--- a/ffi/diplomat/ffi_coverage/tests/missing_apis.txt
+++ b/ffi/diplomat/ffi_coverage/tests/missing_apis.txt
@@ -1,5 +1,7 @@
 fixed_decimal::CompactDecimal#Struct
+fixed_decimal::CompactDecimal::exponent#FnInStruct
 fixed_decimal::CompactDecimal::from_str#FnInStruct
+fixed_decimal::CompactDecimal::into_significand#FnInStruct
 fixed_decimal::CompactDecimal::write_to#FnInStruct
 fixed_decimal::FixedInteger#Struct
 fixed_decimal::FixedInteger::from_str#FnInStruct

--- a/utils/fixed_decimal/src/compact.rs
+++ b/utils/fixed_decimal/src/compact.rs
@@ -30,7 +30,7 @@ impl CompactDecimal {
         self.significand
     }
 
-    pub fn exponent(self) -> i16 {
+    pub fn exponent(&self) -> i16 {
         self.exponent
     }
 }

--- a/utils/fixed_decimal/src/compact.rs
+++ b/utils/fixed_decimal/src/compact.rs
@@ -12,8 +12,10 @@ use crate::FixedDecimal;
 
 /// A struct containing a [`FixedDecimal`] significand together with an exponent, representing a
 /// number written in compact notation (such as 1.2M).
-/// This represents a _source number_ that uses compact decimal notation, as defined
+/// This represents a _source number_, as defined
 /// [in UTS #35](https://www.unicode.org/reports/tr35/tr35-numbers.html#Plural_rules_syntax).
+/// The value exponent=0 is used internally to represent a non-compact notation
+/// (such as 1 200 000).
 ///
 /// This is distinct from [`crate::ScientificDecimal`] because it does not represent leading 0s
 /// nor a sign in the exponent, and behaves differently in pluralization.
@@ -21,6 +23,16 @@ use crate::FixedDecimal;
 pub struct CompactDecimal {
     significand: FixedDecimal,
     exponent: i16,
+}
+
+impl CompactDecimal {
+    pub fn significand(self) -> FixedDecimal {
+        self.significand
+    }
+
+    pub fn exponent(self) -> i16 {
+        self.exponent
+    }
 }
 
 /// Render the [`CompactDecimal`] in sampleValue syntax.
@@ -34,12 +46,16 @@ pub struct CompactDecimal {
 /// # use writeable::assert_writeable_eq;
 /// #
 /// assert_writeable_eq!(CompactDecimal::from_str("+1.20c6").unwrap(), "+1.20c6");
+/// assert_writeable_eq!(CompactDecimal::from_str("+1729").unwrap(), "+1729");
 /// ```
 impl writeable::Writeable for CompactDecimal {
     fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
         self.significand.write_to(sink)?;
-        sink.write_char('c')?;
-        self.exponent.write_to(sink)
+        if self.exponent != 0 {
+            sink.write_char('c')?;
+            self.exponent.write_to(sink)?;
+        }
+        Ok(())
     }
 
     fn writeable_length_hint(&self) -> writeable::LengthHint {
@@ -65,37 +81,42 @@ impl TryFrom<&[u8]> for CompactDecimal {
         }
         let mut parts = input_str.split(|&c| c == b'c');
         let significand = FixedDecimal::try_from(parts.next().ok_or(Error::Syntax)?)?;
-        let exponent_str =
-            core::str::from_utf8(parts.next().ok_or(Error::Syntax)?).map_err(|_| Error::Syntax)?;
-        if parts.next().is_some() {
-            return Err(Error::Syntax);
+        match parts.next() {
+            None => Ok(CompactDecimal {
+                significand,
+                exponent: 0,
+            }),
+            Some(exponent_str) => {
+                let exponent_str = core::str::from_utf8(exponent_str).map_err(|_| Error::Syntax)?;
+                if parts.next().is_some() {
+                    return Err(Error::Syntax);
+                }
+                if exponent_str.is_empty()
+                    || exponent_str.bytes().next() == Some(b'0')
+                    || !exponent_str.bytes().all(|c| (b'0'..=b'9').contains(&c))
+                {
+                    return Err(Error::Syntax);
+                }
+                let exponent = exponent_str.parse().map_err(|_| Error::Limit)?;
+                Ok(CompactDecimal {
+                    significand,
+                    exponent,
+                })
+            }
         }
-        if exponent_str.is_empty()
-            || exponent_str.bytes().next() == Some(b'0')
-            || !exponent_str.bytes().all(|c| (b'0'..=b'9').contains(&c))
-        {
-            return Err(Error::Syntax);
-        }
-        let exponent = exponent_str.parse().map_err(|_| Error::Limit)?;
-        Ok(CompactDecimal {
-            significand,
-            exponent,
-        })
     }
 }
 
 #[test]
 fn test_compact_syntax_error() {
+    assert_eq!(CompactDecimal::from_str("+1729").unwrap().significand(), FixedDecimal::from_str("+1729").unwrap());
+    assert_eq!(format!("{}", CompactDecimal::from_str("+1729").unwrap()), "+1729");
     #[derive(Debug)]
     struct TestCase {
         pub input_str: &'static str,
         pub expected_err: Option<Error>,
     }
     let cases = [
-        TestCase {
-            input_str: "5",
-            expected_err: Some(Error::Syntax),
-        },
         TestCase {
             input_str: "-123e4",
             expected_err: Some(Error::Syntax),

--- a/utils/fixed_decimal/src/compact.rs
+++ b/utils/fixed_decimal/src/compact.rs
@@ -14,8 +14,8 @@ use crate::FixedDecimal;
 /// number written in compact notation (such as 1.2M).
 /// This represents a _source number_, as defined
 /// [in UTS #35](https://www.unicode.org/reports/tr35/tr35-numbers.html#Plural_rules_syntax).
-/// The value exponent=0 is used internally to represent a non-compact notation
-/// (such as 1 200 000).
+/// The value exponent=0 is used internally to represent a number in non-compact
+/// notation (such as 1 200 000).
 ///
 /// This is distinct from [`crate::ScientificDecimal`] because it does not represent leading 0s
 /// nor a sign in the exponent, and behaves differently in pluralization.

--- a/utils/fixed_decimal/src/compact.rs
+++ b/utils/fixed_decimal/src/compact.rs
@@ -26,10 +26,27 @@ pub struct CompactDecimal {
 }
 
 impl CompactDecimal {
+    /// Returns the significand of `self`.
+    /// ```
+    /// # use fixed_decimal::CompactDecimal;
+    /// # use fixed_decimal::FixedDecimal;
+    /// # use std::str::FromStr;
+    /// #
+    /// assert_eq!(CompactDecimal::from_str("+1.20c6").unwrap().into_significand(), FixedDecimal::from_str("+1.20").unwrap());
+    /// ```
     pub fn into_significand(self) -> FixedDecimal {
         self.significand
     }
 
+    /// Returns the exponent of `self`.
+    /// ```
+    /// # use fixed_decimal::CompactDecimal;
+    /// # use fixed_decimal::FixedDecimal;
+    /// # use std::str::FromStr;
+    /// #
+    /// assert_eq!(CompactDecimal::from_str("+1.20c6").unwrap().exponent(), 6);
+    /// assert_eq!(CompactDecimal::from_str("1729").unwrap().exponent(), 0);
+    /// ```
     pub fn exponent(&self) -> i16 {
         self.exponent
     }

--- a/utils/fixed_decimal/src/compact.rs
+++ b/utils/fixed_decimal/src/compact.rs
@@ -76,7 +76,11 @@ impl writeable::Writeable for CompactDecimal {
     }
 
     fn writeable_length_hint(&self) -> writeable::LengthHint {
-        self.significand.writeable_length_hint() + 1 + self.exponent.writeable_length_hint()
+        let mut result = self.significand.writeable_length_hint();
+        if self.exponent != 0 {
+            result += self.exponent.writeable_length_hint() + 1;
+        }
+        return result;
     }
 }
 

--- a/utils/fixed_decimal/src/compact.rs
+++ b/utils/fixed_decimal/src/compact.rs
@@ -14,7 +14,7 @@ use crate::FixedDecimal;
 /// number written in compact notation (such as 1.2M).
 /// This represents a _source number_, as defined
 /// [in UTS #35](https://www.unicode.org/reports/tr35/tr35-numbers.html#Plural_rules_syntax).
-/// The value exponent=0 is used internally to represent a number in non-compact
+/// The value exponent=0 represents a number in non-compact
 /// notation (such as 1 200 000).
 ///
 /// This is distinct from [`crate::ScientificDecimal`] because it does not represent leading 0s

--- a/utils/fixed_decimal/src/compact.rs
+++ b/utils/fixed_decimal/src/compact.rs
@@ -109,8 +109,6 @@ impl TryFrom<&[u8]> for CompactDecimal {
 
 #[test]
 fn test_compact_syntax_error() {
-    assert_eq!(CompactDecimal::from_str("+1729").unwrap().significand(), FixedDecimal::from_str("+1729").unwrap());
-    assert_eq!(format!("{}", CompactDecimal::from_str("+1729").unwrap()), "+1729");
     #[derive(Debug)]
     struct TestCase {
         pub input_str: &'static str,

--- a/utils/fixed_decimal/src/compact.rs
+++ b/utils/fixed_decimal/src/compact.rs
@@ -80,7 +80,7 @@ impl writeable::Writeable for CompactDecimal {
         if self.exponent != 0 {
             result += self.exponent.writeable_length_hint() + 1;
         }
-        return result;
+        result
     }
 }
 

--- a/utils/fixed_decimal/src/compact.rs
+++ b/utils/fixed_decimal/src/compact.rs
@@ -26,7 +26,7 @@ pub struct CompactDecimal {
 }
 
 impl CompactDecimal {
-    pub fn significand(self) -> FixedDecimal {
+    pub fn into_significand(self) -> FixedDecimal {
         self.significand
     }
 

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -329,9 +329,17 @@ macro_rules! assert_writeable_eq {
         assert_eq!(actual_str, $expected_str, $($arg)*);
         assert_eq!(actual_str, $crate::Writeable::write_to_string(actual_writeable), $($arg)+);
         let length_hint = $crate::Writeable::writeable_length_hint(actual_writeable);
-        assert!(length_hint.0 <= actual_str.len(), $($arg)*);
+        assert!(
+            length_hint.0 <= actual_str.len(),
+            "hint lower bound {} larger than actual length {}: {}",
+            length_hint.0, actual_str.len(), format!($($arg)*),
+        );
         if let Some(upper) = length_hint.1 {
-            assert!(actual_str.len() <= upper, $($arg)*);
+            assert!(
+                actual_str.len() <= upper,
+                "hint upper bound {} smaller than actual length {}: {}",
+                length_hint.0, actual_str.len(), format!($($arg)*),
+            );
         }
         assert_eq!(actual_writeable.to_string(), $expected_str);
     }};


### PR DESCRIPTION
As discussed with @sffc; towards https://github.com/unicode-org/icu4x/issues/1267.