### PR TITLE
Set the DateTimeFormat size test to #[ignore]

### DIFF
--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -200,6 +200,8 @@ mod tests {
     }
 
     #[test]
+    // TODO(#3413): Delete this test when no longer needed.
+    #[ignore] // Changes too much across nightlies.
     fn check_sizes() {
         check_size_of!(4616, DateFormatter);
         check_size_of!(5488, DateTimeFormatter);


### PR DESCRIPTION
I added this test and I would like to set it to `#[ignore]`. It causes too many problems and is mostly a diagnostic tool, not an actual test.

Currently the problem is a test failure in Coverage CI:

```
failures:

---- tests::check_sizes stdout ----
thread 'tests::check_sizes' panicked at 'DateFormatter is of size 5824', components/datetime/src/lib.rs:204:9


failures:
    tests::check_sizes

test result: FAILED. 46 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
```