### PR TITLE
Less ZeroMap mutation in datagen

### DIFF
--- a/provider/datagen/src/transform/cldr/datetime/symbols.rs
+++ b/provider/datagen/src/transform/cldr/datetime/symbols.rs
@@ -8,7 +8,6 @@ use icu_datetime::provider::calendar::*;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use tinystr::{tinystr, TinyStr16, TinyStr4};
-use zerovec::ZeroMap;
 
 pub fn convert_dates(other: &cldr_serde::ca::Dates, calendar: &str) -> DateSymbolsV1<'static> {
     DateSymbolsV1 {
@@ -222,7 +221,7 @@ impl cldr_serde::ca::months::Symbols {
             }
             months::SymbolsV1::SolarTwelve(arr)
         } else {
-            let mut map: ZeroMap<MonthCode, str> = ZeroMap::default();
+            let mut map = BTreeMap::new();
             for (k, v) in self.0.iter() {
                 let index: usize = k
                     .parse()
@@ -234,9 +233,9 @@ impl cldr_serde::ca::months::Symbols {
                     .get(index - 1)
                     .expect("Found out of bounds month index for calendar");
 
-                map.insert(&MonthCode(*code), v);
+                map.insert(MonthCode(*code), v.as_ref());
             }
-            months::SymbolsV1::Other(map)
+            months::SymbolsV1::Other(map.into_iter().collect())
         }
     }
 }

--- a/provider/datagen/src/transform/cldr/displaynames/language.rs
+++ b/provider/datagen/src/transform/cldr/displaynames/language.rs
@@ -7,8 +7,8 @@ use core::convert::TryFrom;
 use icu_displaynames::provider::*;
 use icu_provider::datagen::IterableDataProvider;
 use icu_provider::prelude::*;
+use std::collections::BTreeMap;
 use zerovec::ule::UnvalidatedStr;
-use zerovec::ZeroMap;
 
 impl DataProvider<LanguageDisplayNamesV1Marker> for crate::DatagenProvider {
     fn load(
@@ -57,10 +57,10 @@ const ALT_MENU_SUBSTRING: &str = "-alt-menu";
 
 impl From<&cldr_serde::language_displaynames::Resource> for LanguageDisplayNamesV1<'static> {
     fn from(other: &cldr_serde::language_displaynames::Resource) -> Self {
-        let mut names = ZeroMap::new();
-        let mut short_names = ZeroMap::new();
-        let mut long_names = ZeroMap::new();
-        let mut menu_names = ZeroMap::new();
+        let mut names = BTreeMap::new();
+        let mut short_names = BTreeMap::new();
+        let mut long_names = BTreeMap::new();
+        let mut menu_names = BTreeMap::new();
         for lang_data_entry in other.main.0.iter() {
             for entry in lang_data_entry.1.localedisplaynames.languages.iter() {
                 if let Some(region) = entry.0.strip_suffix(ALT_SHORT_SUBSTRING) {
@@ -79,10 +79,10 @@ impl From<&cldr_serde::language_displaynames::Resource> for LanguageDisplayNames
             }
         }
         Self {
-            names,
-            short_names,
-            long_names,
-            menu_names,
+            names: names.into_iter().collect(),
+            short_names: short_names.into_iter().collect(),
+            long_names: long_names.into_iter().collect(),
+            menu_names: menu_names.into_iter().collect(),
         }
     }
 }

--- a/provider/datagen/src/transform/cldr/displaynames/region.rs
+++ b/provider/datagen/src/transform/cldr/displaynames/region.rs
@@ -62,7 +62,7 @@ impl TryFrom<&cldr_serde::region_displaynames::Resource> for RegionDisplayNamesV
                 if let Some(region) = region.strip_suffix(SHORT_SUBSTRING) {
                     short_names.insert(TinyAsciiStr::from_str(region)?, value.as_ref());
                 } else if !region.contains(ALT_SUBSTRING) {
-                    names.insert(TinyAsciiStr::from_str(&region)?, value.as_ref());
+                    names.insert(TinyAsciiStr::from_str(region)?, value.as_ref());
                 }
             }
         }

--- a/provider/datagen/src/transform/cldr/displaynames/region.rs
+++ b/provider/datagen/src/transform/cldr/displaynames/region.rs
@@ -7,9 +7,9 @@ use core::convert::TryFrom;
 use icu_displaynames::provider::*;
 use icu_provider::datagen::IterableDataProvider;
 use icu_provider::prelude::*;
