### PR TITLE
Add CartableOptionPointer and helpers to the yoke crate

### DIFF
--- a/utils/yoke/src/cartable_ptr.rs
+++ b/utils/yoke/src/cartable_ptr.rs
@@ -32,7 +32,9 @@ trait Sealed {}
 
 /// An object fully representable by a non-null pointer.
 ///
-/// # Implementer Safety
+/// # Safety
+///
+/// Implementer safety:
 ///
 /// 1. `into_raw` transfers ownership of the values referenced by StableDeref to the caller,
 ///    if there is ownership to transfer
@@ -53,7 +55,9 @@ pub unsafe trait CartablePointerLike: StableDeref + Sealed {
 
     /// Drops any memory associated with this pointer-like.
     ///
-    /// # Caller Safety
+    /// # Safety
+    ///
+    /// Caller safety:
     ///
     /// 1. The pointer MUST have been returned by this impl's `into_raw`.
     /// 2. The pointer MUST NOT be dangling.
@@ -64,7 +68,9 @@ pub unsafe trait CartablePointerLike: StableDeref + Sealed {
 /// An object that implements [`CartablePointerLike`] that also
 /// supports cloning without changing the address of referenced data.
 ///
-/// # Implementer Safety
+/// # Safety
+///
+/// Implementer safety:
 ///
 /// 1. `clone_raw` must create a new owner such that an additoinal call to
 ///    `drop_raw` does not create a dangling pointer
@@ -72,7 +78,9 @@ pub unsafe trait CartablePointerLike: StableDeref + Sealed {
 pub unsafe trait CloneableCartablePointerLike: CartablePointerLike {
     /// Clones this pointer-like.
     ///
-    /// # Caller Safety
+    /// # Safety
+    ///
+    /// Caller safety:
     ///
     /// 1. The pointer MUST have been returned by this impl's `into_raw`.
     /// 2. The pointer MUST NOT be dangling.
@@ -108,7 +116,7 @@ unsafe impl<'a, T> CloneableCartablePointerLike for &'a T {
 }
 
 #[cfg(feature = "alloc")]
-impl<'a, T> Sealed for Box<T> {}
+impl<T> Sealed for Box<T> {}
 
 // Safety:
 // 1. `Box::into_raw` says: "After calling this function, the caller is responsible for the
@@ -135,7 +143,7 @@ unsafe impl<T> CartablePointerLike for Box<T> {
 }
 
 #[cfg(feature = "alloc")]
-impl<'a, T> Sealed for Rc<T> {}
+impl<T> Sealed for Rc<T> {}
 
 // Safety:
 // 1. `Rc::into_raw` says: "Consumes the Rc, returning the wrapped pointer. To avoid a memory
@@ -166,7 +174,7 @@ unsafe impl<T> CartablePointerLike for Rc<T> {
 // 1. The impl increases the refcount such that `Drop` will decrease it.
 // 2. The impl increases refcount without changing the address of data.
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> CloneableCartablePointerLike for Rc<T> {
+unsafe impl<T> CloneableCartablePointerLike for Rc<T> {
     unsafe fn clone_raw(pointer: NonNull<T>) {
         // Safety: The caller safety of this function says that:
         // 1. The pointer was obtained through Rc::into_raw
@@ -177,7 +185,7 @@ unsafe impl<'a, T> CloneableCartablePointerLike for Rc<T> {
 }
 
 #[cfg(feature = "alloc")]
-impl<'a, T> Sealed for Arc<T> {}
+impl<T> Sealed for Arc<T> {}
 
 // Safety:
 // 1. `Rc::into_raw` says: "Consumes the Arc, returning the wrapped pointer. To avoid a memory
@@ -208,7 +216,7 @@ unsafe impl<T> CartablePointerLike for Arc<T> {
 // 1. The impl increases the refcount such that `Drop` will decrease it.
 // 2. The impl increases refcount without changing the address of data.
 #[cfg(feature = "alloc")]
-unsafe impl<'a, T> CloneableCartablePointerLike for Arc<T> {
+unsafe impl<T> CloneableCartablePointerLike for Arc<T> {
     unsafe fn clone_raw(pointer: NonNull<T>) {
         // Safety: The caller safety of this function says that:
         // 1. The pointer was obtained through Arc::into_raw

--- a/utils/yoke/src/cartable_ptr.rs
+++ b/utils/yoke/src/cartable_ptr.rs
@@ -1,0 +1,227 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+//! Types for optional pointers that may be dropped with niche optimization.
+
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+#[cfg(feature = "alloc")]
+use alloc::rc::Rc;
+#[cfg(feature = "alloc")]
+use alloc::sync::Arc;
+use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
+use core::ptr::NonNull;
+
+const fn sentinel_for<T>() -> NonNull<T> {
+    // Safety: align_of anything is always at least 1
+    unsafe { NonNull::new_unchecked(core::mem::align_of::<T>() as *mut T) }
+}
+
+#[test]
+fn test_min_alignment() {
+    assert_eq!(1, core::mem::align_of::<()>());
+}
+
+/// An object fully representable by a non-null pointer.
+///
+/// # Safety
+///
+/// 1. `into_raw` must not change the address of any referenced data.
+pub unsafe trait CartablePointerLike {
+    type Ptr;
+
+    /// Converts this pointer-like into a pointer.
+    fn into_raw(self) -> NonNull<Self::Ptr>;
+
+    /// Drops any memory associated with this pointer-like.
+    ///
+    /// # Safety
+    ///
+    /// 1. The pointer MUST have been returned by this impl's `into_raw`.
+    /// 2. The pointer MUST NOT be dangling.
+    unsafe fn drop_raw(pointer: NonNull<Self::Ptr>);
+}
+
+/// An object that implements [`CartablePointerLike`] that also
+/// supports cloning without changing the address of referenced data.
+///
+/// # Safety
+///
+/// 1. `clone_raw` must not change the address of any referenced data.
+pub unsafe trait CloneableCartablePointerLike: CartablePointerLike {
+    /// Clones this pointer-like.
+    ///
+    /// # Safety
+    ///
+    /// 1. The pointer MUST have been returned by this impl's `into_raw`.
+    /// 2. The pointer MUST NOT be dangling.
+    unsafe fn clone_raw(pointer: NonNull<Self::Ptr>);
+}
+
+unsafe impl<'a, T> CartablePointerLike for &'a T {
+    type Ptr = T;
+
+    fn into_raw(self) -> NonNull<T> {
+        self.into()
+    }
+    unsafe fn drop_raw(_pointer: NonNull<T>) {
+        // No-op: references are borrowed from elsewhere
+    }
+}
+
+unsafe impl<'a, T> CloneableCartablePointerLike for &'a T {
+    unsafe fn clone_raw(_pointer: NonNull<T>) {
+        // No-op: references are borrowed from elsewhere
+    }
+}
+
+#[cfg(feature = "alloc")]
+unsafe impl<T> CartablePointerLike for Box<T> {
+    type Ptr = T;
+
+    fn into_raw(self) -> NonNull<T> {
+        // Safety: Boxes must contain data (and not be null)
+        unsafe { NonNull::new_unchecked(Box::into_raw(self)) }
+    }
+    unsafe fn drop_raw(pointer: NonNull<T>) {
+        let _ = Box::from_raw(pointer.as_ptr());
+    }
+}
+
+#[cfg(feature = "alloc")]
+unsafe impl<T> CartablePointerLike for Rc<T> {
+    type Ptr = T;
+
+    fn into_raw(self) -> NonNull<T> {
+        // Safety: Rcs must contain data (and not be null)
+        unsafe { NonNull::new_unchecked(Rc::into_raw(self) as *mut T) }
+    }
+    unsafe fn drop_raw(pointer: NonNull<T>) {
+        let _ = Rc::from_raw(pointer.as_ptr());
+    }
+}
+
+#[cfg(feature = "alloc")]
+unsafe impl<'a, T> CloneableCartablePointerLike for Rc<T> {
+    unsafe fn clone_raw(pointer: NonNull<T>) {
+        let rc = Rc::from_raw(pointer.as_ptr());
+        let _ = ManuallyDrop::new(rc.clone());
+        let _ = ManuallyDrop::new(rc);
+    }
+}
+
+#[cfg(feature = "alloc")]
+unsafe impl<T> CartablePointerLike for Arc<T> {
+    type Ptr = T;
+
+    fn into_raw(self) -> NonNull<T> {
+        // Safety: Arcs must contain data (and not be null)
+        unsafe { NonNull::new_unchecked(Arc::into_raw(self) as *mut T) }
+    }
+    unsafe fn drop_raw(pointer: NonNull<T>) {
+        let _ = Arc::from_raw(pointer.as_ptr());
+    }
+}
+
+#[cfg(feature = "alloc")]
+unsafe impl<'a, T> CloneableCartablePointerLike for Arc<T> {
+    unsafe fn clone_raw(pointer: NonNull<T>) {
+        let rc = Rc::from_raw(pointer.as_ptr());
+        let _ = ManuallyDrop::new(rc.clone());
+        let _ = ManuallyDrop::new(rc);
+    }
+}
+
+/// A type with similar semantics as `Option<C<T>>` but with a niche.
+#[derive(Debug)]
+pub struct CartableOptionPointer<C>
+where
+    C: CartablePointerLike,
+{
+    /// The inner pointer.
+    ///
+    /// # Invariants
+    ///
+    /// 1. Must be either `SENTINEL_PTR` or created from `CartablePointerLike::into_raw`
+    /// 2. If non-sentinel, must _always_ be for a valid SelectedRc
+    inner: NonNull<C::Ptr>,
+    _cartable: PhantomData<C>,
+}
+
+impl<C> CartableOptionPointer<C>
+where
+    C: CartablePointerLike,
+{
+    /// Creates a new instance corresponding to a `None` value.
+    #[inline]
+    pub(crate) const fn none() -> Self {
+        Self {
+            inner: sentinel_for::<C::Ptr>(),
+            _cartable: PhantomData,
+        }
+    }
+
+    /// Creates a new instance corresponding to a `Some` value.
+    #[inline]
+    pub(crate) fn from_cartable(cartable: C) -> Self {
+        let ptr = cartable.into_raw();
+        debug_assert_ne!(
+            ptr,
+            sentinel_for::<C::Ptr>(),
+            "Creating from [A]Rc is not expected to be the sentinel ptr"
+        );
+        // Safety: ptr is non-null because ptr is from SelectedRc::into_raw.
+        // SelectedRc can't return a null ptr because it implements Deref.
+        Self {
+            inner: ptr,
+            _cartable: PhantomData,
+        }
+    }
+
+    /// Returns whether this instance is `None`. From the return value:
+    ///
+    /// - If `true`, the instance is `None`
+    /// - If `false`, the instance is a valid `SelectedRc`
+    #[inline]
+    pub fn is_none(&self) -> bool {
+        self.inner == sentinel_for::<C::Ptr>()
+    }
+}
+
+impl<C> Drop for CartableOptionPointer<C>
+where
+    C: CartablePointerLike,
+{
+    fn drop(&mut self) {
+        let ptr = self.inner;
+        if ptr != sentinel_for::<C::Ptr>() {
+            // By the invariants, `ptr` is a valid raw value since it's
+            // either that or sentinel, and we just checked for sentinel.
+            // We will replace it with the sentinel and then drop `ptr`.
+            self.inner = sentinel_for::<C::Ptr>();
+            // Safety: by the invariants, `ptr` is a valid raw value.
+            unsafe { C::drop_raw(ptr) }
+        }
+    }
+}
+
+impl<C> Clone for CartableOptionPointer<C>
+where
+    C: CloneableCartablePointerLike,
+{
+    fn clone(&self) -> Self {
+        let ptr = self.inner;
+        if ptr != sentinel_for::<C::Ptr>() {
+            // By the invariants, `ptr` is a valid raw value since it's
+            // either that or sentinel, and we just checked for sentinel.
+            // Safety: by the invariants, `ptr` is a valid raw value.
+            unsafe { C::clone_raw(ptr) }
+        }
+        Self {
+            inner: self.inner,
+            _cartable: PhantomData,
+        }
+    }
+}

--- a/utils/yoke/src/cartable_ptr.rs
+++ b/utils/yoke/src/cartable_ptr.rs
@@ -11,12 +11,12 @@ use alloc::boxed::Box;
 use alloc::rc::Rc;
 #[cfg(feature = "alloc")]
 use alloc::sync::Arc;
-use stable_deref_trait::StableDeref;
+#[cfg(test)]
+use core::cell::Cell;
 use core::marker::PhantomData;
 use core::mem::align_of;
 use core::ptr::NonNull;
-#[cfg(test)]
-use core::cell::Cell;
+use stable_deref_trait::StableDeref;
 
 const fn sentinel_for<T>() -> NonNull<T> {
     // Safety: 1 is non-zero
@@ -336,11 +336,20 @@ mod tests {
     fn test_sizes() {
         assert_eq!(W * 4, size_of::<Yoke<Cow<'static, str>, &&[u8]>>());
         assert_eq!(W * 4, size_of::<Yoke<Cow<'static, str>, Option<&&[u8]>>>());
-        assert_eq!(W * 4, size_of::<Yoke<Cow<'static, str>, CartableOptionPointer<&&[u8]>>>());
+        assert_eq!(
+            W * 4,
+            size_of::<Yoke<Cow<'static, str>, CartableOptionPointer<&&[u8]>>>()
+        );
 
         assert_eq!(W * 4, size_of::<Option<Yoke<Cow<'static, str>, &&[u8]>>>());
-        assert_eq!(W * 5, size_of::<Option<Yoke<Cow<'static, str>, Option<&&[u8]>>>>());
-        assert_eq!(W * 4, size_of::<Option<Yoke<Cow<'static, str>, CartableOptionPointer<&&[u8]>>>>());
+        assert_eq!(
+            W * 5,
+            size_of::<Option<Yoke<Cow<'static, str>, Option<&&[u8]>>>>()
+        );
+        assert_eq!(
+            W * 4,
+            size_of::<Option<Yoke<Cow<'static, str>, CartableOptionPointer<&&[u8]>>>>()
+        );
     }
 
     #[test]
@@ -360,9 +369,7 @@ mod tests {
     fn test_new_rc() {
         let start = DROP_INVOCATIONS.get();
         {
-            let _ = CartableOptionPointer::<Rc<&[u8]>>::from_cartable(
-                SAMPLE_BYTES.into(),
-            );
+            let _ = CartableOptionPointer::<Rc<&[u8]>>::from_cartable(SAMPLE_BYTES.into());
         }
         assert_eq!(start + 1, DROP_INVOCATIONS.get());
     }
@@ -371,9 +378,7 @@ mod tests {
     fn test_rc_clone() {
         let start = DROP_INVOCATIONS.get();
         {
-            let x = CartableOptionPointer::<Rc<&[u8]>>::from_cartable(
-                SAMPLE_BYTES.into(),
-            );
+            let x = CartableOptionPointer::<Rc<&[u8]>>::from_cartable(SAMPLE_BYTES.into());
             assert_eq!(start, DROP_INVOCATIONS.get());
             {
                 let _ = x.clone();

--- a/utils/yoke/src/cartable_ptr.rs
+++ b/utils/yoke/src/cartable_ptr.rs
@@ -28,7 +28,11 @@ thread_local! {
     static DROP_INVOCATIONS: Cell<usize> = const { Cell::new(0) };
 }
 
-trait Sealed {}
+mod private {
+    pub trait Sealed {}
+}
+
+use private::Sealed;
 
 /// An object fully representable by a non-null pointer.
 ///
@@ -44,7 +48,6 @@ trait Sealed {}
 ///
 /// Note: the pointer `NonNull<Self::Raw>` may or may not be aligned and it should never
 /// be dereferenced. Rust allows unaligned pointers; see [`std::ptr::read_unaligned`].
-#[allow(private_bounds)] // sealed trait
 pub unsafe trait CartablePointerLike: StableDeref + Sealed {
     /// The raw type used for [`Self::into_raw`] and [`Self::drop_raw`].
     type Raw;

--- a/utils/yoke/src/cartable_ptr.rs
+++ b/utils/yoke/src/cartable_ptr.rs
@@ -353,43 +353,43 @@ mod tests {
 
     #[test]
     fn test_new_sentinel() {
-        let start = DROP_INVOCATIONS.get();
+        let start = DROP_INVOCATIONS.with(Cell::get);
         {
             let _ = CartableOptionPointer::<Rc<&[u8]>>::none();
         }
-        assert_eq!(start, DROP_INVOCATIONS.get());
+        assert_eq!(start, DROP_INVOCATIONS.with(Cell::get));
         {
             let _ = CartableOptionPointer::<Rc<&[u8]>>::none();
         }
-        assert_eq!(start, DROP_INVOCATIONS.get());
+        assert_eq!(start, DROP_INVOCATIONS.with(Cell::get));
     }
 
     #[test]
     fn test_new_rc() {
-        let start = DROP_INVOCATIONS.get();
+        let start = DROP_INVOCATIONS.with(Cell::get);
         {
             let _ = CartableOptionPointer::<Rc<&[u8]>>::from_cartable(SAMPLE_BYTES.into());
         }
-        assert_eq!(start + 1, DROP_INVOCATIONS.get());
+        assert_eq!(start + 1, DROP_INVOCATIONS.with(Cell::get));
     }
 
     #[test]
     fn test_rc_clone() {
-        let start = DROP_INVOCATIONS.get();
+        let start = DROP_INVOCATIONS.with(Cell::get);
         {
             let x = CartableOptionPointer::<Rc<&[u8]>>::from_cartable(SAMPLE_BYTES.into());
-            assert_eq!(start, DROP_INVOCATIONS.get());
+            assert_eq!(start, DROP_INVOCATIONS.with(Cell::get));
             {
                 let _ = x.clone();
             }
-            assert_eq!(start, DROP_INVOCATIONS.get());
+            assert_eq!(start, DROP_INVOCATIONS.with(Cell::get));
             {
                 let _ = x.clone();
                 let _ = x.clone();
                 let _ = x.clone();
             }
-            assert_eq!(start, DROP_INVOCATIONS.get());
+            assert_eq!(start, DROP_INVOCATIONS.with(Cell::get));
         }
-        assert_eq!(start + 1, DROP_INVOCATIONS.get());
+        assert_eq!(start + 1, DROP_INVOCATIONS.with(Cell::get));
     }
 }

--- a/utils/yoke/src/cartable_ptr.rs
+++ b/utils/yoke/src/cartable_ptr.rs
@@ -4,6 +4,7 @@
 
 //! Types for optional pointers that may be dropped with niche optimization.
 
+use crate::CloneableCart;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
@@ -11,6 +12,7 @@ use alloc::rc::Rc;
 #[cfg(feature = "alloc")]
 use alloc::sync::Arc;
 use core::marker::PhantomData;
+#[cfg(feature = "alloc")]
 use core::mem::ManuallyDrop;
 use core::ptr::NonNull;
 
@@ -225,3 +227,16 @@ where
         }
     }
 }
+
+// Safety: type has the same semantics as Option<C>
+// which implements CloneableCart
+unsafe impl<C> CloneableCart for CartableOptionPointer<C> where
+    C: CloneableCartablePointerLike + CloneableCart
+{
+}
+
+// Safety: same bounds as Arc
+unsafe impl<C> Send for CartableOptionPointer<C> where C: Sync + Send + CartablePointerLike {}
+
+// Safety: same bounds as Arc
+unsafe impl<C> Sync for CartableOptionPointer<C> where C: Sync + Send + CartablePointerLike {}

--- a/utils/yoke/src/cartable_ptr.rs
+++ b/utils/yoke/src/cartable_ptr.rs
@@ -227,6 +227,8 @@ unsafe impl<T> CloneableCartablePointerLike for Arc<T> {
 }
 
 /// A type with similar semantics as `Option<C<T>>` but with a niche.
+///
+/// Will panic on types with alignment 1.
 #[derive(Debug)]
 pub struct CartableOptionPointer<C>
 where

--- a/utils/yoke/src/cartable_ptr.rs
+++ b/utils/yoke/src/cartable_ptr.rs
@@ -61,6 +61,7 @@ use private::Sealed;
 /// be dereferenced. Rust allows unaligned pointers; see [`std::ptr::read_unaligned`].
 pub unsafe trait CartablePointerLike: StableDeref + Sealed {
     /// The raw type used for [`Self::into_raw`] and [`Self::drop_raw`].
+    #[doc(hidden)]
     type Raw;
 
     /// Converts this pointer-like into a pointer.

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -45,6 +45,7 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+pub mod cartable_ptr;
 pub mod either;
 #[cfg(feature = "alloc")]
 pub mod erased;

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -508,6 +508,38 @@ impl<Y: for<'a> Yokeable<'a>, C: StableDeref> Yoke<Y, Option<C>> {
 impl<Y: for<'a> Yokeable<'a>, C: CartablePointerLike> Yoke<Y, Option<C>> {
     /// Converts a `Yoke<Y, Option<C>>` to `Yoke<Y, CartableOptionPointer<C>>`
     /// for better niche optimization when stored as a field.
+    ///
+    /// Panics on types with alignment 1.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use yoke::Yoke;
+    /// use std::borrow::Cow;
+    ///
+    /// let yoke: Yoke<Cow<[u8]>, Box<Vec<u8>>> = Yoke::attach_to_cart(
+    ///     vec![10, 20, 30].into(),
+    ///     |c| c.into(),
+    /// );
+    ///
+    /// let yoke_option = yoke.wrap_cart_in_option();
+    /// let yoke_option_pointer = yoke_option.convert_cart_into_option_pointer();
+    /// ```
+    ///
+    /// Panics if the type has alignment 1:
+    ///
+    /// ```should_panic
+    /// use yoke::Yoke;
+    /// use std::borrow::Cow;
+    ///
+    /// let yoke: Yoke<Cow<[u8]>, Box<[u8; 3]>> = Yoke::attach_to_cart(
+    ///     [10, 20, 30].into(),
+    ///     |c| c.as_slice().into(),
+    /// );
+    ///
+    /// let yoke_option = yoke.wrap_cart_in_option();
+    /// let yoke_option_pointer = yoke_option.convert_cart_into_option_pointer();
+    /// ```
     #[inline]
     pub fn convert_cart_into_option_pointer(self) -> Yoke<Y, CartableOptionPointer<C>> {
         match self.cart {

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -509,8 +509,6 @@ impl<Y: for<'a> Yokeable<'a>, C: CartablePointerLike> Yoke<Y, Option<C>> {
     /// Converts a `Yoke<Y, Option<C>>` to `Yoke<Y, CartableOptionPointer<C>>`
     /// for better niche optimization when stored as a field.
     ///
-    /// Panics on types with alignment 1.
-    ///
     /// # Examples
     ///
     /// ```
@@ -520,21 +518,6 @@ impl<Y: for<'a> Yokeable<'a>, C: CartablePointerLike> Yoke<Y, Option<C>> {
     /// let yoke: Yoke<Cow<[u8]>, Box<Vec<u8>>> = Yoke::attach_to_cart(
     ///     vec![10, 20, 30].into(),
     ///     |c| c.into(),
-    /// );
-    ///
-    /// let yoke_option = yoke.wrap_cart_in_option();
-    /// let yoke_option_pointer = yoke_option.convert_cart_into_option_pointer();
-    /// ```
-    ///
-    /// Panics if the type has alignment 1:
-    ///
-    /// ```should_panic
-    /// use yoke::Yoke;
-    /// use std::borrow::Cow;
-    ///
-    /// let yoke: Yoke<Cow<[u8]>, Box<[u8; 3]>> = Yoke::attach_to_cart(
-    ///     [10, 20, 30].into(),
-    ///     |c| c.as_slice().into(),
     /// );
     ///
     /// let yoke_option = yoke.wrap_cart_in_option();


### PR DESCRIPTION
Split from #4442

I do think this is in scope for `yoke` because the type can be a "one-way" type that is a more efficient cart than either `Option<Rc<T>>` or `Option<ErasedRcCart>`.