### PR TITLE
Adding crate-level deprecation for `icu_testdata` and adding it to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ A subset of crates received a 1.3.1 patch release, to incorporate documentation 
     - Fix empty keys in `BlobDataProvider` (https://github.com/unicode-org/icu4x/pull/3551) 
   - `icu_provider_fs`:
     - Correct error types for `icu_provider_fs` (https://github.com/unicode-org/icu4x/pull/3682) 
+  - `icu_testdata`:
+    - This crate has been superseded by `compiled_data` and is now deprecated.
+    - Data for new components will not be added, and it will not be updated for ICU4X 2.0.
 - Components:
   - Cross component:
     - All component crates now have a default `compiled_data` feature that enables constructors that do not require data providers, instead using data compiled into the library

--- a/provider/testdata/Cargo.lock
+++ b/provider/testdata/Cargo.lock
@@ -227,7 +227,7 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "fixed_decimal"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "displaydoc",
  "smallvec",
@@ -263,7 +263,7 @@ checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "icu"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "icu_calendar",
  "icu_casemap",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "calendrical_calculations",
  "displaydoc",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "icu_casemap"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "icu_collator"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "icu_compactdecimal"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "displaydoc",
  "fixed_decimal",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "icu_datetime"
-version = "1.2.1"
+version = "1.3.2"
 dependencies = [
  "displaydoc",
  "either",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "icu_decimal"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "displaydoc",
  "fixed_decimal",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "icu_displaynames"
-version = "0.10.0"
+version = "0.11.1"
 dependencies = [
  "icu_locid",
  "icu_provider",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "icu_list"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "displaydoc",
  "icu_provider",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "icu_locid"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform"
-version = "1.2.1"
+version = "1.3.2"
 dependencies = [
  "displaydoc",
  "icu_locid",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "icu_plurals"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "displaydoc",
  "fixed_decimal",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "icu_properties"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "displaydoc",
  "icu_locid",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_adapters"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "icu_locid",
  "icu_locid_transform",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_blob"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "icu_provider",
  "postcard",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_macros"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "icu_relativetime"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "displaydoc",
  "fixed_decimal",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "icu_segmenter"
-version = "1.2.1"
+version = "1.3.2"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "icu_testdata"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "criterion",
  "icu",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "icu_timezone"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "displaydoc",
  "icu_calendar",
@@ -630,7 +630,7 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "litemap"
-version = "0.7.0"
+version = "0.7.1"
 
 [[package]]
 name = "log"
@@ -901,7 +901,7 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "tinystr"
-version = "0.7.1"
+version = "0.7.4"
 dependencies = [
  "displaydoc",
  "serde",
@@ -1055,11 +1055,11 @@ checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
-version = "0.5.2"
+version = "0.5.3"
 
 [[package]]
 name = "yoke"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1079,14 +1079,14 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.0.0"
+version = "0.1.1"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "serde",
  "yoke",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_testdata"
 description = "Pre-built test data for ICU4X"
-version = "1.3.2"
+version = "1.3.3"
 rust-version = "1.66.0"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"

--- a/provider/testdata/src/lib.rs
+++ b/provider/testdata/src/lib.rs
@@ -49,7 +49,7 @@
 //! ).unwrap();
 //! ```
 //!
-//! [`ICU4X`]: ../icu/index.html
+//! [`ICU4X`]: icu
 
 // https://github.com/unicode-org/icu4x/blob/main/docs/process/boilerplate.md#library-annotations
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
@@ -68,12 +68,14 @@
 #![warn(missing_docs)]
 #![allow(unused_imports)] // too many feature combinations too keep track of
 #![allow(deprecated)]
+#![deprecated(since = "1.3.0", note = "this crate has been superseded by `ICU4X`'s `compiled_data` feature. Data for new components will not be added, and it will not be updated for `ICU4X` 2.0.")]
 
 extern crate alloc;
 
 #[path = "../data/metadata.rs.data"]
 mod metadata;
 
+#[deprecated(since = "1.3.0")]
 pub mod versions {
     //! Functions to access version info of the ICU test data.
 
@@ -84,7 +86,7 @@ pub mod versions {
     /// ```
     /// assert_eq!("43.1.0", icu_testdata::versions::cldr_tag());
     /// ```
-    #[deprecated(since = "1.3.0", note = "use `compiled_data`")]
+    #[deprecated(since = "1.3.0")]
     pub fn cldr_tag() -> alloc::string::String {
         alloc::string::String::from(super::metadata::CLDR_TAG)
     }
@@ -96,7 +98,7 @@ pub mod versions {
     /// ```
     /// assert_eq!("icu4x/2023-05-02/73.x", icu_testdata::versions::icu_tag());
     /// ```
-    #[deprecated(since = "1.3.0", note = "use `compiled_data`")]
+    #[deprecated(since = "1.3.0")]
     pub fn icu_tag() -> alloc::string::String {
         alloc::string::String::from(super::metadata::ICUEXPORT_TAG)
     }
@@ -111,38 +113,38 @@ pub mod versions {
 /// assert!(icu_testdata::locales().contains(&langid!("es-AR")));
 /// assert!(icu_testdata::locales().len() > 10);
 /// ```
-#[deprecated(since = "1.3.0", note = "use `compiled_data`")]
+#[deprecated(since = "1.3.0")]
 pub fn locales() -> alloc::vec::Vec<icu_locid::LanguageIdentifier> {
     alloc::vec::Vec::from(metadata::LOCALES)
 }
 
 #[cfg(feature = "std")]
-#[deprecated]
+#[deprecated(since = "1.3.0")]
 /// Get paths to the test data directories. Some of these paths do not
 /// exist anymore, and data should only be accessed through the functions
 /// provided by this crate.
 pub mod paths {
     use std::path::PathBuf;
 
-    #[deprecated(since = "1.3.0", note = "use `compiled_data`")]
+    #[deprecated(since = "1.3.0")]
     /// Returns the absolute path to the top-level data directory.
     pub fn data_root() -> PathBuf {
         PathBuf::from(std::env!("CARGO_MANIFEST_DIR")).join("data")
     }
 
-    #[deprecated(since = "1.3.0", note = "use `compiled_data`")]
+    #[deprecated(since = "1.3.0")]
     /// Returns the absolute path to the CLDR JSON root directory.
     pub fn cldr_json_root() -> PathBuf {
         data_root().join("cldr")
     }
 
-    #[deprecated(since = "1.3.0", note = "use `compiled_data`")]
+    #[deprecated(since = "1.3.0")]
     /// Returns the absolute path to the icuexport TOML root directory.
     pub fn icuexport_toml_root() -> PathBuf {
         data_root().join("icuexport")
     }
 
-    #[deprecated(since = "1.3.0", note = "use `compiled_data`")]
+    #[deprecated(since = "1.3.0")]
     /// Returns the absolute path to the collation tailoring TOML root directory.
     pub fn coll_toml_root() -> PathBuf {
         data_root().join("coll")


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->