### PR TITLE
Exclude baked data sources from rustdoc

### DIFF
--- a/provider/baked/_template_/src/lib.rs
+++ b/provider/baked/_template_/src/lib.rs
@@ -6,6 +6,9 @@
 
 #![no_std]
 
+// The source is not readable and is massive as HTML.
+#![doc(html_no_source)]
+
 #[cfg(icu4x_custom_data)]
 include!(concat!(core::env!("ICU4X_DATA_DIR"), "/macros.rs"));
 #[cfg(not(icu4x_custom_data))]

--- a/provider/baked/_template_/src/lib.rs
+++ b/provider/baked/_template_/src/lib.rs
@@ -5,7 +5,6 @@
 //! Data for the icu__component_ crate
 
 #![no_std]
-
 // The source is not readable and is massive as HTML.
 #![doc(html_no_source)]
 

--- a/provider/baked/calendar/src/lib.rs
+++ b/provider/baked/calendar/src/lib.rs
@@ -5,7 +5,6 @@
 //! Data for the icu_calendar crate
 
 #![no_std]
-
 // The source is not readable and is massive as HTML.
 #![doc(html_no_source)]
 

--- a/provider/baked/calendar/src/lib.rs
+++ b/provider/baked/calendar/src/lib.rs
@@ -6,6 +6,9 @@
 
 #![no_std]
 
+// The source is not readable and is massive as HTML.
+#![doc(html_no_source)]
+
 #[cfg(icu4x_custom_data)]
 include!(concat!(core::env!("ICU4X_DATA_DIR"), "/macros.rs"));
 #[cfg(not(icu4x_custom_data))]

--- a/provider/baked/casemap/src/lib.rs
+++ b/provider/baked/casemap/src/lib.rs
@@ -5,7 +5,6 @@
 //! Data for the icu_casemap crate
 
 #![no_std]
-
 // The source is not readable and is massive as HTML.
 #![doc(html_no_source)]
 

--- a/provider/baked/casemap/src/lib.rs
+++ b/provider/baked/casemap/src/lib.rs
@@ -6,6 +6,9 @@
 
 #![no_std]
 
+// The source is not readable and is massive as HTML.
+#![doc(html_no_source)]
+
 #[cfg(icu4x_custom_data)]
 include!(concat!(core::env!("ICU4X_DATA_DIR"), "/macros.rs"));
 #[cfg(not(icu4x_custom_data))]

--- a/provider/baked/collator/src/lib.rs
+++ b/provider/baked/collator/src/lib.rs
@@ -5,7 +5,6 @@
 //! Data for the icu_collator crate
 
 #![no_std]
-
 // The source is not readable and is massive as HTML.
 #![doc(html_no_source)]
 

--- a/provider/baked/collator/src/lib.rs
+++ b/provider/baked/collator/src/lib.rs
@@ -6,6 +6,9 @@
 
 #![no_std]
 
+// The source is not readable and is massive as HTML.
+#![doc(html_no_source)]
+
 #[cfg(icu4x_custom_data)]
 include!(concat!(core::env!("ICU4X_DATA_DIR"), "/macros.rs"));
 #[cfg(not(icu4x_custom_data))]

--- a/provider/baked/compactdecimal/src/lib.rs
+++ b/provider/baked/compactdecimal/src/lib.rs
@@ -5,7 +5,6 @@
 //! Data for the icu_compactdecimal crate
 
 #![no_std]
-
 // The source is not readable and is massive as HTML.
 #![doc(html_no_source)]
 

--- a/provider/baked/compactdecimal/src/lib.rs
+++ b/provider/baked/compactdecimal/src/lib.rs
@@ -6,6 +6,9 @@
 
 #![no_std]
 
+// The source is not readable and is massive as HTML.
+#![doc(html_no_source)]
+
 #[cfg(icu4x_custom_data)]
 include!(concat!(core::env!("ICU4X_DATA_DIR"), "/macros.rs"));
 #[cfg(not(icu4x_custom_data))]

--- a/provider/baked/datetime/src/lib.rs
+++ b/provider/baked/datetime/src/lib.rs
@@ -5,7 +5,6 @@
 //! Data for the icu_datetime crate
 
 #![no_std]
