### PR TITLE
Remove a bunch of calendar unwraps

### DIFF
--- a/components/calendar/src/astronomy.rs
+++ b/components/calendar/src/astronomy.rs
@@ -380,7 +380,7 @@ impl Astronomical {
         angle + poly(c, coefs)
     }
 
-    /// Calculates the declination at a given [`Moment`] of UTC time of an object at latitude `beta` and longitude `lambda`; all angles are in degrees.
+    /// Calculates the declination at a given [`Moment`] of UTC time of an object at ecliptic latitude `beta` and ecliptic longitude `lambda`; all angles are in degrees.
     /// the declination is the angular distance north or south of an object in the sky with respect to the plane
     /// of the Earth's equator; analogous to latitude.
     ///
@@ -394,14 +394,13 @@ impl Astronomical {
         )
     }
 
-    /// Calculates the right ascension at a given [`Moment`] of UTC time of an object at celestial latitude `beta` and celestial longitude `lambda`; all angles are in degrees.
+    /// Calculates the right ascension at a given [`Moment`] of UTC time of an object at ecliptic latitude `beta` and ecliptic longitude `lambda`; all angles are in degrees.
     /// the right ascension is the angular distance east or west of an object in the sky with respect to the plane
     /// of the vernal equinox, which is the celestial coordinate point at which the ecliptic intersects the celestial
     /// equator marking spring in the northern hemisphere; analogous to longitude.
     ///
-    /// This will return None for an object at the celestial pole. Note that this is not when latitude = 90°,
-    /// since the celestial pole is at 90° from the celestial equator, not from the plane of the ecliptic (which
-    /// is what latitude is relative to)
+    /// This will return None for an object at the ecliptic pole. Note that this is not when latitude = 90°,
+    /// since that point is 90° from the celestial equator, not from the plane of the ecliptic.
     ///
     /// Based on functions from _Calendrical Calculations_ by Reingold & Dershowitz.
     /// Reference lisp code: https://github.com/EdReingold/calendar-code2/blob/9afc1f3/calendar.l#L3578-L3588
@@ -771,7 +770,7 @@ impl Astronomical {
         div_rem_euclid_f64(angle, 360.0).1
     }
 
-    /// Celestial latitude of the moon (in degrees)
+    /// Ecliptic (aka celestial) latitude of the moon (in degrees)
     ///
     /// This is not a geocentric or geodetic latitude, it does not take into account the
     /// rotation of the Earth and is instead measured from the ecliptic.
@@ -971,7 +970,7 @@ impl Astronomical {
         correction + venus + flat_earth + extra
     }
 
-    /// Celestial longitude of the moon (in degrees)
+    /// Ecliptic (aka celestial) longitude of the moon (in degrees)
     ///
     /// This is not a geocentric or geodetic longitude, it does not take into account the
     /// rotation of the Earth and is instead measured from the ecliptic and the vernal equinox.
