### PR TITLE
ZeroTrie: Refactor helpers to not require as many Options

### DIFF
--- a/experimental/zerotrie/src/byte_phf/mod.rs
+++ b/experimental/zerotrie/src/byte_phf/mod.rs
@@ -213,7 +213,7 @@ where
         if n == 0 {
             return None;
         }
-        let (qq, eks) = debug_split_at(buffer, n)?;
+        let (qq, eks) = debug_split_at(buffer, n);
         debug_assert_eq!(qq.len(), eks.len());
         let q = debug_get(qq, f1(key, *p, n))?;
         let l2 = f2(key, q, n);
@@ -232,9 +232,7 @@ where
     /// Get an iterator over the keys in the order in which they are stored in the map.
     pub fn keys(&self) -> &[u8] {
         let n = self.num_items();
-        debug_split_at(self.0.as_ref(), 1 + n)
-            .map(|s| s.1)
-            .unwrap_or(&[])
+        debug_split_at(self.0.as_ref(), 1 + n).1
     }
     /// Diagnostic function that returns `p` and the maximum value of `q`
     #[cfg(test)]
@@ -244,7 +242,7 @@ where
         if n == 0 {
             return None;
         }
-        let (qq, _) = debug_split_at(buffer, n)?;
+        let (qq, _) = debug_split_at(buffer, n);
         Some((*p, *qq.iter().max().unwrap()))
     }
     /// Returns the map as bytes. The map can be recovered with [`Self::from_store`]

--- a/experimental/zerotrie/src/byte_phf/mod.rs
+++ b/experimental/zerotrie/src/byte_phf/mod.rs
@@ -213,12 +213,12 @@ where
         if n == 0 {
             return None;
         }
-        let (qq, eks) = debug_split_at(buffer, n);
+        let (qq, eks) = buffer.debug_split_at(n);
         debug_assert_eq!(qq.len(), eks.len());
-        let q = debug_get(qq, f1(key, *p, n))?;
-        let l2 = f2(key, q, n);
-        let ek = debug_get(eks, l2)?;
-        if ek == key {
+        let q = debug_unwrap!(qq.get(f1(key, *p, n)), return None);
+        let l2 = f2(key, *q, n);
+        let ek = debug_unwrap!(eks.get(l2), return None);
+        if *ek == key {
             Some(l2)
         } else {
             None
@@ -232,7 +232,7 @@ where
     /// Get an iterator over the keys in the order in which they are stored in the map.
     pub fn keys(&self) -> &[u8] {
         let n = self.num_items();
-        debug_split_at(self.0.as_ref(), 1 + n).1
+        self.0.as_ref().debug_split_at(1 + n).1
     }
     /// Diagnostic function that returns `p` and the maximum value of `q`
     #[cfg(test)]
@@ -242,7 +242,7 @@ where
         if n == 0 {
             return None;
         }
-        let (qq, _) = debug_split_at(buffer, n);
+        let (qq, _) = buffer.debug_split_at(n);
         Some((*p, *qq.iter().max().unwrap()))
     }
     /// Returns the map as bytes. The map can be recovered with [`Self::from_store`]

--- a/experimental/zerotrie/src/helpers.rs
+++ b/experimental/zerotrie/src/helpers.rs
@@ -54,3 +54,24 @@ pub(crate) fn debug_get_range(slice: &[u8], range: Range<usize>) -> Option<&[u8]
         }
     }
 }
+
+macro_rules! debug_unwrap {
+    ($expr:expr, return $retval:expr, $($arg:tt)+) => {
+        match $expr {
+            Some(x) => x,
+            None => {
+                debug_assert!(false, $($arg)*);
+                return $retval;
+            }
+        }
+    };
+    ($expr:expr, return $retval:expr) => {
+        debug_unwrap!($expr, return $retval, "invalid trie")
+    };
+    ($expr:expr, $($arg:tt)+) => {
+        debug_unwrap!($expr, return (), $($arg)*)
+    };
+    ($expr:expr) => {
+        debug_unwrap!($expr, return ())
+    };
+}

