### PR TITLE
Provide a getter for the resolved options for the collator

### DIFF
--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -247,6 +247,12 @@ impl Collator {
         })
     }
 
+    /// The resolved options showing how the default options, the requested options,
+    /// and the options from locale data were combined.
+    pub fn resolved_options(&self) -> CollatorOptions {
+        self.options.into()
+    }
+
     /// Compare potentially ill-formed UTF-16 slices. Unpaired surrogates
     /// are compared as if each one was a REPLACEMENT CHARACTER.
     pub fn compare_utf16(&self, left: &[u16], right: &[u16]) -> Ordering {

--- a/components/collator/src/options.rs
+++ b/components/collator/src/options.rs
@@ -359,6 +359,32 @@ impl CollatorOptions {
     }
 }
 
+impl From<CollatorOptionsBitField> for CollatorOptions {
+    fn from(options: CollatorOptionsBitField) -> CollatorOptions {
+        Self {
+            strength: Some(options.strength()),
+            alternate_handling: Some(options.alternate_handling()),
+            case_first: Some(options.case_first()),
+            max_variable: Some(options.max_variable()),
+            case_level: Some(if options.case_level() {
+                CaseLevel::On
+            } else {
+                CaseLevel::Off
+            }),
+            numeric: Some(if options.numeric() {
+                Numeric::On
+            } else {
+                Numeric::Off
+            }),
+            backward_second_level: Some(if options.backward_second_level() {
+                BackwardSecondLevel::On
+            } else {
+                BackwardSecondLevel::Off
+            }),
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct CollatorOptionsBitField(u32);
 
@@ -518,6 +544,18 @@ impl CollatorOptionsBitField {
                 self.set_case_level(Some(false));
             }
             _ => self.set_case_level(None),
+        }
+    }
+
+    fn case_first(&self) -> CaseFirst {
+        if (self.0 & CollatorOptionsBitField::CASE_FIRST_MASK) != 0 {
+            if (self.0 & CollatorOptionsBitField::UPPER_FIRST_MASK) != 0 {
+                CaseFirst::UpperFirst
+            } else {
+                CaseFirst::LowerFirst
+            }
+        } else {
+            CaseFirst::Off
         }
     }
 

--- a/components/collator/tests/tests.rs
+++ b/components/collator/tests/tests.rs
@@ -1453,6 +1453,158 @@ fn test_case_level() {
     );
 }
 
