### PR TITLE
Verifying databake list fragments

### DIFF
--- a/components/list/src/provider/mod.rs
+++ b/components/list/src/provider/mod.rs
@@ -226,9 +226,10 @@ impl<'de: 'data, 'data> serde::Deserialize<'de> for ListJoinerPattern<'data> {
 impl<'a> ListJoinerPattern<'a> {
     /// Constructs a [`ListJoinerPattern`] from raw parts. Used by databake.
     ///
-    /// # Safety
-    /// index_1 may be at most string.len()
-    pub const unsafe fn from_parts_unchecked(string: &'a str, index_1: u8) -> Self {
+    /// # Panics
+    /// If `string[..index_1]` panics.
+    pub const fn from_parts(string: &'a str, index_1: u8) -> Self {
+        assert!(string.len() <= 255 && index_1 <= string.len() as u8);
         Self {
             string: Cow::Borrowed(string),
             index_0: 0,
@@ -243,10 +244,9 @@ impl databake::Bake for ListJoinerPattern<'_> {
         env.insert("icu_list");
         let string = (&*self.string).bake(env);
         let index_1 = self.index_1.bake(env);
-        // Safe because our own data is safe
-        databake::quote! { unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(#string, #index_1)
-        }}
+        databake::quote! {
+            ::icu_list::provider::ListJoinerPattern::from_parts(#string, #index_1)
+        }
     }
 }
 

--- a/components/list/src/provider/mod.rs
+++ b/components/list/src/provider/mod.rs
@@ -255,7 +255,7 @@ impl databake::Bake for ListJoinerPattern<'_> {
 fn databake() {
     databake::test_bake!(
         ListJoinerPattern,
-        const: unsafe { crate::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8) },
+        const: crate::provider::ListJoinerPattern::from_parts(", ", 2u8),
         icu_list
     );
 }

--- a/provider/testdata/data/baked/list/and_v1/ar.rs.data
+++ b/provider/testdata/data/baked/list/and_v1/ar.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" و", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" و", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" و", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" و", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" و", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" و", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" و", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" و", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" و", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" و", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" و", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" و", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" و", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" و", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" و", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" و", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" و", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" و", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" و", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" و", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" و", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" و", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" و", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" و", 3u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/and_v1/bn.rs.data
+++ b/provider/testdata/data/baked/list/and_v1/bn.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" এবং ", 11u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" এবং ", 11u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" এবং ", 11u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" এবং ", 11u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" এবং ", 11u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" এবং ", 11u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" এবং ", 11u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" এবং ", 11u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/and_v1/ccp.rs.data
+++ b/provider/testdata/data/baked/list/and_v1/ccp.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" 𑄃\u{11133}𑄃 ", 14u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" 𑄃\u{11133}𑄃 ", 14u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" 𑄃\u{11133}𑄃 ", 14u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" 𑄃\u{11133}𑄃 ", 14u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" 𑄃\u{11133}𑄃 ", 14u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" 𑄃\u{11133}𑄃 ", 14u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" 𑄃\u{11133}𑄃 ", 14u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" 𑄃\u{11133}𑄃 ", 14u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" 𑄃\u{11133}𑄃 ", 14u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" 𑄃\u{11133}𑄃 ", 14u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" 𑄃\u{11133}𑄃 ", 14u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" 𑄃\u{11133}𑄃 ", 14u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/and_v1/en-001.rs.data
+++ b/provider/testdata/data/baked/list/and_v1/en-001.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" and ", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" and ", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" and ", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" and ", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" and ", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" and ", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" and ", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" and ", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/and_v1/en.rs.data
+++ b/provider/testdata/data/baked/list/and_v1/en.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", and ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", and ", 6u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" and ", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" and ", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", & ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", & ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" & ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" & ", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/and_v1/es.rs.data
+++ b/provider/testdata/data/baked/list/and_v1/es.rs.data
@@ -1,20 +1,14 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" y ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" y ", 3u8),
         special_case: Some(::icu_list::provider::SpecialCasePattern {
             condition: unsafe {
                 ::icu_list::provider::SerdeDFA::from_dfa_bytes_unchecked(
@@ -139,15 +133,11 @@
                     },
                 )
             },
-            pattern: unsafe {
-                ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" e ", 3u8)
-            },
+            pattern: ::icu_list::provider::ListJoinerPattern::from_parts(" e ", 3u8),
         }),
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" y ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" y ", 3u8),
         special_case: Some(::icu_list::provider::SpecialCasePattern {
             condition: unsafe {
                 ::icu_list::provider::SerdeDFA::from_dfa_bytes_unchecked(
@@ -272,27 +262,19 @@
                     },
                 )
             },
-            pattern: unsafe {
-                ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" e ", 3u8)
-            },
+            pattern: ::icu_list::provider::ListJoinerPattern::from_parts(" e ", 3u8),
         }),
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" y ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" y ", 3u8),
         special_case: Some(::icu_list::provider::SpecialCasePattern {
             condition: unsafe {
                 ::icu_list::provider::SerdeDFA::from_dfa_bytes_unchecked(
@@ -417,15 +399,11 @@
                     },
                 )
             },
-            pattern: unsafe {
-                ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" e ", 3u8)
-            },
+            pattern: ::icu_list::provider::ListJoinerPattern::from_parts(" e ", 3u8),
         }),
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" y ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" y ", 3u8),
         special_case: Some(::icu_list::provider::SpecialCasePattern {
             condition: unsafe {
                 ::icu_list::provider::SerdeDFA::from_dfa_bytes_unchecked(
@@ -550,27 +528,19 @@
                     },
                 )
             },
-            pattern: unsafe {
-                ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" e ", 3u8)
-            },
+            pattern: ::icu_list::provider::ListJoinerPattern::from_parts(" e ", 3u8),
         }),
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" y ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" y ", 3u8),
         special_case: Some(::icu_list::provider::SpecialCasePattern {
             condition: unsafe {
                 ::icu_list::provider::SerdeDFA::from_dfa_bytes_unchecked(
@@ -695,15 +665,11 @@
                     },
                 )
             },
-            pattern: unsafe {
-                ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" e ", 3u8)
-            },
+            pattern: ::icu_list::provider::ListJoinerPattern::from_parts(" e ", 3u8),
         }),
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" y ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" y ", 3u8),
         special_case: Some(::icu_list::provider::SpecialCasePattern {
             condition: unsafe {
                 ::icu_list::provider::SerdeDFA::from_dfa_bytes_unchecked(
@@ -828,9 +794,7 @@
                     },
                 )
             },
-            pattern: unsafe {
-                ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" e ", 3u8)
-            },
+            pattern: ::icu_list::provider::ListJoinerPattern::from_parts(" e ", 3u8),
         }),
     },
 ])

