### PR TITLE
New datagen API

### DIFF
--- a/provider/datagen/src/options.rs
+++ b/provider/datagen/src/options.rs
@@ -1,0 +1,85 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use crate::prelude::*;
+use icu_provider::prelude::*;
+use std::collections::{HashSet, BTreeSet};
+
+#[non_exhaustive]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct Options {
+    #[serde(with = "data_key_as_str")]
+    pub keys: HashSet<DataKey>,
+    pub locales: LocaleOptions,
+    pub fallback: FallbackOptions,
+}
+
+mod data_key_as_str {
+    use serde::{de::*, ser::*};
+    use super::*;
+    use std::borrow::Cow;
+
+    pub fn serialize<S: Serializer>(selff: &HashSet<DataKey>, ser: S) -> Result<S::Ok, S::Error> {
+        selff.iter().map(|k| k.path().get()).collect::<BTreeSet<_>>().serialize(ser)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<HashSet<DataKey>, D::Error> {
+        HashSet::<Cow<'de, str>>::deserialize(de)?
+            .into_iter()
+            .map(|s| crate::key(&s).ok_or(s))
+            .collect::<Result<_, _>>()
+            .map_err(|s| D::Error::custom(format!("Unknown key {s}")))
+    }
+}
+
+#[non_exhaustive]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct LocaleOptions {
+    pub locales: LocaleInclude,
+    pub regions: RegionInclude,
+    pub include_root: bool,
+    pub some_segmenter_flag: bool,
+}
+
+#[non_exhaustive]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum LocaleInclude {
+    All,
+    None,
+    Explicit(Vec<LanguageIdentifier>),
+    CldrSet(Vec<CoverageLevel>),
+}
+
+impl LocaleInclude {
+    pub(crate) fn resolved(
+        self,
+        sources: &crate::SourceData,
+    ) -> Result<Self, DataError> {
+        Ok(match self {
+            LocaleInclude::CldrSet(levels) => LocaleInclude::Explicit(sources.locales(&levels)?),
+            s => s
+        })
+    }
+}
+
+#[non_exhaustive]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum RegionInclude {
+    All,
+    Explicit(Vec<Region>),
+}
+
+#[non_exhaustive]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct FallbackOptions {
+    pub variant: FallbackVariant,
+}
+
+#[non_exhaustive]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum FallbackVariant {
+    None,
+    Naive,
+    Full,
+}

--- a/provider/datagen/src/transform/cldr/source.rs
+++ b/provider/datagen/src/transform/cldr/source.rs
@@ -9,7 +9,7 @@ use std::fmt::Debug;
 use std::str::FromStr;
 
 /// Specifies a variant of CLDR JSON
-#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub enum CoverageLevel {
     /// Locales listed as modern coverage targets by the CLDR subcomittee.


### PR DESCRIPTION
Publishing something to kick off a discussion:

