### PR TITLE
Add const `CharULE::from_array` and `impl_ule_from_array!` macro

### DIFF
--- a/components/collator/src/elements.rs
+++ b/components/collator/src/elements.rs
@@ -26,7 +26,6 @@ use icu_normalizer::provider::DecompositionTablesV1;
 use icu_properties::CanonicalCombiningClass;
 use smallvec::SmallVec;
 use zerovec::ule::AsULE;
-use zerovec::ule::CharULE;
 use zerovec::ule::RawBytesULE;
 use zerovec::ZeroSlice;
 
@@ -157,9 +156,8 @@ const SINGLE_REPLACEMENT_CHARACTER_U16: &ZeroSlice<u16> =
 
 pub(crate) const EMPTY_CHAR: &ZeroSlice<char> = ZeroSlice::new_empty();
 
-const SINGLE_REPLACEMENT_CHARACTER_CHAR: &ZeroSlice<char> = ZeroSlice::from_ule_slice(&[unsafe {
-    core::mem::transmute::<[u8; 3], CharULE>([0xFDu8, 0xFFu8, 0u8])
-}]);
+const SINGLE_REPLACEMENT_CHARACTER_CHAR: &ZeroSlice<char> =
+    ZeroSlice::<char>::from_ule_slice(&<char as AsULE>::ULE::from_array([REPLACEMENT_CHARACTER]));
 
 /// If `opt` is `Some`, unwrap it. If `None`, panic if debug assertions
 /// are enabled and return `default` if debug assertions are not enabled.

