### PR TITLE
Update peaceiris/actions-gh-pages in GitHub Actions workflow to v3.9.0

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1278,7 +1278,7 @@ jobs:
     # Doc-GH-Pages job > Copy docs (+ bench dashboard HTML) to remote docs repo's GH pages branch step
 
     - name: Doc -> Github Pages
-      uses: peaceiris/actions-gh-pages@v3.7.0
+      uses: peaceiris/actions-gh-pages@v3.9.0
       with:
         # Setup for publishing to an external repo using `deploy_key` option:
         #


### PR DESCRIPTION
Updates the `peaceiris/actions-gh-pages` action used in the GitHub Actions workflow to its newest version.

Changes in [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages/releases):

> ## v3.9.0
> - deps: bump node12 to node16
> - deps: bump @actions/core from 1.6.0 to 1.10.0

For other versions see [the changelog](https://github.com/peaceiris/actions-gh-pages/blob/v3.9.0/CHANGELOG.md).

Still using v3.7.0 of `peaceiris/actions-gh-pages` will generate some warning like in this run: https://github.com/unicode-org/icu4x/actions/runs/3799125745

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/download-artifact@v2, peaceiris/actions-gh-pages@v3.7.0

The PR will get rid of those warnings for `peaceiris/actions-gh-pages`, because v3.9.0 uses Node.js 16.