### PR TITLE
Patching broken `icu_testdata`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ dhat-heap.json
 /benchmarks
 
 # Do not check-in binary file tree test data
-provider/testdata/data/bincode
 provider/testdata/data/postcard/*
 !provider/testdata/data/postcard/fingerprints.csv
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "icu_testdata"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "criterion",
  "icu",

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_testdata"
 description = "Pre-built test data for ICU4X"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["The ICU4X Project Developers"]
 edition = "2018"
 readme = "README.md"

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -24,6 +24,7 @@ include = [
     # Exception: We want to be able to run tests, so
     # we include the test data
     "data/**/*",
+    "!data/postcard/**/*",
     "metadata.rs.data",
 ]
 


### PR DESCRIPTION
This just needs a rerelease. I pushed dirty to get under the size limit, which introduced a bug. Now that we have an exception we can publish as-is.

Fixes #3048.