-
 // The source is not readable and is massive as HTML.
 #![doc(html_no_source)]
 

--- a/provider/baked/datetime/src/lib.rs
+++ b/provider/baked/datetime/src/lib.rs
@@ -6,6 +6,9 @@
 
 #![no_std]
 
+// The source is not readable and is massive as HTML.
+#![doc(html_no_source)]
+
 #[cfg(icu4x_custom_data)]
 include!(concat!(core::env!("ICU4X_DATA_DIR"), "/macros.rs"));
 #[cfg(not(icu4x_custom_data))]

--- a/provider/baked/decimal/src/lib.rs
+++ b/provider/baked/decimal/src/lib.rs
@@ -5,7 +5,6 @@
 //! Data for the icu_decimal crate
 
 #![no_std]
-
 // The source is not readable and is massive as HTML.
 #![doc(html_no_source)]
 

--- a/provider/baked/decimal/src/lib.rs
+++ b/provider/baked/decimal/src/lib.rs
@@ -6,6 +6,9 @@
 
 #![no_std]
 
+// The source is not readable and is massive as HTML.
+#![doc(html_no_source)]
+
 #[cfg(icu4x_custom_data)]
 include!(concat!(core::env!("ICU4X_DATA_DIR"), "/macros.rs"));
 #[cfg(not(icu4x_custom_data))]

--- a/provider/baked/displaynames/src/lib.rs
+++ b/provider/baked/displaynames/src/lib.rs
@@ -5,7 +5,6 @@
 //! Data for the icu_displaynames crate
 
 #![no_std]
-
 // The source is not readable and is massive as HTML.
 #![doc(html_no_source)]
 

--- a/provider/baked/displaynames/src/lib.rs
+++ b/provider/baked/displaynames/src/lib.rs
@@ -6,6 +6,9 @@
 
 #![no_std]
 
+// The source is not readable and is massive as HTML.
+#![doc(html_no_source)]
+
 #[cfg(icu4x_custom_data)]
 include!(concat!(core::env!("ICU4X_DATA_DIR"), "/macros.rs"));
 #[cfg(not(icu4x_custom_data))]

--- a/provider/baked/list/src/lib.rs
+++ b/provider/baked/list/src/lib.rs
@@ -5,7 +5,6 @@
 //! Data for the icu_list crate
 
 #![no_std]
-
 // The source is not readable and is massive as HTML.
 #![doc(html_no_source)]
 

--- a/provider/baked/list/src/lib.rs
+++ b/provider/baked/list/src/lib.rs
@@ -6,6 +6,9 @@
 
 #![no_std]
 
+// The source is not readable and is massive as HTML.
+#![doc(html_no_source)]
+
 #[cfg(icu4x_custom_data)]
 include!(concat!(core::env!("ICU4X_DATA_DIR"), "/macros.rs"));
 #[cfg(not(icu4x_custom_data))]

--- a/provider/baked/locid_transform/src/lib.rs
+++ b/provider/baked/locid_transform/src/lib.rs
@@ -6,6 +6,9 @@
 
 #![no_std]
 
+// The source is not readable and is massive as HTML.
+#![doc(html_no_source)]
+
 #[cfg(icu4x_custom_data)]
 include!(concat!(core::env!("ICU4X_DATA_DIR"), "/macros.rs"));
 #[cfg(not(icu4x_custom_data))]

--- a/provider/baked/locid_transform/src/lib.rs
+++ b/provider/baked/locid_transform/src/lib.rs
@@ -5,7 +5,6 @@
 //! Data for the icu_locid_transform crate
 
 #![no_std]
-
 // The source is not readable and is massive as HTML.
 #![doc(html_no_source)]
 

--- a/provider/baked/normalizer/src/lib.rs
+++ b/provider/baked/normalizer/src/lib.rs
@@ -6,6 +6,9 @@
 
 #![no_std]
 
+// The source is not readable and is massive as HTML.
+#![doc(html_no_source)]
+
 #[cfg(icu4x_custom_data)]
 include!(concat!(core::env!("ICU4X_DATA_DIR"), "/macros.rs"));
 #[cfg(not(icu4x_custom_data))]

