### PR TITLE
Add Ord on locale related structs

### DIFF
--- a/components/locid/src/extensions/mod.rs
+++ b/components/locid/src/extensions/mod.rs
@@ -99,7 +99,7 @@ impl ExtensionType {
 }
 
 /// A map of extensions associated with a given [`Locale`](crate::Locale).
-#[derive(Debug, Default, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 #[non_exhaustive]
 pub struct Extensions {
     /// A representation of the data for a Unicode extension, when present in the locale identifier.

--- a/components/locid/src/extensions/transform/mod.rs
+++ b/components/locid/src/extensions/transform/mod.rs
@@ -72,7 +72,7 @@ use litemap::LiteMap;
 /// [`Unicode BCP47 T Extensions`]: https://unicode.org/reports/tr35/#t_Extension
 /// [`RFC 6497`]: https://www.ietf.org/rfc/rfc6497.txt
 /// [`Unicode Locale Identifier`]: https://unicode.org/reports/tr35/#Unicode_locale_identifier
-#[derive(Clone, PartialEq, Eq, Debug, Default, Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Default, Hash, PartialOrd, Ord)]
 #[allow(clippy::exhaustive_structs)] // spec-backed stable datastructure
 pub struct Transform {
     /// The [`LanguageIdentifier`] specified with this locale extension, or `None` if not present.

--- a/components/locid/src/langid.rs
+++ b/components/locid/src/langid.rs
@@ -59,7 +59,7 @@ use writeable::Writeable;
 /// ```
 ///
 /// [`Unicode BCP47 Language Identifier`]: https://unicode.org/reports/tr35/tr35.html#Unicode_language_identifier
-#[derive(Default, PartialEq, Eq, Clone, Hash)]
+#[derive(Default, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 #[allow(clippy::exhaustive_structs)] // This struct is stable (and invoked by a macro)
 pub struct LanguageIdentifier {
     /// Language subtag of the language identifier.

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -77,7 +77,7 @@ use writeable::Writeable;
 /// );
 /// ```
 /// [`Unicode Locale Identifier`]: https://unicode.org/reports/tr35/tr35.html#Unicode_locale_identifier
-#[derive(Default, PartialEq, Eq, Clone, Hash)]
+#[derive(Default, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 #[allow(clippy::exhaustive_structs)] // This struct is stable (and invoked by a macro)
 pub struct Locale {
     /// The basic language/script/region components in the locale identifier along with any variants.


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

Adds `Ord` to Locale related structs so a `Locale` can be used as a key in a `BTreeMap`.