### PR TITLE
Avoid using derive on autogenerated packed types, bump zerovec-derive to 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "bincode",
  "proc-macro2",

--- a/ffi/gn/Cargo.lock
+++ b/ffi/gn/Cargo.lock
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ffi/gn/icu4x/BUILD.gn
+++ b/ffi/gn/icu4x/BUILD.gn
@@ -1447,7 +1447,7 @@ rust_library("zerovec-v0_9_2") {
   deps = []
   deps += [ ":yoke-v0_7_0" ]
   deps += [ ":zerofrom-v0_1_1" ]
-  deps += [ ":zerovec-derive-v0_9_2($host_toolchain)" ]
+  deps += [ ":zerovec-derive-v0_9_3($host_toolchain)" ]
 
   rustenv = []
 
@@ -1463,10 +1463,10 @@ rust_library("zerovec-v0_9_2") {
   visibility = [ ":*" ]
 }
 
-rust_proc_macro("zerovec-derive-v0_9_2") {
+rust_proc_macro("zerovec-derive-v0_9_3") {
   crate_name = "zerovec_derive"
   crate_root = "//utils/zerovec/derive/src/lib.rs"
-  output_name = "zerovec_derive-7ef1f6966b3a74c7"
+  output_name = "zerovec_derive-4d58846cb210946f"
 
   deps = []
   deps += [ ":proc-macro2-v1_0_32" ]
@@ -1479,8 +1479,8 @@ rust_proc_macro("zerovec-derive-v0_9_2") {
   rustflags = [
     "--cap-lints=allow",
     "--edition=2018",
-    "-Cmetadata=7ef1f6966b3a74c7",
-    "-Cextra-filename=-7ef1f6966b3a74c7",
+    "-Cmetadata=4d58846cb210946f",
+    "-Cextra-filename=-4d58846cb210946f",
   ]
 
   visibility = [ ":*" ]

--- a/utils/zerovec/derive/Cargo.toml
+++ b/utils/zerovec/derive/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "zerovec-derive"
-version = "0.9.2"
+version = "0.9.3"
 description = "Custom derive for the zerovec crate"
 repository = "https://github.com/unicode-org/icu4x"
 license = "Unicode-DFS-2016"

--- a/utils/zerovec/derive/src/make_varule.rs
+++ b/utils/zerovec/derive/src/make_varule.rs
@@ -115,7 +115,6 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
     let doc = format!("[`VarULE`](zerovec::ule::VarULE) type for {name}");
     let varule_struct: DeriveInput = parse_quote!(
         #[repr(#repr_attr)]
-        #[derive(PartialEq, Eq)]
         #[doc = #doc]
         #vis struct #ule_name #field_inits #semi
     );
@@ -140,6 +139,19 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
         &ule_name,
         lt,
         input.span(),
+    );
+
+    let eq_impl = quote!(
+        impl core::cmp::PartialEq for #ule_name {
+            fn eq(&self, other: &Self) -> bool {
+                // The VarULE invariants allow us to assume that equality is byte equality
+                // in non-safety-critical contexts
+                <Self as zerovec::ule::VarULE>::as_byte_slice(&self)
+                == <Self as zerovec::ule::VarULE>::as_byte_slice(&other)
+            }
+        }
+
+        impl core::cmp::Eq for #ule_name {}
     );
 
     let zerofrom_fq_path =
@@ -233,6 +245,8 @@ pub fn make_varule_impl(attr: AttributeArgs, mut input: DeriveInput) -> TokenStr
         #derived
 
         #maybe_ord_impls
+
+        #eq_impl
 
         #zmkv
 


### PR DESCRIPTION
Fixes #3060

Introduced by https://github.com/rust-lang/rust/pull/104429



<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->