### PR TITLE
Revert "Use relative paths in tests"

### DIFF
--- a/components/casemap/tests/gen_greek_to_me.rs
+++ b/components/casemap/tests/gen_greek_to_me.rs
@@ -10,6 +10,8 @@ use icu_normalizer::DecomposingNormalizer;
 use icu_properties::{maps, GeneralCategoryGroup, Script};
 use std::collections::BTreeMap;
 use std::fmt::Write;
+use std::fs;
+use std::path::Path;
 
 fn main() {
     let decomposer = DecomposingNormalizer::new_nfd();
@@ -168,7 +170,9 @@ pub(crate) fn match_extras(ch: char) -> Option<u8> {{
         vec_1f00.len(),
     );
 
-    let local = include_str!("../src/greek_to_me/data.rs");
+    let local = Path::new(std::env!("CARGO_MANIFEST_DIR")).join("src/greek_to_me/data.rs");
+
+    let local = fs::read_to_string(local).expect("src/greek_to_me/data.rs should be a UTF-8 file");
 
     // We cannot just check if the two are unequal because on Windows core.autocrlf
     // may have messed with the line endings on the file, or it may have not (either

--- a/experimental/transliterate/tests/cldr.rs
+++ b/experimental/transliterate/tests/cldr.rs
@@ -12,10 +12,11 @@ include!("data/baked/mod.rs");
 
 #[test]
 fn test_all_cldr() {
-    let mut in_order = std::fs::read_dir("tests/data/fixtures")
-        .unwrap()
-        .map(|x| x.unwrap().path())
-        .collect::<Vec<_>>();
+    let mut in_order =
+        std::fs::read_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/data/fixtures"))
+            .unwrap()
+            .map(|x| x.unwrap().path())
+            .collect::<Vec<_>>();
     in_order.sort();
     for path in in_order {
         if path.ends_with("_readme.txt") {

--- a/provider/adapters/src/fork/predicates.rs
+++ b/provider/adapters/src/fork/predicates.rs
@@ -76,8 +76,10 @@ impl ForkByErrorPredicate for MissingDataKeyPredicate {
 /// use icu_locid::locale;
 ///
 /// // The `tests` directory contains two separate "language packs" for Hello World data.
-/// let provider_de = FsDataProvider::try_new("tests/data/langtest/de").unwrap();
-/// let provider_ro = FsDataProvider::try_new("tests/data/langtest/ro").unwrap();
+/// let base_dir = std::path::PathBuf::from(std::env!("CARGO_MANIFEST_DIR"))
+///     .join("tests/data/langtest");
+/// let provider_de = FsDataProvider::try_new(base_dir.join("de")).unwrap();
+/// let provider_ro = FsDataProvider::try_new(base_dir.join("ro")).unwrap();
 ///
 /// // Create the forking provider:
 /// let provider = ForkByErrorProvider::new_with_predicate(

--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -36,7 +36,10 @@ use yoke::*;
 /// use writeable::assert_writeable_eq;
 ///
 /// // Read an ICU4X data blob dynamically:
-/// let blob = std::fs::read("tests/data/v2.postcard")
+/// let blob = std::fs::read(concat!(
+///     env!("CARGO_MANIFEST_DIR"),
+///     "/tests/data/v2.postcard",
+/// ))
 /// .expect("Reading pre-computed postcard buffer");
 ///
 /// // Create a DataProvider from it:
@@ -64,7 +67,10 @@ use yoke::*;
 /// use writeable::assert_writeable_eq;
 ///
 /// // Read an ICU4X data blob statically:
-/// const HELLO_WORLD_BLOB: &[u8] = include_bytes!("../tests/data/v2.postcard");
+/// const HELLO_WORLD_BLOB: &[u8] = include_bytes!(concat!(
+///     env!("CARGO_MANIFEST_DIR"),
+///     "/tests/data/v2.postcard"
+/// ));
 ///
 /// // Create a DataProvider from it:
 /// let provider = BlobDataProvider::try_new_from_static_blob(HELLO_WORLD_BLOB)

--- a/provider/blob/src/export/mod.rs
+++ b/provider/blob/src/export/mod.rs
@@ -27,7 +27,8 @@
 //!     .unwrap();
 //!
 //! // communicate the blob to the client application (network, disk, etc.)
-//! # assert_eq!(blob, include_bytes!("../../tests/data/v2.postcard"));
+//! # let golden_blob = std::fs::read(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/data/v2.postcard")).unwrap();
+//! # assert_eq!(blob, golden_blob);
 //! ```
 //!
 //! The resulting blob can now be used like this:
@@ -39,18 +40,15 @@
 //! use icu_provider_blob::BlobDataProvider;
 //!
 //! // obtain the data blob
-//! # let blob = include_bytes!("../../tests/data/v2.postcard").to_vec();
+//! # let blob = std::fs::read(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/data/v2.postcard")).unwrap();
 //!
 //! // Create a provider reading from the blob
-//! let provider = BlobDataProvider::try_new_from_blob(blob.into_boxed_slice())
-//!     .expect("Should successfully read from blob");
+//! let provider =
+//!     BlobDataProvider::try_new_from_blob(blob.into_boxed_slice())
+//!         .expect("Should successfully read from blob");
 //!
 //! // Use the provider as a `BufferProvider`
-//! let formatter = HelloWorldFormatter::try_new_with_buffer_provider(
-//!     &provider,
-//!     &langid!("en").into(),
-//! )
-//! .unwrap();
+//! let formatter = HelloWorldFormatter::try_new_with_buffer_provider(&provider, &langid!("en").into()).unwrap();
 //!
 //! assert_eq!(formatter.format_to_string(), "Hello World");
 //! ```

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -383,18 +383,13 @@ pub fn keys<S: AsRef<str>>(strings: &[S]) -> Vec<DataKey> {
 #[deprecated(since = "1.3.0", note = "use Rust code")]
 #[cfg(feature = "legacy_api")]
 pub fn keys_from_file<P: AsRef<Path>>(path: P) -> std::io::Result<Vec<DataKey>> {
-    let file = std::fs::File::open(path.as_ref())?;
-    keys_from_file_inner(&file)
-}
-
-#[cfg(feature = "legacy_api")]
-fn keys_from_file_inner<R: std::io::Read>(source: R) -> std::io::Result<Vec<DataKey>> {
     use std::io::{BufRead, BufReader};
-    BufReader::new(source)
+    BufReader::new(std::fs::File::open(path.as_ref())?)
         .lines()
         .filter_map(|k| k.map(crate::key).transpose())
         .collect()
 }
+
 /// Parses a compiled binary and returns a list of [`DataKey`]s that it uses *at runtime*.
 ///
 /// This function is intended to be used for binaries that use `AnyProvider` or `BufferProvider`,
@@ -421,23 +416,19 @@ fn keys_from_file_inner<R: std::io::Read>(source: R) -> std::io::Result<Vec<Data
 /// ```
 //  Supports the hello world key
 pub fn keys_from_bin<P: AsRef<Path>>(path: P) -> std::io::Result<Vec<DataKey>> {
+    use memchr::memmem::*;
+
     let file = std::fs::read(path.as_ref())?;
     let file = file.as_slice();
-
-    Ok(keys_from_bin_inner(file))
-}
-
-fn keys_from_bin_inner(bytes: &[u8]) -> Vec<DataKey> {
-    use memchr::memmem::*;
 
     const LEADING_TAG: &[u8] = icu_provider::leading_tag!().as_bytes();
     const TRAILING_TAG: &[u8] = icu_provider::trailing_tag!().as_bytes();
 
     let trailing_tag = Finder::new(TRAILING_TAG);
 
-    let mut result: Vec<DataKey> = find_iter(bytes, LEADING_TAG)
+    let mut result: Vec<DataKey> = find_iter(file, LEADING_TAG)
         .map(|tag_position| tag_position + LEADING_TAG.len())
-        .map(|key_start| &bytes[key_start..])
+        .map(|key_start| &file[key_start..])
         .filter_map(move |key_fragment| {
             trailing_tag
                 .find(key_fragment)
@@ -451,7 +442,7 @@ fn keys_from_bin_inner(bytes: &[u8]) -> Vec<DataKey> {
     result.sort();
     result.dedup();
 
-    result
+    Ok(result)
 }
 
 #[deprecated(since = "1.3.0", note = "use `DatagenDriver`")]
@@ -681,11 +672,12 @@ fn test_keys() {
 #[cfg(feature = "legacy_api")]
 fn test_keys_from_file() {
     #![allow(deprecated)]
-
-    const BYTES: &[u8] = include_bytes!("../tests/data/tutorial_buffer+keys.txt");
-
     assert_eq!(
-        keys_from_file_inner(BYTES).unwrap(),
+        keys_from_file(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/data/tutorial_buffer+keys.txt"
+        ))
+        .unwrap(),
         vec![
             icu_datetime::provider::calendar::GregorianDateLengthsV1Marker::KEY,
             icu_datetime::provider::calendar::GregorianDateSymbolsV1Marker::KEY,
@@ -701,10 +693,12 @@ fn test_keys_from_file() {
 fn test_keys_from_bin() {
     // File obtained by running
     // cargo +nightly --config docs/tutorials/testing/patch.toml build -p tutorial_buffer --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --manifest-path docs/tutorials/crates/buffer/Cargo.toml && cp docs/tutorials/target/wasm32-unknown-unknown/release/tutorial_buffer.wasm provider/datagen/tests/data/
-    const BYTES: &[u8] = include_bytes!("../tests/data/tutorial_buffer.wasm");
-
     assert_eq!(
-        keys_from_bin_inner(BYTES),
+        keys_from_bin(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/data/tutorial_buffer.wasm"
+        ))
+        .unwrap(),
         vec![
             icu_datetime::provider::calendar::GregorianDateLengthsV1Marker::KEY,
             icu_datetime::provider::calendar::GregorianDateSymbolsV1Marker::KEY,

--- a/provider/datagen/src/provider.rs
+++ b/provider/datagen/src/provider.rs
@@ -62,19 +62,21 @@ impl DatagenProvider {
     }
 
     #[cfg(test)]
-    // This is equivalent for the files defined in `tools/testdata-scripts/globs.rs.data`.
     pub fn new_testing() -> Self {
         // Singleton so that all instantiations share the same cache.
         static SINGLETON: once_cell::sync::OnceCell<DatagenProvider> =
             once_cell::sync::OnceCell::new();
         SINGLETON
             .get_or_init(|| {
+                // This is equivalent for the files defined in `tools/testdata-scripts/globs.rs.data`.
+                let data_root =
+                    std::path::Path::new(core::env!("CARGO_MANIFEST_DIR")).join("tests/data");
                 Self::new_custom()
-                    .with_cldr("tests/data/cldr".into())
+                    .with_cldr(data_root.join("cldr"))
                     .unwrap()
-                    .with_icuexport("tests/data/icuexport".into())
+                    .with_icuexport(data_root.join("icuexport"))
                     .unwrap()
-                    .with_segmenter_lstm("tests/data/lstm".into())
+                    .with_segmenter_lstm(data_root.join("lstm"))
                     .unwrap()
             })
             .clone()

--- a/provider/datagen/src/tests/make_testdata.rs
+++ b/provider/datagen/src/tests/make_testdata.rs
@@ -13,6 +13,7 @@ use std::cell::Cell;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::io::Write;
+use std::path::Path;
 use std::sync::Mutex;
 
 include!("../../tests/locales.rs.data");
@@ -26,10 +27,12 @@ fn generate_json_and_verify_postcard() {
         .init()
         .unwrap();
 
+    let data_root = Path::new(concat!(core::env!("CARGO_MANIFEST_DIR"), "/tests/data/"));
+
     let json_out = Box::new(
         FilesystemExporter::try_new(Box::new(Json::pretty()), {
             let mut options = ExporterOptions::default();
-            options.root = "tests/data/json".into();
+            options.root = data_root.join("json");
             options.overwrite = OverwriteOption::RemoveAndReplace;
             options
         })
@@ -42,7 +45,7 @@ fn generate_json_and_verify_postcard() {
         zero_copy_transient_violations: Default::default(),
         rountrip_errors: Default::default(),
         fingerprints: BufWriterWithLineEndingFix::new(
-            File::create("tests/data/postcard/fingerprints.csv").unwrap(),
+            File::create(data_root.join("postcard/fingerprints.csv")).unwrap(),
         ),
     });
 

--- a/provider/datagen/tests/test-options.rs
+++ b/provider/datagen/tests/test-options.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use std::collections::{BTreeMap, HashSet};
+use std::path::Path;
 
 use elsa::sync::FrozenMap;
 use icu_datagen::prelude::*;
@@ -59,10 +60,12 @@ fn test_fallback_options() {
         .init()
         .unwrap();
 
+    let data_root = Path::new(concat!(core::env!("CARGO_MANIFEST_DIR"), "/tests/data/"));
+
     let provider = DatagenProvider::new_custom()
-        .with_cldr("tests/data/cldr".into())
+        .with_cldr(data_root.join("cldr"))
         .unwrap()
-        .with_icuexport("tests/data/icuexport".into())
+        .with_icuexport(data_root.join("icuexport"))
         .unwrap();
 
     let mut testing_exporter = TestingExporter::default();

--- a/provider/fs/src/export/mod.rs
+++ b/provider/fs/src/export/mod.rs
@@ -42,17 +42,13 @@
 //! use icu_provider::prelude::*;
 //! use icu_provider_fs::FsDataProvider;
 //!
-//! # let demo_path = "tests/data/json";
+//! # let demo_path = std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/data/json"));
 //! // Create a filesystem provider reading from the demo directory
 //! let provider = FsDataProvider::try_new(&demo_path)
 //!     .expect("Should successfully read from filesystem");
 //!
 //! // Use the provider as a `BufferProvider`
-//! let formatter = HelloWorldFormatter::try_new_with_buffer_provider(
-//!     &provider,
-//!     &langid!("en").into(),
-//! )
-//! .unwrap();
+//! let formatter = HelloWorldFormatter::try_new_with_buffer_provider(&provider, &langid!("en").into()).unwrap();
 //!
 //! assert_eq!(formatter.format_to_string(), "Hello World");
 //! ```

--- a/provider/fs/src/fs_data_provider.rs
+++ b/provider/fs/src/fs_data_provider.rs
@@ -24,8 +24,11 @@ use std::path::PathBuf;
 /// use writeable::assert_writeable_eq;
 ///
 /// // Create a DataProvider from data files stored in a filesystem directory:
-/// let provider =
-///     FsDataProvider::try_new("tests/data/json").expect("Directory exists");
+/// let provider = FsDataProvider::try_new(concat!(
+///     env!("CARGO_MANIFEST_DIR"),
+///     "/tests/data/json",
+/// ))
+/// .expect("Directory exists");
 ///
 /// // Check that it works:
 /// let formatter = HelloWorldFormatter::try_new_with_buffer_provider(

--- a/provider/fs/tests/test_file_io.rs
+++ b/provider/fs/tests/test_file_io.rs
@@ -8,11 +8,11 @@ use icu_provider::hello_world::{HelloWorldProvider, HelloWorldV1, HelloWorldV1Ma
 use icu_provider::prelude::*;
 use icu_provider_fs::FsDataProvider;
 
-const PATHS: &[&str] = &[
-    "tests/data/json",
-    "tests/data/bincode",
-    "tests/data/postcard",
-];
+const JSON_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/data/json");
+const BINCODE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/data/bincode");
+const POSTCARD_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/data/postcard");
+
+const PATHS: &[&str] = &[JSON_PATH, BINCODE_PATH, POSTCARD_PATH];
 
 #[test]
 fn test_provider() {

--- a/provider/testdata/benches/providers.rs
+++ b/provider/testdata/benches/providers.rs
@@ -11,12 +11,15 @@ use icu_provider::prelude::*;
 use icu_provider::AsDeserializingBufferProvider;
 use icu_provider_blob::BlobDataProvider;
 
-static POSTCARD_BYTES: &[u8] = include_bytes!("../data/testdata.postcard");
+static POSTCARD_BYTES: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/data/testdata.postcard"
+));
 
 struct BakedDataProvider;
 
 mod baked {
-    include!("../data/baked/mod.rs");
+    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/data/baked/mod.rs"));
     impl_data_provider!(super::BakedDataProvider);
     impl_any_provider!(super::BakedDataProvider);
 }

--- a/utils/resb/examples/time_zone_rule.rs
+++ b/utils/resb/examples/time_zone_rule.rs
@@ -2,7 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use std::{char::DecodeUtf16Error, collections::HashMap, fmt::Debug, marker::PhantomData};
+use std::{
+    char::DecodeUtf16Error, collections::HashMap, fmt::Debug, marker::PhantomData, path::Path,
+};
 
 use serde::{
     de::{self, Visitor},
@@ -145,9 +147,13 @@ pub struct ZoneInfo64<'a> {
 }
 
 fn main() {
-    let in_bytes = include_bytes!("data/zoneinfo64.res");
+    let in_bytes = std::fs::read(Path::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/examples/data/zoneinfo64.res"
+    )))
+    .expect("Unable to read resource bundle file");
 
-    let out = resb::binary::from_bytes::<ZoneInfo64>(in_bytes)
+    let out = resb::binary::from_bytes::<ZoneInfo64>(&in_bytes)
         .expect("Error processing resource bundle file");
 
     println!("{:#?}", out);


### PR DESCRIPTION
Reverts unicode-org/icu4x#4294

It's a regression in behavior to not use absolute paths in integration test binaries. The changes to docs tests seem fine but I don't have time today to split the PR into pieces.