### PR TITLE
Moving datagen options to `export`

### DIFF
--- a/provider/blob/src/export/mod.rs
+++ b/provider/blob/src/export/mod.rs
@@ -19,8 +19,11 @@
 //!
 //! // Export something
 //! DatagenProvider::default()
-//!     .export(
-//!         [icu_provider::hello_world::HelloWorldV1Marker::KEY].into_iter().collect(),
+//!     .export({
+//!             let mut options = options::Options::default();
+//!             options.keys = [icu_provider::hello_world::HelloWorldV1Marker::KEY].into_iter().collect();
+//!             options
+//!         },
 //!         exporter
 //!     ).unwrap();
 //!

--- a/provider/datagen/README.md
+++ b/provider/datagen/README.md
@@ -20,7 +20,11 @@ use std::fs::File;
 fn main() {
     DatagenProvider::default()
         .export(
-            [icu::list::provider::AndListV1Marker::KEY].into_iter().collect(),
+            {
+                let mut options = options::Options::default();
+                options.keys = [icu::list::provider::AndListV1Marker::KEY].into_iter().collect();
+                options
+            },
             BlobExporter::new_with_sink(Box::new(File::create("data.postcard").unwrap())),
         )
         .unwrap();

--- a/provider/datagen/src/baked_exporter.rs
+++ b/provider/datagen/src/baked_exporter.rs
@@ -20,8 +20,11 @@
 //!
 //! // Export something
 //! DatagenProvider::default()
-//!     .export(
-//!         [icu_provider::hello_world::HelloWorldV1Marker::KEY].into_iter().collect(),
+//!     .export({
+//!             let mut options = options::Options::default();
+//!             options.keys = [icu_provider::hello_world::HelloWorldV1Marker::KEY].into_iter().collect();
+//!             options
+//!         },
 //!         exporter
 //!     ).unwrap();
 //! #

--- a/provider/datagen/src/bin/datagen/config.rs
+++ b/provider/datagen/src/bin/datagen/config.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 pub use icu_datagen::options::*;
+pub use icu_datagen::{CollationHanDatabase, TrieType};
 
 use icu_provider::prelude::*;
 use std::collections::HashSet;

--- a/provider/datagen/src/bin/datagen/mod.rs
+++ b/provider/datagen/src/bin/datagen/mod.rs
@@ -34,13 +34,24 @@ fn main() -> eyre::Result<()> {
     let config = matches.as_config()?;
 
     let mut options = options::Options::default();
+    options.keys = match config.keys {
+        config::KeyInclude::None => Default::default(),
+        config::KeyInclude::All => icu_datagen::all_keys().into_iter().collect(),
+        config::KeyInclude::Explicit(set) => set,
+        config::KeyInclude::ForBinary(path) => {
+            icu_datagen::keys_from_bin(path)?.into_iter().collect()
+        }
+    };
     options.locales = config.locales;
-    options.trie_type = config.trie_type;
-    options.collation_han_database = config.collation_han_database;
     options.collations = config.collations;
+    options.segmenter_models = config.segmenter_models;
     options.fallback = config.fallback;
 
     let mut source_data = SourceData::offline();
+    source_data = source_data.with_collation_han_database(config.collation_han_database);
+    if config.trie_type == crate::config::TrieType::Fast {
+        source_data = source_data.with_fast_tries();
+    }
     source_data = match config.cldr {
         config::PathOrTag::Path(path) => source_data.with_cldr(path, Default::default())?,
         #[cfg(feature = "networking")]
@@ -80,16 +91,7 @@ fn main() -> eyre::Result<()> {
         _ => eyre::bail!("Download data from tags requires the `networking` Cargo feature"),
     };
 
-    let provider = DatagenProvider::try_new(options, source_data)?;
-
-    let keys = match config.keys {
-        config::KeyInclude::None => Default::default(),
-        config::KeyInclude::All => icu_datagen::all_keys().into_iter().collect(),
-        config::KeyInclude::Explicit(set) => set,
-        config::KeyInclude::ForBinary(path) => {
-            icu_datagen::keys_from_bin(path)?.into_iter().collect()
-        }
-    };
+    let provider = DatagenProvider::new(source_data);
 
     match config.export {
         config::Export::Fs {
@@ -122,7 +124,7 @@ fn main() -> eyre::Result<()> {
                         options
                     },
                 )?;
-                Ok(provider.export(keys, exporter)?)
+                Ok(provider.export(options, exporter)?)
             }
         }
         config::Export::Blob { ref path } => {
@@ -142,7 +144,7 @@ fn main() -> eyre::Result<()> {
                         )
                     },
                 );
-                Ok(provider.export(keys, exporter)?)
+                Ok(provider.export(options, exporter)?)
             }
         }
         config::Export::Baked {
@@ -168,7 +170,7 @@ fn main() -> eyre::Result<()> {
                     options
                 })?;
 
