### PR TITLE
Correct doc comment

### DIFF
--- a/provider/core/src/buf.rs
+++ b/provider/core/src/buf.rs
@@ -110,7 +110,7 @@ pub enum BufferFormat {
     Json,
     /// Serialize using Bincode version 1.
     Bincode1,
-    /// Serialize using Postcard version 0.7.
+    /// Serialize using Postcard version 1.
     Postcard1,
 }
 


### PR DESCRIPTION
I noticed that the docs still referred to the old 0.7 release of postcard, which is no longer used by ICU4X.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->