### PR TITLE
Add const litemap getter functions for common types

### DIFF
--- a/utils/litemap/src/lib.rs
+++ b/utils/litemap/src/lib.rs
@@ -51,7 +51,7 @@ mod serde;
 mod serde_helpers;
 pub mod store;
 
-#[cfg(feature = "testing")]
+#[cfg(any(test, feature = "testing"))]
 pub mod testing;
 
 pub use map::LiteMap;

--- a/utils/litemap/src/map.rs
+++ b/utils/litemap/src/map.rs
@@ -91,6 +91,40 @@ where
     pub fn get_indexed(&self, index: usize) -> Option<(&K, &V)> {
         self.values.lm_get(index)
     }
+
+    /// Get the lowest-rank key/value pair from the `LiteMap`, if it exists.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use litemap::LiteMap;
+    ///
+    /// let mut map: LiteMap<i32, &str, Vec<_>> =
+    ///     LiteMap::from_iter([(1, "uno"), (3, "tres")].into_iter());
+    ///
+    /// assert_eq!(map.first(), Some((&1, &"uno")));
+    /// ```
+    #[inline]
+    pub fn first(&self) -> Option<(&K, &V)> {
+        self.values.lm_get(0).map(|(k, v)| (k, v))
+    }
+
+    /// Get the highest-rank key/value pair from the `LiteMap`, if it exists.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use litemap::LiteMap;
+    ///
+    /// let mut map: LiteMap<i32, &str, Vec<_>> =
+    ///     LiteMap::from_iter([(1, "uno"), (3, "tres")].into_iter());
+    ///
+    /// assert_eq!(map.last(), Some((&3, &"tres")));
+    /// ```
+    #[inline]
+    pub fn last(&self) -> Option<(&K, &V)> {
+        self.values.lm_get(self.len() - 1).map(|(k, v)| (k, v))
+    }
 }
 
 impl<K: ?Sized, V: ?Sized, S> LiteMap<K, V, S>
@@ -144,40 +178,6 @@ where
         Q: Ord,
     {
         self.find_index(key).is_ok()
-    }
-
-    /// Get the lowest-rank key/value pair from the `LiteMap`, if it exists.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use litemap::LiteMap;
-    ///
-    /// let mut map: LiteMap<i32, &str, Vec<_>> =
-    ///     LiteMap::from_iter([(1, "uno"), (3, "tres")].into_iter());
-    ///
-    /// assert_eq!(map.first(), Some((&1, &"uno")));
-    /// ```
-    #[inline]
-    pub fn first(&self) -> Option<(&K, &V)> {
-        self.values.lm_get(0).map(|(k, v)| (k, v))
-    }
-
-    /// Get the highest-rank key/value pair from the `LiteMap`, if it exists.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use litemap::LiteMap;
-    ///
-    /// let mut map: LiteMap<i32, &str, Vec<_>> =
-    ///     LiteMap::from_iter([(1, "uno"), (3, "tres")].into_iter());
-    ///
-    /// assert_eq!(map.last(), Some((&3, &"tres")));
-    /// ```
-    #[inline]
-    pub fn last(&self) -> Option<(&K, &V)> {
-        self.values.lm_get(self.len() - 1).map(|(k, v)| (k, v))
     }
 
     /// Obtain the index for a given key, or if the key is not found, the index

--- a/utils/litemap/src/map.rs
+++ b/utils/litemap/src/map.rs
@@ -586,6 +586,7 @@ impl<'a, K, V> LiteMap<K, V, &'a [(K, V)]> {
     /// static len: usize = map.const_len();
     /// assert_eq!(len, 2);
     /// ```
+    #[inline]
     pub const fn const_len(&self) -> usize {
         self.values.len()
     }
@@ -601,6 +602,7 @@ impl<'a, K, V> LiteMap<K, V, &'a [(K, V)]> {
     /// static is_empty: bool = map.const_is_empty();
     /// assert!(is_empty);
     /// ```
+    #[inline]
     pub const fn const_is_empty(&self) -> bool {
         self.values.is_empty()
     }
@@ -625,6 +627,7 @@ impl<'a, K, V> LiteMap<K, V, &'a [(K, V)]> {
     /// assert_eq!(t.1, 11);
     /// ```
     #[inline]
+    #[allow(clippy::indexing_slicing)] // documented
     pub const fn const_get_indexed_or_panic(&self, index: usize) -> &'a (K, V) {
         &self.values[index]
     }
@@ -639,6 +642,7 @@ const fn const_cmp_bytes(a: &[u8], b: &[u8]) -> Ordering {
         (b.len(), Ordering::Greater)
     };
     let mut i = 0;
+    #[allow(clippy::indexing_slicing)] // indexes in range by above checks
     while i < max {
         if a[i] == b[i] {
             i += 1;
@@ -649,7 +653,7 @@ const fn const_cmp_bytes(a: &[u8], b: &[u8]) -> Ordering {
             return Ordering::Greater;
         }
     }
-    return default;
+    default
 }
 
 impl<'a, V> LiteMap<&'a str, V, &'a [(&'a str, V)]> {
@@ -681,6 +685,7 @@ impl<'a, V> LiteMap<&'a str, V, &'a [(&'a str, V)]> {
         let mut j = self.const_len();
         while i < j {
             let mid = (i + j) / 2;
+            #[allow(clippy::indexing_slicing)] // in range
             let x = &self.values[mid];
             match const_cmp_bytes(key.as_bytes(), x.0.as_bytes()) {
                 Ordering::Equal => return Some((mid, &x.1)),
@@ -688,7 +693,7 @@ impl<'a, V> LiteMap<&'a str, V, &'a [(&'a str, V)]> {
                 Ordering::Less => j = mid,
             };
         }
