### PR TITLE
Datagen API improvements

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -91,6 +91,7 @@ description = "Run all tests for the CI 'testdata' job"
 category = "CI"
 dependencies = [
     "testdata-check",
+    "testdata-legacy",
 ]
 
 [tasks.ci-job-test-docs]

--- a/components/calendar/data/config.json
+++ b/components/calendar/data/config.json
@@ -12,8 +12,7 @@
     "segmenter_lstm": "Latest",
     "export": {
         "Baked": {
-            "output_path": "data",
-            "use_separate_crates": true,
+            "path": "data",
             "pretty": true
         }
     },

--- a/components/collator/data/config.json
+++ b/components/collator/data/config.json
@@ -16,8 +16,7 @@
     "segmenter_lstm": "Latest",
     "export": {
         "Baked": {
-            "output_path": "data",
-            "use_separate_crates": true,
+            "path": "data",
             "pretty": true
         }
     },

--- a/components/datetime/data/config.json
+++ b/components/datetime/data/config.json
@@ -33,8 +33,7 @@
     "segmenter_lstm": "Latest",
     "export": {
         "Baked": {
-            "output_path": "data",
-            "use_separate_crates": true,
+            "path": "data",
             "pretty": true
         }
     },

--- a/components/decimal/data/config.json
+++ b/components/decimal/data/config.json
@@ -10,8 +10,7 @@
     "segmenter_lstm": "Latest",
     "export": {
         "Baked": {
-            "output_path": "data",
-            "use_separate_crates": true,
+            "path": "data",
             "pretty": true
         }
     },

--- a/components/list/data/config.json
+++ b/components/list/data/config.json
@@ -13,8 +13,7 @@
     "segmenter_lstm": "Latest",
     "export": {
         "Baked": {
-            "output_path": "data",
-            "use_separate_crates": true,
+            "path": "data",
             "pretty": true
         }
     },

--- a/components/locid_transform/data/config.json
+++ b/components/locid_transform/data/config.json
@@ -17,8 +17,7 @@
     "segmenter_lstm": "Latest",
     "export": {
         "Baked": {
-            "output_path": "data",
-            "use_separate_crates": true,
+            "path": "data",
             "pretty": true
         }
     },

--- a/components/normalizer/data/config.json
+++ b/components/normalizer/data/config.json
@@ -16,8 +16,7 @@
     "segmenter_lstm": "Latest",
     "export": {
         "Baked": {
-            "output_path": "data",
-            "use_separate_crates": true,
+            "path": "data",
             "pretty": true
         }
     },

--- a/components/plurals/data/config.json
+++ b/components/plurals/data/config.json
@@ -11,8 +11,7 @@
     "segmenter_lstm": "Latest",
     "export": {
         "Baked": {
-            "output_path": "data",
-            "use_separate_crates": true,
+            "path": "data",
             "pretty": true
         }
     },

--- a/components/properties/data/config.json
+++ b/components/properties/data/config.json
@@ -119,8 +119,7 @@
     "segmenter_lstm": "Latest",
     "export": {
         "Baked": {
-            "output_path": "data",
-            "use_separate_crates": true,
+            "path": "data",
             "pretty": true
         }
     },

--- a/components/segmenter/data/config.json
+++ b/components/segmenter/data/config.json
@@ -16,8 +16,7 @@
     "segmenter_lstm": "Latest",
     "export": {
         "Baked": {
-            "output_path": "data",
-            "use_separate_crates": true,
+            "path": "data",
             "pretty": true
         }
     },

--- a/components/timezone/data/config.json
+++ b/components/timezone/data/config.json
@@ -10,8 +10,7 @@
     "segmenter_lstm": "Latest",
     "export": {
         "Baked": {
-            "output_path": "data",
-            "use_separate_crates": true,
+            "path": "data",
             "pretty": true
         }
     },

