### PR TITLE
Add cyclic year to `FormattableYear`

### DIFF
--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -216,7 +216,7 @@ fn iso_year_as_buddhist(year: i32) -> types::FormattableYear {
     types::FormattableYear {
         era: types::Era(tinystr!(16, "be")),
         number: buddhist_year,
-        cyclic: 0,
+        cyclic: None,
         related_iso: None,
     }
 }

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -216,6 +216,7 @@ fn iso_year_as_buddhist(year: i32) -> types::FormattableYear {
     types::FormattableYear {
         era: types::Era(tinystr!(16, "be")),
         number: buddhist_year,
+        cyclic: 0,
         related_iso: None,
     }
 }

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -326,14 +326,14 @@ fn year_as_coptic(year: i32) -> types::FormattableYear {
         types::FormattableYear {
             era: types::Era(tinystr!(16, "ad")),
             number: year,
-            cyclic: 0,
+            cyclic: None,
             related_iso: None,
         }
     } else {
         types::FormattableYear {
             era: types::Era(tinystr!(16, "bd")),
             number: 1 - year,
-            cyclic: 0,
+            cyclic: None,
             related_iso: None,
         }
     }

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -326,12 +326,14 @@ fn year_as_coptic(year: i32) -> types::FormattableYear {
         types::FormattableYear {
             era: types::Era(tinystr!(16, "ad")),
             number: year,
+            cyclic: 0,
             related_iso: None,
         }
     } else {
         types::FormattableYear {
             era: types::Era(tinystr!(16, "bd")),
             number: 1 - year,
+            cyclic: 0,
             related_iso: None,
         }
     }

--- a/components/calendar/src/ethiopian.rs
+++ b/components/calendar/src/ethiopian.rs
@@ -292,18 +292,21 @@ impl Ethiopian {
             types::FormattableYear {
                 era: types::Era(tinystr!(16, "mundi")),
                 number: year + AMETE_ALEM_OFFSET,
+                cyclic: 0,
                 related_iso: None,
             }
         } else if year > 0 {
             types::FormattableYear {
                 era: types::Era(tinystr!(16, "incar")),
                 number: year,
+                cyclic: 0,
                 related_iso: None,
             }
         } else {
             types::FormattableYear {
                 era: types::Era(tinystr!(16, "pre-incar")),
                 number: 1 - year,
+                cyclic: 0,
                 related_iso: None,
             }
         }

--- a/components/calendar/src/ethiopian.rs
+++ b/components/calendar/src/ethiopian.rs
@@ -292,21 +292,21 @@ impl Ethiopian {
             types::FormattableYear {
                 era: types::Era(tinystr!(16, "mundi")),
                 number: year + AMETE_ALEM_OFFSET,
-                cyclic: 0,
+                cyclic: None,
                 related_iso: None,
             }
         } else if year > 0 {
             types::FormattableYear {
                 era: types::Era(tinystr!(16, "incar")),
                 number: year,
-                cyclic: 0,
+                cyclic: None,
                 related_iso: None,
             }
         } else {
             types::FormattableYear {
                 era: types::Era(tinystr!(16, "pre-incar")),
                 number: 1 - year,
-                cyclic: 0,
+                cyclic: None,
                 related_iso: None,
             }
         }

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -223,14 +223,14 @@ pub(crate) fn year_as_gregorian(year: i32) -> types::FormattableYear {
         types::FormattableYear {
             era: types::Era(tinystr!(16, "ce")),
             number: year,
-            cyclic: 0,
+            cyclic: None,
             related_iso: None,
         }
     } else {
         types::FormattableYear {
             era: types::Era(tinystr!(16, "bce")),
             number: 1_i32.saturating_sub(year),
-            cyclic: 0,
+            cyclic: None,
             related_iso: None,
         }
     }

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -223,12 +223,14 @@ pub(crate) fn year_as_gregorian(year: i32) -> types::FormattableYear {
         types::FormattableYear {
             era: types::Era(tinystr!(16, "ce")),
             number: year,
+            cyclic: 0,
             related_iso: None,
         }
     } else {
         types::FormattableYear {
             era: types::Era(tinystr!(16, "bce")),
             number: 1_i32.saturating_sub(year),
+            cyclic: 0,
             related_iso: None,
         }
     }

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -188,6 +188,7 @@ impl Calendar for Indian {
         types::FormattableYear {
             era: types::Era(tinystr!(16, "saka")),
             number: date.0.year,
+            cyclic: 0,
             related_iso: None,
         }
     }
