### PR TITLE
Inline locid AsRef

### DIFF
--- a/components/locid/src/langid.rs
+++ b/components/locid/src/langid.rs
@@ -401,6 +401,7 @@ impl LanguageIdentifier {
 }
 
 impl AsRef<LanguageIdentifier> for LanguageIdentifier {
+    #[inline(always)]
     fn as_ref(&self) -> &Self {
         self
     }

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -374,6 +374,7 @@ impl From<Locale> for LanguageIdentifier {
 }
 
 impl AsRef<LanguageIdentifier> for Locale {
+    #[inline(always)]
     fn as_ref(&self) -> &LanguageIdentifier {
         &self.id
     }


### PR DESCRIPTION
While porting https://github.com/projectfluent/fluent-langneg-rs to icu_locid I noticed a major performance impact of inlining `AsRef`.

This patch speeds up language negotiation in that crate by 16%:

```
negotiate               time:   [746.45 ns 758.98 ns 782.69 ns]
                        change: [-17.338% -16.591% -15.434%] (p = 0.00 < 0.05)
                        Performance has improved.
```