### PR TITLE
Add icu_provider_fs feature to datagen; bump to 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 # Changelog
 
-## icu4x 1.2.1 (Apr 17, 2023)
+
+## icu4x 1.2.1 & 1.2.2 (Apr 17, 2023)
 
 Note: A subset of crates received patch releases in the 1.2 stream.
 
 - `icu_capi`
   - Fixed [#3344](https://github.com/unicode-org/icu4x/pull/3344), `buffer_provider` feature accidentally pulling in extra crates
-- `icu_datagen`
+- `icu_datagen` 1.2.1
   - Fixed [#3339](https://github.com/unicode-org/icu4x/pull/3339), incorrect Cargo features
+- `icu_datagen` 1.2.2
+  - Fixed [#3354](https://github.com/unicode-org/icu4x/pull/3354), ability to run datagen without support for `icu_provider_fs::FsDataProvider`
 - `icu_locid_transform`
   - Fixed [#3332](https://github.com/unicode-org/icu4x/issues/3332), missing `+?Sized` bound
 - `icu_segmenter`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "icu_datagen"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "cached-path",
  "clap 4.0.32",

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -51,7 +51,7 @@ icu_timezone = { version = "1.2.0", path = "../../components/timezone", features
 icu_provider = { version = "1.2.0", path = "../core", features = ["std", "log_error_context", "datagen"]}
 icu_provider_adapters = { version = "1.2.0", path = "../adapters", features = ["datagen"] }
 icu_provider_blob = { version = "1.2.0", path = "../blob", features = ["export"] }
-icu_provider_fs = { version = "1.2.0", path = "../fs", features = ["export"] }
+icu_provider_fs = { version = "1.2.0", path = "../fs", features = ["export"], optional = true }
 
 # Other
 cached-path = { version = ">=0.5, <0.7", optional = true }
@@ -106,6 +106,7 @@ use_wasm = ["icu_codepointtrie_builder/wasm"]
 # rule based segmenter data will not be generated.
 use_icu4c = ["icu_codepointtrie_builder/icu4c"]
 networking = ["dep:cached-path"]
+icu_provider_fs = ["dep:icu_provider_fs"]
 
 [[bin]]
 name = "icu4x-datagen"

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_datagen"
 description = "Generate data for ICU4X DataProvider"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
@@ -106,7 +106,7 @@ use_wasm = ["icu_codepointtrie_builder/wasm"]
 # rule based segmenter data will not be generated.
 use_icu4c = ["icu_codepointtrie_builder/icu4c"]
 networking = ["dep:cached-path"]
-icu_provider_fs = ["dep:icu_provider_fs"]
+fs = ["dep:icu_provider_fs"]
 
 [[bin]]
 name = "icu4x-datagen"

--- a/provider/datagen/src/bin/datagen.rs
+++ b/provider/datagen/src/bin/datagen.rs
@@ -336,7 +336,7 @@ fn main() -> eyre::Result<()> {
                 log::warn!("Defaulting to --format=dir. This will become a required parameter in the future.");
             }
             #[cfg(not(feature = "icu_provider_fs"))]
-            eyre::bail!("--format=dir only available with the icu_provider_fs feature");
+            eyre::bail!("--format=dir only available with the icu_provider_fs Cargo feature");
             #[cfg(feature = "icu_provider_fs")]
             icu_datagen::Out::Fs {
                 output_path: matches

--- a/provider/datagen/src/bin/datagen.rs
+++ b/provider/datagen/src/bin/datagen.rs
@@ -13,7 +13,7 @@ mod cli {
 
     #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
     pub(crate) enum Format {
-        #[cfg_attr(feature = "icu_provider_fs", value(hide = true))]
+        #[cfg_attr(feature = "fs", value(hide = true))]
         Dir,
         Blob,
         Mod,
@@ -85,7 +85,7 @@ struct Cli {
 
     #[arg(short, long, value_enum, default_value_t = cli::Syntax::Json)]
     #[arg(help = "--format=dir only: serde serialization format.")]
-    #[cfg_attr(feature = "icu_provider_fs", arg(hide = true))]
+    #[cfg_attr(feature = "fs", arg(hide = true))]
     syntax: cli::Syntax,
 
     #[arg(short, long)]
@@ -335,9 +335,9 @@ fn main() -> eyre::Result<()> {
             if v == cli::Format::DeprecatedDefault {
                 log::warn!("Defaulting to --format=dir. This will become a required parameter in the future.");
             }
-            #[cfg(not(feature = "icu_provider_fs"))]
-            eyre::bail!("--format=dir only available with the icu_provider_fs Cargo feature");
-            #[cfg(feature = "icu_provider_fs")]
+            #[cfg(not(feature = "fs"))]
+            eyre::bail!("--format=dir only available with the `fs` Cargo feature");
+            #[cfg(feature = "fs")]
             icu_datagen::Out::Fs {
                 output_path: matches
                     .output

--- a/provider/datagen/src/bin/datagen.rs
+++ b/provider/datagen/src/bin/datagen.rs
@@ -13,6 +13,7 @@ mod cli {
 
     #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
     pub(crate) enum Format {
+        #[cfg_attr(feature = "icu_provider_fs", value(hide = true))]
         Dir,
         Blob,
         Mod,
@@ -84,6 +85,7 @@ struct Cli {
 
     #[arg(short, long, value_enum, default_value_t = cli::Syntax::Json)]
     #[arg(help = "--format=dir only: serde serialization format.")]
+    #[cfg_attr(feature = "icu_provider_fs", arg(hide = true))]
     syntax: cli::Syntax,
 
     #[arg(short, long)]
@@ -333,6 +335,9 @@ fn main() -> eyre::Result<()> {
             if v == cli::Format::DeprecatedDefault {
                 log::warn!("Defaulting to --format=dir. This will become a required parameter in the future.");
             }
+            #[cfg(not(feature = "icu_provider_fs"))]
+            eyre::bail!("--format=dir only available with the icu_provider_fs feature");
+            #[cfg(feature = "icu_provider_fs")]
             icu_datagen::Out::Fs {
                 output_path: matches
                     .output

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -99,10 +99,13 @@ impl CldrLocaleSubset {
 /// [Out::Fs] serialization formats.
 pub mod syntax {
     #[doc(no_inline)]
+    #[cfg(feature = "icu_provider_fs")]
     pub use icu_provider_fs::export::serializers::bincode::Serializer as Bincode;
     #[doc(no_inline)]
+    #[cfg(feature = "icu_provider_fs")]
     pub use icu_provider_fs::export::serializers::json::Serializer as Json;
     #[doc(no_inline)]
+    #[cfg(feature = "icu_provider_fs")]
     pub use icu_provider_fs::export::serializers::postcard::Serializer as Postcard;
 }
 
@@ -122,6 +125,7 @@ use icu_provider::datagen::*;
 use icu_provider::prelude::*;
 use icu_provider_adapters::empty::EmptyDataProvider;
 use icu_provider_adapters::filter::Filterable;
+#[cfg(feature = "icu_provider_fs")]
 use icu_provider_fs::export::serializers::AbstractSerializer;
 use prelude::*;
 use rayon::prelude::*;
@@ -315,6 +319,9 @@ impl Default for BakedOptions {
 #[non_exhaustive]
 pub enum Out {
     /// Output to a file system tree
+    ///
+    /// Only available with the `icu_provider_fs` feature
+    #[cfg(feature = "icu_provider_fs")]
     Fs {
         /// The root path.
         output_path: PathBuf,
@@ -348,6 +355,7 @@ pub enum Out {
 impl core::fmt::Debug for Out {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            #[cfg(feature = "icu_provider_fs")]
             Self::Fs {
                 output_path,
                 serializer,
@@ -407,6 +415,7 @@ pub fn datagen(
         .into_iter()
         .map(|out| -> Result<Box<dyn DataExporter>, DataError> {
             Ok(match out {
+                #[cfg(feature = "icu_provider_fs")]
                 Out::Fs {
                     output_path,
                     serializer,

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -320,7 +320,7 @@ impl Default for BakedOptions {
 pub enum Out {
     /// Output to a file system tree
     ///
-    /// Only available with the `fs` Cargo feature
+    /// **Enabled with the `fs` Cargo feature.**
     #[cfg(feature = "fs")]
     Fs {
         /// The root path.

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -99,13 +99,13 @@ impl CldrLocaleSubset {
 /// [Out::Fs] serialization formats.
 pub mod syntax {
     #[doc(no_inline)]
-    #[cfg(feature = "icu_provider_fs")]
+    #[cfg(feature = "fs")]
     pub use icu_provider_fs::export::serializers::bincode::Serializer as Bincode;
     #[doc(no_inline)]
-    #[cfg(feature = "icu_provider_fs")]
+    #[cfg(feature = "fs")]
     pub use icu_provider_fs::export::serializers::json::Serializer as Json;
     #[doc(no_inline)]
-    #[cfg(feature = "icu_provider_fs")]
+    #[cfg(feature = "fs")]
     pub use icu_provider_fs::export::serializers::postcard::Serializer as Postcard;
 }
 
@@ -125,7 +125,7 @@ use icu_provider::datagen::*;
 use icu_provider::prelude::*;
 use icu_provider_adapters::empty::EmptyDataProvider;
 use icu_provider_adapters::filter::Filterable;
-#[cfg(feature = "icu_provider_fs")]
+#[cfg(feature = "fs")]
 use icu_provider_fs::export::serializers::AbstractSerializer;
 use prelude::*;
 use rayon::prelude::*;
@@ -320,8 +320,8 @@ impl Default for BakedOptions {
 pub enum Out {
     /// Output to a file system tree
     ///
-    /// Only available with the `icu_provider_fs` feature
-    #[cfg(feature = "icu_provider_fs")]
+    /// Only available with the `fs` Cargo feature
+    #[cfg(feature = "fs")]
     Fs {
         /// The root path.
         output_path: PathBuf,
@@ -355,7 +355,7 @@ pub enum Out {
 impl core::fmt::Debug for Out {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            #[cfg(feature = "icu_provider_fs")]
+            #[cfg(feature = "fs")]
             Self::Fs {
                 output_path,
                 serializer,
@@ -415,7 +415,7 @@ pub fn datagen(
         .into_iter()
         .map(|out| -> Result<Box<dyn DataExporter>, DataError> {
             Ok(match out {
-                #[cfg(feature = "icu_provider_fs")]
+                #[cfg(feature = "fs")]
                 Out::Fs {
                     output_path,
                     serializer,

--- a/provider/datagen/src/source.rs
+++ b/provider/datagen/src/source.rs
@@ -329,7 +329,9 @@ impl SerdeCache {
         for<'de> S: serde::Deserialize<'de> + 'static + Send + Sync,
     {
         self.read_and_parse(path, |bytes| {
-            serde_json::from_slice(bytes).map_err(DataError::from)
+            serde_json::from_slice(bytes)
+                .map_err(std::io::Error::from)
+                .map_err(DataError::from)
         })
     }
 

--- a/tools/testdata-scripts/Cargo.toml
+++ b/tools/testdata-scripts/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 crlify = { path = "../../utils/crlify" }
 databake = { path = "../../utils/databake" }
-icu_datagen = { path = "../../provider/datagen", default-features = false }
+icu_datagen = { path = "../../provider/datagen", default-features = false, features = ["fs"] }
 icu_locid = { path = "../../components/locid", features = ["databake"] }
 icu_provider = { path = "../../provider/core" }
 repodata = { path = "../../provider/repodata" }


### PR DESCRIPTION
Not sure what the feature itself should be called.

Most users of datagen shouldn't actually need the fs feature, and it pulls in some deps + enables the `sync` feature on `icu_provider`, which we should avoid in unified-build situations.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->