### PR TITLE
Add negative num tests for Buddhist

### DIFF
--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -242,7 +242,7 @@ mod test {
     #[test]
     fn test_buddhist_roundtrip_near_epoch() {
         // Buddhist epoch start RD: -198326
-        for i in 188326..=208326 {
+        for i in -208326..=-188326 {
             let rd = RataDie::new(i);
             let iso1 = Iso::iso_from_fixed(rd);
             let buddhist = iso1.to_calendar(Buddhist);
@@ -280,8 +280,8 @@ mod test {
     #[test]
     fn test_buddhist_directionality_near_epoch() {
         // Buddhist epoch start RD: -198326
-        for i in 198226..=198426 {
-            for j in 198226..=198426 {
+        for i in -198426..=-198226 {
+            for j in -198426..=-198226 {
                 let iso_i = Iso::iso_from_fixed(RataDie::new(i));
                 let iso_j = Iso::iso_from_fixed(RataDie::new(j));
 
@@ -413,6 +413,30 @@ mod test {
     fn test_buddhist_cases_near_epoch() {
         // 1 BE = 543 BCE = -542 ISO
         let cases = [
+            TestCase {
+                iso_year: -554,
+                iso_month: 12,
+                iso_day: 31,
+                buddhist_year: -11,
+                buddhist_month: 12,
+                buddhist_day: 31,
+            },
+            TestCase {
+                iso_year: -553,
+                iso_month: 1,
+                iso_day: 1,
+                buddhist_year: -10,
+                buddhist_month: 1,
+                buddhist_day: 1,
+            },
+            TestCase {
+                iso_year: -544,
+                iso_month: 8,
+                iso_day: 31,
+                buddhist_year: -1,
+                buddhist_month: 8,
+                buddhist_day: 31,
+            },
             TestCase {
                 iso_year: -543,
                 iso_month: 5,

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -220,3 +220,233 @@ fn iso_year_as_buddhist(year: i32) -> types::FormattableYear {
         related_iso: None,
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::rata_die::RataDie;
+
+    use super::*;
+
+    #[test]
+    fn test_buddhist_roundtrip_near_rd_zero() {
+        for i in -10000..=10000 {
+            let rd = RataDie::new(i);
+            let iso1 = Iso::iso_from_fixed(rd);
+            let buddhist = iso1.to_calendar(Buddhist);
+            let iso2 = buddhist.to_calendar(Iso);
+            let result = Iso::fixed_from_iso(iso2.inner);
+            assert_eq!(rd, result);
+        }
+    }
+
+    #[test]
+    fn test_buddhist_roundtrip_near_epoch() {
+        for i in 188330..=208330 {
+            let rd = RataDie::new(i);
+            let iso1 = Iso::iso_from_fixed(rd);
+            let buddhist = iso1.to_calendar(Buddhist);
+            let iso2 = buddhist.to_calendar(Iso);
+            let result = Iso::fixed_from_iso(iso2.inner);
+            assert_eq!(rd, result);
+        }
+    }
+
+    #[test]
+    fn test_buddhist_directionality_near_rd_zero() {
+        for i in -100..=100 {
+            for j in -100..=100 {
+                let iso_i = Iso::iso_from_fixed(RataDie::new(i));
+                let iso_j = Iso::iso_from_fixed(RataDie::new(j));
+
+                let buddhist_i = Date::new_from_iso(iso_i, Buddhist);
+                let buddhist_j = Date::new_from_iso(iso_j, Buddhist);
+
+                assert_eq!(
+                    i.cmp(&j),
+                    iso_i.cmp(&iso_j),
+                    "ISO directionality inconsistent with directionality for i: {i}, j: {j}"
+                );
+
+                assert_eq!(
+                    i.cmp(&j),
+                    buddhist_i.cmp(&buddhist_j),
+                    "Buddhist directionality inconsistent with directionality for i: {i}, j: {j}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_buddhist_directionality_near_epoch() {
+        for i in 198230..=198430 {
+            for j in 198230..=198430 {
+                let iso_i = Iso::iso_from_fixed(RataDie::new(i));
+                let iso_j = Iso::iso_from_fixed(RataDie::new(j));
+
+                let buddhist_i = Date::new_from_iso(iso_i, Buddhist);
+                let buddhist_j = Date::new_from_iso(iso_j, Buddhist);
+
+                assert_eq!(
+                    i.cmp(&j),
+                    iso_i.cmp(&iso_j),
+                    "ISO directionality inconsistent with directionality for i: {i}, j: {j}"
+                );
+
+                assert_eq!(
+                    i.cmp(&j),
+                    buddhist_i.cmp(&buddhist_j),
+                    "Buddhist directionality inconsistent with directionality for i: {i}, j: {j}"
+                );
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestCase {
+        iso_year: i32,
+        iso_month: u8,
+        iso_day: u8,
+        buddhist_year: i32,
+        buddhist_month: u8,
+        buddhist_day: u8,
+    }
+
+    fn check_test_case(case: TestCase) {
+        let iso_year = case.iso_year;
+        let iso_month = case.iso_month;
+        let iso_day = case.iso_day;
+        let buddhist_year = case.buddhist_year;
+        let buddhist_month = case.buddhist_month;
+        let buddhist_day = case.buddhist_day;
+
+        let iso1 = Date::try_new_iso_date(iso_year, iso_month, iso_day).unwrap();
+        let buddhist1 = iso1.to_calendar(Buddhist);
+        assert_eq!(
+            buddhist1.year().number,
+            buddhist_year as i32,
+            "Iso -> Buddhist year check failed for case: {case:?}"
+        );
+        assert_eq!(
+            buddhist1.month().ordinal,
+            buddhist_month as u32,
+            "Iso -> Buddhist month check failed for case: {case:?}"
+        );
+        assert_eq!(
+            buddhist1.day_of_month().0,
+            buddhist_day as u32,
+            "Iso -> Buddhist day check failed for case: {case:?}"
+        );
+
+        let buddhist2 =
+            Date::try_new_buddhist_date(buddhist_year, buddhist_month, buddhist_day).unwrap();
+        let iso2 = buddhist2.to_calendar(Iso);
+        assert_eq!(
+            iso2.year().number,
+            iso_year as i32,
+            "Buddhist -> Iso year check failed for case: {case:?}"
+        );
+        assert_eq!(
+            iso2.month().ordinal,
+            iso_month as u32,
+            "Buddhist -> Iso month check failed for case: {case:?}"
+        );
+        assert_eq!(
+            iso2.day_of_month().0,
+            iso_day as u32,
+            "Buddhist -> Iso day check failed for case: {case:?}"
+        );
+    }
+
+    #[test]
+    fn test_buddhist_cases_near_rd_zero() {
+        let cases = [
+            TestCase {
+                iso_year: -100,
+                iso_month: 2,
+                iso_day: 15,
+                buddhist_year: 443,
+                buddhist_month: 2,
+                buddhist_day: 15,
+            },
+            TestCase {
+                iso_year: -3,
+                iso_month: 10,
+                iso_day: 29,
+                buddhist_year: 540,
+                buddhist_month: 10,
+                buddhist_day: 29,
+            },
+            TestCase {
+                iso_year: 0,
+                iso_month: 12,
+                iso_day: 31,
+                buddhist_year: 543,
+                buddhist_month: 12,
+                buddhist_day: 31,
+            },
+            TestCase {
+                iso_year: 1,
+                iso_month: 1,
+                iso_day: 1,
+                buddhist_year: 544,
+                buddhist_month: 1,
+                buddhist_day: 1,
+            },
+            TestCase {
+                iso_year: 4,
+                iso_month: 2,
+                iso_day: 29,
+                buddhist_year: 547,
+                buddhist_month: 2,
+                buddhist_day: 29,
+            },
+        ];
+
+        for case in cases {
+            check_test_case(case);
+        }
+    }
+
+    #[test]
+    fn test_buddhist_cases_near_epoch() {
+        // 1 BE = 543 BCE = -542 ISO
+        let cases = [
+            TestCase {
+                iso_year: -543,
+                iso_month: 5,
+                iso_day: 12,
+                buddhist_year: 0,
+                buddhist_month: 5,
+                buddhist_day: 12,
+            },
+            TestCase {
+                iso_year: -543,
+                iso_month: 12,
+                iso_day: 31,
+                buddhist_year: 0,
+                buddhist_month: 12,
+                buddhist_day: 31,
+            },
+            TestCase {
+                iso_year: -542,
+                iso_month: 1,
+                iso_day: 1,
+                buddhist_year: 1,
+                buddhist_month: 1,
+                buddhist_day: 1,
+            },
+            TestCase {
+                iso_year: -541,
+                iso_month: 7,
+                iso_day: 9,
+                buddhist_year: 2,
+                buddhist_month: 7,
+                buddhist_day: 9,
+            },
+        ];
+
+        for case in cases {
+            check_test_case(case);
+        }
+    }
+}

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -325,7 +325,7 @@ mod test {
         let buddhist1 = iso1.to_calendar(Buddhist);
         assert_eq!(
             buddhist1.year().number,
-            buddhist_year as i32,
+            buddhist_year,
             "Iso -> Buddhist year check failed for case: {case:?}"
         );
         assert_eq!(
@@ -344,7 +344,7 @@ mod test {
         let iso2 = buddhist2.to_calendar(Iso);
         assert_eq!(
             iso2.year().number,
-            iso_year as i32,
+            iso_year,
             "Buddhist -> Iso year check failed for case: {case:?}"
         );
         assert_eq!(

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -241,7 +241,8 @@ mod test {
 
     #[test]
     fn test_buddhist_roundtrip_near_epoch() {
-        for i in 188330..=208330 {
+        // Buddhist epoch start RD: -198326
+        for i in 188326..=208326 {
             let rd = RataDie::new(i);
             let iso1 = Iso::iso_from_fixed(rd);
             let buddhist = iso1.to_calendar(Buddhist);
@@ -278,8 +279,9 @@ mod test {
 
     #[test]
     fn test_buddhist_directionality_near_epoch() {
-        for i in 198230..=198430 {
-            for j in 198230..=198430 {
+        // Buddhist epoch start RD: -198326
+        for i in 198226..=198426 {
+            for j in 198226..=198426 {
                 let iso_i = Iso::iso_from_fixed(RataDie::new(i));
                 let iso_j = Iso::iso_from_fixed(RataDie::new(j));
 


### PR DESCRIPTION
Tests for `Buddhist` calendar including:

- Roundtrip testing for negative and positive RataDie values near RD 0
- Roundtrip testing for negative and positive RataDie values near the Buddhist epoch start date (RD -198326)
- Test case checks for negative and positive ISO years near ISO year 1 (Buddhist year 544)
- Test case checks for negative and positive Buddhist years near Buddhist year 1 (ISO year -542)