### PR TITLE
Fixing a bug in `baked_exporter`

### DIFF
--- a/provider/blob/src/blob_schema.rs
+++ b/provider/blob/src/blob_schema.rs
@@ -126,5 +126,6 @@ impl<'a> ZeroMapKV<'a> for Index32U8 {
 }
 
 impl Index32U8 {
+    #[allow(dead_code)]
     pub(crate) const SENTINEL: &'static Self = unsafe { core::mem::transmute::<&[u8], _>(&[]) };
 }

--- a/provider/datagen/src/baked_exporter.rs
+++ b/provider/datagen/src/baked_exporter.rs
@@ -440,7 +440,7 @@ impl DataExporter for BakedExporter {
             .replace('/', "_");
 
         let body = if values.is_empty() {
-            quote!(Err(icu_provider::DataErrorKind::MissingLocale))
+            quote!(Err(icu_provider::DataErrorKind::MissingLocale.with_req(<#marker as icu_provider::KeyedDataMarker>::KEY, req)))
         } else {
             let mut map = BTreeMap::new();
             let mut statics = Vec::new();


### PR DESCRIPTION
The empty case doesn't currently generate compiling code.