### PR TITLE
gitattributes: Don't consider postcard fingerprints as generated

### DIFF
--- a/provider/datagen/.gitattributes
+++ b/provider/datagen/.gitattributes
@@ -1,2 +1,5 @@
 data/** linguist-generated=true
-tests/data/** linguist-generated=true
+tests/data/cldr/** linguist-generated=true
+tests/data/icuexport/** linguist-generated=true
+tests/data/json/** linguist-generated=true
+tests/data/lstm/** linguist-generated=true


### PR DESCRIPTION
I think the recent changes to gitattributes caused this change. I don't want the fingerprints file caught up in the generated file hiding stuff.