### PR TITLE
Avoid allocations when parsing multi-escapes in UnicodeSets

### DIFF
--- a/experimental/unicodeset_parser/src/parse.rs
+++ b/experimental/unicodeset_parser/src/parse.rs
@@ -1078,8 +1078,8 @@ where
         // safety: validate_hex_digits ensures that chars (including the last one) are ascii hex digits,
         // which are all exactly one UTF-8 byte long, so slicing on these offsets always respects char boundaries
         #[allow(clippy::indexing_slicing)]
-        let hex_src = &self.source[first_offset..=end_offset];
-        let num = u32::from_str_radix(&hex_src, 16).map_err(|_| PEK::Internal)?;
+        let hex_source = &self.source[first_offset..=end_offset];
+        let num = u32::from_str_radix(hex_source, 16).map_err(|_| PEK::Internal)?;
         char::try_from(num)
             .map(|c| (end_offset, c))
             .map_err(|_| PEK::InvalidEscape.with_offset(end_offset))
@@ -1088,8 +1088,7 @@ where
     // validates [0-9a-fA-F]{min,max}, returns the offset of the last digit, consuming everything in the process
     fn validate_hex_digits(&mut self, min: usize, max: usize) -> Result<usize> {
         let mut last_offset = 0;
-        let mut count = 0;
-        for _ in 0..max {
+        for count in 0..max {
             let (offset, c) = self.must_peek()?;
             if !c.is_ascii_hexdigit() {
                 if count < min {
@@ -1100,7 +1099,6 @@ where
             }
             self.iter.next();
             last_offset = offset;
-            count += 1;
         }
         Ok(last_offset)
     }

--- a/experimental/unicodeset_parser/src/parse.rs
+++ b/experimental/unicodeset_parser/src/parse.rs
@@ -1963,6 +1963,14 @@ mod tests {
                 r"[\x{10ffff0}]",
                 r"[\x{10ffff0← error: unexpected character '0'",
             ),
+            (
+                r"[\x{11ffff}]",
+                r"[\x{11ffff← error: invalid escape sequence",
+            ),
+            (
+                r"[\x{10ffff 1 10ffff0}]",
+                r"[\x{10ffff 1 10ffff0← error: unexpected character '0'",
+            ),
             // > 1 byte in UTF-8 edge case
             (r"ä", r"ä← error: unexpected character 'ä'"),
             (r"\p{gc=ä}", r"\p{gc=ä← error: unknown property"),

--- a/experimental/unicodeset_parser/src/parse.rs
+++ b/experimental/unicodeset_parser/src/parse.rs
@@ -844,17 +844,20 @@ where
             }
             'u' => {
                 // 'u' hex{4}
-                self.parse_hex_digits_into_char(4, 4).map(|(offset, c)| (offset, vec![c]))
+                self.parse_hex_digits_into_char(4, 4)
+                    .map(|(offset, c)| (offset, vec![c]))
             }
             'x' => {
                 // 'x' hex{2}
-                self.parse_hex_digits_into_char(2, 2).map(|(offset, c)| (offset, vec![c]))
+                self.parse_hex_digits_into_char(2, 2)
+                    .map(|(offset, c)| (offset, vec![c]))
             }
             'U' => {
                 // 'U00' ('0' hex{5} | '10' hex{4})
                 self.consume('0')?;
                 self.consume('0')?;
-                self.parse_hex_digits_into_char(6, 6).map(|(offset, c)| (offset, vec![c]))
+                self.parse_hex_digits_into_char(6, 6)
+                    .map(|(offset, c)| (offset, vec![c]))
             }
             'N' => {
                 // parse code point with name in {}

--- a/experimental/unicodeset_parser/src/parse.rs
+++ b/experimental/unicodeset_parser/src/parse.rs
@@ -812,6 +812,7 @@ where
         Ok((last_offset, literal))
     }
 
+    // note: would be good to somehow merge the two multi_escape methods.
     // finishes a partial multi escape parse. in case of a parse error, self.single_set
     // may be left in an inconsistent state
     fn parse_multi_escape_into_set(&mut self) -> Result<()> {

--- a/experimental/unicodeset_parser/src/parse.rs
+++ b/experimental/unicodeset_parser/src/parse.rs
@@ -874,7 +874,8 @@ where
         }
     }
 
