### PR TITLE
Expose if a date is in a leap year

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -515,6 +515,11 @@ impl Calendar for AnyCalendar {
         match_cal_and_date!(match (self, date): (c, d) => c.year(d))
     }
 
+    /// The calendar-specific check if year is a leap year represented by `date`
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        match_cal_and_date!(match (self, date): (c, d) => c.year_is_leap(d))
+    }
+
     /// The calendar-specific month represented by `date`
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         match_cal_and_date!(match (self, date): (c, d) => c.month(d))

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -122,6 +122,10 @@ impl Calendar for Buddhist {
         iso_year_as_buddhist(date.0.year)
     }
 
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        Iso.year_is_leap(date)
+    }
+
     /// The calendar-specific month represented by `date`
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         Iso.month(date)

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -75,6 +75,9 @@ pub trait Calendar {
     /// The calendar-specific year represented by `date`
     fn year(&self, date: &Self::DateInner) -> types::FormattableYear;
 
+    /// Calculate if a date is in a leap year
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool;
+
     /// The calendar-specific month represented by `date`
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth;
 

--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -226,6 +226,10 @@ impl Calendar for Chinese {
         Self::format_chinese_year(date.0 .0.year, Some(date.0 .1))
     }
 
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        Self::is_leap_year(date.0 .0.year)
+    }
+
     /// The calendar-specific month code represented by `date`;
     /// since the Chinese calendar has leap months, an "L" is appended to the month code for
     /// leap months. For example, in a year where an intercalary month is added after the second

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -176,6 +176,10 @@ impl Calendar for Coptic {
         year_as_coptic(date.0.year)
     }
 
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        Self::is_leap_year(date.0.year)
+    }
+
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         date.0.month()
     }

--- a/components/calendar/src/dangi.rs
+++ b/components/calendar/src/dangi.rs
@@ -206,6 +206,10 @@ impl Calendar for Dangi {
         Self::format_dangi_year(date.0 .0.year, Some(date.0 .1))
     }
 
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        Self::is_leap_year(date.0 .0.year)
+    }
+
     fn month(&self, date: &Self::DateInner) -> crate::types::FormattableMonth {
         let ordinal = date.0 .0.month;
         let leap_month_option = date.0 .1.get_leap_month();

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -214,6 +214,12 @@ impl<A: AsCalendar> Date<A> {
         self.calendar.as_calendar().year(&self.inner)
     }
 
+    /// The calendar-specific year represented by `self` is a leap year
+    #[inline]
+    pub fn year_is_leap(&self) -> bool {
+        self.calendar.as_calendar().year_is_leap(&self.inner)
+    }
+
     /// The calendar-specific month represented by `self`
     #[inline]
     pub fn month(&self) -> types::FormattableMonth {

--- a/components/calendar/src/ethiopian.rs
+++ b/components/calendar/src/ethiopian.rs
@@ -198,6 +198,10 @@ impl Calendar for Ethiopian {
         Self::year_as_ethiopian(date.0.year, self.0)
     }
 
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        Self::is_leap_year(date.0.year)
+    }
+
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         date.0.month()
     }

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -126,6 +126,10 @@ impl Calendar for Gregorian {
         year_as_gregorian(date.0 .0.year)
     }
 
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        Iso.year_is_leap(&date.0)
+    }
+
     /// The calendar-specific month represented by `date`
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         Iso.month(&date.0)

--- a/components/calendar/src/hebrew.rs
+++ b/components/calendar/src/hebrew.rs
@@ -228,6 +228,10 @@ impl Calendar for Hebrew {
         Self::year_as_hebrew(date.0.year)
     }
 
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        Self::is_leap_year(date.0.year)
+    }
+
     fn month(&self, date: &Self::DateInner) -> FormattableMonth {
         let mut ordinal = date.0.month;
         let is_leap_year = Self::is_leap_year(date.0.year);

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -200,6 +200,10 @@ impl Calendar for Indian {
         }
     }
 
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        Self::is_leap_year(date.0.year)
+    }
+
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         date.0.month()
     }

