### PR TITLE
Fix benchmark CI

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -251,7 +251,7 @@ jobs:
       run: |
         # We're on main, so the previous run is the parent.
         export BASELINE=$(git log --pretty=format:'%H' -1 -r HEAD^)
-        gsutil -m cp -rn gs://${{ env.GCP_BUCKET_ID }}/gha/$BASELINE/benchmarks/perf/${{ matrix.component }} benchmarks/perf
+        gsutil -m cp -rn gs://${{ env.GCP_BUCKET_ID }}/gha/$BASELINE/benchmarks/perf/${{ matrix.component }}/* benchmarks/perf/${{ matrix.component }}
 
     - name: Store benchmark result & create dashboard
       uses: rhysd/github-action-benchmark@v1.15.0


### PR DESCRIPTION
The previous invocation didn't work because `${{ matrix.component }}` is more than one level.