### PR TITLE
Allocation-free hex escape parsing in UnicodeSet parsing

### DIFF
--- a/experimental/unicodeset_parser/src/parse.rs
+++ b/experimental/unicodeset_parser/src/parse.rs
@@ -1078,8 +1078,8 @@ where
         // safety: validate_hex_digits ensures that chars (including the last one) are ascii hex digits,
         // which are all exactly one UTF-8 byte long, so slicing on these offsets always respects char boundaries
         #[allow(clippy::indexing_slicing)]
-        let hex_src = &self.source[first_offset..=end_offset];
-        let num = u32::from_str_radix(&hex_src, 16).map_err(|_| PEK::Internal)?;
+        let hex_source = &self.source[first_offset..=end_offset];
+        let num = u32::from_str_radix(hex_source, 16).map_err(|_| PEK::Internal)?;
         char::try_from(num)
             .map(|c| (end_offset, c))
             .map_err(|_| PEK::InvalidEscape.with_offset(end_offset))
@@ -1088,8 +1088,7 @@ where
     // validates [0-9a-fA-F]{min,max}, returns the offset of the last digit, consuming everything in the process
     fn validate_hex_digits(&mut self, min: usize, max: usize) -> Result<usize> {
         let mut last_offset = 0;
-        let mut count = 0;
-        for _ in 0..max {
+        for count in 0..max {
             let (offset, c) = self.must_peek()?;
             if !c.is_ascii_hexdigit() {
                 if count < min {
@@ -1100,7 +1099,6 @@ where
             }
             self.iter.next();
             last_offset = offset;
-            count += 1;
         }
         Ok(last_offset)
     }

--- a/experimental/unicodeset_parser/src/parse.rs
+++ b/experimental/unicodeset_parser/src/parse.rs
@@ -1071,6 +1071,8 @@ where
         }
     }
 
