### PR TITLE
Bump clap to 4.0, move to using derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,10 +352,33 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_lex",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -480,7 +503,7 @@ checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools",
@@ -1353,7 +1376,7 @@ name = "icu_benchmark_memory"
 version = "0.0.0"
 dependencies = [
  "cargo_metadata",
- "clap",
+ "clap 2.34.0",
  "libc",
  "serde_json",
 ]
@@ -1516,7 +1539,7 @@ name = "icu_datagen"
 version = "1.1.2"
 dependencies = [
  "cached-path",
- "clap",
+ "clap 4.0.26",
  "crlify",
  "databake",
  "dhat",
@@ -1929,7 +1952,7 @@ name = "icu_testdata_scripts"
 version = "0.0.0"
 dependencies = [
  "cached-path",
- "clap",
+ "clap 2.34.0",
  "crlify",
  "databake",
  "eyre",
@@ -2438,6 +2461,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "parking_lot"
@@ -3235,6 +3264,12 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,10 +366,24 @@ checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "clap_lex",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1211,6 +1225,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -3286,7 +3306,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "syn",

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -80,7 +80,7 @@ zerovec = { version = "0.9.2", path = "../../utils/zerovec", features = ["serde"
 zip = "0.5"
 
 # Dependencies for "bin" feature
-clap = { version = "4", optional = true, features = ["cargo"] }
+clap = { version = "4", optional = true, features = ["cargo", "derive"] }
 eyre = { version = "0.6", optional = true }
 simple_logger = { version = "1.12", default-features = false, optional = true }
 

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -80,7 +80,7 @@ zerovec = { version = "0.9.2", path = "../../utils/zerovec", features = ["serde"
 zip = "0.5"
 
 # Dependencies for "bin" feature
-clap = { version = "2.33", optional = true }
+clap = { version = "4", optional = true, features = ["cargo"] }
 eyre = { version = "0.6", optional = true }
 simple_logger = { version = "1.12", default-features = false, optional = true }
 

--- a/provider/datagen/src/bin/datagen.rs
+++ b/provider/datagen/src/bin/datagen.rs
@@ -8,7 +8,7 @@ use icu_datagen::prelude::*;
 use simple_logger::SimpleLogger;
 use std::path::PathBuf;
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
 enum Format {
     Dir,
     Blob,
@@ -16,25 +16,25 @@ enum Format {
     DeprecatedDefault,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
 enum Syntax {
     Json,
     Bincode,
     Postcard,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
 enum TrieType {
     Small,
     Fast,
 }
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
 enum CliCollationHanDatabase {
     Unihan,
     Implicit,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
 enum CollationTable {
     Gb2312,
     Big5han,
@@ -79,7 +79,7 @@ struct Cli {
     #[arg(help = "Delete the output before writing data.")]
     overwrite: bool,
 
-    #[arg(short, long, value_enum)]
+    #[arg(short, long, value_enum, default_value_t = Syntax::Json)]
     #[arg(help = "--format=dir only: serde serialization format.")]
     syntax: Syntax,
 
@@ -135,7 +135,7 @@ struct Cli {
     #[arg(help = "Which collation han database to use.")]
     collation_han_database: CliCollationHanDatabase,
 
-    #[arg(long, value_enum)]
+    #[arg(long, value_enum, num_args = 0..)]
     #[arg(
         help = "Which less-common collation tables to include. 'search-all' includes all search tables."
     )]
@@ -145,7 +145,7 @@ struct Cli {
     #[arg(help = "Deprecated, use --locales full or --locales modern")]
     cldr_locale_subset: bool,
 
-    #[arg(long, short)]
+    #[arg(long, short, num_args = 0..)]
     #[arg(
         help = "Include these resource keys in the output. Accepts multiple arguments.\n\
                   Set to 'all' for all keys, 'experimental-all' to include experimental keys,\n\
@@ -166,7 +166,7 @@ struct Cli {
     #[arg(help = "Deprecated: alias for --keys all")]
     all_keys: bool,
 
-    #[arg(long, short, required_unless_present = "all_locales")]
+    #[arg(long, short, required_unless_present = "all_locales", num_args = 0..)]
     #[arg(
         help = "Include this locale in the output. Accepts multiple arguments. \
                   Set to 'full' or 'modern' for the respective CLDR locale sets, or 'none' for no locales."
@@ -201,6 +201,7 @@ struct Cli {
 
 fn main() -> eyre::Result<()> {
     let matches = Cli::parse();
+    println!("{:?}", matches.include_collations);
 
     if matches.verbose {
         SimpleLogger::new()

--- a/provider/datagen/src/bin/datagen.rs
+++ b/provider/datagen/src/bin/datagen.rs
@@ -182,7 +182,7 @@ struct Cli {
     #[arg(help = "Deprecated: alias for --locales full")]
     all_locales: bool,
 
-    #[arg(long = "output", short, value_name = "PATH")]
+    #[arg(long = "out", short, value_name = "PATH")]
     #[arg(
         help = "Path to output directory or file. Must be empty or non-existent, unless \
                   --overwrite is present, in which case the directory is deleted first. \

--- a/provider/datagen/src/bin/datagen.rs
+++ b/provider/datagen/src/bin/datagen.rs
@@ -138,7 +138,7 @@ struct Cli {
     #[arg(help = "Which collation han database to use.")]
     collation_han_database: cli::CollationHanDatabase,
 
-    #[arg(long, value_enum, num_args = 0..)]
+    #[arg(long, value_enum, num_args = 1..)]
     #[arg(
         help = "Which less-common collation tables to include. 'search-all' includes all search tables."
     )]
@@ -148,7 +148,7 @@ struct Cli {
     #[arg(help = "Deprecated, use --locales full or --locales modern")]
     cldr_locale_subset: bool,
 
-    #[arg(long, short, num_args = 0..)]
+    #[arg(long, short, num_args = 1..)]
     #[arg(
         help = "Include these resource keys in the output. Accepts multiple arguments.\n\
                   Set to 'all' for all keys, 'experimental-all' to include experimental keys,\n\

--- a/provider/datagen/src/bin/datagen.rs
+++ b/provider/datagen/src/bin/datagen.rs
@@ -152,12 +152,14 @@ struct Cli {
                   or 'none' for no keys."
     )]
     keys: Vec<String>,
+
     #[arg(long, value_name = "KEY_FILE")]
     #[arg(
         help = "Path to text file with resource keys to include, one per line. Empty lines \
                   and lines starting with '#' are ignored."
     )]
     key_file: Option<PathBuf>,
+    
     #[arg(long, value_name = "BINARY")]
     #[arg(help = "Analyzes the binary and only includes keys that are used by the binary.")]
     keys_for_bin: Option<PathBuf>,

--- a/provider/datagen/src/bin/datagen.rs
+++ b/provider/datagen/src/bin/datagen.rs
@@ -177,7 +177,7 @@ struct Cli {
     #[arg(help = "Deprecated: alias for --locales full")]
     all_locales: bool,
 
-    #[arg(long, short, value_name = "PATH")]
+    #[arg(long = "output", short, value_name = "PATH")]
     #[arg(
         help = "Path to output directory or file. Must be empty or non-existent, unless \
                   --overwrite is present, in which case the directory is deleted first. \

--- a/provider/datagen/src/bin/datagen.rs
+++ b/provider/datagen/src/bin/datagen.rs
@@ -2,65 +2,60 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use clap::{crate_authors, crate_version, App, Arg, ArgGroup};
+use clap::{crate_authors, crate_version, Command, Arg, ArgGroup};
 use eyre::WrapErr;
 use icu_datagen::prelude::*;
 use simple_logger::SimpleLogger;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn main() -> eyre::Result<()> {
-    let matches = App::new("icu4x-datagen")
+    let matches = Command::new("icu4x-datagen")
         .version(crate_version!())
         .author(crate_authors!())
         .about(concat!("Learn more at: https://docs.rs/icu_datagen/", crate_version!()))
         .arg(
-            Arg::with_name("VERBOSE")
-                .short("v")
+            Arg::new("VERBOSE")
+                .short('v')
                 .long("verbose")
                 .help("Requests verbose output"),
         )
         .arg(
-            Arg::with_name("FORMAT")
+            Arg::new("FORMAT")
                 .long("format")
-                .takes_value(true)
-                .possible_value("dir")
-                .possible_value("blob")
-                .possible_value("mod")
-                .possible_value("deprecated-default")
+                .num_args(1)
+                .value_parser(["dir", "blob", "mod", "deprecated-default"])
                 .default_value("deprecated-default")
                 .hide_default_value(true)
                 .help("Select the output format: a directory tree of files, a single blob, or a Rust module."),
         )
         .arg(
-            Arg::with_name("OVERWRITE")
-                .short("W")
+            Arg::new("OVERWRITE")
+                .short('W')
                 .long("overwrite")
                 .help("Delete the output before writing data."),
         )
         .arg(
-            Arg::with_name("SYNTAX")
-                .short("s")
+            Arg::new("SYNTAX")
+                .short('s')
                 .long("syntax")
-                .takes_value(true)
-                .possible_value("json")
-                .possible_value("bincode")
-                .possible_value("postcard")
+                .num_args(1)
+                .value_parser(["json", "bincode", "postcard"])
                 .help("--format=dir only: serde serialization format."),
         )
         .arg(
-            Arg::with_name("PRETTY")
-                .short("p")
+            Arg::new("PRETTY")
+                .short('p')
                 .long("pretty")
                 .help("--format=mod, --format=dir only: pretty-print the Rust or JSON output files."),
         )
         .arg(
-            Arg::with_name("FINGERPRINT")
+            Arg::new("FINGERPRINT")
                 .long("fingerprint")
                 .help("--format=dir only: whether to add a fingerprints file to the output.")
         )
         .arg(
-            Arg::with_name("CLDR_TAG")
-                .short("t")
+            Arg::new("CLDR_TAG")
+                .short('t')
                 .long("cldr-tag")
                 .value_name("TAG")
                 .default_value("latest")
@@ -70,20 +65,20 @@ fn main() -> eyre::Result<()> {
                     Ignored if '--cldr-root' is present.\n\
                     Note that some keys do not support versions before 41.0.0.",
                 )
-                .takes_value(true),
+                .num_args(1),
         )
         .arg(
-            Arg::with_name("CLDR_ROOT")
+            Arg::new("CLDR_ROOT")
                 .long("cldr-root")
                 .value_name("PATH")
                 .help(
                     "Path to a local cldr-{version}-json-full.zip directory (see https://github.com/unicode-org/cldr-json/releases).\n\
                     Note that some keys do not support versions before 41.0.0.",
                 )
-                .takes_value(true),
+                .num_args(1),
         )
         .arg(
-            Arg::with_name("ICUEXPORT_TAG")
+            Arg::new("ICUEXPORT_TAG")
                 .long("icuexport-tag")
                 .value_name("TAG")
                 .default_value("latest")
@@ -93,23 +88,23 @@ fn main() -> eyre::Result<()> {
                     Ignored if '--icuexport-root' is present.\n\
                     Note that some keys do not support versions before release-71-1."
                 )
-                .takes_value(true),
+                .num_args(1),
         )
         .arg(
-            Arg::with_name("ICUEXPORT_ROOT")
+            Arg::new("ICUEXPORT_ROOT")
                 .long("icuexport-root")
                 .value_name("PATH")
                 .help(
                     "Path to a local icuexportdata_uprops_full directory (see https://github.com/unicode-org/icu/releases).\n\
                     Note that some keys do not support versions before release-71-1.",
                 )
-                .takes_value(true),
+                .num_args(1),
         )
         .arg(
-            Arg::with_name("TRIE_TYPE")
+            Arg::new("TRIE_TYPE")
                 .long("trie-type")
-                .takes_value(true)
-                .possible_values(&["small", "fast"])
+                .num_args(1)
+                .value_parser(["small", "fast"])
                 .help(
                     "Whether to optimize CodePointTrie data structures for size (\"small\") or speed (\"fast\").\n\
                     Using \"fast\" mode increases performance of CJK text processing and segmentation. For more\n\
@@ -118,34 +113,34 @@ fn main() -> eyre::Result<()> {
                 .default_value("small"),
         )
         .arg(
-            Arg::with_name("COLLATION_HAN_DATABASE")
+            Arg::new("COLLATION_HAN_DATABASE")
                 .long("collation-han-database")
-                .takes_value(true)
-                .possible_values(&["unihan", "implicit"])
+                .num_args(1)
+                .value_parser(["unihan", "implicit"])
                 .default_value("implicit")
                 .help("Which collation han database to use.")
         )
         .arg(
-            Arg::with_name("INCLUDE_COLLATIONS")
+            Arg::new("INCLUDE_COLLATIONS")
                 .long("include-collations")
-                .multiple(true)
-                .takes_value(true)
-                .possible_values(&["gb2312", "big5han", "search", "searchjl", "search*"])
+                .action(clap::ArgAction::Append)
+                .num_args(1)
+                .value_parser(["gb2312", "big5han", "search", "searchjl", "search*"])
                 .help("Which less-common collation tables to include. 'search*' includes all search tables.")
         )
         .arg(
-            Arg::with_name("CLDR_LOCALE_SUBSET")
+            Arg::new("CLDR_LOCALE_SUBSET")
                 .long("cldr-locale-subset")
-                .hidden(true)
+                .hide(true)
                 .help("Deprecated, use --locales full or --locales modern")
-                .takes_value(true),
+                .num_args(1),
         )
         .arg(
-            Arg::with_name("KEYS")
-                .short("k")
+            Arg::new("KEYS")
+                .short('k')
                 .long("keys")
-                .multiple(true)
-                .takes_value(true)
+                .action(clap::ArgAction::Append)
+                .num_args(1)
                 .help(
                     "Include these resource keys in the output. Accepts multiple arguments.\n\
                     Set to 'all' for all keys, 'experimental-all' to include experimental keys,\n\
@@ -153,30 +148,30 @@ fn main() -> eyre::Result<()> {
                 ),
         )
         .arg(
-            Arg::with_name("KEY_FILE")
+            Arg::new("KEY_FILE")
                 .long("key-file")
-                .takes_value(true)
+                .num_args(1)
                 .help(
                     "Path to text file with resource keys to include, one per line. Empty lines \
                     and lines starting with '#' are ignored.",
                 ),
         )
         .arg(
-            Arg::with_name("KEYS_FOR_BIN")
+            Arg::new("KEYS_FOR_BIN")
                 .long("keys-for-bin")
-                .takes_value(true)
+                .num_args(1)
                 .help(
                     "Analyzes the binary and only includes keys that are used by the binary."
                 ),
         )
         .arg(
-            Arg::with_name("ALL_KEYS")
+            Arg::new("ALL_KEYS")
                 .long("all-keys")
-                .hidden(true)
+                .hide(true)
                 .help("Deprecated: alias for --keys all"),
         )
         .group(
-            ArgGroup::with_name("KEY_MODE")
+            ArgGroup::new("KEY_MODE")
                 .arg("KEYS")
                 .arg("KEY_FILE")
                 .arg("KEYS_FOR_BIN")
@@ -184,26 +179,26 @@ fn main() -> eyre::Result<()> {
                 .required(true),
         )
         .arg(
-            Arg::with_name("LOCALES")
-                .short("l")
+            Arg::new("LOCALES")
+                .short('l')
                 .long("locales")
-                .multiple(true)
-                .takes_value(true)
-                .required_unless("ALL_LOCALES")
+                .action(clap::ArgAction::Append)
+                .num_args(1)
+                .required_unless_present("ALL_LOCALES")
                 .help(
                     "Include this locale in the output. Accepts multiple arguments. \
                     Set to 'full' or 'modern' for the respective CLDR locale sets, or 'none' for no locales.",
                 ),
         )
         .arg(
-            Arg::with_name("ALL_LOCALES")
+            Arg::new("ALL_LOCALES")
                 .long("all-locales")
-                .hidden(true)
+                .hide(true)
                 .help("Deprecated: alias for --locales full"),
         )
         .arg(
-            Arg::with_name("OUTPUT")
-                .short("o")
+            Arg::new("OUTPUT")
+                .short('o')
                 .long("out")
                 .help(
                     "Path to output directory or file. Must be empty or non-existent, unless \
@@ -211,19 +206,19 @@ fn main() -> eyre::Result<()> {
                     For --format=blob, omit this option to dump to stdout. \
                     For --format={dir,mod} defaults to 'icu4x_data'.",
                 )
-                .takes_value(true),
+                .num_args(1),
         )
-        .arg(Arg::with_name("INSERT_FEATURE_GATES")
+        .arg(Arg::new("INSERT_FEATURE_GATES")
             .long("insert-feature-gates")
             .help("--format=mod only: insert feature gates for individual `icu_*` crates. Requires --use-separate-crates")
         )
-        .arg(Arg::with_name("USE_SEPARATE_CRATES")
+        .arg(Arg::new("USE_SEPARATE_CRATES")
             .long("use-separate-crates")
             .help("--format=mod only: use types from individual `icu_*` crates instead of the `icu` meta-crate.")
         )
         .get_matches();
 
-    if matches.is_present("VERBOSE") {
+    if matches.contains_id("VERBOSE") {
         SimpleLogger::new()
             .with_level(log::LevelFilter::Trace)
             .init()
@@ -236,20 +231,20 @@ fn main() -> eyre::Result<()> {
             .unwrap()
     }
 
-    let selected_keys = if matches.is_present("ALL_KEYS") {
+    let selected_keys = if matches.contains_id("ALL_KEYS") {
         icu_datagen::all_keys()
-    } else if let Some(paths) = matches.values_of("KEYS") {
-        match paths.collect::<Vec<_>>().as_slice() {
+    } else if let Some(paths) = matches.get_many("KEYS") {
+        match paths.copied().collect::<Vec<_>>().as_slice() {
             ["none"] => vec![],
             ["all"] => icu_datagen::all_keys(),
             ["experimental-all"] => icu_datagen::all_keys_with_experimental(),
             keys => icu_datagen::keys(keys),
         }
-    } else if let Some(key_file_path) = matches.value_of_os("KEY_FILE") {
-        icu_datagen::keys_from_file(key_file_path)
+    } else if let Some(key_file_path) = matches.get_one::<&Path>("KEY_FILE") {
+        icu_datagen::keys_from_file(*key_file_path)
             .with_context(|| key_file_path.to_string_lossy().into_owned())?
-    } else if let Some(bin_path) = matches.value_of_os("KEYS_FOR_BIN") {
-        icu_datagen::keys_from_bin(bin_path)
+    } else if let Some(bin_path) = matches.get_one::<&Path>("KEYS_FOR_BIN") {
+        icu_datagen::keys_from_bin(*bin_path)
             .with_context(|| bin_path.to_string_lossy().into_owned())?
     } else {
         unreachable!("required group")
@@ -260,51 +255,55 @@ fn main() -> eyre::Result<()> {
     }
 
     let mut source_data = SourceData::default();
-    if let Some(path) = matches.value_of("CLDR_ROOT") {
+    if let Some(path) = matches.get_one::<&Path>("CLDR_ROOT") {
         source_data = source_data.with_cldr(PathBuf::from(path), Default::default())?;
     } else {
         source_data = source_data.with_cldr_for_tag(
-            if Some("latest") == matches.value_of("CLDR_TAG") {
+            if Some(&"latest") == matches.get_one("CLDR_TAG") {
                 SourceData::LATEST_TESTED_CLDR_TAG
             } else {
-                matches.value_of("CLDR_TAG").unwrap()
+                *matches.get_one("CLDR_TAG").unwrap()
             },
             Default::default(),
         )?
     }
 
-    if let Some(path) = matches.value_of("ICUEXPORT_ROOT") {
-        source_data = source_data.with_icuexport(PathBuf::from(path))?;
+    if let Some(path) = matches.get_one::<&Path>("ICUEXPORT_ROOT") {
+        source_data = source_data.with_icuexport(PathBuf::from(*path))?;
     } else {
         source_data = source_data.with_icuexport_for_tag(
-            if Some("latest") == matches.value_of("ICUEXPORT_TAG") {
+            if Some(&"latest") == matches.get_one("ICUEXPORT_TAG") {
                 SourceData::LATEST_TESTED_ICUEXPORT_TAG
             } else {
-                matches.value_of("ICUEXPORT_TAG").unwrap()
+                *matches.get_one("ICUEXPORT_TAG").unwrap()
             },
         )?;
     }
 
-    if matches.value_of("TRIE_TYPE") == Some("fast") {
+    if matches.get_one("TRIE_TYPE") == Some(&"fast") {
         source_data = source_data.with_fast_tries();
     }
 
     source_data =
-        source_data.with_collation_han_database(match matches.value_of("COLLATION_HAN_DATABASE") {
-            Some("unihan") => CollationHanDatabase::Unihan,
+        source_data.with_collation_han_database(match matches.get_one("COLLATION_HAN_DATABASE") {
+            Some(&"unihan") => CollationHanDatabase::Unihan,
             _ => CollationHanDatabase::Implicit,
         });
 
-    if let Some(collations) = matches.values_of("INCLUDE_COLLATIONS") {
+    if let Some(collations) = matches.get_many::<String>("INCLUDE_COLLATIONS") {
         source_data =
             source_data.with_collations(collations.into_iter().map(String::from).collect());
     }
 
-    let raw_locales = matches.values_of("LOCALES").unwrap().collect::<Vec<_>>();
+    let raw_locales = matches
+        .get_many("LOCALES")
+        .unwrap()
+        .copied()
+        .collect::<Vec<_>>();
 
     let selected_locales = if raw_locales == ["none"] || selected_keys.is_empty() {
         Some(vec![])
-    } else if raw_locales == ["full"] || matches.is_present("ALL_LOCALES") {
+    } else if raw_locales == ["full"] || matches.contains_id("ALL_LOCALES") {
         None
     } else if let Some(locale_subsets) = raw_locales
         .iter()
@@ -329,29 +328,29 @@ fn main() -> eyre::Result<()> {
         )
     };
 
-    let out = match matches.value_of("FORMAT").expect("required") {
+    let out = match *matches.get_one("FORMAT").expect("required") {
         v @ ("dir" | "deprecated-default") => {
             if v == "deprecated-default" {
                 log::warn!("Defaulting to --format=dir. This will become a required parameter in the future.");
             }
             icu_datagen::Out::Fs {
                 output_path: matches
-                    .value_of_os("OUTPUT")
+                    .get_one::<&Path>("OUTPUT")
                     .map(PathBuf::from)
                     .unwrap_or_else(|| PathBuf::from("icu4x_data")),
-                serializer: match matches.value_of("SYNTAX") {
-                    Some("bincode") => Box::<syntax::Bincode>::default(),
-                    Some("postcard") => Box::<syntax::Postcard>::default(),
-                    _ if matches.is_present("PRETTY") => Box::new(syntax::Json::pretty()),
+                serializer: match matches.get_one("SYNTAX") {
+                    Some(&"bincode") => Box::<syntax::Bincode>::default(),
+                    Some(&"postcard") => Box::<syntax::Postcard>::default(),
+                    _ if matches.contains_id("PRETTY") => Box::new(syntax::Json::pretty()),
                     _ => Box::<syntax::Json>::default(),
                 },
-                overwrite: matches.is_present("OVERWRITE"),
-                fingerprint: matches.is_present("FINGERPRINT"),
+                overwrite: matches.contains_id("OVERWRITE"),
+                fingerprint: matches.contains_id("FINGERPRINT"),
             }
         }
-        "blob" => icu_datagen::Out::Blob(if let Some(path) = matches.value_of_os("OUTPUT") {
+        "blob" => icu_datagen::Out::Blob(if let Some(path) = matches.get_one::<&Path>("OUTPUT") {
             let path_buf = PathBuf::from(path);
-            if !matches.is_present("OVERWRITE") && path_buf.exists() {
+            if !matches.contains_id("OVERWRITE") && path_buf.exists() {
                 eyre::bail!("Output path is present: {:?}", path_buf);
             }
             Box::new(
@@ -363,15 +362,15 @@ fn main() -> eyre::Result<()> {
         }),
         "mod" => {
             let mod_directory = matches
-                .value_of_os("OUTPUT")
+                .get_one::<&Path>("OUTPUT")
                 .map(PathBuf::from)
                 .unwrap_or_else(|| PathBuf::from("icu4x_data"));
 
             let mut options = BakedOptions::default();
-            options.pretty = matches.is_present("PRETTY");
-            options.insert_feature_gates = matches.is_present("INSERT_FEATURE_GATES");
-            options.use_separate_crates = matches.is_present("USE_SEPARATE_CRATES");
-            options.overwrite = matches.is_present("OVERWRITE");
+            options.pretty = matches.contains_id("PRETTY");
+            options.insert_feature_gates = matches.contains_id("INSERT_FEATURE_GATES");
+            options.use_separate_crates = matches.contains_id("USE_SEPARATE_CRATES");
+            options.overwrite = matches.contains_id("OVERWRITE");
 
             icu_datagen::Out::Baked {
                 mod_directory,

--- a/provider/datagen/src/bin/datagen.rs
+++ b/provider/datagen/src/bin/datagen.rs
@@ -2,60 +2,63 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use clap::{crate_version, ArgGroup, Parser, ValueEnum};
+use clap::{crate_version, ArgGroup, Parser};
 use eyre::WrapErr;
 use icu_datagen::prelude::*;
 use simple_logger::SimpleLogger;
 use std::path::PathBuf;
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
-enum Format {
-    Dir,
-    Blob,
-    Mod,
-    DeprecatedDefault,
-}
+mod cli {
+    use clap::ValueEnum;
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
-enum Syntax {
-    Json,
-    Bincode,
-    Postcard,
-}
+    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+    pub(crate) enum Format {
+        Dir,
+        Blob,
+        Mod,
+        DeprecatedDefault,
+    }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
-enum TrieType {
-    Small,
-    Fast,
-}
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
-enum CliCollationHanDatabase {
-    Unihan,
-    Implicit,
-}
+    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+    pub(crate) enum Syntax {
+        Json,
+        Bincode,
+        Postcard,
+    }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
-enum CollationTable {
-    Gb2312,
-    Big5han,
-    Search,
-    Searchji,
-    #[value(alias = "search*")] // for backwards compatability
-    SearchAll,
-}
+    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+    pub(crate) enum TrieType {
+        Small,
+        Fast,
+    }
+    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+    pub(crate) enum CollationHanDatabase {
+        Unihan,
+        Implicit,
+    }
 
-impl CollationTable {
-    fn to_datagen_value(self) -> &'static str {
-        match self {
-            Self::Gb2312 => "gb2312",
-            Self::Big5han => "big5han",
-            Self::Search => "search",
-            Self::Searchji => "searchji",
-            Self::SearchAll => "search*",
+    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+    pub(crate) enum CollationTable {
+        Gb2312,
+        Big5han,
+        Search,
+        Searchji,
+        #[value(alias = "search*")] // for backwards compatability
+        SearchAll,
+    }
+
+    impl CollationTable {
+        pub(crate) fn to_datagen_value(self) -> &'static str {
+            match self {
+                Self::Gb2312 => "gb2312",
+                Self::Big5han => "big5han",
+                Self::Search => "search",
+                Self::Searchji => "searchji",
+                Self::SearchAll => "search*",
+            }
         }
     }
 }
-
 #[derive(Parser)]
 #[command(name = "icu4x-datagen", author, version)]
 #[command(about = concat!("Learn more at: https://docs.rs/icu_datagen/", crate_version!()), long_about = None)]
@@ -69,19 +72,19 @@ struct Cli {
     #[arg(help = "Requests verbose output")]
     verbose: bool,
 
-    #[arg(long, value_enum, default_value_t = Format::DeprecatedDefault, hide_default_value = true)]
+    #[arg(long, value_enum, default_value_t = cli::Format::DeprecatedDefault, hide_default_value = true)]
     #[arg(
         help = "Select the output format: a directory tree of files, a single blob, or a Rust module."
     )]
-    format: Format,
+    format: cli::Format,
 
     #[arg(short = 'W', long)]
     #[arg(help = "Delete the output before writing data.")]
     overwrite: bool,
 
-    #[arg(short, long, value_enum, default_value_t = Syntax::Json)]
+    #[arg(short, long, value_enum, default_value_t = cli::Syntax::Json)]
     #[arg(help = "--format=dir only: serde serialization format.")]
-    syntax: Syntax,
+    syntax: cli::Syntax,
 
     #[arg(short, long)]
     #[arg(help = "--format=mod, --format=dir only: pretty-print the Rust or JSON output files.")]
@@ -123,23 +126,23 @@ struct Cli {
     )]
     icuexport_root: Option<PathBuf>,
 
-    #[arg(long, value_enum, default_value_t = TrieType::Small)]
+    #[arg(long, value_enum, default_value_t = cli::TrieType::Small)]
     #[arg(
         help = "Whether to optimize CodePointTrie data structures for size (\"small\") or speed (\"fast\").\n\
                   Using \"fast\" mode increases performance of CJK text processing and segmentation. For more\n\
                   information, see the TrieType enum."
     )]
-    trie_type: TrieType,
+    trie_type: cli::TrieType,
 
-    #[arg(long, value_enum, default_value_t = CliCollationHanDatabase::Implicit)]
+    #[arg(long, value_enum, default_value_t = cli::CollationHanDatabase::Implicit)]
     #[arg(help = "Which collation han database to use.")]
-    collation_han_database: CliCollationHanDatabase,
+    collation_han_database: cli::CollationHanDatabase,
 
     #[arg(long, value_enum, num_args = 0..)]
     #[arg(
         help = "Which less-common collation tables to include. 'search-all' includes all search tables."
     )]
-    include_collations: Vec<CollationTable>,
+    include_collations: Vec<cli::CollationTable>,
 
     #[arg(long, hide = true)]
     #[arg(help = "Deprecated, use --locales full or --locales modern")]
@@ -159,7 +162,7 @@ struct Cli {
                   and lines starting with '#' are ignored."
     )]
     key_file: Option<PathBuf>,
-    
+
     #[arg(long, value_name = "BINARY")]
     #[arg(help = "Analyzes the binary and only includes keys that are used by the binary.")]
     keys_for_bin: Option<PathBuf>,
@@ -261,13 +264,13 @@ fn main() -> eyre::Result<()> {
         source_data = source_data.with_icuexport_for_tag(tag)?;
     }
 
-    if matches.trie_type == TrieType::Fast {
+    if matches.trie_type == cli::TrieType::Fast {
         source_data = source_data.with_fast_tries();
     }
 
     source_data = source_data.with_collation_han_database(match matches.collation_han_database {
-        CliCollationHanDatabase::Unihan => CollationHanDatabase::Unihan,
-        CliCollationHanDatabase::Implicit => CollationHanDatabase::Implicit,
+        cli::CollationHanDatabase::Unihan => CollationHanDatabase::Unihan,
+        cli::CollationHanDatabase::Implicit => CollationHanDatabase::Implicit,
     });
 
     if !matches.include_collations.is_empty() {
@@ -310,8 +313,8 @@ fn main() -> eyre::Result<()> {
     };
 
     let out = match matches.format {
-        v @ (Format::Dir | Format::DeprecatedDefault) => {
-            if v == Format::DeprecatedDefault {
+        v @ (cli::Format::Dir | cli::Format::DeprecatedDefault) => {
+            if v == cli::Format::DeprecatedDefault {
                 log::warn!("Defaulting to --format=dir. This will become a required parameter in the future.");
             }
             icu_datagen::Out::Fs {
@@ -319,16 +322,16 @@ fn main() -> eyre::Result<()> {
                     .output
                     .unwrap_or_else(|| PathBuf::from("icu4x_data")),
                 serializer: match matches.syntax {
-                    Syntax::Bincode => Box::<syntax::Bincode>::default(),
-                    Syntax::Postcard => Box::<syntax::Postcard>::default(),
-                    Syntax::Json if matches.pretty => Box::new(syntax::Json::pretty()),
-                    Syntax::Json => Box::<syntax::Json>::default(),
+                    cli::Syntax::Bincode => Box::<syntax::Bincode>::default(),
+                    cli::Syntax::Postcard => Box::<syntax::Postcard>::default(),
+                    cli::Syntax::Json if matches.pretty => Box::new(syntax::Json::pretty()),
+                    cli::Syntax::Json => Box::<syntax::Json>::default(),
                 },
                 overwrite: matches.overwrite,
                 fingerprint: matches.fingerprint,
             }
         }
-        Format::Blob => icu_datagen::Out::Blob(if let Some(path) = matches.output {
+        cli::Format::Blob => icu_datagen::Out::Blob(if let Some(path) = matches.output {
             if !matches.overwrite && path.exists() {
                 eyre::bail!("Output path is present: {:?}", path);
             }
@@ -338,7 +341,7 @@ fn main() -> eyre::Result<()> {
         } else {
             Box::new(std::io::stdout())
         }),
-        Format::Mod => {
+        cli::Format::Mod => {
             let mod_directory = matches
                 .output
                 .unwrap_or_else(|| PathBuf::from("icu4x_data"));

--- a/provider/datagen/src/bin/datagen.rs
+++ b/provider/datagen/src/bin/datagen.rs
@@ -2,11 +2,11 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use clap::{crate_authors, crate_version, Arg, ArgGroup, Command, Parser, ValueEnum};
+use clap::{crate_version, ArgGroup, Parser, ValueEnum};
 use eyre::WrapErr;
 use icu_datagen::prelude::*;
 use simple_logger::SimpleLogger;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 enum Format {
@@ -42,6 +42,18 @@ enum CollationTable {
     Searchji,
     #[value(alias = "search*")] // for backwards compatability
     SearchAll,
+}
+
+impl CollationTable {
+    fn to_datagen_value(self) -> &'static str {
+        match self {
+            Self::Gb2312 => "gb2312",
+            Self::Big5han => "big5han",
+            Self::Search => "search",
+            Self::Searchji => "searchji",
+            Self::SearchAll => "search*",
+        }
+    }
 }
 
 #[derive(Parser)]
@@ -93,7 +105,7 @@ struct Cli {
         help = "Path to a local cldr-{version}-json-full.zip directory (see https://github.com/unicode-org/cldr-json/releases).\n\
                   Note that some keys do not support versions before 41.0.0."
     )]
-    cldr_root: PathBuf,
+    cldr_root: Option<PathBuf>,
 
     #[arg(long, value_name = "TAG", default_value = "latest")]
     #[arg(
@@ -109,7 +121,7 @@ struct Cli {
         help = "Path to a local icuexportdata_uprops_full directory (see https://github.com/unicode-org/icu/releases).\n\
                   Note that some keys do not support versions before release-71-1."
     )]
-    icuexport_root: PathBuf,
+    icuexport_root: Option<PathBuf>,
 
     #[arg(long, value_enum, default_value_t = TrieType::Small)]
     #[arg(
@@ -172,7 +184,7 @@ struct Cli {
                   For --format=blob, omit this option to dump to stdout. \
                   For --format={dir,mod} defaults to 'icu4x_data'."
     )]
-    output: PathBuf,
+    output: Option<PathBuf>,
 
     #[arg(long)]
     #[arg(
@@ -189,217 +201,8 @@ struct Cli {
 
 fn main() -> eyre::Result<()> {
     let matches = Cli::parse();
-    unimplemented!();
-    let matches = Command::new("icu4x-datagen")
-        .version(crate_version!())
-        .author(crate_authors!())
-        .about(concat!("Learn more at: https://docs.rs/icu_datagen/", crate_version!()))
-        .arg(
-            Arg::new("VERBOSE")
-                .short('v')
-                .long("verbose")
-                .help("Requests verbose output"),
-        )
-        .arg(
-            Arg::new("FORMAT")
-                .long("format")
-                .num_args(1)
-                .value_parser(["dir", "blob", "mod", "deprecated-default"])
-                .default_value("deprecated-default")
-                .hide_default_value(true)
-                .help("Select the output format: a directory tree of files, a single blob, or a Rust module."),
-        )
-        .arg(
-            Arg::new("OVERWRITE")
-                .short('W')
-                .long("overwrite")
-                .help("Delete the output before writing data."),
-        )
-        .arg(
-            Arg::new("SYNTAX")
-                .short('s')
-                .long("syntax")
-                .num_args(1)
-                .value_parser(["json", "bincode", "postcard"])
-                .help("--format=dir only: serde serialization format."),
-        )
-        .arg(
-            Arg::new("PRETTY")
-                .short('p')
-                .long("pretty")
-                .help("--format=mod, --format=dir only: pretty-print the Rust or JSON output files."),
-        )
-        .arg(
-            Arg::new("FINGERPRINT")
-                .long("fingerprint")
-                .help("--format=dir only: whether to add a fingerprints file to the output.")
-        )
-        .arg(
-            Arg::new("CLDR_TAG")
-                .short('t')
-                .long("cldr-tag")
-                .value_name("TAG")
-                .default_value("latest")
-                .help(
-                    "Download CLDR JSON data from this GitHub tag (https://github.com/unicode-org/cldr-json/tags)\n\
-                    Use 'latest' for the latest version verified to work with this version of the binary.\n\
-                    Ignored if '--cldr-root' is present.\n\
-                    Note that some keys do not support versions before 41.0.0.",
-                )
-                .num_args(1),
-        )
-        .arg(
-            Arg::new("CLDR_ROOT")
-                .long("cldr-root")
-                .value_name("PATH")
-                .help(
-                    "Path to a local cldr-{version}-json-full.zip directory (see https://github.com/unicode-org/cldr-json/releases).\n\
-                    Note that some keys do not support versions before 41.0.0.",
-                )
-                .num_args(1),
-        )
-        .arg(
-            Arg::new("ICUEXPORT_TAG")
-                .long("icuexport-tag")
-                .value_name("TAG")
-                .default_value("latest")
-                .help(
-                    "Download Unicode Properties data from this GitHub tag (https://github.com/unicode-org/icu/tags)\n\
-                    Use 'latest' for the latest version verified to work with this version of the binary.\n\
-                    Ignored if '--icuexport-root' is present.\n\
-                    Note that some keys do not support versions before release-71-1."
-                )
-                .num_args(1),
-        )
-        .arg(
-            Arg::new("ICUEXPORT_ROOT")
-                .long("icuexport-root")
-                .value_name("PATH")
-                .help(
-                    "Path to a local icuexportdata_uprops_full directory (see https://github.com/unicode-org/icu/releases).\n\
-                    Note that some keys do not support versions before release-71-1.",
-                )
-                .num_args(1),
-        )
-        .arg(
-            Arg::new("TRIE_TYPE")
-                .long("trie-type")
-                .num_args(1)
-                .value_parser(["small", "fast"])
-                .help(
-                    "Whether to optimize CodePointTrie data structures for size (\"small\") or speed (\"fast\").\n\
-                    Using \"fast\" mode increases performance of CJK text processing and segmentation. For more\n\
-                    information, see the TrieType enum."
-                )
-                .default_value("small"),
-        )
-        .arg(
-            Arg::new("COLLATION_HAN_DATABASE")
-                .long("collation-han-database")
-                .num_args(1)
-                .value_parser(["unihan", "implicit"])
-                .default_value("implicit")
-                .help("Which collation han database to use.")
-        )
-        .arg(
-            Arg::new("INCLUDE_COLLATIONS")
-                .long("include-collations")
-                .action(clap::ArgAction::Append)
-                .num_args(1)
-                .value_parser(["gb2312", "big5han", "search", "searchjl", "search*"])
-                .help("Which less-common collation tables to include. 'search-all' includes all search tables.")
-        )
-        .arg(
-            Arg::new("CLDR_LOCALE_SUBSET")
-                .long("cldr-locale-subset")
-                .hide(true)
-                .help("Deprecated, use --locales full or --locales modern")
-                .num_args(1),
-        )
-        .arg(
-            Arg::new("KEYS")
-                .short('k')
-                .long("keys")
-                .action(clap::ArgAction::Append)
-                .num_args(1)
-                .help(
-                    "Include these resource keys in the output. Accepts multiple arguments.\n\
-                    Set to 'all' for all keys, 'experimental-all' to include experimental keys,\n\
-                    or 'none' for no keys.",
-                ),
-        )
-        .arg(
-            Arg::new("KEY_FILE")
-                .long("key-file")
-                .num_args(1)
-                .help(
-                    "Path to text file with resource keys to include, one per line. Empty lines \
-                    and lines starting with '#' are ignored.",
-                ),
-        )
-        .arg(
-            Arg::new("KEYS_FOR_BIN")
-                .long("keys-for-bin")
-                .num_args(1)
-                .help(
-                    "Analyzes the binary and only includes keys that are used by the binary."
-                ),
-        )
-        .arg(
-            Arg::new("ALL_KEYS")
-                .long("all-keys")
-                .hide(true)
-                .help("Deprecated: alias for --keys all"),
-        )
-        .group(
-            ArgGroup::new("KEY_MODE")
-                .arg("KEYS")
-                .arg("KEY_FILE")
-                .arg("KEYS_FOR_BIN")
-                .arg("ALL_KEYS")
-                .required(true),
-        )
-        .arg(
-            Arg::new("LOCALES")
-                .short('l')
-                .long("locales")
-                .action(clap::ArgAction::Append)
-                .num_args(1)
-                .required_unless_present("ALL_LOCALES")
-                .help(
-                    "Include this locale in the output. Accepts multiple arguments. \
-                    Set to 'full' or 'modern' for the respective CLDR locale sets, or 'none' for no locales.",
-                ),
-        )
-        .arg(
-            Arg::new("ALL_LOCALES")
-                .long("all-locales")
-                .hide(true)
-                .help("Deprecated: alias for --locales full"),
-        )
-        .arg(
-            Arg::new("OUTPUT")
-                .short('o')
-                .long("out")
-                .help(
-                    "Path to output directory or file. Must be empty or non-existent, unless \
-                    --overwrite is present, in which case the directory is deleted first. \
-                    For --format=blob, omit this option to dump to stdout. \
-                    For --format={dir,mod} defaults to 'icu4x_data'.",
-                )
-                .num_args(1),
-        )
-        .arg(Arg::new("INSERT_FEATURE_GATES")
-            .long("insert-feature-gates")
-            .help("--format=mod only: insert feature gates for individual `icu_*` crates. Requires --use-separate-crates")
-        )
-        .arg(Arg::new("USE_SEPARATE_CRATES")
-            .long("use-separate-crates")
-            .help("--format=mod only: use types from individual `icu_*` crates instead of the `icu` meta-crate.")
-        )
-        .get_matches();
 
-    if matches.contains_id("VERBOSE") {
+    if matches.verbose {
         SimpleLogger::new()
             .with_level(log::LevelFilter::Trace)
             .init()
@@ -412,20 +215,20 @@ fn main() -> eyre::Result<()> {
             .unwrap()
     }
 
-    let selected_keys = if matches.contains_id("ALL_KEYS") {
+    let selected_keys = if matches.all_keys {
         icu_datagen::all_keys()
-    } else if let Some(paths) = matches.get_many("KEYS") {
-        match paths.copied().collect::<Vec<_>>().as_slice() {
-            ["none"] => vec![],
-            ["all"] => icu_datagen::all_keys(),
-            ["experimental-all"] => icu_datagen::all_keys_with_experimental(),
+    } else if !matches.keys.is_empty() {
+        match matches.keys.as_slice() {
+            [x] if x == "none" => vec![],
+            [x] if x == "all" => icu_datagen::all_keys(),
+            [x] if x == "experimental-all" => icu_datagen::all_keys_with_experimental(),
             keys => icu_datagen::keys(keys),
         }
-    } else if let Some(key_file_path) = matches.get_one::<&Path>("KEY_FILE") {
-        icu_datagen::keys_from_file(*key_file_path)
+    } else if let Some(ref key_file_path) = matches.key_file {
+        icu_datagen::keys_from_file(key_file_path)
             .with_context(|| key_file_path.to_string_lossy().into_owned())?
-    } else if let Some(bin_path) = matches.get_one::<&Path>("KEYS_FOR_BIN") {
-        icu_datagen::keys_from_bin(*bin_path)
+    } else if let Some(ref bin_path) = matches.keys_for_bin {
+        icu_datagen::keys_from_bin(bin_path)
             .with_context(|| bin_path.to_string_lossy().into_owned())?
     } else {
         unreachable!("required group")
@@ -436,59 +239,54 @@ fn main() -> eyre::Result<()> {
     }
 
     let mut source_data = SourceData::default();
-    if let Some(path) = matches.get_one::<&Path>("CLDR_ROOT") {
-        source_data = source_data.with_cldr(PathBuf::from(path), Default::default())?;
+    if let Some(path) = matches.cldr_root {
+        source_data = source_data.with_cldr(path, Default::default())?;
     } else {
-        source_data = source_data.with_cldr_for_tag(
-            if Some(&"latest") == matches.get_one("CLDR_TAG") {
-                SourceData::LATEST_TESTED_CLDR_TAG
-            } else {
-                *matches.get_one("CLDR_TAG").unwrap()
-            },
-            Default::default(),
-        )?
+        let tag = match &*matches.cldr_tag {
+            "latest" => SourceData::LATEST_TESTED_CLDR_TAG,
+            other => other,
+        };
+        source_data = source_data.with_cldr_for_tag(tag, Default::default())?
     }
 
-    if let Some(path) = matches.get_one::<&Path>("ICUEXPORT_ROOT") {
-        source_data = source_data.with_icuexport(PathBuf::from(*path))?;
+    if let Some(path) = matches.icuexport_root {
+        source_data = source_data.with_icuexport(path)?;
     } else {
-        source_data = source_data.with_icuexport_for_tag(
-            if Some(&"latest") == matches.get_one("ICUEXPORT_TAG") {
-                SourceData::LATEST_TESTED_ICUEXPORT_TAG
-            } else {
-                *matches.get_one("ICUEXPORT_TAG").unwrap()
-            },
-        )?;
+        let tag = match &*matches.icuexport_tag {
+            "latest" => SourceData::LATEST_TESTED_ICUEXPORT_TAG,
+            other => other,
+        };
+        source_data = source_data.with_icuexport_for_tag(tag)?;
     }
 
-    if matches.get_one("TRIE_TYPE") == Some(&"fast") {
+    if matches.trie_type == TrieType::Fast {
         source_data = source_data.with_fast_tries();
     }
 
-    source_data =
-        source_data.with_collation_han_database(match matches.get_one("COLLATION_HAN_DATABASE") {
-            Some(&"unihan") => CollationHanDatabase::Unihan,
-            _ => CollationHanDatabase::Implicit,
-        });
+    source_data = source_data.with_collation_han_database(match matches.collation_han_database {
+        CliCollationHanDatabase::Unihan => CollationHanDatabase::Unihan,
+        CliCollationHanDatabase::Implicit => CollationHanDatabase::Implicit,
+    });
 
-    if let Some(collations) = matches.get_many::<String>("INCLUDE_COLLATIONS") {
-        source_data =
-            source_data.with_collations(collations.into_iter().map(String::from).collect());
+    if !matches.include_collations.is_empty() {
+        source_data = source_data.with_collations(
+            matches
+                .include_collations
+                .iter()
+                .map(|c| c.to_datagen_value().to_owned())
+                .collect(),
+        );
     }
 
-    let raw_locales = matches
-        .get_many("LOCALES")
-        .unwrap()
-        .copied()
-        .collect::<Vec<_>>();
+    let raw_locales = &matches.locales;
 
-    let selected_locales = if raw_locales == ["none"] || selected_keys.is_empty() {
+    let selected_locales = if raw_locales == &["none"] || selected_keys.is_empty() {
         Some(vec![])
-    } else if raw_locales == ["full"] || matches.contains_id("ALL_LOCALES") {
+    } else if raw_locales == &["full"] || matches.all_locales {
         None
     } else if let Some(locale_subsets) = raw_locales
         .iter()
-        .map(|&s| match s {
+        .map(|s| match &**s {
             "basic" => Some(CoverageLevel::Basic),
             "moderate" => Some(CoverageLevel::Moderate),
             "modern" => Some(CoverageLevel::Modern),
@@ -500,7 +298,7 @@ fn main() -> eyre::Result<()> {
     } else {
         Some(
             raw_locales
-                .into_iter()
+                .iter()
                 .map(|s| {
                     s.parse::<LanguageIdentifier>()
                         .with_context(|| s.to_string())
@@ -509,56 +307,51 @@ fn main() -> eyre::Result<()> {
         )
     };
 
-    let out = match *matches.get_one("FORMAT").expect("required") {
-        v @ ("dir" | "deprecated-default") => {
-            if v == "deprecated-default" {
+    let out = match matches.format {
+        v @ (Format::Dir | Format::DeprecatedDefault) => {
+            if v == Format::DeprecatedDefault {
                 log::warn!("Defaulting to --format=dir. This will become a required parameter in the future.");
             }
             icu_datagen::Out::Fs {
                 output_path: matches
-                    .get_one::<&Path>("OUTPUT")
-                    .map(PathBuf::from)
+                    .output
                     .unwrap_or_else(|| PathBuf::from("icu4x_data")),
-                serializer: match matches.get_one("SYNTAX") {
-                    Some(&"bincode") => Box::<syntax::Bincode>::default(),
-                    Some(&"postcard") => Box::<syntax::Postcard>::default(),
-                    _ if matches.contains_id("PRETTY") => Box::new(syntax::Json::pretty()),
-                    _ => Box::<syntax::Json>::default(),
+                serializer: match matches.syntax {
+                    Syntax::Bincode => Box::<syntax::Bincode>::default(),
+                    Syntax::Postcard => Box::<syntax::Postcard>::default(),
+                    Syntax::Json if matches.pretty => Box::new(syntax::Json::pretty()),
+                    Syntax::Json => Box::<syntax::Json>::default(),
                 },
-                overwrite: matches.contains_id("OVERWRITE"),
-                fingerprint: matches.contains_id("FINGERPRINT"),
+                overwrite: matches.overwrite,
+                fingerprint: matches.fingerprint,
             }
         }
-        "blob" => icu_datagen::Out::Blob(if let Some(path) = matches.get_one::<&Path>("OUTPUT") {
-            let path_buf = PathBuf::from(path);
-            if !matches.contains_id("OVERWRITE") && path_buf.exists() {
-                eyre::bail!("Output path is present: {:?}", path_buf);
+        Format::Blob => icu_datagen::Out::Blob(if let Some(path) = matches.output {
+            if !matches.overwrite && path.exists() {
+                eyre::bail!("Output path is present: {:?}", path);
             }
             Box::new(
-                std::fs::File::create(&path_buf)
-                    .with_context(|| path_buf.to_string_lossy().to_string())?,
+                std::fs::File::create(&path).with_context(|| path.to_string_lossy().to_string())?,
             )
         } else {
             Box::new(std::io::stdout())
         }),
-        "mod" => {
+        Format::Mod => {
             let mod_directory = matches
-                .get_one::<&Path>("OUTPUT")
-                .map(PathBuf::from)
+                .output
                 .unwrap_or_else(|| PathBuf::from("icu4x_data"));
 
             let mut options = BakedOptions::default();
-            options.pretty = matches.contains_id("PRETTY");
-            options.insert_feature_gates = matches.contains_id("INSERT_FEATURE_GATES");
-            options.use_separate_crates = matches.contains_id("USE_SEPARATE_CRATES");
-            options.overwrite = matches.contains_id("OVERWRITE");
+            options.pretty = matches.pretty;
+            options.insert_feature_gates = matches.insert_feature_gates;
+            options.use_separate_crates = matches.use_separate_crates;
+            options.overwrite = matches.overwrite;
 
             icu_datagen::Out::Baked {
                 mod_directory,
                 options,
             }
         }
-        _ => unreachable!(),
     };
 
     icu_datagen::datagen(

--- a/provider/datagen/src/bin/datagen.rs
+++ b/provider/datagen/src/bin/datagen.rs
@@ -201,7 +201,6 @@ struct Cli {
 
 fn main() -> eyre::Result<()> {
     let matches = Cli::parse();
-    println!("{:?}", matches.include_collations);
 
     if matches.verbose {
         SimpleLogger::new()


### PR DESCRIPTION
This moves our `clap` dependency to `4.0` (we're on `2.0`, which is three years old).

This also moves us to the more typesafe derive feature.