### PR TITLE
Fix doc link in timezone crate

### DIFF
--- a/components/timezone/README.md
+++ b/components/timezone/README.md
@@ -51,8 +51,7 @@ As with time zone IDs, there are two interchangeable forms:
 ICU4X uses the short form.
 
 Note: in ICU4X, "metazone" is one word and "time zone" is two words, except for this crate
-and module name, where "timezone" is used with no separators. See
-<https://github.com/unicode-org/icu4x/issues/2507>.
+and module name, where "timezone" is used with no separators.
 
 ### Zone Variant
 

--- a/components/timezone/README.md
+++ b/components/timezone/README.md
@@ -51,7 +51,8 @@ As with time zone IDs, there are two interchangeable forms:
 ICU4X uses the short form.
 
 Note: in ICU4X, "metazone" is one word and "time zone" is two words, except for this crate
-and module name, where "timezone" is used with no separators.
+and module name, where "timezone" is used with no separators. See
+<https://github.com/unicode-org/icu4x/issues/2507>.
 
 ### Zone Variant
 

--- a/components/timezone/src/lib.rs
+++ b/components/timezone/src/lib.rs
@@ -51,7 +51,8 @@
 //! ICU4X uses the short form.
 //!
 //! Note: in ICU4X, "metazone" is one word and "time zone" is two words, except for this crate
-//! and module name, where "timezone" is used with no separators.
+//! and module name, where "timezone" is used with no separators. See
+//! <https://github.com/unicode-org/icu4x/issues/2507>.
 //!
 //! ## Zone Variant
 //!


### PR DESCRIPTION
Fixes #3362 

However, of the 2 issues, I could only address teh first. The second (hyperlink to a struct) wasn't possible because that struct is marked as `#[doc(hidden)]`