### PR TITLE
Removing `slice::from_raw_parts` canaries

### DIFF
--- a/provider/core/src/key.rs
+++ b/provider/core/src/key.rs
@@ -140,12 +140,6 @@ impl DataKeyPath {
     /// Gets the path as a static string slice.
     #[inline]
     pub const fn get(self) -> &'static str {
-        /// core::slice::from_raw_parts(a, b) = core::mem::transmute((a, b)) hack
-        /// ```compile_fail
-        /// const unsafe fn canary() { core::slice::from_raw_parts(0 as *const u8, 0); }
-        /// ```
-        #[cfg(not(ICU4X_BUILDING_WITH_FORCED_NIGHTLY))]
-        const _: () = ();
         unsafe {
             // Safe due to invariant that self.path is tagged correctly
             core::str::from_utf8_unchecked(core::mem::transmute((

--- a/utils/tinystr/src/ascii.rs
+++ b/utils/tinystr/src/ascii.rs
@@ -138,12 +138,6 @@ impl<const N: usize> TinyAsciiStr<N> {
     #[inline]
     #[must_use]
     pub const fn as_bytes(&self) -> &[u8] {
-        /// core::slice::from_raw_parts(a, b) = core::mem::transmute((a, b)) hack
-        /// ```compile_fail
-        /// const unsafe fn canary() { core::slice::from_raw_parts(0 as *const u8, 0); }
-        /// ```
-        #[cfg(not(ICU4X_BUILDING_WITH_FORCED_NIGHTLY))]
-        const _: () = ();
         // Safe because `self.bytes.as_slice()` pointer-casts to `&[u8]`,
         // and changing the length of that slice to self.len() < N is safe.
         unsafe { core::mem::transmute((self.bytes.as_slice().as_ptr(), self.len())) }

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -7,10 +7,7 @@
 
 use super::*;
 use crate::ZeroSlice;
-use core::{
-    mem,
-    num::{NonZeroI8, NonZeroU8},
-};
+use core::num::{NonZeroI8, NonZeroU8};
 
 /// A u8 array of little-endian data with infallible conversions to and from &[u8].
 #[repr(transparent)]
@@ -97,25 +94,10 @@ macro_rules! impl_const_constructors {
             ///
             /// See [`ZeroSlice::cast()`] for an example.
             pub const fn try_from_bytes(bytes: &[u8]) -> Result<&Self, ZeroVecError> {
-                /// core::slice::from_raw_parts(a, b) = core::mem::transmute((a, b)) hack
-                /// ```compile_fail
-                /// const unsafe fn canary() { core::slice::from_raw_parts(0 as *const u8, 0); }
-                /// ```
-                #[cfg(not(ICU4X_BUILDING_WITH_FORCED_NIGHTLY))]
-                const _: () = ();
                 let len = bytes.len();
                 #[allow(clippy::modulo_one)]
                 if len % $size == 0 {
-                    unsafe {
-                        // Most of the slice manipulation functions are not yet const-stable,
-                        // so we construct a slice with the right metadata and cast its type
-                        // https://rust-lang.github.io/unsafe-code-guidelines/layout/pointers.html#notes
-                        //
-                        // Safety:
-                        // * [u8] and [RawBytesULE<N>] have different lengths but the same alignment
-                        // * ZeroSlice<$base> is repr(transparent) with [RawBytesULE<N>]
-                        Ok(mem::transmute((bytes.as_ptr(), len / $size)))
-                    }
+                    Ok(unsafe { Self::from_bytes_unchecked(bytes) })
                 } else {
                     Err(ZeroVecError::InvalidLength {
                         ty: concat!("<const construct: ", $size, ">"),

--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -352,12 +352,6 @@ where
     /// `bytes` need to be an output from [`ZeroSlice::as_bytes()`].
     pub const unsafe fn from_bytes_unchecked(bytes: &'a [u8]) -> Self {
         // &[u8] and &[T::ULE] are the same slice with different length metadata.
-        /// core::slice::from_raw_parts(a, b) = core::mem::transmute((a, b)) hack
-        /// ```compile_fail
-        /// const unsafe fn canary() { core::slice::from_raw_parts(0 as *const u8, 0); }
-        /// ```
-        #[cfg(not(ICU4X_BUILDING_WITH_FORCED_NIGHTLY))]
-        const _: () = ();
         Self::new_borrowed(core::mem::transmute((
             bytes.as_ptr(),
             bytes.len() / core::mem::size_of::<T::ULE>(),

--- a/utils/zerovec/src/zerovec/slice.rs
+++ b/utils/zerovec/src/zerovec/slice.rs
@@ -65,13 +65,10 @@ where
     /// `bytes` need to be an output from [`ZeroSlice::as_bytes()`].
     pub const unsafe fn from_bytes_unchecked(bytes: &[u8]) -> &Self {
         // &[u8] and &[T::ULE] are the same slice with different length metadata.
-        /// core::slice::from_raw_parts(a, b) = core::mem::transmute((a, b)) hack
-        /// ```compile_fail
-        /// const unsafe fn canary() { core::slice::from_raw_parts(0 as *const u8, 0); }
-        /// ```
-        #[cfg(not(ICU4X_BUILDING_WITH_FORCED_NIGHTLY))]
-        const _: () = ();
-        core::mem::transmute((bytes.as_ptr(), bytes.len() / core::mem::size_of::<T::ULE>()))
+        Self::from_ule_slice(core::mem::transmute((
+            bytes.as_ptr(),
+            bytes.len() / core::mem::size_of::<T::ULE>(),
+        )))
     }
 
     /// Construct a `&ZeroSlice<T>` from a slice of ULEs.


### PR DESCRIPTION
Part of #2873

These are blocking toolchain updates. I've created a clippy lint that's MSRV aware instead (https://github.com/rust-lang/rust-clippy/pull/10223).