### PR TITLE
Make `DataPayload` constructible from `&'static M::Yokeable`

### DIFF
--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -207,36 +207,36 @@ mod tests {
 
     #[test]
     fn check_sizes() {
-        check_size_of!(5784 | 4576, DateFormatter);
-        check_size_of!(6784 | 5448, DateTimeFormatter);
-        check_size_of!(7896 | 6464, ZonedDateTimeFormatter);
+        check_size_of!(5800 | 4592, DateFormatter);
+        check_size_of!(6792 | 5456, DateTimeFormatter);
+        check_size_of!(7904 | 6480, ZonedDateTimeFormatter);
         check_size_of!(1496 | 1320, TimeFormatter);
-        check_size_of!(1112 | 1016, TimeZoneFormatter);
-        check_size_of!(5744 | 4536, TypedDateFormatter::<Gregorian>);
+        check_size_of!(1112 | 1024, TimeZoneFormatter);
+        check_size_of!(5752 | 4544, TypedDateFormatter::<Gregorian>);
         check_size_of!(6744 | 5408, TypedDateTimeFormatter::<Gregorian>);
 
         check_size_of!(80, DateTimeError);
         check_size_of!(176, FormattedDateTime);
         check_size_of!(16, FormattedTimeZone::<CustomTimeZone>);
         check_size_of!(160, FormattedZonedDateTime);
-        check_size_of!(13, DateTimeFormatterOptions);
+        check_size_of!(2, DateTimeFormatterOptions);
 
         type DP<M> = DataPayload<M>;
         check_size_of!(208, DP::<PatternPluralsFromPatternsV1Marker>);
         check_size_of!(1032 | 904, DP::<TimeSymbolsV1Marker>);
-        check_size_of!(32, DP::<GenericPatternV1Marker>);
+        check_size_of!(40, DP::<GenericPatternV1Marker>);
         check_size_of!(208, DP::<PatternPluralsFromPatternsV1Marker>);
         check_size_of!(5064 | 3904, DP::<ErasedDateSymbolsV1Marker>);
         check_size_of!(16, DP::<WeekDataV1Marker>);
-        check_size_of!(288 | 224, DP::<TimeZoneFormatsV1Marker>);
+        check_size_of!(288 | 232, DP::<TimeZoneFormatsV1Marker>);
         check_size_of!(64 | 56, DP::<ExemplarCitiesV1Marker>);
-        check_size_of!(120 | 104, DP::<MetazoneGenericNamesLongV1Marker>);
-        check_size_of!(120 | 104, DP::<MetazoneGenericNamesShortV1Marker>);
-        check_size_of!(216 | 200, DP::<MetazoneSpecificNamesLongV1Marker>);
-        check_size_of!(216 | 200, DP::<MetazoneSpecificNamesShortV1Marker>);
+        check_size_of!(120 | 112, DP::<MetazoneGenericNamesLongV1Marker>);
+        check_size_of!(120 | 112, DP::<MetazoneGenericNamesShortV1Marker>);
+        check_size_of!(216 | 208, DP::<MetazoneSpecificNamesLongV1Marker>);
+        check_size_of!(216 | 208, DP::<MetazoneSpecificNamesShortV1Marker>);
         check_size_of!(168, PluralRules);
         check_size_of!(256 | 208, FixedDecimalFormatter);
-        check_size_of!(1024 | 928, TimeZoneDataPayloads);
+        check_size_of!(1024 | 936, TimeZoneDataPayloads);
         check_size_of!(3, TimeZoneFormatterUnit);
     }
 }

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -219,7 +219,7 @@ mod tests {
         check_size_of!(176, FormattedDateTime);
         check_size_of!(16, FormattedTimeZone::<CustomTimeZone>);
         check_size_of!(160, FormattedZonedDateTime);
-        check_size_of!(2, DateTimeFormatterOptions);
+        check_size_of!(13, DateTimeFormatterOptions);
 
         type DP<M> = DataPayload<M>;
         check_size_of!(208, DP::<PatternPluralsFromPatternsV1Marker>);

--- a/provider/core/src/datagen/payload.rs
+++ b/provider/core/src/datagen/payload.rs
@@ -8,7 +8,7 @@ use alloc::boxed::Box;
 use databake::{Bake, CrateEnv, TokenStream};
 use yoke::*;
 
-trait ExportableYoke {
+trait ExportableDataPayload {
     fn bake_yoke(&self, env: &CrateEnv) -> TokenStream;
     fn serialize_yoke(
         &self,
@@ -16,10 +16,9 @@ trait ExportableYoke {
     ) -> Result<(), DataError>;
 }
 
-impl<Y, C> ExportableYoke for Yoke<Y, C>
+impl<M: DataMarker> ExportableDataPayload for DataPayload<M>
 where
-    Y: for<'a> Yokeable<'a>,
-    for<'a> <Y as Yokeable<'a>>::Output: Bake + serde::Serialize,
+    for<'a> <M::Yokeable as Yokeable<'a>>::Output: Bake + serde::Serialize,
 {
     fn bake_yoke(&self, ctx: &CrateEnv) -> TokenStream {
         self.get().bake(ctx)
@@ -40,7 +39,7 @@ where
 #[doc(hidden)] // exposed for make_exportable_provider
 #[derive(yoke::Yokeable)]
 pub struct ExportBox {
-    payload: Box<dyn ExportableYoke + Sync>,
+    payload: Box<dyn ExportableDataPayload + Sync>,
 }
 
 impl core::fmt::Debug for ExportBox {
@@ -59,7 +58,7 @@ where
 {
     fn upcast(other: DataPayload<M>) -> DataPayload<ExportMarker> {
         DataPayload::from_owned(ExportBox {
-            payload: Box::new(other.yoke),
+            payload: Box::new(other),
         })
     }
 }

--- a/provider/core/src/response.rs
+++ b/provider/core/src/response.rs
@@ -199,7 +199,7 @@ where
 
     #[doc(hidden)]
     #[inline]
-    pub fn from_static_ref(data: &'static M::Yokeable) -> Self {
+    pub const fn from_static_ref(data: &'static M::Yokeable) -> Self {
         Self(DataPayloadInner::StaticRef(data))
     }
 

--- a/provider/datagen/src/baked_exporter.rs
+++ b/provider/datagen/src/baked_exporter.rs
@@ -142,8 +142,6 @@ struct ImplData {
     feature: SyncTokenStream,
     macro_ident: SyncTokenStream,
     hash_ident: SyncTokenStream,
-    // These are required for the skeletons special case
-    into_data_payload: SyncTokenStream,
     into_any_payload: SyncTokenStream,
 }
 
@@ -401,20 +399,10 @@ impl DataExporter for BakedExporter {
             }
         };
 
-        let into_data_payload = if is_datetime_skeletons {
+        let into_any_payload = if is_datetime_skeletons {
             quote! {
                 .map(icu_provider::prelude::zerofrom::ZeroFrom::zero_from)
                 .map(icu_provider::DataPayload::<#marker>::from_owned)
-            }
-        } else {
-            quote! {
-                .map(icu_provider::DataPayload::from_static_ref)
-            }
-        };
-
-        let into_any_payload = if is_datetime_skeletons {
-            quote! {
-                #into_data_payload
                 .map(icu_provider::DataPayload::wrap_into_any_payload)
             }
         } else {
@@ -430,7 +418,6 @@ impl DataExporter for BakedExporter {
             singleton: singleton.map(|t| t.to_string()),
             macro_ident: format!("impl_{ident}"),
             hash_ident: ident.to_ascii_uppercase(),
-            into_data_payload: into_data_payload.to_string(),
             into_any_payload: into_any_payload.to_string(),
         };
 
@@ -491,10 +478,6 @@ impl DataExporter for BakedExporter {
         let hash_idents = data
             .values()
             .map(|data| data.hash_ident.parse::<TokenStream>().unwrap())
-            .collect::<Vec<_>>();
-        let into_data_payloads = data
-            .values()
-            .map(|data| data.into_data_payload.parse::<TokenStream>().unwrap())
             .collect::<Vec<_>>();
         let into_any_payloads = data
             .values()
@@ -567,7 +550,8 @@ impl DataExporter for BakedExporter {
                                     req: icu_provider::DataRequest,
                                 ) -> Result<icu_provider::DataResponse<#markers>, icu_provider::DataError> {
                                     #lookups
-                                        #into_data_payloads
+                                        .map(icu_provider::prelude::zerofrom::ZeroFrom::zero_from)
+                                        .map(icu_provider::DataPayload::from_owned)
                                         .map(|payload| {
                                             icu_provider::DataResponse {
                                                 metadata: Default::default(),

--- a/utils/zerofrom/src/zero_from.rs
+++ b/utils/zerofrom/src/zero_from.rs
@@ -113,9 +113,9 @@ impl<'zf, B: ToOwned + ?Sized> ZeroFrom<'zf, Cow<'_, B>> for Cow<'zf, B> {
     }
 }
 
-impl<'zf> ZeroFrom<'zf, &'_ str> for &'zf str {
-    #[inline]
-    fn zero_from(other: &'zf &'_ str) -> &'zf str {
+impl<'zf, T: ?Sized> ZeroFrom<'zf, &'_ T> for &'zf T {
+#[inline]
+    fn zero_from(other: &'zf &'_ T) -> &'zf T {
         other
     }
 }

--- a/utils/zerofrom/src/zero_from.rs
+++ b/utils/zerofrom/src/zero_from.rs
@@ -114,7 +114,7 @@ impl<'zf, B: ToOwned + ?Sized> ZeroFrom<'zf, Cow<'_, B>> for Cow<'zf, B> {
 }
 
 impl<'zf, T: ?Sized> ZeroFrom<'zf, &'_ T> for &'zf T {
-#[inline]
+    #[inline]
     fn zero_from(other: &'zf &'_ T) -> &'zf T {
         other
     }


### PR DESCRIPTION
Part of #3020 

This adds `M::Yokeable: ZeroFrom<'static, M::Yokeable>` bounds to `DataPayload::map_project` and `DataPayload::try_map_project`. This is a breaking change, however `ZeroFrom` is implemented for all data structs (through `#[data_struct]` or convention).