### PR TITLE
Replacing `chain(core::iter::once(x))` by `chain([x])`

### DIFF
--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -227,9 +227,7 @@ pub fn key<S: AsRef<str>>(string: S) -> Option<DataKey> {
     lazy_static::lazy_static! {
         static ref LOOKUP: std::collections::HashMap<&'static str, DataKey> = all_keys_with_experimental()
                     .into_iter()
-                    .chain(std::iter::once(
-                        icu_provider::hello_world::HelloWorldV1Marker::KEY,
-                    ))
+                    .chain([icu_provider::hello_world::HelloWorldV1Marker::KEY])
                     .map(|k| (k.path().get(), k))
                     .collect();
     }
@@ -452,7 +450,7 @@ pub fn datagen(
                     LocaleInclude::Explicit(
                         ls.iter()
                             .cloned()
-                            .chain(core::iter::once(icu_locid::LanguageIdentifier::UND))
+                            .chain([icu_locid::LanguageIdentifier::UND])
                             .collect(),
                     )
                 })

--- a/provider/datagen/src/transform/cldr/decimal/mod.rs
+++ b/provider/datagen/src/transform/cldr/decimal/mod.rs
@@ -97,7 +97,7 @@ impl crate::DatagenProvider {
                             );
                             data_locale
                         })
-                        .chain(core::iter::once(last))
+                        .chain([last])
                 })
                 .collect(),
         ))

--- a/tools/testdata-scripts/src/bin/make-testdata.rs
+++ b/tools/testdata-scripts/src/bin/make-testdata.rs
@@ -65,9 +65,7 @@ fn main() {
         Some(LOCALES),
         &icu_datagen::all_keys_with_experimental()
             .into_iter()
-            .chain(core::iter::once(
-                icu_provider::hello_world::HelloWorldV1Marker::KEY,
-            ))
+            .chain([icu_provider::hello_world::HelloWorldV1Marker::KEY])
             .collect::<Vec<_>>(),
         &source,
         vec![json_out, blob_out, mod_out, postcard_out],

--- a/utils/zerovec/src/flexzerovec/slice.rs
+++ b/utils/zerovec/src/flexzerovec/slice.rs
@@ -298,8 +298,7 @@ impl FlexZeroSlice {
     /// assert_eq!(pairs_it.next(), None);
     /// ```
     pub fn iter_pairs(&self) -> impl Iterator<Item = (usize, Option<usize>)> + '_ {
-        self.iter()
-            .zip(self.iter().skip(1).map(Some).chain(core::iter::once(None)))
+        self.iter().zip(self.iter().skip(1).map(Some).chain([None]))
     }
 
     /// Creates a `Vec<usize>` from a [`FlexZeroSlice`] (or `FlexZeroVec`).

--- a/utils/zerovec/src/varzerovec/components.rs
+++ b/utils/zerovec/src/varzerovec/components.rs
@@ -369,7 +369,7 @@ impl<'a, T: VarULE + ?Sized, F: VarZeroVecFormat> VarZeroVecComponents<'a, T, F>
                     .copied()
                     .map(F::rawbytes_to_usize)
                     .skip(1)
-                    .chain(core::iter::once(self.things.len())),
+                    .chain([self.things.len()]),
             )
             .map(move |(start, end)| unsafe { self.things.get_unchecked(start..end) })
             .map(|bytes| unsafe { T::from_byte_slice_unchecked(bytes) })


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->