### PR TITLE
Remove tinystr old-version benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,7 +1577,7 @@ dependencies = [
  "icu_testdata",
  "serde",
  "serde_json",
- "tinystr 0.7.1",
+ "tinystr",
  "writeable",
  "zerovec",
 ]
@@ -1611,7 +1611,7 @@ dependencies = [
  "log",
  "serde",
  "simple_logger",
- "tinystr 0.7.1",
+ "tinystr",
  "unicode-bidi",
  "writeable",
 ]
@@ -1769,7 +1769,7 @@ dependencies = [
  "serde_json",
  "simple_logger",
  "syn 1.0.109",
- "tinystr 0.7.1",
+ "tinystr",
  "toml",
  "writeable",
  "zerovec",
@@ -1800,7 +1800,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "tinystr 0.7.1",
+ "tinystr",
  "writeable",
  "zerovec",
 ]
@@ -1841,7 +1841,7 @@ dependencies = [
  "icu_provider",
  "icu_testdata",
  "serde",
- "tinystr 0.7.1",
+ "tinystr",
  "zerovec",
 ]
 
@@ -1877,7 +1877,7 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "icu_testdata",
- "tinystr 0.7.1",
+ "tinystr",
 ]
 
 [[package]]
@@ -1912,7 +1912,7 @@ dependencies = [
  "postcard",
  "serde",
  "serde_json",
- "tinystr 0.7.1",
+ "tinystr",
  "writeable",
  "zerovec",
 ]
@@ -1930,7 +1930,7 @@ dependencies = [
  "icu_testdata",
  "serde",
  "serde_json",
- "tinystr 0.7.1",
+ "tinystr",
  "writeable",
  "zerovec",
 ]
@@ -1996,7 +1996,7 @@ dependencies = [
  "icu_provider",
  "icu_testdata",
  "serde",
- "tinystr 0.7.1",
+ "tinystr",
  "unicode-bidi",
  "zerovec",
 ]
