### PR TITLE
Use UnvalidatedStr for era symbol keys

### DIFF
--- a/components/datetime/src/provider/calendar/symbols.rs
+++ b/components/datetime/src/provider/calendar/symbols.rs
@@ -9,7 +9,7 @@ use alloc::borrow::Cow;
 use icu_calendar::types::MonthCode;
 use icu_provider::prelude::*;
 use tinystr::{tinystr, TinyStr4};
-use zerovec::ZeroMap;
+use zerovec::{ule::UnvalidatedStr, ZeroMap};
 
 /// Symbol data for the months, weekdays, and eras needed to format a date.
 ///
@@ -111,17 +111,17 @@ pub struct Eras<'data> {
     ///
     /// Keys are era codes, and values are display names. See [`Eras`].
     #[cfg_attr(feature = "serde", serde(borrow))]
-    pub names: ZeroMap<'data, str, str>,
+    pub names: ZeroMap<'data, UnvalidatedStr, str>,
     /// Symbol data for era abbreviations.
     ///
     /// Keys are era codes, and values are display names. See [`Eras`].
     #[cfg_attr(feature = "serde", serde(borrow))]
-    pub abbr: ZeroMap<'data, str, str>,
+    pub abbr: ZeroMap<'data, UnvalidatedStr, str>,
     /// Symbol data for era narrow forms.
     ///
     /// Keys are era codes, and values are display names. See [`Eras`].
     #[cfg_attr(feature = "serde", serde(borrow))]
-    pub narrow: ZeroMap<'data, str, str>,
+    pub narrow: ZeroMap<'data, UnvalidatedStr, str>,
 }
 
 // Note: the SymbolsV* struct doc strings metadata are attached to `$name` in the macro invocation to

--- a/components/datetime/src/provider/date_time.rs
+++ b/components/datetime/src/provider/date_time.rs
@@ -412,7 +412,9 @@ impl<'data> DateSymbols for provider::calendar::DateSymbolsV1<'data> {
             fields::FieldLength::Narrow => &self.eras.narrow,
             _ => &self.eras.abbr,
         };
-        symbols.get(&era_code.0).unwrap_or(&era_code.0)
+        symbols
+            .get(era_code.0.as_str().into())
+            .unwrap_or(&era_code.0)
     }
 }
 

--- a/provider/datagen/src/transform/cldr/datetime/symbols.rs
+++ b/provider/datagen/src/transform/cldr/datetime/symbols.rs
@@ -29,13 +29,13 @@ fn convert_eras(eras: &cldr_serde::ca::Eras, calendar: &str) -> Eras<'static> {
 
     for (cldr, code) in map.into_iter() {
         if let Some(name) = eras.names.get(&cldr) {
-            out_eras.names.insert(&code, name);
+            out_eras.names.insert(code.as_str().into(), name);
         }
         if let Some(abbr) = eras.abbr.get(&cldr) {
-            out_eras.abbr.insert(&code, abbr);
+            out_eras.abbr.insert(code.as_str().into(), abbr);
         }
         if let Some(narrow) = eras.narrow.get(&cldr) {
-            out_eras.narrow.insert(&code, narrow);
+            out_eras.narrow.insert(code.as_str().into(), narrow);
         }
     }
     out_eras


### PR DESCRIPTION
Fixes #2725

Baked `testdata` did not change, as the type parameters are implicit in the generated code.


