### PR TITLE
Fix MultiFieldsULE

### DIFF
--- a/utils/zerovec/derive/examples/make_var.rs
+++ b/utils/zerovec/derive/examples/make_var.rs
@@ -153,9 +153,10 @@ fn main() {
         assert_eq!(stack, &MultiFieldStruct::zero_from(zero))
     });
 
-    assert_zerovec::<MultiFieldConsecutiveStructULE, MultiFieldConsecutiveStruct, _>(TEST_MULTICONSECUTIVE, |stack, zero| {
-        assert_eq!(stack, &MultiFieldConsecutiveStruct::zero_from(zero))
-    });
+    assert_zerovec::<MultiFieldConsecutiveStructULE, MultiFieldConsecutiveStruct, _>(
+        TEST_MULTICONSECUTIVE,
+        |stack, zero| assert_eq!(stack, &MultiFieldConsecutiveStruct::zero_from(zero)),
+    );
 
     let vartuples = &[
         VarTupleStruct(101, 'ø', TEST_STRINGS1.into()),
@@ -216,11 +217,10 @@ const TEST_MULTIFIELD: &[MultiFieldStruct<'static>] = &[
     },
 ];
 
-const TEST_MULTICONSECUTIVE: &[MultiFieldConsecutiveStruct<'static>] = &[
-    MultiFieldConsecutiveStruct {
+const TEST_MULTICONSECUTIVE: &[MultiFieldConsecutiveStruct<'static>] =
+    &[MultiFieldConsecutiveStruct {
         a: Cow::Borrowed("one"),
         b: Cow::Borrowed("2"),
         c: Cow::Borrowed("three"),
         d: Cow::Borrowed("four"),
-    },
-];
+    }];

--- a/utils/zerovec/derive/examples/make_var.rs
+++ b/utils/zerovec/derive/examples/make_var.rs
@@ -165,8 +165,6 @@ fn main() {
     assert_zerovec::<VarTupleStructULE, VarTupleStruct, _>(vartuples, |stack, zero| {
         assert_eq!(stack, &VarTupleStruct::zero_from(zero))
     });
-
-    println!("successful");
 }
 
 const TEST_VARSTRUCTS: &[VarStruct<'static>] = &[

--- a/utils/zerovec/derive/examples/make_var.rs
+++ b/utils/zerovec/derive/examples/make_var.rs
@@ -59,6 +59,20 @@ struct MultiFieldStruct<'a> {
     f: char,
 }
 
+#[make_varule(MultiFieldConsecutiveStructULE)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
+#[zerovec::derive(Serialize, Deserialize, Debug)]
+struct MultiFieldConsecutiveStruct<'a> {
+    #[serde(borrow)]
+    a: Cow<'a, str>,
+    #[serde(borrow)]
+    b: Cow<'a, str>,
+    #[serde(borrow)]
+    c: Cow<'a, str>,
+    #[serde(borrow)]
+    d: Cow<'a, str>,
+}
+
 #[make_varule(CustomVarFieldULE)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
 #[zerovec::derive(Serialize, Deserialize, Debug)]
@@ -139,6 +153,10 @@ fn main() {
         assert_eq!(stack, &MultiFieldStruct::zero_from(zero))
     });
 
+    assert_zerovec::<MultiFieldConsecutiveStructULE, MultiFieldConsecutiveStruct, _>(TEST_MULTICONSECUTIVE, |stack, zero| {
+        assert_eq!(stack, &MultiFieldConsecutiveStruct::zero_from(zero))
+    });
+
     let vartuples = &[
         VarTupleStruct(101, 'ø', TEST_STRINGS1.into()),
         VarTupleStruct(9499, '⸘', TEST_STRINGS2.into()),
@@ -147,6 +165,8 @@ fn main() {
     assert_zerovec::<VarTupleStructULE, VarTupleStruct, _>(vartuples, |stack, zero| {
         assert_eq!(stack, &VarTupleStruct::zero_from(zero))
     });
+
+    println!("successful");
 }
 
 const TEST_VARSTRUCTS: &[VarStruct<'static>] = &[
@@ -195,5 +215,14 @@ const TEST_MULTIFIELD: &[MultiFieldStruct<'static>] = &[
         d: 89,
         e: Cow::Borrowed("many 好多嘅 string"),
         f: 'ə',
+    },
+];
+
+const TEST_MULTICONSECUTIVE: &[MultiFieldConsecutiveStruct<'static>] = &[
+    MultiFieldConsecutiveStruct {
+        a: Cow::Borrowed("one"),
+        b: Cow::Borrowed("2"),
+        c: Cow::Borrowed("three"),
+        d: Cow::Borrowed("four"),
     },
 ];

--- a/utils/zerovec/src/ule/multi.rs
+++ b/utils/zerovec/src/ule/multi.rs
@@ -147,6 +147,8 @@ unsafe impl VarULE for MultiFieldsULE {
     #[inline]
     unsafe fn from_byte_slice_unchecked(bytes: &[u8]) -> &Self {
         // &Self is transparent over &VZS<..>
-        mem::transmute(<VarZeroSlice<[u8], Index32>>::from_byte_slice_unchecked(bytes))
+        mem::transmute(<VarZeroSlice<[u8], Index32>>::from_byte_slice_unchecked(
+            bytes,
+        ))
     }
 }

--- a/utils/zerovec/src/ule/multi.rs
+++ b/utils/zerovec/src/ule/multi.rs
@@ -44,7 +44,7 @@ impl MultiFieldsULE {
                 lengths, output,
             );
             debug_assert!(
-                <VarZeroSlice<[u8]>>::validate_byte_slice(output).is_ok(),
+                <VarZeroSlice<[u8], Index32>>::validate_byte_slice(output).is_ok(),
                 "Encoded slice must be valid VarZeroSlice"
             );
             // Safe since write_serializable_bytes produces a valid VarZeroSlice buffer
@@ -141,12 +141,12 @@ unsafe impl VarULE for MultiFieldsULE {
     /// This impl exists so that EncodeAsVarULE can work.
     #[inline]
     fn validate_byte_slice(slice: &[u8]) -> Result<(), ZeroVecError> {
-        <VarZeroSlice<[u8]>>::validate_byte_slice(slice)
+        <VarZeroSlice<[u8], Index32>>::validate_byte_slice(slice)
     }
 
     #[inline]
     unsafe fn from_byte_slice_unchecked(bytes: &[u8]) -> &Self {
         // &Self is transparent over &VZS<..>
-        mem::transmute(<VarZeroSlice<[u8]>>::from_byte_slice_unchecked(bytes))
+        mem::transmute(<VarZeroSlice<[u8], Index32>>::from_byte_slice_unchecked(bytes))
     }
 }


### PR DESCRIPTION
MultiFieldsULE uses `Index32`, but this wasn't passed explicitly everywhere, so some places incorrectly defaulted to `Index16`.

The existing test suite did not discover this error, but I'm not sure why. Added a new struct with four internal VZVs, which triggers the bug. A struct with three internal VZVs also does not trigger the bug.

