### PR TITLE
Update actions/checkout in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -50,7 +50,7 @@ jobs:
       GCP_PROJECT_ID: "dev-infra-273822"
       GCP_BUCKET_ID: "icu4x-pr-artifacts"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
     - name: Authenticate to Google Cloud
@@ -81,7 +81,7 @@ jobs:
       GCP_PROJECT_ID: "dev-infra-273822"
       GCP_BUCKET_ID: "icu4x-pr-artifacts"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Authenticate to Google Cloud
       uses: google-github-actions/setup-gcloud@v0.2
       with:
@@ -128,7 +128,7 @@ jobs:
       GCP_PROJECT_ID: "dev-infra-273822"
       GCP_BUCKET_ID: "icu4x-pr-artifacts"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Authenticate to Google Cloud
       uses: google-github-actions/setup-gcloud@v0.2
@@ -200,7 +200,7 @@ jobs:
     #   run: |
     #     cp index.html /tmp/wasm-demo-index.html
     # - name: Checkout gh-pages
-    #   uses: actions/checkout@v2
+    #   uses: actions/checkout@v3
     #   with:
     #     ref: gh-pages
     # - name: Retrieve index.html

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -50,7 +50,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -95,7 +95,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -138,7 +138,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -192,7 +192,7 @@ jobs:
   test-docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
@@ -231,7 +231,7 @@ jobs:
   full-datagen:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -311,7 +311,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -380,7 +380,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
@@ -459,7 +459,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -526,7 +526,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
@@ -567,7 +567,7 @@ jobs:
     needs: [check]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
@@ -619,7 +619,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
@@ -663,7 +663,7 @@ jobs:
   tidy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
@@ -725,7 +725,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # We don't expect to keep being clippy-clean on nightly Rust,
     # so the "toolchain boilerplate" is deliberately omitted
@@ -769,7 +769,7 @@ jobs:
     needs: [check]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
@@ -916,7 +916,7 @@ jobs:
     needs: [check]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
@@ -1028,7 +1028,7 @@ jobs:
         type: [wasm, gz]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # Cargo-make boilerplate
     - name: Get cargo-make version
       id: cargo-make-version
@@ -1147,7 +1147,7 @@ jobs:
   datasize:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup output data directory
       run: |
@@ -1198,7 +1198,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show
@@ -1234,7 +1234,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Load the default Rust toolchain via the rust-toolchain file.
       run: rustup show

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on:                    ubuntu-latest
 
     steps:
-      - uses:                   actions/checkout@v2
+      - uses:                   actions/checkout@v3
 
       # TODO(#315) Re-include caching that also includes the Rust version in the cache key
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Updates the `actions/checkout` action used in the GitHub Actions workflow to its newest major version.

Changes in [actions/checkout](https://github.com/actions/checkout):

> ## v3.1.0
> - Use @actions/core `saveState` and `getState`
> - Add `github-server-url` input
>
> ## v3.0.2
> - Add input `set-safe-directory`
>
> ## v3.0.1
> - Fixed an issue where checkout failed to run in container jobs due to the new git setting `safe.directory`
> - Bumped various npm package versions
>
> ## v3.0.0
>
> - Update to node 16

Still using v2 of `actions/checkout` will generate some warning like in this run: https://github.com/unicode-org/icu4x/actions/runs/3761518854

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/cache@v2, actions-rs/cargo@v1.0.1

The PR will get rid of those warnings for `actions/checkout`, because v3 uses Node.js 16.