### PR TITLE
Datagen: Add workaround for variants table in CLDR 44

### DIFF
--- a/provider/datagen/src/transform/cldr/cldr_serde/displaynames/variant.rs
+++ b/provider/datagen/src/transform/cldr/cldr_serde/displaynames/variant.rs
@@ -11,8 +11,18 @@ use serde::Deserialize;
 use std::collections::HashMap;
 
 #[derive(PartialEq, Debug, Deserialize)]
+#[serde(untagged)]
+pub enum StringOrEmptyMap {
+    String(String),
+    // CLDR-JSON 44 contains some empty maps in place of strings in the
+    // variants table. This might be a bug. Track progress:
+    // <https://unicode-org.atlassian.net/browse/CLDR-17171>
+    Empty {},
+}
+
+#[derive(PartialEq, Debug, Deserialize)]
 pub struct Variants {
-    pub variants: HashMap<String, String>,
+    pub variants: HashMap<String, StringOrEmptyMap>,
 }
 
 #[derive(PartialEq, Debug, Deserialize)]

--- a/provider/datagen/src/transform/cldr/displaynames/variant.rs
+++ b/provider/datagen/src/transform/cldr/displaynames/variant.rs
@@ -63,9 +63,11 @@ impl TryFrom<&cldr_serde::displaynames::variant::Resource> for VariantDisplayNam
     fn try_from(other: &cldr_serde::displaynames::variant::Resource) -> Result<Self, Self::Error> {
         let mut names = BTreeMap::new();
         for entry in other.main.value.localedisplaynames.variants.iter() {
-            // TODO: Support alt variants for variant display names.
-            if !entry.0.contains(ALT_SUBSTRING) {
-                names.insert(Variant::from_str(entry.0)?.into_tinystr(), entry.1.as_str());
+            if let cldr_serde::displaynames::variant::StringOrEmptyMap::String(variant) = entry.1 {
+                // TODO: Support alt variants for variant display names.
+                if !entry.0.contains(ALT_SUBSTRING) {
+                    names.insert(Variant::from_str(entry.0)?.into_tinystr(), variant.as_str());
+                }
             }
         }
         Ok(Self {


### PR DESCRIPTION
Part of #4155

CLDR 44 BETA contains data such as

```json
{
  "main": {
    "vec": {
      "identity": {
        "version": {
          "_cldrVersion": "44"
        },
        "language": "vec"
      },
      "localeDisplayNames": {
        "variants": {
          "1901": {},
          "1994": {},
          "1996": "ortografìa todesca de’l 1996",
          "1606NICT": "franseze mezo tardivo fin el 1606",
```

This may be a bug, but in the mean time I created some code to work around it. See:

https://unicode-org.atlassian.net/browse/CLDR-17171