-                Ok(provider.export(keys, exporter)?)
+                Ok(provider.export(options, exporter)?)
             }
         }
     }

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -102,10 +102,10 @@ pub mod prelude {
     // SEMVER GRAVEYARD
     #[cfg(feature = "legacy_api")]
     #[doc(hidden)]
-    pub use crate::source::CollationHanDatabase;
+    pub use crate::options::CoverageLevel;
     #[cfg(feature = "legacy_api")]
     #[doc(hidden)]
-    pub use crate::options::{CoverageLevel};
+    pub use crate::source::CollationHanDatabase;
     #[cfg(feature = "legacy_api")]
     #[allow(deprecated)]
     #[doc(hidden)]

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -23,7 +23,11 @@
 //! fn main() {
 //!     DatagenProvider::default()
 //!         .export(
-//!             [icu::list::provider::AndListV1Marker::KEY].into_iter().collect(),
+//!             {
+//!                 let mut options = options::Options::default();
+//!                 options.keys = [icu::list::provider::AndListV1Marker::KEY].into_iter().collect();
+//!                 options
+//!             },
 //!             BlobExporter::new_with_sink(Box::new(File::create("data.postcard").unwrap())),
 //!         )
 //!         .unwrap();
@@ -72,7 +76,10 @@ mod transform;
 pub use error::{is_missing_cldr_error, is_missing_icuexport_error};
 #[allow(deprecated)] // ugh
 pub use registry::{all_keys, all_keys_with_experimental, deserialize_and_measure, key};
+pub use source::CollationHanDatabase;
 pub use source::SourceData;
+#[doc(hidden)] // for CLI serde
+pub use source::TrieType;
 
 #[cfg(feature = "provider_baked")]
 pub mod baked_exporter;
@@ -95,7 +102,10 @@ pub mod prelude {
     // SEMVER GRAVEYARD
     #[cfg(feature = "legacy_api")]
     #[doc(hidden)]
-    pub use crate::options::{CollationHanDatabase, CoverageLevel};
+    pub use crate::source::CollationHanDatabase;
+    #[cfg(feature = "legacy_api")]
+    #[doc(hidden)]
+    pub use crate::options::{CoverageLevel};
     #[cfg(feature = "legacy_api")]
     #[allow(deprecated)]
     #[doc(hidden)]
@@ -103,6 +113,7 @@ pub mod prelude {
 }
 
 use icu_locid::subtags::Language;
+use icu_locid_transform::fallback::LocaleFallbacker;
 use icu_provider::datagen::*;
 use icu_provider::prelude::*;
 use memchr::memmem;
@@ -138,54 +149,9 @@ pub struct DatagenProvider {
 }
 
 impl DatagenProvider {
-    /// Creates a new data provider with the given `source` and `options`.
-    ///
-    /// Fails if `options` is using CLDR locale sets and `source` does not contain CLDR data.
-    pub fn try_new(options: options::Options, mut source: SourceData) -> Result<Self, DataError> {
-        if source.options != Default::default() {
-            log::warn!("Trie type, collation database, or collations set on SourceData. These will be ignored in favor of options.");
-        }
-
-        source.options = options;
-
-        if matches!(source.options.fallback, options::FallbackMode::Expand)
-            && !matches!(source.options.locales, options::LocaleInclude::Explicit(_))
-        {
-            return Err(DataError::custom(
-                "FallbackMode::Expand requires LocaleInclude::Explicit",
-            ));
-        }
-
-        source.options.locales = match core::mem::take(&mut source.options.locales) {
-            options::LocaleInclude::None => options::LocaleInclude::Explicit(Default::default()),
-            options::LocaleInclude::CldrSet(levels) => options::LocaleInclude::Explicit(
-                source
-                    .locales(levels.iter().copied().collect::<Vec<_>>().as_slice())?
-                    .into_iter()
-                    .collect(),
-            ),
-            options::LocaleInclude::Explicit(set) => options::LocaleInclude::Explicit(set),
-            options::LocaleInclude::All => options::LocaleInclude::All,
-            options::LocaleInclude::Recommended => options::LocaleInclude::Explicit(
-                source
-                    .locales(&[
-                        options::CoverageLevel::Modern,
-                        options::CoverageLevel::Moderate,
-                        options::CoverageLevel::Basic,
-                    ])?
-                    .into_iter()
-                    .collect(),
-            ),
-        };
-
-        let mut provider = Self { source };
-
-        if provider.source.options.fallback == options::FallbackMode::Runtime {
-            provider.source.fallbacker =
-                Some(icu_locid_transform::fallback::LocaleFallbacker::try_new_unstable(&provider)?);
-        }
-
-        Ok(provider)
+    /// Creates a new data provider with the given `source`.
+    pub fn new(source: SourceData) -> Self {
+        Self { source }
     }
 
     #[cfg(test)]
@@ -206,16 +172,23 @@ impl DatagenProvider {
         TEST_PROVIDER.clone()
     }
 
-    pub(crate) fn filter_data_locales(
+    pub(crate) fn select_locales_for_key(
         &self,
-        supported: Vec<icu_provider::DataLocale>,
-    ) -> Vec<icu_provider::DataLocale> {
-        match &self.source.options.locales {
-            options::LocaleInclude::All => supported,
-            options::LocaleInclude::Explicit(set) => supported
+        key: DataKey,
+        options: &options::Options,
+        fallbacker: Option<&LocaleFallbacker>,
+    ) -> Result<HashSet<icu_provider::DataLocale>, DataError> {
+        let supported_locales = self
+            .supported_locales_for_key(key)
+            .map_err(|e| e.with_key(key))?
+            .into_iter()
+            .collect::<HashSet<_>>();
+        let resolved_locales = match &options.locales {
+            options::LocaleInclude::All => supported_locales,
+            options::LocaleInclude::Explicit(set) => supported_locales
                 .into_iter()
                 .filter(|l| {
-                    if let Some(fallbacker) = &self.source.fallbacker {
+                    if let Some(fallbacker) = fallbacker {
                         // Include any UND-*
                         if l.get_langid().language == Language::UND {
                             return true;
@@ -231,15 +204,44 @@ impl DatagenProvider {
                         }
                         false
                     } else {
-                        set.contains(&l.get_langid())
+                        set.contains(&l.get_langid().language.into())
                     }
                 })
                 .collect(),
             _ => unreachable!("resolved"),
-        }
+        };
+
+        Ok(
+            if key == icu_collator::provider::CollationDataV1Marker::KEY
+                || key == icu_collator::provider::CollationDiacriticsV1Marker::KEY
+                || key == icu_collator::provider::CollationJamoV1Marker::KEY
+                || key == icu_collator::provider::CollationMetadataV1Marker::KEY
+                || key == icu_collator::provider::CollationReorderingV1Marker::KEY
+                || key == icu_collator::provider::CollationSpecialPrimariesV1Marker::KEY
+            {
+                transform::icuexport::collator::filter_data_locales(
+                    resolved_locales,
+                    &options.collations,
+                )
+            } else if key == icu_segmenter::provider::LstmForWordLineAutoV1Marker::KEY {
+                transform::segmenter::lstm::filter_data_locales(
+                    resolved_locales,
+                    &options.segmenter_models,
+                )
+            } else if key == icu_segmenter::provider::DictionaryForWordOnlyAutoV1Marker::KEY
+                || key == icu_segmenter::provider::DictionaryForWordLineExtendedV1Marker::KEY
+            {
+                transform::segmenter::dictionary::filter_data_locales(
+                    resolved_locales,
+                    &options.segmenter_models,
+                )
+            } else {
+                resolved_locales
+            },
+        )
     }
 
-    /// Exports data for the set of keys to the given exporter.
+    /// Exports data for the given options to the given exporter.
     ///
     /// See
     /// [`BlobExporter`](icu_provider_blob::export),
@@ -247,22 +249,70 @@ impl DatagenProvider {
     /// and [`BakedExporter`](crate::baked_exporter).
     pub fn export(
         &self,
-        keys: HashSet<DataKey>,
+        mut options: options::Options,
         mut exporter: impl DataExporter,
     ) -> Result<(), DataError> {
-        if keys.is_empty() {
+        if options.keys.is_empty() {
             log::warn!("No keys selected");
         }
+
+        if !self.source.collations.is_empty()
+            && options.collations
+                != self
+                    .source
+                    .collations
+                    .iter()
+                    .cloned()
+                    .collect::<HashSet<_>>()
+        {
+            log::warn!("SourceData::with_collations was used and differs from Options#collations (which will be used).")
+        }
+
+        if matches!(options.fallback, options::FallbackMode::Expand)
+            && !matches!(options.locales, options::LocaleInclude::Explicit(_))
+        {
+            return Err(DataError::custom(
+                "FallbackMode::Expand requires LocaleInclude::Explicit",
+            ));
+        }
+
+        options.locales = match core::mem::take(&mut options.locales) {
+            options::LocaleInclude::None => options::LocaleInclude::Explicit(Default::default()),
+            options::LocaleInclude::CldrSet(levels) => options::LocaleInclude::Explicit(
+                self.source
+                    .locales(levels.iter().copied().collect::<Vec<_>>().as_slice())?
+                    .into_iter()
+                    .collect(),
+            ),
+            options::LocaleInclude::Explicit(set) => options::LocaleInclude::Explicit(set),
+            options::LocaleInclude::All => options::LocaleInclude::All,
+            options::LocaleInclude::Recommended => options::LocaleInclude::Explicit(
+                self.source
+                    .locales(&[
+                        options::CoverageLevel::Modern,
+                        options::CoverageLevel::Moderate,
+                        options::CoverageLevel::Basic,
+                    ])?
+                    .into_iter()
+                    .collect(),
+            ),
+        };
 
         // Avoid multiple monomorphizations
         fn internal(
             provider: &DatagenProvider,
-            keys: HashSet<DataKey>,
+            mut options: options::Options,
             exporter: &mut dyn DataExporter,
         ) -> Result<(), DataError> {
             use rayon_prelude::*;
 
-            keys.into_par_iter().try_for_each(|key| {
+            let fallbacker = if options.fallback == options::FallbackMode::Runtime {
+                Some(LocaleFallbacker::try_new_unstable(provider)?)
+            } else {
+                None
+            };
+
+            core::mem::take(&mut options.keys).into_par_iter().try_for_each(|key| {
                 log::info!("Generating key {key}");
 
                 if key.metadata().singleton {
@@ -274,11 +324,9 @@ impl DatagenProvider {
                     return exporter.flush_singleton(key, &payload).map_err(|e| e.with_req(key, Default::default()));
                 }
 
-                let mut supported_locales: HashSet<DataLocale> = provider
-                    .supported_locales_for_key(key)
-                    .map_err(|e| e.with_key(key))?.into_iter().collect();
+                let mut supported_locales = provider.select_locales_for_key(key, &options, fallbacker.as_ref())?;
 
-                match provider.source.options.fallback {
+                match options.fallback {
                     options::FallbackMode::Legacy => {
                         supported_locales
                             .into_par_iter()
@@ -328,7 +376,7 @@ impl DatagenProvider {
                             .flush_with_fallback(key, icu_provider::datagen::FallbackMode::Full)
                             .map_err(|e| e.with_key(key))
                     }
-                    options::FallbackMode::Expand => match &provider.source.options.locales {
+                    options::FallbackMode::Expand => match &options.locales {
                         options::LocaleInclude::Explicit(requested_locales) => {
                             let provider = icu_provider_adapters::fallback::LocaleFallbackProvider::try_new_unstable(provider.clone())?;
                             supported_locales.extend(requested_locales.iter().map(Into::into));
@@ -362,7 +410,7 @@ impl DatagenProvider {
 
             exporter.close()
         }
-        internal(self, keys, &mut exporter)
+        internal(self, options, &mut exporter)
     }
 }
 
@@ -575,8 +623,10 @@ pub fn datagen(
     outs: Vec<Out>,
 ) -> Result<(), DataError> {
     use options::*;
-    let provider = DatagenProvider::try_new(
+
+    DatagenProvider::new(source.clone()).export(
         Options {
+            keys: keys.iter().cloned().collect(),
             locales: locales
                 .map(|ls| {
                     LocaleInclude::Explicit(
@@ -607,17 +657,9 @@ pub fn datagen(
                     models
                 }),
             },
-            ..source.options.clone()
+            collations: source.collations.iter().cloned().collect(),
+            ..Default::default()
         },
-        {
-            let mut source = source.clone();
-            source.options = Default::default();
-            source
-        },
-    )?;
-
-    provider.export(
-        keys.iter().cloned().collect(),
         MultiExporter::new(
             outs.into_iter()
                 .map(|out| -> Result<Box<dyn DataExporter>, DataError> {
@@ -731,7 +773,7 @@ fn test_keys_from_bin() {
 
 #[cfg(feature = "legacy_api")]
 #[doc(hidden)]
-pub use source::{CollationHanDatabase, CoverageLevel};
+pub use source::CoverageLevel;
 
 #[cfg(feature = "legacy_api")]
 #[doc(hidden)]

--- a/provider/datagen/src/options.rs
+++ b/provider/datagen/src/options.rs
@@ -44,6 +44,11 @@ use std::collections::HashSet;
 pub struct Options {
     /// The set of keys to generate. See [`icu_datagen::keys`],
     /// [`icu_datagen::all_keys`], [`icu_datagen::key`] and [`icu_datagen::keys_from_bin`].
+    ///
+    /// [`icu_datagen::keys`]: crate::keys
+    /// [`icu_datagen::all_keys`]: crate::all_keys
+    /// [`icu_datagen::key`]: crate::key
+    /// [`icu_datagen::keys_from_bin`]: crate::keys_from_bin
     pub keys: HashSet<icu_provider::DataKey>,
     /// Defines the locales to include
     pub locales: LocaleInclude,

--- a/provider/datagen/src/options.rs
+++ b/provider/datagen/src/options.rs
@@ -42,12 +42,11 @@ use std::collections::HashSet;
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Options {
+    /// The set of keys to generate. See [`icu_datagen::keys`], 
+    /// [`icu_datagen::all_keys`], [`icu_datagen::key`] and [`icu_datagen::keys_for_bin`].
+    pub keys: HashSet<icu_provider::DataKey>,
     /// Defines the locales to include
     pub locales: LocaleInclude,
-    /// Whether to optimize tries for speed or size
-    pub trie_type: TrieType,
-    /// Which Han collation to use
-    pub collation_han_database: CollationHanDatabase,
     /// The collation types to include.
     ///
     /// The special string `"search*"` causes all search collation tables to be included.
@@ -81,63 +80,6 @@ pub enum LocaleInclude {
 impl Default for LocaleInclude {
     fn default() -> Self {
         Self::All
-    }
-}
-
-/// Specifies the collation Han database to use.
-///
-/// Unihan is more precise but significantly increases data size. See
-/// <https://github.com/unicode-org/icu/blob/main/docs/userguide/icu_data/buildtool.md#collation-ucadata>
-#[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
-#[non_exhaustive]
-pub enum CollationHanDatabase {
-    /// Implicit
-    #[serde(rename = "implicit")]
-    Implicit,
-    /// Unihan
-    #[serde(rename = "unihan")]
-    Unihan,
-}
-
-impl std::fmt::Display for CollationHanDatabase {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        match self {
-            CollationHanDatabase::Implicit => write!(f, "implicithan"),
-            CollationHanDatabase::Unihan => write!(f, "unihan"),
-        }
-    }
-}
-
-impl Default for CollationHanDatabase {
-    fn default() -> Self {
-        Self::Implicit
-    }
-}
-
-/// Specifies the trie type to use.
-#[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
-#[non_exhaustive]
-pub enum TrieType {
-    /// Fast tries are optimized for speed
-    #[serde(rename = "fast")]
-    Fast,
-    /// Small tries are optimized for size
-    #[serde(rename = "small")]
-    Small,
-}
-
-impl std::fmt::Display for TrieType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        match self {
-            TrieType::Fast => write!(f, "fast"),
-            TrieType::Small => write!(f, "small"),
-        }
-    }
-}
-
-impl Default for TrieType {
-    fn default() -> Self {
-        Self::Small
     }
 }
 

--- a/provider/datagen/src/options.rs
+++ b/provider/datagen/src/options.rs
@@ -43,7 +43,7 @@ use std::collections::HashSet;
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Options {
     /// The set of keys to generate. See [`icu_datagen::keys`],
-    /// [`icu_datagen::all_keys`], [`icu_datagen::key`] and [`icu_datagen::keys_for_bin`].
+    /// [`icu_datagen::all_keys`], [`icu_datagen::key`] and [`icu_datagen::keys_from_bin`].
     pub keys: HashSet<icu_provider::DataKey>,
     /// Defines the locales to include
     pub locales: LocaleInclude,

--- a/provider/datagen/src/options.rs
+++ b/provider/datagen/src/options.rs
@@ -42,7 +42,7 @@ use std::collections::HashSet;
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Options {
-    /// The set of keys to generate. See [`icu_datagen::keys`], 
+    /// The set of keys to generate. See [`icu_datagen::keys`],
     /// [`icu_datagen::all_keys`], [`icu_datagen::key`] and [`icu_datagen::keys_for_bin`].
     pub keys: HashSet<icu_provider::DataKey>,
     /// Defines the locales to include

--- a/provider/datagen/src/transform/cldr/characters/mod.rs
+++ b/provider/datagen/src/transform/cldr/characters/mod.rs
@@ -49,14 +49,13 @@ macro_rules! exemplar_chars_impls {
 
         impl IterableDataProvider<$data_marker_name> for crate::DatagenProvider {
             fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
-                Ok(self.filter_data_locales(
-                    self.source
-                        .cldr()?
-                        .misc()
-                        .list_langs()?
-                        .map(DataLocale::from)
-                        .collect(),
-                ))
+                Ok(self
+                    .source
+                    .cldr()?
+                    .misc()
+                    .list_langs()?
+                    .map(DataLocale::from)
+                    .collect())
             }
         }
 

--- a/provider/datagen/src/transform/cldr/datetime/mod.rs
+++ b/provider/datagen/src/transform/cldr/datetime/mod.rs
@@ -279,7 +279,7 @@ macro_rules! impl_data_provider {
                     r.retain(|l| l.get_langid() != icu_locid::langid!("byn") && l.get_langid() != icu_locid::langid!("ssy"));
                 }
 
-                Ok(self.filter_data_locales(r))
+                Ok(r)
             }
         }
     };

--- a/provider/datagen/src/transform/cldr/decimal/mod.rs
+++ b/provider/datagen/src/transform/cldr/decimal/mod.rs
@@ -80,28 +80,27 @@ impl crate::DatagenProvider {
     }
 
     fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
-        Ok(self.filter_data_locales(
-            self.source
-                .cldr()?
-                .numbers()
-                .list_langs()?
-                .flat_map(|langid| {
-                    let last = DataLocale::from(&langid);
-                    self.get_supported_numsys_for_langid_without_default(&langid)
-                        .expect("All languages from list_langs should be present")
-                        .into_iter()
-                        .map(move |nsname| {
-                            let mut data_locale = DataLocale::from(&langid);
-                            data_locale.set_unicode_ext(
-                                key!("nu"),
-                                Value::try_from_single_subtag(nsname.as_bytes())
-                                    .expect("CLDR should have valid numbering system names"),
-                            );
-                            data_locale
-                        })
-                        .chain([last])
-                })
-                .collect(),
-        ))
+        Ok(self
+            .source
+            .cldr()?
+            .numbers()
+            .list_langs()?
+            .flat_map(|langid| {
+                let last = DataLocale::from(&langid);
+                self.get_supported_numsys_for_langid_without_default(&langid)
+                    .expect("All languages from list_langs should be present")
+                    .into_iter()
+                    .map(move |nsname| {
+                        let mut data_locale = DataLocale::from(&langid);
+                        data_locale.set_unicode_ext(
+                            key!("nu"),
+                            Value::try_from_single_subtag(nsname.as_bytes())
+                                .expect("CLDR should have valid numbering system names"),
+                        );
+                        data_locale
+                    })
+                    .chain([last])
+            })
+            .collect())
     }
 }

--- a/provider/datagen/src/transform/cldr/displaynames/language.rs
+++ b/provider/datagen/src/transform/cldr/displaynames/language.rs
@@ -62,45 +62,43 @@ impl DataProvider<LocaleDisplayNamesV1Marker> for crate::DatagenProvider {
 
 impl IterableDataProvider<LanguageDisplayNamesV1Marker> for crate::DatagenProvider {
     fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
-        Ok(self.filter_data_locales(
-            self.source
-                .cldr()?
-                .displaynames()
-                .list_langs()?
-                .filter(|langid| {
-                    // The directory might exist without languages.json
-                    self.source
-                        .cldr()
-                        .unwrap()
-                        .displaynames()
-                        .file_exists(langid, "languages.json")
-                        .unwrap_or_default()
-                })
-                .map(DataLocale::from)
-                .collect(),
-        ))
+        Ok(self
+            .source
+            .cldr()?
+            .displaynames()
+            .list_langs()?
+            .filter(|langid| {
+                // The directory might exist without languages.json
+                self.source
+                    .cldr()
+                    .unwrap()
+                    .displaynames()
+                    .file_exists(langid, "languages.json")
+                    .unwrap_or_default()
+            })
+            .map(DataLocale::from)
+            .collect())
     }
 }
 
 impl IterableDataProvider<LocaleDisplayNamesV1Marker> for crate::DatagenProvider {
     fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
-        Ok(self.filter_data_locales(
-            self.source
-                .cldr()?
-                .displaynames()
-                .list_langs()?
-                .filter(|langid| {
-                    // The directory might exist without languages.json
-                    self.source
-                        .cldr()
-                        .unwrap()
-                        .displaynames()
-                        .file_exists(langid, "languages.json")
-                        .unwrap_or_default()
-                })
-                .map(DataLocale::from)
-                .collect(),
-        ))
+        Ok(self
+            .source
+            .cldr()?
+            .displaynames()
+            .list_langs()?
+            .filter(|langid| {
+                // The directory might exist without languages.json
+                self.source
+                    .cldr()
+                    .unwrap()
+                    .displaynames()
+                    .file_exists(langid, "languages.json")
+                    .unwrap_or_default()
+            })
+            .map(DataLocale::from)
+            .collect())
     }
 }
 

--- a/provider/datagen/src/transform/cldr/displaynames/region.rs
+++ b/provider/datagen/src/transform/cldr/displaynames/region.rs
@@ -38,23 +38,22 @@ impl DataProvider<RegionDisplayNamesV1Marker> for crate::DatagenProvider {
 
 impl IterableDataProvider<RegionDisplayNamesV1Marker> for crate::DatagenProvider {
     fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
-        Ok(self.filter_data_locales(
-            self.source
-                .cldr()?
-                .displaynames()
-                .list_langs()?
-                .filter(|langid| {
-                    // The directory might exist without territories.json
-                    self.source
-                        .cldr()
-                        .unwrap()
-                        .displaynames()
-                        .file_exists(langid, "territories.json")
-                        .unwrap_or_default()
-                })
-                .map(DataLocale::from)
-                .collect(),
-        ))
+        Ok(self
+            .source
+            .cldr()?
+            .displaynames()
+            .list_langs()?
+            .filter(|langid| {
+                // The directory might exist without territories.json
+                self.source
+                    .cldr()
+                    .unwrap()
+                    .displaynames()
+                    .file_exists(langid, "territories.json")
+                    .unwrap_or_default()
+            })
+            .map(DataLocale::from)
+            .collect())
     }
 }
 

--- a/provider/datagen/src/transform/cldr/displaynames/script.rs
+++ b/provider/datagen/src/transform/cldr/displaynames/script.rs
@@ -38,23 +38,22 @@ impl DataProvider<ScriptDisplayNamesV1Marker> for crate::DatagenProvider {
 
 impl IterableDataProvider<ScriptDisplayNamesV1Marker> for crate::DatagenProvider {
     fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
-        Ok(self.filter_data_locales(
-            self.source
-                .cldr()?
-                .displaynames()
-                .list_langs()?
-                .filter(|langid| {
-                    // The directory might exist without scripts.json
-                    self.source
-                        .cldr()
-                        .unwrap()
-                        .displaynames()
-                        .file_exists(langid, "scripts.json")
-                        .unwrap_or_default()
-                })
-                .map(DataLocale::from)
-                .collect(),
-        ))
+        Ok(self
+            .source
+            .cldr()?
+            .displaynames()
+            .list_langs()?
+            .filter(|langid| {
+                // The directory might exist without scripts.json
+                self.source
+                    .cldr()
+                    .unwrap()
+                    .displaynames()
+                    .file_exists(langid, "scripts.json")
+                    .unwrap_or_default()
+            })
+            .map(DataLocale::from)
+            .collect())
     }
 }
 

--- a/provider/datagen/src/transform/cldr/displaynames/variant.rs
+++ b/provider/datagen/src/transform/cldr/displaynames/variant.rs
@@ -38,23 +38,22 @@ impl DataProvider<VariantDisplayNamesV1Marker> for crate::DatagenProvider {
 
 impl IterableDataProvider<VariantDisplayNamesV1Marker> for crate::DatagenProvider {
     fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
-        Ok(self.filter_data_locales(
-            self.source
-                .cldr()?
-                .displaynames()
-                .list_langs()?
-                .filter(|langid| {
-                    // The directory might exist without variants.json
-                    self.source
-                        .cldr()
-                        .unwrap()
-                        .displaynames()
-                        .file_exists(langid, "variants.json")
-                        .unwrap_or_default()
-                })
-                .map(DataLocale::from)
-                .collect(),
-        ))
+        Ok(self
+            .source
+            .cldr()?
+            .displaynames()
+            .list_langs()?
+            .filter(|langid| {
+                // The directory might exist without variants.json
+                self.source
+                    .cldr()
+                    .unwrap()
+                    .displaynames()
+                    .file_exists(langid, "variants.json")
+                    .unwrap_or_default()
+            })
+            .map(DataLocale::from)
+            .collect())
     }
 }
 

--- a/provider/datagen/src/transform/cldr/list/mod.rs
+++ b/provider/datagen/src/transform/cldr/list/mod.rs
@@ -129,14 +129,13 @@ macro_rules! implement {
 
         impl IterableDataProvider<$marker> for crate::DatagenProvider {
             fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
-                Ok(self.filter_data_locales(
-                    self.source
-                        .cldr()?
-                        .misc()
-                        .list_langs()?
-                        .map(DataLocale::from)
-                        .collect(),
-                ))
+                Ok(self
+                    .source
+                    .cldr()?
+                    .misc()
+                    .list_langs()?
+                    .map(DataLocale::from)
+                    .collect())
             }
         }
     };

--- a/provider/datagen/src/transform/cldr/plurals/mod.rs
+++ b/provider/datagen/src/transform/cldr/plurals/mod.rs
@@ -52,15 +52,14 @@ macro_rules! implement {
 
         impl IterableDataProvider<$marker> for crate::DatagenProvider {
             fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
-                Ok(self.filter_data_locales(
-                    self.get_rules_for(<$marker>::KEY)?
-                        .0
-                        .keys()
-                        // TODO(#568): Avoid the clone
-                        .cloned()
-                        .map(DataLocale::from)
-                        .collect(),
-                ))
+                Ok(self
+                    .get_rules_for(<$marker>::KEY)?
+                    .0
+                    .keys()
+                    // TODO(#568): Avoid the clone
+                    .cloned()
+                    .map(DataLocale::from)
+                    .collect())
             }
         }
     };

--- a/provider/datagen/src/transform/cldr/relativetime/mod.rs
+++ b/provider/datagen/src/transform/cldr/relativetime/mod.rs
@@ -105,13 +105,13 @@ macro_rules! make_data_provider {
 
             impl IterableDataProvider<$marker> for crate::DatagenProvider {
                 fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
-                    Ok(self.filter_data_locales(self
+                    Ok(self
                         .source
                         .cldr()?
                         .dates("gregorian")
                         .list_langs()?
                         .map(DataLocale::from)
-                        .collect()))
+                        .collect())
                 }
             }
 

--- a/provider/datagen/src/transform/cldr/time_zones/mod.rs
+++ b/provider/datagen/src/transform/cldr/time_zones/mod.rs
@@ -85,13 +85,13 @@ macro_rules! impl_data_provider {
                         Ok(vec![Default::default()])
                     } else {
 
-                    Ok(self.filter_data_locales(self
+                    Ok(self
                         .source
                         .cldr()?
                         .dates("gregorian")
                         .list_langs()?
                         .map(DataLocale::from)
-                        .collect()))
+                        .collect())
 }
                 }
             }

--- a/provider/datagen/src/transform/icuexport/collator/mod.rs
+++ b/provider/datagen/src/transform/icuexport/collator/mod.rs
@@ -14,6 +14,7 @@ use icu_locid::LanguageIdentifier;
 use icu_locid::Locale;
 use icu_provider::datagen::IterableDataProvider;
 use icu_provider::prelude::*;
+use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::str::FromStr;
 use writeable::Writeable;
@@ -31,7 +32,7 @@ fn has_legacy_swedish_variants(source: &crate::SourceData) -> bool {
         .and_then(|i| {
             i.file_exists(&format!(
                 "collation/{}/sv_reformed_meta.toml",
-                source.options.collation_han_database,
+                source.collation_han_database,
             ))
         })
         .unwrap_or(false)
@@ -107,20 +108,29 @@ fn file_name_to_locale(file_name: &str, has_legacy_swedish_variants: bool) -> Op
     Some(locale)
 }
 
-impl crate::DatagenProvider {
-    /// Whether to include the given collation value based on
-    /// the default excludes and explicit includes.
-    fn should_include_collation(&self, collation: &Value) -> bool {
-        let collation_str = &*collation.write_to_string();
-        if self.source.options.collations.contains(collation_str) {
-            true
-        } else if collation_str.starts_with("search") {
-            // Note: literal "search" and "searchjl" are handled above
-            self.source.options.collations.contains("search*")
-        } else {
-            !DEFAULT_REMOVED_COLLATIONS.contains(&collation_str)
-        }
-    }
+pub(crate) fn filter_data_locales(
+    locales: HashSet<DataLocale>,
+    collations: &HashSet<String>,
+) -> HashSet<DataLocale> {
+    locales
+        .into_iter()
+        .filter(|locale| {
+            locale
+                .get_unicode_ext(&key!("co"))
+                .and_then(|co| co.as_single_subtag().copied())
+                .map(|collation| {
+                    if collations.contains(collation.as_str()) {
+                        true
+                    } else if collation.starts_with("search") {
+                        // Note: literal "search" and "searchjl" are handled above
+                        collations.contains("search*")
+                    } else {
+                        !DEFAULT_REMOVED_COLLATIONS.contains(&collation.as_str())
+                    }
+                })
+                .unwrap_or(true)
+        })
+        .collect()
 }
 
 macro_rules! collation_provider {
@@ -134,7 +144,7 @@ macro_rules! collation_provider {
                         .icuexport()?
                         .read_and_parse_toml(&format!(
                             "collation/{}/{}{}.toml",
-                            self.source.options.collation_han_database,
+                            self.source.collation_han_database,
                             locale_to_file_name(&req.locale, has_legacy_swedish_variants(&self.source)),
                             $suffix
                         ))
@@ -161,12 +171,12 @@ macro_rules! collation_provider {
                     if <$marker>::KEY.metadata().singleton {
                         return Ok(vec![Default::default()])
                     }
-                    Ok(self.filter_data_locales(self
+                    Ok(self
                         .source
                         .icuexport()?
                         .list(&format!(
                             "collation/{}",
-                            self.source.options.collation_han_database
+                            self.source.collation_han_database
                         ))?
                         .filter_map(|mut file_name| {
                             file_name.truncate(file_name.len() - ".toml".len());
@@ -176,17 +186,8 @@ macro_rules! collation_provider {
                             })
                         })
                         .filter_map(|s| file_name_to_locale(&s, has_legacy_swedish_variants(&self.source)))
-                        .filter(|locale| {
-                            locale
-                                .extensions
-                                .unicode
-                                .keywords
-                                .get(&key!("co"))
-                                .map(|l| self.should_include_collation(l))
-                                .unwrap_or(true)
-                        })
                         .map(DataLocale::from)
-                        .collect()))
+                        .collect())
                 }
             }
         )+
@@ -254,6 +255,7 @@ collation_provider!(
 
 #[test]
 fn test_collation_filtering() {
+    use crate::options;
     use icu_locid::langid;
     use std::collections::BTreeSet;
 
@@ -329,21 +331,23 @@ fn test_collation_filtering() {
         },
     ];
     for cas in cases {
-        let mut provider = crate::DatagenProvider::for_test();
-        provider.source.options.collations = cas
+        let provider = crate::DatagenProvider::for_test();
+        let mut options = options::Options::default();
+        options.collations = cas
             .include_collations
             .iter()
             .copied()
             .map(String::from)
             .collect();
-        provider.source.options.locales =
+        options.locales =
             crate::options::LocaleInclude::Explicit([cas.language.clone()].into_iter().collect());
-        let resolved_locales =
-            IterableDataProvider::<CollationDataV1Marker>::supported_locales(&provider)
-                .unwrap()
-                .into_iter()
-                .map(|l| l.to_string())
-                .collect::<BTreeSet<_>>();
+
+        let resolved_locales = provider
+            .select_locales_for_key(CollationDataV1Marker::KEY, &options, None)
+            .unwrap()
+            .into_iter()
+            .map(|l| l.to_string())
+            .collect::<BTreeSet<_>>();
         let expected_locales = cas
             .expected
             .iter()

--- a/provider/datagen/src/transform/icuexport/normalizer/mod.rs
+++ b/provider/datagen/src/transform/icuexport/normalizer/mod.rs
@@ -25,7 +25,7 @@ macro_rules! normalization_provider {
                 let $toml_data: &normalizer_serde::$serde_struct =
                     self.source.icuexport()?.read_and_parse_toml(&format!(
                         "norm/{}/{}.toml",
-                        self.source.options.trie_type, $file_name
+                        self.source.trie_type, $file_name
                     ))?;
 
                 $conversion

--- a/provider/datagen/src/transform/icuexport/ucase/mod.rs
+++ b/provider/datagen/src/transform/icuexport/ucase/mod.rs
@@ -21,7 +21,7 @@ impl DataProvider<CaseMapV1Marker> for crate::DatagenProvider {
             .icuexport()?
             .read_and_parse_toml::<ucase_serde::Main>(&format!(
                 "ucase/{}/ucase.toml",
-                self.source.options.trie_type
+                self.source.trie_type
             ))?
             .ucase;
 
@@ -61,7 +61,7 @@ impl DataProvider<CaseMapUnfoldV1Marker> for crate::DatagenProvider {
             .icuexport()?
             .read_and_parse_toml::<ucase_serde::Main>(&format!(
                 "ucase/{}/ucase.toml",
-                self.source.options.trie_type
+                self.source.trie_type
             ))?
             .ucase;
 

--- a/provider/datagen/src/transform/icuexport/uprops/bidi_data.rs
+++ b/provider/datagen/src/transform/icuexport/uprops/bidi_data.rs
@@ -18,7 +18,7 @@ fn get_code_point_prop_map<'a>(
         .icuexport()?
         .read_and_parse_toml::<super::uprops_serde::code_point_prop::Main>(&format!(
             "uprops/{}/{}.toml",
-            source.options.trie_type, key
+            source.trie_type, key
         ))?
         .enum_property
         .get(0)

--- a/provider/datagen/src/transform/icuexport/uprops/bin_cp_set.rs
+++ b/provider/datagen/src/transform/icuexport/uprops/bin_cp_set.rs
@@ -17,7 +17,7 @@ pub(crate) fn get_binary_prop_for_code_point_set<'a>(
         .icuexport()?
         .read_and_parse_toml::<super::uprops_serde::binary::Main>(&format!(
             "uprops/{}/{}.toml",
-            source.options.trie_type, key
+            source.trie_type, key
         ))?
         .binary_property
         .get(0)

--- a/provider/datagen/src/transform/icuexport/uprops/bin_uniset.rs
+++ b/provider/datagen/src/transform/icuexport/uprops/bin_uniset.rs
@@ -18,7 +18,7 @@ fn get_binary_prop_for_unicodeset<'a>(
         .icuexport()?
         .read_and_parse_toml::<super::uprops_serde::binary::Main>(&format!(
             "uprops/{}/{}.toml",
-            source.options.trie_type, key
+            source.trie_type, key
         ))?
         .binary_property
         .get(0)

--- a/provider/datagen/src/transform/icuexport/uprops/enum_codepointtrie.rs
+++ b/provider/datagen/src/transform/icuexport/uprops/enum_codepointtrie.rs
@@ -20,7 +20,7 @@ pub(crate) fn get_enumerated_prop<'a>(
         .icuexport()?
         .read_and_parse_toml::<super::uprops_serde::enumerated::Main>(&format!(
             "uprops/{}/{}.toml",
-            source.options.trie_type, key
+            source.trie_type, key
         ))?
         .enum_property
         .get(0)
@@ -379,7 +379,7 @@ fn get_mask_prop<'a>(
         .icuexport()?
         .read_and_parse_toml::<super::uprops_serde::mask::Main>(&format!(
             "uprops/{}/{}.toml",
-            source.options.trie_type,
+            source.trie_type,
             key
         ))?
         .mask_property

--- a/provider/datagen/src/transform/icuexport/uprops/script.rs
+++ b/provider/datagen/src/transform/icuexport/uprops/script.rs
@@ -25,7 +25,7 @@ impl DataProvider<ScriptWithExtensionsPropertyV1Marker> for crate::DatagenProvid
             .icuexport()?
             .read_and_parse_toml::<super::uprops_serde::script_extensions::Main>(&format!(
                 "uprops/{}/scx.toml",
-                self.source.options.trie_type,
+                self.source.trie_type,
             ))?
             .script_extensions
             .get(0)

--- a/provider/datagen/src/transform/mod.rs
+++ b/provider/datagen/src/transform/mod.rs
@@ -20,7 +20,7 @@ impl DataProvider<HelloWorldV1Marker> for DatagenProvider {
 
 impl IterableDataProvider<HelloWorldV1Marker> for DatagenProvider {
     fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
-        Ok(self.filter_data_locales(HelloWorldProvider.supported_locales()?))
+        HelloWorldProvider.supported_locales()
     }
 }
 
@@ -43,9 +43,7 @@ impl DatagenProvider {
 #[test]
 fn test_missing_locale() {
     use icu_locid::langid;
-    let mut provider = DatagenProvider::for_test();
-    provider.source.options.locales =
-        crate::options::LocaleInclude::Explicit([langid!("fi")].into());
+    let provider = DatagenProvider::for_test();
     assert!(DataProvider::<HelloWorldV1Marker>::load(
         &provider,
         DataRequest {
@@ -54,11 +52,10 @@ fn test_missing_locale() {
         }
     )
     .is_ok());
-    // HelloWorldProvider supports Portuguese, so the error must correctly come from `check_req`
     assert!(DataProvider::<HelloWorldV1Marker>::load(
         &provider,
         DataRequest {
-            locale: &langid!("pt").into(),
+            locale: &langid!("arc").into(),
             metadata: Default::default()
         }
     )

--- a/provider/datagen/src/transform/segmenter/mod.rs
+++ b/provider/datagen/src/transform/segmenter/mod.rs
@@ -585,9 +585,9 @@ impl crate::DatagenProvider {
             data: CodePointTrieBuilderData::ValuesByCodePoint(&properties_map),
             default_value: 0,
             error_value: 0,
-            trie_type: match self.source.options.trie_type {
-                crate::options::TrieType::Fast => icu_collections::codepointtrie::TrieType::Fast,
-                crate::options::TrieType::Small => icu_collections::codepointtrie::TrieType::Small,
+            trie_type: match self.source.trie_type {
+                crate::source::TrieType::Fast => icu_collections::codepointtrie::TrieType::Fast,
+                crate::source::TrieType::Small => icu_collections::codepointtrie::TrieType::Small,
             },
         }
         .build();

--- a/provider/datagen/tests/make-testdata.rs
+++ b/provider/datagen/tests/make-testdata.rs
@@ -55,18 +55,15 @@ fn generate_json_and_verify_postcard() {
     });
 
     let mut options = options::Options::default();
+    options.keys = icu_datagen::all_keys().into_iter().collect();
     options.locales = options::LocaleInclude::Explicit(LOCALES.iter().cloned().collect());
     options.segmenter_models = options::SegmenterModelInclude::Explicit(vec![
         "thaidict".into(),
         "Thai_codepoints_exclusive_model4_heavy".into(),
     ]);
 
-    DatagenProvider::try_new(options, source)
-        .unwrap()
-        .export(
-            icu_datagen::all_keys().into_iter().collect(),
-            MultiExporter::new(vec![json_out, postcard_out]),
-        )
+    DatagenProvider::new(source)
+        .export(options, MultiExporter::new(vec![json_out, postcard_out]))
         .unwrap();
 }
 

--- a/provider/fs/src/export/mod.rs
+++ b/provider/fs/src/export/mod.rs
@@ -24,8 +24,11 @@
 //!
 //! // Export something
 //! DatagenProvider::default()
-//!     .export(
-//!         [icu_provider::hello_world::HelloWorldV1Marker::KEY].into_iter().collect(),
+//!     .export({
+//!             let mut options = options::Options::default();
+//!             options.keys = [icu_provider::hello_world::HelloWorldV1Marker::KEY].into_iter().collect();
+//!             options
+//!         },
 //!         exporter
 //!     ).unwrap();
 //! #


### PR DESCRIPTION
This also necessarily moves the locale filtering from `supported_locales` into `export`, and resolves #3409.

Part of #3487.

Resolves most todos in https://github.com/unicode-org/icu4x/pull/3640#issuecomment-1662683203