### PR TITLE
Create RataDie type with i64 capacity; add unix_epoch and midnight functions to Date and Time

### DIFF
--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -22,6 +22,7 @@ pub trait CalendarArithmetic: Calendar {
     fn month_days(year: i32, month: u8) -> u8;
     fn months_for_every_year(year: i32) -> u8;
     fn is_leap_year(year: i32) -> bool;
+    fn last_month_day_in_year(year: i32) -> (u8, u8);
 
     /// Calculate the days in a given year
     /// Can be overridden with simpler implementations for solar calendars
@@ -44,6 +45,28 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
     pub fn new(year: i32, month: u8, day: u8) -> Self {
         ArithmeticDate {
             year,
+            month,
+            day,
+            marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn min_date() -> Self {
+        ArithmeticDate {
+            year: i32::MIN,
+            month: 1,
+            day: 1,
+            marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn max_date() -> Self {
+        let year = i32::MAX;
+        let (month, day) = C::last_month_day_in_year(year);
+        ArithmeticDate {
+            year: i32::MAX,
             month,
             day,
             marker: PhantomData,

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -33,9 +33,10 @@
 
 use crate::any_calendar::AnyCalendarKind;
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
-use crate::helpers::quotient;
+use crate::helpers::{i64_to_i32, quotient, quotient64, ConvertIntegerResult};
 use crate::iso::Iso;
 use crate::julian::Julian;
+use crate::rata_die::RataDie;
 use crate::{types, Calendar, CalendarError, Date, DateDuration, DateDurationUnit, DateTime};
 use core::marker::PhantomData;
 use tinystr::tinystr;
@@ -82,6 +83,14 @@ impl CalendarArithmetic for Coptic {
 
     fn is_leap_year(year: i32) -> bool {
         year % 4 == 3
+    }
+
+    fn last_month_day_in_year(year: i32) -> (u8, u8) {
+        if Self::is_leap_year(year) {
+            (13, 6)
+        } else {
+            (13, 5)
+        }
     }
 
     fn days_in_provided_year(year: i32) -> u32 {
@@ -193,7 +202,7 @@ impl Calendar for Coptic {
     }
 }
 
-pub(crate) const COPTIC_EPOCH: i32 = Julian::fixed_from_julian_integers(284, 8, 29);
+pub(crate) const COPTIC_EPOCH: RataDie = Julian::fixed_from_julian_integers(284, 8, 29);
 
 impl Coptic {
     // "Fixed" is a day count representation of calendars staring from Jan 1st of year 1 of the Georgian Calendar.
@@ -201,15 +210,15 @@ impl Coptic {
     // Dershowitz, Nachum, and Edward M. Reingold. _Calendrical calculations_. Cambridge University Press, 2008.
     //
     // Lisp code reference: https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L1978
-    fn fixed_from_coptic(date: ArithmeticDate<Coptic>) -> i32 {
+    fn fixed_from_coptic(date: ArithmeticDate<Coptic>) -> RataDie {
         COPTIC_EPOCH - 1
-            + 365 * (date.year - 1)
-            + quotient(date.year, 4)
-            + 30 * (date.month as i32 - 1)
-            + date.day as i32
+            + 365 * (date.year as i64 - 1)
+            + quotient(date.year, 4) as i64
+            + 30 * (date.month as i64 - 1)
+            + date.day as i64
     }
 
-    pub(crate) fn fixed_from_coptic_integers(year: i32, month: u8, day: u8) -> i32 {
+    pub(crate) fn fixed_from_coptic_integers(year: i32, month: u8, day: u8) -> RataDie {
         Self::fixed_from_coptic(ArithmeticDate {
             year,
             month,
@@ -219,10 +228,16 @@ impl Coptic {
     }
 
     // Lisp code reference: https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L1990
-    pub(crate) fn coptic_from_fixed(date: i32) -> CopticDateInner {
-        let year = quotient(4 * (date - COPTIC_EPOCH) + 1463, 1461);
-        let month = (quotient(date - Self::fixed_from_coptic_integers(year, 1, 1), 30) + 1) as u8; // <= 12 < u8::MAX
-        let day = (date + 1 - Self::fixed_from_coptic_integers(year, month, 1)) as u8; // <= days_in_month < u8::MAX
+    pub(crate) fn coptic_from_fixed(date: RataDie) -> CopticDateInner {
+        let year = quotient64(4 * (date - COPTIC_EPOCH).0 + 1463, 1461);
+        let year = match i64_to_i32(year) {
+            ConvertIntegerResult::BelowMin(_) => return CopticDateInner(ArithmeticDate::min_date()),
+            ConvertIntegerResult::AboveMax(_) => return CopticDateInner(ArithmeticDate::max_date()),
+            ConvertIntegerResult::WithinRange(y) => y,
+        };
+        let month =
+            (quotient64(date.0 - Self::fixed_from_coptic_integers(year, 1, 1).0, 30) + 1) as u8; // <= 12 < u8::MAX
+        let day = (date.0 + 1 - Self::fixed_from_coptic_integers(year, month, 1).0) as u8; // <= days_in_month < u8::MAX
 
         #[allow(clippy::unwrap_used)] // day and month have the correct bounds
         *Date::try_new_coptic_date(year, month, day).unwrap().inner()

--- a/components/calendar/src/ethiopian.rs
+++ b/components/calendar/src/ethiopian.rs
@@ -229,7 +229,7 @@ impl Calendar for Ethiopian {
 }
 
 const ETHIOPIC_TO_COPTIC_OFFSET: i64 =
-    super::coptic::COPTIC_EPOCH.0 - Julian::fixed_from_julian_integers(8, 8, 29).0;
+    super::coptic::COPTIC_EPOCH.const_diff(Julian::fixed_from_julian_integers(8, 8, 29));
 
 impl Ethiopian {
     /// Construct a new Ethiopian Calendar for the Amete Mihret era naming scheme

--- a/components/calendar/src/ethiopian.rs
+++ b/components/calendar/src/ethiopian.rs
@@ -37,6 +37,7 @@ use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::coptic::Coptic;
 use crate::iso::Iso;
 use crate::julian::Julian;
+use crate::rata_die::RataDie;
 use crate::{types, Calendar, CalendarError, Date, DateDuration, DateDurationUnit, DateTime};
 use core::marker::PhantomData;
 use tinystr::tinystr;
@@ -102,6 +103,14 @@ impl CalendarArithmetic for Ethiopian {
 
     fn is_leap_year(year: i32) -> bool {
         year % 4 == 3
+    }
+
+    fn last_month_day_in_year(year: i32) -> (u8, u8) {
+        if Self::is_leap_year(year) {
+            (13, 6)
+        } else {
+            (13, 5)
+        }
     }
 
     fn days_in_provided_year(year: i32) -> u32 {
@@ -219,8 +228,8 @@ impl Calendar for Ethiopian {
     }
 }
 
-const ETHIOPIC_TO_COPTIC_OFFSET: i32 =
-    super::coptic::COPTIC_EPOCH - Julian::fixed_from_julian_integers(8, 8, 29);
+const ETHIOPIC_TO_COPTIC_OFFSET: i64 =
+    super::coptic::COPTIC_EPOCH.0 - Julian::fixed_from_julian_integers(8, 8, 29).0;
 
 impl Ethiopian {
     /// Construct a new Ethiopian Calendar for the Amete Mihret era naming scheme
@@ -250,13 +259,13 @@ impl Ethiopian {
     // Dershowitz, Nachum, and Edward M. Reingold. _Calendrical calculations_. Cambridge University Press, 2008.
     //
     // Lisp code reference: https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L2017
-    fn fixed_from_ethiopian(date: ArithmeticDate<Ethiopian>) -> i32 {
+    fn fixed_from_ethiopian(date: ArithmeticDate<Ethiopian>) -> RataDie {
         Coptic::fixed_from_coptic_integers(date.year, date.month, date.day)
             - ETHIOPIC_TO_COPTIC_OFFSET
     }
 
     // Lisp code reference: https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L2028
-    fn ethiopian_from_fixed(date: i32) -> EthiopianDateInner {
+    fn ethiopian_from_fixed(date: RataDie) -> EthiopianDateInner {
         let coptic_date = Coptic::coptic_from_fixed(date + ETHIOPIC_TO_COPTIC_OFFSET);
 
         #[allow(clippy::unwrap_used)] // Coptic and Ethiopic have the same allowed ranges for dates

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -236,6 +236,8 @@ pub(crate) fn year_as_gregorian(year: i32) -> types::FormattableYear {
 
 #[cfg(test)]
 mod test {
+    use crate::rata_die::RataDie;
+
     use super::*;
     use types::Era;
 
@@ -345,7 +347,7 @@ mod test {
 
     #[derive(Debug)]
     struct TestCase {
-        fixed_date: i32,
+        fixed_date: RataDie,
         iso_year: i32,
         iso_month: u8,
         iso_day: u8,
@@ -384,7 +386,7 @@ mod test {
 
         let cases = [
             TestCase {
-                fixed_date: 1,
+                fixed_date: RataDie::new(1),
                 iso_year: 1,
                 iso_month: 1,
                 iso_day: 1,
@@ -394,7 +396,7 @@ mod test {
                 expected_day: 1,
             },
             TestCase {
-                fixed_date: 181,
+                fixed_date: RataDie::new(181),
                 iso_year: 1,
                 iso_month: 6,
                 iso_day: 30,
@@ -404,7 +406,7 @@ mod test {
                 expected_day: 30,
             },
             TestCase {
-                fixed_date: 1155,
+                fixed_date: RataDie::new(1155),
                 iso_year: 4,
                 iso_month: 2,
                 iso_day: 29,
@@ -414,7 +416,7 @@ mod test {
                 expected_day: 29,
             },
             TestCase {
-                fixed_date: 1344,
+                fixed_date: RataDie::new(1344),
                 iso_year: 4,
                 iso_month: 9,
                 iso_day: 5,
@@ -424,7 +426,7 @@ mod test {
                 expected_day: 5,
             },
             TestCase {
-                fixed_date: 36219,
+                fixed_date: RataDie::new(36219),
                 iso_year: 100,
                 iso_month: 3,
                 iso_day: 1,
@@ -558,7 +560,7 @@ mod test {
 
         let cases = [
             TestCase {
-                fixed_date: 0,
+                fixed_date: RataDie::new(0),
                 iso_year: 0,
                 iso_month: 12,
                 iso_day: 31,
@@ -568,7 +570,7 @@ mod test {
                 expected_day: 31,
             },
             TestCase {
-                fixed_date: -365, // This is a leap year
+                fixed_date: RataDie::new(-365), // This is a leap year
                 iso_year: 0,
                 iso_month: 1,
                 iso_day: 1,
@@ -578,7 +580,7 @@ mod test {
                 expected_day: 1,
             },
             TestCase {
-                fixed_date: -366,
+                fixed_date: RataDie::new(-366),
                 iso_year: -1,
                 iso_month: 12,
                 iso_day: 31,
@@ -588,7 +590,7 @@ mod test {
                 expected_day: 31,
             },
             TestCase {
-                fixed_date: -1461,
+                fixed_date: RataDie::new(-1461),
                 iso_year: -4,
                 iso_month: 12,
                 iso_day: 31,
@@ -598,7 +600,7 @@ mod test {
                 expected_day: 31,
             },
             TestCase {
-                fixed_date: -1826,
+                fixed_date: RataDie::new(-1826),
                 iso_year: -4,
                 iso_month: 1,
                 iso_day: 1,
@@ -621,8 +623,8 @@ mod test {
         // than the other, without exception.
         for i in -100..100 {
             for j in -100..100 {
-                let iso_i: Date<Iso> = Iso::iso_from_fixed(i);
-                let iso_j: Date<Iso> = Iso::iso_from_fixed(j);
+                let iso_i: Date<Iso> = Iso::iso_from_fixed(RataDie::new(i));
+                let iso_j: Date<Iso> = Iso::iso_from_fixed(RataDie::new(j));
 
                 let greg_i: Date<Gregorian> = Date::new_from_iso(iso_i, Gregorian);
                 let greg_j: Date<Gregorian> = Date::new_from_iso(iso_j, Gregorian);

--- a/components/calendar/src/helpers.rs
+++ b/components/calendar/src/helpers.rs
@@ -106,29 +106,29 @@ fn test_div_rem_euclid() {
     assert_eq!(div_rem_euclid(i32::MAX, 3), (715827882, 1));
 }
 
-pub enum ConvertIntegerResult {
+pub enum I32Result {
     BelowMin(i64),
     WithinRange(i32),
     AboveMax(i64),
 }
 
 #[inline]
-pub const fn i64_to_i32(input: i64) -> ConvertIntegerResult {
+pub const fn i64_to_i32(input: i64) -> I32Result {
     if input < i32::MIN as i64 {
-        ConvertIntegerResult::BelowMin(input)
+        I32Result::BelowMin(input)
     } else if input > i32::MAX as i64 {
-        ConvertIntegerResult::AboveMax(input)
+        I32Result::AboveMax(input)
     } else {
-        ConvertIntegerResult::WithinRange(input as i32)
+        I32Result::WithinRange(input as i32)
     }
 }
 
 #[inline]
 pub const fn i64_to_saturated_i32(input: i64) -> i32 {
     match i64_to_i32(input) {
-        ConvertIntegerResult::BelowMin(_) => i32::MIN,
-        ConvertIntegerResult::WithinRange(x) => x,
-        ConvertIntegerResult::AboveMax(_) => i32::MAX,
+        I32Result::BelowMin(_) => i32::MIN,
+        I32Result::WithinRange(x) => x,
+        I32Result::AboveMax(_) => i32::MAX,
     }
 }
 

--- a/components/calendar/src/helpers.rs
+++ b/components/calendar/src/helpers.rs
@@ -3,6 +3,8 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 /// Calculate `(n / d, n % d)` such that the remainder is always positive.
+///
+/// Also see [`i32::div_euclid`], [`i32::rem_euclid`].
 pub fn div_rem_euclid(n: i32, d: i32) -> (i32, i32) {
     debug_assert!(d > 0);
     let (a, b) = (n / d, n % d);
@@ -14,6 +16,8 @@ pub fn div_rem_euclid(n: i32, d: i32) -> (i32, i32) {
 }
 
 /// [`div_rem_euclid`] for 64-bit inputs
+///
+/// Also see [`i64::div_euclid`], [`i64::rem_euclid`].
 pub fn div_rem_euclid64(n: i64, d: i64) -> (i64, i64) {
     debug_assert!(d > 0);
     let (a, b) = (n / d, n % d);
@@ -26,6 +30,8 @@ pub fn div_rem_euclid64(n: i64, d: i64) -> (i64, i64) {
 
 /// Calculate `n / d` such that the remainder is always positive.
 /// This is equivalent to quotient() in the Reingold/Dershowitz Lisp code
+///
+/// Also see [`i32::div_euclid`]
 pub const fn quotient(n: i32, d: i32) -> i32 {
     debug_assert!(d > 0);
     // Code can use int_roundings once stabilized
@@ -39,6 +45,8 @@ pub const fn quotient(n: i32, d: i32) -> i32 {
 }
 
 /// [`quotient`] for 64-bit inputs
+///
+/// Also see [`i64::div_euclid`]
 pub const fn quotient64(n: i64, d: i64) -> i64 {
     debug_assert!(d > 0);
     // Code can use int_roundings once stabilized
@@ -104,6 +112,18 @@ fn test_div_rem_euclid() {
     assert_eq!(div_rem_euclid(i32::MAX, 1), (2147483647, 0));
     assert_eq!(div_rem_euclid(i32::MAX, 2), (1073741823, 1));
     assert_eq!(div_rem_euclid(i32::MAX, 3), (715827882, 1));
+
+    for n in -100..100 {
+        for d in 1..5 {
+            let (x1, y1) = div_rem_euclid(n, d);
+            let (x2, y2) = div_rem_euclid64(n as i64, d as i64);
+            let (x3, y3) = (n.div_euclid(d), n.rem_euclid(d));
+            assert_eq!(x1, x2 as i32);
+            assert_eq!(x1, x3);
+            assert_eq!(y1, y2 as i32);
+            assert_eq!(y1, y3);
+        }
+    }
 }
 
 pub enum I32Result {

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -82,6 +82,10 @@ impl CalendarArithmetic for Indian {
         Iso::is_leap_year(year + 78)
     }
 
+    fn last_month_day_in_year(_year: i32) -> (u8, u8) {
+        (12, 30)
+    }
+
     fn days_in_provided_year(year: i32) -> u32 {
         if Self::is_leap_year(year) {
             366

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -694,9 +694,7 @@ mod test {
     #[test]
     fn min_year() {
         assert_eq!(
-            Iso::iso_from_fixed(RataDie::big_negative())
-                .year()
-                .number,
+            Iso::iso_from_fixed(RataDie::big_negative()).year().number,
             i32::MIN
         );
     }

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -694,7 +694,7 @@ mod test {
     #[test]
     fn min_year() {
         assert_eq!(
-            Iso::iso_from_fixed(RataDie::new(-999999999999))
+            Iso::iso_from_fixed(RataDie::big_negative())
                 .year()
                 .number,
             i32::MIN

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -556,7 +556,9 @@ mod test {
             saturating: bool,
         }
         // Calculates the max possible year representable using i32::MAX as the fixed date
-        let max_year = Iso::iso_from_fixed(RataDie::new(i32::MAX as i64)).year().number;
+        let max_year = Iso::iso_from_fixed(RataDie::new(i32::MAX as i64))
+            .year()
+            .number;
 
         // Calculates the minimum possible year representable using i32::MIN as the fixed date
         // *Cannot be tested yet due to hard coded date not being available yet (see line 436)
@@ -582,36 +584,8 @@ mod test {
                 year: min_year,
                 month: 6,
                 day: 21,
-                fixed: RataDie::new(i32::MIN as i64),
-                saturating: true,
-            },
-            TestCase {
-                year: min_year,
-                month: 5,
-                day: 21,
-                fixed: RataDie::new(i32::MIN as i64),
-                saturating: true,
-            },
-            TestCase {
-                year: min_year - 1,
-                month: 12,
-                day: 31,
-                fixed: RataDie::new(i32::MIN as i64),
-                saturating: true,
-            },
-            TestCase {
-                year: min_year - 1,
-                month: 12,
-                day: 30,
-                fixed: RataDie::new(i32::MIN as i64),
-                saturating: true,
-            },
-            TestCase {
-                year: min_year - 1,
-                month: 12,
-                day: 1,
-                fixed: RataDie::new(i32::MIN as i64),
-                saturating: true,
+                fixed: RataDie::new(i32::MIN as i64 - 1),
+                saturating: false,
             },
             TestCase {
                 year: min_year,
@@ -660,28 +634,49 @@ mod test {
                 year: max_year,
                 month: 7,
                 day: 12,
-                fixed: RataDie::new(i32::MAX as i64),
+                fixed: RataDie::new(i32::MAX as i64 + 1),
+                saturating: false,
+            },
+            TestCase {
+                year: i32::MIN,
+                month: 1,
+                day: 2,
+                fixed: RataDie::new(-784352296669),
+                saturating: false,
+            },
+            TestCase {
+                year: i32::MIN,
+                month: 1,
+                day: 1,
+                fixed: RataDie::new(-784352296670),
+                saturating: false,
+            },
+            TestCase {
+                year: i32::MIN,
+                month: 1,
+                day: 1,
+                fixed: RataDie::new(-784352296671),
                 saturating: true,
             },
             TestCase {
-                year: max_year,
-                month: 8,
-                day: 11,
-                fixed: RataDie::new(i32::MAX as i64),
-                saturating: true,
+                year: i32::MAX,
+                month: 12,
+                day: 30,
+                fixed: RataDie::new(784352295938),
+                saturating: false,
             },
             TestCase {
-                year: max_year,
+                year: i32::MAX,
                 month: 12,
                 day: 31,
-                fixed: RataDie::new(i32::MAX as i64),
-                saturating: true,
+                fixed: RataDie::new(784352295939),
+                saturating: false,
             },
             TestCase {
-                year: max_year + 1,
-                month: 7,
-                day: 11,
-                fixed: RataDie::new(i32::MAX as i64),
+                year: i32::MAX,
+                month: 12,
+                day: 31,
+                fixed: RataDie::new(784352295940),
                 saturating: true,
             },
         ];
@@ -689,16 +684,21 @@ mod test {
         for case in cases {
             let date = Date::try_new_iso_date(case.year, case.month, case.day).unwrap();
             if !case.saturating {
-                assert_eq!(Iso::iso_from_fixed(case.fixed), date, "{case:?}");
+                assert_eq!(Iso::fixed_from_iso(date.inner), case.fixed, "{case:?}");
             }
-            assert_eq!(Iso::fixed_from_iso(date.inner), case.fixed, "{case:?}");
+            assert_eq!(Iso::iso_from_fixed(case.fixed), date, "{case:?}");
         }
     }
 
     // Calculates the minimum possible year representable using a large negative fixed date
     #[test]
     fn min_year() {
-        assert_eq!(Iso::iso_from_fixed(RataDie::new(-999999999999)).year().number, i32::MIN);
+        assert_eq!(
+            Iso::iso_from_fixed(RataDie::new(-999999999999))
+                .year()
+                .number,
+            i32::MIN
+        );
     }
 
     #[test]
@@ -853,7 +853,11 @@ mod test {
         // Year 0 is a leap year due to the 400-year rule.
         fn check(fixed: i64, year: i32, month: u8, day: u8) {
             let fixed = RataDie::new(fixed);
-            assert_eq!(Iso::iso_year_from_fixed(fixed), year as i64, "fixed: {fixed:?}");
+            assert_eq!(
+                Iso::iso_year_from_fixed(fixed),
+                year as i64,
+                "fixed: {fixed:?}"
+            );
             assert_eq!(
                 Iso::iso_from_fixed(fixed),
                 Date::try_new_iso_date(year, month, day).unwrap(),

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -31,10 +31,7 @@
 
 use crate::any_calendar::AnyCalendarKind;
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
-use crate::helpers::{
-    div_rem_euclid, div_rem_euclid64, i64_to_i32, i64_to_saturated_i32, quotient, quotient64,
-    I32Result,
-};
+use crate::helpers::{div_rem_euclid64, i64_to_i32, i64_to_saturated_i32, quotient64, I32Result};
 use crate::rata_die::RataDie;
 use crate::{types, Calendar, CalendarError, Date, DateDuration, DateDurationUnit, DateTime};
 use tinystr::tinystr;
@@ -83,7 +80,7 @@ impl CalendarArithmetic for Iso {
         year % 4 == 0 && (year % 400 == 0 || year % 100 != 0)
     }
 
-    fn last_month_day_in_year(year: i32) -> (u8, u8) {
+    fn last_month_day_in_year(_year: i32) -> (u8, u8) {
         (12, 31)
     }
 

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -390,7 +390,7 @@ impl Iso {
     pub(crate) fn fixed_from_iso(date: IsoDateInner) -> RataDie {
         let prev_year = (date.0.year as i64) - 1;
         // Calculate days per year
-        let mut fixed: i64 = (EPOCH.to_fixed_date() - 1) + 365 * prev_year;
+        let mut fixed: i64 = (EPOCH.to_i64_date() - 1) + 365 * prev_year;
         // Calculate leap year offset
         let offset =
             quotient64(prev_year, 4) - quotient64(prev_year, 100) + quotient64(prev_year, 400);

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -33,15 +33,16 @@
 
 use crate::any_calendar::AnyCalendarKind;
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
-use crate::helpers::quotient;
+use crate::helpers::{i64_to_i32, quotient, quotient64, ConvertIntegerResult};
 use crate::iso::Iso;
+use crate::rata_die::RataDie;
 use crate::{types, Calendar, CalendarError, Date, DateDuration, DateDurationUnit, DateTime};
 use core::marker::PhantomData;
 use tinystr::tinystr;
 
 // Julian epoch is equivalent to fixed_from_iso of December 30th of 0 year
 // 1st Jan of 1st year Julian is equivalent to December 30th of 0th year of ISO year
-const JULIAN_EPOCH: i32 = -1;
+const JULIAN_EPOCH: i64 = -1;
 
 /// The [Julian Calendar]
 ///
@@ -80,6 +81,10 @@ impl CalendarArithmetic for Julian {
 
     fn is_leap_year(year: i32) -> bool {
         Self::is_leap_year_const(year)
+    }
+
+    fn last_month_day_in_year(_year: i32) -> (u8, u8) {
+        (12, 31)
     }
 
     fn days_in_provided_year(year: i32) -> u32 {
@@ -211,14 +216,15 @@ impl Julian {
     // Dershowitz, Nachum, and Edward M. Reingold. _Calendrical calculations_. Cambridge University Press, 2008.
     //
     // Lisp code reference: https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L1689-L1709
-    pub(crate) const fn fixed_from_julian(date: ArithmeticDate<Julian>) -> i32 {
+    pub(crate) const fn fixed_from_julian(date: ArithmeticDate<Julian>) -> RataDie {
         let year = if date.year < 0 {
             date.year + 1
         } else {
             date.year
         };
-        let mut fixed: i32 = JULIAN_EPOCH - 1 + 365 * (year - 1) + quotient(year - 1, 4);
-        fixed += quotient(367 * (date.month as i32) - 362, 12);
+        let mut fixed: i64 =
+            JULIAN_EPOCH - 1 + 365 * (year as i64 - 1) + quotient64(year as i64 - 1, 4);
+        fixed += quotient64(367 * (date.month as i64) - 362, 12);
         fixed += if date.month <= 2 {
             0
         } else if Self::is_leap_year_const(date.year) {
@@ -227,10 +233,10 @@ impl Julian {
             -2
         };
 
-        fixed + (date.day as i32)
+        RataDie(fixed + (date.day as i64))
     }
 
-    pub(crate) const fn fixed_from_julian_integers(year: i32, month: u8, day: u8) -> i32 {
+    pub(crate) const fn fixed_from_julian_integers(year: i32, month: u8, day: u8) -> RataDie {
         Self::fixed_from_julian(ArithmeticDate {
             year,
             month,
@@ -250,10 +256,15 @@ impl Julian {
     }
 
     // Lisp code reference: https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L1711-L1738
-    fn julian_from_fixed(date: i32) -> JulianDateInner {
-        let approx = quotient((4 * date) + 1464, 1461);
+    fn julian_from_fixed(date: RataDie) -> JulianDateInner {
+        let approx = quotient64((4 * date.0) + 1464, 1461);
         let year = if approx <= 0 { approx - 1 } else { approx };
-        let prior_days = date - Self::fixed_from_julian_integers(year, 1, 1);
+        let year = match i64_to_i32(year) {
+            ConvertIntegerResult::BelowMin(_) => return JulianDateInner(ArithmeticDate::min_date()),
+            ConvertIntegerResult::AboveMax(_) => return JulianDateInner(ArithmeticDate::max_date()),
+            ConvertIntegerResult::WithinRange(y) => y,
+        };
+        let prior_days = date.0 - Self::fixed_from_julian_integers(year, 1, 1).0;
         let correction = if date < Self::fixed_from_julian_integers(year, 3, 1) {
             0
         } else if Julian::is_leap_year(year) {
@@ -261,8 +272,8 @@ impl Julian {
         } else {
             2
         };
-        let month = quotient(12 * (prior_days + correction) + 373, 367) as u8; // this expression is in 1..=12
-        let day = (date - Self::fixed_from_julian_integers(year, month, 1) + 1) as u8; // as days_in_month is < u8::MAX
+        let month = quotient64(12 * (prior_days + correction) + 373, 367) as u8; // this expression is in 1..=12
+        let day = (date.0 - Self::fixed_from_julian_integers(year, month, 1).0 + 1) as u8; // as days_in_month is < u8::MAX
 
         #[allow(clippy::unwrap_used)] // day and month have the correct bounds
         *Date::try_new_julian_date(year, month, day).unwrap().inner()

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -42,7 +42,7 @@ use tinystr::tinystr;
 
 // Julian epoch is equivalent to fixed_from_iso of December 30th of 0 year
 // 1st Jan of 1st year Julian is equivalent to December 30th of 0th year of ISO year
-const JULIAN_EPOCH: RataDie = RataDie::new_from_fixed_date(-1);
+const JULIAN_EPOCH: RataDie = RataDie::new(-1);
 
 /// The [Julian Calendar]
 ///
@@ -234,7 +234,7 @@ impl Julian {
             -2
         };
 
-        RataDie::new_from_fixed_date(fixed + (date.day as i64))
+        RataDie::new(fixed + (date.day as i64))
     }
 
     pub(crate) const fn fixed_from_julian_integers(year: i32, month: u8, day: u8) -> RataDie {

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -42,7 +42,7 @@ use tinystr::tinystr;
 
 // Julian epoch is equivalent to fixed_from_iso of December 30th of 0 year
 // 1st Jan of 1st year Julian is equivalent to December 30th of 0th year of ISO year
-const JULIAN_EPOCH: i64 = -1;
+const JULIAN_EPOCH: RataDie = RataDie::new_from_fixed_date(-1);
 
 /// The [Julian Calendar]
 ///
@@ -222,8 +222,9 @@ impl Julian {
         } else {
             date.year
         };
-        let mut fixed: i64 =
-            JULIAN_EPOCH - 1 + 365 * (year as i64 - 1) + quotient64(year as i64 - 1, 4);
+        let mut fixed: i64 = JULIAN_EPOCH.to_fixed_date() - 1
+            + 365 * (year as i64 - 1)
+            + quotient64(year as i64 - 1, 4);
         fixed += quotient64(367 * (date.month as i64) - 362, 12);
         fixed += if date.month <= 2 {
             0
@@ -233,7 +234,7 @@ impl Julian {
             -2
         };
 
-        RataDie(fixed + (date.day as i64))
+        RataDie::new_from_fixed_date(fixed + (date.day as i64))
     }
 
     pub(crate) const fn fixed_from_julian_integers(year: i32, month: u8, day: u8) -> RataDie {
@@ -257,7 +258,7 @@ impl Julian {
 
     // Lisp code reference: https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L1711-L1738
     fn julian_from_fixed(date: RataDie) -> JulianDateInner {
-        let approx = quotient64((4 * date.0) + 1464, 1461);
+        let approx = quotient64((4 * date.to_fixed_date()) + 1464, 1461);
         let year = if approx <= 0 { approx - 1 } else { approx };
         let year = match i64_to_i32(year) {
             I32Result::BelowMin(_) => return JulianDateInner(ArithmeticDate::min_date()),

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -222,7 +222,7 @@ impl Julian {
         } else {
             date.year
         };
-        let mut fixed: i64 = JULIAN_EPOCH.to_fixed_date() - 1
+        let mut fixed: i64 = JULIAN_EPOCH.to_i64_date() - 1
             + 365 * (year as i64 - 1)
             + quotient64(year as i64 - 1, 4);
         fixed += quotient64(367 * (date.month as i64) - 362, 12);
@@ -258,7 +258,7 @@ impl Julian {
 
     // Lisp code reference: https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L1711-L1738
     fn julian_from_fixed(date: RataDie) -> JulianDateInner {
-        let approx = quotient64((4 * date.to_fixed_date()) + 1464, 1461);
+        let approx = quotient64((4 * date.to_i64_date()) + 1464, 1461);
         let year = if approx <= 0 { approx - 1 } else { approx };
         let year = match i64_to_i32(year) {
             I32Result::BelowMin(_) => return JulianDateInner(ArithmeticDate::min_date()),

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -33,7 +33,7 @@
 
 use crate::any_calendar::AnyCalendarKind;
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
-use crate::helpers::{i64_to_i32, quotient, quotient64, I32Result};
+use crate::helpers::{i64_to_i32, quotient64, I32Result};
 use crate::iso::Iso;
 use crate::rata_die::RataDie;
 use crate::{types, Calendar, CalendarError, Date, DateDuration, DateDurationUnit, DateTime};

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -130,6 +130,7 @@ pub mod iso;
 pub mod japanese;
 pub mod julian;
 pub mod provider;
+mod rata_die;
 pub mod types;
 mod week_of;
 

--- a/components/calendar/src/rata_die.rs
+++ b/components/calendar/src/rata_die.rs
@@ -21,13 +21,7 @@ impl RataDie {
     }
 }
 
-impl Add for RataDie {
-    type Output = Self;
-    fn add(self, rhs: Self) -> Self::Output {
-        Self(self.0 + rhs.0)
-    }
-}
-
+/// Shift a RataDie N days into the future
 impl Add<i64> for RataDie {
     type Output = Self;
     fn add(self, rhs: i64) -> Self::Output {
@@ -35,13 +29,7 @@ impl Add<i64> for RataDie {
     }
 }
 
-impl Sub for RataDie {
-    type Output = Self;
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self(self.0 - rhs.0)
-    }
-}
-
+/// Shift a RataDie N days into the past
 impl Sub<i64> for RataDie {
     type Output = Self;
     fn sub(self, rhs: i64) -> Self::Output {
@@ -49,9 +37,10 @@ impl Sub<i64> for RataDie {
     }
 }
 
-impl Mul<i64> for RataDie {
-    type Output = Self;
-    fn mul(self, rhs: i64) -> Self::Output {
-        Self(self.0 * rhs)
+/// Calculate the number of days between two RataDie
+impl Sub for RataDie {
+    type Output = i64;
+    fn sub(self, rhs: Self) -> Self::Output {
+        self.0 - rhs.0
     }
 }

--- a/components/calendar/src/rata_die.rs
+++ b/components/calendar/src/rata_die.rs
@@ -2,9 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use core::ops::{Add, Mul, Sub};
-
-use crate::helpers::div_rem_euclid64;
+use core::ops::{Add, Sub};
 
 /// The *Rata Die*, or *R.D.*, or `fixed_date`: number of days since January 1, 1 CE.
 ///
@@ -14,12 +12,6 @@ use crate::helpers::div_rem_euclid64;
 /// except from a date that is in range of one of the official calendars.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct RataDie(pub i64);
-
-impl RataDie {
-    pub fn div_rem_euclid64(self, divisor: i64) -> (i64, i64) {
-        div_rem_euclid64(self.0, divisor)
-    }
-}
 
 /// Shift a RataDie N days into the future
 impl Add<i64> for RataDie {

--- a/components/calendar/src/rata_die.rs
+++ b/components/calendar/src/rata_die.rs
@@ -40,7 +40,7 @@ impl RataDie {
     pub const fn big_negative() -> Self {
         Self::new(i64::MIN / 256 / 256)
     }
-    pub const fn to_fixed_date(self) -> i64 {
+    pub const fn to_i64_date(self) -> i64 {
         self.0
     }
     /// Calculate the number of days between two RataDie in a const-friendly way

--- a/components/calendar/src/rata_die.rs
+++ b/components/calendar/src/rata_die.rs
@@ -1,0 +1,57 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use core::ops::{Add, Mul, Sub};
+
+use crate::helpers::div_rem_euclid64;
+
+/// The *Rata Die*, or *R.D.*, or `fixed_date`: number of days since January 1, 1 CE.
+///
+/// See: <https://en.wikipedia.org/wiki/Rata_Die>
+///
+/// Keep this class INTERNAL because it shouldn't be possible to construct a RataDie
+/// except from a date that is in range of one of the official calendars.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct RataDie(pub i64);
+
+impl RataDie {
+    pub fn div_rem_euclid64(self, divisor: i64) -> (i64, i64) {
+        div_rem_euclid64(self.0, divisor)
+    }
+}
+
+impl Add for RataDie {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl Add<i64> for RataDie {
+    type Output = Self;
+    fn add(self, rhs: i64) -> Self::Output {
+        Self(self.0 + rhs)
+    }
+}
+
+impl Sub for RataDie {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self(self.0 - rhs.0)
+    }
+}
+
+impl Sub<i64> for RataDie {
+    type Output = Self;
+    fn sub(self, rhs: i64) -> Self::Output {
+        Self(self.0 - rhs)
+    }
+}
+
+impl Mul<i64> for RataDie {
+    type Output = Self;
+    fn mul(self, rhs: i64) -> Self::Output {
+        Self(self.0 * rhs)
+    }
+}

--- a/components/calendar/src/rata_die.rs
+++ b/components/calendar/src/rata_die.rs
@@ -15,7 +15,30 @@ pub(crate) struct RataDie(i64);
 
 impl RataDie {
     pub const fn new(fixed_date: i64) -> Self {
-        Self(fixed_date)
+        let result = Self(fixed_date);
+        #[cfg(debug_assertions)]
+        result.check();
+        result
+    }
+    #[cfg(debug_assertions)]
+    pub const fn check(&self) {
+        if self.0 > i64::MAX / 256 {
+            debug_assert!(
+                false,
+                "RataDie is not designed to store values near to the overflow boundary"
+            );
+        }
+        if self.0 < i64::MIN / 256 {
+            debug_assert!(
+                false,
+                "RataDie is not designed to store values near to the overflow boundary"
+            );
+        }
+    }
+    /// A valid RataDie that is intended to be below all dates representable in calendars
+    #[cfg(test)]
+    pub const fn big_negative() -> Self {
+        Self::new(i64::MIN / 256 / 256)
     }
     pub const fn to_fixed_date(self) -> i64 {
         self.0
@@ -30,13 +53,18 @@ impl RataDie {
 impl Add<i64> for RataDie {
     type Output = Self;
     fn add(self, rhs: i64) -> Self::Output {
-        Self(self.0 + rhs)
+        let result = Self(self.0 + rhs);
+        #[cfg(debug_assertions)]
+        result.check();
+        result
     }
 }
 
 impl AddAssign<i64> for RataDie {
     fn add_assign(&mut self, rhs: i64) {
         self.0 += rhs;
+        #[cfg(debug_assertions)]
+        self.check();
     }
 }
 
@@ -44,13 +72,18 @@ impl AddAssign<i64> for RataDie {
 impl Sub<i64> for RataDie {
     type Output = Self;
     fn sub(self, rhs: i64) -> Self::Output {
-        Self(self.0 - rhs)
+        let result = Self(self.0 - rhs);
+        #[cfg(debug_assertions)]
+        result.check();
+        result
     }
 }
 
 impl SubAssign<i64> for RataDie {
     fn sub_assign(&mut self, rhs: i64) {
         self.0 -= rhs;
+        #[cfg(debug_assertions)]
+        self.check();
     }
 }
 

--- a/components/calendar/src/rata_die.rs
+++ b/components/calendar/src/rata_die.rs
@@ -14,7 +14,7 @@ use core::ops::{Add, AddAssign, Sub, SubAssign};
 pub(crate) struct RataDie(i64);
 
 impl RataDie {
-    pub const fn new_from_fixed_date(fixed_date: i64) -> Self {
+    pub const fn new(fixed_date: i64) -> Self {
         Self(fixed_date)
     }
     pub const fn to_fixed_date(self) -> i64 {

--- a/components/calendar/src/rata_die.rs
+++ b/components/calendar/src/rata_die.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use core::ops::{Add, Sub};
+use core::ops::{Add, AddAssign, Sub, SubAssign};
 
 /// The *Rata Die*, or *R.D.*, or `fixed_date`: number of days since January 1, 1 CE.
 ///
@@ -11,7 +11,20 @@ use core::ops::{Add, Sub};
 /// Keep this class INTERNAL because it shouldn't be possible to construct a RataDie
 /// except from a date that is in range of one of the official calendars.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct RataDie(pub i64);
+pub(crate) struct RataDie(i64);
+
+impl RataDie {
+    pub const fn new_from_fixed_date(fixed_date: i64) -> Self {
+        Self(fixed_date)
+    }
+    pub const fn to_fixed_date(self) -> i64 {
+        self.0
+    }
+    /// Calculate the number of days between two RataDie in a const-friendly way
+    pub const fn const_diff(self, rhs: Self) -> i64 {
+        self.0 - rhs.0
+    }
+}
 
 /// Shift a RataDie N days into the future
 impl Add<i64> for RataDie {
@@ -21,11 +34,23 @@ impl Add<i64> for RataDie {
     }
 }
 
+impl AddAssign<i64> for RataDie {
+    fn add_assign(&mut self, rhs: i64) {
+        self.0 += rhs;
+    }
+}
+
 /// Shift a RataDie N days into the past
 impl Sub<i64> for RataDie {
     type Output = Self;
     fn sub(self, rhs: i64) -> Self::Output {
         Self(self.0 - rhs)
+    }
+}
+
+impl SubAssign<i64> for RataDie {
+    fn sub_assign(&mut self, rhs: i64) {
+        self.0 -= rhs;
     }
 }
 

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -479,6 +479,16 @@ impl Time {
         }
     }
 
+    /// Construct a new [`Time`] representing midnight (00:00.000)
+    pub const fn midnight() -> Self {
+        Self {
+            hour: IsoHour::zero(),
+            minute: IsoMinute::zero(),
+            second: IsoSecond::zero(),
+            nanosecond: NanoSecond::zero(),
+        }
+    }
+
     /// Construct a new [`Time`], whilst validating that all components are in range
     pub fn try_new(
         hour: u8,

--- a/ffi/diplomat/c/include/ICU4XIsoDate.h
+++ b/ffi/diplomat/c/include/ICU4XIsoDate.h
@@ -27,6 +27,8 @@ extern "C" {
 
 diplomat_result_box_ICU4XIsoDate_ICU4XError ICU4XIsoDate_create(int32_t year, uint8_t month, uint8_t day);
 
+ICU4XIsoDate* ICU4XIsoDate_create_for_unix_epoch(int32_t year, uint8_t month, uint8_t day);
+
 ICU4XDate* ICU4XIsoDate_to_calendar(const ICU4XIsoDate* self, const ICU4XCalendar* calendar);
 
 ICU4XDate* ICU4XIsoDate_to_any(const ICU4XIsoDate* self);

--- a/ffi/diplomat/c/include/ICU4XIsoDate.h
+++ b/ffi/diplomat/c/include/ICU4XIsoDate.h
@@ -27,7 +27,7 @@ extern "C" {
 
 diplomat_result_box_ICU4XIsoDate_ICU4XError ICU4XIsoDate_create(int32_t year, uint8_t month, uint8_t day);
 
-ICU4XIsoDate* ICU4XIsoDate_create_for_unix_epoch(int32_t year, uint8_t month, uint8_t day);
+ICU4XIsoDate* ICU4XIsoDate_create_for_unix_epoch();
 
 ICU4XDate* ICU4XIsoDate_to_calendar(const ICU4XIsoDate* self, const ICU4XCalendar* calendar);
 

--- a/ffi/diplomat/c/include/ICU4XTime.h
+++ b/ffi/diplomat/c/include/ICU4XTime.h
@@ -22,7 +22,7 @@ extern "C" {
 
 diplomat_result_box_ICU4XTime_ICU4XError ICU4XTime_create(uint8_t hour, uint8_t minute, uint8_t second, uint32_t nanosecond);
 
-diplomat_result_box_ICU4XTime_ICU4XError ICU4XTime_create_midnight(uint8_t hour, uint8_t minute, uint8_t second, uint32_t nanosecond);
+diplomat_result_box_ICU4XTime_ICU4XError ICU4XTime_create_midnight();
 
 uint8_t ICU4XTime_hour(const ICU4XTime* self);
 

--- a/ffi/diplomat/c/include/ICU4XTime.h
+++ b/ffi/diplomat/c/include/ICU4XTime.h
@@ -22,6 +22,8 @@ extern "C" {
 
 diplomat_result_box_ICU4XTime_ICU4XError ICU4XTime_create(uint8_t hour, uint8_t minute, uint8_t second, uint32_t nanosecond);
 
+diplomat_result_box_ICU4XTime_ICU4XError ICU4XTime_create_midnight(uint8_t hour, uint8_t minute, uint8_t second, uint32_t nanosecond);
+
 uint8_t ICU4XTime_hour(const ICU4XTime* self);
 
 uint8_t ICU4XTime_minute(const ICU4XTime* self);

--- a/ffi/diplomat/cpp/docs/source/date_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/date_ffi.rst
@@ -156,6 +156,13 @@
         See the `Rust documentation for try_new_iso_date <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.try_new_iso_date>`__ for more information.
 
 
+    .. cpp:function:: static ICU4XIsoDate create_for_unix_epoch(int32_t year, uint8_t month, uint8_t day)
+
+        Creates a new :cpp:class:`ICU4XIsoDate` representing January 1, 1970.
+
+        See the `Rust documentation for unix_epoch <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.unix_epoch>`__ for more information.
+
+
     .. cpp:function:: ICU4XDate to_calendar(const ICU4XCalendar& calendar) const
 
         Convert this date to one in a different calendar

--- a/ffi/diplomat/cpp/docs/source/date_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/date_ffi.rst
@@ -156,7 +156,7 @@
         See the `Rust documentation for try_new_iso_date <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.try_new_iso_date>`__ for more information.
 
 
-    .. cpp:function:: static ICU4XIsoDate create_for_unix_epoch(int32_t year, uint8_t month, uint8_t day)
+    .. cpp:function:: static ICU4XIsoDate create_for_unix_epoch()
 
         Creates a new :cpp:class:`ICU4XIsoDate` representing January 1, 1970.
 

--- a/ffi/diplomat/cpp/docs/source/time_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/time_ffi.rst
@@ -15,6 +15,13 @@
         See the `Rust documentation for Time <https://docs.rs/icu/latest/icu/calendar/types/struct.Time.html>`__ for more information.
 
 
+    .. cpp:function:: static diplomat::result<ICU4XTime, ICU4XError> create_midnight(uint8_t hour, uint8_t minute, uint8_t second, uint32_t nanosecond)
+
+        Creates a new :cpp:class:`ICU4XTime` representing midnight (00:00.000).
+
+        See the `Rust documentation for Time <https://docs.rs/icu/latest/icu/calendar/types/struct.Time.html>`__ for more information.
+
+
     .. cpp:function:: uint8_t hour() const
 
         Returns the hour in this time

--- a/ffi/diplomat/cpp/docs/source/time_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/time_ffi.rst
@@ -15,7 +15,7 @@
         See the `Rust documentation for Time <https://docs.rs/icu/latest/icu/calendar/types/struct.Time.html>`__ for more information.
 
 
-    .. cpp:function:: static diplomat::result<ICU4XTime, ICU4XError> create_midnight(uint8_t hour, uint8_t minute, uint8_t second, uint32_t nanosecond)
+    .. cpp:function:: static diplomat::result<ICU4XTime, ICU4XError> create_midnight()
 
         Creates a new :cpp:class:`ICU4XTime` representing midnight (00:00.000).
 

--- a/ffi/diplomat/cpp/include/ICU4XIsoDate.h
+++ b/ffi/diplomat/cpp/include/ICU4XIsoDate.h
@@ -27,6 +27,8 @@ extern "C" {
 
 diplomat_result_box_ICU4XIsoDate_ICU4XError ICU4XIsoDate_create(int32_t year, uint8_t month, uint8_t day);
 
+ICU4XIsoDate* ICU4XIsoDate_create_for_unix_epoch(int32_t year, uint8_t month, uint8_t day);
+
 ICU4XDate* ICU4XIsoDate_to_calendar(const ICU4XIsoDate* self, const ICU4XCalendar* calendar);
 
 ICU4XDate* ICU4XIsoDate_to_any(const ICU4XIsoDate* self);

--- a/ffi/diplomat/cpp/include/ICU4XIsoDate.h
+++ b/ffi/diplomat/cpp/include/ICU4XIsoDate.h
@@ -27,7 +27,7 @@ extern "C" {
 
 diplomat_result_box_ICU4XIsoDate_ICU4XError ICU4XIsoDate_create(int32_t year, uint8_t month, uint8_t day);
 
-ICU4XIsoDate* ICU4XIsoDate_create_for_unix_epoch(int32_t year, uint8_t month, uint8_t day);
+ICU4XIsoDate* ICU4XIsoDate_create_for_unix_epoch();
 
 ICU4XDate* ICU4XIsoDate_to_calendar(const ICU4XIsoDate* self, const ICU4XCalendar* calendar);
 

--- a/ffi/diplomat/cpp/include/ICU4XIsoDate.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XIsoDate.hpp
@@ -44,6 +44,13 @@ class ICU4XIsoDate {
   static diplomat::result<ICU4XIsoDate, ICU4XError> create(int32_t year, uint8_t month, uint8_t day);
 
   /**
+   * Creates a new [`ICU4XIsoDate`] representing January 1, 1970.
+   * 
+   * See the [Rust documentation for `unix_epoch`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.unix_epoch) for more information.
+   */
+  static ICU4XIsoDate create_for_unix_epoch(int32_t year, uint8_t month, uint8_t day);
+
+  /**
    * Convert this date to one in a different calendar
    * 
    * See the [Rust documentation for `to_calendar`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.to_calendar) for more information.
@@ -146,6 +153,9 @@ inline diplomat::result<ICU4XIsoDate, ICU4XError> ICU4XIsoDate::create(int32_t y
     diplomat_result_out_value = diplomat::Err<ICU4XError>(std::move(static_cast<ICU4XError>(diplomat_result_raw_out_value.err)));
   }
   return diplomat_result_out_value;
+}
+inline ICU4XIsoDate ICU4XIsoDate::create_for_unix_epoch(int32_t year, uint8_t month, uint8_t day) {
+  return ICU4XIsoDate(capi::ICU4XIsoDate_create_for_unix_epoch(year, month, day));
 }
 inline ICU4XDate ICU4XIsoDate::to_calendar(const ICU4XCalendar& calendar) const {
   return ICU4XDate(capi::ICU4XIsoDate_to_calendar(this->inner.get(), calendar.AsFFI()));

--- a/ffi/diplomat/cpp/include/ICU4XIsoDate.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XIsoDate.hpp
@@ -48,7 +48,7 @@ class ICU4XIsoDate {
    * 
    * See the [Rust documentation for `unix_epoch`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.unix_epoch) for more information.
    */
-  static ICU4XIsoDate create_for_unix_epoch(int32_t year, uint8_t month, uint8_t day);
+  static ICU4XIsoDate create_for_unix_epoch();
 
   /**
    * Convert this date to one in a different calendar
@@ -154,8 +154,8 @@ inline diplomat::result<ICU4XIsoDate, ICU4XError> ICU4XIsoDate::create(int32_t y
   }
   return diplomat_result_out_value;
 }
-inline ICU4XIsoDate ICU4XIsoDate::create_for_unix_epoch(int32_t year, uint8_t month, uint8_t day) {
-  return ICU4XIsoDate(capi::ICU4XIsoDate_create_for_unix_epoch(year, month, day));
+inline ICU4XIsoDate ICU4XIsoDate::create_for_unix_epoch() {
+  return ICU4XIsoDate(capi::ICU4XIsoDate_create_for_unix_epoch());
 }
 inline ICU4XDate ICU4XIsoDate::to_calendar(const ICU4XCalendar& calendar) const {
   return ICU4XDate(capi::ICU4XIsoDate_to_calendar(this->inner.get(), calendar.AsFFI()));

--- a/ffi/diplomat/cpp/include/ICU4XTime.h
+++ b/ffi/diplomat/cpp/include/ICU4XTime.h
@@ -22,7 +22,7 @@ extern "C" {
 
 diplomat_result_box_ICU4XTime_ICU4XError ICU4XTime_create(uint8_t hour, uint8_t minute, uint8_t second, uint32_t nanosecond);
 
-diplomat_result_box_ICU4XTime_ICU4XError ICU4XTime_create_midnight(uint8_t hour, uint8_t minute, uint8_t second, uint32_t nanosecond);
+diplomat_result_box_ICU4XTime_ICU4XError ICU4XTime_create_midnight();
 
 uint8_t ICU4XTime_hour(const ICU4XTime* self);
 

--- a/ffi/diplomat/cpp/include/ICU4XTime.h
+++ b/ffi/diplomat/cpp/include/ICU4XTime.h
@@ -22,6 +22,8 @@ extern "C" {
 
 diplomat_result_box_ICU4XTime_ICU4XError ICU4XTime_create(uint8_t hour, uint8_t minute, uint8_t second, uint32_t nanosecond);
 
+diplomat_result_box_ICU4XTime_ICU4XError ICU4XTime_create_midnight(uint8_t hour, uint8_t minute, uint8_t second, uint32_t nanosecond);
+
 uint8_t ICU4XTime_hour(const ICU4XTime* self);
 
 uint8_t ICU4XTime_minute(const ICU4XTime* self);

--- a/ffi/diplomat/cpp/include/ICU4XTime.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XTime.hpp
@@ -43,7 +43,7 @@ class ICU4XTime {
    * 
    * See the [Rust documentation for `Time`](https://docs.rs/icu/latest/icu/calendar/types/struct.Time.html) for more information.
    */
-  static diplomat::result<ICU4XTime, ICU4XError> create_midnight(uint8_t hour, uint8_t minute, uint8_t second, uint32_t nanosecond);
+  static diplomat::result<ICU4XTime, ICU4XError> create_midnight();
 
   /**
    * Returns the hour in this time
@@ -93,8 +93,8 @@ inline diplomat::result<ICU4XTime, ICU4XError> ICU4XTime::create(uint8_t hour, u
   }
   return diplomat_result_out_value;
 }
-inline diplomat::result<ICU4XTime, ICU4XError> ICU4XTime::create_midnight(uint8_t hour, uint8_t minute, uint8_t second, uint32_t nanosecond) {
-  auto diplomat_result_raw_out_value = capi::ICU4XTime_create_midnight(hour, minute, second, nanosecond);
+inline diplomat::result<ICU4XTime, ICU4XError> ICU4XTime::create_midnight() {
+  auto diplomat_result_raw_out_value = capi::ICU4XTime_create_midnight();
   diplomat::result<ICU4XTime, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
     diplomat_result_out_value = diplomat::Ok<ICU4XTime>(std::move(ICU4XTime(diplomat_result_raw_out_value.ok)));

--- a/ffi/diplomat/cpp/include/ICU4XTime.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XTime.hpp
@@ -39,6 +39,13 @@ class ICU4XTime {
   static diplomat::result<ICU4XTime, ICU4XError> create(uint8_t hour, uint8_t minute, uint8_t second, uint32_t nanosecond);
 
   /**
+   * Creates a new [`ICU4XTime`] representing midnight (00:00.000).
+   * 
+   * See the [Rust documentation for `Time`](https://docs.rs/icu/latest/icu/calendar/types/struct.Time.html) for more information.
+   */
+  static diplomat::result<ICU4XTime, ICU4XError> create_midnight(uint8_t hour, uint8_t minute, uint8_t second, uint32_t nanosecond);
+
+  /**
    * Returns the hour in this time
    * 
    * See the [Rust documentation for `hour`](https://docs.rs/icu/latest/icu/calendar/types/struct.Time.html#structfield.hour) for more information.
@@ -78,6 +85,16 @@ class ICU4XTime {
 
 inline diplomat::result<ICU4XTime, ICU4XError> ICU4XTime::create(uint8_t hour, uint8_t minute, uint8_t second, uint32_t nanosecond) {
   auto diplomat_result_raw_out_value = capi::ICU4XTime_create(hour, minute, second, nanosecond);
+  diplomat::result<ICU4XTime, ICU4XError> diplomat_result_out_value;
+  if (diplomat_result_raw_out_value.is_ok) {
+    diplomat_result_out_value = diplomat::Ok<ICU4XTime>(std::move(ICU4XTime(diplomat_result_raw_out_value.ok)));
+  } else {
+    diplomat_result_out_value = diplomat::Err<ICU4XError>(std::move(static_cast<ICU4XError>(diplomat_result_raw_out_value.err)));
+  }
+  return diplomat_result_out_value;
+}
+inline diplomat::result<ICU4XTime, ICU4XError> ICU4XTime::create_midnight(uint8_t hour, uint8_t minute, uint8_t second, uint32_t nanosecond) {
+  auto diplomat_result_raw_out_value = capi::ICU4XTime_create_midnight(hour, minute, second, nanosecond);
   diplomat::result<ICU4XTime, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
     diplomat_result_out_value = diplomat::Ok<ICU4XTime>(std::move(ICU4XTime(diplomat_result_raw_out_value.ok)));

--- a/ffi/diplomat/js/docs/source/date_ffi.rst
+++ b/ffi/diplomat/js/docs/source/date_ffi.rst
@@ -140,7 +140,7 @@
         See the `Rust documentation for try_new_iso_date <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.try_new_iso_date>`__ for more information.
 
 
-    .. js:function:: create_for_unix_epoch(year, month, day)
+    .. js:function:: create_for_unix_epoch()
 
         Creates a new :js:class:`ICU4XIsoDate` representing January 1, 1970.
 

--- a/ffi/diplomat/js/docs/source/date_ffi.rst
+++ b/ffi/diplomat/js/docs/source/date_ffi.rst
@@ -140,6 +140,13 @@
         See the `Rust documentation for try_new_iso_date <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.try_new_iso_date>`__ for more information.
 
 
+    .. js:function:: create_for_unix_epoch(year, month, day)
+
+        Creates a new :js:class:`ICU4XIsoDate` representing January 1, 1970.
+
+        See the `Rust documentation for unix_epoch <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.unix_epoch>`__ for more information.
+
+
     .. js:method:: to_calendar(calendar)
 
         Convert this date to one in a different calendar

--- a/ffi/diplomat/js/docs/source/time_ffi.rst
+++ b/ffi/diplomat/js/docs/source/time_ffi.rst
@@ -15,7 +15,7 @@
         See the `Rust documentation for Time <https://docs.rs/icu/latest/icu/calendar/types/struct.Time.html>`__ for more information.
 
 
-    .. js:function:: create_midnight(hour, minute, second, nanosecond)
+    .. js:function:: create_midnight()
 
         Creates a new :js:class:`ICU4XTime` representing midnight (00:00.000).
 

--- a/ffi/diplomat/js/docs/source/time_ffi.rst
+++ b/ffi/diplomat/js/docs/source/time_ffi.rst
@@ -15,6 +15,13 @@
         See the `Rust documentation for Time <https://docs.rs/icu/latest/icu/calendar/types/struct.Time.html>`__ for more information.
 
 
+    .. js:function:: create_midnight(hour, minute, second, nanosecond)
+
+        Creates a new :js:class:`ICU4XTime` representing midnight (00:00.000).
+
+        See the `Rust documentation for Time <https://docs.rs/icu/latest/icu/calendar/types/struct.Time.html>`__ for more information.
+
+
     .. js:method:: hour()
 
         Returns the hour in this time

--- a/ffi/diplomat/js/include/ICU4XIsoDate.d.ts
+++ b/ffi/diplomat/js/include/ICU4XIsoDate.d.ts
@@ -26,6 +26,14 @@ export class ICU4XIsoDate {
 
   /**
 
+   * Creates a new {@link ICU4XIsoDate `ICU4XIsoDate`} representing January 1, 1970.
+
+   * See the {@link https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.unix_epoch Rust documentation for `unix_epoch`} for more information.
+   */
+  static create_for_unix_epoch(year: i32, month: u8, day: u8): ICU4XIsoDate;
+
+  /**
+
    * Convert this date to one in a different calendar
 
    * See the {@link https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.to_calendar Rust documentation for `to_calendar`} for more information.

--- a/ffi/diplomat/js/include/ICU4XIsoDate.d.ts
+++ b/ffi/diplomat/js/include/ICU4XIsoDate.d.ts
@@ -30,7 +30,7 @@ export class ICU4XIsoDate {
 
    * See the {@link https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.unix_epoch Rust documentation for `unix_epoch`} for more information.
    */
-  static create_for_unix_epoch(year: i32, month: u8, day: u8): ICU4XIsoDate;
+  static create_for_unix_epoch(): ICU4XIsoDate;
 
   /**
 

--- a/ffi/diplomat/js/include/ICU4XIsoDate.js
+++ b/ffi/diplomat/js/include/ICU4XIsoDate.js
@@ -37,8 +37,8 @@ export class ICU4XIsoDate {
     })();
   }
 
-  static create_for_unix_epoch(arg_year, arg_month, arg_day) {
-    return new ICU4XIsoDate(wasm.ICU4XIsoDate_create_for_unix_epoch(arg_year, arg_month, arg_day), true, []);
+  static create_for_unix_epoch() {
+    return new ICU4XIsoDate(wasm.ICU4XIsoDate_create_for_unix_epoch(), true, []);
   }
 
   to_calendar(arg_calendar) {

--- a/ffi/diplomat/js/include/ICU4XIsoDate.js
+++ b/ffi/diplomat/js/include/ICU4XIsoDate.js
@@ -37,6 +37,10 @@ export class ICU4XIsoDate {
     })();
   }
 
+  static create_for_unix_epoch(arg_year, arg_month, arg_day) {
+    return new ICU4XIsoDate(wasm.ICU4XIsoDate_create_for_unix_epoch(arg_year, arg_month, arg_day), true, []);
+  }
+
   to_calendar(arg_calendar) {
     return new ICU4XDate(wasm.ICU4XIsoDate_to_calendar(this.underlying, arg_calendar.underlying), true, []);
   }

--- a/ffi/diplomat/js/include/ICU4XTime.d.ts
+++ b/ffi/diplomat/js/include/ICU4XTime.d.ts
@@ -21,6 +21,15 @@ export class ICU4XTime {
 
   /**
 
+   * Creates a new {@link ICU4XTime `ICU4XTime`} representing midnight (00:00.000).
+
+   * See the {@link https://docs.rs/icu/latest/icu/calendar/types/struct.Time.html Rust documentation for `Time`} for more information.
+   * @throws {@link FFIError}<{@link ICU4XError}>
+   */
+  static create_midnight(hour: u8, minute: u8, second: u8, nanosecond: u32): ICU4XTime | never;
+
+  /**
+
    * Returns the hour in this time
 
    * See the {@link https://docs.rs/icu/latest/icu/calendar/types/struct.Time.html#structfield.hour Rust documentation for `hour`} for more information.

--- a/ffi/diplomat/js/include/ICU4XTime.d.ts
+++ b/ffi/diplomat/js/include/ICU4XTime.d.ts
@@ -26,7 +26,7 @@ export class ICU4XTime {
    * See the {@link https://docs.rs/icu/latest/icu/calendar/types/struct.Time.html Rust documentation for `Time`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
-  static create_midnight(hour: u8, minute: u8, second: u8, nanosecond: u32): ICU4XTime | never;
+  static create_midnight(): ICU4XTime | never;
 
   /**
 

--- a/ffi/diplomat/js/include/ICU4XTime.js
+++ b/ffi/diplomat/js/include/ICU4XTime.js
@@ -33,6 +33,23 @@ export class ICU4XTime {
     })();
   }
 
+  static create_midnight(arg_hour, arg_minute, arg_second, arg_nanosecond) {
+    return (() => {
+      const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
+      wasm.ICU4XTime_create_midnight(diplomat_receive_buffer, arg_hour, arg_minute, arg_second, arg_nanosecond);
+      const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
+      if (is_ok) {
+        const ok_value = new ICU4XTime(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true, []);
+        wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
+        return ok_value;
+      } else {
+        const throw_value = ICU4XError_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, diplomat_receive_buffer)];
+        wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
+        throw new diplomatRuntime.FFIError(throw_value);
+      }
+    })();
+  }
+
   hour() {
     return wasm.ICU4XTime_hour(this.underlying);
   }

--- a/ffi/diplomat/js/include/ICU4XTime.js
+++ b/ffi/diplomat/js/include/ICU4XTime.js
@@ -33,10 +33,10 @@ export class ICU4XTime {
     })();
   }
 
-  static create_midnight(arg_hour, arg_minute, arg_second, arg_nanosecond) {
+  static create_midnight() {
     return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
-      wasm.ICU4XTime_create_midnight(diplomat_receive_buffer, arg_hour, arg_minute, arg_second, arg_nanosecond);
+      wasm.ICU4XTime_create_midnight(diplomat_receive_buffer);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
         const ok_value = new ICU4XTime(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true, []);

--- a/ffi/diplomat/src/date.rs
+++ b/ffi/diplomat/src/date.rs
@@ -45,7 +45,7 @@ pub mod ffi {
 
         /// Creates a new [`ICU4XIsoDate`] representing January 1, 1970.
         #[diplomat::rust_link(icu::calendar::Date::unix_epoch, FnInStruct)]
-        pub fn create_for_unix_epoch(year: i32, month: u8, day: u8) -> Box<ICU4XIsoDate> {
+        pub fn create_for_unix_epoch() -> Box<ICU4XIsoDate> {
             Box::new(ICU4XIsoDate(Date::unix_epoch()))
         }
 

--- a/ffi/diplomat/src/date.rs
+++ b/ffi/diplomat/src/date.rs
@@ -43,6 +43,12 @@ pub mod ffi {
             )?)))
         }
 
+        /// Creates a new [`ICU4XIsoDate`] representing January 1, 1970.
+        #[diplomat::rust_link(icu::calendar::Date::unix_epoch, FnInStruct)]
+        pub fn create_for_unix_epoch(year: i32, month: u8, day: u8) -> Box<ICU4XIsoDate> {
+            Box::new(ICU4XIsoDate(Date::unix_epoch()))
+        }
+
         /// Convert this date to one in a different calendar
         #[diplomat::rust_link(icu::calendar::Date::to_calendar, FnInStruct)]
         pub fn to_calendar(&self, calendar: &ICU4XCalendar) -> Box<ICU4XDate> {

--- a/ffi/diplomat/src/time.rs
+++ b/ffi/diplomat/src/time.rs
@@ -37,6 +37,18 @@ pub mod ffi {
             Ok(Box::new(ICU4XTime(time)))
         }
 
+        /// Creates a new [`ICU4XTime`] representing midnight (00:00.000).
+        #[diplomat::rust_link(icu::calendar::types::Time, Struct)]
+        pub fn create_midnight(
+            hour: u8,
+            minute: u8,
+            second: u8,
+            nanosecond: u32,
+        ) -> Result<Box<ICU4XTime>, ICU4XError> {
+            let time = Time::midnight();
+            Ok(Box::new(ICU4XTime(time)))
+        }
+
         /// Returns the hour in this time
         #[diplomat::rust_link(icu::calendar::types::Time::hour, StructField)]
         pub fn hour(&self) -> u8 {

--- a/ffi/diplomat/src/time.rs
+++ b/ffi/diplomat/src/time.rs
@@ -39,12 +39,7 @@ pub mod ffi {
 
         /// Creates a new [`ICU4XTime`] representing midnight (00:00.000).
         #[diplomat::rust_link(icu::calendar::types::Time, Struct)]
-        pub fn create_midnight(
-            hour: u8,
-            minute: u8,
-            second: u8,
-            nanosecond: u32,
-        ) -> Result<Box<ICU4XTime>, ICU4XError> {
+        pub fn create_midnight() -> Result<Box<ICU4XTime>, ICU4XError> {
             let time = Time::midnight();
             Ok(Box::new(ICU4XTime(time)))
         }


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/3488

See https://github.com/unicode-org/icu4x/issues/2151

This change makes boundary conditions easier to find and allows for more robust calculations. I also added a new type `RataDie`, corresponding to `fixed_date` or `R.D.` from the text, for better type safety.

I also added two new public functions while I was refactoring the code.