### PR TITLE
LSTM: Rewrite dot_3d in terms of iter_mut and try with Rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2069,6 +2069,7 @@ dependencies = [
  "icu_provider",
  "icu_testdata",
  "num-traits",
+ "rayon",
  "serde",
  "serde_json",
  "utf8_iter",
@@ -2889,9 +2890,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
  "either",
  "rayon-core",
@@ -2899,9 +2900,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",

--- a/experimental/segmenter/Cargo.toml
+++ b/experimental/segmenter/Cargo.toml
@@ -42,6 +42,7 @@ databake = { version = "0.1.3", path = "../../utils/databake", optional = true, 
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 
 num-traits = { version = "0.2", default-features = false, features = ["libm"], optional = true }
+rayon = { version = "1.7", optional = true }
 
 [dev-dependencies]
 criterion = "0.4"
@@ -55,7 +56,7 @@ default = ["auto"]
 std = ["icu_collections/std", "icu_locid/std", "icu_provider/std"]
 serde = ["dep:serde", "zerovec/serde", "icu_collections/serde", "icu_provider/serde"]
 datagen = ["serde", "dep:databake", "zerovec/databake", "icu_collections/databake"]
-lstm = ["dep:num-traits"]
+lstm = ["dep:num-traits", "dep:rayon"]
 auto = ["lstm"] # Enabled try_new_auto_unstable constructors
 
 [lib]

--- a/experimental/segmenter/src/math_helper.rs
+++ b/experimental/segmenter/src/math_helper.rs
@@ -277,9 +277,10 @@ impl<'a> MatrixBorrowedMut<'a, 2> {
         //         dest.add_dot_2d(a, rhs);
         //     }
         // }
+        use rayon::prelude::*;
         let lhs = a.as_slice();
         self.as_mut_slice()
-            .iter_mut()
+            .par_iter_mut()
             .enumerate()
             .for_each(|(i, dest)| {
                 if let Some(rhs) = b.as_slice().get_subslice(i * m..(i + 1) * m) {
@@ -317,9 +318,10 @@ impl<'a> MatrixBorrowedMut<'a, 2> {
         //         dest.add_dot_2d(a, rhs);
         //     }
         // }
+        use rayon::prelude::*;
         let lhs = a.as_slice();
         self.as_mut_slice()
-            .iter_mut()
+            .par_iter_mut()
             .enumerate()
             .for_each(|(i, dest)| {
                 if let Some(rhs) = b.as_slice().get_subslice(i * m..(i + 1) * m) {

--- a/experimental/segmenter/src/math_helper.rs
+++ b/experimental/segmenter/src/math_helper.rs
@@ -273,19 +273,19 @@ impl<'a> MatrixBorrowedMut<'a, 2> {
         // Note: The following two loops are equivalent, but the second has more opportunity for
         // vectorization since it allows the vectorization to span submatrices.
         // for i in 0..b.dim().0 {
-        //     self.submatrix_mut::<1>(i).add_dot_2d(a, b.submatrix(i));
+        //     if let (Some(mut dest), Some(rhs)) = (self.submatrix_mut::<1>(i), b.submatrix(i)) {
+        //         dest.add_dot_2d(a, rhs);
+        //     }
         // }
         let lhs = a.as_slice();
-        for i in 0..n {
-            if let (Some(dest), Some(rhs)) = (
-                self.as_mut_slice().get_mut(i),
-                b.as_slice().get_subslice(i * m..(i + 1) * m),
-            ) {
-                *dest += unrolled_dot_1(lhs, rhs);
-            } else {
-                debug_assert!(false, "unreachable: dims checked above");
-            }
-        }
+        self.as_mut_slice()
+            .iter_mut()
+            .enumerate()
+            .for_each(|(i, dest)| {
+                if let Some(rhs) = b.as_slice().get_subslice(i * m..(i + 1) * m) {
+                    *dest += unrolled_dot_1(lhs, rhs)
+                }
+            })
     }
 
     /// Calculate the dot product of a and b, adding the result to self.
@@ -313,19 +313,19 @@ impl<'a> MatrixBorrowedMut<'a, 2> {
         // Note: The following two loops are equivalent, but the second has more opportunity for
         // vectorization since it allows the vectorization to span submatrices.
         // for i in 0..b.dim().0 {
-        //     self.submatrix_mut::<1>(i).add_dot_2d(a, b.submatrix(i));
+        //     if let (Some(mut dest), Some(rhs)) = (self.submatrix_mut::<1>(i), b.submatrix(i)) {
+        //         dest.add_dot_2d(a, rhs);
+        //     }
         // }
         let lhs = a.as_slice();
-        for i in 0..n {
-            if let (Some(dest), Some(rhs)) = (
-                self.as_mut_slice().get_mut(i),
-                b.as_slice().get_subslice(i * m..(i + 1) * m),
-            ) {
-                *dest += unrolled_dot_2(lhs, rhs);
-            } else {
-                debug_assert!(false, "unreachable: dims checked above");
-            }
-        }
+        self.as_mut_slice()
+            .iter_mut()
+            .enumerate()
+            .for_each(|(i, dest)| {
+                if let Some(rhs) = b.as_slice().get_subslice(i * m..(i + 1) * m) {
+                    *dest += unrolled_dot_2(lhs, rhs)
+                }
+            })
     }
 }
 


### PR DESCRIPTION
The main opportunity for parallel computation in the LSTM is when multiplying the `1xE*Ex4xH` and `1xH*Hx4xH` matrices. To accomplish this, I tried changing the `dot_3d` function to use Rayon. However, the result with using Rayon is 20x slower. I suspect that this is because the cost of splitting and joining threads is just simply more than the win we get out of the parallel computing.

@robertbastian @pdogr @FrankYFTang