### PR TITLE
Handle missing `languages.json` and `territories.json`

### DIFF
--- a/provider/datagen/src/source.rs
+++ b/provider/datagen/src/source.rs
@@ -344,6 +344,10 @@ impl SerdeCache {
     pub fn list(&self, path: &str) -> Result<impl Iterator<Item = String>, DataError> {
         self.root.list(path)
     }
+
+    pub fn file_exists(&self, path: &str) -> Result<bool, DataError> {
+        self.root.file_exists(path)
+    }
 }
 
 pub(crate) enum AbstractFs {
@@ -466,6 +470,21 @@ impl AbstractFs {
                 .map(String::from)
                 .collect::<HashSet<_>>()
                 .into_iter(),
+        })
+    }
+
+    fn file_exists(&self, path: &str) -> Result<bool, DataError> {
+        self.init()?;
+        Ok(match self {
+            Self::Fs(root) => root.join(path).is_file(),
+            Self::Zip(zip) => zip
+            .read()
+            .expect("poison")
+            .as_ref()
+            .ok()
+            .unwrap() // init called
+            .file_names()
+            .any(|p| p == path)
         })
     }
 }

--- a/provider/datagen/src/source.rs
+++ b/provider/datagen/src/source.rs
@@ -478,13 +478,13 @@ impl AbstractFs {
         Ok(match self {
             Self::Fs(root) => root.join(path).is_file(),
             Self::Zip(zip) => zip
-            .read()
-            .expect("poison")
-            .as_ref()
-            .ok()
-            .unwrap() // init called
-            .file_names()
-            .any(|p| p == path)
+                .read()
+                .expect("poison")
+                .as_ref()
+                .ok()
+                .unwrap() // init called
+                .file_names()
+                .any(|p| p == path),
         })
     }
 }

--- a/provider/datagen/src/transform/cldr/displaynames/language.rs
+++ b/provider/datagen/src/transform/cldr/displaynames/language.rs
@@ -41,6 +41,15 @@ impl IterableDataProvider<LanguageDisplayNamesV1Marker> for crate::DatagenProvid
             .cldr()?
             .displaynames()
             .list_langs()?
+            .filter(|langid| {
+                // The directory might exist without languages.json
+                self.source
+                    .cldr()
+                    .unwrap()
+                    .displaynames()
+                    .file_exists(langid, "languages.json")
+                    .unwrap_or_default()
+            })
             .map(DataLocale::from)
             .collect())
     }

--- a/provider/datagen/src/transform/cldr/displaynames/region.rs
+++ b/provider/datagen/src/transform/cldr/displaynames/region.rs
@@ -42,6 +42,15 @@ impl IterableDataProvider<RegionDisplayNamesV1Marker> for crate::DatagenProvider
             .cldr()?
             .displaynames()
             .list_langs()?
+            .filter(|langid| {
+                // The directory might exist without territories.json
+                self.source
+                    .cldr()
+                    .unwrap()
+                    .displaynames()
+                    .file_exists(langid, "territories.json")
+                    .unwrap_or_default()
+            })
             .map(DataLocale::from)
             .collect())
     }

--- a/provider/datagen/src/transform/cldr/source.rs
+++ b/provider/datagen/src/transform/cldr/source.rs
@@ -118,4 +118,13 @@ impl<'a> CldrDirLang<'a> {
         dir.push_str("/main");
         Ok(dir)
     }
+
+    pub fn file_exists(
+        &self,
+        lang: &LanguageIdentifier,
+        file_name: &str,
+    ) -> Result<bool, DataError> {
+        self.0
+            .file_exists(&format!("{}/{lang}/{file_name}", self.dir()?))
+    }
 }


### PR DESCRIPTION
Displaynames may have the directory for a locale, but still not include all files inside, so for supported locales we have to look for the actual file.

This is not a problem in CLDR42 because all files are present. CLDR43 removes trivial files.

#3181 