### PR TITLE
Update toolchain to 1.67.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,5 +3,5 @@
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 [toolchain]
-# Version updated on 2023-02-04
-channel = "1.67"
+# Version updated on 2023-02-15
+channel = "1.67.1"


### PR DESCRIPTION
This contains some compiler fixes and disables the clippy inline-format-args lint.