### PR TITLE
Improving docs in preludes

### DIFF
--- a/components/calendar/src/provider.rs
+++ b/components/calendar/src/provider.rs
@@ -17,7 +17,7 @@
 
 use crate::types::IsoWeekday;
 use core::str::FromStr;
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 use tinystr::TinyStr16;
 use zerovec::ZeroVec;
 

--- a/components/collator/src/error.rs
+++ b/components/collator/src/error.rs
@@ -6,7 +6,7 @@
 
 use displaydoc::Display;
 use icu_properties::PropertiesError;
-use icu_provider::prelude::DataError;
+use icu_provider::DataError;
 
 /// A list of error outcomes for various operations in the `icu_collator` crate.
 ///

--- a/components/collator/src/provider.rs
+++ b/components/collator/src/provider.rs
@@ -20,7 +20,7 @@
 
 use icu_collections::char16trie::Char16TrieIterator;
 use icu_collections::codepointtrie::CodePointTrie;
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 use zerovec::ule::AsULE;
 use zerovec::ZeroSlice;
 use zerovec::ZeroVec;

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -12,7 +12,7 @@ use icu_calendar::any_calendar::AnyCalendarKind;
 use icu_calendar::types::MonthCode;
 use icu_decimal::DecimalError;
 use icu_plurals::PluralsError;
-use icu_provider::prelude::DataError;
+use icu_provider::DataError;
 
 #[cfg(feature = "std")]
 impl std::error::Error for DateTimeError {}

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -5,7 +5,7 @@
 use crate::fields::FieldLength;
 use core::{cmp::Ordering, convert::TryFrom};
 use displaydoc::Display;
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 use zerovec::ule::{AsULE, ZeroVecError, ULE};
 
 /// An error relating to the field symbol for a date pattern field.

--- a/components/datetime/src/pattern/hour_cycle.rs
+++ b/components/datetime/src/pattern/hour_cycle.rs
@@ -6,7 +6,7 @@ use super::{reference, runtime, PatternItem};
 use crate::{fields, options::preferences};
 #[cfg(all(feature = "datagen"))]
 use crate::{provider, skeleton};
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 
 /// Used to represent either H11/H12, or H23/H24. Skeletons only store these
 /// hour cycles as H12 or H23.

--- a/components/datetime/src/pattern/mod.rs
+++ b/components/datetime/src/pattern/mod.rs
@@ -12,7 +12,7 @@ pub mod runtime;
 use crate::fields;
 pub use error::PatternError;
 pub use hour_cycle::CoarseHourCycle;
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 pub use item::{GenericPatternItem, PatternItem};
 
 /// The granularity of time represented in a pattern item.

--- a/components/datetime/src/pattern/runtime/generic.rs
+++ b/components/datetime/src/pattern/runtime/generic.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use alloc::vec::Vec;
 use core::str::FromStr;
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 use zerovec::ZeroVec;
 
 #[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]

--- a/components/datetime/src/pattern/runtime/pattern.rs
+++ b/components/datetime/src/pattern/runtime/pattern.rs
@@ -5,7 +5,7 @@
 use super::super::{reference, PatternError, PatternItem, TimeGranularity};
 use alloc::vec::Vec;
 use core::str::FromStr;
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 use zerovec::ZeroVec;
 
 #[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]

--- a/components/datetime/src/pattern/runtime/plural.rs
+++ b/components/datetime/src/pattern/runtime/plural.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use either::Either;
 use icu_plurals::{PluralCategory, PluralRules};
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 
 /// A collection of plural variants of a pattern.
 #[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]

--- a/components/datetime/src/provider/calendar/mod.rs
+++ b/components/datetime/src/provider/calendar/mod.rs
@@ -10,7 +10,6 @@ mod symbols;
 
 use crate::pattern;
 use icu_provider::prelude::*;
-use icu_provider::{yoke, zerofrom};
 #[cfg(any(feature = "datagen", feature = "experimental"))]
 pub use skeletons::*;
 pub use symbols::*;
