### PR TITLE
More casemapping fixes

### DIFF
--- a/experimental/casemapping/Cargo.toml
+++ b/experimental/casemapping/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
 homepage = "https://icu4x.unicode.org"
 license = "Unicode-DFS-2016"
+categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions
 include = [
     "src/**/*",
@@ -47,5 +48,5 @@ icu_casemapping_data = { path = "data", optional = true }
 [features]
 std = ["icu_collections/std", "icu_provider/std"]
 serde = ["dep:serde", "zerovec/serde", "icu_collections/serde", "icu_provider/serde"]
-datagen = ["serde", "std", "dep:databake", "zerovec/databake", "icu_collections/databake"]
+datagen = ["serde", "dep:databake", "zerovec/databake", "icu_collections/databake"]
 data = ["dep:icu_casemapping_data"]

--- a/experimental/casemapping/src/casemapping.rs
+++ b/experimental/casemapping/src/casemapping.rs
@@ -7,6 +7,7 @@ use crate::provider::data::MappingKind;
 use crate::provider::CaseMappingV1Marker;
 use icu_locid::Locale;
 use icu_provider::prelude::*;
+use alloc::string::String;
 use writeable::Writeable;
 
 /// A struct with the ability to convert characters and strings to uppercase or lowercase,

--- a/experimental/casemapping/src/casemapping.rs
+++ b/experimental/casemapping/src/casemapping.rs
@@ -139,9 +139,62 @@ impl CaseMapping {
             .simple_fold(c, FoldOptions::with_turkic_mappings())
     }
 
-    /// Returns the full lowercase mapping of the given string.
+    /// Returns the full lowercase mapping of the given string as a [`Writeable`].
     /// This function is context and locale sensitive.
-    pub fn to_full_lowercase(&self, src: &str) -> String {
+    ///
+    /// See [`Self::to_full_lowercase_string()`] for the equivalent convenience function that returns a String
+    pub fn to_full_lowercase<'a>(&'a self, src: &'a str) -> impl Writeable + 'a {
+        self.data
+            .get()
+            .full_helper_writeable(src, self.locale, MappingKind::Lower)
+    }
+
+    /// Returns the full uppercase mapping of the given string as a [`Writeable`].
+    /// This function is context and locale sensitive.
+    ///
+    /// See [`Self::to_full_uppercase_string()`] for the equivalent convenience function that returns a String
+    pub fn to_full_uppercase<'a>(&'a self, src: &'a str) -> impl Writeable + 'a {
+        self.data
+            .get()
+            .full_helper_writeable(src, self.locale, MappingKind::Upper)
+    }
+
+    /// Returns the full titlecase mapping of the given string as a [`Writeable`].
+    /// This function is context and locale sensitive.
+    ///
+    /// See [`Self::to_full_titlecase_string()`] for the equivalent convenience function that returns a String
+    pub fn to_full_titlecase<'a>(&'a self, src: &'a str) -> impl Writeable + 'a {
+        self.data
+            .get()
+            .full_helper_writeable(src, self.locale, MappingKind::Title)
+    }
+
+    /// Case-folds the characters in the given string as a [`Writeable`].
+    /// This function is locale-independent and context-insensitive.
+    ///
+    /// See [`Self::full_fold_string()`] for the equivalent convenience function that returns a String
+    pub fn full_fold<'a>(&'a self, src: &'a str) -> impl Writeable + 'a {
+        self.data
+            .get()
+            .full_helper_writeable(src, CaseMapLocale::Root, MappingKind::Fold)
+    }
+
+    /// Case-folds the characters in the given string as a [`Writeable`],
+    /// using Turkic (T) mappings for dotted/dotless I.
+    /// This function is locale-independent and context-insensitive.
+    ///
+    /// See [`Self::full_fold_turkic_string()`] for the equivalent convenience function that returns a String
+    pub fn full_fold_turkic<'a>(&'a self, src: &'a str) -> impl Writeable + 'a {
+        self.data
+            .get()
+            .full_helper_writeable(src, CaseMapLocale::Turkish, MappingKind::Fold)
+    }
+
+    /// Returns the full lowercase mapping of the given string as a String.
+    /// This function is context and locale sensitive.
+    ///
+    /// See [`Self::to_full_lowercase()`] for the equivalent lower-level function that returns a [`Writeable`]
+    pub fn to_full_lowercase_string(&self, src: &str) -> String {
         self.data
             .get()
             .full_helper_writeable(src, self.locale, MappingKind::Lower)
@@ -149,9 +202,11 @@ impl CaseMapping {
             .into_owned()
     }
 
-    /// Returns the full uppercase mapping of the given string.
+    /// Returns the full uppercase mapping of the given string as a String.
     /// This function is context and locale sensitive.
-    pub fn to_full_uppercase(&self, src: &str) -> String {
+    ///
+    /// See [`Self::to_full_uppercase()`] for the equivalent lower-level function that returns a [`Writeable`]
+    pub fn to_full_uppercase_string(&self, src: &str) -> String {
         self.data
             .get()
             .full_helper_writeable(src, self.locale, MappingKind::Upper)
@@ -159,9 +214,11 @@ impl CaseMapping {
             .into_owned()
     }
 
-    /// Returns the full titlecase mapping of the given string.
+    /// Returns the full titlecase mapping of the given string as a String.
     /// This function is context and locale sensitive.
-    pub fn to_full_titlecase(&self, src: &str) -> String {
+    ///
+    /// See [`Self::to_full_titlecase()`] for the equivalent lower-level function that returns a [`Writeable`]
+    pub fn to_full_titlecase_string(&self, src: &str) -> String {
         self.data
             .get()
             .full_helper_writeable(src, self.locale, MappingKind::Title)
@@ -169,9 +226,11 @@ impl CaseMapping {
             .into_owned()
     }
 
-    /// Case-folds the characters in the given string.
+    /// Case-folds the characters in the given string as a String.
     /// This function is locale-independent and context-insensitive.
-    pub fn full_fold(&self, src: &str) -> String {
+    ///
+    /// See [`Self::full_fold()`] for the equivalent lower-level function that returns a [`Writeable`]
+    pub fn full_fold_string(&self, src: &str) -> String {
         self.data
             .get()
             .full_helper_writeable(src, CaseMapLocale::Root, MappingKind::Fold)
@@ -179,9 +238,12 @@ impl CaseMapping {
             .into_owned()
     }
 
-    /// Case-folds the characters in the given string, using Turkic (T) mappings for dotted/dotless I.
+    /// Case-folds the characters in the given string as a String,
+    /// using Turkic (T) mappings for dotted/dotless I.
     /// This function is locale-independent and context-insensitive.
-    pub fn full_fold_turkic(&self, src: &str) -> String {
+    ///
+    /// See [`Self::full_fold_turkic()`] for the equivalent lower-level function that returns a [`Writeable`]
+    pub fn full_fold_turkic_string(&self, src: &str) -> String {
         self.data
             .get()
             .full_helper_writeable(src, CaseMapLocale::Turkish, MappingKind::Fold)

--- a/experimental/casemapping/src/casemapping.rs
+++ b/experimental/casemapping/src/casemapping.rs
@@ -5,6 +5,7 @@
 use crate::internals::{CaseMapLocale, FoldOptions};
 use crate::provider::data::MappingKind;
 use crate::provider::CaseMappingV1Marker;
+use crate::set::ClosureSet;
 use alloc::string::String;
 use icu_locid::Locale;
 use icu_provider::prelude::*;
@@ -250,5 +251,35 @@ impl CaseMapping {
             .full_helper_writeable(src, CaseMapLocale::Turkish, MappingKind::Fold)
             .write_to_string()
             .into_owned()
+    }
+
+    /// Adds all simple case mappings and the full case folding for `c` to `set`.
+    /// Also adds special case closure mappings.
+    ///
+    /// In other words, this adds all strings/characters that this casemaps to, as
+    /// well as all characters that may casemap to this one.
+    ///
+    /// The character itself is not added.
+    ///
+    /// For example, the mappings
+    /// - for s include long s
+    /// - for sharp s include ss
+    /// - for k include the Kelvin sign
+    pub fn add_case_closure<S: ClosureSet>(&self, c: char, set: &mut S) {
+        self.data.get().add_case_closure(c, set);
+    }
+
+    /// Maps the string to single code points and adds the associated case closure
+    /// mappings, if they exist.
+    ///
+    /// The string is mapped to code points if it is their full case folding string.
+    /// In other words, this performs a reverse full case folding and then
+    /// adds the case closure items of the resulting code points.
+    /// If the string is found and its closure applied, then
+    /// the string itself is added as well as part of its code points' closure.
+    ///
+    /// Returns true if the string was found
+    pub fn add_string_case_closure<S: ClosureSet>(&self, s: &str, set: &mut S) -> bool {
+        self.data.get().add_string_case_closure(s, set)
     }
 }

--- a/experimental/casemapping/src/casemapping.rs
+++ b/experimental/casemapping/src/casemapping.rs
@@ -5,9 +5,9 @@
 use crate::internals::{CaseMapLocale, FoldOptions};
 use crate::provider::data::MappingKind;
 use crate::provider::CaseMappingV1Marker;
+use alloc::string::String;
 use icu_locid::Locale;
 use icu_provider::prelude::*;
-use alloc::string::String;
 use writeable::Writeable;
 
 /// A struct with the ability to convert characters and strings to uppercase or lowercase,
@@ -19,7 +19,7 @@ use writeable::Writeable;
 /// of the icu meta-crate. Use with caution.
 /// <a href="https://github.com/unicode-org/icu4x/issues/2535">#2535</a>
 /// </div>
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CaseMapping {
     data: DataPayload<CaseMappingV1Marker>,
     locale: CaseMapLocale,

--- a/experimental/casemapping/src/error.rs
+++ b/experimental/casemapping/src/error.rs
@@ -18,6 +18,7 @@ use icu_collections::codepointtrie::CodePointTrieError;
 /// <a href="https://github.com/unicode-org/icu4x/issues/2535">#2535</a>
 /// </div>
 #[derive(Clone, Display, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum Error {
     /// An error occurred while building and validating the data
     #[displaydoc("Failed to validate: {0}")]

--- a/experimental/casemapping/src/internals.rs
+++ b/experimental/casemapping/src/internals.rs
@@ -492,7 +492,7 @@ impl<'data> CaseMappingV1<'data> {
 // An internal representation of locale. Non-Root values of this
 // enumeration imply that hard-coded special cases exist for this
 // language.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum CaseMapLocale {
     Root,
     Turkish,

--- a/experimental/casemapping/src/internals.rs
+++ b/experimental/casemapping/src/internals.rs
@@ -9,8 +9,8 @@
 use crate::provider::data::{DotType, MappingKind};
 use crate::provider::exception_helpers::ExceptionSlot;
 use crate::provider::CaseMappingV1;
+use crate::set::ClosureSet;
 use core::fmt;
-use icu_collections::codepointinvlist::CodePointInversionListBuilder;
 use icu_locid::Locale;
 use writeable::Writeable;
 
@@ -386,14 +386,14 @@ impl<'data> CaseMappingV1<'data> {
         }
     }
 
-    // Adds all simple case mappings and the full case folding for `c` to `set`.
-    // Also adds special case closure mappings.
-    // The character itself is not added.
-    // For example, the mappings
-    // - for s include long s
-    // - for sharp s include ss
-    // - for k include the Kelvin sign
-    fn add_case_closure<S: ClosureSet>(&self, c: char, set: &mut S) {
+    /// Adds all simple case mappings and the full case folding for `c` to `set`.
+    /// Also adds special case closure mappings.
+    /// The character itself is not added.
+    /// For example, the mappings
+    /// - for s include long s
+    /// - for sharp s include ss
+    /// - for k include the Kelvin sign
+    pub(crate) fn add_case_closure<S: ClosureSet>(&self, c: char, set: &mut S) {
         // Hardcode the case closure of i and its relatives and ignore the
         // data file data for these characters.
         // The Turkic dotless i and dotted I with their case mapping conditions
@@ -461,17 +461,11 @@ impl<'data> CaseMappingV1<'data> {
         exception.add_full_and_closure_mappings(set);
     }
 
-    // Maps the string to single code points and adds the associated case closure
-    // mappings.
-    // The string is mapped to code points if it is their full case folding string.
-    // In other words, this performs a reverse full case folding and then
-    // adds the case closure items of the resulting code points.
-    // If the string is found and its closure applied, then
-    // the string itself is added as well as part of its code points' closure.
-    //
-    // Returns true if the string was found
-    #[allow(dead_code)]
-    fn add_string_case_closure<S: ClosureSet>(&self, s: &str, set: &mut S) -> bool {
+    /// Maps the string to single code points and adds the associated case closure
+    /// mappings.
+    ///
+    /// (see docs on CaseMapping::add_string_case_closure)
+    pub(crate) fn add_string_case_closure<S: ClosureSet>(&self, s: &str, set: &mut S) -> bool {
         if s.chars().count() <= 1 {
             // The string is too short to find any match.
             return false;
@@ -537,25 +531,6 @@ impl<'a> FullMappingResult<'a> {
             FullMappingResult::Remove => {}
         }
     }
-}
-
-// Interface for adding items to a closure set.
-pub trait ClosureSet {
-    /// Add a character to the set
-    fn add_char(&mut self, c: char);
-    /// Add a string to the set
-    fn add_string(&mut self, string: &str);
-}
-
-impl ClosureSet for CodePointInversionListBuilder {
-    fn add_char(&mut self, c: char) {
-        self.add_char(c)
-    }
-
-    // The current version of CodePointInversionList doesn't include strings.
-    // Trying to add a string is a no-op that will be optimized away.
-    #[inline]
-    fn add_string(&mut self, _string: &str) {}
 }
 
 pub(crate) struct ContextIterator<'a> {

--- a/experimental/casemapping/src/internals.rs
+++ b/experimental/casemapping/src/internals.rs
@@ -9,9 +9,9 @@
 use crate::provider::data::{DotType, MappingKind};
 use crate::provider::exception_helpers::ExceptionSlot;
 use crate::provider::CaseMappingV1;
+use core::fmt;
 use icu_collections::codepointinvlist::CodePointInversionListBuilder;
 use icu_locid::Locale;
-use std::fmt;
 use writeable::Writeable;
 
 // Used to control the behavior of CaseMapping::fold.

--- a/experimental/casemapping/src/lib.rs
+++ b/experimental/casemapping/src/lib.rs
@@ -18,18 +18,18 @@
 
 // https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations_
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
-// #![cfg_attr(
-//     not(test),
-//     deny(
-//         clippy::indexing_slicing,
-//         clippy::unwrap_used,
-//         clippy::expect_used,
-//         clippy::panic,
-//         clippy::exhaustive_structs,
-//         clippy::exhaustive_enums,
-//         missing_debug_implementations,
-//     )
-// )]
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::indexing_slicing,
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::exhaustive_structs,
+        clippy::exhaustive_enums,
+        missing_debug_implementations,
+    )
+)]
 #![warn(missing_docs)]
 
 extern crate alloc;

--- a/experimental/casemapping/src/lib.rs
+++ b/experimental/casemapping/src/lib.rs
@@ -16,7 +16,23 @@
 //!
 //! [`ICU4X`]: ../icu/index.html
 
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations_
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
+// #![cfg_attr(
+//     not(test),
+//     deny(
+//         clippy::indexing_slicing,
+//         clippy::unwrap_used,
+//         clippy::expect_used,
+//         clippy::panic,
+//         clippy::exhaustive_structs,
+//         clippy::exhaustive_enums,
+//         missing_debug_implementations,
+//     )
+// )]
 #![warn(missing_docs)]
+
+extern crate alloc;
 
 mod casemapping;
 pub mod provider;

--- a/experimental/casemapping/src/lib.rs
+++ b/experimental/casemapping/src/lib.rs
@@ -36,11 +36,13 @@ extern crate alloc;
 
 mod casemapping;
 pub mod provider;
+mod set;
 
 mod error;
 mod internals;
 
 pub use casemapping::CaseMapping;
 pub use error::Error as CaseMappingError;
+pub use set::ClosureSet;
 #[doc(no_inline)]
 pub use CaseMappingError as Error;

--- a/experimental/casemapping/src/provider/data.rs
+++ b/experimental/casemapping/src/provider/data.rs
@@ -4,10 +4,10 @@
 
 //! The primary per-codepoint casefolding data
 
+#[cfg(feature = "datagen")]
+use alloc::collections::BTreeMap;
 use core::num::TryFromIntError;
 use icu_collections::codepointtrie::TrieValue;
-#[cfg(feature = "datagen")]
-use std::collections::HashMap;
 use zerovec::ule::{AsULE, RawBytesULE, ULE};
 use zerovec::ZeroVecError;
 
@@ -258,7 +258,7 @@ impl CaseMappingData {
     // a mapping from old to new, this function updates the exception
     // index if necessary.
     #[cfg(feature = "datagen")]
-    pub(crate) fn with_updated_exception(self, updates: &HashMap<u16, u16>) -> Self {
+    pub(crate) fn with_updated_exception(self, updates: &BTreeMap<u16, u16>) -> Self {
         let kind = if let CaseMappingDataKind::Exception(ty, index) = self.kind {
             if let Some(updated_exception) = updates.get(&index) {
                 CaseMappingDataKind::Exception(ty, *updated_exception)

--- a/experimental/casemapping/src/provider/exception_helpers.rs
+++ b/experimental/casemapping/src/provider/exception_helpers.rs
@@ -158,7 +158,7 @@ impl SlotPresence {
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Copy, Clone, PartialEq, Eq, ULE)]
+#[derive(Copy, Clone, PartialEq, Eq, ULE, Debug)]
 #[repr(transparent)]
 pub struct ExceptionBitsULE(pub u8);
 

--- a/experimental/casemapping/src/provider/exception_helpers.rs
+++ b/experimental/casemapping/src/provider/exception_helpers.rs
@@ -134,7 +134,22 @@ impl SlotPresence {
     }
 }
 
-/// The bitflags on an exception header (bits 8-15, see docs on [`ExceptionHeaderULE`])
+/// The bitflags on an exception header.
+///
+/// Format from icu4c, documented in casepropsbuilder.cpp, shifted 8 bits since ICU4C has this packed
+/// alongside a SlotPresence
+///
+/// ```text
+///            0  Double-width slots. If set, then each optional slot is stored as two
+///               elements of the array (high and low halves of 32-bit values) instead of
+///               a single element.
+///            1  Has no simple case folding, even if there is a simple lowercase mapping
+///           2  The value in the delta slot is negative
+///           3  Is case-sensitive (not exposed)
+///       4..5  Dot type
+///           6  Has conditional special casing
+///           7  Has conditional case folding
+/// ```
 ///
 /// All bits are valid, though in ICU4X data bits 0 and 2 are not used
 ///

--- a/experimental/casemapping/src/provider/exceptions.rs
+++ b/experimental/casemapping/src/provider/exceptions.rs
@@ -92,7 +92,7 @@ impl<'data> CaseMappingExceptions<'data> {
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
 #[zerovec::make_varule(ExceptionULE)]
-#[derive(PartialEq, Eq, Clone, Default)]
+#[derive(PartialEq, Eq, Clone, Default, Debug)]
 #[zerovec::skip_derive(Ord)]
 #[cfg_attr(
     feature = "serde",

--- a/experimental/casemapping/src/provider/exceptions.rs
+++ b/experimental/casemapping/src/provider/exceptions.rs
@@ -387,7 +387,7 @@ impl ExceptionULE {
             if decoded.full.is_some() {
                 let data = self
                     .get_fullmappings_slot_data()
-                    .expect("already known to succeed");
+                    .ok_or(Error::Validation("fullmappings slot doesn't parse"))?;
                 let mut chars = data.chars();
                 let i1 = u32::from(
                     chars
@@ -411,7 +411,8 @@ impl ExceptionULE {
                     ));
                 }
                 let rest = chars.as_str();
-                let len = u32::try_from(rest.len()).unwrap();
+                let len = u32::try_from(rest.len())
+                    .map_err(|_| Error::Validation("len too large for u32"))?;
 
                 if i1 > len || i2 > len || i3 > len {
                     return Err(Error::Validation(
@@ -491,7 +492,7 @@ impl<'a> DecodedException<'a> {
             if simple_case_delta >= SURROGATES_START {
                 simple_case_delta += SURROGATES_LEN;
             }
-            let simple_case_delta = char::try_from(simple_case_delta).unwrap();
+            let simple_case_delta = char::try_from(simple_case_delta).unwrap_or('\0');
             data.push(simple_case_delta)
         }
 

--- a/experimental/casemapping/src/provider/exceptions.rs
+++ b/experimental/casemapping/src/provider/exceptions.rs
@@ -15,11 +15,11 @@ use super::exception_helpers::{ExceptionBits, ExceptionSlot, SlotPresence};
 #[cfg(any(feature = "serde", feature = "datagen"))]
 use crate::error::Error;
 use crate::internals::ClosureSet;
+use alloc::borrow::Cow;
 use core::fmt;
 #[cfg(any(feature = "serde", feature = "datagen"))]
 use core::ops::Range;
 use core::ptr;
-use std::borrow::Cow;
 use zerovec::ule::AsULE;
 use zerovec::VarZeroVec;
 
@@ -466,6 +466,7 @@ pub struct DecodedException<'a> {
 impl<'a> DecodedException<'a> {
     /// Convert to a wire-format encodeable (VarULE-encodeable) [`Exception`]
     pub fn encode(&self) -> Exception<'static> {
+        use alloc::string::String;
         let bits = self.bits;
         let mut slot_presence = SlotPresence(0);
         let mut data = String::new();

--- a/experimental/casemapping/src/provider/exceptions.rs
+++ b/experimental/casemapping/src/provider/exceptions.rs
@@ -466,10 +466,9 @@ pub struct DecodedException<'a> {
 impl<'a> DecodedException<'a> {
     /// Convert to a wire-format encodeable (VarULE-encodeable) [`Exception`]
     pub fn encode(&self) -> Exception<'static> {
-        use alloc::string::String;
         let bits = self.bits;
         let mut slot_presence = SlotPresence(0);
-        let mut data = String::new();
+        let mut data = alloc::string::String::new();
         if let Some(lowercase) = self.lowercase {
             slot_presence.add_slot(ExceptionSlot::Lower);
             data.push(lowercase)

--- a/experimental/casemapping/src/provider/exceptions.rs
+++ b/experimental/casemapping/src/provider/exceptions.rs
@@ -14,7 +14,7 @@ use super::data::MappingKind;
 use super::exception_helpers::{ExceptionBits, ExceptionSlot, SlotPresence};
 #[cfg(any(feature = "serde", feature = "datagen"))]
 use crate::error::Error;
-use crate::internals::ClosureSet;
+use crate::set::ClosureSet;
 use alloc::borrow::Cow;
 use core::fmt;
 #[cfg(any(feature = "serde", feature = "datagen"))]

--- a/experimental/casemapping/src/provider/exceptions_builder.rs
+++ b/experimental/casemapping/src/provider/exceptions_builder.rs
@@ -7,8 +7,10 @@ use crate::provider::exception_helpers::{
     ExceptionBits, ExceptionBitsULE, ExceptionSlot, SlotPresence,
 };
 use crate::provider::exceptions::{CaseMappingExceptions, DecodedException};
-use std::borrow::Cow;
-use std::collections::HashMap;
+use alloc::borrow::Cow;
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec::Vec;
 use zerovec::ule::{AsULE, ULE};
 
 /// The header for exception types as found in ICU4C data. See [`ExceptionHeaderULE`]
@@ -155,9 +157,9 @@ impl<'a> CaseMappingExceptionsBuilder<'a> {
 
     pub(crate) fn build(
         mut self,
-    ) -> Result<(CaseMappingExceptions<'static>, HashMap<u16, u16>), Error> {
+    ) -> Result<(CaseMappingExceptions<'static>, BTreeMap<u16, u16>), Error> {
         let mut exceptions = Vec::new();
-        let mut idx_map = HashMap::new();
+        let mut idx_map = BTreeMap::new();
         // The format of the raw data from ICU4C is the same as the format described in
         // exceptions.rs, with the exception of full mapping and closure strings. The
         // header and non-string slots can be copied over without modification. For string

--- a/experimental/casemapping/src/provider/mod.rs
+++ b/experimental/casemapping/src/provider/mod.rs
@@ -122,6 +122,7 @@ impl<'data> CaseMappingV1<'data> {
 
         let trie_index = ZeroVec::alloc_from_slice(trie_index);
 
+        #[allow(clippy::unwrap_used)] // datagen only
         let trie_data = trie_data
             .iter()
             .map(|&i| {

--- a/experimental/casemapping/src/provider/mod.rs
+++ b/experimental/casemapping/src/provider/mod.rs
@@ -150,6 +150,7 @@ impl<'data> CaseMappingV1<'data> {
     /// necessary if you are concerned about data corruption after
     /// deserializing.
     #[cfg(any(feature = "serde", feature = "datagen"))]
+    #[allow(unused)] // is only used in debug mode for serde
     pub(crate) fn validate(&self) -> Result<(), crate::error::Error> {
         // First, validate that exception data is well-formed.
         let valid_exception_indices = self.exceptions.validate()?;

--- a/experimental/casemapping/src/provider/unfold.rs
+++ b/experimental/casemapping/src/provider/unfold.rs
@@ -48,6 +48,7 @@ impl<'data> CaseMappingUnfoldData<'data> {
     // Rust strings are UTF8 by default. To avoid the cost of converting from UTF16 on access,
     // we convert the ICU data into a more convenient format during construction.
     #[cfg(feature = "datagen")]
+    #[allow(clippy::indexing_slicing)] // panics are ok in datagen
     pub(crate) fn try_from_icu(raw: &[u16]) -> Result<Self, Error> {
         const ROWS_INDEX: usize = 0;
         const ROW_WIDTH_INDEX: usize = 1;

--- a/experimental/casemapping/src/provider/unfold.rs
+++ b/experimental/casemapping/src/provider/unfold.rs
@@ -6,6 +6,8 @@
 
 #[cfg(feature = "datagen")]
 use crate::error::Error;
+#[cfg(feature = "datagen")]
+use alloc::string::String;
 use icu_provider::prelude::*;
 use zerovec::ZeroMap;
 

--- a/experimental/casemapping/src/set.rs
+++ b/experimental/casemapping/src/set.rs
@@ -1,0 +1,27 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use icu_collections::codepointinvlist::CodePointInversionListBuilder;
+
+/// A setlike object that can hold characters and/or strings
+/// to be used with [`CaseMapping::add_string_case_closure()`]
+///
+/// [`CaseMapping::add_string_case_closure()`]: crate::CaseMapping::add_string_case_closure
+pub trait ClosureSet {
+    /// Add a character to the set
+    fn add_char(&mut self, c: char);
+    /// Add a string to the set
+    fn add_string(&mut self, string: &str);
+}
+
+impl ClosureSet for CodePointInversionListBuilder {
+    fn add_char(&mut self, c: char) {
+        self.add_char(c)
+    }
+
+    // The current version of CodePointInversionList doesn't include strings.
+    // Trying to add a string is a no-op that will be optimized away.
+    #[inline]
+    fn add_string(&mut self, _string: &str) {}
+}

--- a/provider/datagen/src/transform/icuexport/ucase/mod.rs
+++ b/provider/datagen/src/transform/icuexport/ucase/mod.rs
@@ -130,78 +130,78 @@ mod tests {
         let uppercase_greek = "ΙΕΣΥΣ ΧΡΙΣΤΟΣ"; // "IESUS CHRISTOS"
         let lowercase_greek = "ιεσυς χριστος"; // "IESUS CHRISTOS"
         assert_eq!(
-            case_mapping.to_full_uppercase(lowercase_greek),
+            case_mapping.to_full_uppercase_string(lowercase_greek),
             uppercase_greek
         );
         assert_eq!(
-            case_mapping.to_full_lowercase(uppercase_greek),
+            case_mapping.to_full_lowercase_string(uppercase_greek),
             lowercase_greek
         );
         assert_eq!(
-            case_mapping.full_fold(uppercase_greek),
-            case_mapping.full_fold(lowercase_greek)
+            case_mapping.full_fold_string(uppercase_greek),
+            case_mapping.full_fold_string(lowercase_greek)
         );
 
         let lowercase_turkish_1 = "istanbul, not constantınople";
         let uppercase_turkish_1 = "İSTANBUL, NOT CONSTANTINOPLE";
         assert_eq!(
-            case_mapping.to_full_lowercase(uppercase_turkish_1),
+            case_mapping.to_full_lowercase_string(uppercase_turkish_1),
             "i\u{307}stanbul, not constantinople"
         );
         assert_eq!(
-            turkish_case_mapping.to_full_lowercase(uppercase_turkish_1),
+            turkish_case_mapping.to_full_lowercase_string(uppercase_turkish_1),
             lowercase_turkish_1
         );
 
         let lowercase_turkish_2 = "topkapı palace, istanbul";
         let uppercase_turkish_2 = "TOPKAPI PALACE, İSTANBUL";
         assert_eq!(
-            case_mapping.to_full_uppercase(lowercase_turkish_2),
+            case_mapping.to_full_uppercase_string(lowercase_turkish_2),
             "TOPKAPI PALACE, ISTANBUL"
         );
         assert_eq!(
-            turkish_case_mapping.to_full_uppercase(lowercase_turkish_2),
+            turkish_case_mapping.to_full_uppercase_string(lowercase_turkish_2),
             uppercase_turkish_2
         );
 
         let initial_german = "Süßmayrstraße";
         let uppercase_german = "SÜSSMAYRSTRASSE";
         assert_eq!(
-            case_mapping.to_full_uppercase(initial_german),
+            case_mapping.to_full_uppercase_string(initial_german),
             uppercase_german
         );
 
         let before = "aBIΣßΣ/\u{5ffff}";
         let after = "abiσßς/\u{5ffff}";
         let after_turkish = "abıσßς/\u{5ffff}";
-        assert_eq!(case_mapping.to_full_lowercase(before), after);
+        assert_eq!(case_mapping.to_full_lowercase_string(before), after);
         assert_eq!(
-            turkish_case_mapping.to_full_lowercase(before),
+            turkish_case_mapping.to_full_lowercase_string(before),
             after_turkish
         );
 
         let before = "aBiςßσ/\u{fb03}\u{fb03}\u{fb03}\u{5ffff}";
         let after = "ABIΣSSΣ/FFIFFIFFI\u{5ffff}";
         let after_turkish = "ABİΣSSΣ/FFIFFIFFI\u{5ffff}";
-        assert_eq!(case_mapping.to_full_uppercase(before), after);
+        assert_eq!(case_mapping.to_full_uppercase_string(before), after);
         assert_eq!(
-            turkish_case_mapping.to_full_uppercase(before),
+            turkish_case_mapping.to_full_uppercase_string(before),
             after_turkish
         );
 
         let before = "ßa";
         let after = "SSA";
-        assert_eq!(case_mapping.to_full_uppercase(before), after);
+        assert_eq!(case_mapping.to_full_uppercase_string(before), after);
 
         let initial_deseret = "\u{1043c}\u{10414}";
         let upper_deseret = "\u{10414}\u{10414}";
         let lower_deseret = "\u{1043c}\u{1043c}";
         assert_eq!(
-            case_mapping.to_full_uppercase(initial_deseret),
+            case_mapping.to_full_uppercase_string(initial_deseret),
             upper_deseret
         );
         assert_eq!(
-            case_mapping.to_full_lowercase(initial_deseret),
+            case_mapping.to_full_lowercase_string(initial_deseret),
             lower_deseret
         );
 
@@ -210,11 +210,11 @@ mod tests {
         let lower_ligature = "\u{1c9}\u{1c9}\u{1c9}";
         let upper_ligature = "\u{1c7}\u{1c7}\u{1c7}";
         assert_eq!(
-            case_mapping.to_full_uppercase(initial_ligature),
+            case_mapping.to_full_uppercase_string(initial_ligature),
             upper_ligature
         );
         assert_eq!(
-            case_mapping.to_full_lowercase(initial_ligature),
+            case_mapping.to_full_lowercase_string(initial_ligature),
             lower_ligature
         );
 
@@ -222,17 +222,23 @@ mod tests {
         let initial_sigmas = "i\u{307}\u{3a3}\u{308}j \u{307}\u{3a3}\u{308}j i\u{ad}\u{3a3}\u{308} \u{307}\u{3a3}\u{308}";
         let lower_sigmas = "i\u{307}\u{3c3}\u{308}j \u{307}\u{3c3}\u{308}j i\u{ad}\u{3c2}\u{308} \u{307}\u{3c3}\u{308}";
         let upper_sigmas = "I\u{307}\u{3a3}\u{308}J \u{307}\u{3a3}\u{308}J I\u{ad}\u{3a3}\u{308} \u{307}\u{3a3}\u{308}";
-        assert_eq!(case_mapping.to_full_uppercase(initial_sigmas), upper_sigmas);
-        assert_eq!(case_mapping.to_full_lowercase(initial_sigmas), lower_sigmas);
+        assert_eq!(
+            case_mapping.to_full_uppercase_string(initial_sigmas),
+            upper_sigmas
+        );
+        assert_eq!(
+            case_mapping.to_full_lowercase_string(initial_sigmas),
+            lower_sigmas
+        );
 
         // Turkish & Azerbaijani dotless i & dotted I:
         // Remove dot above if there was a capital I before and there are no more accents above.
         let initial_dots = "I İ I\u{307} I\u{327}\u{307} I\u{301}\u{307} I\u{327}\u{307}\u{301}";
         let after = "i i\u{307} i\u{307} i\u{327}\u{307} i\u{301}\u{307} i\u{327}\u{307}\u{301}";
         let after_turkish = "ı i i i\u{327} ı\u{301}\u{307} i\u{327}\u{301}";
-        assert_eq!(case_mapping.to_full_lowercase(initial_dots), after);
+        assert_eq!(case_mapping.to_full_lowercase_string(initial_dots), after);
         assert_eq!(
-            turkish_case_mapping.to_full_lowercase(initial_dots),
+            turkish_case_mapping.to_full_lowercase_string(initial_dots),
             after_turkish
         );
 
@@ -240,9 +246,9 @@ mod tests {
         let initial_dots = "a\u{307} \u{307} i\u{307} j\u{327}\u{307} j\u{301}\u{307}";
         let after = "A\u{307} \u{307} I\u{307} J\u{327}\u{307} J\u{301}\u{307}";
         let after_lithuanian = "A\u{307} \u{307} I J\u{327} J\u{301}\u{307}";
-        assert_eq!(case_mapping.to_full_uppercase(initial_dots), after);
+        assert_eq!(case_mapping.to_full_uppercase_string(initial_dots), after);
         assert_eq!(
-            lithuanian_case_mapping.to_full_uppercase(initial_dots),
+            lithuanian_case_mapping.to_full_uppercase_string(initial_dots),
             after_lithuanian
         );
 
@@ -250,9 +256,9 @@ mod tests {
         let initial_dots = "I I\u{301} J J\u{301} \u{12e} \u{12e}\u{301} \u{cc}\u{cd}\u{128}";
         let after = "i i\u{301} j j\u{301} \u{12f} \u{12f}\u{301} \u{ec}\u{ed}\u{129}";
         let after_lithuanian = "i i\u{307}\u{301} j j\u{307}\u{301} \u{12f} \u{12f}\u{307}\u{301} i\u{307}\u{300}i\u{307}\u{301}i\u{307}\u{303}";
-        assert_eq!(case_mapping.to_full_lowercase(initial_dots), after);
+        assert_eq!(case_mapping.to_full_lowercase_string(initial_dots), after);
         assert_eq!(
-            lithuanian_case_mapping.to_full_lowercase(initial_dots),
+            lithuanian_case_mapping.to_full_lowercase_string(initial_dots),
             after_lithuanian
         );
 
@@ -260,7 +266,7 @@ mod tests {
         let initial = "Aßµ\u{fb03}\u{1040c}İı";
         let simple = "assμffi\u{10434}i\u{307}ı";
         let turkic = "assμffi\u{10434}iı";
-        assert_eq!(case_mapping.full_fold(initial), simple);
-        assert_eq!(case_mapping.full_fold_turkic(initial), turkic);
+        assert_eq!(case_mapping.full_fold_string(initial), simple);
+        assert_eq!(case_mapping.full_fold_turkic_string(initial), turkic);
     }
 }


### PR DESCRIPTION
- Exposed Writeable methods (tell me what to call them please)
 - `no_std`  and library boilerplate
 - Case closure methods

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->