### PR TITLE
Doc fix release

### DIFF
--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -6,6 +6,7 @@
 name = "icu_calendar"
 description = "API for supporting various types of calendars"
 license-file = "LICENSE"
+version = "1.3.1"
 
 authors.workspace = true
 categories.workspace = true
@@ -14,7 +15,6 @@ homepage.workspace = true
 include.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/components/casemap/Cargo.toml
+++ b/components/casemap/Cargo.toml
@@ -6,6 +6,7 @@
 name = "icu_casemap"
 description = "Unicode case mapping and folding algorithms"
 license-file = "LICENSE"
+version = "1.3.1"
 
 authors.workspace = true
 categories.workspace = true
@@ -14,7 +15,6 @@ homepage.workspace = true
 include.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -5,8 +5,8 @@
 [package]
 name = "icu_datetime"
 description = "API for formatting date and time to user readable textual representation"
-version = "1.3.0"
 license-file = "LICENSE"
+version = "1.3.1"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/locid_transform/Cargo.toml
+++ b/components/locid_transform/Cargo.toml
@@ -5,8 +5,8 @@
 [package]
 name = "icu_locid_transform"
 description = "API for Unicode Language and Locale Identifiers canonicalization"
-version = "1.3.0"
 license-file = "LICENSE"
+version = "1.3.1"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/segmenter/Cargo.toml
+++ b/components/segmenter/Cargo.toml
@@ -5,7 +5,6 @@
 [package]
 name = "icu_segmenter"
 description = "Unicode line breaking and text segmentation algorithms for text boundaries analysis"
-version = "1.3.0"
 license-file = "LICENSE"
 
 authors.workspace = true
@@ -15,7 +14,7 @@ homepage.workspace = true
 include.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-
+version.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 

--- a/ffi/diplomat/Cargo.toml
+++ b/ffi/diplomat/Cargo.toml
@@ -5,7 +5,6 @@
 [package]
 name = "icu_capi"
 description = "C interface to ICU4X"
