### PR TITLE
`DataMarker: 'static`

### DIFF
--- a/components/datetime/src/calendar.rs
+++ b/components/datetime/src/calendar.rs
@@ -23,10 +23,10 @@ pub trait CldrCalendar {
     const DEFAULT_BCP_47_IDENTIFIER: Value;
 
     /// The data marker for loading symbols for this calendar.
-    type DateSymbolsV1Marker: KeyedDataMarker<Yokeable = DateSymbolsV1<'static>> + 'static;
+    type DateSymbolsV1Marker: KeyedDataMarker<Yokeable = DateSymbolsV1<'static>>;
 
     /// The data marker for loading length-patterns for this calendar.
-    type DateLengthsV1Marker: KeyedDataMarker<Yokeable = DateLengthsV1<'static>> + 'static;
+    type DateLengthsV1Marker: KeyedDataMarker<Yokeable = DateLengthsV1<'static>>;
 
     /// Checks if a given BCP 47 identifier is allowed to be used with this calendar
     ///

--- a/docs/tutorials/data_provider.md
+++ b/docs/tutorials/data_provider.md
@@ -104,7 +104,7 @@ impl<'a> Borrow<CacheKey<'a>> for lru::KeyRef<CacheKeyWrap> {
 
 impl<M, P> DataProvider<M> for LruDataCache<P>
 where
-    M: KeyedDataMarker + 'static,
+    M: KeyedDataMarker,
     M::Yokeable: ZeroFrom<'static, M::Yokeable>,
     M::Yokeable: icu_provider::MaybeSendSync,
     for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,

--- a/ffi/diplomat/src/properties_maps.rs
+++ b/ffi/diplomat/src/properties_maps.rs
@@ -21,9 +21,7 @@ pub mod ffi {
     #[diplomat::rust_link(icu::properties::maps::CodePointMapDataBorrowed, Struct)]
     pub struct ICU4XCodePointMapData8(maps::CodePointMapData<u8>);
 
-    fn convert_8<P: TrieValue + 'static>(
-        data: maps::CodePointMapData<P>,
-    ) -> Box<ICU4XCodePointMapData8> {
+    fn convert_8<P: TrieValue>(data: maps::CodePointMapData<P>) -> Box<ICU4XCodePointMapData8> {
         #[allow(clippy::expect_used)] // infallible for the chosen properties
         Box::new(ICU4XCodePointMapData8(
             data.try_into_converted()

--- a/ffi/diplomat/src/provider.rs
+++ b/ffi/diplomat/src/provider.rs
@@ -255,7 +255,7 @@ macro_rules! load {
 #[cfg(not(any(feature = "any_provider", feature = "buffer_provider")))]
 impl<M> DataProvider<M> for ICU4XDataProviderInner
 where
-    M: KeyedDataMarker + 'static,
+    M: KeyedDataMarker,
 {
     load!();
 }
@@ -263,7 +263,7 @@ where
 #[cfg(all(feature = "buffer_provider", not(feature = "any_provider")))]
 impl<M> DataProvider<M> for ICU4XDataProviderInner
 where
-    M: KeyedDataMarker + 'static,
+    M: KeyedDataMarker,
     // Actual bound:
     //     for<'de> <M::Yokeable as Yokeable<'de>>::Output: Deserialize<'de>,
     // Necessary workaround bound (see `yoke::trait_hack` docs):
@@ -275,7 +275,7 @@ where
 #[cfg(all(feature = "any_provider", not(feature = "buffer_provider")))]
 impl<M> DataProvider<M> for ICU4XDataProviderInner
 where
-    M: KeyedDataMarker + 'static,
+    M: KeyedDataMarker,
     for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
     M::Yokeable: ZeroFrom<'static, M::Yokeable>,
     M::Yokeable: MaybeSendSync,
@@ -286,7 +286,7 @@ where
 #[cfg(all(feature = "buffer_provider", feature = "any_provider"))]
 impl<M> DataProvider<M> for ICU4XDataProviderInner
 where
-    M: KeyedDataMarker + 'static,
+    M: KeyedDataMarker,
     for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
     M::Yokeable: ZeroFrom<'static, M::Yokeable>,
     M::Yokeable: MaybeSendSync,

--- a/provider/adapters/src/any_payload.rs
+++ b/provider/adapters/src/any_payload.rs
@@ -56,7 +56,7 @@ pub struct AnyPayloadProvider {
 
 impl AnyPayloadProvider {
     /// Creates an `AnyPayloadProvider` with an owned (allocated) payload of the given data.
-    pub fn from_owned<M: KeyedDataMarker + 'static>(data: M::Yokeable) -> Self
+    pub fn from_owned<M: KeyedDataMarker>(data: M::Yokeable) -> Self
     where
         M::Yokeable: icu_provider::MaybeSendSync,
     {
@@ -72,7 +72,7 @@ impl AnyPayloadProvider {
     }
 
     /// Creates an `AnyPayloadProvider` from an existing [`DataPayload`].
-    pub fn from_payload<M: KeyedDataMarker + 'static>(payload: DataPayload<M>) -> Self
+    pub fn from_payload<M: KeyedDataMarker>(payload: DataPayload<M>) -> Self
     where
         M::Yokeable: icu_provider::MaybeSendSync,
     {
@@ -83,7 +83,7 @@ impl AnyPayloadProvider {
     }
 
     /// Creates an `AnyPayloadProvider` from an existing [`AnyPayload`].
-    pub fn from_any_payload<M: KeyedDataMarker + 'static>(payload: AnyPayload) -> Self {
+    pub fn from_any_payload<M: KeyedDataMarker>(payload: AnyPayload) -> Self {
         AnyPayloadProvider {
             key: M::KEY,
             data: payload,
@@ -91,7 +91,7 @@ impl AnyPayloadProvider {
     }
 
     /// Creates an `AnyPayloadProvider` with the default (allocated) version of the data struct.
-    pub fn new_default<M: KeyedDataMarker + 'static>() -> Self
+    pub fn new_default<M: KeyedDataMarker>() -> Self
     where
         M::Yokeable: Default,
         M::Yokeable: icu_provider::MaybeSendSync,
@@ -112,7 +112,7 @@ impl AnyProvider for AnyPayloadProvider {
 
 impl<M> DataProvider<M> for AnyPayloadProvider
 where
-    M: KeyedDataMarker + 'static,
+    M: KeyedDataMarker,
     for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
     M::Yokeable: ZeroFrom<'static, M::Yokeable>,
     M::Yokeable: icu_provider::MaybeSendSync,

--- a/provider/core/src/any.rs
+++ b/provider/core/src/any.rs
@@ -73,7 +73,7 @@ impl DataMarker for AnyMarker {
 
 impl<M> crate::dynutil::UpcastDataPayload<M> for AnyMarker
 where
-    M: DataMarker + 'static,
+    M: DataMarker,
     M::Yokeable: MaybeSendSync,
 {
     #[inline]
@@ -90,7 +90,7 @@ impl AnyPayload {
     /// the type stored in the `AnyPayload`.
     pub fn downcast<M>(self) -> Result<DataPayload<M>, DataError>
     where
-        M: DataMarker + 'static,
+        M: DataMarker,
         // For the StructRef case:
         M::Yokeable: ZeroFrom<'static, M::Yokeable>,
         // For the PayloadRc case:
@@ -118,7 +118,7 @@ impl AnyPayload {
     /// Clones and then transforms a type-erased `AnyPayload` into a concrete `DataPayload<M>`.
     pub fn downcast_cloned<M>(&self) -> Result<DataPayload<M>, DataError>
     where
-        M: DataMarker + 'static,
+        M: DataMarker,
         // For the StructRef case:
         M::Yokeable: ZeroFrom<'static, M::Yokeable>,
         // For the PayloadRc case:
@@ -162,7 +162,7 @@ impl AnyPayload {
 
 impl<M> DataPayload<M>
 where
-    M: DataMarker + 'static,
+    M: DataMarker,
     M::Yokeable: MaybeSendSync,
 {
     /// Moves this DataPayload to the heap (requiring an allocation) and returns it as an
@@ -200,7 +200,7 @@ impl DataPayload<AnyMarker> {
     #[inline]
     pub fn downcast<M>(self) -> Result<DataPayload<M>, DataError>
     where
-        M: DataMarker + 'static,
+        M: DataMarker,
         for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
         M::Yokeable: ZeroFrom<'static, M::Yokeable>,
         M::Yokeable: MaybeSendSync,
@@ -247,7 +247,7 @@ impl AnyResponse {
     #[inline]
     pub fn downcast<M>(self) -> Result<DataResponse<M>, DataError>
     where
-        M: DataMarker + 'static,
+        M: DataMarker,
         for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
         M::Yokeable: ZeroFrom<'static, M::Yokeable>,
         M::Yokeable: MaybeSendSync,
@@ -261,7 +261,7 @@ impl AnyResponse {
     /// Clones and then transforms a type-erased `AnyResponse` into a concrete `DataResponse<M>`.
     pub fn downcast_cloned<M>(&self) -> Result<DataResponse<M>, DataError>
     where
-        M: DataMarker + 'static,
+        M: DataMarker,
         M::Yokeable: ZeroFrom<'static, M::Yokeable>,
         M::Yokeable: MaybeSendSync,
         for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
@@ -279,7 +279,7 @@ impl AnyResponse {
 
 impl<M> DataResponse<M>
 where
-    M: DataMarker + 'static,
+    M: DataMarker,
     M::Yokeable: MaybeSendSync,
 {
     /// Moves the inner DataPayload to the heap (requiring an allocation) and returns it as an
@@ -384,7 +384,7 @@ where
 impl<M, P> DataProvider<M> for DowncastingAnyProvider<'_, P>
 where
     P: AnyProvider + ?Sized,
-    M: KeyedDataMarker + 'static,
+    M: KeyedDataMarker,
     for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
     M::Yokeable: ZeroFrom<'static, M::Yokeable>,
     M::Yokeable: MaybeSendSync,
@@ -401,7 +401,7 @@ where
 impl<M, P> DynamicDataProvider<M> for DowncastingAnyProvider<'_, P>
 where
     P: AnyProvider + ?Sized,
-    M: DataMarker + 'static,
+    M: DataMarker,
     for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
     M::Yokeable: ZeroFrom<'static, M::Yokeable>,
     M::Yokeable: MaybeSendSync,

--- a/provider/core/src/marker.rs
+++ b/provider/core/src/marker.rs
@@ -21,7 +21,7 @@ use crate::yoke::Yokeable;
 /// - `impl ZeroFrom<Self>`
 ///
 /// Also see [`KeyedDataMarker`].
-/// 
+///
 /// Note: `DataMarker`s are quasi-const-generic compile-time objects, and as such are expected
 /// to be unit structs. As this is not something that can be enforced by the type system, we
 /// currently only have a `'static` bound on them (which is needed by a lot of our code).
@@ -73,7 +73,7 @@ pub trait DataMarker: 'static {
 ///
 /// [`BufferMarker`] and [`AnyMarker`] are examples of markers that do _not_ implement this trait
 /// because they are not specific to a single key.
-/// 
+///
 /// Note: `KeyedDataMarker`s are quasi-const-generic compile-time objects, and as such are expected
 /// to be unit structs. As this is not something that can be enforced by the type system, we
 /// currently only have a `'static` bound on them (which is needed by a lot of our code).

--- a/provider/core/src/marker.rs
+++ b/provider/core/src/marker.rs
@@ -21,6 +21,10 @@ use crate::yoke::Yokeable;
 /// - `impl ZeroFrom<Self>`
 ///
 /// Also see [`KeyedDataMarker`].
+/// 
+/// Note: `DataMarker`s are quasi-const-generic compile-time objects, and as such are expected
+/// to be unit structs. As this is not something that can be enforced by the type system, we
+/// currently only have a `'static` bound on them (which is needed by a lot of our code).
 ///
 /// # Examples
 ///
@@ -53,7 +57,7 @@ use crate::yoke::Yokeable;
 /// ```
 ///
 /// [`data_struct`]: crate::data_struct
-pub trait DataMarker {
+pub trait DataMarker: 'static {
     /// A type that implements [`Yokeable`]. This should typically be the `'static` version of a
     /// data struct.
     type Yokeable: for<'a> Yokeable<'a>;
@@ -69,6 +73,10 @@ pub trait DataMarker {
 ///
 /// [`BufferMarker`] and [`AnyMarker`] are examples of markers that do _not_ implement this trait
 /// because they are not specific to a single key.
+/// 
+/// Note: `KeyedDataMarker`s are quasi-const-generic compile-time objects, and as such are expected
+/// to be unit structs. As this is not something that can be enforced by the type system, we
+/// currently only have a `'static` bound on them (which is needed by a lot of our code).
 ///
 /// [`data_struct!`]: crate::data_struct
 /// [`DataProvider`]: crate::DataProvider


### PR DESCRIPTION
`DataMarker`s are compile-time objects/types and should not contain any borrowed data.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->