### PR TITLE
Fix an issue where uppercase Cherokee syllables were erroneously case folded to lowercase forms

### DIFF
--- a/experimental/casemap/src/casemapper.rs
+++ b/experimental/casemap/src/casemapper.rs
@@ -687,4 +687,17 @@ mod tests {
         assert_eq!(cm.uppercase_to_string("i", &tr), "İ");
         assert_eq!(cm.uppercase_to_string("i", &az), "İ");
     }
+
+    #[test]
+    fn test_cherokee_case_folding() {
+        let case_mapping = CaseMapper::new();
+        assert_eq!(case_mapping.simple_fold('Ꭰ'), 'Ꭰ');
+        assert_eq!(case_mapping.simple_fold('ꭰ'), 'Ꭰ');
+        assert_eq!(case_mapping.simple_fold_turkic('Ꭰ'), 'Ꭰ');
+        assert_eq!(case_mapping.simple_fold_turkic('ꭰ'), 'Ꭰ');
+        assert_eq!(case_mapping.fold_string("Ꭰ"), "Ꭰ");
+        assert_eq!(case_mapping.fold_string("ꭰ"), "Ꭰ");
+        assert_eq!(case_mapping.fold_turkic_string("Ꭰ"), "Ꭰ");
+        assert_eq!(case_mapping.fold_turkic_string("ꭰ"), "Ꭰ");
+    }
 }

--- a/experimental/casemap/src/internals.rs
+++ b/experimental/casemap/src/internals.rs
@@ -283,13 +283,15 @@ impl<'data> CaseMapV1<'data> {
                     return sink.write_str(mapped_string);
                 }
             }
+
+            if kind == MappingKind::Fold && exception.bits.no_simple_case_folding() {
+                return sink.write_char(c);
+            }
+
             if data.is_relevant_to(kind) {
                 if let Some(simple) = exception.get_simple_case_slot_for(c) {
                     return sink.write_char(simple);
                 }
-            }
-            if kind == MappingKind::Fold && exception.bits.no_simple_case_folding() {
-                return sink.write_char(c);
             }
 
             if let Some(slot_char) = exception.slot_char_for_kind(kind) {


### PR DESCRIPTION
While most characters end up being lowercase after case folding, Cherokee syllables are case folded to uppercase forms because lowercase syllables were added to the standard later.

Going from lowercase forms to uppercase forms works because of explicit mappings in `CaseFolding.txt`. Uppercase forms were erroneously case folded to lowercase forms, however, as ICU data provides a delta value to use for that even though it [also provides a marker saying that it shouldn't be used](https://github.com/unicode-org/icu/blob/main/tools/unicode/c/genprops/casepropsbuilder.cpp#L454).

ICU4X code deviated from [the ICU4C code it was ported from](https://github.com/unicode-org/icu/blob/main/icu4c/source/common/ucase.cpp#L1636), checking the existence of the delta value before checking that marker. This pull request fixes that. Since I've seen issues with Cherokee case folding before, it must be an easy mistake to make, so I've also added a simple unit test as a safeguard.