### PR TITLE
Publish utils in preparation for 1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crlify"
-version = "1.0.2"
+version = "1.0.3"
 
 [[package]]
 name = "crossbeam-deque"
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "databake"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "databake-derive",
  "proc-macro2",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "databake-derive"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "databake",
  "proc-macro2",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "deduplicating_array"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "postcard",
  "serde",
@@ -929,7 +929,7 @@ checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "fixed_decimal"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "criterion",
  "displaydoc",
@@ -1679,7 +1679,7 @@ version = "1.2.0"
 
 [[package]]
 name = "icu_pattern"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "displaydoc",
  "iai",
@@ -2095,7 +2095,7 @@ checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
 name = "litemap"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bincode",
  "bytecheck",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bincode",
  "criterion",
@@ -3365,7 +3365,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "tzif"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "combine",
  "walkdir",
@@ -4097,7 +4097,7 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "criterion",
  "icu_benchmark_macros",
@@ -4115,7 +4115,7 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bincode",
  "serde",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4138,14 +4138,14 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4177,7 +4177,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "bincode",
  "criterion",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "bincode",
  "proc-macro2",

--- a/docs/tutorials/Cargo.lock
+++ b/docs/tutorials/Cargo.lock
@@ -18,17 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aes"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,15 +26,6 @@ dependencies = [
  "getrandom",
  "once_cell",
  "version_check",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -145,12 +125,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,15 +155,6 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -227,52 +192,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
-name = "bytes"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
-
-[[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+name = "calendrical_calculations"
+version = "0.1.0"
 dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
-name = "cached-path"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "097968e38f1319207f057d0f4d76452e4f4f847a5de61c5215379f297fa034f3"
-dependencies = [
- "flate2",
- "fs2",
- "glob",
- "indicatif",
- "log",
- "rand",
- "reqwest",
- "serde",
- "serde_json",
- "sha2",
- "tar",
- "tempfile",
- "thiserror",
- "zip",
+ "core_maths",
+ "displaydoc",
 ]
 
 [[package]]
@@ -281,7 +205,6 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
- "jobserver",
  "libc",
 ]
 
@@ -300,17 +223,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
+ "windows-targets",
 ]
 
 [[package]]
@@ -366,44 +279,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "console"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "const_fn"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "core-foundation"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "core_maths"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b02505ccb8c50b0aa21ace0fc08c3e53adebd4e58caa18a36152803c7709a3"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "corosensei"
@@ -419,15 +313,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,9 +323,7 @@ dependencies = [
 
 [[package]]
 name = "crlify"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61d949bc6625db810f1828a7508855176cf62d623e8c3ed693356313ea602696"
+version = "1.0.3"
 
 [[package]]
 name = "crossbeam-deque"
@@ -473,16 +356,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
 ]
 
 [[package]]
@@ -525,10 +398,20 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142b0851e71c009e7f5582a8fa13de2cb133643026a57c7e4ae1b8c4369948e9"
 dependencies = [
- "databake-derive",
+ "databake-derive 0.1.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "databake"
+version = "0.1.6"
+dependencies = [
+ "databake-derive 0.1.6",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -540,33 +423,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "synstructure",
+ "synstructure 0.12.6",
+]
+
+[[package]]
+name = "databake-derive"
+version = "0.1.6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+ "synstructure 0.13.0",
 ]
 
 [[package]]
 name = "deduplicating_array"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5426e8a7610ceca8b2f2c40a25ddd4476606c96a0c1e3524fdfdbeb64c1331"