+use std::collections::BTreeMap;
 use tinystr::TinyAsciiStr;
 use tinystr::TinyStrError;
-use zerovec::ZeroMap;
 
 impl DataProvider<RegionDisplayNamesV1Marker> for crate::DatagenProvider {
     fn load(
@@ -50,39 +50,26 @@ impl IterableDataProvider<RegionDisplayNamesV1Marker> for crate::DatagenProvider
 /// Substring used to denote alternative region names data variants for a given region. For example: "BA-alt-short", "TL-alt-variant".
 const ALT_SUBSTRING: &str = "-alt-";
 /// Substring used to denote short region display names data variants for a given region. For example: "BA-alt-short".
-const SHORT_SUBSTRING: &str = "-short";
+const SHORT_SUBSTRING: &str = "-alt-short";
 
 impl TryFrom<&cldr_serde::region_displaynames::Resource> for RegionDisplayNamesV1<'static> {
     type Error = TinyStrError;
     fn try_from(other: &cldr_serde::region_displaynames::Resource) -> Result<Self, Self::Error> {
-        let mut names = ZeroMap::new();
-        let mut short_names = ZeroMap::new();
-        for lang_data_entry in other.main.0.iter() {
-            for entry in lang_data_entry.1.localedisplaynames.regions.iter() {
-                let mut region = String::from(entry.0);
-                if !region.contains(ALT_SUBSTRING) {
-                    match <TinyAsciiStr<3>>::from_str(&region) {
-                        Ok(key) => {
-                            names.insert(&key, entry.1.as_ref());
-                        }
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    }
-                } else if region.contains(SHORT_SUBSTRING) {
-                    region.truncate(region.find('-').unwrap());
-                    match <TinyAsciiStr<3>>::from_str(&region) {
-                        Ok(key) => {
-                            short_names.insert(&key, entry.1.as_ref());
-                        }
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    }
+        let mut names = BTreeMap::new();
+        let mut short_names = BTreeMap::new();
+        for (_, lang_display_names) in other.main.0.iter() {
+            for (region, value) in lang_display_names.localedisplaynames.regions.iter() {
+                if let Some(region) = region.strip_suffix(SHORT_SUBSTRING) {
+                    short_names.insert(TinyAsciiStr::from_str(region)?, value.as_ref());
+                } else if !region.contains(ALT_SUBSTRING) {
+                    names.insert(TinyAsciiStr::from_str(&region)?, value.as_ref());
                 }
             }
         }
-        Ok(Self { names, short_names })
+        Ok(Self {
+            names: names.into_iter().collect(),
+            short_names: short_names.into_iter().collect(),
+        })
     }
 }
 

--- a/provider/datagen/src/transform/cldr/fallback/mod.rs
+++ b/provider/datagen/src/transform/cldr/fallback/mod.rs
@@ -13,9 +13,10 @@ use icu_locid::{
 use icu_provider::datagen::IterableDataProvider;
 use icu_provider::prelude::*;
 use icu_provider_adapters::fallback::provider::*;
-
+use std::collections::BTreeMap;
+use tinystr::TinyAsciiStr;
 use writeable::Writeable;
-use zerovec::{maps::ZeroMap2d, ule::UnvalidatedStr, ZeroMap};
+use zerovec::{maps::ZeroMap2d, ule::UnvalidatedStr};
 
 impl DataProvider<LocaleFallbackLikelySubtagsV1Marker> for crate::DatagenProvider {
     fn load(
@@ -119,9 +120,9 @@ impl IterableDataProvider<CollationFallbackSupplementV1Marker> for crate::Datage
 
 impl From<&cldr_serde::likely_subtags::Resource> for LocaleFallbackLikelySubtagsV1<'static> {
     fn from(source_data: &cldr_serde::likely_subtags::Resource) -> Self {
-        let mut l2s = ZeroMap::new();
+        let mut l2s = BTreeMap::<TinyAsciiStr<3>, _>::new();
         let mut lr2s = ZeroMap2d::new();
-        let mut l2r = ZeroMap::new();
+        let mut l2r = BTreeMap::<TinyAsciiStr<3>, _>::new();
         let mut ls2r = ZeroMap2d::new();
 
         // First collect the l2s and l2r maps
@@ -138,10 +139,10 @@ impl From<&cldr_serde::likely_subtags::Resource> for LocaleFallbackLikelySubtags
             let script = maximized.script.expect("maximized");
             let region = maximized.region.expect("maximized");
             if script != DEFAULT_SCRIPT {
-                l2s.insert(&language.into(), &script);
+                l2s.insert(language.into(), script);
             }
             if region != DEFAULT_REGION {
-                l2r.insert(&language.into(), &region);
+                l2r.insert(language.into(), region);
             }
         }
 
@@ -160,14 +161,14 @@ impl From<&cldr_serde::likely_subtags::Resource> for LocaleFallbackLikelySubtags
             let region = maximized.region.expect("maximized");
             if minimized.script.is_some() {
                 assert!(minimized.region.is_none(), "{minimized:?}");
-                let region_for_lang = l2r.get_copied(&language.into()).unwrap_or(DEFAULT_REGION);
+                let region_for_lang = l2r.get(&language.into()).copied().unwrap_or(DEFAULT_REGION);
                 if region != region_for_lang {
                     ls2r.insert(&language.into(), &script.into(), &region);
                 }
                 continue;
             }
             if minimized.region.is_some() {
-                let script_for_lang = l2s.get_copied(&language.into()).unwrap_or(DEFAULT_SCRIPT);
+                let script_for_lang = l2s.get(&language.into()).copied().unwrap_or(DEFAULT_SCRIPT);
                 if script != script_for_lang {
                     lr2s.insert(&language.into(), &region.into(), &script);
                 }
@@ -177,9 +178,9 @@ impl From<&cldr_serde::likely_subtags::Resource> for LocaleFallbackLikelySubtags
         }
 
         LocaleFallbackLikelySubtagsV1 {
-            l2s,
+            l2s: l2s.into_iter().collect(),
             lr2s,
-            l2r,
+            l2r: l2r.into_iter().collect(),
             ls2r,
         }
     }
@@ -187,7 +188,7 @@ impl From<&cldr_serde::likely_subtags::Resource> for LocaleFallbackLikelySubtags
 
 impl From<&cldr_serde::parent_locales::Resource> for LocaleFallbackParentsV1<'static> {
     fn from(source_data: &cldr_serde::parent_locales::Resource) -> Self {
-        let mut parents = ZeroMap::new();
+        let mut parents = BTreeMap::<_, (Language, Option<Script>, Option<Region>)>::new();
 
         for (source, target) in source_data.supplemental.parent_locales.parent_locale.iter() {
             assert!(!source.language.is_empty());
@@ -198,10 +199,15 @@ impl From<&cldr_serde::parent_locales::Resource> for LocaleFallbackParentsV1<'st
                 // We always fall back from language-script to und
                 continue;
             }
-            parents.insert((&*source.write_to_string()).into(), &target.into());
+            parents.insert(source.write_to_string(), target.into());
         }
 
-        LocaleFallbackParentsV1 { parents }
+        LocaleFallbackParentsV1 {
+            parents: parents
+                .iter()
+                .map(|(k, v)| (<&UnvalidatedStr>::from(k.as_ref()), v))
+                .collect(),
+        }
     }
 }
 

--- a/provider/datagen/src/transform/cldr/locale_canonicalizer/aliases.rs
+++ b/provider/datagen/src/transform/cldr/locale_canonicalizer/aliases.rs
@@ -7,8 +7,9 @@ use icu_locid::{subtags, subtags_language as language, LanguageIdentifier};
 use icu_locid_transform::provider::*;
 use icu_provider::datagen::IterableDataProvider;
 use icu_provider::prelude::*;
+use std::collections::BTreeMap;
 use tinystr::TinyAsciiStr;
-use zerovec::{ZeroMap, ZeroSlice};
+use zerovec::ZeroSlice;
 
 impl DataProvider<AliasesV1Marker> for crate::DatagenProvider {
     fn load(&self, req: DataRequest) -> Result<DataResponse<AliasesV1Marker>, DataError> {
@@ -68,28 +69,28 @@ impl From<&cldr_serde::aliases::Resource> for AliasesV1<'_> {
         // a special case, but we retain the catchall language category in case new or
         // customized CLDR data is used.
         let mut language_variants = Vec::new();
-        let mut sgn_region = ZeroMap::new();
-        let mut language_len2 = ZeroMap::new();
-        let mut language_len3 = ZeroMap::new();
+        let mut sgn_region = BTreeMap::<TinyAsciiStr<3>, _>::new();
+        let mut language_len2 = BTreeMap::new();
+        let mut language_len3 = BTreeMap::new();
         let mut language = Vec::new();
 
-        let mut script = ZeroMap::new();
+        let mut script = BTreeMap::new();
 
         // There are many more aliases for numeric region codes than for alphabetic,
         // so by storing them separately, we can minimize comparisons for alphabetic codes.
-        let mut region_alpha = ZeroMap::new();
-        let mut region_num = ZeroMap::new();
+        let mut region_alpha = BTreeMap::new();
+        let mut region_num = BTreeMap::new();
 
         // Complex regions are cases similar to the Soviet Union, where an old region
         // is replaced by multiple new regions. Determining the new region requires using
         // likely subtags. Many implementations preprocess the complex regions into simple
         // regions as part of data import, but that would introduce a dependency between
         // CDLR providers that we're not currently set up to handle.
-        let mut complex_region = ZeroMap::new();
+        let mut complex_region = BTreeMap::new();
 
-        let mut variant = ZeroMap::new();
+        let mut variant = BTreeMap::new();
 
-        let mut subdivision = ZeroMap::new();
+        let mut subdivision = BTreeMap::new();
 
         // Step 2. Capture all languageAlias rules where the type is an invalid languageId
         // into a set of BCP47 LegacyRules. This implementation discards these.
@@ -113,9 +114,9 @@ impl From<&cldr_serde::aliases::Resource> for AliasesV1<'_> {
                             // common identifiers.
                             let lang: TinyAsciiStr<3> = langid.language.into();
                             if lang.len() == 2 {
-                                language_len2.insert(&lang.resize(), to.replacement.as_str());
+                                language_len2.insert(lang.resize(), to.replacement.as_str());
                             } else {
-                                language_len3.insert(&lang, to.replacement.as_str());
+                                language_len3.insert(lang, to.replacement.as_str());
                             }
                         }
                         // sgn-<region> -> <language>
@@ -126,7 +127,7 @@ impl From<&cldr_serde::aliases::Resource> for AliasesV1<'_> {
                                 && replacement.region.is_none()
                                 && replacement.variants.is_empty() =>
                         {
-                            sgn_region.insert(&region.into(), &replacement.language);
+                            sgn_region.insert(region.into(), replacement.language);
                         }
                         _ => language.push((langid, replacement)),
                     }
@@ -146,7 +147,7 @@ impl From<&cldr_serde::aliases::Resource> for AliasesV1<'_> {
             }
 
             if let Ok(to) = to.replacement.parse::<subtags::Script>() {
-                script.insert(from, &to);
+                script.insert(from, to);
             }
         }
 
@@ -159,49 +160,40 @@ impl From<&cldr_serde::aliases::Resource> for AliasesV1<'_> {
 
             if let Ok(replacement) = to.replacement.parse::<subtags::Region>() {
                 if from.is_ascii_alphabetic() {
-                    region_alpha.insert(&from.resize(), &replacement);
+                    region_alpha.insert(from.resize(), replacement);
                 } else {
-                    region_num.insert(from, &replacement);
+                    region_num.insert(from, replacement);
                 }
             } else {
                 complex_region.insert(
                     from,
-                    ZeroSlice::from_boxed_slice(
-                        to.replacement
-                            .split(' ')
-                            .into_iter()
-                            .filter_map(|r| r.parse::<subtags::Region>().ok())
-                            .collect::<Box<[_]>>(),
-                    )
-                    .as_ref(),
+                    to.replacement
+                        .split(' ')
+                        .into_iter()
+                        .filter_map(|r| r.parse::<subtags::Region>().ok())
+                        .collect::<Box<[_]>>(),
                 );
             }
         }
 
         for (from, to) in other.supplemental.metadata.alias.variant_aliases.iter() {
             if let Ok(to) = to.replacement.parse::<subtags::Variant>() {
-                variant.insert(from, &to);
+                variant.insert(from, to);
             }
         }
 
         for (from, to) in other.supplemental.metadata.alias.subdivision_aliases.iter() {
-            if let Some(replacement) = to
-                .replacement
-                .split(' ')
-                .into_iter()
-                .filter_map(|r| {
-                    if r.len() == 2 {
-                        // Following http://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers,
-                        // append "zzzz" to make this syntactically correct.
-                        let replacement = r.to_string().to_ascii_lowercase() + "zzzz";
-                        <TinyAsciiStr<7>>::from_bytes(replacement.as_bytes()).ok()
-                    } else {
-                        <TinyAsciiStr<7>>::from_bytes(r.as_bytes()).ok()
-                    }
-                })
-                .next()
-            {
-                subdivision.insert(from, &replacement);
+            if let Some(replacement) = to.replacement.split(' ').into_iter().find_map(|r| {
+                if r.len() == 2 {
+                    // Following http://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers,
+                    // append "zzzz" to make this syntactically correct.
+                    let replacement = r.to_string().to_ascii_lowercase() + "zzzz";
+                    TinyAsciiStr::<7>::from_str(&replacement).ok()
+                } else {
+                    TinyAsciiStr::<7>::from_str(r).ok()
+                }
+            }) {
+                subdivision.insert(from, replacement);
             }
         }
 
@@ -209,42 +201,34 @@ impl From<&cldr_serde::aliases::Resource> for AliasesV1<'_> {
         language_variants.sort_unstable_by_key(|(langid, _)| appendix_c_cmp(langid));
         language.sort_unstable_by_key(|(langid, _)| appendix_c_cmp(langid));
 
-        let language_variants = zerovec::VarZeroVec::Owned(
-            zerovec::vecs::VarZeroVecOwned::try_from_elements(
-                &language_variants
-                    .into_iter()
-                    .map(|(from, to)| StrStrPair(from.to_string().into(), to.to_string().into()))
-                    .collect::<Vec<_>>(),
-            )
-            .unwrap(),
-        );
-
-        let language = zerovec::VarZeroVec::Owned(
-            zerovec::vecs::VarZeroVecOwned::try_from_elements(
-                &language
-                    .into_iter()
-                    .map(|(from, to)| StrStrPair(from.to_string().into(), to.to_string().into()))
-                    .collect::<Vec<_>>(),
-            )
-            .unwrap(),
-        );
+        let language_variants = language_variants
+            .iter()
+            .map(|(from, to)| StrStrPair(from.to_string().into(), to.to_string().into()))
+            .collect::<Vec<_>>();
+        let language = language
+            .iter()
+            .map(|(from, to)| StrStrPair(from.to_string().into(), to.to_string().into()))
+            .collect::<Vec<_>>();
 
         Self {
-            language_variants,
-            sgn_region,
-            language_len2,
-            language_len3,
-            language,
+            language_variants: language_variants.into(),
+            sgn_region: sgn_region.into_iter().collect(),
+            language_len2: language_len2.into_iter().collect(),
+            language_len3: language_len3.into_iter().collect(),
+            language: language.into(),
 
-            script,
+            script: script.into_iter().collect(),
 
-            region_alpha,
-            region_num,
-            complex_region,
+            region_alpha: region_alpha.into_iter().collect(),
+            region_num: region_num.into_iter().collect(),
+            complex_region: complex_region
+                .into_iter()
+                .map(|(k, v)| (k, ZeroSlice::from_boxed_slice(v)))
+                .collect(),
 
-            variant,
+            variant: variant.into_iter().collect(),
 
-            subdivision,
+            subdivision: subdivision.into_iter().collect(),
         }
     }
 }

