### PR TITLE
Cleaning up the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "icu_personnames"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "databake",
  "icu_collections",
@@ -1924,7 +1924,7 @@ version = "1.2.0"
 
 [[package]]
 name = "icu_singlenumberformatter"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "databake",
  "displaydoc",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "icu_unitsconversion"
-version = "1.2.0"
+version = "0.0.0"
 dependencies = [
  "databake",
  "displaydoc",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "icu_unitsconversion_data"
-version = "1.3.0"
+version = "0.0.0"
 
 [[package]]
 name = "ident_case"
@@ -4293,7 +4293,7 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bincode",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,69 +5,72 @@
 [workspace]
 resolver = "2"
 members = [
+    # KEEP IN SYNC WITH workspace.dependencies and docs/tutorials/testing/patch.toml
+
+    # Components
     "components/calendar",
-    "components/calendar/data",
     "components/casemap",
-    "components/casemap/data",
     "components/collator",
-    "components/collator/data",
     "components/collections",
     "components/collections/codepointtrie_builder",
     "components/datetime",
-    "components/datetime/data",
     "components/decimal",
-    "components/decimal/data",
     "components/icu",
     "components/list",
-    "components/list/data",
     "components/locid_transform",
-    "components/locid_transform/data",
     "components/locid",
     "components/normalizer",
-    "components/normalizer/data",
     "components/plurals",
-    "components/plurals/data",
     "components/properties",
-    "components/properties/data",
     "components/segmenter",
-    "components/segmenter/data",
     "components/timezone",
-    "components/timezone/data",
-    "experimental/bies",
     "experimental/compactdecimal",
-    "experimental/compactdecimal/data",
     "experimental/displaynames",
-    "experimental/displaynames/data",
-    "experimental/harfbuzz",
-    "experimental/ixdtf",
     "experimental/personnames",
     "experimental/relativetime",
-    "experimental/relativetime/data",
     "experimental/single_number_formatter",
-    "experimental/single_number_formatter/data",
     "experimental/transliteration",
     "experimental/transliterator_parser",
     "experimental/unicodeset_parser",
     "experimental/unitsconversion",
+
+    # Components data
+    "components/calendar/data",
+    "components/casemap/data",
+    "components/collator/data",
+    "components/datetime/data",
+    "components/decimal/data",
+    "components/list/data",
+    "components/locid_transform/data",
+    "components/normalizer/data",
+    "components/plurals/data",
+    "components/properties/data",
+    "components/segmenter/data",
+    "components/timezone/data",
+    "experimental/compactdecimal/data",
+    "experimental/displaynames/data",
+    "experimental/relativetime/data",
+    "experimental/single_number_formatter/data",
     "experimental/unitsconversion/data",
-    "experimental/zerotrie",
+
+    # FFI
     "ffi/capi_cdylib",
     "ffi/capi_staticlib",
     "ffi/diplomat",
     "ffi/ecma402",
     "ffi/freertos",
+    "experimental/harfbuzz",
+
+    # Provider
     "provider/adapters",
     "provider/blob",
     "provider/core",
     "provider/datagen",
     "provider/fs",
     "provider/macros",
-    "tools/benchmark/binsize",
-    "tools/benchmark/macros",
-    "tools/benchmark/memory",
-    "tools/depcheck",
-    "tools/ffi_coverage",
-    "tools/testdata-scripts",
+
+    # Utils
+    "utils/crlify",
     "utils/databake",
     "utils/databake/derive",
     "utils/deduplicating_array",
@@ -83,6 +86,17 @@ members = [
     "utils/zerofrom/derive",
     "utils/zerovec",
     "utils/zerovec/derive",
+    "experimental/bies",
+    "experimental/ixdtf",
+    "experimental/zerotrie",
+
+    # Tools
+    "tools/benchmark/binsize",
+    "tools/benchmark/macros",
+    "tools/benchmark/memory",
+    "tools/depcheck",
+    "tools/ffi_coverage",
+    "tools/testdata-scripts",
 ]
 # Note: Workspaces in subdirectories, such as docs/tutorials/crates, are
 # implicitly excluded from the main workspace.
@@ -116,10 +130,13 @@ include = [
     "tests/**/*",
     "Cargo.toml",
     "LICENSE",
-    "README.md"
+    "README.md",
 ]
 
 [workspace.dependencies]
+# KEEP IN SYNC WITH workspace.members and docs/tutorials/testing/patch.toml
+
+# Components
 icu = { version = "~1.2.0", path = "components/icu", default-features = false }
 icu_calendar = { version = "~1.2.0", path = "components/calendar", default-features = false }
 icu_casemap = { version = "~1.2.0", path = "components/casemap", default-features = false }
@@ -136,16 +153,17 @@ icu_plurals = { version = "~1.2.0", path = "components/plurals", default-feature
 icu_properties = { version = "~1.2.0", path = "components/properties", default-features = false }
 icu_segmenter = { version = "~1.2.0", path = "components/segmenter", default-features = false }
 icu_timezone = { version = "~1.2.0", path = "components/timezone", default-features = false }
-
 icu_compactdecimal = { version = "0.2.0", path = "experimental/compactdecimal", default-features = false }
 icu_displaynames = { version = "0.10.0", path = "experimental/displaynames", default-features = false }
+icu_personnames = { version = "0.0.0", path = "experimental/personnames", default-features = false }
 icu_relativetime = { version = "0.1.0", path = "experimental/relativetime", default-features = false }
-icu_singlenumberformatter = { version = "0.1.0", path = "experimental/single_number_formatter", default-features = false}
+icu_singlenumberformatter = { version = "0.0.0", path = "experimental/single_number_formatter", default-features = false }
 icu_transliteration = { version = "0.0.0", path = "experimental/transliteration", default-features = false }
 icu_transliterator_parser = { version = "0.0.0", path = "experimental/transliterator_parser", default-features = false }
 icu_unicodeset_parser = { version = "0.0.0", path = "experimental/unicodeset_parser", default-features = false }
-icu_unitsconversion = { version = "1.2.0", path = "experimental/unitsconversion", default-features = false }
+icu_unitsconversion = { version = "0.0.0", path = "experimental/unitsconversion", default-features = false }
 
+# Components data
 icu_calendar_data = { version = "~1.2.0", path = "components/calendar/data", default-features = false }
 icu_casemap_data = { version = "~1.2.0", path = "components/casemap/data", default-features = false }
 icu_collator_data = { version = "~1.2.0", path = "components/collator/data", default-features = false }
@@ -155,20 +173,24 @@ icu_list_data = { version = "~1.2.0", path = "components/list/data", default-fea
 icu_locid_transform_data = { version = "~1.2.0", path = "components/locid_transform/data", default-features = false }
 icu_normalizer_data = { version = "~1.2.0", path = "components/normalizer/data", default-features = false }
 icu_plurals_data = { version = "~1.2.0", path = "components/plurals/data", default-features = false }
-icu_properties_data = { version = "~1.2.0", path = "components/properties/data", default-features = false}
+icu_properties_data = { version = "~1.2.0", path = "components/properties/data", default-features = false }
 icu_segmenter_data = { version = "~1.2.0", path = "components/segmenter/data", default-features = false }
 icu_timezone_data = { version = "~1.2.0", path = "components/timezone/data", default-features = false }
-
 icu_compactdecimal_data = { version = "~1.2.0", path = "experimental/compactdecimal/data", default-features = false }
 icu_displaynames_data = { version = "~1.2.0", path = "experimental/displaynames/data", default-features = false }
 icu_relativetime_data = { version = "1.2.0", path = "experimental/relativetime/data", default-features = false }
-icu_singlenumberformatter_data = { version = "~1.2.0", path = "experimental/single_number_formatter/data", default-features = false}
+icu_singlenumberformatter_data = { version = "~1.2.0", path = "experimental/single_number_formatter/data", default-features = false }
 icu_transliteration_data = { version = "0.0.0", path = "experimental/transliteration/data", default-features = false }
 
+# FFI
 icu_capi = { version = "~1.2.0", path = "ffi/diplomat", default-features = false }
 icu_capi_cdylib = { version = "~1.2.0", path = "ffi/capi_cdylib", default-features = false }
 icu_capi_staticlib = { version = "~1.2.0", path = "ffi/capi_staticlib", default-features = false }
+icu4x_ecma402 = { version = "0.8.0", path = "ffi/ecma402", default-features = false }
+icu_freertos = { version = "~1.2.0", path = "ffi/freertos", default-features = false }
+icu_harfbuzz = { version = "~1.2.0", path = "experimental/harfbuzz", default-features = false }
 
+# Provider
 icu_datagen = { version = "~1.2.0", path = "provider/datagen", default-features = false }
 icu_provider = { version = "~1.2.0", path = "provider/core", default-features = false }
 icu_provider_adapters = { version = "~1.2.0", path = "provider/adapters", default-features = false }
@@ -176,22 +198,34 @@ icu_provider_blob = { version = "~1.2.0", path = "provider/blob", default-featur
 icu_provider_fs = { version = "~1.2.0", path = "provider/fs/", default-features = false }
 icu_provider_macros = { version = "~1.2.0", path = "provider/macros", default-features = false }
 
+# Utils
 crlify = { version = "1.0.1", path = "utils/crlify", default-features = false }
 databake = { version = "0.1.3", path = "utils/databake", default-features = false }
 databake-derive = { version = "0.1.3", path = "utils/databake/derive", default-features = false }
 deduplicating_array = { version = "0.1.3", path = "utils/deduplicating_array", default-features = false }
 fixed_decimal = { version = "0.5.2", path = "utils/fixed_decimal", default-features = false }
 litemap = { version = "0.7.0", path = "utils/litemap", default-features = false }
+icu_pattern = { version = "0.0.0", path = "utils/pattern", default-features = false }
 tinystr = { version = "0.7.1", path = "utils/tinystr", default-features = false }
+tzif = { version = "0.0.0", path = "utils/tzif", default-features = false }
 writeable = { version = "0.5.1", path = "utils/writeable/", default-features = false }
 yoke = { version = "0.7.1", path = "utils/yoke", default-features = false }
 yoke-derive = { version = "0.7.1", path = "utils/yoke/derive", default-features = false }
-zerovec = { version = "0.9.4", path = "utils/zerovec", default-features = false }
-zerovec-derive = { version = "0.9.4", path = "utils/zerovec/derive", default-features = false }
 zerofrom = { version = "0.1.1", path = "utils/zerofrom", default-features = false }
 zerofrom-derive = { version = "0.1.1", path = "utils/zerofrom/derive", default-features = false }
+zerovec = { version = "0.9.4", path = "utils/zerovec", default-features = false }
+zerovec-derive = { version = "0.9.4", path = "utils/zerovec/derive", default-features = false }
+bies = { version = "0.2.1", path = "experimental/bies", default-features = false }
+ixdtf = { version = "0.1.0", path = "experimental/ixdtf", default-features = false }
+zerotrie = { version = "0.0.0", path = "experimental/zerotrie", default-features = false }
 
+# Tools
 icu_benchmark_macros = { path = "tools/benchmark/macros" }
+# icu_benchmark_binsize never used as a dep
+# icu_benchmark_memory never used as a dep
+# depcheck never used as a dep
+# ffi_coverage never used as a dep
+# testdata-scripts never used as a dep
 
 # LTO is needed for WASM and other size-optimized builds,
 # and it improve the performance of benchmarks

--- a/components/collator/Cargo.toml
+++ b/components/collator/Cargo.toml
@@ -52,10 +52,6 @@ serde = ["dep:serde", "zerovec/serde", "icu_properties/serde", "icu_normalizer/s
 datagen = ["serde", "dep:databake", "zerovec/databake", "icu_properties/datagen", "icu_normalizer/datagen", "icu_collections/databake"]
 compiled_data = ["dep:icu_collator_data", "icu_normalizer/compiled_data", "dep:icu_locid_transform"]
 
-[[test]]
-name = "tests"
-path = "tests/tests.rs"
-
 [[bench]]
 name = "bench"
 harness = false

--- a/components/collections/Cargo.toml
+++ b/components/collections/Cargo.toml
@@ -69,7 +69,3 @@ path = "src/codepointtrie/benches/iai_cpt.rs"
 name = "inv_list"
 harness = false
 path = "src/codepointinvlist/benches/inv_list.rs"
-
-[[example]]
-name = "unicode_bmp_blocks_selector"
-path = "src/codepointinvlist/examples/unicode_bmp_blocks_selector.rs"

--- a/components/normalizer/Cargo.toml
+++ b/components/normalizer/Cargo.toml
@@ -52,10 +52,6 @@ datagen = ["serde", "dep:databake", "icu_collections/databake", "zerovec/databak
 experimental = []
 compiled_data = ["dep:icu_normalizer_data", "icu_properties/compiled_data"]
 
-[[test]]
-name = "tests"
-path = "tests/tests.rs"
-
 [[bench]]
 name = "bench"
 harness = false

--- a/docs/tutorials/Cargo.lock
+++ b/docs/tutorials/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar_data"
-version = "1.3.0"
+version = "1.2.0"
 
 [[package]]
 name = "icu_casemap"
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "icu_casemap_data"
-version = "1.3.0"
+version = "1.2.0"
 
 [[package]]
 name = "icu_codepointtrie_builder"
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "icu_collator_data"
-version = "1.3.0"
+version = "1.2.0"
 
 [[package]]
 name = "icu_collections"
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "icu_compactdecimal_data"
-version = "1.3.0"
+version = "1.2.0"
 
 [[package]]
 name = "icu_datagen"
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "icu_datetime_data"
-version = "1.3.0"
+version = "1.2.0"
 
 [[package]]
 name = "icu_decimal"
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "icu_decimal_data"
-version = "1.3.0"
+version = "1.2.0"
 
 [[package]]
 name = "icu_displaynames"
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "icu_displaynames_data"
-version = "1.3.0"
+version = "1.2.0"
 
 [[package]]
 name = "icu_list"
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "icu_list_data"
-version = "1.3.0"
+version = "1.2.0"
 
 [[package]]
 name = "icu_locid"
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.3.0"
+version = "1.2.0"
 
 [[package]]
 name = "icu_normalizer"
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.3.0"
+version = "1.2.0"
 
 [[package]]
 name = "icu_plurals"
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "icu_plurals_data"
-version = "1.3.0"
+version = "1.2.0"
 
 [[package]]
 name = "icu_properties"
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.3.0"
+version = "1.2.0"
 
 [[package]]
 name = "icu_provider"
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "icu_relativetime_data"
-version = "1.3.0"
+version = "1.2.0"
 
 [[package]]
 name = "icu_segmenter"
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "icu_segmenter_data"
-version = "1.3.0"
+version = "1.2.0"
 
 [[package]]
 name = "icu_testdata"
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "icu_timezone_data"
-version = "1.3.0"
+version = "1.2.0"
 
 [[package]]
 name = "ident_case"
@@ -3041,6 +3041,10 @@ name = "icu4x_ecma402"
 version = "0.8.0"
 
 [[patch.unused]]
+name = "icu_benchmark_macros"
+version = "0.0.0"
+
+[[patch.unused]]
 name = "icu_capi"
 version = "1.2.2"
 
@@ -3065,7 +3069,35 @@ name = "icu_pattern"
 version = "0.1.4"
 
 [[patch.unused]]
+name = "icu_personnames"
+version = "0.0.0"
+
+[[patch.unused]]
+name = "icu_singlenumberformatter"
+version = "0.0.0"
+
+[[patch.unused]]
+name = "icu_singlenumberformatter_data"
+version = "1.2.0"
+
+[[patch.unused]]
+name = "icu_transliteration"
+version = "0.0.0"
+
+[[patch.unused]]
+name = "icu_transliteration_data"
+version = "0.0.0"
+
+[[patch.unused]]
+name = "icu_transliterator_parser"
+version = "0.0.0"
+
+[[patch.unused]]
 name = "icu_unicodeset_parser"
+version = "0.0.0"
+
+[[patch.unused]]
+name = "icu_unitsconversion"
 version = "0.0.0"
 
 [[patch.unused]]
@@ -3075,3 +3107,7 @@ version = "0.1.0"
 [[patch.unused]]
 name = "tzif"
 version = "0.2.1"
+
+[[patch.unused]]
+name = "zerotrie"
+version = "0.0.0"

--- a/docs/tutorials/testing/patch.toml
+++ b/docs/tutorials/testing/patch.toml
@@ -3,56 +3,72 @@
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 [patch.crates-io]
+# KEEP IN SYNC WITH TOP-LEVEL Cargo.toml
+
+# Components
+icu = { path = "../../components/icu" }
 icu_calendar = { path = "../../components/calendar" }
-icu_calendar_data = { path = "../../components/calendar/data" }
 icu_casemap = { path = "../../components/casemap" }
-icu_casemap_data = { path = "../../components/casemap/data" }
 icu_collator = { path = "../../components/collator" }
-icu_collator_data = { path = "../../components/collator/data" }
 icu_collections = { path = "../../components/collections" }
 icu_codepointtrie_builder = { path = "../../components/collections/codepointtrie_builder" }
 icu_datetime = { path = "../../components/datetime" }
-icu_datetime_data = { path = "../../components/datetime/data" }
 icu_decimal = { path = "../../components/decimal" }
-icu_decimal_data = { path = "../../components/decimal/data" }
-icu = { path = "../../components/icu" }
 icu_list = { path = "../../components/list" }
-icu_list_data = { path = "../../components/list/data" }
-icu_locid_transform = { path = "../../components/locid_transform" }
-icu_locid_transform_data = { path = "../../components/locid_transform/data" }
 icu_locid = { path = "../../components/locid" }
+icu_locid_transform = { path = "../../components/locid_transform" }
 icu_normalizer = { path = "../../components/normalizer" }
-icu_normalizer_data = { path = "../../components/normalizer/data" }
 icu_plurals = { path = "../../components/plurals" }
-icu_plurals_data = { path = "../../components/plurals/data" }
 icu_properties = { path = "../../components/properties" }
-icu_properties_data = { path = "../../components/properties/data" }
 icu_segmenter = { path = "../../components/segmenter" }
-icu_segmenter_data = { path = "../../components/segmenter/data" }
 icu_timezone = { path = "../../components/timezone" }
-icu_timezone_data = { path = "../../components/timezone/data" }
-bies = { path = "../../experimental/bies" }
 icu_compactdecimal = { path = "../../experimental/compactdecimal" }
-icu_compactdecimal_data = { path = "../../experimental/compactdecimal/data" }
-icu_displaynames = { path = "../../experimental/displaynames" }
-icu_displaynames_data = { path = "../../experimental/displaynames/data" }
-icu_harfbuzz = { path = "../../experimental/harfbuzz" }
-ixdtf = { path = "../../experimental/ixdtf" }
+icu_displaynames = {  path = "../../experimental/displaynames" }
+icu_personnames = { path = "../../experimental/personnames" }
 icu_relativetime = { path = "../../experimental/relativetime" }
-icu_relativetime_data = { path = "../../experimental/relativetime/data" }
+icu_singlenumberformatter = { path = "../../experimental/single_number_formatter"}
+icu_transliteration = { path = "../../experimental/transliteration" }
+icu_transliterator_parser = { path = "../../experimental/transliterator_parser" }
 icu_unicodeset_parser = { path = "../../experimental/unicodeset_parser" }
+icu_unitsconversion = { path = "../../experimental/unitsconversion" }
+
+# Components data
+icu_calendar_data = { path = "../../components/calendar/data" }
+icu_casemap_data = { path = "../../components/casemap/data" }
+icu_collator_data = { path = "../../components/collator/data" }
+icu_datetime_data = { path = "../../components/datetime/data" }
+icu_decimal_data = { path = "../../components/decimal/data" }
+icu_list_data = { path = "../../components/list/data" }
+icu_locid_transform_data = { path = "../../components/locid_transform/data" }
+icu_normalizer_data = { path = "../../components/normalizer/data" }
+icu_plurals_data = { path = "../../components/plurals/data" }
+icu_properties_data = { path = "../../components/properties/data"}
+icu_segmenter_data = { path = "../../components/segmenter/data" }
+icu_timezone_data = { path = "../../components/timezone/data" }
+icu_compactdecimal_data = { path = "../../experimental/compactdecimal/data" }
+icu_displaynames_data = { path = "../../experimental/displaynames/data" }
+icu_relativetime_data = { path = "../../experimental/relativetime/data" }
+icu_singlenumberformatter_data = { path = "../../experimental/single_number_formatter/data"}
+icu_transliteration_data = { path = "../../experimental/transliteration/data" }
+
+# FFI
+icu_capi = { path = "../../ffi/diplomat" }
 icu_capi_cdylib = { path = "../../ffi/capi_cdylib" }
 icu_capi_staticlib = { path = "../../ffi/capi_staticlib" }
-icu_capi = { path = "../../ffi/diplomat" }
 icu4x_ecma402 = { path = "../../ffi/ecma402" }
 icu_freertos = { path = "../../ffi/freertos" }
+icu_harfbuzz = { path = "../../experimental/harfbuzz" }
+
+# Provider
+icu_datagen = { path = "../../provider/datagen" }
+icu_provider = { path = "../../provider/core" }
 icu_provider_adapters = { path = "../../provider/adapters" }
 icu_provider_blob = { path = "../../provider/blob" }
-icu_provider = { path = "../../provider/core" }
-icu_datagen = { path = "../../provider/datagen" }
-icu_provider_fs = { path = "../../provider/fs" }
+icu_provider_fs = { path = "../../provider/fs/" }
 icu_provider_macros = { path = "../../provider/macros" }
 icu_testdata = { path = "testing/legacy_testdata" }
+
+crlify = { path = "../../utils/crlify" }
 databake = { path = "../../utils/databake" }
 databake-derive = { path = "../../utils/databake/derive" }
 deduplicating_array = { path = "../../utils/deduplicating_array" }
@@ -61,10 +77,15 @@ litemap = { path = "../../utils/litemap" }
 icu_pattern = { path = "../../utils/pattern" }
 tinystr = { path = "../../utils/tinystr" }
 tzif = { path = "../../utils/tzif" }
-writeable = { path = "../../utils/writeable" }
+writeable = { path = "../../utils/writeable/" }
 yoke = { path = "../../utils/yoke" }
 yoke-derive = { path = "../../utils/yoke/derive" }
 zerofrom = { path = "../../utils/zerofrom" }
 zerofrom-derive = { path = "../../utils/zerofrom/derive" }
 zerovec = { path = "../../utils/zerovec" }
 zerovec-derive = { path = "../../utils/zerovec/derive" }
+bies = { path = "../../experimental/bies" }
+ixdtf = { path = "../../experimental/ixdtf" }
+zerotrie = { path = "../../experimental/zerotrie" }
+
+icu_benchmark_macros = { path = "../../tools/benchmark/macros" }

--- a/experimental/personnames/Cargo.toml
+++ b/experimental/personnames/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_personnames"
 description = "API for formatting person names according to language-dependent conventions"
-version = "0.1.0"
+version = "0.0.0"
 
 authors.workspace = true
 categories.workspace = true
@@ -30,7 +30,3 @@ litemap = { workspace = true }
 std = ["icu_collections/std", "icu_locid/std", "icu_provider/std"]
 serde = ["dep:serde", "zerovec/serde", "icu_collections/serde", "icu_provider/serde"]
 datagen = ["serde", "std", "dep:databake", "zerovec/databake", "icu_collections/databake"]
-
-[[test]]
-name = "tests"
-path = "tests/tests.rs"

--- a/experimental/relativetime/Cargo.toml
+++ b/experimental/relativetime/Cargo.toml
@@ -46,7 +46,3 @@ std = ["fixed_decimal/std", "icu_decimal/std", "icu_plurals/std", "icu_provider/
 serde = ["dep:serde", "zerovec/serde", "icu_provider/serde", "icu_plurals/serde", "icu_decimal/serde"]
 datagen = ["std", "serde", "dep:databake", "zerovec/databake"]
 compiled_data = ["dep:icu_relativetime_data", "dep:icu_locid_transform", "icu_decimal/compiled_data", "icu_plurals/compiled_data"]
-
-[[test]]
-name = "tests"
-path = "tests/tests.rs"

--- a/experimental/single_number_formatter/Cargo.toml
+++ b/experimental/single_number_formatter/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "icu_singlenumberformatter"
-version = "0.1.0"
+version = "0.0.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/experimental/transliteration/data/Cargo.toml
+++ b/experimental/transliteration/data/Cargo.toml
@@ -3,24 +3,15 @@
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 [package]
 name = "icu_transliteration_data"
-version = "0.0.0"
 description = "Data for the icu_transliteration crate"
-rust-version = "1.65.0"
-authors = ["The ICU4X Project Developers"]
-edition = "2021"
-readme = "README.md"
-repository = "https://github.com/unicode-org/icu4x"
-homepage = "https://icu4x.unicode.org"
-license = "Unicode-DFS-2016"
-categories = ["internationalization"]
-# Keep this in sync with other crates unless there are exceptions
-include = [
-    "data/**/*",
-    "src/**/*",
-    "examples/**/*",
-    "benches/**/*",
-    "tests/**/*",
-    "Cargo.toml",
-    "LICENSE",
-    "README.md"
-]
+version = "0.0.0"
+
+rust-version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license-file.workspace = true
+categories.workspace = true
+include.workspace = true
+

--- a/experimental/unitsconversion/Cargo.toml
+++ b/experimental/unitsconversion/Cargo.toml
@@ -5,10 +5,16 @@
 
 [package]
 name = "icu_unitsconversion"
-version = "1.2.0"
-edition = "2021"
+version = "0.0.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+rust-version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license-file.workspace = true
+categories.workspace = true
+include.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/experimental/unitsconversion/data/Cargo.toml
+++ b/experimental/unitsconversion/data/Cargo.toml
@@ -3,25 +3,15 @@
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 [package]
 name = "icu_unitsconversion_data"
-version = "1.3.0"
 description = "Data for the icu_unitsconversion crate"
-rust-version = "1.65.0"
-authors = ["The ICU4X Project Developers"]
-edition = "2021"
-readme = "README.md"
-repository = "https://github.com/unicode-org/icu4x"
-homepage = "https://icu4x.unicode.org"
-license = "Unicode-DFS-2016"
-categories = ["internationalization"]
-# Keep this in sync with other crates unless there are exceptions
-include = [
-    "data/**/*",
-    "src/**/*",
-    "examples/**/*",
-    "benches/**/*",
-    "tests/**/*",
-    "Cargo.toml",
-    "LICENSE",
-    "README.md"
-]
+version = "0.0.0"
+
+rust-version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license-file.workspace = true
+categories.workspace = true
+include.workspace = true
 

--- a/experimental/zerotrie/Cargo.toml
+++ b/experimental/zerotrie/Cargo.toml
@@ -5,22 +5,16 @@
 [package]
 name = "zerotrie"
 description = "A data structure that efficiently maps strings to integers"
-version = "0.1.0"
-authors = ["The ICU4X Project Developers"]
-edition = "2021"
-readme = "README.md"
-repository = "https://github.com/unicode-org/icu4x"
-license-file = "LICENSE"
-# Keep this in sync with other crates unless there are exceptions
-include = [
-    "src/**/*",
-    "examples/**/*",
-    "benches/**/*",
-    "tests/**/*",
-    "Cargo.toml",
-    "LICENSE",
-    "README.md"
-]
+version = "0.0.0"
+
+rust-version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license-file.workspace = true
+categories.workspace = true
+include.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -57,9 +57,6 @@ export = [
 ]
 bench = []
 
-[lib]
-path = "src/lib.rs"
-
 [package.metadata.cargo-all-features]
 # Bench feature gets tested separately and is only relevant for CI
 denylist = ["bench"]


### PR DESCRIPTION
Adding all crates to workspace members, workspace dependencies, and tutorials test patch. These lists have to stay in sync!

Also setting crates that have not been published yet to `0.0.0`, so the releaser doesn't set them to `0.2.0`.