@@ -204,11 +205,13 @@ impl Calendar for Indian {
         let prev_year = types::FormattableYear {
             era: types::Era(tinystr!(16, "saka")),
             number: date.0.year - 1,
+            cyclic: 0,
             related_iso: None,
         };
         let next_year = types::FormattableYear {
             era: types::Era(tinystr!(16, "saka")),
             number: date.0.year + 1,
+            cyclic: 0,
             related_iso: None,
         };
         types::DayOfYearInfo {

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -188,7 +188,7 @@ impl Calendar for Indian {
         types::FormattableYear {
             era: types::Era(tinystr!(16, "saka")),
             number: date.0.year,
-            cyclic: 0,
+            cyclic: None,
             related_iso: None,
         }
     }
@@ -205,13 +205,13 @@ impl Calendar for Indian {
         let prev_year = types::FormattableYear {
             era: types::Era(tinystr!(16, "saka")),
             number: date.0.year - 1,
-            cyclic: 0,
+            cyclic: None,
             related_iso: None,
         };
         let next_year = types::FormattableYear {
             era: types::Era(tinystr!(16, "saka")),
             number: date.0.year + 1,
-            cyclic: 0,
+            cyclic: None,
             related_iso: None,
         };
         types::DayOfYearInfo {

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -516,7 +516,7 @@ impl Iso {
         types::FormattableYear {
             era: types::Era(tinystr!(16, "default")),
             number: year,
-            cyclic: 0,
+            cyclic: None,
             related_iso: None,
         }
     }

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -516,6 +516,7 @@ impl Iso {
         types::FormattableYear {
             era: types::Era(tinystr!(16, "default")),
             number: year,
+            cyclic: 0,
             related_iso: None,
         }
     }

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -272,7 +272,7 @@ impl Calendar for Japanese {
         types::FormattableYear {
             era: types::Era(date.era),
             number: date.adjusted_year,
-            cyclic: 0,
+            cyclic: None,
             related_iso: None,
         }
     }

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -272,6 +272,7 @@ impl Calendar for Japanese {
         types::FormattableYear {
             era: types::Era(date.era),
             number: date.adjusted_year,
+            cyclic: 0,
             related_iso: None,
         }
     }

--- a/components/calendar/src/persian.rs
+++ b/components/calendar/src/persian.rs
@@ -298,7 +298,7 @@ impl Persian {
         types::FormattableYear {
             era: types::Era(tinystr!(16, "ah")),
             number: year,
-            cyclic: 0,
+            cyclic: None,
             related_iso: None,
         }
     }

--- a/components/calendar/src/persian.rs
+++ b/components/calendar/src/persian.rs
@@ -298,6 +298,7 @@ impl Persian {
         types::FormattableYear {
             era: types::Era(tinystr!(16, "ah")),
             number: year,
+            cyclic: 0,
             related_iso: None,
         }
     }

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -37,9 +37,6 @@ impl FromStr for Era {
 }
 
 /// Representation of a formattable year.
-///
-/// More fields may be added in the future, for things like
-/// the cyclic or extended year
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub struct FormattableYear {
@@ -48,6 +45,10 @@ pub struct FormattableYear {
 
     /// The year number in the current era (usually 1-based).
     pub number: i32,
+
+    /// The year in the current cycle for cyclic calendars;
+    /// can be ignored and set to any value for non-cyclic calendars.
+    pub cyclic: i32,
 
     /// The related ISO year. This is normally the ISO (proleptic Gregorian) year having the greatest
     /// overlap with the calendar year. It is used in certain date formatting patterns.
@@ -62,10 +63,11 @@ impl FormattableYear {
     ///
     /// Other fields can be set mutably after construction
     /// as needed
-    pub fn new(era: Era, number: i32) -> Self {
+    pub fn new(era: Era, number: i32, cyclic: i32) -> Self {
         Self {
             era,
             number,
+            cyclic,
             related_iso: None,
         }
     }

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -48,7 +48,7 @@ pub struct FormattableYear {
 
     /// The year in the current cycle for cyclic calendars;
     /// can be ignored and set to any value for non-cyclic calendars.
-    pub cyclic: i32,
+    pub cyclic: Option<i32>,
 
     /// The related ISO year. This is normally the ISO (proleptic Gregorian) year having the greatest
     /// overlap with the calendar year. It is used in certain date formatting patterns.
@@ -63,7 +63,7 @@ impl FormattableYear {
     ///
     /// Other fields can be set mutably after construction
     /// as needed
-    pub fn new(era: Era, number: i32, cyclic: i32) -> Self {
+    pub fn new(era: Era, number: i32, cyclic: Option<i32>) -> Self {
         Self {
             era,
             number,

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -37,6 +37,8 @@ impl FromStr for Era {
 }
 
 /// Representation of a formattable year.
+///
+/// More fields may be added in the future for things like extended year
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub struct FormattableYear {
@@ -47,7 +49,7 @@ pub struct FormattableYear {
     pub number: i32,
 
     /// The year in the current cycle for cyclic calendars;
-    /// can be ignored and set to any value for non-cyclic calendars.
+    /// can be set to None for non-cyclic calendars
     pub cyclic: Option<i32>,
 
     /// The related ISO year. This is normally the ISO (proleptic Gregorian) year having the greatest

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -216,9 +216,9 @@ mod tests {
         check_size_of!(6744 | 5408, TypedDateTimeFormatter::<Gregorian>);
 
         check_size_of!(88, DateTimeError);
-        check_size_of!(176, FormattedDateTime);
+        check_size_of!(200, FormattedDateTime);
         check_size_of!(16, FormattedTimeZone::<CustomTimeZone>);
-        check_size_of!(160, FormattedZonedDateTime);
+        check_size_of!(184, FormattedZonedDateTime);
         check_size_of!(13, DateTimeFormatterOptions);
 
         type DP<M> = DataPayload<M>;


### PR DESCRIPTION
Traditionally, instead of counting ordinal years (ex. 1, 2, 3, ... 2022, 2023, ...), the Chinese calendar counts years in cycles of 60 (ex. 1, 2, 3, ... 59, 60, 1, 2, 3, ...), at least insofar as the names of years repeat each 60 years. Although in modern times the year can be counted by using the associated Gregorian/ISO year (which already has a `related_iso` field in `FormattableYear`), cyclic year is still necessary to provide complete date formatting for the Chinese calendar.

Considering this, I propose adding a single field `pub cyclic: i32` to `FormattableYear`, which can be set to any value for non-cyclic calendars (I set the field to be 0 in all currently-existing calendars, but it doesn't matter for those calendars since this value should not be read), and set to an integer value for calendars like the Chinese calendar which use cyclic years.