### PR TITLE
Improve segmenter docs and mention "invariant locale"

### DIFF
--- a/experimental/segmenter/src/grapheme.rs
+++ b/experimental/segmenter/src/grapheme.rs
@@ -152,7 +152,7 @@ pub struct GraphemeClusterSegmenter {
 }
 
 impl GraphemeClusterSegmenter {
-    /// Construct a [`GraphemeClusterSegmenter`].
+    /// Constructs a [`GraphemeClusterSegmenter`] with an invariant locale.
     pub fn try_new_unstable<D>(provider: &D) -> Result<Self, SegmenterError>
     where
         D: DataProvider<GraphemeClusterBreakDataV1Marker> + ?Sized,
@@ -163,7 +163,7 @@ impl GraphemeClusterSegmenter {
 
     icu_provider::gen_any_buffer_constructors!(locale: skip, options: skip, error: SegmenterError);
 
-    /// Create a grapheme cluster break iterator for an `str` (a UTF-8 string).
+    /// Creates a grapheme cluster break iterator for an `str` (a UTF-8 string).
     pub fn segment_str<'l, 's>(
         &'l self,
         input: &'s str,
@@ -171,7 +171,7 @@ impl GraphemeClusterSegmenter {
         GraphemeClusterSegmenter::new_and_segment_str(input, self.payload.get())
     }
 
-    /// Create a grapheme cluster break iterator from grapheme cluster rule payload.
+    /// Creates a grapheme cluster break iterator from grapheme cluster rule payload.
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
     pub(crate) fn new_and_segment_str<'l, 's>(
@@ -189,7 +189,7 @@ impl GraphemeClusterSegmenter {
         })
     }
 
-    /// Create a grapheme cluster break iterator for a potentially ill-formed UTF8 string
+    /// Creates a grapheme cluster break iterator for a potentially ill-formed UTF8 string
     ///
     /// Invalid characters are treated as REPLACEMENT CHARACTER
     ///
@@ -208,7 +208,7 @@ impl GraphemeClusterSegmenter {
             boundary_property: 0,
         })
     }
-    /// Create a grapheme cluster break iterator for a Latin-1 (8-bit) string.
+    /// Creates a grapheme cluster break iterator for a Latin-1 (8-bit) string.
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
     pub fn segment_latin1<'l, 's>(
@@ -226,7 +226,7 @@ impl GraphemeClusterSegmenter {
         })
     }
 
