### PR TITLE
Add field-getters for MultiVarULE fields

### DIFF
--- a/utils/zerovec/derive/examples/make_var.rs
+++ b/utils/zerovec/derive/examples/make_var.rs
@@ -5,7 +5,7 @@
 use std::borrow::Cow;
 
 use zerofrom::ZeroFrom;
-use zerovec::*;
+use zerovec::{ule::AsULE, *};
 
 #[make_varule(VarStructULE)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
@@ -166,6 +166,15 @@ fn main() {
     assert_zerovec::<VarTupleStructULE, VarTupleStruct, _>(vartuples, |stack, zero| {
         assert_eq!(stack, &VarTupleStruct::zero_from(zero))
     });
+
+    // Test that all fields are accessible on a type using multifieldule
+    let multi_ule = ule::encode_varule_to_box(&TEST_MULTIFIELD[0]);
+    assert_eq!(multi_ule.a, TEST_MULTIFIELD[0].a.to_unaligned());
+    assert_eq!(multi_ule.b, TEST_MULTIFIELD[0].b.to_unaligned());
+    assert_eq!(multi_ule.c(), TEST_MULTIFIELD[0].c);
+    assert_eq!(multi_ule.d, TEST_MULTIFIELD[0].d);
+    assert_eq!(multi_ule.e(), TEST_MULTIFIELD[0].e);
+    assert_eq!(multi_ule.f, TEST_MULTIFIELD[0].f.to_unaligned());
 }
 
 const TEST_VARSTRUCTS: &[VarStruct<'static>] = &[

--- a/utils/zerovec/derive/src/make_varule.rs
+++ b/utils/zerovec/derive/src/make_varule.rs
@@ -254,10 +254,22 @@ pub fn make_varule_impl(ule_name: Ident, mut input: DeriveInput) -> TokenStream2
         quote!()
     };
 
+    let maybe_multi_getters = if let Some(getters) = unsized_field_info.maybe_multi_getters() {
+        quote! {
+            impl #ule_name {
+                #getters
+            }
+        }
+    } else {
+        quote!()
+    };
+
     quote!(
         #input
 
         #varule_struct
+
+        #maybe_multi_getters
 
         #encode_impl
 
@@ -541,16 +553,41 @@ impl<'a> UnsizedFields<'a> {
             let last_field_ule_ty = self.fields[0].kind.varule_ty();
             field_inits.push(quote!(#setter <#last_field_ty as #zerofrom_trait <#lt, #last_field_ule_ty>>::zero_from(&other.#accessor) ));
         } else {
-            let multi_accessor = self.varule_accessor();
-            for (i, field) in self.fields.iter().enumerate() {
+            for field in self.fields.iter() {
                 let setter = field.field.setter();
+                let getter = field.field.getter();
                 let field_ty = &field.field.field.ty;
                 let field_ule_ty = field.kind.varule_ty();
 
-                field_inits.push(quote!(#setter unsafe {
-                    <#field_ty as #zerofrom_trait <#lt, #field_ule_ty>>::zero_from(&other.#multi_accessor.get_field::<#field_ule_ty>(#i))
-                }));
+                field_inits.push(quote!(#setter
+                    <#field_ty as #zerofrom_trait <#lt, #field_ule_ty>>::zero_from(&other.#getter())
+                ));
             }
+        }
+    }
+
+    fn maybe_multi_getters(&self) -> Option<TokenStream2> {
+        if self.fields.len() == 1 {
+            None
+        } else {
+            let multi_accessor = self.varule_accessor();
+            let field_getters = self.fields.iter().enumerate().map(|(i, field)| {
+                let getter = field.field.getter();
+
+                let field_ule_ty = field.kind.varule_ty();
+                let doc_name = field.field.getter_doc_name();
+                let doc = format!("Access the VarULE type behind {doc_name}");
+                quote!(
+                    #[doc = #doc]
+                    pub fn #getter<'a>(&'a self) -> &'a #field_ule_ty {
+                        unsafe {
+                            self.#multi_accessor.get_field::<#field_ule_ty>(#i)
+                        }
+                    }
+                )
+            });
+
+            Some(quote!(#(#field_getters)*))
         }
     }
 

--- a/utils/zerovec/derive/src/utils.rs
+++ b/utils/zerovec/derive/src/utils.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use quote::quote;
+use quote::{quote, ToTokens};
 
 use proc_macro2::Span;
 use proc_macro2::TokenStream as TokenStream2;
@@ -146,6 +146,24 @@ impl<'a> FieldInfo<'a> {
             quote!(#i: )
         } else {
             quote!()
+        }
+    }
+
+    /// Produce a name for a getter for the field
+    pub fn getter(&self) -> TokenStream2 {
+        if let Some(ref i) = self.field.ident {
+            quote!(#i)
+        } else {
+            suffixed_ident("field", self.index, self.field.span()).into_token_stream()
+        }
+    }
+
+    /// Produce a prose name for the field for use in docs
+    pub fn getter_doc_name(&self) -> String {
+        if let Some(ref i) = self.field.ident {
+            format!("the unsized `{i}` field")
+        } else {
+            format!("tuple struct field #{}", self.index)
         }
     }
 }


### PR DESCRIPTION
I was surprised we didn't have this already; @younies needed something like this.

This for VarULE types that have multiple unsized fields (which end up in a private MultiFieldsULE type), this adds `.fieldname()` getters for those fields producing the appropriate VarULE values. You can then call ZeroFrom on them to get the non-VarULE versions if needed.

(It may also be worth *always* adding a `.decode()` method to every VarULE type that just proxies ZeroFrom, for ease-of-discovery reasons)

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->