### PR TITLE
Fix baked fallback to work with auxiliary keys

### DIFF
--- a/components/datetime/src/format/neo.rs
+++ b/components/datetime/src/format/neo.rs
@@ -1290,20 +1290,20 @@ mod tests {
             .load_month_names(
                 &crate::provider::Baked,
                 fields::Month::Format,
-                FieldLength::Abbreviated,
+                fields::FieldLength::Wide,
             )
             .unwrap()
             .load_weekday_names(
                 &crate::provider::Baked,
                 fields::Weekday::Format,
-                FieldLength::Wide,
+                fields::FieldLength::Abbreviated,
             )
             .unwrap()
             .load_year_names(&crate::provider::Baked, FieldLength::Narrow)
             .unwrap()
             .load_day_period_names(&crate::provider::Baked, FieldLength::Abbreviated)
             .unwrap();
-        let reference_pattern: reference::Pattern = "'It is' EEEE, MMM d, y GGGGG 'at' hh:mm a'!'"
+        let reference_pattern: reference::Pattern = "'It is' E, MMMM d, y GGGGG 'at' hh:mm a'!'"
             .parse()
             .unwrap();
         let pattern: Pattern = (&reference_pattern).into();
@@ -1312,7 +1312,7 @@ mod tests {
 
         assert_writeable_eq!(
             formatted_pattern,
-            "It is Wednesday, Oct 25, 2023 A at 03:00 PM!"
+            "It is Wed, October 25, 2023 A at 03:00 PM!"
         );
     }
 

--- a/provider/baked/calendar/data/macros/datetime_week_data_v1.rs.data
+++ b/provider/baked/calendar/data/macros/datetime_week_data_v1.rs.data
@@ -30,6 +30,9 @@ macro_rules! __impl_datetime_week_data_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::calendar::provider::WeekDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/collator/data/macros/collator_data_v1.rs.data
+++ b/provider/baked/collator/data/macros/collator_data_v1.rs.data
@@ -113,6 +113,9 @@ macro_rules! __impl_collator_data_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::collator::provider::CollationDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/collator/data/macros/collator_dia_v1.rs.data
+++ b/provider/baked/collator/data/macros/collator_dia_v1.rs.data
@@ -26,6 +26,9 @@ macro_rules! __impl_collator_dia_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::collator::provider::CollationDiacriticsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/collator/data/macros/collator_meta_v1.rs.data
+++ b/provider/baked/collator/data/macros/collator_meta_v1.rs.data
@@ -33,6 +33,9 @@ macro_rules! __impl_collator_meta_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::collator::provider::CollationMetadataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/collator/data/macros/collator_reord_v1.rs.data
+++ b/provider/baked/collator/data/macros/collator_reord_v1.rs.data
@@ -50,12 +50,12 @@ macro_rules! __impl_collator_reord_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::collator::provider::CollationReorderingV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::collator::provider::CollationReorderingV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::collator::provider::CollationReorderingV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/compactdecimal/data/macros/compactdecimal_long_v1.rs.data
+++ b/provider/baked/compactdecimal/data/macros/compactdecimal_long_v1.rs.data
@@ -744,6 +744,9 @@ macro_rules! __impl_compactdecimal_long_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::compactdecimal::provider::LongCompactDecimalFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/compactdecimal/data/macros/compactdecimal_short_v1.rs.data
+++ b/provider/baked/compactdecimal/data/macros/compactdecimal_short_v1.rs.data
@@ -642,6 +642,9 @@ macro_rules! __impl_compactdecimal_short_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::compactdecimal::provider::ShortCompactDecimalFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_buddhist_datelengths_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_buddhist_datelengths_v1.rs.data
@@ -165,6 +165,9 @@ macro_rules! __impl_datetime_buddhist_datelengths_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::BuddhistDateLengthsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_buddhist_datesymbols_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_buddhist_datesymbols_v1.rs.data
@@ -3408,6 +3408,9 @@ macro_rules! __impl_datetime_buddhist_datesymbols_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::BuddhistDateSymbolsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_chinese_datelengths_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_chinese_datelengths_v1.rs.data
@@ -66,6 +66,9 @@ macro_rules! __impl_datetime_chinese_datelengths_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::ChineseDateLengthsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_chinese_datesymbols_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_chinese_datesymbols_v1.rs.data
@@ -3174,6 +3174,9 @@ macro_rules! __impl_datetime_chinese_datesymbols_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::ChineseDateSymbolsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_coptic_datelengths_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_coptic_datelengths_v1.rs.data
@@ -168,6 +168,9 @@ macro_rules! __impl_datetime_coptic_datelengths_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::CopticDateLengthsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_coptic_datesymbols_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_coptic_datesymbols_v1.rs.data
@@ -6163,6 +6163,9 @@ macro_rules! __impl_datetime_coptic_datesymbols_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::CopticDateSymbolsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_dangi_datelengths_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_dangi_datelengths_v1.rs.data
@@ -65,6 +65,9 @@ macro_rules! __impl_datetime_dangi_datelengths_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::DangiDateLengthsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_dangi_datesymbols_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_dangi_datesymbols_v1.rs.data
@@ -3156,6 +3156,9 @@ macro_rules! __impl_datetime_dangi_datesymbols_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::DangiDateSymbolsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_ethiopic_datelengths_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_ethiopic_datelengths_v1.rs.data
@@ -168,6 +168,9 @@ macro_rules! __impl_datetime_ethiopic_datelengths_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::EthiopianDateLengthsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_ethiopic_datesymbols_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_ethiopic_datesymbols_v1.rs.data
@@ -6187,6 +6187,9 @@ macro_rules! __impl_datetime_ethiopic_datesymbols_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::EthiopianDateSymbolsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_gregory_datelengths_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_gregory_datelengths_v1.rs.data
@@ -174,6 +174,9 @@ macro_rules! __impl_datetime_gregory_datelengths_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::GregorianDateLengthsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_gregory_datesymbols_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_gregory_datesymbols_v1.rs.data
@@ -3480,6 +3480,9 @@ macro_rules! __impl_datetime_gregory_datesymbols_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::GregorianDateSymbolsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_hebrew_datelengths_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_hebrew_datelengths_v1.rs.data
@@ -151,6 +151,9 @@ macro_rules! __impl_datetime_hebrew_datelengths_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::HebrewDateLengthsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_hebrew_datesymbols_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_hebrew_datesymbols_v1.rs.data
@@ -6160,6 +6160,9 @@ macro_rules! __impl_datetime_hebrew_datesymbols_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::HebrewDateSymbolsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_indian_datelengths_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_indian_datelengths_v1.rs.data
@@ -166,6 +166,9 @@ macro_rules! __impl_datetime_indian_datelengths_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::IndianDateLengthsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_indian_datesymbols_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_indian_datesymbols_v1.rs.data
@@ -3174,6 +3174,9 @@ macro_rules! __impl_datetime_indian_datesymbols_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::IndianDateSymbolsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_islamic_datelengths_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_islamic_datelengths_v1.rs.data
@@ -153,6 +153,9 @@ macro_rules! __impl_datetime_islamic_datelengths_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::IslamicDateLengthsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_islamic_datesymbols_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_islamic_datesymbols_v1.rs.data
@@ -3192,6 +3192,9 @@ macro_rules! __impl_datetime_islamic_datesymbols_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::IslamicDateSymbolsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_japanese_datelengths_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_japanese_datelengths_v1.rs.data
@@ -149,6 +149,9 @@ macro_rules! __impl_datetime_japanese_datelengths_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::JapaneseDateLengthsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_japanese_datesymbols_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_japanese_datesymbols_v1.rs.data
@@ -3480,6 +3480,9 @@ macro_rules! __impl_datetime_japanese_datesymbols_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::JapaneseDateSymbolsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_japanext_datelengths_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_japanext_datelengths_v1.rs.data
@@ -149,6 +149,9 @@ macro_rules! __impl_datetime_japanext_datelengths_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::JapaneseExtendedDateLengthsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_patterns_buddhist_date_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_patterns_buddhist_date_v1.rs.data
@@ -244,12 +244,12 @@ macro_rules! __impl_datetime_patterns_buddhist_date_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::BuddhistDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::BuddhistDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::BuddhistDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_patterns_chinese_date_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_patterns_chinese_date_v1.rs.data
@@ -121,12 +121,12 @@ macro_rules! __impl_datetime_patterns_chinese_date_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::ChineseDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::ChineseDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::ChineseDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_patterns_coptic_date_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_patterns_coptic_date_v1.rs.data
@@ -248,12 +248,12 @@ macro_rules! __impl_datetime_patterns_coptic_date_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::CopticDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::CopticDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::CopticDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_patterns_dangi_date_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_patterns_dangi_date_v1.rs.data
@@ -116,12 +116,12 @@ macro_rules! __impl_datetime_patterns_dangi_date_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::DangiDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::DangiDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::DangiDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_patterns_datetime_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_patterns_datetime_v1.rs.data
@@ -30,12 +30,12 @@ macro_rules! __impl_datetime_patterns_datetime_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::DateTimePatternV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::DateTimePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::DateTimePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_patterns_ethiopic_date_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_patterns_ethiopic_date_v1.rs.data
@@ -244,12 +244,12 @@ macro_rules! __impl_datetime_patterns_ethiopic_date_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::EthiopianDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::EthiopianDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::EthiopianDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_patterns_gregory_date_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_patterns_gregory_date_v1.rs.data
@@ -211,12 +211,12 @@ macro_rules! __impl_datetime_patterns_gregory_date_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::GregorianDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::GregorianDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::GregorianDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_patterns_hebrew_date_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_patterns_hebrew_date_v1.rs.data
@@ -244,12 +244,12 @@ macro_rules! __impl_datetime_patterns_hebrew_date_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::HebrewDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::HebrewDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::HebrewDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_patterns_indian_date_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_patterns_indian_date_v1.rs.data
@@ -243,12 +243,12 @@ macro_rules! __impl_datetime_patterns_indian_date_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::IndianDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::IndianDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::IndianDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_patterns_islamic_date_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_patterns_islamic_date_v1.rs.data
@@ -238,12 +238,12 @@ macro_rules! __impl_datetime_patterns_islamic_date_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::IslamicDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::IslamicDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::IslamicDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_patterns_japanese_date_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_patterns_japanese_date_v1.rs.data
@@ -236,12 +236,12 @@ macro_rules! __impl_datetime_patterns_japanese_date_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::JapaneseDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::JapaneseDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::JapaneseDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_patterns_japanext_date_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_patterns_japanext_date_v1.rs.data
@@ -236,12 +236,12 @@ macro_rules! __impl_datetime_patterns_japanext_date_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::JapaneseExtendedDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::JapaneseExtendedDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::JapaneseExtendedDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_patterns_persian_date_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_patterns_persian_date_v1.rs.data
@@ -249,12 +249,12 @@ macro_rules! __impl_datetime_patterns_persian_date_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::PersianDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::PersianDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::PersianDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_patterns_roc_date_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_patterns_roc_date_v1.rs.data
@@ -238,12 +238,12 @@ macro_rules! __impl_datetime_patterns_roc_date_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::RocDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::RocDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::RocDatePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_patterns_time_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_patterns_time_v1.rs.data
@@ -151,12 +151,12 @@ macro_rules! __impl_datetime_patterns_time_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::TimePatternV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::TimePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::TimePatternV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_persian_datelengths_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_persian_datelengths_v1.rs.data
@@ -167,6 +167,9 @@ macro_rules! __impl_datetime_persian_datelengths_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::PersianDateLengthsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_persian_datesymbols_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_persian_datesymbols_v1.rs.data
@@ -3192,6 +3192,9 @@ macro_rules! __impl_datetime_persian_datesymbols_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::PersianDateSymbolsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_roc_datelengths_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_roc_datelengths_v1.rs.data
@@ -167,6 +167,9 @@ macro_rules! __impl_datetime_roc_datelengths_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::RocDateLengthsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_roc_datesymbols_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_roc_datesymbols_v1.rs.data
@@ -3408,6 +3408,9 @@ macro_rules! __impl_datetime_roc_datesymbols_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::RocDateSymbolsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_symbols_buddhist_months_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_buddhist_months_v1.rs.data
@@ -484,12 +484,12 @@ macro_rules! __impl_datetime_symbols_buddhist_months_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::BuddhistMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::BuddhistMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::BuddhistMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_buddhist_years_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_buddhist_years_v1.rs.data
@@ -220,12 +220,12 @@ macro_rules! __impl_datetime_symbols_buddhist_years_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::BuddhistYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::BuddhistYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::BuddhistYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_chinese_months_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_chinese_months_v1.rs.data
@@ -84,12 +84,12 @@ macro_rules! __impl_datetime_symbols_chinese_months_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::ChineseMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::ChineseMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::ChineseMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_chinese_years_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_chinese_years_v1.rs.data
@@ -28,12 +28,12 @@ macro_rules! __impl_datetime_symbols_chinese_years_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::ChineseYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::ChineseYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::ChineseYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_coptic_months_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_coptic_months_v1.rs.data
@@ -78,12 +78,12 @@ macro_rules! __impl_datetime_symbols_coptic_months_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::CopticMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::CopticMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::CopticMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_coptic_years_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_coptic_years_v1.rs.data
@@ -144,12 +144,12 @@ macro_rules! __impl_datetime_symbols_coptic_years_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::CopticYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::CopticYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::CopticYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_dangi_months_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_dangi_months_v1.rs.data
@@ -83,12 +83,12 @@ macro_rules! __impl_datetime_symbols_dangi_months_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::DangiMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::DangiMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::DangiMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_dangi_years_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_dangi_years_v1.rs.data
@@ -29,12 +29,12 @@ macro_rules! __impl_datetime_symbols_dangi_years_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::DangiYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::DangiYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::DangiYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_dayperiods_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_dayperiods_v1.rs.data
@@ -316,12 +316,12 @@ macro_rules! __impl_datetime_symbols_dayperiods_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::DayPeriodNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::DayPeriodNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::DayPeriodNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_ethiopic_months_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_ethiopic_months_v1.rs.data
@@ -73,12 +73,12 @@ macro_rules! __impl_datetime_symbols_ethiopic_months_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::EthiopianMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::EthiopianMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::EthiopianMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_ethiopic_years_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_ethiopic_years_v1.rs.data
@@ -160,12 +160,12 @@ macro_rules! __impl_datetime_symbols_ethiopic_years_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::EthiopianYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::EthiopianYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::EthiopianYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_gregory_months_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_gregory_months_v1.rs.data
@@ -484,12 +484,12 @@ macro_rules! __impl_datetime_symbols_gregory_months_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::GregorianMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::GregorianMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::GregorianMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_gregory_years_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_gregory_years_v1.rs.data
@@ -1032,12 +1032,12 @@ macro_rules! __impl_datetime_symbols_gregory_years_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::GregorianYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::GregorianYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::GregorianYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_hebrew_months_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_hebrew_months_v1.rs.data
@@ -82,12 +82,12 @@ macro_rules! __impl_datetime_symbols_hebrew_months_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::HebrewMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::HebrewMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::HebrewMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_hebrew_years_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_hebrew_years_v1.rs.data
@@ -96,12 +96,12 @@ macro_rules! __impl_datetime_symbols_hebrew_years_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::HebrewYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::HebrewYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::HebrewYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_indian_months_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_indian_months_v1.rs.data
@@ -89,12 +89,12 @@ macro_rules! __impl_datetime_symbols_indian_months_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::IndianMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::IndianMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::IndianMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_indian_years_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_indian_years_v1.rs.data
@@ -156,12 +156,12 @@ macro_rules! __impl_datetime_symbols_indian_years_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::IndianYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::IndianYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::IndianYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_islamic_months_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_islamic_months_v1.rs.data
@@ -152,12 +152,12 @@ macro_rules! __impl_datetime_symbols_islamic_months_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::IslamicMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::IslamicMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::IslamicMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_islamic_years_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_islamic_years_v1.rs.data
@@ -188,12 +188,12 @@ macro_rules! __impl_datetime_symbols_islamic_years_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::IslamicYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::IslamicYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::IslamicYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_japanese_months_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_japanese_months_v1.rs.data
@@ -484,12 +484,12 @@ macro_rules! __impl_datetime_symbols_japanese_months_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::JapaneseMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::JapaneseMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::JapaneseMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_japanese_years_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_japanese_years_v1.rs.data
@@ -1424,12 +1424,12 @@ macro_rules! __impl_datetime_symbols_japanese_years_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::JapaneseYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::JapaneseYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::JapaneseYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_japanext_months_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_japanext_months_v1.rs.data
@@ -484,12 +484,12 @@ macro_rules! __impl_datetime_symbols_japanext_months_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::JapaneseExtendedMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::JapaneseExtendedMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::JapaneseExtendedMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_persian_months_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_persian_months_v1.rs.data
@@ -85,12 +85,12 @@ macro_rules! __impl_datetime_symbols_persian_months_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::PersianMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::PersianMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::PersianMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_persian_years_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_persian_years_v1.rs.data
@@ -108,12 +108,12 @@ macro_rules! __impl_datetime_symbols_persian_years_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::PersianYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::PersianYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::PersianYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_roc_months_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_roc_months_v1.rs.data
@@ -484,12 +484,12 @@ macro_rules! __impl_datetime_symbols_roc_months_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::RocMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::RocMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::RocMonthNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_roc_years_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_roc_years_v1.rs.data
@@ -356,12 +356,12 @@ macro_rules! __impl_datetime_symbols_roc_years_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::RocYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::RocYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::RocYearNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_symbols_weekdays_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_symbols_weekdays_v1.rs.data
@@ -510,12 +510,12 @@ macro_rules! __impl_datetime_symbols_weekdays_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::datetime::provider::neo::WeekdayNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::WeekdayNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::neo::WeekdayNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/datetime/data/macros/datetime_timelengths_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_timelengths_v1.rs.data
@@ -89,6 +89,9 @@ macro_rules! __impl_datetime_timelengths_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::TimeLengthsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/datetime_timesymbols_v1.rs.data
+++ b/provider/baked/datetime/data/macros/datetime_timesymbols_v1.rs.data
@@ -192,6 +192,9 @@ macro_rules! __impl_datetime_timesymbols_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::calendar::TimeSymbolsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/time_zone_exemplar_cities_v1.rs.data
+++ b/provider/baked/datetime/data/macros/time_zone_exemplar_cities_v1.rs.data
@@ -660,6 +660,9 @@ macro_rules! __impl_time_zone_exemplar_cities_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::time_zones::ExemplarCitiesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/time_zone_formats_v1.rs.data
+++ b/provider/baked/datetime/data/macros/time_zone_formats_v1.rs.data
@@ -1920,6 +1920,9 @@ macro_rules! __impl_time_zone_formats_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::time_zones::TimeZoneFormatsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/time_zone_generic_long_v1.rs.data
+++ b/provider/baked/datetime/data/macros/time_zone_generic_long_v1.rs.data
@@ -1784,6 +1784,9 @@ macro_rules! __impl_time_zone_generic_long_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::time_zones::MetazoneGenericNamesLongV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/time_zone_generic_short_v1.rs.data
+++ b/provider/baked/datetime/data/macros/time_zone_generic_short_v1.rs.data
@@ -604,6 +604,9 @@ macro_rules! __impl_time_zone_generic_short_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::time_zones::MetazoneGenericNamesShortV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/time_zone_specific_long_v1.rs.data
+++ b/provider/baked/datetime/data/macros/time_zone_specific_long_v1.rs.data
@@ -1784,6 +1784,9 @@ macro_rules! __impl_time_zone_specific_long_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::time_zones::MetazoneSpecificNamesLongV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/datetime/data/macros/time_zone_specific_short_v1.rs.data
+++ b/provider/baked/datetime/data/macros/time_zone_specific_short_v1.rs.data
@@ -604,6 +604,9 @@ macro_rules! __impl_time_zone_specific_short_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::datetime::provider::time_zones::MetazoneSpecificNamesShortV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/decimal/data/macros/decimal_symbols_v1.rs.data
+++ b/provider/baked/decimal/data/macros/decimal_symbols_v1.rs.data
@@ -70,6 +70,9 @@ macro_rules! __impl_decimal_symbols_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::decimal::provider::DecimalSymbolsV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/displaynames/data/macros/displaynames_languages_v1.rs.data
+++ b/provider/baked/displaynames/data/macros/displaynames_languages_v1.rs.data
@@ -3530,12 +3530,12 @@ macro_rules! __impl_displaynames_languages_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::displaynames::provider::LanguageDisplayNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::displaynames::provider::LanguageDisplayNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::displaynames::provider::LanguageDisplayNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/displaynames/data/macros/displaynames_locales_v1.rs.data
+++ b/provider/baked/displaynames/data/macros/displaynames_locales_v1.rs.data
@@ -2972,12 +2972,12 @@ macro_rules! __impl_displaynames_locales_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::displaynames::provider::LocaleDisplayNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::displaynames::provider::LocaleDisplayNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::displaynames::provider::LocaleDisplayNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/displaynames/data/macros/displaynames_regions_v1.rs.data
+++ b/provider/baked/displaynames/data/macros/displaynames_regions_v1.rs.data
@@ -1940,12 +1940,12 @@ macro_rules! __impl_displaynames_regions_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::displaynames::provider::RegionDisplayNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::displaynames::provider::RegionDisplayNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::displaynames::provider::RegionDisplayNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/displaynames/data/macros/displaynames_scripts_v1.rs.data
+++ b/provider/baked/displaynames/data/macros/displaynames_scripts_v1.rs.data
@@ -1710,12 +1710,12 @@ macro_rules! __impl_displaynames_scripts_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::displaynames::provider::ScriptDisplayNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::displaynames::provider::ScriptDisplayNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::displaynames::provider::ScriptDisplayNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/displaynames/data/macros/displaynames_variants_v1.rs.data
+++ b/provider/baked/displaynames/data/macros/displaynames_variants_v1.rs.data
@@ -542,12 +542,12 @@ macro_rules! __impl_displaynames_variants_v1 {
                     const FALLBACKER: icu::locid_transform::fallback::LocaleFallbackerWithConfig<'static> = icu::locid_transform::fallback::LocaleFallbacker::new().for_config(<icu::displaynames::provider::VariantDisplayNamesV1Marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                     loop {
-                        if fallback_iterator.get().is_und() {
-                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::displaynames::provider::VariantDisplayNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
-                        }
                         if let Ok(payload) = KEYS.binary_search_by(|k| fallback_iterator.get().strict_cmp(k.as_bytes()).reverse()).map(|i| *unsafe { VALUES.get_unchecked(i) }) {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
+                        }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::displaynames::provider::VariantDisplayNamesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
                         }
                         fallback_iterator.step();
                     }

