### PR TITLE
Minor improvements to segmenter doc

### DIFF
--- a/experimental/segmenter/README.md
+++ b/experimental/segmenter/README.md
@@ -1,15 +1,17 @@
 # icu_segmenter [![crates.io](https://img.shields.io/crates/v/icu_segmenter)](https://crates.io/crates/icu_segmenter)
 
-🚧 \[Experimental\] Segment strings by lines, graphemes, word, and sentences.
+🚧 \[Experimental\] Segment strings by lines, graphemes, words, and sentences.
 
 This module is published as its own crate ([`icu_segmenter`](https://docs.rs/icu_segmenter/latest/icu_segmenter/))
 and as part of the [`icu`](https://docs.rs/icu/latest/icu/) crate. See the latter for more details on the ICU4X project.
 
 This module contains segmenter implementation for the following rules.
 
-- Line breaker that is compatible with [Unicode Standard Annex #14][UAX14] and CSS properties.
-- Grapheme cluster breaker, word breaker, and sentence breaker that are compatible with
-  [Unicode Standard Annex #29][UAX29].
+- Line segmenter that is compatible with [Unicode Standard Annex #14][UAX14], _Unicode Line
+  Breaking Algorithm_, with options to tailor line-breaking behavior for CSS [`line-break`] and
+  [`word-break`] properties.
+- Grapheme cluster segmenter, word segmenter, and sentence segmenter that are compatible with
+  [Unicode Standard Annex #29][UAX29], _Unicode Text Segmentation_.
 
 <div class="stab unstable">
 🚧 This code is experimental; it may change at any time, in breaking or non-breaking ways,
@@ -20,6 +22,8 @@ of the icu meta-crate. Use with caution.
 
 [UAX14]: https://www.unicode.org/reports/tr14/
 [UAX29]: https://www.unicode.org/reports/tr29/
+[`line-break`]: https://drafts.csswg.org/css-text-3/#line-break-property
+[`word-break`]: https://drafts.csswg.org/css-text-3/#word-break-property
 
 ## Examples
 

--- a/experimental/segmenter/src/error.rs
+++ b/experimental/segmenter/src/error.rs
@@ -9,7 +9,7 @@ use icu_provider::prelude::DataError;
 #[cfg(feature = "std")]
 impl std::error::Error for SegmenterError {}
 
-/// A list of error outcomes for various operations in the `icu_timezone` crate.
+/// A list of error outcomes for various operations in the `icu_segmenter` crate.
 ///
 /// Re-exported as [`Error`](crate::Error).
 #[derive(Display, Debug, Copy, Clone, PartialEq)]

--- a/experimental/segmenter/src/lib.rs
+++ b/experimental/segmenter/src/lib.rs
@@ -2,16 +2,18 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-//! 🚧 \[Experimental\] Segment strings by lines, graphemes, word, and sentences.
+//! 🚧 \[Experimental\] Segment strings by lines, graphemes, words, and sentences.
 //!
 //! This module is published as its own crate ([`icu_segmenter`](https://docs.rs/icu_segmenter/latest/icu_segmenter/))
 //! and as part of the [`icu`](https://docs.rs/icu/latest/icu/) crate. See the latter for more details on the ICU4X project.
 //!
 //! This module contains segmenter implementation for the following rules.
 //!
-//! - Line breaker that is compatible with [Unicode Standard Annex #14][UAX14] and CSS properties.
-//! - Grapheme cluster breaker, word breaker, and sentence breaker that are compatible with
-//!   [Unicode Standard Annex #29][UAX29].
+//! - Line segmenter that is compatible with [Unicode Standard Annex #14][UAX14], _Unicode Line
+//!   Breaking Algorithm_, with options to tailor line-breaking behavior for CSS [`line-break`] and
+//!   [`word-break`] properties.
+//! - Grapheme cluster segmenter, word segmenter, and sentence segmenter that are compatible with
+//!   [Unicode Standard Annex #29][UAX29], _Unicode Text Segmentation_.
 //!
 //! <div class="stab unstable">
 //! 🚧 This code is experimental; it may change at any time, in breaking or non-breaking ways,
@@ -22,6 +24,8 @@
 //!
 //! [UAX14]: https://www.unicode.org/reports/tr14/
 //! [UAX29]: https://www.unicode.org/reports/tr29/
+//! [`line-break`]: https://drafts.csswg.org/css-text-3/#line-break-property
+//! [`word-break`]: https://drafts.csswg.org/css-text-3/#word-break-property
 //!
 //! # Examples
 //!

--- a/experimental/segmenter/src/line.rs
+++ b/experimental/segmenter/src/line.rs
@@ -16,7 +16,7 @@ use icu_provider::prelude::*;
 use utf8_iter::Utf8CharIndices;
 
 /// An enum specifies the strictness of line-breaking rules. It can be passed as
-/// an argument when creating a line breaker.
+/// an argument when creating a line segmenter.
 ///
 /// Each enum value has the same meaning with respect to the `line-break`
 /// property values in the CSS Text spec. See the details in
@@ -57,7 +57,7 @@ pub enum LineBreakRule {
 }
 
 /// An enum specifies the line break opportunities between letters. It can be
-/// passed as an argument when creating a line breaker.
+/// passed as an argument when creating a line segmenter.
 ///
 /// Each enum value has the same meaning with respect to the `word-break`
 /// property values in the CSS Text spec. See the details in
@@ -85,7 +85,7 @@ pub enum WordBreakRule {
     KeepAll,
 }
 
-/// Options to tailor line breaking behavior, such as for CSS.
+/// Options to tailor line-breaking behavior.
 ///
 /// <div class="stab unstable">
 /// 🚧 This code is experimental; it may change at any time, in breaking or non-breaking ways,
@@ -102,7 +102,7 @@ pub struct LineBreakOptions {
     /// Line break opportunities between letters. See [`WordBreakRule`].
     pub word_break_rule: WordBreakRule,
 
-    /// Use `true` as a hint to the line breaker that the writing
+    /// Use `true` as a hint to the line segmenter that the writing
     /// system is Chinese or Japanese. This allows more break opportunities when
     /// `LineBreakRule` is `Normal` or `Loose`. See
     /// <https://drafts.csswg.org/css-text-3/#line-break-property> for details.

--- a/experimental/segmenter/src/rule_segmenter.rs
+++ b/experimental/segmenter/src/rule_segmenter.rs
@@ -9,7 +9,8 @@ use crate::symbols::*;
 use core::str::CharIndices;
 use utf8_iter::Utf8CharIndices;
 
-/// The category tag that is returned by rule_status.
+/// The category tag that is returned by
+/// [`WordBreakIterator::rule_status()`][crate::WordBreakIterator::rule_status()].
 #[non_exhaustive]
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[repr(u8)]

--- a/experimental/segmenter/src/word.rs
+++ b/experimental/segmenter/src/word.rs
@@ -42,12 +42,12 @@ pub struct WordBreakIterator<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized>(
 derive_usize_iterator_with_type!(WordBreakIterator);
 
 impl<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> WordBreakIterator<'l, 's, Y> {
-    /// Return the status value of break boundary.
+    /// Return the status value of the current word break boundary.
     #[inline]
     pub fn rule_status(&self) -> RuleStatusType {
         self.0.rule_status()
     }
-    /// Return true when break boundary is word-like such as letter/number/CJK
+    /// Return `true` when the current word break boundary is word-like such as letter/number/CJK.
     #[inline]
     pub fn is_word_like(&self) -> bool {
         self.0.is_word_like()
@@ -131,7 +131,7 @@ pub type WordBreakIteratorUtf16<'l, 's> = WordBreakIterator<'l, 's, WordBreakTyp
 ///
 /// Not all segments delimited by word boundaries are words; some are interword
 /// segments such as spaces and punctuation.
-/// The [`RuleBreakIterator::rule_status()`] of a boundary can be used to
+/// The [`WordBreakIterator::rule_status()`] of a boundary can be used to
 /// classify the preceding segment.
 /// ```rust
 /// # use itertools::Itertools;


### PR DESCRIPTION
- Use "segmenter" instead of "breaker" for consistency.
- Fix links.