+#[test]
+fn test_default_resolved_options() {
+    let collator = Collator::try_new(&Default::default(), CollatorOptions::new()).unwrap();
+    let resolved = collator.resolved_options();
+    assert_eq!(resolved.strength, Some(Strength::Tertiary));
+    assert_eq!(
+        resolved.alternate_handling,
+        Some(AlternateHandling::NonIgnorable)
+    );
+    assert_eq!(resolved.case_first, Some(CaseFirst::Off));
+    assert_eq!(resolved.max_variable, Some(MaxVariable::Punctuation));
+    assert_eq!(resolved.case_level, Some(CaseLevel::Off));
+    assert_eq!(resolved.numeric, Some(Numeric::Off));
+    assert_eq!(
+        resolved.backward_second_level,
+        Some(BackwardSecondLevel::Off)
+    );
+
+    assert_eq!(collator.compare("𝕒", "A"), core::cmp::Ordering::Less);
+    assert_eq!(collator.compare("coté", "côte"), core::cmp::Ordering::Less);
+}
+
+#[test]
+fn test_data_resolved_options_th() {
+    let locale: DataLocale = langid!("th").into();
+    let collator = Collator::try_new(&locale, CollatorOptions::new()).unwrap();
+    let resolved = collator.resolved_options();
+    assert_eq!(resolved.strength, Some(Strength::Tertiary));
+    assert_eq!(
+        resolved.alternate_handling,
+        Some(AlternateHandling::Shifted)
+    );
+    assert_eq!(resolved.case_first, Some(CaseFirst::Off));
+    assert_eq!(resolved.max_variable, Some(MaxVariable::Punctuation));
+    assert_eq!(resolved.case_level, Some(CaseLevel::Off));
+    assert_eq!(resolved.numeric, Some(Numeric::Off));
+    assert_eq!(
+        resolved.backward_second_level,
+        Some(BackwardSecondLevel::Off)
+    );
+
+    // There's a separate more comprehensive test for the shifted behavior
+    assert_eq!(collator.compare("𝕒", "A"), core::cmp::Ordering::Less);
+    assert_eq!(collator.compare("coté", "côte"), core::cmp::Ordering::Less);
+}
+
+#[test]
+fn test_data_resolved_options_da() {
+    let locale: DataLocale = langid!("da").into();
+    let collator = Collator::try_new(&locale, CollatorOptions::new()).unwrap();
+    let resolved = collator.resolved_options();
+    assert_eq!(resolved.strength, Some(Strength::Tertiary));
+    assert_eq!(
+        resolved.alternate_handling,
+        Some(AlternateHandling::NonIgnorable)
+    );
+    assert_eq!(resolved.case_first, Some(CaseFirst::UpperFirst));
+    assert_eq!(resolved.max_variable, Some(MaxVariable::Punctuation));
+    assert_eq!(resolved.case_level, Some(CaseLevel::Off));
+    assert_eq!(resolved.numeric, Some(Numeric::Off));
+    assert_eq!(
+        resolved.backward_second_level,
+        Some(BackwardSecondLevel::Off)
+    );
+
+    assert_eq!(collator.compare("𝕒", "A"), core::cmp::Ordering::Greater);
+    assert_eq!(collator.compare("coté", "côte"), core::cmp::Ordering::Less);
+}
+
+#[test]
+fn test_data_resolved_options_fr_ca() {
+    let locale: DataLocale = langid!("fr-CA").into();
+    let collator = Collator::try_new(&locale, CollatorOptions::new()).unwrap();
+    let resolved = collator.resolved_options();
+    assert_eq!(resolved.strength, Some(Strength::Tertiary));
+    assert_eq!(
+        resolved.alternate_handling,
+        Some(AlternateHandling::NonIgnorable)
+    );
+    assert_eq!(resolved.case_first, Some(CaseFirst::Off));
+    assert_eq!(resolved.max_variable, Some(MaxVariable::Punctuation));
+    assert_eq!(resolved.case_level, Some(CaseLevel::Off));
+    assert_eq!(resolved.numeric, Some(Numeric::Off));
+    assert_eq!(
+        resolved.backward_second_level,
+        Some(BackwardSecondLevel::On)
+    );
+
+    assert_eq!(collator.compare("𝕒", "A"), core::cmp::Ordering::Less);
+    assert_eq!(
+        collator.compare("coté", "côte"),
+        core::cmp::Ordering::Greater
+    );
+}
+
+#[test]
+fn test_manual_and_data_resolved_options_fr_ca() {
+    let locale: DataLocale = langid!("fr-CA").into();
+
+    let mut options = CollatorOptions::new();
+    options.case_first = Some(CaseFirst::UpperFirst);
+
+    let collator = Collator::try_new(&locale, options).unwrap();
+    let resolved = collator.resolved_options();
+    assert_eq!(resolved.strength, Some(Strength::Tertiary));
+    assert_eq!(
+        resolved.alternate_handling,
+        Some(AlternateHandling::NonIgnorable)
+    );
+    assert_eq!(resolved.case_first, Some(CaseFirst::UpperFirst));
+    assert_eq!(resolved.max_variable, Some(MaxVariable::Punctuation));
+    assert_eq!(resolved.case_level, Some(CaseLevel::Off));
+    assert_eq!(resolved.numeric, Some(Numeric::Off));
+    assert_eq!(
+        resolved.backward_second_level,
+        Some(BackwardSecondLevel::On)
+    );
+
+    assert_eq!(collator.compare("𝕒", "A"), core::cmp::Ordering::Greater);
+    assert_eq!(
+        collator.compare("coté", "côte"),
+        core::cmp::Ordering::Greater
+    );
+}
+
+#[test]
+fn test_manual_resolved_options_da() {
+    let locale: DataLocale = langid!("da").into();
+
+    let mut options = CollatorOptions::new();
+    options.case_first = Some(CaseFirst::Off);
+
+    let collator = Collator::try_new(&locale, options).unwrap();
+    let resolved = collator.resolved_options();
+    assert_eq!(resolved.strength, Some(Strength::Tertiary));
+    assert_eq!(
+        resolved.alternate_handling,
+        Some(AlternateHandling::NonIgnorable)
+    );
+    assert_eq!(resolved.case_first, Some(CaseFirst::Off));
+    assert_eq!(resolved.max_variable, Some(MaxVariable::Punctuation));
+    assert_eq!(resolved.case_level, Some(CaseLevel::Off));
+    assert_eq!(resolved.numeric, Some(Numeric::Off));
+    assert_eq!(
+        resolved.backward_second_level,
+        Some(BackwardSecondLevel::Off)
+    );
+
+    assert_eq!(collator.compare("𝕒", "A"), core::cmp::Ordering::Less);
+    assert_eq!(collator.compare("coté", "côte"), core::cmp::Ordering::Less);
+}
+
 // TODO: Test languages that map to the root.
 // The languages that map to root without script reordering are:
 // ca (at least for now)
@@ -1499,6 +1651,3 @@ fn test_case_level() {
 // TODO: Test Tibetan
 
 // TODO: Test de-AT-u-co-phonebk vs de-DE-u-co-phonebk
-
-// TODO: Test da defaulting to [caseFirst upper]
-// TODO: Test fr-CA defaulting to backward second level


### PR DESCRIPTION
Fixes #3880

(Before merging, we should decide if we want the return type to be `CollatorOptions` of if we want a `ResolvedCollatorOptions` that doesn't wrap each field in `Option`.)