--- a/utils/zerovec/src/ule/chars.rs
+++ b/utils/zerovec/src/ule/chars.rs
@@ -47,12 +47,12 @@ impl CharULE {
     ///
     /// See the type-level documentation for [`CharULE`] for more information.
     #[inline]
-    pub const fn from_char(c: char) -> Self {
+    pub const fn from_aligned(c: char) -> Self {
         let [u0, u1, u2, _u3] = (c as u32).to_le_bytes();
         Self([u0, u1, u2])
     }
 
-    impl_ule_from_array!(char, CharULE, CharULE::from_char);
+    impl_ule_from_array!(char, CharULE);
 }
 
 // Safety (based on the safety checklist on the ULE trait):
@@ -87,7 +87,7 @@ impl AsULE for char {
 
     #[inline]
     fn to_unaligned(self) -> Self::ULE {
-        CharULE::from_char(self)
+        CharULE::from_aligned(self)
     }
 
     #[inline]

--- a/utils/zerovec/src/ule/chars.rs
+++ b/utils/zerovec/src/ule/chars.rs
@@ -131,6 +131,15 @@ mod test {
     }
 
     #[test]
+    fn test_from_array_zst() {
+        const CHARS: [char; 0] = [];
+        const CHARS_ULE: [CharULE; 0] = CharULE::from_array(CHARS);
+        let bytes = CharULE::as_byte_slice(&CHARS_ULE);
+        let empty: &[u8] = &[];
+        assert_eq!(bytes, empty);
+    }
+
+    #[test]
     fn test_parse() {
         // 1-byte, 2-byte, 3-byte, and two 4-byte character in UTF-8 (not as relevant in UTF-32)
         let chars = ['w', 'ω', '文', '𑄃', '🙃'];

--- a/utils/zerovec/src/ule/chars.rs
+++ b/utils/zerovec/src/ule/chars.rs
@@ -52,7 +52,7 @@ impl CharULE {
         Self([u0, u1, u2])
     }
 
-    impl_ule_from_array!(char, CharULE, CharULE::from_char, Self([0; 3]));
+    impl_ule_from_array!(char, CharULE, CharULE::from_char);
 }
 
 // Safety (based on the safety checklist on the ULE trait):

--- a/utils/zerovec/src/ule/chars.rs
+++ b/utils/zerovec/src/ule/chars.rs
@@ -52,7 +52,7 @@ impl CharULE {
         Self([u0, u1, u2])
     }
 
-    impl_ule_from_array!(char, CharULE);
+    impl_ule_from_array!(char, CharULE, Self([0; 3]));
 }
 
 // Safety (based on the safety checklist on the ULE trait):

--- a/utils/zerovec/src/ule/macros.rs
+++ b/utils/zerovec/src/ule/macros.rs
@@ -8,7 +8,7 @@ macro_rules! impl_ule_from_array {
         #[doc = concat!("Convert an array of `", stringify!($aligned), "` to an array of `", stringify!($unaligned), "`.")]
         pub const fn from_array<const N: usize>(arr: [$aligned; N]) -> [Self; N] {
             if N == 0 {
-                return unsafe { *(&arr as *const _ as *const [Self; N]) };
+                return unsafe { *(core::ptr::NonNull::dangling().as_ptr() as *const [Self; N]) };
             }
             let mut result = [$single(arr[0]); N];
             let mut i = 0;

--- a/utils/zerovec/src/ule/macros.rs
+++ b/utils/zerovec/src/ule/macros.rs
@@ -11,7 +11,8 @@ macro_rules! impl_ule_from_array {
                 return unsafe { *(core::ptr::NonNull::dangling().as_ptr() as *const [Self; N]) };
             }
             let mut result = [$single(arr[0]); N];
-            let mut i = 0;
+            // Starting at i=1 since result[0] is already initialized with the above line
+            let mut i = 1;
             // Won't panic because i < N and arr has length N
             #[allow(clippy::indexing_slicing)]
             while i < N {

--- a/utils/zerovec/src/ule/macros.rs
+++ b/utils/zerovec/src/ule/macros.rs
@@ -2,18 +2,18 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+/// Given `Self` (`$aligned`), `Self::ULE` (`$unaligned`), and a conversion function (`$single` or
+/// `Self::from_aligned`), implement `from_array` for arrays of `$aligned` to `$unaligned`.
+///
+/// The `$default` argument is due to current compiler limitations.
+/// Pass any (cheap to construct) value.
 #[macro_export]
 macro_rules! impl_ule_from_array {
-    ($aligned:ty, $unaligned:ty, $single:path) => {
+    ($aligned:ty, $unaligned:ty, $default:expr, $single:path) => {
         #[doc = concat!("Convert an array of `", stringify!($aligned), "` to an array of `", stringify!($unaligned), "`.")]
         pub const fn from_array<const N: usize>(arr: [$aligned; N]) -> [Self; N] {
-            if N == 0 {
-                // Safety: The pointer is aligned and to a zero-sized type.
-                return unsafe { *(core::ptr::NonNull::dangling().as_ptr() as *const [Self; N]) };
-            }
-            let mut result = [$single(arr[0]); N];
-            // Starting at i=1 since result[0] is already initialized with the above line
-            let mut i = 1;
+            let mut result = [$default; N];
+            let mut i = 0;
             // Won't panic because i < N and arr has length N
             #[allow(clippy::indexing_slicing)]
             while i < N {
@@ -23,7 +23,7 @@ macro_rules! impl_ule_from_array {
             result
         }
     };
-    ($aligned:ty, $unaligned:ty) => {
-        impl_ule_from_array!($aligned, $unaligned, Self::from_aligned);
+    ($aligned:ty, $unaligned:ty, $default:expr) => {
+        impl_ule_from_array!($aligned, $unaligned, $default, Self::from_aligned);
     };
 }

--- a/utils/zerovec/src/ule/macros.rs
+++ b/utils/zerovec/src/ule/macros.rs
@@ -4,10 +4,13 @@
 
 #[macro_export]
 macro_rules! impl_ule_from_array {
-    ($source:ty, $dest:ty, $single:path, $zero:expr) => {
-        /// Convert an array of `$source` to an array of `$dest`.
-        pub const fn from_array<const N: usize>(arr: [$source; N]) -> [Self; N] {
-            let mut result = [$zero; N];
+    ($aligned:ty, $unaligned:ty, $single:path) => {
+        #[doc = concat!("Convert an array of `", stringify!($aligned), "` to an array of `", stringify!($unaligned), "`.")]
+        pub const fn from_array<const N: usize>(arr: [$aligned; N]) -> [Self; N] {
+            if N == 0 {
+                return unsafe { *(&arr as *const _ as *const [Self; N]) };
+            }
+            let mut result = [$single(arr[0]); N];
             let mut i = 0;
             // Won't panic because i < N and arr has length N
             #[allow(clippy::indexing_slicing)]

--- a/utils/zerovec/src/ule/macros.rs
+++ b/utils/zerovec/src/ule/macros.rs
@@ -8,6 +8,7 @@ macro_rules! impl_ule_from_array {
         #[doc = concat!("Convert an array of `", stringify!($aligned), "` to an array of `", stringify!($unaligned), "`.")]
         pub const fn from_array<const N: usize>(arr: [$aligned; N]) -> [Self; N] {
             if N == 0 {
+                // Safety: The pointer is aligned and to a zero-sized type.
                 return unsafe { *(core::ptr::NonNull::dangling().as_ptr() as *const [Self; N]) };
             }
             let mut result = [$single(arr[0]); N];

--- a/utils/zerovec/src/ule/macros.rs
+++ b/utils/zerovec/src/ule/macros.rs
@@ -1,0 +1,21 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+#[macro_export]
+macro_rules! impl_ule_from_array {
+    ($source:ty, $dest:ty, $single:path, $zero:expr) => {
+        /// Convert an array of `$source` to an array of `$dest`.
+        pub const fn from_array<const N: usize>(arr: [$source; N]) -> [Self; N] {
+            let mut result = [$zero; N];
+            let mut i = 0;
+            // Won't panic because i < N and arr has length N
+            #[allow(clippy::indexing_slicing)]
+            while i < N {
+                result[i] = $single(arr[i]);
+                i += 1;
+            }
+            result
+        }
+    };
+}

--- a/utils/zerovec/src/ule/macros.rs
+++ b/utils/zerovec/src/ule/macros.rs
@@ -21,4 +21,7 @@ macro_rules! impl_ule_from_array {
             result
         }
     };
+    ($aligned:ty, $unaligned:ty) => {
+        impl_ule_from_array!($aligned, $unaligned, Self::from_aligned);
+    };
 }

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -14,6 +14,7 @@ mod chars;
 #[cfg(doc)]
 pub mod custom;
 mod encode;
+mod macros;
 mod multi;
 mod niche;
 mod option;

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -60,15 +60,13 @@ macro_rules! impl_byte_slice_size {
                 unsafe { core::slice::from_raw_parts_mut(data as *mut Self, len) }
             }
 
-            /// Gets this `RawBytesULE` as a `$unsigned`. This is equivalent to calling
-            /// [`AsULE::from_unaligned()`] on the appropriately sized type.
+            #[doc = concat!("Gets this `RawBytesULE` as a `", stringify!($unsigned), "`. This is equivalent to calling [`AsULE::from_unaligned()`] on the appropriately sized type.")]
             #[inline]
             pub fn as_unsigned_int(&self) -> $unsigned {
                 <$unsigned as $crate::ule::AsULE>::from_unaligned(*self)
             }
 
-            /// Convert a `$unsigned` to `RawBytesULE`. This is equivalent to calling
-            /// [`AsULE::to_unaligned()`] on the appropriately sized type.
+            #[doc = concat!("Converts a `", stringify!($unsigned), "` to a `RawBytesULE`. This is equivalent to calling [`AsULE::to_unaligned()`] on the appropriately sized type.")]
             #[inline]
             pub const fn from_unsigned_int(value: $unsigned) -> Self {
                 Self(value.to_le_bytes())
@@ -77,8 +75,7 @@ macro_rules! impl_byte_slice_size {
             impl_ule_from_array!(
                 $unsigned,
                 RawBytesULE<$size>,
-                RawBytesULE::<$size>::from_unsigned_int,
-                Self([0; $size])
+                RawBytesULE::<$size>::from_unsigned_int
             );
         }
     };

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -68,14 +68,13 @@ macro_rules! impl_byte_slice_size {
 
             #[doc = concat!("Converts a `", stringify!($unsigned), "` to a `RawBytesULE`. This is equivalent to calling [`AsULE::to_unaligned()`] on the appropriately sized type.")]
             #[inline]
-            pub const fn from_unsigned_int(value: $unsigned) -> Self {
+            pub const fn from_aligned(value: $unsigned) -> Self {
                 Self(value.to_le_bytes())
             }
 
             impl_ule_from_array!(
                 $unsigned,
-                RawBytesULE<$size>,
-                RawBytesULE::<$size>::from_unsigned_int
+                RawBytesULE<$size>
             );
         }
     };

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -6,6 +6,7 @@
 //! ULE implementation for Plain Old Data types, including all sized integers.
 
 use super::*;
+use crate::impl_ule_from_array;
 use crate::ZeroSlice;
 use core::num::{NonZeroI8, NonZeroU8};
 
@@ -59,25 +60,26 @@ macro_rules! impl_byte_slice_size {
                 unsafe { core::slice::from_raw_parts_mut(data as *mut Self, len) }
             }
 
-            /// Gets this RawBytesULE as an unsigned int. This is equivalent to calling
-            /// [AsULE::from_unaligned()] on the appropriately sized type.
+            /// Gets this `RawBytesULE` as a `$unsigned`. This is equivalent to calling
+            /// [`AsULE::from_unaligned()`] on the appropriately sized type.
             #[inline]
             pub fn as_unsigned_int(&self) -> $unsigned {
                 <$unsigned as $crate::ule::AsULE>::from_unaligned(*self)
             }
 
-            /// Convert an array of native-endian aligned integers to an array of RawBytesULE.
-            pub const fn from_array<const N: usize>(arr: [$unsigned; N]) -> [Self; N] {
-                let mut result = [RawBytesULE([0; $size]); N];
-                let mut i = 0;
-                // Won't panic because i < N and arr has length N
-                #[allow(clippy::indexing_slicing)]
-                while i < N {
-                    result[i].0 = arr[i].to_le_bytes();
-                    i += 1;
-                }
-                result
+            /// Convert a `$unsigned` to `RawBytesULE`. This is equivalent to calling
+            /// [`AsULE::to_unaligned()`] on the appropriately sized type.
+            #[inline]
+            pub const fn from_unsigned_int(value: $unsigned) -> Self {
+                Self(value.to_le_bytes())
             }
+
+            impl_ule_from_array!(
+                $unsigned,
+                RawBytesULE<$size>,
+                RawBytesULE::<$size>::from_unsigned_int,
+                Self([0; $size])
+            );
         }
     };
 }

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -74,7 +74,8 @@ macro_rules! impl_byte_slice_size {
 
             impl_ule_from_array!(
                 $unsigned,
-                RawBytesULE<$size>
+                RawBytesULE<$size>,
+                RawBytesULE([0; $size])
             );
         }
     };


### PR DESCRIPTION
Fixes #2491 

Traits still do not support const functions, so implementing a const `from_array` for each type that needs it seems to be the only way at the moment.

This adds a const `CharULE::from_array` function and a macro to automatically generate such functions when a single-element transformation function is available.

