### PR TITLE
Be semver safe for `icu_capi/test_provider`

### DIFF
--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -65,7 +65,7 @@ logging = ["icu_provider/logging", "dep:log"]
 simple_logger = ["dep:simple_logger", "logging"]
 
 # Legacy features
-provider_test = []
+provider_test = ["compiled_data"]
 cpp_default = ["logging"]
 wasm_default = ["logging"]
 

--- a/ffi/diplomat/cpp/docs/source/locale_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/locale_ffi.rst
@@ -166,14 +166,14 @@
 
     .. cpp:function:: static ICU4XLocale create_en()
 
-        Unconditionally panics.
+        Deprecated
 
         Use `create_from_string("en").
 
 
     .. cpp:function:: static ICU4XLocale create_bn()
 
-        Unconditionally panics.
+        Deprecated
 
         Use `create_from_string("bn").
 

--- a/ffi/diplomat/cpp/docs/source/provider_ffi.rst
+++ b/ffi/diplomat/cpp/docs/source/provider_ffi.rst
@@ -26,9 +26,9 @@
 
     .. cpp:function:: static ICU4XDataProvider create_test()
 
-        Unconditionally panics.
+        Deprecated
 
-        It used to provide a test data provider, but has been superseded by ``create_compiled``.
+        Use ``create_compiled()``.
 
 
     .. cpp:function:: static diplomat::result<ICU4XDataProvider, ICU4XError> create_from_byte_slice(const diplomat::span<const uint8_t> blob)

--- a/ffi/diplomat/cpp/include/ICU4XDataProvider.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XDataProvider.hpp
@@ -52,9 +52,9 @@ class ICU4XDataProvider {
   static diplomat::result<ICU4XDataProvider, ICU4XError> create_fs(const std::string_view path);
 
   /**
-   * Unconditionally panics.
+   * Deprecated
    * 
-   * It used to provide a test data provider, but has been superseded by `create_compiled`.
+   * Use `create_compiled()`.
    */
   static ICU4XDataProvider create_test();
 

--- a/ffi/diplomat/cpp/include/ICU4XLocale.hpp
+++ b/ffi/diplomat/cpp/include/ICU4XLocale.hpp
@@ -197,14 +197,14 @@ class ICU4XLocale {
   ICU4XOrdering strict_cmp(const std::string_view other) const;
 
   /**
-   * Unconditionally panics.
+   * Deprecated
    * 
    * Use `create_from_string("en").
    */
   static ICU4XLocale create_en();
 
   /**
-   * Unconditionally panics.
+   * Deprecated
    * 
    * Use `create_from_string("bn").
    */

--- a/ffi/diplomat/js/docs/source/locale_ffi.rst
+++ b/ffi/diplomat/js/docs/source/locale_ffi.rst
@@ -115,14 +115,14 @@
 
     .. js:function:: create_en()
 
-        Unconditionally panics.
+        Deprecated
 
         Use `create_from_string("en").
 
 
     .. js:function:: create_bn()
 
-        Unconditionally panics.
+        Deprecated
 
         Use `create_from_string("bn").
 

--- a/ffi/diplomat/js/docs/source/provider_ffi.rst
+++ b/ffi/diplomat/js/docs/source/provider_ffi.rst
@@ -26,9 +26,9 @@
 
     .. js:function:: create_test()
 
-        Unconditionally panics.
+        Deprecated
 
-        It used to provide a test data provider, but has been superseded by ``create_compiled``.
+        Use ``create_compiled()``.
 
 
     .. js:function:: create_from_byte_slice(blob)

--- a/ffi/diplomat/js/include/ICU4XDataProvider.d.ts
+++ b/ffi/diplomat/js/include/ICU4XDataProvider.d.ts
@@ -31,9 +31,9 @@ export class ICU4XDataProvider {
 
   /**
 
-   * Unconditionally panics.
+   * Deprecated
 
-   * It used to provide a test data provider, but has been superseded by `create_compiled`.
+   * Use `create_compiled()`.
    */
   static create_test(): ICU4XDataProvider;
 

--- a/ffi/diplomat/js/include/ICU4XLocale.d.ts
+++ b/ffi/diplomat/js/include/ICU4XLocale.d.ts
@@ -143,7 +143,7 @@ export class ICU4XLocale {
 
   /**
 
-   * Unconditionally panics.
+   * Deprecated
 
    * Use `create_from_string("en").
    */
@@ -151,7 +151,7 @@ export class ICU4XLocale {
 
   /**
 
-   * Unconditionally panics.
+   * Deprecated
 
    * Use `create_from_string("bn").
    */

--- a/ffi/diplomat/src/datetime_formatter.rs
+++ b/ffi/diplomat/src/datetime_formatter.rs
@@ -25,8 +25,6 @@ pub mod ffi {
     #[diplomat::opaque]
     /// An ICU4X TimeFormatter object capable of formatting an [`ICU4XTime`] type (and others) as a string
     #[diplomat::rust_link(icu::datetime::TimeFormatter, Struct)]
-    // TODO(#2153) - Rename to ICU4XTimeFormatter when we remove the dependency on calendar
-    // from TimeFormatter.
     pub struct ICU4XTimeFormatter(pub TimeFormatter);
 
     #[diplomat::enum_convert(length::Time, needs_wildcard)]

--- a/ffi/diplomat/src/locale.rs
+++ b/ffi/diplomat/src/locale.rs
@@ -185,20 +185,20 @@ pub mod ffi {
             self.0.strict_cmp(other).into()
         }
 
-        /// Unconditionally panics.
+        /// Deprecated
         ///
         /// Use `create_from_string("en").
         #[cfg(feature = "provider_test")]
         pub fn create_en() -> Box<ICU4XLocale> {
-            unimplemented!()
+            Box::new(ICU4XLocale(icu_locid::locale!("en")))
         }
 
-        /// Unconditionally panics.
+        /// Deprecated
         ///
         /// Use `create_from_string("bn").
         #[cfg(feature = "provider_test")]
         pub fn create_bn() -> Box<ICU4XLocale> {
-            unimplemented!()
+            Box::new(ICU4XLocale(icu_locid::locale!("bn")))
         }
     }
 }

--- a/ffi/diplomat/src/provider.rs
+++ b/ffi/diplomat/src/provider.rs
@@ -75,15 +75,15 @@ pub mod ffi {
             )))
         }
 
-        /// Unconditionally panics.
+        /// Deprecated
         ///
-        /// It used to provide a test data provider, but has been superseded by `create_compiled`.
+        /// Use `create_compiled()`.
         #[cfg(all(
             feature = "provider_test",
             any(feature = "any_provider", feature = "buffer_provider")
         ))]
         pub fn create_test() -> Box<ICU4XDataProvider> {
-            unimplemented!()
+            create_compiled()
         }
 
         /// Constructs a `BlobDataProvider` and returns it as an [`ICU4XDataProvider`].


### PR DESCRIPTION
Turns out people actually use this in production, so let's be nice.