+version = "0.1.5"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "deranged"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -620,26 +494,10 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elsa"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714f766f3556b44e7e4776ad133fcc3445a489517c25c704ace411bb14790194"
+version = "1.8.1"
+source = "git+https://github.com/Manishearth/elsa?rev=56d05375eea36596432a0843721d26edf3b0ec75#56d05375eea36596432a0843721d26edf3b0ec75"
 dependencies = [
  "stable_deref_trait",
-]
-
-[[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -736,26 +594,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
-name = "filetime"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "fixed_decimal"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9eab2dd2aadbc55056ed228ccc4be42d07cd61aee72d48768f8ac2e4ab7d54"
+version = "0.5.4"
 dependencies = [
  "displaydoc",
  "smallvec",
- "writeable",
+ "writeable 0.5.3",
 ]
 
 [[package]]
@@ -775,21 +619,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,68 +628,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "futures-channel"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
-
-[[package]]
-name = "futures-io"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
-
-[[package]]
-name = "futures-task"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
-
-[[package]]
-name = "futures-util"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
-dependencies = [
- "futures-core",
- "futures-io",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
 
 [[package]]
 name = "generational-arena"
@@ -869,16 +640,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -910,31 +671,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "h2"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,98 +695,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "home"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "http"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
-dependencies = [
- "bytes",
- "http",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "hyper"
-version = "0.14.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.4.9",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -1079,13 +729,12 @@ dependencies = [
 [[package]]
 name = "icu"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c200640729e9f7cf6a7a1140dbf797121b70e8f2d1f347090aff8394f7e8f863"
 dependencies = [
  "icu_calendar",
- "icu_casemapping",
+ "icu_casemap",
  "icu_collator",
  "icu_collections",
+ "icu_compactdecimal",
  "icu_datetime",
  "icu_decimal",
  "icu_displaynames",
@@ -1104,43 +753,50 @@ dependencies = [
 [[package]]
 name = "icu_calendar"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee1e8c25ed44743d03e2d58ca1c0226786dc1aac1f9cb27485e2da2de5e0918"
 dependencies = [
- "databake",
+ "calendrical_calculations",
+ "databake 0.1.6",
  "displaydoc",
+ "icu_calendar_data",
  "icu_locid",
+ "icu_locid_transform",
  "icu_provider",
  "serde",
- "tinystr",
- "writeable",
- "zerovec",
+ "tinystr 0.7.2",
+ "writeable 0.5.3",
+ "zerovec 0.9.5",
 ]
 
 [[package]]
-name = "icu_casemapping"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44be22dcbc418f34dbf0fc444a538fdeac5bd52c8688ad6f328603a90af9c2e0"
+name = "icu_calendar_data"
+version = "1.2.0"
+
+[[package]]
+name = "icu_casemap"
+version = "1.2.0"
 dependencies = [
- "databake",
+ "databake 0.1.6",
  "displaydoc",
+ "icu_casemap_data",
  "icu_collections",
  "icu_locid",
+ "icu_properties",
  "icu_provider",
  "serde",
- "yoke",
- "zerovec",
+ "writeable 0.5.3",
+ "zerovec 0.9.5",
 ]
+
+[[package]]
+name = "icu_casemap_data"
+version = "1.2.0"
 
 [[package]]
 name = "icu_codepointtrie_builder"
 version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f848e681eee3907b3a5ecda6f1e6ce47e50cbafad37c5e85d2135e52bc481e80"
 dependencies = [
  "icu_collections",
- "lazy_static",
+ "once_cell",
  "toml",
  "wasmer",
  "wasmer-wasi",
@@ -1149,13 +805,13 @@ dependencies = [
 [[package]]
 name = "icu_collator"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088882827079b243dc01883f92290dd3952b656faddc7a2972e6d3ab47e1fc7a"
 dependencies = [
- "databake",
+ "databake 0.1.6",
  "displaydoc",
+ "icu_collator_data",
  "icu_collections",
  "icu_locid",
+ "icu_locid_transform",
  "icu_normalizer",
  "icu_properties",
  "icu_provider",
@@ -1163,62 +819,61 @@ dependencies = [
  "smallvec",
  "utf16_iter",
  "utf8_iter",
- "zerovec",
+ "zerovec 0.9.5",
 ]
+
+[[package]]
+name = "icu_collator_data"
+version = "1.2.0"
 
 [[package]]
 name = "icu_collections"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8302d8dfd6044d3ddb3f807a5ef3d7bbca9a574959c6d6e4dc39aa7012d0d5"
 dependencies = [
- "databake",
+ "databake 0.1.6",
  "displaydoc",
  "serde",
  "yoke",
- "zerofrom",
- "zerovec",
+ "zerofrom 0.1.3",
+ "zerovec 0.9.5",
 ]
 
 [[package]]
 name = "icu_compactdecimal"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5beccaf2a6328d0860a8bca9b20d84a70af7c7d09536fa184f0c4401d044b57"
 dependencies = [
- "databake",
  "displaydoc",
  "fixed_decimal",
+ "icu_compactdecimal_data",
  "icu_decimal",
+ "icu_locid_transform",
  "icu_plurals",
  "icu_provider",
- "serde",
- "writeable",
- "zerovec",
+ "writeable 0.5.3",
+ "zerovec 0.9.5",
 ]
+
+[[package]]
+name = "icu_compactdecimal_data"
+version = "1.2.0"
 
 [[package]]
 name = "icu_datagen"
 version = "1.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3533f2d19ca2842eec28f8ba60bc6cd0053a6215e97b19ffe74256cd347e5e0f"
 dependencies = [
- "cached-path",
  "clap",
  "crlify",
- "databake",
+ "databake 0.1.6",
  "displaydoc",
  "elsa",
  "eyre",
  "icu_calendar",
- "icu_casemapping",
+ "icu_casemap",
  "icu_codepointtrie_builder",
  "icu_collator",
  "icu_collections",
- "icu_compactdecimal",
  "icu_datetime",
  "icu_decimal",
- "icu_displaynames",
  "icu_list",
  "icu_locid",
  "icu_locid_transform",
@@ -1229,136 +884,151 @@ dependencies = [
  "icu_provider_adapters",
  "icu_provider_blob",
  "icu_provider_fs",
- "icu_relativetime",
  "icu_segmenter",
  "icu_timezone",
  "itertools",
- "lazy_static",
  "log",
+ "memchr",
  "ndarray",
- "proc-macro2",
- "quote",
+ "once_cell",
  "rayon",
  "serde",
  "serde-aux",
  "serde_json",
  "simple_logger",
- "syn 1.0.109",
- "tinystr",
+ "syn 2.0.37",
+ "tinystr 0.7.2",
  "toml",
- "writeable",
- "zerovec",
+ "twox-hash",
+ "ureq",
+ "writeable 0.5.3",
+ "zerotrie",
+ "zerovec 0.9.5",
  "zip",
 ]
 
 [[package]]
 name = "icu_datetime"
 version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d61014bb8604505baa84ed522aa039951bd81177828d165e80ea8a0543c8a7"
 dependencies = [
- "databake",
+ "databake 0.1.6",
  "displaydoc",
  "either",
  "fixed_decimal",
  "icu_calendar",
+ "icu_datetime_data",
  "icu_decimal",
  "icu_locid",
+ "icu_locid_transform",
  "icu_plurals",
  "icu_provider",
  "icu_timezone",
- "litemap",
+ "litemap 0.7.1",
  "serde",
  "smallvec",
- "tinystr",
- "writeable",
- "zerovec",
+ "tinystr 0.7.2",
+ "writeable 0.5.3",
+ "zerovec 0.9.5",
 ]
+
+[[package]]
+name = "icu_datetime_data"
+version = "1.2.0"
 
 [[package]]
 name = "icu_decimal"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839d40602460578482205f1def416a6442cf29a24dc366aa8cf8d9f95a53c9d2"
 dependencies = [
- "databake",
+ "databake 0.1.6",
  "displaydoc",
  "fixed_decimal",
+ "icu_decimal_data",
  "icu_locid",
+ "icu_locid_transform",
  "icu_provider",
  "serde",
- "writeable",
+ "writeable 0.5.3",
 ]
+
+[[package]]
+name = "icu_decimal_data"
+version = "1.2.0"
 
 [[package]]
 name = "icu_displaynames"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a689e3da02298e6681cda6d02e30bb449f46e941664e5f372a64c15bf934369"
 dependencies = [
- "databake",
- "icu_collections",
+ "icu_displaynames_data",
  "icu_locid",
+ "icu_locid_transform",
  "icu_provider",
  "serde",
- "tinystr",
- "zerovec",
+ "tinystr 0.7.2",
+ "zerovec 0.9.5",
 ]
+
+[[package]]
+name = "icu_displaynames_data"
+version = "1.2.0"
 
 [[package]]
 name = "icu_list"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7ba7442d9235b689d4fdce17c452ea229934980fd81ba50cc28275752c9f90"
 dependencies = [
- "databake",
+ "databake 0.1.6",
  "deduplicating_array",
  "displaydoc",
+ "icu_list_data",
+ "icu_locid_transform",
  "icu_provider",
- "regex-automata 0.2.0",
+ "regex-automata",
  "serde",
- "writeable",
+ "writeable 0.5.3",
 ]
+
+[[package]]
+name = "icu_list_data"
+version = "1.2.0"
 
 [[package]]
 name = "icu_locid"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3003f85dccfc0e238ff567693248c59153a46f4e6125ba4020b973cef4d1d335"
 dependencies = [
- "databake",
+ "databake 0.1.6",
  "displaydoc",
- "litemap",
+ "litemap 0.7.1",
  "serde",
- "tinystr",
- "writeable",
- "zerovec",
+ "tinystr 0.7.2",
+ "writeable 0.5.3",
+ "zerovec 0.9.5",
 ]
 
 [[package]]
 name = "icu_locid_transform"
 version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd89f392982141a878a9321c9298cce46d14e1c17efc5f428dbfd96b443e57d0"
 dependencies = [
- "databake",
+ "databake 0.1.6",
  "displaydoc",
  "icu_locid",
+ "icu_locid_transform_data",
  "icu_provider",
  "serde",
- "tinystr",
- "zerovec",
+ "tinystr 0.7.2",
+ "zerovec 0.9.5",
 ]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.2.0"
 
 [[package]]
 name = "icu_normalizer"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "652869735c9fb9f5a64ba180ee16f2c848390469c116deef517ecc53f4343598"
 dependencies = [
- "databake",
+ "databake 0.1.6",
  "displaydoc",
  "icu_collections",
+ "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "serde",
@@ -1366,47 +1036,57 @@ dependencies = [
  "utf16_iter",
  "utf8_iter",
  "write16",
- "zerovec",
+ "zerovec 0.9.5",
 ]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.2.0"
 
 [[package]]
 name = "icu_plurals"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18fbe19656b3cbae9a40a27b0303f06b2b51165e3b06d596dfdff8f06bfce9a"
 dependencies = [
- "databake",
+ "databake 0.1.6",
  "displaydoc",
  "fixed_decimal",
  "icu_locid",
+ "icu_locid_transform",
+ "icu_plurals_data",
  "icu_provider",
  "serde",
- "zerovec",
+ "zerovec 0.9.5",
 ]
+
+[[package]]
+name = "icu_plurals_data"
+version = "1.2.0"
 
 [[package]]
 name = "icu_properties"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce0e1aa26851f16c9e04412a5911c86b7f8768dac8f8d4c5f1c568a7e5d7a434"
 dependencies = [
- "databake",
+ "databake 0.1.6",
  "displaydoc",
  "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
  "icu_provider",
  "serde",
- "tinystr",
- "zerovec",
+ "tinystr 0.7.2",
+ "zerovec 0.9.5",
 ]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.2.0"
 
 [[package]]
 name = "icu_provider"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc312a7b6148f7dfe098047ae2494d12d4034f48ade58d4f353000db376e305"
 dependencies = [
  "bincode",
- "databake",
+ "databake 0.1.6",
  "displaydoc",
  "erased-serde",
  "icu_locid",
@@ -1416,47 +1096,40 @@ dependencies = [
  "serde",
  "serde_json",
  "stable_deref_trait",
- "writeable",
+ "tinystr 0.7.2",
+ "writeable 0.5.3",
  "yoke",
- "zerofrom",
- "zerovec",
+ "zerofrom 0.1.3",
+ "zerovec 0.9.5",
 ]
 
 [[package]]
 name = "icu_provider_adapters"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ae1e2bd0c41728b77e7c46e9afdec5e2127d1eedacc684724667d50c126bd3"
 dependencies = [
- "databake",
  "icu_locid",
+ "icu_locid_transform",
  "icu_provider",
  "serde",
- "tinystr",
- "yoke",
- "zerovec",
+ "tinystr 0.7.2",
+ "zerovec 0.9.5",
 ]
 
 [[package]]
 name = "icu_provider_blob"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd364c9a01f791a4bc04a74cf2a1d01d9f6926a40fd5ae1c28004e1e70d8338b"
 dependencies = [
  "icu_provider",
  "log",
  "postcard",
  "serde",
- "writeable",
- "yoke",
- "zerovec",
+ "writeable 0.5.3",
+ "zerovec 0.9.5",
 ]
 
 [[package]]
 name = "icu_provider_fs"
 version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b861a88223338dcb70466b04918f1d8bc136575e6d252d1dc349ef4848d388e1"
 dependencies = [
  "bincode",
  "crlify",
@@ -1467,94 +1140,91 @@ dependencies = [
  "serde",
  "serde-json-core",
  "serde_json",
- "writeable",
 ]
 
 [[package]]
 name = "icu_provider_macros"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b728b9421e93eff1d9f8681101b78fa745e0748c95c655c83f337044a7e10"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
 name = "icu_relativetime"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28810733e575bda56b7b20581b202908138125904ed87fd5c3db242a79232471"
 dependencies = [
- "databake",
  "displaydoc",
  "fixed_decimal",
  "icu_decimal",
+ "icu_locid_transform",
  "icu_plurals",
  "icu_provider",
+ "icu_relativetime_data",
  "serde",
- "writeable",
- "zerovec",
+ "writeable 0.5.3",
+ "zerovec 0.9.5",
 ]
+
+[[package]]
+name = "icu_relativetime_data"
+version = "1.2.0"
 
 [[package]]
 name = "icu_segmenter"
 version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3300a7b6bf187be98a57264ad094f11f2e062c2e8263132af010ff522ee5495"
 dependencies = [
- "databake",
+ "core_maths",
+ "databake 0.1.6",
  "displaydoc",
  "icu_collections",
  "icu_locid",
  "icu_provider",
- "num-traits",
+ "icu_segmenter_data",
  "serde",
  "utf8_iter",
- "zerovec",
+ "zerovec 0.9.5",
 ]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "1.2.0"
 
 [[package]]
 name = "icu_testdata"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c91edb7412e04e7f71ec935d0b88954c6d414ad21ede85ab80d512e27540c9"
 dependencies = [
  "icu_calendar",
- "icu_collator",
- "icu_collections",
  "icu_datetime",
  "icu_decimal",
  "icu_displaynames",
  "icu_list",
- "icu_locid",
  "icu_locid_transform",
- "icu_normalizer",
  "icu_plurals",
- "icu_properties",
  "icu_provider",
- "icu_provider_adapters",
- "icu_segmenter",
- "icu_timezone",
- "zerovec",
+ "zerovec 0.9.4",
 ]
 
 [[package]]
 name = "icu_timezone"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e22da75a450de2d54161838efa9e1a1f5baa7bc1fffdb015f260e0992b01977"
 dependencies = [
- "databake",
+ "databake 0.1.6",
  "displaydoc",
  "icu_calendar",
  "icu_locid",
  "icu_provider",
+ "icu_timezone_data",
  "serde",
- "tinystr",
- "zerovec",
+ "tinystr 0.7.2",
+ "zerotrie",
+ "zerovec 0.9.5",
 ]
+
+[[package]]
+name = "icu_timezone_data"
+version = "1.2.0"
 
 [[package]]
 name = "ident_case"
@@ -1590,33 +1260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
-dependencies = [
- "console",
- "lazy_static",
- "number_prefix",
- "regex",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "ipnet"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,15 +1273,6 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
-
-[[package]]
-name = "jobserver"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -1694,6 +1328,10 @@ name = "litemap"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a04a5b2b6f54acba899926491d0a6c59d98012938ca2ab5befb281c034e8f94"
+
+[[package]]
+name = "litemap"
+version = "0.7.1"
 dependencies = [
  "serde",
 ]
@@ -1787,12 +1425,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1802,39 +1434,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "more-asserts"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
-
-[[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
 
 [[package]]
 name = "ndarray"
@@ -1875,24 +1478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
- "libm",
 ]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -1922,73 +1508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "openssl"
-version = "0.10.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
-dependencies = [
- "bitflags 2.4.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.93"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest",
- "hmac",
- "password-hash",
- "sha2",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,18 +1520,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
-
-[[package]]
 name = "postcard"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2021,12 +1528,6 @@ dependencies = [
  "cobs",
  "serde",
 ]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-error"
@@ -2103,36 +1604,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,36 +1639,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata 0.3.8",
- "regex-syntax 0.7.5",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9368763f5a9b804326f3af749e16f9abf378d227bcdee7634b13d8f17793782"
 dependencies = [
  "memchr",
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2205,12 +1653,6 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "region"
@@ -2234,40 +1676,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.11.20"
+name = "ring"
+version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-tls",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
+ "cc",
+ "libc",
  "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
+ "spin",
+ "untrusted",
  "web-sys",
- "winreg",
+ "winapi",
 ]
 
 [[package]]
@@ -2327,6 +1747,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.6",
+ "sct",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6a5fc258f1c1276dfe3016516945546e2d5383911efc0fc4f1cdc5df3a4ae3"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2339,48 +1791,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
-name = "schannel"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
-dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
-name = "security-framework"
-version = "2.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -2459,18 +1889,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "sha1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2480,32 +1898,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha1_smol"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
-
-[[package]]
-name = "sha2"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
 
 [[package]]
 name = "simdutf8"
@@ -2542,24 +1938,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "socket2"
-version = "0.4.9"
+name = "spin"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
-]
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2575,6 +1957,12 @@ checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdweb"
@@ -2615,7 +2003,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha1 0.6.1",
+ "sha1",
  "syn 1.0.109",
 ]
 
@@ -2630,12 +2018,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "subtle"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -2672,21 +2054,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "285ba80e733fac80aa4270fbcdf83772a79b80aa35c97075320abfee4a915b06"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+ "unicode-xid",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tar"
-version = "0.4.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
 
 [[package]]
 name = "target-lexicon"
@@ -2743,23 +2126,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
-dependencies = [
- "deranged",
- "serde",
- "time-core",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
-
-[[package]]
 name = "time-macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2788,10 +2154,17 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ac3f5b6856e931e15e07b478e98c8045239829a65f9156d4fa7e7788197a5ef"
 dependencies = [
- "databake",
+ "displaydoc",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.7.2"
+dependencies = [
+ "databake 0.1.6",
  "displaydoc",
  "serde",
- "zerovec",
+ "zerovec 0.9.5",
 ]
 
 [[package]]
@@ -2810,46 +2183,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokio"
-version = "1.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
-dependencies = [
- "backtrace",
- "bytes",
- "libc",
- "mio",
- "num_cpus",
- "pin-project-lite",
- "socket2 0.5.4",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,12 +2190,6 @@ checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "tower-service"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -2898,19 +2225,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "try-lock"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
-
-[[package]]
 name = "tutorial_baked"
 version = "0.0.0"
 dependencies = [
  "icu",
  "icu_datagen",
  "icu_provider",
- "zerovec",
+ "zerovec 0.9.4",
 ]
 
 [[package]]
@@ -2951,7 +2272,7 @@ dependencies = [
 name = "tutorials-test"
 version = "0.0.0"
 dependencies = [
- "databake",
+ "databake 0.1.5",
  "displaydoc",
  "icu",
  "icu_datagen",
@@ -2961,19 +2282,23 @@ dependencies = [
  "icu_provider_fs",
  "icu_testdata",
  "itertools",
- "litemap",
+ "litemap 0.7.0",
  "lru",
  "serde",
  "serde-aux",
- "tinystr",
- "writeable",
+ "tinystr 0.7.1",
+ "writeable 0.5.2",
 ]
 
 [[package]]
-name = "typenum"
-version = "1.17.0"
+name = "twox-hash"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -3001,6 +2326,28 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-webpki 0.100.3",
+ "url",
+ "webpki-roots",
+]
 
 [[package]]
 name = "url"
@@ -3038,25 +2385,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
 
 [[package]]
 name = "wasi"
@@ -3087,18 +2419,6 @@ dependencies = [
  "quote",
  "syn 2.0.37",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -3396,7 +2716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22dc83aadbdf97388de3211cb6f105374f245a3cf2a5c65a16776e7a087a8468"
 dependencies = [
  "byteorder",
- "time 0.2.27",
+ "time",
  "wasmer-types",
 ]
 
@@ -3414,6 +2734,15 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki 0.100.3",
 ]
 
 [[package]]
@@ -3456,7 +2785,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3489,35 +2818,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3650,16 +2955,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3672,6 +2967,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60e49e42bdb1d5dc76f4cd78102f8f0714d32edfa3efb82286eb0f0b1fc0da0f"
 
 [[package]]
+name = "writeable"
+version = "0.5.3"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3681,36 +2980,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "xattr"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "yoke"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1848075a23a28f9773498ee9a0f2cf58fcbad4f8c0ccf84a210ab33c6ae495de"
+version = "0.7.2"
 dependencies = [
  "serde",
  "stable_deref_trait",
  "yoke-derive",
- "zerofrom",
+ "zerofrom 0.1.3",
 ]
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af46c169923ed7516eef0aa32b56d2651b229f57458ebe46b49ddd6efef5b7a2"
+version = "0.7.2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "synstructure",
+ "syn 2.0.37",
+ "synstructure 0.13.0",
 ]
 
 [[package]]
@@ -3718,20 +3004,35 @@ name = "zerofrom"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df54d76c3251de27615dfcce21e636c172dafb2549cd7fd93e21c66f6ca6bea2"
+
+[[package]]
+name = "zerofrom"
+version = "0.1.3"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eae7c1f7d4b8eafce526bc0771449ddc2f250881ae31c50d22c032b5a1c499"
+version = "0.1.3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "synstructure",
+ "syn 2.0.37",
+ "synstructure 0.13.0",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.0.0"
+dependencies = [
+ "databake 0.1.6",
+ "displaydoc",
+ "litemap 0.7.1",
+ "serde",
+ "yoke",
+ "zerofrom 0.1.3",
+ "zerovec 0.9.5",
 ]
 
 [[package]]
@@ -3740,23 +3041,27 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "198f54134cd865f437820aa3b43d0ad518af4e68ee161b444cdd15d8e567c8ea"
 dependencies = [
- "databake",
+ "zerofrom 0.1.2",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.9.5"
+dependencies = [
+ "databake 0.1.6",
  "serde",
  "yoke",
- "zerofrom",
+ "zerofrom 0.1.3",
  "zerovec-derive",
 ]
 
 [[package]]
 name = "zerovec-derive"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486558732d5dde10d0f8cb2936507c1bb21bc539d924c949baf5f36a58e51bac"
+version = "0.9.5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "synstructure",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3765,46 +3070,76 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
- "aes",
  "byteorder",
- "bzip2",
- "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "hmac",
- "pbkdf2",
- "sha1 0.10.6",
- "time 0.3.28",
- "zstd",
 ]
 
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
+[[patch.unused]]
+name = "bies"
+version = "0.2.1"
 
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
+[[patch.unused]]
+name = "icu4x_ecma402"
+version = "0.8.0"
 
-[[package]]
-name = "zstd-sys"
-version = "2.0.8+zstd.1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
+[[patch.unused]]
+name = "icu_benchmark_macros"
+version = "0.0.0"
+
+[[patch.unused]]
+name = "icu_capi"
+version = "1.2.2"
+
+[[patch.unused]]
+name = "icu_capi_cdylib"
+version = "1.2.0"
+
+[[patch.unused]]
+name = "icu_capi_staticlib"
+version = "1.2.0"
+
+[[patch.unused]]
+name = "icu_freertos"
+version = "1.2.1"
+
+[[patch.unused]]
+name = "icu_harfbuzz"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "icu_pattern"
+version = "0.1.5"
+
+[[patch.unused]]
+name = "icu_personnames"
+version = "0.0.0"
+
+[[patch.unused]]
+name = "icu_singlenumberformatter"
+version = "0.0.0"
+
+[[patch.unused]]
+name = "icu_singlenumberformatter_data"
+version = "1.2.0"
+
+[[patch.unused]]
+name = "icu_transliterate"
+version = "0.0.0"
+
+[[patch.unused]]
+name = "icu_unicodeset_parse"
+version = "0.0.0"
+
+[[patch.unused]]
+name = "icu_unitsconversion"
+version = "0.0.0"
+
+[[patch.unused]]
+name = "ixdtf"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "tzif"
+version = "0.2.2"

--- a/docs/tutorials/Cargo.lock
+++ b/docs/tutorials/Cargo.lock
@@ -1203,7 +1203,7 @@ dependencies = [
  "icu_locid_transform",
  "icu_plurals",
  "icu_provider",
- "zerovec 0.9.4",
+ "zerovec 0.9.5",
 ]
 
 [[package]]

--- a/docs/tutorials/Cargo.lock
+++ b/docs/tutorials/Cargo.lock
@@ -394,36 +394,12 @@ dependencies = [
 
 [[package]]
 name = "databake"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142b0851e71c009e7f5582a8fa13de2cb133643026a57c7e4ae1b8c4369948e9"
-dependencies = [
- "databake-derive 0.1.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "databake"
 version = "0.1.6"
 dependencies = [
- "databake-derive 0.1.6",
+ "databake-derive",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
-]
-
-[[package]]
-name = "databake-derive"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbf8a83d97ace23f6e0f07dcb4f777ac575cab5d6f56c413129b047abac5d5d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -433,7 +409,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.37",
- "synstructure 0.13.0",
+ "synstructure",
 ]
 
 [[package]]
@@ -756,7 +732,7 @@ name = "icu_calendar"
 version = "1.2.0"
 dependencies = [
  "calendrical_calculations",
- "databake 0.1.6",
+ "databake",
  "displaydoc",
  "icu_calendar_data",
  "icu_locid",
@@ -765,7 +741,7 @@ dependencies = [
  "serde",
  "tinystr",
  "writeable",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -776,7 +752,7 @@ version = "1.2.0"
 name = "icu_casemap"
 version = "1.2.0"
 dependencies = [
- "databake 0.1.6",
+ "databake",
  "displaydoc",
  "icu_casemap_data",
  "icu_collections",
@@ -785,7 +761,7 @@ dependencies = [
  "icu_provider",
  "serde",
  "writeable",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -807,7 +783,7 @@ dependencies = [
 name = "icu_collator"
 version = "1.2.0"
 dependencies = [
- "databake 0.1.6",
+ "databake",
  "displaydoc",
  "icu_collator_data",
  "icu_collections",
@@ -820,7 +796,7 @@ dependencies = [
  "smallvec",
  "utf16_iter",
  "utf8_iter",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -831,12 +807,12 @@ version = "1.2.0"
 name = "icu_collections"
 version = "1.2.0"
 dependencies = [
- "databake 0.1.6",
+ "databake",
  "displaydoc",
  "serde",
  "yoke",
- "zerofrom 0.1.3",
- "zerovec 0.9.5",
+ "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -851,7 +827,7 @@ dependencies = [
  "icu_plurals",
  "icu_provider",
  "writeable",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -864,7 +840,7 @@ version = "1.2.5"
 dependencies = [
  "clap",
  "crlify",
- "databake 0.1.6",
+ "databake",
  "displaydoc",
  "elsa",
  "eyre",
@@ -904,7 +880,7 @@ dependencies = [
  "ureq",
  "writeable",
  "zerotrie",
- "zerovec 0.9.5",
+ "zerovec",
  "zip",
 ]
 
@@ -912,7 +888,7 @@ dependencies = [
 name = "icu_datetime"
 version = "1.2.1"
 dependencies = [
- "databake 0.1.6",
+ "databake",
  "displaydoc",
  "either",
  "fixed_decimal",
@@ -924,12 +900,12 @@ dependencies = [
  "icu_plurals",
  "icu_provider",
  "icu_timezone",
- "litemap 0.7.1",
+ "litemap",
  "serde",
  "smallvec",
  "tinystr",
  "writeable",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -940,7 +916,7 @@ version = "1.2.0"
 name = "icu_decimal"
 version = "1.2.0"
 dependencies = [
- "databake 0.1.6",
+ "databake",
  "displaydoc",
  "fixed_decimal",
  "icu_decimal_data",
@@ -965,7 +941,7 @@ dependencies = [
  "icu_provider",
  "serde",
  "tinystr",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -976,7 +952,7 @@ version = "1.2.0"
 name = "icu_list"
 version = "1.2.0"
 dependencies = [
- "databake 0.1.6",
+ "databake",
  "deduplicating_array",
  "displaydoc",
  "icu_list_data",
@@ -995,27 +971,27 @@ version = "1.2.0"
 name = "icu_locid"
 version = "1.2.0"
 dependencies = [
- "databake 0.1.6",
+ "databake",
  "displaydoc",
- "litemap 0.7.1",
+ "litemap",
  "serde",
  "tinystr",
  "writeable",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
 name = "icu_locid_transform"
 version = "1.2.1"
 dependencies = [
- "databake 0.1.6",
+ "databake",
  "displaydoc",
  "icu_locid",
  "icu_locid_transform_data",
  "icu_provider",
  "serde",
  "tinystr",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -1026,7 +1002,7 @@ version = "1.2.0"
 name = "icu_normalizer"
 version = "1.2.0"
 dependencies = [
- "databake 0.1.6",
+ "databake",
  "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
@@ -1037,7 +1013,7 @@ dependencies = [
  "utf16_iter",
  "utf8_iter",
  "write16",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -1048,7 +1024,7 @@ version = "1.2.0"
 name = "icu_plurals"
 version = "1.2.0"
 dependencies = [
- "databake 0.1.6",
+ "databake",
  "displaydoc",
  "fixed_decimal",
  "icu_locid",
@@ -1056,7 +1032,7 @@ dependencies = [
  "icu_plurals_data",
  "icu_provider",
  "serde",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -1067,7 +1043,7 @@ version = "1.2.0"
 name = "icu_properties"
 version = "1.2.0"
 dependencies = [
- "databake 0.1.6",
+ "databake",
  "displaydoc",
  "icu_collections",
  "icu_locid_transform",
@@ -1075,7 +1051,7 @@ dependencies = [
  "icu_provider",
  "serde",
  "tinystr",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -1087,7 +1063,7 @@ name = "icu_provider"
 version = "1.2.0"
 dependencies = [
  "bincode",
- "databake 0.1.6",
+ "databake",
  "displaydoc",
  "erased-serde",
  "icu_locid",
@@ -1100,8 +1076,8 @@ dependencies = [
  "tinystr",
  "writeable",
  "yoke",
- "zerofrom 0.1.3",
- "zerovec 0.9.5",
+ "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -1113,7 +1089,7 @@ dependencies = [
  "icu_provider",
  "serde",
  "tinystr",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -1125,7 +1101,7 @@ dependencies = [
  "postcard",
  "serde",
  "writeable",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -1165,7 +1141,7 @@ dependencies = [
  "icu_relativetime_data",
  "serde",
  "writeable",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -1177,7 +1153,7 @@ name = "icu_segmenter"
 version = "1.2.1"
 dependencies = [
  "core_maths",
- "databake 0.1.6",
+ "databake",
  "displaydoc",
  "icu_collections",
  "icu_locid",
@@ -1185,7 +1161,7 @@ dependencies = [
  "icu_segmenter_data",
  "serde",
  "utf8_iter",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -1204,14 +1180,14 @@ dependencies = [
  "icu_locid_transform",
  "icu_plurals",
  "icu_provider",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
 name = "icu_timezone"
 version = "1.2.0"
 dependencies = [
- "databake 0.1.6",
+ "databake",
  "displaydoc",
  "icu_calendar",
  "icu_locid",
@@ -1220,7 +1196,7 @@ dependencies = [
  "serde",
  "tinystr",
  "zerotrie",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -1238,9 +1214,9 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "icu_unicodeset_parse",
- "litemap 0.7.1",
+ "litemap",
  "serde",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -1251,7 +1227,7 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "tinystr",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -1350,12 +1326,6 @@ name = "linux-raw-sys"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
-
-[[package]]
-name = "litemap"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a04a5b2b6f54acba899926491d0a6c59d98012938ca2ab5befb281c034e8f94"
 
 [[package]]
 name = "litemap"
@@ -2071,18 +2041,6 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "285ba80e733fac80aa4270fbcdf83772a79b80aa35c97075320abfee4a915b06"
@@ -2180,10 +2138,10 @@ dependencies = [
 name = "tinystr"
 version = "0.7.2"
 dependencies = [
- "databake 0.1.6",
+ "databake",
  "displaydoc",
  "serde",
- "zerovec 0.9.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -2250,7 +2208,7 @@ dependencies = [
  "icu",
  "icu_datagen",
  "icu_provider",
- "zerovec 0.9.4",
+ "zerovec",
 ]
 
 [[package]]
@@ -2291,7 +2249,7 @@ dependencies = [
 name = "tutorials-test"
 version = "0.0.0"
 dependencies = [
- "databake 0.1.5",
+ "databake",
  "displaydoc",
  "icu",
  "icu_datagen",
@@ -2301,7 +2259,7 @@ dependencies = [
  "icu_provider_fs",
  "icu_testdata",
  "itertools",
- "litemap 0.7.0",
+ "litemap",
  "lru",
  "serde",
  "serde-aux",
@@ -2999,7 +2957,7 @@ dependencies = [
  "serde",
  "stable_deref_trait",
  "yoke-derive",
- "zerofrom 0.1.3",
+ "zerofrom",
 ]
 
 [[package]]
@@ -3009,14 +2967,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.37",
- "synstructure 0.13.0",
+ "synstructure",
 ]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df54d76c3251de27615dfcce21e636c172dafb2549cd7fd93e21c66f6ca6bea2"
 
 [[package]]
 name = "zerofrom"
@@ -3032,39 +2984,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.37",
- "synstructure 0.13.0",
+ "synstructure",
 ]
 
 [[package]]
 name = "zerotrie"
 version = "0.0.0"
 dependencies = [
- "databake 0.1.6",
+ "databake",
  "displaydoc",
- "litemap 0.7.1",
+ "litemap",
  "serde",
  "yoke",
- "zerofrom 0.1.3",
- "zerovec 0.9.5",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198f54134cd865f437820aa3b43d0ad518af4e68ee161b444cdd15d8e567c8ea"
-dependencies = [
- "zerofrom 0.1.2",
+ "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
 name = "zerovec"
 version = "0.9.5"
 dependencies = [
- "databake 0.1.6",
+ "databake",
  "serde",
  "yoke",
- "zerofrom 0.1.3",
+ "zerofrom",
  "zerovec-derive",
 ]
 

--- a/docs/tutorials/Cargo.lock
+++ b/docs/tutorials/Cargo.lock
@@ -599,7 +599,7 @@ version = "0.5.4"
 dependencies = [
  "displaydoc",
  "smallvec",
- "writeable 0.5.3",
+ "writeable",
 ]
 
 [[package]]
@@ -748,6 +748,7 @@ dependencies = [
  "icu_relativetime",
  "icu_segmenter",
  "icu_timezone",
+ "icu_transliterate",
 ]
 
 [[package]]
@@ -762,8 +763,8 @@ dependencies = [
  "icu_locid_transform",
  "icu_provider",
  "serde",
- "tinystr 0.7.2",
- "writeable 0.5.3",
+ "tinystr",
+ "writeable",
  "zerovec 0.9.5",
 ]
 
@@ -783,7 +784,7 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "serde",
- "writeable 0.5.3",
+ "writeable",
  "zerovec 0.9.5",
 ]
 
@@ -849,7 +850,7 @@ dependencies = [
  "icu_locid_transform",
  "icu_plurals",
  "icu_provider",
- "writeable 0.5.3",
+ "writeable",
  "zerovec 0.9.5",
 ]
 
@@ -897,11 +898,11 @@ dependencies = [
  "serde_json",
  "simple_logger",
  "syn 2.0.37",
- "tinystr 0.7.2",
+ "tinystr",
  "toml",
  "twox-hash",
  "ureq",
- "writeable 0.5.3",
+ "writeable",
  "zerotrie",
  "zerovec 0.9.5",
  "zip",
@@ -926,8 +927,8 @@ dependencies = [
  "litemap 0.7.1",
  "serde",
  "smallvec",
- "tinystr 0.7.2",
- "writeable 0.5.3",
+ "tinystr",
+ "writeable",
  "zerovec 0.9.5",
 ]
 
@@ -947,7 +948,7 @@ dependencies = [
  "icu_locid_transform",
  "icu_provider",
  "serde",
- "writeable 0.5.3",
+ "writeable",
 ]
 
 [[package]]
@@ -963,7 +964,7 @@ dependencies = [
  "icu_locid_transform",
  "icu_provider",
  "serde",
- "tinystr 0.7.2",
+ "tinystr",
  "zerovec 0.9.5",
 ]
 
@@ -983,7 +984,7 @@ dependencies = [
  "icu_provider",
  "regex-automata",
  "serde",
- "writeable 0.5.3",
+ "writeable",
 ]
 
 [[package]]
@@ -998,8 +999,8 @@ dependencies = [
  "displaydoc",
  "litemap 0.7.1",
  "serde",
- "tinystr 0.7.2",
- "writeable 0.5.3",
+ "tinystr",
+ "writeable",
  "zerovec 0.9.5",
 ]
 
@@ -1013,7 +1014,7 @@ dependencies = [
  "icu_locid_transform_data",
  "icu_provider",
  "serde",
- "tinystr 0.7.2",
+ "tinystr",
  "zerovec 0.9.5",
 ]
 
@@ -1073,7 +1074,7 @@ dependencies = [
  "icu_properties_data",
  "icu_provider",
  "serde",
- "tinystr 0.7.2",
+ "tinystr",
  "zerovec 0.9.5",
 ]
 
@@ -1096,8 +1097,8 @@ dependencies = [
  "serde",
  "serde_json",
  "stable_deref_trait",
- "tinystr 0.7.2",
- "writeable 0.5.3",
+ "tinystr",
+ "writeable",
  "yoke",
  "zerofrom 0.1.3",
  "zerovec 0.9.5",
@@ -1111,7 +1112,7 @@ dependencies = [
  "icu_locid_transform",
  "icu_provider",
  "serde",
- "tinystr 0.7.2",
+ "tinystr",
  "zerovec 0.9.5",
 ]
 
@@ -1123,7 +1124,7 @@ dependencies = [
  "log",
  "postcard",
  "serde",
- "writeable 0.5.3",
+ "writeable",
  "zerovec 0.9.5",
 ]
 
@@ -1163,7 +1164,7 @@ dependencies = [
  "icu_provider",
  "icu_relativetime_data",
  "serde",
- "writeable 0.5.3",
+ "writeable",
  "zerovec 0.9.5",
 ]
 
@@ -1217,7 +1218,7 @@ dependencies = [
  "icu_provider",
  "icu_timezone_data",
  "serde",
- "tinystr 0.7.2",
+ "tinystr",
  "zerotrie",
  "zerovec 0.9.5",
 ]
@@ -1225,6 +1226,33 @@ dependencies = [
 [[package]]
 name = "icu_timezone_data"
 version = "1.2.0"
+
+[[package]]
+name = "icu_transliterate"
+version = "0.0.0"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_provider",
+ "icu_unicodeset_parse",
+ "litemap 0.7.1",
+ "serde",
+ "zerovec 0.9.5",
+]
+
+[[package]]
+name = "icu_unicodeset_parse"
+version = "0.0.0"
+dependencies = [
+ "icu_collections",
+ "icu_properties",
+ "icu_provider",
+ "tinystr",
+ "zerovec 0.9.5",
+]
 
 [[package]]
 name = "ident_case"
@@ -2150,15 +2178,6 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac3f5b6856e931e15e07b478e98c8045239829a65f9156d4fa7e7788197a5ef"
-dependencies = [
- "displaydoc",
-]
-
-[[package]]
-name = "tinystr"
 version = "0.7.2"
 dependencies = [
  "databake 0.1.6",
@@ -2286,8 +2305,8 @@ dependencies = [
  "lru",
  "serde",
  "serde-aux",
- "tinystr 0.7.1",
- "writeable 0.5.2",
+ "tinystr",
+ "writeable",
 ]
 
 [[package]]
@@ -2962,12 +2981,6 @@ checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e49e42bdb1d5dc76f4cd78102f8f0714d32edfa3efb82286eb0f0b1fc0da0f"
-
-[[package]]
-name = "writeable"
 version = "0.5.3"
 
 [[package]]
@@ -3123,14 +3136,6 @@ version = "0.0.0"
 [[patch.unused]]
 name = "icu_singlenumberformatter_data"
 version = "1.2.0"
-
-[[patch.unused]]
-name = "icu_transliterate"
-version = "0.0.0"
-
-[[patch.unused]]
-name = "icu_unicodeset_parse"
-version = "0.0.0"
 
 [[patch.unused]]
 name = "icu_unitsconversion"

--- a/docs/tutorials/testing/legacy_testdata/Cargo.toml
+++ b/docs/tutorials/testing/legacy_testdata/Cargo.toml
@@ -20,4 +20,4 @@ icu_list = "1.2.0"
 icu_locid_transform = "1.2.0"
 icu_plurals = "1.2.0"
 icu_provider = { version = "1.2.0" }
-zerovec = { version = "0.9.4" }
+zerovec = { version = "0.9.5" }

--- a/ffi/gn/Cargo.lock
+++ b/ffi/gn/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "fixed_decimal"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "displaydoc",
  "ryu",
@@ -549,7 +549,7 @@ checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "litemap"
-version = "0.7.0"
+version = "0.7.1"
 
 [[package]]
 name = "memchr"
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -947,11 +947,11 @@ checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
-version = "0.5.2"
+version = "0.5.3"
 
 [[package]]
 name = "yoke"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -971,14 +971,14 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ffi/gn/icu4x/BUILD.gn
+++ b/ffi/gn/icu4x/BUILD.gn
@@ -166,24 +166,24 @@ rust_library("either-v1_8_1") {
   visibility = [ ":*" ]
 }
 
-rust_library("fixed_decimal-v0_5_3") {
+rust_library("fixed_decimal-v0_5_4") {
   crate_name = "fixed_decimal"
   crate_root = "//utils/fixed_decimal/src/lib.rs"
-  output_name = "fixed_decimal-74ba2b51a21a7546"
+  output_name = "fixed_decimal-7a2b983a3b11bdf8"
 
   deps = []
   deps += [ ":displaydoc-v0_2_4($host_toolchain)" ]
   deps += [ ":ryu-v1_0_13" ]
   deps += [ ":smallvec-v1_10_0" ]
-  deps += [ ":writeable-v0_5_2" ]
+  deps += [ ":writeable-v0_5_3" ]
 
   rustenv = []
 
   rustflags = [
     "--cap-lints=allow",
     "--edition=2021",
-    "-Cmetadata=74ba2b51a21a7546",
-    "-Cextra-filename=-74ba2b51a21a7546",
+    "-Cmetadata=7a2b983a3b11bdf8",
+    "-Cextra-filename=-7a2b983a3b11bdf8",
     "--cfg=feature=\"ryu\"",
   ]
 
@@ -234,9 +234,9 @@ rust_library("icu_calendar-v1_2_0") {
   deps += [ ":displaydoc-v0_2_4($host_toolchain)" ]
   deps += [ ":icu_locid-v1_2_0" ]
   deps += [ ":icu_provider-v1_2_0" ]
-  deps += [ ":tinystr-v0_7_1" ]
-  deps += [ ":writeable-v0_5_2" ]
-  deps += [ ":zerovec-v0_9_4" ]
+  deps += [ ":tinystr-v0_7_2" ]
+  deps += [ ":writeable-v0_5_3" ]
+  deps += [ ":zerovec-v0_9_5" ]
 
   rustenv = []
 
@@ -258,7 +258,7 @@ rust_library("icu_capi-v1_2_2") {
   deps = []
   deps += [ ":diplomat-v0_5_2($host_toolchain)" ]
   deps += [ ":diplomat-runtime-v0_5_2" ]
-  deps += [ ":fixed_decimal-v0_5_3" ]
+  deps += [ ":fixed_decimal-v0_5_4" ]
   deps += [ ":icu_calendar-v1_2_0" ]
   deps += [ ":icu_casemap-v1_2_0" ]
   deps += [ ":icu_collator-v1_2_0" ]
@@ -275,9 +275,9 @@ rust_library("icu_capi-v1_2_2") {
   deps += [ ":icu_provider_adapters-v1_2_0" ]
   deps += [ ":icu_segmenter-v1_2_1" ]
   deps += [ ":icu_timezone-v1_2_0" ]
-  deps += [ ":tinystr-v0_7_1" ]
+  deps += [ ":tinystr-v0_7_2" ]
   deps += [ ":unicode-bidi-v0_3_13" ]
-  deps += [ ":writeable-v0_5_2" ]
+  deps += [ ":writeable-v0_5_3" ]
 
   rustenv = []
 
@@ -315,8 +315,8 @@ rust_library("icu_casemap-v1_2_0") {
   deps += [ ":icu_locid-v1_2_0" ]
   deps += [ ":icu_properties-v1_2_0" ]
   deps += [ ":icu_provider-v1_2_0" ]
-  deps += [ ":writeable-v0_5_2" ]
-  deps += [ ":zerovec-v0_9_4" ]
+  deps += [ ":writeable-v0_5_3" ]
+  deps += [ ":zerovec-v0_9_5" ]
 
   rustenv = []
 
@@ -345,7 +345,7 @@ rust_library("icu_collator-v1_2_0") {
   deps += [ ":smallvec-v1_10_0" ]
   deps += [ ":utf16_iter-v1_0_4" ]
   deps += [ ":utf8_iter-v1_0_3" ]
-  deps += [ ":zerovec-v0_9_4" ]
+  deps += [ ":zerovec-v0_9_5" ]
 
   rustenv = []
 
@@ -366,9 +366,9 @@ rust_library("icu_collections-v1_2_0") {
 
   deps = []
   deps += [ ":displaydoc-v0_2_4($host_toolchain)" ]
-  deps += [ ":yoke-v0_7_1" ]
-  deps += [ ":zerofrom-v0_1_2" ]
-  deps += [ ":zerovec-v0_9_4" ]
+  deps += [ ":yoke-v0_7_2" ]
+  deps += [ ":zerofrom-v0_1_3" ]
+  deps += [ ":zerovec-v0_9_5" ]
 
   rustenv = []
 
@@ -390,7 +390,7 @@ rust_library("icu_datetime-v1_2_1") {
   deps = []
   deps += [ ":displaydoc-v0_2_4($host_toolchain)" ]
   deps += [ ":either-v1_8_1" ]
-  deps += [ ":fixed_decimal-v0_5_3" ]
+  deps += [ ":fixed_decimal-v0_5_4" ]
   deps += [ ":icu_calendar-v1_2_0" ]
   deps += [ ":icu_decimal-v1_2_0" ]
   deps += [ ":icu_locid-v1_2_0" ]
@@ -398,9 +398,9 @@ rust_library("icu_datetime-v1_2_1") {
   deps += [ ":icu_provider-v1_2_0" ]
   deps += [ ":icu_timezone-v1_2_0" ]
   deps += [ ":smallvec-v1_10_0" ]
-  deps += [ ":tinystr-v0_7_1" ]
-  deps += [ ":writeable-v0_5_2" ]
-  deps += [ ":zerovec-v0_9_4" ]
+  deps += [ ":tinystr-v0_7_2" ]
+  deps += [ ":writeable-v0_5_3" ]
+  deps += [ ":zerovec-v0_9_5" ]
 
   rustenv = []
 
@@ -421,10 +421,10 @@ rust_library("icu_decimal-v1_2_0") {
 
   deps = []
   deps += [ ":displaydoc-v0_2_4($host_toolchain)" ]
-  deps += [ ":fixed_decimal-v0_5_3" ]
+  deps += [ ":fixed_decimal-v0_5_4" ]
   deps += [ ":icu_locid-v1_2_0" ]
   deps += [ ":icu_provider-v1_2_0" ]
-  deps += [ ":writeable-v0_5_2" ]
+  deps += [ ":writeable-v0_5_3" ]
 
   rustenv = []
 
@@ -447,7 +447,7 @@ rust_library("icu_list-v1_2_0") {
   deps += [ ":displaydoc-v0_2_4($host_toolchain)" ]
   deps += [ ":icu_provider-v1_2_0" ]
   deps += [ ":regex-automata-v0_2_0" ]
-  deps += [ ":writeable-v0_5_2" ]
+  deps += [ ":writeable-v0_5_3" ]
 
   rustenv = []
 
@@ -468,10 +468,10 @@ rust_library("icu_locid-v1_2_0") {
 
   deps = []
   deps += [ ":displaydoc-v0_2_4($host_toolchain)" ]
-  deps += [ ":litemap-v0_7_0" ]
-  deps += [ ":tinystr-v0_7_1" ]
-  deps += [ ":writeable-v0_5_2" ]
-  deps += [ ":zerovec-v0_9_4" ]
+  deps += [ ":litemap-v0_7_1" ]
+  deps += [ ":tinystr-v0_7_2" ]
+  deps += [ ":writeable-v0_5_3" ]
+  deps += [ ":zerovec-v0_9_5" ]
 
   rustenv = []
 
@@ -495,8 +495,8 @@ rust_library("icu_locid_transform-v1_2_1") {
   deps += [ ":displaydoc-v0_2_4($host_toolchain)" ]
   deps += [ ":icu_locid-v1_2_0" ]
   deps += [ ":icu_provider-v1_2_0" ]
-  deps += [ ":tinystr-v0_7_1" ]
-  deps += [ ":zerovec-v0_9_4" ]
+  deps += [ ":tinystr-v0_7_2" ]
+  deps += [ ":zerovec-v0_9_5" ]
 
   rustenv = []
 
@@ -524,7 +524,7 @@ rust_library("icu_normalizer-v1_2_0") {
   deps += [ ":utf16_iter-v1_0_4" ]
   deps += [ ":utf8_iter-v1_0_3" ]
   deps += [ ":write16-v1_0_0" ]
-  deps += [ ":zerovec-v0_9_4" ]
+  deps += [ ":zerovec-v0_9_5" ]
 
   rustenv = []
 
@@ -545,10 +545,10 @@ rust_library("icu_plurals-v1_2_0") {
 
   deps = []
   deps += [ ":displaydoc-v0_2_4($host_toolchain)" ]
-  deps += [ ":fixed_decimal-v0_5_3" ]
+  deps += [ ":fixed_decimal-v0_5_4" ]
   deps += [ ":icu_locid-v1_2_0" ]
   deps += [ ":icu_provider-v1_2_0" ]
-  deps += [ ":zerovec-v0_9_4" ]
+  deps += [ ":zerovec-v0_9_5" ]
 
   rustenv = []
 
@@ -571,9 +571,9 @@ rust_library("icu_properties-v1_2_0") {
   deps += [ ":displaydoc-v0_2_4($host_toolchain)" ]
   deps += [ ":icu_collections-v1_2_0" ]
   deps += [ ":icu_provider-v1_2_0" ]
-  deps += [ ":tinystr-v0_7_1" ]
+  deps += [ ":tinystr-v0_7_2" ]
   deps += [ ":unicode-bidi-v0_3_13" ]
-  deps += [ ":zerovec-v0_9_4" ]
+  deps += [ ":zerovec-v0_9_5" ]
 
   rustenv = []
 
@@ -598,11 +598,11 @@ rust_library("icu_provider-v1_2_0") {
   deps += [ ":icu_locid-v1_2_0" ]
   deps += [ ":icu_provider_macros-v1_2_0($host_toolchain)" ]
   deps += [ ":stable_deref_trait-v1_2_0" ]
-  deps += [ ":tinystr-v0_7_1" ]
-  deps += [ ":writeable-v0_5_2" ]
-  deps += [ ":yoke-v0_7_1" ]
-  deps += [ ":zerofrom-v0_1_2" ]
-  deps += [ ":zerovec-v0_9_4" ]
+  deps += [ ":tinystr-v0_7_2" ]
+  deps += [ ":writeable-v0_5_3" ]
+  deps += [ ":yoke-v0_7_2" ]
+  deps += [ ":zerofrom-v0_1_3" ]
+  deps += [ ":zerovec-v0_9_5" ]
 
   rustenv = []
 
@@ -626,8 +626,8 @@ rust_library("icu_provider_adapters-v1_2_0") {
   deps += [ ":icu_locid-v1_2_0" ]
   deps += [ ":icu_locid_transform-v1_2_1" ]
   deps += [ ":icu_provider-v1_2_0" ]
-  deps += [ ":tinystr-v0_7_1" ]
-  deps += [ ":zerovec-v0_9_4" ]
+  deps += [ ":tinystr-v0_7_2" ]
+  deps += [ ":zerovec-v0_9_5" ]
 
   rustenv = []
 
@@ -675,7 +675,7 @@ rust_library("icu_segmenter-v1_2_1") {
   deps += [ ":icu_locid-v1_2_0" ]
   deps += [ ":icu_provider-v1_2_0" ]
   deps += [ ":utf8_iter-v1_0_3" ]
-  deps += [ ":zerovec-v0_9_4" ]
+  deps += [ ":zerovec-v0_9_5" ]
 
   rustenv = []
 
@@ -701,9 +701,9 @@ rust_library("icu_timezone-v1_2_0") {
   deps += [ ":icu_calendar-v1_2_0" ]
   deps += [ ":icu_locid-v1_2_0" ]
   deps += [ ":icu_provider-v1_2_0" ]
-  deps += [ ":tinystr-v0_7_1" ]
+  deps += [ ":tinystr-v0_7_2" ]
   deps += [ ":zerotrie-v0_0_0" ]
-  deps += [ ":zerovec-v0_9_4" ]
+  deps += [ ":zerovec-v0_9_5" ]
 
   rustenv = []
 
@@ -756,10 +756,10 @@ rust_library("libm-v0_2_6") {
   visibility = [ ":*" ]
 }
 
-rust_library("litemap-v0_7_0") {
+rust_library("litemap-v0_7_1") {
   crate_name = "litemap"
   crate_root = "//utils/litemap/src/lib.rs"
-  output_name = "litemap-9af155724df6c491"
+  output_name = "litemap-f5257f2692ce04a0"
 
   deps = []
 
@@ -768,8 +768,8 @@ rust_library("litemap-v0_7_0") {
   rustflags = [
     "--cap-lints=allow",
     "--edition=2021",
-    "-Cmetadata=9af155724df6c491",
-    "-Cextra-filename=-9af155724df6c491",
+    "-Cmetadata=f5257f2692ce04a0",
+    "-Cextra-filename=-f5257f2692ce04a0",
     "--cfg=feature=\"alloc\"",
   ]
 
@@ -1071,22 +1071,22 @@ rust_library("synstructure-v0_13_0") {
   visibility = [ ":*" ]
 }
 
-rust_library("tinystr-v0_7_1") {
+rust_library("tinystr-v0_7_2") {
   crate_name = "tinystr"
   crate_root = "//utils/tinystr/src/lib.rs"
-  output_name = "tinystr-29f1288a310491e0"
+  output_name = "tinystr-29c48faa62bdaa63"
 
   deps = []
   deps += [ ":displaydoc-v0_2_4($host_toolchain)" ]
-  deps += [ ":zerovec-v0_9_4" ]
+  deps += [ ":zerovec-v0_9_5" ]
 
   rustenv = []
 
   rustflags = [
     "--cap-lints=allow",
     "--edition=2021",
-    "-Cmetadata=29f1288a310491e0",
-    "-Cextra-filename=-29f1288a310491e0",
+    "-Cmetadata=29c48faa62bdaa63",
+    "-Cextra-filename=-29c48faa62bdaa63",
     "--cfg=feature=\"alloc\"",
     "--cfg=feature=\"zerovec\"",
   ]
@@ -1210,10 +1210,10 @@ rust_library("write16-v1_0_0") {
   visibility = [ ":*" ]
 }
 
-rust_library("writeable-v0_5_2") {
+rust_library("writeable-v0_5_3") {
   crate_name = "writeable"
   crate_root = "//utils/writeable/src/lib.rs"
-  output_name = "writeable-5d4800cd816b8765"
+  output_name = "writeable-bf0a7243c39e985a"
 
   deps = []
 
@@ -1222,31 +1222,31 @@ rust_library("writeable-v0_5_2") {
   rustflags = [
     "--cap-lints=allow",
     "--edition=2021",
-    "-Cmetadata=5d4800cd816b8765",
-    "-Cextra-filename=-5d4800cd816b8765",
+    "-Cmetadata=bf0a7243c39e985a",
+    "-Cextra-filename=-bf0a7243c39e985a",
   ]
 
   visibility = [ ":*" ]
 }
 
-rust_library("yoke-v0_7_1") {
+rust_library("yoke-v0_7_2") {
   crate_name = "yoke"
   crate_root = "//utils/yoke/src/lib.rs"
-  output_name = "yoke-818e8d8f2b7ee24f"
+  output_name = "yoke-352c973dd2409e4d"
 
   deps = []
   deps += [ ":serde-v1_0_160" ]
   deps += [ ":stable_deref_trait-v1_2_0" ]
-  deps += [ ":yoke-derive-v0_7_1($host_toolchain)" ]
-  deps += [ ":zerofrom-v0_1_2" ]
+  deps += [ ":yoke-derive-v0_7_2($host_toolchain)" ]
+  deps += [ ":zerofrom-v0_1_3" ]
 
   rustenv = []
 
   rustflags = [
     "--cap-lints=allow",
     "--edition=2021",
-    "-Cmetadata=818e8d8f2b7ee24f",
-    "-Cextra-filename=-818e8d8f2b7ee24f",
+    "-Cmetadata=352c973dd2409e4d",
+    "-Cextra-filename=-352c973dd2409e4d",
     "--cfg=feature=\"alloc\"",
     "--cfg=feature=\"default\"",
     "--cfg=feature=\"derive\"",
@@ -1256,10 +1256,10 @@ rust_library("yoke-v0_7_1") {
   visibility = [ ":*" ]
 }
 
-rust_proc_macro("yoke-derive-v0_7_1") {
+rust_proc_macro("yoke-derive-v0_7_2") {
   crate_name = "yoke_derive"
   crate_root = "//utils/yoke/derive/src/lib.rs"
-  output_name = "yoke_derive-180241e4c4b5d7c6"
+  output_name = "yoke_derive-38bd1f732d6bd35d"
 
   deps = []
   deps += [ ":proc-macro2-v1_0_63" ]
@@ -1272,28 +1272,28 @@ rust_proc_macro("yoke-derive-v0_7_1") {
   rustflags = [
     "--cap-lints=allow",
     "--edition=2021",
-    "-Cmetadata=180241e4c4b5d7c6",
-    "-Cextra-filename=-180241e4c4b5d7c6",
+    "-Cmetadata=38bd1f732d6bd35d",
+    "-Cextra-filename=-38bd1f732d6bd35d",
   ]
 
   visibility = [ ":*" ]
 }
 
-rust_library("zerofrom-v0_1_2") {
+rust_library("zerofrom-v0_1_3") {
   crate_name = "zerofrom"
   crate_root = "//utils/zerofrom/src/lib.rs"
-  output_name = "zerofrom-ea522fe78acdecd7"
+  output_name = "zerofrom-8c68d65440a87b70"
 
   deps = []
-  deps += [ ":zerofrom-derive-v0_1_2($host_toolchain)" ]
+  deps += [ ":zerofrom-derive-v0_1_3($host_toolchain)" ]
 
   rustenv = []
 
   rustflags = [
     "--cap-lints=allow",
     "--edition=2021",
-    "-Cmetadata=ea522fe78acdecd7",
-    "-Cextra-filename=-ea522fe78acdecd7",
+    "-Cmetadata=8c68d65440a87b70",
+    "-Cextra-filename=-8c68d65440a87b70",
     "--cfg=feature=\"alloc\"",
     "--cfg=feature=\"derive\"",
   ]
@@ -1301,10 +1301,10 @@ rust_library("zerofrom-v0_1_2") {
   visibility = [ ":*" ]
 }
 
-rust_proc_macro("zerofrom-derive-v0_1_2") {
+rust_proc_macro("zerofrom-derive-v0_1_3") {
   crate_name = "zerofrom_derive"
   crate_root = "//utils/zerofrom/derive/src/lib.rs"
-  output_name = "zerofrom_derive-14d5187e3af872ae"
+  output_name = "zerofrom_derive-46c88e941d1a9497"
 
   deps = []
   deps += [ ":proc-macro2-v1_0_63" ]
@@ -1317,8 +1317,8 @@ rust_proc_macro("zerofrom-derive-v0_1_2") {
   rustflags = [
     "--cap-lints=allow",
     "--edition=2021",
-    "-Cmetadata=14d5187e3af872ae",
-    "-Cextra-filename=-14d5187e3af872ae",
+    "-Cmetadata=46c88e941d1a9497",
+    "-Cextra-filename=-46c88e941d1a9497",
   ]
 
   visibility = [ ":*" ]
@@ -1331,8 +1331,8 @@ rust_library("zerotrie-v0_0_0") {
 
   deps = []
   deps += [ ":displaydoc-v0_2_4($host_toolchain)" ]
-  deps += [ ":yoke-v0_7_1" ]
-  deps += [ ":zerofrom-v0_1_2" ]
+  deps += [ ":yoke-v0_7_2" ]
+  deps += [ ":zerofrom-v0_1_3" ]
 
   rustenv = []
 
@@ -1348,23 +1348,23 @@ rust_library("zerotrie-v0_0_0") {
   visibility = [ ":*" ]
 }
 
-rust_library("zerovec-v0_9_4") {
+rust_library("zerovec-v0_9_5") {
   crate_name = "zerovec"
   crate_root = "//utils/zerovec/src/lib.rs"
-  output_name = "zerovec-78f54fc60dcbccf9"
+  output_name = "zerovec-53f4595c77bcdee7"
 
   deps = []
-  deps += [ ":yoke-v0_7_1" ]
-  deps += [ ":zerofrom-v0_1_2" ]
-  deps += [ ":zerovec-derive-v0_9_4($host_toolchain)" ]
+  deps += [ ":yoke-v0_7_2" ]
+  deps += [ ":zerofrom-v0_1_3" ]
+  deps += [ ":zerovec-derive-v0_9_5($host_toolchain)" ]
 
   rustenv = []
 
   rustflags = [
     "--cap-lints=allow",
     "--edition=2021",
-    "-Cmetadata=78f54fc60dcbccf9",
-    "-Cextra-filename=-78f54fc60dcbccf9",
+    "-Cmetadata=53f4595c77bcdee7",
+    "-Cextra-filename=-53f4595c77bcdee7",
     "--cfg=feature=\"derive\"",
     "--cfg=feature=\"yoke\"",
   ]
@@ -1372,10 +1372,10 @@ rust_library("zerovec-v0_9_4") {
   visibility = [ ":*" ]
 }
 
-rust_proc_macro("zerovec-derive-v0_9_4") {
+rust_proc_macro("zerovec-derive-v0_9_5") {
   crate_name = "zerovec_derive"
   crate_root = "//utils/zerovec/derive/src/lib.rs"
-  output_name = "zerovec_derive-4c240664175f9014"
+  output_name = "zerovec_derive-e74eda60d8fc56f9"
 
   deps = []
   deps += [ ":proc-macro2-v1_0_63" ]
@@ -1387,8 +1387,8 @@ rust_proc_macro("zerovec-derive-v0_9_4") {
   rustflags = [
     "--cap-lints=allow",
     "--edition=2021",
-    "-Cmetadata=4c240664175f9014",
-    "-Cextra-filename=-4c240664175f9014",
+    "-Cmetadata=e74eda60d8fc56f9",
+    "-Cextra-filename=-e74eda60d8fc56f9",
   ]
 
   visibility = [ ":*" ]

--- a/utils/crlify/Cargo.toml
+++ b/utils/crlify/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "crlify"
-version = "1.0.2"
+version = "1.0.3"
 keywords = ["io", "crlf", "windows", "line", "ending"]
 description = "A std::io::Write wrapper that replaces \n with \r\n on Windows."
 documentation = "https://docs.rs/litemap"

--- a/utils/databake/Cargo.toml
+++ b/utils/databake/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "databake"
 description = "Trait that lets structs represent themselves as (const) Rust expressions"
-version = "0.1.5"
+version = "0.1.6"
 categories = ["rust-patterns", "memory-management", "development-tools::procedural-macro-helpers", "development-tools::build-utils"]
 keywords = ["zerocopy", "serialization", "const", "proc"]
 

--- a/utils/databake/derive/Cargo.toml
+++ b/utils/databake/derive/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "databake-derive"
 description = "Custom derive for the databake crate"
-version = "0.1.5"
+version = "0.1.6"
 categories = ["rust-patterns", "memory-management", "development-tools::procedural-macro-helpers", "development-tools::build-utils"]
 keywords = ["zerocopy", "serialization", "const", "proc"]
 

--- a/utils/deduplicating_array/Cargo.toml
+++ b/utils/deduplicating_array/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "deduplicating_array"
 description = "A serde serialization strategy that uses PartialEq to reduce serialized size."
-version = "0.1.4"
+version = "0.1.5"
 
 authors.workspace = true
 edition.workspace = true

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "fixed_decimal"
 description = "An API for representing numbers in a human-readable form"
-version = "0.5.3"
+version = "0.5.4"
 
 authors.workspace = true
 categories.workspace = true

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "litemap"
-version = "0.7.0"
+version = "0.7.1"
 keywords = ["sorted", "vec", "map", "hashmap", "btreemap"]
 description = "A key-value Map implementation based on a flat, sorted Vec."
 documentation = "https://docs.rs/litemap"

--- a/utils/pattern/Cargo.toml
+++ b/utils/pattern/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_pattern"
 description = "ICU pattern utilities"
-version = "0.1.4"
+version = "0.1.5"
 
 authors.workspace = true
 edition.workspace = true

--- a/utils/tinystr/Cargo.toml
+++ b/utils/tinystr/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "tinystr"
 description = "A small ASCII-only bounded length string representation."
-version = "0.7.1"
+version = "0.7.2"
 keywords = ["string", "str", "small", "tiny", "no_std"]
 categories = ["data-structures"]
 

--- a/utils/tzif/Cargo.toml
+++ b/utils/tzif/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "tzif"
 description = "A parser for TZif files"
-version = "0.2.1"
+version = "0.2.2"
 keywords = ["time-zone", "posix", "iana", "parse", "data"]
 categories = ["date-and-time", "parser-implementations"]
 

--- a/utils/writeable/Cargo.toml
+++ b/utils/writeable/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "writeable"
 description = "A more efficient alternative to fmt::Display"
-version = "0.5.2"
+version = "0.5.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "yoke"
 description = "Abstraction allowing borrowed data to be carried along with the backing data it borrows from"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 categories = ["data-structures", "memory-management", "caching", "no-std"]
 keywords = ["zerocopy", "serialization", "lifetime", "borrow", "self-referential"]

--- a/utils/yoke/derive/Cargo.toml
+++ b/utils/yoke/derive/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "yoke-derive"
 description = "Custom derive for the yoke crate"
-version = "0.7.1"
+version = "0.7.2"
 categories = ["data-structures", "memory-management", "caching", "no-std"]
 keywords = ["zerocopy", "serialization", "lifetime", "borrow", "self-referential"]
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]

--- a/utils/zerofrom/Cargo.toml
+++ b/utils/zerofrom/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "zerofrom"
 description = "ZeroFrom trait for constructing"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 categories = ["data-structures", "caching", "no-std"]
 keywords = ["zerocopy", "serialization", "lifetime", "borrow"]

--- a/utils/zerofrom/derive/Cargo.toml
+++ b/utils/zerofrom/derive/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "zerofrom-derive"
 description = "Custom derive for the zerofrom crate"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 categories = ["data-structures", "memory-management", "caching", "no-std"]
 keywords = ["zerocopy", "serialization", "lifetime", "borrow"]

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "zerovec"
 description = "Zero-copy vector backed by a byte array"
-version = "0.9.4"
+version = "0.9.5"
 categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
 keywords = ["zerocopy", "serialization", "zero-copy", "serde"]
 

--- a/utils/zerovec/derive/Cargo.toml
+++ b/utils/zerovec/derive/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "zerovec-derive"
 description = "Custom derive for the zerovec crate"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
 keywords = ["zerocopy", "serialization", "zero-copy", "serde"]


### PR DESCRIPTION
https://github.com/unicode-org/icu4x/issues/4066

Depends on https://github.com/unicode-org/icu4x/pull/4069

 - calendrical_calculations: New crate, 0.1.0
 - crlify: 1.0.2 -> 1.0.3
 - databake and databake_derive: 1.0.5 -> 1.0.6
 - deduplicating_array: 0.1.4 -> 0.1.5
 - fixed_decimal: 0.5.3 -> 0.5.4
 - litemap: 0.7.0 -> 0.7.1
 - icu_pattern: 0.1.4 -> 0.1.5
 - tinystr: 0.7.1 -> 0.7.2
 - writeable: 0.5.2 -> 0.5.3
 - yoke and yoke_derive: 0.7.1 -> 0.7.2
 - zerofrom and zerofrom_derive: 0.1.2 -> 0.1.3
 - zerovec and zerovec_derive: 0.9.4 -> 0.9.5