### PR TITLE
Add Writeable::write_cmp_bytes and use it in DataLocale and Locale

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,6 +1882,7 @@ name = "icu_provider"
 version = "1.4.0"
 dependencies = [
  "bincode",
+ "criterion",
  "databake",
  "displaydoc",
  "erased-serde",

--- a/components/locid/src/extensions/unicode/keywords.rs
+++ b/components/locid/src/extensions/unicode/keywords.rs
@@ -6,10 +6,12 @@ use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::iter::FromIterator;
 use litemap::LiteMap;
+use writeable::Writeable;
 
 use super::Key;
 use super::Value;
 use crate::helpers::ShortSlice;
+#[allow(deprecated)]
 use crate::ordering::SubtagOrderingResult;
 
 /// A list of [`Key`]-[`Value`] pairs representing functional information
@@ -303,7 +305,7 @@ impl Keywords {
     /// }
     /// ```
     pub fn strict_cmp(&self, other: &[u8]) -> Ordering {
-        self.strict_cmp_iter(other.split(|b| *b == b'-')).end()
+        self.write_cmp_bytes(other)
     }
 
     /// Compare this [`Keywords`] with an iterator of BCP-47 subtags.
@@ -340,6 +342,8 @@ impl Keywords {
     ///     kwds.strict_cmp_iter(subtags.iter().copied()).end()
     /// );
     /// ```
+    #[deprecated(since = "1.5.0", note = "if you need this, please file an issue")]
+    #[allow(deprecated)]
     pub fn strict_cmp_iter<'l, I>(&self, mut subtags: I) -> SubtagOrderingResult<I>
     where
         I: Iterator<Item = &'l [u8]>,

--- a/components/locid/src/langid.rs
+++ b/components/locid/src/langid.rs
@@ -5,6 +5,7 @@
 use core::cmp::Ordering;
 use core::str::FromStr;
 
+#[allow(deprecated)]
 use crate::ordering::SubtagOrderingResult;
 use crate::parser::{
     parse_language_identifier, parse_language_identifier_with_single_variant, ParserError,
@@ -199,7 +200,7 @@ impl LanguageIdentifier {
     /// }
     /// ```
     pub fn strict_cmp(&self, other: &[u8]) -> Ordering {
-        self.strict_cmp_iter(other.split(|b| *b == b'-')).end()
+        self.write_cmp_bytes(other)
     }
 
     /// Compare this [`LanguageIdentifier`] with an iterator of BCP-47 subtags.
@@ -235,6 +236,8 @@ impl LanguageIdentifier {
     ///     loc.strict_cmp_iter(subtags.iter().copied()).end()
     /// );
     /// ```
+    #[deprecated(since = "1.5.0", note = "if you need this, please file an issue")]
+    #[allow(deprecated)]
     pub fn strict_cmp_iter<'l, I>(&self, mut subtags: I) -> SubtagOrderingResult<I>
     where
         I: Iterator<Item = &'l [u8]>,

--- a/components/locid/src/lib.rs
+++ b/components/locid/src/lib.rs
@@ -75,6 +75,7 @@ mod parser;
 
 pub use langid::LanguageIdentifier;
 pub use locale::Locale;
+#[allow(deprecated)]
 pub use ordering::SubtagOrderingResult;
 pub use parser::errors::ParserError;
 

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+#[allow(deprecated)]
 use crate::ordering::SubtagOrderingResult;
 use crate::parser::{
     parse_locale, parse_locale_with_single_variant_single_keyword_unicode_keyword_extension,
@@ -192,7 +193,7 @@ impl Locale {
     /// }
     /// ```
     pub fn strict_cmp(&self, other: &[u8]) -> Ordering {
-        self.strict_cmp_iter(other.split(|b| *b == b'-')).end()
+        self.write_cmp_bytes(other)
     }
 
     /// Compare this [`Locale`] with an iterator of BCP-47 subtags.
@@ -229,6 +230,8 @@ impl Locale {
     ///     loc.strict_cmp_iter(subtags.iter().copied()).end()
     /// );
     /// ```
+    #[deprecated(since = "1.5.0", note = "if you need this, please file an issue")]
+    #[allow(deprecated)]
     pub fn strict_cmp_iter<'l, I>(&self, mut subtags: I) -> SubtagOrderingResult<I>
     where
         I: Iterator<Item = &'l [u8]>,

--- a/components/locid/src/ordering.rs
+++ b/components/locid/src/ordering.rs
@@ -36,13 +36,17 @@ use core::cmp::Ordering;
 /// [`Locale::strict_cmp_iter`]: crate::Locale::strict_cmp_iter
 #[allow(clippy::exhaustive_enums)] // well-defined exhaustive enum semantics
 #[derive(Debug)]
+#[deprecated(since = "1.5.0", note = "if you need this, please file an issue")]
 pub enum SubtagOrderingResult<I> {
     /// Potentially remaining subtags after the comparison operation.
+    #[deprecated(since = "1.5.0", note = "if you need this, please file an issue")]
     Subtags(I),
     /// Resolved ordering between the locale object and the subtags.
+    #[deprecated(since = "1.5.0", note = "if you need this, please file an issue")]
     Ordering(Ordering),
 }
 
+#[allow(deprecated)]
 impl<I> SubtagOrderingResult<I>
 where
     I: Iterator,

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -50,7 +50,11 @@ serde_json = "1.0"
 icu_provider_adapters = { path = "../../provider/adapters" }
 icu_locid_transform = { path = "../../components/locid_transform" }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = "0.4"
+
 [features]
+bench = []
 std = ["icu_locid/std"]
 sync = []
 experimental = []
@@ -75,3 +79,10 @@ datagen = ["serde", "dep:erased-serde", "dep:databake", "std", "sync"]
 denylist = ["macros"]
 # We have tons of features here, limit the amount of tests we run
 max_combination_size = 3
+
+[lib]
+bench = false  # This option is required for Benchmark CI
+
+[[bench]]
+name = "data_locale_bench"
+harness = false

--- a/provider/core/benches/data_locale_bench.rs
+++ b/provider/core/benches/data_locale_bench.rs
@@ -1,0 +1,86 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+extern crate alloc;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use icu_provider::prelude::*;
+use std::str::FromStr;
+use writeable::Writeable;
+
+static BCP47_STRINGS: &[&str] = &[
+    "ca",
+    "ca-ES",
+    "ca-ES-u-ca-buddhist",
+    "ca-ES-valencia",
+    "ca-ES-x-gbp",
+    "ca-ES-x-gbp-short",
+    "ca-ES-x-usd",
+    "ca-ES-xyzabc",
+    "ca-x-eur",
+    "cat",
+    "pl-Latn-PL",
+    "und",
+    "und-fonipa",
+    "und-u-ca-hebrew",
+    "und-u-ca-japanese",
+    "und-x-mxn",
+    "zh",
+];
+
+fn overview_bench(c: &mut Criterion) {
+    c.bench_function("data_locale/overview", |b| {
+        b.iter(|| {
+            for s in black_box(BCP47_STRINGS).iter() {
+                let loc = DataLocale::from_str(s).unwrap();
+                let loc = loc.clone();
+                let s = loc.write_to_string();
+                loc.strict_cmp(s.as_bytes());
+            }
+        });
+    });
+
+    #[cfg(feature = "bench")]
+    data_locale_bench(c);
+}
+
+#[cfg(feature = "bench")]
+fn data_locale_bench(c: &mut Criterion) {
+    c.bench_function("data_locale/parse", |b| {
+        b.iter(|| {
+            for s in black_box(BCP47_STRINGS).iter() {
+                DataLocale::from_str(s).unwrap();
+            }
+        });
+    });
+
+    let data_locales: Vec<DataLocale> = BCP47_STRINGS.iter().map(|s| s.parse().unwrap()).collect();
+
+    c.bench_function("data_locale/write_to_string", |b| {
+        b.iter(|| {
+            for loc in black_box(&data_locales).iter() {
+                loc.write_to_string();
+            }
+        });
+    });
+    c.bench_function("data_locale/clone", |b| {
+        b.iter(|| {
+            for loc in black_box(&data_locales).iter() {
+                let _ = loc.clone();
+            }
+        });
+    });
+    c.bench_function("data_locale/strict_cmp", |b| {
+        b.iter(|| {
+            for loc in black_box(&data_locales).iter() {
+                for s in black_box(BCP47_STRINGS).iter() {
+                    loc.strict_cmp(s.as_bytes());
+                }
+            }
+        });
+    });
+}
+
+criterion_group!(benches, overview_bench,);
+criterion_main!(benches);

--- a/utils/writeable/src/cmp.rs
+++ b/utils/writeable/src/cmp.rs
@@ -1,0 +1,138 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use core::cmp::Ordering;
+use core::fmt;
+
+pub(crate) struct WriteComparator<'a> {
+    string: &'a str,
+    result: Ordering,
+}
+
+/// This is an infallible impl. Functions always return Ok, not Err.
+impl<'a> fmt::Write for WriteComparator<'a> {
+    fn write_char(&mut self, other: char) -> fmt::Result {
+        if self.result != Ordering::Equal {
+            return Ok(());
+        }
+        let Some(this) = self.pop_front() else {
+            // Self is shorter than Other
+            self.result = Ordering::Less;
+            return Ok(());
+        };
+        self.result = this.cmp(&other);
+        Ok(())
+    }
+
+    fn write_str(&mut self, other: &str) -> fmt::Result {
+        if self.result != Ordering::Equal {
+            return Ok(());
+        }
+        let this = if self.string.is_char_boundary(other.len()) {
+            let (this, remainder) = self.string.split_at(other.len());
+            self.string = remainder;
+            this
+        } else {
+            let tmp = self.string;
+            self.string = "";
+            tmp
+        };
+        self.result = this.cmp(other);
+        Ok(())
+    }
+}
+
+impl<'a> WriteComparator<'a> {
+    #[inline]
+    pub fn new(string: &'a str) -> Self {
+        Self {
+            string,
+            result: Ordering::Equal,
+        }
+    }
+
+    #[inline]
+    pub fn finish(self) -> Ordering {
+        if matches!(self.result, Ordering::Equal) && !self.string.is_empty() {
+            // Self is longer than Other
+            Ordering::Greater
+        } else {
+            self.result
+        }
+    }
+
+    #[inline]
+    pub(crate) fn pop_front(&mut self) -> Option<char> {
+        let mut chars = self.string.chars();
+        let option_this = chars.next();
+        self.string = chars.as_str();
+        option_this
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::fmt::Write;
+
+    mod data {
+        include!("../tests/data/data.rs");
+    }
+
+    #[test]
+    fn test_pop_front() {
+        let s = "aéi🧺øü";
+        let mut wc = WriteComparator::new(s);
+        assert_eq!(wc.pop_front(), Some('a'));
+        assert_eq!(wc.pop_front(), Some('é'));
+        assert_eq!(wc.pop_front(), Some('i'));
+        assert_eq!(wc.pop_front(), Some('🧺'));
+        assert_eq!(wc.pop_front(), Some('ø'));
+        assert_eq!(wc.pop_front(), Some('ü'));
+        assert_eq!(wc.pop_front(), None);
+    }
+
+    #[test]
+    fn test_write_char() {
+        for a in data::KEBAB_CASE_STRINGS {
+            for b in data::KEBAB_CASE_STRINGS {
+                let mut wc = WriteComparator::new(a);
+                for ch in b.chars() {
+                    wc.write_char(ch).unwrap();
+                }
+                assert_eq!(a.cmp(b), wc.finish(), "{a} <=> {b}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_write_str() {
+        for a in data::KEBAB_CASE_STRINGS {
+            for b in data::KEBAB_CASE_STRINGS {
+                let mut wc = WriteComparator::new(a);
+                wc.write_str(b).unwrap();
+                assert_eq!(a.cmp(b), wc.finish(), "{a} <=> {b}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_mixed() {
+        for a in data::KEBAB_CASE_STRINGS {
+            for b in data::KEBAB_CASE_STRINGS {
+                let mut wc = WriteComparator::new(a);
+                let mut first = true;
+                for substr in b.split('-') {
+                    if first {
+                        first = false;
+                    } else {
+                        wc.write_char('-').unwrap();
+                    }
+                    wc.write_str(substr).unwrap();
+                }
+                assert_eq!(a.cmp(b), wc.finish(), "{a} <=> {b}");
+            }
+        }
+    }
+}

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -118,8 +118,8 @@ impl Writeable for str {
     }
 
     #[inline]
-    fn write_cmp(&self, other: &str) -> core::cmp::Ordering {
-        self.cmp(other)
+    fn write_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
+        self.as_bytes().cmp(other)
     }
 }
 
@@ -140,8 +140,8 @@ impl Writeable for String {
     }
 
     #[inline]
-    fn write_cmp(&self, other: &str) -> core::cmp::Ordering {
-        self.as_str().cmp(other)
+    fn write_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
+        self.as_bytes().cmp(other)
     }
 }
 
@@ -167,8 +167,8 @@ impl<T: Writeable + ?Sized> Writeable for &T {
     }
 
     #[inline]
-    fn write_cmp(&self, other: &str) -> core::cmp::Ordering {
-        (*self).write_cmp(other)
+    fn write_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
+        (*self).write_cmp_bytes(other)
     }
 }
 

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -116,6 +116,11 @@ impl Writeable for str {
     fn write_to_string(&self) -> Cow<str> {
         Cow::Borrowed(self)
     }
+
+    #[inline]
+    fn write_cmp(&self, other: &str) -> core::cmp::Ordering {
+        self.cmp(other)
+    }
 }
 
 impl Writeable for String {
@@ -132,6 +137,11 @@ impl Writeable for String {
     #[inline]
     fn write_to_string(&self) -> Cow<str> {
         Cow::Borrowed(self)
+    }
+
+    #[inline]
+    fn write_cmp(&self, other: &str) -> core::cmp::Ordering {
+        self.as_str().cmp(other)
     }
 }
 
@@ -154,6 +164,11 @@ impl<T: Writeable + ?Sized> Writeable for &T {
     #[inline]
     fn write_to_string(&self) -> Cow<str> {
         (*self).write_to_string()
+    }
+
+    #[inline]
+    fn write_cmp(&self, other: &str) -> core::cmp::Ordering {
+        (*self).write_cmp(other)
     }
 }
 

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -66,6 +66,7 @@
 
 extern crate alloc;
 
+mod cmp;
 mod impls;
 mod ops;
 
@@ -269,6 +270,52 @@ pub trait Writeable {
         let mut output = String::with_capacity(hint.capacity());
         let _ = self.write_to(&mut output);
         Cow::Owned(output)
+    }
+
+    /// Compares the contents of this `Writeable` to the given string
+    /// without allocating a String to hold the `Writeable` contents.
+    ///
+    /// This returns a lexicographical comparison, the same as if the Writeable
+    /// were first converted to a String and then compared with `Ord`. For a
+    /// locale-sensitive string ordering, use an ICU4X Collator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use core::cmp::Ordering;
+    /// use core::fmt;
+    /// use writeable::Writeable;
+    ///
+    /// struct WelcomeMessage<'s> {
+    ///     pub name: &'s str,
+    /// }
+    ///
+    /// impl<'s> Writeable for WelcomeMessage<'s> {
+    ///     // see impl in Writeable docs
+    /// #    fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
+    /// #        sink.write_str("Hello, ")?;
+    /// #        sink.write_str(self.name)?;
+    /// #        sink.write_char('!')?;
+    /// #        Ok(())
+    /// #    }
+    /// }
+    ///
+    /// let message = WelcomeMessage { name: "Alice" };
+    /// let message_str = message.write_to_string();
+    ///
+    /// assert_eq!(Ordering::Equal, message.write_cmp("Hello, Alice!"));
+    ///
+    /// assert_eq!(Ordering::Greater, message.write_cmp("Alice!"));
+    /// assert_eq!(Ordering::Greater, (*message_str).cmp("Alice!"));
+    ///
+    /// assert_eq!(Ordering::Less, message.write_cmp("Hello, Bob!"));
+    /// assert_eq!(Ordering::Less, (*message_str).cmp("Hello, Bob!"));
+    /// ```
+    fn write_cmp(&self, other: &str) -> core::cmp::Ordering {
+        let mut wc = cmp::WriteComparator::new(other);
+        #[allow(clippy::unwrap_used)] // infallible impl
+        self.write_to(&mut wc).unwrap();
+        wc.finish().reverse()
     }
 }
 

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -272,7 +272,7 @@ pub trait Writeable {
         Cow::Owned(output)
     }
 
-    /// Compares the contents of this `Writeable` to the given string
+    /// Compares the contents of this `Writeable` to the given bytes
     /// without allocating a String to hold the `Writeable` contents.
     ///
     /// This returns a lexicographical comparison, the same as if the Writeable
@@ -303,15 +303,15 @@ pub trait Writeable {
     /// let message = WelcomeMessage { name: "Alice" };
     /// let message_str = message.write_to_string();
     ///
-    /// assert_eq!(Ordering::Equal, message.write_cmp("Hello, Alice!"));
+    /// assert_eq!(Ordering::Equal, message.write_cmp_bytes(b"Hello, Alice!"));
     ///
-    /// assert_eq!(Ordering::Greater, message.write_cmp("Alice!"));
+    /// assert_eq!(Ordering::Greater, message.write_cmp_bytes(b"Alice!"));
     /// assert_eq!(Ordering::Greater, (*message_str).cmp("Alice!"));
     ///
-    /// assert_eq!(Ordering::Less, message.write_cmp("Hello, Bob!"));
+    /// assert_eq!(Ordering::Less, message.write_cmp_bytes(b"Hello, Bob!"));
     /// assert_eq!(Ordering::Less, (*message_str).cmp("Hello, Bob!"));
     /// ```
-    fn write_cmp(&self, other: &str) -> core::cmp::Ordering {
+    fn write_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
         let mut wc = cmp::WriteComparator::new(other);
         #[allow(clippy::unwrap_used)] // infallible impl
         self.write_to(&mut wc).unwrap();

--- a/utils/writeable/tests/data/data.rs
+++ b/utils/writeable/tests/data/data.rs
@@ -1,0 +1,26 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+#[allow(dead_code)]
+pub const KEBAB_CASE_STRINGS: &[&str] = &[
+    "ca",
+    "ca-ÉS",
+    "ca-ÉS-u-ca-buddhist",
+    "ca-ÉS-valencia",
+    "ca-ÉS-x-gbp",
+    "ca-ÉS-x-gbp-short",
+    "ca-ÉS-x-usd",
+    "ca-ÉS-xyzabc",
+    "ca-x-eur",
+    "cat",
+    "cat-bus",
+    "cat-🚐",
+    "pl-Latn-PL",
+    "und",
+    "und-fonipa",
+    "und-u-ca-hebrew",
+    "und-u-ca-japanese",
+    "und-x-mxn",
+    "zh",
+];


### PR DESCRIPTION
I realized today that we can do the allocation-free comparisons much more easily than we had been. This new comparison impl is easier to reason about, less code, and faster.

```
data_locale/strict_cmp  time:   [2.4656 µs 2.4698 µs 2.4742 µs]
                        change: [-14.891% -14.703% -14.533%] (p = 0.00 < 0.05)
                        Performance has improved.

langid/compare/strict_cmp/langid
                        time:   [220.81 ns 221.10 ns 221.42 ns]
                        change: [-5.5894% -5.2507% -4.7995%] (p = 0.00 < 0.05)
                        Performance has improved.

locale/compare/strict_cmp/locale
                        time:   [331.43 ns 331.65 ns 331.86 ns]
                        change: [+4.5129% +4.7702% +5.0030%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

(not sure about the Locale comparison bench; since it makes the others faster, I'm inclined to ignore that or eat the 5%)