### PR TITLE
Installing `grcov` on stable

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - uses:                   actions/checkout@v3
 
-      # TODO(#315) Re-include caching that also includes the Rust version in the cache key
-
       ## Coverage steps
 
       - name: Get grcov version
@@ -38,10 +36,8 @@ jobs:
           key: ${{ runner.os }}-make-${{ steps.grcov-version.outputs.hash }}
       - name: Install grcov
         if: steps.grcov-cache.outputs.cache-hit != 'true'
-        uses: actions-rs/install@v0.1.2
-        with:
-          crate: grcov
-          version: latest
+        run: |
+          cargo +stable install grcov
   
       - uses:                   actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
Doesn't build on our pinned toolchain anymore