### PR TITLE
Remove StableDeref bound on Option<Cart> methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
       - Correctly handle chars (https://github.com/unicode-org/icu4x/pull/4349)
     - JS
       - Fixed a bug where slice length is computed incorrectly (https://github.com/rust-diplomat/diplomat/pull/372)
+- Utilities
+    - `yoke`
+        - Remove `StableDeref` bound from `Yoke<Y, Option<C>>` methods (https://github.com/unicode-org/icu4x/pull/4457)
 
 ## icu4x 1.4 (Nov 16, 2023)
 


### PR DESCRIPTION
We don't need it