--- a/provider/testdata/data/baked/list/and_v1/fil.rs.data
+++ b/provider/testdata/data/baked/list/and_v1/fil.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", at ", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", at ", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" at ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" at ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", at ", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", at ", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" at ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" at ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/and_v1/fr.rs.data
+++ b/provider/testdata/data/baked/list/and_v1/fr.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" et ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" et ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" et ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" et ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" et ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" et ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" et ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" et ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/and_v1/ja.rs.data
+++ b/provider/testdata/data/baked/list/and_v1/ja.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、", 3u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/and_v1/ru.rs.data
+++ b/provider/testdata/data/baked/list/and_v1/ru.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" и ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" и ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" и ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" и ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" и ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" и ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" и ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" и ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/and_v1/sr-Latn.rs.data
+++ b/provider/testdata/data/baked/list/and_v1/sr-Latn.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" i ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" i ", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" i ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" i ", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" i ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" i ", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" i ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" i ", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" i ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" i ", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" i ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" i ", 3u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/and_v1/sr.rs.data
+++ b/provider/testdata/data/baked/list/and_v1/sr.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" и ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" и ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" и ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" и ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" и ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" и ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" и ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" и ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" и ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" и ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" и ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" и ", 4u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/and_v1/th.rs.data
+++ b/provider/testdata/data/baked/list/and_v1/th.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" และ", 10u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" และ", 10u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("และ", 9u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("และ", 9u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" และ", 10u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" และ", 10u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("และ", 9u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("และ", 9u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" และ", 10u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" และ", 10u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("และ", 9u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("และ", 9u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/and_v1/tr.rs.data
+++ b/provider/testdata/data/baked/list/and_v1/tr.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ve ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ve ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ve ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ve ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ve ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ve ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ve ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ve ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/and_v1/und.rs.data
+++ b/provider/testdata/data/baked/list/and_v1/und.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/or_v1/ar.rs.data
+++ b/provider/testdata/data/baked/list/or_v1/ar.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" أو ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" أو ", 6u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" أو ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" أو ", 6u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" أو ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" أو ", 6u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" أو ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" أو ", 6u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" أو ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" أو ", 6u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" أو ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" أو ", 6u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" أو ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" أو ", 6u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" أو ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" أو ", 6u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" أو ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" أو ", 6u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" أو ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" أو ", 6u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" أو ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" أو ", 6u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" أو ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" أو ", 6u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/or_v1/bn.rs.data
+++ b/provider/testdata/data/baked/list/or_v1/bn.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ব\u{9be} ", 9u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ব\u{9be} ", 9u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ব\u{9be} ", 8u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ব\u{9be} ", 8u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ব\u{9be} ", 9u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ব\u{9be} ", 9u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ব\u{9be} ", 8u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ব\u{9be} ", 8u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ব\u{9be} ", 9u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ব\u{9be} ", 9u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ব\u{9be} ", 8u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ব\u{9be} ", 8u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/or_v1/ccp.rs.data
+++ b/provider/testdata/data/baked/list/or_v1/ccp.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", or ", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", or ", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" or ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" or ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", or ", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", or ", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" or ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" or ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", or ", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", or ", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" or ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" or ", 4u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/or_v1/en-001.rs.data
+++ b/provider/testdata/data/baked/list/or_v1/en-001.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" or ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" or ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" or ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" or ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" or ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" or ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" or ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" or ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" or ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" or ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" or ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" or ", 4u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/or_v1/es.rs.data
+++ b/provider/testdata/data/baked/list/or_v1/es.rs.data
@@ -1,20 +1,14 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" o ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" o ", 3u8),
         special_case: Some(::icu_list::provider::SpecialCasePattern {
             condition: unsafe {
                 ::icu_list::provider::SerdeDFA::from_dfa_bytes_unchecked(
@@ -187,15 +181,11 @@
                     },
                 )
             },
-            pattern: unsafe {
-                ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" u ", 3u8)
-            },
+            pattern: ::icu_list::provider::ListJoinerPattern::from_parts(" u ", 3u8),
         }),
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" o ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" o ", 3u8),
         special_case: Some(::icu_list::provider::SpecialCasePattern {
             condition: unsafe {
                 ::icu_list::provider::SerdeDFA::from_dfa_bytes_unchecked(
@@ -368,27 +358,19 @@
                     },
                 )
             },
-            pattern: unsafe {
-                ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" u ", 3u8)
-            },
+            pattern: ::icu_list::provider::ListJoinerPattern::from_parts(" u ", 3u8),
         }),
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" o ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" o ", 3u8),
         special_case: Some(::icu_list::provider::SpecialCasePattern {
             condition: unsafe {
                 ::icu_list::provider::SerdeDFA::from_dfa_bytes_unchecked(
@@ -561,15 +543,11 @@
                     },
                 )
             },
-            pattern: unsafe {
-                ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" u ", 3u8)
-            },
+            pattern: ::icu_list::provider::ListJoinerPattern::from_parts(" u ", 3u8),
         }),
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" o ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" o ", 3u8),
         special_case: Some(::icu_list::provider::SpecialCasePattern {
             condition: unsafe {
                 ::icu_list::provider::SerdeDFA::from_dfa_bytes_unchecked(
@@ -742,27 +720,19 @@
                     },
                 )
             },
-            pattern: unsafe {
-                ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" u ", 3u8)
-            },
+            pattern: ::icu_list::provider::ListJoinerPattern::from_parts(" u ", 3u8),
         }),
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" o ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" o ", 3u8),
         special_case: Some(::icu_list::provider::SpecialCasePattern {
             condition: unsafe {
                 ::icu_list::provider::SerdeDFA::from_dfa_bytes_unchecked(
@@ -935,15 +905,11 @@
                     },
                 )
             },
-            pattern: unsafe {
-                ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" u ", 3u8)
-            },
+            pattern: ::icu_list::provider::ListJoinerPattern::from_parts(" u ", 3u8),
         }),
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" o ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" o ", 3u8),
         special_case: Some(::icu_list::provider::SpecialCasePattern {
             condition: unsafe {
                 ::icu_list::provider::SerdeDFA::from_dfa_bytes_unchecked(
@@ -1116,9 +1082,7 @@
                     },
                 )
             },
-            pattern: unsafe {
-                ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" u ", 3u8)
-            },
+            pattern: ::icu_list::provider::ListJoinerPattern::from_parts(" u ", 3u8),
         }),
     },
 ])