-    // starts with \ and consumes the whole escape sequence
+    // starts with \ and consumes the whole escape sequence if a single
+    // char is escaped, otherwise pauses the parse after the first char
     fn parse_escaped_char(&mut self) -> Result<(usize, SingleOrMultiChar)> {
         self.consume('\\')?;
 

--- a/experimental/unicodeset_parser/src/parse.rs
+++ b/experimental/unicodeset_parser/src/parse.rs
@@ -1678,7 +1678,6 @@ mod tests {
             source.escape_debug()
         );
         let mut expected_size = cpinvlistandstrlist.code_points().size();
-        eprintln!("{:?}", cpinvlistandstrlist.strings());
         for s in strings {
             expected_size += 1;
             assert!(

--- a/experimental/unicodeset_parser/src/parse.rs
+++ b/experimental/unicodeset_parser/src/parse.rs
@@ -796,7 +796,7 @@ where
                         SingleOrMultiChar::Single(c) => buffer.push(c),
                         SingleOrMultiChar::Multi(first) => {
                             buffer.push(first);
-                            self.parse_multi_escape(|c| buffer.push(c))?;
+                            self.parse_multi_escape_into_string(&mut buffer)?;
                         }
                     }
                 }
@@ -844,9 +844,9 @@ where
         }
     }
 
-    // finishes a partial multi escape parse. in case of a parse error, the caller must clean up partial
-    // state left behind by the callback
-    fn parse_multi_escape<F: FnMut(char)>(&mut self, mut cb: F) -> Result<()> {
+    // finishes a partial multi escape parse. in case of a parse error, the caller must clean up the
+    // string if necessary.
+    fn parse_multi_escape_into_string(&mut self, s: &mut String) -> Result<()> {
         // whitespace before first char of this loop (ie, second char in this multi_escape) must be
         // enforced when creating the SingleOrMultiChar::Multi.
         let mut first = true;
@@ -865,7 +865,7 @@ where
                     first = false;
 
                     let (_, c) = self.parse_hex_digits_into_char(1, 6)?;
-                    cb(c);
+                    s.push(c);
                 }
             }
         }

