### PR TITLE
Use DataProvider without AnyProvider in tutorial example

### DIFF
--- a/docs/tutorials/data_provider.md
+++ b/docs/tutorials/data_provider.md
@@ -274,8 +274,6 @@ impl<P, M> DataProvider<M> for CustomDecimalSymbolsProvider<P>
 where
     P: DataProvider<M>,
     M: KeyedDataMarker,
-    M::Yokeable: icu_provider::MaybeSendSync + zerofrom::ZeroFrom<'static, M::Yokeable>,
-    for<'a> yoke::trait_hack::YokeTraitHack<<M::Yokeable as yoke::Yokeable<'a>>::Output>: Clone,
 {
     #[inline]
     fn load(&self, req: DataRequest) -> Result<DataResponse<M>, DataError> {


### PR DESCRIPTION
Do we like this better or worse?

This is one of the main use cases for AnyProvider. If we're okay with users making this type of blanket impl and saying that `_unstable` constructors are safe with blanket impls, then it's a step toward phasing out AnyProvider.

See #3947