### PR TITLE
Some cleanups for chinese in preparation of precomputed data

### DIFF
--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -228,64 +228,7 @@ impl Calendar for Chinese {
     /// leap months. For example, in a year where an intercalary month is added after the second
     /// month, the month codes for ordinal months 1, 2, 3, 4, 5 would be "M01", "M02", "M02L", "M03", "M04".
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
-        let ordinal = date.0 .0.month;
-        let leap_month_option = date.0 .0.year_info.leap_month();
-        let leap_month = if let Some(leap) = leap_month_option {
-            leap.get()
-        } else {
-            14
-        };
-        let code_inner = if leap_month == ordinal {
-            // Month cannot be 1 because a year cannot have a leap month before the first actual month,
-            // and the maximum num of months ina leap year is 13.
-            debug_assert!((2..=13).contains(&ordinal));
-            match ordinal {
-                2 => tinystr!(4, "M01L"),
-                3 => tinystr!(4, "M02L"),
-                4 => tinystr!(4, "M03L"),
-                5 => tinystr!(4, "M04L"),
-                6 => tinystr!(4, "M05L"),
-                7 => tinystr!(4, "M06L"),
-                8 => tinystr!(4, "M07L"),
-                9 => tinystr!(4, "M08L"),
-                10 => tinystr!(4, "M09L"),
-                11 => tinystr!(4, "M10L"),
-                12 => tinystr!(4, "M11L"),
-                13 => tinystr!(4, "M12L"),
-                _ => tinystr!(4, "und"),
-            }
-        } else {
-            let mut adjusted_ordinal = ordinal;
-            if ordinal > leap_month {
-                // Before adjusting for leap month, if ordinal > leap_month,
-                // the month cannot be 1 because this implies the leap month is < 1, which is impossible;
-                // cannot be 2 because that implies the leap month is = 1, which is impossible,
-                // and cannot be more than 13 because max number of months in a year is 13.
-                debug_assert!((2..=13).contains(&ordinal));
-                adjusted_ordinal -= 1;
-            }
-            debug_assert!((1..=12).contains(&adjusted_ordinal));
-            match adjusted_ordinal {
-                1 => tinystr!(4, "M01"),
-                2 => tinystr!(4, "M02"),
-                3 => tinystr!(4, "M03"),
-                4 => tinystr!(4, "M04"),
-                5 => tinystr!(4, "M05"),
-                6 => tinystr!(4, "M06"),
-                7 => tinystr!(4, "M07"),
-                8 => tinystr!(4, "M08"),
-                9 => tinystr!(4, "M09"),
-                10 => tinystr!(4, "M10"),
-                11 => tinystr!(4, "M11"),
-                12 => tinystr!(4, "M12"),
-                _ => tinystr!(4, "und"),
-            }
-        };
-        let code = types::MonthCode(code_inner);
-        types::FormattableMonth {
-            ordinal: ordinal as u32,
-            code,
-        }
+        date.0.month()
     }
 
     /// The calendar-specific day-of-month represented by `date`

