### PR TITLE
Remove dep on `fraction`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,15 +1088,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fraction"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a78dd758a47a7305478e0e054f9fde4e983b9f9eccda162bf7ca03b79e9d40"
-dependencies = [
- "num",
-]
-
-[[package]]
 name = "freertos-rust"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1537,7 +1528,6 @@ dependencies = [
  "either",
  "elsa",
  "eyre",
- "fraction",
  "icu",
  "icu_calendar",
  "icu_casemap",
@@ -1569,6 +1559,7 @@ dependencies = [
  "memchr",
  "ndarray",
  "num-bigint",
+ "num-rational",
  "once_cell",
  "postcard",
  "proc-macro2",
@@ -2439,19 +2430,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
-dependencies = [
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2478,17 +2456,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -88,8 +88,8 @@ zip = { version = ">=0.5, <0.7", default-features = false, features = ["deflate"
 rayon = { version = "1.5", optional = true }
 ureq = { version = "2", optional = true }
 
-fraction = { version = "0.14.0", default-features = false, optional = true }
 num-bigint = { version = "0.4.4", default-features = false, optional = true }
+num-rational = { version = "0.4", default-features = false, optional = true }
 
 
 # Dependencies for "bin" feature
@@ -130,7 +130,7 @@ icu_compactdecimal = ["dep:icu_compactdecimal"]
 icu_displaynames = ["dep:icu_displaynames"]
 icu_relativetime = ["dep:icu_relativetime"]
 icu_transliterate = ["dep:icu_transliterate"]
-icu_unitsconversion = ["dep:icu_unitsconversion", "dep:fraction", "dep:num-bigint"]
+icu_unitsconversion = ["dep:icu_unitsconversion", "dep:num-bigint", "dep:num-rational"]
 experimental_components = [
     "icu_compactdecimal",
     "icu_displaynames",

--- a/provider/datagen/src/transform/cldr/units/info.rs
+++ b/provider/datagen/src/transform/cldr/units/info.rs
@@ -109,12 +109,11 @@ impl IterableDataProvider<UnitsInfoV1Marker> for crate::DatagenProvider {
 
 #[test]
 fn test_basic() {
-    use fraction::GenericFraction;
-    use fraction::Zero;
     use icu_locid::locale;
     use icu_provider::prelude::*;
     use icu_unitsconversion::provider::*;
     use num_bigint::BigUint;
+    use num_rational::Ratio;
     use zerofrom::ZeroFrom;
     use zerovec::maps::ZeroVecLike;
     use zerovec::ZeroVec;
@@ -173,7 +172,7 @@ fn test_basic() {
             factor_num: ZeroVec::from(big_one.to_bytes_le()),
             factor_den: ZeroVec::from(big_one.to_bytes_le()),
             offset_sign: Sign::Positive,
-            offset_num: ZeroVec::from(BigUint::zero().to_bytes_le()),
+            offset_num: ZeroVec::from(BigUint::from(0u32).to_bytes_le()),
             offset_den: ZeroVec::from(big_one.to_bytes_le()),
             exactness: Exactness::Exact,
         }
@@ -182,7 +181,7 @@ fn test_basic() {
     let foot_convert_index = units_info_map.get("foot").unwrap();
     let foot_convert_ule = convert_units.zvl_get(foot_convert_index).unwrap();
     let foot_convert: ConversionInfo = ZeroFrom::zero_from(foot_convert_ule);
-    let ft_to_m = GenericFraction::<BigUint>::new(BigUint::from(3048u32), BigUint::from(10000u32));
+    let ft_to_m = Ratio::new(BigUint::from(3048u32), BigUint::from(10000u32));
 
     assert_eq!(
         foot_convert,
@@ -199,10 +198,10 @@ fn test_basic() {
                 ZeroVec::from_iter(base_unit.into_iter())
             },
             factor_sign: Sign::Positive,
-            factor_num: ZeroVec::from(ft_to_m.numer().unwrap().to_bytes_le()),
-            factor_den: ZeroVec::from(ft_to_m.denom().unwrap().to_bytes_le()),
+            factor_num: ZeroVec::from(ft_to_m.numer().to_bytes_le()),
+            factor_den: ZeroVec::from(ft_to_m.denom().to_bytes_le()),
             offset_sign: Sign::Positive,
-            offset_num: ZeroVec::from(BigUint::zero().to_bytes_le()),
+            offset_num: ZeroVec::from(BigUint::from(0u32).to_bytes_le()),
             offset_den: ZeroVec::from(big_one.to_bytes_le()),
             exactness: Exactness::Exact,
         }


### PR DESCRIPTION
See discussion in https://github.com/unicode-org/icu4x/pull/3922#discussion_r1355488989

Doesn't seem too complicated.

cc @younies @robertbastian
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->