### PR TITLE
Fixing datagen features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "icu_datagen"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cached-path",
  "clap 4.0.32",

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -105,7 +105,7 @@ use_wasm = ["icu_codepointtrie_builder/wasm"]
 # If neither `use_wasm` nor `use_icu4c` are enabled,
 # rule based segmenter data will not be generated.
 use_icu4c = ["icu_codepointtrie_builder/icu4c"]
-networking = ["cached-path"]
+networking = ["dep:cached-path"]
 
 [[bin]]
 name = "icu4x-datagen"

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_datagen"
 description = "Generate data for ICU4X DataProvider"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"

--- a/provider/datagen/src/source.rs
+++ b/provider/datagen/src/source.rs
@@ -11,7 +11,6 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 use std::io::Cursor;
 use std::io::Read;
-use std::ops::Deref;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -61,6 +60,9 @@ impl SourceData {
     /// The latest `SourceData` that has been verified to work with this version of `icu_datagen`.
     ///
     /// See [`SourceData::LATEST_TESTED_CLDR_TAG`] and [`SourceData::LATEST_TESTED_ICUEXPORT_TAG`].
+    ///
+    /// Requires `networking` Cargo feature.
+    #[cfg(feature = "networking")]
     pub fn latest_tested() -> Self {
         Self::default()
             .with_cldr_for_tag(Self::LATEST_TESTED_CLDR_TAG, Default::default())
@@ -110,6 +112,9 @@ impl SourceData {
     /// using the given tag (see [GitHub releases](https://github.com/unicode-org/cldr-json/releases)).
     ///
     /// Also see: [`LATEST_TESTED_CLDR_TAG`](Self::LATEST_TESTED_CLDR_TAG)
+    ///
+    /// Requires `networking` Cargo feature.
+    #[cfg(feature = "networking")]
     pub fn with_cldr_for_tag(
         self,
         tag: &str,
@@ -128,6 +133,9 @@ impl SourceData {
     /// using the given tag. (see [GitHub releases](https://github.com/unicode-org/icu/releases)).
     ///
     /// Also see: [`LATEST_TESTED_ICUEXPORT_TAG`](Self::LATEST_TESTED_ICUEXPORT_TAG)
+    ///
+    /// Requires `networking` Cargo feature.
+    #[cfg(feature = "networking")]
     pub fn with_icuexport_for_tag(self, mut tag: &str) -> Result<Self, DataError> {
         if tag == "release-71-1" {
             tag = "icu4x/2022-08-17/71.x";
@@ -147,6 +155,7 @@ impl SourceData {
         since = "1.1.0",
         note = "Use `with_cldr_for_tag(SourceData::LATEST_TESTED_CLDR_TAG)`"
     )]
+    #[cfg(feature = "networking")]
     /// Deprecated
     pub fn with_cldr_latest(
         self,
@@ -159,6 +168,7 @@ impl SourceData {
         since = "1.1.0",
         note = "Use `with_icuexport_for_tag(SourceData::LATEST_TESTED_ICUEXPORT_TAG)`"
     )]
+    #[cfg(feature = "networking")]
     /// Deprecated
     pub fn with_icuexport_latest(self) -> Result<Self, DataError> {
         self.with_icuexport_for_tag(Self::LATEST_TESTED_ICUEXPORT_TAG)
@@ -237,15 +247,6 @@ impl SourceData {
 pub(crate) enum IcuTrieType {
     Fast,
     Small,
-}
-
-impl IcuTrieType {
-    pub(crate) fn to_internal(self) -> icu_collections::codepointtrie::TrieType {
-        match self {
-            IcuTrieType::Fast => icu_collections::codepointtrie::TrieType::Fast,
-            IcuTrieType::Small => icu_collections::codepointtrie::TrieType::Small,
-        }
-    }
 }
 
 impl std::fmt::Display for IcuTrieType {
@@ -378,48 +379,44 @@ impl AbstractFs {
         }
     }
 
+    #[cfg(feature = "networking")]
     fn new_from_url(path: String) -> Self {
         Self::Zip(RwLock::new(Err(path)))
     }
 
     fn init(&self) -> Result<(), DataError> {
+        #[cfg(feature = "networking")]
         match self {
             Self::Zip(lock) => {
                 if lock.read().expect("poison").is_ok() {
                     return Ok(());
                 }
                 let mut lock = lock.write().expect("poison");
-                let resource = if let Err(resource) = lock.deref() {
+                let resource = if let Err(resource) = &*lock {
                     resource
                 } else {
                     return Ok(());
                 };
 
                 let root: PathBuf = {
-                    #[cfg(not(feature = "networking"))]
-                    unreachable!("AbstractFs URL mode only possible when using CLDR/ICU tags, which cannot be set without the `networking` feature");
-
-                    #[cfg(feature = "networking")]
-                    {
-                        lazy_static::lazy_static! {
-                            static ref CACHE: cached_path::Cache = cached_path::CacheBuilder::new()
-                                .freshness_lifetime(u64::MAX)
-                                .progress_bar(None)
-                                .build()
-                                .unwrap();
-                        }
-
-                        CACHE
-                            .cached_path(resource)
-                            .map_err(|e| DataError::custom("Download").with_display_context(&e))?
+                    lazy_static::lazy_static! {
+                        static ref CACHE: cached_path::Cache = cached_path::CacheBuilder::new()
+                            .freshness_lifetime(u64::MAX)
+                            .progress_bar(None)
+                            .build()
+                            .unwrap();
                     }
+
+                    CACHE
+                        .cached_path(resource)
+                        .map_err(|e| DataError::custom("Download").with_display_context(&e))?
                 };
                 *lock = Ok(ZipArchive::new(Cursor::new(std::fs::read(root)?))
                     .map_err(|e| DataError::custom("Zip").with_display_context(&e))?);
-                Ok(())
             }
-            _ => Ok(()),
+            _ => {}
         }
+        Ok(())
     }
 
     fn read_to_buf(&self, path: &str) -> Result<Vec<u8>, DataError> {


### PR DESCRIPTION
* `SourceData::with_foo_for_tag` were not gated behind `feature = "networking"`, which would lead to an `unreachable!` panic when used without the feature
* Building with `--no-default-features` would produce dead code warnings
* The `cached_path` dependency wasn't used with `dep:` so it created an implicit feature

We should do a patch release with this change