### PR TITLE
Manually name the output file for grcov

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -2,6 +2,8 @@
 # called LICENSE at the top level of the ICU4X source tree
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+output-type: lcov
+output-path: ./gcov.lcov
 ignore:
   - "/*"
   - "C:/*"


### PR DESCRIPTION
Trial by firing. See #3897 for context.