### PR TITLE
ci: Update to `actions/checkout@v4`.

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -58,7 +58,7 @@ jobs:
     needs: credentials
     runs-on: "ubuntu-latest"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # GCP Boilerplate for jobs in main or forked repository (needs credentials)
     - id: gcp-auth
@@ -98,7 +98,7 @@ jobs:
     needs: credentials
     runs-on: "ubuntu-latest"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # GCP Boilerplate for jobs in main or forked repository (needs credentials)
     - id: gcp-auth
@@ -151,7 +151,7 @@ jobs:
     name: WASM Demo
     runs-on: "ubuntu-latest"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # GCP Boilerplate for jobs in main repository
     - id: gcp-auth
@@ -228,7 +228,7 @@ jobs:
     # Example "debugging" workflow: https://github.com/echeran/icu4x/actions/runs/296714990
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # GCP Boilerplate for jobs in main repository
     - id: gcp-auth
@@ -324,7 +324,7 @@ jobs:
       group: bench-memory-${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # GCP Boilerplate for jobs in main repository
     - id: gcp-auth
@@ -401,7 +401,7 @@ jobs:
       group: bench-binsize
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # GCP Boilerplate for jobs in main repository
     - id: gcp-auth
@@ -519,7 +519,7 @@ jobs:
       group: bench-datasize
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # GCP Boilerplate for jobs in main repository
     - id: gcp-auth
@@ -583,7 +583,7 @@ jobs:
       group: "pages"
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # GCP Boilerplate for jobs in main repository
       - id: gcp-auth
         name: "Authenticate to Google Cloud with Workload Identity Provider"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,7 +46,7 @@ jobs:
     env:
       CARGO_HTTP_MULTIPLEXING: false
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -100,7 +100,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -139,7 +139,7 @@ jobs:
   test-docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -178,7 +178,7 @@ jobs:
         behavior: [local, cratesio]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -224,7 +224,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -266,7 +266,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -325,7 +325,7 @@ jobs:
   full-datagen:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -372,7 +372,7 @@ jobs:
       image: rust:bookworm
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     # Software setup/installation for the container
     - name: Install Rust toolchains
@@ -434,7 +434,7 @@ jobs:
       image: rust:bookworm
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     # Software setup/installation for the container
     - name: Install Rust toolchains
@@ -489,7 +489,7 @@ jobs:
   nostd:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -524,7 +524,7 @@ jobs:
   diplomat:
     runs-on: [ ubuntu-latest ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -560,7 +560,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -627,7 +627,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -666,7 +666,7 @@ jobs:
   tidy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -725,7 +725,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Cargo-make boilerplate
     - name: Get cargo-make version
@@ -764,7 +764,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Cargo-make boilerplate
     - name: Get cargo-make version

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on:                    ubuntu-latest
 
     steps:
-      - uses:                   actions/checkout@v3
+      - uses:                   actions/checkout@v4
 
       ## Coverage steps
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v4.1.1
         with:
           persist-credentials: false
 


### PR DESCRIPTION
The main change here is that it switches to an undeprecated version of NodeJS within the GitHub Actions infrastructure.

Changelog: https://github.com/actions/checkout/blob/main/CHANGELOG.md
