### PR TITLE
Remove dep on CARGO_MANIFEST_DIR in testdata

### DIFF
--- a/ffi/gn/Cargo.toml
+++ b/ffi/gn/Cargo.toml
@@ -14,9 +14,6 @@ icu_capi = { version = "1.0", path = "../../ffi/diplomat", default-features = fa
 icu = { version = "1.0", path = "../../components/icu" }
 icu_provider = { version = "1.0", path = "../../provider/core" }
 
-[gn.package.icu_testdata."1.1.2"]
-env_vars = ["CARGO_MANIFEST_DIR=.."]
-
 [gn.package.log."0.4.14"]
 rustflags = ["--cfg=atomic_cas", "--cfg=has_atomics"]
 

--- a/ffi/gn/icu4x/BUILD.gn
+++ b/ffi/gn/icu4x/BUILD.gn
@@ -697,7 +697,7 @@ rust_library("icu_testdata-v1_1_2") {
   deps += [ ":icu_timezone-v1_1_0" ]
   deps += [ ":zerovec-v0_9_3" ]
 
-  rustenv = [ "CARGO_MANIFEST_DIR=.." ]
+  rustenv = []
 
   rustflags = [
     "--cap-lints=allow",

--- a/provider/testdata/src/lib.rs
+++ b/provider/testdata/src/lib.rs
@@ -169,10 +169,9 @@ pub fn buffer() -> impl BufferProvider {
 #[cfg(feature = "buffer")]
 pub fn buffer_no_fallback() -> impl BufferProvider {
     #[allow(clippy::unwrap_used)] // The statically compiled data file is valid.
-    icu_provider_blob::BlobDataProvider::try_new_from_static_blob(include_bytes!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/data/testdata.postcard"
-    )))
+    icu_provider_blob::BlobDataProvider::try_new_from_static_blob(include_bytes!(
+        "../data/testdata.postcard"
+    ))
     .unwrap()
 }
 
@@ -182,7 +181,7 @@ pub fn buffer_no_fallback() -> impl BufferProvider {
 pub struct UnstableDataProvider;
 
 mod baked {
-    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/data/baked/mod.rs"));
+    include!("../data/baked/mod.rs");
     impl_data_provider!(super::UnstableDataProvider);
     impl_any_provider!(super::UnstableDataProvider);
 }


### PR DESCRIPTION
The core problem with doing this "correctly" in GN is that `include!()` is resolved relative to the current file, which breaks if `CARGO_MANIFEST_DIR` is a relative path, which is what's going to happen if we're trying to use the correct GN way of doing this (via `rebase_path`)


But we don't need to do this, we can just use a local relative path.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->