### PR TITLE
Try making Windows CI not run out of disk again

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -123,7 +123,11 @@ jobs:
 
     # Actual job
     - name: Run `cargo make ci-job-test`
+      if: matrix.os != 'windows-latest'
       run: cargo make ci-job-test
+    - name: Run `cargo make ci-job-test-windows`
+      if: matrix.os == 'windows-latest'
+      run: cargo make ci-job-test-windows
 
   # ci-job-test-tutorials
   test-tutorials:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,3 +110,8 @@ opt-level = "s"
 [profile.bench]
 debug = true
 debug-assertions = false
+
+[profile.windows-test-ci]
+inherits = "dev"
+debug-assertions = true
+debug = false

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -72,6 +72,13 @@ dependencies = [
     "test-all-features",
 ]
 
+[tasks.ci-job-test-windows]
+description = "Run all tests for the CI 'test' job (with special changes to reduce Windows disk space)"
+category = "CI"
+dependencies = [
+    "test-all-features-windows",
+]
+
 [tasks.ci-job-test-tutorials-local]
 description = "Run all checks for the CI 'test-tutorials' job"
 category = "CI"

--- a/tools/make/tests.toml
+++ b/tools/make/tests.toml
@@ -34,6 +34,13 @@ category = "ICU4X Development"
 command = "cargo"
 args = ["test", "--all-features", "--all-targets", "--no-fail-fast"]
 
+[tasks.test-all-features-windows]
+description = "Run all Rust tests with all features and targets (with special changes to reduce Windows disk space)"
+category = "ICU4X Development"
+command = "cargo"
+args = ["test", "--all-features", "--all-targets", "--no-fail-fast", "--profile", "windows-test-ci"]
+
+
 [tasks.test-docs]
 description = "Run all Rust doctests with all features"
 category = "ICU4X Development"


### PR DESCRIPTION
Hopefully fixes the windows CI issue. We can tweak the profile, I'm hoping just turning off debug symbols is sufficient but if not we can instead build in release mode.
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->