### PR TITLE
Create new_from_solar_codes and use it

### DIFF
--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -75,7 +75,7 @@ impl Calendar for Buddhist {
         }
         let year = year - BUDDHIST_ERA_OFFSET;
 
-        ArithmeticDate::new_from_solar(self, year, month_code, day).map(IsoDateInner)
+        ArithmeticDate::new_from_solar_codes(self, year, month_code, day).map(IsoDateInner)
     }
     fn date_from_iso(&self, iso: Date<Iso>) -> IsoDateInner {
         *iso.inner()

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -42,6 +42,7 @@ pub trait CalendarArithmetic: Calendar {
 }
 
 impl<C: CalendarArithmetic> ArithmeticDate<C> {
+    /// Create a new `ArithmeticDate` without checking that `month` and `day` are in bounds.
     #[inline]
     pub const fn new_unchecked(year: i32, month: u8, day: u8) -> Self {
         ArithmeticDate {

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -43,7 +43,7 @@ pub trait CalendarArithmetic: Calendar {
 
 impl<C: CalendarArithmetic> ArithmeticDate<C> {
     #[inline]
-    pub fn new(year: i32, month: u8, day: u8) -> Self {
+    pub fn new_unchecked(year: i32, month: u8, day: u8) -> Self {
         ArithmeticDate {
             year,
             month,
@@ -222,7 +222,7 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
 
     /// Construct a new arithmetic date from a year, month code, and day, bounds checking
     /// the month
-    pub fn new_from_solar<C2: Calendar>(
+    pub fn new_from_solar_codes<C2: Calendar>(
         // Separate type since the debug_name() impl may differ when DateInner types
         // are nested (e.g. in GregorianDateInner)
         cal: &C2,
@@ -246,11 +246,43 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
             ));
         }
 
-        if day > C::month_days(year, month) {
-            return Err(CalendarError::OutOfRange);
+        let max_day = C::month_days(year, month);
+        if day > max_day {
+            return Err(CalendarError::Overflow {
+                field: "day",
+                max: max_day as usize,
+            });
         }
 
-        Ok(Self::new(year, month, day))
+        Ok(Self::new_unchecked(year, month, day))
+    }
+
+    /// Construct a new arithmetic date from a year, month ordinal, and day, bounds checking
+    /// the month
+    pub fn new_from_solar_ordinals(
+        // Separate type since the debug_name() impl may differ when DateInner types
+        // are nested (e.g. in GregorianDateInner)
+        year: i32,
+        month: u8,
+        day: u8,
+    ) -> Result<Self, CalendarError> {
+        let max_month = C::months_for_every_year(year);
+        if month > max_month {
+            return Err(CalendarError::Overflow {
+                field: "month",
+                max: max_month as usize,
+            });
+        }
+
+        let max_day = C::month_days(year, month);
+        if day > max_day {
+            return Err(CalendarError::Overflow {
+                field: "day",
+                max: max_day as usize,
+            });
+        }
+
+        Ok(Self::new_unchecked(year, month, day))
     }
 }
 
@@ -283,21 +315,21 @@ mod tests {
     #[test]
     fn test_ord() {
         let dates_in_order = [
-            ArithmeticDate::<Iso>::new(-10, 1, 1),
-            ArithmeticDate::<Iso>::new(-10, 1, 2),
-            ArithmeticDate::<Iso>::new(-10, 2, 1),
-            ArithmeticDate::<Iso>::new(-1, 1, 1),
-            ArithmeticDate::<Iso>::new(-1, 1, 2),
-            ArithmeticDate::<Iso>::new(-1, 2, 1),
-            ArithmeticDate::<Iso>::new(0, 1, 1),
-            ArithmeticDate::<Iso>::new(0, 1, 2),
-            ArithmeticDate::<Iso>::new(0, 2, 1),
-            ArithmeticDate::<Iso>::new(1, 1, 1),
-            ArithmeticDate::<Iso>::new(1, 1, 2),
-            ArithmeticDate::<Iso>::new(1, 2, 1),
-            ArithmeticDate::<Iso>::new(10, 1, 1),
-            ArithmeticDate::<Iso>::new(10, 1, 2),
-            ArithmeticDate::<Iso>::new(10, 2, 1),
+            ArithmeticDate::<Iso>::new_unchecked(-10, 1, 1),
+            ArithmeticDate::<Iso>::new_unchecked(-10, 1, 2),
+            ArithmeticDate::<Iso>::new_unchecked(-10, 2, 1),
+            ArithmeticDate::<Iso>::new_unchecked(-1, 1, 1),
+            ArithmeticDate::<Iso>::new_unchecked(-1, 1, 2),
+            ArithmeticDate::<Iso>::new_unchecked(-1, 2, 1),
+            ArithmeticDate::<Iso>::new_unchecked(0, 1, 1),
+            ArithmeticDate::<Iso>::new_unchecked(0, 1, 2),
+            ArithmeticDate::<Iso>::new_unchecked(0, 2, 1),
+            ArithmeticDate::<Iso>::new_unchecked(1, 1, 1),
+            ArithmeticDate::<Iso>::new_unchecked(1, 1, 2),
+            ArithmeticDate::<Iso>::new_unchecked(1, 2, 1),
+            ArithmeticDate::<Iso>::new_unchecked(10, 1, 1),
+            ArithmeticDate::<Iso>::new_unchecked(10, 1, 2),
+            ArithmeticDate::<Iso>::new_unchecked(10, 2, 1),
         ];
         for (i, i_date) in dates_in_order.iter().enumerate() {
             for (j, j_date) in dates_in_order.iter().enumerate() {

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -260,11 +260,7 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
 
     /// Construct a new arithmetic date from a year, month ordinal, and day, bounds checking
     /// the month and day
-    pub fn new_from_solar_ordinals(
-        year: i32,
-        month: u8,
-        day: u8,
-    ) -> Result<Self, CalendarError> {
+    pub fn new_from_solar_ordinals(year: i32, month: u8, day: u8) -> Result<Self, CalendarError> {
         let max_month = C::months_for_every_year(year);
         if month > max_month {
             return Err(CalendarError::Overflow {

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -261,8 +261,6 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
     /// Construct a new arithmetic date from a year, month ordinal, and day, bounds checking
     /// the month
     pub fn new_from_solar_ordinals(
-        // Separate type since the debug_name() impl may differ when DateInner types
-        // are nested (e.g. in GregorianDateInner)
         year: i32,
         month: u8,
         day: u8,

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -222,7 +222,7 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
     }
 
     /// Construct a new arithmetic date from a year, month code, and day, bounds checking
-    /// the month
+    /// the month and day
     pub fn new_from_solar_codes<C2: Calendar>(
         // Separate type since the debug_name() impl may differ when DateInner types
         // are nested (e.g. in GregorianDateInner)
@@ -259,7 +259,7 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
     }
 
     /// Construct a new arithmetic date from a year, month ordinal, and day, bounds checking
-    /// the month
+    /// the month and day
     pub fn new_from_solar_ordinals(
         year: i32,
         month: u8,

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -16,7 +16,7 @@ pub struct ArithmeticDate<C: CalendarArithmetic> {
     pub month: u8,
     /// 1-based day of month
     pub day: u8,
-    pub marker: PhantomData<C>,
+    marker: PhantomData<C>,
 }
 
 pub trait CalendarArithmetic: Calendar {
@@ -43,7 +43,7 @@ pub trait CalendarArithmetic: Calendar {
 
 impl<C: CalendarArithmetic> ArithmeticDate<C> {
     #[inline]
-    pub fn new_unchecked(year: i32, month: u8, day: u8) -> Self {
+    pub const fn new_unchecked(year: i32, month: u8, day: u8) -> Self {
         ArithmeticDate {
             year,
             month,

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -38,7 +38,6 @@ use crate::iso::Iso;
 use crate::julian::Julian;
 use crate::rata_die::RataDie;
 use crate::{types, Calendar, CalendarError, Date, DateDuration, DateDurationUnit, DateTime};
-use core::marker::PhantomData;
 use tinystr::tinystr;
 
 /// The [Coptic Calendar]
@@ -219,12 +218,8 @@ impl Coptic {
     }
 
     pub(crate) fn fixed_from_coptic_integers(year: i32, month: u8, day: u8) -> RataDie {
-        Self::fixed_from_coptic(ArithmeticDate {
-            year,
-            month,
-            day,
-            marker: PhantomData,
-        })
+        // TODO: Should we check bounds here?
+        Self::fixed_from_coptic(ArithmeticDate::new_unchecked(year, month, day))
     }
 
     // Lisp code reference: https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L1990

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -125,7 +125,7 @@ impl Calendar for Coptic {
             return Err(CalendarError::UnknownEra(era.0, self.debug_name()));
         };
 
-        ArithmeticDate::new_from_solar(self, year, month_code, day).map(CopticDateInner)
+        ArithmeticDate::new_from_solar_codes(self, year, month_code, day).map(CopticDateInner)
     }
     fn date_from_iso(&self, iso: Date<Iso>) -> CopticDateInner {
         let fixed_iso = Iso::fixed_from_iso(*iso.inner());
@@ -271,19 +271,9 @@ impl Date<Coptic> {
         month: u8,
         day: u8,
     ) -> Result<Date<Coptic>, CalendarError> {
-        let inner = ArithmeticDate {
-            year,
-            month,
-            day,
-            marker: PhantomData,
-        };
-
-        let bound = inner.days_in_month();
-        if day > bound {
-            return Err(CalendarError::OutOfRange);
-        }
-
-        Ok(Date::from_raw(CopticDateInner(inner), Coptic))
+        ArithmeticDate::new_from_solar_ordinals(year, month, day)
+            .map(CopticDateInner)
+            .map(|inner| Date::from_raw(inner, Coptic))
     }
 }
 

--- a/components/calendar/src/ethiopian.rs
+++ b/components/calendar/src/ethiopian.rs
@@ -39,7 +39,6 @@ use crate::iso::Iso;
 use crate::julian::Julian;
 use crate::rata_die::RataDie;
 use crate::{types, Calendar, CalendarError, Date, DateDuration, DateDurationUnit, DateTime};
-use core::marker::PhantomData;
 use tinystr::tinystr;
 
 /// The number of years the Amete Alem epoch precedes the Amete Mihret epoch
@@ -147,7 +146,7 @@ impl Calendar for Ethiopian {
             return Err(CalendarError::UnknownEra(era.0, self.debug_name()));
         };
 
-        ArithmeticDate::new_from_solar(self, year, month_code, day).map(EthiopianDateInner)
+        ArithmeticDate::new_from_solar_codes(self, year, month_code, day).map(EthiopianDateInner)
     }
     fn date_from_iso(&self, iso: Date<Iso>) -> EthiopianDateInner {
         let fixed_iso = Iso::fixed_from_iso(*iso.inner());
@@ -342,22 +341,9 @@ impl Date<Ethiopian> {
         if era_style == EthiopianEraStyle::AmeteAlem {
             year -= AMETE_ALEM_OFFSET;
         }
-        let inner = ArithmeticDate {
-            year,
-            month,
-            day,
-            marker: PhantomData,
-        };
-
-        let bound = inner.days_in_month();
-        if day > bound {
-            return Err(CalendarError::OutOfRange);
-        }
-
-        Ok(Date::from_raw(
-            EthiopianDateInner(inner),
-            Ethiopian::new_with_era_style(era_style),
-        ))
+        ArithmeticDate::new_from_solar_ordinals(year, month, day)
+            .map(EthiopianDateInner)
+            .map(|inner| Date::from_raw(inner, Ethiopian::new_with_era_style(era_style)))
     }
 }
 

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -79,7 +79,7 @@ impl Calendar for Gregorian {
             return Err(CalendarError::UnknownEra(era.0, self.debug_name()));
         };
 
-        ArithmeticDate::new_from_solar(self, year, month_code, day)
+        ArithmeticDate::new_from_solar_codes(self, year, month_code, day)
             .map(IsoDateInner)
             .map(GregorianDateInner)
     }

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -35,7 +35,6 @@ use crate::any_calendar::AnyCalendarKind;
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::iso::Iso;
 use crate::{types, Calendar, CalendarError, Date, DateDuration, DateDurationUnit, DateTime};
-use core::marker::PhantomData;
 use tinystr::tinystr;
 
 /// The Indian National Calendar (aka the Saka calendar)
@@ -114,7 +113,7 @@ impl Calendar for Indian {
             return Err(CalendarError::UnknownEra(era.0, self.debug_name()));
         }
 
-        ArithmeticDate::new_from_solar(self, year, month_code, day).map(IndianDateInner)
+        ArithmeticDate::new_from_solar_codes(self, year, month_code, day).map(IndianDateInner)
     }
 
     //
@@ -262,19 +261,9 @@ impl Date<Indian> {
         month: u8,
         day: u8,
     ) -> Result<Date<Indian>, CalendarError> {
-        let inner = ArithmeticDate {
-            year,
-            month,
-            day,
-            marker: PhantomData,
-        };
-
-        let bound = inner.days_in_month();
-        if day > bound {
-            return Err(CalendarError::OutOfRange);
-        }
-
-        Ok(Date::from_raw(IndianDateInner(inner), Indian))
+        ArithmeticDate::new_from_solar_ordinals(year, month, day)
+            .map(IndianDateInner)
+            .map(|inner| Date::from_raw(inner, Indian))
     }
 }
 

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -249,7 +249,7 @@ impl Date<Iso> {
 
     /// Constructs an ISO date representing the UNIX epoch on January 1, 1970.
     pub fn unix_epoch() -> Self {
-        Date::from_raw(IsoDateInner(ArithmeticDate::new(1970, 1, 1)), Iso)
+        Date::from_raw(IsoDateInner(ArithmeticDate::new_unchecked(1970, 1, 1)), Iso)
     }
 }
 

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -107,7 +107,7 @@ impl Calendar for Iso {
             return Err(CalendarError::UnknownEra(era.0, self.debug_name()));
         }
 
-        ArithmeticDate::new_from_solar(self, year, month_code, day).map(IsoDateInner)
+        ArithmeticDate::new_from_solar_codes(self, year, month_code, day).map(IsoDateInner)
     }
 
     fn date_from_iso(&self, iso: Date<Iso>) -> IsoDateInner {
@@ -242,16 +242,9 @@ impl Date<Iso> {
     /// assert_eq!(date_iso.day_of_month().0, 2);
     /// ```
     pub fn try_new_iso_date(year: i32, month: u8, day: u8) -> Result<Date<Iso>, CalendarError> {
-        if !(1..=12).contains(&month) {
-            return Err(CalendarError::OutOfRange);
-        }
-        if day == 0 || day > Iso::days_in_month(year, month) {
-            return Err(CalendarError::OutOfRange);
-        }
-        Ok(Date::from_raw(
-            IsoDateInner(ArithmeticDate::new(year, month, day)),
-            Iso,
-        ))
+        ArithmeticDate::new_from_solar_ordinals(year, month, day)
+            .map(IsoDateInner)
+            .map(|inner| Date::from_raw(inner, Iso))
     }
 
     /// Constructs an ISO date representing the UNIX epoch on January 1, 1970.
@@ -523,10 +516,10 @@ impl Iso {
 
 impl IsoDateInner {
     pub(crate) fn jan_1(year: i32) -> Self {
-        Self(ArithmeticDate::new(year, 1, 1))
+        Self(ArithmeticDate::new_unchecked(year, 1, 1))
     }
     pub(crate) fn dec_31(year: i32) -> Self {
-        Self(ArithmeticDate::new(year, 12, 1))
+        Self(ArithmeticDate::new_unchecked(year, 12, 1))
     }
 }
 

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -119,7 +119,7 @@ impl Calendar for Julian {
             return Err(CalendarError::UnknownEra(era.0, self.debug_name()));
         };
 
-        ArithmeticDate::new_from_solar(self, year, month_code, day).map(JulianDateInner)
+        ArithmeticDate::new_from_solar_codes(self, year, month_code, day).map(JulianDateInner)
     }
     fn date_from_iso(&self, iso: Date<Iso>) -> JulianDateInner {
         let fixed_iso = Iso::fixed_from_iso(*iso.inner());
@@ -301,21 +301,9 @@ impl Date<Julian> {
         month: u8,
         day: u8,
     ) -> Result<Date<Julian>, CalendarError> {
-        let inner = ArithmeticDate {
-            year,
-            month,
-            day,
-            marker: PhantomData,
-        };
-
-        if day > 28 {
-            let bound = inner.days_in_month();
-            if day > bound {
-                return Err(CalendarError::OutOfRange);
-            }
-        }
-
-        Ok(Date::from_raw(JulianDateInner(inner), Julian))
+        ArithmeticDate::new_from_solar_ordinals(year, month, day)
+            .map(JulianDateInner)
+            .map(|inner| Date::from_raw(inner, Julian))
     }
 }
 

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -37,7 +37,6 @@ use crate::helpers::{i64_to_i32, quotient64, I32Result};
 use crate::iso::Iso;
 use crate::rata_die::RataDie;
 use crate::{types, Calendar, CalendarError, Date, DateDuration, DateDurationUnit, DateTime};
-use core::marker::PhantomData;
 use tinystr::tinystr;
 
 // Julian epoch is equivalent to fixed_from_iso of December 30th of 0 year
@@ -238,12 +237,8 @@ impl Julian {
     }
 
     pub(crate) const fn fixed_from_julian_integers(year: i32, month: u8, day: u8) -> RataDie {
-        Self::fixed_from_julian(ArithmeticDate {
-            year,
-            month,
-            day,
-            marker: PhantomData,
-        })
+        // TODO: Should we check bounds here?
+        Self::fixed_from_julian(ArithmeticDate::new_unchecked(year, month, day))
     }
 
     /// Convenience function so we can call days_in_year without


### PR DESCRIPTION
Just some cleanup to more consistently enforce bounds checks.