### PR TITLE
`CharULE` docs nitpick, it represents a scalar value not a code point

### DIFF
--- a/utils/zerovec/src/ule/chars.rs
+++ b/utils/zerovec/src/ule/chars.rs
@@ -10,7 +10,7 @@ use crate::impl_ule_from_array;
 use core::cmp::Ordering;
 use core::convert::TryFrom;
 
-/// A u8 array of little-endian data corresponding to a Unicode code point.
+/// A u8 array of little-endian data corresponding to a Unicode scalar value.
 ///
 /// The bytes of a `CharULE` are guaranteed to represent a little-endian-encoded u32 that is a
 /// valid `char` and can be converted without validation.
@@ -92,7 +92,7 @@ impl AsULE for char {
 
     #[inline]
     fn from_unaligned(unaligned: Self::ULE) -> Self {
-        // Safe because the bytes of CharULE are defined to represent a valid Unicode code point.
+        // Safe because the bytes of CharULE are defined to represent a valid Unicode scalar value.
         unsafe {
             Self::from_u32_unchecked(u32::from_le_bytes([
                 unaligned.0[0],


### PR DESCRIPTION
Rust's `char` only permits Unicode scalar values, i.e., surrogates are disallowed. The implementation copies that behavior (we use Rust's fallible `char` conversion methods), but the docs disagree.

Also, `UnvalidatedChar` uses a surrogate code point in `test_char_bake`, I think we should probably get rid of that?

I didn't go through the rest of ICU4X, but I think being nitpicky about `CharULE` is enough 