### PR TITLE
Implement `databake::Bake` for `rend` endian-aware integers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,7 @@ dependencies = [
  "databake-derive",
  "proc-macro2",
  "quote",
+ "rend",
 ]
 
 [[package]]

--- a/utils/databake/Cargo.toml
+++ b/utils/databake/Cargo.toml
@@ -29,3 +29,4 @@ derive = ["dep:databake-derive"]
 proc-macro2 = "1.0.27"
 quote = "1.0.9"
 databake-derive = { workspace = true, optional = true}
+rend = { version = "0.4.0", optional = true, default-features = false }


### PR DESCRIPTION
Add support for endian-aware integers provided by [`rend`](https://docs.rs/rend/latest/rend/).

`impl databake::Bake for rend::{uN, iN}_{ne, le, be}`