### PR TITLE
Fix name and link to icu_plurals crate in README

### DIFF
--- a/components/plurals/README.md
+++ b/components/plurals/README.md
@@ -2,7 +2,7 @@
 
 Determine the plural category appropriate for a given number in a given language.
 
-This module is published as its own crate ([`icu_plural`](https://docs.rs/icu_plural/latest/icu_plural/))
+This module is published as its own crate ([`icu_plurals`](https://docs.rs/icu_plurals/latest/icu_plurals/))
 and as part of the [`icu`](https://docs.rs/icu/latest/icu/) crate. See the latter for more details on the ICU4X project.
 
 For example in English, when constructing a message

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -4,7 +4,7 @@
 
 //! Determine the plural category appropriate for a given number in a given language.
 //!
-//! This module is published as its own crate ([`icu_plural`](https://docs.rs/icu_plural/latest/icu_plural/))
+//! This module is published as its own crate ([`icu_plurals`](https://docs.rs/icu_plurals/latest/icu_plurals/))
 //! and as part of the [`icu`](https://docs.rs/icu/latest/icu/) crate. See the latter for more details on the ICU4X project.
 //!
 //! For example in English, when constructing a message


### PR DESCRIPTION
This PR fixes the name of the `icu_plurals` crate and link to it in the README of that component.