### PR TITLE
docs: Mention installing `cargo-rdme` not `cargo readme`.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ To build ICU4X, you will need the following dependencies:
 
  - Rust (and Cargo) installed [via `rustup`](https://doc.rust-lang.org/book/ch01-01-installation.html)
  - `cargo-make` installed via `cargo install cargo-make`
- - `cargo-readme` installed via `cargo install cargo-readme`
+ - `cargo-rdme` installed via `cargo install cargo-rdme`
 
 Certain tests may need further dependencies, these are documented below in the [Testing](#testing) section.
 


### PR DESCRIPTION
Since 0c65d4c94f124a0d2a8b681a901c791bc0d3eb89, `cargo-rdme` is used and not `cargo-readme`.
