### PR TITLE
LSTM with integer arithmetic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,6 +2154,7 @@ dependencies = [
  "icu_locid",
  "icu_provider",
  "icu_testdata",
+ "intmath",
  "ndarray",
  "num-traits",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2282,6 +2282,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "intmath"
+version = "0.1.0"
+dependencies = [
+ "criterion 0.3.6",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "experimental/casemapping",
     "experimental/compactdecimal",
     "experimental/displaynames",
+    "experimental/intmath",
     "experimental/harfbuzz",
     "experimental/ixdtf",
     "experimental/relativetime",

--- a/experimental/intmath/Cargo.toml
+++ b/experimental/intmath/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "intmath"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "bench"
+harness = false

--- a/experimental/intmath/benches/bench.rs
+++ b/experimental/intmath/benches/bench.rs
@@ -1,0 +1,87 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use intmath::i8_mul_div_128;
+use intmath::i8_mul_div_128_reference;
+use intmath::saturating_i16_mul_div_1024;
+use intmath::saturating_i16_mul_div_1024_reference;
+
+fn bench_i8_mul_div_128(c: &mut Criterion) {
+    let mut group = c.benchmark_group("intmath/muldiv/i8/128");
+
+    let values = [0i8, 1, 2, 3, 4, 5, 10, 16, 20, 32, 40, 63, 64, 65, 90, 127];
+
+    group.bench_function("impl", |b| {
+        b.iter(|| {
+            for a in black_box(values).iter() {
+                for b in black_box(values).iter() {
+                    for (p, q) in [(1, 1), (1, -1), (-1, 1), (-1, -1)] {
+                        let a = a * p;
+                        let b = b * q;
+                        let _ = i8_mul_div_128(a, b);
+                    }
+                }
+            }
+        })
+    });
+
+    group.bench_function("ref", |b| {
+        b.iter(|| {
+            for a in black_box(values).iter() {
+                for b in black_box(values).iter() {
+                    for (p, q) in [(1, 1), (1, -1), (-1, 1), (-1, -1)] {
+                        let a = a * p;
+                        let b = b * q;
+                        let _ = i8_mul_div_128_reference(a, b);
+                    }
+                }
+            }
+        })
+    });
+}
+
+fn bench_saturating_i16_mul_div_1024(c: &mut Criterion) {
+    let mut group = c.benchmark_group("intmath/muldiv/i16/1024");
+
+    let values = [
+        0, 1, 2, 3, 10, 16, 20, 63, 64, 65, 90, 128, 511, 512, 1023, 1024, 4000,
+    ];
+
+    group.bench_function("impl", |b| {
+        b.iter(|| {
+            for a in black_box(values).iter() {
+                for b in black_box(values).iter() {
+                    for (p, q) in [(1, 1), (1, -1), (-1, 1), (-1, -1)] {
+                        let a = a * p;
+                        let b = b * q;
+                        let _ = saturating_i16_mul_div_1024(a, b);
+                    }
+                }
+            }
+        })
+    });
+
+    group.bench_function("ref", |b| {
+        b.iter(|| {
+            for a in black_box(values).iter() {
+                for b in black_box(values).iter() {
+                    for (p, q) in [(1, 1), (1, -1), (-1, 1), (-1, -1)] {
+                        let a = a * p;
+                        let b = b * q;
+                        let _ = saturating_i16_mul_div_1024_reference(a, b);
+                    }
+                }
+            }
+        })
+    });
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default();
+    targets = bench_i8_mul_div_128, bench_saturating_i16_mul_div_1024
+);
+criterion_main!(benches);

--- a/experimental/intmath/src/lib.rs
+++ b/experimental/intmath/src/lib.rs
@@ -1,0 +1,226 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+#![no_std]
+
+//! Routines for performing integer arithmetic.
+//!
+//! This focus of this crate is currently on functions to perform operations
+//! of the form `a * b / 2^c`. Normally this operation requires using the
+//! integer one size larger than the size of `a` and `b`, but this crate
+//! performs these operations without resorting to a larger integer type.
+//!
+//! The included Criterion benchmarks indicate that, individually, these
+//! operations are slightly faster than the equivalent operations utilizing
+//! the larger integer type.
+//!
+//! The motivation to write this crate was to experiment with vectorization;
+//! in theory, 8 ops in i8 could take as long as 4 ops in i16. This has not
+//! been definitively measured.
+
+/// Computes `a * b / 128` without exceeding the bounds of an `i8`.
+///
+/// `a` and `b` must not be `i8::MIN` since `i8::MIN * i8::MIN / 128` is not
+/// within the bounds of an i8. The caller is responsible for enforcing this
+/// invariant. If the invariant is violated, an unexpected-but-deterministic
+/// value will be returned.
+///
+/// # Examples
+///
+/// ```
+/// use intmath::i8_mul_div_128;
+///
+/// assert_eq!(29, 50 * 75 / 128);
+/// assert_eq!(29, i8_mul_div_128(50, 75));
+/// ```
+pub fn i8_mul_div_128(a: i8, b: i8) -> i8 {
+    debug_assert_ne!(a, i8::MIN);
+    debug_assert_ne!(b, i8::MIN);
+    let au8 = a.unsigned_abs();
+    let bu8 = b.unsigned_abs();
+    let mut result = 0u8;
+    result += if (au8 & 0b00000001) != 0 { bu8 } else { 0 };
+    result >>= 1;
+    result += if (au8 & 0b00000010) != 0 { bu8 } else { 0 };
+    result >>= 1;
+    result += if (au8 & 0b00000100) != 0 { bu8 } else { 0 };
+    result >>= 1;
+    result += if (au8 & 0b00001000) != 0 { bu8 } else { 0 };
+    result >>= 1;
+    result += if (au8 & 0b00010000) != 0 { bu8 } else { 0 };
+    result >>= 1;
+    result += if (au8 & 0b00100000) != 0 { bu8 } else { 0 };
+    result >>= 1;
+    result += if (au8 & 0b01000000) != 0 { bu8 } else { 0 };
+    result >>= 1;
+    let result = result as i8;
+    if (a as u8 & 0x80) ^ (b as u8 & 0x80) == 0 {
+        result
+    } else {
+        -result
+    }
+}
+
+#[doc(hidden)]
+pub fn i8_mul_div_128_reference(a: i8, b: i8) -> i8 {
+    (a as i16 * b as i16 / 128) as i8
+}
+
+/// Computes `a * b / 1024` without exceeding the bounds of an `i16`.
+///
+/// Saturates the `i16` if overflow would occur. Never returns `i16::MIN`;
+/// negative values are saturated to `-i16::MAX`.
+///
+/// # Examples
+///
+/// ```
+/// use intmath::saturating_i16_mul_div_1024;
+///
+/// assert_eq!(146, 200 * 750 / 1024);
+/// assert_eq!(146, saturating_i16_mul_div_1024(200, 750));
+/// ```
+///
+/// Saturates the `i16` if the result does not fit:
+///
+/// ```
+/// use intmath::saturating_i16_mul_div_1024;
+///
+/// assert_eq!(62500, 8000 * 8000 / 1024);
+/// assert_eq!(32767, saturating_i16_mul_div_1024(8000, 8000));
+/// ```
+pub fn saturating_i16_mul_div_1024(a: i16, b: i16) -> i16 {
+    let au16 = a.unsigned_abs();
+    let bu16 = b.unsigned_abs();
+    let mut result = 0u16;
+    result += if (au16 & 0b0000000000000001) != 0 {
+        bu16
+    } else {
+        0
+    };
+    result >>= 1;
+    result += if (au16 & 0b0000000000000010) != 0 {
+        bu16
+    } else {
+        0
+    };
+    result >>= 1;
+    result += if (au16 & 0b0000000000000100) != 0 {
+        bu16
+    } else {
+        0
+    };
+    result >>= 1;
+    result += if (au16 & 0b0000000000001000) != 0 {
+        bu16
+    } else {
+        0
+    };
+    result >>= 1;
+    result += if (au16 & 0b0000000000010000) != 0 {
+        bu16
+    } else {
+        0
+    };
+    result >>= 1;
+    result += if (au16 & 0b0000000000100000) != 0 {
+        bu16
+    } else {
+        0
+    };
+    result >>= 1;
+    result += if (au16 & 0b0000000001000000) != 0 {
+        bu16
+    } else {
+        0
+    };
+    result >>= 1;
+    result += if (au16 & 0b0000000010000000) != 0 {
+        bu16
+    } else {
+        0
+    };
+    result >>= 1;
+    result += if (au16 & 0b0000000100000000) != 0 {
+        bu16
+    } else {
+        0
+    };
+    result >>= 1;
+    result += if (au16 & 0b0000001000000000) != 0 {
+        bu16
+    } else {
+        0
+    };
+    result >>= 1;
+    result += if (au16 & 0b0000010000000000) != 0 {
+        bu16
+    } else {
+        0
+    };
+    // Have done enough right-shifts; now need to do some left-shifts
+    result = result.saturating_add(if (au16 & 0b0000100000000000) != 0 {
+        if bu16 >= 0b1000000000000000 {
+            u16::MAX
+        } else {
+            bu16 << 1
+        }
+    } else {
+        0
+    });
+    result = result.saturating_add(if (au16 & 0b0001000000000000) != 0 {
+        if bu16 >= 0b0100000000000000 {
+            u16::MAX
+        } else {
+            bu16 << 2
+        }
+    } else {
+        0
+    });
+    result = result.saturating_add(if (au16 & 0b0010000000000000) != 0 {
+        if bu16 >= 0b0010000000000000 {
+            u16::MAX
+        } else {
+            bu16 << 3
+        }
+    } else {
+        0
+    });
+    result = result.saturating_add(if (au16 & 0b0100000000000000) != 0 {
+        if bu16 >= 0b0001000000000000 {
+            u16::MAX
+        } else {
+            bu16 << 4
+        }
+    } else {
+        0
+    });
+    result = result.saturating_add(if (au16 & 0b1000000000000000) != 0 {
+        if bu16 >= 0b0000100000000000 {
+            u16::MAX
+        } else {
+            bu16 << 5
+        }
+    } else {
+        0
+    });
+    result = core::cmp::min(result, i16::MAX as u16);
+    let result = result as i16;
+    if (a as u16 & 0x8000) ^ (b as u16 & 0x8000) == 0 {
+        result
+    } else {
+        -result
+    }
+}
+
+#[doc(hidden)]
+pub fn saturating_i16_mul_div_1024_reference(a: i16, b: i16) -> i16 {
+    let result = a as i32 * b as i32 / 1024;
+    if result > i16::MAX as i32 {
+        i16::MAX
+    } else if result < -i16::MAX as i32 {
+        -i16::MAX
+    } else {
+        result as i16
+    }
+}

--- a/experimental/intmath/tests/test.rs
+++ b/experimental/intmath/tests/test.rs
@@ -1,0 +1,95 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use intmath::i8_mul_div_128;
+use intmath::i8_mul_div_128_reference;
+use intmath::saturating_i16_mul_div_1024;
+use intmath::saturating_i16_mul_div_1024_reference;
+
+#[test]
+fn test_i8_mul_div_128() {
+    assert_eq!(25, i8_mul_div_128(50, 64));
+    assert_eq!(25, i8_mul_div_128(64, 50));
+    assert_eq!(-25, i8_mul_div_128(-50, 64));
+    assert_eq!(-25, i8_mul_div_128(64, -50));
+    assert_eq!(-25, i8_mul_div_128(50, -64));
+    assert_eq!(-25, i8_mul_div_128(-64, 50));
+    assert_eq!(25, i8_mul_div_128(-50, -64));
+    assert_eq!(25, i8_mul_div_128(-64, -50));
+
+    let values = [0i8, 1, 2, 3, 4, 5, 10, 16, 20, 32, 40, 63, 64, 65, 90, 127];
+    for a in values.iter() {
+        for b in values.iter() {
+            for (p, q) in [(1, 1), (1, -1), (-1, 1), (-1, -1)] {
+                let a = a * p;
+                let b = b * q;
+                let expected = i8_mul_div_128_reference(a, b);
+                let actual = i8_mul_div_128(a, b);
+                assert_eq!(expected, actual, "{a}*{b}");
+            }
+        }
+    }
+}
+
+fn check_i16_mul_div_1024(a: u16, b: u16) {
+    for (p, q) in [(1, 1), (1, -1), (-1, 1), (-1, -1)] {
+        let a = a as i16 * p;
+        let b = b as i16 * q;
+        let expected = saturating_i16_mul_div_1024_reference(a, b);
+        let actual = saturating_i16_mul_div_1024(a, b);
+        assert_eq!(expected, actual, "{a}*{b}");
+    }
+}
+
+#[test]
+fn test_i16_mul_div_1024() {
+    assert_eq!(200, saturating_i16_mul_div_1024(400, 512));
+    assert_eq!(200, saturating_i16_mul_div_1024(512, 400));
+    assert_eq!(-200, saturating_i16_mul_div_1024(-400, 512));
+    assert_eq!(-200, saturating_i16_mul_div_1024(512, -400));
+    assert_eq!(-200, saturating_i16_mul_div_1024(400, -512));
+    assert_eq!(-200, saturating_i16_mul_div_1024(-512, 400));
+    assert_eq!(200, saturating_i16_mul_div_1024(-400, -512));
+    assert_eq!(200, saturating_i16_mul_div_1024(-512, -400));
+
+    assert_eq!(-3200, saturating_i16_mul_div_1024(i16::MIN, 100));
+    assert_eq!(-3200, saturating_i16_mul_div_1024(100, i16::MIN));
+
+    let values = [
+        0, 1, 2, 3, 10, 16, 20, 63, 64, 65, 90, 128, 511, 512, 1023, 1024, 4000,
+    ];
+    for a in values.iter() {
+        for b in values.iter() {
+            check_i16_mul_div_1024(*a, *b);
+        }
+    }
+}
+
+#[test]
+fn test_saturating_i16_mul_div_1024() {
+    // Note: The non-saturating behavior is tested above
+
+    // These values are barely in bounds:
+    check_i16_mul_div_1024(4200, 7500);
+    check_i16_mul_div_1024(7500, 4200);
+    check_i16_mul_div_1024(1000, 32000);
+    check_i16_mul_div_1024(32000, 1000);
+    check_i16_mul_div_1024(i16::MAX as u16, 1000);
+    check_i16_mul_div_1024(1000, i16::MAX as u16);
+
+    // These values exceed bounds:
+    check_i16_mul_div_1024(8000, 8000);
+    check_i16_mul_div_1024(2000, 32000);
+    check_i16_mul_div_1024(32000, 2000);
+    check_i16_mul_div_1024(32000, 32000);
+    check_i16_mul_div_1024(24576, 24576);
+    check_i16_mul_div_1024(i16::MAX as u16, i16::MAX as u16);
+
+    // Test saturating behavior with i16::MIN:
+    assert_eq!(i16::MIN + 1, saturating_i16_mul_div_1024(1024, i16::MIN));
+    assert_eq!(i16::MIN + 1, saturating_i16_mul_div_1024(i16::MIN, 1024));
+    assert_eq!(i16::MIN + 1, saturating_i16_mul_div_1024(2000, i16::MIN));
+    assert_eq!(i16::MIN + 1, saturating_i16_mul_div_1024(i16::MIN, 2000));
+    assert_eq!(i16::MAX, saturating_i16_mul_div_1024(i16::MIN, i16::MIN));
+}

--- a/experimental/segmenter/Cargo.toml
+++ b/experimental/segmenter/Cargo.toml
@@ -43,6 +43,7 @@ serde = { version = "1.0", default-features = false, features = ["derive", "allo
 
 ndarray = { version = "0.15.5", default-features = false, optional = true }
 num-traits = { version = "0.2", default-features = false, features = ["libm"], optional = true }
+intmath = { version = "0.1", path = "../../experimental/intmath", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -56,7 +57,7 @@ default = ["auto"]
 std = ["icu_collections/std", "icu_locid/std", "icu_provider/std"]
 serde = ["dep:serde", "zerovec/serde", "icu_collections/serde", "icu_provider/serde"]
 datagen = ["serde", "dep:databake", "zerovec/databake", "icu_collections/databake"]
-lstm = ["dep:ndarray", "dep:num-traits"]
+lstm = ["dep:ndarray", "dep:num-traits", "dep:intmath"]
 auto = ["lstm"] # Enabled try_new_auto_unstable constructors
 
 [lib]

--- a/experimental/segmenter/src/lstm_bies.rs
+++ b/experimental/segmenter/src/lstm_bies.rs
@@ -145,11 +145,12 @@ impl<'l> Lstm<'l> {
     ) -> (Array1<f32>, Array1<f32>) {
         // i, f, and o respectively stand for input, forget, and output gates
         let s_t = Array1::from(math_helper::mul_mul_sum(x_t.as_slice().unwrap(), warr.as_slice().unwrap(), h_tm1.as_slice().unwrap(), uarr.as_slice().unwrap(), barr.as_slice().unwrap()));
-        let i = math_helper::sigmoid_arr1(s_t.slice(ndarray::s![..hunits]));
-        let f = math_helper::sigmoid_arr1(s_t.slice(ndarray::s![hunits..2 * hunits]));
-        let _c = math_helper::tanh_arr1(s_t.slice(ndarray::s![2 * hunits..3 * hunits]));
+        // let i = math_helper::sigmoid_arr1(s_t.slice(ndarray::s![..hunits]));
+        // let f = math_helper::sigmoid_arr1(s_t.slice(ndarray::s![hunits..2 * hunits]));
+        // let _c = math_helper::tanh_arr1(s_t.slice(ndarray::s![2 * hunits..3 * hunits]));
         let o = math_helper::sigmoid_arr1(s_t.slice(ndarray::s![3 * hunits..]));
-        let c_t = i * _c + f * c_tm1;
+        // let c_t = i * _c + f * c_tm1;
+        let c_t = Array1::from(math_helper::sigmoid_mul_tanh_sigmoid_mul(s_t.slice(ndarray::s![..hunits]).as_slice().unwrap(), s_t.slice(ndarray::s![2 * hunits..3 * hunits]).as_slice().unwrap(), s_t.slice(ndarray::s![hunits..2 * hunits]).as_slice().unwrap(), c_tm1.as_slice().unwrap()));
         let h_t = o * math_helper::tanh_arr1(c_t.view());
         (h_t, c_t)
     }

--- a/experimental/segmenter/src/lstm_bies.rs
+++ b/experimental/segmenter/src/lstm_bies.rs
@@ -51,11 +51,11 @@ impl<'l> Lstm<'l> {
         }
 
         let mat1 = data.get().mat1.as_ndarray2()?;
-        let mat2 = data.get().mat2.as_ndarray2()?;
-        let mat3 = data.get().mat3.as_ndarray2()?;
+        let mut mat2 = data.get().mat2.as_ndarray2()?;
+        let mut mat3 = data.get().mat3.as_ndarray2()?;
         let mat4 = data.get().mat4.as_ndarray1()?;
-        let mat5 = data.get().mat5.as_ndarray2()?;
-        let mat6 = data.get().mat6.as_ndarray2()?;
+        let mut mat5 = data.get().mat5.as_ndarray2()?;
+        let mut mat6 = data.get().mat6.as_ndarray2()?;
         let mat7 = data.get().mat7.as_ndarray1()?;
         let mat8 = data.get().mat8.as_ndarray2()?;
         let mat9 = data.get().mat9.as_ndarray1()?;
@@ -73,6 +73,14 @@ impl<'l> Lstm<'l> {
         {
             return Err(Error::DimensionMismatch);
         }
+        mat2.swap_axes(0, 1);
+        mat3.swap_axes(0, 1);
+        mat5.swap_axes(0, 1);
+        mat6.swap_axes(0, 1);
+        let mat2 = mat2.as_standard_layout().into_owned();
+        let mat3 = mat3.as_standard_layout().into_owned();
+        let mat5 = mat5.as_standard_layout().into_owned();
+        let mat6 = mat6.as_standard_layout().into_owned();
         Ok(Self {
             data,
             mat1,
@@ -136,7 +144,7 @@ impl<'l> Lstm<'l> {
         hunits: usize,
     ) -> (Array1<f32>, Array1<f32>) {
         // i, f, and o respectively stand for input, forget, and output gates
-        let s_t = x_t.dot(&warr) + h_tm1.dot(&uarr) + barr;
+        let s_t = Array1::from(math_helper::mul_mul_sum(x_t.as_slice().unwrap(), warr.as_slice().unwrap(), h_tm1.as_slice().unwrap(), uarr.as_slice().unwrap(), barr.as_slice().unwrap()));
         let i = math_helper::sigmoid_arr1(s_t.slice(ndarray::s![..hunits]));
         let f = math_helper::sigmoid_arr1(s_t.slice(ndarray::s![hunits..2 * hunits]));
         let _c = math_helper::tanh_arr1(s_t.slice(ndarray::s![2 * hunits..3 * hunits]));

--- a/experimental/segmenter/src/lstm_bies.rs
+++ b/experimental/segmenter/src/lstm_bies.rs
@@ -4,7 +4,7 @@
 
 use crate::grapheme::GraphemeClusterSegmenter;
 use crate::lstm_error::Error;
-use crate::math_helper;
+use crate::math_helper::{self, MatrixOwned};
 use crate::provider::{LstmDataV1Marker, RuleBreakDataV1};
 use alloc::string::String;
 use alloc::string::ToString;
@@ -18,12 +18,12 @@ use crate::math_helper::MatrixBorrowed;
 pub struct Lstm<'l> {
     data: &'l DataPayload<LstmDataV1Marker>,
     mat1: Array2<f32>,
-    mat2: Array3<f32>,
-    mat3: Array3<f32>,
-    mat4: Array2<f32>,
-    mat5: Array3<f32>,
-    mat6: Array3<f32>,
-    mat7: Array2<f32>,
+    mat2: MatrixOwned<3>,
+    mat3: MatrixOwned<3>,
+    mat4: MatrixOwned<2>,
+    mat5: MatrixOwned<3>,
+    mat6: MatrixOwned<3>,
+    mat7: MatrixOwned<2>,
     mat8: Array2<f32>,
     mat9: Array1<f32>,
     grapheme: Option<&'l RuleBreakDataV1<'l>>,
@@ -97,12 +97,12 @@ impl<'l> Lstm<'l> {
         Ok(Self {
             data,
             mat1,
-            mat2,
-            mat3,
-            mat4,
-            mat5,
-            mat6,
-            mat7,
+            mat2: MatrixOwned::from_ndarray(mat2),
+            mat3: MatrixOwned::from_ndarray(mat3),
+            mat4: MatrixOwned::from_ndarray(mat4),
+            mat5: MatrixOwned::from_ndarray(mat5),
+            mat6: MatrixOwned::from_ndarray(mat6),
+            mat7: MatrixOwned::from_ndarray(mat7),
             mat8,
             mat9,
             grapheme: if data.get().model.contains("_codepoints_") {
@@ -244,9 +244,9 @@ impl<'l> Lstm<'l> {
                 x_t,
                 &h_fw,
                 &c_fw,
-                MatrixBorrowed::from_ndarray(&self.mat2.view()),
-                MatrixBorrowed::from_ndarray(&self.mat3.view()),
-                MatrixBorrowed::from_ndarray(&self.mat4.view()),
+                self.mat2.as_borrowed(),
+                self.mat3.as_borrowed(),
+                self.mat4.as_borrowed(),
                 hunits,
             );
             h_fw = new_h;
@@ -264,9 +264,9 @@ impl<'l> Lstm<'l> {
                 x_t,
                 &h_bw,
                 &c_bw,
-                MatrixBorrowed::from_ndarray(&self.mat5.view()),
-                MatrixBorrowed::from_ndarray(&self.mat6.view()),
-                MatrixBorrowed::from_ndarray(&self.mat7.view()),
+                self.mat5.as_borrowed(),
+                self.mat6.as_borrowed(),
+                self.mat7.as_borrowed(),
                 self.backward_hunits,
             );
             h_bw = new_h;

--- a/experimental/segmenter/src/lstm_bies.rs
+++ b/experimental/segmenter/src/lstm_bies.rs
@@ -283,8 +283,8 @@ impl<'l> Lstm<'l> {
             let mut curr_est = MatrixOwned::<1>::new_zero([4]);
             curr_est.as_mut().add_dot_2d(curr_fw, timew_fw);
             curr_est.as_mut().add_dot_2d(curr_bw, timew_bw);
-            curr_est.as_mut().add(timeb);
-            curr_est.as_mut().to_softmax();
+            curr_est.as_mut().add(timeb)?;
+            curr_est.as_mut().softmax_transform();
             // We use `unwrap_or` to fall back and prevent panics.
             bies.push(self.compute_bies(curr_est.as_borrowed()).unwrap_or('s'));
         }

--- a/experimental/segmenter/src/lstm_bies.rs
+++ b/experimental/segmenter/src/lstm_bies.rs
@@ -183,9 +183,6 @@ impl<'l> Lstm<'l> {
         }
         }
 
-        let mut c_t = MatrixOwned::new_zero([hunits]);
-        let mut h_t = MatrixOwned::new_zero([hunits]);
-
         for i in 0..hunits {
             // For matrices with short stride for the four inner values:
             let p = math_helper::sigmoid(s_t[i*4]);
@@ -197,15 +194,14 @@ impl<'l> Lstm<'l> {
             // let f = math_helper::sigmoid(s_t[i+hunits]);
             // let c = math_helper::tanh(s_t[i+hunits*2]);
             // let o = math_helper::sigmoid(s_t[i+hunits*3]);
-            c_t.as_mut().as_mut_slice()[i] = p*c + f*c_tm1.as_borrowed().as_slice()[i];
-            h_t.as_mut().as_mut_slice()[i] = o*math_helper::tanh(c_t.as_borrowed().as_slice()[i]);
+            let c_old = c_tm1.as_borrowed().as_slice()[i];
+            let c_new = p*c + f*c_old;
+            c_tm1.as_mut_slice()[i] = c_new;
+            h_tm1.as_mut_slice()[i] = o*math_helper::tanh(c_new);
         }
 
         // std::println!("h_t = {:?}", h_t.as_borrowed());
         // std::println!("c_t = {:?}", c_t.as_borrowed());
-
-        h_tm1.set_to(h_t.as_borrowed());
-        c_tm1.set_to(c_t.as_borrowed());
     }
 
     /// `word_segmenter` is a function that gets a "clean" unsegmented string as its input and returns a BIES (B: Beginning, I: Inside, E: End,

--- a/experimental/segmenter/src/lstm_bies.rs
+++ b/experimental/segmenter/src/lstm_bies.rs
@@ -50,6 +50,7 @@ impl<'l> Lstm<'l> {
             return Err(Error::Syntax);
         }
 
+        // TODO: Perform this matrix reshaping in datagen.
         let mat1 = data.get().mat1.as_ndarray2()?;
         let mat2 = data.get().mat2.as_ndarray2()?;
         let mat3 = data.get().mat3.as_ndarray2()?;

--- a/experimental/segmenter/src/lstm_error.rs
+++ b/experimental/segmenter/src/lstm_error.rs
@@ -17,7 +17,7 @@ pub enum Error {
 }
 
 impl From<ndarray::ShapeError> for Error {
-    fn from(value: ndarray::ShapeError) -> Self {
+    fn from(_: ndarray::ShapeError) -> Self {
         Self::DimensionMismatch
     }
 }

--- a/experimental/segmenter/src/lstm_error.rs
+++ b/experimental/segmenter/src/lstm_error.rs
@@ -15,3 +15,9 @@ pub enum Error {
     /// This error shows if matrices are not compatible for multiplication.
     DimensionMismatch,
 }
+
+impl From<ndarray::ShapeError> for Error {
+    fn from(value: ndarray::ShapeError) -> Self {
+        Self::DimensionMismatch
+    }
+}

--- a/experimental/segmenter/src/math_helper.rs
+++ b/experimental/segmenter/src/math_helper.rs
@@ -346,6 +346,8 @@ fn pocket_tanh_128(x: i16) -> i16 {
     }
 }
 
+/// An integer approximation of `1024*tanh(x/1024)`
+/// <https://octav.onl/sigmoid-tanh-1024-a>
 fn tanh_1024(x: MatType) -> MatType {
     let y = match x.unsigned_abs() {
         x if x <= 273 => x,
@@ -379,6 +381,8 @@ fn test_tanh_1024() {
     }
 }
 
+/// An integer approximation of `1024*sigmoid(x/1024)`
+/// <https://octav.onl/sigmoid-tanh-1024-a>
 fn sigmoid_1024(x: MatType) -> MatType {
     let y = match x.unsigned_abs() {
         x if x <= 470 => x * 1 / 4 + 512,

--- a/experimental/segmenter/src/math_helper.rs
+++ b/experimental/segmenter/src/math_helper.rs
@@ -5,10 +5,21 @@
 use core::ops::Range;
 
 use ndarray::{ArrayBase, Dim, Dimension, OwnedRepr};
+use intmath::saturating_i16_mul_div_1024;
+
+pub type MatType = i16;
+pub const FACTOR: MatType = 1024;
+pub const ZERO: MatType = 0;
+pub use intmath::saturating_i16_mul_div_1024 as muldiv;
+
+#[inline]
+pub fn to_mat_type(input: f32) -> MatType {
+    (input * FACTOR as f32).round() as i16
+}
 
 #[derive(Debug, Clone)]
 pub struct MatrixOwned<const D: usize> {
-    data: Vec<f32>,
+    data: Vec<MatType>,
     dims: [usize; D],
 }
 
@@ -27,7 +38,7 @@ impl<const D: usize> MatrixOwned<D> {
         }
     }
 
-    pub fn from_ndarray(nd: ArrayBase<OwnedRepr<f32>, Dim<[usize; D]>>) -> Self
+    pub fn from_ndarray(nd: ArrayBase<OwnedRepr<MatType>, Dim<[usize; D]>>) -> Self
     where
         Dim<[usize; D]>: Dimension,
     {
@@ -45,7 +56,7 @@ impl<const D: usize> MatrixOwned<D> {
     pub fn new_zero(dims: [usize; D]) -> Self {
         let total_len = dims.iter().product::<usize>();
         MatrixOwned {
-            data: vec![0.0; total_len],
+            data: vec![ZERO; total_len],
             dims,
         }
     }
@@ -76,7 +87,7 @@ impl<const D: usize> MatrixOwned<D> {
 
 #[derive(Debug, Clone, Copy)]
 pub struct MatrixBorrowed<'a, const D: usize> {
-    data: &'a [f32],
+    data: &'a [MatType],
     dims: [usize; D],
 }
 
@@ -88,7 +99,7 @@ impl<'a, const D: usize> MatrixBorrowed<'a, D> {
         debug_assert_eq!(expected_len, self.data.len());
     }
 
-    pub fn as_slice(&self) -> &'a [f32] {
+    pub fn as_slice(&self) -> &'a [MatType] {
         self.data
     }
 
@@ -101,7 +112,7 @@ impl<'a, const D: usize> MatrixBorrowed<'a, D> {
     }
 
     pub fn argmax(&self) -> usize {
-        let mut mx: f32 = 0.0;
+        let mut mx = ZERO;
         let mut ind = 0;
         self.data.iter().enumerate().for_each(|(i, v)| {
             if mx < *v {
@@ -140,7 +151,7 @@ impl<'a> MatrixBorrowed<'a, 1> {
         self.dims[0]
     }
 
-    pub fn read_4(&self) -> Option<(f32, f32, f32, f32)> {
+    pub fn read_4(&self) -> Option<(MatType, MatType, MatType, MatType)> {
         debug_assert_eq!(self.dims, [4]);
         debug_assert_eq!(self.data.len(), 4);
         if self.data.len() == 4 {
@@ -176,7 +187,7 @@ impl<'a> MatrixBorrowed<'a, 3> {
 }
 
 pub struct MatrixBorrowedMut<'a, const D: usize> {
-    data: &'a mut [f32],
+    data: &'a mut [MatType],
     dims: [usize; D],
 }
 
@@ -188,7 +199,7 @@ impl<'a, const D: usize> MatrixBorrowedMut<'a, D> {
         }
     }
 
-    pub fn as_mut_slice(&mut self) -> &mut [f32] {
+    pub fn as_mut_slice(&mut self) -> &mut [MatType] {
         self.data
     }
 
@@ -210,18 +221,21 @@ impl<'a, const D: usize> MatrixBorrowedMut<'a, D> {
     }
 
     pub fn softmax_transform(&mut self) {
-        let sm = self.data.iter().fold(0.0, |sm, v| sm + v.exp());
+        let sm = self
+            .data
+            .iter()
+            .fold(0.0, |sm, v| sm + (*v as f32 / FACTOR as f32).exp());
         self.data.iter_mut().for_each(|v| {
-            *v = v.exp() / sm;
+            *v = to_mat_type((*v as f32 / FACTOR as f32).exp() / sm);
         });
     }
 }
 
 impl<'a> MatrixBorrowed<'a, 1> {
     #[allow(dead_code)] // could be useful
-    pub fn dot_1d(&self, other: MatrixBorrowed<1>) -> f32 {
+    pub fn dot_1d(&self, other: MatrixBorrowed<1>) -> MatType {
         debug_assert_eq!(self.dims, other.dims);
-        unrolled_dot(self.data, other.data)
+        unrolled_dot_1024(self.data, other.data) / FACTOR
     }
 }
 
@@ -238,7 +252,7 @@ impl<'a> MatrixBorrowedMut<'a, 1> {
         for i in 0..n {
             if let (Some(dest), Some(b_sub)) = (self.as_mut_slice().get_mut(i), b.submatrix::<1>(i))
             {
-                *dest += unrolled_dot(a.data, b_sub.data);
+                *dest += unrolled_dot_1024(a.data, b_sub.data);
             } else {
                 debug_assert!(false);
             }
@@ -266,7 +280,7 @@ impl<'a> MatrixBorrowedMut<'a, 2> {
                 self.as_mut_slice().get_mut(i),
                 b.as_slice().get(i * m..(i + 1) * m),
             ) {
-                *dest += unrolled_dot(lhs, rhs);
+                *dest = dest.saturating_add(unrolled_dot_1024(lhs, rhs));
             } else {
                 debug_assert!(false);
             }
@@ -280,14 +294,122 @@ use num_traits::Float;
 
 /// `tanh` computes the tanh function for a scalar value.
 #[inline]
-pub fn tanh(x: f32) -> f32 {
-    x.tanh()
+pub fn tanh(x: MatType) -> MatType {
+    // to_mat_type((x as f32 / FACTOR as f32).tanh())
+    // pocket_tanh_128(x / 4)
+    tanh_1024(x)
 }
 
 /// `sigmoid` computes the sigmoid function for a scalar value.
 #[inline]
-pub fn sigmoid(x: f32) -> f32 {
-    1.0 / (1.0 + (-x).exp())
+pub fn sigmoid(x: MatType) -> MatType {
+    // to_mat_type(1.0 / (1.0 + (-(x as f32) / FACTOR as f32).exp()))
+    // pocket_sigmoid_128(x / 2)
+    sigmoid_1024(x)
+}
+
+/// Approximation of 128*sigmoid(x/32)
+fn pocket_sigmoid_128(x: i16) -> i16 {
+    if x <= -128 {
+        1
+    } else if x <= -75 {
+        x / 8 + 20
+    } else if x <= -32 {
+        x / 2 + 48
+    } else if x <= 31 {
+        x + 64
+    } else if x <= 74 {
+        x / 2 + 80
+    } else if x <= 127 {
+        x / 8 + 108
+    } else {
+        127
+    }
+}
+
+/// Approximation of 128*tanh(x/64)
+fn pocket_tanh_128(x: i16) -> i16 {
+    if x <= -128 {
+        -128
+    } else if x <= -75 {
+        x / 4 - 88
+    } else if x <= -32 {
+        x - 32
+    } else if x <= 31 {
+        2 * x
+    } else if x <= 74 {
+        x + 32
+    } else if x <= 127 {
+        x / 4 + 88
+    } else {
+        127
+    }
+}
+
+fn tanh_1024(x: MatType) -> MatType {
+    let y = match x.unsigned_abs() {
+        x if x <= 273 => x,
+        x if x <= 567 => x * 5 / 6 + 46,
+        x if x <= 788 => x * 2 / 3 + 140,
+        x if x <= 999 => x * 1 / 2 + 272,
+        x if x <= 1210 => x * 3 / 8 + 396,
+        x if x <= 1527 => x * 1 / 4 + 548,
+        x if x <= 1920 => x * 1 / 8 + 738,
+        x if x <= 2286 => x * 1 / 16 + 859,
+        x if x <= 2604 => x * 1 / 32 + 930,
+        x if x <= 3335 => x * 1 / 64 + 971,
+        _ => 1023,
+    };
+    if x < 0 {
+        -(y as i16)
+    } else {
+        y as i16
+    }
+}
+
+#[test]
+fn test_tanh_1024() {
+    for x in -4000..4000 {
+        let tanh_exact = 1024.0 * ((x as f32).tanh() / 1024.0);
+        let tanh_appx = tanh_1024(x);
+        assert!(
+            (tanh_exact - tanh_appx as f32).abs() < 10.0,
+            "tanh: {x} {tanh_appx} {tanh_exact}"
+        );
+    }
+}
+
+fn sigmoid_1024(x: MatType) -> MatType {
+    let y = match x.unsigned_abs() {
+        x if x <= 470 => x * 1 / 4 + 512,
+        x if x <= 958 => x * 7 / 32 + 527,
+        x if x <= 1293 => x * 3 / 16 + 557,
+        x if x <= 1629 => x * 5 / 32 + 597,
+        x if x <= 1992 => x * 1 / 8 + 648,
+        x if x <= 2423 => x * 3 / 32 + 710,
+        x if x <= 3054 => x * 1 / 16 + 786,
+        x if x <= 3843 => x * 1 / 32 + 881,
+        x if x <= 4487 => x * 1 / 64 + 941,
+        x if x <= 5956 => x * 1 / 128 + 976,
+        _ => 1023,
+    };
+    if x < 0 {
+        1024 - y as i16
+    } else {
+        y as i16
+    }
+}
+
+#[test]
+fn test_sigmoid_1024() {
+    for x in -4000..4000 {
+        let sigmoid_exact = 1024.0 / (1.0 + (-x as f32 / 1024.0));
+        let sigmoid_appx = sigmoid_1024(x);
+        assert!(
+            (sigmoid_exact - sigmoid_appx as f32).abs() < 10.0,
+            "sigmoid: {x} {sigmoid_appx} {sigmoid_exact}"
+        );
+    }
 }
 
 /// Compute the dot product.
@@ -296,28 +418,28 @@ pub fn sigmoid(x: f32) -> f32 {
 ///
 /// (From ndarray 0.15.6)
 #[allow(clippy::indexing_slicing)] // all indexing is protected by the entry assertion
-fn unrolled_dot(xs: &[f32], ys: &[f32]) -> f32 {
+fn unrolled_dot(xs: &[MatType], ys: &[MatType]) -> MatType {
     debug_assert_eq!(xs.len(), ys.len());
     if xs.len() != ys.len() {
-        return 0.0;
+        return ZERO;
     }
     // eightfold unrolled so that floating point can be vectorized
     // (even with strict floating point accuracy semantics)
     let len = core::cmp::min(xs.len(), ys.len());
     let mut xs = &xs[..len];
     let mut ys = &ys[..len];
-    let mut sum = 0.0;
+    let mut sum: MatType = ZERO;
     let (mut p0, mut p1, mut p2, mut p3, mut p4, mut p5, mut p6, mut p7) =
-        (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        (ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO);
     while xs.len() >= 8 {
-        p0 += xs[0] * ys[0];
-        p1 += xs[1] * ys[1];
-        p2 += xs[2] * ys[2];
-        p3 += xs[3] * ys[3];
-        p4 += xs[4] * ys[4];
-        p5 += xs[5] * ys[5];
-        p6 += xs[6] * ys[6];
-        p7 += xs[7] * ys[7];
+        p0 += xs[0] * ys[0] / FACTOR;
+        p1 += xs[1] * ys[1] / FACTOR;
+        p2 += xs[2] * ys[2] / FACTOR;
+        p3 += xs[3] * ys[3] / FACTOR;
+        p4 += xs[4] * ys[4] / FACTOR;
+        p5 += xs[5] * ys[5] / FACTOR;
+        p6 += xs[6] * ys[6] / FACTOR;
+        p7 += xs[7] * ys[7] / FACTOR;
 
         xs = &xs[8..];
         ys = &ys[8..];
@@ -331,7 +453,49 @@ fn unrolled_dot(xs: &[f32], ys: &[f32]) -> f32 {
         if i >= 7 {
             break;
         }
-        sum += x * y;
+        sum += x * y / FACTOR;
+    }
+    sum
+}
+
+#[allow(clippy::indexing_slicing)] // all indexing is protected by the entry assertion
+fn unrolled_dot_1024(xs: &[i16], ys: &[i16]) -> i16 {
+    debug_assert_eq!(FACTOR, 1024);
+    debug_assert_eq!(xs.len(), ys.len());
+    if xs.len() != ys.len() {
+        return 0;
+    }
+    // eightfold unrolled so that floating point can be vectorized
+    // (even with strict floating point accuracy semantics)
+    let len = core::cmp::min(xs.len(), ys.len());
+    let mut xs = &xs[..len];
+    let mut ys = &ys[..len];
+    let mut sum = 0i16;
+    let (mut p0, mut p1, mut p2, mut p3, mut p4, mut p5, mut p6, mut p7) =
+        (0i16, 0i16, 0i16, 0i16, 0i16, 0i16, 0i16, 0i16);
+    while xs.len() >= 8 {
+        p0 = p0.saturating_add(saturating_i16_mul_div_1024(xs[0], ys[0]));
+        p1 = p1.saturating_add(saturating_i16_mul_div_1024(xs[1], ys[1]));
+        p2 = p2.saturating_add(saturating_i16_mul_div_1024(xs[2], ys[2]));
+        p3 = p3.saturating_add(saturating_i16_mul_div_1024(xs[3], ys[3]));
+        p4 = p4.saturating_add(saturating_i16_mul_div_1024(xs[4], ys[4]));
+        p5 = p5.saturating_add(saturating_i16_mul_div_1024(xs[5], ys[5]));
+        p6 = p6.saturating_add(saturating_i16_mul_div_1024(xs[6], ys[6]));
+        p7 = p7.saturating_add(saturating_i16_mul_div_1024(xs[7], ys[7]));
+
+        xs = &xs[8..];
+        ys = &ys[8..];
+    }
+    sum = sum.saturating_add(p0.saturating_add(p4));
+    sum = sum.saturating_add(p1.saturating_add(p5));
+    sum = sum.saturating_add(p2.saturating_add(p6));
+    sum = sum.saturating_add(p3.saturating_add(p7));
+
+    for (i, (&x, &y)) in xs.iter().zip(ys).enumerate() {
+        if i >= 7 {
+            break;
+        }
+        sum = sum.saturating_add(saturating_i16_mul_div_1024(x, y));
     }
     sum
 }

--- a/experimental/segmenter/src/math_helper.rs
+++ b/experimental/segmenter/src/math_helper.rs
@@ -58,3 +58,72 @@ pub fn concatenate_arr1(
 ) -> Array1<f32> {
     concatenate![Axis(0), arr1, arr2]
 }
+
+pub fn mul_mul_sum(a: &[f32], b: &[f32], c: &[f32], d: &[f32], e: &[f32]) -> Vec<f32> {
+    let m = a.len();
+    let n = b.len() / m;
+    debug_assert_eq!(n / 4, c.len());
+    debug_assert_eq!(n*n/4, d.len());
+    debug_assert_eq!(n, e.len());
+    let mut result = Vec::from(e);
+    for i in 0..n {
+        let x = result.get_mut(i).unwrap();
+        *x += unrolled_dot(a, &b[i*m..(i+1)*m]);
+    }
+    for i in 0..n {
+        let x = result.get_mut(i).unwrap();
+        *x += unrolled_dot(c, &d[i*n/4..(i+1)*n/4]);
+    }
+    result
+}
+
+/// Compute the dot product.
+///
+/// `xs` and `ys` must be the same length
+///
+/// (From ndarray 0.15.6)
+pub fn unrolled_dot(xs: &[f32], ys: &[f32]) -> f32
+{
+    debug_assert_eq!(xs.len(), ys.len());
+    // eightfold unrolled so that floating point can be vectorized
+    // (even with strict floating point accuracy semantics)
+    let len = core::cmp::min(xs.len(), ys.len());
+    let mut xs = &xs[..len];
+    let mut ys = &ys[..len];
+    let mut sum = 0.0;
+    let (mut p0, mut p1, mut p2, mut p3, mut p4, mut p5, mut p6, mut p7) = (
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+    );
+    while xs.len() >= 8 {
+        p0 = p0 + xs[0] * ys[0];
+        p1 = p1 + xs[1] * ys[1];
+        p2 = p2 + xs[2] * ys[2];
+        p3 = p3 + xs[3] * ys[3];
+        p4 = p4 + xs[4] * ys[4];
+        p5 = p5 + xs[5] * ys[5];
+        p6 = p6 + xs[6] * ys[6];
+        p7 = p7 + xs[7] * ys[7];
+
+        xs = &xs[8..];
+        ys = &ys[8..];
+    }
+    sum = sum + (p0 + p4);
+    sum = sum + (p1 + p5);
+    sum = sum + (p2 + p6);
+    sum = sum + (p3 + p7);
+
+    for (i, (&x, &y)) in xs.iter().zip(ys).enumerate() {
+        if i >= 7 {
+            break;
+        }
+        sum = sum + x * y;
+    }
+    sum
+}

--- a/experimental/segmenter/src/math_helper.rs
+++ b/experimental/segmenter/src/math_helper.rs
@@ -8,6 +8,12 @@ use ndarray::{concatenate, Array1, Array2, ArrayBase, Axis, Dim, ViewRepr};
 #[allow(unused_imports)]
 use num_traits::Float;
 
+/// `tanh` computes the tanh function for a scalar value.
+#[inline]
+fn tanh(x: f32) -> f32 {
+    x.tanh()
+}
+
 /// `sigmoid` computes the sigmoid function for a scalar value.
 #[inline]
 fn sigmoid(x: f32) -> f32 {
@@ -73,6 +79,19 @@ pub fn mul_mul_sum(a: &[f32], b: &[f32], c: &[f32], d: &[f32], e: &[f32]) -> Vec
     for i in 0..n {
         let x = result.get_mut(i).unwrap();
         *x += unrolled_dot(c, &d[i*n/4..(i+1)*n/4]);
+    }
+    result
+}
+
+pub fn sigmoid_mul_tanh_sigmoid_mul(a: &[f32], b: &[f32], c: &[f32], d: &[f32]) -> Vec<f32> {
+    let n = a.len();
+    debug_assert_eq!(n, b.len());
+    debug_assert_eq!(n, c.len());
+    debug_assert_eq!(n, d.len());
+    let mut result = vec![0.0; n];
+    for i in 0..n {
+        let x = result.get_mut(i).unwrap();
+        *x += sigmoid(a[i]) * tanh(b[i]) + sigmoid(c[i]) * d[i];
     }
     result
 }

--- a/experimental/segmenter/src/math_helper.rs
+++ b/experimental/segmenter/src/math_helper.rs
@@ -40,16 +40,6 @@ pub fn max_arr1(arr: ArrayBase<ViewRepr<&f32>, Dim<[usize; 1]>>) -> usize {
     ind
 }
 
-/// `tanh_arr1` computes elementwise sigmoid function for elements of a 1d array
-pub fn sigmoid_arr1(arr: ArrayBase<ViewRepr<&f32>, Dim<[usize; 1]>>) -> Array1<f32> {
-    arr.map(|v| sigmoid(*v))
-}
-
-/// `tanh_arr1` computes elementwise tanh function for elements of a 1d array
-pub fn tanh_arr1(arr: ArrayBase<ViewRepr<&f32>, Dim<[usize; 1]>>) -> Array1<f32> {
-    arr.map(|v| v.tanh())
-}
-
 /// `change_row` gets one 2d array (`arr`), one 1d array (`arr1`), and an index (`row_id`), and replaces the `row_id`-th row of
 /// `arr` with `arr1`
 pub fn change_row(mut arr: Array2<f32>, row_id: usize, new_row: &Array1<f32>) -> Array2<f32> {
@@ -63,37 +53,6 @@ pub fn concatenate_arr1(
     arr2: ArrayBase<ViewRepr<&f32>, Dim<[usize; 1]>>,
 ) -> Array1<f32> {
     concatenate![Axis(0), arr1, arr2]
-}
-
-pub fn mul_mul_sum(a: &[f32], b: &[f32], c: &[f32], d: &[f32], e: &[f32]) -> Vec<f32> {
-    let m = a.len();
-    let n = b.len() / m;
-    debug_assert_eq!(n / 4, c.len());
-    debug_assert_eq!(n*n/4, d.len());
-    debug_assert_eq!(n, e.len());
-    let mut result = Vec::from(e);
-    for i in 0..n {
-        let x = result.get_mut(i).unwrap();
-        *x += unrolled_dot(a, &b[i*m..(i+1)*m]);
-    }
-    for i in 0..n {
-        let x = result.get_mut(i).unwrap();
-        *x += unrolled_dot(c, &d[i*n/4..(i+1)*n/4]);
-    }
-    result
-}
-
-pub fn sigmoid_mul_tanh_sigmoid_mul(a: &[f32], b: &[f32], c: &[f32], d: &[f32]) -> Vec<f32> {
-    let n = a.len();
-    debug_assert_eq!(n, b.len());
-    debug_assert_eq!(n, c.len());
-    debug_assert_eq!(n, d.len());
-    let mut result = vec![0.0; n];
-    for i in 0..n {
-        let x = result.get_mut(i).unwrap();
-        *x += sigmoid(a[i]) * tanh(b[i]) + sigmoid(c[i]) * d[i];
-    }
-    result
 }
 
 /// Compute the dot product.

--- a/experimental/segmenter/src/math_helper.rs
+++ b/experimental/segmenter/src/math_helper.rs
@@ -171,7 +171,7 @@ pub struct MatrixBorrowedMut<'a, const D: usize> {
 impl<'a, const D: usize> MatrixBorrowedMut<'a, D> {
     pub fn as_borrowed(&self) -> MatrixBorrowed<D> {
         MatrixBorrowed {
-            data: &self.data,
+            data: self.data,
             dims: self.dims,
         }
     }
@@ -296,28 +296,28 @@ pub fn unrolled_dot(xs: &[f32], ys: &[f32]) -> f32 {
     let (mut p0, mut p1, mut p2, mut p3, mut p4, mut p5, mut p6, mut p7) =
         (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
     while xs.len() >= 8 {
-        p0 = p0 + xs[0] * ys[0];
-        p1 = p1 + xs[1] * ys[1];
-        p2 = p2 + xs[2] * ys[2];
-        p3 = p3 + xs[3] * ys[3];
-        p4 = p4 + xs[4] * ys[4];
-        p5 = p5 + xs[5] * ys[5];
-        p6 = p6 + xs[6] * ys[6];
-        p7 = p7 + xs[7] * ys[7];
+        p0 += xs[0] * ys[0];
+        p1 += xs[1] * ys[1];
+        p2 += xs[2] * ys[2];
+        p3 += xs[3] * ys[3];
+        p4 += xs[4] * ys[4];
+        p5 += xs[5] * ys[5];
+        p6 += xs[6] * ys[6];
+        p7 += xs[7] * ys[7];
 
         xs = &xs[8..];
         ys = &ys[8..];
     }
-    sum = sum + (p0 + p4);
-    sum = sum + (p1 + p5);
-    sum = sum + (p2 + p6);
-    sum = sum + (p3 + p7);
+    sum += p0 + p4;
+    sum += p1 + p5;
+    sum += p2 + p6;
+    sum += p3 + p7;
 
     for (i, (&x, &y)) in xs.iter().zip(ys).enumerate() {
         if i >= 7 {
             break;
         }
-        sum = sum + x * y;
+        sum += x * y;
     }
     sum
 }

--- a/experimental/segmenter/src/math_helper.rs
+++ b/experimental/segmenter/src/math_helper.rs
@@ -2,7 +2,32 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use ndarray::{concatenate, Array1, Array2, ArrayBase, Axis, Dim, ViewRepr};
+use ndarray::{concatenate, Array1, Array2, ArrayBase, Axis, Dim, ViewRepr, Dimension};
+
+pub struct MatrixBorrowed<'a, const D: usize> {
+    data: &'a [f32],
+    dims: [usize; D],
+}
+
+impl<'a, const D: usize> MatrixBorrowed<'a, D> {
+    #[cfg(debug_assertions)]
+    pub fn debug_assert_dims(&self, dims: [usize; D]) {
+        debug_assert_eq!(dims, self.dims);
+        let expected_len = dims.iter().product::<usize>();
+        debug_assert_eq!(expected_len, self.data.len());
+    }
+
+    pub fn as_slice(&self) -> &'a [f32] {
+        self.data
+    }
+
+    pub fn from_ndarray(nd: &'a ArrayBase<ViewRepr<&f32>, Dim<[usize; D]>>) -> Self where Dim<[usize; D]>: Dimension {
+        Self {
+            data: nd.as_slice().unwrap(),
+            dims: nd.shape().try_into().unwrap()
+        }
+    }
+}
 
 // Polyfill float operations with libm in case we're no_std.
 #[allow(unused_imports)]

--- a/experimental/segmenter/src/math_helper.rs
+++ b/experimental/segmenter/src/math_helper.rs
@@ -2,7 +2,29 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use ndarray::{concatenate, Array1, Array2, ArrayBase, Axis, Dim, ViewRepr, Dimension};
+use ndarray::{concatenate, Array1, Array2, ArrayBase, Axis, Dim, ViewRepr, Dimension, OwnedRepr};
+
+pub struct MatrixOwned<const D: usize> {
+    data: Vec<f32>,
+    dims: [usize; D],
+}
+
+impl<const D: usize> MatrixOwned<D> {
+    pub fn as_borrowed(&self) -> MatrixBorrowed<D> {
+        MatrixBorrowed {
+            data: &self.data,
+            dims: self.dims
+        }
+    }
+
+    pub fn from_ndarray(nd: ArrayBase<OwnedRepr<f32>, Dim<[usize; D]>>) -> Self where Dim<[usize; D]>: Dimension {
+        let dims = nd.shape().try_into().unwrap();
+        Self {
+            data: nd.into_raw_vec(),
+            dims,
+        }
+    }
+}
 
 pub struct MatrixBorrowed<'a, const D: usize> {
     data: &'a [f32],

--- a/experimental/segmenter/src/math_helper.rs
+++ b/experimental/segmenter/src/math_helper.rs
@@ -10,13 +10,13 @@ use num_traits::Float;
 
 /// `tanh` computes the tanh function for a scalar value.
 #[inline]
-fn tanh(x: f32) -> f32 {
+pub fn tanh(x: f32) -> f32 {
     x.tanh()
 }
 
 /// `sigmoid` computes the sigmoid function for a scalar value.
 #[inline]
-fn sigmoid(x: f32) -> f32 {
+pub fn sigmoid(x: f32) -> f32 {
     1.0 / (1.0 + (-x).exp())
 }
 


### PR DESCRIPTION
Replaces #3184
Builds on #3192 and #3194

This PR demonstrates the LSTM passing all tests using exclusively i16 arithmetic.

Currently, the performance is worse than with f32 operations, so I don't plan to merge this PR. I suspect that this is due to my heavy use (by necessity) of `saturating_add` operations, which add branches everywhere.