### PR TITLE
Replace rust-format crate with direct call to `rustfmt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1763,7 +1763,6 @@ dependencies = [
  "quote",
  "rayon",
  "repodata",
- "rust-format",
  "serde",
  "serde-aux",
  "serde_json",

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -69,7 +69,6 @@ ndarray = { version = "0.15.5", default-features = false }
 proc-macro2 = "1.0"
 quote = "1.0.9"
 rayon = "1.5"
-rust-format = { version = "0.3.4", features = ["token_stream"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde-aux = { version = "4.1.2", default-features = false }

--- a/provider/datagen/src/databake.rs
+++ b/provider/datagen/src/databake.rs
@@ -96,33 +96,39 @@ impl BakedDataExporter {
             .with_extension(if is_expr { "rs.data" } else { "rs" });
 
         let mut formatted = if self.pretty {
-            use rust_format::*;
-            RustFmt::from_config(
-                Config::new_str()
-                    // We deal with line encoding later
-                    .option("newline_style", "unix")
-                    .option("normalize_doc_attributes", "true")
-                    // Rustfmt silently gives up if it cannot achieve the max width, which happens for the root mod.rs
-                    .option(
-                        "max_width",
-                        if relative_path.as_ref().as_os_str().to_str() == Some("mod") {
-                            "150"
-                        } else {
-                            "100"
-                        },
-                    ),
-            )
-            .format_tokens(if is_expr {
-                // Rustfmt cannot format Rust expressions, only full files. We need to wrap expressions in a main function
-                quote!(fn main() { #data })
+            use std::process::{Command, Stdio};
+            let mw = if relative_path.as_ref().as_os_str().to_str() == Some("mod") {
+                "max_width=150"
             } else {
-                data
-            })
-            .map_err(|e| {
-                DataError::custom("Formatting error")
-                    .with_display_context(&e)
-                    .with_path_context(&path)
-            })?
+                "max_width=100"
+            };
+            let mut rustfmt = Command::new("rustfmt")
+                .arg("--config")
+                .arg("newline_style=unix")
+                .arg("--config")
+                .arg("normalize_doc_attributes=true")
+                .arg("--config")
+                .arg(mw)
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()?;
+            let rustfmt_stdin = rustfmt.stdin.as_mut().unwrap();
+            if is_expr {
+                write!(rustfmt_stdin, "fn main () {{ {data} }}")?
+            } else {
+                write!(rustfmt_stdin, "{data}")?
+            };
+
+            drop(rustfmt_stdin); // EOF
+
+            let output = rustfmt.wait_with_output()?;
+            if !output.status.success() {
+                let stderr = String::from_utf8(output.stderr)
+                    .map_err(|_| DataError::custom("rustfmt output not utf-8"))?;
+                return Err(DataError::custom("rustfmt failed").with_display_context(&stderr));
+            }
+            String::from_utf8(output.stdout)
+                .map_err(|_| DataError::custom("rustfmt output not utf-8"))?
         } else {
             data.to_string()
         };

--- a/provider/datagen/src/databake.rs
+++ b/provider/datagen/src/databake.rs
@@ -112,7 +112,7 @@ impl BakedDataExporter {
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .spawn()?;
-            let rustfmt_stdin = rustfmt.stdin.as_mut().unwrap();
+            let mut rustfmt_stdin = rustfmt.stdin.take().unwrap();
             if is_expr {
                 write!(rustfmt_stdin, "fn main () {{ {data} }}")?
             } else {

--- a/provider/testdata/data/baked/mod.rs
+++ b/provider/testdata/data/baked/mod.rs
@@ -34,7 +34,7 @@ mod segmenter;
 #[clippy::msrv = "1.61"]
 mod time_zone;
 #[clippy::msrv = "1.61"]
-use ::icu_provider::prelude::*;
+use icu_provider::prelude::*;
 /// Implement [`DataProvider<M>`] on the given struct using the data
 /// hardcoded in this module. This allows the struct to be used with
 /// `icu`'s `_unstable` constructors.

--- a/tools/depcheck/src/allowlist.rs
+++ b/tools/depcheck/src/allowlist.rs
@@ -124,7 +124,6 @@ pub const EXTRA_DATAGEN_DEPS: &[&str] = &[
     "num-integer",
     "rawpointer",
     "regex-syntax",
-    "rust-format",
     "ryu",
     "serde-aux",
     "serde_json",


### PR DESCRIPTION
Supersedes https://github.com/unicode-org/icu4x/pull/3363


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->