### PR TITLE
Add `get` and `insert` methods to the UnicodeSet VariableMap

### DIFF
--- a/experimental/unicodeset_parser/src/parse.rs
+++ b/experimental/unicodeset_parser/src/parse.rs
@@ -216,6 +216,34 @@ impl<'a> VariableMap<'a> {
         self.0.remove(key)
     }
 
+    /// Get a reference to the value associated with this key, if it exists.
+    pub fn get(&self, key: &str) -> Option<&VariableValue<'a>> {
+        self.0.get(key)
+    }
+
+    /// Insert a `VariableValue` into the `VariableMap`.
+    ///
+    /// Returns `Err` with the old value, if it exists, and does not update the map.
+    pub fn insert(&mut self, key: String, value: VariableValue<'a>) -> Result<(), &VariableValue> {
+        // borrow-checker shenanigans, otherwise we could use if let
+        if self.0.get(&key).is_some() {
+            // we just checked that this key exists
+            #[allow(clippy::indexing_slicing)]
+            return Err(&self.0[&key]);
+        }
+
+        if let VariableValue::String(s) = &value {
+            let mut chars = s.chars();
+            if let (Some(c), None) = (chars.next(), chars.next()) {
+                self.0.insert(key, VariableValue::Char(c));
+                return Ok(());
+            };
+        }
+
+        self.0.insert(key, value);
+        Ok(())
+    }
+
     /// Insert a `char` into the `VariableMap`.    
     ///
     /// Returns `Err` with the old value, if it exists, and does not update the map.


### PR DESCRIPTION
This allows reusing the UnicodeSet parser's `VariableMap` in other parsers, such as TransliteratorParser in #3730.

(cc @younies)