### PR TITLE
Update yoke to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4375,7 +4375,7 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "bincode",
  "serde",
@@ -4386,7 +4386,7 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/components/collections/Cargo.toml
+++ b/components/collections/Cargo.toml
@@ -28,7 +28,7 @@ all-features = true
 
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
-yoke = { version = "0.6.0", path = "../../utils/yoke", features = ["derive"] }
+yoke = { version = "0.7.0", path = "../../utils/yoke", features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../../utils/zerofrom", features = ["derive"] }
 zerovec = { version = "0.9", path = "../../utils/zerovec", features = ["yoke"] }
 

--- a/experimental/casemapping/Cargo.toml
+++ b/experimental/casemapping/Cargo.toml
@@ -30,7 +30,7 @@ displaydoc = { version = "0.2.3", default-features = false }
 icu_collections = { version = "1.0.0", path = "../../components/collections" }
 icu_locid = { version = "1.0.0", path = "../../components/locid" }
 icu_provider = { version = "1.0.0", path = "../../provider/core", features = ["macros"] }
-yoke = { version = "0.6.0", path = "../../utils/yoke", features = ["derive"] }
+yoke = { version = "0.7.0", path = "../../utils/yoke", features = ["derive"] }
 zerovec = { version = "0.9", path = "../../utils/zerovec", features = ["yoke"] }
 
 databake = { version = "0.1.0", path = "../../utils/databake", features = ["derive"], optional = true}

--- a/provider/adapters/Cargo.toml
+++ b/provider/adapters/Cargo.toml
@@ -27,7 +27,7 @@ include = [
 icu_locid = { version = "1.0.0", path = "../../components/locid", features = ["zerovec"] }
 icu_provider = { version = "1.0.0", path = "../core", features = ["macros"] }
 tinystr = { version = "0.7", path = "../../utils/tinystr", features = ["zerovec"] }
-yoke = { version = "0.6", path = "../../utils/yoke" }
+yoke = { version = "0.7.0", path = "../../utils/yoke" }
 zerovec = { version = "0.9", path = "../../utils/zerovec", features = ["yoke"] }
 
 databake = { version = "0.1.0", path = "../../utils/databake", features = ["derive"], optional = true}

--- a/provider/blob/Cargo.toml
+++ b/provider/blob/Cargo.toml
@@ -31,7 +31,7 @@ icu_provider = { version = "1.0.0", path = "../core", features = ["deserialize_p
 postcard = { version = "1.0.0", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", default-features = false, features = ["alloc"] }
 writeable = { version = "0.5", path = "../../utils/writeable" }
-yoke = { version = "0.6.0", path = "../../utils/yoke" }
+yoke = { version = "0.7.0", path = "../../utils/yoke" }
 zerovec = { version = "0.9", path = "../../utils/zerovec", features = ["serde", "yoke"] }
 
 log = { version = "0.4", optional = true }

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -31,7 +31,7 @@ displaydoc = { version = "0.2.3", default-features = false }
 icu_locid = { version = "1.0.0", path = "../../components/locid" }
 stable_deref_trait = { version = "1.2.0", default-features = false }
 writeable = { version = "0.5", path = "../../utils/writeable" }
-yoke = { version = "0.6.2", path = "../../utils/yoke", features = ["derive"] }
+yoke = { version = "0.7.0", path = "../../utils/yoke", features = ["derive"] }
 zerofrom = { version = "0.1.0", path = "../../utils/zerofrom", features = ["derive"] }
 zerovec = { version = "0.9", path = "../../utils/zerovec", features = ["derive"]}
 

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -29,7 +29,7 @@ all-features = true
 
 [dependencies]
 serde = {version = "1", optional = true, default-features = false, features = ["alloc"]}
-yoke = { version = "0.6.0", path = "../yoke", features = ["derive"], optional = true }
+yoke = { version = "0.7.0", path = "../yoke", features = ["derive"], optional = true }
 
 [dev-dependencies]
 bincode = "1"

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "yoke"
-version = "0.6.2"
+version = "0.7.0"
 description = "Abstraction allowing borrowed data to be carried along with the backing data it borrows from"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2018"
@@ -32,7 +32,7 @@ all-features = true
 [dependencies]
 stable_deref_trait = { version = "1.2.0", default-features = false }
 
-yoke-derive = { version = "0.6.0", path = "./derive", optional = true }
+yoke-derive = { version = "0.7.0", path = "./derive", optional = true }
 
 serde = { version = "1.0", default-features = false, optional = true }
 zerofrom = { version = "0.1.0", path = "../zerofrom", default-features = false, optional = true} 

--- a/utils/yoke/derive/Cargo.toml
+++ b/utils/yoke/derive/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "yoke-derive"
-version = "0.6.1"
+version = "0.7.0"
 description = "Custom derive for the yoke crate"
 repository = "https://github.com/unicode-org/icu4x"
 license = "Unicode-DFS-2016"
@@ -26,5 +26,5 @@ syn = { version = "1.0.73", features = ["derive", "fold"] }
 synstructure = "0.12.4"
 
 [dev-dependencies]
-yoke = { version = "0.6.0", path = "..", features = ["derive"]}
+yoke = { version = "0.7.0", path = "..", features = ["derive"]}
 zerovec = { version = "0.9", path = "../../zerovec", features = ["yoke"] }

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -32,7 +32,7 @@ zerovec-derive = {version = "0.9.0", path = "./derive", optional = true}
 
 databake = { version = "0.1.0", path = "../../utils/databake", features = ["derive"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
-yoke = { version = "0.6.0", path = "../yoke", optional = true }
+yoke = { version = "0.7.0", path = "../yoke", optional = true }
 
 [dev-dependencies]
 bincode = "1.3"
@@ -46,7 +46,7 @@ rand_distr = "0.4"
 rand_pcg = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-yoke = { version = "0.6.0", path = "../yoke", features = ["derive"] }
+yoke = { version = "0.7.0", path = "../yoke", features = ["derive"] }
 zerofrom = { path = "../zerofrom", features = ["derive"] }
 
 [features]


### PR DESCRIPTION
The soundness fix in https://github.com/unicode-org/icu4x/pull/2949 is technically breaking, and we're doing an ICU4X release anyway so might as well.




<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->