### PR TITLE
Improving error documentation

### DIFF
--- a/components/calendar/src/error.rs
+++ b/components/calendar/src/error.rs
@@ -10,7 +10,7 @@ use writeable::Writeable;
 #[cfg(feature = "std")]
 impl std::error::Error for CalendarError {}
 
-/// A list of error outcomes for various operations in the `icu_calendar` crate.
+/// A list of error outcomes for various operations in this module.
 ///
 /// Re-exported as [`Error`](crate::Error).
 #[derive(Display, Debug, Copy, Clone, PartialEq)]

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -151,4 +151,5 @@ pub use error::CalendarError;
 pub use gregorian::Gregorian;
 pub use iso::Iso;
 
+#[doc(no_inline)]
 pub use CalendarError as Error;

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -151,6 +151,4 @@ pub use error::CalendarError;
 pub use gregorian::Gregorian;
 pub use iso::Iso;
 
-/// Re-export of [`CalendarError`].
-#[doc(no_inline)]
 pub use CalendarError as Error;

--- a/components/collator/src/error.rs
+++ b/components/collator/src/error.rs
@@ -8,7 +8,7 @@ use displaydoc::Display;
 use icu_properties::PropertiesError;
 use icu_provider::prelude::DataError;
 
-/// A list of error outcomes for various operations in the `icu_collator` crate.
+/// A list of error outcomes for various operations in this module.
 ///
 /// Re-exported as [`Error`](crate::Error).
 #[derive(Display, Debug)]

--- a/components/collator/src/lib.rs
+++ b/components/collator/src/lib.rs
@@ -328,4 +328,5 @@ pub use options::MaxVariable;
 pub use options::Numeric;
 pub use options::Strength;
 
+#[doc(no_inline)]
 pub use CollatorError as Error;

--- a/components/collator/src/lib.rs
+++ b/components/collator/src/lib.rs
@@ -328,5 +328,4 @@ pub use options::MaxVariable;
 pub use options::Numeric;
 pub use options::Strength;
 
-#[doc(inline)]
 pub use CollatorError as Error;

