### PR TITLE
Do not autoenable postcard/use-std from provider-fs

### DIFF
--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -37,7 +37,7 @@ writeable = { version = "0.5.1", path = "../../utils/writeable" }
 bincode = { version = "1.3", optional = true }
 crlify = { version = "1.0.1", path = "../../utils/crlify", optional = true }
 log = { version = "0.4", optional = true }
-postcard = { version = "1.0.0", features = ["use-std"], default-features = false, optional = true }
+postcard = { version = "1.0.0", features = ["alloc"], default-features = false, optional = true }
 serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
It's not needed, we shouldn't enable it.

I would benefit in a minor way from a patch release, but it's minor enough that I'd rather ignore it.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->