@@ -91,7 +90,6 @@ pub struct TimeLengthsV1<'data> {
 pub mod patterns {
     use super::*;
     use crate::pattern::runtime::{self, GenericPattern, PatternPlurals};
-    use icu_provider::{yoke, zerofrom};
 
     /// Data struct for date/time patterns broken down by pattern length.
     ///

--- a/components/datetime/src/provider/calendar/skeletons.rs
+++ b/components/datetime/src/provider/calendar/skeletons.rs
@@ -7,7 +7,7 @@ use crate::{
     skeleton::{reference::Skeleton, SkeletonError},
 };
 use core::convert::TryFrom;
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 use litemap::LiteMap;
 
 // Manually implement DataMarker so that we can keep it in the proper experimental feature

--- a/components/datetime/src/provider/calendar/symbols.rs
+++ b/components/datetime/src/provider/calendar/symbols.rs
@@ -8,7 +8,6 @@
 use alloc::borrow::Cow;
 use icu_calendar::types::MonthCode;
 use icu_provider::prelude::*;
-use icu_provider::{yoke, zerofrom};
 use tinystr::{tinystr, TinyStr4};
 use zerovec::ZeroMap;
 

--- a/components/datetime/src/provider/time_zones.rs
+++ b/components/datetime/src/provider/time_zones.rs
@@ -5,7 +5,7 @@
 //! Data provider structs for time zones.
 
 use alloc::borrow::Cow;
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 use tinystr::TinyStr8;
 use zerovec::{ZeroMap, ZeroMap2d};
 

--- a/components/decimal/src/provider.rs
+++ b/components/decimal/src/provider.rs
@@ -17,7 +17,7 @@
 #![allow(clippy::exhaustive_enums)]
 
 use alloc::borrow::Cow;
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 
 /// A collection of strings to affix to a decimal number.
 ///

--- a/components/list/src/error.rs
+++ b/components/list/src/error.rs
@@ -4,7 +4,7 @@
 
 use core::fmt::Debug;
 use displaydoc::Display;
-use icu_provider::prelude::DataError;
+use icu_provider::DataError;
 
 #[cfg(feature = "std")]
 impl std::error::Error for ListError {}

--- a/components/list/src/provider/mod.rs
+++ b/components/list/src/provider/mod.rs
@@ -17,8 +17,8 @@
 
 use crate::ListLength;
 use alloc::borrow::Cow;
+use icu_provider::prelude::*;
 use icu_provider::DataMarker;
-use icu_provider::{yoke, zerofrom};
 
 mod serde_dfa;
 pub use serde_dfa::SerdeDFA;

--- a/components/list/src/provider/serde_dfa.rs
+++ b/components/list/src/provider/serde_dfa.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use alloc::borrow::Cow;
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 use regex_automata::dfa::sparse::DFA;
 
 /// A serde-compatible version of [regex_automata::dfa::sparse::DFA]. This does not implement

--- a/components/locid_transform/src/error.rs
+++ b/components/locid_transform/src/error.rs
@@ -4,7 +4,7 @@
 
 use core::fmt::Debug;
 use displaydoc::Display;
-use icu_provider::prelude::DataError;
+use icu_provider::DataError;
 
 #[cfg(feature = "std")]
 impl std::error::Error for LocaleTransformError {}

--- a/components/normalizer/src/error.rs
+++ b/components/normalizer/src/error.rs
@@ -6,7 +6,7 @@
 
 use displaydoc::Display;
 use icu_properties::PropertiesError;
-use icu_provider::prelude::DataError;
+use icu_provider::DataError;
 
 /// Normalizer-specific error
 #[derive(Display, Debug)]

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -88,7 +88,6 @@ use icu_collections::char16trie::TrieResult;
 use icu_collections::codepointtrie::CodePointTrie;
 use icu_properties::CanonicalCombiningClass;
 use icu_provider::prelude::*;
-use icu_provider::zerofrom::ZeroFrom;
 use provider::CanonicalCompositionsV1Marker;
 use provider::CanonicalDecompositionTablesV1Marker;
 use provider::CompatibilityDecompositionTablesV1Marker;
@@ -98,6 +97,7 @@ use smallvec::SmallVec;
 use utf16_iter::Utf16CharsEx;
 use utf8_iter::Utf8CharsEx;
 use write16::Write16;
+use zerofrom::ZeroFrom;
 use zerovec::ule::AsULE;
 use zerovec::ZeroSlice;
 

--- a/components/normalizer/src/provider.rs
+++ b/components/normalizer/src/provider.rs
@@ -17,7 +17,7 @@
 
 use icu_collections::char16trie::Char16Trie;
 use icu_collections::codepointtrie::CodePointTrie;
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 use zerovec::ZeroVec;
 
 /// Main data for NFD

--- a/components/plurals/src/error.rs
+++ b/components/plurals/src/error.rs
@@ -5,7 +5,7 @@
 #[cfg(feature = "experimental")]
 use crate::rules::reference::parser::ParserError;
 use displaydoc::Display;
-use icu_provider::prelude::DataError;
+use icu_provider::DataError;
 
 /// A list of error outcomes for various operations in the `icu_plurals` crate.
 ///

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -16,8 +16,8 @@
 //! Read more about data providers: [`icu_provider`]
 
 use crate::rules::runtime::ast::Rule;
+use icu_provider::prelude::*;
 use icu_provider::DataMarker;
-use icu_provider::{yoke, zerofrom};
 
 #[cfg(doc)]
 use crate::PluralCategory;

--- a/components/plurals/src/rules/runtime/ast.rs
+++ b/components/plurals/src/rules/runtime/ast.rs
@@ -8,7 +8,7 @@ use core::{
     fmt, num,
     str::FromStr,
 };
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 use zerovec::{
     ule::{tuple::Tuple2ULE, AsULE, ZeroVecError, ULE},
     {VarZeroVec, ZeroVec},

--- a/components/segmenter/src/error.rs
+++ b/components/segmenter/src/error.rs
@@ -4,7 +4,7 @@
 
 use core::fmt::Debug;
 use displaydoc::Display;
-use icu_provider::prelude::DataError;
+use icu_provider::DataError;
 
 #[cfg(feature = "std")]
 impl std::error::Error for SegmenterError {}

--- a/components/timezone/src/error.rs
+++ b/components/timezone/src/error.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use displaydoc::Display;
-use icu_provider::prelude::DataError;
+use icu_provider::DataError;
 
 #[cfg(feature = "std")]
 impl std::error::Error for TimeZoneError {}

--- a/components/timezone/src/provider.rs
+++ b/components/timezone/src/provider.rs
@@ -16,7 +16,7 @@
 //! Read more about data providers: [`icu_provider`]
 
 use core::str::FromStr;
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 use tinystr::TinyAsciiStr;
 use zerovec::ule::{AsULE, ULE};
 use zerovec::{ZeroMap2d, ZeroSlice, ZeroVec};

--- a/docs/tutorials/data_provider.md
+++ b/docs/tutorials/data_provider.md
@@ -20,7 +20,7 @@ Each component should use `DataProvider` only to construct the instance of each 
 
 ```rust
 use displaydoc::Display;
-use icu_provider::{DataPayload, DataProvider, DataRequest, DataError};
+use icu_provider::prelude::*;
 use icu::locid::Locale;
 use icu::decimal::provider::{DecimalSymbolsV1Marker, DecimalSymbolsV1};
 

--- a/docs/tutorials/writing_a_new_data_struct.md
+++ b/docs/tutorials/writing_a_new_data_struct.md
@@ -138,7 +138,7 @@ The following example shows all the pieces that make up the data pipeline for `D
 
 ```rust
 use std::borrow::Cow;
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 use icu::decimal::provider::{ AffixesV1, GroupingSizesV1 };
 
 /// Symbols and metadata required for formatting a [`FixedDecimal`](crate::FixedDecimal).

--- a/experimental/casemapping/src/exceptions.rs
+++ b/experimental/casemapping/src/exceptions.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 use zerovec::{VarZeroVec, ZeroVec};
 
 use crate::error::Error;

--- a/experimental/casemapping/src/internals.rs
+++ b/experimental/casemapping/src/internals.rs
@@ -9,7 +9,7 @@ use icu_collections::codepointinvlist::CodePointInversionListBuilder;
 use icu_collections::codepointtrie::CodePointTrieHeader;
 use icu_collections::codepointtrie::{CodePointTrie, TrieValue};
 use icu_locid::Locale;
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 #[cfg(feature = "datagen")]
 use std::collections::HashMap;
 use zerovec::ule::{AsULE, RawBytesULE};

--- a/experimental/casemapping/src/provider.rs
+++ b/experimental/casemapping/src/provider.rs
@@ -6,7 +6,7 @@
 //!
 //! Read more about data providers: [`icu_provider`]
 
-use icu_provider::{yoke, zerofrom};
+use icu_provider::prelude::*;
 
 pub use crate::exceptions::CaseMappingExceptions;
 pub use crate::internals::CaseMappingData;

--- a/experimental/compactdecimal/src/compactdecimal.rs
+++ b/experimental/compactdecimal/src/compactdecimal.rs
@@ -10,7 +10,7 @@ use icu_decimal::{
     FixedDecimalFormatter,
 };
 use icu_plurals::PluralRules;
-use icu_provider::{DataLocale, DataPayload, DataProvider, DataRequest};
+use icu_provider::prelude::*;
 use zerovec::maps::ZeroMap2dCursor;
 
 use crate::{

--- a/experimental/compactdecimal/src/provider.rs
+++ b/experimental/compactdecimal/src/provider.rs
@@ -13,7 +13,7 @@
 
 use alloc::borrow::Cow;
 use icu_plurals::PluralCategory;
-use icu_provider::{yoke, zerofrom, DataMarker};
+use icu_provider::prelude::*;
 use zerovec::ZeroMap2d;
 
 /// Relative time format V1 data struct.

--- a/experimental/displaynames/src/displaynames.rs
+++ b/experimental/displaynames/src/displaynames.rs
@@ -9,7 +9,6 @@ use crate::provider::*;
 use alloc::borrow::Cow;
 use icu_locid::{subtags::Language, subtags::Region, subtags::Script, Locale};
 use icu_provider::prelude::*;
-use icu_provider::{DataError, DataPayload};
 
 /// Lookup of the locale-specific display names by region code.
 ///

--- a/experimental/relativetime/src/provider.rs
+++ b/experimental/relativetime/src/provider.rs
@@ -10,7 +10,7 @@
 //! Read more about data providers: [`icu_provider`]
 
 use alloc::borrow::Cow;
-use icu_provider::{yoke, zerofrom, DataError, DataMarker};
+use icu_provider::prelude::*;
 use zerovec::ZeroMap;
 
 /// Relative time format V1 data struct.

--- a/experimental/relativetime/src/relativetime.rs
+++ b/experimental/relativetime/src/relativetime.rs
@@ -7,7 +7,7 @@ use icu_decimal::{
     options::FixedDecimalFormatterOptions, provider::DecimalSymbolsV1Marker, FixedDecimalFormatter,
 };
 use icu_plurals::{provider::CardinalV1Marker, PluralRules};
-use icu_provider::{DataLocale, DataPayload, DataProvider, DataRequest};
+use icu_provider::prelude::*;
 
 use crate::format::FormattedRelativeTime;
 use crate::provider::*;

--- a/ffi/diplomat/src/data_struct.rs
+++ b/ffi/diplomat/src/data_struct.rs
@@ -11,7 +11,7 @@ pub mod ffi {
     #[cfg(feature = "icu_decimal")]
     use crate::errors::ffi::ICU4XError;
     use alloc::boxed::Box;
-    use icu_provider::prelude::AnyPayload;
+    use icu_provider::AnyPayload;
 
     #[diplomat::opaque]
     /// A generic data struct to be used by ICU4X
@@ -42,7 +42,7 @@ pub mod ffi {
             use icu_decimal::provider::{
                 AffixesV1, DecimalSymbolsV1, DecimalSymbolsV1Marker, GroupingSizesV1,
             };
-            use icu_provider::prelude::DataPayload;
+            use icu_provider::DataPayload;
             let digits = if digits.len() == 10 {
                 let mut new_digits = ['\0'; 10];
                 new_digits.copy_from_slice(digits);

--- a/ffi/diplomat/src/data_struct.rs
+++ b/ffi/diplomat/src/data_struct.rs
@@ -11,7 +11,7 @@ pub mod ffi {
     #[cfg(feature = "icu_decimal")]
     use crate::errors::ffi::ICU4XError;
     use alloc::boxed::Box;
-    use icu_provider::prelude::*;
+    use icu_provider::{AnyPayload, DataPayload};
 
     #[diplomat::opaque]
     /// A generic data struct to be used by ICU4X

--- a/ffi/diplomat/src/data_struct.rs
+++ b/ffi/diplomat/src/data_struct.rs
@@ -11,7 +11,7 @@ pub mod ffi {
     #[cfg(feature = "icu_decimal")]
     use crate::errors::ffi::ICU4XError;
     use alloc::boxed::Box;
-    use icu_provider::AnyPayload;
+    use icu_provider::prelude::*;
 
     #[diplomat::opaque]
     /// A generic data struct to be used by ICU4X
@@ -42,7 +42,6 @@ pub mod ffi {
             use icu_decimal::provider::{
                 AffixesV1, DecimalSymbolsV1, DecimalSymbolsV1Marker, GroupingSizesV1,
             };
-            use icu_provider::DataPayload;
             let digits = if digits.len() == 10 {
                 let mut new_digits = ['\0'; 10];
                 new_digits.copy_from_slice(digits);

--- a/ffi/diplomat/src/decimal.rs
+++ b/ffi/diplomat/src/decimal.rs
@@ -54,7 +54,7 @@ pub mod ffi {
             data_struct: &ICU4XDataStruct,
             grouping_strategy: ICU4XFixedDecimalGroupingStrategy,
         ) -> Result<Box<ICU4XFixedDecimalFormatter>, ICU4XError> {
-            use icu_provider::prelude::AsDowncastingAnyProvider;
+            use icu_provider::AsDowncastingAnyProvider;
             let provider = AnyPayloadProvider::from_any_payload::<DecimalSymbolsV1Marker>(
                 // Note: This clone is free, since cloning AnyPayload is free.
                 data_struct.0.clone(),

--- a/ffi/diplomat/src/locale.rs
+++ b/ffi/diplomat/src/locale.rs
@@ -206,7 +206,7 @@ pub mod ffi {
 }
 
 impl ffi::ICU4XLocale {
-    pub fn to_datalocale(&self) -> icu_provider::prelude::DataLocale {
+    pub fn to_datalocale(&self) -> icu_provider::DataLocale {
         (&self.0).into()
     }
 }

--- a/ffi/diplomat/src/properties_names.rs
+++ b/ffi/diplomat/src/properties_names.rs
@@ -7,7 +7,7 @@ pub mod ffi {
     use crate::provider::ffi::ICU4XDataProvider;
     use alloc::boxed::Box;
     use icu_properties::{names::PropertyValueNameToEnumMapper, provider, GeneralCategoryGroup};
-    use icu_provider::prelude::*;
+    use icu_provider::prelude::{DataProvider, DataResponse, KeyedDataMarker};
 
     use crate::errors::ffi::ICU4XError;
 

--- a/ffi/diplomat/src/properties_names.rs
+++ b/ffi/diplomat/src/properties_names.rs
@@ -7,7 +7,7 @@ pub mod ffi {
     use crate::provider::ffi::ICU4XDataProvider;
     use alloc::boxed::Box;
     use icu_properties::{names::PropertyValueNameToEnumMapper, provider, GeneralCategoryGroup};
-    use icu_provider::prelude::{DataProvider, DataResponse, KeyedDataMarker};
+    use icu_provider::prelude::*;
 
     use crate::errors::ffi::ICU4XError;
 

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -53,8 +53,6 @@ mod test {
     use super::*;
     use crate::hello_world::*;
     use crate::prelude::*;
-    use crate::yoke::Yokeable;
-    use crate::zerofrom;
     use alloc::borrow::Cow;
     use alloc::string::String;
     use core::fmt::Debug;
@@ -68,7 +66,7 @@ mod test {
 
     /// A data struct serialization-compatible with HelloWorldV1 used for testing mismatched types
     #[derive(
-        Serialize, Deserialize, Debug, Clone, Default, PartialEq, Yokeable, zerofrom::ZeroFrom,
+        Serialize, Deserialize, Debug, Clone, Default, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom,
     )]
     struct HelloAlt {
         #[zerofrom(clone)]

--- a/provider/core/src/datagen/payload.rs
+++ b/provider/core/src/datagen/payload.rs
@@ -4,9 +4,9 @@
 
 use crate::dynutil::UpcastDataPayload;
 use crate::prelude::*;
-use crate::yoke::*;
 use alloc::boxed::Box;
 use databake::{Bake, CrateEnv, TokenStream};
+use yoke::*;
 
 trait ExportableYoke {
     fn bake_yoke(&self, env: &CrateEnv) -> TokenStream;

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -9,12 +9,12 @@
 #[cfg(feature = "datagen")]
 use crate::datagen::IterableDataProvider;
 use crate::prelude::*;
-use crate::yoke::{self, *};
-use crate::zerofrom::{self, *};
 use alloc::borrow::Cow;
 use alloc::string::String;
 use core::fmt::Debug;
 use writeable::Writeable;
+use yoke::*;
+use zerofrom::*;
 
 /// A struct containing "Hello World" in the requested language.
 #[derive(Debug, PartialEq, Clone, Yokeable, ZeroFrom)]

--- a/provider/core/src/key.rs
+++ b/provider/core/src/key.rs
@@ -213,7 +213,7 @@ impl Default for DataKeyMetadata {
 /// `DataKey`s are created with the [`data_key!`](crate::data_key) macro:
 ///
 /// ```
-/// # use icu_provider::prelude::DataKey;
+/// # use icu_provider::DataKey;
 /// const K: DataKey = icu_provider::data_key!("foo/bar@1");
 /// ```
 ///
@@ -223,7 +223,7 @@ impl Default for DataKeyMetadata {
 /// Invalid paths are compile-time errors (as [`data_key!`](crate::data_key) uses `const`).
 ///
 /// ```compile_fail,E0080
-/// # use icu_provider::prelude::DataKey;
+/// # use icu_provider::DataKey;
 /// const K: DataKey = icu_provider::data_key!("foo/../bar@1");
 /// ```
 #[derive(Copy, Clone)]

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -137,76 +137,120 @@
 
 extern crate alloc;
 
+mod data_provider;
+mod error;
+mod helpers;
+mod key;
+mod request;
+mod response;
+
 pub mod any;
 pub mod buf;
 pub mod constructors;
-mod data_provider;
 #[cfg(feature = "datagen")]
 #[macro_use]
 pub mod datagen;
 #[macro_use]
 pub mod dynutil;
-mod error;
 pub mod hello_world;
-mod helpers;
 #[macro_use]
-mod key;
 pub mod marker;
-mod request;
-mod response;
 #[cfg(feature = "serde")]
 pub mod serde;
 
+// Types from private modules
+pub use crate::data_provider::DataProvider;
+pub use crate::data_provider::DynamicDataProvider;
+pub use crate::error::DataError;
+pub use crate::error::DataErrorKind;
+pub use crate::key::DataKey;
+pub use crate::key::DataKeyHash;
+pub use crate::key::DataKeyMetadata;
+pub use crate::key::DataKeyPath;
+pub use crate::key::FallbackPriority;
+pub use crate::key::FallbackSupplement;
+pub use crate::request::DataLocale;
+pub use crate::request::DataRequest;
+pub use crate::request::DataRequestMetadata;
+pub use crate::response::Cart;
+pub use crate::response::DataPayload;
+pub use crate::response::DataResponse;
+pub use crate::response::DataResponseMetadata;
 #[cfg(feature = "macros")]
 pub use icu_provider_macros::data_struct;
 
+// Reexports from public modules
+pub use crate::any::AnyMarker;
+pub use crate::any::AnyPayload;
+pub use crate::any::AnyProvider;
+pub use crate::any::AnyResponse;
+pub use crate::any::AsDowncastingAnyProvider;
+pub use crate::any::AsDynamicDataProviderAnyMarkerWrap;
+pub use crate::any::MaybeSendSync;
+pub use crate::buf::BufferMarker;
+pub use crate::buf::BufferProvider;
+pub use crate::marker::DataMarker;
+pub use crate::marker::KeyedDataMarker;
+#[cfg(feature = "serde")]
+pub use crate::serde::AsDeserializingBufferProvider;
+
+/// Core selection of APIs and structures for the ICU4X data provider.
 pub mod prelude {
-    //! Core selection of APIs and structures for the ICU4X data provider.
-    pub use crate::any::AnyMarker;
-    pub use crate::any::AnyPayload;
-    pub use crate::any::AnyProvider;
-    pub use crate::any::AnyResponse;
-    pub use crate::buf::BufferMarker;
-    pub use crate::buf::BufferProvider;
+    #[doc(no_inline)]
     pub use crate::data_key;
-    pub use crate::data_provider::DataProvider;
-    pub use crate::data_provider::DynamicDataProvider;
-    pub use crate::error::DataError;
-    pub use crate::error::DataErrorKind;
-    pub use crate::key::DataKey;
-    pub use crate::key::DataKeyHash;
-    pub use crate::marker::DataMarker;
-    pub use crate::marker::KeyedDataMarker;
-    pub use crate::request::DataLocale;
-    pub use crate::request::DataRequest;
-    pub use crate::request::DataRequestMetadata;
-    pub use crate::response::DataPayload;
-    pub use crate::response::DataResponse;
-    pub use crate::response::DataResponseMetadata;
-
-    pub use crate::any::AsDowncastingAnyProvider;
-    pub use crate::any::AsDynamicDataProviderAnyMarkerWrap;
+    #[doc(no_inline)]
+    pub use crate::AnyMarker;
+    #[doc(no_inline)]
+    pub use crate::AnyPayload;
+    #[doc(no_inline)]
+    pub use crate::AnyProvider;
+    #[doc(no_inline)]
+    pub use crate::AnyResponse;
+    #[doc(no_inline)]
     #[cfg(feature = "serde")]
-    pub use crate::serde::AsDeserializingBufferProvider;
+    pub use crate::AsDeserializingBufferProvider;
+    #[doc(no_inline)]
+    pub use crate::AsDowncastingAnyProvider;
+    #[doc(no_inline)]
+    pub use crate::AsDynamicDataProviderAnyMarkerWrap;
+    #[doc(no_inline)]
+    pub use crate::BufferMarker;
+    #[doc(no_inline)]
+    pub use crate::BufferProvider;
+    #[doc(no_inline)]
+    pub use crate::DataError;
+    #[doc(no_inline)]
+    pub use crate::DataErrorKind;
+    #[doc(no_inline)]
+    pub use crate::DataKey;
+    #[doc(no_inline)]
+    pub use crate::DataKeyHash;
+    #[doc(no_inline)]
+    pub use crate::DataLocale;
+    #[doc(no_inline)]
+    pub use crate::DataMarker;
+    #[doc(no_inline)]
+    pub use crate::DataPayload;
+    #[doc(no_inline)]
+    pub use crate::DataProvider;
+    #[doc(no_inline)]
+    pub use crate::DataRequest;
+    #[doc(no_inline)]
+    pub use crate::DataRequestMetadata;
+    #[doc(no_inline)]
+    pub use crate::DataResponse;
+    #[doc(no_inline)]
+    pub use crate::DataResponseMetadata;
+    #[doc(no_inline)]
+    pub use crate::DynamicDataProvider;
+    #[doc(no_inline)]
+    pub use crate::KeyedDataMarker;
 
-    /// Re-export of the yoke and zerofrom crates for convenience of downstream implementors.
     #[doc(hidden)]
     pub use yoke;
     #[doc(hidden)]
     pub use zerofrom;
 }
-
-// Also include the same symbols at the top level for selective inclusion
-pub use prelude::*;
-
-// Less important non-prelude items
-pub use crate::any::MaybeSendSync;
-pub use crate::key::DataKeyMetadata;
-pub use crate::key::DataKeyPath;
-pub use crate::key::FallbackPriority;
-pub use crate::key::FallbackSupplement;
-pub use crate::request::DataRequestMetadata;
-pub use crate::response::Cart;
 
 // For macros
 #[doc(hidden)]

--- a/provider/core/src/marker.rs
+++ b/provider/core/src/marker.rs
@@ -5,7 +5,7 @@
 //! Marker types and traits for DataProvider.
 
 use crate::key::DataKey;
-use crate::yoke::Yokeable;
+use yoke::Yokeable;
 
 /// Trait marker for data structs. All types delivered by the data provider must be associated with
 /// something implementing this trait.
@@ -32,12 +32,10 @@ use crate::yoke::Yokeable;
 ///
 /// ```
 /// use icu_provider::prelude::*;
-/// use icu_provider::yoke::*;
-/// use icu_provider::zerofrom::*;
 /// use std::borrow::Cow;
 /// use std::rc::Rc;
 ///
-/// #[derive(Yokeable, ZeroFrom)]
+/// #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
 /// struct MyDataStruct<'data> {
 ///     message: Cow<'data, str>,
 /// }

--- a/provider/core/src/response.rs
+++ b/provider/core/src/response.rs
@@ -6,13 +6,13 @@ use crate::buf::BufferMarker;
 use crate::error::{DataError, DataErrorKind};
 use crate::marker::DataMarker;
 use crate::request::DataLocale;
-use crate::yoke::trait_hack::YokeTraitHack;
-use crate::yoke::*;
 use alloc::boxed::Box;
 use core::convert::TryFrom;
 use core::fmt::Debug;
 use core::marker::PhantomData;
 use core::ops::Deref;
+use yoke::trait_hack::YokeTraitHack;
+use yoke::*;
 
 #[cfg(not(feature = "sync"))]
 use alloc::rc::Rc as SelectedRc;

--- a/provider/datagen/README.md
+++ b/provider/datagen/README.md
@@ -29,7 +29,7 @@ fn main() {
 
 ### Command line
 
-The command line interface can be installed with the `bin` Cargo feature.
+The command line interface can be installed through Cargo.
 
 ```bash
 $ cargo install icu4x-datagen

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -105,11 +105,13 @@ pub mod syntax {
 
 /// A prelude for using the datagen API
 pub mod prelude {
-    pub use super::{
-        syntax, BakedOptions, CldrLocaleSubset, CollationHanDatabase, CoverageLevel, Out,
-        SourceData,
-    };
+    #[doc(hidden)]
+    pub use crate::CldrLocaleSubset;
+    #[doc(no_inline)]
+    pub use crate::{syntax, BakedOptions, CollationHanDatabase, CoverageLevel, Out, SourceData};
+    #[doc(no_inline)]
     pub use icu_locid::{langid, LanguageIdentifier};
+    #[doc(no_inline)]
     pub use icu_provider::KeyedDataMarker;
 }
 

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -98,8 +98,11 @@ impl CldrLocaleSubset {
 
 /// [Out::Fs] serialization formats.
 pub mod syntax {
+    #[doc(no_inline)]
     pub use icu_provider_fs::export::serializers::bincode::Serializer as Bincode;
+    #[doc(no_inline)]
     pub use icu_provider_fs::export::serializers::json::Serializer as Json;
+    #[doc(no_inline)]
     pub use icu_provider_fs::export::serializers::postcard::Serializer as Postcard;
 }
 

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -32,7 +32,7 @@
 //!
 //! ## Command line
 //!
-//! The command line interface can be installed with the `bin` Cargo feature.
+//! The command line interface can be installed through Cargo.
 //!
 //! ```bash
 //! $ cargo install icu4x-datagen

--- a/provider/datagen/src/transform/cldr/decimal/compact.rs
+++ b/provider/datagen/src/transform/cldr/decimal/compact.rs
@@ -132,7 +132,6 @@ impl IterableDataProvider<LongCompactDecimalFormatDataV1Marker> for crate::Datag
 mod tests {
     use super::*;
     use icu_locid::locale;
-    use icu_provider::prelude::*;
     use std::borrow::Cow;
     use zerofrom::ZeroFrom;
     use zerovec::ule::AsULE;

--- a/provider/datagen/src/transform/cldr/decimal/compact.rs
+++ b/provider/datagen/src/transform/cldr/decimal/compact.rs
@@ -132,7 +132,7 @@ impl IterableDataProvider<LongCompactDecimalFormatDataV1Marker> for crate::Datag
 mod tests {
     use super::*;
     use icu_locid::locale;
-    use icu_provider::zerofrom::ZeroFrom;
+    use icu_provider::prelude::zerofrom::ZeroFrom;
     use std::borrow::Cow;
     use zerovec::ule::AsULE;
 

--- a/provider/datagen/src/transform/cldr/decimal/compact.rs
+++ b/provider/datagen/src/transform/cldr/decimal/compact.rs
@@ -132,8 +132,9 @@ impl IterableDataProvider<LongCompactDecimalFormatDataV1Marker> for crate::Datag
 mod tests {
     use super::*;
     use icu_locid::locale;
-    use icu_provider::prelude::zerofrom::ZeroFrom;
+    use icu_provider::prelude::*;
     use std::borrow::Cow;
+    use zerofrom::ZeroFrom;
     use zerovec::ule::AsULE;
 
     #[test]

--- a/provider/datagen/src/transform/cldr/decimal/compact_decimal_pattern.rs
+++ b/provider/datagen/src/transform/cldr/decimal/compact_decimal_pattern.rs
@@ -371,7 +371,7 @@ impl TryFrom<&DecimalFormat> for CompactDecimalPatternDataV1<'static> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icu_provider::zerofrom::ZeroFrom;
+    use icu_provider::prelude::zerofrom::ZeroFrom;
     use zerovec::ule::AsULE;
 
     #[test]

--- a/provider/datagen/src/transform/cldr/decimal/compact_decimal_pattern.rs
+++ b/provider/datagen/src/transform/cldr/decimal/compact_decimal_pattern.rs
@@ -371,7 +371,8 @@ impl TryFrom<&DecimalFormat> for CompactDecimalPatternDataV1<'static> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icu_provider::prelude::zerofrom::ZeroFrom;
+    use icu_provider::prelude::*;
+    use zerofrom::ZeroFrom;
     use zerovec::ule::AsULE;
 
     #[test]

--- a/provider/macros/src/lib.rs
+++ b/provider/macros/src/lib.rs
@@ -260,7 +260,7 @@ fn data_struct_impl(attr: AttributeArgs, input: DeriveInput) -> TokenStream2 {
     }
 
     result.extend(quote!(
-        #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
+        #[derive(icu_provider::prelude::yoke::Yokeable, icu_provider::prelude::zerofrom::ZeroFrom)]
         #input
     ));
 

--- a/provider/macros/src/tests.rs
+++ b/provider/macros/src/tests.rs
@@ -27,7 +27,9 @@ fn test_basic() {
             pub struct FooV1;
         ),
         quote!(
-            #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
+            #[derive(
+                icu_provider::prelude::yoke::Yokeable, icu_provider::prelude::zerofrom::ZeroFrom,
+            )]
             pub struct FooV1;
         ),
     );
@@ -47,7 +49,7 @@ fn test_data_marker() {
             impl icu_provider::DataMarker for FooV1Marker {
                 type Yokeable = FooV1;
             }
-            #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
+            #[derive(icu_provider::prelude::yoke::Yokeable, icu_provider::prelude::zerofrom::ZeroFrom)]
             pub struct FooV1;
         ),
     );
@@ -76,7 +78,7 @@ fn test_keyed_data_marker() {
                         None
                     ));
             }
-            #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
+            #[derive(icu_provider::prelude::yoke::Yokeable, icu_provider::prelude::zerofrom::ZeroFrom)]
             pub struct FooV1;
         ),
     );
