### PR TITLE
Testing `full-data` with all keys

### DIFF
--- a/provider/datagen/src/transform/cldr/displaynames/variant.rs
+++ b/provider/datagen/src/transform/cldr/displaynames/variant.rs
@@ -51,6 +51,8 @@ impl IterableDataProvider<VariantDisplayNamesV1Marker> for crate::DatagenProvide
                         .file_exists(langid, "variants.json")
                         .unwrap_or_default()
                 })
+                // TODO(#3463)
+                .filter(|langid| langid != &icu_locid::langid!("fi"))
                 .map(DataLocale::from)
                 .collect(),
         ))

--- a/tools/make/data.toml
+++ b/tools/make/data.toml
@@ -140,7 +140,7 @@ args = [
     "run",
     "--bin=icu4x-datagen",
     "--",
-    "--keys=all",
+    "--keys=experimental-all",
     "--locales=full",
     "--format=blob",
     "--out=/dev/null",


### PR DESCRIPTION
This was not running on experimental keys before.

Includes workaround for #3463 