### PR TITLE
Add experimental transliteration component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,6 +1931,16 @@ name = "icu_timezone_data"
 version = "1.3.0"
 
 [[package]]
+name = "icu_transliteration"
+version = "0.0.0"
+dependencies = [
+ "icu_collections",
+ "icu_provider",
+ "serde",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_unicodeset_parser"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
     "experimental/ixdtf",
     "experimental/relativetime",
     "experimental/relativetime/data",
+    "experimental/transliteration",
     "experimental/unicodeset_parser",
     "ffi/capi_cdylib",
     "ffi/capi_staticlib",

--- a/experimental/transliteration/Cargo.toml
+++ b/experimental/transliteration/Cargo.toml
@@ -1,0 +1,30 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+[package]
+name = "icu_transliteration"
+description = "API for Transliteration"
+version = "0.0.0"
+authors = ["The ICU4X Project Developers"]
+edition = "2021"
+readme = "README.md"
+repository = "https://github.com/unicode-org/icu4x"
+license = "Unicode-DFS-2016"
+categories = ["internationalization"]
+# Keep this in sync with other crates unless there are exceptions
+include = [
+    "src/**/*",
+    "tests/**/*",
+    "Cargo.toml",
+    "LICENSE",
+    "README.md"
+]
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+icu_provider = { path = "../../provider/core" }
+
+zerovec = { version = "0.9.4", path = "../../utils/zerovec",  features = ["derive", "yoke"] }

--- a/experimental/transliteration/Cargo.toml
+++ b/experimental/transliteration/Cargo.toml
@@ -26,5 +26,9 @@ all-features = true
 
 [dependencies]
 icu_provider = { path = "../../provider/core" }
+icu_collections = { version = "1.2.0", path = "../../components/collections", features = ["serde"] }
 
-zerovec = { version = "0.9.4", path = "../../utils/zerovec",  features = ["derive", "yoke"] }
+serde = { version = "1.0", features = ["derive"] }
+zerovec = { version = "0.9.4", path = "../../utils/zerovec", features = ["derive"] }
+
+# TODO: Add serde, datagen, compiled_data features

--- a/experimental/transliteration/LICENSE
+++ b/experimental/transliteration/LICENSE
@@ -1,0 +1,51 @@
+UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE
+
+See Terms of Use <https://www.unicode.org/copyright.html>
+for definitions of Unicode Inc.’s Data Files and Software.
+
+NOTICE TO USER: Carefully read the following legal agreement.
+BY DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.'S
+DATA FILES ("DATA FILES"), AND/OR SOFTWARE ("SOFTWARE"),
+YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT.
+IF YOU DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE
+THE DATA FILES OR SOFTWARE.
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 1991-2022 Unicode, Inc. All rights reserved.
+Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Unicode data files and any associated documentation
+(the "Data Files") or Unicode software and any associated documentation
+(the "Software") to deal in the Data Files or Software
+without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, and/or sell copies of
+the Data Files or Software, and to permit persons to whom the Data Files
+or Software are furnished to do so, provided that either
+(a) this copyright and permission notice appear with all copies
+of the Data Files or Software, or
+(b) this copyright and permission notice appear in associated
+Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in these Data Files or Software without prior
+written authorization of the copyright holder.
+
+—
+
+Portions of ICU4X may have been adapted from ICU4C and/or ICU4J.
+ICU 1.8.1 to ICU 57.1 © 1995-2016 International Business Machines Corporation and others.

--- a/experimental/transliteration/README.md
+++ b/experimental/transliteration/README.md
@@ -1,0 +1,16 @@
+# icu_transliteration [![crates.io](https://img.shields.io/crates/v/icu_transliteration)](https://crates.io/crates/icu_transliteration)
+
+🚧 \[Experimental\] Transliteration
+
+This module is published as its own crate ([`icu_transliteration`](https://docs.rs/icu_transliteration/latest/icu_transliteration/))
+and as part of the [`icu`](https://docs.rs/icu/latest/icu/) crate. See the latter for more details on the ICU4X project.
+
+<div class="stab unstable">
+🚧 This code is experimental; it may change at any time, in breaking or non-breaking ways,
+including in SemVer minor releases. It can be enabled with the "experimental" Cargo feature
+of the icu meta-crate. Use with caution.
+</div>
+
+## More Information
+
+For more information on development, authorship, contributing etc. please visit [`ICU4X home page`](https://github.com/unicode-org/icu4x).

--- a/experimental/transliteration/src/lib.rs
+++ b/experimental/transliteration/src/lib.rs
@@ -31,4 +31,4 @@
 
 extern crate alloc;
 
-mod provider;
+pub mod provider;

--- a/experimental/transliteration/src/lib.rs
+++ b/experimental/transliteration/src/lib.rs
@@ -13,7 +13,6 @@
 //! of the icu meta-crate. Use with caution.
 //! </div>
 
-
 // https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(
@@ -29,3 +28,7 @@
     )
 )]
 #![warn(missing_docs)]
+
+extern crate alloc;
+
+mod provider;

--- a/experimental/transliteration/src/lib.rs
+++ b/experimental/transliteration/src/lib.rs
@@ -1,0 +1,31 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+//! 🚧 \[Experimental\] Transliteration
+//!
+//! This module is published as its own crate ([`icu_transliteration`](https://docs.rs/icu_transliteration/latest/icu_transliteration/))
+//! and as part of the [`icu`](https://docs.rs/icu/latest/icu/) crate. See the latter for more details on the ICU4X project.
+//!
+//! <div class="stab unstable">
+//! 🚧 This code is experimental; it may change at any time, in breaking or non-breaking ways,
+//! including in SemVer minor releases. It can be enabled with the "experimental" Cargo feature
+//! of the icu meta-crate. Use with caution.
+//! </div>
+
+
+// https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
+#![cfg_attr(not(test), no_std)]
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::indexing_slicing,
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::exhaustive_structs,
+        clippy::exhaustive_enums,
+        missing_debug_implementations,
+    )
+)]
+#![warn(missing_docs)]

