### PR TITLE
Improve unsafe: better provenance for `FlexZeroVec`, and remove `forget`

### DIFF
--- a/utils/zerovec/src/flexzerovec/slice.rs
+++ b/utils/zerovec/src/flexzerovec/slice.rs
@@ -133,19 +133,18 @@ impl FlexZeroSlice {
         // Safety: The DST of FlexZeroSlice is a pointer to the `width` element and has a metadata
         // equal to the length of the `data` field, which will be one less than the length of the
         // overall array.
-        #[allow(clippy::panic)] // panic is documented in function contract
-        let (_, remainder) = match bytes.split_last() {
-            Some(v) => v,
-            None => panic!("slice should be non-empty"),
-        };
-        &*(remainder as *const [u8] as *const Self)
+        assert!(!bytes.is_empty());
+        let remainder = core::ptr::slice_from_raw_parts(bytes.as_ptr(), bytes.len() - 1);
+        &*(remainder as *const Self)
     }
 
     #[inline]
     pub(crate) unsafe fn from_byte_slice_mut_unchecked(bytes: &mut [u8]) -> &mut Self {
+        debug_assert!(!bytes.is_empty());
         // Safety: See comments in `from_byte_slice_unchecked`
-        let remainder = core::slice::from_raw_parts_mut(bytes.as_mut_ptr(), bytes.len() - 1);
-        &mut *(remainder as *mut [u8] as *mut Self)
+        let len = bytes.len() - 1;
+        let remainder = core::ptr::slice_from_raw_parts_mut(bytes.as_mut_ptr(), len);
+        &mut *(remainder as *mut Self)
     }
 
     /// Returns this slice as its underlying `&[u8]` byte buffer representation.

--- a/utils/zerovec/src/ule/encode.rs
+++ b/utils/zerovec/src/ule/encode.rs
@@ -86,12 +86,11 @@ pub fn encode_varule_to_box<S: EncodeAsVarULE<T>, T: VarULE + ?Sized>(x: &S) -> 
     // zero-fill the vector to avoid uninitialized data UB
     vec.resize(x.encode_var_ule_len(), 0);
     x.encode_var_ule_write(&mut vec);
-    let boxed = vec.into_boxed_slice();
+    let boxed = mem::ManuallyDrop::new(vec.into_boxed_slice());
     unsafe {
         // Safety: `ptr` is a box, and `T` is a VarULE which guarantees it has the same memory layout as `[u8]`
         // and can be recouped via from_byte_slice_unchecked()
         let ptr: *mut T = T::from_byte_slice_unchecked(&boxed) as *const T as *mut T;
-        mem::forget(boxed);
 
         // Safety: we can construct an owned version since we have mem::forgotten the older owner
         Box::from_raw(ptr)

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -357,13 +357,12 @@ pub unsafe trait VarULE: 'static {
     #[inline]
     fn to_boxed(&self) -> Box<Self> {
         let bytesvec = self.as_byte_slice().to_owned().into_boxed_slice();
+        let bytesvec = ::core::mem::ManuallyDrop::new(bytesvec);
         unsafe {
             // Get the pointer representation
             let ptr: *mut Self =
                 Self::from_byte_slice_unchecked(&bytesvec) as *const Self as *mut Self;
             assert_eq!(Layout::for_value(&*ptr), Layout::for_value(&*bytesvec));
-            // Forget the allocation
-            mem::forget(bytesvec);
             // Transmute the pointer to an owned pointer
             Box::from_raw(ptr)
         }

--- a/utils/zerovec/src/yoke_impls.rs
+++ b/utils/zerovec/src/yoke_impls.rs
@@ -33,8 +33,8 @@ unsafe impl<'a, T: 'static + AsULE + ?Sized> Yokeable<'a> for ZeroVec<'static, T
     #[inline]
     unsafe fn make(from: Self::Output) -> Self {
         debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
-        let ptr: *const Self = (&from as *const Self::Output).cast();
-        mem::forget(from);
+        let from = mem::ManuallyDrop::new(from);
+        let ptr: *const Self = (&*from as *const Self::Output).cast();
         ptr::read(ptr)
     }
     #[inline]
@@ -61,8 +61,8 @@ unsafe impl<'a, T: 'static + VarULE + ?Sized> Yokeable<'a> for VarZeroVec<'stati
     #[inline]
     unsafe fn make(from: Self::Output) -> Self {
         debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
-        let ptr: *const Self = (&from as *const Self::Output).cast();
-        mem::forget(from);
+        let from = mem::ManuallyDrop::new(from);
+        let ptr: *const Self = (&*from as *const Self::Output).cast();
         ptr::read(ptr)
     }
     #[inline]
@@ -89,8 +89,8 @@ unsafe impl<'a> Yokeable<'a> for FlexZeroVec<'static> {
     #[inline]
     unsafe fn make(from: Self::Output) -> Self {
         debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
-        let ptr: *const Self = (&from as *const Self::Output).cast();
-        mem::forget(from);
+        let from = mem::ManuallyDrop::new(from);
+        let ptr: *const Self = (&*from as *const Self::Output).cast();
         ptr::read(ptr)
     }
     #[inline]
@@ -127,16 +127,16 @@ where
         unsafe {
             // Similar problem as transform(), but we need to use ptr::read since
             // the compiler isn't sure of the sizes
-            let ptr: *const Self::Output = (&self as *const Self).cast();
-            mem::forget(self);
+            let this = mem::ManuallyDrop::new(self);
+            let ptr: *const Self::Output = (&*this as *const Self).cast();
             ptr::read(ptr)
         }
     }
     #[inline]
     unsafe fn make(from: Self::Output) -> Self {
         debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
-        let ptr: *const Self = (&from as *const Self::Output).cast();
-        mem::forget(from);
+        let from = mem::ManuallyDrop::new(from);
+        let ptr: *const Self = (&*from as *const Self::Output).cast();
         ptr::read(ptr)
     }
     #[inline]
@@ -173,16 +173,16 @@ where
         unsafe {
             // Similar problem as transform(), but we need to use ptr::read since
             // the compiler isn't sure of the sizes
-            let ptr: *const Self::Output = (&self as *const Self).cast();
-            mem::forget(self);
+            let this = mem::ManuallyDrop::new(self);
+            let ptr: *const Self::Output = (&*this as *const Self).cast();
             ptr::read(ptr)
         }
     }
     #[inline]
     unsafe fn make(from: Self::Output) -> Self {
         debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
-        let ptr: *const Self = (&from as *const Self::Output).cast();
-        mem::forget(from);
+        let from = mem::ManuallyDrop::new(from);
+        let ptr: *const Self = (&*from as *const Self::Output).cast();
         ptr::read(ptr)
     }
     #[inline]
