### PR TITLE
Update rhysd/github-action-benchmark in GHA workflows to v1.15.0

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -830,7 +830,7 @@ jobs:
 
     - name: Store benchmark result & create dashboard (unmerged PR only)
       if: github.event_name == 'pull_request'
-      uses: rhysd/github-action-benchmark@v1.8.1
+      uses: rhysd/github-action-benchmark@v1.15.0
       with:
         name: Rust Benchmark
         tool: 'cargo'
@@ -850,7 +850,7 @@ jobs:
     - name: Store benchmark result & create dashboard (merge to main only)
       # only merges to main (implies PR is finished and approved by this point)
       if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
-      uses: rhysd/github-action-benchmark@v1.8.1
+      uses: rhysd/github-action-benchmark@v1.15.0
       with:
         name: Rust Benchmark
         tool: 'cargo'


### PR DESCRIPTION
Updates the `rhysd/github-action-benchmarkt` action used in the GitHub Actions workflow to its newest major version.

Changes in [rhysd/github-action-benchmark](https://github.com/rhysd/github-action-benchmark/releases):


> # [v1.15.0](https://github.com/benchmark-action/github-action-benchmark/releases/tag/v1.15.0) - 03 Nov 2022
> 
> - **Feat** Add support for Java via JMH
> - **Chore** Update @actions/core, @actions/exec and @actions/io to the latest version
> 
> # [v1.14.0](https://github.com/benchmark-action/github-action-benchmark/releases/tag/v1.14.0) - 28 May 2022
> 
> - **Feat** Added benchmark luau support
> - **Chore** Bump minimist from 1.2.5 to 1.2.6
> - **Feat** Implement deploy to another repository
> 
> # [v1.13.0](https://github.com/benchmark-action/github-action-benchmark/releases/tag/v1.13.0) - 17 Feb 2022
> 
> - **Feat:** Updated urls to support GHES
> - **Feat:** Add support for BenchmarkDotNet
> - **Chore** Bump node-fetch from 2.6.6 to 2.6.7
> 
> # [v1.12.0](https://github.com/benchmark-action/github-action-benchmark/releases/tag/v1.12.0) - 28 Jan 2022
> 
> - **Feat:** Support private repositories
> - **Chore** Bump action runner to node v16
> 
> # [v1.11.3](https://github.com/benchmark-action/github-action-benchmark/releases/tag/v1.11.3) - 31 Dec 2021
> 
> - **Fix:** Fix trailing whitespace characters in cargo benchmarks
> 
> # [v1.11.2](https://github.com/benchmark-action/github-action-benchmark/releases/tag/v1.11.2) - 28 Dec 2021
> 
> - **Fix:** Added option to use Rust benchmark names with spaces
>
> # [v1.11.1](https://github.com/benchmark-action/github-action-benchmark/releases/tag/v1.11.1) - 04 Dec 2021
> 
> - **Fix:** Fix/go tabled benchmarks
> - **New:** Support BenchmarkTools.jl in Julia
> - **Improve:** Update several dependencies including TypeScript v4.5.2
> - **Improve:** Use [Jest](https://jestjs.io/) for unit testing
> 
> # [v1.10.0](https://github.com/benchmark-action/github-action-benchmark/releases/tag/v1.10.0) - 28 Oct 2021
> 
> - **New:** Allow user defined custom benchmarks
> 
> # [v1.9.0](https://github.com/benchmark-action/github-action-benchmark/releases/tag/v1.9.0) - 12 Oct 2021
> 
> - **Fix:** manual and scheduled runs

Still using v1.8.1 of `rhysd/github-action-benchmark` will generate some warning like in this run: https://github.com/unicode-org/icu4x/actions/runs/3805074588

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: rhysd/github-action-benchmark@v1.8.1

The PR will get rid of those warnings for `rhysd/github-action-benchmark`, because v1.15.0 uses Node.js 16.