### PR TITLE
Avoid stacked borrows violation in ZeroVec::new_owned()

### DIFF
--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -281,12 +281,12 @@ where
     /// If you have a slice of `&[T]`s, prefer using
     /// [`Self::alloc_from_slice()`].
     #[inline]
-    pub fn new_owned(vec: Vec<T::ULE>) -> Self {
+    pub fn new_owned(mut vec: Vec<T::ULE>) -> Self {
         // Deconstruct the vector into parts
         // This is the only part of the code that goes from Vec
         // to ZeroVec, all other such operations should use this function
-        let slice: &[T::ULE] = &vec;
-        let slice = slice as *const [_] as *mut [_];
+        let slice: &mut [T::ULE] = &mut vec;
+        let slice = slice as *mut [_];
         let capacity = vec.capacity();
         mem::forget(vec);
         Self {


### PR DESCRIPTION
Part of https://github.com/unicode-org/icu4x/issues/3510

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->