+    // note: could turn this from the current two-pass approach into a one-pass approach
+    // by manually parsing the digits instead of using u32::from_str_radix.
     fn parse_hex_digits_into_char(&mut self, min: usize, max: usize) -> Result<(usize, char)> {
         let first_offset = self.must_peek_index()?;
         let end_offset = self.validate_hex_digits(min, max)?;

--- a/experimental/unicodeset_parser/src/parse.rs
+++ b/experimental/unicodeset_parser/src/parse.rs
@@ -844,17 +844,20 @@ where
             }
             'u' => {
                 // 'u' hex{4}
-                self.parse_hex_digits_into_char(4, 4).map(|(offset, c)| (offset, vec![c]))
+                self.parse_hex_digits_into_char(4, 4)
+                    .map(|(offset, c)| (offset, vec![c]))
             }
             'x' => {
                 // 'x' hex{2}
-                self.parse_hex_digits_into_char(2, 2).map(|(offset, c)| (offset, vec![c]))
+                self.parse_hex_digits_into_char(2, 2)
+                    .map(|(offset, c)| (offset, vec![c]))
             }
             'U' => {
                 // 'U00' ('0' hex{5} | '10' hex{4})
                 self.consume('0')?;
                 self.consume('0')?;
-                self.parse_hex_digits_into_char(6, 6).map(|(offset, c)| (offset, vec![c]))
+                self.parse_hex_digits_into_char(6, 6)
+                    .map(|(offset, c)| (offset, vec![c]))
             }
             'N' => {
                 // parse code point with name in {}

--- a/experimental/unicodeset_parser/src/parse.rs
+++ b/experimental/unicodeset_parser/src/parse.rs
@@ -358,6 +358,7 @@ struct UnicodeSetBuilder<'a, 'b, P: ?Sized> {
     single_set: CodePointInversionListBuilder,
     string_set: HashSet<String>,
     iter: &'a mut Peekable<CharIndices<'b>>,
+    source: &'b str,
     inverted: bool,
     variable_map: &'a VariableMap<'a>,
     xid_start: &'a CodePointInversionList<'a>,
@@ -427,6 +428,7 @@ where
 {
     fn new_internal(
         iter: &'a mut Peekable<CharIndices<'b>>,
+        source: &'b str,
         variable_map: &'a VariableMap<'a>,
         xid_start: &'a CodePointInversionList<'a>,
         xid_continue: &'a CodePointInversionList<'a>,
@@ -437,6 +439,7 @@ where
             single_set: CodePointInversionListBuilder::new(),
             string_set: Default::default(),
             iter,
+            source,
             inverted: false,
             variable_map,
             xid_start,
@@ -690,6 +693,7 @@ where
             ('\\', 'p' | 'P') | ('[', _) => {
                 let mut inner_builder = UnicodeSetBuilder::new_internal(
                     self.iter,
+                    self.source,
                     self.variable_map,
                     self.xid_start,
                     self.xid_continue,
@@ -1454,6 +1458,7 @@ where
 
     let mut builder = UnicodeSetBuilder::new_internal(
         &mut iter,
+        source,
         variable_map,
         &xid_start_list,
         &xid_continue_list,

--- a/experimental/unicodeset_parser/src/parse.rs
+++ b/experimental/unicodeset_parser/src/parse.rs
@@ -222,7 +222,7 @@ impl<'a> VariableMap<'a> {
     pub fn insert_char(&mut self, key: String, c: char) -> Result<(), &VariableValue> {
         // borrow-checker shenanigans, otherwise we could use if let
         if self.0.get(&key).is_some() {
-            // safety: we just checked that this key exists
+            // we just checked that this key exists
             #[allow(clippy::indexing_slicing)]
             return Err(&self.0[&key]);
         }
@@ -237,7 +237,7 @@ impl<'a> VariableMap<'a> {
     pub fn insert_string(&mut self, key: String, s: String) -> Result<(), &VariableValue> {
         // borrow-checker shenanigans, otherwise we could use if let
         if self.0.get(&key).is_some() {
-            // safety: we just checked that this key exists
+            // we just checked that this key exists
             #[allow(clippy::indexing_slicing)]
             return Err(&self.0[&key]);
         }
@@ -258,7 +258,7 @@ impl<'a> VariableMap<'a> {
     pub fn insert_str(&mut self, key: String, s: &'a str) -> Result<(), &VariableValue> {
         // borrow-checker shenanigans, otherwise we could use if let
         if self.0.get(&key).is_some() {
-            // safety: we just checked that this key exists
+            // we just checked that this key exists
             #[allow(clippy::indexing_slicing)]
             return Err(&self.0[&key]);
         }
@@ -283,7 +283,7 @@ impl<'a> VariableMap<'a> {
     ) -> Result<(), &VariableValue> {
         // borrow-checker shenanigans, otherwise we could use if let
         if self.0.get(&key).is_some() {
-            // safety: we just checked that this key exists
+            // we just checked that this key exists
             #[allow(clippy::indexing_slicing)]
             return Err(&self.0[&key]);
         }
@@ -589,7 +589,7 @@ where
                     if let Some(prev) = prev_char.take() {
                         self.single_set.add_char(prev);
                     }
-                    // safety: the match guard checks length == 1
+                    // the match guard checks length == 1
                     #[allow(clippy::indexing_slicing)]
                     let c = c_vec[0];
                     prev_char = Some(c);
@@ -620,7 +620,7 @@ where
                 // parse a literal char as the end of a range
                 (CharMinus, MT::CharOrString(CS::Char(c_vec))) if c_vec.len() == 1 => {
                     let start = prev_char.ok_or(PEK::Internal.with_offset(tok_offset))?;
-                    // safety: the match guard checks length == 1
+                    // the match guard checks length == 1
                     #[allow(clippy::indexing_slicing)]
                     let end = c_vec[0];
                     if start > end {
@@ -1075,7 +1075,7 @@ where
         let first_offset = self.must_peek_index()?;
         let end_offset = self.validate_hex_digits(min, max)?;
 
-        // safety: validate_hex_digits ensures that chars (including the last one) are ascii hex digits,
+        // validate_hex_digits ensures that chars (including the last one) are ascii hex digits,
         // which are all exactly one UTF-8 byte long, so slicing on these offsets always respects char boundaries
         #[allow(clippy::indexing_slicing)]
         let hex_source = &self.source[first_offset..=end_offset];


### PR DESCRIPTION
Avoids unnecessary allocations when parsing hex digits, instead creates a subslice from the source &str.

Part of #3684 

Depends on #3670 

(cc @younies)