### PR TITLE
Remove JapaneseEraV1 bound from TypedZonedDateTimeFormatter; release icu_datetime 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Note: A subset of crates received patch releases in the 1.2 stream.
   - Fixed [#3341](https://github.com/unicode-org/icu4x/pull/3341), incorrect results on some strings with mixed scripts
 - `icu_provider` 1.2.1
   - Do not autoenable `postcard/use-std` ([#3376](https://github.com/unicode-org/icu4x/pull/3376))
-
+- `icu_datetime` 1.2.1
+  - Remove superfluous `JapaneseEraV1` provider bounds on `TypedZonedDateTimeFormatter` [#3379](https://github.com/unicode-org/icu4x/pull/3379)
 ## icu4x 1.2 (Apr 13, 2023)
 
 - General

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "icu_datetime"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "bincode",
  "criterion",

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_datetime"
 description = "API for formatting date and time to user readable textual representation"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"

--- a/components/datetime/src/zoned_datetime.rs
+++ b/components/datetime/src/zoned_datetime.rs
@@ -4,7 +4,7 @@
 
 use alloc::string::String;
 use core::marker::PhantomData;
-use icu_calendar::provider::{JapaneseErasV1Marker, WeekDataV1Marker};
+use icu_calendar::provider::WeekDataV1Marker;
 use icu_decimal::provider::DecimalSymbolsV1Marker;
 use icu_plurals::provider::OrdinalV1Marker;
 use icu_provider::prelude::*;
@@ -147,7 +147,6 @@ impl<C: CldrCalendar> TypedZonedDateTimeFormatter<C> {
             + DataProvider<provider::time_zones::MetazoneSpecificNamesShortV1Marker>
             + DataProvider<OrdinalV1Marker>
             + DataProvider<DecimalSymbolsV1Marker>
-            + DataProvider<JapaneseErasV1Marker>
             + ?Sized,
     {
         let patterns = PatternSelector::for_options_experimental(
@@ -232,7 +231,6 @@ impl<C: CldrCalendar> TypedZonedDateTimeFormatter<C> {
             + DataProvider<provider::time_zones::MetazoneSpecificNamesShortV1Marker>
             + DataProvider<OrdinalV1Marker>
             + DataProvider<DecimalSymbolsV1Marker>
-            + DataProvider<JapaneseErasV1Marker>
             + ?Sized,
     {
         let patterns = PatternSelector::for_options(

--- a/ffi/gn/Cargo.lock
+++ b/ffi/gn/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "icu_datetime"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "either",

--- a/ffi/gn/icu4x/BUILD.gn
+++ b/ffi/gn/icu4x/BUILD.gn
@@ -177,7 +177,7 @@ rust_library("icu-v1_2_0") {
   deps += [ ":icu_calendar-v1_2_0" ]
   deps += [ ":icu_collator-v1_2_0" ]
   deps += [ ":icu_collections-v1_2_0" ]
-  deps += [ ":icu_datetime-v1_2_0" ]
+  deps += [ ":icu_datetime-v1_2_1" ]
   deps += [ ":icu_decimal-v1_2_0" ]
   deps += [ ":icu_list-v1_2_0" ]
   deps += [ ":icu_locid-v1_2_0" ]
@@ -239,7 +239,7 @@ rust_library("icu_capi-v1_2_1") {
   deps += [ ":icu_calendar-v1_2_0" ]
   deps += [ ":icu_collator-v1_2_0" ]
   deps += [ ":icu_collections-v1_2_0" ]
-  deps += [ ":icu_datetime-v1_2_0" ]
+  deps += [ ":icu_datetime-v1_2_1" ]
   deps += [ ":icu_decimal-v1_2_0" ]
   deps += [ ":icu_list-v1_2_0" ]
   deps += [ ":icu_locid-v1_2_0" ]
@@ -337,10 +337,10 @@ rust_library("icu_collections-v1_2_0") {
   visibility = [ ":*" ]
 }
 
-rust_library("icu_datetime-v1_2_0") {
+rust_library("icu_datetime-v1_2_1") {
   crate_name = "icu_datetime"
   crate_root = "//components/datetime/src/lib.rs"
-  output_name = "icu_datetime-30f748f42eae6a87"
+  output_name = "icu_datetime-cf91c73a3ee7499c"
 
   deps = []
   deps += [ ":displaydoc-v0_2_3($host_toolchain)" ]
@@ -362,8 +362,8 @@ rust_library("icu_datetime-v1_2_0") {
   rustflags = [
     "--cap-lints=allow",
     "--edition=2021",
-    "-Cmetadata=30f748f42eae6a87",
-    "-Cextra-filename=-30f748f42eae6a87",
+    "-Cmetadata=cf91c73a3ee7499c",
+    "-Cextra-filename=-cf91c73a3ee7499c",
   ]
 
   visibility = [ ":*" ]
@@ -656,7 +656,7 @@ rust_library("icu_testdata-v1_2_0") {
   deps += [ ":icu_calendar-v1_2_0" ]
   deps += [ ":icu_collator-v1_2_0" ]
   deps += [ ":icu_collections-v1_2_0" ]
-  deps += [ ":icu_datetime-v1_2_0" ]
+  deps += [ ":icu_datetime-v1_2_1" ]
   deps += [ ":icu_decimal-v1_2_0" ]
   deps += [ ":icu_list-v1_2_0" ]
   deps += [ ":icu_locid-v1_2_0" ]


### PR DESCRIPTION
Fixes #3378