### PR TITLE
Make auxiliary key code experimental

### DIFF
--- a/experimental/transliterate/Cargo.toml
+++ b/experimental/transliterate/Cargo.toml
@@ -20,7 +20,7 @@ rust-version.workspace = true
 all-features = true
 
 [dependencies]
-icu_provider = { workspace = true, features = ["macros"] }
+icu_provider = { workspace = true, features = ["macros", "experimental"] }
 icu_locid = { workspace = true }
 icu_collections = { workspace = true }
 icu_normalizer = { workspace = true }

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -53,6 +53,7 @@ icu_locid_transform = { workspace = true }
 [features]
 std = ["icu_locid/std"]
 sync = []
+experimental = []
 macros = ["dep:icu_provider_macros"]
 # Enable logging of additional context of data errors
 logging = ["dep:log"]

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -161,6 +161,7 @@ pub use crate::key::DataKey;
 pub use crate::key::DataKeyHash;
 pub use crate::key::DataKeyMetadata;
 pub use crate::key::DataKeyPath;
+#[cfg(feature = "experimental")]
 pub use crate::request::AuxiliaryKeys;
 pub use crate::request::DataLocale;
 pub use crate::request::DataRequest;
@@ -207,6 +208,7 @@ pub mod prelude {
     #[doc(no_inline)]
     pub use crate::AsDynamicDataProviderAnyMarkerWrap;
     #[doc(no_inline)]
+    #[cfg(feature = "experimental")]
     pub use crate::AuxiliaryKeys;
     #[doc(no_inline)]
     pub use crate::BufferMarker;

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -58,7 +58,7 @@ icu_unitsconversion = { workspace = true, features = ["datagen"], optional = tru
 icu_codepointtrie_builder = { workspace = true }
 icu_collections = { workspace = true, features = ["serde"] }
 icu_locid = { workspace = true, features = ["std", "serde"] }
-icu_provider = { workspace = true, features = ["std", "logging", "datagen"]}
+icu_provider = { workspace = true, features = ["std", "logging", "datagen", "experimental"]}
 icu_provider_adapters = { workspace = true }
 tinystr = { workspace = true, features = ["alloc", "serde", "zerovec"] }
 writeable = { workspace = true }


### PR DESCRIPTION
Resolves 1.3 blocking aspects of #3632

I added an experimental feature instead of simply using doc(hidden) because

1. These items are on stabilization track and we should use an experimental feature for that
2. Using doc(hidden) would not prevent people from accidentally using the feature because it is still exposed in the FromStr impl