### PR TITLE
Rename _legacy to _adjust_to_cased

### DIFF
--- a/components/casemap/benches/casemap.rs
+++ b/components/casemap/benches/casemap.rs
@@ -28,7 +28,7 @@ fn overview_bench(c: &mut Criterion) {
     c.bench_function("icu_casemap/titlecase_segment", |b| {
         b.iter(|| {
             for s in TEST_STRING_EN.split(' ') {
-                black_box(casemapper.titlecase_segment_legacy_to_string(
+                black_box(casemapper.titlecase_segment_adjust_to_cased_to_string(
                     black_box(s),
                     &root,
                     Default::default(),

--- a/components/casemap/src/casemapper.rs
+++ b/components/casemap/src/casemapper.rs
@@ -146,7 +146,7 @@ impl CaseMapper {
     /// as a `LanguageIdentifier` (usually the `id` field of the `Locale`) if available, or
     /// `Default::default()` for the root locale.
     ///
-    /// This function performs legacy head adjustment behavior when [`HeadAdjustment::Adjust`] is set. See
+    /// This function performs "adjust to cased" head adjustment behavior when [`HeadAdjustment::Adjust`] is set. See
     /// the docs of [`TitlecaseMapper`] for more information on what this means. There is no difference between
     /// the behavior of this function and the equivalent ones on [`TitlecaseMapper`] when the head adjustment mode
     /// is [`HeadAdjustment::NoAdjust`].

--- a/components/casemap/src/casemapper.rs
+++ b/components/casemap/src/casemapper.rs
@@ -151,11 +151,11 @@ impl CaseMapper {
     /// the behavior of this function and the equivalent ones on [`TitlecaseMapper`] when the head adjustment mode
     /// is [`HeadAdjustment::NoAdjust`].
     ///
-    /// See [`Self::titlecase_segment_legacy_to_string()`] for the equivalent convenience function that returns a String,
+    /// See [`Self::titlecase_segment_adjust_to_cased_to_string()`] for the equivalent convenience function that returns a String,
     /// as well as for an example.
     ///
     /// [`TitlecaseMapper`]: crate::TitlecaseMapper
-    pub fn titlecase_segment_legacy<'a>(
+    pub fn titlecase_segment_adjust_to_cased<'a>(
         &'a self,
         src: &'a str,
         langid: &LanguageIdentifier,
@@ -315,7 +315,7 @@ impl CaseMapper {
     /// the behavior of this function and the equivalent ones on [`TitlecaseMapper`] when the head adjustment mode
     /// is [`HeadAdjustment::NoAdjust`].
     ///
-    /// See [`Self::titlecase_segment_legacy()`] for the equivalent lower-level function that returns a [`Writeable`]
+    /// See [`Self::titlecase_segment_adjust_to_cased()`] for the equivalent lower-level function that returns a [`Writeable`]
     ///
     /// # Examples
     ///
@@ -330,30 +330,30 @@ impl CaseMapper {
     ///
     /// // note that the subsequent words are not titlecased, this function assumes
     /// // that the entire string is a single segment and only titlecases at the beginning.
-    /// assert_eq!(cm.titlecase_segment_legacy_to_string("hEllO WorLd", &root, default_options), "Hello world");
-    /// assert_eq!(cm.titlecase_segment_legacy_to_string("Γειά σου Κόσμε", &root, default_options), "Γειά σου κόσμε");
-    /// assert_eq!(cm.titlecase_segment_legacy_to_string("नमस्ते दुनिया", &root, default_options), "नमस्ते दुनिया");
-    /// assert_eq!(cm.titlecase_segment_legacy_to_string("Привет мир", &root, default_options), "Привет мир");
+    /// assert_eq!(cm.titlecase_segment_adjust_to_cased_to_string("hEllO WorLd", &root, default_options), "Hello world");
+    /// assert_eq!(cm.titlecase_segment_adjust_to_cased_to_string("Γειά σου Κόσμε", &root, default_options), "Γειά σου κόσμε");
+    /// assert_eq!(cm.titlecase_segment_adjust_to_cased_to_string("नमस्ते दुनिया", &root, default_options), "नमस्ते दुनिया");
+    /// assert_eq!(cm.titlecase_segment_adjust_to_cased_to_string("Привет мир", &root, default_options), "Привет мир");
     ///
     /// // Some behavior is language-sensitive
-    /// assert_eq!(cm.titlecase_segment_legacy_to_string("istanbul", &root, default_options), "Istanbul");
-    /// assert_eq!(cm.titlecase_segment_legacy_to_string("istanbul", &langid!("tr"), default_options), "İstanbul"); // Turkish dotted i
+    /// assert_eq!(cm.titlecase_segment_adjust_to_cased_to_string("istanbul", &root, default_options), "Istanbul");
+    /// assert_eq!(cm.titlecase_segment_adjust_to_cased_to_string("istanbul", &langid!("tr"), default_options), "İstanbul"); // Turkish dotted i
     ///
-    /// assert_eq!(cm.titlecase_segment_legacy_to_string("և Երևանի", &root, default_options), "Եւ երևանի");
-    /// assert_eq!(cm.titlecase_segment_legacy_to_string("և Երևանի", &langid!("hy"), default_options), "Եվ երևանի"); // Eastern Armenian ech-yiwn ligature
+    /// assert_eq!(cm.titlecase_segment_adjust_to_cased_to_string("և Երևանի", &root, default_options), "Եւ երևանի");
+    /// assert_eq!(cm.titlecase_segment_adjust_to_cased_to_string("և Երևանի", &langid!("hy"), default_options), "Եվ երևանի"); // Eastern Armenian ech-yiwn ligature
     ///
-    /// assert_eq!(cm.titlecase_segment_legacy_to_string("ijkdijk", &root, default_options), "Ijkdijk");
-    /// assert_eq!(cm.titlecase_segment_legacy_to_string("ijkdijk", &langid!("nl"), default_options), "IJkdijk"); // Dutch IJ digraph
+    /// assert_eq!(cm.titlecase_segment_adjust_to_cased_to_string("ijkdijk", &root, default_options), "Ijkdijk");
+    /// assert_eq!(cm.titlecase_segment_adjust_to_cased_to_string("ijkdijk", &langid!("nl"), default_options), "IJkdijk"); // Dutch IJ digraph
     /// ```
     ///
     /// [`TitlecaseMapper`]: crate::TitlecaseMapper
-    pub fn titlecase_segment_legacy_to_string(
+    pub fn titlecase_segment_adjust_to_cased_to_string(
         &self,
         src: &str,
         langid: &LanguageIdentifier,
         options: TitlecaseOptions,
     ) -> String {
-        self.titlecase_segment_legacy(src, langid, options)
+        self.titlecase_segment_adjust_to_cased(src, langid, options)
             .write_to_string()
             .into_owned()
     }
@@ -621,13 +621,13 @@ mod tests {
         );
         // but the YPOGEGRAMMENI should not titlecase
         assert_eq!(
-            cm.titlecase_segment_legacy_to_string("α\u{0313}\u{0345}", &root, default_options),
+            cm.titlecase_segment_adjust_to_cased_to_string("α\u{0313}\u{0345}", &root, default_options),
             "Α\u{0313}\u{0345}"
         );
 
         // U+1F80 GREEK SMALL LETTER ALPHA WITH PSILI AND YPOGEGRAMMENI
         assert_eq!(
-            cm.titlecase_segment_legacy_to_string("ᾀ", &root, default_options),
+            cm.titlecase_segment_adjust_to_cased_to_string("ᾀ", &root, default_options),
             "ᾈ"
         );
         assert_eq!(cm.uppercase_to_string("ᾀ", &root), "ἈΙ");
@@ -635,7 +635,7 @@ mod tests {
         // U+1FFC GREEK CAPITAL LETTER OMEGA WITH PROSGEGRAMMENI
         assert_eq!(cm.lowercase_to_string("ῼ", &root), "ῳ");
         assert_eq!(
-            cm.titlecase_segment_legacy_to_string("ῼ", &root, default_options),
+            cm.titlecase_segment_adjust_to_cased_to_string("ῼ", &root, default_options),
             "ῼ"
         );
         assert_eq!(cm.uppercase_to_string("ῼ", &root), "ΩΙ");
@@ -643,7 +643,7 @@ mod tests {
         // U+1F98 GREEK CAPITAL LETTER ETA WITH PSILI AND PROSGEGRAMMENI
         assert_eq!(cm.lowercase_to_string("ᾘ", &root), "ᾐ");
         assert_eq!(
-            cm.titlecase_segment_legacy_to_string("ᾘ", &root, default_options),
+            cm.titlecase_segment_adjust_to_cased_to_string("ᾘ", &root, default_options),
             "ᾘ"
         );
         assert_eq!(cm.uppercase_to_string("ᾘ", &root), "ἨΙ");
@@ -651,7 +651,7 @@ mod tests {
         // U+1FB2 GREEK SMALL LETTER ALPHA WITH VARIA AND YPOGEGRAMMENI
         assert_eq!(cm.lowercase_to_string("ᾲ", &root), "ᾲ");
         assert_eq!(
-            cm.titlecase_segment_legacy_to_string("ᾲ", &root, default_options),
+            cm.titlecase_segment_adjust_to_cased_to_string("ᾲ", &root, default_options),
             "Ὰ\u{345}"
         );
         assert_eq!(cm.uppercase_to_string("ᾲ", &root), "ᾺΙ");
@@ -667,11 +667,11 @@ mod tests {
         assert_eq!(cm.lowercase_to_string("İ", &tr), "i");
         assert_eq!(cm.lowercase_to_string("İ", &az), "i");
         assert_eq!(
-            cm.titlecase_segment_legacy_to_string("İ", &tr, default_options),
+            cm.titlecase_segment_adjust_to_cased_to_string("İ", &tr, default_options),
             "İ"
         );
         assert_eq!(
-            cm.titlecase_segment_legacy_to_string("İ", &az, default_options),
+            cm.titlecase_segment_adjust_to_cased_to_string("İ", &az, default_options),
             "İ"
         );
         assert_eq!(cm.uppercase_to_string("İ", &tr), "İ");
@@ -681,11 +681,11 @@ mod tests {
         assert_eq!(cm.lowercase_to_string("I\u{0307}", &tr), "i");
         assert_eq!(cm.lowercase_to_string("I\u{0307}", &az), "i");
         assert_eq!(
-            cm.titlecase_segment_legacy_to_string("I\u{0307}", &tr, default_options),
+            cm.titlecase_segment_adjust_to_cased_to_string("I\u{0307}", &tr, default_options),
             "I\u{0307}"
         );
         assert_eq!(
-            cm.titlecase_segment_legacy_to_string("I\u{0307}", &az, default_options),
+            cm.titlecase_segment_adjust_to_cased_to_string("I\u{0307}", &az, default_options),
             "I\u{0307}"
         );
         assert_eq!(cm.uppercase_to_string("I\u{0307}", &tr), "I\u{0307}");
@@ -695,11 +695,11 @@ mod tests {
         assert_eq!(cm.lowercase_to_string("I", &tr), "ı");
         assert_eq!(cm.lowercase_to_string("I", &az), "ı");
         assert_eq!(
-            cm.titlecase_segment_legacy_to_string("I", &tr, default_options),
+            cm.titlecase_segment_adjust_to_cased_to_string("I", &tr, default_options),
             "I"
         );
         assert_eq!(
-            cm.titlecase_segment_legacy_to_string("I", &az, default_options),
+            cm.titlecase_segment_adjust_to_cased_to_string("I", &az, default_options),
             "I"
         );
         assert_eq!(cm.uppercase_to_string("I", &tr), "I");
@@ -709,11 +709,11 @@ mod tests {
         assert_eq!(cm.lowercase_to_string("i", &tr), "i");
         assert_eq!(cm.lowercase_to_string("i", &az), "i");
         assert_eq!(
-            cm.titlecase_segment_legacy_to_string("i", &tr, default_options),
+            cm.titlecase_segment_adjust_to_cased_to_string("i", &tr, default_options),
             "İ"
         );
         assert_eq!(
-            cm.titlecase_segment_legacy_to_string("i", &az, default_options),
+            cm.titlecase_segment_adjust_to_cased_to_string("i", &az, default_options),
             "İ"
         );
         assert_eq!(cm.uppercase_to_string("i", &tr), "İ");

--- a/components/casemap/src/casemapper.rs
+++ b/components/casemap/src/casemapper.rs
@@ -621,7 +621,11 @@ mod tests {
         );
         // but the YPOGEGRAMMENI should not titlecase
         assert_eq!(
-            cm.titlecase_segment_adjust_to_cased_to_string("α\u{0313}\u{0345}", &root, default_options),
+            cm.titlecase_segment_adjust_to_cased_to_string(
+                "α\u{0313}\u{0345}",
+                &root,
+                default_options
+            ),
             "Α\u{0313}\u{0345}"
         );
 

--- a/components/casemap/src/titlecase.rs
+++ b/components/casemap/src/titlecase.rs
@@ -54,7 +54,7 @@ pub struct TitlecaseOptions {
 }
 
 /// A wrapper around [`CaseMapper`] that can compute titlecasing stuff, and is able to load additional data
-/// to support the non-legacy "head adjustment" behavior.
+/// to support the non-"adjust to cased" "head adjustment" behavior.
 ///
 ///
 /// By default, [`Self::titlecase_segment()`] and [`Self::titlecase_segment_to_string()`] perform "head adjustment",
@@ -62,7 +62,7 @@ pub struct TitlecaseOptions {
 /// is ignored because the word starts at the first "t", which will get titlecased (producing `'Twixt`). Other punctuation will
 /// also be ignored, like in the string `«hello»`, which will get titlecased to `«Hello»`.
 ///
-/// Opinions on exactly what is a "relevant" character may differ. In "legacy" mode the first cased character is considered "relevant",
+/// Opinions on exactly what is a "relevant" character may differ. In "adjust to cased" mode the first cased character is considered "relevant",
 /// whereas in the normal mode, it is the first character that is a letter, number, symbol, or private use character. This means
 /// that the strings `49ers` and `«丰(abc)»` will titlecase to `49Ers` and `«丰(Abc)»`, whereas in the normal mode they stay unchanged.
 /// This difference largely matters for things that mix numbers and letters, or mix writing systems, within a single segment.
@@ -146,7 +146,7 @@ pub struct TitlecaseMapper<CM> {
 }
 
 impl TitlecaseMapper<CaseMapper> {
-    /// A constructor which creates a [`TitlecaseMapper`] using compiled data, with the normal (non-legacy) head adjustment behavior.
+    /// A constructor which creates a [`TitlecaseMapper`] using compiled data, with the normal (non-"adjust to cased") head adjustment behavior.
     /// See struct docs on [`TitlecaseMapper`] for more information on head adjustment behavior and usage examples.
     ///
     /// ✨ *Enabled with the `compiled_data` Cargo feature.*
@@ -159,7 +159,7 @@ impl TitlecaseMapper<CaseMapper> {
             gc: Some(icu_properties::maps::general_category().static_to_owned()),
         }
     }
-    /// A constructor which creates a [`TitlecaseMapper`] using compiled data, with the legacy head adjustment behavior.
+    /// A constructor which creates a [`TitlecaseMapper`] using compiled data, with the "adjust to cased" head adjustment behavior.
     /// See struct docs on [`TitlecaseMapper`] for more information on head adjustment behavior and usage examples.
     ///
     /// ✨ *Enabled with the `compiled_data` Cargo feature.*

--- a/components/casemap/src/titlecase.rs
+++ b/components/casemap/src/titlecase.rs
@@ -111,7 +111,7 @@ pub struct TitlecaseOptions {
 /// use icu_locid::langid;
 ///
 /// let cm_normal = TitlecaseMapper::new();
-/// let cm_legacy = TitlecaseMapper::new_legacy();
+/// let cm_adjust_to_cased = TitlecaseMapper::new_adjust_to_cased();
 /// let root = langid!("und");
 ///
 /// let default_options = Default::default();
@@ -120,17 +120,17 @@ pub struct TitlecaseOptions {
 ///
 /// // Exhibits head adjustment when set:
 /// assert_eq!(cm_normal.titlecase_segment_to_string("«hello»", &root, default_options), "«Hello»");
-/// assert_eq!(cm_legacy.titlecase_segment_to_string("«hello»", &root, default_options), "«Hello»");
+/// assert_eq!(cm_adjust_to_cased.titlecase_segment_to_string("«hello»", &root, default_options), "«Hello»");
 /// assert_eq!(cm_normal.titlecase_segment_to_string("«hello»", &root, no_adjust), "«hello»");
 ///
 /// // Only changed in legacy mode:
 /// assert_eq!(cm_normal.titlecase_segment_to_string("丰(abc)", &root, default_options), "丰(abc)");
-/// assert_eq!(cm_legacy.titlecase_segment_to_string("丰(abc)", &root, default_options), "丰(Abc)");
+/// assert_eq!(cm_adjust_to_cased.titlecase_segment_to_string("丰(abc)", &root, default_options), "丰(Abc)");
 /// assert_eq!(cm_normal.titlecase_segment_to_string("丰(abc)", &root, no_adjust), "丰(abc)");
 ///
 /// // Only changed in legacy mode:
 /// assert_eq!(cm_normal.titlecase_segment_to_string("49ers", &root, default_options), "49ers");
-/// assert_eq!(cm_legacy.titlecase_segment_to_string("49ers", &root, default_options), "49Ers");
+/// assert_eq!(cm_adjust_to_cased.titlecase_segment_to_string("49ers", &root, default_options), "49Ers");
 /// assert_eq!(cm_normal.titlecase_segment_to_string("49ers", &root, no_adjust), "49ers");
 /// ```
 /// <div class="stab unstable">
@@ -166,7 +166,7 @@ impl TitlecaseMapper<CaseMapper> {
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
-    pub const fn new_legacy() -> Self {
+    pub const fn new_adjust_to_cased() -> Self {
         Self {
             cm: CaseMapper::new(),
             gc: None,
@@ -185,10 +185,10 @@ impl TitlecaseMapper<CaseMapper> {
     icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
     #[cfg(skip)]
     functions: [
-        new_legacy,
-        try_new_legacy_with_any_provider,
-        try_new_legacy_with_buffer_provider,
-        try_new_legacy_unstable,
+        new_adjust_to_cased,
+        try_new_adjust_to_cased_with_any_provider,
+        try_new_adjust_to_cased_with_buffer_provider,
+        try_new_adjust_to_cased_unstable,
         Self,
     ]);
 
@@ -207,7 +207,7 @@ impl TitlecaseMapper<CaseMapper> {
         Ok(Self { cm, gc })
     }
     #[doc = icu_provider::gen_any_buffer_unstable_docs!(UNSTABLE, Self::new)]
-    pub fn try_new_legacy_unstable<P>(provider: &P) -> Result<Self, DataError>
+    pub fn try_new_adjust_to_cased_unstable<P>(provider: &P) -> Result<Self, DataError>
     where
         P: DataProvider<CaseMapV1Marker> + ?Sized,
     {
@@ -247,7 +247,7 @@ impl<CM: AsRef<CaseMapper>> TitlecaseMapper<CM> {
     /// See struct docs on [`TitlecaseMapper`] for more information on head adjustment behavior.
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
-    pub const fn new_with_mapper_legacy(casemapper: CM) -> Self {
+    pub const fn new_with_mapper_adjust_to_cased(casemapper: CM) -> Self {
         Self {
             cm: casemapper,
             gc: None,

--- a/components/casemap/tests/conversions.rs
+++ b/components/casemap/tests/conversions.rs
@@ -209,27 +209,27 @@ fn test_armenian() {
     let ew = "և";
     let yerevan = "Երևանի";
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string(ew, &root, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string(ew, &root, default_options),
         "Եւ"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string(yerevan, &root, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string(yerevan, &root, default_options),
         "Երևանի"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string(ew, &east, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string(ew, &east, default_options),
         "Եվ"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string(yerevan, &east, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string(yerevan, &east, default_options),
         "Երևանի"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string(ew, &west, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string(ew, &west, default_options),
         "Եւ"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string(yerevan, &west, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string(yerevan, &west, default_options),
         "Երևանի"
     );
 }
@@ -241,105 +241,105 @@ fn test_dutch() {
     let default_options = Default::default();
 
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("ijssel", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("ijssel", &nl, default_options),
         "IJssel"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("igloo", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("igloo", &nl, default_options),
         "Igloo"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("IJMUIDEN", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("IJMUIDEN", &nl, default_options),
         "IJmuiden"
     );
 
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("ij", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("ij", &nl, default_options),
         "IJ"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("IJ", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("IJ", &nl, default_options),
         "IJ"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("íj́", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("íj́", &nl, default_options),
         "ÍJ́"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("ÍJ́", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("ÍJ́", &nl, default_options),
         "ÍJ́"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("íJ́", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("íJ́", &nl, default_options),
         "ÍJ́"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("Ij́", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("Ij́", &nl, default_options),
         "Ij́"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("ij́", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("ij́", &nl, default_options),
         "Ij́"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("ïj́", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("ïj́", &nl, default_options),
         "Ïj́"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("íj\u{0308}", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("íj\u{0308}", &nl, default_options),
         "Íj\u{0308}"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("íj́\u{1D16E}", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("íj́\u{1D16E}", &nl, default_options),
         "Íj́\u{1D16E}"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("íj\u{1ABE}", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("íj\u{1ABE}", &nl, default_options),
         "Íj\u{1ABE}"
     );
 
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("ijabc", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("ijabc", &nl, default_options),
         "IJabc"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("IJabc", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("IJabc", &nl, default_options),
         "IJabc"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("íj́abc", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("íj́abc", &nl, default_options),
         "ÍJ́abc"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("ÍJ́abc", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("ÍJ́abc", &nl, default_options),
         "ÍJ́abc"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("íJ́abc", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("íJ́abc", &nl, default_options),
         "ÍJ́abc"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("Ij́abc", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("Ij́abc", &nl, default_options),
         "Ij́abc"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("ij́abc", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("ij́abc", &nl, default_options),
         "Ij́abc"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("ïj́abc", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("ïj́abc", &nl, default_options),
         "Ïj́abc"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("íjabc\u{0308}", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("íjabc\u{0308}", &nl, default_options),
         "Íjabc\u{0308}"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("íj́abc\u{1D16E}", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("íj́abc\u{1D16E}", &nl, default_options),
         "ÍJ́abc\u{1D16E}"
     );
     assert_eq!(
-        cm.titlecase_segment_legacy_to_string("íjabc\u{1ABE}", &nl, default_options),
+        cm.titlecase_segment_adjust_to_cased_to_string("íjabc\u{1ABE}", &nl, default_options),
         "Íjabc\u{1ABE}"
     );
 }

--- a/ffi/diplomat/c/include/ICU4XCaseMapper.h
+++ b/ffi/diplomat/c/include/ICU4XCaseMapper.h
@@ -31,7 +31,7 @@ diplomat_result_void_ICU4XError ICU4XCaseMapper_lowercase(const ICU4XCaseMapper*
 
 diplomat_result_void_ICU4XError ICU4XCaseMapper_uppercase(const ICU4XCaseMapper* self, const char* s_data, size_t s_len, const ICU4XLocale* locale, DiplomatWriteable* write);
 
-diplomat_result_void_ICU4XError ICU4XCaseMapper_titlecase_segment_legacy_v1(const ICU4XCaseMapper* self, const char* s_data, size_t s_len, const ICU4XLocale* locale, ICU4XTitlecaseOptionsV1 options, DiplomatWriteable* write);
+diplomat_result_void_ICU4XError ICU4XCaseMapper_titlecase_segment_adjust_to_cased_v1(const ICU4XCaseMapper* self, const char* s_data, size_t s_len, const ICU4XLocale* locale, ICU4XTitlecaseOptionsV1 options, DiplomatWriteable* write);
 
 diplomat_result_void_ICU4XError ICU4XCaseMapper_fold(const ICU4XCaseMapper* self, const char* s_data, size_t s_len, DiplomatWriteable* write);
 

--- a/ffi/diplomat/c/include/ICU4XTitlecaseMapper.h
+++ b/ffi/diplomat/c/include/ICU4XTitlecaseMapper.h
@@ -26,7 +26,7 @@ extern "C" {
 
 diplomat_result_box_ICU4XTitlecaseMapper_ICU4XError ICU4XTitlecaseMapper_create(const ICU4XDataProvider* provider);
 
-diplomat_result_box_ICU4XTitlecaseMapper_ICU4XError ICU4XTitlecaseMapper_create_legacy(const ICU4XDataProvider* provider);
+diplomat_result_box_ICU4XTitlecaseMapper_ICU4XError ICU4XTitlecaseMapper_create_adjust_to_cased(const ICU4XDataProvider* provider);
 
 diplomat_result_void_ICU4XError ICU4XTitlecaseMapper_titlecase_segment_v1(const ICU4XTitlecaseMapper* self, const char* s_data, size_t s_len, const ICU4XLocale* locale, ICU4XTitlecaseOptionsV1 options, DiplomatWriteable* write);
 void ICU4XTitlecaseMapper_destroy(ICU4XTitlecaseMapper* self);

--- a/ffi/diplomat/cpp/docs/source/casemap_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/casemap_ffi.rst
@@ -69,22 +69,22 @@
         See the `Rust documentation for uppercase <https://docs.rs/icu/latest/icu/casemap/struct.CaseMapper.html#method.uppercase>`__ for more information.
 
 
-    .. cpp:function:: template<typename W> diplomat::result<std::monostate, ICU4XError> titlecase_segment_legacy_v1_to_writeable(const std::string_view s, const ICU4XLocale& locale, ICU4XTitlecaseOptionsV1 options, W& write) const
+    .. cpp:function:: template<typename W> diplomat::result<std::monostate, ICU4XError> titlecase_segment_adjust_to_cased_v1_to_writeable(const std::string_view s, const ICU4XLocale& locale, ICU4XTitlecaseOptionsV1 options, W& write) const
 
-        Returns the full titlecase mapping of the given string, using legacy head adjustment behavior (if head adjustment is enabled in the options)
-
-        The ``v1`` refers to the version of the options struct, which may change as we add more options
-
-        See the `Rust documentation for titlecase_segment_legacy <https://docs.rs/icu/latest/icu/casemap/struct.CaseMapper.html#method.titlecase_segment_legacy>`__ for more information.
-
-
-    .. cpp:function:: diplomat::result<std::string, ICU4XError> titlecase_segment_legacy_v1(const std::string_view s, const ICU4XLocale& locale, ICU4XTitlecaseOptionsV1 options) const
-
-        Returns the full titlecase mapping of the given string, using legacy head adjustment behavior (if head adjustment is enabled in the options)
+        Returns the full titlecase mapping of the given string, using "adjust to cased" head adjustment behavior (if head adjustment is enabled in the options)
 
         The ``v1`` refers to the version of the options struct, which may change as we add more options
 
-        See the `Rust documentation for titlecase_segment_legacy <https://docs.rs/icu/latest/icu/casemap/struct.CaseMapper.html#method.titlecase_segment_legacy>`__ for more information.
+        See the `Rust documentation for titlecase_segment_adjust_to_cased <https://docs.rs/icu/latest/icu/casemap/struct.CaseMapper.html#method.titlecase_segment_adjust_to_cased>`__ for more information.
+
+
+    .. cpp:function:: diplomat::result<std::string, ICU4XError> titlecase_segment_adjust_to_cased_v1(const std::string_view s, const ICU4XLocale& locale, ICU4XTitlecaseOptionsV1 options) const
+
+        Returns the full titlecase mapping of the given string, using "adjust to cased" head adjustment behavior (if head adjustment is enabled in the options)
+
+        The ``v1`` refers to the version of the options struct, which may change as we add more options
+
+        See the `Rust documentation for titlecase_segment_adjust_to_cased <https://docs.rs/icu/latest/icu/casemap/struct.CaseMapper.html#method.titlecase_segment_adjust_to_cased>`__ for more information.
 
 
     .. cpp:function:: template<typename W> diplomat::result<std::monostate, ICU4XError> fold_to_writeable(const std::string_view s, W& write) const
@@ -203,13 +203,13 @@
         See the `Rust documentation for new <https://docs.rs/icu/latest/icu/casemap/struct.TitlecaseMapper.html#method.new>`__ for more information.
 
 
-    .. cpp:function:: static diplomat::result<ICU4XTitlecaseMapper, ICU4XError> create_legacy(const ICU4XDataProvider& provider)
+    .. cpp:function:: static diplomat::result<ICU4XTitlecaseMapper, ICU4XError> create_adjust_to_cased(const ICU4XDataProvider& provider)
 
-        Construct a new ``ICU4XTitlecaseMapper`` instance with legacy head-adjustment behavior
+        Construct a new ``ICU4XTitlecaseMapper`` instance with "adjust to cased" head-adjustment behavior
 
-        Behaves identically to using ``titlecase_segment_legacy`` on ``CaseMapper``
+        Behaves identically to using ``titlecase_segment_adjust_to_cased`` on ``CaseMapper``
 
-        See the `Rust documentation for new_legacy <https://docs.rs/icu/latest/icu/casemap/struct.TitlecaseMapper.html#method.new_legacy>`__ for more information.
+        See the `Rust documentation for new_adjust_to_cased <https://docs.rs/icu/latest/icu/casemap/struct.TitlecaseMapper.html#method.new_adjust_to_cased>`__ for more information.
 
 
     .. cpp:function:: template<typename W> diplomat::result<std::monostate, ICU4XError> titlecase_segment_v1_to_writeable(const std::string_view s, const ICU4XLocale& locale, ICU4XTitlecaseOptionsV1 options, W& write) const

--- a/ffi/diplomat/cpp/include/ICU4XCaseMapper.h
+++ b/ffi/diplomat/cpp/include/ICU4XCaseMapper.h
@@ -31,7 +31,7 @@ diplomat_result_void_ICU4XError ICU4XCaseMapper_lowercase(const ICU4XCaseMapper*
 
 diplomat_result_void_ICU4XError ICU4XCaseMapper_uppercase(const ICU4XCaseMapper* self, const char* s_data, size_t s_len, const ICU4XLocale* locale, DiplomatWriteable* write);
 
-diplomat_result_void_ICU4XError ICU4XCaseMapper_titlecase_segment_legacy_v1(const ICU4XCaseMapper* self, const char* s_data, size_t s_len, const ICU4XLocale* locale, ICU4XTitlecaseOptionsV1 options, DiplomatWriteable* write);
+diplomat_result_void_ICU4XError ICU4XCaseMapper_titlecase_segment_adjust_to_cased_v1(const ICU4XCaseMapper* self, const char* s_data, size_t s_len, const ICU4XLocale* locale, ICU4XTitlecaseOptionsV1 options, DiplomatWriteable* write);
 
 diplomat_result_void_ICU4XError ICU4XCaseMapper_fold(const ICU4XCaseMapper* self, const char* s_data, size_t s_len, DiplomatWriteable* write);
 

--- a/ffi/diplomat/cpp/include/ICU4XCaseMapper.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XCaseMapper.hpp
@@ -71,24 +71,24 @@ class ICU4XCaseMapper {
   diplomat::result<std::string, ICU4XError> uppercase(const std::string_view s, const ICU4XLocale& locale) const;
 
   /**
-   * Returns the full titlecase mapping of the given string, using legacy head adjustment behavior
+   * Returns the full titlecase mapping of the given string, using "adjust to cased" head adjustment behavior
    * (if head adjustment is enabled in the options)
    * 
    * The `v1` refers to the version of the options struct, which may change as we add more options
    * 
-   * See the [Rust documentation for `titlecase_segment_legacy`](https://docs.rs/icu/latest/icu/casemap/struct.CaseMapper.html#method.titlecase_segment_legacy) for more information.
+   * See the [Rust documentation for `titlecase_segment_adjust_to_cased`](https://docs.rs/icu/latest/icu/casemap/struct.CaseMapper.html#method.titlecase_segment_adjust_to_cased) for more information.
    */
-  template<typename W> diplomat::result<std::monostate, ICU4XError> titlecase_segment_legacy_v1_to_writeable(const std::string_view s, const ICU4XLocale& locale, ICU4XTitlecaseOptionsV1 options, W& write) const;
+  template<typename W> diplomat::result<std::monostate, ICU4XError> titlecase_segment_adjust_to_cased_v1_to_writeable(const std::string_view s, const ICU4XLocale& locale, ICU4XTitlecaseOptionsV1 options, W& write) const;
 
   /**
-   * Returns the full titlecase mapping of the given string, using legacy head adjustment behavior
+   * Returns the full titlecase mapping of the given string, using "adjust to cased" head adjustment behavior
    * (if head adjustment is enabled in the options)
    * 
    * The `v1` refers to the version of the options struct, which may change as we add more options
    * 
-   * See the [Rust documentation for `titlecase_segment_legacy`](https://docs.rs/icu/latest/icu/casemap/struct.CaseMapper.html#method.titlecase_segment_legacy) for more information.
+   * See the [Rust documentation for `titlecase_segment_adjust_to_cased`](https://docs.rs/icu/latest/icu/casemap/struct.CaseMapper.html#method.titlecase_segment_adjust_to_cased) for more information.
    */
-  diplomat::result<std::string, ICU4XError> titlecase_segment_legacy_v1(const std::string_view s, const ICU4XLocale& locale, ICU4XTitlecaseOptionsV1 options) const;
+  diplomat::result<std::string, ICU4XError> titlecase_segment_adjust_to_cased_v1(const std::string_view s, const ICU4XLocale& locale, ICU4XTitlecaseOptionsV1 options) const;
 
   /**
    * Case-folds the characters in the given string
@@ -260,10 +260,10 @@ inline diplomat::result<std::string, ICU4XError> ICU4XCaseMapper::uppercase(cons
   }
   return diplomat_result_out_value.replace_ok(std::move(diplomat_writeable_string));
 }
-template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XCaseMapper::titlecase_segment_legacy_v1_to_writeable(const std::string_view s, const ICU4XLocale& locale, ICU4XTitlecaseOptionsV1 options, W& write) const {
+template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XCaseMapper::titlecase_segment_adjust_to_cased_v1_to_writeable(const std::string_view s, const ICU4XLocale& locale, ICU4XTitlecaseOptionsV1 options, W& write) const {
   ICU4XTitlecaseOptionsV1 diplomat_wrapped_struct_options = options;
   capi::DiplomatWriteable write_writer = diplomat::WriteableTrait<W>::Construct(write);
-  auto diplomat_result_raw_out_value = capi::ICU4XCaseMapper_titlecase_segment_legacy_v1(this->inner.get(), s.data(), s.size(), locale.AsFFI(), capi::ICU4XTitlecaseOptionsV1{ .head_adjustment = static_cast<capi::ICU4XHeadAdjustment>(diplomat_wrapped_struct_options.head_adjustment), .tail_casing = static_cast<capi::ICU4XTailCasing>(diplomat_wrapped_struct_options.tail_casing) }, &write_writer);
+  auto diplomat_result_raw_out_value = capi::ICU4XCaseMapper_titlecase_segment_adjust_to_cased_v1(this->inner.get(), s.data(), s.size(), locale.AsFFI(), capi::ICU4XTitlecaseOptionsV1{ .head_adjustment = static_cast<capi::ICU4XHeadAdjustment>(diplomat_wrapped_struct_options.head_adjustment), .tail_casing = static_cast<capi::ICU4XTailCasing>(diplomat_wrapped_struct_options.tail_casing) }, &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
     diplomat_result_out_value = diplomat::Ok(std::monostate());
@@ -272,11 +272,11 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XCa
   }
   return diplomat_result_out_value;
 }
-inline diplomat::result<std::string, ICU4XError> ICU4XCaseMapper::titlecase_segment_legacy_v1(const std::string_view s, const ICU4XLocale& locale, ICU4XTitlecaseOptionsV1 options) const {
+inline diplomat::result<std::string, ICU4XError> ICU4XCaseMapper::titlecase_segment_adjust_to_cased_v1(const std::string_view s, const ICU4XLocale& locale, ICU4XTitlecaseOptionsV1 options) const {
   ICU4XTitlecaseOptionsV1 diplomat_wrapped_struct_options = options;
   std::string diplomat_writeable_string;
   capi::DiplomatWriteable diplomat_writeable_out = diplomat::WriteableFromString(diplomat_writeable_string);
-  auto diplomat_result_raw_out_value = capi::ICU4XCaseMapper_titlecase_segment_legacy_v1(this->inner.get(), s.data(), s.size(), locale.AsFFI(), capi::ICU4XTitlecaseOptionsV1{ .head_adjustment = static_cast<capi::ICU4XHeadAdjustment>(diplomat_wrapped_struct_options.head_adjustment), .tail_casing = static_cast<capi::ICU4XTailCasing>(diplomat_wrapped_struct_options.tail_casing) }, &diplomat_writeable_out);
+  auto diplomat_result_raw_out_value = capi::ICU4XCaseMapper_titlecase_segment_adjust_to_cased_v1(this->inner.get(), s.data(), s.size(), locale.AsFFI(), capi::ICU4XTitlecaseOptionsV1{ .head_adjustment = static_cast<capi::ICU4XHeadAdjustment>(diplomat_wrapped_struct_options.head_adjustment), .tail_casing = static_cast<capi::ICU4XTailCasing>(diplomat_wrapped_struct_options.tail_casing) }, &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
     diplomat_result_out_value = diplomat::Ok(std::monostate());

--- a/ffi/diplomat/cpp/include/ICU4XTitlecaseMapper.h
+++ b/ffi/diplomat/cpp/include/ICU4XTitlecaseMapper.h
@@ -26,7 +26,7 @@ extern "C" {
 
 diplomat_result_box_ICU4XTitlecaseMapper_ICU4XError ICU4XTitlecaseMapper_create(const ICU4XDataProvider* provider);
 
-diplomat_result_box_ICU4XTitlecaseMapper_ICU4XError ICU4XTitlecaseMapper_create_legacy(const ICU4XDataProvider* provider);
+diplomat_result_box_ICU4XTitlecaseMapper_ICU4XError ICU4XTitlecaseMapper_create_adjust_to_cased(const ICU4XDataProvider* provider);
 
 diplomat_result_void_ICU4XError ICU4XTitlecaseMapper_titlecase_segment_v1(const ICU4XTitlecaseMapper* self, const char* s_data, size_t s_len, const ICU4XLocale* locale, ICU4XTitlecaseOptionsV1 options, DiplomatWriteable* write);
 void ICU4XTitlecaseMapper_destroy(ICU4XTitlecaseMapper* self);

--- a/ffi/diplomat/cpp/include/ICU4XTitlecaseMapper.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XTitlecaseMapper.hpp
@@ -42,13 +42,13 @@ class ICU4XTitlecaseMapper {
   static diplomat::result<ICU4XTitlecaseMapper, ICU4XError> create(const ICU4XDataProvider& provider);
 
   /**
-   * Construct a new `ICU4XTitlecaseMapper` instance with legacy head-adjustment behavior
+   * Construct a new `ICU4XTitlecaseMapper` instance with "adjust to cased" head-adjustment behavior
    * 
-   * Behaves identically to using `titlecase_segment_legacy` on `CaseMapper`
+   * Behaves identically to using `titlecase_segment_adjust_to_cased` on `CaseMapper`
    * 
-   * See the [Rust documentation for `new_legacy`](https://docs.rs/icu/latest/icu/casemap/struct.TitlecaseMapper.html#method.new_legacy) for more information.
+   * See the [Rust documentation for `new_adjust_to_cased`](https://docs.rs/icu/latest/icu/casemap/struct.TitlecaseMapper.html#method.new_adjust_to_cased) for more information.
    */
-  static diplomat::result<ICU4XTitlecaseMapper, ICU4XError> create_legacy(const ICU4XDataProvider& provider);
+  static diplomat::result<ICU4XTitlecaseMapper, ICU4XError> create_adjust_to_cased(const ICU4XDataProvider& provider);
 
   /**
    * Returns the full titlecase mapping of the given string
@@ -91,8 +91,8 @@ inline diplomat::result<ICU4XTitlecaseMapper, ICU4XError> ICU4XTitlecaseMapper::
   }
   return diplomat_result_out_value;
 }
-inline diplomat::result<ICU4XTitlecaseMapper, ICU4XError> ICU4XTitlecaseMapper::create_legacy(const ICU4XDataProvider& provider) {
-  auto diplomat_result_raw_out_value = capi::ICU4XTitlecaseMapper_create_legacy(provider.AsFFI());
+inline diplomat::result<ICU4XTitlecaseMapper, ICU4XError> ICU4XTitlecaseMapper::create_adjust_to_cased(const ICU4XDataProvider& provider) {
+  auto diplomat_result_raw_out_value = capi::ICU4XTitlecaseMapper_create_adjust_to_cased(provider.AsFFI());
   diplomat::result<ICU4XTitlecaseMapper, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
     diplomat_result_out_value = diplomat::Ok<ICU4XTitlecaseMapper>(std::move(ICU4XTitlecaseMapper(diplomat_result_raw_out_value.ok)));

--- a/ffi/diplomat/js/docs/source/casemap_ffi.rst
+++ b/ffi/diplomat/js/docs/source/casemap_ffi.rst
@@ -55,13 +55,13 @@
         See the `Rust documentation for uppercase <https://docs.rs/icu/latest/icu/casemap/struct.CaseMapper.html#method.uppercase>`__ for more information.
 
 
-    .. js:method:: titlecase_segment_legacy_v1(s, locale, options)
+    .. js:method:: titlecase_segment_adjust_to_cased_v1(s, locale, options)
 
-        Returns the full titlecase mapping of the given string, using legacy head adjustment behavior (if head adjustment is enabled in the options)
+        Returns the full titlecase mapping of the given string, using "adjust to cased" head adjustment behavior (if head adjustment is enabled in the options)
 
         The ``v1`` refers to the version of the options struct, which may change as we add more options
 
-        See the `Rust documentation for titlecase_segment_legacy <https://docs.rs/icu/latest/icu/casemap/struct.CaseMapper.html#method.titlecase_segment_legacy>`__ for more information.
+        See the `Rust documentation for titlecase_segment_adjust_to_cased <https://docs.rs/icu/latest/icu/casemap/struct.CaseMapper.html#method.titlecase_segment_adjust_to_cased>`__ for more information.
 
 
     .. js:method:: fold(s)
@@ -158,13 +158,13 @@
         See the `Rust documentation for new <https://docs.rs/icu/latest/icu/casemap/struct.TitlecaseMapper.html#method.new>`__ for more information.
 
 
-    .. js:function:: create_legacy(provider)
+    .. js:function:: create_adjust_to_cased(provider)
 
-        Construct a new ``ICU4XTitlecaseMapper`` instance with legacy head-adjustment behavior
+        Construct a new ``ICU4XTitlecaseMapper`` instance with "adjust to cased" head-adjustment behavior
 
-        Behaves identically to using ``titlecase_segment_legacy`` on ``CaseMapper``
+        Behaves identically to using ``titlecase_segment_adjust_to_cased`` on ``CaseMapper``
 
-        See the `Rust documentation for new_legacy <https://docs.rs/icu/latest/icu/casemap/struct.TitlecaseMapper.html#method.new_legacy>`__ for more information.
+        See the `Rust documentation for new_adjust_to_cased <https://docs.rs/icu/latest/icu/casemap/struct.TitlecaseMapper.html#method.new_adjust_to_cased>`__ for more information.
 
 
     .. js:method:: titlecase_segment_v1(s, locale, options)

--- a/ffi/diplomat/js/include/ICU4XCaseMapper.d.ts
+++ b/ffi/diplomat/js/include/ICU4XCaseMapper.d.ts
@@ -41,14 +41,14 @@ export class ICU4XCaseMapper {
 
   /**
 
-   * Returns the full titlecase mapping of the given string, using legacy head adjustment behavior (if head adjustment is enabled in the options)
+   * Returns the full titlecase mapping of the given string, using "adjust to cased" head adjustment behavior (if head adjustment is enabled in the options)
 
    * The `v1` refers to the version of the options struct, which may change as we add more options
 
-   * See the {@link https://docs.rs/icu/latest/icu/casemap/struct.CaseMapper.html#method.titlecase_segment_legacy Rust documentation for `titlecase_segment_legacy`} for more information.
+   * See the {@link https://docs.rs/icu/latest/icu/casemap/struct.CaseMapper.html#method.titlecase_segment_adjust_to_cased Rust documentation for `titlecase_segment_adjust_to_cased`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
-  titlecase_segment_legacy_v1(s: string, locale: ICU4XLocale, options: ICU4XTitlecaseOptionsV1): string | never;
+  titlecase_segment_adjust_to_cased_v1(s: string, locale: ICU4XLocale, options: ICU4XTitlecaseOptionsV1): string | never;
 
   /**
 

--- a/ffi/diplomat/js/include/ICU4XCaseMapper.js
+++ b/ffi/diplomat/js/include/ICU4XCaseMapper.js
@@ -79,14 +79,14 @@ export class ICU4XCaseMapper {
     return diplomat_out;
   }
 
-  titlecase_segment_legacy_v1(arg_s, arg_locale, arg_options) {
+  titlecase_segment_adjust_to_cased_v1(arg_s, arg_locale, arg_options) {
     const buf_arg_s = diplomatRuntime.DiplomatBuf.str(wasm, arg_s);
     const field_head_adjustment_arg_options = arg_options["head_adjustment"];
     const field_tail_casing_arg_options = arg_options["tail_casing"];
     const diplomat_out = diplomatRuntime.withWriteable(wasm, (writeable) => {
       return (() => {
         const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
-        wasm.ICU4XCaseMapper_titlecase_segment_legacy_v1(diplomat_receive_buffer, this.underlying, buf_arg_s.ptr, buf_arg_s.size, arg_locale.underlying, ICU4XHeadAdjustment_js_to_rust[field_head_adjustment_arg_options], ICU4XTailCasing_js_to_rust[field_tail_casing_arg_options], writeable);
+        wasm.ICU4XCaseMapper_titlecase_segment_adjust_to_cased_v1(diplomat_receive_buffer, this.underlying, buf_arg_s.ptr, buf_arg_s.size, arg_locale.underlying, ICU4XHeadAdjustment_js_to_rust[field_head_adjustment_arg_options], ICU4XTailCasing_js_to_rust[field_tail_casing_arg_options], writeable);
         const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
         if (is_ok) {
           const ok_value = {};

--- a/ffi/diplomat/js/include/ICU4XTitlecaseMapper.d.ts
+++ b/ffi/diplomat/js/include/ICU4XTitlecaseMapper.d.ts
@@ -21,14 +21,14 @@ export class ICU4XTitlecaseMapper {
 
   /**
 
-   * Construct a new `ICU4XTitlecaseMapper` instance with legacy head-adjustment behavior
+   * Construct a new `ICU4XTitlecaseMapper` instance with "adjust to cased" head-adjustment behavior
 
-   * Behaves identically to using `titlecase_segment_legacy` on `CaseMapper`
+   * Behaves identically to using `titlecase_segment_adjust_to_cased` on `CaseMapper`
 
-   * See the {@link https://docs.rs/icu/latest/icu/casemap/struct.TitlecaseMapper.html#method.new_legacy Rust documentation for `new_legacy`} for more information.
+   * See the {@link https://docs.rs/icu/latest/icu/casemap/struct.TitlecaseMapper.html#method.new_adjust_to_cased Rust documentation for `new_adjust_to_cased`} for more information.
    * @throws {@link FFIError}<{@link ICU4XError}>
    */
-  static create_legacy(provider: ICU4XDataProvider): ICU4XTitlecaseMapper | never;
+  static create_adjust_to_cased(provider: ICU4XDataProvider): ICU4XTitlecaseMapper | never;
 
   /**
 

--- a/ffi/diplomat/js/include/ICU4XTitlecaseMapper.js
+++ b/ffi/diplomat/js/include/ICU4XTitlecaseMapper.js
@@ -35,10 +35,10 @@ export class ICU4XTitlecaseMapper {
     })();
   }
 
-  static create_legacy(arg_provider) {
+  static create_adjust_to_cased(arg_provider) {
     return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
-      wasm.ICU4XTitlecaseMapper_create_legacy(diplomat_receive_buffer, arg_provider.underlying);
+      wasm.ICU4XTitlecaseMapper_create_adjust_to_cased(diplomat_receive_buffer, arg_provider.underlying);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
         const ok_value = new ICU4XTitlecaseMapper(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true, []);

--- a/ffi/diplomat/src/casemap.rs
+++ b/ffi/diplomat/src/casemap.rs
@@ -102,7 +102,10 @@ pub mod ffi {
         /// (if head adjustment is enabled in the options)
         ///
         /// The `v1` refers to the version of the options struct, which may change as we add more options
-        #[diplomat::rust_link(icu::casemap::CaseMapper::titlecase_segment_adjust_to_cased, FnInStruct)]
+        #[diplomat::rust_link(
+            icu::casemap::CaseMapper::titlecase_segment_adjust_to_cased,
+            FnInStruct
+        )]
         #[diplomat::rust_link(
             icu::casemap::CaseMapper::titlecase_segment_adjust_to_cased_to_string,
             FnInStruct,

--- a/ffi/diplomat/src/casemap.rs
+++ b/ffi/diplomat/src/casemap.rs
@@ -98,17 +98,17 @@ pub mod ffi {
             Ok(())
         }
 
-        /// Returns the full titlecase mapping of the given string, using legacy head adjustment behavior
+        /// Returns the full titlecase mapping of the given string, using "adjust to cased" head adjustment behavior
         /// (if head adjustment is enabled in the options)
         ///
         /// The `v1` refers to the version of the options struct, which may change as we add more options
-        #[diplomat::rust_link(icu::casemap::CaseMapper::titlecase_segment_legacy, FnInStruct)]
+        #[diplomat::rust_link(icu::casemap::CaseMapper::titlecase_segment_adjust_to_cased, FnInStruct)]
         #[diplomat::rust_link(
-            icu::casemap::CaseMapper::titlecase_segment_legacy_to_string,
+            icu::casemap::CaseMapper::titlecase_segment_adjust_to_cased_to_string,
             FnInStruct,
             hidden
         )]
-        pub fn titlecase_segment_legacy_v1(
+        pub fn titlecase_segment_adjust_to_cased_v1(
             &self,
             s: &str,
             locale: &ICU4XLocale,
@@ -120,7 +120,7 @@ pub mod ffi {
             core::str::from_utf8(s.as_bytes())
                 .map_err(|e| ICU4XError::DataIoError.log_original(&e))?;
             self.0
-                .titlecase_segment_legacy(s, &locale.0.id, options.into())
+                .titlecase_segment_adjust_to_cased(s, &locale.0.id, options.into())
                 .write_to(write)?;
 
             Ok(())
@@ -290,16 +290,16 @@ pub mod ffi {
                 provider,
             )?)))
         }
-        /// Construct a new `ICU4XTitlecaseMapper` instance with legacy head-adjustment behavior
+        /// Construct a new `ICU4XTitlecaseMapper` instance with "adjust to cased" head-adjustment behavior
         ///
-        /// Behaves identically to using `titlecase_segment_legacy` on `CaseMapper`
-        #[diplomat::rust_link(icu::casemap::TitlecaseMapper::new_legacy, FnInStruct)]
+        /// Behaves identically to using `titlecase_segment_adjust_to_cased` on `CaseMapper`
+        #[diplomat::rust_link(icu::casemap::TitlecaseMapper::new_adjust_to_cased, FnInStruct)]
         #[diplomat::rust_link(
-            icu::casemap::TitlecaseMapper::new_legacy_with_mapper,
+            icu::casemap::TitlecaseMapper::new_adjust_to_cased_with_mapper,
             FnInStruct,
             hidden
         )]
-        pub fn create_legacy(
+        pub fn create_adjust_to_cased(
             provider: &ICU4XDataProvider,
         ) -> Result<Box<ICU4XTitlecaseMapper>, ICU4XError> {
             Ok(Box::new(ICU4XTitlecaseMapper(call_constructor!(


### PR DESCRIPTION
Uses @markusicu's suggestion from #3801 (fixes #3801).

Seems fine, though `adjust_to_cased_to_string()` is kinda clunky.

This is also the final open stabilization issue, so I'm going to mark this as fixing https://github.com/unicode-org/icu4x/issues/3234 . (note for reviewers: if you think there are still outstanding items, feel free to edit the magic issue-closing comment out of this PR body)


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->