### PR TITLE
Change grcov nightly to repo version

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,7 @@ jobs:
   
       - uses:                   actions-rs/toolchain@v1
         with:
-          toolchain:            nightly-2023-01-31
+          toolchain:            nightly-2022-09-26
           override:             true
 
       - run: cargo test --all-features --no-fail-fast


### PR DESCRIPTION
Currently the datetime size test fails