### PR TITLE
Make datagen datetime symbols code generic, add monthPatterns parsing

### DIFF
--- a/provider/datagen/src/transform/cldr/cldr_serde/ca.rs
+++ b/provider/datagen/src/transform/cldr/cldr_serde/ca.rs
@@ -14,6 +14,29 @@ use serde::Deserialize;
 use std::borrow::Cow;
 use std::collections::HashMap;
 
+#[derive(Debug, PartialEq, Clone, Deserialize)]
+pub struct FormatWidths<Symbols> {
+    pub abbreviated: Symbols,
+    pub narrow: Symbols,
+    pub short: Option<Symbols>,
+    pub wide: Symbols,
+}
+
+#[derive(Debug, PartialEq, Clone, Deserialize)]
+pub struct StandAloneWidths<Symbols> {
+    pub abbreviated: Option<Symbols>,
+    pub narrow: Option<Symbols>,
+    pub short: Option<Symbols>,
+    pub wide: Option<Symbols>,
+}
+
+#[derive(Debug, PartialEq, Clone, Deserialize)]
+pub struct Contexts<Symbols> {
+    pub format: FormatWidths<Symbols>,
+    #[serde(rename = "stand-alone")]
+    pub stand_alone: Option<StandAloneWidths<Symbols>>,
+}
+
 macro_rules! symbols {
     ($name: ident, $symbols:item) => {
         pub mod $name {
@@ -26,28 +49,11 @@ macro_rules! symbols {
         }
     };
     () => {
-        #[derive(Debug, PartialEq, Clone, Deserialize)]
-        pub struct FormatWidths {
-            pub abbreviated: Symbols,
-            pub narrow: Symbols,
-            pub short: Option<Symbols>,
-            pub wide: Symbols,
-        }
 
-        #[derive(Debug, PartialEq, Clone, Deserialize)]
-        pub struct StandAloneWidths {
-            pub abbreviated: Option<Symbols>,
-            pub narrow: Option<Symbols>,
-            pub short: Option<Symbols>,
-            pub wide: Option<Symbols>,
-        }
+        pub type FormatWidths = super::FormatWidths<Symbols>;
+        pub type StandAloneWidths = super::StandAloneWidths<Symbols>;
+        pub type Contexts = super::Contexts<Symbols>;
 
-        #[derive(Debug, PartialEq, Clone, Deserialize)]
-        pub struct Contexts {
-            pub format: FormatWidths,
-            #[serde(rename = "stand-alone")]
-            pub stand_alone: Option<StandAloneWidths>,
-        }
     }
 }
 

--- a/provider/datagen/src/transform/cldr/cldr_serde/ca.rs
+++ b/provider/datagen/src/transform/cldr/cldr_serde/ca.rs
@@ -37,59 +37,33 @@ pub struct Contexts<Symbols> {
     pub stand_alone: Option<StandAloneWidths<Symbols>>,
 }
 
-macro_rules! symbols {
-    ($name: ident, $symbols:item) => {
-        pub mod $name {
-            use super::*;
-
-            #[derive(Debug, PartialEq, Clone, Deserialize)]
-            $symbols
-
-            symbols!();
-        }
-    };
-    () => {
-
-        pub type FormatWidths = super::FormatWidths<Symbols>;
-        pub type StandAloneWidths = super::StandAloneWidths<Symbols>;
-        pub type Contexts = super::Contexts<Symbols>;
-
-    }
+#[derive(Debug, PartialEq, Clone, Deserialize)]
+pub struct MonthSymbols(pub HashMap<String, String>);
+#[derive(Debug, PartialEq, Clone, Deserialize)]
+pub struct MonthPatternSymbols {
+    pub leap: String,
 }
 
-symbols!(months, pub struct Symbols(pub HashMap<String, String>););
-
-symbols!(
-    month_patterns,
-    pub struct Symbols {
-        pub leap: String,
-    }
-);
-
-symbols!(
-    days,
-    pub struct Symbols {
-        pub sun: String,
-        pub mon: String,
-        pub tue: String,
-        pub wed: String,
-        pub thu: String,
-        pub fri: String,
-        pub sat: String,
-    }
-);
+#[derive(Debug, PartialEq, Clone, Deserialize)]
+pub struct DaySymbols {
+    pub sun: String,
+    pub mon: String,
+    pub tue: String,
+    pub wed: String,
+    pub thu: String,
+    pub fri: String,
+    pub sat: String,
+}
 
 // The day period symbols are Cow<'static, str> instead of String because the Option
 // needs to be retained when converting them into Cow for the data provider.
-symbols!(
-    day_periods,
-    pub struct Symbols {
-        pub am: Cow<'static, str>,
-        pub pm: Cow<'static, str>,
-        pub noon: Option<Cow<'static, str>>,
-        pub midnight: Option<Cow<'static, str>>,
-    }
-);
+#[derive(Debug, PartialEq, Clone, Deserialize)]
+pub struct DayPeriodSymbols {
+    pub am: Cow<'static, str>,
+    pub pm: Cow<'static, str>,
+    pub noon: Option<Cow<'static, str>>,
+    pub midnight: Option<Cow<'static, str>>,
+}
 
 #[derive(PartialEq, Debug, Deserialize, Clone)]
 #[serde(untagged)]
@@ -151,13 +125,14 @@ pub struct AvailableFormats(pub HashMap<String, String>);
 /// https://github.com/unicode-org/cldr-json/blob/master/cldr-json/cldr-dates-full/main/en/ca-gregorian.json
 #[derive(PartialEq, Debug, Deserialize, Clone)]
 pub struct Dates {
-    pub months: months::Contexts,
+    pub months: Contexts<MonthSymbols>,
     #[serde(rename = "monthPatterns")]
-    pub month_patterns: Option<month_patterns::Contexts>,
-    pub days: days::Contexts,
+    // Not used yet, will be in the future
+    pub month_patterns: Option<Contexts<MonthPatternSymbols>>,
+    pub days: Contexts<DaySymbols>,
     pub eras: Eras,
     #[serde(rename = "dayPeriods")]
-    pub day_periods: day_periods::Contexts,
+    pub day_periods: Contexts<DayPeriodSymbols>,
     #[serde(rename = "dateFormats")]
     pub date_formats: LengthPatterns,
     #[serde(rename = "timeFormats")]

--- a/provider/datagen/src/transform/cldr/cldr_serde/ca.rs
+++ b/provider/datagen/src/transform/cldr/cldr_serde/ca.rs
@@ -54,6 +54,13 @@ macro_rules! symbols {
 symbols!(months, pub struct Symbols(pub HashMap<String, String>););
 
 symbols!(
+    month_patterns,
+    pub struct Symbols {
+        pub leap: String,
+    }
+);
+
+symbols!(
     days,
     pub struct Symbols {
         pub sun: String,
@@ -139,6 +146,8 @@ pub struct AvailableFormats(pub HashMap<String, String>);
 #[derive(PartialEq, Debug, Deserialize, Clone)]
 pub struct Dates {
     pub months: months::Contexts,
+    #[serde(rename = "monthPatterns")]
+    pub month_patterns: Option<month_patterns::Contexts>,
     pub days: days::Contexts,
     pub eras: Eras,
     #[serde(rename = "dayPeriods")]

--- a/provider/datagen/src/transform/cldr/datetime/symbols.rs
+++ b/provider/datagen/src/transform/cldr/datetime/symbols.rs
@@ -113,8 +113,8 @@ fn get_era_code_map(calendar: &str) -> BTreeMap<String, TinyStr16> {
 }
 
 macro_rules! symbols_from {
-    ([$name: ident, $name2: ident $(,)?], $ctx:ty, [ $($element: ident),+ $(,)? ] $(,)?) => {
-        impl cldr_serde::ca::$name::Symbols {
+    ([$symbols: path, $name2: ident $(,)?], $ctx:ty, [ $($element: ident),+ $(,)? ] $(,)?) => {
+        impl $symbols {
             fn get(&self, _ctx: &$ctx) -> $name2::SymbolsV1<'static> {
                 $name2::SymbolsV1([
                     $(
@@ -123,10 +123,10 @@ macro_rules! symbols_from {
                 ])
             }
         }
-        symbols_from!([$name, $name2], $ctx);
+        symbols_from!([$symbols, $name2], $ctx);
     };
-    ([$name: ident, $name2: ident $(,)?], $ctx:ty, { $($element: ident),+ $(,)? } $(,)?) => {
-        impl cldr_serde::ca::$name::Symbols {
+    ([$symbols: path, $name2: ident $(,)?], $ctx:ty, { $($element: ident),+ $(,)? } $(,)?) => {
+        impl $symbols {
             fn get(&self, _ctx: &$ctx) -> $name2::SymbolsV1<'static> {
                 $name2::SymbolsV1 {
                     $(
@@ -135,10 +135,10 @@ macro_rules! symbols_from {
                 }
             }
         }
-        symbols_from!([$name, $name], $ctx);
+        symbols_from!([$symbols, $name2], $ctx);
     };
-    ([$name: ident, $name2: ident], $ctx:ty) => {
-        impl cldr_serde::ca::$name::Symbols {
+    ([$symbols: path, $name2: ident], $ctx:ty) => {
+        impl $symbols {
             // Helper function which returns None if the two groups of symbols overlap.
             pub fn get_unaliased(&self, other: &Self) -> Option<Self> {
                 if self == other {
@@ -149,7 +149,7 @@ macro_rules! symbols_from {
             }
         }
 
-        impl ca::Contexts<cldr_serde::ca::$name::Symbols> {
+        impl ca::Contexts<$symbols> {
             fn get(&self, ctx: &$ctx) -> $name2::ContextsV1<'static> {
                 $name2::ContextsV1 {
                     format: self.format.get(ctx),
@@ -160,9 +160,9 @@ macro_rules! symbols_from {
             }
         }
 
-        impl ca::StandAloneWidths<cldr_serde::ca::$name::Symbols> {
+        impl ca::StandAloneWidths<$symbols> {
             // Helper function which returns None if the two groups of symbols overlap.
-            pub fn get_unaliased(&self, other: &cldr_serde::ca::$name::FormatWidths) -> Option<Self> {
+            pub fn get_unaliased(&self, other: &ca::FormatWidths<$symbols>) -> Option<Self> {
                 let abbreviated = self.abbreviated.as_ref().and_then(|v| v.get_unaliased(&other.abbreviated));
                 let narrow = self.narrow.as_ref().and_then(|v| v.get_unaliased(&other.narrow));
                 let short = if self.short == other.short {
@@ -185,7 +185,7 @@ macro_rules! symbols_from {
             }
         }
 
-        impl ca::FormatWidths<cldr_serde::ca::$name::Symbols> {
+        impl ca::FormatWidths<$symbols> {
             fn get(&self, ctx: &$ctx) -> $name2::FormatWidthsV1<'static> {
                 $name2::FormatWidthsV1 {
                     abbreviated: self.abbreviated.get(ctx),
@@ -196,7 +196,7 @@ macro_rules! symbols_from {
             }
         }
 
-        impl ca::StandAloneWidths<cldr_serde::ca::$name::Symbols> {
+        impl ca::StandAloneWidths<$symbols> {
             fn get(&self, ctx: &$ctx) -> $name2::StandAloneWidthsV1<'static> {
                 $name2::StandAloneWidthsV1 {
                     abbreviated: self.abbreviated.as_ref().map(|width| width.get(ctx)),
@@ -208,9 +208,9 @@ macro_rules! symbols_from {
         }
     };
 }
-symbols_from!([months, months], &'static [TinyStr4]);
+symbols_from!([cldr_serde::ca::MonthSymbols, months], &'static [TinyStr4]);
 
-impl cldr_serde::ca::months::Symbols {
+impl cldr_serde::ca::MonthSymbols {
     fn get(&self, ctx: &&'static [TinyStr4]) -> months::SymbolsV1<'static> {
         if ctx.len() == 12 && self.0.len() == 12 {
             let mut arr: [Cow<'static, str>; 12] = Default::default();
@@ -251,11 +251,15 @@ impl cldr_serde::ca::months::Symbols {
     }
 }
 
-symbols_from!([days, weekdays], (), [sun, mon, tue, wed, thu, fri, sat]);
+symbols_from!(
+    [cldr_serde::ca::DaySymbols, weekdays],
+    (),
+    [sun, mon, tue, wed, thu, fri, sat]
+);
 
 symbols_from!(
     [
-        day_periods,
+        cldr_serde::ca::DayPeriodSymbols,
         day_periods,
     ],
     (),

--- a/provider/datagen/src/transform/cldr/datetime/symbols.rs
+++ b/provider/datagen/src/transform/cldr/datetime/symbols.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::transform::cldr::cldr_serde;
+use crate::transform::cldr::cldr_serde::{self, ca};
 use icu_calendar::types::MonthCode;
 use icu_datetime::provider::calendar::*;
 use std::borrow::Cow;
@@ -149,7 +149,7 @@ macro_rules! symbols_from {
             }
         }
 
-        impl cldr_serde::ca::$name::Contexts {
+        impl ca::Contexts<cldr_serde::ca::$name::Symbols> {
             fn get(&self, ctx: &$ctx) -> $name2::ContextsV1<'static> {
                 $name2::ContextsV1 {
                     format: self.format.get(ctx),
@@ -160,7 +160,7 @@ macro_rules! symbols_from {
             }
         }
 
-        impl cldr_serde::ca::$name::StandAloneWidths {
+        impl ca::StandAloneWidths<cldr_serde::ca::$name::Symbols> {
             // Helper function which returns None if the two groups of symbols overlap.
             pub fn get_unaliased(&self, other: &cldr_serde::ca::$name::FormatWidths) -> Option<Self> {
                 let abbreviated = self.abbreviated.as_ref().and_then(|v| v.get_unaliased(&other.abbreviated));
@@ -185,7 +185,7 @@ macro_rules! symbols_from {
             }
         }
 
-        impl cldr_serde::ca::$name::FormatWidths {
+        impl ca::FormatWidths<cldr_serde::ca::$name::Symbols> {
             fn get(&self, ctx: &$ctx) -> $name2::FormatWidthsV1<'static> {
                 $name2::FormatWidthsV1 {
                     abbreviated: self.abbreviated.get(ctx),
@@ -196,7 +196,7 @@ macro_rules! symbols_from {
             }
         }
 
-        impl cldr_serde::ca::$name::StandAloneWidths {
+        impl ca::StandAloneWidths<cldr_serde::ca::$name::Symbols> {
             fn get(&self, ctx: &$ctx) -> $name2::StandAloneWidthsV1<'static> {
                 $name2::StandAloneWidthsV1 {
                     abbreviated: self.abbreviated.as_ref().map(|width| width.get(ctx)),


### PR DESCRIPTION
I eventually want to do the same in datetime's provider code but that's trickier due to yoke/zerofrom derives.

Doesn't yet use monthPatterns, but I already had the change and it nicely demonstrates the generic type.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->