--- a/provider/baked/list/data/macros/list_and_v1.rs.data
+++ b/provider/baked/list/data/macros/list_and_v1.rs.data
@@ -142,6 +142,9 @@ macro_rules! __impl_list_and_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::list::provider::AndListV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/list/data/macros/list_or_v1.rs.data
+++ b/provider/baked/list/data/macros/list_or_v1.rs.data
@@ -119,6 +119,9 @@ macro_rules! __impl_list_or_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::list::provider::OrListV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/list/data/macros/list_unit_v1.rs.data
+++ b/provider/baked/list/data/macros/list_unit_v1.rs.data
@@ -104,6 +104,9 @@ macro_rules! __impl_list_unit_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::list::provider::UnitListV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/plurals/data/macros/plurals_cardinal_v1.rs.data
+++ b/provider/baked/plurals/data/macros/plurals_cardinal_v1.rs.data
@@ -58,6 +58,9 @@ macro_rules! __impl_plurals_cardinal_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::plurals::provider::CardinalV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/plurals/data/macros/plurals_ordinal_v1.rs.data
+++ b/provider/baked/plurals/data/macros/plurals_ordinal_v1.rs.data
@@ -48,6 +48,9 @@ macro_rules! __impl_plurals_ordinal_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::plurals::provider::OrdinalV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/plurals/data/macros/plurals_ranges_v1.rs.data
+++ b/provider/baked/plurals/data/macros/plurals_ranges_v1.rs.data
@@ -84,6 +84,9 @@ macro_rules! __impl_plurals_ranges_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::plurals::provider::PluralRangesV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/properties/data/macros/props_exemplarchars_auxiliary_v1.rs.data
+++ b/provider/baked/properties/data/macros/props_exemplarchars_auxiliary_v1.rs.data
@@ -976,6 +976,9 @@ macro_rules! __impl_props_exemplarchars_auxiliary_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::properties::provider::ExemplarCharactersAuxiliaryV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/properties/data/macros/props_exemplarchars_index_v1.rs.data
+++ b/provider/baked/properties/data/macros/props_exemplarchars_index_v1.rs.data
@@ -773,6 +773,9 @@ macro_rules! __impl_props_exemplarchars_index_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::properties::provider::ExemplarCharactersIndexV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/properties/data/macros/props_exemplarchars_main_v1.rs.data
+++ b/provider/baked/properties/data/macros/props_exemplarchars_main_v1.rs.data
@@ -1088,6 +1088,9 @@ macro_rules! __impl_props_exemplarchars_main_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::properties::provider::ExemplarCharactersMainV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/properties/data/macros/props_exemplarchars_numbers_v1.rs.data
+++ b/provider/baked/properties/data/macros/props_exemplarchars_numbers_v1.rs.data
@@ -262,6 +262,9 @@ macro_rules! __impl_props_exemplarchars_numbers_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::properties::provider::ExemplarCharactersNumbersV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/properties/data/macros/props_exemplarchars_punctuation_v1.rs.data
+++ b/provider/baked/properties/data/macros/props_exemplarchars_punctuation_v1.rs.data
@@ -591,6 +591,9 @@ macro_rules! __impl_props_exemplarchars_punctuation_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::properties::provider::ExemplarCharactersPunctuationV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_long_day_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_long_day_v1.rs.data
@@ -1208,6 +1208,9 @@ macro_rules! __impl_relativetime_long_day_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::LongDayRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_long_hour_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_long_hour_v1.rs.data
@@ -1032,6 +1032,9 @@ macro_rules! __impl_relativetime_long_hour_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::LongHourRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_long_minute_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_long_minute_v1.rs.data
@@ -1048,6 +1048,9 @@ macro_rules! __impl_relativetime_long_minute_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::LongMinuteRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_long_month_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_long_month_v1.rs.data
@@ -1128,6 +1128,9 @@ macro_rules! __impl_relativetime_long_month_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::LongMonthRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_long_quarter_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_long_quarter_v1.rs.data
@@ -1016,6 +1016,9 @@ macro_rules! __impl_relativetime_long_quarter_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::LongQuarterRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_long_second_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_long_second_v1.rs.data
@@ -1048,6 +1048,9 @@ macro_rules! __impl_relativetime_long_second_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::LongSecondRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_long_week_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_long_week_v1.rs.data
@@ -1144,6 +1144,9 @@ macro_rules! __impl_relativetime_long_week_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::LongWeekRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_long_year_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_long_year_v1.rs.data
@@ -1176,6 +1176,9 @@ macro_rules! __impl_relativetime_long_year_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::LongYearRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_narrow_day_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_narrow_day_v1.rs.data
@@ -1256,6 +1256,9 @@ macro_rules! __impl_relativetime_narrow_day_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::NarrowDayRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_narrow_hour_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_narrow_hour_v1.rs.data
@@ -1072,6 +1072,9 @@ macro_rules! __impl_relativetime_narrow_hour_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::NarrowHourRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_narrow_minute_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_narrow_minute_v1.rs.data
@@ -1080,6 +1080,9 @@ macro_rules! __impl_relativetime_narrow_minute_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::NarrowMinuteRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_narrow_month_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_narrow_month_v1.rs.data
@@ -1160,6 +1160,9 @@ macro_rules! __impl_relativetime_narrow_month_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::NarrowMonthRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_narrow_quarter_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_narrow_quarter_v1.rs.data
@@ -1048,6 +1048,9 @@ macro_rules! __impl_relativetime_narrow_quarter_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::NarrowQuarterRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_narrow_second_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_narrow_second_v1.rs.data
@@ -1088,6 +1088,9 @@ macro_rules! __impl_relativetime_narrow_second_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::NarrowSecondRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_narrow_week_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_narrow_week_v1.rs.data
@@ -1176,6 +1176,9 @@ macro_rules! __impl_relativetime_narrow_week_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::NarrowWeekRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_narrow_year_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_narrow_year_v1.rs.data
@@ -1192,6 +1192,9 @@ macro_rules! __impl_relativetime_narrow_year_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::NarrowYearRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_short_day_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_short_day_v1.rs.data
@@ -1248,6 +1248,9 @@ macro_rules! __impl_relativetime_short_day_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::ShortDayRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_short_hour_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_short_hour_v1.rs.data
@@ -1080,6 +1080,9 @@ macro_rules! __impl_relativetime_short_hour_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::ShortHourRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_short_minute_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_short_minute_v1.rs.data
@@ -1080,6 +1080,9 @@ macro_rules! __impl_relativetime_short_minute_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::ShortMinuteRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_short_month_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_short_month_v1.rs.data
@@ -1152,6 +1152,9 @@ macro_rules! __impl_relativetime_short_month_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::ShortMonthRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_short_quarter_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_short_quarter_v1.rs.data
@@ -1040,6 +1040,9 @@ macro_rules! __impl_relativetime_short_quarter_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::ShortQuarterRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_short_second_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_short_second_v1.rs.data
@@ -1064,6 +1064,9 @@ macro_rules! __impl_relativetime_short_second_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::ShortSecondRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_short_week_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_short_week_v1.rs.data
@@ -1176,6 +1176,9 @@ macro_rules! __impl_relativetime_short_week_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::ShortWeekRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/baked/relativetime/data/macros/relativetime_short_year_v1.rs.data
+++ b/provider/baked/relativetime/data/macros/relativetime_short_year_v1.rs.data
@@ -1200,6 +1200,9 @@ macro_rules! __impl_relativetime_short_year_v1 {
                             metadata.locale = Some(fallback_iterator.take());
                             break payload;
                         }
