### PR TITLE
Datagen: Change time zone untagged enum resolution to work with CLDR 44

### DIFF
--- a/provider/datagen/src/transform/cldr/cldr_serde/time_zones/time_zone_names.rs
+++ b/provider/datagen/src/transform/cldr/cldr_serde/time_zones/time_zone_names.rs
@@ -26,42 +26,29 @@ pub struct Metazone {
 pub struct Metazones(pub HashMap<String, Metazone>);
 
 #[derive(PartialEq, Debug, Clone, Deserialize)]
-pub struct LocationWithExemplarCity {
+// Since this value can be either a Location or a table of sub-regions, we use
+// the presence of fields to distinguish the object types. If CLDR-JSON adds
+// more fields to Location in the future, they must also be added here.
+//
+// Example errors that may be caused by this:
+//
+// - Cannot find bcp47 for "America/Argentina".
+// - Cannot find bcp47 for "Etc/UTC/short".
+#[serde(deny_unknown_fields)]
+pub struct Location {
     pub long: Option<ZoneFormat>,
     pub short: Option<ZoneFormat>,
     #[serde(rename = "exemplarCity")]
-    pub exemplar_city: String,
-}
-
-#[derive(PartialEq, Debug, Clone, Deserialize)]
-pub struct LocationWithShort {
-    pub long: Option<ZoneFormat>,
-    pub short: ZoneFormat,
-    #[serde(rename = "exemplarCity")]
     pub exemplar_city: Option<String>,
-}
-
-#[derive(PartialEq, Debug, Clone, Deserialize)]
-pub struct LocationWithLong {
-    pub long: ZoneFormat,
-    pub short: Option<ZoneFormat>,
-    #[serde(rename = "exemplarCity")]
-    pub exemplar_city: Option<String>,
-}
-
-#[derive(PartialEq, Debug, Clone, Deserialize)]
-#[serde(untagged)]
-pub enum Location {
-    City(LocationWithExemplarCity),
-    Long(LocationWithLong),
-    Short(LocationWithShort),
+    #[serde(rename = "exemplarCity-alt-secondary")]
+    pub exemplar_city_alt_secondary: Option<String>,
 }
 
 #[derive(PartialEq, Debug, Clone, Deserialize)]
 #[serde(untagged)]
 pub enum LocationOrSubRegion {
     Location(Location),
-    SubRegion(HashMap<String, Location>),
+    SubRegion(BTreeMap<String, Location>),
 }
 
 #[derive(PartialEq, Debug, Clone, Default, Deserialize)]

--- a/provider/datagen/src/transform/cldr/time_zones/convert.rs
+++ b/provider/datagen/src/transform/cldr/time_zones/convert.rs
@@ -94,27 +94,15 @@ impl From<CldrTimeZonesData<'_>> for TimeZoneFormatsV1<'static> {
 
 impl Location {
     fn exemplar_city(&self) -> Option<String> {
-        match self {
-            Self::City(place) => Some(place.exemplar_city.clone()),
-            Self::Long(place) => place.exemplar_city.clone(),
-            Self::Short(place) => place.exemplar_city.clone(),
-        }
+        self.exemplar_city.clone()
     }
 
     fn long_metazone_names(&self) -> Option<ZoneFormat> {
-        match self {
-            Self::City(place) => place.long.clone(),
-            Self::Long(place) => Some(place.long.clone()),
-            Self::Short(place) => place.long.clone(),
-        }
+        self.long.clone()
     }
 
     fn short_metazone_names(&self) -> Option<ZoneFormat> {
-        match self {
-            Self::City(place) => place.short.clone(),
-            Self::Long(place) => place.short.clone(),
-            Self::Short(place) => Some(place.short.clone()),
-        }
+        self.short.clone()
     }
 }
 


### PR DESCRIPTION
Part of #4155

CLDR 44 now includes data such as the following:

```json
{
  "main": {
    "fi": {
      "dates": {
        "timeZoneNames": {
          "zone": {
            "America": {
              "Thule": {
                "exemplarCity-alt-secondary": "Qaanaaq"
              }
            },
```

We need to detect that this is a name table and not a sub-region table. Previously we used the presence of either `exemplarCity`, `short`, or `long` to make this determination. I am changing the code to also check for `exemplarCity-alt-secondary`. I'm also reversing the polarity of the check to make the code cleaner.