### PR TITLE
Prepare `CodePointInversionList[AndStringList]` for use in Transliteration

### DIFF
--- a/components/collections/Cargo.toml
+++ b/components/collections/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 displaydoc = { version = "0.2.3", default-features = false }
 yoke = { version = "0.7.1", path = "../../utils/yoke", features = ["derive"] }
 zerofrom = { version = "0.1.1", path = "../../utils/zerofrom", features = ["derive"] }
-zerovec = { version = "0.9.4", path = "../../utils/zerovec", features = ["yoke"] }
+zerovec = { version = "0.9.4", path = "../../utils/zerovec", features = ["derive", "yoke"] }
 
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 databake = { version = "0.1.3", path = "../../utils/databake", features = ["derive"], optional = true }

--- a/components/collections/src/codepointinvlist/cpinvlist.rs
+++ b/components/collections/src/codepointinvlist/cpinvlist.rs
@@ -28,6 +28,8 @@ const ALL_VEC: ZeroVec<u32> =
 ///
 /// Provides exposure to membership functions and constructors from serialized `CodePointSet`s (sets of code points)
 /// and predefined ranges.
+#[zerovec::make_varule(CodePointInversionListULE)]
+#[zerovec::skip_derive(Ord)]
 #[derive(Debug, Eq, PartialEq, Clone, Yokeable, ZeroFrom)]
 pub struct CodePointInversionList<'data> {
     // If we wanted to use an array to keep the memory on the stack, there is an unsafe nightly feature

--- a/components/collections/src/codepointinvlist/mod.rs
+++ b/components/collections/src/codepointinvlist/mod.rs
@@ -66,6 +66,7 @@ use alloc::vec::Vec;
 pub use builder::CodePointInversionListBuilder;
 pub use conversions::*;
 pub use cpinvlist::CodePointInversionList;
+pub use cpinvlist::CodePointInversionListULE;
 use displaydoc::Display;
 
 /// Custom Errors for [`CodePointInversionList`].

--- a/components/collections/src/codepointinvliststringlist/mod.rs
+++ b/components/collections/src/codepointinvliststringlist/mod.rs
@@ -10,14 +10,15 @@
 //! It is an implementation of the the existing [ICU4C UnicodeSet API](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1UnicodeSet.html).
 
 use crate::codepointinvlist::{
-    CodePointInversionList, CodePointInversionListULE, CodePointInversionListBuilder, CodePointInversionListError,
+    CodePointInversionList, CodePointInversionListBuilder, CodePointInversionListError,
+    CodePointInversionListULE,
 };
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use displaydoc::Display;
 use yoke::Yokeable;
 use zerofrom::ZeroFrom;
-use zerovec::{VarZeroVec, VarZeroSlice};
+use zerovec::{VarZeroSlice, VarZeroVec};
 
 /// A data structure providing a concrete implementation of a `UnicodeSet`
 /// (which represents a set of code points and strings) using an inversion list for the code points and a simple

--- a/components/collections/src/codepointinvliststringlist/mod.rs
+++ b/components/collections/src/codepointinvliststringlist/mod.rs
@@ -10,23 +10,27 @@
 //! It is an implementation of the the existing [ICU4C UnicodeSet API](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1UnicodeSet.html).
 
 use crate::codepointinvlist::{
-    CodePointInversionList, CodePointInversionListBuilder, CodePointInversionListError,
+    CodePointInversionList, CodePointInversionListULE, CodePointInversionListBuilder, CodePointInversionListError,
 };
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use displaydoc::Display;
 use yoke::Yokeable;
 use zerofrom::ZeroFrom;
-use zerovec::VarZeroVec;
+use zerovec::{VarZeroVec, VarZeroSlice};
 
 /// A data structure providing a concrete implementation of a `UnicodeSet`
 /// (which represents a set of code points and strings) using an inversion list for the code points and a simple
 /// list-like structure to store and iterate over the strings.
+#[zerovec::make_varule(CodePointInversionListAndStringListULE)]
+#[zerovec::skip_derive(Ord)]
 #[derive(Debug, Eq, PartialEq, Clone, Yokeable, ZeroFrom)]
 // Valid to auto-derive Deserialize because the invariants are weakly held
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", zerovec::derive(Serialize, Deserialize, Debug))]
 pub struct CodePointInversionListAndStringList<'data> {
     #[cfg_attr(feature = "serde", serde(borrow))]
+    #[zerovec::varule(CodePointInversionListULE)]
     cp_inv_list: CodePointInversionList<'data>,
     // Invariants (weakly held):
     //   - no input string is length 1 (a length 1 string should be a single code point)
@@ -209,6 +213,11 @@ impl<'data> CodePointInversionListAndStringList<'data> {
     /// Access the underlying [`CodePointInversionList`].
     pub fn code_points(&self) -> &CodePointInversionList<'data> {
         &self.cp_inv_list
+    }
+
+    /// Access the contained strings.
+    pub fn strings(&self) -> &VarZeroSlice<str> {
+        &self.str_list
     }
 }
 


### PR DESCRIPTION
This PR adds VarULE types for `CodePointInversionList` and `CodePointInversionListAndStringList`. This is necessary, because they will be stored in some variable length structure in the transliterator.

Also adds access to the "AndStringList" portion of the type