### PR TITLE
Rename year_is_leap to is_in_leap_year

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -515,9 +515,9 @@ impl Calendar for AnyCalendar {
         match_cal_and_date!(match (self, date): (c, d) => c.year(d))
     }
 
-    /// The calendar-specific check if year is a leap year represented by `date`
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
-        match_cal_and_date!(match (self, date): (c, d) => c.year_is_leap(d))
+    /// The calendar-specific check if `date` is in a leap year
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
+        match_cal_and_date!(match (self, date): (c, d) => c.is_in_leap_year(d))
     }
 
     /// The calendar-specific month represented by `date`

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -122,8 +122,8 @@ impl Calendar for Buddhist {
         iso_year_as_buddhist(date.0.year)
     }
 
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
-        Iso.year_is_leap(date)
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
+        Iso.is_in_leap_year(date)
     }
 
     /// The calendar-specific month represented by `date`

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -76,7 +76,7 @@ pub trait Calendar {
     fn year(&self, date: &Self::DateInner) -> types::FormattableYear;
 
     /// Calculate if a date is in a leap year
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool;
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool;
 
     /// The calendar-specific month represented by `date`
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth;

--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -226,7 +226,7 @@ impl Calendar for Chinese {
         Self::format_chinese_year(date.0 .0.year, Some(date.0 .1))
     }
 
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::is_leap_year(date.0 .0.year)
     }
 

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -176,7 +176,7 @@ impl Calendar for Coptic {
         year_as_coptic(date.0.year)
     }
 
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::is_leap_year(date.0.year)
     }
 

--- a/components/calendar/src/dangi.rs
+++ b/components/calendar/src/dangi.rs
@@ -206,7 +206,7 @@ impl Calendar for Dangi {
         Self::format_dangi_year(date.0 .0.year, Some(date.0 .1))
     }
 
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::is_leap_year(date.0 .0.year)
     }
 

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -214,10 +214,10 @@ impl<A: AsCalendar> Date<A> {
         self.calendar.as_calendar().year(&self.inner)
     }
 
-    /// The calendar-specific year represented by `self` is a leap year
+    /// Returns whether `self` is in a calendar-specific leap year
     #[inline]
-    pub fn year_is_leap(&self) -> bool {
-        self.calendar.as_calendar().year_is_leap(&self.inner)
+    pub fn is_in_leap_year(&self) -> bool {
+        self.calendar.as_calendar().is_in_leap_year(&self.inner)
     }
 
     /// The calendar-specific month represented by `self`

--- a/components/calendar/src/ethiopian.rs
+++ b/components/calendar/src/ethiopian.rs
@@ -198,7 +198,7 @@ impl Calendar for Ethiopian {
         Self::year_as_ethiopian(date.0.year, self.0)
     }
 
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::is_leap_year(date.0.year)
     }
 

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -126,8 +126,8 @@ impl Calendar for Gregorian {
         year_as_gregorian(date.0 .0.year)
     }
 
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
-        Iso.year_is_leap(&date.0)
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
+        Iso.is_in_leap_year(&date.0)
     }
 
     /// The calendar-specific month represented by `date`

--- a/components/calendar/src/hebrew.rs
+++ b/components/calendar/src/hebrew.rs
@@ -228,7 +228,7 @@ impl Calendar for Hebrew {
         Self::year_as_hebrew(date.0.year)
     }
 
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::is_leap_year(date.0.year)
     }
 

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -200,7 +200,7 @@ impl Calendar for Indian {
         }
     }
 
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::is_leap_year(date.0.year)
     }
 

--- a/components/calendar/src/islamic.rs
+++ b/components/calendar/src/islamic.rs
@@ -239,7 +239,7 @@ impl Calendar for IslamicObservational {
         Self::year_as_islamic(date.0.year)
     }
 
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::is_leap_year(date.0.year)
     }
 
@@ -468,7 +468,7 @@ impl Calendar for IslamicUmmAlQura {
         Self::year_as_islamic(date.0.year)
     }
 
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::is_leap_year(date.0.year)
     }
 