@@ -2033,7 +2033,7 @@ dependencies = [
  "icu_provider_fs",
  "icu_testdata",
  "serde",
- "tinystr 0.7.1",
+ "tinystr",
  "writeable",
  "yoke",
  "zerovec",
@@ -2183,7 +2183,7 @@ dependencies = [
  "icu_provider",
  "icu_testdata",
  "serde",
- "tinystr 0.7.1",
+ "tinystr",
  "zerovec",
 ]
 
@@ -3776,17 +3776,6 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954af207a9e273b644c2c0d29d79d7cba9c22a66e633535d0d0d3712d7e50563"
-dependencies = [
- "serde",
- "tinystr-macros",
- "tinystr-raw",
-]
-
-[[package]]
-name = "tinystr"
 version = "0.7.1"
 dependencies = [
  "bincode",
@@ -3797,24 +3786,8 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "tinystr 0.4.12",
  "zerovec",
 ]
-
-[[package]]
-name = "tinystr-macros"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f65be51117c325c2b58eec529be7a0857d11527a9029973b58810a4c63e77a6"
-dependencies = [
- "tinystr-raw",
-]
-
-[[package]]
-name = "tinystr-raw"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f87ef8b0485e4efff5cac95608adc3251e412fef6039ecd56c5618c8003895"
 
 [[package]]
 name = "tinytemplate"
@@ -3953,7 +3926,7 @@ dependencies = [
  "lru",
  "serde",
  "serde-aux",
- "tinystr 0.7.1",
+ "tinystr",
  "writeable",
  "yoke",
  "zerofrom",

--- a/utils/tinystr/Cargo.toml
+++ b/utils/tinystr/Cargo.toml
@@ -41,7 +41,6 @@ criterion = "0.4"
 postcard = { version = "1.0.0", features = ["use-std"], default-features = false }
 rand = { version = "0.8.5", features = ["small_rng"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-tinystr_old = { version = "0.4", package = "tinystr", features = ["serde"] }
 
 [features]
 default = ["alloc"]

--- a/utils/tinystr/benches/common/mod.rs
+++ b/utils/tinystr/benches/common/mod.rs
@@ -37,43 +37,19 @@ macro_rules! bench_block {
         let mut group4 = $c.benchmark_group(&format!("{}/4", $name));
         group4.bench_function("String", $action!(String, STRINGS_4));
         group4.bench_function("TinyAsciiStr<4>", $action!(TinyAsciiStr<4>, STRINGS_4));
-        group4.bench_function(
-            "tinystr_old::TinyStr4",
-            $action!(tinystr_old::TinyStr4, STRINGS_4),
-        );
         group4.bench_function("TinyAsciiStr<8>", $action!(TinyAsciiStr<8>, STRINGS_4));
-        group4.bench_function(
-            "tinystr_old::TinyStr8",
-            $action!(tinystr_old::TinyStr8, STRINGS_4),
-        );
         group4.bench_function("TinyAsciiStr<16>", $action!(TinyAsciiStr<16>, STRINGS_4));
-        group4.bench_function(
-            "tinystr_old::TinyStr16",
-            $action!(tinystr_old::TinyStr16, STRINGS_4),
-        );
         group4.finish();
 
         let mut group8 = $c.benchmark_group(&format!("{}/8", $name));
         group8.bench_function("String", $action!(String, STRINGS_8));
         group8.bench_function("TinyAsciiStr<8>", $action!(TinyAsciiStr<8>, STRINGS_8));
         group8.bench_function("TinyAsciiStr<16>", $action!(TinyAsciiStr<16>, STRINGS_8));
-        group8.bench_function(
-            "tinystr_old::TinyStr8",
-            $action!(tinystr_old::TinyStr8, STRINGS_8),
-        );
-        group8.bench_function(
-            "tinystr_old::TinyStr16",
-            $action!(tinystr_old::TinyStr16, STRINGS_8),
-        );
         group8.finish();
 
         let mut group16 = $c.benchmark_group(&format!("{}/16", $name));
         group16.bench_function("String", $action!(String, STRINGS_16));
         group16.bench_function("TinyAsciiStr<16>", $action!(TinyAsciiStr<16>, STRINGS_16));
-        group16.bench_function(
-            "tinystr_old::TinyStr16",
-            $action!(tinystr_old::TinyStr16, STRINGS_16),
-        );
         group16.finish();
     };
 }

--- a/utils/tinystr/benches/construct.rs
+++ b/utils/tinystr/benches/construct.rs
@@ -47,41 +47,17 @@ fn construct_from_bytes(c: &mut Criterion) {
 
     let mut group4 = c.benchmark_group("construct_from_bytes/4");
     group4.bench_function("TinyAsciiStr<4>", cfu!(TinyAsciiStr<4>, STRINGS_4));
-    group4.bench_function(
-        "tinystr_old::TinyStr4",
-        cfu!(tinystr_old::TinyStr4, STRINGS_4),
-    );
     group4.bench_function("TinyAsciiStr<8>", cfu!(TinyAsciiStr<8>, STRINGS_4));
-    group4.bench_function(
-        "tinystr_old::TinyStr8",
-        cfu!(tinystr_old::TinyStr8, STRINGS_4),
-    );
     group4.bench_function("TinyAsciiStr<16>", cfu!(TinyAsciiStr<16>, STRINGS_4));
-    group4.bench_function(
-        "tinystr_old::TinyStr16",
-        cfu!(tinystr_old::TinyStr16, STRINGS_4),
-    );
     group4.finish();
 
     let mut group8 = c.benchmark_group("construct_from_bytes/8");
     group8.bench_function("TinyAsciiStr<8>", cfu!(TinyAsciiStr<8>, STRINGS_8));
-    group8.bench_function(
-        "tinystr_old::TinyStr8",
-        cfu!(tinystr_old::TinyStr8, STRINGS_8),
-    );
     group8.bench_function("TinyAsciiStr<16>", cfu!(TinyAsciiStr<16>, STRINGS_8));
-    group8.bench_function(
-        "tinystr_old::TinyStr16",
-        cfu!(tinystr_old::TinyStr16, STRINGS_8),
-    );
     group8.finish();
 
     let mut group16 = c.benchmark_group("construct_from_bytes/16");
     group16.bench_function("TinyAsciiStr<16>", cfu!(TinyAsciiStr<16>, STRINGS_16));
-    group16.bench_function(
-        "tinystr_old::TinyStr16",
-        cfu!(tinystr_old::TinyStr16, STRINGS_16),
-    );
     group16.finish();
 }
 

--- a/utils/tinystr/benches/overview.rs
+++ b/utils/tinystr/benches/overview.rs
@@ -11,9 +11,6 @@ use criterion::criterion_main;
 use criterion::Criterion;
 
 use tinystr::TinyAsciiStr;
-use tinystr_old::TinyStr16;
-use tinystr_old::TinyStr4;
-use tinystr_old::TinyStr8;
 
 fn overview(c: &mut Criterion) {
     let mut g = c.benchmark_group("overview");
@@ -35,22 +32,6 @@ fn overview(c: &mut Criterion) {
         });
     });
 
-    g.bench_function("construct/TinyStr", |b| {
-        b.iter(|| {
-            for s in STRINGS_4 {
-                let _: TinyStr4 = black_box(s).parse().unwrap();
-                let _: TinyStr8 = black_box(s).parse().unwrap();
-                let _: TinyStr16 = black_box(s).parse().unwrap();
-            }
-            for s in STRINGS_8 {
-                let _: TinyStr8 = black_box(s).parse().unwrap();
-                let _: TinyStr16 = black_box(s).parse().unwrap();
-            }
-            for s in STRINGS_16 {
-                let _: TinyStr16 = black_box(s).parse().unwrap();
-            }
-        });
-    });
 
     let parsed_ascii_4: Vec<TinyAsciiStr<4>> = STRINGS_4
         .iter()
@@ -68,21 +49,6 @@ fn overview(c: &mut Criterion) {
         .map(|s| s.parse::<TinyAsciiStr<16>>().unwrap())
         .collect();
 
-    let parsed_tiny_4: Vec<TinyStr4> = STRINGS_4
-        .iter()
-        .map(|s| s.parse::<TinyStr4>().unwrap())
-        .collect();
-    let parsed_tiny_8: Vec<TinyStr8> = STRINGS_4
-        .iter()
-        .chain(STRINGS_8)
-        .map(|s| s.parse::<TinyStr8>().unwrap())
-        .collect();
-    let parsed_tiny_16: Vec<TinyStr16> = STRINGS_4
-        .iter()
-        .chain(STRINGS_8)
-        .chain(STRINGS_16)
-        .map(|s| s.parse::<TinyStr16>().unwrap())
-        .collect();
 
     g.bench_function("read/TinyAsciiStr", |b| {
         b.iter(|| {
@@ -103,24 +69,6 @@ fn overview(c: &mut Criterion) {
         });
     });
 
-    g.bench_function("read/TinyStr", |b| {
-        b.iter(|| {
-            let mut collector: usize = 0;
-            for t in black_box(&parsed_tiny_4) {
-                let s: &str = t;
-                collector += s.bytes().map(usize::from).sum::<usize>();
-            }
-            for t in black_box(&parsed_tiny_8) {
-                let s: &str = t;
-                collector += s.bytes().map(usize::from).sum::<usize>();
-            }
-            for t in black_box(&parsed_tiny_16) {
-                let s: &str = t;
-                collector += s.bytes().map(usize::from).sum::<usize>();
-            }
-            collector
-        });
-    });
 
     g.bench_function("compare/TinyAsciiStr", |b| {
         b.iter(|| {
@@ -141,24 +89,6 @@ fn overview(c: &mut Criterion) {
         });
     });
 
-    g.bench_function("compare/TinyStr", |b| {
-        b.iter(|| {
-            let mut collector: usize = 0;
-            for ts in black_box(&parsed_tiny_4).windows(2) {
-                let o = ts[0].cmp(&ts[1]);
-                collector ^= o as usize;
-            }
-            for ts in black_box(&parsed_tiny_8).windows(2) {
-                let o = ts[0].cmp(&ts[1]);
-                collector ^= o as usize;
-            }
-            for ts in black_box(&parsed_tiny_16).windows(2) {
-                let o = ts[0].cmp(&ts[1]);
-                collector ^= o as usize;
-            }
-            collector
-        });
-    });
 }
 
 criterion_group!(benches, overview,);

--- a/utils/tinystr/benches/overview.rs
+++ b/utils/tinystr/benches/overview.rs
@@ -32,7 +32,6 @@ fn overview(c: &mut Criterion) {
         });
     });
 
-
     let parsed_ascii_4: Vec<TinyAsciiStr<4>> = STRINGS_4
         .iter()
         .map(|s| s.parse::<TinyAsciiStr<4>>().unwrap())
@@ -48,7 +47,6 @@ fn overview(c: &mut Criterion) {
         .chain(STRINGS_16)
         .map(|s| s.parse::<TinyAsciiStr<16>>().unwrap())
         .collect();
-
 
     g.bench_function("read/TinyAsciiStr", |b| {
         b.iter(|| {
@@ -69,7 +67,6 @@ fn overview(c: &mut Criterion) {
         });
     });
 
-
     g.bench_function("compare/TinyAsciiStr", |b| {
         b.iter(|| {
             let mut collector: usize = 0;
@@ -88,7 +85,6 @@ fn overview(c: &mut Criterion) {
             collector
         });
     });
-
 }
 
 criterion_group!(benches, overview,);


### PR DESCRIPTION
They clutter up the lockfile and we really don't need them anymore

This is also an attempt to narrow down the failure in #3319

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->