### PR TITLE
Segmenter performance improvements

### DIFF
--- a/experimental/segmenter/src/complex.rs
+++ b/experimental/segmenter/src/complex.rs
@@ -162,7 +162,7 @@ pub fn complex_language_segment_utf16(
             if let Some(lstm) = lstm {
                 if let Some(model) = lstm.best(*first_ch as u32) {
                     if let Ok(segmenter) = LstmSegmenter::try_new_unstable(model, grapheme) {
-                        let breaks = segmenter.segment_utf16(&str_per_lang);
+                        let breaks = segmenter.segment_utf16(str_per_lang);
                         result.extend(breaks.map(|n| offset + n));
                         offset += str_per_lang.len();
                         result.push(offset);
@@ -177,7 +177,7 @@ pub fn complex_language_segment_utf16(
                         if let Ok(segmenter) =
                             DictionarySegmenter::try_new_unstable(payload, grapheme)
                         {
-                            let breaks = segmenter.segment_utf16(&str_per_lang);
+                            let breaks = segmenter.segment_utf16(str_per_lang);
                             result.extend(breaks.map(|n| offset + n));
                             offset += str_per_lang.len();
                             continue;
@@ -210,7 +210,7 @@ pub fn complex_language_segment_str(
             if let Some(lstm) = lstm {
                 if let Some(model) = lstm.best(first_ch as u32) {
                     if let Ok(segmenter) = LstmSegmenter::try_new_unstable(model, grapheme) {
-                        let breaks = segmenter.segment_str(&str_per_lang);
+                        let breaks = segmenter.segment_str(str_per_lang);
                         result.extend(breaks.map(|n| offset + n));
                         offset += str_per_lang.chars().map(|c| c.len_utf8()).sum::<usize>();
                         result.push(offset);
@@ -225,7 +225,7 @@ pub fn complex_language_segment_str(
                         if let Ok(segmenter) =
                             DictionarySegmenter::try_new_unstable(payload, grapheme)
                         {
-                            let breaks = segmenter.segment_str(&str_per_lang);
+                            let breaks = segmenter.segment_str(str_per_lang);
                             result.extend(breaks.map(|n| offset + n));
                             offset += str_per_lang.chars().map(|c| c.len_utf8()).sum::<usize>();
                             continue;

--- a/experimental/segmenter/src/language.rs
+++ b/experimental/segmenter/src/language.rs
@@ -2,11 +2,6 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use alloc::string::String;
-use alloc::vec::Vec;
-use core::slice::Iter;
-use core::str::Chars;
-
 #[derive(PartialEq)]
 pub enum Language {
     Burmese,
@@ -52,74 +47,61 @@ pub fn get_language(codepoint: u32) -> Language {
 /// Actually supported LSTM model is Thai and Burmese only. If using other
 /// code point, it causes panic.
 pub struct LanguageIterator<'s> {
-    input: Chars<'s>,
-    current_ch: Option<char>,
+    rest: &'s str,
 }
 
 impl<'s> LanguageIterator<'s> {
     #[allow(dead_code)]
     pub fn new(input: &'s str) -> Self {
-        let mut input = input.chars();
-        let current_ch = input.next();
-        Self { input, current_ch }
+        Self { rest: input }
     }
 }
 
 impl<'s> Iterator for LanguageIterator<'s> {
-    type Item = String;
+    type Item = &'s str;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut s = String::new();
-
-        let current_ch = self.current_ch?;
-        let lang = get_language(current_ch as u32);
-        s.push(current_ch);
-        for c in self.input.by_ref() {
-            self.current_ch = Some(c);
-            let new_lang = get_language(c as u32);
-            if lang != new_lang {
-                return Some(s);
+        let mut indices = self.rest.char_indices();
+        let lang = get_language(indices.next()?.1 as u32);
+        match indices.find(|&(_, ch)| get_language(ch as u32) != lang) {
+            Some((i, _)) => {
+                let (result, rest) = self.rest.split_at(i);
+                self.rest = rest;
+                Some(result)
             }
-            s.push(c);
+            None => Some(core::mem::take(&mut self.rest)),
         }
-        self.current_ch = None;
-        Some(s)
     }
 }
 
 pub struct LanguageIteratorUtf16<'s> {
-    input: Iter<'s, u16>,
-    current_ch: Option<&'s u16>,
+    rest: &'s [u16],
 }
 
 impl<'s> LanguageIteratorUtf16<'s> {
     #[allow(dead_code)]
     pub fn new(input: &'s [u16]) -> Self {
-        let mut input = input.iter();
-        let current_ch = input.next();
-        Self { input, current_ch }
+        Self { rest: input }
     }
 }
 
 impl<'s> Iterator for LanguageIteratorUtf16<'s> {
-    type Item = Vec<u16>;
+    type Item = &'s [u16];
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut s: Vec<u16> = Vec::new();
-
-        let current_ch = *self.current_ch?;
-        let lang = get_language(current_ch as u32);
-        s.push(current_ch);
-        for c in self.input.by_ref() {
-            self.current_ch = Some(c);
-            let new_lang = get_language(*c as u32);
-            if lang != new_lang {
-                return Some(s);
+        let lang = get_language(*self.rest.first()? as u32);
+        match self
+            .rest
+            .iter()
+            .position(|&ch| get_language(ch as u32) != lang)
+        {
+            Some(i) => {
+                let (result, rest) = self.rest.split_at(i);
+                self.rest = rest;
+                Some(result)
             }
-            s.push(*c);
+            None => Some(core::mem::take(&mut self.rest)),
         }
-        self.current_ch = None;
-        Some(s)
     }
 }
 
@@ -132,13 +114,13 @@ mod tests {
         let s = "ภาษาไทยภาษาไทย";
         let utf16: Vec<u16> = s.encode_utf16().collect();
         let mut iter = LanguageIteratorUtf16::new(&utf16);
-        assert_eq!(iter.next(), Some(utf16), "Thai language only with UTF-16");
-        let mut iter = LanguageIterator::new(s);
         assert_eq!(
-            iter.next().as_deref(),
-            Some(s),
-            "Thai language only with UTF-8"
+            iter.next(),
+            Some(utf16.as_slice()),
+            "Thai language only with UTF-16"
         );
+        let mut iter = LanguageIterator::new(s);
+        assert_eq!(iter.next(), Some(s), "Thai language only with UTF-8");
         assert_eq!(iter.next(), None, "Iterator for UTF-8 is finished");
     }
 
@@ -154,24 +136,24 @@ mod tests {
         let mut iter = LanguageIteratorUtf16::new(&utf16);
         assert_eq!(
             iter.next(),
-            Some(thai_utf16),
+            Some(thai_utf16.as_slice()),
             "Thai language with UTF-16 at first"
         );
         assert_eq!(
             iter.next(),
-            Some(burmese_utf16),
+            Some(burmese_utf16.as_slice()),
             "Burmese language with UTF-16 at second"
         );
         assert_eq!(iter.next(), None, "Iterator for UTF-16 is finished");
 
         let mut iter = LanguageIterator::new(&s);
         assert_eq!(
-            iter.next().as_deref(),
+            iter.next(),
             Some(TEST_STR_THAI),
             "Thai language with UTF-8 at first"
         );
         assert_eq!(
-            iter.next().as_deref(),
+            iter.next(),
             Some(TEST_STR_BURMESE),
             "Burmese language with UTF-8 at second"
         );

--- a/experimental/segmenter/src/lstm.rs
+++ b/experimental/segmenter/src/lstm.rs
@@ -5,50 +5,48 @@
 use crate::lstm_bies::Lstm;
 use crate::provider::{LstmDataV1Marker, RuleBreakDataV1};
 use crate::SegmenterError;
-use alloc::borrow::ToOwned;
 use alloc::string::String;
 use core::char::{decode_utf16, REPLACEMENT_CHARACTER};
 use icu_provider::DataPayload;
 
 // A word break iterator using LSTM model. Input string have to be same language.
 
-pub struct LstmSegmenterIterator {
-    input: String,
-    bies_str: String,
-    pos: usize,
-    pos_utf8: usize,
+pub struct LstmSegmenterIterator<'a> {
+    chars: core::str::CharIndices<'a>,
+    bies: alloc::vec::IntoIter<u8>,
 }
 
-impl Iterator for LstmSegmenterIterator {
+impl Iterator for LstmSegmenterIterator<'_> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            let ch = self.bies_str.chars().nth(self.pos)?;
-            self.pos_utf8 += self.input.chars().nth(self.pos)?.len_utf8();
-            self.pos += 1;
-            if ch == 'e' && self.bies_str.len() > self.pos {
-                return Some(self.pos_utf8);
+            let (i, _) = self.chars.next()?;
+            let bies = self.bies.next()?;
+
+            if matches!(bies, b'b' | b's') {
+                return Some(i);
             }
         }
     }
 }
 
-impl LstmSegmenterIterator {
-    pub fn new(lstm: &Lstm, input: &str) -> Self {
-        let lstm_output = lstm.word_segmenter(input);
-        Self {
-            input: input.to_owned(),
-            bies_str: lstm_output,
-            pos: 0,
-            pos_utf8: 0,
-        }
+impl<'a> LstmSegmenterIterator<'a> {
+    pub fn new(lstm: &Lstm, input: &'a str) -> Self {
+        let bies = lstm.word_segmenter(input);
+        debug_assert_eq!(bies.len(), input.chars().count());
+        let mut chars = input.char_indices();
+        let mut bies = bies.into_bytes().into_iter();
+        // Skip first char as we don't want to output 0 as the first element
+        // TODO: why not actually?
+        chars.next();
+        bies.next();
+        Self { chars, bies }
     }
 }
 
 pub struct LstmSegmenterIteratorUtf16 {
-    bies_str: String,
-    pos: usize,
+    bies: core::iter::Enumerate<alloc::vec::IntoIter<u8>>,
 }
 
 impl Iterator for LstmSegmenterIteratorUtf16 {
@@ -56,11 +54,9 @@ impl Iterator for LstmSegmenterIteratorUtf16 {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            let ch = self.bies_str.chars().nth(self.pos)?;
-            // This ch is always in bitmap.
-            self.pos += 1;
-            if ch == 'e' && self.bies_str.len() > self.pos {
-                return Some(self.pos);
+            let (i, bies) = self.bies.next()?;
+            if matches!(bies, b'b' | b's') {
+                return Some(i);
             }
         }
     }
@@ -68,14 +64,15 @@ impl Iterator for LstmSegmenterIteratorUtf16 {
 
 impl LstmSegmenterIteratorUtf16 {
     pub fn new(lstm: &Lstm, input: &[u16]) -> Self {
-        let input: String = decode_utf16(input.iter().cloned())
+        let input: String = decode_utf16(input.iter().copied())
             .map(|r| r.unwrap_or(REPLACEMENT_CHARACTER))
             .collect();
-        let lstm_output = lstm.word_segmenter(&input);
-        Self {
-            bies_str: lstm_output,
-            pos: 0,
-        }
+        let bies = lstm.word_segmenter(&input);
+        let mut bies = bies.into_bytes().into_iter().enumerate();
+        // Skip first char as we don't want to output 0 as the first element
+        // TODO: why not actually?
+        bies.next();
+        Self { bies }
     }
 }
 
@@ -93,7 +90,7 @@ impl<'l> LstmSegmenter<'l> {
     }
 
     /// Create a dictionary based break iterator for an `str` (a UTF-8 string).
-    pub fn segment_str(&self, input: &str) -> LstmSegmenterIterator {
+    pub fn segment_str(&self, input: &'l str) -> LstmSegmenterIterator {
         LstmSegmenterIterator::new(&self.lstm, input)
     }
 


### PR DESCRIPTION
Reducing string allocations. Mostly noticeable in dictionary mode.

```
Line Break/Latin1/En    time:   [5.6400 µs 5.6509 µs 5.6627 µs]                                  
                        change: [-0.7285% -0.4760% -0.2138%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
Line Break/Latin1/En CSS                                                                             
                        time:   [4.8874 µs 4.8957 µs 4.9049 µs]
                        change: [+3.5165% +4.0746% +4.5868%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

Line Break/UTF8/En      time:   [12.162 µs 12.177 µs 12.195 µs]                                
                        change: [-6.1528% -5.9502% -5.7570%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe
Line Break/UTF8/En CSS  time:   [11.701 µs 11.722 µs 11.745 µs]                                    
                        change: [-1.7091% -1.2712% -0.8771%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 14 outliers among 100 measurements (14.00%)
  9 (9.00%) high mild
  5 (5.00%) high severe
Line Break/UTF8/Th/auto time:   [494.21 µs 494.79 µs 495.47 µs]                                    
                        change: [+0.9365% +1.1126% +1.2930%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
Line Break/UTF8/Th/lstm time:   [494.60 µs 495.17 µs 495.82 µs]                                    
                        change: [+1.0661% +1.2626% +1.4677%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 14 outliers among 100 measurements (14.00%)
  10 (10.00%) high mild
  4 (4.00%) high severe
Line Break/UTF8/Th/dictionary                                                                             
                        time:   [4.6666 µs 4.6723 µs 4.6790 µs]
                        change: [-13.748% -13.580% -13.405%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

Line Break/UTF16/En     time:   [11.965 µs 12.018 µs 12.100 µs]                                 
                        change: [-11.108% -10.548% -10.033%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
Line Break/UTF16/En CSS time:   [11.434 µs 11.465 µs 11.498 µs]                                     
                        change: [-10.562% -10.284% -9.9902%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
Line Break/UTF16/Th/auto                                                                            
                        time:   [492.07 µs 492.68 µs 493.29 µs]
                        change: [-0.9509% -0.0908% +0.6572%] (p = 0.85 > 0.05)
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  7 (7.00%) high mild
  8 (8.00%) high severe
Line Break/UTF16/Th/lstm                                                                            
                        time:   [493.69 µs 494.34 µs 494.98 µs]
                        change: [+1.1125% +1.2662% +1.4013%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
Line Break/UTF16/Th/dictionary                                                                             
                        time:   [3.4984 µs 3.5043 µs 3.5113 µs]
                        change: [-11.808% -11.260% -10.758%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe
```