### PR TITLE
Some casemapping fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,6 +1444,7 @@ dependencies = [
  "icu_locid",
  "icu_provider",
  "serde",
+ "writeable",
  "yoke",
  "zerovec",
 ]

--- a/experimental/casemapping/Cargo.toml
+++ b/experimental/casemapping/Cargo.toml
@@ -37,6 +37,7 @@ icu_locid = { version = "1.2.0", path = "../../components/locid" }
 icu_provider = { version = "1.2.0", path = "../../provider/core", features = ["macros"] }
 yoke = { version = "0.7.1", path = "../../utils/yoke", features = ["derive"] }
 zerovec = { version = "0.9.4", path = "../../utils/zerovec", features = ["yoke"] }
+writeable = { version = "0.5.1", path = "../../utils/writeable" }
 
 databake = { version = "0.1.3", path = "../../utils/databake", features = ["derive"], optional = true}
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/experimental/casemapping/src/casemapping.rs
+++ b/experimental/casemapping/src/casemapping.rs
@@ -3,9 +3,11 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::internals::{CaseMapLocale, FoldOptions};
+use crate::provider::data::MappingKind;
 use crate::provider::CaseMappingV1Marker;
 use icu_locid::Locale;
 use icu_provider::prelude::*;
+use writeable::Writeable;
 
 /// A struct with the ability to convert characters and strings to uppercase or lowercase,
 /// or fold them to a normalized form for case-insensitive comparison.
@@ -88,24 +90,50 @@ impl CaseMapping {
     /// Returns the full lowercase mapping of the given string.
     /// This function is context and locale sensitive.
     pub fn to_full_lowercase(&self, src: &str) -> String {
-        self.data.get().full_lowercase(src, self.locale)
+        self.data
+            .get()
+            .full_helper_writeable(src, self.locale, MappingKind::Lower)
+            .write_to_string()
+            .into_owned()
     }
 
     /// Returns the full uppercase mapping of the given string.
     /// This function is context and locale sensitive.
     pub fn to_full_uppercase(&self, src: &str) -> String {
-        self.data.get().full_uppercase(src, self.locale)
+        self.data
+            .get()
+            .full_helper_writeable(src, self.locale, MappingKind::Upper)
+            .write_to_string()
+            .into_owned()
+    }
+
+    /// Returns the full titlecase mapping of the given string.
+    /// This function is context and locale sensitive.
+    pub fn to_full_titlecase(&self, src: &str) -> String {
+        self.data
+            .get()
+            .full_helper_writeable(src, self.locale, MappingKind::Title)
+            .write_to_string()
+            .into_owned()
     }
 
     /// Case-folds the characters in the given string.
     /// This function is locale-independent and context-insensitive.
     pub fn full_fold(&self, src: &str) -> String {
-        self.data.get().full_folding(src, CaseMapLocale::Root)
+        self.data
+            .get()
+            .full_helper_writeable(src, CaseMapLocale::Root, MappingKind::Fold)
+            .write_to_string()
+            .into_owned()
     }
 
     /// Case-folds the characters in the given string, using Turkic (T) mappings for dotted/dotless I.
     /// This function is locale-independent and context-insensitive.
     pub fn full_fold_turkic(&self, src: &str) -> String {
-        self.data.get().full_folding(src, CaseMapLocale::Turkish)
+        self.data
+            .get()
+            .full_helper_writeable(src, CaseMapLocale::Turkish, MappingKind::Fold)
+            .write_to_string()
+            .into_owned()
     }
 }

--- a/experimental/casemapping/src/internals.rs
+++ b/experimental/casemapping/src/internals.rs
@@ -33,7 +33,8 @@ impl<'data> CaseMappingV1<'data> {
         if !data.has_exception() {
             if data.is_relevant_to(kind) {
                 let folded = c as i32 + data.delta() as i32;
-                char::from_u32(folded as u32).expect("Checked in validate()")
+                // GIGO: delta should be valid
+                char::from_u32(folded as u32).unwrap_or(c)
             } else {
                 c
             }
@@ -74,7 +75,8 @@ impl<'data> CaseMappingV1<'data> {
         if !data.has_exception() {
             if data.is_upper_or_title() {
                 let folded = c as i32 + data.delta() as i32;
-                char::from_u32(folded as u32).expect("Checked in validate()")
+                // GIGO: delta should be valid
+                char::from_u32(folded as u32).unwrap_or(c)
             } else {
                 c
             }
@@ -133,7 +135,8 @@ impl<'data> CaseMappingV1<'data> {
         if !data.has_exception() {
             if data.is_relevant_to(kind) {
                 let mapped = c as i32 + data.delta() as i32;
-                let mapped = char::from_u32(mapped as u32).expect("Checked in validate()");
+                // GIGO: delta should be valid
+                let mapped = char::from_u32(mapped as u32).unwrap_or(c);
                 FullMappingResult::CodePoint(mapped)
             } else {
                 FullMappingResult::CodePoint(c)
@@ -515,7 +518,8 @@ impl<'data> CaseMappingV1<'data> {
                 if delta != 0 {
                     // Add the one simple case mapping, no matter what type it is.
                     let codepoint = c as i32 + delta;
-                    let mapped = char::from_u32(codepoint as u32).expect("Checked in validate()");
+                    // GIGO: delta should be valid
+                    let mapped = char::from_u32(codepoint as u32).unwrap_or(c);
                     set.add_char(mapped);
                 }
             }


### PR DESCRIPTION
Didn't finish the Writeable work; pushing what I have so far

 - Using GIGO everywhere so validate() is not required
 - Adding Writeable-based APIs (but not yet exposing a Writeable returning API since that needs a Borrowed type)


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->