### PR TITLE
Tweaks to MSRV policy

### DIFF
--- a/docs/process/rust_versions.md
+++ b/docs/process/rust_versions.md
@@ -3,7 +3,7 @@
 
 ## For ICU4X users
 
-Each ICU4X release guarantee a minimum supported rust version (MSRV) of four Rust versions before the release, and attempt an MSRV of six Rust versions. For example, if today's current Rust stable version is 1.70, and we release ICU4X x.y.0, then we guarantee that ICU4X x.y.z will have an MSRV of 1.66 or earlier. We will *attempt* an MSRV of 1.64.
+Each ICU4X release and its patches guarantee a minimum supported rust version (MSRV) of four Rust versions before the release, and attempt an MSRV of six Rust versions. For example, if today's current Rust stable version is 1.70, and we release ICU4X x.y.0, then we guarantee that ICU4X x.y.z will have an MSRV of 1.66 or earlier. We will *attempt* an MSRV of 1.64.
 
 The MSRV shall be included in the `rust-version` Cargo toml key, resulting in an error if used with an insufficiently updated toolchain.
 

--- a/docs/process/rust_versions.md
+++ b/docs/process/rust_versions.md
@@ -18,7 +18,7 @@ The main ICU4X library does not use nightly; however nightly is required for bui
 
 Currently ICU4X pins a stable Rust version [in the `rust-toolchain` file](https://github.com/unicode-org/icu4x/blob/main/rust-toolchain), and additionally uses specific nightlies for [WASM tests](https://github.com/unicode-org/icu4x/blob/1f4a9505f21a6d5c9bb4833e0cf3fe969f734c54/Makefile.toml#L158) and [coverage](https://github.com/unicode-org/icu4x/blob/1f4a9505f21a6d5c9bb4833e0cf3fe969f734c54/.github/workflows/build-test.yml#L332). Furthermore, we enforce the current MSRV as a separate CI job.
 
-One may update the MSRV to a Rust version that is 6 or more versions before the current stable (or the stable version that shall exist at the time of the next ICU4X release if it is planned) without needing additional approval by stating which features in that release are useful for ICU4X develoment. One may not update the MSRV to a Rust version that is not at least 4 versions before current stable.
+One may update the MSRV to a Rust version that is 6 or more versions before the current stable (or the stable version that shall exist at the time of the next ICU4X release if it is planned) without needing additional approval by stating which features in that release are useful for ICU4X development. One may not update the MSRV to a Rust version that is not at least 4 versions before current stable.
 
 For updating the MSRV to a Rust version that is between 4 and 6 versions the ICU4X developer must make a per-case argument as to why this update is beneficial to the project. Some example arguments may include that it serves a client need, or fixes a soundness issue.
 

--- a/docs/process/rust_versions.md
+++ b/docs/process/rust_versions.md
@@ -3,7 +3,7 @@
 
 ## For ICU4X users
 
-Each ICU4X release and its patches guarantee a minimum supported rust version (MSRV) of four Rust versions before the release, and attempt an MSRV of six Rust versions. For example, if today's current Rust stable version is 1.70, and we release ICU4X 1.3, then we guarantee that ICU4X 1.3 will have an MSRV of 1.66 or earlier. We will *attempt* an MSRV of 1.64.
+Each ICU4X release guarantee a minimum supported rust version (MSRV) of four Rust versions before the release, and attempt an MSRV of six Rust versions. For example, if today's current Rust stable version is 1.70, and we release ICU4X x.y.0, then we guarantee that ICU4X x.y.z will have an MSRV of 1.66 or earlier. We will *attempt* an MSRV of 1.64.
 
 The MSRV shall be included in the `rust-version` Cargo toml key, resulting in an error if used with an insufficiently updated toolchain.
 
@@ -18,7 +18,7 @@ The main ICU4X library does not use nightly; however nightly is required for bui
 
 Currently ICU4X pins a stable Rust version [in the `rust-toolchain` file](https://github.com/unicode-org/icu4x/blob/main/rust-toolchain), and additionally uses specific nightlies for [WASM tests](https://github.com/unicode-org/icu4x/blob/1f4a9505f21a6d5c9bb4833e0cf3fe969f734c54/Makefile.toml#L158) and [coverage](https://github.com/unicode-org/icu4x/blob/1f4a9505f21a6d5c9bb4833e0cf3fe969f734c54/.github/workflows/build-test.yml#L332). Furthermore, we enforce the current MSRV as a separate CI job.
 
-One may update the MSRV to a Rust version that is 6 or more versions before the current stable (or the stable version that shall exist at the time of the next ICU4X release if it is planned) without needing any discussion. One may not update the MSRV to a Rust version that is not at least 4 versions before current stable.
+One may update the MSRV to a Rust version that is 6 or more versions before the current stable (or the stable version that shall exist at the time of the next ICU4X release if it is planned) without needing additional approval by stating which features in that release are useful for ICU4X develoment. One may not update the MSRV to a Rust version that is not at least 4 versions before current stable.
 
 For updating the MSRV to a Rust version that is between 4 and 6 versions the ICU4X developer must make a per-case argument as to why this update is beneficial to the project. Some example arguments may include that it serves a client need, or fixes a soundness issue.
 


### PR DESCRIPTION
I don't think we should change MSRV within a patch release. Patch updates should always be as low-impact as possible. I don't know if we explicitly discussed this.

I also added a clause that updating MSRV should explicitly state what we want to use from that MSRV.