### PR TITLE
Update actions/download-artifact in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1248,7 +1248,7 @@ jobs:
 
     # Doc-GH-Pages job > Download docs files from previous jobs into folder of files to copy to remote repo
     - name: Download previous content destined for GH pages
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         path: doc
         name: doc


### PR DESCRIPTION
Updates the `actions/download-artifact` action used in the GitHub Actions workflow to its newest major version.

Changes in [actions/download-artifact](https://github.com/actions/download-artifact):

> ## v3.0.1
> - Bump @actions/core to 1.10.0
> - Update actions/core package to latest version to remove `set-output` deprecation warning
>
> ## v3.0.0
>
> - Update default runtime to node16
> - Update package-lock.json file version to 2

Still using v2 of `actions/download-artifact` will generate some warning like in this run: https://github.com/unicode-org/icu4x/actions/runs/3799125745

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/download-artifact@v2, peaceiris/actions-gh-pages@v3.7.0

The PR will get rid of those warnings for `actions/download-artifact`, because v3 uses Node.js 16.