--- a/experimental/unicodeset_parser/src/parse.rs
+++ b/experimental/unicodeset_parser/src/parse.rs
@@ -358,6 +358,7 @@ struct UnicodeSetBuilder<'a, 'b, P: ?Sized> {
     single_set: CodePointInversionListBuilder,
     string_set: HashSet<String>,
     iter: &'a mut Peekable<CharIndices<'b>>,
+    source: &'b str,
     inverted: bool,
     variable_map: &'a VariableMap<'a>,
     xid_start: &'a CodePointInversionList<'a>,
@@ -427,6 +428,7 @@ where
 {
     fn new_internal(
         iter: &'a mut Peekable<CharIndices<'b>>,
+        source: &'b str,
         variable_map: &'a VariableMap<'a>,
         xid_start: &'a CodePointInversionList<'a>,
         xid_continue: &'a CodePointInversionList<'a>,
@@ -437,6 +439,7 @@ where
             single_set: CodePointInversionListBuilder::new(),
             string_set: Default::default(),
             iter,
+            source,
             inverted: false,
             variable_map,
             xid_start,
@@ -690,6 +693,7 @@ where
             ('\\', 'p' | 'P') | ('[', _) => {
                 let mut inner_builder = UnicodeSetBuilder::new_internal(
                     self.iter,
+                    self.source,
                     self.variable_map,
                     self.xid_start,
                     self.xid_continue,
@@ -1454,6 +1458,7 @@ where
 
     let mut builder = UnicodeSetBuilder::new_internal(
         &mut iter,
+        source,
         variable_map,
         &xid_start_list,
         &xid_continue_list,

--- a/experimental/unicodeset_parser/src/parse.rs
+++ b/experimental/unicodeset_parser/src/parse.rs
@@ -812,10 +812,14 @@ where
         Ok((last_offset, literal))
     }
 
-    // note: would be good to somehow merge the two multi_escape methods.
     // finishes a partial multi escape parse. in case of a parse error, self.single_set
     // may be left in an inconsistent state
     fn parse_multi_escape_into_set(&mut self) -> Result<()> {
+        // note: would be good to somehow merge the two multi_escape methods. splitting up the UnicodeSetBuilder into a more
+        // conventional parser + lexer combo might allow this.
+        // issue is that we cannot pass this method an argument that somehow mutates `self` in the current architecture.
+        // self.lexer.parse_multi_into_charappendable(&mut self.single_set) should work because the lifetimes are separate
+
         let mut first = true;
         loop {
             let skipped = self.skip_whitespace();

--- a/experimental/unicodeset_parser/src/parse.rs
+++ b/experimental/unicodeset_parser/src/parse.rs
@@ -308,7 +308,7 @@ fn legal_char_in_string_start(c: char) -> bool {
 #[derive(Debug)]
 enum SingleOrMultiChar {
     Single(char),
-    // Multi indicates parsing was paused and needs to be resumed using parse_multi_escape when
+    // Multi is a marker that indicates parsing was paused and needs to be resumed using parse_multi_escape* when
     // this token is consumed. The contained char is the first char of the multi sequence.
     Multi(char),
 }

--- a/experimental/unicodeset_parser/src/parse.rs
+++ b/experimental/unicodeset_parser/src/parse.rs
@@ -820,6 +820,8 @@ where
         // issue is that we cannot pass this method an argument that somehow mutates `self` in the current architecture.
         // self.lexer.parse_multi_into_charappendable(&mut self.single_set) should work because the lifetimes are separate
 
+        // whitespace before first char of this loop (ie, second char in this multi_escape) must be
+        // enforced when creating the SingleOrMultiChar::Multi.
         let mut first = true;
         loop {
             let skipped = self.skip_whitespace();
@@ -845,6 +847,8 @@ where
     // finishes a partial multi escape parse. in case of a parse error, the caller must clean up partial
     // state left behind by the callback
     fn parse_multi_escape<F: FnMut(char)>(&mut self, mut cb: F) -> Result<()> {
+        // whitespace before first char of this loop (ie, second char in this multi_escape) must be
+        // enforced when creating the SingleOrMultiChar::Multi.
         let mut first = true;
         loop {
             let skipped = self.skip_whitespace();
@@ -887,6 +891,8 @@ where
                         self.iter.next();
                         Ok((offset, SingleOrMultiChar::Single(first_c)))
                     }
+                    // note: enforcing whitespace after the first char here, because the parse_multi_escape functions
+                    // won't have access to this information anymore
                     (offset, c) if c.is_ascii_hexdigit() && skipped > 0 => {
                         Ok((offset, SingleOrMultiChar::Multi(first_c)))
                     }

--- a/experimental/unicodeset_parser/src/parse.rs
+++ b/experimental/unicodeset_parser/src/parse.rs
@@ -548,6 +548,9 @@ where
             let (immediate_offset, immediate_char) = self.must_peek()?;
 
             let (tok_offset, from_var, tok) = self.parse_main_token()?;
+            // warning: self.iter should not be advanced any more after this point on any path to
+            // MT::Literal(Literal::CharKind(SingleOrMultiChar::Multi)), because that variant
+            // expects a certain self.iter state
 
             use MainToken as MT;
             use SingleOrMultiChar as SMC;


### PR DESCRIPTION
Represents multi-escapes (`\x{61 62 63}`) as a marker variant for "must continue parsing this multi-escape" in an allocation-free manner.

Unfortunately the current architecture makes this a bit clunky, leading us to have a `parse_multi_escape_into_string` and a `parse_multi_escape_into_set`. This is because we cannot call a method on self with a self-&mut argument (e.g., a closure updating `self.single_set` or even just a mutable reference to `self.single_set`).

A workaround would be switching to a separate lexer architecture e.g.

```rust
self.lexer.parse_multi_escape(&mut string);
self.lexer.parse_multi_escape(&mut self.single_set); // should borrow check because of disjoint struct fields?
```


Part of #3684 

Depends on #3725 

(cc @younies)