### PR TITLE
Add UnvalidatedChar

### DIFF
--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -29,7 +29,7 @@ pub use multi::MultiFieldsULE;
 pub use niche::{NicheBytes, NichedOption, NichedOptionULE};
 pub use option::{OptionULE, OptionVarULE};
 pub use plain::RawBytesULE;
-pub use unvalidated::UnvalidatedStr;
+pub use unvalidated::{UnvalidatedChar, UnvalidatedStr};
 
 use alloc::alloc::Layout;
 use alloc::borrow::ToOwned;

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -25,7 +25,7 @@ impl<const N: usize> RawBytesULE<N> {
     pub fn from_byte_slice_unchecked_mut(bytes: &mut [u8]) -> &mut [Self] {
         let data = bytes.as_mut_ptr();
         let len = bytes.len() / N;
-        // Safe because Self is transparent over [u8; $size]
+        // Safe because Self is transparent over [u8; N]
         unsafe { core::slice::from_raw_parts_mut(data as *mut Self, len) }
     }
 }
@@ -43,7 +43,7 @@ unsafe impl<const N: usize> ULE for RawBytesULE<N> {
     #[inline]
     fn validate_byte_slice(bytes: &[u8]) -> Result<(), ZeroVecError> {
         if bytes.len() % N == 0 {
-            // Safe because Self is transparent over [u8; $size]
+            // Safe because Self is transparent over [u8; N]
             Ok(())
         } else {
             Err(ZeroVecError::length::<Self>(bytes.len()))

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -16,7 +16,7 @@ use core::num::{NonZeroI8, NonZeroU8};
 pub struct RawBytesULE<const N: usize>(pub [u8; N]);
 
 macro_rules! impl_byte_slice_size {
-    ($unsigned:ty, $size:literal) => {
+    ($size:literal) => {
         impl From<[u8; $size]> for RawBytesULE<$size> {
             #[inline]
             fn from(le_bytes: [u8; $size]) -> Self {
@@ -58,7 +58,11 @@ macro_rules! impl_byte_slice_size {
                 // Safe because Self is transparent over [u8; $size]
                 unsafe { core::slice::from_raw_parts_mut(data as *mut Self, len) }
             }
-
+        }
+    };
+    ($unsigned:ty, $size:literal) => {
+        impl_byte_slice_size!($size);
+        impl RawBytesULE<$size> {
             /// Gets this RawBytesULE as an unsigned int. This is equivalent to calling
             /// [AsULE::from_unaligned()] on the appropriately sized type.
             #[inline]
@@ -133,6 +137,8 @@ macro_rules! impl_byte_slice_type {
         unsafe impl EqULE for $type {}
     };
 }
+
+impl_byte_slice_size!(3);
 
 impl_byte_slice_size!(u16, 2);
 impl_byte_slice_size!(u32, 4);

--- a/utils/zerovec/src/ule/unvalidated.rs
+++ b/utils/zerovec/src/ule/unvalidated.rs
@@ -329,7 +329,6 @@ impl AsULE for UnvalidatedChar {
     }
 }
 
-// TODO: As EqULE is being phased out, do we even need to add it?
 // Safety: UnvalidatedChar is always the little-endian representation of a char,
 // which corresponds to its AsULE::ULE type
 unsafe impl EqULE for UnvalidatedChar {}
@@ -353,8 +352,6 @@ impl PartialOrd for UnvalidatedChar {
         }
     }
 }
-
-// TODO: Do we need Ord? If so, how should we order invalid chars?
 
 impl From<char> for UnvalidatedChar {
     #[inline]

--- a/utils/zerovec/src/ule/unvalidated.rs
+++ b/utils/zerovec/src/ule/unvalidated.rs
@@ -268,7 +268,7 @@ impl UnvalidatedChar {
     /// let a = UnvalidatedChar::from_char('a');
     /// assert_eq!(a.try_as_char(), Ok('a'));
     ///
-    /// let b = UnvalidatedChar::from_unaligned([0xFF, 0xFF, 0xFF, 0xFF].into());
+    /// let b = UnvalidatedChar::from_unaligned([0xFF, 0xFF, 0xFF].into());
     /// assert!(matches!(b.try_as_char(), Err(_)));
     /// ```
     #[inline]
@@ -285,7 +285,7 @@ impl UnvalidatedChar {
     /// ```
     /// use zerovec::ule::{AsULE, UnvalidatedChar};
     ///
-    /// let a = UnvalidatedChar::from_unaligned([0xFF, 0xFF, 0xFF, 0xFF].into());
+    /// let a = UnvalidatedChar::from_unaligned([0xFF, 0xFF, 0xFF].into());
     /// assert_eq!(a.as_char_lossy(), char::REPLACEMENT_CHARACTER);
     /// ```
     #[inline]


### PR DESCRIPTION
Fixes #1968 

This adds the unvalidated, three-byte char type `UnvalidatedChar` with `AsULE`. 

It lives next to `UnvalidatedStr` for now, but it can easily be moved again. 

I borrowed some decisions from `UnvalidatedStr` in regards to the `Debug` and `Serialize` implementations:
* `Debug` will try to pretty-print but fall back to bytes if invalid
* `Serialize` will fail if the data contained in the `UnvalidatedChar` is invalid

I implemented `EqULE` because it applies, but from reading other discussions, it seems we want to move away from it? In which case I would remove it.

Furthermore, I was unsure about `Ord` - I couldn't think of any reasonable total order we could use here that is consistent with `<char as Ord>`. If we need it, I'm open to suggestions.