### PR TITLE
Fix collator `supported_locales`

### DIFF
--- a/provider/datagen/src/transform/icuexport/collator/mod.rs
+++ b/provider/datagen/src/transform/icuexport/collator/mod.rs
@@ -139,11 +139,7 @@ macro_rules! collation_provider {
 
             impl IterableDataProvider<$marker> for crate::DatagenProvider {
                 fn supported_locales(&self) -> Result<Vec<DataLocale>, DataError> {
-                    if <$marker>::KEY.metadata().singleton {
-                        return Ok(vec![Default::default()])
-                    }
                     Ok(self
-
                         .icuexport()?
                         .list(&format!(
                             "collation/{}",


### PR DESCRIPTION
This is the only `supported_locales` method that inspects the singleton key. It should not do that and instead just return the locales that are supported in the source.

#4168