--- a/experimental/transliteration/src/provider.rs
+++ b/experimental/transliteration/src/provider.rs
@@ -70,10 +70,6 @@ pub struct SimpleID<'a> {
 #[zerovec::derive(Serialize, Deserialize)]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Rule<'a> {
-    /// If this is true, the rule only matches directly after the start of the input.
-    pub anchored_to_start: bool,
-    /// If this is true, the rule only matches if the end of the input follows immediately.
-    pub anchored_to_end: bool,
     /// The pattern for the ante context. This is not replaced.
     #[serde(borrow)]
     pub ante: Cow<'a, str>,

--- a/experimental/transliteration/src/provider.rs
+++ b/experimental/transliteration/src/provider.rs
@@ -33,13 +33,14 @@ pub struct RuleBasedTransliterator<'a> {
     /// see, e.g., [Devanagari-Latin](https://github.com/unicode-org/cldr/blob/main/common/transforms/Devanagari-Latin.xml)
     pub visibility: bool,
     /// The [`VarTable`] containing any special matchers (variables, UnicodeSets, ...) used by this transliterator.
+    #[serde(borrow)]
     pub variable_table: VarTable<'a>,
     /// The filter for this transliterator. If there is none, the set of all code points is used.
     #[serde(borrow)]
     pub filter: CodePointInversionList<'a>,
     /// The list of transform rule groups this transliterator uses.
     #[serde(borrow)]
-    pub id_group_list: VarZeroVec<'a, VarZeroSlice<SimpleIDULE>>,
+    pub id_group_list: VarZeroVec<'a, VarZeroSlice<SimpleIdULE>>,
     /// The list of conversion rule groups this transliterator uses.
     #[serde(borrow)]
     pub rule_group_list: VarZeroVec<'a, VarZeroSlice<RuleULE>>,