--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -297,13 +297,11 @@ impl Calendar for Chinese {
     fn day_of_year_info(&self, date: &Self::DateInner) -> types::DayOfYearInfo {
         let prev_year = date.0 .0.year.saturating_sub(1);
         let next_year = date.0 .0.year.saturating_add(1);
-        // TODO(#3933): we should maybe have this cached already
-        let prev_info = self.get_precomputed_data().load_or_compute_info(prev_year);
         types::DayOfYearInfo {
             day_of_year: date.0.day_of_year(),
             days_in_year: date.0.days_in_year_inner(),
             prev_year: Self::format_chinese_year(prev_year, None),
-            days_in_prev_year: Self::days_in_provided_year(prev_year, prev_info),
+            days_in_prev_year: date.0.days_in_prev_year(),
             next_year: Self::format_chinese_year(next_year, None),
         }
     }

--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -229,7 +229,7 @@ impl Calendar for Chinese {
     /// month, the month codes for ordinal months 1, 2, 3, 4, 5 would be "M01", "M02", "M02L", "M03", "M04".
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         let ordinal = date.0 .0.month;
-        let leap_month_option = date.0 .0.year_info.leap_month;
+        let leap_month_option = date.0 .0.year_info.leap_month();
         let leap_month = if let Some(leap) = leap_month_option {
             leap.get()
         } else {
@@ -424,7 +424,7 @@ impl Chinese {
         let cyclic = (number - 1).rem_euclid(60) as u8;
         let cyclic = NonZeroU8::new(cyclic + 1); // 1-indexed
         let rata_die_in_year = if let Some(info) = year_info_option {
-            info.new_year
+            info.new_year()
         } else {
             Inner::fixed_mid_year_from_year(number)
         };
@@ -690,7 +690,7 @@ mod test {
             let iso = Date::try_new_iso_date(year, 6, 1).unwrap();
             let chinese_date = iso.to_calendar(Chinese);
             assert!(chinese_date.is_in_leap_year());
-            let new_year = chinese_date.inner.0 .0.year_info.new_year;
+            let new_year = chinese_date.inner.0 .0.year_info.new_year();
             assert_eq!(
                 expected_month,
                 calendrical_calculations::chinese_based::get_leap_month_from_new_year::<

--- a/components/calendar/src/chinese_based.rs
+++ b/components/calendar/src/chinese_based.rs
@@ -121,8 +121,8 @@ impl PackedChineseBasedYearInfo {
         }
 
         let new_year_offset = ((self.0 & 0b11111000) >> 3) as u16;
-        let new_year =
-            Iso::fixed_from_iso(Iso::iso_from_year_day(related_iso, 21 + new_year_offset).inner);
+        let iso_ny = calendrical_calculations::iso::fixed_from_iso(related_iso, 1, 1);
+        let new_year = iso_ny + 21 + i64::from(new_year_offset);
 
         let mut last_day_of_month: [u16; 13] = [0; 13];
         let mut months_total = 0;

--- a/components/calendar/src/chinese_based.rs
+++ b/components/calendar/src/chinese_based.rs
@@ -175,19 +175,27 @@ impl PackedChineseBasedYearInfo {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 // TODO(#3933): potentially make this smaller
 pub(crate) struct ChineseBasedYearInfo {
-    pub(crate) new_year: RataDie,
+    new_year: RataDie,
     days_in_prev_year: u16,
     /// last_day_of_month[12] = last_day_of_month[11] in non-leap years
     /// These days are 1-indexed: so the last day of month for a 30-day 一月 is 30
     /// The array itself is zero-indexed, be careful passing it self.0.month!
     last_day_of_month: [u16; 13],
     ///
-    pub(crate) leap_month: Option<NonZeroU8>,
+    leap_month: Option<NonZeroU8>,
 }
 
 impl ChineseBasedYearInfo {
+    pub(crate) fn new_year(self) -> RataDie {
+        self.new_year
+    }
+
     fn next_new_year(self) -> RataDie {
         self.new_year + i64::from(self.last_day_of_month[12])
+    }
+
+    pub(crate) fn leap_month(self) -> Option<NonZeroU8> {
+        self.leap_month
     }
 
     /// The last day of year in the previous month.
@@ -208,6 +216,14 @@ impl ChineseBasedYearInfo {
                 .copied()
                 .unwrap_or(0)
         }
+    }
+
+    fn days_in_year(self) -> u16 {
+        self.last_day_of_month[12]
+    }
+
+    fn days_in_prev_year(self) -> u16 {
+        self.days_in_prev_year
     }
 
     /// The last day of year in the current month.
@@ -386,17 +402,11 @@ impl<C: ChineseBasedWithDataLoading + CalendarArithmetic<YearInfo = ChineseBased
 
     /// Calls days_in_year on an instance of ChineseBasedDateInner
     pub(crate) fn days_in_year_inner(&self) -> u16 {
-        let next_new_year = self.0.year_info.next_new_year();
-        let new_year = self.0.year_info.new_year;
-        YearBounds {
-            new_year,
-            next_new_year,
-        }
-        .count_days()
+        self.0.year_info.days_in_year()
     }
     /// Gets the days in the previous year
     pub(crate) fn days_in_prev_year(&self) -> u16 {
-        self.0.year_info.days_in_prev_year
+        self.0.year_info.days_in_prev_year()
     }
 
     /// Calculate the number of days in the year so far for a ChineseBasedDate;

--- a/components/calendar/src/dangi.rs
+++ b/components/calendar/src/dangi.rs
@@ -206,64 +206,7 @@ impl Calendar for Dangi {
     }
 
     fn month(&self, date: &Self::DateInner) -> crate::types::FormattableMonth {
-        let ordinal = date.0 .0.month;
-        let leap_month_option = date.0 .0.year_info.leap_month();
-        let leap_month = if let Some(leap) = leap_month_option {
-            leap.get()
-        } else {
-            14
-        };
-        let code_inner = if leap_month == ordinal {
-            // Month cannot be 1 because a year cannot have a leap month before the first actual month,
-            // and the maximum num of months ina leap year is 13.
-            debug_assert!((2..=13).contains(&ordinal));
-            match ordinal {
-                2 => tinystr!(4, "M01L"),
-                3 => tinystr!(4, "M02L"),
-                4 => tinystr!(4, "M03L"),
-                5 => tinystr!(4, "M04L"),
-                6 => tinystr!(4, "M05L"),
-                7 => tinystr!(4, "M06L"),
-                8 => tinystr!(4, "M07L"),
-                9 => tinystr!(4, "M08L"),
-                10 => tinystr!(4, "M09L"),
-                11 => tinystr!(4, "M10L"),
-                12 => tinystr!(4, "M11L"),
-                13 => tinystr!(4, "M12L"),
-                _ => tinystr!(4, "und"),
-            }
-        } else {
-            let mut adjusted_ordinal = ordinal;
-            if ordinal > leap_month {
-                // Before adjusting for leap month, if ordinal > leap_month,
-                // the month cannot be 1 because this implies the leap month is < 1, which is impossible;
-                // cannot be 2 because that implies the leap month is = 1, which is impossible,
-                // and cannot be more than 13 because max number of months in a year is 13.
-                debug_assert!((2..=13).contains(&ordinal));
-                adjusted_ordinal -= 1;
-            }
-            debug_assert!((1..=12).contains(&adjusted_ordinal));
-            match adjusted_ordinal {
-                1 => tinystr!(4, "M01"),
-                2 => tinystr!(4, "M02"),
-                3 => tinystr!(4, "M03"),
-                4 => tinystr!(4, "M04"),
-                5 => tinystr!(4, "M05"),
-                6 => tinystr!(4, "M06"),
-                7 => tinystr!(4, "M07"),
-                8 => tinystr!(4, "M08"),
-                9 => tinystr!(4, "M09"),
-                10 => tinystr!(4, "M10"),
-                11 => tinystr!(4, "M11"),
-                12 => tinystr!(4, "M12"),
-                _ => tinystr!(4, "und"),
-            }
-        };
-        let code = types::MonthCode(code_inner);
-        types::FormattableMonth {
-            ordinal: ordinal as u32,
-            code,
-        }
+        date.0.month()
     }
 
     fn day_of_month(&self, date: &Self::DateInner) -> crate::types::DayOfMonth {

--- a/components/calendar/src/dangi.rs
+++ b/components/calendar/src/dangi.rs
@@ -277,7 +277,7 @@ impl Calendar for Dangi {
             day_of_year: date.0 .0.day_of_year(),
             days_in_year: date.0.days_in_year_inner(),
             prev_year: Self::format_dangi_year(prev_year, None),
-            days_in_prev_year: Self::days_in_provided_year(prev_year, date.0 .0.year_info),
+            days_in_prev_year: date.0.days_in_prev_year(),
             next_year: Self::format_dangi_year(next_year, None),
         }
     }

--- a/components/calendar/src/dangi.rs
+++ b/components/calendar/src/dangi.rs
@@ -207,7 +207,7 @@ impl Calendar for Dangi {
 
     fn month(&self, date: &Self::DateInner) -> crate::types::FormattableMonth {
         let ordinal = date.0 .0.month;
-        let leap_month_option = date.0 .0.year_info.leap_month;
+        let leap_month_option = date.0 .0.year_info.leap_month();
         let leap_month = if let Some(leap) = leap_month_option {
             leap.get()
         } else {
@@ -395,7 +395,7 @@ impl Dangi {
         let cyclic = (number as i64 - 1 + 364).rem_euclid(60) as u8;
         let cyclic = NonZeroU8::new(cyclic + 1); // 1-indexed
         let rata_die_in_year = if let Some(info) = year_info_option {
-            info.new_year
+            info.new_year()
         } else {
             Inner::fixed_mid_year_from_year(number)
         };

--- a/utils/calendrical_calculations/src/chinese_based.rs
+++ b/utils/calendrical_calculations/src/chinese_based.rs
@@ -473,6 +473,14 @@ pub fn days_in_month<C: ChineseBased>(
     (result, next_new_moon)
 }
 
+/// Given a new year, calculate the number of days in the previous year
+pub fn days_in_prev_year<C: ChineseBased>(new_year: RataDie) -> u16 {
+    let date = new_year - 300;
+    let prev_solstice = winter_solstice_on_or_before::<C>(date);
+    let (prev_new_year, _) = new_year_on_or_before_fixed_date::<C>(date, prev_solstice);
+    u16::try_from(new_year - prev_new_year).unwrap_or(360)
+}
+
 /// Returns the last day of every month in the year, as well as a leap month index (1-indexed) if any
 /// In the case of no leap months, month 12 and 13 will have identical "last day"
 /// values


### PR DESCRIPTION
Caches `days_in_prev_year`. The structure of ChineseBasedYearInfo is going to change in the next PR, so don't focus too much on that, this PR just makes it easy to make that change without needing to update everything.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->