-version = "1.3.0"
 license-file = "LICENSE"
 include = [
     "src/**/*",
@@ -24,6 +23,7 @@ edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ffi/diplomat/c/examples/fixeddecimal_tiny/icu_capi_staticlib_tiny/Cargo.lock
+++ b/ffi/diplomat/c/examples/fixeddecimal_tiny/icu_capi_staticlib_tiny/Cargo.lock
@@ -3,9 +3,27 @@
 version = 3
 
 [[package]]
+name = "calendrical_calculations"
+version = "0.1.0"
+dependencies = [
+ "core_maths",
+ "displaydoc",
+]
+
+[[package]]
+name = "core_maths"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b02505ccb8c50b0aa21ace0fc08c3e53adebd4e58caa18a36152803c7709a3"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "diplomat"
-version = "0.5.2"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=8d125999893fedfdf30595e97334c21ec4b18da9#8d125999893fedfdf30595e97334c21ec4b18da9"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92bd5669c330d5cafd10588707f6b75a1448f9758cb6fad19f83649fe1e2e9c"
 dependencies = [
  "diplomat_core",
  "proc-macro2",
@@ -15,13 +33,15 @@ dependencies = [
 
 [[package]]
 name = "diplomat-runtime"
-version = "0.5.2"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=8d125999893fedfdf30595e97334c21ec4b18da9#8d125999893fedfdf30595e97334c21ec4b18da9"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0c0116d8e7fea6b2554fdb90289782b1e4e5e35d259525e4882a48ce09cbe7a"
 
 [[package]]
 name = "diplomat_core"
-version = "0.5.2"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=8d125999893fedfdf30595e97334c21ec4b18da9#8d125999893fedfdf30595e97334c21ec4b18da9"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c5577c28e7ed9d8f984ab7286a734a154307d09c976a3d6cb08d6fcb2f2740"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -60,7 +80,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "fixed_decimal"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "displaydoc",
  "ryu",
@@ -70,14 +90,14 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar"
-version = "1.2.0"
+version = "1.3.1"
 dependencies = [
+ "calendrical_calculations",
  "displaydoc",
  "icu_calendar_data",
  "icu_locid",
  "icu_locid_transform",
  "icu_provider",
- "libm",
  "tinystr",
  "writeable",
  "zerovec",
@@ -89,7 +109,7 @@ version = "1.3.0"
 
 [[package]]
 name = "icu_capi"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
@@ -124,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "icu_casemap"
-version = "1.2.0"
+version = "1.3.1"
 dependencies = [
  "displaydoc",
  "icu_casemap_data",
@@ -133,7 +153,6 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "writeable",
- "yoke",
  "zerovec",
 ]
 
@@ -143,7 +162,7 @@ version = "1.3.0"
 
 [[package]]
 name = "icu_collator"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "displaydoc",
  "icu_collator_data",
@@ -165,7 +184,7 @@ version = "1.3.0"
 
 [[package]]
 name = "icu_collections"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -175,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "icu_datetime"
-version = "1.2.1"
+version = "1.3.1"
 dependencies = [
  "displaydoc",
  "either",
@@ -200,7 +219,7 @@ version = "1.3.0"
 
 [[package]]
 name = "icu_decimal"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "displaydoc",
  "fixed_decimal",
@@ -217,9 +236,8 @@ version = "1.3.0"
 
 [[package]]
 name = "icu_displaynames"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
- "icu_collections",
  "icu_displaynames_data",
  "icu_locid",
  "icu_locid_transform",
@@ -234,7 +252,7 @@ version = "1.3.0"
 
 [[package]]
 name = "icu_list"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "displaydoc",
  "icu_list_data",
@@ -250,7 +268,7 @@ version = "1.3.0"
 
 [[package]]
 name = "icu_locid"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -261,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform"
-version = "1.2.1"
+version = "1.3.1"
 dependencies = [
  "displaydoc",
  "icu_locid",
@@ -277,7 +295,7 @@ version = "1.3.0"
 
 [[package]]
 name = "icu_normalizer"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -297,7 +315,7 @@ version = "1.3.0"
 
 [[package]]
 name = "icu_plurals"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "displaydoc",
  "fixed_decimal",
@@ -314,7 +332,7 @@ version = "1.3.0"
 
 [[package]]
 name = "icu_properties"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -332,12 +350,13 @@ version = "1.3.0"
 
 [[package]]
 name = "icu_provider"
-version = "1.2.0"
+version = "1.3.1"
 dependencies = [
  "displaydoc",
  "icu_locid",
  "icu_provider_macros",
  "stable_deref_trait",
+ "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -346,19 +365,18 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_adapters"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "icu_locid",
  "icu_locid_transform",
  "icu_provider",
  "tinystr",
- "yoke",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_provider_macros"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -367,14 +385,14 @@ dependencies = [
 
 [[package]]
 name = "icu_segmenter"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
+ "core_maths",
  "displaydoc",
  "icu_collections",
  "icu_locid",
  "icu_provider",
  "icu_segmenter_data",
- "libm",
  "utf8_iter",
  "zerovec",
 ]
@@ -385,7 +403,7 @@ version = "1.3.0"
 
 [[package]]
 name = "icu_timezone"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "displaydoc",
  "icu_calendar",
@@ -393,6 +411,7 @@ dependencies = [
  "icu_provider",
  "icu_timezone_data",
  "tinystr",
+ "zerotrie",
  "zerovec",
 ]
 
@@ -420,7 +439,7 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "litemap"
-version = "0.7.0"
+version = "0.7.1"
 
 [[package]]
 name = "memchr"
@@ -534,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.1"
+version = "0.7.3"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -578,11 +597,11 @@ checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
-version = "0.5.2"
+version = "0.5.3"
 
 [[package]]
 name = "yoke"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -592,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -602,14 +621,14 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -618,8 +637,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerotrie"
+version = "0.1.0"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
 name = "zerovec"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -628,10 +656,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "synstructure",
 ]

--- a/ffi/freertos/Cargo.toml
+++ b/ffi/freertos/Cargo.toml
@@ -5,7 +5,6 @@
 [package]
 name = "icu_freertos"
 description = "C interface to ICU4X"
-version = "1.3.0"
 license-file = "LICENSE"
 include = [
     "build.rs",
@@ -25,6 +24,7 @@ edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -6,6 +6,7 @@
 name = "icu_provider"
 description = "Trait and struct definitions for the ICU data provider"
 license-file = "LICENSE"
+version = "1.3.1"
 
 authors.workspace = true
 categories.workspace = true
@@ -14,7 +15,6 @@ homepage.workspace = true
 include.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -5,7 +5,6 @@
 [package]
 name = "icu_datagen"
 description = "Generate data for ICU4X DataProvider"
-version = "1.3.0"
 license-file = "LICENSE"
 include = [
     "data/**/*",
@@ -27,6 +26,7 @@ edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -5,7 +5,6 @@
 [package]
 name = "icu_provider_fs"
 description = "ICU4X data provider that reads from structured data files"
-version = "1.3.0"
 license-file = "LICENSE"
 
 authors.workspace = true
@@ -15,6 +14,7 @@ homepage.workspace = true
 include.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
1.0.1 for some crates. Component crates that don't get patched here will need to request a docs.rs rerun to pick up the `icu_provider` patch.