--- a/provider/testdata/data/baked/list/or_v1/fil.rs.data
+++ b/provider/testdata/data/baked/list/or_v1/fil.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", o ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", o ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" o ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" o ", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", o ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", o ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" o ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" o ", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", o ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", o ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" o ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" o ", 3u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/or_v1/fr.rs.data
+++ b/provider/testdata/data/baked/list/or_v1/fr.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ou ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ou ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ou ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ou ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ou ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ou ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ou ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ou ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ou ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ou ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ou ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ou ", 4u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/or_v1/ja.rs.data
+++ b/provider/testdata/data/baked/list/or_v1/ja.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、または", 12u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、または", 12u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("または", 9u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("または", 9u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、または", 12u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、または", 12u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("または", 9u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("または", 9u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("、または", 12u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("、または", 12u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("または", 9u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("または", 9u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/or_v1/ru.rs.data
+++ b/provider/testdata/data/baked/list/or_v1/ru.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" или ", 8u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" или ", 8u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" или ", 8u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" или ", 8u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" или ", 8u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" или ", 8u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" или ", 8u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" или ", 8u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" или ", 8u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" или ", 8u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" или ", 8u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" или ", 8u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/or_v1/sr-Latn.rs.data
+++ b/provider/testdata/data/baked/list/or_v1/sr-Latn.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ili ", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ili ", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ili ", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ili ", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ili ", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ili ", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ili ", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ili ", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ili ", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ili ", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ili ", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ili ", 5u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/or_v1/th.rs.data
+++ b/provider/testdata/data/baked/list/or_v1/th.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" หร\u{e37}อ ", 14u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" หร\u{e37}อ ", 14u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" หร\u{e37}อ ", 14u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" หร\u{e37}อ ", 14u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" หร\u{e37}อ ", 14u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" หร\u{e37}อ ", 14u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("หร\u{e37}อ", 12u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("หร\u{e37}อ", 12u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" หร\u{e37}อ ", 14u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" หร\u{e37}อ ", 14u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("หร\u{e37}อ", 12u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("หร\u{e37}อ", 12u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/or_v1/tr.rs.data
+++ b/provider/testdata/data/baked/list/or_v1/tr.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" veya ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" veya ", 6u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" veya ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" veya ", 6u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" veya ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" veya ", 6u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" veya ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" veya ", 6u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" veya ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" veya ", 6u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" veya ", 6u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" veya ", 6u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/unit_v1/ar.rs.data
+++ b/provider/testdata/data/baked/list/unit_v1/ar.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("، و", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("، و", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("، و", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("، و", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("، و", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("، و", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" و", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" و", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("، و", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("، و", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("، و", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("، و", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("، و", 5u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("، و", 5u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" و", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" و", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" و", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" و", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" و", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" و", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" و", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" و", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" و", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" و", 3u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/unit_v1/bn.rs.data
+++ b/provider/testdata/data/baked/list/unit_v1/bn.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/unit_v1/en.rs.data
+++ b/provider/testdata/data/baked/list/unit_v1/en.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/unit_v1/es.rs.data
+++ b/provider/testdata/data/baked/list/unit_v1/es.rs.data
@@ -1,20 +1,14 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" y ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" y ", 3u8),
         special_case: Some(::icu_list::provider::SpecialCasePattern {
             condition: unsafe {
                 ::icu_list::provider::SerdeDFA::from_dfa_bytes_unchecked(
@@ -139,15 +133,11 @@
                     },
                 )
             },
-            pattern: unsafe {
-                ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" e ", 3u8)
-            },
+            pattern: ::icu_list::provider::ListJoinerPattern::from_parts(" e ", 3u8),
         }),
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" y ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" y ", 3u8),
         special_case: Some(::icu_list::provider::SpecialCasePattern {
             condition: unsafe {
                 ::icu_list::provider::SerdeDFA::from_dfa_bytes_unchecked(
@@ -272,33 +262,23 @@
                     },
                 )
             },
-            pattern: unsafe {
-                ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" e ", 3u8)
-            },
+            pattern: ::icu_list::provider::ListJoinerPattern::from_parts(" e ", 3u8),
         }),
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" y ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" y ", 3u8),
         special_case: Some(::icu_list::provider::SpecialCasePattern {
             condition: unsafe {
                 ::icu_list::provider::SerdeDFA::from_dfa_bytes_unchecked(
@@ -423,33 +403,23 @@
                     },
                 )
             },
-            pattern: unsafe {
-                ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" e ", 3u8)
-            },
+            pattern: ::icu_list::provider::ListJoinerPattern::from_parts(" e ", 3u8),
         }),
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/unit_v1/fr.rs.data
+++ b/provider/testdata/data/baked/list/unit_v1/fr.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" et ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" et ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" et ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" et ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" et ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" et ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" et ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" et ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/unit_v1/ja.rs.data
+++ b/provider/testdata/data/baked/list/unit_v1/ja.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("", 0u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("", 0u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("", 0u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("", 0u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("", 0u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("", 0u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked("", 0u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts("", 0u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/unit_v1/ru.rs.data
+++ b/provider/testdata/data/baked/list/unit_v1/ru.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/unit_v1/sr-Latn.rs.data
+++ b/provider/testdata/data/baked/list/unit_v1/sr-Latn.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" i ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" i ", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" i ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" i ", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" i ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" i ", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" i ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" i ", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" i ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" i ", 3u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" i ", 3u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" i ", 3u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/unit_v1/sr.rs.data
+++ b/provider/testdata/data/baked/list/unit_v1/sr.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" и ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" и ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" и ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" и ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" и ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" и ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" и ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" и ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(", ", 2u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(", ", 2u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" и ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" и ", 4u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" и ", 4u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" и ", 4u8),
         special_case: None,
     },
 ])

--- a/provider/testdata/data/baked/list/unit_v1/th.rs.data
+++ b/provider/testdata/data/baked/list/unit_v1/th.rs.data
@@ -1,74 +1,50 @@
 ::icu_list::provider::ListFormatterPatternsV1([
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" และ ", 11u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" และ ", 11u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" และ ", 11u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" และ ", 11u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" และ ", 11u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" และ ", 11u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
     ::icu_list::provider::ConditionalListJoinerPattern {
-        default: unsafe {
-            ::icu_list::provider::ListJoinerPattern::from_parts_unchecked(" ", 1u8)
-        },
+        default: ::icu_list::provider::ListJoinerPattern::from_parts(" ", 1u8),
         special_case: None,
     },
 ])


### PR DESCRIPTION
`ListJoinerPattern::from_parts_unchecked` was `unsafe`, which was not correct, as invalid parameters introduced a runtime panic, not UB. We can actually check the parameters though, so this now panics (at build time) and becomes safe and checked.

Would have caught #3048 