### PR TITLE
Fixing datagen error with zip files

### DIFF
--- a/provider/datagen/src/source.rs
+++ b/provider/datagen/src/source.rs
@@ -6,7 +6,7 @@ use crate::options::Options;
 use crate::transform::cldr::source::CldrCache;
 pub use crate::transform::cldr::source::CoverageLevel;
 use elsa::sync::FrozenMap;
-use icu_provider::DataError;
+use icu_provider::prelude::*;
 use std::any::Any;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::Debug;
@@ -360,7 +360,9 @@ impl AbstractFs {
                 std::fs::read(&root)?,
             ))
             .map_err(|e| {
-                DataError::custom("Zip").with_display_context(&e)
+                DataError::custom("Invalid ZIP file")
+                    .with_display_context(&e)
+                    .with_path_context(&root)
             })?))))
         }
     }
@@ -478,8 +480,13 @@ impl AbstractFs {
                     .cached_path(resource)
                     .map_err(|e| DataError::custom("Download").with_display_context(&e))?
             };
-            *lock = Ok(ZipArchive::new(Cursor::new(std::fs::read(root)?))
-                .map_err(|e| DataError::custom("Zip").with_display_context(&e))?);
+            *lock = Ok(
+                ZipArchive::new(Cursor::new(std::fs::read(&root)?)).map_err(|e| {
+                    DataError::custom("Invalid ZIP file")
+                        .with_display_context(&e)
+                        .with_path_context(&root)
+                })?,
+            );
         }
         Ok(())
     }
@@ -502,7 +509,8 @@ impl AbstractFs {
                     .unwrap() // init called
                     .by_name(path)
                     .map_err(|e| {
-                        DataError::custom("Zip")
+                        DataErrorKind::Io(std::io::ErrorKind::NotFound)
+                            .into_error()
                             .with_display_context(&e)
                             .with_display_context(path)
                     })?


### PR DESCRIPTION
Collator datagen relies on `read_and_parse_toml` to return `DataErrorKind::Io` when a file is not present, but `AbstractFs::Zip` currently returns `DataErrorKind::Custom`.