### PR TITLE
Split FFI CI job

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -385,10 +385,6 @@ jobs:
       with:
         key: download-cache
         path: /tmp/icu4x-source-cache
-    - name: Warm up datagen
-      # We do this so its compilation doesn't go on the time bugdet of the 
-      # first test that uses it.
-      run: cargo build -p icu_datagen
 
     # Actual job
     - name: Run `cargo make ci-job-test-c`
@@ -454,10 +450,6 @@ jobs:
       with:
         key: download-cache
         path: /tmp/icu4x-source-cache
-    - name: Warm up datagen
-      # We do this so its compilation doesn't go on the time bugdet of the 
-      # first test that uses it.
-      run: cargo build -p icu_datagen
 
     # Actual job
     - name: Run `cargo make ci-job-test-js`

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
 
   # ci-job-check & ci-job-features
-  # Running at MSRV (1.67)
+  # Running at MSRV
   msrv:
     runs-on: ubuntu-latest
     # Defined as a matrix so that features can start immediately, but
@@ -132,6 +132,41 @@ jobs:
     - name: Run `cargo make ci-job-test-windows`
       if: matrix.os == 'windows-latest'
       run: cargo make ci-job-test-windows
+
+  # ci-job-test-docs
+  test-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    # Cargo-make boilerplate
+    - name: Get cargo-make version
+      id: cargo-make-version
+      run: |
+        echo "hash=$(cargo search cargo-make | grep '^cargo-make =' | md5sum)" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Attempt to load cached cargo-make
+      uses: actions/cache@v3
+      id: cargo-make-cache
+      with:
+        path: |
+          ~/.cargo/bin/cargo-make
+          ~/.cargo/bin/cargo-make.exe
+        key: ${{ runner.os }}-make-${{ steps.cargo-make-version.outputs.hash }}
+    - name: Install cargo-make
+      if: steps.cargo-make-cache.outputs.cache-hit != 'true'
+      run: cargo +stable install cargo-make
+
+
+    # Toolchain boilerplate
+    - name: Potentially override rust version with nightly
+      run: cargo make set-nightly-version-for-ci
+    - name: Show the selected Rust toolchain
+      run: rustup show
+
+    # Actual job
+    - name: Run `cargo make ci-job-test-docs`
+      run: cargo make ci-job-test-docs
 
   # ci-job-test-tutorials
   test-tutorials:
@@ -251,41 +286,6 @@ jobs:
       run: cargo make testdata-legacy-test
 
 
-  # ci-job-test-docs
-  test-docs:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-
-    # Cargo-make boilerplate
-    - name: Get cargo-make version
-      id: cargo-make-version
-      run: |
-        echo "hash=$(cargo search cargo-make | grep '^cargo-make =' | md5sum)" >> $GITHUB_OUTPUT
-      shell: bash
-    - name: Attempt to load cached cargo-make
-      uses: actions/cache@v3
-      id: cargo-make-cache
-      with:
-        path: |
-          ~/.cargo/bin/cargo-make
-          ~/.cargo/bin/cargo-make.exe
-        key: ${{ runner.os }}-make-${{ steps.cargo-make-version.outputs.hash }}
-    - name: Install cargo-make
-      if: steps.cargo-make-cache.outputs.cache-hit != 'true'
-      run: cargo +stable install cargo-make
-
-
-    # Toolchain boilerplate
-    - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
-    - name: Show the selected Rust toolchain
-      run: rustup show
-
-    # Actual job
-    - name: Run `cargo make ci-job-test-docs`
-      run: cargo make ci-job-test-docs
-
   # ci-job-full-datagen
   full-datagen:
     runs-on: ubuntu-latest
@@ -330,8 +330,8 @@ jobs:
     - name: Run `cargo make ci-job-full-datagen`
       run: cargo make ci-job-full-datagen
 
-  # ci-job-ffi
-  ffi:
+  # ci-job-test-c
+  test-c:
     runs-on: ubuntu-latest
     container:
       image: rust:bookworm
@@ -340,21 +340,6 @@ jobs:
     - uses: actions/checkout@v3
     
     # Software setup/installation for the container
-    - name: Run apt-get update
-      run: |
-        apt-get update
-    - name: Install Clang-15
-      run: |
-        apt-get install -y clang-15 lld-15 llvm-15-dev libc++-15-dev
-    - name: Install GCC 11
-      run: |
-        apt-get install -y gcc-11 g++-11
-    - name: Install Node.js v16.18.0
-      uses: actions/setup-node@v3
-      with:
-        node-version: 16.18.0
-        cache: 'npm'
-        cache-dependency-path: '**/package-lock.json'
     - name: Install Rust toolchains
       run: |
         rustup toolchain install stable
