### PR TITLE
Update robinraju/release-downloader in GitHub Actions workflows to v1.7

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -271,7 +271,7 @@ jobs:
         key: source-data/cldr-42/icuexport_release-72-1
     - name: Download CLDR source data
       if: steps.source-data-cache.outputs.cache-hit != 'true'
-      uses: robinraju/release-downloader@v1.3
+      uses: robinraju/release-downloader@v1.7
       with: 
         repository: "unicode-org/cldr-json"
         tag: "42.0.0"
@@ -279,7 +279,7 @@ jobs:
         out-file-path: "data/source/"
     - name: Download ICU source data
       if: steps.source-data-cache.outputs.cache-hit != 'true'
-      uses: robinraju/release-downloader@v1.3
+      uses: robinraju/release-downloader@v1.7
       with: 
         repository: "unicode-org/icu"
         tag: "release-72-1"


### PR DESCRIPTION
Updates the `robinraju/release-downloader` action used in the GitHub Actions workflow to its newest minor version.

A complete list of changes in [robinraju/release-downloader](https://github.com/robinraju/release-downloader) would be to long, mainly because of the numerous dependency updates in v1.4 and v1.5. So for the full list of changes see https://github.com/robinraju/release-downloader/releases instead.