@@ -712,7 +712,7 @@ impl Calendar for IslamicCivil {
         Self::year_as_islamic(date.0.year)
     }
 
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::is_leap_year(date.0.year)
     }
 
@@ -956,7 +956,7 @@ impl Calendar for IslamicTabular {
         Self::year_as_islamic(date.0.year)
     }
 
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::is_leap_year(date.0.year)
     }
 

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -194,7 +194,7 @@ impl Calendar for Iso {
         Self::year_as_iso(date.0.year)
     }
 
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::is_leap_year(date.0.year)
     }
 

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -282,8 +282,8 @@ impl Calendar for Japanese {
         }
     }
 
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
-        Iso.year_is_leap(&date.inner)
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
+        Iso.is_in_leap_year(&date.inner)
     }
 
     /// The calendar-specific month represented by `date`
@@ -383,8 +383,8 @@ impl Calendar for JapaneseExtended {
         Japanese::year(&self.0, date)
     }
 
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
-        Japanese::year_is_leap(&self.0, date)
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
+        Japanese::is_in_leap_year(&self.0, date)
     }
 
     /// The calendar-specific month represented by `date`

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -169,7 +169,7 @@ impl Calendar for Julian {
         year_as_gregorian(date.0.year)
     }
 
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::is_leap_year(date.0.year)
     }
 

--- a/components/calendar/src/persian.rs
+++ b/components/calendar/src/persian.rs
@@ -171,7 +171,7 @@ impl Calendar for Persian {
         Self::year_as_persian(date.0.year)
     }
 
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::is_leap_year(date.0.year)
     }
 

--- a/components/calendar/src/roc.rs
+++ b/components/calendar/src/roc.rs
@@ -146,8 +146,8 @@ impl Calendar for Roc {
         year_as_roc(date.0 .0.year as i64)
     }
 