@@ -1257,10 +1256,13 @@ impl Astronomical {
         let phi = location.latitude;
         let psi = location.longitude;
         let c = Self::julian_centuries(moment);
-        let lambda = Self::lunar_longitude(c); // This works
-        let beta = Self::lunar_latitude(c); // This works
+        let lambda = Self::lunar_longitude(c);
+        let beta = Self::lunar_latitude(c);
         let alpha = Self::right_ascension(moment, beta, lambda);
-        // If the moon is at the celestial poles, we have a problem. We use a dummy value to limit the impact of bugs
+        // If the moon is at the celestial poles, we have a problem.
+        // We use a dummy value to avoid panicking
+        // In this case the declination will be ±90° anyway, so ultimately the value
+        // used here is irrelevant since the term involving alpha is multiplied by cos(delta)
         debug_assert!(alpha.is_some(), "please put the moon back");
         let alpha = alpha.unwrap_or(0.);
         let delta = Self::declination(moment, beta, lambda);

--- a/components/calendar/src/hebrew.rs
+++ b/components/calendar/src/hebrew.rs
@@ -279,8 +279,7 @@ impl Hebrew {
     }
 
     // Converts a Biblical Hebrew Date to a Civil Hebrew Date
-    #[allow(clippy::unwrap_used)]
-    fn biblical_to_civil_date(biblical_date: BookHebrew) -> Date<Hebrew> {
+    fn biblical_to_civil_date(biblical_date: BookHebrew) -> HebrewDateInner {
         let biblical_month = biblical_date.month;
         let biblical_year = biblical_date.year;
         let mut civil_month;
@@ -294,7 +293,17 @@ impl Hebrew {
             civil_month += 1;
         }
 
-        Date::try_new_hebrew_date(biblical_year, civil_month, biblical_date.day).unwrap()
+        debug_assert!(ArithmeticDate::<Hebrew>::new_from_lunar_ordinals(
+            biblical_year,
+            civil_month,
+            biblical_date.day
+        )
+        .is_ok());
+        HebrewDateInner(ArithmeticDate::new_unchecked(
+            biblical_year,
+            civil_month,
+            biblical_date.day,
+        ))
     }
 
     // Converts a Civil Hebrew Date to a Biblical Hebrew Date
@@ -369,10 +378,9 @@ impl Hebrew {
         BookHebrew::fixed_from_book_hebrew(book_date)
     }
 
-    #[allow(clippy::unwrap_used)]
     fn civil_hebrew_from_fixed(date: RataDie) -> Date<Hebrew> {
         let book_hebrew = BookHebrew::book_hebrew_from_fixed(date);
-        Hebrew::biblical_to_civil_date(book_hebrew)
+        Date::from_raw(Hebrew::biblical_to_civil_date(book_hebrew), Hebrew)
     }
 
     fn year_as_hebrew(civil_year: i32) -> types::FormattableYear {
@@ -600,7 +608,6 @@ impl BookHebrew {
     }
 
     // Lisp code reference: https://github.com/EdReingold/calendar-code2/blob/main/calendar.l#L2352
-    #[allow(dead_code, clippy::unwrap_used)]
     fn book_hebrew_from_fixed(date: RataDie) -> BookHebrew {
         let approx = helpers::i64_to_i32(
             (div_rem_euclid_f64((date - FIXED_HEBREW_EPOCH) as f64, 35975351.0 / 98496.0).0) as i64, //  The value 35975351/98496, the average length of a BookHebrew year, can be approximated by 365.25
@@ -1069,8 +1076,7 @@ mod tests {
                 year: case.year,
                 month: case.month,
                 day: case.day,
-            })
-            .inner;
+            });
             let days_in_month =
                 Hebrew::last_day_of_civil_hebrew_month(civil_date.0.year, civil_date.0.month);
             assert_eq!(days_in_month, *expected);
@@ -1285,7 +1291,7 @@ mod tests {
                 civil_date_nums.0,
             ));
 
-            let book_to_civil = Hebrew::biblical_to_civil_date(book_date).inner;
+            let book_to_civil = Hebrew::biblical_to_civil_date(book_date);
             let civil_to_book = Hebrew::civil_to_biblical_date(civil_date);
 
             assert_eq!(civil_date, book_to_civil);

--- a/components/calendar/src/helpers.rs
+++ b/components/calendar/src/helpers.rs
@@ -140,19 +140,8 @@ pub fn mod3(x: f64, a: f64, b: f64) -> f64 {
 // Arctan of y/x in degrees, handling zero cases
 //
 // Returns None if x and y are both 0
-pub fn arctan_degrees(y: f64, x: f64) -> Option<f64> {
-    if x == 0.0 && y == 0.0 {
-        None
-    } else if x == 0.0 {
-        if y > 0.0 {
-            Some(90.0)
-        } else {
-            Some(-90.0)
-        }
-    } else {
-        let alpha = libm::atan(y / x) * 180.0 / PI;
-        Some(mod_degrees(if x >= 0.0 { alpha } else { alpha + 180.0 }))
-    }
+pub fn arctan_degrees(y: f64, x: f64) -> f64 {
+    mod_degrees(libm::atan2(y, x) * 180.0 / PI)
 }
 
 // TODO: convert recursive into iterative

--- a/components/calendar/src/helpers.rs
+++ b/components/calendar/src/helpers.rs
@@ -137,19 +137,21 @@ pub fn mod3(x: f64, a: f64, b: f64) -> f64 {
     }
 }
 
-// Arctan of x,y in degrees
-pub fn arctan_degrees(y: f64, x: f64) -> Result<f64, &'static str> {
+// Arctan of y/x in degrees, handling zero cases
+//
+// Returns None if x and y are both 0
+pub fn arctan_degrees(y: f64, x: f64) -> Option<f64> {
     if x == 0.0 && y == 0.0 {
-        Err("Both x and y are zero")
+        None
     } else if x == 0.0 {
         if y > 0.0 {
-            Ok(90.0)
+            Some(90.0)
         } else {
-            Ok(-90.0)
+            Some(-90.0)
         }
     } else {
         let alpha = libm::atan(y / x) * 180.0 / PI;
-        Ok(mod_degrees(if x >= 0.0 { alpha } else { alpha + 180.0 }))
+        Some(mod_degrees(if x >= 0.0 { alpha } else { alpha + 180.0 }))
     }
 }
 

--- a/components/calendar/src/helpers.rs
+++ b/components/calendar/src/helpers.rs
@@ -137,9 +137,7 @@ pub fn mod3(x: f64, a: f64, b: f64) -> f64 {
     }
 }
 
-// Arctan of y/x in degrees, handling zero cases
-//
-// Returns None if x and y are both 0
+// Arctangent of y/x in degrees, handling zero cases (using atan2)
 pub fn arctan_degrees(y: f64, x: f64) -> f64 {
     mod_degrees(libm::atan2(y, x) * 180.0 / PI)
 }

--- a/components/calendar/src/islamic.rs
+++ b/components/calendar/src/islamic.rs
@@ -217,7 +217,6 @@ impl IslamicObservational {
     // The fixed date algorithms are from
     // Dershowitz, Nachum, and Edward M. Reingold. _Calendrical calculations_. Cambridge University Press, 2008.
     // Lisp code reference: https://github.com/EdReingold/calendar-code2/blob/main/calendar.l#L6904
-    #[allow(clippy::unwrap_used)]
     fn fixed_from_islamic(i_date: IslamicDateInner) -> RataDie {
         let year = i64::from(i_date.0.year);
         let month = i64::from(i_date.0.month);
@@ -231,7 +230,6 @@ impl IslamicObservational {
             - 1
     }
 
-    #[allow(clippy::unwrap_used)]
     fn islamic_from_fixed(date: RataDie) -> Date<IslamicObservational> {
         let lunar_phase = Astronomical::calculate_lunar_phase_at_or_before(date);
         let crescent = Astronomical::phasis_on_or_before(date, CAIRO, Some(lunar_phase));
@@ -561,7 +559,6 @@ impl IslamicUmmAlQura {
     }
 
     // Lisp code reference: https://github.com/EdReingold/calendar-code2/blob/main/calendar.l#L6996
-    #[allow(clippy::unwrap_used)]
     fn saudi_islamic_from_fixed(date: RataDie) -> Date<IslamicUmmAlQura> {
         let crescent = Self::saudi_new_month_on_or_before(date);
         let elapsed_months =
@@ -765,20 +762,21 @@ impl IslamicCivil {
         )
     }
     // Lisp code reference: https://github.com/EdReingold/calendar-code2/blob/main/calendar.l#L2090
-    #[allow(clippy::unwrap_used)]
     fn islamic_from_fixed(date: RataDie) -> Date<IslamicCivil> {
         let year = helpers::i64_to_saturated_i32(
             div_rem_euclid64(((date - FIXED_ISLAMIC_EPOCH_FRIDAY) * 30) + 10646, 10631).0,
         );
         let prior_days = date.to_f64_date()
             - ((Self::fixed_from_islamic(IslamicCivilDateInner(
-                ArithmeticDate::new_from_lunar_ordinals(year, 1, 1).unwrap(), // Safe unwrap due to hardcoded values,
+                ArithmeticDate::new_unchecked(year, 1, 1), // Unchecked ok because of hardcoded values,
             )))
             .to_f64_date());
-        let month = div_rem_euclid_f64((prior_days * 11.0) + 330.0, 325.0).0 as u8; // Prior days will always be a number between 354-355, making the value within the bounds of a u8.
+        debug_assert!(prior_days <= 354.);
+        let month = div_rem_euclid_f64((prior_days * 11.0) + 330.0, 325.0).0 as u8; // Prior days is maximum 354 (when year length is 355), making the value always less than 12
+        debug_assert!(month <= 12);
         let day = (date.to_f64_date()
             - (Self::fixed_from_islamic(IslamicCivilDateInner(
-                ArithmeticDate::new_from_lunar_ordinals(year, month, 1).unwrap(), // Safe unwrap,
+                ArithmeticDate::new_unchecked(year, month, 1), // Unchecked is ok because of hardcoded date and month being in range
             ))
             .to_f64_date())
             + 1.0) as u8; // The value will always be number between 1-30 because of the difference between the date and lunar ordinals function.
@@ -1013,20 +1011,21 @@ impl IslamicTabular {
         )
     }
     // Lisp code reference: https://github.com/EdReingold/calendar-code2/blob/main/calendar.l#L2090
-    #[allow(clippy::unwrap_used)]
     fn islamic_from_fixed(date: RataDie) -> Date<IslamicTabular> {
         let year = helpers::i64_to_saturated_i32(
             div_rem_euclid64(((date - FIXED_ISLAMIC_EPOCH_THURSDAY) * 30) + 10646, 10631).0,
         );
         let prior_days = date.to_f64_date()
             - ((Self::fixed_from_islamic(IslamicTabularDateInner(
-                ArithmeticDate::new_from_lunar_ordinals(year, 1, 1).unwrap(), // Safe unwrap due to hardcoded values,
+                ArithmeticDate::new_unchecked(year, 1, 1), // Unchecked ok to hardcoded values,
             )))
             .to_f64_date());
-        let month = div_rem_euclid_f64((prior_days * 11.0) + 330.0, 325.0).0 as u8; // Prior days will always be a number between 354-355, making the value within the bounds of a u8.
+        debug_assert!(prior_days <= 354.);
+        let month = div_rem_euclid_f64((prior_days * 11.0) + 330.0, 325.0).0 as u8; // Prior days is at most 354 (with year length 355), making the value 12 or less and within bounds of u8
+        debug_assert!(month <= 12);
         let day = (date.to_f64_date()
             - (Self::fixed_from_islamic(IslamicTabularDateInner(
-                ArithmeticDate::new_from_lunar_ordinals(year, month, 1).unwrap(), // Safe unwrap,
+                ArithmeticDate::new_unchecked(year, month, 1), // Unchecked ok due to hardcoded day value and month being in range,
             ))
             .to_f64_date())
             + 1.0) as u8; // The value will always be number between 1-30 because of the difference between the date and lunar ordinals function.


### PR DESCRIPTION
We should really avoid panicking when we attempt to construct a date from components we have just computed, we should instead silently construct whatever we have and debug assert when validation fails.

Also went down a rabbithole in fixing unwraps in astronomy.rs and figured out what was going on in the right_ascension function (ty @eggrobin for help!)

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->