### PR TITLE
Add `std` feature and Error impl for `TinyStrError`

### DIFF
--- a/utils/tinystr/Cargo.toml
+++ b/utils/tinystr/Cargo.toml
@@ -44,6 +44,7 @@ tinystr_old = { version = "0.4", package = "tinystr", features = ["serde"] }
 default = ["alloc"]
 alloc = []
 bench = []
+std = []
 
 [package.metadata.cargo-all-features]
 # Bench feature gets tested separately and is only relevant for CI

--- a/utils/tinystr/src/error.rs
+++ b/utils/tinystr/src/error.rs
@@ -4,6 +4,9 @@
 
 use displaydoc::Display;
 
+#[cfg(feature = "std")]
+impl std::error::Error for TinyStrError {}
+
 #[derive(Display, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum TinyStrError {

--- a/utils/tinystr/src/lib.rs
+++ b/utils/tinystr/src/lib.rs
@@ -52,7 +52,7 @@
 //! [`ICU4X`]: ../icu/index.html
 
 // https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
     not(test),
     deny(


### PR DESCRIPTION
Fixes: #3007

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->