### PR TITLE
[WIP] Using dynutil to implement baked data `AnyProvider`

### DIFF
--- a/provider/core/src/any.rs
+++ b/provider/core/src/any.rs
@@ -189,6 +189,7 @@ where
     ///     any_payload.downcast().expect("TypeId matches");
     /// assert_eq!("Custom Hello World", payload.get().message);
     /// ```
+    #[inline]
     pub fn wrap_into_any_payload(self) -> AnyPayload {
         AnyPayload {
             inner: match self.0 {
@@ -290,6 +291,7 @@ where
 {
     /// Moves the inner DataPayload to the heap (requiring an allocation) and returns it as an
     /// erased `AnyResponse`.
+    #[inline]
     pub fn wrap_into_any_response(self) -> AnyResponse {
         AnyResponse {
             metadata: self.metadata,

--- a/provider/core/src/dynutil.rs
+++ b/provider/core/src/dynutil.rs
@@ -223,7 +223,7 @@ macro_rules! impl_dynamic_data_provider {
         }
 
     };
-    ($provider:ty, [ $($(#[$cfg:meta])? $struct_m:ty),+, ], $dyn_m:path) => {
+    ($provider:ty, [ $($(#[$cfg:meta])? $struct_m:ty),+ $(,)? ], $dyn_m:path) => {
         impl $crate::DynamicDataProvider<$dyn_m> for $provider
         {
             fn load_data(
@@ -237,14 +237,14 @@ macro_rules! impl_dynamic_data_provider {
                 match key.hashed() {
                     $(
                         $(#[$cfg])?
-                        h if h == <$struct_m>::KEY.hashed() => {
-                            let result: $crate::DataResponse<$struct_m> =
-                                $crate::DataProvider::load(self, req)?;
-                            Ok($crate::DataResponse {
-                                metadata: result.metadata,
-                                payload: result.payload.map(|p| {
-                                    $crate::dynutil::UpcastDataPayload::<$struct_m>::upcast(p)
-                                }),
+                        h if h == <$struct_m as $crate::KeyedDataMarker>::KEY.hashed() => {
+                            $crate::DataProvider::load(self, req).map(|r| {
+                                $crate::DataResponse {
+                                    metadata: r.metadata,
+                                    payload: r.payload.map(|p| {
+                                        $crate::dynutil::UpcastDataPayload::<$struct_m>::upcast(p)
+                                    })
+                                }
                             })
                         }
                     )+,

--- a/provider/core/src/response.rs
+++ b/provider/core/src/response.rs
@@ -206,6 +206,7 @@ where
 
     /// Convert a DataPayload that was created via [`DataPayload::from_owned()`] back into the
     /// concrete type used to construct it.
+    #[inline]
     pub fn try_unwrap_owned(self) -> Result<M::Yokeable, DataError> {
         match self.0 {
             DataPayloadInner::Yoke(yoke) => yoke.try_into_yokeable().ok(),

--- a/provider/datagen/src/baked_exporter.rs
+++ b/provider/datagen/src/baked_exporter.rs
@@ -698,24 +698,12 @@ impl BakedExporter {
                     };
                 }
 
-                // Not public because `impl_data_provider` isn't. Users can implement `DynamicDataProvider<AnyMarker>`
-                // using `impl_dynamic_data_provider!`.
+                // Not public because `impl_data_provider` isn't.
                 #[allow(unused_macros)]
                 macro_rules! impl_any_provider {
                     ($provider:ty) => {
                         #maybe_msrv
-                        impl icu_provider::AnyProvider for $provider {
-                            fn load_any(&self, key: icu_provider::DataKey, req: icu_provider::DataRequest) -> Result<icu_provider::AnyResponse, icu_provider::DataError> {
-                                match key.hashed() {
-                                    #(
-                                        #features
-                                        h if h == <#markers as icu_provider::KeyedDataMarker>::KEY.hashed() =>
-                                            icu_provider::DataProvider::<#markers>::load(self, req).map(icu_provider::DataResponse::wrap_into_any_response),
-                                    )*
-                                    _ => Err(icu_provider::DataErrorKind::MissingDataKey.with_req(key, req)),
-                                }
-                            }
-                        }
+                        icu_provider::impl_dynamic_data_provider!($provider, [#(#features #markers),*], icu_provider::AnyMarker);
                     }
                 }
 

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -496,6 +496,7 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, Option<C>> {
     ///
     /// If the cart is `None`, this returns `Some`, but if the cart is `Some`,
     /// this returns `self` as an error.
+    #[inline]
     pub fn try_into_yokeable(self) -> Result<Y, Self> {
         match self.cart {
             Some(_) => Err(self),


### PR DESCRIPTION
Now that `DataPayload` has a `&'static` case we might not need `AnyProvider`/`AnyResponse`/`AnyPayload` anymore, and could just use `AnyMarker` with the standard types.

#3947