@@ -386,6 +371,15 @@ jobs:
       run: rustup show
 
     # Job-specific dependencies
+    - name: Run apt-get update
+      run: |
+        apt-get update
+    - name: Install Clang-15
+      run: |
+        apt-get install -y clang-15 lld-15 llvm-15-dev libc++-15-dev
+    - name: Install GCC 11
+      run: |
+        apt-get install -y gcc-11 g++-11
     - name: Attempt to load download cache
       uses: actions/cache@v3
       with:
@@ -397,13 +391,115 @@ jobs:
       run: cargo build -p icu_datagen
 
     # Actual job
-    - name: Run `cargo make ci-job-ffi`
-      run: cargo make ci-job-ffi
+    - name: Run `cargo make ci-job-test-c`
+      run: cargo make ci-job-test-c
       env:
         CXX: "g++-11"
 
-  # ci-job-verify-ffi
-  verify-ffi:
+  # ci-job-test-js
+  test-js:
+    runs-on: ubuntu-latest
+    container:
+      image: rust:bookworm
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    # Software setup/installation for the container
+    - name: Install Rust toolchains
+      run: |
+        rustup toolchain install stable
+
+    # Cargo-make boilerplate
+    - name: Get cargo-make version
+      id: cargo-make-version
+      run: |
+        echo "hash=$(cargo search cargo-make | grep '^cargo-make =' | md5sum)" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Attempt to load cached cargo-make
+      uses: actions/cache@v3
+      id: cargo-make-cache
+      with:
+        path: |
+          ~/.cargo/bin/cargo-make
+          ~/.cargo/bin/cargo-make.exe
+        # Since this is inside a container, use a different key than the other jobs
+        key: ${{ runner.os }}-make-ffi-${{ steps.cargo-make-version.outputs.hash }}
+    - name: Install cargo-make
+      if: steps.cargo-make-cache.outputs.cache-hit != 'true'
+      run: cargo +stable install cargo-make
+
+
+    # Toolchain boilerplate
+    - name: Potentially override rust version with nightly
+      run: cargo make set-nightly-version-for-ci
+    - name: Show the selected Rust toolchain
+      run: rustup show
+
+    # Job-specific dependencies
+    - name: Install Node.js v16.18.0
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.18.0
+        cache: 'npm'
+        cache-dependency-path: '**/package-lock.json'
+    - name: Run apt-get update
+      run: |
+        apt-get update
+    - name: Install lld-15
+      run: |
+        apt-get install -y lld-15
+    - name: Attempt to load download cache
+      uses: actions/cache@v3
+      with:
+        key: download-cache
+        path: /tmp/icu4x-source-cache
+    - name: Warm up datagen
+      # We do this so its compilation doesn't go on the time bugdet of the 
+      # first test that uses it.
+      run: cargo build -p icu_datagen
+
+    # Actual job
+    - name: Run `cargo make ci-job-test-js`
+      run: cargo make ci-job-test-js
+ 
+  # ci-job-nostd
+  nostd:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    # Cargo-make boilerplate
+    - name: Get cargo-make version
+      id: cargo-make-version
+      run: |
+        echo "hash=$(cargo search cargo-make | grep '^cargo-make =' | md5sum)" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Attempt to load cached cargo-make
+      uses: actions/cache@v3
+      id: cargo-make-cache
+      with:
+        path: |
+          ~/.cargo/bin/cargo-make
+          ~/.cargo/bin/cargo-make.exe
+        key: ${{ runner.os }}-make-${{ steps.cargo-make-version.outputs.hash }}
+    - name: Install cargo-make
+      if: steps.cargo-make-cache.outputs.cache-hit != 'true'
+      run: cargo +stable install cargo-make
+
+
+    # Toolchain boilerplate
+    - name: Potentially override rust version with nightly
+      run: cargo make set-nightly-version-for-ci
+    - name: Show the selected Rust toolchain
+      run: rustup show
+
+    # Actual job
+    - name: Run `cargo make ci-job-nostd`
+      run: cargo make ci-job-nostd
+
+  # ci-job-diplomat
+  diplomat:
     runs-on: [ ubuntu-latest ]
     steps:
     - uses: actions/checkout@v3