@@ -221,16 +221,16 @@ where
         unsafe {
             // Similar problem as transform(), but we need to use ptr::read since
             // the compiler isn't sure of the sizes
-            let ptr: *const Self::Output = (&self as *const Self).cast();
-            mem::forget(self);
+            let this = mem::ManuallyDrop::new(self);
+            let ptr: *const Self::Output = (&*this as *const Self).cast();
             ptr::read(ptr)
         }
     }
     #[inline]
     unsafe fn make(from: Self::Output) -> Self {
         debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
-        let ptr: *const Self = (&from as *const Self::Output).cast();
-        mem::forget(from);
+        let from = mem::ManuallyDrop::new(from);
+        let ptr: *const Self = (&*from as *const Self::Output).cast();
         ptr::read(ptr)
     }
     #[inline]
@@ -269,16 +269,16 @@ where
         unsafe {
             // Similar problem as transform(), but we need to use ptr::read since
             // the compiler isn't sure of the sizes
-            let ptr: *const Self::Output = (&self as *const Self).cast();
-            mem::forget(self);
+            let this = mem::ManuallyDrop::new(self);
+            let ptr: *const Self::Output = (&*this as *const Self).cast();
             ptr::read(ptr)
         }
     }
     #[inline]
     unsafe fn make(from: Self::Output) -> Self {
         debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
-        let ptr: *const Self = (&from as *const Self::Output).cast();
-        mem::forget(from);
+        let from = mem::ManuallyDrop::new(from);
+        let ptr: *const Self = (&*from as *const Self::Output).cast();
         ptr::read(ptr)
     }
     #[inline]

--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -281,14 +281,14 @@ where
     /// If you have a slice of `&[T]`s, prefer using
     /// [`Self::alloc_from_slice()`].
     #[inline]
-    pub fn new_owned(mut vec: Vec<T::ULE>) -> Self {
+    pub fn new_owned(vec: Vec<T::ULE>) -> Self {
         // Deconstruct the vector into parts
         // This is the only part of the code that goes from Vec
         // to ZeroVec, all other such operations should use this function
-        let slice: &mut [T::ULE] = &mut vec;
-        let slice = slice as *mut [_];
         let capacity = vec.capacity();
-        mem::forget(vec);
+        let len = vec.len();
+        let ptr = ::core::mem::ManuallyDrop::new(vec).as_mut_ptr();
+        let slice = ::core::ptr::slice_from_raw_parts_mut(ptr, len);
         Self {
             vector: EyepatchHackVector {
                 buf: slice,
@@ -889,21 +889,18 @@ where
     /// the logical equivalent of this type's internal representation
     #[inline]
     pub fn into_cow(self) -> Cow<'a, [T::ULE]> {
-        if self.is_owned() {
+        let this = ::core::mem::ManuallyDrop::new(self);
+        if this.is_owned() {
             let vec = unsafe {
                 // safe to call: we know it's owned,
-                // and we mem::forget self immediately afterwards
-                self.vector.get_vec()
+                // and `self`/`this` are thenceforth no longer used or dropped
+                { this }.vector.get_vec()
             };
-            mem::forget(self);
             Cow::Owned(vec)
         } else {
             // We can extend the lifetime of the slice to 'a
             // since we know it is borrowed
-            let slice = unsafe { self.vector.as_arbitrary_slice() };
-            // The borrowed destructor is a no-op, but we want to prevent
-            // the check being run
-            mem::forget(self);
+            let slice = unsafe { { this }.vector.as_arbitrary_slice() };
             Cow::Borrowed(slice)
         }
     }


### PR DESCRIPTION
Ref: https://github.com/unicode-org/icu4x/issues/3510#issuecomment-1582355329