### PR TITLE
Simplify / rustify implementation of `keys_from_bin`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,6 +1758,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log",
+ "memchr",
  "ndarray",
  "proc-macro2",
  "quote",

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -78,6 +78,7 @@ toml = "0.5"
 writeable = { version = "0.5.1", path = "../../utils/writeable" }
 zerovec = { version = "0.9.4", path = "../../utils/zerovec", features = ["serde", "yoke"] }
 zip = { version = ">=0.5, <0.7", default-features = false, features = ["deflate"] }
+memchr = "2.5.0"
 
 # Dependencies for "bin" feature
 clap = { version = "4", optional = true, features = ["derive"] }

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -272,7 +272,8 @@ pub fn keys_from_bin<P: AsRef<Path>>(path: P) -> std::io::Result<Vec<DataKey>> {
                 .find(key_fragment)
                 .map(|end| &key_fragment[..end])
         })
-        .filter_map(|key| std::str::from_utf8(key).ok())
+        .map(std::str::from_utf8)
+        .filter_map(Result::ok)
         .filter_map(crate::key)
         .collect();
 

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -123,6 +123,7 @@ use icu_provider::prelude::*;
 use icu_provider_adapters::empty::EmptyDataProvider;
 use icu_provider_adapters::filter::Filterable;
 use icu_provider_fs::export::serializers::AbstractSerializer;
+use memchr::memmem;
 use prelude::*;
 use rayon::prelude::*;
 use std::collections::HashSet;
@@ -259,20 +260,27 @@ pub fn keys_from_bin<P: AsRef<Path>>(path: P) -> std::io::Result<Vec<DataKey>> {
     let file = std::fs::read(path.as_ref())?;
     let mut file = file.as_slice();
 
-    const LEADING_TAG: &[u8] = icu_provider::leading_tag!().as_bytes();
-    const TRAILING_TAG: &[u8] = icu_provider::trailing_tag!().as_bytes();
+    let leading_tag = memmem::Finder::new(icu_provider::leading_tag!().as_bytes());
+    let trailing_tag = memmem::Finder::new(icu_provider::trailing_tag!().as_bytes());
 
-    /// Given a needle like "abc" and a haystack like "123abc456", return ("123", "456")
-    fn split_at_tag<'a>(haystack: &'a [u8], needle: &[u8]) -> Option<(&'a [u8], &'a [u8])> {
-        memchr::memmem::find(haystack, needle)
-            .map(|idx| (&haystack[..idx], &haystack[idx + needle.len()..]))
+    /// Given a needle like "abc" and a haystack like "123abc456", return
+    /// ("123", "456")
+    fn split_at_tag<'a>(
+        haystack: &'a [u8],
+        needle: &memmem::Finder<'_>,
+    ) -> Option<(&'a [u8], &'a [u8])> {
+        let needle_len = needle.needle().len();
+
+        needle
+            .find(haystack)
+            .map(|idx| (&haystack[..idx], &haystack[idx + needle_len..]))
     }
 
     // An iterator of all of the tags we can find in `file`, delimited by
-    // LEADING_TAG and TRAILING_TAG
+    // leading_tag and trailing_tag
     let tag_stream = iter::from_fn(move || {
-        let (_, suffix) = split_at_tag(file, LEADING_TAG)?;
-        let (tag, suffix) = split_at_tag(suffix, TRAILING_TAG)?;
+        let (_, suffix) = split_at_tag(file, &leading_tag)?;
+        let (tag, suffix) = split_at_tag(suffix, &trailing_tag)?;
         file = suffix;
         Some(tag)
     });


### PR DESCRIPTION
This MR refactors `icu_datagen::keys_from_bin` to use an iterator, rather than a highly manual C-style index tracking style. Mostly this change is made for readability reasons, and in the hope that the function will be easier to understand and maintain. It additionally uses `memchr::memmem` to search for the tags.