### PR TITLE
Detect nightly in icu_capi_freertos, bump to 1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "icu_freertos"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cortex-m",
  "freertos-rust",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,6 +1863,7 @@ dependencies = [
  "cortex-m",
  "freertos-rust",
  "icu_capi",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]

--- a/ffi/freertos/Cargo.toml
+++ b/ffi/freertos/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_freertos"
 description = "C interface to ICU4X"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 resolver = "2"

--- a/ffi/freertos/Cargo.toml
+++ b/ffi/freertos/Cargo.toml
@@ -42,3 +42,6 @@ freertos-rust = "0.1.2"
 # Currently we don't enable anything here as WearOS loads data manually, but the feature remains for future use
 wearos = []
 default = ["icu_capi/default_components"]
+
+[build-dependencies]
+rustc_version = "0.4"

--- a/ffi/freertos/README.md
+++ b/ffi/freertos/README.md
@@ -1,6 +1,15 @@
 # icu_freertos [![crates.io](https://img.shields.io/crates/v/icu_freertos)](https://crates.io/crates/icu_freertos)
 
+This crate is a shim that enables one to use icu4x on Cortex-M + FreeRTOS by setting up the
+relevant Rust runtime hooks.
 
+Note that compiling to this platform needs Rust nightly, and this crate attempts to
+build across multiple nightly versions.
+
+This crate has a build script that will attempt to detect the nightly version and configure
+things appropriately, where possible. Older nightlies will end up setting the
+`--cfg needs_alloc_error_handler` flag: if using a custom build system and a nightly from
+2022 or earlier, please set this flag.
 
 ## More Information
 

--- a/ffi/freertos/build.rs
+++ b/ffi/freertos/build.rs
@@ -1,0 +1,37 @@
+use std::env;
+
+/// Returns whether the Rust compiler needs an `#[alloc_error_handler]`
+/// set. Returns None for cases where we cannot determine the nightly version of the
+/// compiler.
+fn needs_alloc_error_handler() -> Option<bool> {
+    use rustc_version::Channel;
+    let version = rustc_version::version_meta().ok()?;
+    if version.channel != Channel::Nightly {
+        // Ignore custom/dev toolchains, commit date
+        // may not be meaningful
+        return None;
+    }
+    let commit_date = version.commit_date?;
+
+    let year = commit_date.split("-").next()?.parse::<u32>().ok()?;
+
+    // alloc_error_handler became defaulted to the panic handler
+    // in December 2022. Since it still works until April 2023,
+    // we can be fuzzy with our dates and just set the boundary at
+    // 2022/2023
+    Some(year <= 2022)
+}
+
+fn main() {
+    match env::var("CARGO_CFG_TARGET_OS") {
+        Ok(v) if v == "none" => (),
+        // Only on target_os = none
+        _ => return,
+    };
+
+    if let Some(true) = needs_alloc_error_handler() {
+        println!("cargo:rustc-cfg=needs_alloc_error_handler");
+    }
+
+    // For unknown compilers, assume that the nightly is recent.
+}

--- a/ffi/freertos/build.rs
+++ b/ffi/freertos/build.rs
@@ -1,3 +1,7 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
 use std::env;
 
 /// Returns whether the Rust compiler needs an `#[alloc_error_handler]`
@@ -13,7 +17,7 @@ fn needs_alloc_error_handler() -> Option<bool> {
     }
     let commit_date = version.commit_date?;
 
-    let year = commit_date.split("-").next()?.parse::<u32>().ok()?;
+    let year = commit_date.split('-').next()?.parse::<u32>().ok()?;
 
     // alloc_error_handler became defaulted to the panic handler
     // in December 2022. Since it still works until April 2023,


### PR DESCRIPTION
Alternative to https://github.com/unicode-org/icu4x/pull/3382

This fixes the nightly breakage by introducing `--cfg needs_alloc_error_handler` and setting it via build script using the `rustc_version` crate.

I'm okay adding this dependency for now because FreeRTOS is a rare use case and it is likely that people who care about precise dep count will also be using a custom build system (where this build script won't run in the first place)


The polarity of this check is that recent nightly needs no `cfg`, since as I've mentioned in chat it is good practice when using Rust nightly to focus on recent nightly; and our happy path should be aligned with that.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->