--- a/components/collections/src/codepointinvlist/mod.rs
+++ b/components/collections/src/codepointinvlist/mod.rs
@@ -84,5 +84,5 @@ pub enum CodePointInversionListError {
 #[cfg(feature = "std")]
 impl std::error::Error for CodePointInversionListError {}
 
-#[doc(inline)]
+#[doc(no_inline)]
 pub use CodePointInversionListError as Error;

--- a/components/collections/src/codepointinvliststringlist/mod.rs
+++ b/components/collections/src/codepointinvliststringlist/mod.rs
@@ -259,7 +259,7 @@ pub enum CodePointInversionListAndStringListError {
     StringListNotSorted(String, String),
 }
 
-#[doc(inline)]
+#[doc(no_inline)]
 pub use CodePointInversionListAndStringListError as Error;
 
 #[cfg(test)]

--- a/components/collections/src/codepointtrie/mod.rs
+++ b/components/collections/src/codepointtrie/mod.rs
@@ -50,5 +50,5 @@ pub use cptrie::TrieType;
 pub use cptrie::TrieValue;
 pub use error::Error as CodePointTrieError;
 
-#[doc(inline)]
+#[doc(no_inline)]
 pub use CodePointTrieError as Error;

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -17,7 +17,7 @@ use icu_provider::prelude::DataError;
 #[cfg(feature = "std")]
 impl std::error::Error for DateTimeError {}
 
-/// A list of error outcomes for various operations in the `icu_datetime` crate.
+/// A list of error outcomes for various operations in this module.
 ///
 /// Re-exported as [`Error`](crate::Error).
 #[derive(Display, Debug, Copy, Clone, PartialEq)]

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -166,4 +166,5 @@ pub use format::zoned_datetime::FormattedZonedDateTime;
 pub use options::DateTimeFormatterOptions;
 pub use zoned_datetime::TypedZonedDateTimeFormatter;
 
+#[doc(no_inline)]
 pub use DateTimeError as Error;

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -166,5 +166,4 @@ pub use format::zoned_datetime::FormattedZonedDateTime;
 pub use options::DateTimeFormatterOptions;
 pub use zoned_datetime::TypedZonedDateTimeFormatter;
 
-#[doc(inline)]
 pub use DateTimeError as Error;

--- a/components/decimal/src/error.rs
+++ b/components/decimal/src/error.rs
@@ -6,7 +6,7 @@
 
 use displaydoc::Display;
 
-/// A list of error outcomes for various operations in the `icu_decimal` crate.
+/// A list of error outcomes for various operations in this module.
 ///
 /// Re-exported as [`Error`](crate::Error).
 #[derive(Display, Debug, Copy, Clone, PartialEq)]

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -106,6 +106,7 @@ pub mod provider;
 pub use error::DecimalError;
 pub use format::FormattedFixedDecimal;
 
+#[doc(no_inline)]
 pub use DecimalError as Error;
 
 use alloc::string::String;

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -106,7 +106,6 @@ pub mod provider;
 pub use error::DecimalError;
 pub use format::FormattedFixedDecimal;
 
-#[doc(inline)]
 pub use DecimalError as Error;
 
 use alloc::string::String;

--- a/components/list/src/error.rs
+++ b/components/list/src/error.rs
@@ -9,7 +9,7 @@ use icu_provider::prelude::DataError;
 #[cfg(feature = "std")]
 impl std::error::Error for ListError {}
 
-/// A list of error outcomes for various operations in the `icu_timezone` crate.
+/// A list of error outcomes for various operations in this module.
 ///
 /// Re-exported as [`Error`](crate::Error).
 #[derive(Display, Debug, Copy, Clone, PartialEq)]

--- a/components/list/src/lib.rs
+++ b/components/list/src/lib.rs
@@ -103,6 +103,7 @@ pub use list_formatter::*;
 
 pub use error::ListError;
 
+#[doc(no_inline)]
 pub use ListError as Error;
 
 /// Represents the style of a list. See the

--- a/components/list/src/lib.rs
+++ b/components/list/src/lib.rs
@@ -103,7 +103,6 @@ pub use list_formatter::*;
 
 pub use error::ListError;
 
-#[doc(inline)]
 pub use ListError as Error;
 
 /// Represents the style of a list. See the

--- a/components/locid/src/lib.rs
+++ b/components/locid/src/lib.rs
@@ -77,6 +77,8 @@ pub use locale::Locale;
 pub use ordering::SubtagOrderingResult;
 pub use parser::errors::ParserError;
 
+pub use ParserError as Error;
+
 pub mod extensions;
 pub mod subtags;
 pub mod zerovec;

--- a/components/locid/src/lib.rs
+++ b/components/locid/src/lib.rs
@@ -77,6 +77,7 @@ pub use locale::Locale;
 pub use ordering::SubtagOrderingResult;
 pub use parser::errors::ParserError;
 
+#[doc(no_inline)]
 pub use ParserError as Error;
 
 pub mod extensions;

--- a/components/locid/src/parser/errors.rs
+++ b/components/locid/src/parser/errors.rs
@@ -7,6 +7,8 @@ use displaydoc::Display;
 /// List of parser errors that can be generated
 /// while parsing [`LanguageIdentifier`](crate::LanguageIdentifier), [`Locale`](crate::Locale),
 /// [`subtags`](crate::subtags) or [`extensions`](crate::extensions).
+///
+/// Re-exported as [`Error`](crate::Error).
 #[derive(Display, Debug, PartialEq, Copy, Clone)]
 #[non_exhaustive]
 pub enum ParserError {

--- a/components/locid_transform/src/error.rs
+++ b/components/locid_transform/src/error.rs
@@ -9,7 +9,7 @@ use icu_provider::prelude::DataError;
 #[cfg(feature = "std")]
 impl std::error::Error for LocaleTransformError {}
 
-/// A list of error outcomes for various operations in the `icu_timezone` crate.
+/// A list of error outcomes for various operations in this module.
 ///
 /// Re-exported as [`Error`](crate::Error).
 #[derive(Display, Debug, Copy, Clone, PartialEq)]

--- a/components/locid_transform/src/lib.rs
+++ b/components/locid_transform/src/lib.rs
@@ -110,5 +110,4 @@ pub enum TransformResult {
     Unmodified,
 }
 
-#[doc(inline)]
 pub use LocaleTransformError as Error;

--- a/components/locid_transform/src/lib.rs
+++ b/components/locid_transform/src/lib.rs
@@ -110,4 +110,5 @@ pub enum TransformResult {
     Unmodified,
 }
 
+#[doc(no_inline)]
 pub use LocaleTransformError as Error;

--- a/components/normalizer/src/error.rs
+++ b/components/normalizer/src/error.rs
@@ -8,7 +8,9 @@ use displaydoc::Display;
 use icu_properties::PropertiesError;
 use icu_provider::prelude::DataError;
 
-/// Normalizer-specific error
+/// A list of error outcomes for various operations in this module.
+///
+/// Re-exported as [`Error`](crate::Error).
 #[derive(Display, Debug)]
 #[non_exhaustive]
 pub enum NormalizerError {

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -73,6 +73,8 @@ pub mod provider;
 
 pub use crate::error::NormalizerError;
 
+pub use NormalizerError as Error;
+
 use crate::provider::CanonicalDecompositionDataV1Marker;
 use crate::provider::CompatibilityDecompositionSupplementV1Marker;
 use crate::provider::DecompositionDataV1;

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -73,6 +73,7 @@ pub mod provider;
 
 pub use crate::error::NormalizerError;
 
+#[doc(no_inline)]
 pub use NormalizerError as Error;
 
 use crate::provider::CanonicalDecompositionDataV1Marker;

--- a/components/plurals/src/error.rs
+++ b/components/plurals/src/error.rs
@@ -7,7 +7,7 @@ use crate::rules::reference::parser::ParserError;
 use displaydoc::Display;
 use icu_provider::prelude::DataError;
 
-/// A list of error outcomes for various operations in the `icu_plurals` crate.
+/// A list of error outcomes for various operations in this module.
 ///
 /// Re-exported as [`Error`](crate::Error).
 #[derive(Display, Debug, Clone, Copy, PartialEq)]

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -93,6 +93,7 @@ use provider::ErasedPluralRulesV1Marker;
 use provider::OrdinalV1Marker;
 use rules::runtime::test_rule;
 
+#[doc(no_inline)]
 pub use PluralsError as Error;
 
 /// A type of a plural rule which can be associated with the [`PluralRules`] struct.

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -93,7 +93,6 @@ use provider::ErasedPluralRulesV1Marker;
 use provider::OrdinalV1Marker;
 use rules::runtime::test_rule;
 
-#[doc(inline)]
 pub use PluralsError as Error;
 
 /// A type of a plural rule which can be associated with the [`PluralRules`] struct.

--- a/components/properties/src/error.rs
+++ b/components/properties/src/error.rs
@@ -13,7 +13,7 @@ use crate::Script;
 #[cfg(feature = "std")]
 impl std::error::Error for PropertiesError {}
 
-/// A list of error outcomes for various operations in the `icu_properties` crate.
+/// A list of error outcomes for various operations in this module.
 ///
 /// Re-exported as [`Error`](crate::Error).
 #[derive(Display, Debug, Copy, Clone)]

--- a/components/properties/src/lib.rs
+++ b/components/properties/src/lib.rs
@@ -121,4 +121,5 @@ pub mod names {
 
 pub use error::PropertiesError;
 
+#[doc(no_inline)]
 pub use PropertiesError as Error;

--- a/components/properties/src/lib.rs
+++ b/components/properties/src/lib.rs
@@ -121,5 +121,4 @@ pub mod names {
 
 pub use error::PropertiesError;
 
-#[doc(inline)]
 pub use PropertiesError as Error;

--- a/components/segmenter/src/error.rs
+++ b/components/segmenter/src/error.rs
@@ -9,7 +9,7 @@ use icu_provider::prelude::DataError;
 #[cfg(feature = "std")]
 impl std::error::Error for SegmenterError {}
 
-/// A list of error outcomes for various operations in the `icu_segmenter` crate.
+/// A list of error outcomes for various operations in this module.
 ///
 /// Re-exported as [`Error`](crate::Error).
 #[derive(Display, Debug, Copy, Clone, PartialEq)]

--- a/components/segmenter/src/lib.rs
+++ b/components/segmenter/src/lib.rs
@@ -185,5 +185,4 @@ pub use crate::word::WordBreakIteratorUtf8;
 
 pub use error::SegmenterError;
 
-#[doc(inline)]
 pub use SegmenterError as Error;

--- a/components/segmenter/src/lib.rs
+++ b/components/segmenter/src/lib.rs
@@ -185,4 +185,5 @@ pub use crate::word::WordBreakIteratorUtf8;
 
 pub use error::SegmenterError;
 
+#[doc(no_inline)]
 pub use SegmenterError as Error;

--- a/components/timezone/src/error.rs
+++ b/components/timezone/src/error.rs
@@ -8,7 +8,7 @@ use icu_provider::prelude::DataError;
 #[cfg(feature = "std")]
 impl std::error::Error for TimeZoneError {}
 
-/// A list of error outcomes for various operations in the `icu_timezone` crate.
+/// A list of error outcomes for various operations in this module.
 ///
 /// Re-exported as [`Error`](crate::Error).
 #[derive(Display, Debug, Copy, Clone, PartialEq)]

--- a/components/timezone/src/lib.rs
+++ b/components/timezone/src/lib.rs
@@ -132,4 +132,5 @@ pub use provider::{MetazoneId, TimeZoneBcp47Id};
 pub use time_zone::CustomTimeZone;
 pub use types::{GmtOffset, ZoneVariant};
 
+#[doc(no_inline)]
 pub use TimeZoneError as Error;

--- a/components/timezone/src/lib.rs
+++ b/components/timezone/src/lib.rs
@@ -132,5 +132,4 @@ pub use provider::{MetazoneId, TimeZoneBcp47Id};
 pub use time_zone::CustomTimeZone;
 pub use types::{GmtOffset, ZoneVariant};
 
-#[doc(inline)]
 pub use TimeZoneError as Error;

--- a/experimental/casemapping/src/error.rs
+++ b/experimental/casemapping/src/error.rs
@@ -6,8 +6,9 @@ use core::char::DecodeUtf16Error;
 use displaydoc::Display;
 use icu_collections::codepointtrie::CodePointTrieError;
 
-/// A list of possible errors for the [`CaseMapping`](crate::CaseMapping) struct
+/// A list of error outcomes for various operations in this module.
 ///
+/// Re-exported as [`Error`](crate::Error).
 /// <div class="stab unstable">
 /// 🚧 This code is experimental; it may change at any time, in breaking or non-breaking ways,
 /// including in SemVer minor releases. It can be enabled with the "experimental" Cargo feature

--- a/experimental/casemapping/src/lib.rs
+++ b/experimental/casemapping/src/lib.rs
@@ -29,7 +29,7 @@ mod internals;
 
 pub use casemapping::CaseMapping;
 pub use error::Error as CaseMappingError;
-#[doc(no_inline)]
-pub use CaseMappingError as Error;
 #[cfg(feature = "datagen")]
 pub use internals::CaseMappingInternals;
+#[doc(no_inline)]
+pub use CaseMappingError as Error;

--- a/experimental/casemapping/src/lib.rs
+++ b/experimental/casemapping/src/lib.rs
@@ -29,5 +29,7 @@ mod internals;
 
 pub use casemapping::CaseMapping;
 pub use error::Error as CaseMappingError;
+#[doc(no_inline)]
+pub use CaseMappingError as Error;
 #[cfg(feature = "datagen")]
 pub use internals::CaseMappingInternals;

--- a/experimental/compactdecimal/src/error.rs
+++ b/experimental/compactdecimal/src/error.rs
@@ -7,7 +7,9 @@ use icu_decimal::DecimalError;
 use icu_plurals::PluralsError;
 use icu_provider::DataError;
 
-/// A list of error outcomes for various operations in the `icu_compactdecimal` crate.
+/// A list of error outcomes for various operations in this module.
+///
+/// Re-exported as [`Error`](crate::Error).
 #[derive(Display, Debug, Copy, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum CompactDecimalError {

--- a/experimental/compactdecimal/src/lib.rs
+++ b/experimental/compactdecimal/src/lib.rs
@@ -38,4 +38,5 @@ pub mod provider;
 
 pub use compactdecimal::CompactDecimalFormatter;
 pub use error::CompactDecimalError;
+#[doc(no_inline)]
 pub use CompactDecimalError as Error;

--- a/experimental/compactdecimal/src/lib.rs
+++ b/experimental/compactdecimal/src/lib.rs
@@ -38,3 +38,4 @@ pub mod provider;
 
 pub use compactdecimal::CompactDecimalFormatter;
 pub use error::CompactDecimalError;
+pub use CompactDecimalError as Error;

--- a/experimental/relativetime/src/error.rs
+++ b/experimental/relativetime/src/error.rs
@@ -7,7 +7,9 @@ use icu_decimal::DecimalError;
 use icu_plurals::PluralsError;
 use icu_provider::DataError;
 
-/// A list of error outcomes for various operations in the `icu_relativetime` crate.
+/// A list of error outcomes for various operations in this module.
+///
+/// Re-exported as [`Error`](crate::Error).
 #[derive(Display, Debug, Copy, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum RelativeTimeError {

--- a/experimental/relativetime/src/lib.rs
+++ b/experimental/relativetime/src/lib.rs
@@ -27,3 +27,4 @@ pub use error::RelativeTimeError;
 pub use format::FormattedRelativeTime;
 pub use options::RelativeTimeFormatterOptions;
 pub use relativetime::RelativeTimeFormatter;
+pub use RelativeTimeError as Error;

--- a/experimental/relativetime/src/lib.rs
+++ b/experimental/relativetime/src/lib.rs
@@ -27,4 +27,5 @@ pub use error::RelativeTimeError;
 pub use format::FormattedRelativeTime;
 pub use options::RelativeTimeFormatterOptions;
 pub use relativetime::RelativeTimeFormatter;
+#[doc(no_inline)]
 pub use RelativeTimeError as Error;

--- a/tools/ffi_coverage/src/allowlist.rs
+++ b/tools/ffi_coverage/src/allowlist.rs
@@ -308,6 +308,7 @@ lazy_static::lazy_static! {
         "icu::datetime::Error",
         "icu::decimal::Error",
         "icu::list::Error",
+        "icu::locid::Error",
         "icu::locid_transform::Error",
         "icu::normalizer::Error",
         "icu::plurals::Error",

--- a/tools/ffi_coverage/src/allowlist.rs
+++ b/tools/ffi_coverage/src/allowlist.rs
@@ -305,6 +305,7 @@ lazy_static::lazy_static! {
 
         // Re-exports of errors
         "icu::calendar::Error",
+        "icu::compactdecimal::Error",
         "icu::datetime::Error",
         "icu::decimal::Error",
         "icu::list::Error",
@@ -313,6 +314,7 @@ lazy_static::lazy_static! {
         "icu::normalizer::Error",
         "icu::plurals::Error",
         "icu::properties::Error",
+        "icu::relativetime::Error",
         "icu::segmenter::Error",
         "icu::timezone::Error",
         "icu::collator::Error",


### PR DESCRIPTION
Replacing the `#[doc(inline)]` on `pub use CrateError as Error` re-exports by `#[doc(no_inline)]`, as `inline` creates duplicate docs entries where it's unclear that they are the same type. `no_inline` adds an entry to the Re-exports section ([`icu_calendar` already did it](https://docs.rs/icu_calendar/latest/icu_calendar/#reexports)).

Also adding the reexport in some modules that were missing it, and updating the phrasing to be meta-crate compatible.

#2612

#3297 