### PR TITLE
Hebrew fixes

### DIFF
--- a/components/calendar/src/hebrew.rs
+++ b/components/calendar/src/hebrew.rs
@@ -250,7 +250,7 @@ impl Calendar for Hebrew {
         };
 
         types::FormattableMonth {
-            ordinal: ordinal as u32,
+            ordinal: date.0.month as u32,
             code: types::MonthCode(code),
         }
     }

--- a/components/calendar/src/hebrew.rs
+++ b/components/calendar/src/hebrew.rs
@@ -139,6 +139,7 @@ impl Calendar for Hebrew {
                 "M09" => 10,
                 "M10" => 11,
                 "M11" => 12,
+                "M12" => 13,
                 _ => {
                     return Err(CalendarError::UnknownMonthCode(
                         month_code.0,


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

Fixes:

* Allow M12 during leap years.
* Don't map M05L and M06 to ordinal 6 during leap years.