### PR TITLE
Add notify-on-failure job to cronjob CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1163,3 +1163,25 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         comment-on-alert: true
         alert-comment-cc-users: '@gnrunge,@sffc,@zbraniecki,@echeran'
+
+  # Notify on slack  
+  notify-slack:
+    ## For Rob's PR:
+    ## Skipped tasks: bench-perf, bench-memory, bench-binsize, bench-datasize
+    ## needs: [msrv, test, testdata, test-docs, full-datagen, ffi, verify-ffi, gn, wasm, fmt, tidy, clippy, doc]
+    
+    # Skipped tasks: benchmark, memory, datasize, binsize
+    needs: [check-msrv, test, testdata, test-docs, full-datagen, ffi, verify-ffi, gn, features, wasm, fmt, tidy, clippy, doc, ]
+    if: ${{ always() && contains(needs.*.result, 'failure') && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify slack of failure
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          notify_when: failure
+          status: failure # We do the filtering earlier
+          notification_title: ''
+          message_format: ${{ format('{{emoji}} {0} CI failed!' , ((github.event_name == 'schedule') && 'Nightly' || 'Manually dispatched')) }}
+          footer: '<{run_url}|View failure> | <https://github.com/unicode-org/icu4x/actions?query=event%3A${{ github.event_name }}|CI history for `${{ github.event_name }}`>'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Based on #3070

Looks like the following (the second message, not the first). Says "nightly" instead of "manually dispatched" for nightly CI.

![image](https://user-images.githubusercontent.com/1617736/216481727-6f969a5d-ef27-4591-9494-e78b6631663a.png)



<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->