### PR TITLE
Exclude icu_personnames from release

### DIFF
--- a/experimental/personnames/Cargo.toml
+++ b/experimental/personnames/Cargo.toml
@@ -7,6 +7,7 @@ name = "icu_personnames"
 description = "API for formatting person names according to language-dependent conventions"
 version = "0.0.0"
 license-file = "LICENSE"
+publish = false # excluded from 1.3 release
 
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
https://github.com/unicode-org/icu4x/issues/4065

I did publish some crates from this commit (icu_capi, icu_capi_cdylib, icu_capi_staticlib, icu4x_ecma402, icu_freertos, tzif) so I'd like to fast-forward merge main.