### PR TITLE
Fix cargo check --all-targets --no-default-features

### DIFF
--- a/components/datetime/benches/datetime.rs
+++ b/components/datetime/benches/datetime.rs
@@ -11,8 +11,10 @@ use icu_calendar::{DateTime, Gregorian};
 use icu_datetime::TypedDateTimeFormatter;
 use icu_datetime::{time_zone::TimeZoneFormatterOptions, TypedZonedDateTimeFormatter};
 use icu_locid::Locale;
-use icu_provider::AsDeserializingBufferProvider;
 use icu_timezone::CustomTimeZone;
+
+#[cfg(feature = "experimental")]
+use icu_provider::AsDeserializingBufferProvider;
 
 #[path = "../tests/mock.rs"]
 mod mock;

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -145,7 +145,7 @@ impl Bag {
     /// Converts the components::Bag into a Vec<Field>. The fields will be ordered in from most
     /// significant field to least significant. This is the order the fields are listed in
     /// the UTS 35 table - https://unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
-    #[cfg(feature = "experimental")] // only used in experimental code
+    #[cfg(any(test, feature = "experimental"))] // only used in test and experimental code
     pub(crate) fn to_vec_fields(&self) -> Vec<Field> {
         let mut fields = Vec::new();
         if let Some(era) = self.era {


### PR DESCRIPTION
Seems we don't run this exact check command in CI. cargo-all-features doesn't build tests