### PR TITLE
Setting MSRV and homepage in `Cargo.toml`s

### DIFF
--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_calendar"
 description = "API for supporting various types of calendars"
 version = "1.2.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/components/collator/Cargo.toml
+++ b/components/collator/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_collator"
 description = "API for comparing strings according to language-dependent conventions"
 version = "1.2.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/components/collections/Cargo.toml
+++ b/components/collections/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_collections"
 description = "Collection of API for use in ICU libraries."
 version = "1.2.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/components/collections/codepointtrie_builder/Cargo.toml
+++ b/components/collections/codepointtrie_builder/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_codepointtrie_builder"
 description = "Runtime builder for CodePointTrie"
 version = "0.3.5"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_datetime"
 description = "API for formatting date and time to user readable textual representation"
 version = "1.2.1"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -6,9 +6,11 @@
 name = "icu_decimal"
 description = "API for formatting basic decimal numbers in a locale-sensitive way"
 version = "1.2.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/components/icu/Cargo.toml
+++ b/components/icu/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu"
 description = "International Components for Unicode"
 version = "1.2.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/components/list/Cargo.toml
+++ b/components/list/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_list"
 description = "ECMA-402 ListFormatter"
 version = "1.2.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_locid"
 description = "API for managing Unicode Language and Locale Identifiers"
 version = "1.2.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/components/locid_transform/Cargo.toml
+++ b/components/locid_transform/Cargo.toml
@@ -6,9 +6,11 @@
 name = "icu_locid_transform"
 description = "API for Unicode Language and Locale Identifiers canonicalization"
 version = "1.2.1"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/components/normalizer/Cargo.toml
+++ b/components/normalizer/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_normalizer"
 description = "API for normalizing text into Unicode Normalization Forms"
 version = "1.2.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_plurals"
 description = "Unicode Plural Rules categorizer for numeric input"
 version = "1.2.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/components/properties/Cargo.toml
+++ b/components/properties/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_properties"
 description = "Definitions for Unicode properties"
 version = "1.2.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/components/segmenter/Cargo.toml
+++ b/components/segmenter/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_segmenter"
 description = "Unicode line breaking and text segmentation algorithms for text boundaries analysis"
 version = "1.2.1"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/components/timezone/Cargo.toml
+++ b/components/timezone/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_timezone"
 description = "API for resolving and manipulating time zone information"
 version = "1.2.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/experimental/bies/Cargo.toml