-    /// Create a grapheme cluster break iterator for a UTF-16 string.
+    /// Creates a grapheme cluster break iterator for a UTF-16 string.
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
     pub fn segment_utf16<'l, 's>(
@@ -236,7 +236,7 @@ impl GraphemeClusterSegmenter {
         GraphemeClusterSegmenter::new_and_segment_utf16(input, self.payload.get())
     }
 
-    /// Create a grapheme cluster break iterator from grapheme cluster rule payload.
+    /// Creates a grapheme cluster break iterator from grapheme cluster rule payload.
     pub(crate) fn new_and_segment_utf16<'l, 's>(
         input: &'s [u16],
         payload: &'l RuleBreakDataV1<'l>,

--- a/experimental/segmenter/src/line.rs
+++ b/experimental/segmenter/src/line.rs
@@ -363,7 +363,7 @@ impl LineSegmenter {
     ///
     /// The current behavior, which is subject to change, is to use the LSTM model when available.
     ///
-    /// See also [`Self::try_new_auto_with_options_unstable`].
+    /// See also [`Self::try_new_auto_unstable`].
     #[cfg(feature = "auto")]
     pub fn try_new_auto_with_options_unstable<D>(
         provider: &D,
@@ -396,7 +396,7 @@ impl LineSegmenter {
     /// The LSTM, or Long Term Short Memory, is a machine learning model. It is smaller than
     /// the full dictionary but more expensive during inference.
     ///
-    /// See also [`Self::try_new_dictionary_with_options_unstable`].
+    /// See also [`Self::try_new_dictionary_unstable`].
     #[cfg(feature = "lstm")]
     pub fn try_new_lstm_with_options_unstable<D>(
         provider: &D,
@@ -433,7 +433,7 @@ impl LineSegmenter {
     /// The dictionary model uses a list of words to determine appropriate breakpoints. It is
     /// faster than the LSTM model but requires more data.
     ///
-    /// See also [`Self::try_new_dictionary_with_options_unstable`].
+    /// See also [`Self::try_new_dictionary_unstable`].
     pub fn try_new_dictionary_with_options_unstable<D>(
         provider: &D,
         options: LineBreakOptions,
@@ -468,7 +468,7 @@ impl LineSegmenter {
         ]
     );
 
-    /// Create a line break iterator for an `str` (a UTF-8 string).
+    /// Creates a line break iterator for an `str` (a UTF-8 string).
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
     pub fn segment_str<'l, 's>(&'l self, input: &'s str) -> LineBreakIteratorUtf8<'l, 's> {
@@ -482,7 +482,7 @@ impl LineSegmenter {
             complex: &self.complex,
         }
     }
-    /// Create a line break iterator for a potentially ill-formed UTF8 string
+    /// Creates a line break iterator for a potentially ill-formed UTF8 string
     ///
     /// Invalid characters are treated as REPLACEMENT CHARACTER
     ///
@@ -501,7 +501,7 @@ impl LineSegmenter {
             complex: &self.complex,
         }
     }
-    /// Create a line break iterator for a Latin-1 (8-bit) string.
+    /// Creates a line break iterator for a Latin-1 (8-bit) string.
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
     pub fn segment_latin1<'l, 's>(&'l self, input: &'s [u8]) -> LineBreakIteratorLatin1<'l, 's> {
@@ -516,7 +516,7 @@ impl LineSegmenter {
         }
     }
 
-    /// Create a line break iterator for a UTF-16 string.
+    /// Creates a line break iterator for a UTF-16 string.
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
     pub fn segment_utf16<'l, 's>(&'l self, input: &'s [u16]) -> LineBreakIteratorUtf16<'l, 's> {

--- a/experimental/segmenter/src/line.rs
+++ b/experimental/segmenter/src/line.rs
@@ -271,8 +271,12 @@ pub struct LineSegmenter {
 }
 
 impl LineSegmenter {
-    /// Construct a [`LineSegmenter`] via [`Self::try_new_auto_with_options_unstable`] with default
-    /// [`LineBreakOptions`].
+    /// Constructs a [`LineSegmenter`] with an invariant locale and the best available data for
+    /// complex scripts (Khmer, Lao, Myanmar, and Thai).
+    ///
+    /// The current behavior, which is subject to change, is to use the LSTM model when available.
+    ///
+    /// See also [`Self::try_new_auto_with_options_unstable`].
     #[cfg(feature = "auto")]
     pub fn try_new_auto_unstable<D>(provider: &D) -> Result<Self, SegmenterError>
     where
@@ -296,8 +300,13 @@ impl LineSegmenter {
         ]
     );
 
-    /// Construct a [`LineSegmenter`] via [`Self::try_new_lstm_with_options_unstable`] with default
-    /// [`LineBreakOptions`].
+    /// Constructs a [`LineSegmenter`] with an invariant locale and LSTM data for
+    /// complex scripts (Khmer, Lao, Myanmar, and Thai).
+    ///
+    /// The LSTM, or Long Term Short Memory, is a machine learning model. It is smaller than
+    /// the full dictionary but more expensive during inference.
+    ///
+    /// See also [`Self::try_new_lstm_with_options_unstable`].
     #[cfg(feature = "lstm")]
     pub fn try_new_lstm_unstable<D>(provider: &D) -> Result<Self, SegmenterError>
     where
@@ -321,8 +330,13 @@ impl LineSegmenter {
         ]
     );
 
-    /// Construct a [`LineSegmenter`] via [`Self::try_new_dictionary_with_options_unstable`] with
-    /// default [`LineBreakOptions`].
+    /// Constructs a [`LineSegmenter`] with an invariant locale and dictionary data for
+    /// complex scripts (Khmer, Lao, Myanmar, and Thai).
+    ///
+    /// The dictionary model uses a list of words to determine appropriate breakpoints. It is
+    /// faster than the LSTM model but requires more data.
+    ///
+    /// See also [`Self::try_new_dictionary_with_options_unstable`].
     pub fn try_new_dictionary_unstable<D>(provider: &D) -> Result<Self, SegmenterError>
     where
         D: DataProvider<LineBreakDataV1Marker>
@@ -344,8 +358,12 @@ impl LineSegmenter {
         ]
     );
 
-    /// Construct a [`LineSegmenter`] with custom [`LineBreakOptions`]. It automatically loads the
-    /// best available payload data for Burmese, Khmer, Lao, and Thai.
+    /// Constructs a [`LineSegmenter`] with an invariant locale, custom [`LineBreakOptions`], and
+    /// the best available data for complex scripts (Khmer, Lao, Myanmar, and Thai).
+    ///
+    /// The current behavior, which is subject to change, is to use the LSTM model when available.
+    ///
+    /// See also [`Self::try_new_auto_with_options_unstable`].
     #[cfg(feature = "auto")]
     pub fn try_new_auto_with_options_unstable<D>(
         provider: &D,
@@ -372,8 +390,13 @@ impl LineSegmenter {
         ]
     );
 
-    /// Construct a [`LineSegmenter`] with custom [`LineBreakOptions`] and LSTM payload data for
-    /// Burmese, Khmer, Lao, and Thai.
+    /// Constructs a [`LineSegmenter`] with an invariant locale, custom [`LineBreakOptions`], and
+    /// LSTM data for complex scripts (Khmer, Lao, Myanmar, and Thai).
+    ///
+    /// The LSTM, or Long Term Short Memory, is a machine learning model. It is smaller than
+    /// the full dictionary but more expensive during inference.
+    ///
+    /// See also [`Self::try_new_dictionary_with_options_unstable`].
     #[cfg(feature = "lstm")]
     pub fn try_new_lstm_with_options_unstable<D>(
         provider: &D,
@@ -404,8 +427,13 @@ impl LineSegmenter {
         ]
     );
 
-    /// Construct a [`LineSegmenter`] with custom [`LineBreakOptions`] and dictionary payload data
-    /// for Burmese, Khmer, Lao, and Thai.
+    /// Constructs a [`LineSegmenter`] with an invariant locale, custom [`LineBreakOptions`], and
+    /// dictionary data for complex scripts (Khmer, Lao, Myanmar, and Thai).
+    ///
+    /// The dictionary model uses a list of words to determine appropriate breakpoints. It is
+    /// faster than the LSTM model but requires more data.
+    ///
+    /// See also [`Self::try_new_dictionary_with_options_unstable`].
     pub fn try_new_dictionary_with_options_unstable<D>(
         provider: &D,
         options: LineBreakOptions,

--- a/experimental/segmenter/src/sentence.rs
+++ b/experimental/segmenter/src/sentence.rs
@@ -120,7 +120,7 @@ pub struct SentenceSegmenter {
 }
 
 impl SentenceSegmenter {
-    /// Construct a [`SentenceSegmenter`].
+    /// Constructs a [`SentenceSegmenter`] with an invariant locale.
     pub fn try_new_unstable<D>(provider: &D) -> Result<Self, SegmenterError>
     where
         D: DataProvider<SentenceBreakDataV1Marker> + ?Sized,
@@ -131,7 +131,7 @@ impl SentenceSegmenter {
 
     icu_provider::gen_any_buffer_constructors!(locale: skip, options: skip, error: SegmenterError);
 
-    /// Create a sentence break iterator for an `str` (a UTF-8 string).
+    /// Creates a sentence break iterator for an `str` (a UTF-8 string).
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
     pub fn segment_str<'l, 's>(&'l self, input: &'s str) -> SentenceBreakIteratorUtf8<'l, 's> {
@@ -145,7 +145,7 @@ impl SentenceSegmenter {
             boundary_property: 0,
         })
     }
-    /// Create a sentence break iterator for a potentially ill-formed UTF8 string
+    /// Creates a sentence break iterator for a potentially ill-formed UTF8 string
     ///
     /// Invalid characters are treated as REPLACEMENT CHARACTER
     ///
@@ -164,7 +164,7 @@ impl SentenceSegmenter {
             boundary_property: 0,
         })
     }
-    /// Create a sentence break iterator for a Latin-1 (8-bit) string.
+    /// Creates a sentence break iterator for a Latin-1 (8-bit) string.
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
     pub fn segment_latin1<'l, 's>(
@@ -182,7 +182,7 @@ impl SentenceSegmenter {
         })
     }
 
-    /// Create a sentence break iterator for a UTF-16 string.
+    /// Creates a sentence break iterator for a UTF-16 string.
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
     pub fn segment_utf16<'l, 's>(&'l self, input: &'s [u16]) -> SentenceBreakIteratorUtf16<'l, 's> {

--- a/experimental/segmenter/src/word.rs
+++ b/experimental/segmenter/src/word.rs
@@ -309,7 +309,7 @@ impl WordSegmenter {
         ]
     );
 
-    /// Create a word break iterator for an `str` (a UTF-8 string).
+    /// Creates a word break iterator for an `str` (a UTF-8 string).
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
     pub fn segment_str<'l, 's>(&'l self, input: &'s str) -> WordBreakIteratorUtf8<'l, 's> {
@@ -324,7 +324,7 @@ impl WordSegmenter {
         })
     }
 
-    /// Create a word break iterator for a potentially ill-formed UTF8 string
+    /// Creates a word break iterator for a potentially ill-formed UTF8 string
     ///
     /// Invalid characters are treated as REPLACEMENT CHARACTER
     ///
@@ -344,7 +344,7 @@ impl WordSegmenter {
         })
     }
 
-    /// Create a word break iterator for a Latin-1 (8-bit) string.
+    /// Creates a word break iterator for a Latin-1 (8-bit) string.
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
     pub fn segment_latin1<'l, 's>(&'l self, input: &'s [u8]) -> WordBreakIteratorLatin1<'l, 's> {
@@ -359,7 +359,7 @@ impl WordSegmenter {
         })
     }
 
