### PR TITLE
Add Republic of China (ROC) calendar

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -13,6 +13,7 @@ use crate::indian::Indian;
 use crate::iso::Iso;
 use crate::japanese::{Japanese, JapaneseExtended};
 use crate::persian::Persian;
+use crate::roc::Roc;
 use crate::{
     types, AsCalendar, Calendar, CalendarError, Date, DateDuration, DateDurationUnit, DateTime, Ref,
 };
@@ -92,6 +93,8 @@ pub enum AnyCalendar {
     Iso(Iso),
     /// A [`Chinese`] calendar
     Chinese(Chinese),
+    /// A [`Roc`] calendar
+    Roc(Roc),
 }
 
 // TODO(#3469): Decide on the best way to implement Ord.
@@ -117,6 +120,8 @@ pub enum AnyDateInner {
     Chinese(<Chinese as Calendar>::DateInner),
     /// A date for a [`Coptic`] calendar
     Coptic(<Coptic as Calendar>::DateInner),
+    /// A date for a [`Roc`] calendar
+    Roc(<Roc as Calendar>::DateInner),
     /// A date for an [`Iso`] calendar
     Iso(<Iso as Calendar>::DateInner),
 }
@@ -182,6 +187,7 @@ impl Calendar for AnyCalendar {
             Self::Coptic(ref c) => {
                 AnyDateInner::Coptic(c.date_from_codes(era, year, month_code, day)?)
             }
+            Self::Roc(ref c) => AnyDateInner::Roc(c.date_from_codes(era, year, month_code, day)?),
             Self::Iso(ref c) => AnyDateInner::Iso(c.date_from_codes(era, year, month_code, day)?),
         };
         Ok(ret)
@@ -198,6 +204,7 @@ impl Calendar for AnyCalendar {
             Self::Iso(ref c) => AnyDateInner::Iso(c.date_from_iso(iso)),
             Self::Persian(ref c) => AnyDateInner::Persian(c.date_from_iso(iso)),
             Self::Chinese(ref c) => AnyDateInner::Chinese(c.date_from_iso(iso)),
+            Self::Roc(ref c) => AnyDateInner::Roc(c.date_from_iso(iso)),
         }
     }
 
@@ -379,6 +386,7 @@ impl Calendar for AnyCalendar {
             Self::Iso(_) => "AnyCalendar (Iso)",
             Self::Persian(_) => "AnyCalendar (Persian)",
             Self::Chinese(_) => "AnyCalendar (Chinese)",
+            Self::Roc(_) => "AnyCalendar (Roc)",
         }
     }
 
