### PR TITLE
More calendar fixups

### DIFF
--- a/components/calendar/benches/date.rs
+++ b/components/calendar/benches/date.rs
@@ -112,6 +112,24 @@ fn date_benches(c: &mut Criterion) {
     #[cfg(feature = "bench")]
     bench_calendar(
         &mut group,
+        "calendar/persian",
+        &fxs,
+        icu::calendar::persian::Persian,
+        |y, m, d| Date::try_new_persian_date(y, m, d).unwrap(),
+    );
+
+    #[cfg(feature = "bench")]
+    bench_calendar(
+        &mut group,
+        "calendar/roc",
+        &fxs,
+        icu::calendar::roc::Roc,
+        |y, m, d| Date::try_new_roc_date(y, m, d).unwrap(),
+    );
+
+    #[cfg(feature = "bench")]
+    bench_calendar(
+        &mut group,
         "calendar/julian",
         &fxs,
         icu::calendar::julian::Julian,
@@ -130,6 +148,40 @@ fn date_benches(c: &mut Criterion) {
                 m,
                 d,
                 icu::calendar::chinese::Chinese::new_always_calculating(),
+            )
+            .unwrap()
+        },
+    );
+
+    #[cfg(feature = "bench")]
+    bench_calendar(
+        &mut group,
+        "calendar/dangi",
+        &fxs,
+        icu::calendar::dangi::Dangi::new_always_calculating(),
+        |y, m, d| {
+            Date::try_new_dangi_date_with_calendar(
+                y,
+                m,
+                d,
+                icu::calendar::dangi::Dangi::new_always_calculating(),
+            )
+            .unwrap()
+        },
+    );
+
+    #[cfg(feature = "bench")]
+    bench_calendar(
+        &mut group,
+        "calendar/hebrew",
+        &fxs,
+        icu::calendar::hebrew::Hebrew::new_always_calculating(),
+        |y, m, d| {
+            Date::try_new_hebrew_date_with_calendar(
+                y,
+                m,
+                d,
+                icu::calendar::hebrew::Hebrew::new_always_calculating(),
             )
             .unwrap()
         },

--- a/components/calendar/src/roc.rs
+++ b/components/calendar/src/roc.rs
@@ -175,7 +175,9 @@ impl Calendar for Roc {
 impl Date<Roc> {
     /// Construct a new Republic of China calendar Date.
     ///
-    /// Years are specified in the "roc" era, Before Minguo dates are negative (year 0 is 1 Before Minguo)
+    /// Years are specified in the "roc" era. This function accepts an extended year in that era, so dates
+    /// before Minguo are negative and year 0 is 1 Before Minguo. To specify dates using explicit era
+    /// codes, use [`Roc::date_from_codes()`].
     ///
     /// ```rust
     /// use icu::calendar::Date;

--- a/components/calendar/src/roc.rs
+++ b/components/calendar/src/roc.rs
@@ -35,7 +35,7 @@ use crate::{
     calendar_arithmetic::ArithmeticDate,
     iso::IsoDateInner,
     types::{self, Era},
-    Calendar, CalendarError, Date, DateTime, Iso,
+    AnyCalendarKind, Calendar, CalendarError, Date, DateTime, Iso,
 };
 use calendrical_calculations::helpers::i64_to_saturated_i32;
 use tinystr::tinystr;
@@ -166,6 +166,11 @@ impl Calendar for Roc {
             days_in_prev_year: Iso::days_in_year_direct(prev_year),
             next_year: year_as_roc(next_year as i64),
         }
+    }
+
+    /// The [`AnyCalendarKind`] corresponding to this calendar
+    fn any_calendar_kind(&self) -> Option<AnyCalendarKind> {
+        Some(AnyCalendarKind::Roc)
     }
 }
 

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -22,7 +22,7 @@ use icu_calendar::{
     persian::Persian,
     provider::WeekDataV1Marker,
     roc::Roc,
-    AsCalendar, DateTime, Gregorian, Iso,
+    AsCalendar, Calendar, DateTime, Gregorian, Iso,
 };
 use icu_datetime::provider::time_zones::{
     ExemplarCitiesV1Marker, MetazoneGenericNamesLongV1Marker, MetazoneGenericNamesShortV1Marker,
@@ -264,6 +264,11 @@ fn assert_fixture_element<A>(
     icu_datetime::provider::Baked: DataProvider<<A::Calendar as CldrCalendar>::DateSymbolsV1Marker>,
     icu_datetime::provider::Baked: DataProvider<<A::Calendar as CldrCalendar>::DateLengthsV1Marker>,
 {
+    assert!(
+        input_value.date.calendar().any_calendar_kind().is_some(),
+        "{} has no AsCalendar",
+        input_value.date.calendar().debug_name()
+    );
     let any_input = input_value.to_any();
     let iso_any_input = input_iso.to_any();
     #[cfg(feature = "experimental")]

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -266,7 +266,7 @@ fn assert_fixture_element<A>(
 {
     assert!(
         input_value.date.calendar().any_calendar_kind().is_some(),
-        "{} has no AsCalendar",
+        "{} does not specify its AsCalendarKind",
         input_value.date.calendar().debug_name()
     );
     let any_input = input_value.to_any();


### PR DESCRIPTION
Progress on #4053, benches and tests

I also went ahead and fixed `roc`'s Date/Time ctors to not take an era; this is what Gregorian/etc do.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->