### PR TITLE
Add max_combination_size to some crates

### DIFF
--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -61,7 +61,6 @@ icu_provider_adapters = { path = "../../provider/adapters" }
 std = ["icu_locid/std"]
 sync = []
 macros = ["dep:icu_provider_macros"]
-
 # Enable logging of additional context of data errors
 logging = ["dep:log"]
 # Legacy name
@@ -80,3 +79,5 @@ datagen = ["serde", "dep:erased-serde", "dep:databake", "std", "sync"]
 
 [package.metadata.cargo-all-features]
 denylist = ["macros"]
+# We have tons of features here, limit the amount of tests we run
+max_combination_size = 3

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -134,6 +134,6 @@ required-features = ["provider_fs", "use_wasm"]
 skip_feature_sets = [["use_icu4c"], ["use_wasm"]]
 skip_optional_dependencies = true
 # Always enable wasm and the experimental deps
-always_include_features = ["use_wasm", icu_casemap", "icu_compactdecimal", "icu_displaynames", "icu_relativetime"]
+always_include_features = ["use_wasm", "icu_casemap", "icu_compactdecimal", "icu_displaynames", "icu_relativetime"]
 # We have a *lot* of features here
 max_combination_size = 2

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -103,6 +103,7 @@ provider_blob = ["dep:icu_provider_blob"]
 provider_fs = ["dep:icu_provider_fs"]
 legacy_api = ["provider_fs", "provider_blob", "provider_baked"]
 bin = ["dep:clap", "dep:eyre", "dep:simple_logger"]
+rayon = ["dep:rayon"]
 # Use wasm for building codepointtries
 use_wasm = ["icu_codepointtrie_builder/wasm"]
 # Use local ICU4C libraries for building codepointtries
@@ -111,6 +112,12 @@ use_wasm = ["icu_codepointtrie_builder/wasm"]
 # rule based segmenter data will not be generated.
 use_icu4c = ["icu_codepointtrie_builder/icu4c"]
 networking = ["dep:ureq"]
+
+# experimental deps
+icu_casemap = ["dep:icu_casemap"]
+icu_compactdecimal = ["dep:icu_compactdecimal"]
+icu_displaynames = ["dep:icu_displaynames"]
+icu_relativetime = ["dep:icu_relativetime"]
 
 [[bin]]
 name = "icu4x-datagen"
@@ -125,5 +132,8 @@ required-features = ["provider_fs", "use_wasm"]
 [package.metadata.cargo-all-features]
 # We don't need working CPT builders for check
 skip_feature_sets = [["use_icu4c"], ["use_wasm"]]
-always_include_features = ["icu_casemap", "icu_compactdecimal", "icu_displaynames", "icu_relativetime"]
-max_combination_size = 3
+skip_optional_dependencies = true
+# Always enable wasm and the experimental deps
+always_include_features = ["use_wasm", icu_casemap", "icu_compactdecimal", "icu_displaynames", "icu_relativetime"]
+# We have a *lot* of features here
+max_combination_size = 2

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -131,13 +131,10 @@ required-features = ["provider_fs", "use_wasm"]
 
 [package.metadata.cargo-all-features]
 # We don't need working CPT builders for check
-skip_feature_sets = [["use_icu4c"]]
+skip_feature_sets = [["use_icu4c"], ["use_wasm"]]
 skip_optional_dependencies = true
-# Always enable wasm and the experimental deps
-# wasm because no-wasm mode is basically just panicky and wasm pulls in a lot of deps which we don't want
-# to have contribute to thrashing incremental caches, the experimental deps because we want to all-or-nothing them
+# Always the experimental deps because we want to all-or-nothing them
 # and the nothing case is already tested in regular check CI
-# If use_wasm is ever removed from here, please add it to skip_feature_sets with icu4c
-always_include_features = ["use_wasm", "icu_casemap", "icu_compactdecimal", "icu_displaynames", "icu_relativetime"]
+always_include_features = ["icu_casemap", "icu_compactdecimal", "icu_displaynames", "icu_relativetime"]
 # We have a *lot* of features here
 max_combination_size = 2

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -131,9 +131,13 @@ required-features = ["provider_fs", "use_wasm"]
 
 [package.metadata.cargo-all-features]
 # We don't need working CPT builders for check
-skip_feature_sets = [["use_icu4c"], ["use_wasm"]]
+skip_feature_sets = [["use_icu4c"]]
 skip_optional_dependencies = true
 # Always enable wasm and the experimental deps
+# wasm because no-wasm mode is basically just panicky and wasm pulls in a lot of deps which we don't want
+# to have contribute to thrashing incremental caches, the experimental deps because we want to all-or-nothing them
+# and the nothing case is already tested in regular check CI
+# If use_wasm is ever removed from here, please add it to skip_feature_sets with icu4c
 always_include_features = ["use_wasm", "icu_casemap", "icu_compactdecimal", "icu_displaynames", "icu_relativetime"]
 # We have a *lot* of features here
 max_combination_size = 2

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -48,6 +48,7 @@ rand_pcg = "0.3"
 [features]
 std = []
 bench = []
+ryu = ["dep:ryu"]
 
 [lib]
 bench = false  # This option is required for Benchmark CI

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -26,12 +26,18 @@ include = [
 independent = true
 
 [features]
+default = ["alloc", "zerofrom"]
 derive = ["dep:yoke-derive", "zerofrom/derive"]
 alloc = ["stable_deref_trait/alloc", "serde?/alloc", "zerofrom/alloc"]
-default = ["alloc", "zerofrom"]
+serde = ["dep:serde"]
+zerofrom = ["dep:zerofrom"]
 
 [package.metadata.docs.rs]
 all-features = true
+
+[package.metadata.cargo-all-features]
+# We have tons of features here, limit the amount of tests we run
+max_combination_size = 3
 
 [dependencies]
 stable_deref_trait = { version = "1.2.0", default-features = false }

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -65,10 +65,15 @@ std = []
 derive = ["dep:zerovec-derive"]
 hashmap = ["dep:t1ha"]
 bench = []
+yoke = ["dep:yoke"]
+serde = ["dep:serde"]
+databake = ["dep:databake"]
 
 [package.metadata.cargo-all-features]
 # Bench feature gets tested separately and is only relevant for CI
 denylist = ["bench"]
+# We have tons of features here, limit the amount of tests we run
+max_combination_size = 3
 
 [[bench]]
 name = "zerovec"


### PR DESCRIPTION
Also uses the opportunity to add explicit `dep:` in places where they were missing.

May improve CI times sufficiently, https://github.com/unicode-org/icu4x/pull/3741 is more likely to be successful.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->