### PR TITLE
Add more Eq impls to datetime pattern types

### DIFF
--- a/components/datetime/src/pattern/item/generic.rs
+++ b/components/datetime/src/pattern/item/generic.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake), databake(path = icu_datetime::pattern))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[allow(clippy::exhaustive_enums)] // this type is stable

--- a/components/datetime/src/pattern/item/mod.rs
+++ b/components/datetime/src/pattern/item/mod.rs
@@ -10,7 +10,7 @@ use crate::pattern::PatternError;
 use core::convert::TryFrom;
 pub use generic::GenericPatternItem;
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(
     feature = "datagen",
     derive(serde::Serialize, databake::Bake),

--- a/components/datetime/src/pattern/runtime/generic.rs
+++ b/components/datetime/src/pattern/runtime/generic.rs
@@ -12,7 +12,7 @@ use core::str::FromStr;
 use icu_provider::prelude::*;
 use zerovec::ZeroVec;
 
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Eq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
 #[cfg_attr(
     feature = "datagen",

--- a/components/datetime/src/pattern/runtime/pattern.rs
+++ b/components/datetime/src/pattern/runtime/pattern.rs
@@ -8,7 +8,7 @@ use core::str::FromStr;
 use icu_provider::prelude::*;
 use zerovec::ZeroVec;
 
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Eq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[cfg_attr(
     feature = "datagen",
     derive(databake::Bake),


### PR DESCRIPTION
Not sure if we want these or not; I noticed that they were missing, and it prevents us from adding `Eq` on the top-level pattern type.