### PR TITLE
Split ExceptionHeader into ExceptionBits and SlotPresence

### DIFF
--- a/experimental/casemapping/src/exceptions.rs
+++ b/experimental/casemapping/src/exceptions.rs
@@ -153,7 +153,7 @@ impl<'data> CaseMappingExceptions<'data> {
     pub(crate) fn delta(&self, hdr_idx: u16) -> i32 {
         debug_assert!(self.has_delta(hdr_idx));
         let raw: i32 = self.slot_value(hdr_idx, ExceptionSlot::Delta) as _;
-        if self.header(hdr_idx).negative_delta {
+        if self.header(hdr_idx).bits.negative_delta {
             -raw
         } else {
             raw
@@ -163,38 +163,38 @@ impl<'data> CaseMappingExceptions<'data> {
     // Returns whether an entry has double-width slots.
     #[inline]
     fn has_double_slots(&self, hdr_idx: u16) -> bool {
-        self.header(hdr_idx).double_width_slots
+        self.header(hdr_idx).bits.double_width_slots
     }
 
     // Returns whether there is no simple case folding for an entry.
     #[inline]
     pub(crate) fn no_simple_case_folding(&self, hdr_idx: u16) -> bool {
-        self.header(hdr_idx).no_simple_case_folding
+        self.header(hdr_idx).bits.no_simple_case_folding
     }
 
     // Returns whether this code point is case-sensitive.
     // (Note that this information is stored in the trie for code points without
     // exception data, but the exception index requires more bits than the delta.)
     pub(crate) fn is_sensitive(&self, hdr_idx: u16) -> bool {
-        self.header(hdr_idx).is_sensitive
+        self.header(hdr_idx).bits.is_sensitive
     }
 
     // Returns whether there is a conditional case fold for this entry.
     // (This is used to implement Turkic mappings for dotted/dotless i.)
     pub(crate) fn has_conditional_fold(&self, hdr_idx: u16) -> bool {
-        self.header(hdr_idx).has_conditional_fold
+        self.header(hdr_idx).bits.has_conditional_fold
     }
 
     // Given a header index, returns whether there is a language-specific case mapping.
     pub(crate) fn has_conditional_special(&self, hdr_idx: u16) -> bool {
-        self.header(hdr_idx).has_conditional_special
+        self.header(hdr_idx).bits.has_conditional_special
     }
 
     // Given a header index, returns the dot type.
     // (Note that this information is stored in the trie for code points without
     // exception data, but the exception index requires more bits than the delta.)
     pub(crate) fn dot_type(&self, hdr_idx: u16) -> DotType {
-        self.header(hdr_idx).dot_type
+        self.header(hdr_idx).bits.dot_type
     }
 
     // Given a header index and a mapping kind, returns the full mapping string.

--- a/experimental/casemapping/src/exceptions_builder.rs
+++ b/experimental/casemapping/src/exceptions_builder.rs
@@ -120,7 +120,7 @@ impl<'a> CaseMappingExceptionsBuilder<'a> {
             // Copy header.
             let header = ExceptionHeader::from_integer(self.read_raw()?);
             self.write_raw(header.to_integer());
-            self.double_slots = header.double_width_slots;
+            self.double_slots = header.bits.double_width_slots;
 
             // Copy unmodified slots.
             for slot in [


### PR DESCRIPTION
Progress on #3501

I'm only going to need *some* of these in various parts of the VarULE architecture (the VarULE type needs ExceptionBits and SlotPresence, but the regular type only needs ExceptionBits). Cleaner to split it up right now.

It is likely that once I'm done here some of these AsULE impls can be removed. For now it's neater to just have them here.


Splitting this into a separate PR since I'm not going to be at a computer for a bit and might as well get review on this vaguely independent refactor.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->