### PR TITLE
Replacing `cargo-readme` by `cargo-rdme`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -606,24 +606,24 @@ jobs:
       run: rustup show
 
     # Job-specific dependencies
-    - name: Get cargo-readme version
+    - name: Get cargo-rdme version
       id: cargo-readme-version
       run: |
-        echo "::set-output name=hash::$(cargo search cargo-readme | grep '^cargo-readme =' | md5sum)"
+        echo "::set-output name=hash::$(cargo search cargo-rdme | grep '^cargo-rdme =' | md5sum)"
       shell: bash
-    - name: Attempt to load cached cargo-readme
+    - name: Attempt to load cached cargo-rdme
       uses: actions/cache@v3
-      id: cargo-readme-cache
+      id: cargo-rdme-cache
       with:
         path: |
-          ~/.cargo/bin/cargo-readme
-          ~/.cargo/bin/cargo-readme.exe
-        key: ${{ runner.os }}-readme-${{ steps.cargo-readme-version.outputs.hash }}
-    - name: Install cargo-readme
-      if: steps.cargo-readme-cache.outputs.cache-hit != 'true'
+          ~/.cargo/bin/cargo-rdme
+          ~/.cargo/bin/cargo-rdme.exe
+        key: ${{ runner.os }}-readme-${{ steps.cargo-rdme-version.outputs.hash }}
+    - name: Install cargo-rdme
+      if: steps.cargo-rdme-cache.outputs.cache-hit != 'true'
       uses: actions-rs/install@v0.1.2
       with:
-        crate: cargo-readme
+        crate: cargo-rdme
         version: latest
 
     # Actual job

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -476,6 +476,26 @@ jobs:
       if: steps.gn-third-party-tools-cache.outputs.cache-hit != 'true'
       run: cargo make gn-install
 
+    - name: Get cargo-rdme version
+      id: cargo-readme-version
+      run: |
+        echo "::set-output name=hash::$(cargo search cargo-rdme | grep '^cargo-rdme =' | md5sum)"
+      shell: bash
+    - name: Attempt to load cached cargo-rdme
+      uses: actions/cache@v3
+      id: cargo-rdme-cache
+      with:
+        path: |
+          ~/.cargo/bin/cargo-rdme
+          ~/.cargo/bin/cargo-rdme.exe
+        key: ${{ runner.os }}-readme-${{ steps.cargo-rdme-version.outputs.hash }}
+    - name: Install cargo-rdme
+      if: steps.cargo-rdme-cache.outputs.cache-hit != 'true'
+      uses: actions-rs/install@v0.1.2
+      with:
+        crate: cargo-rdme
+        version: latest
+
     # Actual job
     - name: Run `cargo make ci-job-verify-gn`
       run: cargo make ci-job-verify-gn

