### PR TITLE
Updated regex-automata to 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2767,13 +2767,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9368763f5a9b804326f3af749e16f9abf378d227bcdee7634b13d8f17793782"
-dependencies = [
- "memchr",
- "regex-syntax",
-]
+checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
 
 [[package]]
 name = "regex-syntax"

--- a/components/list/Cargo.toml
+++ b/components/list/Cargo.toml
@@ -31,7 +31,7 @@ all-features = true
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
 icu_provider = { version = "1.2.0", path = "../../provider/core", features = ["macros"] }
-regex-automata = { version = "0.2", default-features = false }
+regex-automata = { version = "0.3", default-features = false, features = ["dfa-search", "dfa-build"] }
 writeable = { version = "0.5.1", path = "../../utils/writeable" }
 
 databake = { version = "0.1.3", path = "../../utils/databake", optional = true, features = ["derive"]}

--- a/components/list/src/lazy_automaton.rs
+++ b/components/list/src/lazy_automaton.rs
@@ -4,7 +4,8 @@
 
 use regex_automata::dfa::sparse::DFA;
 use regex_automata::dfa::Automaton;
-use regex_automata::util::id::StateID;
+use regex_automata::util::primitives::StateID;
+use regex_automata::Input;
 use writeable::Writeable;
 
 pub trait LazyAutomaton: Automaton {
@@ -35,7 +36,7 @@ impl<T: AsRef<[u8]>> LazyAutomaton for DFA<T> {
         let mut stepper = DFAStepper {
             // If start == 0 the start state does not depend on the actual string, so
             // we can just pass an empty slice.
-            state: self.start_state_forward(None, &[], 0, 0),
+            state: self.start_state_forward(&Input::new(&[])),
             dfa: &self.as_ref(),
         };
 


### PR DESCRIPTION
Regex has released the new 0.3 regex-automata crate, used in icu-list, and I wanted to upgrade it, in order to reduce duplicate dependencies and no-longer-updated dependencies.

The only logic change is that now `start_state_forward()` can return an error, which the current `matches_earliest_fwd_lazy()` function cannot propagate.

Since the input is a static empty haystack, should I just call `expect()` on the error?

Awaiting for that feedback before proposing the final solution.