@@ -460,10 +556,10 @@ jobs:
       run: cargo +stable install --git https://github.com/rust-diplomat/diplomat.git --version ${{ steps.diplomat-version.outputs.rev }} diplomat-tool
 
     # Actual job
-    - name: Run `cargo make ci-job-verify-ffi`
-      run: cargo make ci-job-verify-ffi
+    - name: Run `cargo make ci-job-diplomat`
+      run: cargo make ci-job-diplomat
 
-  # ci-job-verify-gn, ci-job-gn
+  # ci-job-gn
   gn:
     runs-on: ubuntu-latest
 
@@ -528,62 +624,8 @@ jobs:
         version: latest
 
     # Actual job
-    - name: Run `cargo make ci-job-verify-gn`
-      run: cargo make ci-job-verify-gn
     - name: Run `cargo make ci-job-gn`
       run: cargo make ci-job-gn
-
-  # ci-job-wasm
-  wasm:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-
-    # Cargo-make boilerplate
-    - name: Get cargo-make version
-      id: cargo-make-version
-      run: |
-        echo "hash=$(cargo search cargo-make | grep '^cargo-make =' | md5sum)" >> $GITHUB_OUTPUT
-      shell: bash
-    - name: Attempt to load cached cargo-make
-      uses: actions/cache@v3
-      id: cargo-make-cache
-      with:
-        path: |
-          ~/.cargo/bin/cargo-make
-          ~/.cargo/bin/cargo-make.exe
-        key: ${{ runner.os }}-make-${{ steps.cargo-make-version.outputs.hash }}
-    - name: Install cargo-make
-      if: steps.cargo-make-cache.outputs.cache-hit != 'true'
-      run: cargo +stable install cargo-make
-
-
-    # Toolchain boilerplate
-    - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
-    - name: Show the selected Rust toolchain
-      run: rustup show
-
-    # Job-specific dependencies
-    - name: Install emsdk
-      run: |
-        cd ~
-        git clone https://github.com/emscripten-core/emsdk.git --branch 2.0.27
-        cd emsdk
-        ./emsdk install latest
-        ./emsdk activate latest
-    - name: Install Node.js v16.18.0
-      uses: actions/setup-node@v3
-      with:
-        node-version: 16.18.0
-        cache: 'npm'
-        cache-dependency-path: '**/package-lock.json'
-    # Actual job
-    - name: Run emscripten/wasm test
-      run: |
-        . ~/emsdk/emsdk_env.sh
-        cargo make ci-job-wasm
 
   # ci-job-fmt
   fmt:
@@ -760,8 +802,7 @@ jobs:
 
   # Notify on slack  
   notify-slack:
-    # Skipped tasks: bench-perf, bench-memory, bench-binsize, bench-datasize
-    needs: [msrv, test, testdata, test-docs, full-datagen, ffi, verify-ffi, gn, wasm, fmt, tidy, clippy, doc]
+    needs: [msrv, test, testdata, test-docs, full-datagen, test-c, test-js, nostd, diplomat, gn, fmt, tidy, clippy, doc]
     if: ${{ always() && contains(needs.*.result, 'failure') && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_name == 'main')) }}
     runs-on: ubuntu-latest
     steps:

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -116,32 +116,46 @@ dependencies = [
     "bakeddata-check",
 ]
 
-[tasks.ci-job-ffi]
-description = "Run all tests for the CI 'ffi' job"
+[tasks.ci-job-test-c]
+description = "Run all tests for the CI 'test-c' job"
 category = "CI"
 dependencies = [
-    "test-ffi",
+    "test-c",
+    "test-c-tiny",
+    "test-cpp",
 ]
 
-[tasks.ci-job-verify-ffi]
-description = "Run all tests for the CI 'verify-ffi' job"
+[tasks.ci-job-test-js]
+description = "Run all tests for the CI 'test-js' job"
 category = "CI"
 dependencies = [
-    "verify-ffi",
+    "test-js",
+    "test-tinywasm",
+]
+
+[tasks.ci-job-nostd]
+description = "Run all tests for the CI 'test-nostd' job"
+category = "CI"
+dependencies = [
+    "check-nostd",
+    "check-freertos-wearos",
+]
+
+
+[tasks.ci-job-diplomat]
+description = "Run all tests for the CI 'diplomat' job"
+category = "CI"
+dependencies = [
+    "verify-diplomat-gen",
+    "verify-diplomat-coverage",
 ]
 
 [tasks.ci-job-gn]
 description = "Run all tests for the CI 'gn' job"
 category = "CI"
 dependencies = [
-    "gn-run",
-]
-
-[tasks.ci-job-verify-gn]
-description = "Run all tests for the CI 'verify-gn' job"
-category = "CI"
-dependencies = [
     "verify-gn-gen",
+    "gn-run",
 ]
 
 [tasks.ci-job-msrv-features-1]
