### PR TITLE
Add `Any-Null` to dependencies in transliterators

### DIFF
--- a/experimental/transliteration/data/data/macros/transliterator_rules_v1.data.rs
+++ b/experimental/transliteration/data/data/macros/transliterator_rules_v1.data.rs
@@ -95,7 +95,7 @@ macro_rules! __impl_transliterator_rules_v1 {
                     },
                     id_group_list: unsafe { zerovec::VarZeroVec::from_bytes_unchecked(b"\x01\0\0\0\0\0\x02\0\0\0\0\0\"\0\x02\0\0\0\0\0\0\0\x0C\0\0\0\0\0\x11\0\0\0\0\0\0\0\x11\0x-any-null\x02\0\0\0\0\0\0\0\x0C\0\0\0\0\0\x11\0\0\0\0\0\0\0\x11\0x-any-null") },
                     rule_group_list: unsafe { zerovec::VarZeroVec::from_bytes_unchecked(b"\x01\0\0\0\0\0") },
-                    dependencies: zerovec::VarZeroVec::new(),
+                    dependencies: unsafe { zerovec::VarZeroVec::from_bytes_unchecked(b"\x01\0\0\0\0\0x-any-null") },
                 };
                 static UND__UND_ARAB_T_UND_BENG: <icu::transliteration::provider::TransliteratorRulesV1Marker as icu_provider::DataMarker>::Yokeable = icu::transliteration::provider::RuleBasedTransliterator {
                     visibility: true,

--- a/experimental/transliterator_parser/src/compile.rs
+++ b/experimental/transliterator_parser/src/compile.rs
@@ -346,15 +346,11 @@ impl<'p> Pass1<'p> {
         reverse_id: Option<&parse::SingleId>,
     ) -> Result<()> {
         let fwd_dep = forward_id.basic_id.clone();
-        if !fwd_dep.is_null() {
-            self.forward_data.used_transliterators.insert(fwd_dep);
-        }
+        self.forward_data.used_transliterators.insert(fwd_dep);
         let rev_dep = reverse_id
             .map(|single_id| single_id.basic_id.clone())
             .unwrap_or_else(|| forward_id.basic_id.clone().reverse());
-        if !rev_dep.is_null() {
-            self.reverse_data.used_transliterators.insert(rev_dep);
-        }
+        self.reverse_data.used_transliterators.insert(rev_dep);
         Ok(())
     }
 
@@ -1094,6 +1090,8 @@ mod tests {
                 num_function_calls: 1,
                 num_unicode_sets: 1,
                 max_backref_num: 1,
+                max_left_placeholders: 0,
+                max_right_placeholders: 0,
                 ..Default::default()
             };
             let expected_fwd_data = pass1data_from_parts(
@@ -1102,6 +1100,7 @@ mod tests {
                     ("Forward", "Dependency", None),
                     ("Any", "AnotherForwardDependency", None),
                     ("YetAnother", "ForwardDependency", None),
+                    ("Any", "Null", None),
                 ],
                 &["used_both", "used_fwd", "literal1", "literal2"],
                 counts,
@@ -1116,6 +1115,8 @@ mod tests {
                 num_segments: 2,
                 num_function_calls: 3,
                 max_backref_num: 2,
+                max_left_placeholders: 0,
+                max_right_placeholders: 0,
                 ..Default::default()
             };
             let expected_rev_data = pass1data_from_parts(
@@ -1126,6 +1127,7 @@ mod tests {
                     ("Any", "Many", None),
                     ("Any", "Backwardz", None),
                     ("Any", "Deps", None),
+                    ("Any", "Null", None),
                 ],
                 &["used_rev", "literal1", "literal2"],
                 counts,
@@ -1240,6 +1242,7 @@ mod tests {
                     ("Forward", "Dependency", None),
                     ("Any", "AnotherForwardDependency", None),
                     ("YetAnother", "ForwardDependency", None),
+                    ("Any", "Null", None),
                 ],
                 &["used_both", "used_fwd", "literal1", "literal2"],
                 fwd_counts,
@@ -1263,6 +1266,7 @@ mod tests {
                     ("Any", "Many", None),
                     ("Any", "Backwardz", None),
                     ("Any", "Deps", None),
+                    ("Any", "Null", None),
                 ],
                 &["used_both", "used_rev", "literal1", "literal2"],
                 rev_counts,

--- a/experimental/transliterator_parser/src/parse.rs
+++ b/experimental/transliterator_parser/src/parse.rs
@@ -109,7 +109,9 @@ pub(crate) struct BasicId {
 
 impl BasicId {
     pub(crate) fn is_null(&self) -> bool {
-        self.source == "Any" && self.target == "Null" && self.variant.is_none()
+        self.source.to_lowercase() == "any"
+            && self.target.to_lowercase() == "null"
+            && self.variant.is_none()
     }
 
     pub(crate) fn reverse(self) -> Self {

--- a/provider/datagen/tests/data/json/transliterator/rules@1/und+und-Latn-t-s0-ascii.json
+++ b/provider/datagen/tests/data/json/transliterator/rules@1/und+und-Latn-t-s0-ascii.json
@@ -33,5 +33,7 @@
   "rule_group_list": [
     []
   ],
-  "dependencies": []
+  "dependencies": [
+    "x-any-null"
+  ]
 }

--- a/provider/datagen/tests/data/postcard/fingerprints.csv
+++ b/provider/datagen/tests/data/postcard/fingerprints.csv
@@ -2049,7 +2049,7 @@ time_zone/specific_short@1, und, 31B, 4b7af6a019fab889
 transliterator/rules@1, und+de-t-de-d0-ascii, 16784B, cbb0f7f795d1c6dc
 transliterator/rules@1, und+el-Latn-t-el-m0-bgn, 13818B, 2293dcb5f5e7fc0b
 transliterator/rules@1, und+und-Arab-t-und-Beng, 381B, 13688c829c4a2176
-transliterator/rules@1, und+und-Latn-t-s0-ascii, 110B, 33cd224df9804b07
+transliterator/rules@1, und+und-Latn-t-s0-ascii, 126B, bd845d3dc35e3b57
 transliterator/rules@1, und+und-t-d0-publish, 3477B, c9558c0f7daee292
 transliterator/rules@1, und+und-t-s0-publish, 1343B, 6084ebbdd93523c2
 transliterator/rules@1, und+und-t-und-Latn-d0-ascii, 27110B, c66743617e3238ff


### PR DESCRIPTION
Used for #3946, avoids special-casing `Any-Null` during runtime, after the constructor.