### PR TITLE
Support Deserialization for `VarZeroVec<VarZeroSlice>`

### DIFF
--- a/utils/zerovec/src/varzerovec/serde.rs
+++ b/utils/zerovec/src/varzerovec/serde.rs
@@ -25,6 +25,32 @@ impl<T: ?Sized, F: VarZeroVecFormat> Default for VarZeroVecVisitor<T, F> {
     }
 }
 
+struct VarZeroSliceBoxVisitor<T: ?Sized, F: VarZeroVecFormat> {
+    #[allow(clippy::type_complexity)] // this is a private marker type, who cares
+    marker: PhantomData<(fn() -> Box<T>, F)>,
+}
+
+impl<T: ?Sized, F: VarZeroVecFormat> Default for VarZeroSliceBoxVisitor<T, F> {
+    fn default() -> Self {
+        Self {
+            marker: PhantomData,
+        }
+    }
+}
+
+struct VarZeroSliceRefVisitor<T: ?Sized, F: VarZeroVecFormat> {
+    #[allow(clippy::type_complexity)] // this is a private marker type, who cares
+    marker: PhantomData<(fn() -> Box<T>, F)>,
+}
+
+impl<T: ?Sized, F: VarZeroVecFormat> Default for VarZeroSliceRefVisitor<T, F> {
+    fn default() -> Self {
+        Self {
+            marker: PhantomData,
+        }
+    }
+}
+
 impl<'de, T, F> Visitor<'de> for VarZeroVecVisitor<T, F>
 where
     T: VarULE + ?Sized,
@@ -60,6 +86,53 @@ where
     }
 }
 
+impl<'de, T, F> Visitor<'de> for VarZeroSliceBoxVisitor<T, F>
+where
+    T: VarULE + ?Sized,
+    Box<T>: Deserialize<'de>,
+    F: VarZeroVecFormat,
+{
+    type Value = Box<VarZeroSlice<T, F>>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a sequence or borrowed buffer of bytes")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut vec: Vec<Box<T>> = if let Some(capacity) = seq.size_hint() {
+            Vec::with_capacity(capacity)
+        } else {
+            Vec::new()
+        };
+        while let Some(value) = seq.next_element::<Box<T>>()? {
+            vec.push(value);
+        }
+        Ok(VarZeroVec::from(&vec).to_boxed())
+    }
+}
+
+impl<'de, T, F> Visitor<'de> for VarZeroSliceRefVisitor<T, F>
+where
+    T: VarULE + ?Sized,
+    F: VarZeroVecFormat,
+{
+    type Value = &'de VarZeroSlice<T, F>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a sequence or borrowed buffer of bytes")
+    }
+
+    fn visit_borrowed_bytes<E>(self, bytes: &'de [u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        VarZeroSlice::parse_byte_slice(bytes).map_err(de::Error::custom)
+    }
+}
+
 /// This impl requires enabling the optional `serde` Cargo feature of the `zerovec` crate
 impl<'de, 'a, T, F> Deserialize<'de> for VarZeroVec<'a, T, F>
 where
@@ -72,7 +145,7 @@ where
     where
         D: Deserializer<'de>,
     {
-        let visitor = VarZeroVecVisitor::default();
+        let visitor: VarZeroVecVisitor<T, F> = VarZeroVecVisitor::default();
         if deserializer.is_human_readable() {
             deserializer.deserialize_seq(visitor)
         } else {
@@ -85,7 +158,6 @@ where
 impl<'de, 'a, T, F> Deserialize<'de> for &'a VarZeroSlice<T, F>
 where
     T: VarULE + ?Sized,
-    Box<T>: Deserialize<'de>,
     F: VarZeroVecFormat,
     'de: 'a,
 {
@@ -98,15 +170,33 @@ where
                 "&VarZeroSlice cannot be deserialized from human-readable formats",
             ))
         } else {
-            let deserialized: VarZeroVec<'a, T, F> = VarZeroVec::deserialize(deserializer)?;
-            let borrowed = if let VarZeroVec::Borrowed(b) = deserialized {
-                b
-            } else {
-                return Err(de::Error::custom(
-                    "&VarZeroSlice can only deserialize in zero-copy ways",
-                ));
-            };
-            Ok(borrowed)
+            let visitor: VarZeroSliceRefVisitor<T, F> = VarZeroSliceRefVisitor::default();
+            let deserialized: &'a VarZeroSlice<_, _> = deserializer.deserialize_bytes(visitor)?;
+            Ok(deserialized)
+        }
+    }
+}
+
+/// This impl requires enabling the optional `serde` Cargo feature of the `zerovec` crate
+impl<'de, 'a, T, F> Deserialize<'de> for Box<VarZeroSlice<T, F>>
+where
+    T: VarULE + ?Sized,
+    Box<T>: Deserialize<'de>,
+    F: VarZeroVecFormat,
+    'de: 'a,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            let visitor: VarZeroSliceBoxVisitor<T, F> = VarZeroSliceBoxVisitor::default();
+            let deserialized: Box<VarZeroSlice<_, _>> = deserializer.deserialize_seq(visitor)?;
+            Ok(deserialized)
+        } else {
+            Err(de::Error::custom(
+                "Box<VarZeroSlice> should not be deserialized from byte-slice formats",
+            ))
         }
     }
 }

--- a/utils/zerovec/src/varzerovec/serde.rs
+++ b/utils/zerovec/src/varzerovec/serde.rs
@@ -161,6 +161,12 @@ mod test {
     }
 
     #[derive(serde::Serialize, serde::Deserialize)]
+    struct DeriveTest_VarZeroVec_of_VarZeroSlice<'data> {
+        #[serde(borrow)]
+        _data: VarZeroVec<'data, VarZeroSlice<str>>,
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize)]
     struct DeriveTest_VarZeroSlice<'data> {
         #[serde(borrow)]
         _data: &'data VarZeroSlice<str>,

--- a/utils/zerovec/src/varzerovec/serde.rs
+++ b/utils/zerovec/src/varzerovec/serde.rs
@@ -102,7 +102,9 @@ where
     where
         E: de::Error,
     {
-        VarZeroSlice::parse_byte_slice(bytes).map(VarULE::to_boxed).map_err(de::Error::custom)
+        VarZeroSlice::parse_byte_slice(bytes)
+            .map(VarULE::to_boxed)
+            .map_err(de::Error::custom)
     }
 
     fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>


### PR DESCRIPTION
This was previously unsupported (see first commit).

cc @Manishearth 

There might be an easier way? As a warning, this was difficult to figure out, because an inferred type (on `let visitor =`) caused a difficult to understand type checking overflow error. Adding type annotations fixed that.