### PR TITLE
Remove cargo feature from clap; bump datagen to 1.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "icu_datagen"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "cached-path",
  "clap 4.0.32",

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_datagen"
 description = "Generate data for ICU4X DataProvider"
-version = "1.2.3"
+version = "1.2.4"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
@@ -80,7 +80,7 @@ zerovec = { version = "0.9.4", path = "../../utils/zerovec", features = ["serde"
 zip = { version = ">=0.5, <0.7", default-features = false, features = ["deflate"] }
 
 # Dependencies for "bin" feature
-clap = { version = "4", optional = true, features = ["cargo", "derive"] }
+clap = { version = "4", optional = true, features = ["derive"] }
 eyre = { version = "0.6", optional = true }
 simple_logger = { version = "4.1.0", default-features = false, optional = true }
 

--- a/provider/datagen/src/bin/datagen.rs
+++ b/provider/datagen/src/bin/datagen.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use clap::{crate_version, ArgGroup, Parser};
+use clap::{ArgGroup, Parser};
 use eyre::WrapErr;
 use icu_datagen::prelude::*;
 use simple_logger::SimpleLogger;
@@ -60,8 +60,9 @@ mod cli {
     }
 }
 #[derive(Parser)]
-#[command(name = "icu4x-datagen", author, version)]
-#[command(about = concat!("Learn more at: https://docs.rs/icu_datagen/", crate_version!()), long_about = None)]
+#[command(name = "icu4x-datagen")]
+#[command(author = "The ICU4X Project Developers", version = option_env!("CARGO_PKG_VERSION"))]
+#[command(about = format!("Learn more at: https://docs.rs/icu_datagen/{}", option_env!("CARGO_PKG_VERSION").unwrap_or("")), long_about = None)]
 #[command(group(
             ArgGroup::new("key_mode")
                 .required(true)


### PR DESCRIPTION
These macros do not compile in non-cargo environments. They all just call `env!("CARGO_FOO")`, and it's sufficient to call `option_env!()` instead to get the same functionality.

This makes datagen compile in non-cargo environments without needing any further tweaks.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->