### PR TITLE
Impl Bake for BTreeSet

### DIFF
--- a/utils/databake/src/alloc.rs
+++ b/utils/databake/src/alloc.rs
@@ -57,6 +57,28 @@ fn vec() {
     test_bake!(Vec<u8>, alloc::vec![1u8, 2u8,], alloc);
 }
 
+impl<T> Bake for alloc::collections::BTreeSet<T>
+where
+    T: Bake,
+{
+    fn bake(&self, ctx: &CrateEnv) -> TokenStream {
+        ctx.insert("alloc");
+        let data = self.iter().map(|d| d.bake(ctx));
+        quote! {
+            alloc::collections::BTreeSet::from([#(#data,)*])
+        }
+    }
+}
+
+#[test]
+fn hash_set() {
+    test_bake!(
+        alloc::collections::BTreeSet<u8>,
+        alloc::collections::BTreeSet::from([1u8, 2u8,]),
+        std
+    );
+}
+
 impl Bake for String {
     fn bake(&self, _: &CrateEnv) -> TokenStream {
         quote! {

--- a/utils/databake/src/alloc.rs
+++ b/utils/databake/src/alloc.rs
@@ -65,17 +65,17 @@ where
         ctx.insert("alloc");
         let data = self.iter().map(|d| d.bake(ctx));
         quote! {
-            alloc::collections::BTreeSet::from([#(#data,)*])
+            alloc::collections::BTreeSet::from([#(#data),*])
         }
     }
 }
 
 #[test]
-fn hash_set() {
+fn btree_set() {
     test_bake!(
         alloc::collections::BTreeSet<u8>,
-        alloc::collections::BTreeSet::from([1u8, 2u8,]),
-        std
+        alloc::collections::BTreeSet::from([1u8, 2u8]),
+        alloc
     );
 }
 


### PR DESCRIPTION
This is my attempt to start https://github.com/unicode-org/icu4x/issues/4266. 

I am confused why the unit test I added is failing -- I might be missing something about how `quote!` works.

```
thread 'alloc::hash_set' panicked at utils/databake/src/alloc.rs:75:5:
assertion `left == right` failed
  left: "alloc :: collections :: BTreeSet :: from ([1u8 , 2u8 ,])"
 right: "alloc :: collections :: BTreeSet :: from ([1u8 , 2u8])"
```

IMO those two should be the same, but I'm not sure why the left has a trailing comma. I'd appreciate help from anyone who understands what's going on there!