### PR TITLE
Using `core` integer log when available

### DIFF
--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -7,12 +7,12 @@ use alloc::borrow::Cow;
 use core::fmt;
 
 macro_rules! impl_write_num {
-    ($u:ty, $i:ty, $test:ident, $log10:ident) => {
+    ($u:ty, $i:ty, $test:ident, $max_ilog_10:expr) => {
         impl $crate::Writeable for $u {
             fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
-                let mut buf = [b'0'; $log10(<$u>::MAX) as usize + 1];
+                let mut buf = [b'0'; $max_ilog_10 + 1];
                 let mut n = *self;
-                let mut i = buf.len();
+                let mut i = $max_ilog_10 + 1;
                 #[allow(clippy::indexing_slicing)] // n < 10^i
                 while n != 0 {
                     i -= 1;
@@ -29,40 +29,38 @@ macro_rules! impl_write_num {
             }
 
             fn writeable_length_hint(&self) -> $crate::LengthHint {
-                $crate::LengthHint::exact(if *self == 0 {
-                    1
-                } else {
-                    $log10(*self) as usize + 1
-                })
+                LengthHint::exact(self.checked_ilog10().unwrap_or(0) as usize + 1)
             }
         }
 
-        // TODO: use the library functions once stabilized.
-        // https://github.com/unicode-org/icu4x/issues/1428
-        #[inline]
-        const fn $log10(s: $u) -> u32 {
-            let b = (<$u>::BITS - 1) - s.leading_zeros();
-            // s ∈ [2ᵇ, 2ᵇ⁺¹-1] => ⌊log₁₀(s)⌋ ∈ [⌊log₁₀(2ᵇ)⌋, ⌊log₁₀(2ᵇ⁺¹-1)⌋]
-            //                 <=> ⌊log₁₀(s)⌋ ∈ [⌊log₁₀(2ᵇ)⌋, ⌊log₁₀(2ᵇ⁺¹)⌋]
-            //                 <=> ⌊log₁₀(s)⌋ ∈ [⌊b log₁₀(2)⌋, ⌊(b+1) log₁₀(2)⌋]
-            // The second line holds because there is no integer in
-            // [log₁₀(2ᶜ-1), log₁₀(2ᶜ)], if there were, there'd be some 10ⁿ in
-            // [2ᶜ-1, 2ᶜ], but it can't be 2ᶜ-1 due to parity nor 2ᶜ due to prime
-            // factors.
+        impl ILog10Ext for $u {
+            fn checked_ilog10(self) -> Option<u32> {
+                if self == 0 {
+                    return None;
+                }
+                let b = (<$u>::BITS - 1) - self.leading_zeros();
+                // self ∈ [2ᵇ, 2ᵇ⁺¹-1] => ⌊log₁₀(self)⌋ ∈ [⌊log₁₀(2ᵇ)⌋, ⌊log₁₀(2ᵇ⁺¹-1)⌋]
+                //                    <=> ⌊log₁₀(self)⌋ ∈ [⌊log₁₀(2ᵇ)⌋, ⌊log₁₀(2ᵇ⁺¹)⌋]
+                //                    <=> ⌊log₁₀(self)⌋ ∈ [⌊b log₁₀(2)⌋, ⌊(b+1) log₁₀(2)⌋]
+                // The second line holds because there is no integer in
+                // [log₁₀(2ᶜ-1), log₁₀(2ᶜ)], if there were, there'd be some 10ⁿ in
+                // [2ᶜ-1, 2ᶜ], but it can't be 2ᶜ-1 due to parity nor 2ᶜ due to prime
+                // factors.
 
-            const M: u32 = (core::f64::consts::LOG10_2 * (1 << 26) as f64) as u32;
-            let low = (b * M) >> 26;
-            let high = ((b + 1) * M) >> 26;
+                const M: u32 = (core::f64::consts::LOG10_2 * (1 << 26) as f64) as u32;
+                let low = (b * M) >> 26;
+                let high = ((b + 1) * M) >> 26;
 
-            // If the bounds aren't tight (e.g. 87 ∈ [64, 127] ⟹ ⌊log₁₀(87)⌋ ∈ [1,2]),
-            // compare to 10ʰ (100). This shouldn't happen too often as there are more
-            // powers of 2 than 10 (it happens for 14% of u32s).
-            if high == low {
-                low
-            } else if s < (10 as $u).pow(high) {
-                low
-            } else {
-                high
+                // If the bounds aren't tight (e.g. 87 ∈ [64, 127] ⟹ ⌊log₁₀(87)⌋ ∈ [1,2]),
+                // compare to 10ʰ (100). This shouldn't happen too often as there are more
+                // powers of 2 than 10 (it happens for 14% of u32s).
+                Some(if high == low {
+                    low
+                } else if self < (10 as $u).pow(high) {
+                    low
+                } else {
+                    high
+                })
             }
         }
 
@@ -84,11 +82,14 @@ macro_rules! impl_write_num {
         fn $test() {
             use $crate::assert_writeable_eq;
             assert_writeable_eq!(&(0 as $u), "0");
-            assert_writeable_eq!(&(0 as $u), "0");
+            assert_writeable_eq!(&(0 as $i), "0");
             assert_writeable_eq!(&(-0 as $i), "0");
             assert_writeable_eq!(&(1 as $u), "1");
             assert_writeable_eq!(&(1 as $i), "1");
             assert_writeable_eq!(&(-1 as $i), "-1");
+            assert_writeable_eq!(&(9 as $u), "9");
+            assert_writeable_eq!(&(9 as $i), "9");
+            assert_writeable_eq!(&(-9 as $i), "-9");
             assert_writeable_eq!(&(10 as $u), "10");
             assert_writeable_eq!(&(10 as $i), "10");
             assert_writeable_eq!(&(-10 as $i), "-10");
@@ -112,19 +113,23 @@ macro_rules! impl_write_num {
     };
 }
 
-impl_write_num!(u8, i8, test_u8, log10_u8);
-impl_write_num!(u16, i16, test_u16, log10_u16);
-impl_write_num!(u32, i32, test_u32, log10_u32);
-impl_write_num!(u64, i64, test_u64, log10_u64);
-impl_write_num!(u128, i128, test_u128, log10_u128);
-impl_write_num!(usize, isize, test_usize, log10_usize);
-
-#[test]
-fn assert_log10_approximation() {
-    for i in 1..u128::BITS {
-        assert_eq!(i * 59 / 196, 2f64.powf(i.into()).log10().floor() as u32);
-    }
+/// `checked_ilog10` is added as a method on integer types in 1.67.
+/// This extension trait provides it for older compilers.
+trait ILog10Ext: Sized {
+    fn checked_ilog10(self) -> Option<u32>;
 }
+
+impl_write_num!(u8, i8, test_u8, 2);
+impl_write_num!(u16, i16, test_u16, 4);
+impl_write_num!(u32, i32, test_u32, 9);
+impl_write_num!(u64, i64, test_u64, 19);
+impl_write_num!(u128, i128, test_u128, 38);
+impl_write_num!(
+    usize,
+    isize,
+    test_usize,
+    if usize::MAX as u64 == u64::MAX { 19 } else { 9 }
+);
 
 impl Writeable for str {
     #[inline]


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->