### PR TITLE
Rust 1.70

### DIFF
--- a/provider/core/src/response.rs
+++ b/provider/core/src/response.rs
@@ -163,6 +163,7 @@ where
 fn test_clone_eq() {
     use crate::hello_world::*;
     let p1 = DataPayload::<HelloWorldV1Marker>::from_static_str("Demo");
+    #[allow(clippy::redundant_clone)]
     let p2 = p1.clone();
     assert_eq!(p1, p2);
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,5 +3,5 @@
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 [toolchain]
-# Version updated on 2023-04-20
-channel = "1.69"
+# Version updated on 2023-06-02
+channel = "1.70"


### PR DESCRIPTION
I couldn't update the lock files because we don't actually build without a lock file at 1.61 anymore.