### PR TITLE
Not relying on key strings for segmentation rules lookup

### DIFF
--- a/provider/datagen/src/source.rs
+++ b/provider/datagen/src/source.rs
@@ -68,7 +68,9 @@ impl SourceData {
         Self {
             cldr_paths: None,
             icuexport_paths: None,
-            icuexport_fallback_paths: Arc::new(SerdeCache::new(AbstractFs::new_icuexport_fallback())),
+            icuexport_fallback_paths: Arc::new(SerdeCache::new(
+                AbstractFs::new_icuexport_fallback(),
+            )),
             segmenter_lstm_paths: Arc::new(SerdeCache::new(AbstractFs::new_lstm_fallback())),
             options: Default::default(),
         }
@@ -227,26 +229,22 @@ impl SourceData {
         }
     }
 
-    /// Paths to CLDR source data.
     pub(crate) fn cldr(&self) -> Result<&CldrCache, DataError> {
         self.cldr_paths
             .as_deref()
             .ok_or(crate::error::MISSING_CLDR_ERROR)
     }
 
-    /// Path to Unicode Properties source data.
     pub(crate) fn icuexport(&self) -> Result<&SerdeCache, DataError> {
         self.icuexport_paths
             .as_deref()
             .ok_or(crate::error::MISSING_ICUEXPORT_ERROR)
     }
 
-    /// Path to built-in data.
     pub(crate) fn icuexport_fallback(&self) -> &SerdeCache {
         &self.icuexport_fallback_paths
     }
 
-    /// Path to segmenter LSTM data
     pub(crate) fn segmenter_lstm(&self) -> Result<&SerdeCache, DataError> {
         Ok(&self.segmenter_lstm_paths)
     }

--- a/provider/datagen/src/source.rs
+++ b/provider/datagen/src/source.rs
@@ -24,7 +24,7 @@ use zip::ZipArchive;
 pub struct SourceData {
     cldr_paths: Option<Arc<CldrCache>>,
     icuexport_paths: Option<Arc<SerdeCache>>,
-    builtin_paths: Arc<SerdeCache>,
+    icuexport_fallback_paths: Arc<SerdeCache>,
     segmenter_lstm_paths: Arc<SerdeCache>,
     // TODO: move this out when we decide we can break the exhaustiveness of DatagenProvider
     pub(crate) options: Options,
@@ -68,8 +68,8 @@ impl SourceData {
         Self {
             cldr_paths: None,
             icuexport_paths: None,
-            builtin_paths: Arc::new(SerdeCache::new(AbstractFs::new_builtin())),
-            segmenter_lstm_paths: Arc::new(SerdeCache::new(AbstractFs::new_lstm())),
+            icuexport_fallback_paths: Arc::new(SerdeCache::new(AbstractFs::new_icuexport_fallback())),
+            segmenter_lstm_paths: Arc::new(SerdeCache::new(AbstractFs::new_lstm_fallback())),
             options: Default::default(),
         }
     }
@@ -242,8 +242,8 @@ impl SourceData {
     }
 
     /// Path to built-in data.
-    pub(crate) fn builtin(&self) -> &SerdeCache {
-        &self.builtin_paths
+    pub(crate) fn icuexport_fallback(&self) -> &SerdeCache {
+        &self.icuexport_fallback_paths
     }
 
     /// Path to segmenter LSTM data
@@ -365,25 +365,9 @@ impl AbstractFs {
         }
     }
 
-    fn new_builtin() -> Self {
+    fn new_icuexport_fallback() -> Self {
         Self::Memory(
             [
-                (
-                    "segmenter/rules/grapheme.toml",
-                    include_bytes!("../data/segmenter/rules/grapheme.toml").as_slice(),
-                ),
-                (
-                    "segmenter/rules/word.toml",
-                    include_bytes!("../data/segmenter/rules/word.toml").as_slice(),
-                ),
-                (
-                    "segmenter/rules/line.toml",
-                    include_bytes!("../data/segmenter/rules/line.toml").as_slice(),
-                ),
-                (
-                    "segmenter/rules/sentence.toml",
-                    include_bytes!("../data/segmenter/rules/sentence.toml").as_slice(),
-                ),
                 (
                     "segmenter/dictionary/cjdict.toml",
                     include_bytes!("../data/segmenter/dictionary/cjdict.toml").as_slice(),
@@ -410,7 +394,7 @@ impl AbstractFs {
         )
     }
 
-    fn new_lstm() -> Self {
+    fn new_lstm_fallback() -> Self {
         Self::Memory(
             [
                 (

--- a/provider/datagen/src/transform/segmenter/dictionary.rs
+++ b/provider/datagen/src/transform/segmenter/dictionary.rs
@@ -39,7 +39,7 @@ impl crate::DatagenProvider {
             .and_then(|e| e.read_and_parse_toml(filename))
             .or_else(|e| {
                 self.source
-                    .builtin()
+                    .icuexport_fallback()
                     .read_and_parse_toml(filename)
                     .map_err(|_| e)
             })?;

--- a/provider/datagen/src/transform/segmenter/mod.rs
+++ b/provider/datagen/src/transform/segmenter/mod.rs
@@ -79,11 +79,9 @@ struct SegmenterRuleTable {
 
 #[cfg(any(feature = "use_wasm", feature = "use_icu4c"))]
 impl crate::DatagenProvider {
-    fn generate_rule_break_data(
-        &self,
-        rule: &str,
-    ) -> RuleBreakDataV1<'static> {
-        let segmenter: SegmenterRuleTable = toml::from_str(rule).expect("The data should be valid!");
+    fn generate_rule_break_data(&self, rules: &str) -> RuleBreakDataV1<'static> {
+        let segmenter: SegmenterRuleTable =
+            toml::from_str(rules).expect("The data should be valid!");
 
         let data = maps::load_word_break(self).expect("The data should be valid!");
         let wb = data.as_borrowed();


### PR DESCRIPTION
We don't need a fully-fledged `AbstractFs` where we look up files by key fragment, we can just include the files directly.