### PR TITLE
ci: Fix cargo-rdme cache key.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -600,9 +600,9 @@ jobs:
       run: cargo make gn-install
 
     - name: Get cargo-rdme version
-      id: cargo-readme-version
+      id: cargo-rdme-version
       run: |
-        echo "::set-output name=hash::$(cargo search cargo-rdme | grep '^cargo-rdme =' | md5sum)"
+        echo "hash=$(cargo search cargo-rdme | grep '^cargo-rdme =' | md5sum)" >> $GITHUB_OUTPUT
       shell: bash
     - name: Attempt to load cached cargo-rdme
       uses: actions/cache@v3
@@ -695,9 +695,9 @@ jobs:
 
     # Job-specific dependencies
     - name: Get cargo-rdme version
-      id: cargo-readme-version
+      id: cargo-rdme-version
       run: |
-        echo "::set-output name=hash::$(cargo search cargo-rdme | grep '^cargo-rdme =' | md5sum)"
+        echo "hash=$(cargo search cargo-rdme | grep '^cargo-rdme =' | md5sum)" >> $GITHUB_OUTPUT
       shell: bash
     - name: Attempt to load cached cargo-rdme
       uses: actions/cache@v3


### PR DESCRIPTION
This key uses the step name to look up the output from a previous step. The step was not fully renamed when switching from `cargo readme` to `cargo rdme` in 0c65d4c94f124a0d2a8b681a901c791bc0d3eb89.

At the same time, fix the use of `::set-output` as this has been deprecated by GitHub: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
