### PR TITLE
Adding `DynamicDataProvider<AnyMarker>` bound to `ExportableProvider`

### DIFF
--- a/provider/core/src/any.rs
+++ b/provider/core/src/any.rs
@@ -365,7 +365,7 @@ pub trait AsDynamicDataProviderAnyMarkerWrap {
 
 impl<P> AsDynamicDataProviderAnyMarkerWrap for P
 where
-    P: DynamicDataProvider<AnyMarker>,
+    P: DynamicDataProvider<AnyMarker> + ?Sized,
 {
     #[inline]
     fn as_any_provider(&self) -> DynamicDataProviderAnyMarkerWrap<P> {

--- a/provider/core/src/datagen/data_conversion.rs
+++ b/provider/core/src/datagen/data_conversion.rs
@@ -9,16 +9,12 @@ use alloc::boxed::Box;
 /// A trait that allows for converting between data payloads of different types.
 ///
 /// These payloads will typically be some kind of erased payload, either with
-/// AnyMarker, BufferMarker, or SerializeMarker, where converting requires reifying the type.
+/// [`AnyMarker`], [`BufferMarker`], or [`ExportMarker`](crate::datagen::ExportMarker), where converting
+/// requires reifying the type.
+///
 /// A type implementing [`DataConverter`] will essentially have a "registry" mapping keys to
 /// concrete marker types M, and reifying the input to a `DataPayload<M>`, performing some conversion
 /// or computation, and erasing the result to `DataPayload<MTo>`.
-///
-/// It will typically be implemented on data providers used in datagen.
-///
-/// The [`make_exportable_provider!`] macro is able to automatically implement this trait.
-///
-/// [`make_exportable_provider!`]: crate::make_exportable_provider
 pub trait DataConverter<MFrom: DataMarker, MTo: DataMarker> {
     /// Attempt to convert a payload corresponding to the given data key
     /// from one marker type to another marker type.

--- a/provider/core/src/datagen/mod.rs
+++ b/provider/core/src/datagen/mod.rs
@@ -90,17 +90,15 @@ pub trait DataExporter: Sync {
 /// A [`DynamicDataProvider`] that can be used for exporting data.
 ///
 /// Use [`make_exportable_provider`](crate::make_exportable_provider) to implement this.
-pub trait ExportableProvider: IterableDynamicDataProvider<ExportMarker> + Sync {
-    /// Returns a struct implementing `DataProvider<M>` by downcasting
-    fn as_downcasting(&self) -> DowncastingExportableDataProvider<Self> {
-        DowncastingExportableDataProvider(self)
-    }
+pub trait ExportableProvider:
+    IterableDynamicDataProvider<ExportMarker> + DynamicDataProvider<AnyMarker> + Sync
+{
 }
-impl<T> ExportableProvider for T where T: IterableDynamicDataProvider<ExportMarker> + Sync {}
 
-#[derive(Debug)]
-#[doc(hidden)]
-pub struct DowncastingExportableDataProvider<'a, P: ?Sized>(&'a P);
+impl<T> ExportableProvider for T where
+    T: IterableDynamicDataProvider<ExportMarker> + DynamicDataProvider<AnyMarker> + Sync
+{
+}
 
 /// This macro can be used on a data provider to allow it to be used for data generation.
 ///

--- a/provider/core/src/datagen/payload.rs
+++ b/provider/core/src/datagen/payload.rs
@@ -95,28 +95,6 @@ where
     }
 }
 
-impl<'a, P: super::ExportableProvider, M: KeyedDataMarker> DataProvider<M>
-    for super::DowncastingExportableDataProvider<'a, P>
-where
-    DataPayload<M>: Clone,
-{
-    fn load(&self, req: DataRequest) -> Result<DataResponse<M>, DataError> {
-        let (metadata, payload) = self.0.load_data(M::KEY, req)?.take_metadata_and_payload()?;
-        Ok(DataResponse {
-            payload: Some(
-                payload
-                    .get()
-                    .payload
-                    .as_any()
-                    .downcast_ref::<DataPayload<M>>()
-                    .ok_or_else(|| DataError::for_type::<M>())?
-                    .clone(),
-            ),
-            metadata,
-        })
-    }
-}
-
 impl DataPayload<ExportMarker> {
     /// Serializes this [`DataPayload`] into a serializer using Serde.
     ///

--- a/provider/datagen/src/driver.rs
+++ b/provider/datagen/src/driver.rs
@@ -235,7 +235,7 @@ impl DatagenDriver {
             log::info!("Generating key {key}");
 
             if key.metadata().singleton {
-                if provider.supported_locales_for_key(key)? != &[Default::default()] {
+                if provider.supported_locales_for_key(key)? != [Default::default()] {
                     return Err(
                         DataError::custom("Invalid supported locales for singleton key")
                             .with_key(key),


### PR DESCRIPTION
This allows us to get rid of `ExportableProvider::as_downcasting` as we can instead use `as_any_provider`. As a consequence `ExportableProvider` becomes `dyn` safe, which is nice.

This is strictly speaking a semver breakage, *however*, `ExportableProvider`s documentation says

> Use `make_exportable_provider!` to implement this.

and that macro implements `DynamicDataProvider<AnyMarker>`, so I think this is ok.