### PR TITLE
Replace unmaintained actions-rs/cargo actions in CI workflows

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -460,10 +460,7 @@ jobs:
         key: ${{ runner.os }}-twiggy-0.7
     - name: Install twiggy
       if: steps.twiggy-cache.outputs.cache-hit != 'true'
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: install
-        args: twiggy --version 0.7.0
+      run: cargo install twiggy --version 0.7.0
 
     # Actual job
     - name: Build wasm executables

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -69,10 +69,7 @@ jobs:
 
     # Actual job
     - name: Check
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: make
-        args: ci-job-msrv-${{ matrix.behavior }}
+      run: cargo make ci-job-msrv-${{ matrix.behavior }}
 
   # ci-job-test
   test:
@@ -111,10 +108,7 @@ jobs:
 
     # Actual job
     - name: Run `cargo make ci-job-test`
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: make
-        args: ci-job-test
+      run: cargo make ci-job-test
 
   # ci-job-testdata
   testdata:
@@ -157,10 +151,7 @@ jobs:
 
     # Actual job
     - name: Run `cargo make ci-job-testdata`
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: make
-        args: ci-job-testdata
+      run: cargo make ci-job-testdata
 
   # ci-job-test-docs
   test-docs:
@@ -195,10 +186,7 @@ jobs:
 
     # Actual job
     - name: Run `cargo make ci-job-test-docs`
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: make
-        args: ci-job-test-docs
+      run: cargo make ci-job-test-docs
 
   # ci-job-full-datagen
   full-datagen:
@@ -241,10 +229,7 @@ jobs:
 
     # Actual job
     - name: Run `cargo make ci-job-full-datagen`
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: make
-        args: ci-job-full-datagen
+      run: cargo make ci-job-full-datagen
 
   # ci-job-ffi
   ffi:
@@ -302,10 +287,7 @@ jobs:
 
     # Actual job
     - name: Run `cargo make ci-job-ffi`
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: make
-        args: ci-job-ffi
+      run: cargo make ci-job-ffi
       env:
         CXX: "g++-10"
 
@@ -368,10 +350,7 @@ jobs:
 
     # Actual job
     - name: Run `cargo make ci-job-verify-ffi`
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: make
-        args: ci-job-verify-ffi
+      run: cargo make ci-job-verify-ffi
 
   # ci-job-verify-gn, ci-job-gn
   gn:
@@ -415,22 +394,13 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('tools/make/gn.toml', 'ffi/gn/Cargo.lock') }}
     - name: Install GN Third-Party Tools
       if: steps.gn-third-party-tools-cache.outputs.cache-hit != 'true'
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: make
-        args: gn-install
+      run: cargo make gn-install
 
     # Actual job
     - name: Run `cargo make ci-job-verify-gn`
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: make
-        args: ci-job-verify-gn
+      run: cargo make ci-job-verify-gn
     - name: Run `cargo make ci-job-gn`
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: make
-        args: ci-job-gn
+      run: cargo make ci-job-gn
 
   # ci-job-wasm
   wasm:
@@ -521,10 +491,7 @@ jobs:
 
     # Actual job
     - name: Check Format
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: make
-        args: ci-job-fmt
+      run: cargo make ci-job-fmt
 
   # ci-job-tidy
   tidy:
@@ -580,10 +547,7 @@ jobs:
 
     # Actual job
     - name: Tidy
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: make
-        args: ci-job-tidy
+      run: cargo make ci-job-tidy
 
   # ci-job-clippy
   clippy:
@@ -665,10 +629,7 @@ jobs:
 
     # Actual job
     - name: Cargo doc
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: make
-        args: ci-job-doc
+      run: cargo make ci-job-doc
 
 
   # Notify on slack  

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,10 +44,7 @@ jobs:
           toolchain:            nightly-2023-01-31
           override:             true
 
-      - uses:                   actions-rs/cargo@v1
-        with:
-          command:              test
-          args:                 --all-features --no-fail-fast
+      - run: cargo test --all-features --no-fail-fast
         env:
           CARGO_INCREMENTAL:    '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests'


### PR DESCRIPTION
Basically all of the `actions-rs/*` actions are unmaintained. See <https://github.com/actions-rs/toolchain/issues/216> for more information. Due to their age they generate several warnings in CI runs, for example in https://github.com/unicode-org/icu4x/actions/runs/4145492610:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions-rs/cargo@v1.0.1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

To get rid of some of those warnings the occurrences of `actions-rs/cargo` are replaced by direct invocations of `cargo`.