+++ b/experimental/bies/Cargo.toml
@@ -6,10 +6,12 @@
 name = "bies"
 description = "Helpers for dealing with BIES vectors with text segmentation applications"
 version = "0.2.1"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 # Keep this in sync with other crates unless there are exceptions
 include = [

--- a/experimental/casemapping/Cargo.toml
+++ b/experimental/casemapping/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_casemapping"
 description = "Unicode case mapping algorithms"
 version = "0.7.2"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 # Keep this in sync with other crates unless there are exceptions
 include = [

--- a/experimental/compactdecimal/Cargo.toml
+++ b/experimental/compactdecimal/Cargo.toml
@@ -6,9 +6,11 @@
 name = "icu_compactdecimal"
 version = "0.2.0"
 description = "Compact decimal"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/experimental/displaynames/Cargo.toml
+++ b/experimental/displaynames/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_displaynames"
 description = "API to enable the translation of Language and Region display names"
 version = "0.10.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 # Keep this in sync with other crates unless there are exceptions
 include = [

--- a/experimental/harfbuzz/Cargo.toml
+++ b/experimental/harfbuzz/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_harfbuzz"
 description = "HarfBuzz glue code for ICU4X"
 version = "0.1.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 resolver = "2"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/experimental/ixdtf/Cargo.toml
+++ b/experimental/ixdtf/Cargo.toml
@@ -6,10 +6,12 @@
 name = "ixdtf"
 description = "Parser for Internet eXtended DateTime Format"
 version = "0.1.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/experimental/relativetime/Cargo.toml
+++ b/experimental/relativetime/Cargo.toml
@@ -6,9 +6,11 @@
 name = "icu_relativetime"
 version = "0.1.1"
 description = "Relative time formatting"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/ffi/capi_cdylib/Cargo.toml
+++ b/ffi/capi_cdylib/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_capi_cdylib"
 description = "C interface to ICU4X"
 version = "1.2.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 resolver = "2"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/ffi/capi_staticlib/Cargo.toml
+++ b/ffi/capi_staticlib/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_capi_staticlib"
 description = "C interface to ICU4X"
 version = "1.2.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 resolver = "2"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_capi"
 description = "C interface to ICU4X"
 version = "1.2.2"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 resolver = "2"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/ffi/ecma402/Cargo.toml
+++ b/ffi/ecma402/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu4x_ecma402"
 description = "ECMA-402 API functionality backed by the ICU4X library"
 version = "0.8.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/ffi/freertos/Cargo.toml
+++ b/ffi/freertos/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_freertos"
 description = "C interface to ICU4X"
 version = "1.2.1"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 resolver = "2"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/provider/adapters/Cargo.toml
+++ b/provider/adapters/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_provider_adapters"
 description = "Adapters for composing and manipulating data providers."
 version = "1.2.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/provider/blob/Cargo.toml
+++ b/provider/blob/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_provider_blob"
 description = "ICU4X data provider that reads from blobs in memory"
 version = "1.2.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_provider"
 description = "Trait and struct definitions for the ICU data provider"
 version = "1.2.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_datagen"
 description = "Generate data for ICU4X DataProvider"
 version = "1.2.5"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_provider_fs"
 description = "ICU4X data provider that reads from structured data files"
 version = "1.2.1"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/provider/macros/Cargo.toml
+++ b/provider/macros/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_provider_macros"
 description = "Proc macros for ICU data providers"
 version = "1.2.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_testdata"
 description = "Pre-built test data for ICU4X"
 version = "1.2.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/utils/crlify/Cargo.toml
+++ b/utils/crlify/Cargo.toml
@@ -8,7 +8,6 @@ version = "1.0.2"
 rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 repository = "https://github.com/unicode-org/icu4x"
-homepage = "https://icu4x.unicode.org"
 edition = "2021"
 license = "Unicode-DFS-2016"
 keywords = ["io", "crlf", "windows", "line", "ending"]

--- a/utils/crlify/Cargo.toml
+++ b/utils/crlify/Cargo.toml
@@ -5,8 +5,10 @@
 [package]
 name = "crlify"
 version = "1.0.2"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 edition = "2021"
 license = "Unicode-DFS-2016"
 keywords = ["io", "crlf", "windows", "line", "ending"]

--- a/utils/databake/Cargo.toml
+++ b/utils/databake/Cargo.toml
@@ -11,7 +11,6 @@ authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
-homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["rust-patterns", "memory-management", "development-tools::procedural-macro-helpers", "development-tools::build-utils"]
 keywords = ["zerocopy", "serialization", "const", "proc"]

--- a/utils/databake/Cargo.toml
+++ b/utils/databake/Cargo.toml
@@ -6,10 +6,12 @@
 name = "databake"
 description = "Trait that lets structs represent themselves as (const) Rust expressions"
 version = "0.1.5"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["rust-patterns", "memory-management", "development-tools::procedural-macro-helpers", "development-tools::build-utils"]
 keywords = ["zerocopy", "serialization", "const", "proc"]

--- a/utils/databake/derive/Cargo.toml
+++ b/utils/databake/derive/Cargo.toml
@@ -6,10 +6,12 @@
 name = "databake-derive"
 description = "Custom derive for the databake crate"
 version = "0.1.5"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/utils/databake/derive/Cargo.toml
+++ b/utils/databake/derive/Cargo.toml
@@ -11,7 +11,6 @@ authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
-homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/utils/deduplicating_array/Cargo.toml
+++ b/utils/deduplicating_array/Cargo.toml
@@ -11,7 +11,6 @@ authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
-homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 include = [
     "src/**/*",

--- a/utils/deduplicating_array/Cargo.toml
+++ b/utils/deduplicating_array/Cargo.toml
@@ -6,10 +6,12 @@
 name = "deduplicating_array"
 description = "A serde serialization strategy that uses PartialEq to reduce serialized size."
 version = "0.1.4"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 include = [
     "src/**/*",

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -11,7 +11,6 @@ authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
-homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -6,10 +6,12 @@
 name = "fixed_decimal"
 description = "An API for representing numbers in a human-readable form"
 version = "0.5.3"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -5,8 +5,10 @@
 [package]
 name = "litemap"
 version = "0.7.0"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 edition = "2021"
 license = "Unicode-DFS-2016"
 keywords = ["sorted", "vec", "map", "hashmap", "btreemap"]

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -8,7 +8,6 @@ version = "0.7.0"
 rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 repository = "https://github.com/unicode-org/icu4x"
-homepage = "https://icu4x.unicode.org"
 edition = "2021"
 license = "Unicode-DFS-2016"
 keywords = ["sorted", "vec", "map", "hashmap", "btreemap"]

--- a/utils/pattern/Cargo.toml
+++ b/utils/pattern/Cargo.toml
@@ -11,7 +11,6 @@ authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
-homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 include = [
     "src/**/*",

--- a/utils/pattern/Cargo.toml
+++ b/utils/pattern/Cargo.toml
@@ -6,10 +6,12 @@
 name = "icu_pattern"
 description = "ICU pattern utilities"
 version = "0.1.4"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 include = [
     "src/**/*",

--- a/utils/tinystr/Cargo.toml
+++ b/utils/tinystr/Cargo.toml
@@ -10,7 +10,6 @@ rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 repository = "https://github.com/unicode-org/icu4x"
-homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 keywords = ["string", "str", "small", "tiny", "no_std"]
 categories = ["data-structures"]

--- a/utils/tinystr/Cargo.toml
+++ b/utils/tinystr/Cargo.toml
@@ -6,9 +6,11 @@
 name = "tinystr"
 version = "0.7.1"
 description = "A small ASCII-only bounded length string representation."
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 keywords = ["string", "str", "small", "tiny", "no_std"]
 categories = ["data-structures"]

--- a/utils/tzif/Cargo.toml
+++ b/utils/tzif/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 readme = "README.md"
 license = "Unicode-DFS-2016"
 repository = "https://github.com/unicode-org/icu4x"
-homepage = "https://icu4x.unicode.org"
 keywords = ["time-zone", "posix", "iana", "parse", "data"]
 categories = ["date-and-time", "parser-implementations"]
 

--- a/utils/tzif/Cargo.toml
+++ b/utils/tzif/Cargo.toml
@@ -4,6 +4,7 @@
 
 [package]
 name = "tzif"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 description = "A parser for TZif files"
 version = "0.2.1"
@@ -11,6 +12,7 @@ edition = "2021"
 readme = "README.md"
 license = "Unicode-DFS-2016"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 keywords = ["time-zone", "posix", "iana", "parse", "data"]
 categories = ["date-and-time", "parser-implementations"]
 

--- a/utils/writeable/Cargo.toml
+++ b/utils/writeable/Cargo.toml
@@ -11,7 +11,6 @@ authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
-homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 # Keep this in sync with other crates unless there are exceptions
 include = [

--- a/utils/writeable/Cargo.toml
+++ b/utils/writeable/Cargo.toml
@@ -6,10 +6,12 @@
 name = "writeable"
 description = "A more efficient alternative to fmt::Display"
 version = "0.5.2"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 # Keep this in sync with other crates unless there are exceptions
 include = [

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -10,7 +10,6 @@ rust-version = "1.61.0"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/unicode-org/icu4x"
-homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["data-structures", "memory-management", "caching", "no-std"]
 keywords = ["zerocopy", "serialization", "lifetime", "borrow", "self-referential"]

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -6,9 +6,11 @@
 name = "yoke"
 version = "0.7.1"
 description = "Abstraction allowing borrowed data to be carried along with the backing data it borrows from"
+rust-version = "1.61.0"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["data-structures", "memory-management", "caching", "no-std"]
 keywords = ["zerocopy", "serialization", "lifetime", "borrow", "self-referential"]

--- a/utils/yoke/derive/Cargo.toml
+++ b/utils/yoke/derive/Cargo.toml
@@ -7,6 +7,7 @@ name = "yoke-derive"
 version = "0.7.1"
 description = "Custom derive for the yoke crate"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["data-structures", "memory-management", "caching", "no-std"]
 keywords = ["zerocopy", "serialization", "lifetime", "borrow", "self-referential"]

--- a/utils/yoke/derive/Cargo.toml
+++ b/utils/yoke/derive/Cargo.toml
@@ -7,7 +7,6 @@ name = "yoke-derive"
 version = "0.7.1"
 description = "Custom derive for the yoke crate"
 repository = "https://github.com/unicode-org/icu4x"
-homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["data-structures", "memory-management", "caching", "no-std"]
 keywords = ["zerocopy", "serialization", "lifetime", "borrow", "self-referential"]

--- a/utils/zerofrom/Cargo.toml
+++ b/utils/zerofrom/Cargo.toml
@@ -10,7 +10,6 @@ rust-version = "1.61.0"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/unicode-org/icu4x"
-homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["data-structures", "caching", "no-std"]
 keywords = ["zerocopy", "serialization", "lifetime", "borrow"]

--- a/utils/zerofrom/Cargo.toml
+++ b/utils/zerofrom/Cargo.toml
@@ -6,9 +6,11 @@
 name = "zerofrom"
 version = "0.1.2"
 description = "ZeroFrom trait for constructing"
+rust-version = "1.61.0"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["data-structures", "caching", "no-std"]
 keywords = ["zerocopy", "serialization", "lifetime", "borrow"]

--- a/utils/zerofrom/derive/Cargo.toml
+++ b/utils/zerofrom/derive/Cargo.toml
@@ -7,6 +7,7 @@ name = "zerofrom-derive"
 version = "0.1.2"
 description = "Custom derive for the zerofrom crate"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["data-structures", "memory-management", "caching", "no-std"]
 keywords = ["zerocopy", "serialization", "lifetime", "borrow"]

--- a/utils/zerofrom/derive/Cargo.toml
+++ b/utils/zerofrom/derive/Cargo.toml
@@ -7,7 +7,6 @@ name = "zerofrom-derive"
 version = "0.1.2"
 description = "Custom derive for the zerofrom crate"
 repository = "https://github.com/unicode-org/icu4x"
-homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["data-structures", "memory-management", "caching", "no-std"]
 keywords = ["zerocopy", "serialization", "lifetime", "borrow"]

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -6,10 +6,12 @@
 name = "zerovec"
 description = "Zero-copy vector backed by a byte array"
 version = "0.9.4"
+rust-version = "1.61.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
 keywords = ["zerocopy", "serialization", "zero-copy", "serde"]

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -11,7 +11,6 @@ authors = ["The ICU4X Project Developers"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
-homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
 keywords = ["zerocopy", "serialization", "zero-copy", "serde"]

--- a/utils/zerovec/derive/Cargo.toml
+++ b/utils/zerovec/derive/Cargo.toml
@@ -7,7 +7,6 @@ name = "zerovec-derive"
 version = "0.9.4"
 description = "Custom derive for the zerovec crate"
 repository = "https://github.com/unicode-org/icu4x"
-homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
 keywords = ["zerocopy", "serialization", "zero-copy", "serde"]

--- a/utils/zerovec/derive/Cargo.toml
+++ b/utils/zerovec/derive/Cargo.toml
@@ -7,6 +7,7 @@ name = "zerovec-derive"
 version = "0.9.4"
 description = "Custom derive for the zerovec crate"
 repository = "https://github.com/unicode-org/icu4x"
+homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
 categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
 keywords = ["zerocopy", "serialization", "zero-copy", "serde"]


### PR DESCRIPTION
While `https://icu4x.unicode.org` currently redirects to `docs.rs`, it might not in the future. It's also useful to link to the `icu` crate from all subcrates.