### PR TITLE
Deprecating `cpp_default` and `wasm_default` cargo features

### DIFF
--- a/docs/tutorials/cpp.md
+++ b/docs/tutorials/cpp.md
@@ -4,7 +4,7 @@ ICU4X's core functionality is completely available from C++, with headers genera
 
 Generated headers can be found under [`ffi/diplomat/cpp/include`], with Sphinx docs at [`ffi/diplomat/cpp/docs`]. The port is header-only; no additional C++ translation units need to be compiled to use ICU4X from C++.
 
-Typically C++ users can build ICU4X by building the `icu_capi_staticlib` crate ([crates.io][staticlib-crates], [source][staticlib-source]) with the `cpp_default` Cargo feature, and link the resultant static library to their C++ application. This crate builds on the `icu_capi` crate: a `no_std` crate containing all of the relevant [Diplomat]-generated `extern "C"` declarations.
+Typically C++ users can build ICU4X by building the `icu_capi_staticlib` crate ([crates.io][staticlib-crates], [source][staticlib-source]), and linking the resultant static library to their C++ application. This crate builds on the `icu_capi` crate: a `no_std` crate containing all of the relevant [Diplomat]-generated `extern "C"` declarations.
 
 Using ICU4X in C++ is best demonstrated via the [examples] present in the codebase. For example, [here's an example showing off decimal formatting in ICU4X][decimal-example-code], built with [this Makefile][decimal-example-makefile].
 
@@ -17,11 +17,10 @@ _We are still working on improving the user experience of using ICU4X from other
 - Inside the crate you can use `cargo build` to build the library
     - Be sure to pass `--release` to get an optimized build
     - Specify Cargo features with `--features ...`:
-        - `compiled_data` to include data (`ICU4XDataProvider::create_compiled()`)
+        - `compiled_data` \[default\] to include data (`ICU4XDataProvider::create_compiled()`)
+        - `simple_logger` \[default\] enable basic stdout logging of error metadata. Further loggers can be added on request.
         - `buffer_provider` for working with blob data providers (`ICU4XDataProvider::create_from_byte_slice()`)
         - `provider_fs` for loading data from the file system (`ICU4XDataProvider::create_fs()`). This also requires enabling a syntax on the `icu_provider` crate.
-        - `logging` and `simple_logger` enable basic stdout logging of error metadata. Further loggers can be added on request.
-        - `cpp_default` turns on a bunch of these and is useful for exploration, but should not be used in production as it enables `provider_test`
     - Set `CARGO_PROFILE_RELEASE_LTO=true` to enable link-time optimization
     - Set `CARGO_PROFILE_RELEASE_OPT_LEVEL="s"` to optimize for size
     - See [cargo profiles](cargo-profiles) for more options
@@ -33,7 +32,7 @@ _We are still working on improving the user experience of using ICU4X from other
  - Compile with `g++ -std=c++17 icu/target/releaselibicu_capi_staticlib.a -ldl -lpthread -lm`. C++ versions beyond C++17 are supported, as are other C++ compilers.
 
 ## Using ICU4X from C++
-Here's an annotated, shorter version of the fixed decimal example, that can be built using the steps above, using `--features cpp_default`:
+Here's an annotated, shorter version of the fixed decimal example, that can be built using the steps above:
 
  ```cpp
 #include "path/to/include/ICU4XFixedDecimalFormatter.hpp"

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -66,8 +66,8 @@ simple_logger = ["dep:simple_logger", "logging"]
 
 # Legacy features
 provider_test = []
-cpp_default = []
-wasm_default = []
+cpp_default = ["logging"]
+wasm_default = ["logging"]
 
 # Components
 default_components = ["icu_calendar", "icu_collator", "icu_datetime", "icu_decimal",

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -32,13 +32,13 @@ all-features = true
 [package.metadata.cargo-all-features]
 # Bench feature gets tested separately and is only relevant for CI.
 # logging enables a feature of a dependency that has no externally visible API changes
-denylist = ["bench", "logging", "cpp_default", "wasm_default"]
+denylist = ["bench", "cpp_default", "wasm_default", "provider_test"]
 # This has a lot of features, run a reduced test that is likely to catch 99% of bugs
 max_combination_size = 2
 
 # Please keep the features list in sync with the icu_capi_staticlib/icu_capi_cdylib crates (except for components features)
 [features]
-default = ["compiled_data", "default_components"]
+default = ["compiled_data", "default_components", "simple_logger"]
 any_provider = []
 buffer_provider = [
     "dep:icu_provider_blob",
@@ -61,16 +61,13 @@ buffer_provider = [
     "icu_timezone?/serde",
 ]
 provider_fs = ["dep:icu_provider_fs", "buffer_provider"]
-provider_test = []
 logging = ["icu_provider/logging", "dep:log"]
-# Use the env_logger functionality to log based on environment variables
-simple_logger = ["dep:simple_logger"]
+simple_logger = ["dep:simple_logger", "logging"]
 
-# meta feature for things we enable by default in C and C++
-cpp_default = ["logging", "simple_logger"]
-
-# meta feature for things we enable by default in wasm
-wasm_default = ["logging"]
+# Legacy features
+provider_test = []
+cpp_default = []
+wasm_default = []
 
 # Components
 default_components = ["icu_calendar", "icu_collator", "icu_datetime", "icu_decimal",
@@ -147,14 +144,11 @@ serde = { version = "1.0", default-features = false, optional = true }
 diplomat = { git = "https://github.com/rust-diplomat/diplomat", rev = "8d125999893fedfdf30595e97334c21ec4b18da9" }
 diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", rev = "8d125999893fedfdf30595e97334c21ec4b18da9" }
 
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-# Logging is automagical in wasm, we only need this for native
-simple_logger = { version = "4.1.0", optional = true }
 log = { version = "0.4", optional = true }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-log = "0.4"
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# Logging uses diplomat_runtime bindings in wasm, we only need this for native
+simple_logger = { version = "4.1.0", optional = true }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "none")))'.dependencies]
 icu_provider_fs = { version = "1.2.0", path = "../../provider/fs/", optional = true }

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -38,7 +38,7 @@ max_combination_size = 2
 
 # Please keep the features list in sync with the icu_capi_staticlib/icu_capi_cdylib crates (except for components features)
 [features]
-default = ["compiled_data", "default_components", "simple_logger"]
+default = ["compiled_data", "default_components", "logging", "simple_logger"]
 any_provider = []
 buffer_provider = [
     "dep:icu_provider_blob",

--- a/ffi/diplomat/c/examples/fixeddecimal/Makefile
+++ b/ffi/diplomat/c/examples/fixeddecimal/Makefile
@@ -11,7 +11,7 @@ ALL_HEADERS := $(wildcard ../../include/*.h)
 $(ALL_HEADERS):
 
 ../../../../../target/debug/libicu_capi_staticlib.a: FORCE
-	cargo build -p icu_capi_staticlib --features cpp_default
+	cargo build -p icu_capi_staticlib
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib.a $(ALL_HEADERS) test.c
 	gcc test.c ../../../../../target/debug/libicu_capi_staticlib.a -ldl -lpthread -lm -g

--- a/ffi/diplomat/c/examples/fixeddecimal_tiny/icu_capi_staticlib_tiny/Cargo.lock
+++ b/ffi/diplomat/c/examples/fixeddecimal_tiny/icu_capi_staticlib_tiny/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "diplomat"
 version = "0.5.2"
 source = "git+https://github.com/rust-diplomat/diplomat?rev=8d125999893fedfdf30595e97334c21ec4b18da9#8d125999893fedfdf30595e97334c21ec4b18da9"
@@ -116,7 +110,6 @@ dependencies = [
  "icu_provider_adapters",
  "icu_segmenter",
  "icu_timezone",
- "log",
  "tinystr",
  "writeable",
 ]
@@ -427,15 +420,6 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 [[package]]
 name = "litemap"
 version = "0.7.0"
-
-[[package]]
-name = "log"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "memchr"

--- a/ffi/diplomat/c/examples/locale/Makefile
+++ b/ffi/diplomat/c/examples/locale/Makefile
@@ -11,7 +11,7 @@ ALL_HEADERS := $(wildcard ../../include/*.h)
 $(ALL_HEADERS):
 
 ../../../../../target/debug/libicu_capi_staticlib.a: FORCE
-	cargo build -p icu_capi_staticlib --features cpp_default
+	cargo build -p icu_capi_staticlib
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib.a $(ALL_HEADERS) test.c
 	gcc test.c ../../../../../target/debug/libicu_capi_staticlib.a -ldl -lpthread -lm -g

--- a/ffi/diplomat/c/examples/pluralrules/Makefile
+++ b/ffi/diplomat/c/examples/pluralrules/Makefile
@@ -11,7 +11,7 @@ ALL_HEADERS := $(wildcard ../../include/*.h)
 $(ALL_HEADERS):
 
 ../../../../../target/debug/libicu_capi_staticlib.a: FORCE
-	cargo build -p icu_capi_staticlib --features cpp_default
+	cargo build -p icu_capi_staticlib
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib.a $(ALL_HEADERS) test.c
 	gcc test.c ../../../../../target/debug/libicu_capi_staticlib.a -ldl -lpthread -lm -g

--- a/ffi/diplomat/c/include/ICU4XLogger.h
+++ b/ffi/diplomat/c/include/ICU4XLogger.h
@@ -20,6 +20,8 @@ extern "C" {
 #endif
 
 bool ICU4XLogger_init_simple_logger();
+
+bool ICU4XLogger_init_console_logger();
 void ICU4XLogger_destroy(ICU4XLogger* self);
 
 #ifdef __cplusplus

--- a/ffi/diplomat/cpp/docs/source/logging_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/logging_ffi.rst
@@ -8,5 +8,7 @@
 
     .. cpp:function:: static bool init_simple_logger()
 
-        Initialize the logger from the ``simple_logger`` crate, which simply logs to stdout. Returns ``false`` if there was already a logger set, or if logging has not been compiled into the platform
+        Initialize the logger using ``simple_logger``, or console.log/warn in WASM.
+
+        Returns ``false`` if there was already a logger set, or if logging has not been compiled into the platform
 

--- a/ffi/diplomat/cpp/docs/source/logging_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/logging_ffi.rst
@@ -8,7 +8,18 @@
 
     .. cpp:function:: static bool init_simple_logger()
 
-        Initialize the logger using ``simple_logger``, or console.log/warn in WASM.
+        Initialize the logger using ``simple_logger``
 
-        Returns ``false`` if there was already a logger set, or if logging has not been compiled into the platform
+        Requires the ``simple_logger`` Cargo feature.
+
+        Returns ``false`` if there was already a logger set.
+
+
+    .. cpp:function:: static bool init_console_logger()
+
+        Initialize the logger to use the WASM console.
+
+        Only available on ``wasm32`` targets.
+
+        Returns ``false`` if there was already a logger set.
 

--- a/ffi/diplomat/cpp/examples/casemapping/Makefile
+++ b/ffi/diplomat/cpp/examples/casemapping/Makefile
@@ -13,7 +13,7 @@ CXX?=g++
 $(ALL_HEADERS):
 
 ../../../../../target/debug/libicu_capi_staticlib.a: FORCE
-	cargo build -p icu_capi_staticlib --features cpp_default,icu_capi/icu_casemap
+	cargo build -p icu_capi_staticlib --features icu_capi/icu_casemap
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib.a $(ALL_HEADERS) test.cpp
 	$(CXX) -std=c++17 test.cpp ../../../../../target/debug/libicu_capi_staticlib.a -ldl -lpthread -lm -g

--- a/ffi/diplomat/cpp/examples/collator/Makefile
+++ b/ffi/diplomat/cpp/examples/collator/Makefile
@@ -13,7 +13,7 @@ CXX?=g++
 $(ALL_HEADERS):
 
 ../../../../../target/debug/libicu_capi_staticlib.a: FORCE
-	cargo build -p icu_capi_staticlib --features cpp_default
+	cargo build -p icu_capi_staticlib
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib.a $(ALL_HEADERS) test.cpp
 	$(CXX) -std=c++17 test.cpp ../../../../../target/debug/libicu_capi_staticlib.a -ldl -lpthread -lm -g

--- a/ffi/diplomat/cpp/examples/datetime/Makefile
+++ b/ffi/diplomat/cpp/examples/datetime/Makefile
@@ -13,7 +13,7 @@ CXX?=g++
 $(ALL_HEADERS):
 
 ../../../../../target/debug/libicu_capi_staticlib.a: FORCE
-	cargo build -p icu_capi_staticlib --features cpp_default
+	cargo build -p icu_capi_staticlib
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib.a $(ALL_HEADERS) test.cpp
 	$(CXX) -std=c++17 test.cpp ../../../../../target/debug/libicu_capi_staticlib.a -ldl -lpthread -lm -g

--- a/ffi/diplomat/cpp/examples/fixeddecimal/Makefile
+++ b/ffi/diplomat/cpp/examples/fixeddecimal/Makefile
@@ -13,7 +13,7 @@ CXX?=g++
 $(ALL_HEADERS):
 
 ../../../../../target/debug/libicu_capi_staticlib.a: FORCE
-	cargo build -p icu_capi_staticlib --features cpp_default
+	cargo build -p icu_capi_staticlib
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib.a $(ALL_HEADERS) test.cpp
 	$(CXX) -std=c++17 test.cpp ../../../../../target/debug/libicu_capi_staticlib.a -ldl -lpthread -lm -g

--- a/ffi/diplomat/cpp/examples/fixeddecimal_wasm/Makefile
+++ b/ffi/diplomat/cpp/examples/fixeddecimal_wasm/Makefile
@@ -15,7 +15,7 @@ EMCC?=emcc
 $(ALL_HEADERS):
 
 ../../../../../target/debug/libicu_capi_staticlib.a: FORCE
-	cargo build -p icu_capi_staticlib --features compiled_data,provider_test
+	cargo build -p icu_capi_staticlib
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib.a $(ALL_HEADERS) test.cpp
 	$(CXX) -std=c++17 test.cpp ../../../../../target/debug/libicu_capi_staticlib.a -ldl -lpthread -lm -g
@@ -23,7 +23,7 @@ a.out: ../../../../../target/debug/libicu_capi_staticlib.a $(ALL_HEADERS) test.c
 ../../../../../target/wasm32-unknown-emscripten/release-opt-size/libicu_capi_staticlib.a: FORCE
 	rustup toolchain install ${ICU4X_NIGHTLY_TOOLCHAIN}
 	rustup component add rust-src --toolchain ${ICU4X_NIGHTLY_TOOLCHAIN}
-	RUSTFLAGS="-Cpanic=abort" cargo +${ICU4X_NIGHTLY_TOOLCHAIN} build --profile=release-opt-size -p icu_capi_staticlib --features provider_test --target wasm32-unknown-emscripten -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
+	RUSTFLAGS="-Cpanic=abort" cargo +${ICU4X_NIGHTLY_TOOLCHAIN} build --profile=release-opt-size -p icu_capi_staticlib --target wasm32-unknown-emscripten -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 
 web-version.html: ../../../../../target/wasm32-unknown-emscripten/release-opt-size/libicu_capi_staticlib.a $(ALL_HEADERS) test.cpp
 	$(EMCC) -std=c++17 test.cpp ../../../../../target/wasm32-unknown-emscripten/release-opt-size/libicu_capi_staticlib.a -ldl -lpthread -lm -g  -o web-version.html --bind --emrun -sENVIRONMENT=web -sWASM=1 -sEXPORT_ES6=1 -sMODULARIZE=1

--- a/ffi/diplomat/cpp/examples/fixeddecimal_wasm/test.cpp
+++ b/ffi/diplomat/cpp/examples/fixeddecimal_wasm/test.cpp
@@ -11,6 +11,7 @@
 
 #include <iostream>
 
+extern "C" void diplomat_init();
 extern "C" void log_js(char* s, u_int len) {
     std::cout<<"LOG: " << std::string_view(s, len) <<std::endl;
 }
@@ -19,7 +20,10 @@ extern "C" void warn_js(char* s, u_int len) {
 }
 
 int runFixedDecimal() {
+#ifdef __EMSCRIPTEN__
+    diplomat_init();
     ICU4XLogger::init_console_logger();
+#endif
     ICU4XLocale locale = ICU4XLocale::create_from_string("bn").ok().value();
     std::cout << "Running test for locale " << locale.to_string().ok().value() << std::endl;
     ICU4XDataProvider dp = ICU4XDataProvider::create_compiled();

--- a/ffi/diplomat/cpp/examples/fixeddecimal_wasm/test.cpp
+++ b/ffi/diplomat/cpp/examples/fixeddecimal_wasm/test.cpp
@@ -7,18 +7,19 @@
 #endif
 
 #include "../../include/ICU4XFixedDecimalFormatter.hpp"
+#include "../../include/ICU4XLogger.hpp"
 
 #include <iostream>
 
-extern "C" void diplomat_init();
-extern "C" void log_js(char* s) {
-    std::cout<<"LOG: " <<s <<std::endl;
+extern "C" void log_js(char* s, u_int len) {
+    std::cout<<"LOG: " << std::string_view(s, len) <<std::endl;
+}
+extern "C" void warn_js(char* s, u_int len) {
+    std::cout<<"WARN: " << std::string_view(s, len) <<std::endl;
 }
 
 int runFixedDecimal() {
-#ifdef __EMSCRIPTEN__
-    diplomat_init();
-#endif
+    ICU4XLogger::init_simple_logger();
     ICU4XLocale locale = ICU4XLocale::create_from_string("bn").ok().value();
     std::cout << "Running test for locale " << locale.to_string().ok().value() << std::endl;
     ICU4XDataProvider dp = ICU4XDataProvider::create_compiled();

--- a/ffi/diplomat/cpp/examples/fixeddecimal_wasm/test.cpp
+++ b/ffi/diplomat/cpp/examples/fixeddecimal_wasm/test.cpp
@@ -19,7 +19,7 @@ extern "C" void warn_js(char* s, u_int len) {
 }
 
 int runFixedDecimal() {
-    ICU4XLogger::init_simple_logger();
+    ICU4XLogger::init_console_logger();
     ICU4XLocale locale = ICU4XLocale::create_from_string("bn").ok().value();
     std::cout << "Running test for locale " << locale.to_string().ok().value() << std::endl;
     ICU4XDataProvider dp = ICU4XDataProvider::create_compiled();

--- a/ffi/diplomat/cpp/examples/locale/Makefile
+++ b/ffi/diplomat/cpp/examples/locale/Makefile
@@ -13,7 +13,7 @@ CXX?=g++
 $(ALL_HEADERS):
 
 ../../../../../target/debug/libicu_capi_staticlib.a: FORCE
-	cargo build -p icu_capi_staticlib --features cpp_default
+	cargo build -p icu_capi_staticlib
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib.a $(ALL_HEADERS) test.cpp
 	$(CXX) -std=c++17 test.cpp ../../../../../target/debug/libicu_capi_staticlib.a -ldl -lpthread -lm -g

--- a/ffi/diplomat/cpp/examples/pluralrules/Makefile
+++ b/ffi/diplomat/cpp/examples/pluralrules/Makefile
@@ -13,7 +13,7 @@ CXX?=g++
 $(ALL_HEADERS):
 
 ../../../../../target/debug/libicu_capi_staticlib.a: FORCE
-	cargo build -p icu_capi_staticlib -p icu_provider --features cpp_default,provider_fs,deserialize_json
+	cargo build -p icu_capi_staticlib -p icu_provider --features provider_fs,deserialize_json
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib.a $(ALL_HEADERS) test.cpp
 	$(CXX) -std=c++17 test.cpp ../../../../../target/debug/libicu_capi_staticlib.a -ldl -lpthread -lm -g

--- a/ffi/diplomat/cpp/examples/properties/Makefile
+++ b/ffi/diplomat/cpp/examples/properties/Makefile
@@ -13,7 +13,7 @@ CXX?=g++
 $(ALL_HEADERS):
 
 ../../../../../target/debug/libicu_capi_staticlib.a: FORCE
-	cargo build -p icu_capi_staticlib --features cpp_default
+	cargo build -p icu_capi_staticlib
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib.a $(ALL_HEADERS) test.cpp
 	$(CXX) -std=c++17 test.cpp ../../../../../target/debug/libicu_capi_staticlib.a -ldl -lpthread -lm -g

--- a/ffi/diplomat/cpp/examples/segmenter/Makefile
+++ b/ffi/diplomat/cpp/examples/segmenter/Makefile
@@ -13,7 +13,7 @@ CXX?=g++
 $(ALL_HEADERS):
 
 ../../../../../target/debug/libicu_capi_staticlib.a: FORCE
-	cargo build -p icu_capi_staticlib --features cpp_default
+	cargo build -p icu_capi_staticlib
 
 a.out: ../../../../../target/debug/libicu_capi_staticlib.a $(ALL_HEADERS) test.cpp
 	$(CXX) -std=c++17 test.cpp ../../../../../target/debug/libicu_capi_staticlib.a -ldl -lpthread -lm -g

--- a/ffi/diplomat/cpp/include/ICU4XLogger.h
+++ b/ffi/diplomat/cpp/include/ICU4XLogger.h
@@ -20,6 +20,8 @@ extern "C" {
 #endif
 
 bool ICU4XLogger_init_simple_logger();
+
+bool ICU4XLogger_init_console_logger();
 void ICU4XLogger_destroy(ICU4XLogger* self);
 
 #ifdef __cplusplus

--- a/ffi/diplomat/cpp/include/ICU4XLogger.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XLogger.hpp
@@ -28,8 +28,9 @@ class ICU4XLogger {
  public:
 
   /**
-   * Initialize the logger from the `simple_logger` crate, which simply logs to
-   * stdout. Returns `false` if there was already a logger set, or if logging has not been
+   * Initialize the logger using `simple_logger`, or console.log/warn in WASM.
+   * 
+   * Returns `false` if there was already a logger set, or if logging has not been
    * compiled into the platform
    */
   static bool init_simple_logger();

--- a/ffi/diplomat/cpp/include/ICU4XLogger.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XLogger.hpp
@@ -28,12 +28,22 @@ class ICU4XLogger {
  public:
 
   /**
-   * Initialize the logger using `simple_logger`, or console.log/warn in WASM.
+   * Initialize the logger using `simple_logger`
    * 
-   * Returns `false` if there was already a logger set, or if logging has not been
-   * compiled into the platform
+   * Requires the `simple_logger` Cargo feature.
+   * 
+   * Returns `false` if there was already a logger set.
    */
   static bool init_simple_logger();
+
+  /**
+   * Initialize the logger to use the WASM console.
+   * 
+   * Only available on `wasm32` targets.
+   * 
+   * Returns `false` if there was already a logger set.
+   */
+  static bool init_console_logger();
   inline const capi::ICU4XLogger* AsFFI() const { return this->inner.get(); }
   inline capi::ICU4XLogger* AsFFIMut() { return this->inner.get(); }
   inline ICU4XLogger(capi::ICU4XLogger* i) : inner(i) {}
@@ -47,5 +57,8 @@ class ICU4XLogger {
 
 inline bool ICU4XLogger::init_simple_logger() {
   return capi::ICU4XLogger_init_simple_logger();
+}
+inline bool ICU4XLogger::init_console_logger() {
+  return capi::ICU4XLogger_init_console_logger();
 }
 #endif

--- a/ffi/diplomat/js/docs/source/logging_ffi.rst
+++ b/ffi/diplomat/js/docs/source/logging_ffi.rst
@@ -8,5 +8,7 @@
 
     .. js:function:: init_simple_logger()
 
-        Initialize the logger from the ``simple_logger`` crate, which simply logs to stdout. Returns ``false`` if there was already a logger set, or if logging has not been compiled into the platform
+        Initialize the logger using ``simple_logger``, or console.log/warn in WASM.
+
+        Returns ``false`` if there was already a logger set, or if logging has not been compiled into the platform
 

--- a/ffi/diplomat/js/docs/source/logging_ffi.rst
+++ b/ffi/diplomat/js/docs/source/logging_ffi.rst
@@ -8,7 +8,18 @@
 
     .. js:function:: init_simple_logger()
 
-        Initialize the logger using ``simple_logger``, or console.log/warn in WASM.
+        Initialize the logger using ``simple_logger``
 
-        Returns ``false`` if there was already a logger set, or if logging has not been compiled into the platform
+        Requires the ``simple_logger`` Cargo feature.
+
+        Returns ``false`` if there was already a logger set.
+
+
+    .. js:function:: init_console_logger()
+
+        Initialize the logger to use the WASM console.
+
+        Only available on ``wasm32`` targets.
+
+        Returns ``false`` if there was already a logger set.
 

--- a/ffi/diplomat/js/examples/node/Makefile
+++ b/ffi/diplomat/js/examples/node/Makefile
@@ -28,8 +28,7 @@ lib: $(ALL_HEADERS)
 		-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort \
 		--target wasm32-unknown-unknown \
 		--release \
-		--package icu_capi_cdylib \
-		--features wasm_default
+		--package icu_capi_cdylib
 
 icu_capi.wasm: ../../../../../target/wasm32-unknown-unknown/release/icu_capi_cdylib.wasm
 	cp ../../../../../target/wasm32-unknown-unknown/release/icu_capi_cdylib.wasm icu_capi.wasm

--- a/ffi/diplomat/js/include/ICU4XLogger.d.ts
+++ b/ffi/diplomat/js/include/ICU4XLogger.d.ts
@@ -7,9 +7,21 @@ export class ICU4XLogger {
 
   /**
 
-   * Initialize the logger using `simple_logger`, or console.log/warn in WASM.
+   * Initialize the logger using `simple_logger`
 
-   * Returns `false` if there was already a logger set, or if logging has not been compiled into the platform
+   * Requires the `simple_logger` Cargo feature.
+
+   * Returns `false` if there was already a logger set.
    */
   static init_simple_logger(): boolean;
+
+  /**
+
+   * Initialize the logger to use the WASM console.
+
+   * Only available on `wasm32` targets.
+
+   * Returns `false` if there was already a logger set.
+   */
+  static init_console_logger(): boolean;
 }

--- a/ffi/diplomat/js/include/ICU4XLogger.d.ts
+++ b/ffi/diplomat/js/include/ICU4XLogger.d.ts
@@ -7,7 +7,9 @@ export class ICU4XLogger {
 
   /**
 
-   * Initialize the logger from the `simple_logger` crate, which simply logs to stdout. Returns `false` if there was already a logger set, or if logging has not been compiled into the platform
+   * Initialize the logger using `simple_logger`, or console.log/warn in WASM.
+
+   * Returns `false` if there was already a logger set, or if logging has not been compiled into the platform
    */
   static init_simple_logger(): boolean;
 }

--- a/ffi/diplomat/js/include/ICU4XLogger.js
+++ b/ffi/diplomat/js/include/ICU4XLogger.js
@@ -18,4 +18,8 @@ export class ICU4XLogger {
   static init_simple_logger() {
     return wasm.ICU4XLogger_init_simple_logger();
   }
+
+  static init_console_logger() {
+    return wasm.ICU4XLogger_init_console_logger();
+  }
 }

--- a/ffi/diplomat/src/lib.rs
+++ b/ffi/diplomat/src/lib.rs
@@ -50,6 +50,7 @@ pub mod common;
 pub mod data_struct;
 pub mod errors;
 pub mod locale;
+#[cfg(feature = "logging")]
 pub mod logging;
 #[macro_use]
 pub mod provider;

--- a/ffi/diplomat/src/logging.rs
+++ b/ffi/diplomat/src/logging.rs
@@ -11,14 +11,44 @@ pub mod ffi {
     pub struct ICU4XLogger;
 
     impl ICU4XLogger {
-        /// Initialize the logger from the `simple_logger` crate, which simply logs to
-        /// stdout. Returns `false` if there was already a logger set, or if logging has not been
+        /// Initialize the logger using `simple_logger`, or console.log/warn in WASM.
+        ///
+        /// Returns `false` if there was already a logger set, or if logging has not been
         /// compiled into the platform
         pub fn init_simple_logger() -> bool {
-            #[cfg(not(all(not(target_arch = "wasm32"), feature = "simple_logger")))]
-            unimplemented!("ICU4X binary not compiled with simple_logger support");
+            #[cfg(all(not(target_arch = "wasm32"), not(feature = "simple_logger")))]
+            return false;
+
             #[cfg(all(not(target_arch = "wasm32"), feature = "simple_logger"))]
-            simple_logger::init().is_ok()
+            return simple_logger::init().is_ok();
+
+            #[cfg(target_arch = "wasm32")]
+            {
+                // Define a custom `log::Log` that uses the `diplomat_runtime` bindings.
+                // TODO: Maybe this logger should be defined in `diplomat_runtime` and use
+                // console.{error, warn, log, debug, info} instead of just {warn, log}.
+                struct ConsoleLogger;
+                impl log::Log for ConsoleLogger {
+                    fn enabled(&self, _: &log::Metadata) -> bool {
+                        true
+                    }
+
+                    fn log(&self, record: &log::Record) {
+                        let msg = alloc::format!("[{}] {}", record.level(), record.args());
+                        if record.level() <= log::Level::Warn {
+                            diplomat_runtime::console_warn(&msg);
+                        } else {
+                            diplomat_runtime::console_log(&msg);
+                        }
+                    }
+
+                    fn flush(&self) {}
+                }
+
+                return log::set_logger(&ConsoleLogger)
+                    .map(|()| log::set_max_level(log::LevelFilter::Debug))
+                    .is_ok();
+            }
         }
     }
 }

--- a/ffi/diplomat/src/logging.rs
+++ b/ffi/diplomat/src/logging.rs
@@ -11,44 +11,47 @@ pub mod ffi {
     pub struct ICU4XLogger;
 
     impl ICU4XLogger {
-        /// Initialize the logger using `simple_logger`, or console.log/warn in WASM.
+        /// Initialize the logger using `simple_logger`
         ///
-        /// Returns `false` if there was already a logger set, or if logging has not been
-        /// compiled into the platform
+        /// Requires the `simple_logger` Cargo feature.
+        ///
+        /// Returns `false` if there was already a logger set.
+        #[cfg(all(not(target_arch = "wasm32"), feature = "simple_logger"))]
         pub fn init_simple_logger() -> bool {
-            #[cfg(all(not(target_arch = "wasm32"), not(feature = "simple_logger")))]
-            return false;
+            simple_logger::init().is_ok()
+        }
 
-            #[cfg(all(not(target_arch = "wasm32"), feature = "simple_logger"))]
-            return simple_logger::init().is_ok();
-
-            #[cfg(target_arch = "wasm32")]
-            {
-                // Define a custom `log::Log` that uses the `diplomat_runtime` bindings.
-                // TODO: Maybe this logger should be defined in `diplomat_runtime` and use
-                // console.{error, warn, log, debug, info} instead of just {warn, log}.
-                struct ConsoleLogger;
-                impl log::Log for ConsoleLogger {
-                    fn enabled(&self, _: &log::Metadata) -> bool {
-                        true
-                    }
-
-                    fn log(&self, record: &log::Record) {
-                        let msg = alloc::format!("[{}] {}", record.level(), record.args());
-                        if record.level() <= log::Level::Warn {
-                            diplomat_runtime::console_warn(&msg);
-                        } else {
-                            diplomat_runtime::console_log(&msg);
-                        }
-                    }
-
-                    fn flush(&self) {}
+        /// Initialize the logger to use the WASM console.
+        ///
+        /// Only available on `wasm32` targets.
+        ///
+        /// Returns `false` if there was already a logger set.
+        #[cfg(target_arch = "wasm32")]
+        pub fn init_console_logger() -> bool {
+            // Define a custom `log::Log` that uses the `diplomat_runtime` bindings.
+            // TODO: Maybe this logger should be defined in `diplomat_runtime` and use
+            // console.{error, warn, log, debug, info} instead of just {warn, log}.
+            struct ConsoleLogger;
+            impl log::Log for ConsoleLogger {
+                fn enabled(&self, _: &log::Metadata) -> bool {
+                    true
                 }
 
-                return log::set_logger(&ConsoleLogger)
-                    .map(|()| log::set_max_level(log::LevelFilter::Debug))
-                    .is_ok();
+                fn log(&self, record: &log::Record) {
+                    let msg = alloc::format!("[{}] {}", record.level(), record.args());
+                    if record.level() <= log::Level::Warn {
+                        diplomat_runtime::console_warn(&msg);
+                    } else {
+                        diplomat_runtime::console_log(&msg);
+                    }
+                }
+
+                fn flush(&self) {}
             }
+
+            log::set_logger(&ConsoleLogger)
+                .map(|()| log::set_max_level(log::LevelFilter::Debug))
+                .is_ok()
         }
     }
 }

--- a/ffi/diplomat/src/wasm_glue.rs
+++ b/ffi/diplomat/src/wasm_glue.rs
@@ -2,33 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use alloc::format;
-use diplomat_runtime::{console_log, console_warn};
-use log::{Level, LevelFilter, Metadata, Record};
-
-struct ConsoleLogger;
-
-impl log::Log for ConsoleLogger {
-    fn enabled(&self, _: &Metadata) -> bool {
-        true
-    }
-
-    fn log(&self, record: &Record) {
-        if record.level() <= Level::Warn {
-            console_warn(format!("[{}] {}", record.level(), record.args()).as_str());
-        } else {
-            console_log(format!("[{}] {}", record.level(), record.args()).as_str());
-        }
-    }
-
-    fn flush(&self) {}
-}
-
-static LOGGER: ConsoleLogger = ConsoleLogger;
-
 #[no_mangle]
+#[cfg(target_arch = "wasm")]
 pub unsafe extern "C" fn icu4x_init() {
-    log::set_logger(&LOGGER)
-        .map(|()| log::set_max_level(LevelFilter::Debug))
-        .unwrap();
+    #[cfg(feature = "logging")]
+    crate::logging::ffi::ICU4XLogger::init_simple_logger();
 }

--- a/ffi/diplomat/src/wasm_glue.rs
+++ b/ffi/diplomat/src/wasm_glue.rs
@@ -6,5 +6,5 @@
 #[cfg(target_arch = "wasm32")]
 pub unsafe extern "C" fn icu4x_init() {
     #[cfg(feature = "logging")]
-    crate::logging::ffi::ICU4XLogger::init_simple_logger();
+    crate::logging::ffi::ICU4XLogger::init_console_logger();
 }

--- a/ffi/diplomat/src/wasm_glue.rs
+++ b/ffi/diplomat/src/wasm_glue.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 #[no_mangle]
-#[cfg(target_arch = "wasm")]
+#[cfg(target_arch = "wasm32")]
 pub unsafe extern "C" fn icu4x_init() {
     #[cfg(feature = "logging")]
     crate::logging::ffi::ICU4XLogger::init_simple_logger();

--- a/ffi/gn/Cargo.lock
+++ b/ffi/gn/Cargo.lock
@@ -264,7 +264,6 @@ dependencies = [
  "icu_provider_adapters",
  "icu_segmenter",
  "icu_timezone",
- "log",
  "tinystr",
  "unicode-bidi",
  "writeable",
@@ -518,15 +517,6 @@ checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 [[package]]
 name = "litemap"
 version = "0.7.0"
-
-[[package]]
-name = "log"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "memchr"

--- a/ffi/gn/Cargo.toml
+++ b/ffi/gn/Cargo.toml
@@ -14,9 +14,6 @@ icu_capi = { version = "1.0", path = "../../ffi/diplomat", default-features = fa
 icu = { version = "1.0", path = "../../components/icu", default-features = false }
 icu_provider = { version = "1.0", path = "../../provider/core" }
 
-[gn.package.log."0.4.17"]
-rustflags = ["--cfg=atomic_cas", "--cfg=has_atomics"]
-
 # TODO: Determine the correct rustflags for memchr
 [gn.package.memchr."2.5.0"]
 rustflags = []

--- a/ffi/gn/icu4x/BUILD.gn
+++ b/ffi/gn/icu4x/BUILD.gn
@@ -16,25 +16,6 @@ group("icu_provider") {
   public_deps = [ ":icu_provider-v1_2_0" ]
 }
 
-rust_library("cfg-if-v1_0_0") {
-  crate_name = "cfg_if"
-  crate_root = "//ffi/gn/vendor/cfg-if/src/lib.rs"
-  output_name = "cfg_if-5f200286e6ae9b7a"
-
-  deps = []
-
-  rustenv = []
-
-  rustflags = [
-    "--cap-lints=allow",
-    "--edition=2018",
-    "-Cmetadata=5f200286e6ae9b7a",
-    "-Cextra-filename=-5f200286e6ae9b7a",
-  ]
-
-  visibility = [ ":*" ]
-}
-
 rust_proc_macro("diplomat-v0_5_2") {
   crate_name = "diplomat"
   crate_root = "//ffi/gn/vendor/diplomat/src/lib.rs"
@@ -254,9 +235,6 @@ rust_library("icu_capi-v1_2_2") {
   deps += [ ":tinystr-v0_7_1" ]
   deps += [ ":unicode-bidi-v0_3_13" ]
   deps += [ ":writeable-v0_5_2" ]
-  if (current_cpu == "wasm32") {
-    deps += [ ":log-v0_4_17" ]
-  }
 
   rustenv = []
 
@@ -722,28 +700,6 @@ rust_library("litemap-v0_7_0") {
     "-Cextra-filename=-9af155724df6c491",
     "--cfg=feature=\"alloc\"",
     "--cfg=feature=\"default\"",
-  ]
-
-  visibility = [ ":*" ]
-}
-
-rust_library("log-v0_4_17") {
-  crate_name = "log"
-  crate_root = "//ffi/gn/vendor/log/src/lib.rs"
-  output_name = "log-69f3eb5ea5870c4"
-
-  deps = []
-  deps += [ ":cfg-if-v1_0_0" ]
-
-  rustenv = []
-
-  rustflags = [
-    "--cap-lints=allow",
-    "--edition=2015",
-    "-Cmetadata=69f3eb5ea5870c4",
-    "-Cextra-filename=-69f3eb5ea5870c4",
-    "--cfg=atomic_cas",
-    "--cfg=has_atomics",
   ]
 
   visibility = [ ":*" ]


### PR DESCRIPTION
With the disappearance of testdata, these become the same, `["logging"]`. Instead I made `logging` a default feature.

I also moved the WASM logging setup from `wasm_glue` into `ICU4XLogger`, to reduce wasm glue.