### PR TITLE
ZeroTrie: change map_store to pub convert_store

### DIFF
--- a/experimental/zerotrie/src/serde.rs
+++ b/experimental/zerotrie/src/serde.rs
@@ -108,12 +108,12 @@ where
             let lm = LiteMap::<Box<ByteStr>, usize>::deserialize(deserializer)?;
             ZeroTrieSimpleAscii::try_from_serde_litemap(&lm)
                 .map_err(D::Error::custom)
-                .map(|trie| trie.cast_store())
+                .map(|trie| trie.convert_store())
         } else {
             // Note: `impl Deserialize for &[u8]` uses visit_borrowed_bytes
             <&[u8]>::deserialize(deserializer)
                 .map(ZeroTrieSimpleAscii::from_store)
-                .map(|x| x.cast_store())
+                .map(|x| x.convert_store())
         }
     }
 }
@@ -149,12 +149,12 @@ where
             let lm = LiteMap::<Box<ByteStr>, usize>::deserialize(deserializer)?;
             ZeroTriePerfectHash::try_from_serde_litemap(&lm)
                 .map_err(D::Error::custom)
-                .map(|trie| trie.cast_store())
+                .map(|trie| trie.convert_store())
         } else {
             // Note: `impl Deserialize for &[u8]` uses visit_borrowed_bytes
             <&[u8]>::deserialize(deserializer)
                 .map(ZeroTriePerfectHash::from_store)
-                .map(|x| x.cast_store())
+                .map(|x| x.convert_store())
         }
     }
 }
@@ -194,12 +194,12 @@ where
             let lm = LiteMap::<Box<ByteStr>, usize>::deserialize(deserializer)?;
             ZeroTrieExtendedCapacity::try_from_serde_litemap(&lm)
                 .map_err(D::Error::custom)
-                .map(|trie| trie.cast_store())
+                .map(|trie| trie.convert_store())
         } else {
             // Note: `impl Deserialize for &[u8]` uses visit_borrowed_bytes
             <&[u8]>::deserialize(deserializer)
                 .map(ZeroTrieExtendedCapacity::from_store)
-                .map(|x| x.cast_store())
+                .map(|x| x.convert_store())
         }
     }
 }
@@ -249,7 +249,7 @@ where
             let lm = LiteMap::<Box<ByteStr>, usize>::deserialize(deserializer)?;
             ZeroTrie::<Vec<u8>>::try_from(&lm)
                 .map_err(D::Error::custom)
-                .map(|trie| trie.cast_store())
+                .map(|trie| trie.convert_store())
         } else {
             // Note: `impl Deserialize for &[u8]` uses visit_borrowed_bytes
             let bytes = <&[u8]>::deserialize(deserializer)?;

--- a/experimental/zerotrie/src/serde.rs
+++ b/experimental/zerotrie/src/serde.rs
@@ -256,16 +256,13 @@ where
             let (tag, trie_bytes) = bytes
                 .split_first()
                 .ok_or(D::Error::custom("expected at least 1 byte for ZeroTrie"))?;
+            let store = Store::from(trie_bytes);
             let zerotrie = match *tag {
-                tags::SIMPLE_ASCII => ZeroTrieSimpleAscii::from_store(trie_bytes)
-                    .cast_store()
-                    .into_zerotrie(),
-                tags::PERFECT_HASH => ZeroTriePerfectHash::from_store(trie_bytes)
-                    .cast_store()
-                    .into_zerotrie(),
-                tags::EXTENDED_CAPACITY => ZeroTrieExtendedCapacity::from_store(trie_bytes)
-                    .cast_store()
-                    .into_zerotrie(),
+                tags::SIMPLE_ASCII => ZeroTrieSimpleAscii::from_store(store).into_zerotrie(),
+                tags::PERFECT_HASH => ZeroTriePerfectHash::from_store(store).into_zerotrie(),
+                tags::EXTENDED_CAPACITY => {
+                    ZeroTrieExtendedCapacity::from_store(store).into_zerotrie()
+                }
                 _ => return Err(D::Error::custom("invalid ZeroTrie tag")),
             };
             Ok(zerotrie)

--- a/experimental/zerotrie/src/serde.rs
+++ b/experimental/zerotrie/src/serde.rs
@@ -108,12 +108,12 @@ where
             let lm = LiteMap::<Box<ByteStr>, usize>::deserialize(deserializer)?;
             ZeroTrieSimpleAscii::try_from_serde_litemap(&lm)
                 .map_err(D::Error::custom)
-                .map(|trie| trie.map_store(From::from))
+                .map(|trie| trie.cast_store())
         } else {
             // Note: `impl Deserialize for &[u8]` uses visit_borrowed_bytes
             <&[u8]>::deserialize(deserializer)
                 .map(ZeroTrieSimpleAscii::from_store)
-                .map(|x| x.map_store(From::from))
+                .map(|x| x.cast_store())
         }
     }
 }