```json
{
  "keys": [
    "calendar/japanese@1",
    "calendar/japanext@1",
    "collator/data@1",
    "collator/dia@1",
    "collator/jamo@1",
    "collator/meta@1",
    "collator/prim@1",
    "collator/reord@1",
    "compactdecimal/long@1",
    "compactdecimal/short@1",
    "core/helloworld@1",
    "datetime/buddhist/datelengths@1",
    "datetime/buddhist/datesymbols@1",
    "datetime/coptic/datelengths@1",
    "datetime/coptic/datesymbols@1",
    "datetime/ethiopic/datelengths@1",
    "datetime/ethiopic/datesymbols@1",
    "datetime/gregory/datelengths@1",
    "datetime/gregory/datesymbols@1",
    "datetime/indian/datelengths@1",
    "datetime/indian/datesymbols@1",
    "datetime/japanese/datelengths@1",
    "datetime/japanese/datesymbols@1",
    "datetime/japanext/datelengths@1",
    "datetime/japanext/datesymbols@1",
    "datetime/skeletons@1",
    "datetime/timelengths@1",
    "datetime/timesymbols@1",
    "datetime/week_data@1",
    "decimal/symbols@1",
    "displaynames/languages@1",
    "displaynames/regions@1",
    "fallback/likelysubtags@1",
    "fallback/parents@1",
    "fallback/supplement/co@1",
    "list/and@1",
    "list/or@1",
    "list/unit@1",
    "locid_transform/aliases@1",
    "locid_transform/likelysubtags@1",
    "normalizer/comp@1",
    "normalizer/decomp@1",
    "normalizer/nfd@1",
    "normalizer/nfdex@1",
    "normalizer/nfkd@1",
    "normalizer/nfkdex@1",
    "normalizer/uts46d@1",
    "plurals/cardinal@1",
    "plurals/ordinal@1",
    "props/AHex@1",
    "props/Alpha@1",
    "props/Basic_Emoji@1",
    "props/Bidi_C@1",
    "props/Bidi_M@1",
    "props/CI@1",
    "props/CWCF@1",
    "props/CWCM@1",
    "props/CWKCF@1",
    "props/CWL@1",
    "props/CWT@1",
    "props/CWU@1",
    "props/Cased@1",
    "props/Comp_Ex@1",
    "props/DI@1",
    "props/Dash@1",
    "props/Dep@1",
    "props/Dia@1",
    "props/EBase@1",
    "props/EComp@1",
    "props/EMod@1",
    "props/EPres@1",
    "props/Emoji@1",
    "props/Ext@1",
    "props/ExtPict@1",
    "props/GCB@1",
    "props/Gr_Base@1",
    "props/Gr_Ext@1",
    "props/Gr_Link@1",
    "props/Hex@1",
    "props/Hyphen@1",
    "props/IDC@1",
    "props/IDS@1",
    "props/IDSB@1",
    "props/IDST@1",
    "props/Ideo@1",
    "props/Join_C@1",
    "props/LOE@1",
    "props/Lower@1",
    "props/Math@1",
    "props/NChar@1",
    "props/PCM@1",
    "props/Pat_Syn@1",
    "props/Pat_WS@1",
    "props/QMark@1",
    "props/RI@1",
    "props/Radical@1",
    "props/SB@1",
    "props/SD@1",
    "props/STerm@1",
    "props/Sensitive@1",
    "props/Term@1",
    "props/UIdeo@1",
    "props/Upper@1",
    "props/VS@1",
    "props/WB@1",
    "props/WSpace@1",
    "props/XIDC@1",
    "props/XIDS@1",
    "props/alnum@1",
    "props/bc@1",
    "props/blank@1",
    "props/casemap@1",
    "props/ccc@1",
    "props/ea@1",
    "props/exemplarchars/auxiliary@1",
    "props/exemplarchars/index@1",
    "props/exemplarchars/main@1",
    "props/exemplarchars/numbers@1",
    "props/exemplarchars/punctuation@1",
    "props/gc@1",
    "props/graph@1",
    "props/lb@1",
    "props/names/GCB@1",
    "props/names/SB@1",
    "props/names/WB@1",
    "props/names/bc@1",
    "props/names/ccc@1",
    "props/names/ea@1",
    "props/names/gc@1",
    "props/names/lb@1",
    "props/names/sc@1",
    "props/nfcinert@1",
    "props/nfdinert@1",
    "props/nfkcinert@1",
    "props/nfkdinert@1",
    "props/print@1",
    "props/sc@1",
    "props/scx@1",
    "props/segstart@1",
    "props/xdigit@1",
    "relativetime/long/day@1",
    "relativetime/long/hour@1",
    "relativetime/long/minute@1",
    "relativetime/long/month@1",
    "relativetime/long/quarter@1",
    "relativetime/long/second@1",
    "relativetime/long/week@1",
    "relativetime/long/year@1",
    "relativetime/narrow/day@1",
    "relativetime/narrow/hour@1",
    "relativetime/narrow/minute@1",
    "relativetime/narrow/month@1",
    "relativetime/narrow/quarter@1",
    "relativetime/narrow/second@1",
    "relativetime/narrow/week@1",
    "relativetime/narrow/year@1",
    "relativetime/short/day@1",
    "relativetime/short/hour@1",
    "relativetime/short/minute@1",
    "relativetime/short/month@1",
    "relativetime/short/quarter@1",
    "relativetime/short/second@1",
    "relativetime/short/week@1",
    "relativetime/short/year@1",
    "segmenter/dictionary@1",
    "segmenter/grapheme@1",
    "segmenter/line@1",
    "segmenter/lstm@1",
    "segmenter/sentence@1",
    "segmenter/word@1",
    "time_zone/exemplar_cities@1",
    "time_zone/formats@1",
    "time_zone/generic_long@1",
    "time_zone/generic_short@1",
    "time_zone/metazone_period@1",
    "time_zone/specific_long@1",
    "time_zone/specific_short@1"
  ],
  "locales": {
    "locales": {
      "Explicit": [
        "ar",
        "ar-EG",
        "bn",
        "ccp",
        "en",
        "en-001",
        "en-ZA",
        "es",
        "es-AR",
        "fr",
        "fil",
        "ja",
        "ru",
        "sr",
        "sr-Cyrl",
        "sr-Latn",
        "th",
        "tr",
        "und"
      ]
    },
    "regions": "All",
    "include_root": true,
    "some_segmenter_flag": false
  },
  "fallback": {
    "variant": "None"
  }
}
```