-    fn year_is_leap(&self, date: &Self::DateInner) -> bool {
-        Iso.year_is_leap(&date.0)
+    fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
+        Iso.is_in_leap_year(&date.0)
     }
 
     fn month(&self, date: &Self::DateInner) -> crate::types::FormattableMonth {

--- a/ffi/capi/c/include/ICU4XIsoDate.h
+++ b/ffi/capi/c/include/ICU4XIsoDate.h
@@ -45,7 +45,7 @@ uint32_t ICU4XIsoDate_month(const ICU4XIsoDate* self);
 
 int32_t ICU4XIsoDate_year(const ICU4XIsoDate* self);
 
-bool ICU4XIsoDate_year_is_leap(const ICU4XIsoDate* self);
+bool ICU4XIsoDate_is_in_leap_year(const ICU4XIsoDate* self);
 
 uint8_t ICU4XIsoDate_months_in_year(const ICU4XIsoDate* self);
 

--- a/ffi/capi/c/include/ICU4XIsoDateTime.h
+++ b/ffi/capi/c/include/ICU4XIsoDateTime.h
@@ -63,7 +63,7 @@ uint32_t ICU4XIsoDateTime_month(const ICU4XIsoDateTime* self);
 
 int32_t ICU4XIsoDateTime_year(const ICU4XIsoDateTime* self);
 
-bool ICU4XIsoDateTime_year_is_leap(const ICU4XIsoDateTime* self);
+bool ICU4XIsoDateTime_is_in_leap_year(const ICU4XIsoDateTime* self);
 
 uint8_t ICU4XIsoDateTime_months_in_year(const ICU4XIsoDateTime* self);
 

--- a/ffi/capi/cpp/docs/source/date_ffi.rst
+++ b/ffi/capi/cpp/docs/source/date_ffi.rst
@@ -219,11 +219,11 @@
         See the `Rust documentation for year <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year>`__ for more information.
 
 
-    .. cpp:function:: bool year_is_leap() const
+    .. cpp:function:: bool is_in_leap_year() const
 
         Returns if the year is a leap year for this date
 
-        See the `Rust documentation for year_is_leap <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap>`__ for more information.
+        See the `Rust documentation for is_in_leap_year <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.is_in_leap_year>`__ for more information.
 
 
     .. cpp:function:: uint8_t months_in_year() const

--- a/ffi/capi/cpp/docs/source/datetime_ffi.rst
+++ b/ffi/capi/cpp/docs/source/datetime_ffi.rst
@@ -322,11 +322,11 @@
         See the `Rust documentation for year <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year>`__ for more information.
 
 
-    .. cpp:function:: bool year_is_leap() const
+    .. cpp:function:: bool is_in_leap_year() const
 
-        Returns if the year is a leap year for this date
+        Returns whether this date is in a leap year
 
-        See the `Rust documentation for year_is_leap <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap>`__ for more information.
+        See the `Rust documentation for is_in_leap_year <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.is_in_leap_year>`__ for more information.
 
 
     .. cpp:function:: uint8_t months_in_year() const

--- a/ffi/capi/cpp/include/ICU4XIsoDate.h
+++ b/ffi/capi/cpp/include/ICU4XIsoDate.h
@@ -45,7 +45,7 @@ uint32_t ICU4XIsoDate_month(const ICU4XIsoDate* self);
 
 int32_t ICU4XIsoDate_year(const ICU4XIsoDate* self);
 
-bool ICU4XIsoDate_year_is_leap(const ICU4XIsoDate* self);
+bool ICU4XIsoDate_is_in_leap_year(const ICU4XIsoDate* self);
 
 uint8_t ICU4XIsoDate_months_in_year(const ICU4XIsoDate* self);
 

--- a/ffi/capi/cpp/include/ICU4XIsoDate.hpp
+++ b/ffi/capi/cpp/include/ICU4XIsoDate.hpp
@@ -110,9 +110,9 @@ class ICU4XIsoDate {
   /**
    * Returns if the year is a leap year for this date
    * 
-   * See the [Rust documentation for `year_is_leap`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap) for more information.
+   * See the [Rust documentation for `is_in_leap_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.is_in_leap_year) for more information.
    */
-  bool year_is_leap() const;
+  bool is_in_leap_year() const;
 
   /**
    * Returns the number of months in the year represented by this date
@@ -194,8 +194,8 @@ inline uint32_t ICU4XIsoDate::month() const {
 inline int32_t ICU4XIsoDate::year() const {
   return capi::ICU4XIsoDate_year(this->inner.get());
 }
-inline bool ICU4XIsoDate::year_is_leap() const {
-  return capi::ICU4XIsoDate_year_is_leap(this->inner.get());
+inline bool ICU4XIsoDate::is_in_leap_year() const {
+  return capi::ICU4XIsoDate_is_in_leap_year(this->inner.get());
 }
 inline uint8_t ICU4XIsoDate::months_in_year() const {
   return capi::ICU4XIsoDate_months_in_year(this->inner.get());

--- a/ffi/capi/cpp/include/ICU4XIsoDateTime.h
+++ b/ffi/capi/cpp/include/ICU4XIsoDateTime.h
@@ -63,7 +63,7 @@ uint32_t ICU4XIsoDateTime_month(const ICU4XIsoDateTime* self);
 
 int32_t ICU4XIsoDateTime_year(const ICU4XIsoDateTime* self);
 
-bool ICU4XIsoDateTime_year_is_leap(const ICU4XIsoDateTime* self);
+bool ICU4XIsoDateTime_is_in_leap_year(const ICU4XIsoDateTime* self);
 
 uint8_t ICU4XIsoDateTime_months_in_year(const ICU4XIsoDateTime* self);
 

--- a/ffi/capi/cpp/include/ICU4XIsoDateTime.hpp
+++ b/ffi/capi/cpp/include/ICU4XIsoDateTime.hpp
@@ -169,11 +169,11 @@ class ICU4XIsoDateTime {
   int32_t year() const;
 
   /**
-   * Returns if the year is a leap year for this date
+   * Returns whether this date is in a leap year
    * 
-   * See the [Rust documentation for `year_is_leap`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap) for more information.
+   * See the [Rust documentation for `is_in_leap_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.is_in_leap_year) for more information.
    */
-  bool year_is_leap() const;
+  bool is_in_leap_year() const;
 
   /**
    * Returns the number of months in the year represented by this date
@@ -281,8 +281,8 @@ inline uint32_t ICU4XIsoDateTime::month() const {
 inline int32_t ICU4XIsoDateTime::year() const {
   return capi::ICU4XIsoDateTime_year(this->inner.get());
 }
-inline bool ICU4XIsoDateTime::year_is_leap() const {
-  return capi::ICU4XIsoDateTime_year_is_leap(this->inner.get());
+inline bool ICU4XIsoDateTime::is_in_leap_year() const {
+  return capi::ICU4XIsoDateTime_is_in_leap_year(this->inner.get());
 }
 inline uint8_t ICU4XIsoDateTime::months_in_year() const {
   return capi::ICU4XIsoDateTime_months_in_year(this->inner.get());

--- a/ffi/capi/dart/package/lib/src/lib.g.dart
+++ b/ffi/capi/dart/package/lib/src/lib.g.dart
@@ -6889,16 +6889,16 @@ class IsoDate implements ffi.Finalizable {
 
   /// Returns if the year is a leap year for this date
   ///
-  /// See the [Rust documentation for `year_is_leap`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap) for more information.
-  bool yearIsLeap() {
-    final result = _ICU4XIsoDate_year_is_leap(_underlying);
+  /// See the [Rust documentation for `is_in_leap_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.is_in_leap_year) for more information.
+  bool get isInLeapYear {
+    final result = _ICU4XIsoDate_is_in_leap_year(_underlying);
     return result;
   }
 
   // ignore: non_constant_identifier_names
-  static final _ICU4XIsoDate_year_is_leap =
+  static final _ICU4XIsoDate_is_in_leap_year =
       _capi<ffi.NativeFunction<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>>(
-              'ICU4XIsoDate_year_is_leap')
+              'ICU4XIsoDate_is_in_leap_year')
           .asFunction<bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
 
   /// Returns the number of months in the year represented by this date
@@ -7250,18 +7250,18 @@ class IsoDateTime implements ffi.Finalizable {
               'ICU4XIsoDateTime_year')
           .asFunction<int Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
 
-  /// Returns if the year is a leap year for this date
+  /// Returns whether this date is in a leap year
   ///
-  /// See the [Rust documentation for `year_is_leap`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap) for more information.
-  bool yearIsLeap() {
-    final result = _ICU4XIsoDateTime_year_is_leap(_underlying);
+  /// See the [Rust documentation for `is_in_leap_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.is_in_leap_year) for more information.
+  bool get isInLeapYear {
+    final result = _ICU4XIsoDateTime_is_in_leap_year(_underlying);
     return result;
   }
 
   // ignore: non_constant_identifier_names
-  static final _ICU4XIsoDateTime_year_is_leap =
+  static final _ICU4XIsoDateTime_is_in_leap_year =
       _capi<ffi.NativeFunction<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>>(
-              'ICU4XIsoDateTime_year_is_leap')
+              'ICU4XIsoDateTime_is_in_leap_year')
           .asFunction<bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
 
   /// Returns the number of months in the year represented by this date

--- a/ffi/capi/js/package/docs/source/date_ffi.rst
+++ b/ffi/capi/js/package/docs/source/date_ffi.rst
@@ -203,11 +203,11 @@
         See the `Rust documentation for year <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year>`__ for more information.
 
 
-    .. js:method:: year_is_leap()
+    .. js:method:: is_in_leap_year()
 
         Returns if the year is a leap year for this date
 
-        See the `Rust documentation for year_is_leap <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap>`__ for more information.
+        See the `Rust documentation for is_in_leap_year <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.is_in_leap_year>`__ for more information.
 
 
     .. js:method:: months_in_year()

--- a/ffi/capi/js/package/docs/source/datetime_ffi.rst
+++ b/ffi/capi/js/package/docs/source/datetime_ffi.rst
@@ -308,11 +308,11 @@
         See the `Rust documentation for year <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year>`__ for more information.
 
 
-    .. js:method:: year_is_leap()
+    .. js:method:: is_in_leap_year()
 
-        Returns if the year is a leap year for this date
+        Returns whether this date is in a leap year
 
-        See the `Rust documentation for year_is_leap <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap>`__ for more information.
+        See the `Rust documentation for is_in_leap_year <https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.is_in_leap_year>`__ for more information.
 
 
     .. js:method:: months_in_year()

--- a/ffi/capi/js/package/lib/ICU4XIsoDate.d.ts
+++ b/ffi/capi/js/package/lib/ICU4XIsoDate.d.ts
@@ -101,9 +101,9 @@ export class ICU4XIsoDate {
 
    * Returns if the year is a leap year for this date
 
-   * See the {@link https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap Rust documentation for `year_is_leap`} for more information.
+   * See the {@link https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.is_in_leap_year Rust documentation for `is_in_leap_year`} for more information.
    */
-  year_is_leap(): boolean;
+  is_in_leap_year(): boolean;
 
   /**
 

--- a/ffi/capi/js/package/lib/ICU4XIsoDate.js
+++ b/ffi/capi/js/package/lib/ICU4XIsoDate.js
@@ -86,8 +86,8 @@ export class ICU4XIsoDate {
     return wasm.ICU4XIsoDate_year(this.underlying);
   }
 
-  year_is_leap() {
-    return wasm.ICU4XIsoDate_year_is_leap(this.underlying);
+  is_in_leap_year() {
+    return wasm.ICU4XIsoDate_is_in_leap_year(this.underlying);
   }
 
   months_in_year() {

--- a/ffi/capi/js/package/lib/ICU4XIsoDateTime.d.ts
+++ b/ffi/capi/js/package/lib/ICU4XIsoDateTime.d.ts
@@ -167,11 +167,11 @@ export class ICU4XIsoDateTime {
 
   /**
 
-   * Returns if the year is a leap year for this date
+   * Returns whether this date is in a leap year
 
-   * See the {@link https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year_is_leap Rust documentation for `year_is_leap`} for more information.
+   * See the {@link https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.is_in_leap_year Rust documentation for `is_in_leap_year`} for more information.
    */
-  year_is_leap(): boolean;
+  is_in_leap_year(): boolean;
 
   /**
 

--- a/ffi/capi/js/package/lib/ICU4XIsoDateTime.js
+++ b/ffi/capi/js/package/lib/ICU4XIsoDateTime.js
@@ -120,8 +120,8 @@ export class ICU4XIsoDateTime {
     return wasm.ICU4XIsoDateTime_year(this.underlying);
   }
 
-  year_is_leap() {
-    return wasm.ICU4XIsoDateTime_year_is_leap(this.underlying);
+  is_in_leap_year() {
+    return wasm.ICU4XIsoDateTime_is_in_leap_year(this.underlying);
   }
 
   months_in_year() {

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -114,9 +114,9 @@ pub mod ffi {
         }
 
         /// Returns if the year is a leap year for this date
-        #[diplomat::rust_link(icu::calendar::Date::year_is_leap, FnInStruct)]
-        pub fn year_is_leap(&self) -> bool {
-            self.0.year_is_leap()
+        #[diplomat::rust_link(icu::calendar::Date::is_in_leap_year, FnInStruct)]
+        pub fn is_in_leap_year(&self) -> bool {
+            self.0.is_in_leap_year()
         }
 
         /// Returns the number of months in the year represented by this date

--- a/ffi/capi/src/datetime.rs
+++ b/ffi/capi/src/datetime.rs
@@ -172,10 +172,10 @@ pub mod ffi {
             self.0.date.year().number
         }
 
-        /// Returns if the year is a leap year for this date
-        #[diplomat::rust_link(icu::calendar::Date::year_is_leap, FnInStruct)]
-        pub fn year_is_leap(&self) -> bool {
-            self.0.date.year_is_leap()
+        /// Returns whether this date is in a leap year
+        #[diplomat::rust_link(icu::calendar::Date::is_in_leap_year, FnInStruct)]
+        pub fn is_in_leap_year(&self) -> bool {
+            self.0.date.is_in_leap_year()
         }
 
         /// Returns the number of months in the year represented by this date


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/3963 (again)