### PR TITLE
LSTM: Pre-compute x_t * warr

### DIFF
--- a/experimental/segmenter/src/lstm_bies.rs
+++ b/experimental/segmenter/src/lstm_bies.rs
@@ -4,7 +4,7 @@
 
 use crate::grapheme::GraphemeClusterSegmenter;
 use crate::lstm_error::Error;
-use crate::math_helper::{self, MatrixBorrowed, MatrixBorrowedMut, MatrixOwned};
+use crate::math_helper::{self, MatrixBorrowedMut, MatrixOwned, MatrixZero};
 use crate::provider::{LstmDataV1Marker, RuleBreakDataV1};
 use alloc::string::String;
 use alloc::string::ToString;
@@ -15,15 +15,15 @@ use zerovec::ule::AsULE;
 
 pub struct Lstm<'l> {
     data: &'l DataPayload<LstmDataV1Marker>,
-    mat1: MatrixOwned<2>,
-    mat2: MatrixOwned<3>,
-    mat3: MatrixOwned<3>,
-    mat4: MatrixOwned<2>,
-    mat5: MatrixOwned<3>,
-    mat6: MatrixOwned<3>,
-    mat7: MatrixOwned<2>,
-    mat8: MatrixOwned<3>,
-    mat9: MatrixOwned<1>,
+    mat1: MatrixZero<'l, 2>,
+    mat2: MatrixZero<'l, 3>,
+    mat3: MatrixZero<'l, 3>,
+    mat4: MatrixZero<'l, 2>,
+    mat5: MatrixZero<'l, 3>,
+    mat6: MatrixZero<'l, 3>,
+    mat7: MatrixZero<'l, 2>,
+    mat8: MatrixZero<'l, 3>,
+    mat9: MatrixZero<'l, 1>,
     grapheme: Option<&'l RuleBreakDataV1<'l>>,
     hunits: usize,
 }