-    /// Create a word break iterator for a UTF-16 string.
+    /// Creates a word break iterator for a UTF-16 string.
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
     pub fn segment_utf16<'l, 's>(&'l self, input: &'s [u16]) -> WordBreakIteratorUtf16<'l, 's> {

--- a/experimental/segmenter/src/word.rs
+++ b/experimental/segmenter/src/word.rs
@@ -156,11 +156,30 @@ pub struct WordSegmenter {
 }
 
 impl WordSegmenter {
-    /// Construct a [`WordSegmenter`] with automatically selecting the best available LSTM and
-    /// dictionary payload data.
+    /// Constructs a [`WordSegmenter`] with an invariant locale and the best available data for
+    /// complex scripts (Chinese, Japanese, Khmer, Lao, Myanmar, and Thai).
     ///
-    /// Note: This function loads dictionary for Chinese and Japanese, and LSTM for Burmese, Khmer,
-    /// Lao, and Thai.
+    /// The current behavior, which is subject to change, is to use the LSTM model when available
+    /// and the dictionary model for Chinese and Japanese.
+    ///
+    /// # Examples
+    ///
+    /// Behavior with complex scripts:
+    ///
+    /// ```
+    /// use icu::segmenter::WordSegmenter;
+    ///
+    /// let th_str = "ทุกสองสัปดาห์";
+    /// let ja_str = "こんにちは世界";
+    ///
+    /// let segmenter = WordSegmenter::try_new_auto_unstable(&icu_testdata::unstable()).unwrap();
+    ///
+    /// let th_bps = segmenter.segment_str(th_str).collect::<Vec<_>>();
+    /// let ja_bps = segmenter.segment_str(ja_str).collect::<Vec<_>>();
+    ///
+    /// assert_eq!(th_bps, [0, 9, 18, 39]);
+    /// assert_eq!(ja_bps, [0, 15, 21]);
+    /// ```
     #[cfg(feature = "auto")]
     pub fn try_new_auto_unstable<D>(provider: &D) -> Result<Self, SegmenterError>
     where
@@ -188,9 +207,33 @@ impl WordSegmenter {
         ]
     );
 
-    /// Construct a [`WordSegmenter`] with LSTM payload data for Burmese, Khmer, Lao, and Thai.
+    /// Constructs a [`WordSegmenter`] with an invariant locale and LSTM data for
+    /// complex scripts (Burmese, Khmer, Lao, and Thai).
     ///
-    /// Warning: [`WordSegmenter`] created by this function doesn't handle Chinese or Japanese.
+    /// The LSTM, or Long Term Short Memory, is a machine learning model. It is smaller than
+    /// the full dictionary but more expensive during inference.
+    ///
+    /// Warning: there is not currently an LSTM model for Chinese or Japanese, so the [`WordSegmenter`]
+    /// created by this function will have unexpected behavior in spans of those languages.
+    ///
+    /// # Examples
+    ///
+    /// Behavior with complex scripts:
+    ///
+    /// ```
+    /// use icu::segmenter::WordSegmenter;
+    ///
+    /// let th_str = "ทุกสองสัปดาห์";
+    /// let ja_str = "こんにちは世界";
+    ///
+    /// let segmenter = WordSegmenter::try_new_lstm_unstable(&icu_testdata::unstable()).unwrap();
+    ///
+    /// let th_bps = segmenter.segment_str(th_str).collect::<Vec<_>>();
+    /// let ja_bps = segmenter.segment_str(ja_str).collect::<Vec<_>>();
+    ///
+    /// assert_eq!(th_bps, [0, 9, 18, 39]);
+    /// assert_eq!(ja_bps, [0, 21]);
+    /// ```
     #[cfg(feature = "lstm")]
     pub fn try_new_lstm_unstable<D>(provider: &D) -> Result<Self, SegmenterError>
     where
@@ -217,8 +260,30 @@ impl WordSegmenter {
         ]
     );
 
