### PR TITLE
Yoke: Mute Clippy warning in derive generated code

### DIFF
--- a/utils/yoke/derive/src/lib.rs
+++ b/utils/yoke/derive/src/lib.rs
@@ -198,7 +198,7 @@ fn yokeable_derive_impl(input: &DeriveInput) -> TokenStream2 {
                         // are the same
                         debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
                         let ptr: *const Self = (&this as *const Self::Output).cast();
-                        #[allow(clippy::forget_copy)] // This is a noop if the struct is copy, which Clippy doesn't like
+                        #[allow(forgetting_copy_types, clippy::forget_non_drop)] // This is a noop if the struct is copy, which Clippy doesn't like
                         mem::forget(this);
                         ptr::read(ptr)
                     }
@@ -237,7 +237,7 @@ fn yokeable_derive_impl(input: &DeriveInput) -> TokenStream2 {
                     // are the same
                     debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
                     let ptr: *const Self = (&this as *const Self::Output).cast();
-                    #[allow(clippy::forget_copy)] // This is a noop if the struct is copy, which Clippy doesn't like
+                    #[allow(forgetting_copy_types, clippy::forget_non_drop)] // This is a noop if the struct is copy, which Clippy doesn't like
                     mem::forget(this);
                     ptr::read(ptr)
                 }


### PR DESCRIPTION
Fixes #2774 (again). See [this comment](https://github.com/unicode-org/icu4x/issues/2774#issuecomment-1762119824) for a minimal reproducible example.