### PR TITLE
Fix race condition in Ci artifacts upload

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -276,7 +276,7 @@ jobs:
     - name: Upload new benchmark data
       run: |
           git checkout empty
-          gsutil -m cp -r benchmarks/perf/ gs://${{ env.GCP_BUCKET_ID }}/gha/${{ github.sha }}/benchmarks/perf
+          gsutil -m cp -r benchmarks/perf/${{ matrix.component }} gs://${{ env.GCP_BUCKET_ID }}/gha/${{ github.sha }}/benchmarks/perf/${{ matrix.component }}
 
   # Run examples with dhat-rs in order to collect memory heap size metrics. These
   # metrics will then be charted over time. See tools/benchmark/memory/README.md for
@@ -404,7 +404,7 @@ jobs:
     - name: Upload new benchmark data
       run: |
           git checkout empty
-          gsutil -m cp -r benchmarks/memory/ gs://${{ env.GCP_BUCKET_ID }}/gha/${{ github.sha }}/benchmarks/memory
+          gsutil -m cp -r benchmarks/memory/${{ matrix.os }} gs://${{ env.GCP_BUCKET_ID }}/gha/${{ github.sha }}/benchmarks/memory/${{ matrix.os }}
 
   # Binary size benchmark: build and size wasm binaries; creates ndjson output data format
   bench-binsize:

--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -602,6 +602,7 @@ jobs:
       group: "pages"
       cancel-in-progress: true
     steps:
+      - uses: actions/checkout@v3
       - name: Download artifacts
         run: |
           gsutil -m cp -rn gs://${{ env.GCP_BUCKET_ID }}/gha/${{ github.sha }}/benchmarks tools/website-skeleton/ || true


### PR DESCRIPTION
The invocation `gsutil -m cp -r benchmarks/perf/ gs://${{ env.GCP_BUCKET_ID }}/gha/${{ github.sha }}/benchmarks/perf` behaves differently depending on whether the `benchmarks/perf` directory already exists. If it doesn't it is created, but if it does a second one is created inside it (`perf/perf`). This means the first benchmark will store their data in `perf/{component}`, while the other ones will end up in `perf/perf/{component}`.