### PR TITLE
Deserialization for VarZeroVec<VarZeroSlice>, take 2

### DIFF
--- a/utils/zerovec/src/varzerovec/serde.rs
+++ b/utils/zerovec/src/varzerovec/serde.rs
@@ -72,7 +72,7 @@ where
     where
         D: Deserializer<'de>,
     {
-        let visitor = VarZeroVecVisitor::default();
+        let visitor = VarZeroVecVisitor::<T, F>::default();
         if deserializer.is_human_readable() {
             deserializer.deserialize_seq(visitor)
         } else {
@@ -98,7 +98,7 @@ where
                 "&VarZeroSlice cannot be deserialized from human-readable formats",
             ))
         } else {
-            let deserialized: VarZeroVec<'a, T, F> = VarZeroVec::deserialize(deserializer)?;
+            let deserialized = VarZeroVec::<'a, T, F>::deserialize(deserializer)?;
             let borrowed = if let VarZeroVec::Borrowed(b) = deserialized {
                 b
             } else {
@@ -108,6 +108,22 @@ where
             };
             Ok(borrowed)
         }
+    }
+}
+
+/// This impl requires enabling the optional `serde` Cargo feature of the `zerovec` crate
+impl<'de, T, F> Deserialize<'de> for Box<VarZeroSlice<T, F>>
+where
+    T: VarULE + ?Sized,
+    Box<T>: Deserialize<'de>,
+    F: VarZeroVecFormat,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let deserialized = VarZeroVec::<T, F>::deserialize(deserializer)?;
+        Ok(crate::ule::encode_varule_to_box(&deserialized))
     }
 }
 
@@ -164,6 +180,12 @@ mod test {
     struct DeriveTest_VarZeroSlice<'data> {
         #[serde(borrow)]
         _data: &'data VarZeroSlice<str>,
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct DeriveTest_VarZeroVec_of_VarZeroSlice<'data> {
+        #[serde(borrow)]
+        _data: VarZeroVec<'data, VarZeroSlice<str>>,
     }
 
     // ["foo", "bar", "baz", "dolor", "quux", "lorem ipsum"];

--- a/utils/zerovec/src/varzerovec/serde.rs
+++ b/utils/zerovec/src/varzerovec/serde.rs
@@ -123,7 +123,7 @@ where
         D: Deserializer<'de>,
     {
         let deserialized = VarZeroVec::<T, F>::deserialize(deserializer)?;
-        Ok(crate::ule::encode_varule_to_box(&deserialized))
+        Ok(deserialized.to_boxed())
     }
 }
 


### PR DESCRIPTION
https://github.com/unicode-org/icu4x/pull/3643

I noticed that the error included Rust slices (`[T]`):

```text
error[E0275]: overflow evaluating the requirement `Box<[_]>: Deserialize<'_>`
   --> utils/zerovec/src/varzerovec/serde.rs:103:66
    |
103 |             let deserialized: VarZeroVec<'a, T, F> = VarZeroVec::deserialize(deserializer)?;
    |                                                                  ^^^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`zerovec`)
note: required for `Box<varzerovec::slice::VarZeroSlice<[_], _>>` to implement `Deserialize<'_>`
   --> utils/zerovec/src/varzerovec/serde.rs:117:21

```


which should absolutely not be getting introduced at any point here. The trait resolver is getting sufficiently confused when looking for an impl and it goes and looks at the `Box<[T]>: Deserialize` from the serde crate. It then continues to confuse itself. I think this is a trait resolver bug.

The fix is to be very specific about which deserialize impl is being called within these impls.