### PR TITLE
Update actions/setup-python in GitHub Actions workflow to v4

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -98,7 +98,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
     - name: Install Sphinx
       uses: BSFishy/pip-action@v1
       with:


### PR DESCRIPTION
Updates the [`actions/setup-python`](https://github.com/actions/setup-python) action used in the GitHub Actions workflow to its newest major version.

Still using v1 of `actions/setup-python` will generate some warning like in this run: https://github.com/unicode-org/icu4x/actions/runs/4187331961

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-python@v1, BSFishy/pip-action@v1, google-github-actions/setup-gcloud@v0.2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings for `actions/setup-python`, because v4 uses Node.js 16.


Unlike in v1, in v4 the Python version has to be specified, because the default value (formerly `'3.x'` in v1) was removed.