### PR TITLE
Fix testdata gen

### DIFF
--- a/tools/make/data.toml
+++ b/tools/make/data.toml
@@ -80,6 +80,7 @@ command = "cargo"
 args = [
     "run",
     "--bin=make-testdata-legacy",
+    "--manifest-path=tools/testdata-scripts/Cargo.toml", # avoid global feature resolution
 ]
 
 [tasks.testdata-legacy-test]

--- a/tools/testdata-scripts/Cargo.toml
+++ b/tools/testdata-scripts/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 crlify = { workspace = true }
 databake = { workspace = true }
-icu_datagen = { workspace = true, features = ["legacy_api", "networking", "icu_compactdecimal", "icu_relativetime", "icu_displaynames"] }
+icu_datagen = { workspace = true, features = ["legacy_api", "use_wasm", "networking", "icu_compactdecimal", "icu_relativetime", "icu_displaynames"] }
 icu_locid = { workspace = true, features = ["databake"] }
 icu_provider = { workspace = true }
 


### PR DESCRIPTION
#4049 pulled in new crates into legacy testdata due to global feature resolution. Noticed this because the data size benchmark failed.