--- a/experimental/zerotrie/src/helpers.rs
+++ b/experimental/zerotrie/src/helpers.rs
@@ -68,6 +68,18 @@ macro_rules! debug_unwrap {
     ($expr:expr, return $retval:expr) => {
         debug_unwrap!($expr, return $retval, "invalid trie")
     };
+    ($expr:expr, break, $($arg:tt)+) => {
+        match $expr {
+            Some(x) => x,
+            None => {
+                debug_assert!(false, $($arg)*);
+                break;
+            }
+        }
+    };
+    ($expr:expr, break) => {
+        debug_unwrap!($expr, break, "invalid trie")
+    };
     ($expr:expr, $($arg:tt)+) => {
         debug_unwrap!($expr, return (), $($arg)*)
     };

--- a/experimental/zerotrie/src/helpers.rs
+++ b/experimental/zerotrie/src/helpers.rs
@@ -2,54 +2,53 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use core::ops::Range;
-
-/// Like slice::split_at but debug-panics and returns an empty second slice
-/// if the index is out of range.
-#[inline]
-pub(crate) fn debug_split_at(slice: &[u8], mid: usize) -> (&[u8], &[u8]) {
-    if mid > slice.len() {
-        debug_assert!(false, "debug_split_at: index expected to be in range");
-        (slice, &[])
-    } else {
-        // Note: We're trusting the compiler to inline this and remove the assertion
-        // hiding on the top of slice::split_at: `assert(mid <= self.len())`
-        slice.split_at(mid)
-    }
+pub(crate) trait MaybeSplitAt<T> {
+    /// Like slice::split_at but returns an Option instead of panicking
+    /// if the index is out of range.
+    fn maybe_split_at(&self, mid: usize) -> Option<(&Self, &Self)>;
+    /// Like slice::split_at but debug-panics and returns an empty second slice
+    /// if the index is out of range.
+    fn debug_split_at(&self, mid: usize) -> (&Self, &Self);
 }
 
-/// Like slice::split_at but returns an Option instead of panicking.
-#[inline]
-pub(crate) fn maybe_split_at(slice: &[u8], mid: usize) -> Option<(&[u8], &[u8])> {
-    if mid > slice.len() {
-        None
-    } else {
-        // Note: We're trusting the compiler to inline this and remove the assertion
-        // hiding on the top of slice::split_at: `assert(mid <= self.len())`
-        Some(slice.split_at(mid))
-    }
-}
-
-/// Gets the item at the specified index, panicking in debug mode if it is not there.
-#[inline]
-pub(crate) fn debug_get(slice: &[u8], index: usize) -> Option<u8> {
-    match slice.get(index) {
-        Some(x) => Some(*x),
-        None => {
-            debug_assert!(false, "debug_get: index expected to be in range");
+impl<T> MaybeSplitAt<T> for [T] {
+    #[inline]
+    fn maybe_split_at(&self, mid: usize) -> Option<(&Self, &Self)> {
+        if mid > self.len() {
             None
+        } else {
+            // Note: We're trusting the compiler to inline this and remove the assertion
+            // hiding on the top of slice::split_at: `assert(mid <= self.len())`
+            Some(self.split_at(mid))
+        }
+    }
+    #[inline]
+    fn debug_split_at(&self, mid: usize) -> (&Self, &Self) {
+        if mid > self.len() {
+            debug_assert!(false, "debug_split_at: index expected to be in range");
+            (self, &[])
+        } else {
+            // Note: We're trusting the compiler to inline this and remove the assertion
+            // hiding on the top of slice::split_at: `assert(mid <= self.len())`
+            self.split_at(mid)
         }
     }
 }
 
-/// Gets the range between the specified indices, panicking in debug mode if not in bounds.
-#[inline]
-pub(crate) fn debug_get_range(slice: &[u8], range: Range<usize>) -> Option<&[u8]> {
-    match slice.get(range) {
-        Some(x) => Some(x),
-        None => {
-            debug_assert!(false, "debug_get_range: indices expected to be in range");
-            None
+pub(crate) trait DebugUnwrapOr<T> {
+    /// Unwraps the option or panics in debug mode, returning the `gigo_value`
+    fn debug_unwrap_or(self, gigo_value: T) -> T;
+}
+
+impl<T> DebugUnwrapOr<T> for Option<T> {
+    #[inline]
+    fn debug_unwrap_or(self, gigo_value: T) -> T {
+        match self {
+            Some(x) => x,
+            None => {
+                debug_assert!(false, "debug_unwrap_or called on a None value");
+                gigo_value
+            }
         }
     }
 }
@@ -86,3 +85,5 @@ macro_rules! debug_unwrap {
         debug_unwrap!($expr, return ())
     };
 }
+
+pub(crate) use debug_unwrap;

--- a/experimental/zerotrie/src/helpers.rs
+++ b/experimental/zerotrie/src/helpers.rs
@@ -4,18 +4,17 @@
 
 use core::ops::Range;
 
-/// Like slice::split_at but returns an Option instead of panicking.
-///
-/// Debug-panics if `mid` is out of range.
+/// Like slice::split_at but debug-panics and returns an empty second slice
+/// if the index is out of range.
 #[inline]
-pub(crate) fn debug_split_at(slice: &[u8], mid: usize) -> Option<(&[u8], &[u8])> {
+pub(crate) fn debug_split_at(slice: &[u8], mid: usize) -> (&[u8], &[u8]) {
     if mid > slice.len() {
         debug_assert!(false, "debug_split_at: index expected to be in range");
-        None
+        (slice, &[])
     } else {
         // Note: We're trusting the compiler to inline this and remove the assertion
         // hiding on the top of slice::split_at: `assert(mid <= self.len())`
-        Some(slice.split_at(mid))
+        slice.split_at(mid)
     }
 }
 

--- a/experimental/zerotrie/src/lib.rs
+++ b/experimental/zerotrie/src/lib.rs
@@ -57,6 +57,7 @@ extern crate alloc;
 mod builder;
 mod byte_phf;
 mod error;
+#[macro_use]
 mod helpers;
 mod reader;
 #[cfg(feature = "serde")]

--- a/experimental/zerotrie/src/reader.rs
+++ b/experimental/zerotrie/src/reader.rs
@@ -311,8 +311,8 @@ pub fn get_bsearch_only(mut trie: &[u8], mut ascii: &[u8]) -> Option<usize> {
         let byte_type = byte_type(*b);
         (x, trie) = match byte_type {
             NodeType::Ascii => (0, trie),
-            NodeType::Span | NodeType::Value => read_varint_meta3(*b, trie)?,
-            NodeType::Branch => read_varint_meta2(*b, trie)?,
+            NodeType::Span | NodeType::Value => read_varint_meta3(*b, trie),
+            NodeType::Branch => read_varint_meta2(*b, trie),
         };
         if let Some((c, temp)) = ascii.split_first() {
             if matches!(byte_type, NodeType::Ascii) {
@@ -375,8 +375,8 @@ pub fn get_phf_limited(mut trie: &[u8], mut ascii: &[u8]) -> Option<usize> {
         let byte_type = byte_type(*b);
         (x, trie) = match byte_type {
             NodeType::Ascii => (0, trie),
-            NodeType::Span | NodeType::Value => read_varint_meta3(*b, trie)?,
-            NodeType::Branch => read_varint_meta2(*b, trie)?,
+            NodeType::Span | NodeType::Value => read_varint_meta3(*b, trie),
+            NodeType::Branch => read_varint_meta2(*b, trie),
         };
         if let Some((c, temp)) = ascii.split_first() {
             if matches!(byte_type, NodeType::Ascii) {
@@ -445,8 +445,8 @@ pub fn get_phf_extended(mut trie: &[u8], mut ascii: &[u8]) -> Option<usize> {
         let byte_type = byte_type(*b);
         (x, trie) = match byte_type {
             NodeType::Ascii => (0, trie),
-            NodeType::Span | NodeType::Value => read_varint_meta3(*b, trie)?,
-            NodeType::Branch => read_varint_meta2(*b, trie)?,
+            NodeType::Span | NodeType::Value => read_varint_meta3(*b, trie),
+            NodeType::Branch => read_varint_meta2(*b, trie),
         };
         if let Some((c, temp)) = ascii.split_first() {
             if matches!(byte_type, NodeType::Ascii) {
@@ -554,8 +554,8 @@ impl<'a> Iterator for ZeroTrieIterator<'a> {
             }
             (x, trie) = match byte_type {
                 NodeType::Ascii => (0, trie),
-                NodeType::Span | NodeType::Value => read_varint_meta3(*b, trie)?,
-                NodeType::Branch => read_varint_meta2(*b, trie)?,
+                NodeType::Span | NodeType::Value => read_varint_meta3(*b, trie),
+                NodeType::Branch => read_varint_meta2(*b, trie),
             };
             if matches!(byte_type, NodeType::Span) {
                 (span, trie) = debug_split_at(trie, x)?;

--- a/experimental/zerotrie/src/reader.rs
+++ b/experimental/zerotrie/src/reader.rs
@@ -224,7 +224,7 @@ fn get_branch(mut trie: &[u8], i: usize, n: usize, mut w: usize) -> Option<&[u8]
     let mut q = 0usize;
     loop {
         let indices;
-        (indices, trie) = debug_split_at(trie, n - 1)?;
+        (indices, trie) = debug_split_at(trie, n - 1);
         p = (p << 8)
             + if i == 0 {
                 0
@@ -247,7 +247,7 @@ fn get_branch(mut trie: &[u8], i: usize, n: usize, mut w: usize) -> Option<&[u8]
 #[inline]
 fn get_branch_w0(mut trie: &[u8], i: usize, n: usize) -> Option<&[u8]> {
     let indices;
-    (indices, trie) = debug_split_at(trie, n - 1)?;
+    (indices, trie) = debug_split_at(trie, n - 1);
     let p = if i == 0 {
         0
     } else {
@@ -331,7 +331,7 @@ pub fn get_bsearch_only(mut trie: &[u8], mut ascii: &[u8]) -> Option<usize> {
             }
             if matches!(byte_type, NodeType::Span) {
                 let (trie_span, ascii_span);
-                (trie_span, trie) = debug_split_at(trie, x)?;
+                (trie_span, trie) = debug_split_at(trie, x);
                 (ascii_span, ascii) = maybe_split_at(ascii, x)?;
                 if trie_span == ascii_span {
                     // Matched a byte span
@@ -348,7 +348,7 @@ pub fn get_bsearch_only(mut trie: &[u8], mut ascii: &[u8]) -> Option<usize> {
             let w = w & 0x3;
             let x = if x == 0 { 256 } else { x };
             // Always use binary search
-            (search, trie) = debug_split_at(trie, x)?;
+            (search, trie) = debug_split_at(trie, x);
             i = search.binary_search(c).ok()?;
             trie = if w == 0 {
                 get_branch_w0(trie, i, x)
@@ -395,7 +395,7 @@ pub fn get_phf_limited(mut trie: &[u8], mut ascii: &[u8]) -> Option<usize> {
             }
             if matches!(byte_type, NodeType::Span) {
                 let (trie_span, ascii_span);
-                (trie_span, trie) = debug_split_at(trie, x)?;
+                (trie_span, trie) = debug_split_at(trie, x);
                 (ascii_span, ascii) = maybe_split_at(ascii, x)?;
                 if trie_span == ascii_span {
                     // Matched a byte span
@@ -413,11 +413,11 @@ pub fn get_phf_limited(mut trie: &[u8], mut ascii: &[u8]) -> Option<usize> {
             let x = if x == 0 { 256 } else { x };
             if x < 16 {
                 // binary search
-                (search, trie) = debug_split_at(trie, x)?;
+                (search, trie) = debug_split_at(trie, x);
                 i = search.binary_search(c).ok()?;
             } else {
                 // phf
-                (search, trie) = debug_split_at(trie, x * 2 + 1)?;
+                (search, trie) = debug_split_at(trie, x * 2 + 1);
                 i = PerfectByteHashMap::from_store(search).get(*c)?;
             }
             trie = if w == 0 {
@@ -465,7 +465,7 @@ pub fn get_phf_extended(mut trie: &[u8], mut ascii: &[u8]) -> Option<usize> {
             }
             if matches!(byte_type, NodeType::Span) {
                 let (trie_span, ascii_span);
-                (trie_span, trie) = debug_split_at(trie, x)?;
+                (trie_span, trie) = debug_split_at(trie, x);
                 (ascii_span, ascii) = maybe_split_at(ascii, x)?;
                 if trie_span == ascii_span {
                     // Matched a byte span
@@ -480,11 +480,11 @@ pub fn get_phf_extended(mut trie: &[u8], mut ascii: &[u8]) -> Option<usize> {
             let x = if x == 0 { 256 } else { x };
             if x < 16 {
                 // binary search
-                (search, trie) = debug_split_at(trie, x)?;
+                (search, trie) = debug_split_at(trie, x);
                 i = search.binary_search(c).ok()?;
             } else {
                 // phf
-                (search, trie) = debug_split_at(trie, x * 2 + 1)?;
+                (search, trie) = debug_split_at(trie, x * 2 + 1);
                 i = PerfectByteHashMap::from_store(search).get(*c)?;
             }
             trie = if w == 0 {
@@ -558,7 +558,7 @@ impl<'a> Iterator for ZeroTrieIterator<'a> {
                 NodeType::Branch => read_varint_meta2(*b, trie),
             };
             if matches!(byte_type, NodeType::Span) {
-                (span, trie) = debug_split_at(trie, x)?;
+                (span, trie) = debug_split_at(trie, x);
                 string.extend(span);
                 continue;
             }
@@ -578,11 +578,11 @@ impl<'a> Iterator for ZeroTrieIterator<'a> {
             }
             let byte = if x < 16 || !self.use_phf {
                 // binary search
-                (search, trie) = debug_split_at(trie, x)?;
+                (search, trie) = debug_split_at(trie, x);
                 debug_get(search, branch_idx)?
             } else {
                 // phf
-                (search, trie) = debug_split_at(trie, x * 2 + 1)?;
+                (search, trie) = debug_split_at(trie, x * 2 + 1);
                 debug_get(search, branch_idx + x + 1)?
             };
             string.push(byte);

--- a/experimental/zerotrie/src/varint.rs
+++ b/experimental/zerotrie/src/varint.rs
@@ -53,10 +53,7 @@ pub const fn read_varint_meta2(start: u8, remainder: &[u8]) -> Option<(usize, &[
     if (start & 0b00100000) != 0 {
         loop {
             let next;
-            (next, remainder) = match remainder.split_first() {
-                Some(t) => t,
-                None => return None,
-            };
+            (next, remainder) = debug_unwrap!(remainder.split_first(), return None);
             // Note: value << 7 could drop high bits. The first addition can't overflow.
             // The second addition could overflow; in such a case we just inform the
             // developer via the debug assertion.
@@ -78,10 +75,7 @@ pub const fn read_varint_meta3(start: u8, remainder: &[u8]) -> Option<(usize, &[
     if (start & 0b00010000) != 0 {
         loop {
             let next;
-            (next, remainder) = match remainder.split_first() {
-                Some(t) => t,
-                None => return None,
-            };
+            (next, remainder) = debug_unwrap!(remainder.split_first(), return None);
             // Note: value << 7 could drop high bits. The first addition can't overflow.
             // The second addition could overflow; in such a case we just inform the
             // developer via the debug assertion.


### PR DESCRIPTION
Unlike the regular `get` function, the new `step` function doesn't have an easy way to return errors. The style guide says we should debug-assert instead, so that's what I'm implementing here.

I also moved the helper functions to be trait functions added to slices and `Option`.