### PR TITLE
Locale performance improvements

### DIFF
--- a/components/locid/src/extensions/other/mod.rs
+++ b/components/locid/src/extensions/other/mod.rs
@@ -21,6 +21,7 @@
 
 mod subtag;
 
+use crate::helpers::ShortSlice;
 use crate::parser::ParserError;
 use crate::parser::SubtagIterator;
 use alloc::vec::Vec;
@@ -49,7 +50,7 @@ pub use subtag::Subtag;
 #[derive(Clone, PartialEq, Eq, Debug, Default, Hash, PartialOrd, Ord)]
 pub struct Other {
     ext: u8,
-    keys: Vec<Subtag>,
+    keys: ShortSlice<Subtag>,
 }
 
 impl Other {
@@ -71,6 +72,10 @@ impl Other {
     /// assert_eq!(&other.to_string(), "a-foo-bar");
     /// ```
     pub fn from_vec_unchecked(ext: u8, keys: Vec<Subtag>) -> Self {
+        Self::from_short_slice_unchecked(ext, keys.into())
+    }
+
+    pub(crate) fn from_short_slice_unchecked(ext: u8, keys: ShortSlice<Subtag>) -> Self {
         assert!(ext.is_ascii_alphabetic());
         Self { ext, keys }
     }
@@ -78,7 +83,7 @@ impl Other {
     pub(crate) fn try_from_iter(ext: u8, iter: &mut SubtagIterator) -> Result<Self, ParserError> {
         debug_assert!(ext.is_ascii_alphabetic());
 
-        let mut keys = Vec::new();
+        let mut keys = ShortSlice::new();
         while let Some(subtag) = iter.peek() {
             if !Subtag::valid_key(subtag) {
                 break;
@@ -89,7 +94,7 @@ impl Other {
             iter.next();
         }
 
-        Ok(Self::from_vec_unchecked(ext, keys))
+        Ok(Self::from_short_slice_unchecked(ext, keys))
     }
 
     /// Gets the tag character for this extension as a &str.

--- a/components/locid/src/extensions/private/mod.rs
+++ b/components/locid/src/extensions/private/mod.rs
@@ -34,6 +34,7 @@ use core::ops::Deref;
 
 pub use other::Subtag;
 
+use crate::helpers::ShortSlice;
 use crate::parser::ParserError;
 use crate::parser::SubtagIterator;
 
@@ -58,7 +59,7 @@ use crate::parser::SubtagIterator;
 /// [`Private Use Extensions`]: https://unicode.org/reports/tr35/#pu_extensions
 /// [`Unicode Locale Identifier`]: https://unicode.org/reports/tr35/#Unicode_locale_identifier
 #[derive(Clone, PartialEq, Eq, Debug, Default, Hash, PartialOrd, Ord)]
-pub struct Private(Vec<Subtag>);
+pub struct Private(ShortSlice<Subtag>);
 
 impl Private {
     /// Returns a new empty list of private-use extensions. Same as [`default()`](Default::default()), but is `const`.
@@ -72,7 +73,7 @@ impl Private {
     /// ```
     #[inline]
     pub const fn new() -> Self {
-        Self(Vec::new())
+        Self(ShortSlice::new())
     }
 
     /// A constructor which takes a pre-sorted list of [`Subtag`].
@@ -89,7 +90,7 @@ impl Private {
     /// assert_eq!(&private.to_string(), "x-foo-bar");
     /// ```
     pub fn from_vec_unchecked(input: Vec<Subtag>) -> Self {
-        Self(input)
+        Self(input.into())
     }
 
     /// Empties the [`Private`] list.
@@ -116,9 +117,9 @@ impl Private {
     pub(crate) fn try_from_iter(iter: &mut SubtagIterator) -> Result<Self, ParserError> {
         let keys = iter
             .map(Subtag::try_from_bytes)
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<ShortSlice<_>, _>>()?;
 
-        Ok(Self::from_vec_unchecked(keys))
+        Ok(Self(keys))
     }
 
     pub(crate) fn for_each_subtag_str<E, F>(&self, f: &mut F) -> Result<(), E>

--- a/components/locid/src/extensions/transform/mod.rs
+++ b/components/locid/src/extensions/transform/mod.rs
@@ -38,11 +38,11 @@ pub use fields::Fields;
 pub use key::Key;
 pub use value::Value;
 
+use crate::helpers::ShortSlice;
 use crate::parser::SubtagIterator;
 use crate::parser::{parse_language_identifier_from_iter, ParserError, ParserMode};
 use crate::subtags::Language;
 use crate::LanguageIdentifier;
-use alloc::vec;
 use litemap::LiteMap;
 
 /// A list of [`Unicode BCP47 T Extensions`] as defined in [`Unicode Locale
@@ -144,21 +144,24 @@ impl Transform {
         }
 
         let mut current_tkey = None;
-        let mut current_tvalue = vec![];
+        let mut current_tvalue = ShortSlice::new();
+        let mut has_current_tvalue = false;
 
         while let Some(subtag) = iter.peek() {
             if let Some(tkey) = current_tkey {
                 if let Ok(val) = Value::parse_subtag(subtag) {
-                    current_tvalue.push(val);
+                    has_current_tvalue = true;
+                    if let Some(val) = val {
+                        current_tvalue.push(val);
+                    }
                 } else {
-                    if current_tvalue.is_empty() {
+                    if !has_current_tvalue {
                         return Err(ParserError::InvalidExtension);
                     }
-                    tfields.try_insert(
-                        tkey,
-                        Value::from_vec_unchecked(current_tvalue.drain(..).flatten().collect()),
-                    );
+                    tfields.try_insert(tkey, Value::from_short_slice_unchecked(current_tvalue));
                     current_tkey = None;
+                    current_tvalue = ShortSlice::new();
+                    has_current_tvalue = false;
                     continue;
                 }
             } else if let Ok(tkey) = Key::try_from_bytes(subtag) {
@@ -171,13 +174,10 @@ impl Transform {
         }
 
         if let Some(tkey) = current_tkey {
-            if current_tvalue.is_empty() {
+            if !has_current_tvalue {
                 return Err(ParserError::InvalidExtension);
             }
-            tfields.try_insert(
-                tkey,
-                Value::from_vec_unchecked(current_tvalue.into_iter().flatten().collect()),
-            );
+            tfields.try_insert(tkey, Value::from_short_slice_unchecked(current_tvalue));
         }
 
         Ok(Self {

--- a/components/locid/src/extensions/transform/value.rs
+++ b/components/locid/src/extensions/transform/value.rs
@@ -2,9 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::helpers::ShortSlice;
 use crate::parser::{ParserError, SubtagIterator};
-use alloc::vec;
-use alloc::vec::Vec;
 use core::ops::RangeInclusive;
 use core::str::FromStr;
 use tinystr::TinyAsciiStr;
@@ -28,7 +27,7 @@ use tinystr::TinyAsciiStr;
 /// "no".parse::<Value>().expect_err("Invalid Value.");
 /// ```
 #[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord, Default)]
-pub struct Value(Vec<TinyAsciiStr<{ *TYPE_LENGTH.end() }>>);
+pub struct Value(ShortSlice<TinyAsciiStr<{ *TYPE_LENGTH.end() }>>);
 
 const TYPE_LENGTH: RangeInclusive<usize> = 3..=8;
 const TRUE_TVALUE: TinyAsciiStr<8> = tinystr::tinystr!(8, "true");
@@ -45,7 +44,7 @@ impl Value {
     /// let value = Value::try_from_bytes(b"hybrid").expect("Parsing failed.");
     /// ```
     pub fn try_from_bytes(input: &[u8]) -> Result<Self, ParserError> {
-        let mut v = vec![];
+        let mut v = ShortSlice::default();
         let mut has_value = false;
 
         for subtag in SubtagIterator::new(input) {
@@ -66,12 +65,14 @@ impl Value {
         Ok(Self(v))
     }
 
-    pub(crate) fn from_vec_unchecked(input: Vec<TinyAsciiStr<{ *TYPE_LENGTH.end() }>>) -> Self {
+    pub(crate) fn from_short_slice_unchecked(
+        input: ShortSlice<TinyAsciiStr<{ *TYPE_LENGTH.end() }>>,
+    ) -> Self {
         Self(input)
     }
 
     pub(crate) fn is_type_subtag(t: &[u8]) -> bool {
-        TYPE_LENGTH.contains(&t.len()) && !t.iter().any(|c: &u8| !c.is_ascii_alphanumeric())
+        TYPE_LENGTH.contains(&t.len()) && t.iter().all(u8::is_ascii_alphanumeric)
     }
 
     pub(crate) fn parse_subtag(
@@ -122,9 +123,9 @@ fn test_writeable() {
     let foobar = "foobar".parse().unwrap();
 
     assert_writeable_eq!(Value::default(), "true");
-    assert_writeable_eq!(Value::from_vec_unchecked(vec![hybrid]), "hybrid");
+    assert_writeable_eq!(Value::from_short_slice_unchecked(vec![hybrid].into()), "hybrid");
     assert_writeable_eq!(
-        Value::from_vec_unchecked(vec![hybrid, foobar]),
+        Value::from_short_slice_unchecked(vec![hybrid, foobar].into()),
         "hybrid-foobar"
     );
 }

--- a/components/locid/src/extensions/transform/value.rs
+++ b/components/locid/src/extensions/transform/value.rs
@@ -123,7 +123,10 @@ fn test_writeable() {
     let foobar = "foobar".parse().unwrap();
 
     assert_writeable_eq!(Value::default(), "true");
-    assert_writeable_eq!(Value::from_short_slice_unchecked(vec![hybrid].into()), "hybrid");
+    assert_writeable_eq!(
+        Value::from_short_slice_unchecked(vec![hybrid].into()),
+        "hybrid"
+    );
     assert_writeable_eq!(
         Value::from_short_slice_unchecked(vec![hybrid, foobar].into()),
         "hybrid-foobar"

--- a/components/locid/src/extensions/unicode/attributes.rs
+++ b/components/locid/src/extensions/unicode/attributes.rs
@@ -4,6 +4,7 @@
 
 use super::Attribute;
 
+use crate::helpers::ShortSlice;
 use alloc::vec::Vec;
 use core::ops::Deref;
 
@@ -30,7 +31,7 @@ use core::ops::Deref;
 /// assert_eq!(attributes.to_string(), "foobar-testing");
 /// ```
 #[derive(Default, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
-pub struct Attributes(Vec<Attribute>);
+pub struct Attributes(ShortSlice<Attribute>);
 
 impl Attributes {
     /// Returns a new empty set of attributes. Same as [`default()`](Default::default()), but is `const`.
@@ -44,7 +45,7 @@ impl Attributes {
     /// ```
     #[inline]
     pub const fn new() -> Self {
-        Self(Vec::new())
+        Self(ShortSlice::new())
     }
 
     /// A constructor which takes a pre-sorted list of [`Attribute`] elements.
@@ -68,6 +69,10 @@ impl Attributes {
     /// for the caller to use [`binary_search`](slice::binary_search) instead of [`sort`](slice::sort)
     /// and [`dedup`](Vec::dedup()).
     pub fn from_vec_unchecked(input: Vec<Attribute>) -> Self {
+        Self(input.into())
+    }
+
+    pub(crate) fn from_short_slice_unchecked(input: ShortSlice<Attribute>) -> Self {
         Self(input)
     }
 

--- a/components/locid/src/extensions/unicode/mod.rs
+++ b/components/locid/src/extensions/unicode/mod.rs
@@ -36,13 +36,13 @@ mod key;
 mod keywords;
 mod value;
 
-use alloc::vec;
 pub use attribute::Attribute;
 pub use attributes::Attributes;
 pub use key::Key;
 pub use keywords::Keywords;
 pub use value::Value;
 
+use crate::helpers::ShortSlice;
 use crate::parser::ParserError;
 use crate::parser::SubtagIterator;
 use litemap::LiteMap;
@@ -138,11 +138,7 @@ impl Unicode {
     }
 
     pub(crate) fn try_from_iter(iter: &mut SubtagIterator) -> Result<Self, ParserError> {
-        let mut attributes = vec![];
-        let mut keywords = LiteMap::new();
-
-        let mut current_keyword = None;
-        let mut current_type = vec![];
+        let mut attributes = ShortSlice::new();
 
         while let Some(subtag) = iter.peek() {
             if let Ok(attr) = Attribute::try_from_bytes(subtag) {
@@ -155,17 +151,22 @@ impl Unicode {
             iter.next();
         }
 
+        let mut keywords = LiteMap::new();
+
+        let mut current_keyword = None;
+        let mut current_value = ShortSlice::new();
+
         while let Some(subtag) = iter.peek() {
             let slen = subtag.len();
             if slen == 2 {
                 if let Some(kw) = current_keyword.take() {
-                    keywords.try_insert(kw, Value::from_vec_unchecked(current_type));
-                    current_type = vec![];
+                    keywords.try_insert(kw, Value::from_short_slice_unchecked(current_value));
+                    current_value = ShortSlice::new();
                 }
                 current_keyword = Some(Key::try_from_bytes(subtag)?);
             } else if current_keyword.is_some() {
                 match Value::parse_subtag(subtag) {
-                    Ok(Some(t)) => current_type.push(t),
+                    Ok(Some(t)) => current_value.push(t),
                     Ok(None) => {}
                     Err(_) => break,
                 }
@@ -176,7 +177,7 @@ impl Unicode {
         }
 
         if let Some(kw) = current_keyword.take() {
-            keywords.try_insert(kw, Value::from_vec_unchecked(current_type));
+            keywords.try_insert(kw, Value::from_short_slice_unchecked(current_value));
         }
 
         // Ensure we've defined at least one attribute or keyword
@@ -186,7 +187,7 @@ impl Unicode {
 
         Ok(Self {
             keywords: keywords.into(),
-            attributes: Attributes::from_vec_unchecked(attributes),
+            attributes: Attributes::from_short_slice_unchecked(attributes),
         })
     }
 

--- a/components/locid/src/extensions/unicode/value.rs
+++ b/components/locid/src/extensions/unicode/value.rs
@@ -4,7 +4,6 @@
 
 use crate::helpers::ShortSlice;
 use crate::parser::{ParserError, SubtagIterator};
-use alloc::vec::Vec;
 use core::ops::RangeInclusive;
 use core::str::FromStr;
 use tinystr::TinyAsciiStr;
@@ -52,7 +51,7 @@ impl Value {
     /// Value::try_from_bytes(b"buddhist").expect("Parsing failed.");
     /// ```
     pub fn try_from_bytes(input: &[u8]) -> Result<Self, ParserError> {
-        let mut v = Vec::new();
+        let mut v = ShortSlice::new();
 
         if !input.is_empty() {
             for subtag in SubtagIterator::new(input) {
@@ -85,7 +84,7 @@ impl Value {
 
     #[doc(hidden)]
     pub fn as_tinystr_slice(&self) -> &[TinyAsciiStr<8>] {
-        self.0.as_slice()
+        &*self.0
     }
 
     #[doc(hidden)]
@@ -105,8 +104,8 @@ impl Value {
         }
     }
 
-    pub(crate) fn from_vec_unchecked(input: Vec<TinyAsciiStr<8>>) -> Self {
-        Self(input.into())
+    pub(crate) fn from_short_slice_unchecked(input: ShortSlice<TinyAsciiStr<8>>) -> Self {
+        Self(input)
     }
 
     #[doc(hidden)]
@@ -140,7 +139,7 @@ impl Value {
     where
         F: FnMut(&str) -> Result<(), E>,
     {
-        self.0.as_slice().iter().map(|t| t.as_str()).try_for_each(f)
+        self.0.iter().map(TinyAsciiStr::as_str).try_for_each(f)
     }
 }
 

--- a/components/locid/src/extensions/unicode/value.rs
+++ b/components/locid/src/extensions/unicode/value.rs
@@ -61,7 +61,7 @@ impl Value {
                 }
             }
         }
-        Ok(Self(v.into()))
+        Ok(Self(v))
     }
 
     /// Const constructor for when the value contains only a single subtag.
@@ -84,7 +84,7 @@ impl Value {
 
     #[doc(hidden)]
     pub fn as_tinystr_slice(&self) -> &[TinyAsciiStr<8>] {
-        &*self.0
+        &self.0
     }
 
     #[doc(hidden)]

--- a/components/locid/src/helpers.rs
+++ b/components/locid/src/helpers.rs
@@ -7,8 +7,8 @@ use core::iter::FromIterator;
 use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
-use litemap::store::*;
 use core::ops::{Deref, DerefMut};
+use litemap::store::*;
 
 /// Internal: A vector that supports no-allocation, constant values if length 0 or 1.
 /// Using ZeroOne(Option<T>) saves 8 bytes in ShortSlice via niche optimization.
@@ -120,17 +120,18 @@ impl<T> ShortSlice<T> {
 
     pub fn retain<F>(&mut self, mut f: F)
     where
-        F: FnMut(&T) -> bool {
-            *self = match core::mem::take(self) {
-                Self::ZeroOne(Some(one)) if f(&one) => Self::ZeroOne(Some(one)),
-                Self::ZeroOne(_) => Self::ZeroOne(None),
-                Self::Multi(slice) => {
-                    let mut vec = slice.into_vec();
-                    vec.retain(f);
-                    Self::from(vec)
-                } 
-            };
-        }
+        F: FnMut(&T) -> bool,
+    {
+        *self = match core::mem::take(self) {
+            Self::ZeroOne(Some(one)) if f(&one) => Self::ZeroOne(Some(one)),
+            Self::ZeroOne(_) => Self::ZeroOne(None),
+            Self::Multi(slice) => {
+                let mut vec = slice.into_vec();
+                vec.retain(f);
+                Self::from(vec)
+            }
+        };
+    }
 }
 
 impl<T> Deref for ShortSlice<T> {
@@ -242,8 +243,7 @@ impl<K, V> StoreMut<K, V> for ShortSlice<(K, V)> {
     fn lm_reserve(&mut self, _additional: usize) {}
 
     fn lm_get_mut(&mut self, index: usize) -> Option<(&K, &mut V)> {
-        self.get_mut(index)
-            .map(|elt| (&elt.0, &mut elt.1))
+        self.get_mut(index).map(|elt| (&elt.0, &mut elt.1))
     }
 
     fn lm_push(&mut self, key: K, value: V) {

--- a/components/locid/src/helpers.rs
+++ b/components/locid/src/helpers.rs
@@ -8,6 +8,7 @@ use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
 use litemap::store::*;
+use core::ops::{Deref, DerefMut};
 
 /// Internal: A vector that supports no-allocation, constant values if length 0 or 1.
 /// Using ZeroOne(Option<T>) saves 8 bytes in ShortSlice via niche optimization.
@@ -40,24 +41,6 @@ impl<T> ShortSlice<T> {
                 ShortSlice::Multi(items.into_boxed_slice())
             }
         };
-    }
-
-    #[inline]
-    pub fn as_slice(&self) -> &[T] {
-        match self {
-            ShortSlice::ZeroOne(None) => &[],
-            ShortSlice::ZeroOne(Some(v)) => core::slice::from_ref(v),
-            ShortSlice::Multi(v) => v,
-        }
-    }
-
-    #[inline]
-    pub fn as_mut_slice(&mut self) -> &mut [T] {
-        match self {
-            ShortSlice::ZeroOne(None) => &mut [],
-            ShortSlice::ZeroOne(Some(v)) => core::slice::from_mut(v),
-            ShortSlice::Multi(v) => v,
-        }
     }
 
     #[inline]
@@ -134,6 +117,42 @@ impl<T> ShortSlice<T> {
     pub fn clear(&mut self) {
         let _ = core::mem::replace(self, ShortSlice::ZeroOne(None));
     }
+
+    pub fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&T) -> bool {
+            *self = match core::mem::take(self) {
+                Self::ZeroOne(Some(one)) if f(&one) => Self::ZeroOne(Some(one)),
+                Self::ZeroOne(_) => Self::ZeroOne(None),
+                Self::Multi(slice) => {
+                    let mut vec = slice.into_vec();
+                    vec.retain(f);
+                    Self::from(vec)
+                } 
+            };
+        }
+}
+
+impl<T> Deref for ShortSlice<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            ShortSlice::ZeroOne(None) => &[],
+            ShortSlice::ZeroOne(Some(v)) => core::slice::from_ref(v),
+            ShortSlice::Multi(v) => v,
+        }
+    }
+}
+
+impl<T> DerefMut for ShortSlice<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            ShortSlice::ZeroOne(None) => &mut [],
+            ShortSlice::ZeroOne(Some(v)) => core::slice::from_mut(v),
+            ShortSlice::Multi(v) => v,
+        }
+    }
 }
 
 impl<T> From<Vec<T>> for ShortSlice<T> {
@@ -155,7 +174,18 @@ impl<T> Default for ShortSlice<T> {
 
 impl<T> FromIterator<T> for ShortSlice<T> {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        iter.into_iter().collect::<Vec<_>>().into()
+        let mut iter = iter.into_iter();
+        match (iter.next(), iter.next()) {
+            (Some(first), Some(second)) => {
+                // Size hint behaviour same as `Vec::extend` + 2
+                let mut vec = Vec::with_capacity(iter.size_hint().0.saturating_add(3));
+                vec.push(first);
+                vec.push(second);
+                vec.extend(iter);
+                Self::Multi(vec.into_boxed_slice())
+            }
+            (first, _) => Self::ZeroOne(first),
+        }
     }
 }
 
@@ -176,7 +206,7 @@ impl<K, V> Store<K, V> for ShortSlice<(K, V)> {
 
     #[inline]
     fn lm_get(&self, index: usize) -> Option<(&K, &V)> {
-        self.as_slice().get(index).map(|elt| (&elt.0, &elt.1))
+        self.get(index).map(|elt| (&elt.0, &elt.1))
     }
 
     #[inline]
@@ -193,7 +223,7 @@ impl<K, V> Store<K, V> for ShortSlice<(K, V)> {
     where
         F: FnMut(&K) -> core::cmp::Ordering,
     {
-        self.as_slice().binary_search_by(|(k, _)| cmp(k))
+        self.binary_search_by(|(k, _)| cmp(k))
     }
 }
 
@@ -212,8 +242,7 @@ impl<K, V> StoreMut<K, V> for ShortSlice<(K, V)> {
     fn lm_reserve(&mut self, _additional: usize) {}
 
     fn lm_get_mut(&mut self, index: usize) -> Option<(&K, &mut V)> {
-        self.as_mut_slice()
-            .get_mut(index)
+        self.get_mut(index)
             .map(|elt| (&elt.0, &mut elt.1))
     }
 
@@ -232,6 +261,13 @@ impl<K, V> StoreMut<K, V> for ShortSlice<(K, V)> {
     fn lm_clear(&mut self) {
         self.clear();
     }
+
+    fn lm_retain<F>(&mut self, mut predicate: F)
+    where
+        F: FnMut(&K, &V) -> bool,
+    {
+        self.retain(|(k, v)| predicate(k, v))
+    }
 }
 
 impl<'a, K: 'a, V: 'a> StoreIterable<'a, K, V> for ShortSlice<(K, V)> {
@@ -239,14 +275,14 @@ impl<'a, K: 'a, V: 'a> StoreIterable<'a, K, V> for ShortSlice<(K, V)> {
         core::iter::Map<core::slice::Iter<'a, (K, V)>, for<'r> fn(&'r (K, V)) -> (&'r K, &'r V)>;
 
     fn lm_iter(&'a self) -> Self::KeyValueIter {
-        self.as_slice().iter().map(|elt| (&elt.0, &elt.1))
+        self.iter().map(|elt| (&elt.0, &elt.1))
     }
 }
 
 impl<K, V> StoreFromIterator<K, V> for ShortSlice<(K, V)> {}
 
 #[test]
-fn test_shortvec_impl() {
+fn test_short_slice_impl() {
     litemap::testing::check_store::<ShortSlice<(u32, u64)>>();
 }
 
@@ -610,20 +646,20 @@ macro_rules! impl_writeable_for_each_subtag_str_no_test {
 
 macro_rules! impl_writeable_for_subtag_list {
     ($type:tt, $sample1:literal, $sample2:literal) => {
-        impl_writeable_for_each_subtag_str_no_test!($type, selff, selff.0.len() == 1 => alloc::borrow::Cow::Borrowed(selff.0.as_slice().get(0).unwrap().as_str()));
+        impl_writeable_for_each_subtag_str_no_test!($type, selff, selff.0.len() == 1 => alloc::borrow::Cow::Borrowed(selff.0.get(0).unwrap().as_str()));
 
         #[test]
         fn test_writeable() {
             writeable::assert_writeable_eq!(&$type::default(), "");
             writeable::assert_writeable_eq!(
-                &$type::from_vec_unchecked(alloc::vec![$sample1.parse().unwrap()]),
+                &$type::from_short_slice_unchecked(alloc::vec![$sample1.parse().unwrap()].into()),
                 $sample1,
             );
             writeable::assert_writeable_eq!(
-                &$type::from_vec_unchecked(vec![
+                &$type::from_short_slice_unchecked(vec![
                     $sample1.parse().unwrap(),
                     $sample2.parse().unwrap()
-                ]),
+                ].into()),
                 core::concat!($sample1, "-", $sample2),
             );
         }

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -98,13 +98,13 @@ fn test_sizes() {
     assert_eq!(core::mem::size_of::<Option<LanguageIdentifier>>(), 32);
     assert_eq!(core::mem::size_of::<extensions::transform::Fields>(), 24);
 
-    assert_eq!(core::mem::size_of::<extensions::unicode::Attributes>(), 24);
+    assert_eq!(core::mem::size_of::<extensions::unicode::Attributes>(), 16);
     assert_eq!(core::mem::size_of::<extensions::unicode::Keywords>(), 24);
     assert_eq!(core::mem::size_of::<Vec<extensions::other::Other>>(), 24);
-    assert_eq!(core::mem::size_of::<extensions::private::Private>(), 24);
-    assert_eq!(core::mem::size_of::<extensions::Extensions>(), 152);
+    assert_eq!(core::mem::size_of::<extensions::private::Private>(), 16);
+    assert_eq!(core::mem::size_of::<extensions::Extensions>(), 136);
 
-    assert_eq!(core::mem::size_of::<Locale>(), 184);
+    assert_eq!(core::mem::size_of::<Locale>(), 168);
 }
 
 impl Locale {

--- a/components/locid/src/parser/langid.rs
+++ b/components/locid/src/parser/langid.rs
@@ -5,10 +5,10 @@
 pub use super::errors::ParserError;
 use crate::extensions::unicode::{Attribute, Key, Value};
 use crate::extensions::ExtensionType;
+use crate::helpers::ShortSlice;
 use crate::parser::SubtagIterator;
 use crate::LanguageIdentifier;
 use crate::{extensions, subtags};
-use alloc::vec::Vec;
 use tinystr::TinyAsciiStr;
 
 #[derive(PartialEq, Clone, Copy)]
@@ -31,7 +31,7 @@ pub fn parse_language_identifier_from_iter(
 ) -> Result<LanguageIdentifier, ParserError> {
     let mut script = None;
     let mut region = None;
-    let mut variants = Vec::new();
+    let mut variants = ShortSlice::new();
 
     let language = if let Some(subtag) = iter.next() {
         subtags::Language::try_from_bytes(subtag)?
@@ -95,7 +95,7 @@ pub fn parse_language_identifier_from_iter(
         language,
         script,
         region,
-        variants: subtags::Variants::from_vec_unchecked(variants),
+        variants: subtags::Variants::from_short_slice_unchecked(variants),
     })
 }
 

--- a/components/locid/src/subtags/variants.rs
+++ b/components/locid/src/subtags/variants.rs
@@ -77,7 +77,11 @@ impl Variants {
     /// for the caller to use [`binary_search`](slice::binary_search) instead of [`sort`](slice::sort)
     /// and [`dedup`](Vec::dedup()).
     pub fn from_vec_unchecked(input: Vec<Variant>) -> Self {
-        Self(ShortSlice::from(input))
+        Self(input.into())
+    }
+
+    pub(crate) fn from_short_slice_unchecked(input: ShortSlice<Variant>) -> Self {
+        Self(input)
     }
 
     /// Empties the [`Variants`] list.
@@ -119,6 +123,6 @@ impl Deref for Variants {
     type Target = [Variant];
 
     fn deref(&self) -> &[Variant] {
-        self.0.as_slice()
+        self.0.deref()
     }
 }


### PR DESCRIPTION
Specifically improving `ShortSlice::retain` and `ShortSlice::from_iterator` to be less allocatey for single-element slices.

Replacing all `Vec` usages in `icu_locid` by `ShortSlice`. This will be less performant for constructing long lists, but more performant for length-1 lists, as those can be constructed allocation-free.

```
langid/overview         time:   [1.5500 µs 1.5515 µs 1.5531 µs]
                        change: [-2.2337% -1.9994% -1.7885%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

     Running benches/locale.rs (target/release/deps/locale-a81f3922e113b14b)
locale/overview         time:   [2.7486 µs 2.7517 µs 2.7554 µs]
                        change: [-5.9166% -5.7892% -5.6582%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```