@@ -188,16 +202,6 @@ dependencies = [
     "depcheck",
 ]
 
-[tasks.ci-job-wasm]
-description = "Run all tests for the CI 'wasm' job"
-category = "CI"
-dependencies = [
-    "test-cpp-emscripten",
-    "test-tinywasm",
-    "build-wearos-ffi",
-    "test-nostd",
-]
-
 [tasks.ci-job-clippy]
 description = "Run all tests for the CI 'clippy' job"
 category = "CI"
@@ -227,15 +231,16 @@ dependencies = [
 
     # Get a coffee
     "ci-job-test",
+    "ci-job-nostd",
     "ci-job-test-docs",
     "ci-job-testdata",
     "ci-job-msrv-features",
     "ci-job-full-datagen",
 
     # Needs tools other than Cargo to be installed
-    "ci-job-ffi",
-    "ci-job-wasm",
-    "ci-job-verify-ffi",
+    "ci-job-diplomat",
+    "ci-job-test-c",
+    "ci-job-test-js",
     "ci-job-gn",
 
     # benchmarking and coverage jobs not included

--- a/tools/make/ffi.toml
+++ b/tools/make/ffi.toml
@@ -4,64 +4,113 @@
 
 # This is a cargo-make file included in the toplevel Makefile.toml
 
-[tasks.test-ffi]
-description = "Run FFI tests"
-category = "ICU4X Development"
-dependencies = [
-    "cargo-make-min-version",
-    "test-c",
-    "test-c-tiny",
-    "test-cpp",
-    "test-js",
-]
+# C/C++ tasks
 
-[tasks.verify-ffi]
-description = "Run FFI tests that verify checked in code is up to date"
+[tasks.test-c]
+description = "Run C API tests"
 category = "ICU4X Development"
-dependencies = [
-    "cargo-make-min-version",
-    "verify-diplomat-gen",
-    "verify-diplomat-coverage",
-]
+script_runner = "@duckscript"
+script = '''
+exit_on_error true
+exec --fail-on-error make -C ffi/capi/c/examples/pluralrules
+exec --fail-on-error make -C ffi/capi/c/examples/fixeddecimal
+exec --fail-on-error make -C ffi/capi/c/examples/locale
+'''
 
-# Some tasks need a minimum version of cargo-make. Configs within cargo-make
-# task stanzas such as this allow setting the minimum version of deps (including
-# min version for cargo-make itself). But cargo-make might only be applying
-# such dep upgrades defined in the `install_crate` field after the task script
-# has run.
-[tasks.cargo-make-min-version]
-description = "Verify that the minimum version of cargo-make exists"
+[tasks.test-c-tiny]
+description = "Run C API tests for tiny targets"
 category = "ICU4X Development"
-install_crate = { crate_name = "cargo-make", binary = "cargo", test_arg = ["make", "--version"], min_version = "0.36.2" }
-
-[tasks.diplomat-coverage]
-description = "Produces the list of ICU APIs that are not exported through Diplomat"
-category = "ICU4X Development"
-dependencies = ["install-nightly"]
+dependencies = ["install-nightly", "install-unknown-linux"]
 script_runner = "@duckscript"
 script = '''
 exit_on_error true
 if "${ICU4X_BUILDING_WITH_FORCED_NIGHTLY}"
-    echo "Skipping diplomat-coverage since ICU4X_BUILDING_WITH_FORCED_NIGHTLY is set"
+    echo "Skipping test-c-tiny since ICU4X_BUILDING_WITH_FORCED_NIGHTLY is set"
 else
-    exec --fail-on-error cargo run -p icu_ffi_coverage --all-features -- ffi/capi/tests/missing_apis.txt
+    exec --fail-on-error make -C ffi/capi/c/examples/fixeddecimal_tiny
+    exec ls -l ffi/capi/c/examples/fixeddecimal_tiny
+
+    exec --fail-on-error make -C ffi/capi/c/examples/segmenter_tiny
+    exec ls -l ffi/capi/c/examples/segmenter_tiny
 end
 '''
 
-[tasks.verify-diplomat-coverage]
-description = "Verify that checked-in Diplomat coverage is up to date"
+[tasks.test-cpp]
+description = "Run CPP tests"
 category = "ICU4X Development"
-dependencies = [
-    "diplomat-coverage",
-]
 script_runner = "@duckscript"
 script = '''
 exit_on_error true
-code = exec --get-exit-code git diff --exit-code -- ffi/capi/tests
-if ${code}
-    trigger_error "Diplomat coverage dump need to be regenerated. Please run `cargo make diplomat-coverage` and commit."
+exec --fail-on-error make -C ffi/capi/cpp/examples/properties
+exec --fail-on-error make -C ffi/capi/cpp/examples/segmenter 
+exec --fail-on-error make -C ffi/capi/cpp/examples/datetime 
+exec --fail-on-error make -C ffi/capi/cpp/examples/fixeddecimal 
+exec --fail-on-error make -C ffi/capi/cpp/examples/locale 
+exec --fail-on-error make -C ffi/capi/cpp/examples/pluralrules 
+exec --fail-on-error make -C ffi/capi/cpp/examples/bidi 
+exec --fail-on-error make -C ffi/capi/cpp/examples/fixeddecimal_wasm test-host
+'''
+
+
+# JS/WASM tasks
+
+[tasks.test-js]
+description = "Run JS tests"
+category = "ICU4X Development"
+dependencies = ["install-nightly", "install-wasm"]
+script_runner = "@duckscript"
+script = '''
+cd ffi/capi/js/examples/node
+exec --fail-on-error make
+# --foreground-scripts makes npm forward the output of make
+exec --fail-on-error npm ci --foreground-scripts
+exec --fail-on-error npm test
+'''
+
+[tasks.test-tinywasm]
+description = "Test the Tiny WASM example"
+category = "ICU4X Development"
+dependencies = ["install-nightly", "install-wasm"]
+script_runner = "@duckscript"
+script = '''
+exit_on_error true
+if "${ICU4X_BUILDING_WITH_FORCED_NIGHTLY}"
+    echo "Skipping test-wasm since ICU4X_BUILDING_WITH_FORCED_NIGHTLY is set"
+else
+    echo "Skipping test-wasm since it's slow https://github.com/unicode-org/icu4x/issues/3582"
+    # cd ffi/capi/js/examples/tinywasm
+
+    # exec --fail-on-error make
+    # exec --fail-on-error ls -l
+    # exec --fail-on-error node tiny.mjs
 end
 '''
+
+# no_std tasks
+
+[tasks.check-freertos-wearos]
+description = "Build ICU4X CAPI for Cortex"
+category = "ICU4X FFI"
+dependencies = ["install-nightly", "install-cortex-8"]
+toolchain = "${ICU4X_NIGHTLY_TOOLCHAIN}"
+env = { RUSTFLAGS = "-Ctarget-cpu=cortex-m33 -Cpanic=abort -Copt-level=s" }
+command = "cargo"
+args = ["check", "--package", "icu_freertos",
+        "--target", "thumbv8m.main-none-eabihf",
+        "--no-default-features", "--features=wearos",
+        "-Zbuild-std=core,alloc", "-Zbuild-std-features=panic_immediate_abort"]
+
+
+# Diplomat gen
+
+[tasks.diplomat-gen]
+description = "Regenerate Diplomat bindings"
+category = "ICU4X Development"
+dependencies = [
+    "diplomat-gen-c",
+    "diplomat-gen-cpp",
+    "diplomat-gen-js",
+]
 
 [tasks.verify-diplomat-gen]
 description = "Verify that checked-in Diplomat bindings are up to date"
@@ -78,133 +127,6 @@ if ${code}
 end
 '''
 
-[tasks.diplomat-gen]
-description = "Regenerate Diplomat bindings"
-category = "ICU4X Development"
-dependencies = [
-    "diplomat-gen-c",
-    "diplomat-gen-cpp",
-    "diplomat-gen-js",
-]
-
-[tasks.test-c]
-description = "Run C API tests"
-category = "ICU4X Development"
-script_runner = "@duckscript"
-script = '''
-exit_on_error true
-cd ffi/capi/c/examples/pluralrules
-exec --fail-on-error make
-cd ../fixeddecimal
-exec --fail-on-error make
-cd ../locale
-exec --fail-on-error make
-'''
-
-[tasks.install-unknown-linux]
-description = "Installs the unknown-linux target"
-category = "ICU4X Development"
-dependencies = ["install-nightly"]
-script_runner = "@duckscript"
-script = '''
-exec --fail-on-error rustup target add x86_64-unknown-linux-gnu --toolchain ${ICU4X_NIGHTLY_TOOLCHAIN}
-'''
-
-[tasks.test-c-tiny]
-description = "Run C API tests for tiny targets"
-category = "ICU4X Development"
-dependencies = ["install-nightly", "install-unknown-linux"]
-script_runner = "@duckscript"
-script = '''
-exit_on_error true
-if "${ICU4X_BUILDING_WITH_FORCED_NIGHTLY}"
-    echo "Skipping test-c-tiny since ICU4X_BUILDING_WITH_FORCED_NIGHTLY is set"
-else
-    cd ffi/capi/c/examples/fixeddecimal_tiny
-    exec --fail-on-error make
-    exec ls -l
-    cd ../segmenter_tiny
-    exec --fail-on-error make
-    exec ls -l
-end
-'''
-
-[tasks.test-cpp]
-description = "Run CPP tests"
-category = "ICU4X Development"
-script_runner = "@duckscript"
-script = '''
-exit_on_error true
-cd ffi/capi/cpp/examples/properties
-exec --fail-on-error make
-cd ../segmenter
-exec --fail-on-error make
-cd ../datetime
-exec --fail-on-error make
-cd ../fixeddecimal
-exec --fail-on-error make
-cd ../locale
-exec --fail-on-error make
-cd ../pluralrules
-exec --fail-on-error make
-cd ../bidi
-exec --fail-on-error make
-cd ../fixeddecimal_wasm
-exec --fail-on-error make test-host
-'''
-
-[tasks.install-emscripten]
-description = "Installs the emscripten target"
-category = "ICU4X Development"
-dependencies = ["install-nightly"]
-script_runner = "@duckscript"
-script = '''
-exec --fail-on-error rustup target add wasm32-unknown-emscripten --toolchain ${ICU4X_NIGHTLY_TOOLCHAIN}
-'''
-
-[tasks.install-wasm]
-description = "Installs the wasm target"
-category = "ICU4X Development"
-dependencies = ["install-nightly"]
-script_runner = "@duckscript"
-script = '''
-exec --fail-on-error rustup target add wasm32-unknown-unknown --toolchain ${ICU4X_NIGHTLY_TOOLCHAIN}
-'''
-
-[tasks.test-cpp-emscripten]
-description = "Run the C++-emscripten test (needs emsdk)"
-category = "ICU4X Development"
-dependencies = ["install-nightly", "install-emscripten"]
-script_runner = "@duckscript"
-script = '''
-exit_on_error true
-cd ffi/capi/cpp/examples/fixeddecimal_wasm
-exec make test
-'''
-
-[tasks.test-js]
-description = "Run JS tests"
-category = "ICU4X Development"
-dependencies = ["install-nightly", "install-wasm"]
-script_runner = "@duckscript"
-script = '''
-cd ffi/capi/js/examples/node
-exec --fail-on-error make
-# --foreground-scripts makes npm forward the output of make
-exec --fail-on-error npm ci --foreground-scripts
-exec --fail-on-error npm test
-'''
-
-[tasks.test-cppdoc]
-description = "Build the cpp tests"
-category = "ICU4X Development"
-script_runner = "@duckscript"
-script = '''
-exit_on_error true
-cd ffi/capi/cpp/docs;
-exec --fail-on-error make html
-'''
-
 [tasks.diplomat-gen-c]
 description = "Generate C headers for the FFI with Diplomat"
 category = "ICU4X Development"
@@ -212,6 +134,7 @@ script_runner = "@duckscript"
 script = '''
 exit_on_error true
 cd ffi/capi
+
 # Duckscript doesn't support globs in rm, so we delete the dir
 rm -r ./c/include/
 mkdir ./c/include
@@ -225,7 +148,6 @@ script_runner = "@duckscript"
 script = '''
 exit_on_error true
 cd ffi/capi
-
 
 # Duckscript doesn't support globs in rm, so we delete the dir.
 # Preserve conf.py across the deletion.
@@ -258,63 +180,66 @@ echo "$conf_py" > ./js/docs/source/conf.py
 diplomat-tool js ./js/include/ --docs ./js/docs/source
 '''
 
-[tasks.install-cortex-8]
-description = "Install the thumbv8m target"
-category = "ICU4X FFI"
-dependencies = ["install-nightly"]
-toolchain = "${ICU4X_NIGHTLY_TOOLCHAIN}"
-command = "rustup"
-args = [
-    "target", "add", "thumbv8m.main-none-eabihf",
-]
+# Diplomat coverage
 
-[tasks.build-wearos-ffi]
-description = "Build ICU4X CAPI for Cortex"
-category = "ICU4X FFI"
-dependencies = ["install-nightly", "install-cortex-8"]
-toolchain = "${ICU4X_NIGHTLY_TOOLCHAIN}"
-env = { RUSTFLAGS = "-Ctarget-cpu=cortex-m33 -Cpanic=abort" }
-command = "cargo"
-args = ["build", "--package", "icu_freertos",
-        "--target", "thumbv8m.main-none-eabihf",
-        "--no-default-features", "--features=wearos",
-        "--profile=release-opt-size",
-        "-Zbuild-std", "-Zbuild-std=std,panic_abort", "-Zbuild-std-features=panic_immediate_abort"]
-
-[tasks.install-cortex-7]
-description = "Install the thumbv7m target"
-category = "ICU4X FFI"
-dependencies = ["install-nightly"]
-toolchain = "${ICU4X_NIGHTLY_TOOLCHAIN}"
-command = "rustup"
-args = [
-    "target", "add", "thumbv7m-none-eabi",
-]
-
-[tasks.test-nostd]
-description = "Ensure ICU4X core builds on no-std"
-category = "ICU4X FFI"
-dependencies = ["install-nightly", "install-cortex-7"]
-toolchain = "${ICU4X_NIGHTLY_TOOLCHAIN}"
-command = "cargo"
-args = ["build", "--package", "icu", "--target", "thumbv7m-none-eabi"]
-
-[tasks.test-tinywasm]
-description = "Test the Tiny WASM example"
+[tasks.diplomat-coverage]
+description = "Produces the list of ICU APIs that are not exported through Diplomat"
 category = "ICU4X Development"
-dependencies = ["install-nightly", "install-wasm"]
+dependencies = ["install-nightly"]
 script_runner = "@duckscript"
 script = '''
 exit_on_error true
 if "${ICU4X_BUILDING_WITH_FORCED_NIGHTLY}"
-    echo "Skipping test-wasm since ICU4X_BUILDING_WITH_FORCED_NIGHTLY is set"
+    echo "Skipping diplomat-coverage since ICU4X_BUILDING_WITH_FORCED_NIGHTLY is set"
 else
-    echo "Skipping test-wasm since it's slow https://github.com/unicode-org/icu4x/issues/3582"
-    # cd ffi/capi/js/examples/tinywasm
+    exec --fail-on-error cargo run -p icu_ffi_coverage --all-features -- ffi/capi/tests/missing_apis.txt
+end
+'''
 
-    # exec --fail-on-error make
-    # exec --fail-on-error ls -l
-    # exec --fail-on-error node tiny.mjs
+[tasks.verify-diplomat-coverage]
+description = "Verify that checked-in Diplomat coverage is up to date"
+category = "ICU4X Development"
+dependencies = [
+    "diplomat-coverage",
+]
+script_runner = "@duckscript"
+script = '''
+exit_on_error true
+code = exec --get-exit-code git diff --exit-code -- ffi/capi/tests
+if ${code}
+    trigger_error "Diplomat coverage dump need to be regenerated. Please run `cargo make diplomat-coverage` and commit."
+end
+'''
+
+
+# Install tasks
+
+# These tasks need a minimum version of cargo-make. Configs within cargo-make
+# task stanzas such as this allow setting the minimum version of deps (including
+# min version for cargo-make itself). But cargo-make might only be applying
+# such dep upgrades defined in the `install_crate` field after the task script
+# has run.
+[tasks.cargo-make-min-version]
+description = "Verify that the minimum version of cargo-make exists"
+category = "ICU4X Development"
+install_crate = { crate_name = "cargo-make", binary = "cargo", test_arg = ["make", "--version"], min_version = "0.36.2" }
+
+[tasks.diplomat-install]
+description = "Install Diplomat at current Diplomat revision"
+category = "ICU4X Development"
+dependencies = [ "cargo-make-min-version" ]
+script_runner = "@duckscript"
+script = '''
+exit_on_error true
+rev = exec --fail-on-error cargo make --loglevel error diplomat-get-rev
+rev = trim ${rev.stdout}
+if contains ${rev} "."
+    echo "Installing Diplomat version ${rev}"
+    exec --fail-on-error cargo install --version ${rev} diplomat-tool -f
+
+else
+    echo "Installing Diplomat rev ${rev}"
+    exec --fail-on-error cargo install --git https://github.com/rust-diplomat/diplomat.git --rev ${rev} diplomat-tool -f
 end
 '''
 
@@ -358,21 +283,51 @@ end
 release --recursive ${metadata}
 '''
 
-[tasks.diplomat-install]
-description = "Install Diplomat at current Diplomat revision"
+[tasks.install-unknown-linux]
+description = "Installs the unknown-linux target"
 category = "ICU4X Development"
-dependencies = [ "cargo-make-min-version" ]
+dependencies = ["install-nightly"]
+script_runner = "@duckscript"
+script = '''
+exec --fail-on-error rustup target add x86_64-unknown-linux-gnu --toolchain ${ICU4X_NIGHTLY_TOOLCHAIN}
+'''
+
+[tasks.install-emscripten]
+description = "Installs the emscripten target"
+category = "ICU4X Development"
+dependencies = ["install-nightly"]
+script_runner = "@duckscript"
+script = '''
+exec --fail-on-error rustup target add wasm32-unknown-emscripten --toolchain ${ICU4X_NIGHTLY_TOOLCHAIN}
+'''
+
+[tasks.install-wasm]
+description = "Installs the wasm target"
+category = "ICU4X Development"
+dependencies = ["install-nightly"]
+script_runner = "@duckscript"
+script = '''
+exec --fail-on-error rustup target add wasm32-unknown-unknown --toolchain ${ICU4X_NIGHTLY_TOOLCHAIN}
+'''
+
+[tasks.install-cortex-8]
+description = "Install the thumbv8m target"
+category = "ICU4X FFI"
+dependencies = ["install-nightly"]
+toolchain = "${ICU4X_NIGHTLY_TOOLCHAIN}"
+command = "rustup"
+args = [
+    "target", "add", "thumbv8m.main-none-eabihf",
+]
+
+# Unused tasks
+
+[tasks.test-cpp-emscripten]
+description = "Run the C++-emscripten test (needs emsdk)"
+category = "ICU4X Development"
+dependencies = ["install-nightly", "install-emscripten"]
 script_runner = "@duckscript"
 script = '''
 exit_on_error true
-rev = exec --fail-on-error cargo make --loglevel error diplomat-get-rev
-rev = trim ${rev.stdout}
-if contains ${rev} "."
-    echo "Installing Diplomat version ${rev}"
-    exec --fail-on-error cargo install --version ${rev} diplomat-tool -f
-
-else
-    echo "Installing Diplomat rev ${rev}"
-    exec --fail-on-error cargo install --git https://github.com/rust-diplomat/diplomat.git --rev ${rev} diplomat-tool -f
-end
+exec make -C ffi/capi/cpp/examples/fixeddecimal_wasm test
 '''

--- a/tools/make/tests.toml
+++ b/tools/make/tests.toml
@@ -138,3 +138,18 @@ exec --fail-on-error make -C crates/custom_compiled
 set_env ICU4X_DATA_DIR ${project_dir}/docs/tutorials/crates/custom_compiled/baked_data
 exec --fail-on-error cargo run --release -p tutorial_custom_compiled
 '''
+
+[tasks.install-cortex-7]
+description = "Install the thumbv7m target"
+category = "ICU4X Development"
+command = "rustup"
+args = [
+    "target", "add", "thumbv7m-none-eabi",
+]
+
+[tasks.check-nostd]
+description = "Ensure ICU4X builds on no-std"
+category = "ICU4X Development"
+dependencies = ["install-cortex-7"]
+command = "cargo"
+args = ["check", "--package", "icu", "--target", "thumbv7m-none-eabi"]


### PR DESCRIPTION
The CI job is running a lot of things and is timing out. I've split this into:
* `test-c`: runs all the C/CPP tests, needs clang and gcc
* `test-js`: runs all JS tests, needs node and lld
* `nostd`: checks that `icu` builds on no-std targets, and that `icu_freertos/wearos` builds. Only needs Cargo
* renamed `verify-ffi` -> `diplomat`, as it checks that Diplomat-generated files are up to date, similar to how the `gn` job checks GN files
* Removed the `wasm` job. To my knowledge this has never exposed an issue, and it's just repeating the C++ tests in emscripten, so it's effectively testing emscripten.

(I've only noticed #4141 after I did this, but I think this is a better solution)