### PR TITLE
Add support to parse UAX#29 properties in unicodeset_parse

### DIFF
--- a/experimental/transliterate/src/compile/mod.rs
+++ b/experimental/transliterate/src/compile/mod.rs
@@ -170,6 +170,8 @@ impl RuleCollection {
             + DataProvider<ExtendedPictographicV1Marker>
             + DataProvider<ExtenderV1Marker>
             + DataProvider<GraphemeBaseV1Marker>
+            + DataProvider<GraphemeClusterBreakV1Marker>
+            + DataProvider<GraphemeClusterBreakNameToValueV1Marker>
             + DataProvider<GraphemeExtendV1Marker>
             + DataProvider<HexDigitV1Marker>
             + DataProvider<IdsBinaryOperatorV1Marker>
@@ -187,6 +189,8 @@ impl RuleCollection {
             + DataProvider<QuotationMarkV1Marker>
             + DataProvider<RadicalV1Marker>
             + DataProvider<RegionalIndicatorV1Marker>
+            + DataProvider<SentenceBreakV1Marker>
+            + DataProvider<SentenceBreakNameToValueV1Marker>
             + DataProvider<SentenceTerminalV1Marker>
             + DataProvider<SoftDottedV1Marker>
             + DataProvider<TerminalPunctuationV1Marker>
@@ -194,6 +198,8 @@ impl RuleCollection {
             + DataProvider<UppercaseV1Marker>
             + DataProvider<VariationSelectorV1Marker>
             + DataProvider<WhiteSpaceV1Marker>
+            + DataProvider<WordBreakV1Marker>
+            + DataProvider<WordBreakNameToValueV1Marker>
             + DataProvider<XidContinueV1Marker>
             + DataProvider<GeneralCategoryMaskNameToValueV1Marker>
             + DataProvider<GeneralCategoryV1Marker>
@@ -267,6 +273,8 @@ where
         + DataProvider<ExtendedPictographicV1Marker>
         + DataProvider<ExtenderV1Marker>
         + DataProvider<GraphemeBaseV1Marker>
+        + DataProvider<GraphemeClusterBreakV1Marker>
+        + DataProvider<GraphemeClusterBreakNameToValueV1Marker>
         + DataProvider<GraphemeExtendV1Marker>
         + DataProvider<HexDigitV1Marker>
         + DataProvider<IdsBinaryOperatorV1Marker>
@@ -284,6 +292,8 @@ where
         + DataProvider<QuotationMarkV1Marker>
         + DataProvider<RadicalV1Marker>
         + DataProvider<RegionalIndicatorV1Marker>
+        + DataProvider<SentenceBreakV1Marker>
+        + DataProvider<SentenceBreakNameToValueV1Marker>
         + DataProvider<SentenceTerminalV1Marker>
         + DataProvider<SoftDottedV1Marker>
         + DataProvider<TerminalPunctuationV1Marker>
@@ -291,6 +301,8 @@ where
         + DataProvider<UppercaseV1Marker>
         + DataProvider<VariationSelectorV1Marker>
         + DataProvider<WhiteSpaceV1Marker>
+        + DataProvider<WordBreakV1Marker>
+        + DataProvider<WordBreakNameToValueV1Marker>
         + DataProvider<XidContinueV1Marker>
         + DataProvider<GeneralCategoryMaskNameToValueV1Marker>
         + DataProvider<GeneralCategoryV1Marker>
@@ -421,6 +433,8 @@ where
         + DataProvider<ExtendedPictographicV1Marker>
         + DataProvider<ExtenderV1Marker>
         + DataProvider<GraphemeBaseV1Marker>
+        + DataProvider<GraphemeClusterBreakV1Marker>
+        + DataProvider<GraphemeClusterBreakNameToValueV1Marker>
         + DataProvider<GraphemeExtendV1Marker>
         + DataProvider<HexDigitV1Marker>
         + DataProvider<IdsBinaryOperatorV1Marker>
@@ -438,6 +452,8 @@ where
         + DataProvider<QuotationMarkV1Marker>
         + DataProvider<RadicalV1Marker>
         + DataProvider<RegionalIndicatorV1Marker>
+        + DataProvider<SentenceBreakV1Marker>
+        + DataProvider<SentenceBreakNameToValueV1Marker>
         + DataProvider<SentenceTerminalV1Marker>
         + DataProvider<SoftDottedV1Marker>
         + DataProvider<TerminalPunctuationV1Marker>
@@ -445,6 +461,8 @@ where
         + DataProvider<UppercaseV1Marker>
         + DataProvider<VariationSelectorV1Marker>
         + DataProvider<WhiteSpaceV1Marker>
+        + DataProvider<WordBreakV1Marker>
+        + DataProvider<WordBreakNameToValueV1Marker>
         + DataProvider<XidContinueV1Marker>
         + DataProvider<GeneralCategoryMaskNameToValueV1Marker>
         + DataProvider<GeneralCategoryV1Marker>

--- a/experimental/transliterate/src/compile/parse.rs
+++ b/experimental/transliterate/src/compile/parse.rs
@@ -286,6 +286,8 @@ where
         + DataProvider<ExtendedPictographicV1Marker>
         + DataProvider<ExtenderV1Marker>
         + DataProvider<GraphemeBaseV1Marker>
+        + DataProvider<GraphemeClusterBreakV1Marker>
+        + DataProvider<GraphemeClusterBreakNameToValueV1Marker>
         + DataProvider<GraphemeExtendV1Marker>
         + DataProvider<HexDigitV1Marker>
         + DataProvider<IdsBinaryOperatorV1Marker>
@@ -303,6 +305,8 @@ where
         + DataProvider<QuotationMarkV1Marker>
         + DataProvider<RadicalV1Marker>
         + DataProvider<RegionalIndicatorV1Marker>
+        + DataProvider<SentenceBreakV1Marker>
+        + DataProvider<SentenceBreakNameToValueV1Marker>
         + DataProvider<SentenceTerminalV1Marker>
         + DataProvider<SoftDottedV1Marker>
         + DataProvider<TerminalPunctuationV1Marker>
@@ -310,6 +314,8 @@ where
         + DataProvider<UppercaseV1Marker>
         + DataProvider<VariationSelectorV1Marker>
         + DataProvider<WhiteSpaceV1Marker>
+        + DataProvider<WordBreakV1Marker>
+        + DataProvider<WordBreakNameToValueV1Marker>
         + DataProvider<XidContinueV1Marker>
         + DataProvider<GeneralCategoryMaskNameToValueV1Marker>
         + DataProvider<GeneralCategoryV1Marker>

--- a/experimental/unicodeset_parse/src/parse.rs
+++ b/experimental/unicodeset_parse/src/parse.rs
@@ -1014,7 +1014,7 @@ where
     }
 
     fn parse_property_inner(&mut self, end: char) -> Result<()> {
-        // only supports ECMA-262. UnicodeSet spec ignores whitespace, '-', and '_',
+        // UnicodeSet spec ignores whitespace, '-', and '_',
         // but ECMA-262 requires '_', so we'll allow that.
         // TODO(#3559): support loose matching on property names (e.g., "AS  -_-  CII_Hex_ D-igit")
         // TODO(#3559): support more properties than ECMA-262
@@ -1095,6 +1095,9 @@ where
         // [:gc = value:]
         // [:sc = value:]
         // [:scx = value:]
+        // [:Grapheme_Cluster_Break = value:]
+        // [:Sentence_Break = value:]
+        // [:Word_Break = value:]
         // [:value:] - looks up value in gc, sc
         // [:prop:] - binary property, returns codepoints that have the property
         // [:prop = truthy/falsy:] - same as above


### PR DESCRIPTION
I would like to parse `\{Grapheme_Cluster_Break=CR}` etc easily, then returns code points.