### PR TITLE
Update `icu_capi` includes

### DIFF
--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -7,11 +7,11 @@ name = "icu_capi"
 description = "C interface to ICU4X"
 license-file = "LICENSE"
 include = [
+    "js/**/*",
+    "c/**/*",
+    "cpp/**/*",
     "src/**/*",
-    "examples/**/*",
-    "benches/**/*",
     "tests/**/*",
-    "**/include/**/*",
     "Cargo.toml",
     "LICENSE",
     "README.md"


### PR DESCRIPTION
This now includes docs and examples, which were excluded before.
It excludes Dart, as that is not stable yet.