### PR TITLE
Adding `T: Bake` bound on `ZeroVec`'s `Bake`

### DIFF
--- a/components/datetime/src/pattern/item/generic.rs
+++ b/components/datetime/src/pattern/item/generic.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 #[derive(Debug, PartialEq, Clone, Copy)]
-#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake), databake(path = icu_datetime::pattern))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[allow(clippy::exhaustive_enums)] // this type is stable
 pub enum GenericPatternItem {

--- a/components/locid_transform/Cargo.toml
+++ b/components/locid_transform/Cargo.toml
@@ -58,7 +58,7 @@ default = []
 std = []
 bench = ["serde"]
 serde = ["dep:serde", "icu_locid/serde", "tinystr/serde", "zerovec/serde", "icu_provider/serde"]
-datagen = ["serde", "dep:databake", "zerovec/databake", "icu_locid/databake"]
+datagen = ["serde", "dep:databake", "zerovec/databake", "icu_locid/databake", "tinystr/databake"]
 
 [[bench]]
 name = "locale_canonicalizer"

--- a/components/properties/Cargo.toml
+++ b/components/properties/Cargo.toml
@@ -46,5 +46,5 @@ icu_testdata = { path = "../../provider/testdata", default-features = false, fea
 [features]
 std = ["icu_collections/std", "icu_provider/std"]
 serde = ["dep:serde", "tinystr/serde", "zerovec/serde", "icu_collections/serde", "icu_provider/serde"]
-datagen = ["serde", "dep:databake", "zerovec/databake", "icu_collections/databake"]
+datagen = ["serde", "dep:databake", "zerovec/databake", "icu_collections/databake", "tinystr/databake"]
 bidi = [ "dep:unicode-bidi" ]

--- a/components/timezone/src/provider.rs
+++ b/components/timezone/src/provider.rs
@@ -30,7 +30,7 @@ use zerovec::{ZeroMap2d, ZeroSlice, ZeroVec};
 /// </div>
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd, yoke::Yokeable, ULE, Hash)]
-#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake), databake(path = icu_timezone::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub struct TimeZoneBcp47Id(pub TinyAsciiStr<8>);
 
@@ -83,7 +83,7 @@ impl<'a> zerovec::maps::ZeroMapKV<'a> for TimeZoneBcp47Id {
 /// </div>
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd, yoke::Yokeable, ULE, Hash)]
-#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake), databake(path = icu_timezone::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub struct MetazoneId(pub TinyAsciiStr<4>);
 

--- a/components/timezone/src/types.rs
+++ b/components/timezone/src/types.rs
@@ -181,7 +181,7 @@ impl FromStr for GmtOffset {
 /// A time zone variant: currently either daylight time or standard time.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, ULE)]
 #[repr(transparent)]
-#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake), databake(path = icu_timezone))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[allow(clippy::exhaustive_structs)] // newtype
 pub struct ZoneVariant(pub TinyAsciiStr<2>);

--- a/experimental/displaynames/Cargo.toml
+++ b/experimental/displaynames/Cargo.toml
@@ -46,4 +46,4 @@ icu_testdata = { path = "../../provider/testdata", default-features = false, fea
 [features]
 std = ["icu_collections/std", "icu_locid/std", "icu_provider/std"]
 serde = ["dep:serde", "zerovec/serde", "icu_collections/serde", "tinystr/serde", "icu_provider/serde"]
-datagen = ["serde", "std", "dep:databake", "zerovec/databake", "icu_collections/databake"]
+datagen = ["serde", "std", "dep:databake", "zerovec/databake", "icu_collections/databake", "tinystr/databake"]

--- a/provider/adapters/Cargo.toml
+++ b/provider/adapters/Cargo.toml
@@ -44,4 +44,4 @@ writeable = { path = "../../utils/writeable" }
 [features]
 std = ["icu_locid/std", "icu_provider/std"]
 serde = ["dep:serde", "zerovec/serde", "icu_locid/serde", "icu_provider/serde"]
-datagen = ["std", "serde", "dep:databake", "icu_provider/datagen", "icu_locid/databake", "zerovec/databake"]
+datagen = ["std", "serde", "dep:databake", "icu_provider/datagen", "icu_locid/databake", "zerovec/databake", "tinystr/databake"]

--- a/utils/tinystr/src/databake.rs
+++ b/utils/tinystr/src/databake.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::TinyAsciiStr;
+use crate::UnvalidatedTinyAsciiStr;
 use databake::*;
 
 impl<const N: usize> Bake for TinyAsciiStr<N> {
@@ -15,7 +16,33 @@ impl<const N: usize> Bake for TinyAsciiStr<N> {
     }
 }
 
+impl<const N: usize> databake::Bake for UnvalidatedTinyAsciiStr<N> {
+    fn bake(&self, env: &databake::CrateEnv) -> databake::TokenStream {
+        match self.try_into_tinystr() {
+            Ok(tiny) => {
+                let tiny = tiny.bake(env);
+                databake::quote! {
+                    #tiny.to_unvalidated()
+                }
+            }
+            Err(_) => {
+                let bytes = self.0.bake(env);
+                env.insert("tinystr");
+                databake::quote! {
+                    tinystr::UnvalidatedTinyAsciiStr::from_bytes_unchecked(*#bytes)
+                }
+            }
+        }
+    }
+}
+
 #[test]
 fn test() {
     test_bake!(TinyAsciiStr<10>, const: crate::tinystr!(10usize, "foo"), tinystr);
+}
+
+#[test]
+fn test_unvalidated() {
+    test_bake!(UnvalidatedTinyAsciiStr<10>, const: crate::tinystr!(10usize, "foo").to_unvalidated(), tinystr);
+    test_bake!(UnvalidatedTinyAsciiStr<3>, const: crate::UnvalidatedTinyAsciiStr::from_bytes_unchecked(*b"AB\xCD"), tinystr);
 }

--- a/utils/tinystr/src/unvalidated.rs
+++ b/utils/tinystr/src/unvalidated.rs
@@ -21,12 +21,17 @@ impl<const N: usize> UnvalidatedTinyAsciiStr<N> {
     pub fn try_into_tinystr(&self) -> Result<TinyAsciiStr<N>, TinyStrError> {
         TinyAsciiStr::try_from_raw(self.0)
     }
+
+    #[doc(hidden)]
+    pub const fn from_bytes_unchecked(bytes: [u8; N]) -> Self {
+        Self(bytes)
+    }
 }
 
 impl<const N: usize> TinyAsciiStr<N> {
     #[inline]
     // Converts into a [`UnvalidatedTinyAsciiStr`]
-    pub fn to_unvalidated(self) -> UnvalidatedTinyAsciiStr<N> {
+    pub const fn to_unvalidated(self) -> UnvalidatedTinyAsciiStr<N> {
         UnvalidatedTinyAsciiStr(*self.all_bytes())
     }
 }

--- a/utils/zerovec/src/zerovec/databake.rs
+++ b/utils/zerovec/src/zerovec/databake.rs
@@ -8,7 +8,7 @@ use databake::*;
 
 impl<T> Bake for ZeroVec<'_, T>
 where
-    T: AsULE + ?Sized,
+    T: AsULE + ?Sized + Bake,
 {
     fn bake(&self, env: &CrateEnv) -> TokenStream {
         env.insert("zerovec");


### PR DESCRIPTION
Based on #3450 

This bound is currently unused, but will be useful as part of #1935 