### PR TITLE
Use let-else to simplify segmenter

### DIFF
--- a/experimental/segmenter/src/line.rs
+++ b/experimental/segmenter/src/line.rs
@@ -785,11 +785,7 @@ impl<'l, 's, Y: LineBreakType<'l, 's>> Iterator for LineBreakIterator<'l, 's, Y>
             let mut left_prop = self.get_linebreak_property(left_codepoint);
             self.advance_iter();
 
-            // Initializing right_codepoint can be simplified with a let-else statement in Rust 1.65.
-            // https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html#let-else-statements
-            let right_codepoint = if let Some(right_codepoint) = self.get_current_codepoint() {
-                right_codepoint
-            } else {
+            let Some(right_codepoint) = self.get_current_codepoint() else {
                 return Some(self.len);
             };
             let right_prop = self.get_linebreak_property(right_codepoint);
@@ -859,11 +855,7 @@ impl<'l, 's, Y: LineBreakType<'l, 's>> Iterator for LineBreakIterator<'l, 's, Y>
                 loop {
                     self.advance_iter();
 
-                    // Initializing prop can be simplified with a let-else statement in Rust 1.65.
-                    // https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html#let-else-statements
-                    let prop = if let Some(prop) = self.get_current_linebreak_property() {
-                        prop
-                    } else {
+                    let Some(prop) = self.get_current_linebreak_property() else {
                         // Reached EOF. But we are analyzing multiple characters now, so next break may be previous point.
                         let break_state = self
                             .get_break_state_from_table(break_state as u8, self.data.eot_property);

--- a/experimental/segmenter/src/rule_segmenter.rs
+++ b/experimental/segmenter/src/rule_segmenter.rs
@@ -112,11 +112,7 @@ impl<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> Iterator for RuleBreakIterator<'
             let left_prop = self.get_break_property(left_codepoint);
             self.advance_iter();
 
-            // Initializing right_prop can be simplified with a let-else statement in Rust 1.65.
-            // https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html#let-else-statements
-            let right_prop = if let Some(right_prop) = self.get_current_break_property() {
-                right_prop
-            } else {
+            let Some(right_prop) = self.get_current_break_property() else {
                 self.boundary_property = left_prop;
                 return Some(self.len);
             };
@@ -147,11 +143,7 @@ impl<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> Iterator for RuleBreakIterator<'
                 loop {
                     self.advance_iter();
 
-                    // Initializing prop can be simplified with a let-else statement in Rust 1.65.
-                    // https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html#let-else-statements
-                    let prop = if let Some(prop) = self.get_current_break_property() {
-                        prop
-                    } else {
+                    let Some(prop) = self.get_current_break_property() else {
                         // Reached EOF. But we are analyzing multiple characters now, so next break may be previous point.
                         self.boundary_property = break_state as u8;
                         if self


### PR DESCRIPTION
We have rust toolchain 1.68.2, so it should be ok to use `let-else`.
https://github.com/unicode-org/icu4x/blob/d8111b8d18ef4e29191fd260f5c3a45cf031e509/rust-toolchain.toml#L7