### PR TITLE
Move all clap users to 4.0 with derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,15 +56,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "arraystring"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,13 +399,9 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
- "strsim 0.8.0",
  "textwrap 0.11.0",
  "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -440,7 +427,7 @@ dependencies = [
  "clap_derive",
  "clap_lex 0.3.0",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
 ]
 
@@ -1606,7 +1593,7 @@ name = "icu_benchmark_memory"
 version = "0.0.0"
 dependencies = [
  "cargo_metadata",
- "clap 2.34.0",
+ "clap 4.0.26",
  "libc",
  "serde_json",
 ]
@@ -2195,7 +2182,7 @@ name = "icu_testdata_scripts"
 version = "0.0.0"
 dependencies = [
  "cached-path",
- "clap 2.34.0",
+ "clap 4.0.26",
  "crlify",
  "databake",
  "eyre",
@@ -3552,12 +3539,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -4071,12 +4052,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 name = "bies"
 version = "0.2.0"
 dependencies = [
- "criterion 0.3.6",
+ "criterion",
  "itertools",
  "num-traits",
  "partial-min-max",
@@ -190,18 +190,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata 0.1.10",
- "serde",
 ]
 
 [[package]]
@@ -395,17 +383,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "bitflags",
- "textwrap 0.11.0",
- "unicode-width",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
@@ -413,7 +390,7 @@ dependencies = [
  "bitflags",
  "clap_lex 0.2.4",
  "indexmap",
- "textwrap 0.16.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -630,32 +607,6 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
-dependencies = [
- "atty",
- "cast",
- "clap 2.34.0",
- "criterion-plot 0.4.5",
- "csv",
- "itertools",
- "lazy_static",
- "num-traits",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_cbor",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
@@ -665,7 +616,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap 3.2.23",
- "criterion-plot 0.5.0",
+ "criterion-plot",
  "itertools",
  "lazy_static",
  "num-traits",
@@ -678,16 +629,6 @@ dependencies = [
  "serde_json",
  "tinytemplate",
  "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
-dependencies = [
- "cast",
- "itertools",
 ]
 
 [[package]]
@@ -761,28 +702,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa 0.4.8",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1133,7 +1052,7 @@ dependencies = [
 name = "fixed_decimal"
 version = "0.5.2"
 dependencies = [
- "criterion 0.3.6",
+ "criterion",
  "displaydoc",
  "getrandom",
  "icu_benchmark_macros",
@@ -1454,7 +1373,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.5",
+ "itoa",
 ]
 
 [[package]]
@@ -1495,7 +1414,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.5",
+ "itoa",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1602,7 +1521,7 @@ dependencies = [
 name = "icu_calendar"
 version = "1.1.0"
 dependencies = [
- "criterion 0.3.6",
+ "criterion",
  "databake",
  "displaydoc",
  "icu",
@@ -1700,7 +1619,7 @@ version = "1.1.0"
 dependencies = [
  "arraystring",
  "atoi",
- "criterion 0.4.0",
+ "criterion",
  "databake",
  "displaydoc",
  "icu",
@@ -1721,7 +1640,7 @@ dependencies = [
 name = "icu_collections"
 version = "1.1.0"
 dependencies = [
- "criterion 0.3.6",
+ "criterion",
  "databake",
  "displaydoc",
  "iai",
@@ -1816,7 +1735,7 @@ name = "icu_datetime"
 version = "1.1.0"
 dependencies = [
  "bincode",
- "criterion 0.3.6",
+ "criterion",
  "databake",
  "displaydoc",
  "either",
@@ -1844,7 +1763,7 @@ dependencies = [
 name = "icu_decimal"
 version = "1.1.0"
 dependencies = [
- "criterion 0.3.6",
+ "criterion",
  "databake",
  "displaydoc",
  "fixed_decimal",
@@ -1924,7 +1843,7 @@ dependencies = [
  "icu_provider",
  "icu_testdata",
  "postcard",
- "regex-automata 0.2.0",
+ "regex-automata",
  "serde",
  "serde_json",
  "writeable",
@@ -1934,7 +1853,7 @@ dependencies = [
 name = "icu_locid"
 version = "1.1.0"
 dependencies = [
- "criterion 0.3.6",
+ "criterion",
  "databake",
  "displaydoc",
  "iai",
@@ -1953,7 +1872,7 @@ dependencies = [
 name = "icu_locid_transform"
 version = "1.1.0"
 dependencies = [
- "criterion 0.3.6",
+ "criterion",
  "databake",
  "displaydoc",
  "icu",
@@ -2001,7 +1920,7 @@ dependencies = [
 name = "icu_plurals"
 version = "1.1.0"
 dependencies = [
- "criterion 0.3.6",
+ "criterion",
  "databake",
  "displaydoc",
  "fixed_decimal",
@@ -2087,7 +2006,7 @@ name = "icu_provider_fs"
 version = "1.1.0"
 dependencies = [
  "bincode",
- "criterion 0.3.6",
+ "criterion",
  "crlify",
  "displaydoc",
  "icu_benchmark_macros",
@@ -2133,7 +2052,7 @@ dependencies = [
 name = "icu_segmenter"
 version = "0.8.0"
 dependencies = [
- "criterion 0.3.6",
+ "criterion",
  "databake",
  "displaydoc",
  "icu",
@@ -2152,7 +2071,7 @@ dependencies = [
 name = "icu_testdata"
 version = "1.1.2"
 dependencies = [
- "criterion 0.3.6",
+ "criterion",
  "icu",
  "icu_calendar",
  "icu_casemapping",
@@ -2284,12 +2203,6 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
@@ -2298,7 +2211,7 @@ checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 name = "ixdtf"
 version = "0.0.0"
 dependencies = [
- "criterion 0.3.6",
+ "criterion",
  "icu_testdata",
  "serde-json-core",
 ]
@@ -2370,7 +2283,7 @@ version = "0.6.1"
 dependencies = [
  "bincode",
  "bytecheck",
- "criterion 0.3.6",
+ "criterion",
  "icu_benchmark_macros",
  "icu_locid",
  "postcard",
@@ -3008,12 +2921,6 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-
-[[package]]
-name = "regex-automata"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9368763f5a9b804326f3af749e16f9abf378d227bcdee7634b13d8f17793782"
@@ -3327,16 +3234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3353,7 +3250,7 @@ version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
- "itoa 1.0.5",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -3365,7 +3262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.5",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -3667,15 +3564,6 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
@@ -3727,7 +3615,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
- "itoa 1.0.5",
+ "itoa",
  "libc",
  "num_threads",
  "serde",
@@ -3789,7 +3677,7 @@ name = "tinystr"
 version = "0.7.1"
 dependencies = [
  "bincode",
- "criterion 0.3.6",
+ "criterion",
  "databake",
  "displaydoc",
  "postcard",
@@ -4641,7 +4529,7 @@ dependencies = [
 name = "writeable"
 version = "0.5.1"
 dependencies = [
- "criterion 0.3.6",
+ "criterion",
  "icu_benchmark_macros",
  "rand",
 ]
@@ -4702,7 +4590,7 @@ name = "zerovec"
 version = "0.9.3"
 dependencies = [
  "bincode",
- "criterion 0.3.6",
+ "criterion",
  "databake",
  "getrandom",
  "iai",

--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -38,7 +38,7 @@ databake = { version = "0.1.3", path = "../../utils/databake", features = ["deri
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 icu = { path = "../icu", default-features = false }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 icu_testdata = { path = "../../provider/testdata", default-features = false, features = ["buffer", "icu_calendar"] }

--- a/components/collator/Cargo.toml
+++ b/components/collator/Cargo.toml
@@ -46,7 +46,7 @@ arraystring = "0.3.0"
 atoi = "1.0.0"
 icu = { path = "../icu" }
 icu_testdata = { path = "../../provider/testdata", default-features = false, features = ["icu_collator", "icu_normalizer"] }
-criterion = "0.4.0"
+criterion = "0.4"
 
 [features]
 std = ["icu_collections/std", "icu_locid/std", "icu_normalizer/std", "icu_properties/std", "icu_provider/std"]

--- a/components/collections/Cargo.toml
+++ b/components/collections/Cargo.toml
@@ -40,7 +40,7 @@ postcard = { version = "1.0.0", features = ["alloc"], default-features = false }
 toml = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-criterion = "0.3.4"
+criterion = "0.4"
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 iai = "0.1.1"
 icu = { path = "../icu", default-features = false }

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -48,7 +48,7 @@ databake = { version = "0.1.3", path = "../../utils/databake", features = ["deri
 litemap = { version = "0.6.1", path = "../../utils/litemap", optional = true }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 icu = { path = "../icu", default-features = false }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 icu_provider = { path = "../../provider/core" }

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -36,7 +36,7 @@ databake = { version = "0.1.3", path = "../../utils/databake", features = ["deri
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 icu = { path = "../icu", default-features = false }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 icu_testdata = { path = "../../provider/testdata", default-features = false, features = ["icu_decimal"] }

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 zerovec = { version = "0.9.2", path = "../../utils/zerovec", optional = true }
 
 [dev-dependencies]
-criterion = "0.3.3"
+criterion = "0.4"
 iai = "0.1.1"
 icu = { path = "../icu", default-features = false }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }

--- a/components/locid_transform/Cargo.toml
+++ b/components/locid_transform/Cargo.toml
@@ -40,7 +40,7 @@ databake = { version = "0.1.3", path = "../../utils/databake", optional = true, 
 displaydoc = { version = "0.2.3", default-features = false }
 
 [dev-dependencies]
-criterion = "0.3.3"
+criterion = "0.4"
 icu_testdata = { path = "../../provider/testdata", default-features = false, features = ["icu_locid_transform"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -37,7 +37,7 @@ databake = { version = "0.1.3", path = "../../utils/databake", features = ["deri
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 icu = { path = "../icu" }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 icu_provider = { path = "../../provider/core" }

--- a/experimental/bies/Cargo.toml
+++ b/experimental/bies/Cargo.toml
@@ -36,7 +36,7 @@ strum = { version = "0.20", features = ["derive"] }
 writeable = { version = "0.5.1", path = "../../utils/writeable" }
 
 [dev-dependencies]
-criterion = "0.3.3"
+criterion = "0.4"
 rand = "0.8"
 rand_distr = "0.4"
 rand_pcg = "0.3"

--- a/experimental/ixdtf/Cargo.toml
+++ b/experimental/ixdtf/Cargo.toml
@@ -32,6 +32,6 @@ all-features = true
 [dependencies]
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 icu_testdata = { path = "../../provider/testdata" }
 serde-json-core = { version = "0.4", features = ["std"] }

--- a/experimental/segmenter/Cargo.toml
+++ b/experimental/segmenter/Cargo.toml
@@ -44,7 +44,7 @@ serde = { version = "1.0", default-features = false, features = ["derive", "allo
 num-traits = { version = "0.2", default-features = false, features = ["libm"], optional = true }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 icu_testdata = { path = "../../provider/testdata", default-features = false, features = ["buffer", "icu_segmenter"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -41,7 +41,7 @@ postcard = { version = "1.0.0", features = ["use-std"], default-features = false
 serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
-criterion = "0.3.3"
+criterion = "0.4"
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 icu_locid = { path = "../../components/locid", features = ["serde"] }
 icu_provider = { path = "../core", features = ["deserialize_json", "deserialize_bincode_1", "deserialize_postcard_1", "datagen"] }

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -62,7 +62,7 @@ icu_timezone = { version = "1.1.0", path = "../../components/timezone", default-
 [dev-dependencies]
 icu = { path = "../../components/icu" }
 icu_provider = { path = "../../provider/core", features = ["deserialize_json"] }
-criterion = "0.3"
+criterion = "0.4"
 
 [features]
 default = [

--- a/tools/benchmark/memory/Cargo.toml
+++ b/tools/benchmark/memory/Cargo.toml
@@ -10,6 +10,6 @@ edition = "2021"
 
 [dependencies]
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-clap = "2.33"
+clap = {version = "4", features = ["derive"] }
 cargo_metadata = "0.13"
 libc = "0.2"

--- a/tools/benchmark/memory/src/main.rs
+++ b/tools/benchmark/memory/src/main.rs
@@ -22,7 +22,7 @@ struct ProcessedArgs {
     )]
     os: Option<String>,
     #[arg(value_name = "EXAMPLES", num_args = 1.., index=1)]
-    #[arg(help = "The space separated list of examples to run, with the form <PACKAGE>/<EXAMPLE>",)]
+    #[arg(help = "The space separated list of examples to run, with the form <PACKAGE>/<EXAMPLE>")]
     examples: Vec<String>,
     #[arg(
         long,

--- a/tools/benchmark/memory/src/main.rs
+++ b/tools/benchmark/memory/src/main.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use cargo_metadata::Metadata;
-use clap::{App, Arg};
+use clap::Parser;
 use serde_json::json;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
@@ -12,68 +12,44 @@ use std::process::Command;
 use std::{env, process::Stdio};
 use std::{fs, io::BufReader};
 
+#[derive(Parser)]
+#[command(about = "Collect a memory report for examples using dhat-rs.")]
 struct ProcessedArgs {
+    #[arg(
+        value_name = "OS",
+        help = "Nests the results of the benchmark in a folder per-OS, primarily needed by CI."
+    )]
     os: Option<String>,
+    #[arg(value_name = "EXAMPLES", help = "The space separated list of examples to run, with the form <PACKAGE>/<EXAMPLE>", num_args = 1..)]
     examples: Vec<String>,
+    #[arg(
+        value_name = "TOOLCHAIN",
+        default_value = "stable",
+        help = "The toolchain for cargo to use.."
+    )]
     toolchain: String,
 }
 
 fn process_cli_args() -> ProcessedArgs {
-    let matches = App::new("ICU4X Memory Benchmarks")
-        .about("Collect a memory report for examples using dhat-rs.")
-        .arg(
-            Arg::with_name("EXAMPLES")
-                .index(1)
-                .multiple(true)
-                .required(true)
-                .help("The space separated list of examples to run, with the form <PACKAGE>/<EXAMPLE>")
-            )
-            .arg(
-                Arg::with_name("OS")
-                    .long("os")
-                    .takes_value(true)
-                    .value_name("OS")
-                    .required(false)
-                    .help("Nests the results of the benchmark in a folder per-OS, primarily needed by CI.")
-            )
-            .arg(
-                Arg::with_name("TOOLCHAIN")
-                    .long("toolchain")
-                    .takes_value(true)
-                    .value_name("TOOLCHAIN")
-                    .default_value("stable")
-                    .help("The toolchain for cargo to use..")
-            ).get_matches();
+    let processed = ProcessedArgs::parse();
 
-    ProcessedArgs {
-        // Validate the OS, and copy into an owned String.
-        os: matches.value_of("OS").map(|os| {
-            if !os
-                .chars()
-                .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
-            {
-                panic!("The OS had an unexpected character");
-            }
-            os.to_string()
-        }),
-
-        // Validate the examples, and map them into owned Strings.
-        examples: matches
-            .values_of("EXAMPLES")
-            .expect("At least one example must be provided.")
-            .map(|example| {
-                if !example
-                    .chars()
-                    .all(|c| c.is_alphanumeric() || c == '_' || c == '/')
-                {
-                    panic!("An example had an unexpected character \"{example:?}\"");
-                }
-                example.to_string()
-            })
-            .collect(),
-
-        toolchain: matches.value_of("TOOLCHAIN").unwrap().to_string(),
+    if let Some(ref os) = processed.os {
+        if !os
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+        {
+            panic!("The OS had an unexpected character");
+        }
     }
+    for example in &processed.examples {
+        if !example
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '/')
+        {
+            panic!("An example had an unexpected character \"{example:?}\"");
+        }
+    }
+    processed
 }
 
 fn parse_dhat_log(dhat_log: &[String]) -> (u64, u64, u64) {

--- a/tools/benchmark/memory/src/main.rs
+++ b/tools/benchmark/memory/src/main.rs
@@ -16,13 +16,16 @@ use std::{fs, io::BufReader};
 #[command(about = "Collect a memory report for examples using dhat-rs.")]
 struct ProcessedArgs {
     #[arg(
+        long,
         value_name = "OS",
         help = "Nests the results of the benchmark in a folder per-OS, primarily needed by CI."
     )]
     os: Option<String>,
-    #[arg(value_name = "EXAMPLES", help = "The space separated list of examples to run, with the form <PACKAGE>/<EXAMPLE>", num_args = 1..)]
+    #[arg(value_name = "EXAMPLES", num_args = 1.., index=1)]
+    #[arg(help = "The space separated list of examples to run, with the form <PACKAGE>/<EXAMPLE>",)]
     examples: Vec<String>,
     #[arg(
+        long,
         value_name = "TOOLCHAIN",
         default_value = "stable",
         help = "The toolchain for cargo to use.."

--- a/tools/testdata-scripts/Cargo.toml
+++ b/tools/testdata-scripts/Cargo.toml
@@ -17,7 +17,7 @@ icu_provider = { path = "../../provider/core" }
 repodata = { path = "../../provider/repodata" }
 
 cached-path = ">=0.5, <0.7"
-clap = "2.33"
+clap = {version = "4", features = ["derive"] }
 eyre = "0.6"
 log = "0.4"
 quote = "1"

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -37,7 +37,7 @@ writeable = { version = "0.5.1", path = "../../utils/writeable" }
 ryu = { version = "1.0.5", features = ["small"], optional = true }
 
 [dev-dependencies]
-criterion = "0.3.4"
+criterion = "0.4"
 getrandom = { version = "0.2", features = ["js"] }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 rand = "0.8"

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -37,7 +37,7 @@ yoke = { version = "0.7.0", path = "../yoke", features = ["derive"], optional = 
 [dev-dependencies]
 bincode = "1"
 bytecheck = "0.6"
-criterion = "0.3.4"
+criterion = "0.4"
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 icu_locid = { path = "../../components/locid" }
 postcard = { version = "1.0.0", features = ["use-std"], default-features = false }

--- a/utils/tinystr/Cargo.toml
+++ b/utils/tinystr/Cargo.toml
@@ -37,7 +37,7 @@ databake = { version = "0.1.3", path = "../../utils/databake", optional = true }
 
 [dev-dependencies]
 bincode = "1.3"
-criterion = "0.3"
+criterion = "0.4"
 postcard = { version = "1.0.0", features = ["use-std"], default-features = false }
 rand = { version = "0.8.5", features = ["small_rng"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }

--- a/utils/writeable/Cargo.toml
+++ b/utils/writeable/Cargo.toml
@@ -29,7 +29,7 @@ independent = true
 all-features = true
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 rand = { version = "0.8", features = ["small_rng"] }
 

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -46,7 +46,7 @@ t1ha = { version = "0.1", optional = true }
 
 [dev-dependencies]
 bincode = "1.3"
-criterion = "0.3.4"
+criterion = "0.4"
 getrandom = { version = "0.2", features = ["js"] }
 iai = "0.1"
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }


### PR DESCRIPTION
Unfortunately criterion still depends on an older clap (though there's work upstream to remove clap from criterion entirely), so we don't get rid of the dependency completely, but it's only a bench-time dep now.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->