@@ -149,12 +149,12 @@ where
             let lm = LiteMap::<Box<ByteStr>, usize>::deserialize(deserializer)?;
             ZeroTriePerfectHash::try_from_serde_litemap(&lm)
                 .map_err(D::Error::custom)
-                .map(|trie| trie.map_store(From::from))
+                .map(|trie| trie.cast_store())
         } else {
             // Note: `impl Deserialize for &[u8]` uses visit_borrowed_bytes
             <&[u8]>::deserialize(deserializer)
                 .map(ZeroTriePerfectHash::from_store)
-                .map(|x| x.map_store(From::from))
+                .map(|x| x.cast_store())
         }
     }
 }
@@ -194,12 +194,12 @@ where
             let lm = LiteMap::<Box<ByteStr>, usize>::deserialize(deserializer)?;
             ZeroTrieExtendedCapacity::try_from_serde_litemap(&lm)
                 .map_err(D::Error::custom)
-                .map(|trie| trie.map_store(From::from))
+                .map(|trie| trie.cast_store())
         } else {
             // Note: `impl Deserialize for &[u8]` uses visit_borrowed_bytes
             <&[u8]>::deserialize(deserializer)
                 .map(ZeroTrieExtendedCapacity::from_store)
-                .map(|x| x.map_store(From::from))
+                .map(|x| x.cast_store())
         }
     }
 }
@@ -249,23 +249,25 @@ where
             let lm = LiteMap::<Box<ByteStr>, usize>::deserialize(deserializer)?;
             ZeroTrie::<Vec<u8>>::try_from(&lm)
                 .map_err(D::Error::custom)
-                .map(|trie| trie.map_store(From::from))
+                .map(|trie| trie.cast_store())
         } else {
             // Note: `impl Deserialize for &[u8]` uses visit_borrowed_bytes
             let bytes = <&[u8]>::deserialize(deserializer)?;
             let (tag, trie_bytes) = bytes
                 .split_first()
                 .ok_or(D::Error::custom("expected at least 1 byte for ZeroTrie"))?;
-            let zerotrie =
-                match *tag {
-                    tags::SIMPLE_ASCII => ZeroTrieSimpleAscii::from_store(trie_bytes)
-                        .map_store_into_zerotrie(From::from),
-                    tags::PERFECT_HASH => ZeroTriePerfectHash::from_store(trie_bytes)
-                        .map_store_into_zerotrie(From::from),
-                    tags::EXTENDED_CAPACITY => ZeroTrieExtendedCapacity::from_store(trie_bytes)
-                        .map_store_into_zerotrie(From::from),
-                    _ => return Err(D::Error::custom("invalid ZeroTrie tag")),
-                };
+            let zerotrie = match *tag {
+                tags::SIMPLE_ASCII => ZeroTrieSimpleAscii::from_store(trie_bytes)
+                    .cast_store()
+                    .into_zerotrie(),
+                tags::PERFECT_HASH => ZeroTriePerfectHash::from_store(trie_bytes)
+                    .cast_store()
+                    .into_zerotrie(),
+                tags::EXTENDED_CAPACITY => ZeroTrieExtendedCapacity::from_store(trie_bytes)
+                    .cast_store()
+                    .into_zerotrie(),
+                _ => return Err(D::Error::custom("invalid ZeroTrie tag")),
+            };
             Ok(zerotrie)
         }
     }

