### PR TITLE
Fix dart Doc

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -138,6 +138,7 @@ jobs:
     - name: Build Dart docs
       run: |
         cd ffi/capi/dart/package
+        dart pub get
         dart doc
         cd ../../../..
 


### PR DESCRIPTION
For some reason Dart generates different docs depending on whether deps have been fetched. ¯\_(ツ)_/¯ 