### PR TITLE
Remove `num_traits` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,7 +2115,7 @@ dependencies = [
  "icu_provider_fs",
  "icu_testdata",
  "itertools",
- "num-traits",
+ "libm",
  "serde",
  "serde_json",
  "utf8_iter",

--- a/components/segmenter/Cargo.toml
+++ b/components/segmenter/Cargo.toml
@@ -38,7 +38,7 @@ zerovec = { version = "0.9.4", path = "../../utils/zerovec", features = ["yoke"]
 databake = { version = "0.1.3", path = "../../utils/databake", optional = true, features = ["derive"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 
-num-traits = { version = "0.2", default-features = false, features = ["libm"], optional = true }
+libm = { version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
 criterion = "0.4"
@@ -56,7 +56,7 @@ default = ["auto"]
 std = ["icu_collections/std", "icu_locid/std", "icu_provider/std"]
 serde = ["dep:serde", "zerovec/serde", "icu_collections/serde", "icu_provider/serde"]
 datagen = ["serde", "dep:databake", "zerovec/databake", "icu_collections/databake"]
-lstm = ["dep:num-traits"]
+lstm = ["dep:libm"]
 auto = ["lstm"] # Enabled try_new_auto_unstable constructors
 
 [lib]

--- a/components/segmenter/src/complex/lstm/matrix.rs
+++ b/components/segmenter/src/complex/lstm/matrix.rs
@@ -216,9 +216,9 @@ impl<'a, const D: usize> MatrixBorrowedMut<'a, D> {
         for v in self.data.iter_mut() {
             *v = v.exp();
         }
-        let sm = self.data.iter().sum::<f32>();
+        let sm = 1.0 / self.data.iter().sum::<f32>();
         for v in self.data.iter_mut() {
-            *v /= sm;
+            *v *= sm;
         }
     }
 

--- a/ffi/gn/Cargo.lock
+++ b/ffi/gn/Cargo.lock
@@ -46,12 +46,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cb94155d965e3d37ffbbe7cc5b82c3dd79dd33bd48e536f73d2cfb8d85506f"
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,7 +450,7 @@ dependencies = [
  "icu_collections",
  "icu_locid",
  "icu_provider",
- "num-traits",
+ "libm",
  "utf8_iter",
  "zerovec",
 ]
@@ -563,16 +557,6 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "num-traits"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
-dependencies = [
- "autocfg",
- "libm",
-]
 
 [[package]]
 name = "pretty_assertions"

--- a/ffi/gn/Cargo.toml
+++ b/ffi/gn/Cargo.toml
@@ -36,9 +36,6 @@ rustflags = []
 [gn.package.syn."1.0.109"]
 rustflags = ["--cfg=syn_disable_nightly_tests"]
 
-[gn.package.num-traits."0.2.15"]
-rustflags = ["--cfg=has_i128"]
-
 [gn.package.libm."0.2.6"]
 rustflags = []
 

--- a/ffi/gn/icu4x/BUILD.gn
+++ b/ffi/gn/icu4x/BUILD.gn
@@ -628,7 +628,7 @@ rust_library("icu_segmenter-v1_2_1") {
   deps += [ ":icu_collections-v1_2_0" ]
   deps += [ ":icu_locid-v1_2_0" ]
   deps += [ ":icu_provider-v1_2_0" ]
-  deps += [ ":num-traits-v0_2_15" ]
+  deps += [ ":libm-v0_2_6" ]
   deps += [ ":utf8_iter-v1_0_3" ]
   deps += [ ":zerovec-v0_9_4" ]
 
@@ -752,7 +752,6 @@ rust_library("libm-v0_2_6") {
     "--edition=2018",
     "-Cmetadata=6b5214f2031c6f9e",
     "-Cextra-filename=-6b5214f2031c6f9e",
-    "--cfg=feature=\"default\"",
   ]
 
   visibility = [ ":*" ]
@@ -815,28 +814,6 @@ rust_library("memchr-v2_5_0") {
     "--edition=2018",
     "-Cmetadata=7487f9414aaf0c2b",
     "-Cextra-filename=-7487f9414aaf0c2b",
-  ]
-
-  visibility = [ ":*" ]
-}
-
-rust_library("num-traits-v0_2_15") {
-  crate_name = "num_traits"
-  crate_root = "//ffi/gn/vendor/num-traits/src/lib.rs"
-  output_name = "num_traits-64c0e09f0f13aa66"
-
-  deps = []
-  deps += [ ":libm-v0_2_6" ]
-
-  rustenv = []
-
-  rustflags = [
-    "--cap-lints=allow",
-    "--edition=2015",
-    "-Cmetadata=64c0e09f0f13aa66",
-    "-Cextra-filename=-64c0e09f0f13aa66",
-    "--cfg=feature=\"libm\"",
-    "--cfg=has_i128",
   ]
 
   visibility = [ ":*" ]

--- a/tools/depcheck/src/allowlist.rs
+++ b/tools/depcheck/src/allowlist.rs
@@ -72,7 +72,7 @@ pub const EXTRA_EXPERIMENTAL_DEPS: &[&str] = &[
 ];
 
 /// Dependencies allowed when opting in to LSTM segmenter
-pub const EXTRA_LSTM_DEPS: &[&str] = &["libm", "num-traits"];
+pub const EXTRA_LSTM_DEPS: &[&str] = &["libm"];
 
 /// Dependencies allowed when opting in to fixed_decimal's `ryu` backend
 /// This should never change
@@ -122,6 +122,7 @@ pub const EXTRA_DATAGEN_DEPS: &[&str] = &[
     "ndarray",
     "num-complex",
     "num-integer",
+    "num-traits",
     "rawpointer",
     "regex-syntax",
     "rust-format",


### PR DESCRIPTION
Similar to #3369, the `num_traits` dependency doesn't add anything, and we only pull it in to get `libm`.

Ideally we wouldn't need that dependency, but https://github.com/rust-lang/rfcs/issues/2505 isn't moving. Currently Rust is in the unfortunate position that any `#[no_std]` build needs to use the Rust `libm` implementation, even if a more efficient native libm is available.