### PR TITLE
[segmenter] Do not use icu as a dev-dep in segmenter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,7 +1925,6 @@ dependencies = [
  "criterion",
  "databake",
  "displaydoc",
- "icu",
  "icu_collections",
  "icu_locid",
  "icu_provider",

--- a/experimental/segmenter/Cargo.toml
+++ b/experimental/segmenter/Cargo.toml
@@ -49,7 +49,6 @@ criterion = "0.3"
 icu_testdata = { path = "../../provider/testdata", default-features = false, features = ["buffer", "icu_segmenter"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
-icu = { path = "../../components/icu", features = ["icu_segmenter"]}
 
 [features]
 default = ["auto"]


### PR DESCRIPTION
The `icu_segmenter` crate has `icu` as a dev-dependency. I don't think we need it and removing it makes dev complation faster.