### PR TITLE
ci: Fix last usage of deprecated `set-output`.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Get grcov version
         id: grcov-version
         run: |
-          echo "::set-output name=hash::$(cargo search grcov | grep '^grcov =' | md5sum)"
+          echo "hash=$(cargo search grcov | grep '^grcov =' | md5sum)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Attempt to load cached grcov
         uses: actions/cache@v3


### PR DESCRIPTION
This has been deprecated by GitHub:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
