### PR TITLE
Address issues in explicit resource bundle handling code

### DIFF
--- a/utils/resb/src/binary/serializer.rs
+++ b/utils/resb/src/binary/serializer.rs
@@ -901,7 +901,7 @@ impl Serializer {
             resources_end,
             bundle_end: resources_end,
             largest_table_entry_count: self.largest_table_entry_count,
-            bundle_attributes: Some(!bundle.is_locale_fallback_enabled() as u32),
+            bundle_attributes: Some(!bundle.is_locale_fallback_enabled as u32),
             data_16_bit_end: Some(data_16_bit_end),
             pool_checksum: None,
         }

--- a/utils/resb/src/text/reader.rs
+++ b/utils/resb/src/text/reader.rs
@@ -536,7 +536,7 @@ impl Reader {
             }
         };
 
-        let keys_in_discovery_order = final_state.take_keys().iter().cloned().collect();
+        let keys_in_discovery_order = final_state.take_keys().into_iter().collect();
 
         Ok((bundle, keys_in_discovery_order))
     }

--- a/utils/resb/src/text/reader.rs
+++ b/utils/resb/src/text/reader.rs
@@ -526,15 +526,15 @@ impl Reader {
     pub fn read(input: &str) -> Result<(ResourceBundle, Vec<Key>), TextParserError> {
         let input = ParseState::new(input);
 
-        let (mut final_state, bundle) =
-            match bundle::<VerboseError<ParseState>>(input.clone()).finish() {
-                Ok(result) => result,
-                Err(err) => {
-                    return Err(TextParserError {
-                        trace: convert_error(input, err),
-                    })
-                }
-            };
+        let (final_state, bundle) = match bundle::<VerboseError<ParseState>>(input.clone()).finish()
+        {
+            Ok(result) => result,
+            Err(err) => {
+                return Err(TextParserError {
+                    trace: convert_error(input, err),
+                })
+            }
+        };
 
         let keys_in_discovery_order = final_state.take_keys().iter().cloned().collect();
 

--- a/utils/resb/src/text/reader.rs
+++ b/utils/resb/src/text/reader.rs
@@ -526,15 +526,11 @@ impl Reader {
     pub fn read(input: &str) -> Result<(ResourceBundle, Vec<Key>), TextParserError> {
         let input = ParseState::new(input);
 
-        let (final_state, bundle) = match bundle::<VerboseError<ParseState>>(input.clone()).finish()
-        {
-            Ok(result) => result,
-            Err(err) => {
-                return Err(TextParserError {
-                    trace: convert_error(input, err),
-                })
-            }
-        };
+        let (final_state, bundle) = bundle::<VerboseError<ParseState>>(input.clone())
+            .finish()
+            .unwrap_or_else(|err| TextParserError {
+                trace: convert_error(input, err),
+            })?;
 
         let keys_in_discovery_order = final_state.take_keys().into_iter().collect();
 

--- a/utils/resb/src/text/reader.rs
+++ b/utils/resb/src/text/reader.rs
@@ -528,7 +528,7 @@ impl Reader {
 
         let (final_state, bundle) = bundle::<VerboseError<ParseState>>(input.clone())
             .finish()
-            .unwrap_or_else(|err| TextParserError {
+            .map_err(|err| TextParserError {
                 trace: convert_error(input, err),
             })?;
 

--- a/utils/resb/src/text/reader/parse_state.rs
+++ b/utils/resb/src/text/reader/parse_state.rs
@@ -47,7 +47,7 @@ impl<'a> ParseState<'a> {
     pub fn new(input: &'a str) -> Self {
         Self {
             input,
-            keys_in_discovery_order: Rc::new(RefCell::new(IndexSet::new())),
+            keys_in_discovery_order: Default::default(),
         }
     }
 
@@ -66,8 +66,8 @@ impl<'a> ParseState<'a> {
 
     /// Takes the set of keys in order of discovery and replaces it with an
     /// empty set.
-    pub fn take_keys(&mut self) -> IndexSet<Key<'a>> {
-        self.keys_in_discovery_order.replace(IndexSet::new())
+    pub fn take_keys(self) -> IndexSet<Key<'a>> {
+        self.keys_in_discovery_order.take()
     }
 }
 


### PR DESCRIPTION
[Initial review](https://github.com/unicode-org/icu4x/pull/4058) identified uses of getter-style functions instead of public fields and unnecessary function forwarding in place of type aliasing, but issues were not deemed blockers to merge.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->