### PR TITLE
Running `full-data` in release mode

### DIFF
--- a/ffi/diplomat/c/examples/fixeddecimal_tiny/Makefile
+++ b/ffi/diplomat/c/examples/fixeddecimal_tiny/Makefile
@@ -30,7 +30,7 @@ icu_capi_staticlib_tiny/target/x86_64-unknown-linux-gnu/release-opt-size/libicu_
 	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" cargo +${ICU4X_NIGHTLY_TOOLCHAIN} panic-abort-build --target x86_64-unknown-linux-gnu --profile=release-opt-size
 
 decimal-bn-en.postcard:
-	cargo run --bin icu4x-datagen --features bin -- --locales en bn --keys "decimal/symbols@1" --cldr-root ../../../../../provider/testdata/data/cldr/ --format blob --out decimal-bn-en.postcard
+	cargo run --manifest-path ../../../../../provider/datagen/Cargo.toml --features bin -- --locales en bn --keys "decimal/symbols@1" --cldr-root ../../../../../provider/testdata/data/cldr/ --format blob --out decimal-bn-en.postcard
 
 decimal_bn_en.h: decimal-bn-en.postcard
 	xxd -i -C decimal-bn-en.postcard > decimal_bn_en.h

--- a/ffi/diplomat/c/examples/fixeddecimal_tiny/Makefile
+++ b/ffi/diplomat/c/examples/fixeddecimal_tiny/Makefile
@@ -30,7 +30,7 @@ icu_capi_staticlib_tiny/target/x86_64-unknown-linux-gnu/release-opt-size/libicu_
 	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" cargo +${ICU4X_NIGHTLY_TOOLCHAIN} panic-abort-build --target x86_64-unknown-linux-gnu --profile=release-opt-size
 
 decimal-bn-en.postcard:
-	cargo run -p icu_datagen --features bin -- --locales en bn --keys "decimal/symbols@1" --cldr-root ../../../../../provider/testdata/data/cldr/ --format blob --out decimal-bn-en.postcard
+	cargo run --bin icu4x-datagen --features bin -- --locales en bn --keys "decimal/symbols@1" --cldr-root ../../../../../provider/testdata/data/cldr/ --format blob --out decimal-bn-en.postcard
 
 decimal_bn_en.h: decimal-bn-en.postcard
 	xxd -i -C decimal-bn-en.postcard > decimal_bn_en.h

--- a/ffi/diplomat/c/examples/fixeddecimal_tiny/icu_capi_staticlib_tiny/Cargo.lock
+++ b/ffi/diplomat/c/examples/fixeddecimal_tiny/icu_capi_staticlib_tiny/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "icu_collator"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -338,7 +338,6 @@ dependencies = [
  "icu_locid",
  "icu_provider",
  "serde",
- "serde_json",
  "utf8_iter",
  "zerovec",
 ]
@@ -381,12 +380,6 @@ dependencies = [
  "tinystr",
  "zerovec",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "lazy_static"
@@ -486,17 +479,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]

--- a/ffi/diplomat/js/examples/node/build.sh
+++ b/ffi/diplomat/js/examples/node/build.sh
@@ -25,7 +25,7 @@ RUSTFLAGS="-Cpanic=abort -Copt-level=s -C link-args=-zstack-size=${WASM_STACK_SI
 # Cache postcard data so as not to regen whenever blowing away `lib/`
 if ! test -f "full-data-cached.postcard"; then
     # Regen all data
-    cargo run -p icu_datagen --features=bin,experimental -- \
+    cargo run --bin icu4x-datagen --features=bin,experimental --release -- \
         --all-locales \
         --all-keys \
         --cldr-tag 42.0.0 \

--- a/ffi/diplomat/js/examples/node/build.sh
+++ b/ffi/diplomat/js/examples/node/build.sh
@@ -25,7 +25,9 @@ RUSTFLAGS="-Cpanic=abort -Copt-level=s -C link-args=-zstack-size=${WASM_STACK_SI
 # Cache postcard data so as not to regen whenever blowing away `lib/`
 if ! test -f "full-data-cached.postcard"; then
     # Regen all data
-    cargo run --bin icu4x-datagen --features=bin,experimental --release -- \
+    cargo run  --manifest-path ../../../../../provider/datagen/Cargo.toml \
+        --features=bin,experimental \
+        --release -- \
         --all-locales \
         --all-keys \
         --cldr-tag 42.0.0 \

--- a/tools/scripts/data.toml
+++ b/tools/scripts/data.toml
@@ -122,7 +122,7 @@ category = "ICU4X Data"
 command = "cargo"
 args = [
     "run",
-    "-bin=icu4x-datagen",
+    "--bin=icu4x-datagen",
     "--features=bin",
     "--release",
     "--",

--- a/tools/scripts/data.toml
+++ b/tools/scripts/data.toml
@@ -122,9 +122,9 @@ category = "ICU4X Data"
 command = "cargo"
 args = [
     "run",
-    "-p",
-    "icu_datagen",
+    "-bin=icu4x-datagen",
     "--features=bin",
+    "--release",
     "--",
     "--cldr-tag=latest",
     "--icuexport-tag=latest",


### PR DESCRIPTION
It's faster:
```
release initial:
real    2m54.109s
user    12m53.818s
sys     1m2.936s

release again:
real    0m2.163s
user    0m4.431s
sys     0m0.422s

debug initial:
real    5m8.120s
user    13m25.818s
sys     1m9.403s

debug again:
real    4m10.702s
user    5m32.642s
sys     0m1.253s
```