### PR TITLE
bump simple_logger to 4.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,7 +1610,7 @@ dependencies = [
  "icu_timezone",
  "log",
  "serde",
- "simple_logger",
+ "simple_logger 1.16.0",
  "tinystr",
  "unicode-bidi",
  "writeable",
@@ -1767,7 +1767,7 @@ dependencies = [
  "serde",
  "serde-aux",
  "serde_json",
- "simple_logger",
+ "simple_logger 4.1.0",
  "syn 1.0.109",
  "tinystr",
  "toml",
@@ -2167,7 +2167,7 @@ dependencies = [
  "quote",
  "repodata",
  "rust-format",
- "simple_logger",
+ "simple_logger 4.1.0",
  "zip",
 ]
 
@@ -3418,6 +3418,17 @@ dependencies = [
  "log",
  "time 0.3.17",
  "winapi",
+]
+
+[[package]]
+name = "simple_logger"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78beb34673091ccf96a8816fce8bfd30d1292c7621ca2bcb5f2ba0fae4f558d"
+dependencies = [
+ "atty",
+ "log",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "colored"
-version = "1.9.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
  "lazy_static",
@@ -1610,7 +1610,7 @@ dependencies = [
  "icu_timezone",
  "log",
  "serde",
- "simple_logger 1.16.0",
+ "simple_logger",
  "tinystr",
  "unicode-bidi",
  "writeable",
@@ -1767,7 +1767,7 @@ dependencies = [
  "serde",
  "serde-aux",
  "serde_json",
- "simple_logger 4.1.0",
+ "simple_logger",
  "syn 1.0.109",
  "tinystr",
  "toml",
@@ -2167,7 +2167,7 @@ dependencies = [
  "quote",
  "repodata",
  "rust-format",
- "simple_logger 4.1.0",
+ "simple_logger",
  "zip",
 ]
 
@@ -3409,25 +3409,14 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "simple_logger"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45b60258a35dc3cb8a16890b8fd6723349bfa458d7960e25e633f1b1c19d7b5e"
-dependencies = [
- "atty",
- "colored",
- "log",
- "time 0.3.17",
- "winapi",
-]
-
-[[package]]
-name = "simple_logger"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78beb34673091ccf96a8816fce8bfd30d1292c7621ca2bcb5f2ba0fae4f558d"
 dependencies = [
  "atty",
+ "colored",
  "log",
+ "time 0.3.17",
  "windows-sys 0.42.0",
 ]
 

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -129,7 +129,7 @@ diplomat-runtime = { version = "0.5.1" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Logging is automagical in wasm, we only need this for native
-simple_logger = { version = "1.12", optional = true }
+simple_logger = { version = "4.1.0", optional = true }
 log = { version = "0.4", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -83,7 +83,7 @@ zip = { version = ">=0.5, <0.7", default-features = false, features = ["deflate"
 # Dependencies for "bin" feature
 clap = { version = "4", optional = true, features = ["cargo", "derive"] }
 eyre = { version = "0.6", optional = true }
-simple_logger = { version = "1.12", default-features = false, optional = true }
+simple_logger = { version = "4.1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 icu = { path = "../../components/icu" }

--- a/tools/testdata-scripts/Cargo.toml
+++ b/tools/testdata-scripts/Cargo.toml
@@ -22,5 +22,5 @@ eyre = "0.6"
 log = "0.4"
 quote = "1"
 rust-format = { version = "0.3.4", features = ["token_stream"] }
-simple_logger = { version = "1.12", default-features = false }
+simple_logger = { version = "4.1.0", default-features = false }
 zip = ">=0.5, <0.7"


### PR DESCRIPTION
Running the command 

`cargo run --release --bin=icu4x-datagen --all-features -- --icuexport-root=provider/repodata/data/icuexport --syntax=postcard --out=/tmp/icu4x_data --overwrite --keys=segmenter/word@1 --all-locales`

leads to the following error 
```
thread 'main' panicked at 'Could not determine the UTC offset on this system. 
Possible causes are that the time crate does not implement "local_offset_at" on your system, 
or that you are running in a multi-threaded environment and the time crate is returning "None" from "local_offset_at" to avoid unsafe behaviour.
```

Bumping simple_logger to latest fixes this 
https://github.com/borntyping/rust-simple_logger/issues/48#issuecomment-1016774867