### PR TITLE
Remove octal workaround

### DIFF
--- a/provider/datagen/src/databake.rs
+++ b/provider/datagen/src/databake.rs
@@ -352,8 +352,6 @@ impl DataExporter for BakedDataExporter {
             quote! {
                 #feature
 
-                #![allow(clippy::octal_escapes)] // https://github.com/dtolnay/proc-macro2/issues/363
-
                 type DataStruct = #struct_type;
 
                 #lookup

--- a/provider/testdata/data/baked/calendar/japanese_v1/mod.rs
+++ b/provider/testdata/data/baked/calendar/japanese_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_calendar")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_calendar::provider::JapaneseErasV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/calendar/japanext_v1/mod.rs
+++ b/provider/testdata/data/baked/calendar/japanext_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_calendar")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_calendar :: provider :: JapaneseExtendedErasV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/collator/data_v1/mod.rs
+++ b/provider/testdata/data/baked/collator/data_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_collator")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_collator::provider::CollationDataV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/collator/dia_v1/mod.rs
+++ b/provider/testdata/data/baked/collator/dia_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_collator")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_collator::provider::CollationDiacriticsV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/collator/jamo_v1/mod.rs
+++ b/provider/testdata/data/baked/collator/jamo_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_collator")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_collator::provider::CollationJamoV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/collator/meta_v1/mod.rs
+++ b/provider/testdata/data/baked/collator/meta_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_collator")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_collator::provider::CollationMetadataV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/collator/prim_v1/mod.rs
+++ b/provider/testdata/data/baked/collator/prim_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_collator")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_collator :: provider :: CollationSpecialPrimariesV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/collator/reord_v1/mod.rs
+++ b/provider/testdata/data/baked/collator/reord_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_collator")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_collator::provider::CollationReorderingV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/compactdecimal/long_v1/mod.rs
+++ b/provider/testdata/data/baked/compactdecimal/long_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_compactdecimal")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_compactdecimal :: provider :: LongCompactDecimalFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 24usize] = [

--- a/provider/testdata/data/baked/compactdecimal/short_v1/mod.rs
+++ b/provider/testdata/data/baked/compactdecimal/short_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_compactdecimal")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_compactdecimal :: provider :: ShortCompactDecimalFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 24usize] = [

--- a/provider/testdata/data/baked/core/helloworld_v1/mod.rs
+++ b/provider/testdata/data/baked/core/helloworld_v1/mod.rs
@@ -1,5 +1,4 @@
 // @generated
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_provider::hello_world::HelloWorldV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/datetime/buddhist/datelengths_v1/mod.rs
+++ b/provider/testdata/data/baked/datetime/buddhist/datelengths_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: calendar :: BuddhistDateLengthsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/datetime/buddhist/datesymbols_v1/mod.rs
+++ b/provider/testdata/data/baked/datetime/buddhist/datesymbols_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: calendar :: BuddhistDateSymbolsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/datetime/coptic/datelengths_v1/mod.rs
+++ b/provider/testdata/data/baked/datetime/coptic/datelengths_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: calendar :: CopticDateLengthsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/datetime/coptic/datesymbols_v1/mod.rs
+++ b/provider/testdata/data/baked/datetime/coptic/datesymbols_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: calendar :: CopticDateSymbolsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/datetime/ethiopic/datelengths_v1/mod.rs
+++ b/provider/testdata/data/baked/datetime/ethiopic/datelengths_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: calendar :: EthiopianDateLengthsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/datetime/ethiopic/datesymbols_v1/mod.rs
+++ b/provider/testdata/data/baked/datetime/ethiopic/datesymbols_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: calendar :: EthiopianDateSymbolsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/datetime/gregory/datelengths_v1/mod.rs
+++ b/provider/testdata/data/baked/datetime/gregory/datelengths_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: calendar :: GregorianDateLengthsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/datetime/gregory/datesymbols_v1/mod.rs
+++ b/provider/testdata/data/baked/datetime/gregory/datesymbols_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: calendar :: GregorianDateSymbolsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/datetime/indian/datelengths_v1/mod.rs
+++ b/provider/testdata/data/baked/datetime/indian/datelengths_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: calendar :: IndianDateLengthsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/datetime/indian/datesymbols_v1/mod.rs
+++ b/provider/testdata/data/baked/datetime/indian/datesymbols_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: calendar :: IndianDateSymbolsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/datetime/japanese/datelengths_v1/mod.rs
+++ b/provider/testdata/data/baked/datetime/japanese/datelengths_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: calendar :: JapaneseDateLengthsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/datetime/japanese/datesymbols_v1/mod.rs
+++ b/provider/testdata/data/baked/datetime/japanese/datesymbols_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: calendar :: JapaneseDateSymbolsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/datetime/japanext/datelengths_v1/mod.rs
+++ b/provider/testdata/data/baked/datetime/japanext/datelengths_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: calendar :: JapaneseExtendedDateLengthsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/datetime/japanext/datesymbols_v1/mod.rs
+++ b/provider/testdata/data/baked/datetime/japanext/datesymbols_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: calendar :: JapaneseExtendedDateSymbolsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/datetime/skeletons_v1/mod.rs
+++ b/provider/testdata/data/baked/datetime/skeletons_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime_experimental")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = &'static [(
     &'static [::icu_datetime::fields::Field],
     ::icu_datetime::pattern::runtime::PatternPlurals<'static>,

--- a/provider/testdata/data/baked/datetime/timelengths_v1/mod.rs
+++ b/provider/testdata/data/baked/datetime/timelengths_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: calendar :: TimeLengthsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/datetime/timesymbols_v1/mod.rs
+++ b/provider/testdata/data/baked/datetime/timesymbols_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: calendar :: TimeSymbolsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/datetime/week_data_v1/mod.rs
+++ b/provider/testdata/data/baked/datetime/week_data_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_calendar")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_calendar::provider::WeekDataV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/decimal/symbols_v1/mod.rs
+++ b/provider/testdata/data/baked/decimal/symbols_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_decimal")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_decimal::provider::DecimalSymbolsV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/displaynames/languages_v1/mod.rs
+++ b/provider/testdata/data/baked/displaynames/languages_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_displaynames")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_displaynames :: provider :: LanguageDisplayNamesV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 18usize] = [

--- a/provider/testdata/data/baked/displaynames/locales_v1/mod.rs
+++ b/provider/testdata/data/baked/displaynames/locales_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_displaynames")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_displaynames :: provider :: LocaleDisplayNamesV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 18usize] = [

--- a/provider/testdata/data/baked/displaynames/regions_v1/mod.rs
+++ b/provider/testdata/data/baked/displaynames/regions_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_displaynames")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_displaynames :: provider :: RegionDisplayNamesV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 18usize] = [

--- a/provider/testdata/data/baked/displaynames/scripts_v1/mod.rs
+++ b/provider/testdata/data/baked/displaynames/scripts_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_displaynames")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_displaynames :: provider :: ScriptDisplayNamesV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 18usize] = [

--- a/provider/testdata/data/baked/fallback/likelysubtags_v1/mod.rs
+++ b/provider/testdata/data/baked/fallback/likelysubtags_v1/mod.rs
@@ -1,5 +1,4 @@
 // @generated
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_provider_adapters :: fallback :: provider :: LocaleFallbackLikelySubtagsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/fallback/parents_v1/mod.rs
+++ b/provider/testdata/data/baked/fallback/parents_v1/mod.rs
@@ -1,5 +1,4 @@
 // @generated
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_provider_adapters :: fallback :: provider :: LocaleFallbackParentsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/fallback/supplement/co_v1/mod.rs
+++ b/provider/testdata/data/baked/fallback/supplement/co_v1/mod.rs
@@ -1,5 +1,4 @@
 // @generated
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_provider_adapters :: fallback :: provider :: CollationFallbackSupplementV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/list/and_v1/mod.rs
+++ b/provider/testdata/data/baked/list/and_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_list")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = <::icu_list::provider::AndListV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/list/or_v1/mod.rs
+++ b/provider/testdata/data/baked/list/or_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_list")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = <::icu_list::provider::OrListV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/list/unit_v1/mod.rs
+++ b/provider/testdata/data/baked/list/unit_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_list")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = <::icu_list::provider::UnitListV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/locid_transform/aliases_v1/mod.rs
+++ b/provider/testdata/data/baked/locid_transform/aliases_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_locid_transform")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_locid_transform::provider::AliasesV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/locid_transform/likelysubtags_ext_v1/mod.rs
+++ b/provider/testdata/data/baked/locid_transform/likelysubtags_ext_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_locid_transform")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_locid_transform :: provider :: LikelySubtagsExtendedV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/locid_transform/likelysubtags_l_v1/mod.rs
+++ b/provider/testdata/data/baked/locid_transform/likelysubtags_l_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_locid_transform")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_locid_transform :: provider :: LikelySubtagsForLanguageV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/locid_transform/likelysubtags_sr_v1/mod.rs
+++ b/provider/testdata/data/baked/locid_transform/likelysubtags_sr_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_locid_transform")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_locid_transform :: provider :: LikelySubtagsForScriptRegionV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/locid_transform/likelysubtags_v1/mod.rs
+++ b/provider/testdata/data/baked/locid_transform/likelysubtags_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_locid_transform")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_locid_transform :: provider :: LikelySubtagsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/normalizer/comp_v1/mod.rs
+++ b/provider/testdata/data/baked/normalizer/comp_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_normalizer")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_normalizer :: provider :: CanonicalCompositionsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/normalizer/decomp_v1/mod.rs
+++ b/provider/testdata/data/baked/normalizer/decomp_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_normalizer")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_normalizer :: provider :: NonRecursiveDecompositionSupplementV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/normalizer/nfd_v1/mod.rs
+++ b/provider/testdata/data/baked/normalizer/nfd_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_normalizer")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_normalizer :: provider :: CanonicalDecompositionDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/normalizer/nfdex_v1/mod.rs
+++ b/provider/testdata/data/baked/normalizer/nfdex_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_normalizer")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_normalizer :: provider :: CanonicalDecompositionTablesV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/normalizer/nfkd_v1/mod.rs
+++ b/provider/testdata/data/baked/normalizer/nfkd_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_normalizer")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_normalizer :: provider :: CompatibilityDecompositionSupplementV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/normalizer/nfkdex_v1/mod.rs
+++ b/provider/testdata/data/baked/normalizer/nfkdex_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_normalizer")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_normalizer :: provider :: CompatibilityDecompositionTablesV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/normalizer/uts46d_v1/mod.rs
+++ b/provider/testdata/data/baked/normalizer/uts46d_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_normalizer")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_normalizer :: provider :: Uts46DecompositionSupplementV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/plurals/cardinal_v1/mod.rs
+++ b/provider/testdata/data/baked/plurals/cardinal_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_plurals")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_plurals::provider::CardinalV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/plurals/ordinal_v1/mod.rs
+++ b/provider/testdata/data/baked/plurals/ordinal_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_plurals")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_plurals::provider::OrdinalV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/propnames/from/bc_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/from/bc_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: BidiClassNameToValueV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/from/ccc_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/from/ccc_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: CanonicalCombiningClassNameToValueV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/from/ea_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/from/ea_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: EastAsianWidthNameToValueV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/from/gc_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/from/gc_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: GeneralCategoryNameToValueV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/from/gcb_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/from/gcb_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: GraphemeClusterBreakNameToValueV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/from/gcm_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/from/gcm_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: names :: GeneralCategoryMaskNameToValueV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/from/lb_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/from/lb_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: LineBreakNameToValueV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/from/sb_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/from/sb_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: SentenceBreakNameToValueV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/from/sc_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/from/sc_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::ScriptNameToValueV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/propnames/from/wb_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/from/wb_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: WordBreakNameToValueV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/to/long/linear/bc_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/to/long/linear/bc_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: BidiClassValueToLongNameV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/to/long/linear/ea_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/to/long/linear/ea_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: EastAsianWidthValueToLongNameV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/to/long/linear/gc_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/to/long/linear/gc_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: GeneralCategoryValueToLongNameV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/to/long/linear/gcb_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/to/long/linear/gcb_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: GraphemeClusterBreakValueToLongNameV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/to/long/linear/lb_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/to/long/linear/lb_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: LineBreakValueToLongNameV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/to/long/linear/sb_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/to/long/linear/sb_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: SentenceBreakValueToLongNameV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/to/long/linear/sc_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/to/long/linear/sc_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: ScriptValueToLongNameV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/to/long/linear/wb_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/to/long/linear/wb_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: WordBreakValueToLongNameV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/to/long/sparse/ccc_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/to/long/sparse/ccc_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: CanonicalCombiningClassValueToLongNameV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/to/short/linear/bc_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/to/short/linear/bc_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: BidiClassValueToShortNameV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/to/short/linear/ea_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/to/short/linear/ea_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: EastAsianWidthValueToShortNameV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/to/short/linear/gc_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/to/short/linear/gc_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: GeneralCategoryValueToShortNameV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/to/short/linear/gcb_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/to/short/linear/gcb_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: GraphemeClusterBreakValueToShortNameV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/to/short/linear/lb_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/to/short/linear/lb_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: LineBreakValueToShortNameV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/to/short/linear/sb_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/to/short/linear/sb_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: SentenceBreakValueToShortNameV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/to/short/linear/wb_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/to/short/linear/wb_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: WordBreakValueToShortNameV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/to/short/linear4/sc_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/to/short/linear4/sc_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: ScriptValueToShortNameV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/propnames/to/short/sparse/ccc_v1/mod.rs
+++ b/provider/testdata/data/baked/propnames/to/short/sparse/ccc_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: CanonicalCombiningClassValueToShortNameV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/ahex_v1/mod.rs
+++ b/provider/testdata/data/baked/props/ahex_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::AsciiHexDigitV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/alnum_v1/mod.rs
+++ b/provider/testdata/data/baked/props/alnum_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::AlnumV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/alpha_v1/mod.rs
+++ b/provider/testdata/data/baked/props/alpha_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::AlphabeticV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/basic_emoji_v1/mod.rs
+++ b/provider/testdata/data/baked/props/basic_emoji_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::BasicEmojiV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/bc_v1/mod.rs
+++ b/provider/testdata/data/baked/props/bc_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::BidiClassV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/bidi_c_v1/mod.rs
+++ b/provider/testdata/data/baked/props/bidi_c_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::BidiControlV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/bidi_m_v1/mod.rs
+++ b/provider/testdata/data/baked/props/bidi_m_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::BidiMirroredV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/bidiauxiliaryprops_v1/mod.rs
+++ b/provider/testdata/data/baked/props/bidiauxiliaryprops_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: bidi_data :: BidiAuxiliaryPropertiesV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/blank_v1/mod.rs
+++ b/provider/testdata/data/baked/props/blank_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::BlankV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/cased_v1/mod.rs
+++ b/provider/testdata/data/baked/props/cased_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::CasedV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/casemap_v1/mod.rs
+++ b/provider/testdata/data/baked/props/casemap_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_casemapping")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_casemapping::provider::CaseMappingV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/ccc_v1/mod.rs
+++ b/provider/testdata/data/baked/props/ccc_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: CanonicalCombiningClassV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/ci_v1/mod.rs
+++ b/provider/testdata/data/baked/props/ci_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::CaseIgnorableV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/comp_ex_v1/mod.rs
+++ b/provider/testdata/data/baked/props/comp_ex_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: FullCompositionExclusionV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/cwcf_v1/mod.rs
+++ b/provider/testdata/data/baked/props/cwcf_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: ChangesWhenCasefoldedV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/cwcm_v1/mod.rs
+++ b/provider/testdata/data/baked/props/cwcm_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: ChangesWhenCasemappedV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/cwkcf_v1/mod.rs
+++ b/provider/testdata/data/baked/props/cwkcf_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: ChangesWhenNfkcCasefoldedV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/cwl_v1/mod.rs
+++ b/provider/testdata/data/baked/props/cwl_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: ChangesWhenLowercasedV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/cwt_v1/mod.rs
+++ b/provider/testdata/data/baked/props/cwt_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: ChangesWhenTitlecasedV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/cwu_v1/mod.rs
+++ b/provider/testdata/data/baked/props/cwu_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: ChangesWhenUppercasedV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/dash_v1/mod.rs
+++ b/provider/testdata/data/baked/props/dash_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::DashV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/dep_v1/mod.rs
+++ b/provider/testdata/data/baked/props/dep_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::DeprecatedV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/di_v1/mod.rs
+++ b/provider/testdata/data/baked/props/di_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: DefaultIgnorableCodePointV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/dia_v1/mod.rs
+++ b/provider/testdata/data/baked/props/dia_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::DiacriticV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/ea_v1/mod.rs
+++ b/provider/testdata/data/baked/props/ea_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::EastAsianWidthV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/ebase_v1/mod.rs
+++ b/provider/testdata/data/baked/props/ebase_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::EmojiModifierBaseV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/ecomp_v1/mod.rs
+++ b/provider/testdata/data/baked/props/ecomp_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::EmojiComponentV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/emod_v1/mod.rs
+++ b/provider/testdata/data/baked/props/emod_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::EmojiModifierV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/emoji_v1/mod.rs
+++ b/provider/testdata/data/baked/props/emoji_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::EmojiV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/epres_v1/mod.rs
+++ b/provider/testdata/data/baked/props/epres_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::EmojiPresentationV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/exemplarchars/auxiliary_v1/mod.rs
+++ b/provider/testdata/data/baked/props/exemplarchars/auxiliary_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: ExemplarCharactersAuxiliaryV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/props/exemplarchars/index_v1/mod.rs
+++ b/provider/testdata/data/baked/props/exemplarchars/index_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: ExemplarCharactersIndexV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/props/exemplarchars/main_v1/mod.rs
+++ b/provider/testdata/data/baked/props/exemplarchars/main_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: ExemplarCharactersMainV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/props/exemplarchars/numbers_v1/mod.rs
+++ b/provider/testdata/data/baked/props/exemplarchars/numbers_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: ExemplarCharactersNumbersV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/props/exemplarchars/punctuation_v1/mod.rs
+++ b/provider/testdata/data/baked/props/exemplarchars/punctuation_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: ExemplarCharactersPunctuationV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/props/ext_v1/mod.rs
+++ b/provider/testdata/data/baked/props/ext_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::ExtenderV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/extpict_v1/mod.rs
+++ b/provider/testdata/data/baked/props/extpict_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: ExtendedPictographicV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/gc_v1/mod.rs
+++ b/provider/testdata/data/baked/props/gc_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::GeneralCategoryV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/gcb_v1/mod.rs
+++ b/provider/testdata/data/baked/props/gcb_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: GraphemeClusterBreakV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/gr_base_v1/mod.rs
+++ b/provider/testdata/data/baked/props/gr_base_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::GraphemeBaseV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/gr_ext_v1/mod.rs
+++ b/provider/testdata/data/baked/props/gr_ext_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::GraphemeExtendV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/gr_link_v1/mod.rs
+++ b/provider/testdata/data/baked/props/gr_link_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::GraphemeLinkV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/graph_v1/mod.rs
+++ b/provider/testdata/data/baked/props/graph_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::GraphV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/hex_v1/mod.rs
+++ b/provider/testdata/data/baked/props/hex_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::HexDigitV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/hyphen_v1/mod.rs
+++ b/provider/testdata/data/baked/props/hyphen_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::HyphenV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/idc_v1/mod.rs
+++ b/provider/testdata/data/baked/props/idc_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::IdContinueV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/ideo_v1/mod.rs
+++ b/provider/testdata/data/baked/props/ideo_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::IdeographicV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/ids_v1/mod.rs
+++ b/provider/testdata/data/baked/props/ids_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::IdStartV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/idsb_v1/mod.rs
+++ b/provider/testdata/data/baked/props/idsb_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::IdsBinaryOperatorV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/idst_v1/mod.rs
+++ b/provider/testdata/data/baked/props/idst_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: IdsTrinaryOperatorV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/join_c_v1/mod.rs
+++ b/provider/testdata/data/baked/props/join_c_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::JoinControlV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/lb_v1/mod.rs
+++ b/provider/testdata/data/baked/props/lb_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::LineBreakV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/loe_v1/mod.rs
+++ b/provider/testdata/data/baked/props/loe_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: LogicalOrderExceptionV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/lower_v1/mod.rs
+++ b/provider/testdata/data/baked/props/lower_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::LowercaseV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/math_v1/mod.rs
+++ b/provider/testdata/data/baked/props/math_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::MathV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/nchar_v1/mod.rs
+++ b/provider/testdata/data/baked/props/nchar_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: NoncharacterCodePointV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/nfcinert_v1/mod.rs
+++ b/provider/testdata/data/baked/props/nfcinert_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::NfcInertV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/nfdinert_v1/mod.rs
+++ b/provider/testdata/data/baked/props/nfdinert_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::NfdInertV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/nfkcinert_v1/mod.rs
+++ b/provider/testdata/data/baked/props/nfkcinert_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::NfkcInertV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/nfkdinert_v1/mod.rs
+++ b/provider/testdata/data/baked/props/nfkdinert_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::NfkdInertV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/pat_syn_v1/mod.rs
+++ b/provider/testdata/data/baked/props/pat_syn_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::PatternSyntaxV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/pat_ws_v1/mod.rs
+++ b/provider/testdata/data/baked/props/pat_ws_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::PatternWhiteSpaceV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/pcm_v1/mod.rs
+++ b/provider/testdata/data/baked/props/pcm_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: PrependedConcatenationMarkV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/print_v1/mod.rs
+++ b/provider/testdata/data/baked/props/print_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::PrintV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/qmark_v1/mod.rs
+++ b/provider/testdata/data/baked/props/qmark_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::QuotationMarkV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/radical_v1/mod.rs
+++ b/provider/testdata/data/baked/props/radical_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::RadicalV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/ri_v1/mod.rs
+++ b/provider/testdata/data/baked/props/ri_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::RegionalIndicatorV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/sb_v1/mod.rs
+++ b/provider/testdata/data/baked/props/sb_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::SentenceBreakV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/sc_v1/mod.rs
+++ b/provider/testdata/data/baked/props/sc_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::ScriptV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/scx_v1/mod.rs
+++ b/provider/testdata/data/baked/props/scx_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: ScriptWithExtensionsPropertyV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/sd_v1/mod.rs
+++ b/provider/testdata/data/baked/props/sd_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::SoftDottedV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/segstart_v1/mod.rs
+++ b/provider/testdata/data/baked/props/segstart_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::SegmentStarterV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/sensitive_v1/mod.rs
+++ b/provider/testdata/data/baked/props/sensitive_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::CaseSensitiveV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/sterm_v1/mod.rs
+++ b/provider/testdata/data/baked/props/sterm_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::SentenceTerminalV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/term_v1/mod.rs
+++ b/provider/testdata/data/baked/props/term_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_properties :: provider :: TerminalPunctuationV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/props/uideo_v1/mod.rs
+++ b/provider/testdata/data/baked/props/uideo_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::UnifiedIdeographV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/upper_v1/mod.rs
+++ b/provider/testdata/data/baked/props/upper_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::UppercaseV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/vs_v1/mod.rs
+++ b/provider/testdata/data/baked/props/vs_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::VariationSelectorV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/wb_v1/mod.rs
+++ b/provider/testdata/data/baked/props/wb_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::WordBreakV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/wspace_v1/mod.rs
+++ b/provider/testdata/data/baked/props/wspace_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::WhiteSpaceV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/xdigit_v1/mod.rs
+++ b/provider/testdata/data/baked/props/xdigit_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::XdigitV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/xidc_v1/mod.rs
+++ b/provider/testdata/data/baked/props/xidc_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::XidContinueV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/props/xids_v1/mod.rs
+++ b/provider/testdata/data/baked/props/xids_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_properties")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_properties::provider::XidStartV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/relativetime/long/day_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/long/day_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: LongDayRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/long/hour_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/long/hour_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: LongHourRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/long/minute_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/long/minute_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: LongMinuteRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/long/month_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/long/month_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: LongMonthRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/long/quarter_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/long/quarter_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: LongQuarterRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/long/second_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/long/second_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: LongSecondRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/long/week_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/long/week_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: LongWeekRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/long/year_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/long/year_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: LongYearRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/narrow/day_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/narrow/day_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: NarrowDayRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/narrow/hour_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/narrow/hour_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: NarrowHourRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/narrow/minute_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/narrow/minute_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: NarrowMinuteRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/narrow/month_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/narrow/month_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: NarrowMonthRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/narrow/quarter_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/narrow/quarter_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: NarrowQuarterRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/narrow/second_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/narrow/second_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: NarrowSecondRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/narrow/week_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/narrow/week_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: NarrowWeekRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/narrow/year_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/narrow/year_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: NarrowYearRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/short/day_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/short/day_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: ShortDayRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/short/hour_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/short/hour_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: ShortHourRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/short/minute_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/short/minute_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: ShortMinuteRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/short/month_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/short/month_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: ShortMonthRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/short/quarter_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/short/quarter_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: ShortQuarterRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/short/second_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/short/second_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: ShortSecondRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/short/week_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/short/week_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: ShortWeekRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/relativetime/short/year_v1/mod.rs
+++ b/provider/testdata/data/baked/relativetime/short/year_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_relativetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_relativetime :: provider :: ShortYearRelativeTimeFormatDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/segmenter/dictionary/w_auto_v1/mod.rs
+++ b/provider/testdata/data/baked/segmenter/dictionary/w_auto_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_segmenter")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_segmenter :: provider :: DictionaryForWordOnlyAutoV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     icu_provider::DataLocale::from(icu_locid::locale!("ja"))

--- a/provider/testdata/data/baked/segmenter/dictionary/wl_ext_v1/mod.rs
+++ b/provider/testdata/data/baked/segmenter/dictionary/wl_ext_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_segmenter")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_segmenter :: provider :: DictionaryForWordLineExtendedV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     icu_provider::DataLocale::from(icu_locid::locale!("th"))

--- a/provider/testdata/data/baked/segmenter/grapheme_v1/mod.rs
+++ b/provider/testdata/data/baked/segmenter/grapheme_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_segmenter")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_segmenter :: provider :: GraphemeClusterBreakDataV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     locale.is_empty().then(|| &UND)

--- a/provider/testdata/data/baked/segmenter/line_v1/mod.rs
+++ b/provider/testdata/data/baked/segmenter/line_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_segmenter")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_segmenter::provider::LineBreakDataV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/segmenter/lstm/wl_auto_v1/mod.rs
+++ b/provider/testdata/data/baked/segmenter/lstm/wl_auto_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_segmenter")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_segmenter :: provider :: LstmForWordLineAutoV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     icu_provider::DataLocale::from(icu_locid::locale!("th"))

--- a/provider/testdata/data/baked/segmenter/sentence_v1/mod.rs
+++ b/provider/testdata/data/baked/segmenter/sentence_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_segmenter")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_segmenter::provider::SentenceBreakDataV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/segmenter/word_v1/mod.rs
+++ b/provider/testdata/data/baked/segmenter/word_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_segmenter")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_segmenter::provider::WordBreakDataV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/time_zone/exemplar_cities_v1/mod.rs
+++ b/provider/testdata/data/baked/time_zone/exemplar_cities_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: time_zones :: ExemplarCitiesV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/time_zone/formats_v1/mod.rs
+++ b/provider/testdata/data/baked/time_zone/formats_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: time_zones :: TimeZoneFormatsV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/time_zone/generic_long_v1/mod.rs
+++ b/provider/testdata/data/baked/time_zone/generic_long_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: time_zones :: MetazoneGenericNamesLongV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/time_zone/generic_short_v1/mod.rs
+++ b/provider/testdata/data/baked/time_zone/generic_short_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: time_zones :: MetazoneGenericNamesShortV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/time_zone/metazone_period_v1/mod.rs
+++ b/provider/testdata/data/baked/time_zone/metazone_period_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_timezone")]
-#![allow(clippy::octal_escapes)]
 type DataStruct =
     <::icu_timezone::provider::MetazonePeriodV1Marker as ::icu_provider::DataMarker>::Yokeable;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {

--- a/provider/testdata/data/baked/time_zone/specific_long_v1/mod.rs
+++ b/provider/testdata/data/baked/time_zone/specific_long_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: time_zones :: MetazoneSpecificNamesLongV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [

--- a/provider/testdata/data/baked/time_zone/specific_short_v1/mod.rs
+++ b/provider/testdata/data/baked/time_zone/specific_short_v1/mod.rs
@@ -1,6 +1,5 @@
 // @generated
 #![cfg(feature = "icu_datetime")]
-#![allow(clippy::octal_escapes)]
 type DataStruct = < :: icu_datetime :: provider :: time_zones :: MetazoneSpecificNamesShortV1Marker as :: icu_provider :: DataMarker > :: Yokeable ;
 pub fn lookup(locale: &icu_provider::DataLocale) -> Option<&'static DataStruct> {
     static KEYS: [&str; 19usize] = [


### PR DESCRIPTION
#3244

Not visible on GH, `provider/testdata/data/baked/segmenter/dictionary/w_auto_v1/ja.rs.data` triggers a false positive and databake detects that and adds an `allow`.