### PR TITLE
Treat strings starting with a decimal point as valid in FixedDecimal::from_str()

### DIFF
--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -2482,7 +2482,6 @@ fn test_from_str() {
             output_str: None,
             magnitudes: [1, 0, 0, -1],
         },
-
         // no leading 0 parsing
         TestCase {
             input_str: ".0123400",

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -2726,16 +2726,8 @@ fn test_syntax_error() {
             expected_err: Some(Error::Syntax),
         },
         TestCase {
-            input_str: "-.00123400",
-            expected_err: Some(Error::Syntax),
-        },
-        TestCase {
             input_str: "-0.00123400",
             expected_err: None,
-        },
-        TestCase {
-            input_str: ".00123400",
-            expected_err: Some(Error::Syntax),
         },
         TestCase {
             input_str: "00123400.",

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -2370,88 +2370,110 @@ fn test_from_str() {
     #[derive(Debug)]
     struct TestCase {
         pub input_str: &'static str,
+        /// The output str, None for roundtrip
+        pub output_str: Option<&'static str>,
         /// [upper magnitude, upper nonzero magnitude, lower nonzero magnitude, lower magnitude]
         pub magnitudes: [i16; 4],
     }
     let cases = [
         TestCase {
             input_str: "-00123400",
+            output_str: None,
             magnitudes: [7, 5, 2, 0],
         },
         TestCase {
             input_str: "+00123400",
+            output_str: None,
             magnitudes: [7, 5, 2, 0],
         },
         TestCase {
             input_str: "0.0123400",
+            output_str: None,
             magnitudes: [0, -2, -5, -7],
         },
         TestCase {
             input_str: "-00.123400",
+            output_str: None,
             magnitudes: [1, -1, -4, -6],
         },
         TestCase {
             input_str: "0012.3400",
+            output_str: None,
             magnitudes: [3, 1, -2, -4],
         },
         TestCase {
             input_str: "-0012340.0",
+            output_str: None,
             magnitudes: [6, 4, 1, -1],
         },
         TestCase {
             input_str: "1234",
+            output_str: None,
             magnitudes: [3, 3, 0, 0],
         },
         TestCase {
             input_str: "0.000000001",
+            output_str: None,
             magnitudes: [0, -9, -9, -9],
         },
         TestCase {
             input_str: "0.0000000010",
+            output_str: None,
             magnitudes: [0, -9, -9, -10],
         },
         TestCase {
             input_str: "1000000",
+            output_str: None,
             magnitudes: [6, 6, 6, 0],
         },
         TestCase {
             input_str: "10000001",
+            output_str: None,
             magnitudes: [7, 7, 0, 0],
         },
         TestCase {
             input_str: "123",
+            output_str: None,
             magnitudes: [2, 2, 0, 0],
         },
         TestCase {
             input_str: "922337203685477580898230948203840239384.9823094820384023938423424",
+            output_str: None,
             magnitudes: [38, 38, -25, -25],
         },
         TestCase {
             input_str: "009223372000.003685477580898230948203840239384000",
+            output_str: None,
             magnitudes: [11, 9, -33, -36],
         },
         TestCase {
             input_str: "-009223372000.003685477580898230948203840239384000",
+            output_str: None,
             magnitudes: [11, 9, -33, -36],
         },
         TestCase {
             input_str: "0",
+            output_str: None,
             magnitudes: [0, 0, 0, 0],
         },
         TestCase {
             input_str: "-0",
+            output_str: None,
             magnitudes: [0, 0, 0, 0],
         },
         TestCase {
             input_str: "+0",
+            output_str: None,
             magnitudes: [0, 0, 0, 0],
         },
         TestCase {
             input_str: "000",
+            output_str: None,
             magnitudes: [2, 0, 0, 0],
         },
         TestCase {
             input_str: "-00.0",
+            output_str: None,
             magnitudes: [1, 0, 0, -1],
         },
     ];
@@ -2466,7 +2488,8 @@ fn test_from_str() {
         assert_eq!(fd.nonzero_magnitude_start(), cas.magnitudes[1], "{:?}", cas);
         assert_eq!(fd.nonzero_magnitude_end(), cas.magnitudes[2], "{:?}", cas);
         let input_str_roundtrip = fd.to_string();
-        assert_eq!(cas.input_str, input_str_roundtrip, "{:?}", cas);
+        let output_str = cas.output_str.unwrap_or(cas.input_str);
+        assert_eq!(output_str, input_str_roundtrip, "{:?}", cas);
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

Fixes https://github.com/unicode-org/icu4x/issues/2739