-    /// Construct a [`WordSegmenter`] with dictionary payload data for Chinese, Japanese, Burmese,
-    /// Khmer, Lao, and Thai.
+    /// Construct a [`WordSegmenter`] with an invariant locale and dictionary data for
+    /// complex scripts (Chinese, Japanese, Khmer, Lao, Myanmar, and Thai).
+    ///
+    /// The dictionary model uses a list of words to determine appropriate breakpoints. It is
+    /// faster than the LSTM model but requires more data.
+    ///
+    /// # Examples
+    ///
+    /// Behavior with complex scripts:
+    ///
+    /// ```
+    /// use icu::segmenter::WordSegmenter;
+    ///
+    /// let th_str = "ทุกสองสัปดาห์";
+    /// let ja_str = "こんにちは世界";
+    ///
+    /// let segmenter = WordSegmenter::try_new_dictionary_unstable(&icu_testdata::unstable()).unwrap();
+    ///
+    /// let th_bps = segmenter.segment_str(th_str).collect::<Vec<_>>();
+    /// let ja_bps = segmenter.segment_str(ja_str).collect::<Vec<_>>();
+    ///
+    /// assert_eq!(th_bps, [0, 9, 18, 39]);
+    /// assert_eq!(ja_bps, [0, 15, 21]);
+    /// ```
     pub fn try_new_dictionary_unstable<D>(provider: &D) -> Result<Self, SegmenterError>
     where
         D: DataProvider<WordBreakDataV1Marker>


### PR DESCRIPTION
I didn't actually change the method names because I think it is _desirable_ in the 2.0 timeframe to add the locale parameter and have people's call sites break so that they can add the locale parameter.