### PR TITLE
Add native option to icu_codepointtrie_builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,12 +47,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
-
-[[package]]
 name = "arraystring"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,10 +1447,10 @@ dependencies = [
  "icu",
  "icu_collections",
  "lazy_static",
- "rust_icu_sys",
  "toml",
  "wasmer",
  "wasmer-wasi",
+ "zerovec",
 ]
 
 [[package]]
@@ -2475,12 +2469,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6448add382c60bbbc64f9dab41309a12ec530c05191601042f911356ac09758c"
 
 [[package]]
-name = "paste"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
-
-[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2850,18 +2838,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60e7c00b6c3bf5e38a880eec01d7e829d12ca682079f8238a464def3c4b31627"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rust_icu_sys"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c9f16b72fb360e84f90651180f0621879e5759b9ac4a762c34d782caac38898"
-dependencies = [
- "anyhow",
- "lazy_static",
- "libc",
- "paste",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+
+[[package]]
 name = "arraystring"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,6 +1453,7 @@ dependencies = [
  "icu",
  "icu_collections",
  "lazy_static",
+ "rust_icu_sys",
  "toml",
  "wasmer",
  "wasmer-wasi",
@@ -2468,6 +2475,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6448add382c60bbbc64f9dab41309a12ec530c05191601042f911356ac09758c"
 
 [[package]]
+name = "paste"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,6 +2850,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60e7c00b6c3bf5e38a880eec01d7e829d12ca682079f8238a464def3c4b31627"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rust_icu_sys"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c9f16b72fb360e84f90651180f0621879e5759b9ac4a762c34d782caac38898"
+dependencies = [
+ "anyhow",
+ "lazy_static",
+ "libc",
+ "paste",
 ]
 
 [[package]]

--- a/components/collections/codepointtrie_builder/Cargo.toml
+++ b/components/collections/codepointtrie_builder/Cargo.toml
@@ -24,8 +24,6 @@ include = [
     "list_to_ucptrie.wasm"
 ]
 
-build = true
-
 [package.metadata.workspaces]
 independent = true
 

--- a/components/collections/codepointtrie_builder/Cargo.toml
+++ b/components/collections/codepointtrie_builder/Cargo.toml
@@ -73,5 +73,6 @@ features = [
 icu = { path = "../../icu" }
 
 [package.metadata.cargo-all-features]
-# No features, so disable cargo-all-features
-skip_feature_sets = [[]]
+skip_optional_dependencies = true
+# these need env vars. They still get `cargo check'd` when doing `--all-features`
+denylist = ["icu4c", "icu4c_unsuffixed"]

--- a/components/collections/codepointtrie_builder/Cargo.toml
+++ b/components/collections/codepointtrie_builder/Cargo.toml
@@ -32,8 +32,9 @@ independent = true
 default = ["wasm"]
 wasm = ["wasmer", "wasmer-wasi"]
 # Use the ICU4C builder
-# needs the ICU4C_LIB_PATH variable set and pointing to an ICU4C *staticlib*
-# Will be silently disabled if the wasm feature is also disabled
+# needs the ICU4C_LIB_PATH variable set and pointing to an ICU4C lib folder
+# containing dylibs. If you want to use staticlibs, set ICU4C_LINK_STATICALLY
+# Will be silently disabled if the wasm feature is enabled
 icu4c = ["zerovec"]
 # Use icu4c with unsuffixed APIs (u_foobar instead of u_foobar_72)
 icu4c_unsuffixed = ["icu4c"]

--- a/components/collections/codepointtrie_builder/Cargo.toml
+++ b/components/collections/codepointtrie_builder/Cargo.toml
@@ -73,4 +73,4 @@ icu = { path = "../../icu" }
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true
 # these need env vars. They still get `cargo check'd` when doing `--all-features`
-denylist = ["icu4c", "icu4c_unsuffixed"]
+denylist = ["icu4c"]

--- a/components/collections/codepointtrie_builder/Cargo.toml
+++ b/components/collections/codepointtrie_builder/Cargo.toml
@@ -24,18 +24,24 @@ include = [
     "list_to_ucptrie.wasm"
 ]
 
+build = true
+
 [package.metadata.workspaces]
 independent = true
 
 [features]
+# Use the wasm builder
 default = ["wasm"]
 wasm = ["wasmer", "wasmer-wasi"]
-icu4c = ["rust_icu_sys"]
+# Use the ICU4C builder
+# needs the ICU4C_LIB_PATH variable set and pointing to an ICU4C *staticlib*
+# Will be silently disabled if the wasm feature is also disabled
+icu4c = ["zerovec"]
 
 [dependencies]
 icu_collections = { version = "1.1.0", path = "..", features = ["serde"] }
+zerovec = { version = "0.9.2", path = "../../../utils/zerovec", optional = true }
 lazy_static = "1.4.0"
-rust_icu_sys = { version = "3.0.0", default-features = false, features = ["renaming"], optional = true}
 toml = "0.5"
 
 [dependencies.wasmer]

--- a/components/collections/codepointtrie_builder/Cargo.toml
+++ b/components/collections/codepointtrie_builder/Cargo.toml
@@ -33,11 +33,9 @@ default = ["wasm"]
 wasm = ["wasmer", "wasmer-wasi"]
 # Use the ICU4C builder
 # needs the ICU4C_LIB_PATH variable set and pointing to an ICU4C lib folder
-# containing dylibs. If you want to use staticlibs, set ICU4C_LINK_STATICALLY
+# containing dylibs. If you want to use staticlibs, set ICU4C_LINK_STATICALLY.
 # Will be silently disabled if the wasm feature is enabled
 icu4c = ["zerovec"]
-# Use icu4c with unsuffixed APIs (u_foobar instead of u_foobar_72)
-icu4c_unsuffixed = ["icu4c"]
 
 [dependencies]
 icu_collections = { version = "1.1.0", path = "..", features = ["serde"] }

--- a/components/collections/codepointtrie_builder/Cargo.toml
+++ b/components/collections/codepointtrie_builder/Cargo.toml
@@ -35,6 +35,8 @@ wasm = ["wasmer", "wasmer-wasi"]
 # needs the ICU4C_LIB_PATH variable set and pointing to an ICU4C *staticlib*
 # Will be silently disabled if the wasm feature is also disabled
 icu4c = ["zerovec"]
+# Use icu4c with unsuffixed APIs (u_foobar instead of u_foobar_72)
+icu4c_unsuffixed = ["icu4c"]
 
 [dependencies]
 icu_collections = { version = "1.1.0", path = "..", features = ["serde"] }

--- a/components/collections/codepointtrie_builder/Cargo.toml
+++ b/components/collections/codepointtrie_builder/Cargo.toml
@@ -27,14 +27,21 @@ include = [
 [package.metadata.workspaces]
 independent = true
 
+[features]
+default = ["wasm"]
+wasm = ["wasmer", "wasmer-wasi"]
+icu4c = ["rust_icu_sys"]
+
 [dependencies]
 icu_collections = { version = "1.1.0", path = "..", features = ["serde"] }
 lazy_static = "1.4.0"
+rust_icu_sys = { version = "3.0.0", default-features = false, features = ["renaming"], optional = true}
 toml = "0.5"
 
 [dependencies.wasmer]
 version = "2.2.1"
 default-features = false
+optional = true
 features = [
     # We are running on the local system (as opposed to JavaScript)
     "sys",
@@ -47,6 +54,7 @@ features = [
 [dependencies.wasmer-wasi]
 version = "2.2.1"
 default-features = false
+optional = true
 features = [
     # We are running on the local system (as opposed to JavaScript)
     "sys",

--- a/components/collections/codepointtrie_builder/README.md
+++ b/components/collections/codepointtrie_builder/README.md
@@ -6,9 +6,29 @@ This crate exposes functionality to build a [`CodePointTrie`] from values provid
 Because it is normally expected for CodePointTrie data to be pre-compiled, this crate is not
 optimized for speed; it should be used during a build phase.
 
-Under the hood, this crate uses the CodePointTrie builder code from ICU4C, [`UMutableCPTrie`],
-shipped as a WebAssembly module and then JIT-compiled at runtime. For more context, see
-<https://github.com/unicode-org/icu4x/issues/1837>.
+Under the hood, this crate uses the CodePointTrie builder code from ICU4C, [`UMutableCPTrie`].
+For more context, see <https://github.com/unicode-org/icu4x/issues/1837>.
+
+## Build configuration
+
+This crate has two primary modes it can be used in: `"wasm"` and `"icu4c"`, exposed as
+Cargo features. If both are enabled, the code will internally use the wasm codepath.
+
+The `"wasm"` mode uses an included wasm module that was built by linking
+it to ICU4C, run on a wasm runtime. It pulls in a lot of dependencies to do this, but
+it should just work with no further effort.
+
+The `"icu4c"` mode requires some extra effort: it links to a local copy of ICU4C.
+If using Cargo, you can use the `ICU4C_LIB_PATH` environment variable to point this to
+a directory full of ICU4X static or shared libraries, and `ICU4C_LINK_STATICALLY` to use
+static linking (if using dynamic linking you will have to set `[DY]LD_LIBRARY_PATH` at runtime
+as well). If building directly, make sure this path is provided via `-L`, and that the
+CLI requests to link against `icuuc`, `icui18n` and `icudata` via `-l` flags.
+
+By default ICU4C uses *renamed* symbols, where each function is suffixed with a version number.
+This crate by default will link to ICU4C 72 symbols. If you have built it with renaming
+disabled, you can provide the `ICU4C_DISABLE_RENAMING` flag to cargo, or pass `--cfg icu4c_disable_renaming`.
+Versions other than ICU4C 72 are not currently supported.
 
 ## Examples
 

--- a/components/collections/codepointtrie_builder/README.md
+++ b/components/collections/codepointtrie_builder/README.md
@@ -1,4 +1,4 @@
-# icu_codepointtrie_builder
+# icu_codepointtrie_builder [![crates.io](https://img.shields.io/crates/v/icu_codepointtrie_builder)](https://crates.io/crates/icu_codepointtrie_builder)
 
 `icu_codepointtrie_builder` is a utility crate of the [`ICU4X`] project.
 
@@ -65,4 +65,6 @@ assert_eq!(cpt.get32(u32::MAX), 2); // error value
 [`ICU4X`]: ../icu/index.html
 [`UMutableCPTrie`]: (https://unicode-org.github.io/icu-docs/apidoc/dev/icu4c/umutablecptrie_8h.html#ad8945cf34ca9d40596a66a1395baa19b)
 
-License: Unicode-DFS-2016
+## More Information
+
+For more information on development, authorship, contributing etc. please visit [`ICU4X home page`](https://github.com/unicode-org/icu4x).

--- a/components/collections/codepointtrie_builder/README.md
+++ b/components/collections/codepointtrie_builder/README.md
@@ -1,4 +1,4 @@
-# icu_codepointtrie_builder [![crates.io](https://img.shields.io/crates/v/icu_codepointtrie_builder)](https://crates.io/crates/icu_codepointtrie_builder)
+# icu_codepointtrie_builder
 
 `icu_codepointtrie_builder` is a utility crate of the [`ICU4X`] project.
 
@@ -25,10 +25,10 @@ static linking (if using dynamic linking you will have to set `[DY]LD_LIBRARY_PA
 as well). If building directly, make sure this path is provided via `-L`, and that the
 CLI requests to link against `icuuc`, `icui18n` and `icudata` via `-l` flags.
 
-By default ICU4C uses *renamed* symbols, where each function is suffixed with a version number.
-This crate by default will link to ICU4C 72 symbols. If you have built it with renaming
-disabled, you can provide the `ICU4C_DISABLE_RENAMING` flag to cargo, or pass `--cfg icu4c_disable_renaming`.
-Versions other than ICU4C 72 are not currently supported.
+ICU4C can  *renamed* symbols, where each function is suffixed with a version number.
+This crate by default will link to unrenamed symbols. If you have built it with renaming
+enabled, you can set the `ICU4C_RENAME_VERSION=<version>` env var. When building without Cargo
+this must be paired with `--cfg icu4c_enable_renaming`.
 
 ## Examples
 
@@ -61,6 +61,4 @@ assert_eq!(cpt.get32(u32::MAX), 2); // error value
 [`ICU4X`]: ../icu/index.html
 [`UMutableCPTrie`]: (https://unicode-org.github.io/icu-docs/apidoc/dev/icu4c/umutablecptrie_8h.html#ad8945cf34ca9d40596a66a1395baa19b)
 
-## More Information
-
-For more information on development, authorship, contributing etc. please visit [`ICU4X home page`](https://github.com/unicode-org/icu4x).
+License: Unicode-DFS-2016

--- a/components/collections/codepointtrie_builder/README.md
+++ b/components/collections/codepointtrie_builder/README.md
@@ -14,21 +14,25 @@ For more context, see <https://github.com/unicode-org/icu4x/issues/1837>.
 This crate has two primary modes it can be used in: `"wasm"` and `"icu4c"`, exposed as
 Cargo features. If both are enabled, the code will internally use the wasm codepath.
 
-The `"wasm"` mode uses an included wasm module that was built by linking
-it to ICU4C, run on a wasm runtime. It pulls in a lot of dependencies to do this, but
-it should just work with no further effort.
+The `"wasm"` mode uses a Wasm module packaged into this Rust crate that contains
+pre-compiled ICU4C CodePointTrie builder code. It evaluates the Wasm module using
+the Wasmer runtime, which "just works", but it requires a large number of
+Rust/Cargo dependencies.
 
-The `"icu4c"` mode requires some extra effort: it links to a local copy of ICU4C.
-If using Cargo, you can use the `ICU4C_LIB_PATH` environment variable to point this to
-a directory full of ICU4X static or shared libraries, and `ICU4C_LINK_STATICALLY` to use
-static linking (if using dynamic linking you will have to set `[DY]LD_LIBRARY_PATH` at runtime
-as well). If building directly, make sure this path is provided via `-L`, and that the
-CLI requests to link against `icuuc`, `icui18n` and `icudata` via `-l` flags.
+The `"icu4c"` mode reduces the number of Rust dependencies, but it requires having a local copy
+of ICU4C available. To configure `"icu4c"` mode in Cargo, set the following environment variables:
 
-ICU4C can  *renamed* symbols, where each function is suffixed with a version number.
-This crate by default will link to unrenamed symbols. If you have built it with renaming
-enabled, you can set the `ICU4C_RENAME_VERSION=<version>` env var. When building without Cargo
-this must be paired with `--cfg icu4c_enable_renaming`.
+- Set `ICU4C_LIB_PATH` to a directory full of ICU4C static or shared libraries.
+- Set `ICU4C_LINK_STATICALLY` to any value to use the static libraries.
+- Set `ICU4C_RENAME_VERSION` to the integer ICU4C version if ICU4C has renaming
+  enabled. By default, we attempt to link non-renamed symbols.
+
+If using dynamic linking, at runtime, you may need to set `[DY]LD_LIBRARY_PATH`
+to the `ICU4C_LIB_PATH`.
+
+If _not_ using Cargo, make sure to pass `ICU4C_LIB_PATH` to the linker via `-L`, link against
+`icuuc`, `icui18n` and `icudata` via `-l` flags, and set `--cfg icu4c_enable_renaming` if you need
+renamed ICU4C symbols.
 
 ## Examples
 

--- a/components/collections/codepointtrie_builder/build.rs
+++ b/components/collections/codepointtrie_builder/build.rs
@@ -12,8 +12,11 @@ fn main() {
             false => "dylib",
         };
 
-        if env::var("ICU4C_DISABLE_RENAMING").is_ok() {
-            println!("cargo:rustc-cfg=icu4c_disable_renaming");
+        if env::var("ICU4C_RENAME_VERSION").is_ok() {
+            println!("cargo:rustc-cfg=icu4c_enable_renaming");
+        } else {
+            // env!() fails for unset env vars even if used inside a disabled cfg_attr
+            println!("cargo:rustc-env=ICU4C_RENAME_VERSION=setbybuildscriptshouldnotbeseen");
         }
 
         println!("cargo:rustc-link-search={lib_path}");
@@ -23,6 +26,6 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib=stdc++");
         println!("cargo:rerun-if-env-changed=ICU4C_LINK_STATICALLY");
         println!("cargo:rerun-if-env-changed=ICU4C_LIB_PATH");
-        println!("cargo:rerun-if-env-changed=ICU4C_DISABLE_RENAMING");
+        println!("cargo:rerun-if-env-changed=ICU4C_RENAME_VERSION");
     }
 }

--- a/components/collections/codepointtrie_builder/build.rs
+++ b/components/collections/codepointtrie_builder/build.rs
@@ -6,7 +6,6 @@ use std::env;
 
 fn main() {
     if env::var("CARGO_FEATURE_ICU4C").is_ok() && env::var("CARGO_FEATURE_WASM").is_err() {
-
         let lib_path = env::var("ICU4C_LIB_PATH").expect("Must have `ICU4C_LIB_PATH` environment variable set when building icu_codepointtrie_builder with the `icu4c` feature");
         let kind = match env::var("ICU4C_LINK_STATICALLY").is_ok() {
             true => "static",

--- a/components/collections/codepointtrie_builder/build.rs
+++ b/components/collections/codepointtrie_builder/build.rs
@@ -12,6 +12,10 @@ fn main() {
             false => "dylib",
         };
 
+        if env::var("ICU4C_DISABLE_RENAMING").is_ok() {
+            println!("cargo:rustc-cfg=icu4c_disable_renaming");
+        }
+
         println!("cargo:rustc-link-search={lib_path}");
         println!("cargo:rustc-link-lib={kind}=icuuc");
         println!("cargo:rustc-link-lib={kind}=icui18n");
@@ -19,5 +23,6 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib=stdc++");
         println!("cargo:rerun-if-env-changed=ICU4C_LINK_STATICALLY");
         println!("cargo:rerun-if-env-changed=ICU4C_LIB_PATH");
+        println!("cargo:rerun-if-env-changed=ICU4C_DISABLE_RENAMING");
     }
 }

--- a/components/collections/codepointtrie_builder/build.rs
+++ b/components/collections/codepointtrie_builder/build.rs
@@ -14,9 +14,6 @@ fn main() {
 
         if env::var("ICU4C_RENAME_VERSION").is_ok() {
             println!("cargo:rustc-cfg=icu4c_enable_renaming");
-        } else {
-            // env!() fails for unset env vars even if used inside a disabled cfg_attr
-            println!("cargo:rustc-env=ICU4C_RENAME_VERSION=setbybuildscriptshouldnotbeseen");
         }
 
         println!("cargo:rustc-link-search={lib_path}");

--- a/components/collections/codepointtrie_builder/build.rs
+++ b/components/collections/codepointtrie_builder/build.rs
@@ -1,0 +1,24 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use std::env;
+
+fn main() {
+    if env::var("CARGO_FEATURE_ICU4C").is_ok() && env::var("CARGO_FEATURE_WASM").is_err() {
+
+        let lib_path = env::var("ICU4C_LIB_PATH").expect("Must have `ICU4C_LIB_PATH` environment variable set when building icu_codepointtrie_builder with the `icu4c` feature");
+        let kind = match env::var("ICU4C_LINK_STATICALLY").is_ok() {
+            true => "static",
+            false => "dylib",
+        };
+
+        println!("cargo:rustc-link-search={lib_path}");
+        println!("cargo:rustc-link-lib={kind}=icuuc");
+        println!("cargo:rustc-link-lib={kind}=icui18n");
+        println!("cargo:rustc-link-lib={kind}=icudata");
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+        println!("cargo:rerun-if-env-changed=ICU4C_LINK_STATICALLY");
+        println!("cargo:rerun-if-env-changed=ICU4C_LIB_PATH");
+    }
+}

--- a/components/collections/codepointtrie_builder/src/lib.rs
+++ b/components/collections/codepointtrie_builder/src/lib.rs
@@ -16,9 +16,10 @@
 //! This crate has two primary modes it can be used in: `"wasm"` and `"icu4c"`, exposed as
 //! Cargo features. If both are enabled, the code will internally use the wasm codepath.
 //!
-//! The `"wasm"` mode uses an included wasm module that was built by linking
-//! it to ICU4C, run on a wasm runtime. It pulls in a lot of dependencies to do this, but
-//! it should just work with no further effort.
+//! The `"wasm"` mode uses a Wasm module packaged into this Rust crate that contains
+//! pre-compiled ICU4C CodePointTrie builder code. It evaluates the Wasm module using
+//! the Wasmer runtime, which "just works", but it requires a large number of
+//! Rust/Cargo dependencies.
 //!
 //! The `"icu4c"` mode reduces the number of Rust dependencies, but it requires having a local copy
 //! of ICU4C available. To configure `"icu4c"` mode in Cargo, set the following environment variables:

--- a/components/collections/codepointtrie_builder/src/lib.rs
+++ b/components/collections/codepointtrie_builder/src/lib.rs
@@ -59,7 +59,6 @@
 #![allow(clippy::panic)]
 #![allow(clippy::expect_used)]
 
-use icu_collections::codepointtrie::CodePointTrie;
 use icu_collections::codepointtrie::TrieType;
 use icu_collections::codepointtrie::TrieValue;
 
@@ -105,7 +104,7 @@ where
     ///
     /// This function needs either the `"wasm"` or `"icu4c"` feature
     #[cfg(any(feature = "wasm", feature = "icu4c"))]
-    pub fn build(self) -> CodePointTrie<'static, T> {
+    pub fn build(self) -> icu_collections::codepointtrie::CodePointTrie<'static, T> {
         #[cfg(feature = "wasm")]
         {
             use icu_collections::codepointtrie::toml::CodePointTrieToml;

--- a/components/collections/codepointtrie_builder/src/lib.rs
+++ b/components/collections/codepointtrie_builder/src/lib.rs
@@ -27,10 +27,10 @@
 //! as well). If building directly, make sure this path is provided via `-L`, and that the
 //! CLI requests to link against `icuuc`, `icui18n` and `icudata` via `-l` flags.
 //!
-//! By default ICU4C uses *renamed* symbols, where each function is suffixed with a version number.
-//! This crate by default will link to ICU4C 72 symbols. If you have built it with renaming
-//! disabled, you can provide the `ICU4C_DISABLE_RENAMING` flag to cargo, or pass `--cfg icu4c_disable_renaming`.
-//! Versions other than ICU4C 72 are not currently supported.
+//! ICU4C can  *renamed* symbols, where each function is suffixed with a version number.
+//! This crate by default will link to unrenamed symbols. If you have built it with renaming
+//! enabled, you can set the `ICU4C_RENAME_VERSION=<version>` env var. When building without Cargo
+//! this must be paired with `--cfg icu4c_enable_renaming`.
 //!
 //! # Examples
 //!

--- a/components/collections/codepointtrie_builder/src/lib.rs
+++ b/components/collections/codepointtrie_builder/src/lib.rs
@@ -8,9 +8,29 @@
 //! Because it is normally expected for CodePointTrie data to be pre-compiled, this crate is not
 //! optimized for speed; it should be used during a build phase.
 //!
-//! Under the hood, this crate uses the CodePointTrie builder code from ICU4C, [`UMutableCPTrie`],
-//! shipped as a WebAssembly module and then JIT-compiled at runtime. For more context, see
-//! <https://github.com/unicode-org/icu4x/issues/1837>.
+//! Under the hood, this crate uses the CodePointTrie builder code from ICU4C, [`UMutableCPTrie`].
+//! For more context, see <https://github.com/unicode-org/icu4x/issues/1837>.
+//!
+//! # Build configuration
+//!
+//! This crate has two primary modes it can be used in: `"wasm"` and `"icu4c"`, exposed as
+//! Cargo features. If both are enabled, the code will internally use the wasm codepath.
+//!
+//! The `"wasm"` mode uses an included wasm module that was built by linking
+//! it to ICU4C, run on a wasm runtime. It pulls in a lot of dependencies to do this, but
+//! it should just work with no further effort.
+//!
+//! The `"icu4c"` mode requires some extra effort: it links to a local copy of ICU4C.
+//! If using Cargo, you can use the `ICU4C_LIB_PATH` environment variable to point this to
+//! a directory full of ICU4X static or shared libraries, and `ICU4C_LINK_STATICALLY` to use
+//! static linking (if using dynamic linking you will have to set `[DY]LD_LIBRARY_PATH` at runtime
+//! as well). If building directly, make sure this path is provided via `-L`, and that the
+//! CLI requests to link against `icuuc`, `icui18n` and `icudata` via `-l` flags.
+//!
+//! By default ICU4C uses *renamed* symbols, where each function is suffixed with a version number.
+//! This crate by default will link to ICU4C 72 symbols. If you have built it with renaming
+//! disabled, you can provide the `ICU4C_DISABLE_RENAMING` flag to cargo, or pass `--cfg icu4c_disable_renaming`.
+//! Versions other than ICU4C 72 are not currently supported.
 //!
 //! # Examples
 //!

--- a/components/collections/codepointtrie_builder/src/lib.rs
+++ b/components/collections/codepointtrie_builder/src/lib.rs
@@ -109,7 +109,6 @@ where
         #[cfg(feature = "wasm")]
         {
             use icu_collections::codepointtrie::toml::CodePointTrieToml;
-            use std::convert::TryInto;
 
             let toml_str = wasm::run_wasm(&self);
             let toml_obj: CodePointTrieToml =

--- a/components/collections/codepointtrie_builder/src/lib.rs
+++ b/components/collections/codepointtrie_builder/src/lib.rs
@@ -65,7 +65,11 @@ use icu_collections::codepointtrie::TrieType;
 use icu_collections::codepointtrie::TrieValue;
 use std::convert::TryInto;
 
+#[cfg(feature = "wasm")]
 mod wasm;
+
+#[cfg(feature = "icu4c")]
+mod native;
 
 /// Wrapper over the data to be encoded into a CodePointTrie.
 ///
@@ -99,6 +103,7 @@ where
     /// Build the [`CodePointTrie`].
     ///
     /// Under the hood, this function runs ICU4C code compiled into WASM.
+    #[cfg(feature = "wasm")]
     pub fn build(self) -> CodePointTrie<'static, T> {
         let toml_str = wasm::run_wasm(&self);
         let toml_obj: CodePointTrieToml =
@@ -112,7 +117,11 @@ where
 #[test]
 fn test_cpt_builder() {
     // Buckets of ten characters for 0 to 100, and then some default values, and then heterogenous "last hex digit" for 0x100 to 0x200
-    let values: Vec<u32> = (0..100).map(|x| x / 10).chain((100..0x100).map(|_| 100)).chain((0x100..0x200).map(|x| x % 16)).collect();
+    let values: Vec<u32> = (0..100)
+        .map(|x| x / 10)
+        .chain((100..0x100).map(|_| 100))
+        .chain((0x100..0x200).map(|x| x % 16))
+        .collect();
 
     let builder = CodePointTrieBuilder {
         data: CodePointTrieBuilderData::ValuesByCodePoint(&values),

--- a/components/collections/codepointtrie_builder/src/lib.rs
+++ b/components/collections/codepointtrie_builder/src/lib.rs
@@ -108,3 +108,32 @@ where
             .expect("the toml should be a valid CPT")
     }
 }
+
+#[test]
+fn test_cpt_builder() {
+    // Buckets of ten characters for 0 to 100, and then some default values, and then heterogenous "last hex digit" for 0x100 to 0x200
+    let values: Vec<u32> = (0..100).map(|x| x / 10).chain((100..0x100).map(|_| 100)).chain((0x100..0x200).map(|x| x % 16)).collect();
+
+    let builder = CodePointTrieBuilder {
+        data: CodePointTrieBuilderData::ValuesByCodePoint(&values),
+        default_value: 100,
+        error_value: 0xFFFF,
+        trie_type: TrieType::Fast,
+    };
+
+    let cpt = builder.build();
+
+    assert_eq!(cpt.get32(0), 0);
+    assert_eq!(cpt.get32(10), 1);
+    assert_eq!(cpt.get32(20), 2);
+    assert_eq!(cpt.get32(21), 2);
+    assert_eq!(cpt.get32(99), 9);
+    assert_eq!(cpt.get32(0x101), 0x1);
+    assert_eq!(cpt.get32(0x102), 0x2);
+    assert_eq!(cpt.get32(0x105), 0x5);
+    assert_eq!(cpt.get32(0x125), 0x5);
+    assert_eq!(cpt.get32(0x135), 0x5);
+    assert_eq!(cpt.get32(0x13F), 0xF);
+    // default value
+    assert_eq!(cpt.get32(0x300), 100);
+}

--- a/components/collections/codepointtrie_builder/src/lib.rs
+++ b/components/collections/codepointtrie_builder/src/lib.rs
@@ -20,17 +20,20 @@
 //! it to ICU4C, run on a wasm runtime. It pulls in a lot of dependencies to do this, but
 //! it should just work with no further effort.
 //!
-//! The `"icu4c"` mode requires some extra effort: it links to a local copy of ICU4C.
-//! If using Cargo, you can use the `ICU4C_LIB_PATH` environment variable to point this to
-//! a directory full of ICU4X static or shared libraries, and `ICU4C_LINK_STATICALLY` to use
-//! static linking (if using dynamic linking you will have to set `[DY]LD_LIBRARY_PATH` at runtime
-//! as well). If building directly, make sure this path is provided via `-L`, and that the
-//! CLI requests to link against `icuuc`, `icui18n` and `icudata` via `-l` flags.
+//! The `"icu4c"` mode reduces the number of Rust dependencies, but it requires having a local copy
+//! of ICU4C available. To configure `"icu4c"` mode in Cargo, set the following environment variables:
 //!
-//! ICU4C can  *renamed* symbols, where each function is suffixed with a version number.
-//! This crate by default will link to unrenamed symbols. If you have built it with renaming
-//! enabled, you can set the `ICU4C_RENAME_VERSION=<version>` env var. When building without Cargo
-//! this must be paired with `--cfg icu4c_enable_renaming`.
+//! - Set `ICU4C_LIB_PATH` to a directory full of ICU4C static or shared libraries.
+//! - Set `ICU4C_LINK_STATICALLY` to any value to use the static libraries.
+//! - Set `ICU4C_RENAME_VERSION` to the integer ICU4C version if ICU4C has renaming
+//!   enabled. By default, we attempt to link non-renamed symbols.
+//!
+//! If using dynamic linking, at runtime, you may need to set `[DY]LD_LIBRARY_PATH`
+//! to the `ICU4C_LIB_PATH`.
+//!
+//! If _not_ using Cargo, make sure to pass `ICU4C_LIB_PATH` to the linker via `-L`, link against
+//! `icuuc`, `icui18n` and `icudata` via `-l` flags, and set `--cfg icu4c_enable_renaming` if you need
+//! renamed ICU4C symbols.
 //!
 //! # Examples
 //!

--- a/components/collections/codepointtrie_builder/src/lib.rs
+++ b/components/collections/codepointtrie_builder/src/lib.rs
@@ -104,6 +104,7 @@ where
     /// or links natively to ICU4C as specified by the `ICU4C_LIB_PATH` env var
     ///
     /// This function needs either the `"wasm"` or `"icu4c"` feature
+    #[cfg(any(feature = "wasm", feature = "icu4c"))]
     pub fn build(self) -> CodePointTrie<'static, T> {
         #[cfg(feature = "wasm")]
         {

--- a/components/collections/codepointtrie_builder/src/native.rs
+++ b/components/collections/codepointtrie_builder/src/native.rs
@@ -158,7 +158,7 @@ where
     };
     let data_vec = ZeroVec::alloc_from_slice(
         &data_vec
-            .map_err(|_| ())
+            .map_err(|s| s.to_string())
             .expect("Failed to parse as TrieValue"),
     );
     let built_trie =

--- a/components/collections/codepointtrie_builder/src/native.rs
+++ b/components/collections/codepointtrie_builder/src/native.rs
@@ -68,7 +68,7 @@ extern "C" {
 
     #[cfg_attr(icu4c_enable_renaming, link_name = concat!("ucptrie_close_", env!("ICU4C_RENAME_VERSION")))]
     fn ucptrie_close(trie: *const UCPTrie);
-    #[cfg_attr(not(icu4c_disable_renaming), link_name = concat!("umutablecptrie_close_", env!("ICU4C_RENAME_VERSION")))]
+    #[cfg_attr(icu4c_enable_renaming, link_name = concat!("umutablecptrie_close_", env!("ICU4C_RENAME_VERSION")))]
     fn umutablecptrie_close(builder: *const UMutableCPTrie);
 }
 

--- a/components/collections/codepointtrie_builder/src/native.rs
+++ b/components/collections/codepointtrie_builder/src/native.rs
@@ -1,0 +1,152 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+use crate::CodePointTrieBuilder;
+use crate::CodePointTrieBuilderData;
+
+use icu_collections::codepointtrie::TrieType;
+use icu_collections::codepointtrie::TrieValue;
+use icu_collections::codepointtrie::{CodePointTrie, CodePointTrieHeader};
+
+use zerovec::ZeroVec;
+
+use core::{mem, slice};
+
+enum UMutableCPTrie {}
+
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct UCPTrie {
+    pub index: *const u16,
+    pub data: UCPTrieData,
+    pub indexLength: i32,
+    pub dataLength: i32,
+    pub highStart: u32,
+    pub shifted12HighStart: u16,
+    pub type_: i8,
+    pub valueWidth: i8,
+    pub reserved32: u32,
+    pub reserved16: u16,
+    pub index3NullOffset: u16,
+    pub dataNullOffset: i32,
+    pub nullValue: u32,
+}
+
+#[repr(C)]
+pub union UCPTrieData {
+    pub ptr0: *const ::std::os::raw::c_void,
+    pub ptr16: *const u16,
+    pub ptr32: *const u32,
+    pub ptr8: *const u8,
+}
+
+extern "C" {
+    fn umutablecptrie_open_72(
+        initial_value: u32,
+        error_value: u32,
+        error_code: &mut u32,
+    ) -> *const UMutableCPTrie;
+    fn umutablecptrie_set_72(
+        trie: *const UMutableCPTrie,
+        cp: u32,
+        value: u32,
+        error_code: &mut u32,
+    ) -> *const UMutableCPTrie;
+    fn umutablecptrie_buildImmutable_72(
+        trie: *const UMutableCPTrie,
+        trie_type: u32,
+        width: u32,
+        error_code: &mut u32,
+    ) -> *const UCPTrie;
+
+    fn ucptrie_close_72(trie: *const UCPTrie);
+    fn umutablecptrie_close_72(builder: *const UMutableCPTrie);
+}
+
+pub(crate) fn run_native<T>(cpt_builder: &CodePointTrieBuilder<T>) -> CodePointTrie<'static, T>
+where
+    T: TrieValue + Into<u32>,
+{
+    let mut error = 0;
+    let builder = unsafe {
+        umutablecptrie_open_72(
+            cpt_builder.default_value.into(),
+            cpt_builder.error_value.into(),
+            &mut error,
+        )
+    };
+
+    if error != 0 {
+        panic!("cpt builder returned error code {}", error);
+    }
+
+    let CodePointTrieBuilderData::ValuesByCodePoint(values) = cpt_builder.data;
+
+    for (cp, value) in values.iter().enumerate() {
+        unsafe {
+            umutablecptrie_set_72(builder, cp as u32, (*value).into(), &mut error);
+        }
+        if error != 0 {
+            panic!("cpt builder returned error code {}", error);
+        }
+    }
+
+    let trie_type = match cpt_builder.trie_type {
+        TrieType::Fast => 0,
+        TrieType::Small => 1,
+    };
+    let width = match mem::size_of::<T::ULE>() {
+        2 => 0, // UCPTRIE_VALUE_BITS_16
+        4 => 1, // UCPTRIE_VALUE_BITS_32
+        1 => 2, // UCPTRIE_VALUE_BITS_8
+        other => panic!("Don't know how to make trie with width {other}"),
+    };
+    let built = unsafe { umutablecptrie_buildImmutable_72(builder, trie_type, width, &mut error) };
+    if error != 0 {
+        panic!("cpt builder returned error code {}", error);
+    }
+    unsafe {
+        umutablecptrie_close_72(builder);
+    }
+
+    let trie = unsafe { &*built };
+
+    let header = CodePointTrieHeader {
+        high_start: trie.highStart,
+        shifted12_high_start: trie.shifted12HighStart,
+        index3_null_offset: trie.index3NullOffset,
+        data_null_offset: trie
+            .dataNullOffset
+            .try_into()
+            .expect("Found negative or out of range dataNullOffset"),
+        null_value: trie.nullValue,
+        trie_type: TrieType::try_from(trie.type_ as u8).expect("Found out of range TrieType"),
+    };
+
+    let index_slice = unsafe { slice::from_raw_parts(trie.index, trie.indexLength as usize) };
+    let index_vec = ZeroVec::alloc_from_slice(index_slice);
+    let data_vec: Result<Vec<T>, _> = unsafe {
+        match mem::size_of::<T::ULE>() {
+            1 => slice::from_raw_parts(trie.data.ptr8, trie.dataLength as usize)
+                .iter()
+                .map(|x| TrieValue::try_from_u32(*x as u32))
+                .collect(),
+            2 => slice::from_raw_parts(trie.data.ptr16, trie.dataLength as usize)
+                .iter()
+                .map(|x| TrieValue::try_from_u32(*x as u32))
+                .collect(),
+            4 => slice::from_raw_parts(trie.data.ptr32, trie.dataLength as usize)
+                .iter()
+                .map(|x| TrieValue::try_from_u32(*x as u32))
+                .collect(),
+            other => panic!("Don't know how to make trie with width {other}"),
+        }
+    };
+    let data_vec = ZeroVec::alloc_from_slice(&data_vec.map_err(|_| ()).expect("Failed to parse as TrieValue"));
+    let built_trie =
+        CodePointTrie::try_new(header, index_vec, data_vec).expect("Failed to construct");
+    unsafe {
+        ucptrie_close_72(built);
+    }
+    built_trie
+}

--- a/components/collections/codepointtrie_builder/src/native.rs
+++ b/components/collections/codepointtrie_builder/src/native.rs
@@ -41,7 +41,10 @@ pub union UCPTrieData {
 }
 
 extern "C" {
-    #[cfg_attr(not(feature = "icu4c_unsuffixed"), link_name = "umutablecptrie_open_72")]
+    #[cfg_attr(
+        not(feature = "icu4c_unsuffixed"),
+        link_name = "umutablecptrie_open_72"
+    )]
     fn umutablecptrie_open(
         initial_value: u32,
         error_value: u32,
@@ -54,7 +57,10 @@ extern "C" {
         value: u32,
         error_code: &mut u32,
     ) -> *const UMutableCPTrie;
-    #[cfg_attr(not(feature = "icu4c_unsuffixed"), link_name = "umutablecptrie_buildImmutable_72")]
+    #[cfg_attr(
+        not(feature = "icu4c_unsuffixed"),
+        link_name = "umutablecptrie_buildImmutable_72"
+    )]
     fn umutablecptrie_buildImmutable(
         trie: *const UMutableCPTrie,
         trie_type: u32,
@@ -64,7 +70,10 @@ extern "C" {
 
     #[cfg_attr(not(feature = "icu4c_unsuffixed"), link_name = "ucptrie_close_72")]
     fn ucptrie_close(trie: *const UCPTrie);
-    #[cfg_attr(not(feature = "icu4c_unsuffixed"), link_name = "umutablecptrie_close_72")]
+    #[cfg_attr(
+        not(feature = "icu4c_unsuffixed"),
+        link_name = "umutablecptrie_close_72"
+    )]
     fn umutablecptrie_close(builder: *const UMutableCPTrie);
 }
 
@@ -147,7 +156,11 @@ where
             other => panic!("Don't know how to make trie with width {other}"),
         }
     };
-    let data_vec = ZeroVec::alloc_from_slice(&data_vec.map_err(|_| ()).expect("Failed to parse as TrieValue"));
+    let data_vec = ZeroVec::alloc_from_slice(
+        &data_vec
+            .map_err(|_| ())
+            .expect("Failed to parse as TrieValue"),
+    );
     let built_trie =
         CodePointTrie::try_new(header, index_vec, data_vec).expect("Failed to construct");
     unsafe {

--- a/components/collections/codepointtrie_builder/src/native.rs
+++ b/components/collections/codepointtrie_builder/src/native.rs
@@ -1,6 +1,7 @@
 // This file is part of ICU4X. For terms of use, please see the file
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
 use crate::CodePointTrieBuilder;
 use crate::CodePointTrieBuilderData;
 
@@ -77,6 +78,9 @@ extern "C" {
     fn umutablecptrie_close(builder: *const UMutableCPTrie);
 }
 
+// When both `wasm` and `icu4c` features are set, we still want the icu4c portion to be built, we just
+// don't want it to bother the linker. In that case, we leave this unused, and silence the warning
+#[allow(unused)]
 pub(crate) fn run_native<T>(cpt_builder: &CodePointTrieBuilder<T>) -> CodePointTrie<'static, T>
 where
     T: TrieValue + Into<u32>,
@@ -165,7 +169,7 @@ where
                 .collect(),
             4 => slice::from_raw_parts(trie.data.ptr32, trie.dataLength as usize)
                 .iter()
-                .map(|x| TrieValue::try_from_u32(*x as u32))
+                .map(|x| TrieValue::try_from_u32(*x))
                 .collect(),
             other => panic!("Don't know how to make trie with width {other}"),
         }

--- a/components/collections/codepointtrie_builder/src/native.rs
+++ b/components/collections/codepointtrie_builder/src/native.rs
@@ -147,9 +147,19 @@ where
 
     // safety: we expect ICU4C to give us a valid slice (index, indexLength). The pointer types
     // are already strongly typed, giving the right slice type.
-    let index_slice = unsafe { slice::from_raw_parts(trie.index, trie.indexLength.try_into().expect("got negative number for length")) };
+    let index_slice = unsafe {
+        slice::from_raw_parts(
+            trie.index,
+            trie.indexLength
+                .try_into()
+                .expect("got negative number for length"),
+        )
+    };
     let index_vec = ZeroVec::alloc_from_slice(index_slice);
-    let data_length = trie.dataLength.try_into().expect("got negative number for length");
+    let data_length = trie
+        .dataLength
+        .try_into()
+        .expect("got negative number for length");
     // safety: based on the trie width used we expect (ptr, dataLength) to be valid for the correct
     // ptr type. The ptr types are already strongly typed, giving the right slice type.
     let data_vec: Result<Vec<T>, _> = unsafe {

--- a/components/collections/codepointtrie_builder/src/native.rs
+++ b/components/collections/codepointtrie_builder/src/native.rs
@@ -41,26 +41,31 @@ pub union UCPTrieData {
 }
 
 extern "C" {
-    fn umutablecptrie_open_72(
+    #[cfg_attr(not(feature = "icu4c_unsuffixed"), link_name = "umutablecptrie_open_72")]
+    fn umutablecptrie_open(
         initial_value: u32,
         error_value: u32,
         error_code: &mut u32,
     ) -> *const UMutableCPTrie;
-    fn umutablecptrie_set_72(
+    #[cfg_attr(not(feature = "icu4c_unsuffixed"), link_name = "umutablecptrie_set_72")]
+    fn umutablecptrie_set(
         trie: *const UMutableCPTrie,
         cp: u32,
         value: u32,
         error_code: &mut u32,
     ) -> *const UMutableCPTrie;
-    fn umutablecptrie_buildImmutable_72(
+    #[cfg_attr(not(feature = "icu4c_unsuffixed"), link_name = "umutablecptrie_buildImmutable_72")]
+    fn umutablecptrie_buildImmutable(
         trie: *const UMutableCPTrie,
         trie_type: u32,
         width: u32,
         error_code: &mut u32,
     ) -> *const UCPTrie;
 
-    fn ucptrie_close_72(trie: *const UCPTrie);
-    fn umutablecptrie_close_72(builder: *const UMutableCPTrie);
+    #[cfg_attr(not(feature = "icu4c_unsuffixed"), link_name = "ucptrie_close_72")]
+    fn ucptrie_close(trie: *const UCPTrie);
+    #[cfg_attr(not(feature = "icu4c_unsuffixed"), link_name = "umutablecptrie_close_72")]
+    fn umutablecptrie_close(builder: *const UMutableCPTrie);
 }
 
 pub(crate) fn run_native<T>(cpt_builder: &CodePointTrieBuilder<T>) -> CodePointTrie<'static, T>
@@ -69,7 +74,7 @@ where
 {
     let mut error = 0;
     let builder = unsafe {
-        umutablecptrie_open_72(
+        umutablecptrie_open(
             cpt_builder.default_value.into(),
             cpt_builder.error_value.into(),
             &mut error,
@@ -84,7 +89,7 @@ where
 
     for (cp, value) in values.iter().enumerate() {
         unsafe {
-            umutablecptrie_set_72(builder, cp as u32, (*value).into(), &mut error);
+            umutablecptrie_set(builder, cp as u32, (*value).into(), &mut error);
         }
         if error != 0 {
             panic!("cpt builder returned error code {}", error);
@@ -101,12 +106,12 @@ where
         1 => 2, // UCPTRIE_VALUE_BITS_8
         other => panic!("Don't know how to make trie with width {other}"),
     };
-    let built = unsafe { umutablecptrie_buildImmutable_72(builder, trie_type, width, &mut error) };
+    let built = unsafe { umutablecptrie_buildImmutable(builder, trie_type, width, &mut error) };
     if error != 0 {
         panic!("cpt builder returned error code {}", error);
     }
     unsafe {
-        umutablecptrie_close_72(builder);
+        umutablecptrie_close(builder);
     }
 
     let trie = unsafe { &*built };
@@ -146,7 +151,7 @@ where
     let built_trie =
         CodePointTrie::try_new(header, index_vec, data_vec).expect("Failed to construct");
     unsafe {
-        ucptrie_close_72(built);
+        ucptrie_close(built);
     }
     built_trie
 }

--- a/components/collections/codepointtrie_builder/src/native.rs
+++ b/components/collections/codepointtrie_builder/src/native.rs
@@ -42,13 +42,13 @@ pub union UCPTrieData {
 }
 
 extern "C" {
-    #[cfg_attr(not(icu4c_disable_renaming), link_name = "umutablecptrie_open_72")]
+    #[cfg_attr(icu4c_enable_renaming, link_name = concat!("umutablecptrie_open_", env!("ICU4C_RENAME_VERSION")))]
     fn umutablecptrie_open(
         initial_value: u32,
         error_value: u32,
         error_code: &mut u32,
     ) -> *const UMutableCPTrie;
-    #[cfg_attr(not(icu4c_disable_renaming), link_name = "umutablecptrie_set_72")]
+    #[cfg_attr(icu4c_enable_renaming, link_name = concat!("umutablecptrie_set_", env!("ICU4C_RENAME_VERSION")))]
     fn umutablecptrie_set(
         trie: *const UMutableCPTrie,
         cp: u32,
@@ -56,8 +56,8 @@ extern "C" {
         error_code: &mut u32,
     ) -> *const UMutableCPTrie;
     #[cfg_attr(
-        not(icu4c_disable_renaming),
-        link_name = "umutablecptrie_buildImmutable_72"
+        icu4c_enable_renaming,
+        link_name = concat!("umutablecptrie_buildImmutable_", env!("ICU4C_RENAME_VERSION"))
     )]
     fn umutablecptrie_buildImmutable(
         trie: *const UMutableCPTrie,
@@ -66,9 +66,9 @@ extern "C" {
         error_code: &mut u32,
     ) -> *const UCPTrie;
 
-    #[cfg_attr(not(icu4c_disable_renaming), link_name = "ucptrie_close_72")]
+    #[cfg_attr(icu4c_enable_renaming, link_name = concat!("ucptrie_close_", env!("ICU4C_RENAME_VERSION")))]
     fn ucptrie_close(trie: *const UCPTrie);
-    #[cfg_attr(not(icu4c_disable_renaming), link_name = "umutablecptrie_close_72")]
+    #[cfg_attr(not(icu4c_disable_renaming), link_name = concat!("umutablecptrie_close_", env!("ICU4C_RENAME_VERSION")))]
     fn umutablecptrie_close(builder: *const UMutableCPTrie);
 }
 


### PR DESCRIPTION
Part of https://github.com/unicode-org/icu4x/issues/3121

Supersedes https://github.com/unicode-org/icu4x/pull/3122

This adds the ability to set the `icu4c` feature on `icu_codepointtrie_builder`, which will link it to ICU4C instead of using the wasm thing. It only happens if the `icu4c` feature is used (not `icu4c` + `wasm`), and the linkage can be controlled in Cargo mode via `ICU4C_LIB_PATH` and the optional `ICU4C_LINK_STATICALLY`.
 

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->