### PR TITLE
Fix datagen with --segmenter-lstm-root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
         - New CLI option `--format=blob2` (https://github.com/unicode-org/icu4x/pull/4207)
         - CLDR 44 compatibility fixes (https://github.com/unicode-org/icu4x/pull/4134, https://github.com/unicode-org/icu4x/pull/4156, https://github.com/unicode-org/icu4x/pull/4158)
         - Fix `supported_locales` for collator keys (https://github.com/unicode-org/icu4x/pull/4169)
+        - CLI: Fix behavior of `--segmenter-lstm-root` such that it does not override `icuexportdata-root` (https://github.com/unicode-org/icu4x/pull/4277)
 - Utilities
     - `databake`
         - Improvements `databake::test_bake!()` (https://github.com/unicode-org/icu4x/pull/4182)

--- a/provider/datagen/src/bin/datagen/mod.rs
+++ b/provider/datagen/src/bin/datagen/mod.rs
@@ -67,7 +67,7 @@ fn main() -> eyre::Result<()> {
     };
 
     provider = match config.segmenter_lstm {
-        config::PathOrTag::Path(path) => provider.with_icuexport(path)?,
+        config::PathOrTag::Path(path) => provider.with_segmenter_lstm(path)?,
         #[cfg(feature = "networking")]
         config::PathOrTag::Latest => {
             provider.with_segmenter_lstm_for_tag(DatagenProvider::LATEST_TESTED_SEGMENTER_LSTM_TAG)


### PR DESCRIPTION
Encountered fun errors where datagen worked fine with `--icuexport-root` but not when you also pass it `--segmenter-lstm-root`; with the segmenter paths overriding icuexportdata.


Thanks to @robertbastian for finding where the bug was.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->