### PR TITLE
Remove use of alloc_error_handler, update nightly to 2023-01-01, update tiny test to LLVM 15

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -310,11 +310,11 @@ jobs:
       run: rustup show
 
     # Job-specific dependencies
-    - name: Set up Clang-14
+    - name: Set up Clang-15
       run: |
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh 14
+        sudo ./llvm.sh 15
     - name: Install Node.js v16.18.0
       uses: actions/setup-node@v3
       with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Our wider testsuite is organized as `ci-job-foo` make tasks corresponding to eac
  - `cargo doc --no-deps --all-features`: Recreates API docs locally; any warning should be fixed since it will be treated as an error in CI.
  - `cargo make ci-job-ffi`: Runs all of the FFI tests; mostly important if you're changing the FFI interface. This has several additional dependencies:
      + [`Diplomat`](https://github.com/rust-diplomat/diplomat) installed at the appropriate version: `cargo make diplomat-install`
-     + `clang-14` and `lld-14` with the `gold` plugin (APT packages `llvm-14` and `lld-14`)
+     + `clang-15` and `lld-15` with the `gold` plugin (APT packages `llvm-15` and `lld-15`)
  - `cargo make ci-job-wasm`: Runs Rust-to-WASM tests. This also has a couple additional dependencies:
      + Node.js version 16.18.0. This may not the one offered by the package manager; get it from the NodeJS website or `nvm`.
      + [`Twiggy`](https://github.com/rustwasm/twiggy) (at least 0.7.0: `cargo install twiggy`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,15 +121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bare-metal"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
-dependencies = [
- "rustc_version 0.2.3",
-]
-
-[[package]]
 name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,12 +161,6 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "bitfield"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
 name = "bitflags"
@@ -577,18 +562,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cortex-m"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
-dependencies = [
- "bare-metal",
- "bitfield",
- "embedded-hal",
- "volatile-register",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,16 +917,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e0aca8dce8856e420195bd13b6a64de3334235ccc9214e824b86b12bf26283"
 dependencies = [
  "stable_deref_trait",
-]
-
-[[package]]
-name = "embedded-hal"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
-dependencies = [
- "nb 0.1.3",
- "void",
 ]
 
 [[package]]
@@ -1860,7 +1823,6 @@ dependencies = [
 name = "icu_freertos"
 version = "1.2.0"
 dependencies = [
- "cortex-m",
  "freertos-rust",
  "icu_capi",
 ]
@@ -2536,21 +2498,6 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
-
-[[package]]
-name = "nb"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
-dependencies = [
- "nb 1.1.0",
-]
-
-[[package]]
-name = "nb"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "ndarray"
@@ -4014,12 +3961,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64a8922555b9500e3d865caed19330172cd67cbf82203f1a3311d8c305cc9f33"
 
 [[package]]
-name = "vcell"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4030,21 +3971,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "volatile-register"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
-dependencies = [
- "vcell",
-]
 
 [[package]]
 name = "walkdir"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -16,7 +16,7 @@ extend = [
 default_to_workspace = false
 
 [env]
-ICU4X_NIGHTLY_TOOLCHAIN = { value = "nightly-2022-04-18", condition = { env_not_set = ["ICU4X_NIGHTLY_TOOLCHAIN"] } }
+ICU4X_NIGHTLY_TOOLCHAIN = { value = "nightly-2023-01-01", condition = { env_not_set = ["ICU4X_NIGHTLY_TOOLCHAIN"] } }
 # To install a specific build of GN, set the ICU4X_GN_PACKAGE environment variable. Choices:
 # https://chrome-infra-packages.appspot.com/p/gn/gn
 # TODO: Choose the correct distribution of GN automatically.

--- a/ffi/diplomat/c/examples/fixeddecimal_tiny/Makefile
+++ b/ffi/diplomat/c/examples/fixeddecimal_tiny/Makefile
@@ -12,8 +12,8 @@ ICU4X_NIGHTLY_TOOLCHAIN ?= "nightly-2023-01-01"
 $(ALL_HEADERS):
 
 GCC := gcc
-CLANG := clang-14
-LLD := lld-14
+CLANG := clang-15
+LLD := lld-15
 
 ../../../../../target/debug/libicu_capi_staticlib.a: FORCE
 	cargo build -p icu_capi_staticlib --no-default-features --features buffer_provider,icu_capi/default_components

--- a/ffi/diplomat/c/examples/fixeddecimal_tiny/Makefile
+++ b/ffi/diplomat/c/examples/fixeddecimal_tiny/Makefile
@@ -7,7 +7,7 @@
 FORCE:
 
 ALL_HEADERS := $(wildcard ../../include/*.h)
-ICU4X_NIGHTLY_TOOLCHAIN ?= "nightly-2022-04-18"
+ICU4X_NIGHTLY_TOOLCHAIN ?= "nightly-2023-01-01"
 
 $(ALL_HEADERS):
 

--- a/ffi/diplomat/c/examples/fixeddecimal_tiny/icu_capi_staticlib_tiny/Cargo.lock
+++ b/ffi/diplomat/c/examples/fixeddecimal_tiny/icu_capi_staticlib_tiny/Cargo.lock
@@ -22,15 +22,16 @@ checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "deduplicating_array"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "diplomat"
-version = "0.5.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=0e9eb4f1b64deca826fdd566bd3eabbf5ad9e807#0e9eb4f1b64deca826fdd566bd3eabbf5ad9e807"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e9eae368e4141b5f1c594afe819c85bad0aec8fd1f4cc9ac1888837a957491"
 dependencies = [
  "diplomat_core",
  "proc-macro2",
@@ -40,13 +41,15 @@ dependencies = [
 
 [[package]]
 name = "diplomat-runtime"
-version = "0.5.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=0e9eb4f1b64deca826fdd566bd3eabbf5ad9e807#0e9eb4f1b64deca826fdd566bd3eabbf5ad9e807"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e401cc0e98682b1a24220a4f3185bb5ddd8ccb2cd861d09fe23455b401e3cce"
 
 [[package]]
 name = "diplomat_core"
-version = "0.5.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=0e9eb4f1b64deca826fdd566bd3eabbf5ad9e807#0e9eb4f1b64deca826fdd566bd3eabbf5ad9e807"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba145991e24046639916a3199216e29493659398fc2f25673f48aee29b122b2"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -85,7 +88,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "fixed_decimal"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "displaydoc",
  "ryu",
@@ -95,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "displaydoc",
  "icu_locid",
@@ -108,14 +111,13 @@ dependencies = [
 
 [[package]]
 name = "icu_capi"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
  "fixed_decimal",
  "icu_calendar",
  "icu_collator",
- "icu_collections",
  "icu_datetime",
  "icu_decimal",
  "icu_displaynames",
@@ -134,7 +136,6 @@ dependencies = [
  "log",
  "serde",
  "tinystr",
- "unicode-bidi",
  "writeable",
 ]
 
@@ -148,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "icu_collator"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -165,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "displaydoc",
  "serde",
@@ -176,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "icu_datetime"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "either",
@@ -197,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "icu_decimal"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "displaydoc",
  "fixed_decimal",
@@ -209,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "icu_displaynames"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "icu_collections",
  "icu_locid",
@@ -221,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "icu_list"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "deduplicating_array",
  "displaydoc",
@@ -233,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "icu_locid"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -245,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "icu_locid",
@@ -257,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -273,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "icu_plurals"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "displaydoc",
  "fixed_decimal",
@@ -285,19 +286,20 @@ dependencies = [
 
 [[package]]
 name = "icu_properties"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "displaydoc",
  "icu_collections",
  "icu_provider",
  "serde",
+ "tinystr",
  "unicode-bidi",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_provider"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "displaydoc",
  "icu_locid",
@@ -313,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_adapters"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "icu_locid",
  "icu_provider",
@@ -325,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_blob"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "icu_provider",
  "postcard",
@@ -337,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_macros"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -346,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "icu_segmenter"
-version = "0.8.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -360,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "icu_testdata"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "icu_calendar",
  "icu_collator",
@@ -383,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "icu_timezone"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "displaydoc",
  "icu_calendar",
@@ -414,7 +416,7 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "litemap"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "serde",
 ]
@@ -608,11 +610,11 @@ checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
-version = "0.5.1"
+version = "0.5.2"
 
 [[package]]
 name = "yoke"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -622,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -632,14 +634,14 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -649,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "serde",
  "yoke",
@@ -659,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ffi/diplomat/c/examples/fixeddecimal_tiny/icu_capi_staticlib_tiny/src/lib.rs
+++ b/ffi/diplomat/c/examples/fixeddecimal_tiny/icu_capi_staticlib_tiny/src/lib.rs
@@ -9,17 +9,11 @@ extern crate icu_capi;
 
 extern crate dlmalloc;
 
-use core::alloc::Layout;
 use core::panic::PanicInfo;
 use dlmalloc::GlobalDlmalloc;
 
 #[global_allocator]
 static ALLOCATOR: GlobalDlmalloc = GlobalDlmalloc;
-
-#[alloc_error_handler]
-fn alloc_error(_layout: Layout) -> ! {
-    loop {}
-}
 
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {

--- a/ffi/diplomat/cpp/examples/fixeddecimal_wasm/Makefile
+++ b/ffi/diplomat/cpp/examples/fixeddecimal_wasm/Makefile
@@ -7,7 +7,7 @@
 FORCE: 
 
 ALL_HEADERS := $(wildcard ../../include/*.hpp) $(wildcard ../../../c/include/*.h)
-ICU4X_NIGHTLY_TOOLCHAIN ?= "nightly-2022-04-18"
+ICU4X_NIGHTLY_TOOLCHAIN ?= "nightly-2023-01-01"
 
 CXX?=g++
 EMCC?=emcc

--- a/ffi/diplomat/js/examples/node/Makefile
+++ b/ffi/diplomat/js/examples/node/Makefile
@@ -6,7 +6,7 @@
 FORCE:
 
 ALL_HEADERS := $(wildcard ../../include/*)
-ICU4X_NIGHTLY_TOOLCHAIN ?= "nightly-2022-04-18"
+ICU4X_NIGHTLY_TOOLCHAIN ?= "nightly-2023-01-01"
 
 $(ALL_HEADERS):
 

--- a/ffi/diplomat/js/examples/tinywasm/Makefile
+++ b/ffi/diplomat/js/examples/tinywasm/Makefile
@@ -6,7 +6,7 @@
 FORCE:
 
 ALL_HEADERS := $(wildcard ../../include/*)
-ICU4X_NIGHTLY_TOOLCHAIN ?= "nightly-2022-04-18"
+ICU4X_NIGHTLY_TOOLCHAIN ?= "nightly-2023-01-01"
 
 $(ALL_HEADERS):
 

--- a/ffi/freertos/Cargo.toml
+++ b/ffi/freertos/Cargo.toml
@@ -35,7 +35,6 @@ path = "src/lib.rs"
 icu_capi = { version = "1.2.0", path = "../diplomat", default-features = false }
 
 [target.'cfg(target_os = "none")'.dependencies]
-cortex-m = "0.7.3"
 freertos-rust = "0.1.2"
 
 [features]

--- a/ffi/freertos/src/lib.rs
+++ b/ffi/freertos/src/lib.rs
@@ -17,7 +17,6 @@
     )
 )]
 #![allow(clippy::upper_case_acronyms)]
-#![cfg_attr(target_os = "none", feature(alloc_error_handler))]
 
 // Necessary to for symbols to be linked in
 extern crate icu_capi;
@@ -26,20 +25,11 @@ extern crate icu_capi;
 #[cfg(target_os = "none")]
 mod stuff {
     extern crate alloc;
-
-    use alloc::alloc::Layout;
     use core::panic::PanicInfo;
-    use cortex_m::asm;
     use freertos_rust::FreeRtosAllocator;
 
     #[global_allocator]
     static GLOBAL: FreeRtosAllocator = FreeRtosAllocator;
-
-    #[alloc_error_handler]
-    fn alloc_error(_layout: Layout) -> ! {
-        asm::bkpt();
-        loop {}
-    }
 
     #[cfg(target_os = "none")]
     #[panic_handler]

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -540,7 +540,7 @@ fn test_keys_from_file() {
 #[test]
 fn test_keys_from_bin() {
     // File obtained by changing work_log.rs to use `try_new_with_buffer_provider` & `icu_testdata::small_buffer`
-    // and running `cargo +nightly-2022-04-18 wasm-build-release --examples -p icu_datetime --features serde \
+    // and running `cargo +nightly-2023-01-01 wasm-build-release --examples -p icu_datetime --features serde \
     // && cp target/wasm32-unknown-unknown/release-opt-size/examples/work_log.wasm provider/datagen/tests/data/`
     assert_eq!(
         keys_from_bin(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/data/work_log.wasm"))


### PR DESCRIPTION
`#[alloc_error_handler]` was removed so our nightly CI is failing.

It was made unnecessary last December, so I'm updating to a nightly past that change. This requires us to update to LLVM 15, which does seem available in APT.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->