### PR TITLE
[WIP] Skipping `DatagenProvider::check_req` in release mode

### DIFF
--- a/provider/datagen/src/transform/mod.rs
+++ b/provider/datagen/src/transform/mod.rs
@@ -31,7 +31,7 @@ impl DatagenProvider {
     {
         if <M as KeyedDataMarker>::KEY.metadata().singleton && !req.locale.is_empty() {
             Err(DataErrorKind::ExtraneousLocale)
-        } else if !self.supported_locales()?.contains(req.locale) {
+        } else if cfg!(debug_assertions) && !self.supported_locales()?.contains(req.locale) {
             Err(DataErrorKind::MissingLocale)
         } else {
             Ok(())


### PR DESCRIPTION
This calls `supported_locales` for each locale, which is expensive. This is a behavior change though so if this makes a big difference we should cache.