+                        if fallback_iterator.get().is_und() {
+                            return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::relativetime::provider::ShortYearRelativeTimeFormatDataV1Marker as icu_provider::KeyedDataMarker>::KEY, req));
+                        }
                         fallback_iterator.step();
                     }
                 };

--- a/provider/datagen/src/baked_exporter.rs
+++ b/provider/datagen/src/baked_exporter.rs
@@ -525,17 +525,6 @@ impl BakedExporter {
                         .insert("icu_locid_transform/compiled_data");
                     let search_direct = search(quote!(req.locale));
                     let search_iterator = search(quote!(fallback_iterator.get()));
-                    let maybe_err = if keys.contains(&String::from("und")) {
-                        // The loop will terminate on its own
-                        quote!()
-                    } else {
-                        // We have to manually break the loop
-                        quote! {
-                            if fallback_iterator.get().is_und() {
-                                return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<#marker as icu_provider::KeyedDataMarker>::KEY, req));
-                            }
-                        }
-                    };
                     quote! {
                         #(#statics)*
 
@@ -549,13 +538,14 @@ impl BakedExporter {
                                     .for_config(<#marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                             let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                             loop {
-                                #maybe_err
-
+                                fallback_iterator.step();
                                 if let Ok(payload) = #search_iterator {
                                     metadata.locale = Some(fallback_iterator.take());
                                     break payload;
                                 }
-                                fallback_iterator.step();
+                                if fallback_iterator.get().is_und() {
+                                    return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<#marker as icu_provider::KeyedDataMarker>::KEY, req));
+                                }
                             }
                         };
 

--- a/provider/datagen/src/baked_exporter.rs
+++ b/provider/datagen/src/baked_exporter.rs
@@ -538,7 +538,6 @@ impl BakedExporter {
                                     .for_config(<#marker as icu_provider::KeyedDataMarker>::KEY.fallback_config());
                             let mut fallback_iterator = FALLBACKER.fallback_for(req.locale.clone());
                             loop {
-                                fallback_iterator.step();
                                 if let Ok(payload) = #search_iterator {
                                     metadata.locale = Some(fallback_iterator.take());
                                     break payload;
@@ -546,6 +545,7 @@ impl BakedExporter {
                                 if fallback_iterator.get().is_und() {
                                     return Err(icu_provider::DataErrorKind::MissingLocale.with_req(<#marker as icu_provider::KeyedDataMarker>::KEY, req));
                                 }
+                                fallback_iterator.step();
                             }
                         };
 


### PR DESCRIPTION
I noticed that Baked Data Fallback does not work with auxiliary keys.

LocaleFallbackProvider has the following algorithm:

1. Initialize fallback iterator with request locale
2. Repeat:
    1. Load for iterator.get()
    2. If error other than missing locale, return result (success or error)
    3. If iterator.get().is_und(), break
    4. Run iterator.step()
3. Return missing locale error

Baked Data fallback when "und" is not present has the following algorithm:

1. Search for request locale; return if found
2. Initialize fallback iterator with request locale
3. Repeat:
    1. If iterator.get().is_und(), break
    2. Load for iterator.get()
    3. Search for request locale; return if found
    4. Run iterator.step()

(When "und" is present, it doesn't include the line that breaks out of the loop.)

This breaks because "en-x-3" falls back to "und-x-3" but not all the way to "und". Example:

```
failures:

---- format::neo::tests::test_basic_pattern_interpolator stdout ----
ICU4X data error: Missing data for locale (key: datetime/symbols/weekdays@1, request: en-x-3)
thread 'format::neo::tests::test_basic_pattern_interpolator' panicked at components/datetime/src/format/neo.rs:988:14:
called `Result::unwrap()` on an `Err` value: Data(DataError { kind: MissingLocale, key: Some(DataKey{datetime/symbols/weekdays@1}), str_context: None, silent: false })
```

I fixed this by doing the following:

1. Evaluate the iterator locale before breaking from the loop (this fixes the bug)
2. Use the same generated code whether or not "und" is present (improves consistency and prevents aux-key-related bugs with no super clear downside: `.is_und()` is cheap)