--- a/README.tpl
+++ b/README.tpl
@@ -1,7 +1,0 @@
-# {{crate}} [![crates.io](https://img.shields.io/crates/v/{{crate}})](https://crates.io/crates/{{crate}})
-
-{{readme}}
-
-## More Information
-
-For more information on development, authorship, contributing etc. please visit [`ICU4X home page`](https://github.com/unicode-org/icu4x).

--- a/components/calendar/README.md
+++ b/components/calendar/README.md
@@ -1,5 +1,7 @@
 # icu_calendar [![crates.io](https://img.shields.io/crates/v/icu_calendar)](https://crates.io/crates/icu_calendar)
 
+<!-- cargo-rdme start -->
+
 Types for dealing with dates, times, and custom calendars.
 
 This module is published as its own crate ([`icu_calendar`](https://docs.rs/icu_calendar/latest/icu_calendar/))
@@ -90,6 +92,8 @@ assert_eq!(datetime_iso.time.second.number(), 0);
 assert_eq!(datetime_iso.time.nanosecond.number(), 0);
 ```
 [`ICU4X`]: ../icu/index.html
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/calendar/data/README.md
+++ b/components/calendar/data/README.md
@@ -1,6 +1,10 @@
 # icu_calendar_data [![crates.io](https://img.shields.io/crates/v/icu_calendar_data)](https://crates.io/crates/icu_calendar_data)
 
+<!-- cargo-rdme start -->
+
 Data for the icu_calendar crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/casemap/README.md
+++ b/components/casemap/README.md
@@ -1,5 +1,7 @@
 # icu_casemap [![crates.io](https://img.shields.io/crates/v/icu_casemap)](https://crates.io/crates/icu_casemap)
 
+<!-- cargo-rdme start -->
+
 🚧 \[Experimental\] Case mapping for Unicode characters and strings.
 
 This module is published as its own crate ([`icu_casemap`](https://docs.rs/icu_casemap/latest/icu_casemap/))
@@ -25,6 +27,8 @@ of the icu meta-crate. Use with caution.
 </div>
 
 [`ICU4X`]: ../icu/index.html
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/casemap/data/README.md
+++ b/components/casemap/data/README.md
@@ -1,6 +1,10 @@
 # icu_casemap_data [![crates.io](https://img.shields.io/crates/v/icu_casemap_data)](https://crates.io/crates/icu_casemap_data)
 
+<!-- cargo-rdme start -->
+
 Data for the icu_casemap crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/collator/README.md
+++ b/components/collator/README.md
@@ -1,5 +1,7 @@
 # icu_collator [![crates.io](https://img.shields.io/crates/v/icu_collator)](https://crates.io/crates/icu_collator)
 
+<!-- cargo-rdme start -->
+
 Comparing strings according to language-dependent conventions.
 
 This module is published as its own crate ([`icu_collator`](https://docs.rs/icu_collator/latest/icu_collator/))
@@ -267,6 +269,8 @@ let collator_num_on: Collator = Collator::try_new(
 .unwrap();
 assert_eq!(collator_num_on.compare("a10b", "a2b"), Ordering::Greater);
 ```
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/collator/data/README.md
+++ b/components/collator/data/README.md
@@ -1,6 +1,10 @@
 # icu_collator_data [![crates.io](https://img.shields.io/crates/v/icu_collator_data)](https://crates.io/crates/icu_collator_data)
 
+<!-- cargo-rdme start -->
+
 Data for the icu_collator crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/collections/README.md
+++ b/components/collections/README.md
@@ -1,22 +1,26 @@
 # icu_collections [![crates.io](https://img.shields.io/crates/v/icu_collections)](https://crates.io/crates/icu_collections)
 
+<!-- cargo-rdme start -->
+
 Efficient collections for Unicode data.
 
 This module is published as its own crate ([`icu_collections`](https://docs.rs/icu_collections/latest/icu_collections/))
 and as part of the [`icu`](https://docs.rs/icu/latest/icu/) crate. See the latter for more details on the ICU4X project.
 
-ICU4X [`CodePointTrie`](crate::codepointtrie::CodePointTrie) provides a read-only view of CodePointTrie data that is exported
+ICU4X `CodePointTrie` provides a read-only view of CodePointTrie data that is exported
 from ICU4C. Detailed information about the design of the data structure can be found in the documentation
-for the [`CodePointTrie`](crate::codepointtrie::CodePointTrie) struct.
+for the `CodePointTrie` struct.
 
-ICU4X [`CodePointInversionList`](`crate::codepointinvlist::CodePointInversionList`) provides necessary functionality for highly efficient querying of sets of Unicode characters.
+ICU4X `CodePointInversionList` provides necessary functionality for highly efficient querying of sets of Unicode characters.
 It is an implementation of the existing [ICU4C UnicodeSet API](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1UnicodeSet.html).
 
-ICU4X [`Char16Trie`](`crate::char16trie::Char16Trie`) provides a data structure for a space-efficient and time-efficient lookup of
+ICU4X `Char16Trie` provides a data structure for a space-efficient and time-efficient lookup of
 sequences of 16-bit units (commonly but not necessarily UTF-16 code units)
 which map to integer values.
 It is an implementation of the existing [ICU4C UCharsTrie](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1UCharsTrie.html)
 / [ICU4J CharsTrie](https://unicode-org.github.io/icu-docs/apidoc/released/icu4j/com/ibm/icu/util/CharsTrie.html) API.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/collections/codepointtrie_builder/README.md
+++ b/components/collections/codepointtrie_builder/README.md
@@ -1,5 +1,7 @@
 # icu_codepointtrie_builder [![crates.io](https://img.shields.io/crates/v/icu_codepointtrie_builder)](https://crates.io/crates/icu_codepointtrie_builder)
 
+<!-- cargo-rdme start -->
+
 `icu_codepointtrie_builder` is a utility crate of the [`ICU4X`] project.
 
 This crate exposes functionality to build a [`CodePointTrie`] from values provided at runtime.
@@ -65,6 +67,8 @@ assert_eq!(cpt.get32(u32::MAX), 2); // error value
 [`ICU4X`]: ../icu/index.html
 [`CodePointTrie`]: icu_collections::codepointtrie::CodePointTrie
 [`UMutableCPTrie`]: (https://unicode-org.github.io/icu-docs/apidoc/dev/icu4c/umutablecptrie_8h.html#ad8945cf34ca9d40596a66a1395baa19b)
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/datetime/README.md
+++ b/components/datetime/README.md
@@ -1,5 +1,7 @@
 # icu_datetime [![crates.io](https://img.shields.io/crates/v/icu_datetime)](https://crates.io/crates/icu_datetime)
 
+<!-- cargo-rdme start -->
+
 Formatting date and time.
 
 This module is published as its own crate ([`icu_datetime`](https://docs.rs/icu_datetime/latest/icu_datetime/))
@@ -112,6 +114,8 @@ we expect to add more ways to customize the output, like skeletons, and componen
 [`AnyCalendar`]: calendar::any_calendar::{AnyCalendar}
 [`timezone::CustomTimeZone`]: icu::timezone::{CustomTimeZone}
 [`TimeZoneFormatter`]: time_zone::TimeZoneFormatter
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/datetime/data/README.md
+++ b/components/datetime/data/README.md
@@ -1,6 +1,10 @@
 # icu_datetime_data [![crates.io](https://img.shields.io/crates/v/icu_datetime_data)](https://crates.io/crates/icu_datetime_data)
 
+<!-- cargo-rdme start -->
+
 Data for the icu_datetime crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/decimal/README.md
+++ b/components/decimal/README.md
@@ -1,5 +1,7 @@
 # icu_decimal [![crates.io](https://img.shields.io/crates/v/icu_decimal)](https://crates.io/crates/icu_decimal)
 
+<!-- cargo-rdme start -->
+
 Formatting basic decimal numbers.
 
 This module is published as its own crate ([`icu_decimal`](https://docs.rs/icu_decimal/latest/icu_decimal/))
@@ -71,6 +73,8 @@ assert_writeable_eq!(fdf.format(&fixed_decimal), "๑,๐๐๐,๐๐๗");
 ```
 
 [`FixedDecimalFormatter`]: FixedDecimalFormatter
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/decimal/data/README.md
+++ b/components/decimal/data/README.md
@@ -1,6 +1,10 @@
 # icu_decimal_data [![crates.io](https://img.shields.io/crates/v/icu_decimal_data)](https://crates.io/crates/icu_decimal_data)
 
+<!-- cargo-rdme start -->
+
 Data for the icu_decimal crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/icu/README.md
+++ b/components/icu/README.md
@@ -1,5 +1,7 @@
 # icu [![crates.io](https://img.shields.io/crates/v/icu)](https://crates.io/crates/icu)
 
+<!-- cargo-rdme start -->
+
 `icu` is the main meta-crate of the `ICU4X` project.
 
 It provides a comprehensive selection of functionality found in
@@ -98,7 +100,7 @@ functionality are compiled. These features are:
 - `std`: Whether to include `std` support. Without this Cargo feature, `icu` is `#[no_std]`-compatible.
 - `sync`: makes most ICU4X objects implement `Send + Sync`. Has a small performance impact when used with non-static data.
 - `logging`: Enables logging through the `log` crate.
-- `serde`: Activates `serde` implementations for core library types, such as [`Locale`], as well
+- `serde`: Activates `serde` implementations for core library types, such as `Locale`, as well
    as `*_with_buffer_provider` constructors for explicit data management.
 - `experimental`: Whether to enable experimental preview features. Modules enabled with
   this feature may not be production-ready and could change at any time.
@@ -116,10 +118,10 @@ The following Cargo features are only available on the individual crates, but no
 [`BlobDataProvider`]: https://docs.rs/icu_provider_blob/latest/icu_provider_blob/struct.BlobDataProvider.html
 [`icu_provider_adapters`]: https://docs.rs/icu_provider_adapters/latest/icu_provider_adapters/
 [`icu_datagen`]: https://docs.rs/icu_datagen/latest/icu_datagen/
-[`Locale`]: crate::locid::Locale
-[`SymbolsV1`]: crate::decimal::provider::DecimalSymbolsV1
 [`icu4x-datagen`]: https://docs.rs/icu_datagen/latest/icu_datagen/
 [data management tutorial]: https://github.com/unicode-org/icu4x/blob/main/docs/tutorials/data_provider.md#loading-additional-data-at-runtime
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/list/README.md
+++ b/components/list/README.md
@@ -1,5 +1,7 @@
 # icu_list [![crates.io](https://img.shields.io/crates/v/icu_list)](https://crates.io/crates/icu_list)
 
+<!-- cargo-rdme start -->
+
 Formatting lists in a locale-sensitive way.
 
 This module is published as its own crate ([`icu_list`](https://docs.rs/icu_list/latest/icu_list/))
@@ -10,7 +12,6 @@ and as part of the [`icu`](https://docs.rs/icu/latest/icu/) crate. See the latte
 ### Formatting *and* lists in Spanish
 
 ```rust
-#
 let list_formatter = ListFormatter::try_new_and_with_length(
     &locale!("es").into(),
     ListLength::Wide,
@@ -32,7 +33,6 @@ assert_writeable_eq!(
 ### Formatting *or* lists in Thai
 
 ```rust
-#
 let list_formatter = ListFormatter::try_new_or_with_length(
     &locale!("th").into(),
     ListLength::Short,
@@ -46,7 +46,6 @@ assert_writeable_eq!(list_formatter.format(1..=3), "1, 2 หรือ 3",);
 ### Formatting unit lists in English
 
 ```rust
-#
 let list_formatter = ListFormatter::try_new_unit_with_length(
     &locale!("en").into(),
     ListLength::Wide,
@@ -60,6 +59,8 @@ assert_writeable_eq!(
 ```
 Note: this last example is not fully internationalized. See [icu4x/2192](https://github.com/unicode-org/icu4x/issues/2192)
 for full unit handling.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/list/data/README.md
+++ b/components/list/data/README.md
@@ -1,6 +1,10 @@
 # icu_list_data [![crates.io](https://img.shields.io/crates/v/icu_list_data)](https://crates.io/crates/icu_list_data)
 
+<!-- cargo-rdme start -->
+
 Data for the icu_list crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/locid/README.md
+++ b/components/locid/README.md
@@ -1,5 +1,7 @@
 # icu_locid [![crates.io](https://img.shields.io/crates/v/icu_locid)](https://crates.io/crates/icu_locid)
 
+<!-- cargo-rdme start -->
+
 Parsing, manipulating, and serializing Unicode Language and Locale Identifiers.
 
 This module is published as its own crate ([`icu_locid`](https://docs.rs/icu_locid/latest/icu_locid/))
@@ -42,6 +44,8 @@ For more details, see [`Locale`] and [`LanguageIdentifier`].
 [`UTS #35: Unicode LDML 3. Unicode Language and Locale Identifiers`]: https://unicode.org/reports/tr35/tr35.html#Unicode_Language_and_Locale_Identifiers
 [`ICU4X`]: ../icu/index.html
 [`Unicode Extensions`]: extensions
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/locid_transform/README.md
+++ b/components/locid_transform/README.md
@@ -1,5 +1,7 @@
 # icu_locid_transform [![crates.io](https://img.shields.io/crates/v/icu_locid_transform)](https://crates.io/crates/icu_locid_transform)
 
+<!-- cargo-rdme start -->
+
 Canonicalization of locale identifiers based on [`CLDR`] data.
 
 This module is published as its own crate ([`icu_locid_transform`](https://docs.rs/icu_locid_transform/latest/icu_locid_transform/))
@@ -67,6 +69,8 @@ assert_eq!(locale, locale!("zh"));
 [`CLDR`]: http://cldr.unicode.org/
 [`UTS #35: Unicode LDML 3. Likely Subtags`]: https://www.unicode.org/reports/tr35/#Likely_Subtags.
 [`UTS #35: Unicode LDML 3. LocaleId Canonicalization`]: http://unicode.org/reports/tr35/#LocaleId_Canonicalization,
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/locid_transform/data/README.md
+++ b/components/locid_transform/data/README.md
@@ -1,6 +1,10 @@
 # icu_locid_transform_data [![crates.io](https://img.shields.io/crates/v/icu_locid_transform_data)](https://crates.io/crates/icu_locid_transform_data)
 
+<!-- cargo-rdme start -->
+
 Data for the icu_locid_transform crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/normalizer/README.md
+++ b/components/normalizer/README.md
@@ -1,5 +1,7 @@
 # icu_normalizer [![crates.io](https://img.shields.io/crates/v/icu_normalizer)](https://crates.io/crates/icu_normalizer)
 
+<!-- cargo-rdme start -->
+
 Normalizing text into Unicode Normalization Forms.
 
 This module is published as its own crate ([`icu_normalizer`](https://docs.rs/icu_normalizer/latest/icu_normalizer/))
@@ -46,6 +48,8 @@ passthrough (only one inversion list lookup per character in the best case) and 
 decompose-then-canonically-compose behavior, whereas ICU4C has other paths between these
 extremes. The ICU4X collator doesn't make use of the FCD concept at all in order to avoid
 doing the work of checking whether the FCD condition holds.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/normalizer/data/README.md
+++ b/components/normalizer/data/README.md
@@ -1,6 +1,10 @@
 # icu_normalizer_data [![crates.io](https://img.shields.io/crates/v/icu_normalizer_data)](https://crates.io/crates/icu_normalizer_data)
 
+<!-- cargo-rdme start -->
+
 Data for the icu_normalizer crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/plurals/README.md
+++ b/components/plurals/README.md
@@ -1,5 +1,7 @@
 # icu_plurals [![crates.io](https://img.shields.io/crates/v/icu_plurals)](https://crates.io/crates/icu_plurals)
 
+<!-- cargo-rdme start -->
+
 Determine the plural category appropriate for a given number in a given language.
 
 This module is published as its own crate ([`icu_plurals`](https://docs.rs/icu_plurals/latest/icu_plurals/))
@@ -57,6 +59,8 @@ Plural rules depend on the use case. This crate supports two types of plural rul
 * [`Ordinal`](PluralRuleType::Ordinal): `1st place`, `10th day`, `11th floor`
 
 [Language Plural Rules]: https://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/plurals/data/README.md
+++ b/components/plurals/data/README.md
@@ -1,6 +1,10 @@
 # icu_plurals_data [![crates.io](https://img.shields.io/crates/v/icu_plurals_data)](https://crates.io/crates/icu_plurals_data)
 
+<!-- cargo-rdme start -->
+
 Data for the icu_plurals crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/properties/README.md
+++ b/components/properties/README.md
@@ -1,5 +1,7 @@
 # icu_properties [![crates.io](https://img.shields.io/crates/v/icu_properties)](https://crates.io/crates/icu_properties)
 
+<!-- cargo-rdme start -->
+
 Definitions of [Unicode Properties] and APIs for
 retrieving property data in an appropriate data structure.
 
@@ -44,9 +46,11 @@ assert_eq!(maps::script().get('木'), Script::Han); // U+6728
 
 [`ICU4X`]: ../icu/index.html
 [Unicode Properties]: https://unicode-org.github.io/icu/userguide/strings/properties.html
-[`CodePointSetData`]: crate::sets::CodePointSetData
-[`CodePointMapData`]: crate::maps::CodePointMapData
-[`sets`]: crate::sets
+[`CodePointSetData`]: https://docs.rs/icu_properties/latest/icu_properties/sets/struct.CodePointSetData.html
+[`CodePointMapData`]: https://docs.rs/icu_properties/latest/icu_properties/maps/struct.CodePointMapData.html
+[`sets`]: https://docs.rs/icu_properties/latest/icu_properties/sets/
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/properties/data/README.md
+++ b/components/properties/data/README.md
@@ -1,6 +1,10 @@
 # icu_properties_data [![crates.io](https://img.shields.io/crates/v/icu_properties_data)](https://crates.io/crates/icu_properties_data)
 
+<!-- cargo-rdme start -->
+
 Data for the icu_properties crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/segmenter/README.md
+++ b/components/segmenter/README.md
@@ -1,5 +1,7 @@
 # icu_segmenter [![crates.io](https://img.shields.io/crates/v/icu_segmenter)](https://crates.io/crates/icu_segmenter)
 
+<!-- cargo-rdme start -->
+
 Segment strings by lines, graphemes, words, and sentences.
 
 This module is published as its own crate ([`icu_segmenter`](https://docs.rs/icu_segmenter/latest/icu_segmenter/))
@@ -100,6 +102,8 @@ assert_eq!(&breakpoints, &[0, 13, 36]);
 ```
 
 See [`SentenceSegmenter`] for more examples.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/segmenter/data/README.md
+++ b/components/segmenter/data/README.md
@@ -1,6 +1,10 @@
 # icu_segmenter_data [![crates.io](https://img.shields.io/crates/v/icu_segmenter_data)](https://crates.io/crates/icu_segmenter_data)
 
+<!-- cargo-rdme start -->
+
 Data for the icu_segmenter crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/timezone/README.md
+++ b/components/timezone/README.md
@@ -1,5 +1,7 @@
 # icu_timezone [![crates.io](https://img.shields.io/crates/v/icu_timezone)](https://crates.io/crates/icu_timezone)
 
+<!-- cargo-rdme start -->
+
 Types for resolving and manipulating time zones.
 
 ## Fields
@@ -98,6 +100,8 @@ time_zone.maybe_calculate_metazone(&mzc, &datetime);
 
 assert_eq!("amce", time_zone.metazone_id.unwrap().0.as_str());
 ```
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/components/timezone/data/README.md
+++ b/components/timezone/data/README.md
@@ -1,6 +1,10 @@
 # icu_timezone_data [![crates.io](https://img.shields.io/crates/v/icu_timezone_data)](https://crates.io/crates/icu_timezone_data)
 
+<!-- cargo-rdme start -->
+
 Data for the icu_timezone crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/bies/README.md
+++ b/experimental/bies/README.md
@@ -1,5 +1,7 @@
 # bies [![crates.io](https://img.shields.io/crates/v/bies)](https://crates.io/crates/bies)
 
+<!-- cargo-rdme start -->
+
 The algorithms in this project convert from a BIES matrix (the output of the LSTM segmentation neural network) to concrete segment boundaries.  In BIES, B = beginning of segment; I = inside segment; E = end of segment; and S = single segment (both beginning and end).
 
 These algorithms always produce valid breakpoint positions (at grapheme cluster boundaries); they don't assume that the neural network always predicts valid positions.
@@ -43,6 +45,8 @@ The following algorithms are implemented:
 **2a:** Step through each element in the BIES sequence. For each element, look at the triplet containing the element and both of its neighbors. By induction, assume the first element in the triplet is correct. Now, depending on whether there is a code point boundary following the element, calculate the probabilities of all valid BIES for the triplet, and based on those results, pick the most likely value for the current element.
 
 **3a:** Exhaustively check the probabilities of all possible BIES for the string. This algorithm has exponential runtime.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/compactdecimal/README.md
+++ b/experimental/compactdecimal/README.md
@@ -1,5 +1,7 @@
 # icu_compactdecimal [![crates.io](https://img.shields.io/crates/v/icu_compactdecimal)](https://crates.io/crates/icu_compactdecimal)
 
+<!-- cargo-rdme start -->
+
 🚧 \[Experimental\] Compact decimal
 
 This module is published as its own crate ([`icu_compactdecimal`](https://docs.rs/icu_compactdecimal/latest/icu_compactdecimal/))
@@ -10,6 +12,8 @@ and as part of the [`icu`](https://docs.rs/icu/latest/icu/) crate. See the latte
 including in SemVer minor releases. It can be enabled with the "experimental" Cargo feature
 of the icu meta-crate. Use with caution.
 </div>
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/compactdecimal/data/README.md
+++ b/experimental/compactdecimal/data/README.md
@@ -1,6 +1,10 @@
 # icu_compactdecimal_data [![crates.io](https://img.shields.io/crates/v/icu_compactdecimal_data)](https://crates.io/crates/icu_compactdecimal_data)
 
+<!-- cargo-rdme start -->
+
 Data for the icu_compactdecimal crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/displaynames/README.md
+++ b/experimental/displaynames/README.md
@@ -1,5 +1,7 @@
 # icu_displaynames [![crates.io](https://img.shields.io/crates/v/icu_displaynames)](https://crates.io/crates/icu_displaynames)
 
+<!-- cargo-rdme start -->
+
 🚧 \[Experimental\] Display names for languages and regions.
 
 This module is published as its own crate ([`icu_displaynames`](https://docs.rs/icu_displaynames/latest/icu_displaynames/))
@@ -12,6 +14,8 @@ of the icu meta-crate. Use with caution.
 </div>
 
 [`ICU4X`]: ../icu/index.html
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/displaynames/data/README.md
+++ b/experimental/displaynames/data/README.md
@@ -1,6 +1,10 @@
 # icu_displaynames_data [![crates.io](https://img.shields.io/crates/v/icu_displaynames_data)](https://crates.io/crates/icu_displaynames_data)
 
+<!-- cargo-rdme start -->
+
 Data for the icu_displaynames crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/harfbuzz/README.md
+++ b/experimental/harfbuzz/README.md
@@ -1,5 +1,7 @@
 # icu_harfbuzz [![crates.io](https://img.shields.io/crates/v/icu_harfbuzz)](https://crates.io/crates/icu_harfbuzz)
 
+<!-- cargo-rdme start -->
+
 Using ICU4X as the Unicode Database back end for HarfBuzz.
 
 ## Examples
@@ -21,6 +23,8 @@ b.guess_segment_properties();
 assert_eq!(b.get_direction(), Direction::RTL);
 assert_eq!(b.get_script(), sys::HB_SCRIPT_ARABIC);
 ```
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/ixdtf/README.md
+++ b/experimental/ixdtf/README.md
@@ -1,6 +1,10 @@
 # ixdtf [![crates.io](https://img.shields.io/crates/v/ixdtf)](https://crates.io/crates/ixdtf)
 
+<!-- cargo-rdme start -->
+
 Experimental.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/personnames/README.md
+++ b/experimental/personnames/README.md
@@ -1,6 +1,10 @@
 # icu_personnames [![crates.io](https://img.shields.io/crates/v/icu_personnames)](https://crates.io/crates/icu_personnames)
 
+<!-- cargo-rdme start -->
+
 Experimental.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/relativetime/README.md
+++ b/experimental/relativetime/README.md
@@ -1,5 +1,7 @@
 # icu_relativetime [![crates.io](https://img.shields.io/crates/v/icu_relativetime)](https://crates.io/crates/icu_relativetime)
 
+<!-- cargo-rdme start -->
+
 🚧 \[Experimental\] Relative time formatting
 
 This module is published as its own crate ([`icu_relativetime`](https://docs.rs/icu_relativetime/latest/icu_relativetime/))
@@ -10,6 +12,8 @@ and as part of the [`icu`](https://docs.rs/icu/latest/icu/) crate. See the latte
 including in SemVer minor releases. It can be enabled with the "experimental" Cargo feature
 of the icu meta-crate. Use with caution.
 </div>
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/relativetime/data/README.md
+++ b/experimental/relativetime/data/README.md
@@ -1,6 +1,10 @@
 # icu_relativetime_data [![crates.io](https://img.shields.io/crates/v/icu_relativetime_data)](https://crates.io/crates/icu_relativetime_data)
 
+<!-- cargo-rdme start -->
+
 Data for the icu_relativetime crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/single_number_formatter/README.md
+++ b/experimental/single_number_formatter/README.md
@@ -1,6 +1,10 @@
 # icu_singlenumberformatter [![crates.io](https://img.shields.io/crates/v/icu_singlenumberformatter)](https://crates.io/crates/icu_singlenumberformatter)
 
+<!-- cargo-rdme start -->
+
 Experimental.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/single_number_formatter/data/README.md
+++ b/experimental/single_number_formatter/data/README.md
@@ -1,6 +1,10 @@
 # icu_singlenumberformatter_data [![crates.io](https://img.shields.io/crates/v/icu_singlenumberformatter_data)](https://crates.io/crates/icu_singlenumberformatter_data)
 
+<!-- cargo-rdme start -->
+
 Data for the icu_singlenumberformatter crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/transliteration/README.md
+++ b/experimental/transliteration/README.md
@@ -1,5 +1,7 @@
 # icu_transliteration [![crates.io](https://img.shields.io/crates/v/icu_transliteration)](https://crates.io/crates/icu_transliteration)
 
+<!-- cargo-rdme start -->
+
 🚧 \[Experimental\] Transliteration
 
 This module is published as its own crate ([`icu_transliteration`](https://docs.rs/icu_transliteration/latest/icu_transliteration/))
@@ -10,6 +12,8 @@ and as part of the [`icu`](https://docs.rs/icu/latest/icu/) crate. See the latte
 including in SemVer minor releases. It can be enabled with the "experimental" Cargo feature
 of the icu meta-crate. Use with caution.
 </div>
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/transliteration/data/README.md
+++ b/experimental/transliteration/data/README.md
@@ -1,6 +1,10 @@
 # icu_transliteration_data [![crates.io](https://img.shields.io/crates/v/icu_transliteration_data)](https://crates.io/crates/icu_transliteration_data)
 
+<!-- cargo-rdme start -->
+
 Data for the icu_transliteration crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/transliterator_parser/README.md
+++ b/experimental/transliterator_parser/README.md
@@ -1,12 +1,16 @@
 # icu_transliterator_parser [![crates.io](https://img.shields.io/crates/v/icu_transliterator_parser)](https://crates.io/crates/icu_transliterator_parser)
 
+<!-- cargo-rdme start -->
+
 `icu_transliterator_parser` is a utility crate of the [`ICU4X`] project.
 
 This crate provides parsing functionality for [UTS #35 - Transliterators](https://unicode.org/reports/tr35/tr35-general.html#Transforms).
 
-See [`parse`](crate::parse()) for more information.
+See `parse` for more information.
 
 [`ICU4X`]: ../icu/index.html
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/unicodeset_parser/README.md
+++ b/experimental/unicodeset_parser/README.md
@@ -1,13 +1,17 @@
 # icu_unicodeset_parser [![crates.io](https://img.shields.io/crates/v/icu_unicodeset_parser)](https://crates.io/crates/icu_unicodeset_parser)
 
+<!-- cargo-rdme start -->
+
 `icu_unicodeset_parser` is a utility crate of the [`ICU4X`] project.
 
 This crate provides parsing functionality for [UTS #35 - Unicode Sets](https://unicode.org/reports/tr35/#Unicode_Sets).
 Parses into [`CodePointInversionListAndStringList`](icu_collections::codepointinvliststringlist::CodePointInversionListAndStringList).
 
-See [`parse`](crate::parse()) for more information.
+See `parse` for more information.
 
 [`ICU4X`]: ../icu/index.html
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/unitsconversion/README.md
+++ b/experimental/unitsconversion/README.md
@@ -1,6 +1,10 @@
 # icu_unitsconversion [![crates.io](https://img.shields.io/crates/v/icu_unitsconversion)](https://crates.io/crates/icu_unitsconversion)
 
+<!-- cargo-rdme start -->
+
 Experimental.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/unitsconversion/data/README.md
+++ b/experimental/unitsconversion/data/README.md
@@ -1,6 +1,10 @@
 # icu_unitsconversion_data [![crates.io](https://img.shields.io/crates/v/icu_unitsconversion_data)](https://crates.io/crates/icu_unitsconversion_data)
 
+<!-- cargo-rdme start -->
+
 Data for the icu_unitsconversion crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/experimental/zerotrie/README.md
+++ b/experimental/zerotrie/README.md
@@ -1,5 +1,7 @@
 # zerotrie [![crates.io](https://img.shields.io/crates/v/zerotrie)](https://crates.io/crates/zerotrie)
 
+<!-- cargo-rdme start -->
+
 A data structure offering zero-copy storage and retrieval of byte strings, with a focus
 on the efficient storage of ASCII strings. Strings are mapped to `usize` values.
 
@@ -35,6 +37,8 @@ cargo doc --document-private-items --all-features --no-deps --open
 
 [`LiteMap`]: litemap::LiteMap
 [`BTreeMap`]: alloc::collections::BTreeMap
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/ffi/capi_cdylib/README.md
+++ b/ffi/capi_cdylib/README.md
@@ -1,5 +1,7 @@
 # icu_capi_cdylib [![crates.io](https://img.shields.io/crates/v/icu_capi_cdylib)](https://crates.io/crates/icu_capi_cdylib)
 
+<!-- cargo-rdme start -->
+
 This exists as a separate crate to work around
 cargo being [unable to conditionally compile crate-types](https://github.com/rust-lang/cargo/issues/4881).
 
@@ -8,6 +10,8 @@ because symbols like log_js are not defined even if the crate_type
 is not actually desired. As a workaround, the `icu_capi_staticlib` and
 `icu_capi_cdylib` crates exist as endpoints to be built when those
 respective library types are needed.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/ffi/capi_staticlib/README.md
+++ b/ffi/capi_staticlib/README.md
@@ -1,5 +1,7 @@
 # icu_capi_staticlib [![crates.io](https://img.shields.io/crates/v/icu_capi_staticlib)](https://crates.io/crates/icu_capi_staticlib)
 
+<!-- cargo-rdme start -->
+
 This exists as a separate crate to work around
 cargo being [unable to conditionally compile crate-types](https://github.com/rust-lang/cargo/issues/4881).
 
@@ -8,6 +10,8 @@ because symbols like log_js are not defined even if the crate_type
 is not actually desired. As a workaround, the `icu_capi_staticlib` and
 `icu_capi_cdylib` crates exist as endpoints to be built when those
 respective library types are needed.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/ffi/diplomat/README.md
+++ b/ffi/diplomat/README.md
@@ -1,5 +1,7 @@
 # icu_capi [![crates.io](https://img.shields.io/crates/v/icu_capi)](https://crates.io/crates/icu_capi)
 
+<!-- cargo-rdme start -->
+
 This crate contains the source of truth for the [Diplomat](https://github.com/rust-diplomat/diplomat)-generated
 FFI bindings. This generates the C, C++, JavaScript, and TypeScript bindings. This crate also contains the `extern "C"`
 FFI for ICU4X.
@@ -20,6 +22,8 @@ an allocator and panic hook.
 More information on using ICU4X from C++ can be found in [our tutorial].
 
 [our tutorial]: https://github.com/unicode-org/icu4x/blob/main/docs/tutorials/cpp.md
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/ffi/ecma402/README.md
+++ b/ffi/ecma402/README.md
@@ -1,6 +1,10 @@
 # icu4x_ecma402 [![crates.io](https://img.shields.io/crates/v/icu4x_ecma402)](https://crates.io/crates/icu4x_ecma402)
 
+<!-- cargo-rdme start -->
+
 This crate provides an experimental implementation of the `ECMA-402` traits using `ICU4X` library.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/ffi/freertos/README.md
+++ b/ffi/freertos/README.md
@@ -1,5 +1,7 @@
 # icu_freertos [![crates.io](https://img.shields.io/crates/v/icu_freertos)](https://crates.io/crates/icu_freertos)
 
+<!-- cargo-rdme start -->
+
 This crate is a shim that enables one to use icu4x on Cortex-M + FreeRTOS by setting up the
 relevant Rust runtime hooks.
 
@@ -10,6 +12,8 @@ This crate has a build script that will attempt to detect the nightly version an
 things appropriately, where possible. Older nightlies will end up setting the
 `--cfg needs_alloc_error_handler` flag: if using a custom build system and a nightly from
 2022 or earlier, please set this flag.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/ffi/gn/README.md
+++ b/ffi/gn/README.md
@@ -1,5 +1,7 @@
 # icu_capi_gn [![crates.io](https://img.shields.io/crates/v/icu_capi_gn)](https://crates.io/crates/icu_capi_gn)
 
+<!-- cargo-rdme start -->
+
 This directory contains ICU4X build rules for the
 [GN meta-build system](https://gn.googlesource.com/gn/).
 
@@ -13,6 +15,8 @@ commands having the "gn" prefix from the top level, including:
 - `cargo make gn-run`: Runs ICU4X from the binaries built with `gn` and `ninja`.
 
 This actual Rust crate is only a placeholder for input to Cargo GNaw.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/ffi/gn/src/lib.rs
+++ b/ffi/gn/src/lib.rs
@@ -15,5 +15,3 @@
 //! - `cargo make gn-run`: Runs ICU4X from the binaries built with `gn` and `ninja`.
 //!
 //! This actual Rust crate is only a placeholder for input to Cargo GNaw.
-
-mod _ {}

--- a/provider/adapters/README.md
+++ b/provider/adapters/README.md
@@ -1,11 +1,15 @@
 # icu_provider_adapters [![crates.io](https://img.shields.io/crates/v/icu_provider_adapters)](https://crates.io/crates/icu_provider_adapters)
 
+<!-- cargo-rdme start -->
+
 Adapters for composing and manipulating data providers.
 
 - Use the [`fork`] module to marshall data requests between multiple possible providers.
 - Use the [`either`] module to choose between multiple provider types at runtime.
 - Use the [`filter`] module to programmatically reject certain data requests.
 - Use the [`fallback`] module to automatically resolve arbitrary locales for data loading.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/provider/blob/README.md
+++ b/provider/blob/README.md
@@ -1,5 +1,7 @@
 # icu_provider_blob [![crates.io](https://img.shields.io/crates/v/icu_provider_blob)](https://crates.io/crates/icu_provider_blob)
 
+<!-- cargo-rdme start -->
+
 `icu_provider_blob` contains [`BlobDataProvider`], a [`BufferProvider`] implementation that
 supports loading data from a single serialized blob.
 
@@ -14,6 +16,8 @@ For examples, see the specific data providers.
 [`ICU4X`]: ../icu/index.html
 [`BufferProvider`]: icu_provider::BufferProvider
 [`icu_datagen`]: ../icu_datagen/index.html
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/provider/core/README.md
+++ b/provider/core/README.md
@@ -1,5 +1,7 @@
 # icu_provider [![crates.io](https://img.shields.io/crates/v/icu_provider)](https://crates.io/crates/icu_provider)
 
+<!-- cargo-rdme start -->
+
 `icu_provider` is one of the [`ICU4X`] components.
 
 Unicode's experience with ICU4X's parent projects, ICU4C and ICU4J, led the team to realize
@@ -112,6 +114,8 @@ data generation implementation.
 [`FsDataProvider`]: ../icu_provider_fs/struct.FsDataProvider.html
 [`BlobDataProvider`]: ../icu_provider_blob/struct.BlobDataProvider.html
 [`icu_datagen`]: ../icu_datagen/index.html
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/provider/datagen/README.md
+++ b/provider/datagen/README.md
@@ -1,5 +1,7 @@
 # icu_datagen [![crates.io](https://img.shields.io/crates/v/icu_datagen)](https://crates.io/crates/icu_datagen)
 
+<!-- cargo-rdme start -->
+
 `icu_datagen` is a library to generate data files that can be used in ICU4X data providers.
 
 Data files can be generated either programmatically (i.e. in `build.rs`), or through a
@@ -41,6 +43,8 @@ $ icu4x-datagen \
 >    --out data.postcard
 ```
 More details can be found by running `--help`.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/provider/fs/README.md
+++ b/provider/fs/README.md
@@ -1,5 +1,7 @@
 # icu_provider_fs [![crates.io](https://img.shields.io/crates/v/icu_provider_fs)](https://crates.io/crates/icu_provider_fs)
 
+<!-- cargo-rdme start -->
+
 `icu_provider_fs` is one of the [`ICU4X`] components.
 
 It reads ICU4X data files from the filesystem in a given directory.
@@ -22,7 +24,7 @@ as the leaf data files. For example, Arabic JSON data for cardinal plural rules 
 The exact form of the directory structure may change over time. ICU4X uses metadata from
 `manifest.json` to dynamically interpret different versions of the directory structure.
 
-```
+```text
 ├── manifest.json
 ├── dates
 │   └── gregory@1
@@ -73,6 +75,8 @@ icu4x-datagen --keys all --locales full --format dir --syntax postcard
 ```
 
 [`ICU4X`]: ../icu/index.html
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/provider/macros/README.md
+++ b/provider/macros/README.md
@@ -1,8 +1,12 @@
 # icu_provider_macros [![crates.io](https://img.shields.io/crates/v/icu_provider_macros)](https://crates.io/crates/icu_provider_macros)
 
+<!-- cargo-rdme start -->
+
 Proc macros for the ICU4X data provider.
 
 These macros are re-exported from `icu_provider`.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/provider/testdata/README.md
+++ b/provider/testdata/README.md
@@ -1,5 +1,7 @@
 # icu_testdata [![crates.io](https://img.shields.io/crates/v/icu_testdata)](https://crates.io/crates/icu_testdata)
 
+<!-- cargo-rdme start -->
+
 `icu_testdata` is a unit testing crate for [`ICU4X`].
 
 The crate exposes data providers with stable data useful for unit testing. The data is
@@ -48,6 +50,8 @@ HelloWorldFormatter::try_new_unstable(
 ```
 
 [`ICU4X`]: ../icu/index.html
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/tools/make/gn.toml
+++ b/tools/make/gn.toml
@@ -92,6 +92,7 @@ icu4x_root = pwd
 cd ffi/gn
 
 exec --fail-on-error ./third_party_tools/bin/gnaw --manifest-path "${icu4x_root}/ffi/gn/Cargo.toml" --project-root ${icu4x_root} --output ${icu4x_root}/ffi/gn/icu4x/BUILD.gn --skip-root --gn-bin ${icu4x_root}/ffi/gn/third_party_tools/bin/gn
+exec --fail-on-error cargo rdme --force
 '''
 
 [tasks.verify-gn-gen]

--- a/tools/make/tidy.toml
+++ b/tools/make/tidy.toml
@@ -107,7 +107,7 @@ script = '''
 exit_on_error true
 
 glob_pattern = set "./**/Cargo.toml"
-glob_skip_pattern = array "ffi/gn/vendor/**/*" "ffi/gn/third_party_tools/**/*" "ffi/diplomat/*/examples/**/*" "tools/**/*" "**/fuzz/*" "**/target/**/*" "docs/**/*"
+glob_skip_pattern = array "ffi/gn/**/*" "ffi/diplomat/*/examples/**/*" "tools/**/*" "**/fuzz/*" "**/target/**/*" "docs/**/*"
 
 cargo_list = exec cargo --list
 if not contains ${cargo_list.stdout} "rdme"

--- a/tools/make/tidy.toml
+++ b/tools/make/tidy.toml
@@ -109,11 +109,9 @@ exit_on_error true
 glob_pattern = set "./**/Cargo.toml"
 glob_skip_pattern = array "ffi/gn/vendor/**/*" "ffi/gn/third_party_tools/**/*" "ffi/diplomat/*/examples/**/*" "tools/**/*" "**/fuzz/*" "**/target/**/*" "docs/**/*"
 
-template = canonicalize README.tpl
-
 cargo_list = exec cargo --list
-if not contains ${cargo_list.stdout} "readme"
-    trigger_error "Please run 'cargo install cargo-readme' to support generating README.md files"
+if not contains ${cargo_list.stdout} "rdme"
+    trigger_error "Please run 'cargo install cargo-rdme' to support generating README.md files"
 end
 
 skip_paths = set_new
@@ -124,6 +122,8 @@ for skip_pattern in ${glob_skip_pattern}
     end
 end
 
+project_dir = pwd
+
 handle = glob_array ${glob_pattern}
 for path in ${handle}
     root_dir = dirname ${path}
@@ -133,7 +133,9 @@ for path in ${handle}
     end
     if not ${skip_this}
         echo "Automatically generating ${root_dir}/README.md"
-        exec --fail-on-error cargo readme -r ${root_dir} -o README.md -t ${template}
+        cd ${root_dir}
+        exec --fail-on-error cargo rdme --force
+        cd ${project_dir}
     end
 end
 '''

--- a/utils/crlify/README.md
+++ b/utils/crlify/README.md
@@ -1,6 +1,10 @@
 # crlify [![crates.io](https://img.shields.io/crates/v/crlify)](https://crates.io/crates/crlify)
 
+<!-- cargo-rdme start -->
+
 [`BufWriterWithLineEndingFix`].
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/utils/databake/README.md
+++ b/utils/databake/README.md
@@ -1,5 +1,7 @@
 # databake [![crates.io](https://img.shields.io/crates/v/databake)](https://crates.io/crates/databake)
 
+<!-- cargo-rdme start -->
+
 This crate allows data to write itself into Rust code (bake itself in).
 
 Types that implement the `Bake` trait can be written into Rust expressions,
@@ -54,6 +56,8 @@ test_bake!(
     my_crate,
 );
 ```
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/utils/databake/derive/README.md
+++ b/utils/databake/derive/README.md
@@ -1,6 +1,10 @@
 # databake-derive [![crates.io](https://img.shields.io/crates/v/databake-derive)](https://crates.io/crates/databake-derive)
 
+<!-- cargo-rdme start -->
+
 Custom derives for `Bake`
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/utils/deduplicating_array/README.md
+++ b/utils/deduplicating_array/README.md
@@ -1,5 +1,7 @@
 # deduplicating_array [![crates.io](https://img.shields.io/crates/v/deduplicating_array)](https://crates.io/crates/deduplicating_array)
 
+<!-- cargo-rdme start -->
+
 A serde serialization strategy that uses `PartialEq` to reduce serialized size.
 
 This create can be used with Serde derive like this:
@@ -23,6 +25,8 @@ target index, e.g. the Rust array `["Foo", "Bar", "Foo"]` will serialize to JSON
 
 This implies that singleton integer arrays cannot be used as array elements (they do work in Bincode,
 but there's really not much point in using them).
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/utils/fixed_decimal/README.md
+++ b/utils/fixed_decimal/README.md
@@ -1,5 +1,7 @@
 # fixed_decimal [![crates.io](https://img.shields.io/crates/v/fixed_decimal)](https://crates.io/crates/fixed_decimal)
 
+<!-- cargo-rdme start -->
+
 `fixed_decimal` is a utility crate of the [`ICU4X`] project.
 
 It includes [`FixedDecimal`], a core API for representing numbers in a human-readable form
@@ -33,6 +35,8 @@ assert_eq!(
 ```
 
 [`ICU4X`]: ../icu/index.html
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/utils/litemap/README.md
+++ b/utils/litemap/README.md
@@ -1,5 +1,7 @@
 # litemap [![crates.io](https://img.shields.io/crates/v/litemap)](https://crates.io/crates/litemap)
 
+<!-- cargo-rdme start -->
+
 ## `litemap`
 
 `litemap` is a crate providing [`LiteMap`], a highly simplistic "flat" key-value map
@@ -20,6 +22,8 @@ random-access data store, giving that data store a map-like interface. See the [
 module for more details.
 
 [`Vec`]: alloc::vec::Vec
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/utils/pattern/README.md
+++ b/utils/pattern/README.md
@@ -1,5 +1,7 @@
 # icu_pattern [![crates.io](https://img.shields.io/crates/v/icu_pattern)](https://crates.io/crates/icu_pattern)
 
+<!-- cargo-rdme start -->
+
 `icu_pattern` is a utility crate of the [`ICU4X`] project.
 
 It includes a [`Pattern`] struct which wraps a paid of [`Parser`] and [`Interpolator`] allowing for parsing and interpolation of ICU placeholder patterns, like "{0} days" or
@@ -99,6 +101,8 @@ pattern to be used.
 
 [`ICU4X`]: ../icu/index.html
 [`FromStr`]: std::str::FromStr
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/utils/tinystr/README.md
+++ b/utils/tinystr/README.md
@@ -1,5 +1,7 @@
 # tinystr [![crates.io](https://img.shields.io/crates/v/tinystr)](https://crates.io/crates/tinystr)
 
+<!-- cargo-rdme start -->
+
 `tinystr` is a utility crate of the [`ICU4X`] project.
 
 It includes [`TinyAsciiStr`], a core API for representing small ASCII-only bounded length strings.
@@ -47,6 +49,8 @@ bitmasking to provide basic string manipulation operations:
 `TinyAsciiStr` will fall back to `u8` character manipulation for strings of length greater than 8.
 
 [`ICU4X`]: ../icu/index.html
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/utils/tzif/README.md
+++ b/utils/tzif/README.md
@@ -1,5 +1,7 @@
 # tzif [![crates.io](https://img.shields.io/crates/v/tzif)](https://crates.io/crates/tzif)
 
+<!-- cargo-rdme start -->
+
 A parser for [Time Zone Information Format (`TZif`)](https://tools.ietf.org/id/draft-murchison-tzdist-tzif-00.html) files.
 
 Also includes a parser for [POSIX time-zone strings](https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html),
@@ -20,6 +22,8 @@ let data = tzif::parse_tzif_file("path_to_file").unwrap();
 let data =
     tzif::parse_posix_tz_string(b"WGT3WGST,M3.5.0/-2,M10.5.0/-1").unwrap();
 ```
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/utils/writeable/README.md
+++ b/utils/writeable/README.md
@@ -1,5 +1,7 @@
 # writeable [![crates.io](https://img.shields.io/crates/v/writeable)](https://crates.io/crates/writeable)
 
+<!-- cargo-rdme start -->
+
 `writeable` is a utility crate of the [`ICU4X`] project.
 
 It includes [`Writeable`], a core trait representing an object that can be written to a
@@ -46,6 +48,8 @@ writeable::impl_display_with_writeable!(WelcomeMessage<'_>);
 ```
 
 [`ICU4X`]: ../icu/index.html
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/utils/yoke/README.md
+++ b/utils/yoke/README.md
@@ -1,5 +1,7 @@
 # yoke [![crates.io](https://img.shields.io/crates/v/yoke)](https://crates.io/crates/yoke)
 
+<!-- cargo-rdme start -->
+
 This crate provides [`Yoke<Y, C>`][Yoke], which allows one to "yoke" (attach) a zero-copy deserialized
 object (say, a [`Cow<'a, str>`](alloc::borrow::Cow)) to the source it was deserialized from, (say, an [`Rc<[u8]>`](alloc::rc::Rc)),
 known in this crate as a "cart", producing a type that looks like `Yoke<Cow<'static, str>, Rc<[u8]>>`
@@ -21,6 +23,8 @@ the cart type `C`, which cannot be interfered with as long as the `Yoke` is borr
 when necessary.
 
 See the documentation of [`Yoke`] for more details.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/utils/yoke/derive/README.md
+++ b/utils/yoke/derive/README.md
@@ -1,6 +1,10 @@
 # yoke-derive [![crates.io](https://img.shields.io/crates/v/yoke-derive)](https://crates.io/crates/yoke-derive)
 
+<!-- cargo-rdme start -->
+
 Custom derives for `Yokeable` from the `yoke` crate.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/utils/zerofrom/README.md
+++ b/utils/zerofrom/README.md
@@ -1,8 +1,12 @@
 # zerofrom [![crates.io](https://img.shields.io/crates/v/zerofrom)](https://crates.io/crates/zerofrom)
 
+<!-- cargo-rdme start -->
+
 This crate provides [`ZeroFrom`], a trait for converting types in a zero-copy way.
 
 See the documentation of [`ZeroFrom`] for more details.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/utils/zerofrom/derive/README.md
+++ b/utils/zerofrom/derive/README.md
@@ -1,6 +1,10 @@
 # zerofrom-derive [![crates.io](https://img.shields.io/crates/v/zerofrom-derive)](https://crates.io/crates/zerofrom-derive)
 
+<!-- cargo-rdme start -->
+
 Custom derives for `ZeroFrom` from the `zerofrom` crate.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/utils/zerovec/README.md
+++ b/utils/zerovec/README.md
@@ -1,5 +1,7 @@
 # zerovec [![crates.io](https://img.shields.io/crates/v/zerovec)](https://crates.io/crates/zerovec)
 
+<!-- cargo-rdme start -->
+
 Zero-copy vector abstractions for arbitrary types, backed by byte slices.
 
 `zerovec` enables a far wider range of types — beyond just `&[u8]` and `&str` — to participate in
@@ -36,9 +38,9 @@ This crate has several optional Cargo features:
  -  `serde`: Allows serializing and deserializing `zerovec`'s abstractions via [`serde`](https://docs.rs/serde)
  -   `yoke`: Enables implementations of `Yokeable` from the [`yoke`](https://docs.rs/yoke/) crate, which is also useful
              in situations involving a lot of zero-copy deserialization.
- - `derive`: Makes it easier to use custom types in these collections by providing the [`#[make_ule]`](crate::make_ule) and
-    [`#[make_varule]`](crate::make_varule) proc macros, which generate appropriate [`ULE`](crate::ule::ULE) and
-    [`VarULE`](crate::ule::VarULE)-conformant types for a given "normal" type.
+ - `derive`: Makes it easier to use custom types in these collections by providing the `#[make_ule]` and
+    `#[make_varule]` proc macros, which generate appropriate [`ULE`](https://docs.rs/zerovec/latest/zerovec/ule/trait.ULE.html) and
+    [`VarULE`](https://docs.rs/zerovec/latest/zerovec/ule/trait.VarULE.html)-conformant types for a given "normal" type.
  - `std`: Enabled `std::Error` implementations for error types. This crate is by default `no_std` with a dependency on `alloc`.
 
 [`ZeroVec<'a, T>`]: ZeroVec
@@ -187,6 +189,8 @@ Small = 16 elements, large = 131,072 elements. Maps contain `<String, String>`.
 The benches used to generate the above table can be found in the `benches` directory in the project repository.
 `zeromap` benches are named by convention, e.g. `zeromap/deserialize/small`, `zeromap/lookup/large`. The type
 is appended for baseline comparisons, e.g. `zeromap/lookup/small/hashmap`.
+
+<!-- cargo-rdme end -->
 
 ## More Information
 

--- a/utils/zerovec/derive/README.md
+++ b/utils/zerovec/derive/README.md
@@ -1,6 +1,10 @@
 # zerovec-derive [![crates.io](https://img.shields.io/crates/v/zerovec-derive)](https://crates.io/crates/zerovec-derive)
 
+<!-- cargo-rdme start -->
+
 Proc macros for generating `ULE`, `VarULE` impls and types for the `zerovec` crate
+
+<!-- cargo-rdme end -->
 
 ## More Information
 


### PR DESCRIPTION
`cargo-readme` is unmaintained and has several bugs, some of which are currently blocking #3908  and #3888. `cargo-rdme` also handles links better, as it points them to `docs.rs`.