### PR TITLE
Re-export logging macros from icu_provider and invoke in icu_datetime

### DIFF
--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -73,7 +73,10 @@ impl<'l> Writeable for FormattedDateTime<'l> {
             self.fixed_decimal_format,
             sink,
         )
-        .map_err(|_| core::fmt::Error)
+        .map_err(|e| {
+            icu_provider::_internal::log::warn!("{e:?}");
+            core::fmt::Error
+        })
     }
 
     // TODO(#489): Implement writeable_length_hint

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -73,8 +73,8 @@ impl<'l> Writeable for FormattedDateTime<'l> {
             self.fixed_decimal_format,
             sink,
         )
-        .map_err(|e| {
-            icu_provider::_internal::log::warn!("{e:?}");
+        .map_err(|_e| {
+            icu_provider::_internal::log::warn!("{_e:?}");
             core::fmt::Error
         })
     }

--- a/docs/process/style_guide.md
+++ b/docs/process/style_guide.md
@@ -322,7 +322,19 @@ An "error type" is an enum or struct that is usually returned in the `Err` varia
 
 In ICU4X, we have a convention of making error types implement `Copy`. This is primarily because highly complex error types carry a code size burden: the `Drop` impls of such types are complex and significantly impact on binary size.
 
-To associate additional metadata with errors, such as file paths, use the `log!` macro.
+To associate additional metadata with errors, such as file paths, use a logging macro. In binaries, including the `log` dependency directly and gate logs with a `"logging"` feature. In component library code, utilize the macros exported by the `icu_provider` crate, as shown below. For more discussion, see [#2648](https://github.com/unicode-org/icu4x/issues/2648).
+
+```rust
+icu_provider::_internal::log::warn!("This is a warning");
+```
+
+The logs are forwarded to one of three places:
+
+1. If `feature = "icu_provider/logging"` is enabled: to the `log` crate.
+2. Else, if both `debug_assertions` and `feature = "std"` are enabled: to stderr.
+3. Else, they compile away completely.
+
+In most cases, when running `cargo test --all-features` inside of a component crate (but not at the repository root), case 2 is triggered and the logs are printed to stderr.
 
 ### Implement Eq / PartialEq, Ord / PartialOrd only as needed :: suggested
 

--- a/provider/core/src/error.rs
+++ b/provider/core/src/error.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::_internal::log;
 use crate::buf::BufferFormat;
 use crate::prelude::*;
 use core::fmt;
@@ -202,7 +203,6 @@ impl DataError {
     /// Sets the string context of a DataError to the given type name, returning a modified error.
     #[inline]
     pub fn with_type_context<T>(self) -> Self {
-        #[cfg(feature = "logging")]
         if !self.silent {
             log::warn!("{self}: Type context: {}", core::any::type_name::<T>());
         }
@@ -213,13 +213,11 @@ impl DataError {
     ///
     /// If the "logging" Cargo feature is enabled, this logs the whole request. Either way,
     /// it returns an error with the resource key portion of the request as context.
-    #[cfg_attr(not(feature = "logging"), allow(unused_variables))]
     pub fn with_req(mut self, key: DataKey, req: DataRequest) -> Self {
         if req.metadata.silent {
             self.silent = true;
         }
         // Don't write out a log for MissingDataKey since there is no context to add
-        #[cfg(feature = "logging")]
         if !self.silent && self.kind != DataErrorKind::MissingDataKey {
             log::warn!("{} (key: {}, request: {})", self, key, req);
         }
@@ -231,9 +229,7 @@ impl DataError {
     /// This does not modify the error, but if the "logging" Cargo feature is enabled,
     /// it will print out the context.
     #[cfg(feature = "std")]
-    #[cfg_attr(not(feature = "logging"), allow(unused_variables))]
     pub fn with_path_context<P: AsRef<std::path::Path> + ?Sized>(self, path: &P) -> Self {
-        #[cfg(feature = "logging")]
         if !self.silent {
             log::warn!("{} (path: {:?})", self, path.as_ref());
         }
@@ -247,7 +243,6 @@ impl DataError {
     #[cfg_attr(not(feature = "logging"), allow(unused_variables))]
     #[inline]
     pub fn with_display_context<D: fmt::Display + ?Sized>(self, context: &D) -> Self {
-        #[cfg(feature = "logging")]
         if !self.silent {
             log::warn!("{}: {}", self, context);
         }
@@ -261,7 +256,6 @@ impl DataError {
     #[cfg_attr(not(feature = "logging"), allow(unused_variables))]
     #[inline]
     pub fn with_debug_context<D: fmt::Debug + ?Sized>(self, context: &D) -> Self {
-        #[cfg(feature = "logging")]
         if !self.silent {
             log::warn!("{}: {:?}", self, context);
         }
@@ -285,7 +279,6 @@ impl std::error::Error for DataError {}
 #[cfg(feature = "std")]
 impl From<std::io::Error> for DataError {
     fn from(e: std::io::Error) -> Self {
-        #[cfg(feature = "logging")]
         log::warn!("I/O error: {}", e);
         DataErrorKind::Io(e.kind()).into_error()
     }

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -264,4 +264,38 @@ pub use zerofrom;
 pub mod _internal {
     pub use super::fallback::{LocaleFallbackPriority, LocaleFallbackSupplement};
     pub use icu_locid as locid;
+
+    #[cfg(feature = "logging")]
+    pub use log;
+
+    #[cfg(all(not(feature = "logging"), debug_assertions, feature = "std"))]
+    pub mod log {
+        pub use std::eprintln as error;
+        pub use std::eprintln as warn;
+        pub use std::eprintln as info;
+        pub use std::eprintln as debug;
+        pub use std::eprintln as trace;
+    }
+
+    #[cfg(all(
+        not(feature = "logging"),
+        any(not(debug_assertions), not(feature = "std"))
+    ))]
+    pub mod log {
+        #[macro_export]
+        macro_rules! _internal_noop_log {
+            ($($t:expr),*) => {};
+        }
+        pub use crate::_internal_noop_log as error;
+        pub use crate::_internal_noop_log as warn;
+        pub use crate::_internal_noop_log as info;
+        pub use crate::_internal_noop_log as debug;
+        pub use crate::_internal_noop_log as trace;
+    }
+}
+
+#[test]
+fn test_logging() {
+    // This should compile on all combinations of features
+    crate::_internal::log::info!("Hello World");
 }


### PR DESCRIPTION
Part of #2648

I want to read log messages in icu_datetime but they mostly get suppressed. I applied a solution that I believe is consistent with the recommendations in #2648.