@@ -52,25 +52,25 @@ impl<'l> Lstm<'l> {
         // The ICU4X style guide discourages this. We do it here because:
         // 1. The data need to be aligned in order to be vectorized.
         // 2. The LSTM is highly performance-sensitive.
-        let mat1 = data.get().mat1.alloc_matrix::<2>()?;
-        let mat2 = data.get().mat2.alloc_matrix::<3>()?;
-        let mat3 = data.get().mat3.alloc_matrix::<3>()?;
-        let mat4 = data.get().mat4.alloc_matrix::<2>()?;
-        let mat5 = data.get().mat5.alloc_matrix::<3>()?;
-        let mat6 = data.get().mat6.alloc_matrix::<3>()?;
-        let mat7 = data.get().mat7.alloc_matrix::<2>()?;
-        let mat8 = data.get().mat8.alloc_matrix::<3>()?;
-        let mat9 = data.get().mat9.alloc_matrix::<1>()?;
-        let embedd_dim = mat1.as_borrowed().dim().1;
-        let hunits = mat3.as_borrowed().dim().0;
-        if mat2.as_borrowed().dim() != (hunits, 4, embedd_dim)
-            || mat3.as_borrowed().dim() != (hunits, 4, hunits)
-            || mat4.as_borrowed().dim() != (hunits, 4)
-            || mat5.as_borrowed().dim() != (hunits, 4, embedd_dim)
-            || mat6.as_borrowed().dim() != (hunits, 4, hunits)
-            || mat7.as_borrowed().dim() != (hunits, 4)
-            || mat8.as_borrowed().dim() != (2, 4, hunits)
-            || mat9.as_borrowed().dim() != (4)
+        let mat1 = data.get().mat1.as_matrix_zero::<2>()?;
+        let mat2 = data.get().mat2.as_matrix_zero::<3>()?;
+        let mat3 = data.get().mat3.as_matrix_zero::<3>()?;
+        let mat4 = data.get().mat4.as_matrix_zero::<2>()?;
+        let mat5 = data.get().mat5.as_matrix_zero::<3>()?;
+        let mat6 = data.get().mat6.as_matrix_zero::<3>()?;
+        let mat7 = data.get().mat7.as_matrix_zero::<2>()?;
+        let mat8 = data.get().mat8.as_matrix_zero::<3>()?;
+        let mat9 = data.get().mat9.as_matrix_zero::<1>()?;
+        let embedd_dim = mat1.dim().1;
+        let hunits = mat3.dim().0;
+        if mat2.dim() != (hunits, 4, embedd_dim)
+            || mat3.dim() != (hunits, 4, hunits)
+            || mat4.dim() != (hunits, 4)
+            || mat5.dim() != (hunits, 4, embedd_dim)
+            || mat6.dim() != (hunits, 4, hunits)
+            || mat7.dim() != (hunits, 4)
+            || mat8.dim() != (2, 4, hunits)
+            || mat9.dim() != (4)
         {
             return Err(Error::DimensionMismatch);
         }
@@ -146,12 +146,12 @@ impl<'l> Lstm<'l> {
     #[must_use] // return value is GIGO path
     fn compute_hc<'a>(
         &self,
-        x_t: MatrixBorrowed<'a, 1>,
+        x_t: MatrixZero<'a, 1>,
         mut h_tm1: MatrixBorrowedMut<'a, 1>,
         mut c_tm1: MatrixBorrowedMut<'a, 1>,
-        warr: MatrixBorrowed<'a, 3>,
-        uarr: MatrixBorrowed<'a, 3>,
-        barr: MatrixBorrowed<'a, 2>,
+        warr: MatrixZero<'a, 3>,
+        uarr: MatrixZero<'a, 3>,
+        barr: MatrixZero<'a, 2>,
         hunits: usize,
     ) -> Option<()> {
         #[cfg(debug_assertions)]
@@ -166,8 +166,8 @@ impl<'l> Lstm<'l> {
 
         let mut s_t = barr.to_owned();
 
-        s_t.as_mut().add_dot_3d(x_t, warr);
-        s_t.as_mut().add_dot_3d(h_tm1.as_borrowed(), uarr);
+        s_t.as_mut().add_dot_3d_2(x_t, warr);
+        s_t.as_mut().add_dot_3d_1(h_tm1.as_borrowed(), uarr);
 
         for i in 0..hunits {
             let [s0, s1, s2, s3] = s_t
@@ -238,9 +238,9 @@ impl<'l> Lstm<'l> {
                 x_t,
                 all_h_fw.submatrix_mut(i)?,
                 c_fw.as_mut(),
-                self.mat2.as_borrowed(),
-                self.mat3.as_borrowed(),
-                self.mat4.as_borrowed(),
+                self.mat2,
+                self.mat3,
+                self.mat4,
                 hunits,
             )?;
         }
@@ -259,15 +259,15 @@ impl<'l> Lstm<'l> {
                 x_t,
                 all_h_bw.submatrix_mut(input_seq_len - i - 1)?,
                 c_bw.as_mut(),
-                self.mat5.as_borrowed(),
-                self.mat6.as_borrowed(),
-                self.mat7.as_borrowed(),
+                self.mat5,
+                self.mat6,
+                self.mat7,
                 self.hunits,
             )?;
         }
 
         // Combining forward and backward LSTMs using the dense time-distributed layer
-        let timeb = self.mat9.as_borrowed();
+        let timeb = self.mat9;
         let mut bies = String::new();
         for i in 0..input_seq_len {
             let curr_fw = all_h_fw.submatrix::<1>(i)?;

--- a/experimental/segmenter/src/math_helper.rs
+++ b/experimental/segmenter/src/math_helper.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use zerovec::ule::AsULE;
+use zerovec::ZeroSlice;
 use crate::lstm_error::Error;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -23,14 +25,6 @@ impl<const D: usize> MatrixOwned<D> {
         MatrixBorrowed {
             data: &self.data,
             dims: self.dims,
-        }
-    }
-
-    pub fn try_from_parts(data: Vec<f32>, dims: [usize; D]) -> Result<Self, Error> {
-        if dims.iter().product::<usize>() == data.len() {
-            Ok(Self { data, dims })
-        } else {
-            Err(Error::DimensionMismatch)
         }
     }
 
@@ -94,14 +88,6 @@ impl<'a, const D: usize> MatrixBorrowed<'a, D> {
         self.data
     }
 
-    #[allow(clippy::wrong_self_convention)] // same convention as slice::to_vec
-    pub fn to_owned(&self) -> MatrixOwned<D> {
-        MatrixOwned {
-            data: self.data.to_vec(),
-            dims: self.dims,
-        }
-    }
-
     /// See [`MatrixOwned::submatrix`].
     #[inline]
     pub fn submatrix<const M: usize>(&self, index: usize) -> Option<MatrixBorrowed<'a, M>> {
@@ -124,28 +110,40 @@ impl<'a, const D: usize> MatrixBorrowed<'a, D> {
     }
 }
 
-impl<'a> MatrixBorrowed<'a, 1> {
-    pub fn dim(&self) -> usize {
-        let [dim] = self.dims;
-        dim
-    }
+macro_rules! impl_basic_dim {
+    ($t1:path, $t2:path, $t3:path) => {
+        impl<'a> $t1 {
+            #[allow(dead_code)]
+            pub fn dim(&self) -> usize {
+                let [dim] = self.dims;
+                dim
+            }
+        }
+        impl<'a> $t2 {
+            #[allow(dead_code)]
+            pub fn dim(&self) -> (usize, usize) {
+                let [d0, d1] = self.dims;
+                (d0, d1)
+            }
+        }
+        impl<'a> $t3 {
+            #[allow(dead_code)]
+            pub fn dim(&self) -> (usize, usize, usize) {
+                let [d0, d1, d2] = self.dims;
+                (d0, d1, d2)
+            }
+        }
+    };
+}
 
