### PR TITLE
Update codecov/codecov-action in GitHub Actions workflow to v3

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -68,7 +68,7 @@ jobs:
           path-to-lcov:         ${{ steps.coverage.outputs.report }}
 
       - name:                   Push grcov results to Codecov via GitHub Action
-        uses:                   codecov/codecov-action@v1
+        uses:                   codecov/codecov-action@v3
         with:
           file:                 ${{ steps.coverage.outputs.report }}
           fail_ci_if_error:     true


### PR DESCRIPTION
Updates the `codecov/codecov-action action used in the GitHub Actions workflow to its newest major version.

Changes in [codecov/codecov-action](https://github.com/codecov/codecov-action/releases):

A complete list of changes in [codecov/codecov-action](https://github.com/codecov/codecov-action) would be to long, mainly because of the numerous dependency updates. So for the full list of changes see https://github.com/codecov/codecov-action/releases instead. As far as I can see on first glance, there are no breaking changes that would affect this repository, but let's wait for the CI to pass.

Still using v1 of `codecov/codecov-action` will generate some warning like in this run: https://github.com/unicode-org/icu4x/actions/runs/3808726032

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1, actions-rs/cargo@v1, actions-rs/grcov@v0.1, coverallsapp/github-action@v1.0.1, codecov/codecov-action@v1

The PR will get rid of those warnings for `codecov/codecov-action`, because v3 uses Node.js 16.