-        return None;
+        None
     }
 }
 
@@ -721,6 +726,7 @@ impl<'a, V> LiteMap<&'a [u8], V, &'a [(&'a [u8], V)]> {
         let mut j = self.const_len();
         while i < j {
             let mid = (i + j) / 2;
+            #[allow(clippy::indexing_slicing)] // in range
             let x = &self.values[mid];
             match const_cmp_bytes(key, x.0) {
                 Ordering::Equal => return Some((mid, &x.1)),
@@ -728,7 +734,7 @@ impl<'a, V> LiteMap<&'a [u8], V, &'a [(&'a [u8], V)]> {
                 Ordering::Less => j = mid,
             };
         }
-        return None;
+        None
     }
 }
 
@@ -743,6 +749,7 @@ macro_rules! impl_const_get_with_index_for_integer {
                 let mut j = self.const_len();
                 while i < j {
                     let mid = (i + j) / 2;
+                    #[allow(clippy::indexing_slicing)] // in range
                     let x = &self.values[mid];
                     if key == x.0 {
                         return Some((mid, &x.1));

--- a/utils/litemap/src/map.rs
+++ b/utils/litemap/src/map.rs
@@ -574,6 +574,8 @@ where
 impl<'a, K, V> LiteMap<K, V, &'a [(K, V)]> {
     /// Const version of [`LiteMap::len()`] for a slice store.
     ///
+    /// Note: This function will no longer be needed if const trait behavior is stabilized.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -593,6 +595,8 @@ impl<'a, K, V> LiteMap<K, V, &'a [(K, V)]> {
 
     /// Const version of [`LiteMap::is_empty()`] for a slice store.
     ///
+    /// Note: This function will no longer be needed if const trait behavior is stabilized.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -608,6 +612,8 @@ impl<'a, K, V> LiteMap<K, V, &'a [(K, V)]> {
     }
 
     /// Const version of [`LiteMap::get_indexed()`] for a slice store.
+    ///
+    /// Note: This function will no longer be needed if const trait behavior is stabilized.
     ///
     /// # Panics
     ///
@@ -661,6 +667,8 @@ impl<'a, V> LiteMap<&'a str, V, &'a [(&'a str, V)]> {
     ///
     /// Also returns the index of the value.
     ///
+    /// Note: This function will no longer be needed if const trait behavior is stabilized.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -702,6 +710,8 @@ impl<'a, V> LiteMap<&'a [u8], V, &'a [(&'a [u8], V)]> {
     ///
     /// Also returns the index of the value.
     ///
+    /// Note: This function will no longer be needed if const trait behavior is stabilized.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -742,6 +752,8 @@ macro_rules! impl_const_get_with_index_for_integer {
     ($integer:ty) => {
         impl<'a, V> LiteMap<$integer, V, &'a [($integer, V)]> {
             /// Const function to get the value associated with an integer key, if it exists.
+            ///
+            /// Note: This function will no longer be needed if const trait behavior is stabilized.
             ///
             /// Also returns the index of the value.
             pub const fn const_get_with_index(&self, key: $integer) -> Option<(usize, &'a V)> {

--- a/utils/litemap/src/map.rs
+++ b/utils/litemap/src/map.rs
@@ -579,11 +579,11 @@ impl<'a, K, V> LiteMap<K, V, &'a [(K, V)]> {
     /// ```rust
     /// use litemap::LiteMap;
     ///
-    /// const map: LiteMap<&str, usize, &[(&str, usize)]> = LiteMap::from_sorted_store_unchecked(&[
+    /// static map: LiteMap<&str, usize, &[(&str, usize)]> = LiteMap::from_sorted_store_unchecked(&[
     ///     ("a", 11),
     ///     ("b", 22),
     /// ]);
-    /// const len: usize = map.const_len();
+    /// static len: usize = map.const_len();
     /// assert_eq!(len, 2);
     /// ```
     pub const fn const_len(&self) -> usize {
@@ -597,8 +597,8 @@ impl<'a, K, V> LiteMap<K, V, &'a [(K, V)]> {
     /// ```rust
     /// use litemap::LiteMap;
     ///
-    /// const map: LiteMap<&str, usize, &[(&str, usize)]> = LiteMap::from_sorted_store_unchecked(&[]);
-    /// const is_empty: bool = map.const_is_empty();
+    /// static map: LiteMap<&str, usize, &[(&str, usize)]> = LiteMap::from_sorted_store_unchecked(&[]);
+    /// static is_empty: bool = map.const_is_empty();
     /// assert!(is_empty);
     /// ```
     pub const fn const_is_empty(&self) -> bool {
@@ -616,11 +616,11 @@ impl<'a, K, V> LiteMap<K, V, &'a [(K, V)]> {
     /// ```rust
     /// use litemap::LiteMap;
     ///
-    /// const map: LiteMap<&str, usize, &[(&str, usize)]> = LiteMap::from_sorted_store_unchecked(&[
+    /// static map: LiteMap<&str, usize, &[(&str, usize)]> = LiteMap::from_sorted_store_unchecked(&[
     ///     ("a", 11),
     ///     ("b", 22),
     /// ]);
-    /// const t: &(&str, usize) = map.const_get_indexed_or_panic(0);
+    /// static t: &(&str, usize) = map.const_get_indexed_or_panic(0);
     /// assert_eq!(t.0, "a");
     /// assert_eq!(t.1, 11);
     /// ```
@@ -662,7 +662,7 @@ impl<'a, V> LiteMap<&'a str, V, &'a [(&'a str, V)]> {
     /// ```rust
     /// use litemap::LiteMap;
     ///
-    /// const map: LiteMap<&str, usize, &[(&str, usize)]> = LiteMap::from_sorted_store_unchecked(&[
+    /// static map: LiteMap<&str, usize, &[(&str, usize)]> = LiteMap::from_sorted_store_unchecked(&[
     ///     ("abc", 11),
     ///     ("bcd", 22),
     ///     ("cde", 33),
@@ -670,10 +670,10 @@ impl<'a, V> LiteMap<&'a str, V, &'a [(&'a str, V)]> {
     ///     ("efg", 55),
     /// ]);
     ///
-    /// const d: Option<(usize, &usize)> = map.const_get_with_index("def");
+    /// static d: Option<(usize, &usize)> = map.const_get_with_index("def");
     /// assert_eq!(d, Some((3, &44)));
     ///
-    /// const n: Option<(usize, &usize)> = map.const_get_with_index("dng");
+    /// static n: Option<(usize, &usize)> = map.const_get_with_index("dng");
     /// assert_eq!(n, None);
     /// ```
     pub const fn const_get_with_index(&self, key: &str) -> Option<(usize, &'a V)> {
@@ -702,7 +702,7 @@ impl<'a, V> LiteMap<&'a [u8], V, &'a [(&'a [u8], V)]> {
     /// ```rust
     /// use litemap::LiteMap;
     ///
-    /// const map: LiteMap<&[u8], usize, &[(&[u8], usize)]> = LiteMap::from_sorted_store_unchecked(&[
+    /// static map: LiteMap<&[u8], usize, &[(&[u8], usize)]> = LiteMap::from_sorted_store_unchecked(&[
     ///     (b"abc", 11),
     ///     (b"bcd", 22),
     ///     (b"cde", 33),
@@ -710,10 +710,10 @@ impl<'a, V> LiteMap<&'a [u8], V, &'a [(&'a [u8], V)]> {
     ///     (b"efg", 55),
     /// ]);
     ///
-    /// const d: Option<(usize, &usize)> = map.const_get_with_index(b"def");
+    /// static d: Option<(usize, &usize)> = map.const_get_with_index(b"def");
     /// assert_eq!(d, Some((3, &44)));
     ///
-    /// const n: Option<(usize, &usize)> = map.const_get_with_index(b"dng");
+    /// static n: Option<(usize, &usize)> = map.const_get_with_index(b"dng");
     /// assert_eq!(n, None);
     /// ```
     pub const fn const_get_with_index(&self, key: &[u8]) -> Option<(usize, &'a V)> {


### PR DESCRIPTION
I wanted to use these so I added them.