--- a/docs/tutorials/Cargo.lock
+++ b/docs/tutorials/Cargo.lock
@@ -744,7 +744,6 @@ version = "1.3.0"
 name = "icu_casemap"
 version = "0.7.2"
 dependencies = [
- "databake",
  "displaydoc",
  "icu_casemap_data",
  "icu_collections",
@@ -811,7 +810,6 @@ dependencies = [
 name = "icu_compactdecimal"
 version = "0.2.0"
 dependencies = [
- "databake",
  "displaydoc",
  "fixed_decimal",
  "icu_compactdecimal_data",
@@ -819,7 +817,6 @@ dependencies = [
  "icu_locid_transform",
  "icu_plurals",
  "icu_provider",
- "serde",
  "writeable",
  "zerovec",
 ]
@@ -839,26 +836,21 @@ dependencies = [
  "elsa",
  "eyre",
  "icu_calendar",
- "icu_casemap",
  "icu_codepointtrie_builder",
  "icu_collator",
  "icu_collections",
- "icu_compactdecimal",
  "icu_datetime",
  "icu_decimal",
- "icu_displaynames",
  "icu_list",
  "icu_locid",
  "icu_locid_transform",
  "icu_normalizer",
- "icu_personnames",
  "icu_plurals",
  "icu_properties",
  "icu_provider",
  "icu_provider_adapters",
  "icu_provider_blob",
  "icu_provider_fs",
- "icu_relativetime",
  "icu_segmenter",
  "icu_timezone",
  "itertools",
@@ -931,7 +923,6 @@ version = "1.3.0"
 name = "icu_displaynames"
 version = "0.10.0"
 dependencies = [
- "databake",
  "icu_collections",
  "icu_displaynames_data",
  "icu_locid",
@@ -1017,19 +1008,6 @@ dependencies = [
 [[package]]
 name = "icu_normalizer_data"
 version = "1.3.0"
-
-[[package]]
-name = "icu_personnames"
-version = "0.1.0"
-dependencies = [
- "databake",
- "icu_collections",
- "icu_locid",
- "icu_provider",
- "litemap",
- "serde",
- "zerovec",
-]
 
 [[package]]
 name = "icu_plurals"
@@ -1144,7 +1122,6 @@ dependencies = [
 name = "icu_relativetime"
 version = "0.1.1"
 dependencies = [
- "databake",
  "displaydoc",
  "fixed_decimal",
  "icu_decimal",

--- a/docs/tutorials/crates/baked/build.rs
+++ b/docs/tutorials/crates/baked/build.rs
@@ -14,6 +14,7 @@ fn main() {
     let mut options = BakedOptions::default();
     // Overwrite the baked data if it was already present:
     options.overwrite = true;
+    options.use_separate_crates = false;
 
 
     icu_datagen::datagen(

--- a/experimental/casemap/data/config.json
+++ b/experimental/casemap/data/config.json
@@ -10,8 +10,7 @@
     "segmenter_lstm": "Latest",
     "export": {
         "Baked": {
-            "output_path": "data",
-            "use_separate_crates": true,
+            "path": "data",
             "pretty": true
         }
     },

--- a/experimental/compactdecimal/data/config.json
+++ b/experimental/compactdecimal/data/config.json
@@ -12,8 +12,7 @@
     "segmenter_lstm": "Latest",
     "export": {
         "Baked": {
-            "output_path": "data",
-            "use_separate_crates": true,
+            "path": "data",
             "pretty": true
         }
     },

--- a/experimental/displaynames/data/config.json
+++ b/experimental/displaynames/data/config.json
@@ -14,8 +14,7 @@
     "segmenter_lstm": "Latest",
     "export": {
         "Baked": {
-            "output_path": "data",
-            "use_separate_crates": true,
+            "path": "data",
             "pretty": true
         }
     },

--- a/experimental/relativetime/data/config.json
+++ b/experimental/relativetime/data/config.json
@@ -33,8 +33,7 @@
     "segmenter_lstm": "Latest",
     "export": {
         "Baked": {
-            "output_path": "data",
-            "use_separate_crates": true,
+            "path": "data",
             "pretty": true
         }
     },

--- a/provider/adapters/tests/data/config.json
+++ b/provider/adapters/tests/data/config.json
@@ -9,10 +9,12 @@
     },
     "locales": "All",
     "cldr": "Latest",
-    "icu_export": "Latest",
-    "segmenter_lstm": "Latest",
+    "icu_export": "None",
+    "segmenter_lstm": "None",
     "export": {
-        "Blob": "blob.postcard"
+        "Blob": {
+            "path": "blob.postcard"
+        }
     },
     "fallback": "Legacy",
     "overwrite": true

--- a/provider/adapters/tests/data/langtest/de.json
+++ b/provider/adapters/tests/data/langtest/de.json
@@ -1,0 +1,22 @@
+{
+    "keys": {
+      "Explicit": [
+        "core/helloworld@1"
+      ]
+    },
+    "locales": {
+      "Explicit": [
+        "de"
+      ]
+    },
+    "cldr": "None",
+    "icu_export": "None",
+    "segmenter_lstm": "None",
+    "export": {
+      "Fs": {
+        "path": "de",
+        "syntax": "Json"
+      }
+    },
+    "overwrite": true
+  }

--- a/provider/adapters/tests/data/langtest/ro.json
+++ b/provider/adapters/tests/data/langtest/ro.json
@@ -1,0 +1,22 @@
+{
+    "keys": {
+      "Explicit": [
+        "core/helloworld@1"
+      ]
+    },
+    "locales": {
+      "Explicit": [
+        "ro"
+      ]
+    },
+    "cldr": "None",
+    "icu_export": "None",
+    "segmenter_lstm": "None",
+    "export": {
+      "Fs": {
+        "path": "ro",
+        "syntax": "Json"
+      }
+    },
+    "overwrite": true
+  }

--- a/provider/blob/tests/data/config.json
+++ b/provider/blob/tests/data/config.json
@@ -1,0 +1,16 @@
+{
+  "keys": {
+    "Explicit": [
+      "core/helloworld@1"
+    ]
+  },
+  "cldr": "None",
+  "icu_export": "None",
+  "segmenter_lstm": "None",
+  "export": {
+    "Blob": {
+      "path": "hello_world.postcard"
+    }
+  },
+  "overwrite": true
+}

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -111,12 +111,6 @@ use_wasm = ["icu_codepointtrie_builder/wasm"]
 # rule based segmenter data will not be generated.
 use_icu4c = ["icu_codepointtrie_builder/icu4c"]
 networking = ["dep:ureq"]
-experimental_components = [
-    "icu_casemap",
-    "icu_compactdecimal",
-    "icu_displaynames",
-    "icu_relativetime",
-]
 
 [[bin]]
 name = "icu4x-datagen"
@@ -130,12 +124,6 @@ required-features = ["provider_fs", "use_wasm"]
 
 [package.metadata.cargo-all-features]
 # We don't need working CPT builders for check
-skip_feature_sets = [
-    ["use_icu4c"],
-    ["use_wasm"],
-    ["icu_casemap"],
-    ["icu_compactdecimal"],
-    ["icu_displaynames"],
-    ["icu_relativetime"],
-]
+skip_feature_sets = [["use_icu4c"], ["use_wasm"]]
+always_include_features = ["icu_casemap", "icu_compactdecimal", "icu_displaynames", "icu_relativetime"]
 max_combination_size = 3

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -111,6 +111,12 @@ use_wasm = ["icu_codepointtrie_builder/wasm"]
 # rule based segmenter data will not be generated.
 use_icu4c = ["icu_codepointtrie_builder/icu4c"]
 networking = ["dep:ureq"]
+experimental_components = [
+    "icu_casemap",
+    "icu_compactdecimal",
+    "icu_displaynames",
+    "icu_relativetime",
+]
 
 [[bin]]
 name = "icu4x-datagen"
@@ -124,6 +130,12 @@ required-features = ["provider_fs", "use_wasm"]
 
 [package.metadata.cargo-all-features]
 # We don't need working CPT builders for check
-skip_feature_sets = [["use_icu4c"], ["use_wasm"]]
-always_include_features = ["icu_casemap", "icu_compactdecimal", "icu_displaynames", "icu_relativetime"]
+skip_feature_sets = [
+    ["use_icu4c"],
+    ["use_wasm"],
+    ["icu_casemap"],
+    ["icu_compactdecimal"],
+    ["icu_displaynames"],
+    ["icu_relativetime"],
+]
 max_combination_size = 3

--- a/provider/datagen/src/baked_exporter.rs
+++ b/provider/datagen/src/baked_exporter.rs
@@ -112,7 +112,7 @@ impl Default for Options {
         Self {
             pretty: false,
             insert_feature_gates: false,
-            use_separate_crates: false,
+            use_separate_crates: true,
             overwrite: false,
         }
     }

--- a/provider/datagen/src/bin/datagen/args.rs
+++ b/provider/datagen/src/bin/datagen/args.rs
@@ -240,8 +240,45 @@ pub struct Cli {
 
 impl Cli {
     pub fn as_config(&self) -> eyre::Result<config::Config> {
-        Ok(if let Some(ref path) = self.config {
-            serde_json::from_str(&std::fs::read_to_string(path)?)?
+        Ok(if let Some(ref config_path) = self.config {
+            let mut config: config::Config =
+                serde_json::from_str(&std::fs::read_to_string(config_path)?)?;
+            let parent = config_path.parent().unwrap();
+            // all paths in the JSON file are relative to its path, not to pwd.
+            for path_or_tag in [
+                &mut config.cldr,
+                &mut config.icu_export,
+                &mut config.segmenter_lstm,
+            ] {
+                if let config::PathOrTag::Path(ref mut path) = path_or_tag {
+                    if path.is_relative() {
+                        *path = parent.join(path.clone());
+                    }
+                }
+            }
+            if let config::KeyInclude::ForBinary(path) = &mut config.keys {
+                if path.is_relative() {
+                    *path = parent.join(path.clone());
+                }
+            }
+            match &mut config.export {
+                config::Export::Fs { path, .. } => {
+                    if path.is_relative() {
+                        *path = parent.join(path.clone());
+                    }
+                }
+                config::Export::Blob { path, .. } => {
+                    if path.is_relative() {
+                        *path = parent.join(path.clone());
+                    }
+                }
+                config::Export::Baked { path, .. } => {
+                    if path.is_relative() {
+                        *path = parent.join(path.clone());
+                    }
+                }
+            }
+            config
         } else {
             config::Config {
                 keys: self.make_keys()?,
@@ -378,7 +415,7 @@ impl Cli {
                 eyre::bail!("FsDataProvider export requires the provider_fs Cargo feature.");
                 #[cfg(feature = "provider_fs")]
                 Ok(config::Export::Fs {
-                    output_path: if let Some(root) = self.output.as_ref() {
+                    path: if let Some(root) = self.output.as_ref() {
                         root.clone()
                     } else {
                         PathBuf::from("icu4x_data")
@@ -396,25 +433,27 @@ impl Cli {
                 #[cfg(not(feature = "provider_blob"))]
                 eyre::bail!("BlobDataProvider export requires the provider_blob Cargo feature.");
                 #[cfg(feature = "provider_blob")]
-                Ok(config::Export::Blob(if let Some(path) = &self.output {
-                    path.clone()
-                } else {
-                    PathBuf::from("/stdout")
-                }))
+                Ok(config::Export::Blob {
+                    path: if let Some(path) = &self.output {
+                        path.clone()
+                    } else {
+                        PathBuf::from("/stdout")
+                    },
+                })
             }
             Format::Mod => {
                 #[cfg(not(feature = "provider_baked"))]
                 eyre::bail!("Baked data export requires the provider_baked Cargo feature.");
                 #[cfg(feature = "provider_baked")]
                 Ok(config::Export::Baked {
-                    output_path: if let Some(mod_directory) = self.output.as_ref() {
+                    path: if let Some(mod_directory) = self.output.as_ref() {
                         mod_directory.clone()
                     } else {
                         PathBuf::from("icu4x_data")
                     },
                     pretty: self.pretty,
                     insert_feature_gates: self.insert_feature_gates,
-                    use_separate_crates: self.use_separate_crates,
+                    use_meta_crate: !self.use_separate_crates,
                 })
             }
         }

--- a/provider/datagen/src/bin/datagen/config.rs
+++ b/provider/datagen/src/bin/datagen/config.rs
@@ -6,7 +6,7 @@ pub use icu_datagen::options::*;
 
 use icu_provider::prelude::*;
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct Config {
@@ -74,39 +74,34 @@ mod data_key_as_str {
 #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 pub enum PathOrTag {
     Path(PathBuf),
-    #[cfg(feature = "networking")]
     Tag(String),
-    #[cfg(feature = "networking")]
     Latest,
-    #[cfg(not(feature = "networking"))]
     None,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 pub enum Export {
-    #[cfg(feature = "provider_fs")]
     Fs {
-        output_path: PathBuf,
+        path: PathBuf,
         syntax: FsSyntax,
         #[serde(default, skip_serializing_if = "is_default")]
         fingerprint: bool,
     },
-    #[cfg(feature = "provider_blob")]
-    Blob(PathBuf),
-    #[cfg(feature = "provider_baked")]
+    Blob {
+        path: PathBuf,
+    },
     Baked {
-        output_path: PathBuf,
+        path: PathBuf,
         #[serde(default, skip_serializing_if = "is_default")]
         pretty: bool,
         #[serde(default, skip_serializing_if = "is_default")]
         insert_feature_gates: bool,
         #[serde(default, skip_serializing_if = "is_default")]
-        use_separate_crates: bool,
+        use_meta_crate: bool,
     },
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
-#[cfg(feature = "provider_fs")]
 pub enum FsSyntax {
     Postcard,
     Json,

--- a/provider/datagen/src/bin/datagen/mod.rs
+++ b/provider/datagen/src/bin/datagen/mod.rs
@@ -49,8 +49,9 @@ fn main() -> eyre::Result<()> {
         }
         #[cfg(feature = "networking")]
         config::PathOrTag::Tag(tag) => source_data.with_cldr_for_tag(&tag, Default::default())?,
-        #[cfg(not(feature = "networking"))]
         config::PathOrTag::None => source_data,
+        #[cfg(not(feature = "networking"))]
+        _ => eyre::bail!("Download data from tags requires the `networking` Cargo feature"),
     };
 
     source_data = match config.icu_export {
@@ -61,8 +62,9 @@ fn main() -> eyre::Result<()> {
         }
         #[cfg(feature = "networking")]
         config::PathOrTag::Tag(tag) => source_data.with_icuexport_for_tag(&tag)?,
-        #[cfg(not(feature = "networking"))]
         config::PathOrTag::None => source_data,
+        #[cfg(not(feature = "networking"))]
+        _ => eyre::bail!("Download data from tags requires the `networking` Cargo feature"),
     };
 
     source_data = match config.segmenter_lstm {
@@ -73,8 +75,9 @@ fn main() -> eyre::Result<()> {
         }
         #[cfg(feature = "networking")]
         config::PathOrTag::Tag(tag) => source_data.with_segmenter_lstm_for_tag(&tag)?,
-        #[cfg(not(feature = "networking"))]
         config::PathOrTag::None => source_data,
+        #[cfg(not(feature = "networking"))]
+        _ => eyre::bail!("Download data from tags requires the `networking` Cargo feature"),
     };
 
     let provider = DatagenProvider::try_new(options, source_data)?;
@@ -89,70 +92,84 @@ fn main() -> eyre::Result<()> {
     };
 
     match config.export {
-        #[cfg(feature = "provider_fs")]
         config::Export::Fs {
-            output_path,
+            path,
             syntax,
             fingerprint,
         } => {
-            use icu_provider_fs::export::{serializers::*, *};
-            let exporter = FilesystemExporter::try_new(
-                match syntax {
-                    config::FsSyntax::Bincode => Box::<bincode::Serializer>::default(),
-                    config::FsSyntax::Postcard => Box::<postcard::Serializer>::default(),
-                    config::FsSyntax::JsonPretty => Box::new(json::Serializer::pretty()),
-                    config::FsSyntax::Json => Box::<json::Serializer>::default(),
-                },
-                {
-                    let mut options = ExporterOptions::default();
-                    options.root = output_path;
-                    if config.overwrite {
-                        options.overwrite = OverwriteOption::RemoveAndReplace
-                    }
-                    #[allow(deprecated)] // obviously
+            #[cfg(not(feature = "provider_fs"))]
+            eyre::bail!("Exporting to an FsProvider requires the `provider_fs` Cargo feature");
+            #[cfg(feature = "provider_fs")]
+            {
+                use icu_provider_fs::export::{serializers::*, *};
+                let exporter = FilesystemExporter::try_new(
+                    match syntax {
+                        config::FsSyntax::Bincode => Box::<bincode::Serializer>::default(),
+                        config::FsSyntax::Postcard => Box::<postcard::Serializer>::default(),
+                        config::FsSyntax::JsonPretty => Box::new(json::Serializer::pretty()),
+                        config::FsSyntax::Json => Box::<json::Serializer>::default(),
+                    },
                     {
-                        options.fingerprint = fingerprint;
-                    }
-                    options
-                },
-            )?;
-            Ok(provider.export(keys, exporter)?)
+                        let mut options = ExporterOptions::default();
+                        options.root = path;
+                        if config.overwrite {
+                            options.overwrite = OverwriteOption::RemoveAndReplace
+                        }
+                        #[allow(deprecated)] // obviously
+                        {
+                            options.fingerprint = fingerprint;
+                        }
+                        options
+                    },
+                )?;
+                Ok(provider.export(keys, exporter)?)
+            }
         }
-        #[cfg(feature = "provider_blob")]
-        config::Export::Blob(ref path) => {
-            let exporter = icu_provider_blob::export::BlobExporter::new_with_sink(
-                if path == std::path::Path::new("/stdout") {
-                    Box::new(std::io::stdout())
-                } else if !config.overwrite && path.exists() {
-                    eyre::bail!("Output path is present: {:?}", path);
-                } else {
-                    Box::new(
-                        std::fs::File::create(path)
-                            .with_context(|| path.to_string_lossy().to_string())?,
-                    )
-                },
-            );
-            Ok(provider.export(keys, exporter)?)
+        config::Export::Blob { ref path } => {
+            #[cfg(not(feature = "provider_blob"))]
+            eyre::bail!("Exporting to a BlobProvider requires the `provider_blob` Cargo feature");
+            #[cfg(feature = "provider_blob")]
+            {
+                let exporter = icu_provider_blob::export::BlobExporter::new_with_sink(
+                    if path == std::path::Path::new("/stdout") {
+                        Box::new(std::io::stdout())
+                    } else if !config.overwrite && path.exists() {
+                        eyre::bail!("Output path is present: {:?}", path);
+                    } else {
+                        Box::new(
+                            std::fs::File::create(path)
+                                .with_context(|| path.to_string_lossy().to_string())?,
+                        )
+                    },
+                );
+                Ok(provider.export(keys, exporter)?)
+            }
         }
-        #[cfg(feature = "provider_baked")]
         config::Export::Baked {
-            output_path,
+            path,
             pretty,
             insert_feature_gates,
-            use_separate_crates,
+            use_meta_crate,
         } => {
-            use icu_datagen::baked_exporter::*;
+            #[cfg(not(feature = "provider_baked"))]
+            eyre::bail!(
+                "Exporting to a baked provider requires the `provider_baked` Cargo feature"
+            );
+            #[cfg(feature = "provider_baked")]
+            {
+                use icu_datagen::baked_exporter::*;
 
-            let exporter = BakedExporter::new(output_path, {
-                let mut options = Options::default();
-                options.pretty = pretty;
-                options.insert_feature_gates = insert_feature_gates;
-                options.use_separate_crates = use_separate_crates;
-                options.overwrite = config.overwrite;
-                options
-            })?;
+                let exporter = BakedExporter::new(path, {
+                    let mut options = Options::default();
+                    options.pretty = pretty;
+                    options.insert_feature_gates = insert_feature_gates;
+                    options.use_separate_crates = !use_meta_crate;
+                    options.overwrite = config.overwrite;
+                    options
+                })?;
 
-            Ok(provider.export(keys, exporter)?)
+                Ok(provider.export(keys, exporter)?)
+            }
         }
     }
 }

--- a/provider/fs/tests/data/bincode.json
+++ b/provider/fs/tests/data/bincode.json
@@ -1,0 +1,17 @@
+{
+    "keys": {
+      "Explicit": [
+        "core/helloworld@1"
+      ]
+    },
+    "cldr": "None",
+    "icu_export": "None",
+    "segmenter_lstm": "None",
+    "export": {
+      "Fs": {
+        "path": "bincode",
+        "syntax": "Bincode"
+      }
+    },
+    "overwrite": true
+  }

--- a/provider/fs/tests/data/json.json
+++ b/provider/fs/tests/data/json.json
@@ -1,0 +1,17 @@
+{
+    "keys": {
+      "Explicit": [
+        "core/helloworld@1"
+      ]
+    },
+    "cldr": "None",
+    "icu_export": "None",
+    "segmenter_lstm": "None",
+    "export": {
+      "Fs": {
+        "path": "json",
+        "syntax": "Json"
+      }
+    },
+    "overwrite": true
+  }

--- a/provider/fs/tests/data/postcard.json
+++ b/provider/fs/tests/data/postcard.json
@@ -1,0 +1,17 @@
+{
+    "keys": {
+      "Explicit": [
+        "core/helloworld@1"
+      ]
+    },
+    "cldr": "None",
+    "icu_export": "None",
+    "segmenter_lstm": "None",
+    "export": {
+      "Fs": {
+        "path": "postcard",
+        "syntax": "Postcard"
+      }
+    },
+    "overwrite": true
+  }

--- a/tools/make/data.toml
+++ b/tools/make/data.toml
@@ -23,7 +23,7 @@ args = [
     "test",
     "-p=icu_datagen",
     "--no-default-features",
-    "--features=provider_fs,use_wasm,rayon,icu_casemap,icu_compactdecimal,icu_displaynames,icu_relativetime",
+    "--features=provider_fs,use_wasm,rayon,experimental_components",
     "generate_json_and_verify_postcard",
     "--",
     "--nocapture"
@@ -86,11 +86,11 @@ script = '''
 exit_on_error true
 
 if array_is_empty ${@}
-    exec --fail-on-error cargo build -p icu_datagen --no-default-features --features rayon,provider_baked,bin,use_wasm,networking,icu_casemap,icu_displaynames,icu_relativetime,icu_compactdecimal --release
+    exec --fail-on-error cargo build -p icu_datagen --no-default-features --features rayon,provider_baked,bin,use_wasm,networking,experimental_components --release
     bin = set "target/release/icu4x-datagen"
     components = array components/calendar components/collator components/datetime components/decimal components/list components/locid_transform components/normalizer components/plurals components/properties components/segmenter components/timezone experimental/casemap experimental/compactdecimal experimental/displaynames experimental/relativetime
 else
-    exec --fail-on-error cargo build -p icu_datagen --no-default-features --features rayon,provider_baked,bin,use_wasm,networking,icu_casemap,icu_displaynames,icu_relativetime,icu_compactdecimal
+    exec --fail-on-error cargo build -p icu_datagen --no-default-features --features rayon,provider_baked,bin,use_wasm,networking,experimental_components
     bin = set "target/debug/icu4x-datagen"
     components = set ${@}
 end

--- a/tools/make/data.toml
+++ b/tools/make/data.toml
@@ -23,7 +23,7 @@ args = [
     "test",
     "-p=icu_datagen",
     "--no-default-features",
-    "--features=provider_fs,use_wasm,rayon,experimental_components",
+    "--features=provider_fs,use_wasm,rayon,icu_casemap,icu_compactdecimal,icu_displaynames,icu_relativetime",
     "generate_json_and_verify_postcard",
     "--",
     "--nocapture"
@@ -86,11 +86,11 @@ script = '''
 exit_on_error true
 
 if array_is_empty ${@}
-    exec --fail-on-error cargo build -p icu_datagen --no-default-features --features rayon,provider_baked,bin,use_wasm,networking,experimental_components --release
+    exec --fail-on-error cargo build -p icu_datagen --no-default-features --features rayon,provider_baked,bin,use_wasm,networking,icu_casemap,icu_displaynames,icu_relativetime,icu_compactdecimal --release
     bin = set "target/release/icu4x-datagen"
     components = array components/calendar components/collator components/datetime components/decimal components/list components/locid_transform components/normalizer components/plurals components/properties components/segmenter components/timezone experimental/casemap experimental/compactdecimal experimental/displaynames experimental/relativetime
 else
-    exec --fail-on-error cargo build -p icu_datagen --no-default-features --features rayon,provider_baked,bin,use_wasm,networking,experimental_components
+    exec --fail-on-error cargo build -p icu_datagen --no-default-features --features rayon,provider_baked,bin,use_wasm,networking,icu_casemap,icu_displaynames,icu_relativetime,icu_compactdecimal
     bin = set "target/debug/icu4x-datagen"
     components = set ${@}
 end

--- a/tools/make/data.toml
+++ b/tools/make/data.toml
@@ -4,7 +4,16 @@
 
 # This is a cargo-make file included in the toplevel Makefile.toml
 
-###### CI TASKS
+[tasks.download-repo-sources]
+description = "Download fresh source testing data into the icu_datagen crate."
+category = "ICU4X Data"
+command = "cargo"
+args = [
+    "run",
+    "--bin=download-repo-sources",
+    "--",
+    "-v",
+]
 
 [tasks.testdata]
 description = "Run the testdata generation test in icu_datagen"
@@ -20,18 +29,24 @@ args = [
     "--nocapture"
 ]
 
-[tasks.testdata-legacy]
-description = "Build the data for the legacy icu_testdata crate"
+[tasks.testdata-hello-world]
+description = "Builds all hello-world testdata for use in provider/{adapters,blob,fs} tests"
 category = "ICU4X Data"
-command = "cargo"
-args = [
-    "run",
-    "--bin=make-testdata-legacy",
-]
+script_runner = "@duckscript"
+script = '''
+exit_on_error true
 
+exec --fail-on-error cargo build -p icu_datagen --no-default-features --features provider_fs,provider_blob,bin,networking
+
+configs = array provider/fs/tests/data/json.json provider/fs/tests/data/bincode.json provider/fs/tests/data/postcard.json provider/blob/tests/data/config.json provider/adapters/tests/data/config.json provider/adapters/tests/data/langtest/de.json provider/adapters/tests/data/langtest/ro.json
+
+for config in ${configs}
+    exec --fail-on-error target/debug/icu4x-datagen --config "${config}"
+end
+'''
 
 [tasks.testdata-check]
-description = "Rebuild ICU4X testdata and ensure that the working copy is clean"
+description = "Rebuild all testdata and ensure that the working copy is clean"
 category = "ICU4X Data"
 dependencies = [
     "download-repo-sources",
@@ -42,11 +57,11 @@ script_runner = "@duckscript"
 script = '''
 exit_on_error true
 
-output = exec git status --porcelain=v1 provider/datagen/tests/data provider/fs/tests/data provider/blob/tests/data
+output = exec git status --porcelain=v1 provider/datagen/tests/data provider/fs/tests/data provider/blob/tests/data provider/adapters/tests/data
 output_length = length ${output.stdout}
 if greater_than ${output_length} 0
     msg = array "" ""
-    array_push ${msg} "Test data needs to be updated. Please run `cargo make testdata` and `cargo make testdata-hello-world:"
+    array_push ${msg} "Test data needs to be updated. Please run `cargo make download-repo-sources`, `cargo make testdata` and `cargo make testdata-hello-world:"
     array_push ${msg} ""
     array_push ${msg} "${output.stdout}"
     msg = array_join ${msg} "\n"
@@ -54,76 +69,13 @@ if greater_than ${output_length} 0
 end
 '''
 
-[tasks.testdata-hello-world-json]
-description = "Build the Hello World JSON tree."
+[tasks.testdata-legacy]
+description = "Build the data for the legacy icu_testdata crate"
 category = "ICU4X Data"
 command = "cargo"
 args = [
     "run",
-    "--bin=icu4x-datagen",
-    "--",
-    "--keys=core/helloworld@1",
-    "--locales=full",
-    "--format=dir",
-    "--out=provider/fs/tests/data/json",
-    "--overwrite",
-]
-
-[tasks.testdata-hello-world-bincode]
-description = "Build the Hello World bincode tree."
-category = "ICU4X Data"
-command = "cargo"
-args = [
-    "run",
-    "--bin=icu4x-datagen",
-    "--",
-    "--keys=core/helloworld@1",
-    "--locales=full",
-    "--format=dir",
-    "--syntax=bincode",
-    "--out=provider/fs/tests/data/bincode",
-    "--overwrite",
-]
-
-[tasks.testdata-hello-world-postcard]
-description = "Build the Hello World postcard tree."
-category = "ICU4X Data"
-command = "cargo"
-args = [
-    "run",
-    "--bin=icu4x-datagen",
-    "--",
-    "--keys=core/helloworld@1",
-    "--locales=full",
-    "--format=dir",
-    "--syntax=postcard",
-    "--out=provider/fs/tests/data/postcard",
-    "--overwrite",
-]
-
-[tasks.testdata-hello-world-blob]
-description = "Build the Hello World postcard testdata file."
-category = "ICU4X Data"
-command = "cargo"
-args = [
-    "run",
-    "--bin=icu4x-datagen",
-    "--",
-    "--keys=core/helloworld@1",
-    "--locales=full",
-    "--format=blob",
-    "--out=provider/blob/tests/data/hello_world.postcard",
-    "--overwrite",
-]
-
-[tasks.testdata-hello-world]
-description = "Build all three the Hello World outputs."
-category = "ICU4X Data"
-dependencies = [
-    "testdata-hello-world-json",
-    "testdata-hello-world-bincode",
-    "testdata-hello-world-postcard",
-    "testdata-hello-world-blob",
+    "--bin=make-testdata-legacy",
 ]
 
 [tasks.bakeddata]
@@ -134,18 +86,17 @@ script = '''
 exit_on_error true
 
 if array_is_empty ${@}
-    mode = set "--release"
+    exec --fail-on-error cargo build -p icu_datagen --no-default-features --features rayon,provider_baked,bin,use_wasm,networking,icu_casemap,icu_displaynames,icu_relativetime,icu_compactdecimal --release
+    bin = set "target/release/icu4x-datagen"
     components = array components/calendar components/collator components/datetime components/decimal components/list components/locid_transform components/normalizer components/plurals components/properties components/segmenter components/timezone experimental/casemap experimental/compactdecimal experimental/displaynames experimental/relativetime
 else
-    mode = set "--bin=icu4x-datagen" # need some valid argument
+    exec --fail-on-error cargo build -p icu_datagen --no-default-features --features rayon,provider_baked,bin,use_wasm,networking,icu_casemap,icu_displaynames,icu_relativetime,icu_compactdecimal
+    bin = set "target/debug/icu4x-datagen"
     components = set ${@}
 end
 
-root = pwd
 for component in ${components}
-    cd "${component}/data"
-    exec --fail-on-error cargo run -p icu_datagen --no-default-features --features rayon,provider_baked,bin,use_wasm,networking,icu_casemap,icu_displaynames,icu_relativetime,icu_compactdecimal ${mode} -- --config config.json
-    cd "${root}"
+    exec --fail-on-error ${bin} --config "${component}/data/config.json"
 end
 '''
 
@@ -168,54 +119,3 @@ if greater_than ${output_length} 0
     trigger_error ${msg}
 end
 '''
-
-[tasks.download-repo-sources]
-description = "Download fresh CLDR JSON and icuexportdata, overwriting the existing CLDR JSON/icuexportdata."
-category = "ICU4X Data"
-command = "cargo"
-args = [
-    "run",
-    "--bin=download-repo-sources",
-    "--",
-    "-v",
-]
-
-###### END CI TASKS
-
-[tasks.provider-adapters-hello-world-lang-de]
-description = "Build Hello World data for 'de'"
-category = "ICU4X Data"
-command = "cargo"
-args = [
-    "run",
-    "--bin=icu4x-datagen",
-    "--",
-    "--keys=core/helloworld@1",
-    "--locales=de",
-    "--format=dir",
-    "--out=provider/adapters/tests/data/langtest/de",
-    "--overwrite",
-]
-
-[tasks.provider-adapters-hello-world-lang-ro]
-description = "Build Hello World data for 'ro'"
-category = "ICU4X Data"
-command = "cargo"
-args = [
-    "run",
-    "--bin=icu4x-datagen",
-    "--",
-    "--keys=core/helloworld@1",
-    "--locales=ro",
-    "--format=dir",
-    "--out=provider/adapters/tests/data/langtest/ro",
-    "--overwrite",
-]
-
-[tasks.provider-adapters-testdata]
-description = "Build all testdata for the icu_provider_adapters crate."
-category = "ICU4X Data"
-dependencies = [
-    "provider-adapters-hello-world-lang-de",
-    "provider-adapters-hello-world-lang-ro",
-]


### PR DESCRIPTION
#3564 

* Paths in config files are now interpreted relative to the config file
* The config serde spec is now `cfg`-free, as that turned out to be quite confusing. The CLI now reports missing features errors
* Legacy testdata gen is now run on CI
* `provider_baked::Options::use_separate_crates` now defaults to true, as that's the mode required for compiled data
  * the config uses `use_meta_crate`, as we want to default to `false`
* All hello world provider testdata is now generated from configs and checked in CI