--- a/components/calendar/src/islamic.rs
+++ b/components/calendar/src/islamic.rs
@@ -239,6 +239,10 @@ impl Calendar for IslamicObservational {
         Self::year_as_islamic(date.0.year)
     }
 
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        Self::is_leap_year(date.0.year)
+    }
+
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         date.0.month()
     }
@@ -462,6 +466,10 @@ impl Calendar for IslamicUmmAlQura {
 
     fn year(&self, date: &Self::DateInner) -> types::FormattableYear {
         Self::year_as_islamic(date.0.year)
+    }
+
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        Self::is_leap_year(date.0.year)
     }
 
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
@@ -704,6 +712,10 @@ impl Calendar for IslamicCivil {
         Self::year_as_islamic(date.0.year)
     }
 
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        Self::is_leap_year(date.0.year)
+    }
+
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         date.0.month()
     }
@@ -942,6 +954,10 @@ impl Calendar for IslamicTabular {
 
     fn year(&self, date: &Self::DateInner) -> types::FormattableYear {
         Self::year_as_islamic(date.0.year)
+    }
+
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        Self::is_leap_year(date.0.year)
     }
 
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -194,6 +194,10 @@ impl Calendar for Iso {
         Self::year_as_iso(date.0.year)
     }
 
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        Self::is_leap_year(date.0.year)
+    }
+
     /// The calendar-specific month represented by `date`
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         date.0.month()

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -282,6 +282,10 @@ impl Calendar for Japanese {
         }
     }
 
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        Iso.year_is_leap(&date.inner)
+    }
+
     /// The calendar-specific month represented by `date`
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         Iso.month(&date.inner)
@@ -377,6 +381,10 @@ impl Calendar for JapaneseExtended {
     /// The calendar-specific year represented by `date`
     fn year(&self, date: &Self::DateInner) -> types::FormattableYear {
         Japanese::year(&self.0, date)
+    }
+
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        Japanese::year_is_leap(&self.0, date)
     }
 
     /// The calendar-specific month represented by `date`

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -169,6 +169,10 @@ impl Calendar for Julian {
         year_as_gregorian(date.0.year)
     }
 
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        Self::is_leap_year(date.0.year)
+    }
+
     /// The calendar-specific month represented by `date`
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         date.0.month()

--- a/components/calendar/src/persian.rs
+++ b/components/calendar/src/persian.rs
@@ -171,6 +171,10 @@ impl Calendar for Persian {
         Self::year_as_persian(date.0.year)
     }
 
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        Self::is_leap_year(date.0.year)
+    }
+
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         date.0.month()
     }

--- a/components/calendar/src/roc.rs
+++ b/components/calendar/src/roc.rs
@@ -146,6 +146,10 @@ impl Calendar for Roc {
         year_as_roc(date.0 .0.year as i64)
     }
 
+    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+        Iso.year_is_leap(&date.0)
+    }
+
     fn month(&self, date: &Self::DateInner) -> crate::types::FormattableMonth {
         Iso.month(&date.0)
     }

--- a/ffi/capi/c/include/ICU4XIsoDate.h
+++ b/ffi/capi/c/include/ICU4XIsoDate.h
@@ -45,6 +45,8 @@ uint32_t ICU4XIsoDate_month(const ICU4XIsoDate* self);
 
 int32_t ICU4XIsoDate_year(const ICU4XIsoDate* self);
 
+bool ICU4XIsoDate_year_is_leap(const ICU4XIsoDate* self);
+
 uint8_t ICU4XIsoDate_months_in_year(const ICU4XIsoDate* self);
 
 uint8_t ICU4XIsoDate_days_in_month(const ICU4XIsoDate* self);

--- a/ffi/capi/c/include/ICU4XIsoDateTime.h
+++ b/ffi/capi/c/include/ICU4XIsoDateTime.h
@@ -63,6 +63,8 @@ uint32_t ICU4XIsoDateTime_month(const ICU4XIsoDateTime* self);
 
 int32_t ICU4XIsoDateTime_year(const ICU4XIsoDateTime* self);
 