--- a/provider/datagen/src/transform/cldr/locale_canonicalizer/aliases.rs
+++ b/provider/datagen/src/transform/cldr/locale_canonicalizer/aliases.rs
@@ -211,11 +211,11 @@ impl From<&cldr_serde::aliases::Resource> for AliasesV1<'_> {
             .collect::<Vec<_>>();
 
         Self {
-            language_variants: language_variants.into(),
+            language_variants: language_variants.as_slice().into(),
             sgn_region: sgn_region.into_iter().collect(),
             language_len2: language_len2.into_iter().collect(),
             language_len3: language_len3.into_iter().collect(),
-            language: language.into(),
+            language: language.as_slice().into(),
 
             script: script.into_iter().collect(),
 

--- a/provider/datagen/src/transform/cldr/relativetime/mod.rs
+++ b/provider/datagen/src/transform/cldr/relativetime/mod.rs
@@ -9,8 +9,7 @@ use icu_provider::datagen::IterableDataProvider;
 use icu_provider::prelude::*;
 use icu_relativetime::provider::*;
 use lazy_static::lazy_static;
-use std::collections::HashMap;
-use zerovec::ZeroMap;
+use std::collections::{BTreeMap, HashMap};
 
 lazy_static! {
     static ref DATAKEY_FILTERS: HashMap<DataKey, &'static str> = {
@@ -122,13 +121,12 @@ macro_rules! make_data_provider {
 impl TryFrom<&cldr_serde::date_fields::Field> for RelativeTimePatternDataV1<'_> {
     type Error = DataError;
     fn try_from(field: &cldr_serde::date_fields::Field) -> Result<Self, Self::Error> {
-        let mut relatives = ZeroMap::new();
-        // TODO(#2826) Make this more efficient as it is worst case linear per element insertion
+        let mut relatives = BTreeMap::new();
         for relative in &field.relatives {
             relatives.insert(&relative.count, relative.pattern.as_ref());
         }
         Ok(Self {
-            relatives,
+            relatives: relatives.into_iter().collect(),
             past: PluralRulesCategoryMapping::try_from(&field.past)?,
             future: PluralRulesCategoryMapping::try_from(&field.future)?,
         })

--- a/provider/datagen/src/transform/cldr/time_zones/convert.rs
+++ b/provider/datagen/src/transform/cldr/time_zones/convert.rs
@@ -20,7 +20,6 @@ use icu_timezone::ZoneVariant;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use tinystr::TinyStr8;
-use zerovec::{ZeroMap, ZeroMap2d};
 
 /// Performs part 1 of type fallback as specified in the UTS-35 spec for TimeZone Goals:
 /// https://unicode.org/reports/tr35/tr35-dates.html#Time_Zone_Goals
@@ -241,7 +240,7 @@ macro_rules! long_short_impls {
                     &compute_meta_zone_ids_hashmap(other.meta_zone_ids_resource);
                 Self {
                     defaults: match &data.metazone {
-                        None => ZeroMap::new(),
+                        None => Default::default(),
                         Some(metazones) => metazones
                             .0
                             .iter()
@@ -328,7 +327,7 @@ macro_rules! long_short_impls {
                     &compute_meta_zone_ids_hashmap(other.meta_zone_ids_resource);
                 Self {
                     defaults: match &data.metazone {
-                        None => ZeroMap2d::new(),
+                        None => Default::default(),
                         Some(metazones) => metazones
                             .0
                             .iter()

--- a/utils/zerovec/src/varzerovec/vec.rs
+++ b/utils/zerovec/src/varzerovec/vec.rs
@@ -405,6 +405,18 @@ impl<'a, T: VarULE + ?Sized, F: VarZeroVecFormat> VarZeroVec<'a, T, F> {
     }
 }
 
+impl<A, T, F> From<Vec<A>> for VarZeroVec<'static, T, F>
+where
+    T: VarULE + ?Sized,
+    A: EncodeAsVarULE<T>,
+    F: VarZeroVecFormat,
+{
+    #[inline]
+    fn from(elements: Vec<A>) -> Self {
+        Self::from(elements.as_slice())
+    }
+}
+
 impl<A, T, F> From<&Vec<A>> for VarZeroVec<'static, T, F>
 where
     T: VarULE + ?Sized,
@@ -413,8 +425,7 @@ where
 {
     #[inline]
     fn from(elements: &Vec<A>) -> Self {
-        #[allow(clippy::unwrap_used)] // TODO(#1410) Better story for fallibility
-        VarZeroVecOwned::try_from_elements(elements).unwrap().into()
+        Self::from(elements.as_slice())
     }
 }
 
@@ -439,8 +450,7 @@ where
 {
     #[inline]
     fn from(elements: &[A; N]) -> Self {
-        #[allow(clippy::unwrap_used)] // TODO(#1410) Better story for fallibility
-        VarZeroVecOwned::try_from_elements(elements).unwrap().into()
+        Self::from(elements.as_slice())
     }
 }
 

--- a/utils/zerovec/src/varzerovec/vec.rs
+++ b/utils/zerovec/src/varzerovec/vec.rs
@@ -405,18 +405,6 @@ impl<'a, T: VarULE + ?Sized, F: VarZeroVecFormat> VarZeroVec<'a, T, F> {
     }
 }
 
-impl<A, T, F> From<Vec<A>> for VarZeroVec<'static, T, F>
-where
-    T: VarULE + ?Sized,
-    A: EncodeAsVarULE<T>,
-    F: VarZeroVecFormat,
-{
-    #[inline]
-    fn from(elements: Vec<A>) -> Self {
-        Self::from(elements.as_slice())
-    }
-}
-
 impl<A, T, F> From<&Vec<A>> for VarZeroVec<'static, T, F>
 where
     T: VarULE + ?Sized,


### PR DESCRIPTION
Construct all `ZeroMap`s using `FromIterator` and `BTreeMap`s. This reduces the issue in #2826 to `ZeroMap`'s `FromIterator`.