### PR TITLE
Update google-github-actions/setup-gcloud in CI workflows to v0.6.2

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -76,7 +76,7 @@ jobs:
           --exclude zerovec-derive
 
     - name: Authenticate to Google Cloud
-      uses: google-github-actions/setup-gcloud@v0.2
+      uses: google-github-actions/setup-gcloud@v0.6.2
       with:
         project_id: ${{ env.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.ICU4X_GCP_SA_KEY }}
@@ -120,7 +120,7 @@ jobs:
         cd ../../../..
 
     - name: Authenticate to Google Cloud
-      uses: google-github-actions/setup-gcloud@v0.2
+      uses: google-github-actions/setup-gcloud@v0.6.2
       with:
         project_id: ${{ env.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.ICU4X_GCP_SA_KEY }}
@@ -178,7 +178,7 @@ jobs:
 
 
     - name: Authenticate to Google Cloud
-      uses: google-github-actions/setup-gcloud@v0.2
+      uses: google-github-actions/setup-gcloud@v0.6.2
       with:
         project_id: ${{ env.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.ICU4X_GCP_SA_KEY }}
@@ -272,7 +272,7 @@ jobs:
 
     - name: Authenticate to Google Cloud
       if: success() || failure()
-      uses: google-github-actions/setup-gcloud@v0.2
+      uses: google-github-actions/setup-gcloud@v0.6.2
       with:
         project_id: ${{ env.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.ICU4X_GCP_SA_KEY }}
@@ -403,7 +403,7 @@ jobs:
 
     - name: Authenticate to Google Cloud
       if: success() || failure()
-      uses: google-github-actions/setup-gcloud@v0.2
+      uses: google-github-actions/setup-gcloud@v0.6.2
       with:
         project_id: ${{ env.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.ICU4X_GCP_SA_KEY }}
@@ -534,7 +534,7 @@ jobs:
 
     - name: Authenticate to Google Cloud
       if: success() || failure()
-      uses: google-github-actions/setup-gcloud@v0.2
+      uses: google-github-actions/setup-gcloud@v0.6.2
       with:
         project_id: ${{ env.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.ICU4X_GCP_SA_KEY }}
@@ -591,7 +591,7 @@ jobs:
 
     - name: Authenticate to Google Cloud
       if: success() || failure()
-      uses: google-github-actions/setup-gcloud@v0.2
+      uses: google-github-actions/setup-gcloud@v0.6.2
       with:
         project_id: ${{ env.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.ICU4X_GCP_SA_KEY }}


### PR DESCRIPTION
Updates the [`google-github-actions/setup-gcloud`](https://github.com/google-github-actions/setup-gcloud) action used in the GitHub Actions workflows to v0.6.2.

Still using v0.2 of `google-github-actions/setup-gcloud` will generate some warning like in this run: https://github.com/unicode-org/icu4x/actions/runs/4187331961

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: google-github-actions/setup-gcloud@v0.2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings for `google-github-actions/setup-gcloud`, because v0.6.2 uses Node.js 16.


Note: I am aware that there also is a newer version v1.1.0 of `google-github-actions/setup-gcloud`, but in v1 some of the configuration options that are currently used in the workflow file have been removed. That's why the update is only to the newest 0.x version.