### PR TITLE
Fix parser for cldr-json exemplar chars for `\"` (escaped double quote)

### DIFF
--- a/provider/datagen/src/transform/cldr/characters/mod.rs
+++ b/provider/datagen/src/transform/cldr/characters/mod.rs
@@ -200,7 +200,7 @@ fn unescape_exemplar_chars(char_block: &str) -> String {
     for _i in 1..=3 {
         ch_for_toml = ch_for_toml.replace("\\\"", "\"");
     }
-    ch_for_toml = ch_for_toml.replace("\"", "\\\"");
+    ch_for_toml = ch_for_toml.replace('\"', "\\\"");
 
     // Unescape the escape sequences like \uXXXX and \UXXXXXXXX into the proper code points.
     // Also, workaround errant extra backslash escaping.


### PR DESCRIPTION
This PR cherry-picks https://github.com/unicode-org/icu4x/pull/4133/commits/8a092658300002dc41b98367147e4367116c324d from PR https://github.com/unicode-org/icu4x/pull/4133 in order to fix the exemplar characters parser in the `provider/datagen` component, as needed for the v44.0.0-BETA version of cldr-json data.