### PR TITLE
Upgrade segmenter to Unicode 15.0.0

### DIFF
--- a/experimental/segmenter/tests/testdata/GraphemeBreakTest.txt
+++ b/experimental/segmenter/tests/testdata/GraphemeBreakTest.txt
@@ -1,11 +1,11 @@
-# GraphemeBreakTest-14.0.0.txt
-# Date: 2021-03-08, 06:22:32 GMT
-# © 2021 Unicode®, Inc.
+# GraphemeBreakTest-15.0.0.txt
+# Date: 2022-02-26, 00:38:37 GMT
+# © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
-# For terms of use, see http://www.unicode.org/terms_of_use.html
+# For terms of use, see https://www.unicode.org/terms_of_use.html
 #
 # Unicode Character Database
-#   For documentation, see http://www.unicode.org/reports/tr44/
+#   For documentation, see https://www.unicode.org/reports/tr44/
 #
 # Default Grapheme_Cluster_Break Test
 #

--- a/experimental/segmenter/tests/testdata/LineBreakTest.txt
+++ b/experimental/segmenter/tests/testdata/LineBreakTest.txt
@@ -1,11 +1,11 @@
-# LineBreakTest-14.0.0.txt
-# Date: 2021-08-20, 21:08:45 GMT
-# © 2021 Unicode®, Inc.
+# LineBreakTest-15.0.0.txt
+# Date: 2022-02-26, 00:38:39 GMT
+# © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
-# For terms of use, see http://www.unicode.org/terms_of_use.html
+# For terms of use, see https://www.unicode.org/terms_of_use.html
 #
 # Unicode Character Database
-#   For documentation, see http://www.unicode.org/reports/tr44/
+#   For documentation, see https://www.unicode.org/reports/tr44/
 #
 # Default Line_Break Test
 #

--- a/experimental/segmenter/tests/testdata/SentenceBreakTest.txt
+++ b/experimental/segmenter/tests/testdata/SentenceBreakTest.txt
@@ -1,11 +1,11 @@
-# SentenceBreakTest-14.0.0.txt
-# Date: 2021-03-08, 06:22:40 GMT
-# © 2021 Unicode®, Inc.
+# SentenceBreakTest-15.0.0.txt
+# Date: 2022-02-26, 00:39:00 GMT
+# © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
-# For terms of use, see http://www.unicode.org/terms_of_use.html
+# For terms of use, see https://www.unicode.org/terms_of_use.html
 #
 # Unicode Character Database
-#   For documentation, see http://www.unicode.org/reports/tr44/
+#   For documentation, see https://www.unicode.org/reports/tr44/
 #
 # Default Sentence_Break Test
 #

--- a/experimental/segmenter/tests/testdata/WordBreakTest.txt
+++ b/experimental/segmenter/tests/testdata/WordBreakTest.txt
@@ -1,11 +1,11 @@
-# WordBreakTest-14.0.0.txt
-# Date: 2021-03-08, 06:22:40 GMT
-# © 2021 Unicode®, Inc.
+# WordBreakTest-15.0.0.txt
+# Date: 2022-02-26, 00:39:00 GMT
+# © 2022 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
-# For terms of use, see http://www.unicode.org/terms_of_use.html
+# For terms of use, see https://www.unicode.org/terms_of_use.html
 #
 # Unicode Character Database
-#   For documentation, see http://www.unicode.org/reports/tr44/
+#   For documentation, see https://www.unicode.org/reports/tr44/
 #
 # Default Word_Break Test
 #

--- a/provider/datagen/data/segmenter/grapheme.toml
+++ b/provider/datagen/data/segmenter/grapheme.toml
@@ -2,8 +2,8 @@
 # called LICENSE at the top level of the ICU4X source tree
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-# These grapheme boundary rules are based on UAX #29, Unicode Version 14.0.0.
-# https://www.unicode.org/reports/tr29/tr29-39.html
+# These grapheme boundary rules are based on UAX #29, Unicode Version 15.0.0.
+# https://www.unicode.org/reports/tr29/tr29-41.html
 
 segmenter_type = "grapheme"
 

--- a/provider/datagen/data/segmenter/line.toml
+++ b/provider/datagen/data/segmenter/line.toml
@@ -2,8 +2,8 @@
 # called LICENSE at the top level of the ICU4X source tree
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-# These line boundary rules are based on UAX #14, Unicode Version 14.0.0.
-# https://www.unicode.org/reports/tr14/tr14-47.html
+# These line boundary rules are based on UAX #14, Unicode Version 15.0.0.
+# https://www.unicode.org/reports/tr14/tr14-49.html
 
 segmenter_type = "line"
 

--- a/provider/datagen/data/segmenter/sentence.toml
+++ b/provider/datagen/data/segmenter/sentence.toml
@@ -2,8 +2,8 @@
 # called LICENSE at the top level of the ICU4X source tree
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-# These sentence boundary rules are based on UAX #29, Unicode Version 14.0.0.
-# https://www.unicode.org/reports/tr29/tr29-39.html
+# These sentence boundary rules are based on UAX #29, Unicode Version 15.0.0.
+# https://www.unicode.org/reports/tr29/tr29-41.html
 
 segmenter_type = "sentence"
 

--- a/provider/datagen/data/segmenter/word.toml
+++ b/provider/datagen/data/segmenter/word.toml
@@ -2,8 +2,8 @@
 # called LICENSE at the top level of the ICU4X source tree
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-# These word boundary rules are based on UAX #29, Unicode Version 14.0.0.
-# https://www.unicode.org/reports/tr29/tr29-39.html
+# These word boundary rules are based on UAX #29, Unicode Version 15.0.0.
+# https://www.unicode.org/reports/tr29/tr29-41.html
 
 segmenter_type = "word"
 


### PR DESCRIPTION
This is an easy upgrade. No rules have been changed for segmenter between Unicode 14.0.0 and 15.0.0. See:
- https://www.unicode.org/reports/tr14/tr14-49.html#Modifications
- https://www.unicode.org/reports/tr29/tr29-41.html#Modifications

The test data was downloaded from
https://www.unicode.org/Public/UCD/latest/ucd/auxiliary/. No test cases have been modified.