### PR TITLE
Introduce `RoundingIncrement` to `FixedDecimal`

### DIFF
--- a/ffi/capi/c/include/ICU4XFixedDecimal.h
+++ b/ffi/capi/c/include/ICU4XFixedDecimal.h
@@ -17,6 +17,7 @@ typedef struct ICU4XFixedDecimal ICU4XFixedDecimal;
 #include "diplomat_result_box_ICU4XFixedDecimal_ICU4XError.h"
 #include "ICU4XFixedDecimalSign.h"
 #include "ICU4XFixedDecimalSignDisplay.h"
+#include "ICU4XRoundingIncrement.h"
 #include "diplomat_result_void_void.h"
 #ifdef __cplusplus
 namespace capi {
@@ -72,6 +73,8 @@ void ICU4XFixedDecimal_pad_end(ICU4XFixedDecimal* self, int16_t position);
 void ICU4XFixedDecimal_set_max_position(ICU4XFixedDecimal* self, int16_t position);
 
 void ICU4XFixedDecimal_trunc(ICU4XFixedDecimal* self, int16_t position);
+
+void ICU4XFixedDecimal_trunc_to_increment(ICU4XFixedDecimal* self, int16_t position, ICU4XRoundingIncrement increment);
 
 void ICU4XFixedDecimal_half_trunc(ICU4XFixedDecimal* self, int16_t position);
 

--- a/ffi/capi/c/include/ICU4XRoundingIncrement.h
+++ b/ffi/capi/c/include/ICU4XRoundingIncrement.h
@@ -1,0 +1,33 @@
+#ifndef ICU4XRoundingIncrement_H
+#define ICU4XRoundingIncrement_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+namespace capi {
+#endif
+
+typedef enum ICU4XRoundingIncrement {
+  ICU4XRoundingIncrement_MultiplesOf1 = 0,
+  ICU4XRoundingIncrement_MultiplesOf2 = 1,
+  ICU4XRoundingIncrement_MultiplesOf5 = 2,
+  ICU4XRoundingIncrement_MultiplesOf25 = 3,
+} ICU4XRoundingIncrement;
+#ifdef __cplusplus
+} // namespace capi
+#endif
+#ifdef __cplusplus
+namespace capi {
+extern "C" {
+#endif
+
+void ICU4XRoundingIncrement_destroy(ICU4XRoundingIncrement* self);
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace capi
+#endif
+#endif

--- a/ffi/capi/cpp/docs/source/fixed_decimal_ffi.rst
+++ b/ffi/capi/cpp/docs/source/fixed_decimal_ffi.rst
@@ -167,6 +167,11 @@
         See the `Rust documentation for trunc <https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.trunc>`__ for more information.
 
 
+    .. cpp:function:: void trunc_to_increment(int16_t position, ICU4XRoundingIncrement increment)
+
+        See the `Rust documentation for trunc_to_increment <https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.trunc_to_increment>`__ for more information.
+
+
     .. cpp:function:: void half_trunc(int16_t position)
 
         See the `Rust documentation for half_trunc <https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.half_trunc>`__ for more information.
@@ -270,3 +275,18 @@
     .. cpp:enumerator:: ExceptZero
 
     .. cpp:enumerator:: Negative
+
+.. cpp:enum-struct:: ICU4XRoundingIncrement
+
+    Increment used in a rounding operation.
+
+    See the `Rust documentation for RoundingIncrement <https://docs.rs/fixed_decimal/latest/fixed_decimal/enum.RoundingIncrement.html>`__ for more information.
+
+
+    .. cpp:enumerator:: MultiplesOf1
+
+    .. cpp:enumerator:: MultiplesOf2
+
+    .. cpp:enumerator:: MultiplesOf5
+
+    .. cpp:enumerator:: MultiplesOf25

--- a/ffi/capi/cpp/include/ICU4XFixedDecimal.h
+++ b/ffi/capi/cpp/include/ICU4XFixedDecimal.h
@@ -17,6 +17,7 @@ typedef struct ICU4XFixedDecimal ICU4XFixedDecimal;
 #include "diplomat_result_box_ICU4XFixedDecimal_ICU4XError.h"
 #include "ICU4XFixedDecimalSign.h"
 #include "ICU4XFixedDecimalSignDisplay.h"
+#include "ICU4XRoundingIncrement.h"
 #include "diplomat_result_void_void.h"
 #ifdef __cplusplus
 namespace capi {
@@ -72,6 +73,8 @@ void ICU4XFixedDecimal_pad_end(ICU4XFixedDecimal* self, int16_t position);
 void ICU4XFixedDecimal_set_max_position(ICU4XFixedDecimal* self, int16_t position);
 
 void ICU4XFixedDecimal_trunc(ICU4XFixedDecimal* self, int16_t position);
+
+void ICU4XFixedDecimal_trunc_to_increment(ICU4XFixedDecimal* self, int16_t position, ICU4XRoundingIncrement increment);
 
 void ICU4XFixedDecimal_half_trunc(ICU4XFixedDecimal* self, int16_t position);
 

--- a/ffi/capi/cpp/include/ICU4XFixedDecimal.hpp
+++ b/ffi/capi/cpp/include/ICU4XFixedDecimal.hpp
@@ -15,6 +15,7 @@ class ICU4XFixedDecimal;
 #include "ICU4XError.hpp"
 #include "ICU4XFixedDecimalSign.hpp"
 #include "ICU4XFixedDecimalSignDisplay.hpp"
+#include "ICU4XRoundingIncrement.hpp"
 
 /**
  * A destruction policy for using ICU4XFixedDecimal with std::unique_ptr.
@@ -221,6 +222,13 @@ class ICU4XFixedDecimal {
   /**
    * 
    * 
+   * See the [Rust documentation for `trunc_to_increment`](https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.trunc_to_increment) for more information.
+   */
+  void trunc_to_increment(int16_t position, ICU4XRoundingIncrement increment);
+
+  /**
+   * 
+   * 
    * See the [Rust documentation for `half_trunc`](https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.half_trunc) for more information.
    */
   void half_trunc(int16_t position);
@@ -418,6 +426,9 @@ inline void ICU4XFixedDecimal::set_max_position(int16_t position) {
 }
 inline void ICU4XFixedDecimal::trunc(int16_t position) {
   capi::ICU4XFixedDecimal_trunc(this->inner.get(), position);
+}
+inline void ICU4XFixedDecimal::trunc_to_increment(int16_t position, ICU4XRoundingIncrement increment) {
+  capi::ICU4XFixedDecimal_trunc_to_increment(this->inner.get(), position, static_cast<capi::ICU4XRoundingIncrement>(increment));
 }
 inline void ICU4XFixedDecimal::half_trunc(int16_t position) {
   capi::ICU4XFixedDecimal_half_trunc(this->inner.get(), position);

--- a/ffi/capi/cpp/include/ICU4XRoundingIncrement.h
+++ b/ffi/capi/cpp/include/ICU4XRoundingIncrement.h
@@ -1,0 +1,33 @@
+#ifndef ICU4XRoundingIncrement_H
+#define ICU4XRoundingIncrement_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+namespace capi {
+#endif
+
+typedef enum ICU4XRoundingIncrement {
+  ICU4XRoundingIncrement_MultiplesOf1 = 0,
+  ICU4XRoundingIncrement_MultiplesOf2 = 1,
+  ICU4XRoundingIncrement_MultiplesOf5 = 2,
+  ICU4XRoundingIncrement_MultiplesOf25 = 3,
+} ICU4XRoundingIncrement;
+#ifdef __cplusplus
+} // namespace capi
+#endif
+#ifdef __cplusplus
+namespace capi {
+extern "C" {
+#endif
+
+void ICU4XRoundingIncrement_destroy(ICU4XRoundingIncrement* self);
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace capi
+#endif
+#endif

--- a/ffi/capi/cpp/include/ICU4XRoundingIncrement.hpp
+++ b/ffi/capi/cpp/include/ICU4XRoundingIncrement.hpp
@@ -1,0 +1,28 @@
+#ifndef ICU4XRoundingIncrement_HPP
+#define ICU4XRoundingIncrement_HPP
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <algorithm>
+#include <memory>
+#include <variant>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+#include "ICU4XRoundingIncrement.h"
+
+
+
+/**
+ * Increment used in a rounding operation.
+ * 
+ * See the [Rust documentation for `RoundingIncrement`](https://docs.rs/fixed_decimal/latest/fixed_decimal/enum.RoundingIncrement.html) for more information.
+ */
+enum struct ICU4XRoundingIncrement {
+  MultiplesOf1 = 0,
+  MultiplesOf2 = 1,
+  MultiplesOf5 = 2,
+  MultiplesOf25 = 3,
+};
+
+#endif

--- a/ffi/capi/js/docs/source/fixed_decimal_ffi.rst
+++ b/ffi/capi/js/docs/source/fixed_decimal_ffi.rst
@@ -167,6 +167,11 @@
         See the `Rust documentation for trunc <https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.trunc>`__ for more information.
 
 
+    .. js:method:: trunc_to_increment(position, increment)
+
+        See the `Rust documentation for trunc_to_increment <https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.trunc_to_increment>`__ for more information.
+
+
     .. js:method:: half_trunc(position)
 
         See the `Rust documentation for half_trunc <https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.half_trunc>`__ for more information.
@@ -237,4 +242,11 @@
     ECMA-402 compatible sign display preference.
 
     See the `Rust documentation for SignDisplay <https://docs.rs/fixed_decimal/latest/fixed_decimal/enum.SignDisplay.html>`__ for more information.
+
+
+.. js:class:: ICU4XRoundingIncrement
+
+    Increment used in a rounding operation.
+
+    See the `Rust documentation for RoundingIncrement <https://docs.rs/fixed_decimal/latest/fixed_decimal/enum.RoundingIncrement.html>`__ for more information.
 

--- a/ffi/capi/js/include/ICU4XFixedDecimal.d.ts
+++ b/ffi/capi/js/include/ICU4XFixedDecimal.d.ts
@@ -3,6 +3,7 @@ import { FFIError } from "./diplomat-runtime"
 import { ICU4XError } from "./ICU4XError";
 import { ICU4XFixedDecimalSign } from "./ICU4XFixedDecimalSign";
 import { ICU4XFixedDecimalSignDisplay } from "./ICU4XFixedDecimalSignDisplay";
+import { ICU4XRoundingIncrement } from "./ICU4XRoundingIncrement";
 
 /**
 
@@ -200,6 +201,12 @@ export class ICU4XFixedDecimal {
    * See the {@link https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.trunc Rust documentation for `trunc`} for more information.
    */
   trunc(position: i16): void;
+
+  /**
+
+   * See the {@link https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.trunc_to_increment Rust documentation for `trunc_to_increment`} for more information.
+   */
+  trunc_to_increment(position: i16, increment: ICU4XRoundingIncrement): void;
 
   /**
 

--- a/ffi/capi/js/include/ICU4XFixedDecimal.js
+++ b/ffi/capi/js/include/ICU4XFixedDecimal.js
@@ -3,6 +3,7 @@ import * as diplomatRuntime from "./diplomat-runtime.js"
 import { ICU4XError_js_to_rust, ICU4XError_rust_to_js } from "./ICU4XError.js"
 import { ICU4XFixedDecimalSign_js_to_rust, ICU4XFixedDecimalSign_rust_to_js } from "./ICU4XFixedDecimalSign.js"
 import { ICU4XFixedDecimalSignDisplay_js_to_rust, ICU4XFixedDecimalSignDisplay_rust_to_js } from "./ICU4XFixedDecimalSignDisplay.js"
+import { ICU4XRoundingIncrement_js_to_rust, ICU4XRoundingIncrement_rust_to_js } from "./ICU4XRoundingIncrement.js"
 
 const ICU4XFixedDecimal_box_destroy_registry = new FinalizationRegistry(underlying => {
   wasm.ICU4XFixedDecimal_destroy(underlying);
@@ -184,6 +185,10 @@ export class ICU4XFixedDecimal {
 
   trunc(arg_position) {
     wasm.ICU4XFixedDecimal_trunc(this.underlying, arg_position);
+  }
+
+  trunc_to_increment(arg_position, arg_increment) {
+    wasm.ICU4XFixedDecimal_trunc_to_increment(this.underlying, arg_position, ICU4XRoundingIncrement_js_to_rust[arg_increment]);
   }
 
   half_trunc(arg_position) {

--- a/ffi/capi/js/include/ICU4XRoundingIncrement.d.ts
+++ b/ffi/capi/js/include/ICU4XRoundingIncrement.d.ts
@@ -1,0 +1,21 @@
+
+/**
+
+ * Increment used in a rounding operation.
+
+ * See the {@link https://docs.rs/fixed_decimal/latest/fixed_decimal/enum.RoundingIncrement.html Rust documentation for `RoundingIncrement`} for more information.
+ */
+export enum ICU4XRoundingIncrement {
+  /**
+   */
+  MultiplesOf1 = 'MultiplesOf1',
+  /**
+   */
+  MultiplesOf2 = 'MultiplesOf2',
+  /**
+   */
+  MultiplesOf5 = 'MultiplesOf5',
+  /**
+   */
+  MultiplesOf25 = 'MultiplesOf25',
+}

--- a/ffi/capi/js/include/ICU4XRoundingIncrement.js
+++ b/ffi/capi/js/include/ICU4XRoundingIncrement.js
@@ -1,0 +1,23 @@
+import wasm from "./diplomat-wasm.mjs"
+import * as diplomatRuntime from "./diplomat-runtime.js"
+
+export const ICU4XRoundingIncrement_js_to_rust = {
+  "MultiplesOf1": 0,
+  "MultiplesOf2": 1,
+  "MultiplesOf5": 2,
+  "MultiplesOf25": 3,
+};
+
+export const ICU4XRoundingIncrement_rust_to_js = {
+  [0]: "MultiplesOf1",
+  [1]: "MultiplesOf2",
+  [2]: "MultiplesOf5",
+  [3]: "MultiplesOf25",
+};
+
+export const ICU4XRoundingIncrement = {
+  "MultiplesOf1": "MultiplesOf1",
+  "MultiplesOf2": "MultiplesOf2",
+  "MultiplesOf5": "MultiplesOf5",
+  "MultiplesOf25": "MultiplesOf25",
+};

--- a/ffi/capi/js/include/index.d.ts
+++ b/ffi/capi/js/include/index.d.ts
@@ -97,6 +97,7 @@ export { ICU4XPluralRulesWithRanges } from './ICU4XPluralRulesWithRanges.js';
 export { ICU4XPropertyValueNameToEnumMapper } from './ICU4XPropertyValueNameToEnumMapper.js';
 export { ICU4XRegionDisplayNames } from './ICU4XRegionDisplayNames.js';
 export { ICU4XReorderedIndexMap } from './ICU4XReorderedIndexMap.js';
+export { ICU4XRoundingIncrement } from './ICU4XRoundingIncrement.js';
 export { ICU4XScriptExtensionsSet } from './ICU4XScriptExtensionsSet.js';
 export { ICU4XScriptWithExtensions } from './ICU4XScriptWithExtensions.js';
 export { ICU4XScriptWithExtensionsBorrowed } from './ICU4XScriptWithExtensionsBorrowed.js';

--- a/ffi/capi/js/include/index.js
+++ b/ffi/capi/js/include/index.js
@@ -97,6 +97,7 @@ export { ICU4XPluralRulesWithRanges } from './ICU4XPluralRulesWithRanges.js';
 export { ICU4XPropertyValueNameToEnumMapper } from './ICU4XPropertyValueNameToEnumMapper.js';
 export { ICU4XRegionDisplayNames } from './ICU4XRegionDisplayNames.js';
 export { ICU4XReorderedIndexMap } from './ICU4XReorderedIndexMap.js';
+export { ICU4XRoundingIncrement } from './ICU4XRoundingIncrement.js';
 export { ICU4XScriptExtensionsSet } from './ICU4XScriptExtensionsSet.js';
 export { ICU4XScriptWithExtensions } from './ICU4XScriptWithExtensions.js';
 export { ICU4XScriptWithExtensionsBorrowed } from './ICU4XScriptWithExtensionsBorrowed.js';

--- a/ffi/capi/src/fixed_decimal.rs
+++ b/ffi/capi/src/fixed_decimal.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use fixed_decimal::RoundingIncrement;
 use fixed_decimal::Sign;
 use fixed_decimal::SignDisplay;
 
@@ -36,6 +37,15 @@ pub mod ffi {
         Always,
         ExceptZero,
         Negative,
+    }
+
+    /// Increment used in a rounding operation.
+    #[diplomat::rust_link(fixed_decimal::RoundingIncrement, Enum)]
+    pub enum ICU4XRoundingIncrement {
+        MultiplesOf1,
+        MultiplesOf2,
+        MultiplesOf5,
+        MultiplesOf25,
     }
 
     impl ICU4XFixedDecimal {
@@ -220,6 +230,16 @@ pub mod ffi {
             self.0.trunc(position)
         }
 
+        #[diplomat::rust_link(fixed_decimal::FixedDecimal::trunc_to_increment, FnInStruct)]
+        #[diplomat::rust_link(
+            fixed_decimal::FixedDecimal::trunced_to_increment,
+            FnInStruct,
+            hidden
+        )]
+        pub fn trunc_to_increment(&mut self, position: i16, increment: ICU4XRoundingIncrement) {
+            self.0.trunc_to_increment(position, increment.into())
+        }
+
         #[diplomat::rust_link(fixed_decimal::FixedDecimal::half_trunc, FnInStruct)]
         #[diplomat::rust_link(fixed_decimal::FixedDecimal::half_trunced, FnInStruct, hidden)]
         pub fn half_trunc(&mut self, position: i16) {
@@ -318,6 +338,17 @@ impl From<ffi::ICU4XFixedDecimalSignDisplay> for SignDisplay {
             ffi::ICU4XFixedDecimalSignDisplay::Always => Self::Always,
             ffi::ICU4XFixedDecimalSignDisplay::ExceptZero => Self::ExceptZero,
             ffi::ICU4XFixedDecimalSignDisplay::Negative => Self::Negative,
+        }
+    }
+}
+
+impl From<ffi::ICU4XRoundingIncrement> for RoundingIncrement {
+    fn from(value: ffi::ICU4XRoundingIncrement) -> Self {
+        match value {
+            ffi::ICU4XRoundingIncrement::MultiplesOf1 => RoundingIncrement::MultiplesOf1,
+            ffi::ICU4XRoundingIncrement::MultiplesOf2 => RoundingIncrement::MultiplesOf2,
+            ffi::ICU4XRoundingIncrement::MultiplesOf5 => RoundingIncrement::MultiplesOf5,
+            ffi::ICU4XRoundingIncrement::MultiplesOf25 => RoundingIncrement::MultiplesOf25,
         }
     }
 }

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -1128,7 +1128,7 @@ impl FixedDecimal {
                 }
                 RoundingIncrement::MultiplesOf2 => {
                     let Some(last_digit) = self.digits.last_mut() else {
-                        // Unreachable
+                        debug_assert!(false, "`self.digits` should have at least a digit");
                         return;
                     };
 
@@ -1138,7 +1138,7 @@ impl FixedDecimal {
                 }
                 RoundingIncrement::MultiplesOf5 => {
                     let Some(last_digit) = self.digits.last_mut() else {
-                        // Unreachable
+                        debug_assert!(false, "`self.digits` should have at least a digit");
                         return;
                     };
 
@@ -1149,7 +1149,7 @@ impl FixedDecimal {
                     self.digits.resize(digits_to_retain as usize, 0);
 
                     let Some((last_digit, digits)) = self.digits.split_last_mut() else {
-                        // Unreachable.
+                        debug_assert!(false, "`self.digits` should have at least a digit");
                         return;
                     };
 

--- a/utils/fixed_decimal/src/lib.rs
+++ b/utils/fixed_decimal/src/lib.rs
@@ -67,6 +67,7 @@ pub use FloatPrecision as DoublePrecision;
 
 pub use compact::CompactDecimal;
 pub use decimal::FixedDecimal;
+pub use decimal::RoundingIncrement;
 pub use decimal::Sign;
 pub use decimal::SignDisplay;
 use displaydoc::Display;


### PR DESCRIPTION
This PR implements an MVP of the `RoundingIncrement` API for `FixedDecimal`, which should allow rounding to increments that are divisors of 10 and 100. It also implements `FixedDecimal::trunc_to_increment` to show the usage of the API.

I plan to implement the remaining methods, but I wanted to create an MVP first to discuss if this would be the desired API.

Mostly based from https://github.com/unicode-org/icu4x/issues/3929#issuecomment-1776586074