### PR TITLE
Update actions/upload-artifact in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1214,7 +1214,7 @@ jobs:
     - name: Upload doc data (merge to main only)
       # Only for PRs that merge into the ICU4X mainline.
       if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         path: target/doc/**
         name: doc

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -46,7 +46,7 @@ jobs:
 
       # Upload the results as artifacts (optional).
       - name: "Upload artifact"
-        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
+        uses: actions/upload-artifact@v3
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
Updates the `actions/upload-artifact` action used in the GitHub Actions workflow to its newest major version.

Changes in [actions/upload-artifact](https://github.com/actions/upload-artifact):

> ## v3.1.1
> - Update actions/core package to latest version to remove `set-output` deprecation warning
>
> ## v3.1.0
> - Bump @actions/artifact to v1.1.0
>   - Adds checksum headers on artifact upload
>
> ## v3.0.0
>
> - Update default runtime to node16
> - Update package-lock.json file version to 2

Still using v2 of `actions/upload-artifact` will generate some warning like in this run: https://github.com/unicode-org/icu4x/actions/runs/3780752478

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579, actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2, github/codeql-action/upload-sarif@5f532563584d71fdef14ee64d17bafb34f751ce5

The PR will get rid of those warnings for `actions/upload-artifact`, because v3 uses Node.js 16.