+bool ICU4XIsoDateTime_year_is_leap(const ICU4XIsoDateTime* self);
+
 uint8_t ICU4XIsoDateTime_months_in_year(const ICU4XIsoDateTime* self);
 
 uint8_t ICU4XIsoDateTime_days_in_month(const ICU4XIsoDateTime* self);

--- a/ffi/capi/cpp/docs/source/date_ffi.rst
+++ b/ffi/capi/cpp/docs/source/date_ffi.rst
@@ -219,6 +219,13 @@
         See the `Rust documentation for year <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year>`__ for more information.
 
 
+    .. cpp:function:: bool year_is_leap() const
+
+        Returns if the year is a leap year for this date
+
+        See the `Rust documentation for year_is_leap <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap>`__ for more information.
+
+
     .. cpp:function:: uint8_t months_in_year() const
 
         Returns the number of months in the year represented by this date

--- a/ffi/capi/cpp/docs/source/datetime_ffi.rst
+++ b/ffi/capi/cpp/docs/source/datetime_ffi.rst
@@ -322,6 +322,13 @@
         See the `Rust documentation for year <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year>`__ for more information.
 
 
+    .. cpp:function:: bool year_is_leap() const
+
+        Returns if the year is a leap year for this date
+
+        See the `Rust documentation for year_is_leap <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap>`__ for more information.
+
+
     .. cpp:function:: uint8_t months_in_year() const
 
         Returns the number of months in the year represented by this date

--- a/ffi/capi/cpp/include/ICU4XIsoDate.h
+++ b/ffi/capi/cpp/include/ICU4XIsoDate.h
@@ -45,6 +45,8 @@ uint32_t ICU4XIsoDate_month(const ICU4XIsoDate* self);
 
 int32_t ICU4XIsoDate_year(const ICU4XIsoDate* self);
 
+bool ICU4XIsoDate_year_is_leap(const ICU4XIsoDate* self);
+
 uint8_t ICU4XIsoDate_months_in_year(const ICU4XIsoDate* self);
 
 uint8_t ICU4XIsoDate_days_in_month(const ICU4XIsoDate* self);

