### PR TITLE
Update link to service account key

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -10,7 +10,7 @@
 # If you are a frequent contributor, you can add the key to your fork. The key is shared with
 # icu4x collaborators and can be viewed here:
 #
-# https://drive.google.com/file/d/17-oMqRfuHOHL9hYp64NYOh8vcJ03DQHm/view
+# https://drive.google.com/file/d/1LHq_sUb5NgpfDrJBcp3EsJFiUmoDbj36/view
 #
 # To add the key, follow these steps:
 #


### PR DESCRIPTION
Everyone using the old key will need to repeat the procedure in the README file to adopt the new key.