### PR TITLE
Add lib boilerplate to displaynames (make it no_std)

### DIFF
--- a/experimental/displaynames/src/lib.rs
+++ b/experimental/displaynames/src/lib.rs
@@ -17,6 +17,20 @@
 
 // TODO: expand documentation
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::indexing_slicing,
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::exhaustive_structs,
+        clippy::exhaustive_enums,
+        // missing_debug_implementations // TBD before stabilization
+    )
+)]
 #![warn(missing_docs)]
 
 pub mod displaynames;


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->