@@ -408,6 +416,7 @@ impl AnyCalendar {
             AnyCalendarKind::Indian => AnyCalendar::Indian(Indian),
             AnyCalendarKind::Persian => AnyCalendar::Persian(Persian),
             AnyCalendarKind::Chinese => AnyCalendar::Chinese(Chinese),
+            AnyCalendarKind::Roc => AnyCalendar::Roc(Roc),
             AnyCalendarKind::Coptic => AnyCalendar::Coptic(Coptic),
             AnyCalendarKind::Iso => AnyCalendar::Iso(Iso),
             AnyCalendarKind::Ethiopian => AnyCalendar::Ethiopian(Ethiopian::new_with_era_style(
@@ -439,6 +448,7 @@ impl AnyCalendar {
             AnyCalendarKind::Indian => AnyCalendar::Indian(Indian),
             AnyCalendarKind::Persian => AnyCalendar::Persian(Persian),
             AnyCalendarKind::Chinese => AnyCalendar::Chinese(Chinese),
+            AnyCalendarKind::Roc => AnyCalendar::Roc(Roc),
             AnyCalendarKind::Coptic => AnyCalendar::Coptic(Coptic),
             AnyCalendarKind::Iso => AnyCalendar::Iso(Iso),
             AnyCalendarKind::Ethiopian => AnyCalendar::Ethiopian(Ethiopian::new_with_era_style(
@@ -471,6 +481,7 @@ impl AnyCalendar {
             AnyCalendarKind::Indian => AnyCalendar::Indian(Indian),
             AnyCalendarKind::Persian => AnyCalendar::Persian(Persian),
             AnyCalendarKind::Chinese => AnyCalendar::Chinese(Chinese),
+            AnyCalendarKind::Roc => AnyCalendar::Roc(Roc),
             AnyCalendarKind::Coptic => AnyCalendar::Coptic(Coptic),
             AnyCalendarKind::Iso => AnyCalendar::Iso(Iso),
             AnyCalendarKind::Ethiopian => AnyCalendar::Ethiopian(Ethiopian::new_with_era_style(
@@ -501,6 +512,7 @@ impl AnyCalendar {
             AnyCalendarKind::Indian => AnyCalendar::Indian(Indian),
             AnyCalendarKind::Persian => AnyCalendar::Persian(Persian),
             AnyCalendarKind::Chinese => AnyCalendar::Chinese(Chinese),
+            AnyCalendarKind::Roc => AnyCalendar::Roc(Roc),
             AnyCalendarKind::Coptic => AnyCalendar::Coptic(Coptic),
             AnyCalendarKind::Iso => AnyCalendar::Iso(Iso),
             AnyCalendarKind::Ethiopian => AnyCalendar::Ethiopian(Ethiopian::new_with_era_style(
@@ -566,6 +578,7 @@ impl AnyCalendar {
             Self::Iso(_) => "Iso",
             Self::Persian(_) => "Persian",
             Self::Chinese(_) => "Chinese",
+            Self::Roc(_) => "Roc",
         }
     }
 
@@ -585,6 +598,7 @@ impl AnyCalendar {
             Self::Iso(_) => AnyCalendarKind::Iso,
             Self::Persian(_) => AnyCalendarKind::Persian,
             Self::Chinese(_) => AnyCalendarKind::Chinese,
+            Self::Roc(_) => AnyCalendarKind::Roc,
         }
     }
 
@@ -630,6 +644,7 @@ impl AnyDateInner {
             AnyDateInner::Iso(_) => "Iso",
             AnyDateInner::Persian(_) => "Persian",
             AnyDateInner::Chinese(_) => "Chinese",
+            AnyDateInner::Roc(_) => "Roc",
         }
     }
 }
@@ -660,6 +675,8 @@ pub enum AnyCalendarKind {
     Persian,
     /// The kind of a [`Chinese`] calendar
     Chinese,
+    /// The kind of a [`Roc`] calendar
+    Roc,
 }
 
 impl AnyCalendarKind {
@@ -733,6 +750,7 @@ impl AnyCalendarKind {
             AnyCalendarKind::EthiopianAmeteAlem => "ethioaa",
             AnyCalendarKind::Persian => "persian",
             AnyCalendarKind::Chinese => "chinese",
+            AnyCalendarKind::Roc => "roc",
         }
     }
 
@@ -750,6 +768,7 @@ impl AnyCalendarKind {
             AnyCalendarKind::EthiopianAmeteAlem => value!("ethioaa"),
             AnyCalendarKind::Persian => value!("persian"),
             AnyCalendarKind::Chinese => value!("chinese"),
+            AnyCalendarKind::Roc => value!("roc"),
         }
     }
 

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -22,7 +22,7 @@
 //! assert_eq!(date_gregorian.month().ordinal, 1);
 //! assert_eq!(date_gregorian.day_of_month().0, 2);
 //!
-//! // `DateTime` type
+//! // `DateTime` checks
 //! assert_eq!(datetime_gregorian.date.year().number, 1970);
 //! assert_eq!(datetime_gregorian.date.month().ordinal, 1);
 //! assert_eq!(datetime_gregorian.date.day_of_month().0, 2);
@@ -165,7 +165,6 @@ impl Date<Gregorian> {
     ///
     /// ```rust
     /// use icu::calendar::Date;
-    /// use std::convert::TryFrom;
     ///
     /// // Conversion from ISO to Gregorian
     /// let date_gregorian = Date::try_new_gregorian_date(1970, 1, 2)

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -134,6 +134,7 @@ pub mod julian;
 pub mod persian;
 pub mod provider;
 mod rata_die;
+pub mod roc;
 pub mod types;
 mod week_of;
 

--- a/components/calendar/src/roc.rs
+++ b/components/calendar/src/roc.rs
@@ -452,4 +452,29 @@ mod test {
             }
         }
     }
+
+    #[test]
+    fn test_roc_directionality_near_rd_zero() {
+        // Same as `test_directionality_near_epoch`, but with a focus around RD 0
+        for i in -100..=100 {
+            for j in -100..100 {
+                let iso_i = Iso::iso_from_fixed(RataDie::new(i));
+                let iso_j = Iso::iso_from_fixed(RataDie::new(j));
+
+                let roc_i = iso_i.to_calendar(Roc);
+                let roc_j = iso_j.to_calendar(Roc);
+
+                assert_eq!(
+                    i.cmp(&j),
+                    iso_i.cmp(&iso_j),
+                    "ISO directionality inconcistent with directionality for i: {i}, j: {j}"
+                );
+                assert_eq!(
+                    i.cmp(&j),
+                    roc_i.cmp(&roc_j),
+                    "ROC directionality inconsistent with directionality for i: {i}, j: {j}"
+                );
+            }
+        }
+    }
 }

--- a/components/calendar/src/roc.rs
+++ b/components/calendar/src/roc.rs
@@ -91,7 +91,7 @@ impl Calendar for Roc {
             return Err(CalendarError::UnknownEra(era.0, self.debug_name()));
         };
 
-        ArithmeticDate::new_from_solar_codes(self, year, month_code, day)
+        ArithmeticDate::new_from_codes(self, year, month_code, day)
             .map(IsoDateInner)
             .map(RocDateInner)
     }

--- a/components/calendar/src/roc.rs
+++ b/components/calendar/src/roc.rs
@@ -33,9 +33,10 @@
 
 use crate::{
     calendar_arithmetic::ArithmeticDate,
+    helpers::{i64_to_i32, I32Result},
     iso::IsoDateInner,
     types::{self, Era},
-    Calendar, CalendarError, Date, DateTime, Iso, helpers::{i64_to_i32, I32Result},
+    Calendar, CalendarError, Date, DateTime, Iso,
 };
 use tinystr::tinystr;
 
@@ -244,12 +245,8 @@ impl DateTime<Roc> {
 
 pub(crate) fn year_as_roc(year: i64) -> types::FormattableYear {
     let year_i32 = match i64_to_i32(year) {
-        I32Result::BelowMin(_) => {
-            i32::MIN
-        }
-        I32Result::AboveMax(_) => {
-            i32::MAX
-        }
+        I32Result::BelowMin(_) => i32::MIN,
+        I32Result::AboveMax(_) => i32::MAX,
         I32Result::WithinRange(y) => y,
     };
     let offset_i64 = ROC_ERA_OFFSET as i64;

--- a/components/calendar/src/roc.rs
+++ b/components/calendar/src/roc.rs
@@ -51,6 +51,9 @@ const ROC_ERA_OFFSET: i32 = 1911;
 ///
 /// [Republic of China calendar]: https://en.wikipedia.org/wiki/Republic_of_China_calendar
 ///
+/// The Republic of China calendar should not be confused with the Chinese traditional lunar calendar
+/// (see [`Chinese`]).
+///
 /// # Era codes
 ///
 /// This calendar supports two era codes: `"minguo"`, corresponding to years in the 民國 (minguo) era (CE year 1912 and

--- a/components/calendar/src/roc.rs
+++ b/components/calendar/src/roc.rs
@@ -46,7 +46,7 @@ const ROC_ERA_OFFSET: i32 = 1911;
 
 /// The Republic of China (ROC) Calendar
 ///
-/// The [ROC calendar] is a solar calendar used in Taiwan and Penghu, as well as by overseas diaspora from
+/// The [Republic of China calendar] is a solar calendar used in Taiwan and Penghu, as well as by overseas diaspora from
 /// those locations. Months and days are identical to the [`Gregorian`] calendar, while years are counted
 /// with 1912, the year of the establishment of the Republic of China, as year 1 of the ROC/Minguo/民国/民國 era.
 ///

--- a/components/calendar/src/roc.rs
+++ b/components/calendar/src/roc.rs
@@ -2,20 +2,64 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use tinystr::tinystr;
+//! This module contains types and implementations for the Republic of China calendar.
+//!
+//! ```rust
+//! use icu::calendar::{roc::Roc, Date, DateTime};
+//!
+//! // `Date` type
+//! let date_iso = Date::try_new_iso_date(1970, 1, 2)
+//!     .expect("Failed to initialize ISO Date instance.");
+//! let date_roc = Date::new_from_iso(date_iso, Roc);
+//!
+//! // `DateTime` type
+//! let datetime_iso = DateTime::try_new_iso_datetime(1970, 1, 2, 13, 1, 0)
+//!     .expect("Failed to initialize ISO DateTime instance.");
+//! let datetime_roc = DateTime::new_from_iso(datetime_iso, Roc);
+//!
+//! // `Date` checks
+//! assert_eq!(date_roc.year().number, 59);
+//! assert_eq!(date_roc.month().ordinal, 1);
+//! assert_eq!(date_roc.day_of_month().0, 2);
+//!
+//! // `DateTime` checks
+//! assert_eq!(datetime_roc.date.year().number, 59);
+//! assert_eq!(datetime_roc.date.month().ordinal, 1);
+//! assert_eq!(datetime_roc.date.day_of_month().0, 2);
+//! assert_eq!(datetime_roc.time.hour.number(), 13);
+//! assert_eq!(datetime_roc.time.minute.number(), 1);
+//! assert_eq!(datetime_roc.time.second.number(), 0);
+//! ```
 
-use crate::{iso::IsoDateInner, Calendar, CalendarError, calendar_arithmetic::ArithmeticDate, Date, Iso, types, DateTime};
+use crate::{
+    calendar_arithmetic::ArithmeticDate,
+    iso::IsoDateInner,
+    types::{self, Era},
+    Calendar, CalendarError, Date, DateTime, Iso,
+};
+use tinystr::tinystr;
 
 /// Year of the beginning of the Taiwanese (ROC/Minguo) calendar.
 /// 1912 ISO = ROC 1
 const ROC_ERA_OFFSET: i32 = 1911;
 
-/// TODO: Documentation
+/// The Republic of China (ROC) Calendar
+///
+/// The [ROC calendar] is a solar calendar used in Taiwan and Penghu, as well as by overseas diaspora from
+/// those locations. Months and days are identical to the [`Gregorian`] calendar, while years are counted
+/// with 1912, the year of the establishment of the Republic of China, as year 1 of the ROC/Minguo/民国/民國 era.
+///
+/// [Republic of China calendar]: https://en.wikipedia.org/wiki/Republic_of_China_calendar
+///
+/// # Era codes
+///
+/// This calendar supports two era codes: `"minguo"`, corresponding to years in the 民國 (minguo) era (CE year 1912 and
+/// after), and `"before minguo"`, corresponding to years before the 民國 (minguo) era (CE year 1911 and before).
 #[derive(Copy, Clone, Debug, Default)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Roc;
 
-/// TODO: Documentation
+/// The inner date type used for representing [`Date`]s of [`Roc`]. See [`Date`] and [`Roc`] for more info.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct RocDateInner(IsoDateInner);
 
@@ -76,7 +120,7 @@ impl Calendar for Roc {
         &self,
         date1: &Self::DateInner,
         date2: &Self::DateInner,
-        calendar2: &Self,
+        _calendar2: &Self,
         largest_unit: crate::DateDurationUnit,
         smallest_unit: crate::DateDurationUnit,
     ) -> crate::DateDuration<Self> {
@@ -89,7 +133,7 @@ impl Calendar for Roc {
     }
 
     fn year(&self, date: &Self::DateInner) -> crate::types::FormattableYear {
-        year_as_roc(date.0.0.year)
+        year_as_roc(date.0 .0.year)
     }
 
     fn month(&self, date: &Self::DateInner) -> crate::types::FormattableMonth {
@@ -101,11 +145,11 @@ impl Calendar for Roc {
     }
 
     fn day_of_year_info(&self, date: &Self::DateInner) -> crate::types::DayOfYearInfo {
-        let prev_year = date.0.0.year.saturating_sub(1);
-        let next_year = date.0.0.year.saturating_add(1);
+        let prev_year = date.0 .0.year.saturating_sub(1);
+        let next_year = date.0 .0.year.saturating_add(1);
         types::DayOfYearInfo {
             day_of_year: Iso::day_of_year(date.0),
-            days_in_year: Iso::days_in_year_direct(date.0.0.year),
+            days_in_year: Iso::days_in_year_direct(date.0 .0.year),
             prev_year: year_as_roc(prev_year),
             days_in_prev_year: Iso::days_in_year_direct(prev_year),
             next_year: year_as_roc(next_year),
@@ -114,19 +158,73 @@ impl Calendar for Roc {
 }
 
 impl Date<Roc> {
-    /// TODO: Documentation
+    /// Construct a new Republic of China calendar Date.
+    ///
+    /// Years are specified in either the "minguo" or "before minguo" eras
+    ///
+    /// ```rust
+    /// use icu::calendar::Date;
+    /// use icu::calendar::types::Era;
+    /// use icu::calendar::gregorian::Gregorian;
+    /// use tinystr::tinystr;
+    ///
+    /// // Create a new ROC Date
+    /// let date_roc = Date::try_new_roc_date(Era(tinystr!(16, "minguo")), 1, 2, 3)
+    ///     .expect("Failed to initialize ROC Date instance.");
+    ///
+    /// assert_eq!(date_roc.year().era.0, tinystr!(16, "minguo"));
+    /// assert_eq!(date_roc.year().number, 1, "ROC year check failed!");
+    /// assert_eq!(date_roc.month().ordinal, 2, "ROC month check failed!");
+    /// assert_eq!(date_roc.day_of_month().0, 3, "ROC day of month check failed!");
+    ///
+    /// // Convert to an equivalent Gregorian date
+    /// let date_gregorian = date_roc.to_calendar(Gregorian);
+    ///
+    /// assert_eq!(date_gregorian.year().number, 1912, "Gregorian from ROC year check failed!");
+    /// assert_eq!(date_gregorian.month().ordinal, 2, "Gregorian from ROC month check failed!");
+    /// assert_eq!(date_gregorian.day_of_month().0, 3, "Gregorian from ROC day of month check failed!");
     pub fn try_new_roc_date(
+        era: Era,
         year: i32,
         month: u8,
         day: u8,
     ) -> Result<Date<Roc>, CalendarError> {
-        Date::try_new_iso_date(year, month, day).map(|d| Date::new_from_iso(d, Roc))
+        let roc_year = if era.0 == tinystr!(16, "minguo") {
+            year.saturating_add(ROC_ERA_OFFSET)
+        } else if era.0 == tinystr!(16, "before minguo") {
+            (ROC_ERA_OFFSET + 1).saturating_sub(year)
+        } else {
+            return Err(CalendarError::UnknownEra(era.0, "ROC"));
+        };
+        Date::try_new_iso_date(roc_year, month, day).map(|d| Date::new_from_iso(d, Roc))
     }
 }
 
 impl DateTime<Roc> {
-    /// TODO: Documentation
+    /// Construct a new Republic of China calendar datetime from integers.
+    ///
+    /// Years are specified in either the "minguo" or "before minguo" eras (see [`Roc`] for more info).
+    ///
+    /// ```rust
+    /// use icu::calendar::DateTime;
+    /// use icu::calendar::types::Era;
+    /// use icu::calendar::gregorian::Gregorian;
+    /// use tinystr::tinystr;
+    ///
+    /// // Create a new ROC DateTime
+    /// let datetime_roc = DateTime::try_new_roc_datetime(Era(tinystr!(16, "minguo")), 1, 2, 3, 13, 1, 0)
+    ///     .expect("Failed to initialize ROC DateTime instance.");
+    ///
+    /// assert_eq!(datetime_roc.date.year().era.0, tinystr!(16, "minguo"));
+    /// assert_eq!(datetime_roc.date.year().number, 1, "ROC year check failed!");
+    /// assert_eq!(datetime_roc.date.month().ordinal, 2, "ROC month check failed!");
+    /// assert_eq!(datetime_roc.date.day_of_month().0, 3, "ROC day of month check failed!");
+    /// assert_eq!(datetime_roc.time.hour.number(), 13);
+    /// assert_eq!(datetime_roc.time.minute.number(), 1);
+    /// assert_eq!(datetime_roc.time.second.number(), 0);
+    /// ```
     pub fn try_new_roc_datetime(
+        era: Era,
         year: i32,
         month: u8,
         day: u8,
@@ -135,7 +233,7 @@ impl DateTime<Roc> {
         second: u8,
     ) -> Result<DateTime<Roc>, CalendarError> {
         Ok(DateTime {
-            date: Date::try_new_roc_date(year, month, day)?,
+            date: Date::try_new_roc_date(era, year, month, day)?,
             time: types::Time::try_new(hour, minute, second, 0)?,
         })
     }
@@ -155,6 +253,203 @@ pub(crate) fn year_as_roc(year: i32) -> types::FormattableYear {
             number: (ROC_ERA_OFFSET + 1).saturating_sub(year),
             cyclic: None,
             related_iso: Some(year),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+    use crate::rata_die::RataDie;
+
+    #[derive(Debug)]
+    struct TestCase {
+        fixed_date: RataDie,
+        iso_year: i32,
+        iso_month: u8,
+        iso_day: u8,
+        expected_year: i32,
+        expected_era: Era,
+        expected_month: u32,
+        expected_day: u32,
+    }
+
+    fn check_test_case(case: TestCase) {
+        let iso_from_fixed = Iso::iso_from_fixed(case.fixed_date);
+        let roc_from_fixed = Date::new_from_iso(iso_from_fixed, Roc);
+        assert_eq!(roc_from_fixed.year().number, case.expected_year,
+            "Failed year check from fixed: {case:?}\nISO: {iso_from_fixed:?}\nROC: {roc_from_fixed:?}");
+        assert_eq!(roc_from_fixed.year().era, case.expected_era,
+            "Failed era check from fixed: {case:?}\nISO: {iso_from_fixed:?}\nROC: {roc_from_fixed:?}");
+        assert_eq!(roc_from_fixed.month().ordinal, case.expected_month,
+            "Failed month check from fixed: {case:?}\nISO: {iso_from_fixed:?}\nROC: {roc_from_fixed:?}");
+        assert_eq!(roc_from_fixed.day_of_month().0, case.expected_day,
+            "Failed day_of_month check from fixed: {case:?}\nISO: {iso_from_fixed:?}\nROC: {roc_from_fixed:?}");
+
+        let iso_from_case = Date::try_new_iso_date(case.iso_year, case.iso_month, case.iso_day)
+            .expect("Failed to initialize ISO date for {case:?}");
+        let roc_from_case = Date::new_from_iso(iso_from_case, Roc);
+        assert_eq!(iso_from_fixed, iso_from_case,
+            "ISO from fixed not equal to ISO generated from manually-input ymd\nCase: {case:?}\nFixed: {iso_from_fixed:?}\nManual: {iso_from_case:?}");
+        assert_eq!(roc_from_fixed, roc_from_case,
+            "ROC date from fixed not equal to ROC generated from manually-input ymd\nCase: {case:?}\nFixed: {roc_from_fixed:?}\nManual: {roc_from_case:?}");
+    }
+
+    #[test]
+    fn test_roc_current_era() {
+        // Tests that the ROC calendar gives the correct expected day, month, and year for years >= 1912
+        // (years in the ROC/minguo era)
+        //
+        // Jan 1. 1912 CE = RD 697978
+
+        let cases = [
+            TestCase {
+                fixed_date: RataDie::new(697978),
+                iso_year: 1912,
+                iso_month: 1,
+                iso_day: 1,
+                expected_year: 1,
+                expected_era: Era(tinystr!(16, "minguo")),
+                expected_month: 1,
+                expected_day: 1,
+            },
+            TestCase {
+                fixed_date: RataDie::new(698037),
+                iso_year: 1912,
+                iso_month: 2,
+                iso_day: 29,
+                expected_year: 1,
+                expected_era: Era(tinystr!(16, "minguo")),
+                expected_month: 2,
+                expected_day: 29,
+            },
+            TestCase {
+                fixed_date: RataDie::new(698524),
+                iso_year: 1913,
+                iso_month: 6,
+                iso_day: 30,
+                expected_year: 2,
+                expected_era: Era(tinystr!(16, "minguo")),
+                expected_month: 6,
+                expected_day: 30,
+            },
+            TestCase {
+                fixed_date: RataDie::new(738714),
+                iso_year: 2023,
+                iso_month: 7,
+                iso_day: 13,
+                expected_year: 112,
+                expected_era: Era(tinystr!(16, "minguo")),
+                expected_month: 7,
+                expected_day: 13,
+            },
+        ];
+
+        for case in cases {
+            check_test_case(case);
+        }
+    }
+
+    #[test]
+    fn test_roc_prior_era() {
+        // Tests that the ROC calendar gives the correct expected day, month, and year for years <= 1911
+        // (years in the ROC/minguo era)
+        //
+        // Jan 1. 1912 CE = RD 697978
+        let cases = [
+            TestCase {
+                fixed_date: RataDie::new(697977),
+                iso_year: 1911,
+                iso_month: 12,
+                iso_day: 31,
+                expected_year: 1,
+                expected_era: Era(tinystr!(16, "before minguo")),
+                expected_month: 12,
+                expected_day: 31,
+            },
+            TestCase {
+                fixed_date: RataDie::new(697613),
+                iso_year: 1911,
+                iso_month: 1,
+                iso_day: 1,
+                expected_year: 1,
+                expected_era: Era(tinystr!(16, "before minguo")),
+                expected_month: 1,
+                expected_day: 1,
+            },
+            TestCase {
+                fixed_date: RataDie::new(697612),
+                iso_year: 1910,
+                iso_month: 12,
+                iso_day: 31,
+                expected_year: 2,
+                expected_era: Era(tinystr!(16, "before minguo")),
+                expected_month: 12,
+                expected_day: 31,
+            },
+            TestCase {
+                fixed_date: RataDie::new(696576),
+                iso_year: 1908,
+                iso_month: 2,
+                iso_day: 29,
+                expected_year: 4,
+                expected_era: Era(tinystr!(16, "before minguo")),
+                expected_month: 2,
+                expected_day: 29,
+            },
+            TestCase {
+                fixed_date: RataDie::new(1),
+                iso_year: 1,
+                iso_month: 1,
+                iso_day: 1,
+                expected_year: 1911,
+                expected_era: Era(tinystr!(16, "before minguo")),
+                expected_month: 1,
+                expected_day: 1,
+            },
+            TestCase {
+                fixed_date: RataDie::new(0),
+                iso_year: 0,
+                iso_month: 12,
+                iso_day: 31,
+                expected_year: 1912,
+                expected_era: Era(tinystr!(16, "before minguo")),
+                expected_month: 12,
+                expected_day: 31,
+            },
+        ];
+
+        for case in cases {
+            check_test_case(case);
+        }
+    }
+
+    #[test]
+    fn test_roc_directionality_near_epoch() {
+        // Tests that for a large range of fixed dates near the beginning of the minguo era (CE 1912),
+        // the comparison between those two fixed dates should be equal to the comparison between their
+        // corresponding YMD.
+        let rd_epoch_start = 697978;
+        for i in (rd_epoch_start - 100)..=(rd_epoch_start + 100) {
+            for j in (rd_epoch_start - 100)..=(rd_epoch_start + 100) {
+                let iso_i = Iso::iso_from_fixed(RataDie::new(i));
+                let iso_j = Iso::iso_from_fixed(RataDie::new(j));
+
+                let roc_i = iso_i.to_calendar(Roc);
+                let roc_j = iso_j.to_calendar(Roc);
+
+                assert_eq!(
+                    i.cmp(&j),
+                    iso_i.cmp(&iso_j),
+                    "ISO directionality inconcistent with directionality for i: {i}, j: {j}"
+                );
+                assert_eq!(
+                    i.cmp(&j),
+                    roc_i.cmp(&roc_j),
+                    "ROC directionality inconsistent with directionality for i: {i}, j: {j}"
+                );
+            }
         }
     }
 }

--- a/components/calendar/src/roc.rs
+++ b/components/calendar/src/roc.rs
@@ -1,0 +1,160 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use tinystr::tinystr;
+
+use crate::{iso::IsoDateInner, Calendar, CalendarError, calendar_arithmetic::ArithmeticDate, Date, Iso, types, DateTime};
+
+/// Year of the beginning of the Taiwanese (ROC/Minguo) calendar.
+/// 1912 ISO = ROC 1
+const ROC_ERA_OFFSET: i32 = 1911;
+
+/// TODO: Documentation
+#[derive(Copy, Clone, Debug, Default)]
+#[allow(clippy::exhaustive_structs)] // this type is stable
+pub struct Roc;
+
+/// TODO: Documentation
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
+pub struct RocDateInner(IsoDateInner);
+
+impl Calendar for Roc {
+    type DateInner = RocDateInner;
+
+    fn date_from_codes(
+        &self,
+        era: crate::types::Era,
+        year: i32,
+        month_code: crate::types::MonthCode,
+        day: u8,
+    ) -> Result<Self::DateInner, crate::Error> {
+        let year = if era.0 == tinystr!(16, "minguo") {
+            if year <= 0 {
+                return Err(CalendarError::OutOfRange);
+            }
+            year + ROC_ERA_OFFSET
+        } else if era.0 == tinystr!(16, "before minguo") {
+            if year <= 0 {
+                return Err(CalendarError::OutOfRange);
+            }
+            1 - (year + ROC_ERA_OFFSET)
+        } else {
+            return Err(CalendarError::UnknownEra(era.0, self.debug_name()));
+        };
+
+        ArithmeticDate::new_from_solar_codes(self, year, month_code, day)
+            .map(IsoDateInner)
+            .map(RocDateInner)
+    }
+
+    fn date_from_iso(&self, iso: crate::Date<crate::Iso>) -> Self::DateInner {
+        RocDateInner(*iso.inner())
+    }
+
+    fn date_to_iso(&self, date: &Self::DateInner) -> crate::Date<crate::Iso> {
+        Date::from_raw(date.0, Iso)
+    }
+
+    fn months_in_year(&self, date: &Self::DateInner) -> u8 {
+        Iso.months_in_year(&date.0)
+    }
+
+    fn days_in_year(&self, date: &Self::DateInner) -> u32 {
+        Iso.days_in_year(&date.0)
+    }
+
+    fn days_in_month(&self, date: &Self::DateInner) -> u8 {
+        Iso.days_in_month(&date.0)
+    }
+
+    fn offset_date(&self, date: &mut Self::DateInner, offset: crate::DateDuration<Self>) {
+        Iso.offset_date(&mut date.0, offset.cast_unit())
+    }
+
+    fn until(
+        &self,
+        date1: &Self::DateInner,
+        date2: &Self::DateInner,
+        calendar2: &Self,
+        largest_unit: crate::DateDurationUnit,
+        smallest_unit: crate::DateDurationUnit,
+    ) -> crate::DateDuration<Self> {
+        Iso.until(&date1.0, &date2.0, &Iso, largest_unit, smallest_unit)
+            .cast_unit()
+    }
+
+    fn debug_name(&self) -> &'static str {
+        "ROC"
+    }
+
+    fn year(&self, date: &Self::DateInner) -> crate::types::FormattableYear {
+        year_as_roc(date.0.0.year)
+    }
+
+    fn month(&self, date: &Self::DateInner) -> crate::types::FormattableMonth {
+        Iso.month(&date.0)
+    }
+
+    fn day_of_month(&self, date: &Self::DateInner) -> crate::types::DayOfMonth {
+        Iso.day_of_month(&date.0)
+    }
+
+    fn day_of_year_info(&self, date: &Self::DateInner) -> crate::types::DayOfYearInfo {
+        let prev_year = date.0.0.year.saturating_sub(1);
+        let next_year = date.0.0.year.saturating_add(1);
+        types::DayOfYearInfo {
+            day_of_year: Iso::day_of_year(date.0),
+            days_in_year: Iso::days_in_year_direct(date.0.0.year),
+            prev_year: year_as_roc(prev_year),
+            days_in_prev_year: Iso::days_in_year_direct(prev_year),
+            next_year: year_as_roc(next_year),
+        }
+    }
+}
+
+impl Date<Roc> {
+    /// TODO: Documentation
+    pub fn try_new_roc_date(
+        year: i32,
+        month: u8,
+        day: u8,
+    ) -> Result<Date<Roc>, CalendarError> {
+        Date::try_new_iso_date(year, month, day).map(|d| Date::new_from_iso(d, Roc))
+    }
+}
+
+impl DateTime<Roc> {
+    /// TODO: Documentation
+    pub fn try_new_roc_datetime(
+        year: i32,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+    ) -> Result<DateTime<Roc>, CalendarError> {
+        Ok(DateTime {
+            date: Date::try_new_roc_date(year, month, day)?,
+            time: types::Time::try_new(hour, minute, second, 0)?,
+        })
+    }
+}
+
+pub(crate) fn year_as_roc(year: i32) -> types::FormattableYear {
+    if year > ROC_ERA_OFFSET {
+        types::FormattableYear {
+            era: types::Era(tinystr!(16, "minguo")),
+            number: year.saturating_sub(ROC_ERA_OFFSET),
+            cyclic: None,
+            related_iso: Some(year),
+        }
+    } else {
+        types::FormattableYear {
+            era: types::Era(tinystr!(16, "before minguo")),
+            number: (ROC_ERA_OFFSET + 1).saturating_sub(year),
+            cyclic: None,
+            related_iso: Some(year),
+        }
+    }
+}

--- a/ffi/diplomat/tests/missing_apis.txt
+++ b/ffi/diplomat/tests/missing_apis.txt
@@ -16,8 +16,10 @@
 
 icu::calendar::Date::try_new_chinese_date#FnInStruct
 icu::calendar::Date::try_new_persian_date#FnInStruct
+icu::calendar::Date::try_new_roc_date#FnInStruct
 icu::calendar::DateTime::try_new_chinese_datetime#FnInStruct
 icu::calendar::DateTime::try_new_persian_datetime#FnInStruct
+icu::calendar::DateTime::try_new_roc_datetime#FnInStruct
 icu::calendar::chinese::Chinese#Struct
 icu::calendar::chinese::Chinese::chinese_new_year_on_or_before_iso#FnInStruct
 icu::calendar::chinese::Chinese::major_solar_term_from_iso#FnInStruct
@@ -26,6 +28,8 @@ icu::calendar::chinese::ChineseDateInner#Struct
 icu::calendar::persian::Persian#Struct
 icu::calendar::persian::Persian::new#FnInStruct
 icu::calendar::persian::PersianDateInner#Struct
+icu::calendar::roc::Roc#Struct
+icu::calendar::roc::RocDateInner#Struct
 icu::casemap::CaseMapper::add_case_closure#FnInStruct
 icu::casemap::CaseMapper::add_string_case_closure#FnInStruct
 icu::casemap::ClosureSet::add_char#FnInTrait


### PR DESCRIPTION
This PR adds math for the [ROC calendar](https://en.wikipedia.org/wiki/Republic_of_China_calendar), used primarily in Taiwan. It includes documentation, tests for manually-input test cases, and directionality tests near both RD 0 and the beginning of the ROC epoch (January 1, 1912).