### PR TITLE
Using new datagen API for testdata

### DIFF
--- a/provider/datagen/src/source.rs
+++ b/provider/datagen/src/source.rs
@@ -10,7 +10,9 @@ use icu_provider::prelude::*;
 use std::any::Any;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::Debug;
+#[cfg(feature = "networking")]
 use std::fs::File;
+#[cfg(feature = "networking")]
 use std::io::BufWriter;
 use std::io::Cursor;
 use std::io::Read;

--- a/provider/datagen/src/transform/segmenter/mod.rs
+++ b/provider/datagen/src/transform/segmenter/mod.rs
@@ -4,6 +4,9 @@
 
 //! This module contains provider implementations backed by built-in segmentation data.
 
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
 use icu_codepointtrie_builder::{CodePointTrieBuilder, CodePointTrieBuilderData};
 use icu_collections::codepointtrie::CodePointTrie;
 use icu_properties::{

--- a/provider/fs/src/export/serializers/mod.rs
+++ b/provider/fs/src/export/serializers/mod.rs
@@ -8,9 +8,16 @@
 //!
 //! [`FilesystemExporter`]: super::FilesystemExporter
 
+#[doc(hidden)]
 pub mod bincode;
+#[doc(hidden)]
 pub mod json;
+#[doc(hidden)]
 pub mod postcard;
+
+pub use self::bincode::Serializer as Bincode;
+pub use self::json::Serializer as Json;
+pub use self::postcard::Serializer as Postcard;
 
 use icu_provider::buf::BufferFormat;
 use icu_provider::datagen::*;

--- a/tools/testdata-scripts/Cargo.toml
+++ b/tools/testdata-scripts/Cargo.toml
@@ -27,3 +27,7 @@ zip = ">=0.5, <0.7"
 
 [features]
 make-testdata-legacy = ["icu_datagen/legacy_api"]
+
+[[bin]]
+name = "make-testdata-legacy"
+required-features = ["make-testdata-legacy"]

--- a/tools/testdata-scripts/Cargo.toml
+++ b/tools/testdata-scripts/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 crlify = { path = "../../utils/crlify" }
 databake = { path = "../../utils/databake" }
-icu_datagen = { path = "../../provider/datagen", default-features = false, features = ["legacy_api"] }
+icu_datagen = { path = "../../provider/datagen", default-features = false, features = ["provider_baked", "provider_fs", "provider_blob", "use_wasm", "rayon"] }
 icu_locid = { path = "../../components/locid", features = ["databake"] }
 icu_provider = { path = "../../provider/core" }
 repodata = { path = "../../provider/repodata" }
@@ -24,3 +24,6 @@ rust-format = { version = "0.3.4", features = ["token_stream"] }
 simple_logger = { version = "4.1.0", default-features = false }
 ureq = "2"
 zip = ">=0.5, <0.7"
+
+[features]
+make-testdata-legacy = ["icu_datagen/legacy_api"]

--- a/tools/testdata-scripts/src/bin/make-testdata-legacy.rs
+++ b/tools/testdata-scripts/src/bin/make-testdata-legacy.rs
@@ -3,12 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crlify::BufWriterWithLineEndingFix;
-use icu_datagen::baked_exporter::*;
-use icu_datagen::blob_exporter::*;
-use icu_datagen::fs_exporter::serializers::*;
-use icu_datagen::fs_exporter::*;
 use icu_datagen::prelude::*;
-use icu_provider::datagen::MultiExporter;
 use rust_format::*;
 use std::fs::File;
 use std::io::Write;
@@ -38,57 +33,44 @@ fn main() {
         .with_segmenter_lstm(repodata::paths::lstm())
         .unwrap();
 
-    let json_out = Box::new(
-        FilesystemExporter::try_new(Box::new(Json::pretty()), {
-            let mut options = ExporterOptions::default();
-            options.root = repodata::paths::json();
-            options.overwrite = OverwriteOption::RemoveAndReplace;
-            options.fingerprint = true;
-            options
-        })
-        .unwrap(),
-    );
+    let json_out = Out::Fs {
+        output_path: repodata::paths::json(),
+        serializer: Box::new(syntax::Json::pretty()),
+        overwrite: true,
+        fingerprint: true,
+    };
 
-    let postcard_out = Box::new(
-        FilesystemExporter::try_new(Box::<Postcard>::default(), {
-            let mut options = ExporterOptions::default();
-            options.root = out_dir.join("postcard");
-            options.overwrite = OverwriteOption::RemoveAndReplace;
-            options.fingerprint = true;
-            options
-        })
-        .unwrap(),
-    );
+    let postcard_out = Out::Fs {
+        output_path: out_dir.join("postcard"),
+        serializer: Box::<syntax::Postcard>::default(),
+        overwrite: true,
+        fingerprint: true,
+    };
 
-    let blob_out = Box::new(BlobExporter::new_with_sink(Box::new(
+    let blob_out = Out::Blob(Box::new(
         File::create(out_dir.join("testdata.postcard")).unwrap(),
-    )));
+    ));
 
-    let mod_out = Box::new(
-        BakedExporter::new(out_dir.join("baked"), {
-            let mut options = Options::default();
-            options.insert_feature_gates = true;
-            options.use_separate_crates = true;
-            options.overwrite = true;
-            options.pretty = true;
-            options
-        })
-        .unwrap(),
-    );
+    let mut options = BakedOptions::default();
+    options.insert_feature_gates = true;
+    options.use_separate_crates = true;
+    options.overwrite = true;
+    options.pretty = true;
+    let mod_out = Out::Baked {
+        mod_directory: out_dir.join("baked"),
+        options,
+    };
 
-    let mut options = options::Options::default();
-    options.locales = options::LocaleInclude::Explicit(LOCALES.iter().cloned().collect());
-
-    DatagenProvider::try_new(options, source)
-        .unwrap()
-        .export(
-            icu_datagen::all_keys_with_experimental()
-                .into_iter()
-                .chain([icu_provider::hello_world::HelloWorldV1Marker::KEY])
-                .collect(),
-            MultiExporter::new(vec![json_out, blob_out, mod_out, postcard_out]),
-        )
-        .unwrap();
+    icu_datagen::datagen(
+        Some(LOCALES),
+        &icu_datagen::all_keys_with_experimental()
+            .into_iter()
+            .chain([icu_provider::hello_world::HelloWorldV1Marker::KEY])
+            .collect::<Vec<_>>(),
+        &source,
+        vec![json_out, blob_out, mod_out, postcard_out],
+    )
+    .unwrap();
 
     let mut metadata =
         BufWriterWithLineEndingFix::new(File::create(out_dir.join("metadata.rs.data")).unwrap());


### PR DESCRIPTION
This exposed some ergonomic issues that I've addressed:
* Exporter reexports in datagen
* Public `MultiExporter`
* Supressed warnings for some feature combinations

I've kept the old script around, so that it can still be `cargo check`ed.