### PR TITLE
Removing clippy action

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -668,13 +668,8 @@ jobs:
       run: rustup component add clippy
 
     # Actual job
-    # Note: this does not use ci-job-clippy, as the GH Action can create code
-    # annotations (although not in PRs: https://github.com/actions-rs/clippy-check/issues/2)
-    - uses: actions-rs/clippy-check@v1.0.7
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        # keep args in sync with `clippy-all` in .cargo/config.toml
-        args: --all-targets --all-features -- -D warnings
+    - name: Run `ci-job-clippy`
+      run: cargo make ci-job-clippy
 
   # ci-job-doc
   doc:

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -195,9 +195,6 @@ dependencies = [
 ]
 
 [tasks.ci-job-clippy]
-# Note: ci-job-clippy is not actually invoked by CI and instead exists
-# for symmetry and predictability. CI instead uses a special GitHub action
-# that allows it to integrate better with GitHub annotations
 description = "Run all tests for the CI 'clippy' job"
 category = "CI"
 dependencies = [


### PR DESCRIPTION
This is erroring with 
>  API rate limit exceeded for installation ID 7570382.

and doesn't work anyway.