### PR TITLE
Add prove_covariance_manually guard for CoerceUnsized

### DIFF
--- a/utils/yoke/derive/src/lib.rs
+++ b/utils/yoke/derive/src/lib.rs
@@ -124,10 +124,13 @@ fn yokeable_derive_impl(input: &DeriveInput) -> TokenStream2 {
                         // `FieldTy<'static>: Yokeable<FieldTy<'a>>`
                         if has_lt {
                             let fty_a = replace_lifetime(&f.ty, custom_lt("'a"));
-                            yoke_bounds
-                                .push(parse_quote!(#fty_static: yoke::Yokeable<'a, Output = #fty_a>));
+                            yoke_bounds.push(
+                                parse_quote!(#fty_static: yoke::Yokeable<'a, Output = #fty_a>),
+                            );
                         } else {
-                            yoke_bounds.push(parse_quote!(#fty_static: yoke::Yokeable<'a, Output = #fty_static>));
+                            yoke_bounds.push(
+                                parse_quote!(#fty_static: yoke::Yokeable<'a, Output = #fty_static>),
+                            );
                         }
                     }
                     if has_ty || has_lt {


### PR DESCRIPTION
Fixes #2928


I'm not sure how best to test this since it relies on an unstable feature. I could simply add some kind of compile_fail test that alerts me when coerce_unsized stabilizes, or something. Or perhaps a separate folder with nightly tests. Thoughts?


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->