--- a/ffi/capi/cpp/include/ICU4XIsoDate.hpp
+++ b/ffi/capi/cpp/include/ICU4XIsoDate.hpp
@@ -108,6 +108,13 @@ class ICU4XIsoDate {
   int32_t year() const;
 
   /**
+   * Returns if the year is a leap year for this date
+   * 
+   * See the [Rust documentation for `year_is_leap`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap) for more information.
+   */
+  bool year_is_leap() const;
+
+  /**
    * Returns the number of months in the year represented by this date
    * 
    * See the [Rust documentation for `months_in_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.months_in_year) for more information.
@@ -186,6 +193,9 @@ inline uint32_t ICU4XIsoDate::month() const {
 }
 inline int32_t ICU4XIsoDate::year() const {
   return capi::ICU4XIsoDate_year(this->inner.get());
+}
+inline bool ICU4XIsoDate::year_is_leap() const {
+  return capi::ICU4XIsoDate_year_is_leap(this->inner.get());
 }
 inline uint8_t ICU4XIsoDate::months_in_year() const {
   return capi::ICU4XIsoDate_months_in_year(this->inner.get());

--- a/ffi/capi/cpp/include/ICU4XIsoDateTime.h
+++ b/ffi/capi/cpp/include/ICU4XIsoDateTime.h
@@ -63,6 +63,8 @@ uint32_t ICU4XIsoDateTime_month(const ICU4XIsoDateTime* self);
 
 int32_t ICU4XIsoDateTime_year(const ICU4XIsoDateTime* self);
 
+bool ICU4XIsoDateTime_year_is_leap(const ICU4XIsoDateTime* self);
+
 uint8_t ICU4XIsoDateTime_months_in_year(const ICU4XIsoDateTime* self);
 
 uint8_t ICU4XIsoDateTime_days_in_month(const ICU4XIsoDateTime* self);

--- a/ffi/capi/cpp/include/ICU4XIsoDateTime.hpp
+++ b/ffi/capi/cpp/include/ICU4XIsoDateTime.hpp
@@ -169,6 +169,13 @@ class ICU4XIsoDateTime {
   int32_t year() const;
 
   /**
+   * Returns if the year is a leap year for this date
+   * 
+   * See the [Rust documentation for `year_is_leap`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap) for more information.
+   */
+  bool year_is_leap() const;
+
+  /**
    * Returns the number of months in the year represented by this date
    * 
    * See the [Rust documentation for `months_in_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.months_in_year) for more information.
@@ -273,6 +280,9 @@ inline uint32_t ICU4XIsoDateTime::month() const {
 }
 inline int32_t ICU4XIsoDateTime::year() const {
   return capi::ICU4XIsoDateTime_year(this->inner.get());
+}
+inline bool ICU4XIsoDateTime::year_is_leap() const {
+  return capi::ICU4XIsoDateTime_year_is_leap(this->inner.get());
 }
 inline uint8_t ICU4XIsoDateTime::months_in_year() const {
   return capi::ICU4XIsoDateTime_months_in_year(this->inner.get());

--- a/ffi/capi/dart/package/lib/src/lib.g.dart
+++ b/ffi/capi/dart/package/lib/src/lib.g.dart
@@ -6887,6 +6887,20 @@ class IsoDate implements ffi.Finalizable {
               'ICU4XIsoDate_year')
           .asFunction<int Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
 
+  /// Returns if the year is a leap year for this date
+  ///
+  /// See the [Rust documentation for `year_is_leap`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap) for more information.
+  bool yearIsLeap() {
+    final result = _ICU4XIsoDate_year_is_leap(_underlying);
+    return result;
+  }
+
+  // ignore: non_constant_identifier_names
+  static final _ICU4XIsoDate_year_is_leap =
+      _capi<ffi.NativeFunction<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>>(
+              'ICU4XIsoDate_year_is_leap')
+          .asFunction<bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
+
   /// Returns the number of months in the year represented by this date
   ///
   /// See the [Rust documentation for `months_in_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.months_in_year) for more information.
@@ -7235,6 +7249,20 @@ class IsoDateTime implements ffi.Finalizable {
       _capi<ffi.NativeFunction<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>>(
               'ICU4XIsoDateTime_year')
           .asFunction<int Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
+
+  /// Returns if the year is a leap year for this date
+  ///
+  /// See the [Rust documentation for `year_is_leap`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap) for more information.
+  bool yearIsLeap() {
+    final result = _ICU4XIsoDateTime_year_is_leap(_underlying);
+    return result;
+  }
+
+  // ignore: non_constant_identifier_names
+  static final _ICU4XIsoDateTime_year_is_leap =
+      _capi<ffi.NativeFunction<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>>(
+              'ICU4XIsoDateTime_year_is_leap')
+          .asFunction<bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
 
   /// Returns the number of months in the year represented by this date
   ///

--- a/ffi/capi/js/package/docs/source/date_ffi.rst
+++ b/ffi/capi/js/package/docs/source/date_ffi.rst
@@ -203,6 +203,13 @@
         See the `Rust documentation for year <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year>`__ for more information.
 
 
+    .. js:method:: year_is_leap()
+
+        Returns if the year is a leap year for this date
+
+        See the `Rust documentation for year_is_leap <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap>`__ for more information.
+
+
     .. js:method:: months_in_year()
 
         Returns the number of months in the year represented by this date

--- a/ffi/capi/js/package/docs/source/datetime_ffi.rst
+++ b/ffi/capi/js/package/docs/source/datetime_ffi.rst
@@ -308,6 +308,13 @@
         See the `Rust documentation for year <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year>`__ for more information.
 
 
+    .. js:method:: year_is_leap()
+
+        Returns if the year is a leap year for this date
+
+        See the `Rust documentation for year_is_leap <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap>`__ for more information.
+
+
     .. js:method:: months_in_year()
 
         Returns the number of months in the year represented by this date

--- a/ffi/capi/js/package/lib/ICU4XIsoDate.d.ts
+++ b/ffi/capi/js/package/lib/ICU4XIsoDate.d.ts
@@ -99,6 +99,14 @@ export class ICU4XIsoDate {
 
   /**
 
+   * Returns if the year is a leap year for this date
+
+   * See the {@link https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap Rust documentation for `year_is_leap`} for more information.
+   */
+  year_is_leap(): boolean;
+
+  /**
+
    * Returns the number of months in the year represented by this date
 
    * See the {@link https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.months_in_year Rust documentation for `months_in_year`} for more information.

--- a/ffi/capi/js/package/lib/ICU4XIsoDate.js
+++ b/ffi/capi/js/package/lib/ICU4XIsoDate.js
@@ -86,6 +86,10 @@ export class ICU4XIsoDate {
     return wasm.ICU4XIsoDate_year(this.underlying);
   }
 
+  year_is_leap() {
+    return wasm.ICU4XIsoDate_year_is_leap(this.underlying);
+  }
+
   months_in_year() {
     return wasm.ICU4XIsoDate_months_in_year(this.underlying);
   }

--- a/ffi/capi/js/package/lib/ICU4XIsoDateTime.d.ts
+++ b/ffi/capi/js/package/lib/ICU4XIsoDateTime.d.ts
@@ -167,6 +167,14 @@ export class ICU4XIsoDateTime {
 
   /**
 
+   * Returns if the year is a leap year for this date
+
+   * See the {@link https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap Rust documentation for `year_is_leap`} for more information.
+   */
+  year_is_leap(): boolean;
+
+  /**
+
    * Returns the number of months in the year represented by this date
 
    * See the {@link https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.months_in_year Rust documentation for `months_in_year`} for more information.

--- a/ffi/capi/js/package/lib/ICU4XIsoDateTime.js
+++ b/ffi/capi/js/package/lib/ICU4XIsoDateTime.js
@@ -120,6 +120,10 @@ export class ICU4XIsoDateTime {
     return wasm.ICU4XIsoDateTime_year(this.underlying);
   }
 
+  year_is_leap() {
+    return wasm.ICU4XIsoDateTime_year_is_leap(this.underlying);
+  }
+
   months_in_year() {
     return wasm.ICU4XIsoDateTime_months_in_year(this.underlying);
   }

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -113,6 +113,12 @@ pub mod ffi {
             self.0.year().number
         }
 
+        /// Returns if the year is a leap year for this date
+        #[diplomat::rust_link(icu::calendar::Date::year_is_leap, FnInStruct)]
+        pub fn year_is_leap(&self) -> bool {
+            self.0.year_is_leap()
+        }
+
         /// Returns the number of months in the year represented by this date
         #[diplomat::rust_link(icu::calendar::Date::months_in_year, FnInStruct)]
         pub fn months_in_year(&self) -> u8 {

--- a/ffi/capi/src/datetime.rs
+++ b/ffi/capi/src/datetime.rs
@@ -172,6 +172,12 @@ pub mod ffi {
             self.0.date.year().number
         }
 
+        /// Returns if the year is a leap year for this date
+        #[diplomat::rust_link(icu::calendar::Date::year_is_leap, FnInStruct)]
+        pub fn year_is_leap(&self) -> bool {
+            self.0.date.year_is_leap()
+        }
+
         /// Returns the number of months in the year represented by this date
         #[diplomat::rust_link(icu::calendar::Date::months_in_year, FnInStruct)]
         pub fn months_in_year(&self) -> u8 {


### PR DESCRIPTION
Adds `year_is_leap` to `Calendar` by using the underlying `ArithmeticCalendar` trait's `is_leap_year` function. Also exposed in `Date`. Closes #3963.