--- a/experimental/zerotrie/src/zerotrie.rs
+++ b/experimental/zerotrie/src/zerotrie.rs
@@ -557,8 +557,8 @@ impl<Store> ZeroTrie<Store> {
         impl_dispatch!(self, take_store())
     }
     /// Converts this trie's store to a different store implementing the `From` trait.
-            ///
-            /// For example, use this to change `ZeroTrie<Vec<u8>>` to `ZeroTrie<Cow<[u8]>>`.
+    ///
+    /// For example, use this to change `ZeroTrie<Vec<u8>>` to `ZeroTrie<Cow<[u8]>>`.
     pub fn convert_store<NewStore>(self) -> ZeroTrie<NewStore>
     where
         NewStore: From<Store>,

--- a/experimental/zerotrie/src/zerotrie.rs
+++ b/experimental/zerotrie/src/zerotrie.rs
@@ -161,6 +161,8 @@ macro_rules! impl_zerotrie_subtype {
             }
             /// Converts this trie's store to a different store implementing the `From` trait.
             ///
+            #[doc = concat!("For example, use this to change `", stringify!($name), "<Vec<u8>>` to `", stringify!($name), "<Cow<[u8]>>`.")]
+            ///
             /// # Examples
             ///
             /// ```
@@ -168,11 +170,11 @@ macro_rules! impl_zerotrie_subtype {
             #[doc = concat!("use zerotrie::", stringify!($name), ";")]
             ///
             #[doc = concat!("let trie: ", stringify!($name), "<Vec<u8>> = ", stringify!($name), "::from_bytes(b\"abc\\x85\").to_owned();")]
-            #[doc = concat!("let cow: ", stringify!($name), "<Cow<[u8]>> = trie.cast_store();")]
+            #[doc = concat!("let cow: ", stringify!($name), "<Cow<[u8]>> = trie.convert_store();")]
             ///
             /// assert_eq!(cow.get(b"abc"), Some(5));
             /// ```
-            pub fn cast_store<X: From<Store>>(self) -> $name<X> {
+            pub fn convert_store<X: From<Store>>(self) -> $name<X> {
                 $name::<X>::from_store(X::from(self.store))
             }
         }
@@ -555,11 +557,13 @@ impl<Store> ZeroTrie<Store> {
         impl_dispatch!(self, take_store())
     }
     /// Converts this trie's store to a different store implementing the `From` trait.
-    pub fn cast_store<NewStore>(self) -> ZeroTrie<NewStore>
+            ///
+            /// For example, use this to change `ZeroTrie<Vec<u8>>` to `ZeroTrie<Cow<[u8]>>`.
+    pub fn convert_store<NewStore>(self) -> ZeroTrie<NewStore>
     where
         NewStore: From<Store>,
     {
-        impl_dispatch!(self, cast_store().into_zerotrie())
+        impl_dispatch!(self, convert_store().into_zerotrie())
     }
 }
 


### PR DESCRIPTION
Toward #2909

I think @robertbastian did not like the `map_store` function, but I needed it again, and this time outside the crate. I made a new function named `cast_store` that requires a `From` impl and made it public. Happy to choose some other name.

Although this logic is possible to write outside this crate, I prefer to keep it in this crate. Here is how one could write this logic without this function:

```rust
ZeroTrieSimpleAscii::from(NewStore::from(trie.take_store()))
```

Note that the trie type needs to be named. With this PR, you can simply do:

```rust
trie.cast_store::<NewStore>()
```