@@ -47,12 +48,12 @@ pub struct RuleBasedTransliterator<'a> {
 
 /// The ID of a transliterator plus an optional filter.
 #[derive(Debug, Clone)]
-#[make_varule(SimpleIDULE)]
+#[make_varule(SimpleIdULE)]
 #[zerovec::skip_derive(Ord)]
 #[zerovec::derive(Debug)]
 #[zerovec::derive(Serialize, Deserialize)]
 #[derive(serde::Serialize, serde::Deserialize)]
-pub struct SimpleID<'a> {
+pub struct SimpleId<'a> {
     /// The filter for the transliterator. If there is none, the set of all code points is used.
     #[zerovec::varule(CodePointInversionListULE)]
     #[serde(borrow)]
@@ -121,9 +122,9 @@ pub struct VarTable<'a> {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FunctionCall<'a> {
     /// The transliterator that will be called.
-    #[zerovec::varule(SimpleIDULE)]
+    #[zerovec::varule(SimpleIdULE)]
     #[serde(borrow)]
-    pub translit: SimpleID<'a>,
+    pub translit: SimpleId<'a>,
     #[serde(borrow)]
     /// The argument to be transliterated given to the transliterator.
     pub arg: Cow<'a, str>,

--- a/experimental/transliteration/src/provider.rs
+++ b/experimental/transliteration/src/provider.rs
@@ -17,8 +17,9 @@
 
 use alloc::borrow::Cow;
 
-use icu_collections::codepointinvliststringlist::{
-    CodePointInversionListAndStringList, CodePointInversionListAndStringListULE,
+use icu_collections::{
+    codepointinvlist::{CodePointInversionList, CodePointInversionListULE},
+    codepointinvliststringlist::CodePointInversionListAndStringListULE,
 };
 use zerovec::*;
 
@@ -35,7 +36,7 @@ pub struct RuleBasedTransliterator<'a> {
     pub variable_table: VarTable<'a>,
     /// The filter for this transliterator. If there is none, the set of all code points is used.
     #[serde(borrow)]
-    pub filter: CodePointInversionListAndStringList<'a>,
+    pub filter: CodePointInversionList<'a>,
     /// The list of transform rule groups this transliterator uses.
     #[serde(borrow)]
     pub id_group_list: VarZeroVec<'a, VarZeroSlice<SimpleIDULE>>,
@@ -53,9 +54,9 @@ pub struct RuleBasedTransliterator<'a> {
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct SimpleID<'a> {
     /// The filter for the transliterator. If there is none, the set of all code points is used.
-    #[zerovec::varule(CodePointInversionListAndStringListULE)]
+    #[zerovec::varule(CodePointInversionListULE)]
     #[serde(borrow)]
-    pub filter: CodePointInversionListAndStringList<'a>,
+    pub filter: CodePointInversionList<'a>,
     /// The ID of the transliterator.
     #[serde(borrow)]
     pub id: Cow<'a, str>,

--- a/experimental/transliteration/src/provider.rs
+++ b/experimental/transliteration/src/provider.rs
@@ -1,0 +1,118 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use alloc::borrow::Cow;
+
+use icu_collections::codepointinvliststringlist::{
+    CodePointInversionListAndStringList, CodePointInversionListAndStringListULE,
+};
+use zerovec::*;
+
+// TODO(): Improve the documentation of this datastruct.
+
+/// The data struct representing [UTS #35 transform rules](https://unicode.org/reports/tr35/tr35-general.html#Transforms).
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct RuleBasedTransliterator<'a> {
+    /// Whether this transliterator is accessible directly through the constructor.
+    /// Hidden transliterators are intended as dependencies for visible transliterators,
+    /// see, e.g., [Devanagari-Latin](https://github.com/unicode-org/cldr/blob/main/common/transforms/Devanagari-Latin.xml)
+    pub visibility: bool,
+    /// The [`VarTable`] containing any special matchers (variables, UnicodeSets, ...) used by this transliterator.
+    pub variable_table: VarTable<'a>,
+    /// The filter for this transliterator. If there is none, the set of all code points is used.
+    #[serde(borrow)]
+    pub filter: CodePointInversionListAndStringList<'a>,
+    /// The list of transform rule groups this transliterator uses.
+    #[serde(borrow)]
+    pub id_group_list: VarZeroVec<'a, VarZeroSlice<SimpleIDULE>>,
+    /// The list of conversion rule groups this transliterator uses.
+    #[serde(borrow)]
+    pub rule_group_list: VarZeroVec<'a, VarZeroSlice<RuleULE>>,
+}
+
+/// The ID of a transliterator plus an optional filter.
+#[derive(Debug, Clone)]
+#[make_varule(SimpleIDULE)]
+#[zerovec::skip_derive(Ord)]
+#[zerovec::derive(Serialize, Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct SimpleID<'a> {
+    /// The filter for the transliterator. If there is none, the set of all code points is used.
+    #[zerovec::varule(CodePointInversionListAndStringListULE)]
+    #[serde(borrow)]
+    pub filter: CodePointInversionListAndStringList<'a>,
+    /// The ID of the transliterator.
+    #[serde(borrow)]
+    pub id: Cow<'a, str>,
+}
+
+/// A conversion rule. The source patterns as well as the replacer use inlined private use characters
+/// that refer to elements of the [`VarTable`] for special matchers (variables, UnicodeSets, ...).
+#[make_varule(RuleULE)]
+#[zerovec::skip_derive(Ord)]
+#[zerovec::derive(Serialize, Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct Rule<'a> {
+    /// If this is true, the rule only matches directly after the start of the input.
+    pub anchored_to_start: bool,
+    /// If this is true, the rule only matches if the end of the input follows immediately.
+    pub anchored_to_end: bool,
+    /// The pattern for the ante context. This is not replaced.
+    #[serde(borrow)]
+    pub ante: Cow<'a, str>,
+    /// The pattern for the key. This is what gets replaced.
+    #[serde(borrow)]
+    pub key: Cow<'a, str>,
+    /// The pattern for the post context. This is not replaced.
+    #[serde(borrow)]
+    pub post: Cow<'a, str>,
+    /// The replacer. The key gets replaced with this.
+    #[serde(borrow)]
+    pub replacer: Cow<'a, str>,
+    /// The offset of the cursor after this rule, if the rule matches.
+    /// The end of the key/replacer is 0, i.e., a no-op.
+    pub cursor_offset: i32,
+}
+
+/// The special matchers and replacers used by this transliterator.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct VarTable<'a> {
+    /// Variable definitions.
+    #[serde(borrow)]
+    pub compounds: VarZeroVec<'a, str>,
+    /// Zero or one quantifiers.
+    #[serde(borrow)]
+    pub quantifiers_opt: VarZeroVec<'a, str>,
+    /// Zero or more quantifiers.
+    #[serde(borrow)]
+    pub quantifiers_kleene: VarZeroVec<'a, str>,
+    /// One or more quantifiers.
+    #[serde(borrow)]
+    pub quantifiers_kleene_plus: VarZeroVec<'a, str>,
+    /// Segments.
+    #[serde(borrow)]
+    pub segments: VarZeroVec<'a, str>,
+    /// UnicodeSets. These are represented as a [`CodePointInversionListAndStringList`](icu_collections::codepointinvliststringlist::CodePointInversionListAndStringList)
+    #[serde(borrow)]
+    pub unicode_sets: VarZeroVec<'a, CodePointInversionListAndStringListULE>,
+    /// Function calls.
+    #[serde(borrow)]
+    pub function_calls: VarZeroVec<'a, FunctionCallULE>,
+}
+
+/// An inline recursive call to a transliterator with an arbitrary argument.
+#[derive(Debug, Clone)]
+#[make_varule(FunctionCallULE)]
+#[zerovec::skip_derive(Ord)]
+#[zerovec::derive(Serialize, Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct FunctionCall<'a> {
+    /// The transliterator that will be called.
+    #[zerovec::varule(SimpleIDULE)]
+    #[serde(borrow)]
+    pub translit: SimpleID<'a>,
+    #[serde(borrow)]
+    /// The argument to be transliterated given to the transliterator.
+    pub arg: Cow<'a, str>,
+}