--- a/provider/baked/normalizer/src/lib.rs
+++ b/provider/baked/normalizer/src/lib.rs
@@ -5,7 +5,6 @@
 //! Data for the icu_normalizer crate
 
 #![no_std]
-
 // The source is not readable and is massive as HTML.
 #![doc(html_no_source)]
 

--- a/provider/baked/plurals/src/lib.rs
+++ b/provider/baked/plurals/src/lib.rs
@@ -5,7 +5,6 @@
 //! Data for the icu_plurals crate
 
 #![no_std]
-
 // The source is not readable and is massive as HTML.
 #![doc(html_no_source)]
 

--- a/provider/baked/plurals/src/lib.rs
+++ b/provider/baked/plurals/src/lib.rs
@@ -6,6 +6,9 @@
 
 #![no_std]
 
+// The source is not readable and is massive as HTML.
+#![doc(html_no_source)]
+
 #[cfg(icu4x_custom_data)]
 include!(concat!(core::env!("ICU4X_DATA_DIR"), "/macros.rs"));
 #[cfg(not(icu4x_custom_data))]

--- a/provider/baked/properties/src/lib.rs
+++ b/provider/baked/properties/src/lib.rs
@@ -5,7 +5,6 @@
 //! Data for the icu_properties crate
 
 #![no_std]
-
 // The source is not readable and is massive as HTML.
 #![doc(html_no_source)]
 

--- a/provider/baked/properties/src/lib.rs
+++ b/provider/baked/properties/src/lib.rs
@@ -6,6 +6,9 @@
 
 #![no_std]
 
+// The source is not readable and is massive as HTML.
+#![doc(html_no_source)]
+
 #[cfg(icu4x_custom_data)]
 include!(concat!(core::env!("ICU4X_DATA_DIR"), "/macros.rs"));
 #[cfg(not(icu4x_custom_data))]

--- a/provider/baked/relativetime/src/lib.rs
+++ b/provider/baked/relativetime/src/lib.rs
@@ -6,6 +6,9 @@
 
 #![no_std]
 
+// The source is not readable and is massive as HTML.
+#![doc(html_no_source)]
+
 #[cfg(icu4x_custom_data)]
 include!(concat!(core::env!("ICU4X_DATA_DIR"), "/macros.rs"));
 #[cfg(not(icu4x_custom_data))]

--- a/provider/baked/relativetime/src/lib.rs
+++ b/provider/baked/relativetime/src/lib.rs
@@ -5,7 +5,6 @@
 //! Data for the icu_relativetime crate
 
 #![no_std]
-
 // The source is not readable and is massive as HTML.
 #![doc(html_no_source)]
 

--- a/provider/baked/segmenter/src/lib.rs
+++ b/provider/baked/segmenter/src/lib.rs
@@ -5,7 +5,6 @@
 //! Data for the icu_segmenter crate
 
 #![no_std]
-
 // The source is not readable and is massive as HTML.
 #![doc(html_no_source)]
 

--- a/provider/baked/segmenter/src/lib.rs
+++ b/provider/baked/segmenter/src/lib.rs
@@ -6,6 +6,9 @@
 
 #![no_std]
 
+// The source is not readable and is massive as HTML.
+#![doc(html_no_source)]
+
 #[cfg(icu4x_custom_data)]
 include!(concat!(core::env!("ICU4X_DATA_DIR"), "/macros.rs"));
 #[cfg(not(icu4x_custom_data))]

--- a/provider/baked/timezone/src/lib.rs
+++ b/provider/baked/timezone/src/lib.rs
@@ -5,7 +5,6 @@
 //! Data for the icu_timezone crate
 
 #![no_std]
-
 // The source is not readable and is massive as HTML.
 #![doc(html_no_source)]
 

--- a/provider/baked/timezone/src/lib.rs
+++ b/provider/baked/timezone/src/lib.rs
@@ -6,6 +6,9 @@
 
 #![no_std]
 
+// The source is not readable and is massive as HTML.
+#![doc(html_no_source)]
+
 #[cfg(icu4x_custom_data)]
 include!(concat!(core::env!("ICU4X_DATA_DIR"), "/macros.rs"));
 #[cfg(not(icu4x_custom_data))]


### PR DESCRIPTION
The baked source converted to HTML adds up to dozens of MB and has no value as it's not readable.