### PR TITLE
Add mutation methods to MultiForkByErrorProvider

### DIFF
--- a/provider/adapters/src/fork/by_error.rs
+++ b/provider/adapters/src/fork/by_error.rs
@@ -142,9 +142,19 @@ impl<P, F> MultiForkByErrorProvider<P, F> {
         &self.providers
     }
 
+    /// Returns a mutable reference to the inner vector of providers.
+    pub fn inner_mut(&mut self) -> &mut Vec<P> {
+        &mut self.providers
+    }
+
     /// Returns ownership of the inner providers to the caller.
     pub fn into_inner(self) -> Vec<P> {
         self.providers
+    }
+
+    /// Adds an additional child provider.
+    pub fn push(&mut self, provider: P) {
+        self.providers.push(provider);
     }
 }
 


### PR DESCRIPTION
It will make https://github.com/unicode-org/icu4x/issues/2970 a little bit easier to implement.