+impl_basic_dim!(MatrixOwned<1>, MatrixOwned<2>, MatrixOwned<3>);
+impl_basic_dim!(MatrixBorrowed<'a, 1>, MatrixBorrowed<'a, 2>, MatrixBorrowed<'a, 3>);
+impl_basic_dim!(MatrixBorrowedMut<'a, 1>, MatrixBorrowedMut<'a, 2>, MatrixBorrowedMut<'a, 3>);
+impl_basic_dim!(MatrixZero<'a, 1>, MatrixZero<'a, 2>, MatrixZero<'a, 3>);
+
+impl<'a> MatrixBorrowed<'a, 1> {
     pub fn read_4(&self) -> Option<[f32; 4]> {
         <&[f32; 4]>::try_from(self.data).ok().copied()
-    }
-}
-
-impl<'a> MatrixBorrowed<'a, 2> {
-    pub fn dim(&self) -> (usize, usize) {
-        let [d0, d1] = self.dims;
-        (d0, d1)
-    }
-}
-
-impl<'a> MatrixBorrowed<'a, 3> {
-    pub fn dim(&self) -> (usize, usize, usize) {
-        let [d0, d1, d2] = self.dims;
-        (d0, d1, d2)
     }
 }
 
@@ -180,7 +178,7 @@ impl<'a, const D: usize> MatrixBorrowedMut<'a, D> {
     }
 
     #[must_use]
-    pub fn add(&mut self, other: MatrixBorrowed<'_, D>) -> Option<()> {
+    pub fn add(&mut self, other: MatrixZero<'_, D>) -> Option<()> {
         debug_assert_eq!(self.dims, other.dims);
         // TODO: Vectorize?
         for i in 0..self.data.len() {
@@ -200,9 +198,9 @@ impl<'a, const D: usize> MatrixBorrowedMut<'a, D> {
 
 impl<'a> MatrixBorrowed<'a, 1> {
     #[allow(dead_code)] // could be useful
-    pub fn dot_1d(&self, other: MatrixBorrowed<1>) -> f32 {
+    pub fn dot_1d(&self, other: MatrixZero<1>) -> f32 {
         debug_assert_eq!(self.dims, other.dims);
-        unrolled_dot(self.data, other.data)
+        unrolled_dot_1(self.data, other.data)
     }
 }
 
@@ -211,7 +209,7 @@ impl<'a> MatrixBorrowedMut<'a, 1> {
     ///
     /// Note: For better dot product efficiency, if `b` is MxN, then `a` should be N;
     /// this is the opposite of standard practice.
-    pub fn add_dot_2d(&mut self, a: MatrixBorrowed<1>, b: MatrixBorrowed<2>) {
+    pub fn add_dot_2d(&mut self, a: MatrixBorrowed<1>, b: MatrixZero<2>) {
         let m = a.dim();
         let n = self.as_borrowed().dim();
         debug_assert_eq!(
@@ -233,7 +231,7 @@ impl<'a> MatrixBorrowedMut<'a, 1> {
         for i in 0..n {
             if let (Some(dest), Some(b_sub)) = (self.as_mut_slice().get_mut(i), b.submatrix::<1>(i))
             {
-                *dest += unrolled_dot(a.data, b_sub.data);
+                *dest += unrolled_dot_1(a.data, b_sub.data);
             } else {
                 debug_assert!(false, "unreachable: dims checked above");
             }
@@ -245,7 +243,7 @@ impl<'a> MatrixBorrowedMut<'a, 2> {
     /// Calculate the dot product of a and b, adding the result to self.
     ///
     /// Self should be _MxN_; `a`, _O_; and `b`, _MxNxO_.
-    pub fn add_dot_3d(&mut self, a: MatrixBorrowed<1>, b: MatrixBorrowed<3>) {
+    pub fn add_dot_3d_1(&mut self, a: MatrixBorrowed<1>, b: MatrixZero<3>) {
         let m = a.dim();
         let n = self.as_borrowed().dim().0 * self.as_borrowed().dim().1;
         debug_assert_eq!(
@@ -273,13 +271,110 @@ impl<'a> MatrixBorrowedMut<'a, 2> {
         for i in 0..n {
             if let (Some(dest), Some(rhs)) = (
                 self.as_mut_slice().get_mut(i),
-                b.as_slice().get(i * m..(i + 1) * m),
+                b.as_slice().get_subslice(i * m..(i + 1) * m),
             ) {
-                *dest += unrolled_dot(lhs, rhs);
+                *dest += unrolled_dot_1(lhs, rhs);
             } else {
                 debug_assert!(false, "unreachable: dims checked above");
             }
         }
+    }
+
+    /// Calculate the dot product of a and b, adding the result to self.
+    ///
+    /// Self should be _MxN_; `a`, _O_; and `b`, _MxNxO_.
+    pub fn add_dot_3d_2(&mut self, a: MatrixZero<1>, b: MatrixZero<3>) {
+        let m = a.dim();
+        let n = self.as_borrowed().dim().0 * self.as_borrowed().dim().1;
+        debug_assert_eq!(
+            m,
+            b.dim().2,
+            "dims: {:?}/{:?}/{:?}",
+            self.as_borrowed().dim(),
+            a.dim(),
+            b.dim()
+        );
+        debug_assert_eq!(
+            n,
+            b.dim().0 * b.dim().1,
+            "dims: {:?}/{:?}/{:?}",
+            self.as_borrowed().dim(),
+            a.dim(),
+            b.dim()
+        );
+        // Note: The following two loops are equivalent, but the second has more opportunity for
+        // vectorization since it allows the vectorization to span submatrices.
+        // for i in 0..b.dim().0 {
+        //     self.submatrix_mut::<1>(i).add_dot_2d(a, b.submatrix(i));
+        // }
+        let lhs = a.as_slice();
+        for i in 0..n {
+            if let (Some(dest), Some(rhs)) = (
+                self.as_mut_slice().get_mut(i),
+                b.as_slice().get_subslice(i * m..(i + 1) * m),
+            ) {
+                *dest += unrolled_dot_2(lhs, rhs);
+            } else {
+                debug_assert!(false, "unreachable: dims checked above");
+            }
+        }
+    }
+}
+
+/// A `D`-dimensional matrix borrowed from a [`ZeroSlice`].
+#[derive(Debug, Clone, Copy)]
+pub struct MatrixZero<'a, const D: usize> {
+    data: &'a ZeroSlice<f32>,
+    dims: [usize; D],
+}
+
+impl<'a, const D: usize> MatrixZero<'a, D> {
+    pub fn try_from_parts(data: &'a ZeroSlice<f32>, dims: [usize; D]) -> Result<Self, Error> {
+        if dims.iter().product::<usize>() == data.len() {
+            Ok(Self { data, dims })
+        } else {
+            Err(Error::DimensionMismatch)
+        }
+    }
+
+    #[allow(clippy::wrong_self_convention)] // same convention as slice::to_vec
+    pub fn to_owned(&self) -> MatrixOwned<D> {
+        MatrixOwned {
+            data: self.data.iter().collect(),
+            dims: self.dims,
+        }
+    }
+
+    pub fn as_slice(&self) -> &ZeroSlice<f32> {
+        self.data
+    }
+
+    #[cfg(debug_assertions)]
+    pub fn debug_assert_dims(&self, dims: [usize; D]) {
+        debug_assert_eq!(dims, self.dims);
+        let expected_len = dims.iter().product::<usize>();
+        debug_assert_eq!(expected_len, self.data.len());
+    }
+
+    /// See [`MatrixOwned::submatrix`].
+    #[inline]
+    pub fn submatrix<const M: usize>(&self, index: usize) -> Option<MatrixZero<'a, M>> {
+        // This assertion is based on const generics; it should always succeed and be elided.
+        assert_eq!(M, D - 1);
+        let (range, dims) = self.submatrix_range(index);
+        let data = &self.data.get_subslice(range)?;
+        Some(MatrixZero { data, dims })
+    }
+
+    #[inline]
+    fn submatrix_range<const M: usize>(&self, index: usize) -> (Range<usize>, [usize; M]) {
+        // This assertion is based on const generics; it should always succeed and be elided.
+        assert_eq!(M, D - 1);
+        // The above assertion guarantees that the following line will succeed
+        #[allow(clippy::indexing_slicing, clippy::unwrap_used)]
+        let sub_dims: [usize; M] = self.dims[1..].try_into().unwrap();
+        let n = sub_dims.iter().product::<usize>();
+        (n * index..n * (index + 1), sub_dims)
     }
 }
 
@@ -299,23 +394,27 @@ pub fn sigmoid(x: f32) -> f32 {
     1.0 / (1.0 + (-x).exp())
 }
 
-/// Compute the dot product.
+macro_rules! f32c {
+    ($ule:expr) => {f32::from_unaligned($ule)};
+}
+
+/// Compute the dot product of an aligned and an unaligned f32 slice.
 ///
 /// `xs` and `ys` must be the same length
 ///
-/// (From ndarray 0.15.6)
-fn unrolled_dot(xs: &[f32], ys: &[f32]) -> f32 {
+/// (Based on ndarray 0.15.6)
+fn unrolled_dot_1(xs: &[f32], ys: &ZeroSlice<f32>) -> f32 {
     debug_assert_eq!(xs.len(), ys.len());
     // eightfold unrolled so that floating point can be vectorized
     // (even with strict floating point accuracy semantics)
     let mut p = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
     let xit = xs.chunks_exact(8);
-    let yit = ys.chunks_exact(8);
+    let yit = ys.as_ule_slice().chunks_exact(8);
     let sum = xit
         .remainder()
         .iter()
         .zip(yit.remainder().iter())
-        .map(|(x, y)| x * y)
+        .map(|(x, y)| x * f32c!(*y))
         .sum::<f32>();
     for (xx, yy) in xit.zip(yit) {
         // TODO: Use array_chunks once stable to avoid the unwrap.
@@ -323,15 +422,52 @@ fn unrolled_dot(xs: &[f32], ys: &[f32]) -> f32 {
         #[allow(clippy::unwrap_used)]
         let [x0, x1, x2, x3, x4, x5, x6, x7] = *<&[f32; 8]>::try_from(xx).unwrap();
         #[allow(clippy::unwrap_used)]
-        let [y0, y1, y2, y3, y4, y5, y6, y7] = *<&[f32; 8]>::try_from(yy).unwrap();
-        p.0 += x0 * y0;
-        p.1 += x1 * y1;
-        p.2 += x2 * y2;
-        p.3 += x3 * y3;
-        p.4 += x4 * y4;
-        p.5 += x5 * y5;
-        p.6 += x6 * y6;
-        p.7 += x7 * y7;
+        let [y0, y1, y2, y3, y4, y5, y6, y7] = *<&[<f32 as AsULE>::ULE; 8]>::try_from(yy).unwrap();
+        p.0 += x0 * f32c!(y0);
+        p.1 += x1 * f32c!(y1);
+        p.2 += x2 * f32c!(y2);
+        p.3 += x3 * f32c!(y3);
+        p.4 += x4 * f32c!(y4);
+        p.5 += x5 * f32c!(y5);
+        p.6 += x6 * f32c!(y6);
+        p.7 += x7 * f32c!(y7);
+    }
+    sum + (p.0 + p.4) + (p.1 + p.5) + (p.2 + p.6) + (p.3 + p.7)
+}
+
+/// Compute the dot product of two unaligned f32 slices.
+///
+/// `xs` and `ys` must be the same length
+///
+/// (Based on ndarray 0.15.6)
+fn unrolled_dot_2(xs: &ZeroSlice<f32>, ys: &ZeroSlice<f32>) -> f32 {
+    debug_assert_eq!(xs.len(), ys.len());
+    // eightfold unrolled so that floating point can be vectorized
+    // (even with strict floating point accuracy semantics)
+    let mut p = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    let xit = xs.as_ule_slice().chunks_exact(8);
+    let yit = ys.as_ule_slice().chunks_exact(8);
+    let sum = xit
+        .remainder()
+        .iter()
+        .zip(yit.remainder().iter())
+        .map(|(x, y)| f32c!(*x) * f32c!(*y))
+        .sum::<f32>();
+    for (xx, yy) in xit.zip(yit) {
+        // TODO: Use array_chunks once stable to avoid the unwrap.
+        // <https://github.com/rust-lang/rust/issues/74985>
+        #[allow(clippy::unwrap_used)]
+        let [x0, x1, x2, x3, x4, x5, x6, x7] = *<&[<f32 as AsULE>::ULE; 8]>::try_from(xx).unwrap();
+        #[allow(clippy::unwrap_used)]
+        let [y0, y1, y2, y3, y4, y5, y6, y7] = *<&[<f32 as AsULE>::ULE; 8]>::try_from(yy).unwrap();
+        p.0 += f32c!(x0) * f32c!(y0);
+        p.1 += f32c!(x1) * f32c!(y1);
+        p.2 += f32c!(x2) * f32c!(y2);
+        p.3 += f32c!(x3) * f32c!(y3);
+        p.4 += f32c!(x4) * f32c!(y4);
+        p.5 += f32c!(x5) * f32c!(y5);
+        p.6 += f32c!(x6) * f32c!(y6);
+        p.7 += f32c!(x7) * f32c!(y7);
     }
     sum + (p.0 + p.4) + (p.1 + p.5) + (p.2 + p.6) + (p.3 + p.7)
 }

--- a/experimental/segmenter/src/provider.rs
+++ b/experimental/segmenter/src/provider.rs
@@ -15,7 +15,7 @@ use icu_provider::prelude::*;
 use zerovec::{ZeroMap, ZeroVec};
 
 #[cfg(feature = "lstm")]
-use crate::{lstm_error::Error, math_helper::MatrixOwned};
+use crate::{lstm_error::Error, math_helper::MatrixZero};
 
 /// Pre-processed Unicode data in the form of tables to be used for rule-based breaking.
 #[icu_provider::data_struct(
@@ -117,14 +117,13 @@ pub struct LstmMatrix<'data> {
 
 #[cfg(feature = "lstm")]
 impl<'data> LstmMatrix<'data> {
-    pub(crate) fn alloc_matrix<const D: usize>(&self) -> Result<MatrixOwned<D>, Error> {
+    pub(crate) fn as_matrix_zero<const D: usize>(&self) -> Result<MatrixZero<D>, Error> {
         let dims = self
             .dims
             .get_as_array()
             .ok_or(Error::DimensionMismatch)?
             .map(|x| x as usize);
-        let data = self.data.iter().collect();
-        MatrixOwned::try_from_parts(data, dims)
+        MatrixZero::try_from_parts(&self.data, dims)
     }
 }
 


### PR DESCRIPTION
Here's another counterintuitive result. I observed that the calculation x_t * warr can always be done ahead of time, and we store one NxHx4 matrix instead of a NxD and a DxHx4 matrix. However, the benchmark shows a major regression on this change, which I don't understand.