--- a/experimental/transliteration/src/provider.rs
+++ b/experimental/transliteration/src/provider.rs
@@ -23,7 +23,7 @@ use icu_collections::{
 };
 use zerovec::*;
 
-// TODO(): Improve the documentation of this datastruct.
+// TODO(#3776): Improve the documentation of this datastruct.
 
 /// The data struct representing [UTS #35 transform rules](https://unicode.org/reports/tr35/tr35-general.html#Transforms).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/experimental/transliteration/src/provider.rs
+++ b/experimental/transliteration/src/provider.rs
@@ -2,6 +2,19 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+// Provider structs must be stable
+#![allow(clippy::exhaustive_structs, clippy::exhaustive_enums)]
+
+//! 🚧 \[Unstable\] Data provider struct definitions for this ICU4X component.
+//!
+//! <div class="stab unstable">
+//! 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
+//! including in SemVer minor releases. While the serde representation of data structs is guaranteed
+//! to be stable, their Rust representation might not be. Use with caution.
+//! </div>
+//!
+//! Read more about data providers: [`icu_provider`]
+
 use alloc::borrow::Cow;
 
 use icu_collections::codepointinvliststringlist::{
@@ -12,7 +25,7 @@ use zerovec::*;
 // TODO(): Improve the documentation of this datastruct.
 
 /// The data struct representing [UTS #35 transform rules](https://unicode.org/reports/tr35/tr35-general.html#Transforms).
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RuleBasedTransliterator<'a> {
     /// Whether this transliterator is accessible directly through the constructor.
     /// Hidden transliterators are intended as dependencies for visible transliterators,
@@ -35,6 +48,7 @@ pub struct RuleBasedTransliterator<'a> {
 #[derive(Debug, Clone)]
 #[make_varule(SimpleIDULE)]
 #[zerovec::skip_derive(Ord)]
+#[zerovec::derive(Debug)]
 #[zerovec::derive(Serialize, Deserialize)]
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct SimpleID<'a> {
@@ -51,8 +65,9 @@ pub struct SimpleID<'a> {
 /// that refer to elements of the [`VarTable`] for special matchers (variables, UnicodeSets, ...).
 #[make_varule(RuleULE)]
 #[zerovec::skip_derive(Ord)]
+#[zerovec::derive(Debug)]
 #[zerovec::derive(Serialize, Deserialize)]
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Rule<'a> {
     /// If this is true, the rule only matches directly after the start of the input.
     pub anchored_to_start: bool,
@@ -76,7 +91,7 @@ pub struct Rule<'a> {
 }
 
 /// The special matchers and replacers used by this transliterator.
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct VarTable<'a> {
     /// Variable definitions.
     #[serde(borrow)]
@@ -102,11 +117,11 @@ pub struct VarTable<'a> {
 }
 
 /// An inline recursive call to a transliterator with an arbitrary argument.
-#[derive(Debug, Clone)]
 #[make_varule(FunctionCallULE)]
 #[zerovec::skip_derive(Ord)]
+#[zerovec::derive(Debug)]
 #[zerovec::derive(Serialize, Deserialize)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FunctionCall<'a> {
     /// The transliterator that will be called.
     #[zerovec::varule(SimpleIDULE)]


### PR DESCRIPTION
This adds the transliteration component that will house the runtime API for transliteration.

Only adds the (already discussed) data struct from https://github.com/unicode-org/icu4x/pull/3627 `data_struct.rs` with minor changes:
1. Transliterator filters are now just CPIL, because strings are disallowed, saving a few bytes
2. `Rule` has one added field `cursor_offset` - an `i32` offset that adjusts the cursor after the rule matches (`@@@|` syntax)

(cc @younies)