### PR TITLE
Add some Debug implementations in datagen

### DIFF
--- a/provider/datagen/src/transform/cldr/characters/mod.rs
+++ b/provider/datagen/src/transform/cldr/characters/mod.rs
@@ -12,6 +12,7 @@ use icu_provider::datagen::IterableDataProvider;
 use icu_provider::prelude::*;
 use itertools::Itertools;
 
+#[derive(Debug)]
 struct AnnotatedResource<'a, M: DataMarker>(
     &'a cldr_serde::exemplar_chars::Resource,
     PhantomData<M>,

--- a/provider/datagen/src/transform/cldr/decimal/symbols.rs
+++ b/provider/datagen/src/transform/cldr/decimal/symbols.rs
@@ -58,6 +58,7 @@ impl IterableDataProvider<DecimalSymbolsV1Marker> for crate::DatagenProvider {
     }
 }
 
+#[derive(Debug)]
 struct NumbersWithNumsys<'a>(pub &'a cldr_serde::numbers::Numbers, pub TinyAsciiStr<8>);
 
 impl TryFrom<NumbersWithNumsys<'_>> for DecimalSymbolsV1<'static> {


### PR DESCRIPTION
This works around the `missing_debug_implementations` regression in https://github.com/rust-lang/rust/issues/111359 . I don't know if that will be fixed soon; I spent some time investigating it and have an idea of what's going on but not enough to fix it (and don't want to spend more time on this right now). So for now, let's just listen to the lint and add these impls.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->