@@ -128,7 +130,7 @@ fn test_multi_named_keyed_data_marker() {
                         None
                     ));
             }
-            #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
+            #[derive(icu_provider::prelude::yoke::Yokeable, icu_provider::prelude::zerofrom::ZeroFrom)]
             pub struct FooV1<'data>;
         ),
     );
@@ -159,7 +161,7 @@ fn test_databake() {
                         None
                     ));
             }
-            #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
+            #[derive(icu_provider::prelude::yoke::Yokeable, icu_provider::prelude::zerofrom::ZeroFrom)]
             #[databake(path = test::path)]
             pub struct FooV1;
         ),
@@ -203,7 +205,7 @@ fn test_attributes() {
                         Some(icu_provider::FallbackSupplement::Collation)
                     ));
             }
-            #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
+            #[derive(icu_provider::prelude::yoke::Yokeable, icu_provider::prelude::zerofrom::ZeroFrom)]
             pub struct FooV1<'data>;
         ),
     );

--- a/provider/macros/src/tests.rs
+++ b/provider/macros/src/tests.rs
@@ -19,6 +19,7 @@ fn check(attr: Vec<TokenStream2>, item: TokenStream2, expected: TokenStream2) {
 }
 
 #[test]
+#[rustfmt::skip] // inserts a comma
 fn test_basic() {
     // #[data_struct]
     check(
@@ -27,9 +28,7 @@ fn test_basic() {
             pub struct FooV1;
         ),
         quote!(
-            #[derive(
-                icu_provider::prelude::yoke::Yokeable, icu_provider::prelude::zerofrom::ZeroFrom,
-            )]
+            #[derive(icu_provider::prelude::yoke::Yokeable, icu_provider::prelude::zerofrom::ZeroFrom)]
             pub struct FooV1;
         ),
     );


### PR DESCRIPTION
`icu_provider` docs are a bit messy right now. The canonical location for types from private modules is in `icu_provider::prelude`, while those from public modules are documented in their modules. Also the `use prelude::*` reexport is not expanded in documentation, so items like `icu_provider::DataKey` are not documented at the root.

This PR updates `icu_provider::prelude` and `icu_datagen::prelude` to contain only re-exports marked with `#[doc(no_inline)]`, placing the canonical documentation at the non-prelude locations.

[Before](https://unicode-org.github.io/icu4x/docs/icu_provider/index.html#reexports)
[After](http://icu4x-pr-artifacts.storage.googleapis.com/gha/b32190561caee200d181a6fe8efa75f9b50e2586/docs/icu_provider/index.html#reexports)

#3297 