### PR TITLE
Fix FFI coverage CI

### DIFF
--- a/ffi/diplomat/tests/missing_apis.txt
+++ b/ffi/diplomat/tests/missing_apis.txt
@@ -15,15 +15,17 @@
 
 
 icu::calendar::Date::try_new_chinese_date#FnInStruct
-icu::calendar::Date::try_new_dangi_date#FnInStruct
+icu::calendar::Date::try_new_hebrew_date#FnInStruct
 icu::calendar::Date::try_new_islamic_civil_date#FnInStruct
+icu::calendar::Date::try_new_islamic_tabular_date#FnInStruct
 icu::calendar::Date::try_new_observational_islamic_date#FnInStruct
 icu::calendar::Date::try_new_persian_date#FnInStruct
 icu::calendar::Date::try_new_roc_date#FnInStruct
 icu::calendar::Date::try_new_ummalqura_date#FnInStruct
 icu::calendar::DateTime::try_new_chinese_datetime#FnInStruct
-icu::calendar::DateTime::try_new_dangi_datetime#FnInStruct
+icu::calendar::DateTime::try_new_hebrew_datetime#FnInStruct
 icu::calendar::DateTime::try_new_islamic_civil_datetime#FnInStruct
+icu::calendar::DateTime::try_new_islamic_tabular_datetime#FnInStruct
 icu::calendar::DateTime::try_new_observational_islamic_datetime#FnInStruct
 icu::calendar::DateTime::try_new_persian_datetime#FnInStruct
 icu::calendar::DateTime::try_new_roc_datetime#FnInStruct
@@ -33,9 +35,9 @@ icu::calendar::chinese::Chinese::chinese_new_year_on_or_before_iso#FnInStruct
 icu::calendar::chinese::Chinese::major_solar_term_from_iso#FnInStruct
 icu::calendar::chinese::Chinese::minor_solar_term_from_iso#FnInStruct
 icu::calendar::chinese::ChineseDateInner#Struct
-icu::calendar::dangi::Dangi#Struct
-icu::calendar::dangi::Dangi::seollal_on_or_before_iso#FnInStruct
-icu::calendar::dangi::DangiDateInner#Struct
+icu::calendar::hebrew::Hebrew#Struct
+icu::calendar::hebrew::Hebrew::new#FnInStruct
+icu::calendar::hebrew::HebrewDateInner#Struct
 icu::calendar::islamic::IslamicCivil#Struct
 icu::calendar::islamic::IslamicCivil::new#FnInStruct
 icu::calendar::islamic::IslamicCivilDateInner#Struct
@@ -43,9 +45,11 @@ icu::calendar::islamic::IslamicDateInner#Struct
 icu::calendar::islamic::IslamicObservational#Struct
 icu::calendar::islamic::IslamicObservational::new#FnInStruct
 icu::calendar::islamic::IslamicTabular#Struct
-icu::calendar::islamic::IslamicUmmalQura#Struct
-icu::calendar::islamic::IslamicUmmalQura::new#FnInStruct
-icu::calendar::islamic::IslamicUmmalQuraDateInner#Struct
+icu::calendar::islamic::IslamicTabular::new#FnInStruct
+icu::calendar::islamic::IslamicTabularDateInner#Struct
+icu::calendar::islamic::IslamicUmmAlQura#Struct
+icu::calendar::islamic::IslamicUmmAlQura::new#FnInStruct
+icu::calendar::islamic::IslamicUmmAlQuraDateInner#Struct
 icu::calendar::persian::Persian#Struct
 icu::calendar::persian::Persian::new#FnInStruct
 icu::calendar::persian::PersianDateInner#Struct

--- a/tools/make/ffi.toml
+++ b/tools/make/ffi.toml
@@ -47,7 +47,7 @@ exit_on_error true
 if "${ICU4X_BUILDING_WITH_FORCED_NIGHTLY}"
     echo "Skipping diplomat-coverage since ICU4X_BUILDING_WITH_FORCED_NIGHTLY is set"
 else
-    exec --fail-on-error cargo run -p icu_ffi_coverage --all-features > ffi/diplomat/tests/missing_apis.txt
+    exec --fail-on-error cargo run -p icu_ffi_coverage --all-features -- ffi/diplomat/tests/missing_apis.txt
 end
 '''
 


### PR DESCRIPTION
It stopped working at some point recently; not sure exactly when or why. The `>` in Duckscript seems to no longer redirect the output. I changed it so that the script takes a single positional argument for the filename. It still prints to stdout if no argument is given.