### PR TITLE
warning: associated const needs explicit lifetime.

### DIFF
--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -169,7 +169,7 @@ impl Japanese {
         self.new_japanese_date_inner(era, year, month, day)
     }
 
-    pub(crate) const DEBUG_NAME: &str = "Japanese";
+    pub(crate) const DEBUG_NAME: &'static str = "Japanese";
 }
 
 impl JapaneseExtended {
@@ -206,7 +206,7 @@ impl JapaneseExtended {
         }))
     }
 
-    pub(crate) const DEBUG_NAME: &str = "Japanese (historical era data)";
+    pub(crate) const DEBUG_NAME: &'static str = "Japanese (historical era data)";
 }
 
 impl Calendar for Japanese {


### PR DESCRIPTION
This is a new warning in an upcoming version of Rust:

```
warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
note: for more information, see issue #115010 <https://github.com/rust-lang/rust/issues/115010>
```
