### PR TITLE
Fix allow attribute in test_bake macro

### DIFF
--- a/utils/databake/src/lib.rs
+++ b/utils/databake/src/lib.rs
@@ -179,7 +179,7 @@ macro_rules! test_bake {
         )?
         assert_eq!(bake, expected_bake);
 
-        #[allow(unused_variable)]
+        #[allow(unused_variables)]
         let _env = env.into_iter().collect::<std::collections::HashSet<_>>();
         $(
             assert!(_env.contains(stringify!($krate)), "Crate {:?} was not added to the CrateEnv", stringify!($krate));


### PR DESCRIPTION
Without this patch, running `cargo +nightly check --all-features --all-targets` locally generates the following warning.

```
warning: unknown lint: `unused_variable`
```