### PR TITLE
Ignore ICU pragmas when parsing transform rules

### DIFF
--- a/experimental/transliterator_parser/src/lib.rs
+++ b/experimental/transliterator_parser/src/lib.rs
@@ -178,6 +178,7 @@ mod tests {
     #[test]
     fn test_source_to_struct() {
         let source = r"
+        use variable range 0xFFF 0xFFFF ;
         :: [1] ;
         :: Latin-InterIndic ;
         $a = [a] [b]+ ;

--- a/experimental/transliterator_parser/src/parse.rs
+++ b/experimental/transliterator_parser/src/parse.rs
@@ -407,6 +407,8 @@ where
         loop {
             self.skip_whitespace();
             if let Some(start) = self.peek_index() {
+                // the returned index comes from `self.source`'s `char_indices`.
+                #[allow(clippy::indexing_slicing)]
                 let start_source = &self.source[start..];
                 if start_source.starts_with("use variable range 0x") {
                     let conv_idx = start_source.find(['>', '<', '→', '←', '↔']);


### PR DESCRIPTION
ICU4C/J support the pragma `use variable range <range> ;` at the very beginning of a file. This PR adds support to parse these (by skipping over them).