### PR TITLE
Fix corner rounding of Calendar in Wasm demo page

### DIFF
--- a/ffi/capi/js/examples/wasm-demo/index.html
+++ b/ffi/capi/js/examples/wasm-demo/index.html
@@ -158,29 +158,26 @@
                                 </div>
                             </div>
                             <div class="input-group" role="group" aria-label="DateTime Formatting Locale">
-                                  <div class="input-group-prepend">
-                                    <span class="input-group-text">Calendar</span>
-                                  </div>
-                                  <select name="dtf-calendar" class="form-select">
-                                      <option value="from-locale" selected>Default for locale</option>
-                                      <option value="buddhist">Buddhist</option>
-                                      <option value="chinese">Chinese</option>
-                                      <option value="coptic">Coptic</option>
-                                      <option value="dangi">Dangi</option>
-                                      <option value="ethiopic">Ethiopian</option>
-                                      <option value="gregory">Gregorian</option>
-                                      <option value="indian">Indian national</option>
-                                      <option value="islamicc">Islamic Civil</option>
-                                      <option value="islamic">Islamic Observational</option>
-                                      <option value="tbla">Islamic Tabular</option>
-                                      <option value="umalqura">Islamic Umm-al-Qura</option>
-                                      <option value="japanese">Japanese</option>
-                                      <option value="japanext">Japanese (historical eras)</option>
-                                      <option value="persian">Persian</option>
-                                      <option value="roc">Republic of China</option>
-                                    </select>
+                                <span class="input-group-text">Calendar</span>
+                                <select name="dtf-calendar" class="form-select">
+                                    <option value="from-locale" selected>Default for locale</option>
+                                    <option value="buddhist">Buddhist</option>
+                                    <option value="chinese">Chinese</option>
+                                    <option value="coptic">Coptic</option>
+                                    <option value="dangi">Dangi</option>
+                                    <option value="ethiopic">Ethiopian</option>
+                                    <option value="gregory">Gregorian</option>
+                                    <option value="indian">Indian national</option>
+                                    <option value="islamicc">Islamic Civil</option>
+                                    <option value="islamic">Islamic Observational</option>
+                                    <option value="tbla">Islamic Tabular</option>
+                                    <option value="umalqura">Islamic Umm-al-Qura</option>
+                                    <option value="japanese">Japanese</option>
+                                    <option value="japanext">Japanese (historical eras)</option>
+                                    <option value="persian">Persian</option>
+                                    <option value="roc">Republic of China</option>
+                                </select>
                             </div>
-
                         </div>
 
                         Date length


### PR DESCRIPTION
Fixes #4017. It should just be a span as Bootstrap 5 uses `:not(:last-child)` to check itself (Bootstrap 4 used the old method which was broken with 5). Also fixed surrounding formatting.