### PR TITLE
Add YearInfo to CalendarArithmetic (but don't use it yet in any calendar)

### DIFF
--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -157,9 +157,10 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
     }
 
     #[inline]
-    pub fn offset_date(&mut self, offset: DateDuration<C>) {
+    pub fn offset_date(&mut self, offset: DateDuration<C>, data: &C::PrecomputedDataSource) {
         // For offset_date to work with lunar calendars, need to handle an edge case where the original month is not valid in the future year.
         self.year += offset.years;
+        self.year_info = data.load_or_compute_info(self.year);
 
         self.offset_months(offset.months);
 
@@ -175,6 +176,8 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
         _largest_unit: DateDurationUnit,
         _smaller_unit: DateDurationUnit,
     ) -> DateDuration<C> {
+        // This simple implementation does not need C::PrecomputedDataSource right now, but it
+        // likely will once we've written a proper implementation
         DateDuration::new(
             self.year - date2.year,
             self.month as i32 - date2.month as i32,

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -377,15 +377,6 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
 
         Ok(Self::new_unchecked(year, month, day))
     }
-
-    /// This fn currently just calls [`new_from_ordinals`], but exists separately for
-    /// lunar calendars in case different logic needs to be implemented later.
-    pub fn new_from_lunar_ordinals(year: i32, month: u8, day: u8) -> Result<Self, CalendarError>
-    where
-        C: CalendarArithmetic<YearInfo = ()>,
-    {
-        Self::new_from_ordinals(year, month, day)
-    }
 }
 
 #[cfg(test)]

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -39,11 +39,6 @@ pub trait CalendarArithmetic: Calendar {
     /// as a field on ArithmeticDate
     // TODO remove Eq/PE/Ord/PO bounds
     type YearInfo: Copy + Debug + Eq + PartialEq + Ord + PartialOrd;
-    /// A data source from which YearInfo may be computed,
-    /// used whenever `year` is set or updated
-    ///
-    /// Default to () if we're not using YearInfo.
-    type PrecomputedDataSource: PrecomputedDataSource<Self::YearInfo>;
     fn month_days(year: i32, month: u8) -> u8;
     fn months_for_every_year(year: i32) -> u8;
     fn is_leap_year(year: i32) -> bool;
@@ -157,7 +152,11 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
     }
 
     #[inline]
-    pub fn offset_date(&mut self, offset: DateDuration<C>, data: &C::PrecomputedDataSource) {
+    pub fn offset_date(
+        &mut self,
+        offset: DateDuration<C>,
+        data: &impl PrecomputedDataSource<C::YearInfo>,
+    ) {
         // For offset_date to work with lunar calendars, need to handle an edge case where the original month is not valid in the future year.
         self.year += offset.years;
         self.year_info = data.load_or_compute_info(self.year);

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -103,9 +103,7 @@ pub(crate) trait PrecomputedDataSource<YearInfo> {
 }
 
 impl PrecomputedDataSource<()> for () {
-    fn load_or_compute_info(&self, _year: i32) -> () {
-        ()
-    }
+    fn load_or_compute_info(&self, _year: i32) {}
 }
 
 impl<C: CalendarArithmetic> ArithmeticDate<C> {

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -13,7 +13,7 @@ use tinystr::tinystr;
 // Note: The Ord/PartialOrd impls can be derived because the fields are in the correct order.
 #[derive(Debug)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
-pub struct ArithmeticDate<C: CalendarArithmetic> {
+pub(crate) struct ArithmeticDate<C: CalendarArithmetic> {
     pub year: i32,
     /// 1-based month of year
     pub month: u8,
@@ -71,7 +71,7 @@ impl<C: CalendarArithmetic> Hash for ArithmeticDate<C> {
 #[allow(dead_code)] // TODO: Remove dead code tag after use
 pub(crate) const MAX_ITERS_FOR_DAYS_OF_MONTH: u8 = 33;
 
-pub trait CalendarArithmetic: Calendar {
+pub(crate) trait CalendarArithmetic: Calendar {
     /// In case we plan to cache per-year data, this stores
     /// useful computational information for the current year
     /// as a field on ArithmeticDate

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -31,6 +31,15 @@ impl<C> Clone for ArithmeticDate<C> {
 pub(crate) const MAX_ITERS_FOR_DAYS_OF_MONTH: u8 = 33;
 
 pub trait CalendarArithmetic: Calendar {
+    /// In case we plan to cache per-year data, this stores
+    /// useful computational information for the current year
+    /// as a field on ArithmeticDate
+    type YearInfo;
+    /// A data source from which YearInfo may be computed,
+    /// used whenever `year` is set or updated
+    ///
+    /// Default to () if we're not using YearInfo.
+    type PrecomputedDataSource: PrecomputedDataSource<Self::YearInfo>;
     fn month_days(year: i32, month: u8) -> u8;
     fn months_for_every_year(year: i32) -> u8;
     fn is_leap_year(year: i32) -> bool;
@@ -49,6 +58,17 @@ pub trait CalendarArithmetic: Calendar {
             days += Self::month_days(year, month) as u16;
         }
         days
+    }
+}
+
+pub(crate) trait PrecomputedDataSource<YearInfo> {
+    /// Given a calendar year, load (or compute) the YearInfo for it
+    fn load_or_compute_info(&self, year: i32) -> YearInfo;
+}
+
+impl PrecomputedDataSource<()> for () {
+    fn load_or_compute_info(&self, _year: i32) -> () {
+        ()
     }
 }
 

--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -193,7 +193,7 @@ impl Calendar for Chinese {
     #[doc(hidden)] // unstable
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
         let year = date.0 .0.year;
-        date.0 .0.offset_date(offset);
+        date.0 .0.offset_date(offset, &());
         if date.0 .0.year != year {
             date.0 .1 = ChineseBasedYearInfo::get_year_info::<Chinese>(year);
         }

--- a/components/calendar/src/chinese_based.rs
+++ b/components/calendar/src/chinese_based.rs
@@ -22,7 +22,7 @@
 use crate::{
     calendar_arithmetic::{ArithmeticDate, CalendarArithmetic},
     types::MonthCode,
-    CalendarError, Iso,
+    Calendar, CalendarError, Iso,
 };
 
 use calendrical_calculations::chinese_based::{self, ChineseBased, YearBounds};
@@ -32,7 +32,7 @@ use core::num::NonZeroU8;
 /// The trait ChineseBased is used by Chinese-based calendars to perform computations shared by such calendar.
 ///
 /// For an example of how to use this trait, see `impl ChineseBasedWithDataLoading for Chinese` in [`Chinese`].
-pub(crate) trait ChineseBasedWithDataLoading: CalendarArithmetic {
+pub(crate) trait ChineseBasedWithDataLoading: Calendar {
     type CB: ChineseBased;
     /// Get the compiled const data for a ChineseBased calendar; can return `None` if the given year
     /// does not correspond to any compiled data.
@@ -467,6 +467,8 @@ impl<C: ChineseBasedWithDataLoading> ChineseBasedDateInner<C> {
 }
 
 impl<C: ChineseBasedWithDataLoading> CalendarArithmetic for C {
+    type YearInfo = ();
+    type PrecomputedDataSource = ();
     fn month_days(year: i32, month: u8) -> u8 {
         chinese_based::month_days::<C::CB>(year, month)
     }

--- a/components/calendar/src/chinese_based.rs
+++ b/components/calendar/src/chinese_based.rs
@@ -41,14 +41,14 @@ pub(crate) trait ChineseBasedWithDataLoading: Calendar {
 
 /// Chinese-based calendars define DateInner as a calendar-specific struct wrapping ChineseBasedDateInner.
 #[derive(Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub(crate) struct ChineseBasedDateInner<C>(
+pub(crate) struct ChineseBasedDateInner<C: CalendarArithmetic>(
     pub(crate) ArithmeticDate<C>,
     pub(crate) ChineseBasedYearInfo,
 );
 
 // we want these impls without the `C: Copy/Clone` bounds
-impl<C> Copy for ChineseBasedDateInner<C> {}
-impl<C> Clone for ChineseBasedDateInner<C> {
+impl<C: CalendarArithmetic> Copy for ChineseBasedDateInner<C> {}
+impl<C: CalendarArithmetic> Clone for ChineseBasedDateInner<C> {
     fn clone(&self) -> Self {
         *self
     }
@@ -240,7 +240,7 @@ impl ChineseBasedCompiledData {
     }
 }
 
-impl<C: ChineseBasedWithDataLoading> ChineseBasedDateInner<C> {
+impl<C: ChineseBasedWithDataLoading + CalendarArithmetic<YearInfo = ()>> ChineseBasedDateInner<C> {
     /// Given a 1-indexed chinese extended year, fetch its data from the cache.
     ///
     /// If the actual year data that was fetched is for a different year, update the getter year

--- a/components/calendar/src/chinese_based.rs
+++ b/components/calendar/src/chinese_based.rs
@@ -468,7 +468,7 @@ impl<C: ChineseBasedWithDataLoading + CalendarArithmetic<YearInfo = ()>> Chinese
 
 impl<C: ChineseBasedWithDataLoading> CalendarArithmetic for C {
     type YearInfo = ();
-    type PrecomputedDataSource = ();
+
     fn month_days(year: i32, month: u8) -> u8 {
         chinese_based::month_days::<C::CB>(year, month)
     }

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -66,6 +66,8 @@ pub struct Coptic;
 pub struct CopticDateInner(pub(crate) ArithmeticDate<Coptic>);
 
 impl CalendarArithmetic for Coptic {
+    type YearInfo = ();
+    type PrecomputedDataSource = ();
     fn month_days(year: i32, month: u8) -> u8 {
         if (1..=12).contains(&month) {
             30

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -67,7 +67,7 @@ pub struct CopticDateInner(pub(crate) ArithmeticDate<Coptic>);
 
 impl CalendarArithmetic for Coptic {
     type YearInfo = ();
-    type PrecomputedDataSource = ();
+
     fn month_days(year: i32, month: u8) -> u8 {
         if (1..=12).contains(&month) {
             30

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -159,7 +159,7 @@ impl Calendar for Coptic {
     }
 
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
-        date.0.offset_date(offset);
+        date.0.offset_date(offset, &());
     }
 
     #[allow(clippy::field_reassign_with_default)]

--- a/components/calendar/src/dangi.rs
+++ b/components/calendar/src/dangi.rs
@@ -181,7 +181,7 @@ impl Calendar for Dangi {
 
     fn offset_date(&self, date: &mut Self::DateInner, offset: crate::DateDuration<Self>) {
         let year = date.0 .0.year;
-        date.0 .0.offset_date(offset);
+        date.0 .0.offset_date(offset, &());
         if date.0 .0.year != year {
             date.0 .1 = ChineseBasedYearInfo::get_year_info::<Dangi>(year);
         }

--- a/components/calendar/src/ethiopian.rs
+++ b/components/calendar/src/ethiopian.rs
@@ -86,6 +86,8 @@ pub struct Ethiopian(pub(crate) bool);
 pub struct EthiopianDateInner(ArithmeticDate<Ethiopian>);
 
 impl CalendarArithmetic for Ethiopian {
+    type YearInfo = ();
+    type PrecomputedDataSource = ();
     fn month_days(year: i32, month: u8) -> u8 {
         if (1..=12).contains(&month) {
             30

--- a/components/calendar/src/ethiopian.rs
+++ b/components/calendar/src/ethiopian.rs
@@ -87,7 +87,7 @@ pub struct EthiopianDateInner(ArithmeticDate<Ethiopian>);
 
 impl CalendarArithmetic for Ethiopian {
     type YearInfo = ();
-    type PrecomputedDataSource = ();
+
     fn month_days(year: i32, month: u8) -> u8 {
         if (1..=12).contains(&month) {
             30

--- a/components/calendar/src/ethiopian.rs
+++ b/components/calendar/src/ethiopian.rs
@@ -181,7 +181,7 @@ impl Calendar for Ethiopian {
     }
 
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
-        date.0.offset_date(offset);
+        date.0.offset_date(offset, &());
     }
 
     #[allow(clippy::field_reassign_with_default)]

--- a/components/calendar/src/hebrew.rs
+++ b/components/calendar/src/hebrew.rs
@@ -90,6 +90,8 @@ impl Hebrew {
 //  HEBREW CALENDAR
 
 impl CalendarArithmetic for Hebrew {
+    type YearInfo = ();
+    type PrecomputedDataSource = ();
     fn month_days(civil_year: i32, civil_month: u8) -> u8 {
         Self::last_day_of_civil_hebrew_month(civil_year, civil_month)
     }

--- a/components/calendar/src/hebrew.rs
+++ b/components/calendar/src/hebrew.rs
@@ -182,7 +182,7 @@ impl Calendar for Hebrew {
             }
         };
 
-        ArithmeticDate::new_from_lunar_ordinals(year, month_ordinal, day).map(HebrewDateInner)
+        ArithmeticDate::new_from_ordinals(year, month_ordinal, day).map(HebrewDateInner)
     }
 
     fn date_from_iso(&self, iso: Date<Iso>) -> Self::DateInner {
@@ -303,7 +303,7 @@ impl Hebrew {
     fn biblical_to_civil_date(biblical_date: BookHebrew) -> HebrewDateInner {
         let (y, m, d) = biblical_date.to_civil_date();
 
-        debug_assert!(ArithmeticDate::<Hebrew>::new_from_lunar_ordinals(y, m, d,).is_ok());
+        debug_assert!(ArithmeticDate::<Hebrew>::new_from_ordinals(y, m, d,).is_ok());
         HebrewDateInner(ArithmeticDate::new_unchecked(y, m, d))
     }
 
@@ -375,7 +375,7 @@ impl<A: AsCalendar<Calendar = Hebrew>> Date<A> {
         day: u8,
         calendar: A,
     ) -> Result<Date<A>, CalendarError> {
-        ArithmeticDate::new_from_lunar_ordinals(year, month, day)
+        ArithmeticDate::new_from_ordinals(year, month, day)
             .map(HebrewDateInner)
             .map(|inner| Date::from_raw(inner, calendar))
     }

--- a/components/calendar/src/hebrew.rs
+++ b/components/calendar/src/hebrew.rs
@@ -208,7 +208,7 @@ impl Calendar for Hebrew {
     }
 
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
-        date.0.offset_date(offset)
+        date.0.offset_date(offset, &())
     }
 
     fn until(

--- a/components/calendar/src/hebrew.rs
+++ b/components/calendar/src/hebrew.rs
@@ -91,7 +91,7 @@ impl Hebrew {
 
 impl CalendarArithmetic for Hebrew {
     type YearInfo = ();
-    type PrecomputedDataSource = ();
+
     fn month_days(civil_year: i32, civil_month: u8) -> u8 {
         Self::last_day_of_civil_hebrew_month(civil_year, civil_month)
     }

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -61,6 +61,8 @@ pub struct Indian;
 pub struct IndianDateInner(ArithmeticDate<Indian>);
 
 impl CalendarArithmetic for Indian {
+    type YearInfo = ();
+    type PrecomputedDataSource = ();
     fn month_days(year: i32, month: u8) -> u8 {
         if month == 1 {
             if Self::is_leap_year(year) {

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -178,7 +178,7 @@ impl Calendar for Indian {
     }
 
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
-        date.0.offset_date(offset);
+        date.0.offset_date(offset, &());
     }
 
     #[allow(clippy::field_reassign_with_default)]

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -62,7 +62,7 @@ pub struct IndianDateInner(ArithmeticDate<Indian>);
 
 impl CalendarArithmetic for Indian {
     type YearInfo = ();
-    type PrecomputedDataSource = ();
+
     fn month_days(year: i32, month: u8) -> u8 {
         if month == 1 {
             if Self::is_leap_year(year) {

--- a/components/calendar/src/islamic.rs
+++ b/components/calendar/src/islamic.rs
@@ -147,7 +147,7 @@ pub struct IslamicDateInner(ArithmeticDate<IslamicObservational>);
 
 impl CalendarArithmetic for IslamicObservational {
     type YearInfo = ();
-    type PrecomputedDataSource = ();
+
     fn month_days(year: i32, month: u8) -> u8 {
         calendrical_calculations::islamic::observational_islamic_month_days(year, month)
     }
@@ -379,7 +379,7 @@ pub struct IslamicUmmAlQuraDateInner(ArithmeticDate<IslamicUmmAlQura>);
 
 impl CalendarArithmetic for IslamicUmmAlQura {
     type YearInfo = ();
-    type PrecomputedDataSource = ();
+
     fn month_days(year: i32, month: u8) -> u8 {
         calendrical_calculations::islamic::saudi_islamic_month_days(year, month)
     }
@@ -609,7 +609,7 @@ pub struct IslamicCivilDateInner(ArithmeticDate<IslamicCivil>);
 
 impl CalendarArithmetic for IslamicCivil {
     type YearInfo = ();
-    type PrecomputedDataSource = ();
+
     fn month_days(year: i32, month: u8) -> u8 {
         match month {
             1 | 3 | 5 | 7 | 9 | 11 => 30,
@@ -857,7 +857,7 @@ pub struct IslamicTabularDateInner(ArithmeticDate<IslamicTabular>);
 
 impl CalendarArithmetic for IslamicTabular {
     type YearInfo = ();
-    type PrecomputedDataSource = ();
+
     fn month_days(year: i32, month: u8) -> u8 {
         match month {
             1 | 3 | 5 | 7 | 9 | 11 => 30,

--- a/components/calendar/src/islamic.rs
+++ b/components/calendar/src/islamic.rs
@@ -219,7 +219,7 @@ impl Calendar for IslamicObservational {
     }
 
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
-        date.0.offset_date(offset)
+        date.0.offset_date(offset, &())
     }
 
     fn until(
@@ -450,7 +450,7 @@ impl Calendar for IslamicUmmAlQura {
     }
 
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
-        date.0.offset_date(offset)
+        date.0.offset_date(offset, &())
     }
 
     fn until(
@@ -696,7 +696,7 @@ impl Calendar for IslamicCivil {
     }
 
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
-        date.0.offset_date(offset)
+        date.0.offset_date(offset, &())
     }
 
     fn until(
@@ -942,7 +942,7 @@ impl Calendar for IslamicTabular {
     }
 
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
-        date.0.offset_date(offset)
+        date.0.offset_date(offset, &())
     }
 
     fn until(

--- a/components/calendar/src/islamic.rs
+++ b/components/calendar/src/islamic.rs
@@ -146,6 +146,8 @@ impl IslamicTabular {
 pub struct IslamicDateInner(ArithmeticDate<IslamicObservational>);
 
 impl CalendarArithmetic for IslamicObservational {
+    type YearInfo = ();
+    type PrecomputedDataSource = ();
     fn month_days(year: i32, month: u8) -> u8 {
         calendrical_calculations::islamic::observational_islamic_month_days(year, month)
     }
@@ -376,6 +378,8 @@ impl<A: AsCalendar<Calendar = IslamicObservational>> DateTime<A> {
 pub struct IslamicUmmAlQuraDateInner(ArithmeticDate<IslamicUmmAlQura>);
 
 impl CalendarArithmetic for IslamicUmmAlQura {
+    type YearInfo = ();
+    type PrecomputedDataSource = ();
     fn month_days(year: i32, month: u8) -> u8 {
         calendrical_calculations::islamic::saudi_islamic_month_days(year, month)
     }
@@ -604,6 +608,8 @@ impl IslamicUmmAlQura {
 pub struct IslamicCivilDateInner(ArithmeticDate<IslamicCivil>);
 
 impl CalendarArithmetic for IslamicCivil {
+    type YearInfo = ();
+    type PrecomputedDataSource = ();
     fn month_days(year: i32, month: u8) -> u8 {
         match month {
             1 | 3 | 5 | 7 | 9 | 11 => 30,
@@ -850,6 +856,8 @@ impl<A: AsCalendar<Calendar = IslamicCivil>> DateTime<A> {
 pub struct IslamicTabularDateInner(ArithmeticDate<IslamicTabular>);
 
 impl CalendarArithmetic for IslamicTabular {
+    type YearInfo = ();
+    type PrecomputedDataSource = ();
     fn month_days(year: i32, month: u8) -> u8 {
         match month {
             1 | 3 | 5 | 7 | 9 | 11 => 30,

--- a/components/calendar/src/islamic.rs
+++ b/components/calendar/src/islamic.rs
@@ -330,7 +330,7 @@ impl<A: AsCalendar<Calendar = IslamicObservational>> Date<A> {
         day: u8,
         calendar: A,
     ) -> Result<Date<A>, CalendarError> {
-        ArithmeticDate::new_from_lunar_ordinals(year, month, day)
+        ArithmeticDate::new_from_ordinals(year, month, day)
             .map(IslamicDateInner)
             .map(|inner| Date::from_raw(inner, calendar))
     }
@@ -525,7 +525,7 @@ impl<A: AsCalendar<Calendar = IslamicUmmAlQura>> Date<A> {
         day: u8,
         calendar: A,
     ) -> Result<Date<A>, CalendarError> {
-        ArithmeticDate::new_from_lunar_ordinals(year, month, day)
+        ArithmeticDate::new_from_ordinals(year, month, day)
             .map(IslamicUmmAlQuraDateInner)
             .map(|inner| Date::from_raw(inner, calendar))
     }
@@ -806,7 +806,7 @@ impl<A: AsCalendar<Calendar = IslamicCivil>> Date<A> {
         day: u8,
         calendar: A,
     ) -> Result<Date<A>, CalendarError> {
-        ArithmeticDate::new_from_lunar_ordinals(year, month, day)
+        ArithmeticDate::new_from_ordinals(year, month, day)
             .map(IslamicCivilDateInner)
             .map(|inner| Date::from_raw(inner, calendar))
     }
@@ -1052,7 +1052,7 @@ impl<A: AsCalendar<Calendar = IslamicTabular>> Date<A> {
         day: u8,
         calendar: A,
     ) -> Result<Date<A>, CalendarError> {
-        ArithmeticDate::new_from_lunar_ordinals(year, month, day)
+        ArithmeticDate::new_from_ordinals(year, month, day)
             .map(IslamicTabularDateInner)
             .map(|inner| Date::from_raw(inner, calendar))
     }
@@ -1927,9 +1927,9 @@ mod test {
             .map(|year| IslamicObservational::days_in_provided_year(year) as i64)
             .sum();
         let expected_number_of_days = IslamicObservational::fixed_from_islamic(IslamicDateInner(
-            ArithmeticDate::new_from_lunar_ordinals(END_YEAR, 1, 1).unwrap(),
+            ArithmeticDate::new_from_ordinals(END_YEAR, 1, 1).unwrap(),
         )) - IslamicObservational::fixed_from_islamic(
-            IslamicDateInner(ArithmeticDate::new_from_lunar_ordinals(START_YEAR, 1, 1).unwrap()),
+            IslamicDateInner(ArithmeticDate::new_from_ordinals(START_YEAR, 1, 1).unwrap()),
         ); // The number of days between Islamic years -1245 and 1518
         let tolerance = 1; // One day tolerance (See Astronomical::month_length for more context)
 
@@ -1948,12 +1948,11 @@ mod test {
             .map(|year| IslamicUmmAlQura::days_in_provided_year(year) as i64)
             .sum();
 
-        let expected_number_of_days =
-            IslamicUmmAlQura::fixed_from_saudi_islamic(IslamicUmmAlQuraDateInner(
-                ArithmeticDate::new_from_lunar_ordinals(END_YEAR, 1, 1).unwrap(),
-            )) - IslamicUmmAlQura::fixed_from_saudi_islamic(IslamicUmmAlQuraDateInner(
-                ArithmeticDate::new_from_lunar_ordinals(START_YEAR, 1, 1).unwrap(),
-            )); // The number of days between Umm al-Qura Islamic years -1245 and 1518
+        let expected_number_of_days = IslamicUmmAlQura::fixed_from_saudi_islamic(
+            IslamicUmmAlQuraDateInner(ArithmeticDate::new_from_ordinals(END_YEAR, 1, 1).unwrap()),
+        ) - IslamicUmmAlQura::fixed_from_saudi_islamic(
+            IslamicUmmAlQuraDateInner(ArithmeticDate::new_from_ordinals(START_YEAR, 1, 1).unwrap()),
+        ); // The number of days between Umm al-Qura Islamic years -1245 and 1518
 
         assert_eq!(sum_days_in_year, expected_number_of_days);
     }

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -176,7 +176,7 @@ impl Calendar for Iso {
     }
 
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
-        date.0.offset_date(offset);
+        date.0.offset_date(offset, &());
     }
 
     #[allow(clippy::field_reassign_with_default)]

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -59,6 +59,8 @@ pub struct Iso;
 pub struct IsoDateInner(pub(crate) ArithmeticDate<Iso>);
 
 impl CalendarArithmetic for Iso {
+    type YearInfo = ();
+    type PrecomputedDataSource = ();
     fn month_days(year: i32, month: u8) -> u8 {
         match month {
             4 | 6 | 9 | 11 => 30,

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -60,7 +60,7 @@ pub struct IsoDateInner(pub(crate) ArithmeticDate<Iso>);
 
 impl CalendarArithmetic for Iso {
     type YearInfo = ();
-    type PrecomputedDataSource = ();
+
     fn month_days(year: i32, month: u8) -> u8 {
         match month {
             4 | 6 | 9 | 11 => 30,

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -150,7 +150,7 @@ impl Calendar for Julian {
     }
 
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
-        date.0.offset_date(offset);
+        date.0.offset_date(offset, &());
     }
 
     #[allow(clippy::field_reassign_with_default)]

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -65,6 +65,8 @@ pub struct Julian;
 pub struct JulianDateInner(pub(crate) ArithmeticDate<Julian>);
 
 impl CalendarArithmetic for Julian {
+    type YearInfo = ();
+    type PrecomputedDataSource = ();
     fn month_days(year: i32, month: u8) -> u8 {
         match month {
             4 | 6 | 9 | 11 => 30,

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -66,7 +66,7 @@ pub struct JulianDateInner(pub(crate) ArithmeticDate<Julian>);
 
 impl CalendarArithmetic for Julian {
     type YearInfo = ();
-    type PrecomputedDataSource = ();
+
     fn month_days(year: i32, month: u8) -> u8 {
         match month {
             4 | 6 | 9 | 11 => 30,

--- a/components/calendar/src/persian.rs
+++ b/components/calendar/src/persian.rs
@@ -154,7 +154,7 @@ impl Calendar for Persian {
     }
 
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
-        date.0.offset_date(offset)
+        date.0.offset_date(offset, &())
     }
 
     #[allow(clippy::field_reassign_with_default)]

--- a/components/calendar/src/persian.rs
+++ b/components/calendar/src/persian.rs
@@ -64,6 +64,8 @@ pub struct Persian;
 pub struct PersianDateInner(ArithmeticDate<Persian>);
 
 impl CalendarArithmetic for Persian {
+    type YearInfo = ();
+    type PrecomputedDataSource = ();
     fn month_days(year: i32, month: u8) -> u8 {
         match month {
             1..=6 => 31,

--- a/components/calendar/src/persian.rs
+++ b/components/calendar/src/persian.rs
@@ -65,7 +65,7 @@ pub struct PersianDateInner(ArithmeticDate<Persian>);
 
 impl CalendarArithmetic for Persian {
     type YearInfo = ();
-    type PrecomputedDataSource = ();
+
     fn month_days(year: i32, month: u8) -> u8 {
         match month {
             1..=6 => 31,


### PR DESCRIPTION
This is mostly a scaffolding PR implementing the first few steps of https://github.com/unicode-org/icu4x/issues/3933#issuecomment-1830962051.

This:

 - Adds a YearInfo type that is stored in CalendarArithmetic and needs to be computed whenever the type is created or has its offset updated
 - Requires `.offset()` to be called with an `&impl PrecomputedDataSource<YearInfo>`. An intermediate state of the PR had a separate PrecomputedDataSource associated type as per the original design, but I realized it wasn't necessary and it had a tendency to lead to worse trait resolution issues with the ChineseBased blanket impl
 - For now, all construction methods for CalendarArithmetic require YearInfo to be `()`. A PR actually using this can add the APIs it needs
 - As a cleanup I removed `new_with_lunar_ordinals()`. We weren't maintaining that distinction correctly; and I considered fixing it, but that method only exists in the case of future needs and when those needs come we can easily re-add it and do the proper refactoring.

Can be reviewed commit-by-commit if desired, though I'd recommend reviewing the whole PR at once. It's probably sufficient to review calendar_arithmetic.rs and chinese_based.rs.