### PR TITLE
Add ZeroVec stack size tests

### DIFF
--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -316,7 +316,7 @@ mod tests {
         assert_eq!(56, size_of::<ZeroMap<str, u32>>());
         assert_eq!(64, size_of::<ZeroMap<str, str>>());
         assert_eq!(120, size_of::<ZeroMap2d<str, str, str>>());
-        assert_eq!(24, size_of::<vecs::FlexZeroVec>());
+        assert_eq!(32, size_of::<vecs::FlexZeroVec>());
 
         assert_eq!(32, size_of::<Option<ZeroVec<u8>>>());
         assert_eq!(32, size_of::<Option<VarZeroVec<str>>>());

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -300,6 +300,32 @@ pub mod vecs {
     pub use crate::flexzerovec::{FlexZeroSlice, FlexZeroVec, FlexZeroVecOwned};
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::size_of;
+
+    #[test]
+    fn check_sizes() {
+        assert_eq!(24, size_of::<ZeroVec<u8>>());
+        assert_eq!(24, size_of::<ZeroVec<u32>>());
+        assert_eq!(32, size_of::<VarZeroVec<[u8]>>());
+        assert_eq!(32, size_of::<VarZeroVec<str>>());
+        assert_eq!(48, size_of::<ZeroMap<u32, u32>>());
+        assert_eq!(56, size_of::<ZeroMap<u32, str>>());
+        assert_eq!(56, size_of::<ZeroMap<str, u32>>());
+        assert_eq!(64, size_of::<ZeroMap<str, str>>());
+        assert_eq!(120, size_of::<ZeroMap2d<str, str, str>>());
+        assert_eq!(24, size_of::<vecs::FlexZeroVec>());
+
+        assert_eq!(32, size_of::<Option<ZeroVec<u8>>>());
+        assert_eq!(32, size_of::<Option<VarZeroVec<str>>>());
+        assert_eq!(64, size_of::<Option<ZeroMap<str, str>>>());
+        assert_eq!(120, size_of::<Option<ZeroMap2d<str, str, str>>>());
+        assert_eq!(32, size_of::<Option<vecs::FlexZeroVec>>());
+    }
+}
+
 // Proc macro reexports
 //
 // These exist so that our docs can use intra-doc links.


### PR DESCRIPTION
Just a few more size tests  in relation to #3413

ZeroVec is the same size as a Vec. I guess we can't easily make it any smaller.

VarZeroVec is 4 words. I think we lose a whole word because of the enum.

ZeroMap is the size of its two components.

ZeroMap2d is the size of three components plus the joiner array. This adds up very quickly!

FlexZeroVec is the same as ZeroVec.

Options of these types add a word for ZeroVec and FlexZeroVec but not for VarZeroVec, ZeroMap, or ZeroMap2d.