### PR TITLE
LSTM runtime computation in i32

### DIFF
--- a/experimental/segmenter/src/lstm_bies.rs
+++ b/experimental/segmenter/src/lstm_bies.rs
@@ -31,7 +31,7 @@ pub struct Lstm<'l> {
 }
 
 fn int_to_f32(x: MatIntType) -> f32 {
-    (x as f32) / 1000.0
+    (x as f32) / 128.0
 }
 
 impl<'l> Lstm<'l> {

--- a/experimental/segmenter/src/lstm_bies.rs
+++ b/experimental/segmenter/src/lstm_bies.rs
@@ -146,10 +146,10 @@ impl<'l> Lstm<'l> {
         hunits: usize,
     ) -> (Array1<CalcType>, Array1<CalcType>) {
         // i, f, and o respectively stand for input, forget, and output gates
-        let s_t = x_t.mapv(int_to_calc).dot(&warr.mapv(int_to_calc)) / FACTOR
-            + h_tm1.dot(&uarr.mapv(int_to_calc)) / FACTOR
-            + barr.mapv(int_to_calc);
-        // std::println!("dots: {x_t:?} * {warr:?} + {h_tm1:?} * {uarr:?} + {barr:?} = {s_t:?}");
+        // std::println!("dots: {x_t:?} * {warr:?} + {h_tm1:?} * {uarr:?} + {barr:?}");
+        let s_t = x_t.dot(&warr) / FACTOR
+            + h_tm1.dot(&uarr) / FACTOR
+            + barr;
         // std::println!("s_t = {s_t:?}");
         let i = math_helper::sigmoid_arr1(s_t.slice(ndarray::s![..hunits]));
         let f = math_helper::sigmoid_arr1(s_t.slice(ndarray::s![hunits..2 * hunits]));
@@ -251,7 +251,7 @@ impl<'l> Lstm<'l> {
             let curr_bw = all_h_bw.slice(ndarray::s![i, ..]);
             let concat_lstm = math_helper::concatenate_arr1(curr_fw, curr_bw);
             let curr_est =
-                concat_lstm.dot(&timew.mapv(int_to_calc)) / FACTOR + timeb.mapv(int_to_calc);
+                concat_lstm.dot(&timew) / FACTOR + timeb;
             let probs = math_helper::softmax(curr_est);
             // We use `unwrap_or` to fall back and prevent panics.
             bies.push(self.compute_bies(probs).unwrap_or('s'));

--- a/experimental/segmenter/src/math_helper.rs
+++ b/experimental/segmenter/src/math_helper.rs
@@ -2,67 +2,11 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use ndarray::{concatenate, Array1, Array2, ArrayBase, Axis, Dim, OwnedRepr, ViewRepr};
+use ndarray::{concatenate, Array1, Array2, ArrayBase, Axis, Dim, ViewRepr};
 
 // Polyfill float operations with libm in case we're no_std.
 #[allow(unused_imports)]
 use num_traits::Float;
-
-/// Approximation of 128*sigmoid(x/32)
-fn pocket_sigmoid_128(x: i32) -> i32 {
-    if x <= -128 {
-        1
-    } else if x <= -75 {
-        x / 8 + 20
-    } else if x <= -32 {
-        x / 2 + 48
-    } else if x <= 31 {
-        x + 64
-    } else if x <= 74 {
-        x / 2 + 80
-    } else if x <= 127 {
-        x / 8 + 108
-    } else {
-        127
-    }
-}
-
-/// Approximation of 128*tanh(x/64)
-fn pocket_tanh_128(x: i32) -> i32 {
-    if x <= -128 {
-        -128
-    } else if x <= -75 {
-        x / 4 - 88
-    } else if x <= -32 {
-        x - 32
-    } else if x <= 31 {
-        2 * x
-    } else if x <= 74 {
-        x + 32
-    } else if x <= 127 {
-        x / 4 + 88
-    } else {
-        127
-    }
-}
-
-#[test]
-fn test_pocket_sigmoid_tanh_128() {
-    for x in -150..150 {
-        let sigmoid_exact = 128.0 * sigmoid(x as f32 / 32.0);
-        let sigmoid_appx = pocket_sigmoid_128(x) as f32;
-        assert!(
-            (sigmoid_appx - sigmoid_exact).abs() < 10.0,
-            "sigmoid: {x} {sigmoid_appx} {sigmoid_exact}"
-        );
-        let tanh_exact = 128.0 * tanh(x as f32 / 64.0);
-        let tanh_appx = pocket_tanh_128(x) as f32;
-        assert!(
-            (tanh_appx - tanh_exact).abs() < 10.0,
-            "tanh: {x} {tanh_appx} {tanh_exact}"
-        );
-    }
-}
 
 fn tanh_1024(x: i32) -> i32 {
     let y = match x.abs() {
@@ -131,11 +75,13 @@ fn test_sigmoid_1024() {
 }
 
 /// `sigmoid` computes the sigmoid function for a scalar value.
+#[cfg(test)]
 #[inline]
 fn sigmoid(x: f32) -> f32 {
     1.0 / (1.0 + (-x).exp())
 }
 
+#[cfg(test)]
 #[inline]
 fn tanh(x: f32) -> f32 {
     x.tanh()
@@ -163,30 +109,14 @@ pub fn max_arr1(arr: ArrayBase<ViewRepr<&f32>, Dim<[usize; 1]>>) -> usize {
     ind
 }
 
-/// `max_arr1` returns the index of the maximum value in a 1d array.
-pub fn max_arr1_owned(arr: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 1]>>) -> usize {
-    // No argmax in rust-ndarray (https://github.com/rust-ndarray/ndarray/issues/416)
-    let mut mx: f32 = 0.0;
-    let mut ind = 0;
-    arr.indexed_iter().for_each(|(i, v)| {
-        if mx < *v {
-            mx = *v;
-            ind = i
-        }
-    });
-    ind
-}
-
 /// `tanh_arr1` computes elementwise sigmoid function for elements of a 1d array
 pub fn sigmoid_arr1(arr: ArrayBase<ViewRepr<&i32>, Dim<[usize; 1]>>) -> Array1<i32> {
     arr.map(|x| sigmoid_1024(*x))
-    // arr.map(|x| (sigmoid(*x as f32 / 1024.0) * 1024.0) as i32)
 }
 
 /// `tanh_arr1` computes elementwise tanh function for elements of a 1d array
 pub fn tanh_arr1(arr: ArrayBase<ViewRepr<&i32>, Dim<[usize; 1]>>) -> Array1<i32> {
     arr.map(|x| tanh_1024(*x))
-    // arr.map(|x| (tanh(*x as f32 / 1024.0) * 1024.0) as i32)
 }
 
 /// `change_row` gets one 2d array (`arr`), one 1d array (`arr1`), and an index (`row_id`), and replaces the `row_id`-th row of

--- a/experimental/segmenter/src/math_helper.rs
+++ b/experimental/segmenter/src/math_helper.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use ndarray::{concatenate, Array1, Array2, ArrayBase, Axis, Dim, ViewRepr, OwnedRepr};
+use ndarray::{concatenate, Array1, Array2, ArrayBase, Axis, Dim, OwnedRepr, ViewRepr};
 
 // Polyfill float operations with libm in case we're no_std.
 #[allow(unused_imports)]
@@ -13,15 +13,15 @@ fn pocket_sigmoid_128(x: i32) -> i32 {
     if x <= -128 {
         1
     } else if x <= -75 {
-        x/8 + 20
+        x / 8 + 20
     } else if x <= -32 {
-        x/2 + 48
+        x / 2 + 48
     } else if x <= 31 {
         x + 64
     } else if x <= 74 {
-        x/2 + 80
+        x / 2 + 80
     } else if x <= 127 {
-        x/8 + 108
+        x / 8 + 108
     } else {
         127
     }
@@ -32,15 +32,15 @@ fn pocket_tanh_128(x: i32) -> i32 {
     if x <= -128 {
         -128
     } else if x <= -75 {
-        x/4 - 88
+        x / 4 - 88
     } else if x <= -32 {
         x - 32
     } else if x <= 31 {
-        2*x
+        2 * x
     } else if x <= 74 {
         x + 32
     } else if x <= 127 {
-        x/4 + 88
+        x / 4 + 88
     } else {
         127
     }
@@ -51,10 +51,82 @@ fn test_pocket_sigmoid_tanh_128() {
     for x in -150..150 {
         let sigmoid_exact = 128.0 * sigmoid(x as f32 / 32.0);
         let sigmoid_appx = pocket_sigmoid_128(x) as f32;
-        assert!((sigmoid_appx - sigmoid_exact).abs() < 10.0, "sigmoid: {x} {sigmoid_appx} {sigmoid_exact}");
+        assert!(
+            (sigmoid_appx - sigmoid_exact).abs() < 10.0,
+            "sigmoid: {x} {sigmoid_appx} {sigmoid_exact}"
+        );
         let tanh_exact = 128.0 * tanh(x as f32 / 64.0);
         let tanh_appx = pocket_tanh_128(x) as f32;
-        assert!((tanh_appx - tanh_exact).abs() < 10.0, "tanh: {x} {tanh_appx} {tanh_exact}");
+        assert!(
+            (tanh_appx - tanh_exact).abs() < 10.0,
+            "tanh: {x} {tanh_appx} {tanh_exact}"
+        );
+    }
+}
+
+fn tanh_1024(x: i32) -> i32 {
+    let y = match x.abs() {
+        x if x <= 273 => x,
+        x if x <= 567 => x * 5 / 6 + 46,
+        x if x <= 788 => x * 2 / 3 + 140,
+        x if x <= 999 => x * 1 / 2 + 272,
+        x if x <= 1210 => x * 3 / 8 + 396,
+        x if x <= 1527 => x * 1 / 4 + 548,
+        x if x <= 1920 => x * 1 / 8 + 738,
+        x if x <= 2286 => x * 1 / 16 + 859,
+        x if x <= 2604 => x * 1 / 32 + 930,
+        x if x <= 3335 => x * 1 / 64 + 971,
+        _ => 1023,
+    };
+    if x < 0 {
+        -y
+    } else {
+        y
+    }
+}
+
+#[test]
+fn test_tanh_1024() {
+    for x in -4000..4000 {
+        let tanh_exact = 1024.0 * tanh(x as f32 / 1024.0);
+        let tanh_appx = tanh_1024(x);
+        assert!(
+            (tanh_exact - tanh_appx as f32).abs() < 10.0,
+            "tanh: {x} {tanh_appx} {tanh_exact}"
+        );
+    }
+}
+
+fn sigmoid_1024(x: i32) -> i32 {
+    let y = match x.abs() {
+        x if x <= 470 => x * 1 / 4 + 512,
+        x if x <= 958 => x * 7 / 32 + 527,
+        x if x <= 1293 => x * 3 / 16 + 557,
+        x if x <= 1629 => x * 5 / 32 + 597,
+        x if x <= 1992 => x * 1 / 8 + 648,
+        x if x <= 2423 => x * 3 / 32 + 710,
+        x if x <= 3054 => x * 1 / 16 + 786,
+        x if x <= 3843 => x * 1 / 32 + 881,
+        x if x <= 4487 => x * 1 / 64 + 941,
+        x if x <= 5956 => x * 1 / 128 + 976,
+        _ => 1023,
+    };
+    if x < 0 {
+        1024 - y
+    } else {
+        y
+    }
+}
+
+#[test]
+fn test_sigmoid_1024() {
+    for x in -4000..4000 {
+        let sigmoid_exact = 1024.0 * sigmoid(x as f32 / 1024.0);
+        let sigmoid_appx = sigmoid_1024(x);
+        assert!(
+            (sigmoid_exact - sigmoid_appx as f32).abs() < 10.0,
+            "sigmoid: {x} {sigmoid_appx} {sigmoid_exact}"
+        );
     }
 }
 
@@ -69,7 +141,7 @@ fn tanh(x: f32) -> f32 {
     x.tanh()
 }
 
-const FACTOR: f32 = 128.0;
+const FACTOR: f32 = 1024.0;
 
 /// `softmax` gets a 1d array of `f32` numbers, and compute the softmax probability for each element in the array.
 pub fn softmax(arr: Array1<i32>) -> Array1<f32> {
@@ -107,12 +179,14 @@ pub fn max_arr1_owned(arr: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 1]>>) -> usize
 
 /// `tanh_arr1` computes elementwise sigmoid function for elements of a 1d array
 pub fn sigmoid_arr1(arr: ArrayBase<ViewRepr<&i32>, Dim<[usize; 1]>>) -> Array1<i32> {
-    arr.map(|x| pocket_sigmoid_128(x/4))
+    arr.map(|x| sigmoid_1024(*x))
+    // arr.map(|x| (sigmoid(*x as f32 / 1024.0) * 1024.0) as i32)
 }
 
 /// `tanh_arr1` computes elementwise tanh function for elements of a 1d array
 pub fn tanh_arr1(arr: ArrayBase<ViewRepr<&i32>, Dim<[usize; 1]>>) -> Array1<i32> {
-    arr.map(|x| pocket_tanh_128(x/2))
+    arr.map(|x| tanh_1024(*x))
+    // arr.map(|x| (tanh(*x as f32 / 1024.0) * 1024.0) as i32)
 }
 
 /// `change_row` gets one 2d array (`arr`), one 1d array (`arr1`), and an index (`row_id`), and replaces the `row_id`-th row of

--- a/experimental/segmenter/src/provider.rs
+++ b/experimental/segmenter/src/provider.rs
@@ -117,7 +117,7 @@ pub struct LstmMatrix<'data> {
     pub data: ZeroVec<'data, f32>,
 }
 
-pub(crate) type MatIntType = i16;
+pub(crate) type MatIntType = i32;
 
 fn f32_to_int(x: f32) -> MatIntType {
     // Note: The `as` cast saturates the MatIntType if the value is too big

--- a/experimental/segmenter/src/provider.rs
+++ b/experimental/segmenter/src/provider.rs
@@ -122,7 +122,7 @@ pub(crate) type MatIntType = i32;
 fn f32_to_int(x: f32) -> MatIntType {
     // Note: The `as` cast saturates the MatIntType if the value is too big
     // <https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions>
-    (x*128.0).round() as MatIntType
+    (x * 1024.0).round() as MatIntType
 }
 
 #[cfg(feature = "lstm")]

--- a/experimental/segmenter/src/provider.rs
+++ b/experimental/segmenter/src/provider.rs
@@ -122,7 +122,7 @@ pub(crate) type MatIntType = i16;
 fn f32_to_int(x: f32) -> MatIntType {
     // Note: The `as` cast saturates the MatIntType if the value is too big
     // <https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions>
-    (x*1000.0).round() as MatIntType
+    (x*128.0).round() as MatIntType
 }
 
 #[cfg(feature = "lstm")]


### PR DESCRIPTION
I changed the _hc_ calculations to run in i32 instead of f32.

Good news: I'm able to pass all of our current tests, suggesting no accuracy regression.

Bad news: It doesn't seem to improve the benchmark performance, at least on x64. We're still getting a dismal ~900 microseconds to segment the 90-code-point bench string, compared to about ~3 microseconds with the dictionary.

I tried running the calculations in i16, but I am still hitting cases where "a*b/c" exceeds the range of the i16, even though all three inputs and the output are well within the bounds of the i16.