### PR TITLE
Disabling criterion dev-dependency when targeting wasm

### DIFF
--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -45,11 +45,14 @@ icu_locid_transform = { version = "1.2.0", path = "../../components/locid_transf
 libm = { version = "0.2", default-features = false }
 
 [dev-dependencies]
-criterion = "0.4"
 icu = { path = "../icu", default-features = false }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 serde = { version = "1.0", features = ["derive", "alloc"] }
 serde_json = "1.0"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = "0.4"
+
 
 [features]
 default = ["compiled_data"]

--- a/components/collator/Cargo.toml
+++ b/components/collator/Cargo.toml
@@ -50,6 +50,8 @@ icu_locid_transform = { version = "1.2.0", path = "../../components/locid_transf
 arraystring = "0.3.0"
 atoi = "1.0.0"
 icu = { path = "../icu" }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = "0.4"
 
 [features]

--- a/components/collections/Cargo.toml
+++ b/components/collections/Cargo.toml
@@ -42,11 +42,13 @@ postcard = { version = "1.0.0", features = ["alloc"], default-features = false }
 toml = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-criterion = "0.4"
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 iai = "0.1.1"
 icu = { path = "../icu", default-features = false }
 icu_properties = { path = "../properties" }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = "0.4"
 
 [features]
 std = []

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -54,7 +54,6 @@ icu_locid_transform = { version = "1.2.0", path = "../../components/locid_transf
 litemap = { version = "0.7.0", path = "../../utils/litemap", optional = true }
 
 [dev-dependencies]
-criterion = "0.4"
 icu = { path = "../icu", default-features = false }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 icu_provider_adapters = { path = "../../provider/adapters" }
@@ -64,6 +63,9 @@ litemap = { path = "../../utils/litemap" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bincode = "1.3"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = "0.4"
 
 [features]
 default = ["compiled_data"]

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -41,7 +41,6 @@ icu_decimal_data = { version = "~1.3.0", path = "data", optional = true }
 icu_locid_transform = { version = "1.2.0", path = "../../components/locid_transform", optional = true }
 
 [dev-dependencies]
-criterion = "0.4"
 icu = { path = "../icu", default-features = false }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 icu_provider_adapters = { path = "../../provider/adapters" }
@@ -49,6 +48,9 @@ rand = "0.8"
 rand_pcg = "0.3"
 rand_distr = "0.4"
 getrandom = { version = "0.2", features = ["js"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = "0.4"
 
 [features]
 default = ["compiled_data"]

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -39,7 +39,6 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 zerovec = { version = "0.9.4", path = "../../utils/zerovec", optional = true }
 
 [dev-dependencies]
-criterion = "0.4"
 iai = "0.1.1"
 icu = { path = "../icu", default-features = false }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
@@ -47,6 +46,9 @@ litemap = { path = "../../utils/litemap", features = ["testing"]}
 postcard = { version = "1.0.0", default-features = false, features = ["use-std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = "0.4"
 
 [features]
 std = []

--- a/components/locid_transform/Cargo.toml
+++ b/components/locid_transform/Cargo.toml
@@ -44,11 +44,13 @@ displaydoc = { version = "0.2.3", default-features = false }
 icu_locid_transform_data = { version = "~1.3.0", path = "data", optional = true }
 
 [dev-dependencies]
-criterion = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 icu = { path = "../icu" }
 writeable = { path = "../../utils/writeable" }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = "0.4"
 
 [lib]
 bench = false  # This option is required for Benchmark CI

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -42,11 +42,13 @@ icu_plurals_data = { version = "~1.3.0", path = "data", optional = true }
 icu_locid_transform = { version = "1.2.0", path = "../../components/locid_transform", optional = true }
 
 [dev-dependencies]
-criterion = "0.4"
 icu = { path = "../icu" }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = "0.4"
 
 [features]
 default = ["compiled_data"]

--- a/components/segmenter/Cargo.toml
+++ b/components/segmenter/Cargo.toml
@@ -45,11 +45,13 @@ icu_segmenter_data = { version = "~1.3.0", path = "data", optional = true }
 icu_locid_transform = { version = "1.2.0", path = "../../components/locid_transform", optional = true }
 
 [dev-dependencies]
-criterion = "0.4"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 icu = { path = "../../components/icu" }
 itertools = "0.10"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = "0.4"
 
 [features]
 default = ["compiled_data", "auto"]

--- a/experimental/bies/Cargo.toml
+++ b/experimental/bies/Cargo.toml
@@ -38,7 +38,9 @@ strum = { version = "0.20", features = ["derive"] }
 writeable = { version = "0.5.1", path = "../../utils/writeable" }
 
 [dev-dependencies]
-criterion = "0.4"
 rand = "0.8"
 rand_distr = "0.4"
 rand_pcg = "0.3"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = "0.4"

--- a/experimental/casemap/Cargo.toml
+++ b/experimental/casemap/Cargo.toml
@@ -62,6 +62,8 @@ icu_normalizer = { path = "../../components/normalizer" }
 icu_collections = { path = "../../components/collections", features = ["databake"] }
 icu_codepointtrie_builder = { version = "0.3.4", path = "../../components/collections/codepointtrie_builder" }
 databake = { version = "0.1.3", path = "../../utils/databake", default-features = false}
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = "0.4"
 
 

--- a/experimental/ixdtf/Cargo.toml
+++ b/experimental/ixdtf/Cargo.toml
@@ -34,5 +34,7 @@ all-features = true
 [dependencies]
 
 [dev-dependencies]
-criterion = "0.4"
 serde-json-core = { version = "0.4", features = ["std"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = "0.4"

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -42,12 +42,14 @@ postcard = { version = "1.0.0", features = ["alloc"], default-features = false, 
 serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
-criterion = "0.4"
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 icu_locid = { path = "../../components/locid", features = ["serde"] }
 icu_provider = { path = "../core", features = ["deserialize_json", "deserialize_bincode_1", "deserialize_postcard_1", "datagen"] }
 icu_datagen = { path = "../datagen" }
 writeable = { path = "../../utils/writeable" }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = "0.4"
 
 [features]
 # Enables the "export" module and FilesystemExporter

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -64,7 +64,10 @@ icu_timezone = { version = "1.2.0", path = "../../components/timezone", default-
 [dev-dependencies]
 icu = { path = "../../components/icu" }
 icu_provider = { path = "../../provider/core", features = ["deserialize_json"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = "0.4"
+
 
 [features]
 default = [

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -38,12 +38,14 @@ writeable = { version = "0.5.1", path = "../../utils/writeable" }
 ryu = { version = "1.0.5", features = ["small"], optional = true }
 
 [dev-dependencies]
-criterion = "0.4"
 getrandom = { version = "0.2", features = ["js"] }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 rand = "0.8"
 rand_distr = "0.4"
 rand_pcg = "0.3"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = "0.4"
 
 [features]
 std = []

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -38,13 +38,15 @@ yoke = { version = "0.7.1", path = "../yoke", features = ["derive"], optional = 
 [dev-dependencies]
 bincode = "1"
 bytecheck = "0.6"
-criterion = "0.4"
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 icu_locid = { path = "../../components/locid" }
 postcard = { version = "1.0.0", features = ["use-std"], default-features = false }
 rkyv = { version = "0.7", features = ["validation"] }
 serde = "1"
 serde_json = "1"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = "0.4"
 
 [features]
 bench = []

--- a/utils/tinystr/Cargo.toml
+++ b/utils/tinystr/Cargo.toml
@@ -38,10 +38,12 @@ databake = { version = "0.1.3", path = "../../utils/databake", optional = true }
 
 [dev-dependencies]
 bincode = "1.3"
-criterion = "0.4"
 postcard = { version = "1.0.0", features = ["use-std"], default-features = false }
 rand = { version = "0.8.5", features = ["small_rng"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = "0.4"
 
 [features]
 default = ["alloc"]

--- a/utils/writeable/Cargo.toml
+++ b/utils/writeable/Cargo.toml
@@ -30,9 +30,11 @@ independent = true
 all-features = true
 
 [dev-dependencies]
-criterion = "0.4"
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 rand = { version = "0.8", features = ["small_rng"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = "0.4"
 
 [features]
 bench = []

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -47,7 +47,6 @@ t1ha = { version = "0.1", optional = true }
 
 [dev-dependencies]
 bincode = "1.3"
-criterion = "0.4"
 getrandom = { version = "0.2", features = ["js"] }
 iai = "0.1"
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
@@ -59,6 +58,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 yoke = { path = "../yoke", features = ["derive"] }
 zerofrom = { path = "../zerofrom", features = ["derive"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = "0.4"
 
 [features]
 std = []


### PR DESCRIPTION
The issue is that examples and benches use the same dependency set (`dev-dependencies`), but we want to be able to build examples in WASM, where criterion doesn't build due to missing multithreading.

This started failing the binsize benchmark when we upgraded to `nightly-2022-09-26`. I have no idea why it worked before.