### PR TITLE
use Box inplace of Vec in ShortVec

### DIFF
--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -91,20 +91,20 @@ fn test_sizes() {
     assert_eq!(core::mem::size_of::<subtags::Script>(), 4);
     assert_eq!(core::mem::size_of::<subtags::Region>(), 3);
     assert_eq!(core::mem::size_of::<subtags::Variant>(), 8);
-    assert_eq!(core::mem::size_of::<subtags::Variants>(), 24);
-    assert_eq!(core::mem::size_of::<LanguageIdentifier>(), 40);
+    assert_eq!(core::mem::size_of::<subtags::Variants>(), 16);
+    assert_eq!(core::mem::size_of::<LanguageIdentifier>(), 32);
 
-    assert_eq!(core::mem::size_of::<extensions::transform::Transform>(), 64);
-    assert_eq!(core::mem::size_of::<Option<LanguageIdentifier>>(), 40);
+    assert_eq!(core::mem::size_of::<extensions::transform::Transform>(), 56);
+    assert_eq!(core::mem::size_of::<Option<LanguageIdentifier>>(), 32);
     assert_eq!(core::mem::size_of::<extensions::transform::Fields>(), 24);
 
     assert_eq!(core::mem::size_of::<extensions::unicode::Attributes>(), 24);
-    assert_eq!(core::mem::size_of::<extensions::unicode::Keywords>(), 32);
+    assert_eq!(core::mem::size_of::<extensions::unicode::Keywords>(), 24);
     assert_eq!(core::mem::size_of::<Vec<extensions::other::Other>>(), 24);
     assert_eq!(core::mem::size_of::<extensions::private::Private>(), 24);
-    assert_eq!(core::mem::size_of::<extensions::Extensions>(), 168);
+    assert_eq!(core::mem::size_of::<extensions::Extensions>(), 152);
 
-    assert_eq!(core::mem::size_of::<Locale>(), 208);
+    assert_eq!(core::mem::size_of::<Locale>(), 184);
 }
 
 impl Locale {


### PR DESCRIPTION
#2084 
Reduces size by 8bytes, but makes `push`, `insert` and `remove` reallocate the container.  These methods are used in `StoreMut` trait which is used by litemap. 
