### PR TITLE
Add code to make Bench CI maybe start working

### DIFF
--- a/provider/blob/Cargo.toml
+++ b/provider/blob/Cargo.toml
@@ -49,6 +49,9 @@ export = [
     "zerotrie/litemap",
 ]
 
+[lib]
+bench = false  # This option is required for Benchmark CI
+
 [[bench]]
 name = "blob_version_bench"
 harness = false


### PR DESCRIPTION
https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

I found this in other Cargo.toml files.