### PR TITLE
Use packed data within ChineseBasedYearInfo

### DIFF
--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -228,64 +228,7 @@ impl Calendar for Chinese {
     /// leap months. For example, in a year where an intercalary month is added after the second
     /// month, the month codes for ordinal months 1, 2, 3, 4, 5 would be "M01", "M02", "M02L", "M03", "M04".
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
-        let ordinal = date.0 .0.month;
-        let leap_month_option = date.0 .0.year_info.leap_month();
-        let leap_month = if let Some(leap) = leap_month_option {
-            leap.get()
-        } else {
-            14
-        };
-        let code_inner = if leap_month == ordinal {
-            // Month cannot be 1 because a year cannot have a leap month before the first actual month,
-            // and the maximum num of months ina leap year is 13.
-            debug_assert!((2..=13).contains(&ordinal));
-            match ordinal {
-                2 => tinystr!(4, "M01L"),
-                3 => tinystr!(4, "M02L"),
-                4 => tinystr!(4, "M03L"),
-                5 => tinystr!(4, "M04L"),
-                6 => tinystr!(4, "M05L"),
-                7 => tinystr!(4, "M06L"),
-                8 => tinystr!(4, "M07L"),
-                9 => tinystr!(4, "M08L"),
-                10 => tinystr!(4, "M09L"),
-                11 => tinystr!(4, "M10L"),
-                12 => tinystr!(4, "M11L"),
-                13 => tinystr!(4, "M12L"),
-                _ => tinystr!(4, "und"),
-            }
-        } else {
-            let mut adjusted_ordinal = ordinal;
-            if ordinal > leap_month {
-                // Before adjusting for leap month, if ordinal > leap_month,
-                // the month cannot be 1 because this implies the leap month is < 1, which is impossible;
-                // cannot be 2 because that implies the leap month is = 1, which is impossible,
-                // and cannot be more than 13 because max number of months in a year is 13.
-                debug_assert!((2..=13).contains(&ordinal));
-                adjusted_ordinal -= 1;
-            }
-            debug_assert!((1..=12).contains(&adjusted_ordinal));
-            match adjusted_ordinal {
-                1 => tinystr!(4, "M01"),
-                2 => tinystr!(4, "M02"),
-                3 => tinystr!(4, "M03"),
-                4 => tinystr!(4, "M04"),
-                5 => tinystr!(4, "M05"),
-                6 => tinystr!(4, "M06"),
-                7 => tinystr!(4, "M07"),
-                8 => tinystr!(4, "M08"),
-                9 => tinystr!(4, "M09"),
-                10 => tinystr!(4, "M10"),
-                11 => tinystr!(4, "M11"),
-                12 => tinystr!(4, "M12"),
-                _ => tinystr!(4, "und"),
-            }
-        };
-        let code = types::MonthCode(code_inner);
-        types::FormattableMonth {
-            ordinal: ordinal as u32,
-            code,
-        }
+        date.0.month()
     }
 
     /// The calendar-specific day-of-month represented by `date`

--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -297,13 +297,11 @@ impl Calendar for Chinese {
     fn day_of_year_info(&self, date: &Self::DateInner) -> types::DayOfYearInfo {
         let prev_year = date.0 .0.year.saturating_sub(1);
         let next_year = date.0 .0.year.saturating_add(1);
-        // TODO(#3933): we should maybe have this cached already
-        let prev_info = self.get_precomputed_data().load_or_compute_info(prev_year);
         types::DayOfYearInfo {
             day_of_year: date.0.day_of_year(),
             days_in_year: date.0.days_in_year_inner(),
             prev_year: Self::format_chinese_year(prev_year, None),
-            days_in_prev_year: Self::days_in_provided_year(prev_year, prev_info),
+            days_in_prev_year: date.0.days_in_prev_year(),
             next_year: Self::format_chinese_year(next_year, None),
         }
     }

--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -343,8 +343,9 @@ impl<A: AsCalendar<Calendar = Chinese>> DateTime<A> {
     }
 }
 
+type ChineseCB = calendrical_calculations::chinese_based::Chinese;
 impl ChineseBasedWithDataLoading for Chinese {
-    type CB = calendrical_calculations::chinese_based::Chinese;
+    type CB = ChineseCB;
     fn get_precomputed_data(&self) -> ChineseBasedPrecomputedData<Self::CB> {
         Default::default()
     }
@@ -367,7 +368,7 @@ impl Chinese {
         let cyclic = (number - 1).rem_euclid(60) as u8;
         let cyclic = NonZeroU8::new(cyclic + 1); // 1-indexed
         let rata_die_in_year = if let Some(info) = year_info_option {
-            info.new_year(year)
+            info.new_year::<ChineseCB>(year)
         } else {
             Inner::fixed_mid_year_from_year(number)
         };
@@ -633,7 +634,7 @@ mod test {
             let iso = Date::try_new_iso_date(year, 6, 1).unwrap();
             let chinese_date = iso.to_calendar(Chinese);
             assert!(chinese_date.is_in_leap_year());
-            let new_year = chinese_date.inner.0 .0.year_info.new_year();
+            let new_year = chinese_date.inner.0.new_year();
             assert_eq!(
                 expected_month,
                 calendrical_calculations::chinese_based::get_leap_month_from_new_year::<

--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -229,7 +229,7 @@ impl Calendar for Chinese {
     /// month, the month codes for ordinal months 1, 2, 3, 4, 5 would be "M01", "M02", "M02L", "M03", "M04".
     fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
         let ordinal = date.0 .0.month;
-        let leap_month_option = date.0 .0.year_info.leap_month;
+        let leap_month_option = date.0 .0.year_info.leap_month();
         let leap_month = if let Some(leap) = leap_month_option {
             leap.get()
         } else {
@@ -424,7 +424,7 @@ impl Chinese {
         let cyclic = (number - 1).rem_euclid(60) as u8;
         let cyclic = NonZeroU8::new(cyclic + 1); // 1-indexed
         let rata_die_in_year = if let Some(info) = year_info_option {
-            info.new_year
+            info.new_year()
         } else {
             Inner::fixed_mid_year_from_year(number)
         };
@@ -690,7 +690,7 @@ mod test {
             let iso = Date::try_new_iso_date(year, 6, 1).unwrap();
             let chinese_date = iso.to_calendar(Chinese);
             assert!(chinese_date.is_in_leap_year());
-            let new_year = chinese_date.inner.0 .0.year_info.new_year;
+            let new_year = chinese_date.inner.0 .0.year_info.new_year();
             assert_eq!(
                 expected_month,
                 calendrical_calculations::chinese_based::get_leap_month_from_new_year::<

--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -367,7 +367,7 @@ impl Chinese {
         let cyclic = (number - 1).rem_euclid(60) as u8;
         let cyclic = NonZeroU8::new(cyclic + 1); // 1-indexed
         let rata_die_in_year = if let Some(info) = year_info_option {
-            info.new_year()
+            info.new_year(year)
         } else {
             Inner::fixed_mid_year_from_year(number)
         };

--- a/components/calendar/src/chinese_based.rs
+++ b/components/calendar/src/chinese_based.rs
@@ -121,8 +121,8 @@ impl PackedChineseBasedYearInfo {
         }
 
         let new_year_offset = ((self.0 & 0b11111000) >> 3) as u16;
-        let new_year =
-            Iso::fixed_from_iso(Iso::iso_from_year_day(related_iso, 21 + new_year_offset).inner);
+        let iso_ny = calendrical_calculations::iso::fixed_from_iso(related_iso, 1, 1);
+        let new_year = iso_ny + 21 + i64::from(new_year_offset);
 
         let mut last_day_of_month: [u16; 13] = [0; 13];
         let mut months_total = 0;

--- a/components/calendar/src/chinese_based.rs
+++ b/components/calendar/src/chinese_based.rs
@@ -175,19 +175,27 @@ impl PackedChineseBasedYearInfo {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 // TODO(#3933): potentially make this smaller
 pub(crate) struct ChineseBasedYearInfo {
-    pub(crate) new_year: RataDie,
+    new_year: RataDie,
     days_in_prev_year: u16,
     /// last_day_of_month[12] = last_day_of_month[11] in non-leap years
     /// These days are 1-indexed: so the last day of month for a 30-day 一月 is 30
     /// The array itself is zero-indexed, be careful passing it self.0.month!
     last_day_of_month: [u16; 13],
     ///
-    pub(crate) leap_month: Option<NonZeroU8>,
+    leap_month: Option<NonZeroU8>,
 }
 
 impl ChineseBasedYearInfo {
+    pub(crate) fn new_year(self) -> RataDie {
+        self.new_year
+    }
+
     fn next_new_year(self) -> RataDie {
         self.new_year + i64::from(self.last_day_of_month[12])
+    }
+
+    pub(crate) fn leap_month(self) -> Option<NonZeroU8> {
+        self.leap_month
     }
 
     /// The last day of year in the previous month.
@@ -208,6 +216,14 @@ impl ChineseBasedYearInfo {
                 .copied()
                 .unwrap_or(0)
         }
+    }
+
+    fn days_in_year(self) -> u16 {
+        self.last_day_of_month[12]
+    }
+
+    fn days_in_prev_year(self) -> u16 {
+        self.days_in_prev_year
     }
 
     /// The last day of year in the current month.
@@ -386,17 +402,11 @@ impl<C: ChineseBasedWithDataLoading + CalendarArithmetic<YearInfo = ChineseBased
 
     /// Calls days_in_year on an instance of ChineseBasedDateInner
     pub(crate) fn days_in_year_inner(&self) -> u16 {
-        let next_new_year = self.0.year_info.next_new_year();
-        let new_year = self.0.year_info.new_year;
-        YearBounds {
-            new_year,
-            next_new_year,
-        }
-        .count_days()
+        self.0.year_info.days_in_year()
     }
     /// Gets the days in the previous year
     pub(crate) fn days_in_prev_year(&self) -> u16 {
-        self.0.year_info.days_in_prev_year
+        self.0.year_info.days_in_prev_year()
     }
 
     /// Calculate the number of days in the year so far for a ChineseBasedDate;

--- a/components/calendar/src/dangi.rs
+++ b/components/calendar/src/dangi.rs
@@ -206,64 +206,7 @@ impl Calendar for Dangi {
     }
 
     fn month(&self, date: &Self::DateInner) -> crate::types::FormattableMonth {
-        let ordinal = date.0 .0.month;
-        let leap_month_option = date.0 .0.year_info.leap_month();
-        let leap_month = if let Some(leap) = leap_month_option {
-            leap.get()
-        } else {
-            14
-        };
-        let code_inner = if leap_month == ordinal {
-            // Month cannot be 1 because a year cannot have a leap month before the first actual month,
-            // and the maximum num of months ina leap year is 13.
-            debug_assert!((2..=13).contains(&ordinal));
-            match ordinal {
-                2 => tinystr!(4, "M01L"),
-                3 => tinystr!(4, "M02L"),
-                4 => tinystr!(4, "M03L"),
-                5 => tinystr!(4, "M04L"),
-                6 => tinystr!(4, "M05L"),
-                7 => tinystr!(4, "M06L"),
-                8 => tinystr!(4, "M07L"),
-                9 => tinystr!(4, "M08L"),
-                10 => tinystr!(4, "M09L"),
-                11 => tinystr!(4, "M10L"),
-                12 => tinystr!(4, "M11L"),
-                13 => tinystr!(4, "M12L"),
-                _ => tinystr!(4, "und"),
-            }
-        } else {
-            let mut adjusted_ordinal = ordinal;
-            if ordinal > leap_month {
-                // Before adjusting for leap month, if ordinal > leap_month,
-                // the month cannot be 1 because this implies the leap month is < 1, which is impossible;
-                // cannot be 2 because that implies the leap month is = 1, which is impossible,
-                // and cannot be more than 13 because max number of months in a year is 13.
-                debug_assert!((2..=13).contains(&ordinal));
-                adjusted_ordinal -= 1;
-            }
-            debug_assert!((1..=12).contains(&adjusted_ordinal));
-            match adjusted_ordinal {
-                1 => tinystr!(4, "M01"),
-                2 => tinystr!(4, "M02"),
-                3 => tinystr!(4, "M03"),
-                4 => tinystr!(4, "M04"),
-                5 => tinystr!(4, "M05"),
-                6 => tinystr!(4, "M06"),
-                7 => tinystr!(4, "M07"),
-                8 => tinystr!(4, "M08"),
-                9 => tinystr!(4, "M09"),
-                10 => tinystr!(4, "M10"),
-                11 => tinystr!(4, "M11"),
-                12 => tinystr!(4, "M12"),
-                _ => tinystr!(4, "und"),
-            }
-        };
-        let code = types::MonthCode(code_inner);
-        types::FormattableMonth {
-            ordinal: ordinal as u32,
-            code,
-        }
+        date.0.month()
     }
 
     fn day_of_month(&self, date: &Self::DateInner) -> crate::types::DayOfMonth {

--- a/components/calendar/src/dangi.rs
+++ b/components/calendar/src/dangi.rs
@@ -277,7 +277,7 @@ impl Calendar for Dangi {
             day_of_year: date.0 .0.day_of_year(),
             days_in_year: date.0.days_in_year_inner(),
             prev_year: Self::format_dangi_year(prev_year, None),
-            days_in_prev_year: Self::days_in_provided_year(prev_year, date.0 .0.year_info),
+            days_in_prev_year: date.0.days_in_prev_year(),
             next_year: Self::format_dangi_year(next_year, None),
         }
     }

--- a/components/calendar/src/dangi.rs
+++ b/components/calendar/src/dangi.rs
@@ -338,7 +338,7 @@ impl Dangi {
         let cyclic = (number as i64 - 1 + 364).rem_euclid(60) as u8;
         let cyclic = NonZeroU8::new(cyclic + 1); // 1-indexed
         let rata_die_in_year = if let Some(info) = year_info_option {
-            info.new_year()
+            info.new_year(year)
         } else {
             Inner::fixed_mid_year_from_year(number)
         };

--- a/components/calendar/src/dangi.rs
+++ b/components/calendar/src/dangi.rs
@@ -318,8 +318,9 @@ impl<A: AsCalendar<Calendar = Dangi>> DateTime<A> {
     }
 }
 
+type DangiCB = calendrical_calculations::chinese_based::Dangi;
 impl ChineseBasedWithDataLoading for Dangi {
-    type CB = calendrical_calculations::chinese_based::Dangi;
+    type CB = DangiCB;
     fn get_precomputed_data(&self) -> ChineseBasedPrecomputedData<Self::CB> {
         Default::default()
     }
@@ -338,7 +339,7 @@ impl Dangi {
         let cyclic = (number as i64 - 1 + 364).rem_euclid(60) as u8;
         let cyclic = NonZeroU8::new(cyclic + 1); // 1-indexed
         let rata_die_in_year = if let Some(info) = year_info_option {
-            info.new_year(year)
+            info.new_year::<DangiCB>(year)
         } else {
             Inner::fixed_mid_year_from_year(number)
         };

--- a/components/calendar/src/dangi.rs
+++ b/components/calendar/src/dangi.rs
@@ -207,7 +207,7 @@ impl Calendar for Dangi {
 
     fn month(&self, date: &Self::DateInner) -> crate::types::FormattableMonth {
         let ordinal = date.0 .0.month;
-        let leap_month_option = date.0 .0.year_info.leap_month;
+        let leap_month_option = date.0 .0.year_info.leap_month();
         let leap_month = if let Some(leap) = leap_month_option {
             leap.get()
         } else {
@@ -395,7 +395,7 @@ impl Dangi {
         let cyclic = (number as i64 - 1 + 364).rem_euclid(60) as u8;
         let cyclic = NonZeroU8::new(cyclic + 1); // 1-indexed
         let rata_die_in_year = if let Some(info) = year_info_option {
-            info.new_year
+            info.new_year()
         } else {
             Inner::fixed_mid_year_from_year(number)
         };

--- a/utils/calendrical_calculations/src/chinese_based.rs
+++ b/utils/calendrical_calculations/src/chinese_based.rs
@@ -25,10 +25,23 @@ pub trait ChineseBased {
     /// reflect traditional methods of year-tracking or eras, since Chinese-based calendars
     /// may not track years ordinally in the same way many western calendars do.
     const EPOCH: RataDie;
+
+    /// The ISO year that corresponds to year 1
+    const EPOCH_ISO: i32;
+    /// Given an ISO year, return the extended year
+
+    fn extended_from_iso(iso_year: i32) -> i32 {
+        iso_year - Self::EPOCH_ISO + 1
+    }
+    /// Given an extended year, return the ISO year
+    fn iso_from_extended(extended_year: i32) -> i32 {
+        extended_year - 1 + Self::EPOCH_ISO
+    }
 }
 
 // The equivalent first day in the Chinese calendar (based on inception of the calendar)
 const CHINESE_EPOCH: RataDie = RataDie::new(-963099); // Feb. 15, 2637 BCE (-2636)
+const CHINESE_EPOCH_ISO: i32 = -2636;
 
 /// The Chinese calendar relies on knowing the current day at the moment of a new moon;
 /// however, this can vary depending on location. As such, new moon calculations are based
@@ -47,6 +60,7 @@ const CHINESE_LOCATION_POST_1929: Location =
 
 // The first day in the Korean Dangi calendar (based on the founding of Gojoseon)
 const KOREAN_EPOCH: RataDie = RataDie::new(-852065); // Lunar new year 2333 BCE (-2332 ISO)
+const KOREAN_EPOCH_ISO: i32 = -2332; // Lunar new year 2333 BCE (-2332 ISO)
 
 /// The Korean Dangi calendar relies on knowing the current day at the moment of a new moon;
 /// however, this can vary depending on location. As such, new moon calculations are based on
@@ -122,6 +136,7 @@ impl ChineseBased for Chinese {
     }
 
     const EPOCH: RataDie = CHINESE_EPOCH;
+    const EPOCH_ISO: i32 = CHINESE_EPOCH_ISO;
 }
 
 impl ChineseBased for Dangi {
@@ -140,6 +155,7 @@ impl ChineseBased for Dangi {
     }
 
     const EPOCH: RataDie = KOREAN_EPOCH;
+    const EPOCH_ISO: i32 = KOREAN_EPOCH_ISO;
 }
 
 /// Marks the bounds of a lunar year
@@ -481,15 +497,14 @@ pub fn days_in_prev_year<C: ChineseBased>(new_year: RataDie) -> u16 {
     u16::try_from(new_year - prev_new_year).unwrap_or(360)
 }
 
-/// Returns the last day of every month in the year, as well as a leap month index (1-indexed) if any
-/// In the case of no leap months, month 12 and 13 will have identical "last day"
-/// values
+/// Returns the length of each month in the year, as well as a leap month index (1-indexed) if any.
+/// Month lengths are stored as true for 30-day, false for 29-day.
+/// In the case of no leap months, month 13 will have value false.
 pub fn month_structure_for_year<C: ChineseBased>(
     new_year: RataDie,
     next_new_year: RataDie,
-) -> ([RataDie; 13], Option<NonZeroU8>) {
-    let mut ret = [RataDie::new(0); 13];
-    ret[12] = next_new_year - 1; // last day of last month is the day before the next new year
+) -> ([bool; 13], Option<NonZeroU8>) {
+    let mut ret = [false; 13];
 
     let mut current_month_start = new_year;
     let mut current_month_major_solar_term = major_solar_term_from_fixed::<C>(new_year);
@@ -498,26 +513,22 @@ pub fn month_structure_for_year<C: ChineseBased>(
         let next_month_start = new_moon_on_or_after::<C>((current_month_start + 28).as_moment());
         let next_month_major_solar_term = major_solar_term_from_fixed::<C>(next_month_start);
 
-        #[allow(clippy::indexing_slicing)] // array is of length 13, we iterate till i=11
-        {
-            ret[usize::from(i)] = next_month_start - 1;
-        }
-
         if next_month_major_solar_term == current_month_major_solar_term {
             leap_month_index = NonZeroU8::new(i + 1);
         }
 
         let diff = next_month_start - current_month_start;
         debug_assert!(diff == 29 || diff == 30);
+        #[allow(clippy::indexing_slicing)] // array is of length 13, we iterate till i=11
+        if diff == 30 {
+            ret[usize::from(i)] = true;
+        }
 
         current_month_start = next_month_start;
         current_month_major_solar_term = next_month_major_solar_term;
     }
 
-    let first_month_diff = ret[0] - new_year + 1; // +1 since new_year is in the current month
-    debug_assert!(first_month_diff == 29 || first_month_diff == 30);
-
-    if ret[11] == ret[12] {
+    if current_month_start == next_new_year {
         // not all months without solar terms are leap months; they are only leap months if
         // the year can admit them
         //
@@ -528,11 +539,17 @@ pub fn month_structure_for_year<C: ChineseBased>(
         //
         // As such, if a month without a solar term is found in a non-leap year, we just ingnore it.
         leap_month_index = None;
+    } else {
+        let diff = next_new_year - current_month_start;
+        debug_assert!(diff == 29 || diff == 30);
+        if diff == 30 {
+            ret[12] = true;
+        }
     }
-    if ret[11] != ret[12] && leap_month_index.is_none() {
+    if current_month_start != next_new_year && leap_month_index.is_none() {
         leap_month_index = NonZeroU8::new(13); // The last month is a leap month
         debug_assert!(
-            major_solar_term_from_fixed::<C>(ret[12]) == current_month_major_solar_term,
+            major_solar_term_from_fixed::<C>(current_month_start) == current_month_major_solar_term,
             "A leap month is required here, but it had a major solar term!"
         );
     }
@@ -588,36 +605,27 @@ mod test {
         for year in 1900..2050 {
             let fixed = crate::iso::fixed_from_iso(year, 1, 1);
             let chinese_year = chinese_based_date_from_fixed::<Chinese>(fixed);
-            let (month_ends, leap) = month_structure_for_year::<Chinese>(
+            let (month_lengths, leap) = month_structure_for_year::<Chinese>(
                 chinese_year.year_bounds.new_year,
                 chinese_year.year_bounds.next_new_year,
             );
-            let chinese_ny = chinese_year.year_bounds.new_year;
-            assert_eq!(
-                month_ends[12] - chinese_ny + 1,
-                i64::from(days_in_provided_year::<Chinese>(chinese_year.year)),
-                "Year length must be the same"
-            );
-            let mut month_start = chinese_ny;
-            for (i, month_end) in month_ends.into_iter().enumerate() {
-                let next_month_start = month_end + 1;
-                let month_len = next_month_start - month_start;
-                if month_len == 0 && i == 12 {
+
+            for (i, month_is_30) in month_lengths.into_iter().enumerate() {
+                if leap.is_none() && i == 12 {
                     // month_days has no defined behavior for month 13 on non-leap-years
                     continue;
                 }
+                let month_len = 29 + i32::from(month_is_30);
                 let month_days = month_days::<Chinese>(chinese_year.year, i as u8 + 1);
                 assert_eq!(
                     month_len,
-                    i64::from(month_days),
+                    i32::from(month_days),
                     "Month length for month {} must be the same",
                     i + 1
                 );
-
-                month_start = next_month_start;
             }
             println!(
-                "{year} (chinese {}): {month_ends:?} {leap:?}",
+                "{year} (chinese {}): {month_lengths:?} {leap:?}",
                 chinese_year.year
             );
         }

--- a/utils/calendrical_calculations/src/chinese_based.rs
+++ b/utils/calendrical_calculations/src/chinese_based.rs
@@ -473,6 +473,14 @@ pub fn days_in_month<C: ChineseBased>(
     (result, next_new_moon)
 }
 
+/// Given a new year, calculate the number of days in the previous year
+pub fn days_in_prev_year<C: ChineseBased>(new_year: RataDie) -> u16 {
+    let date = new_year - 300;
+    let prev_solstice = winter_solstice_on_or_before::<C>(date);
+    let (prev_new_year, _) = new_year_on_or_before_fixed_date::<C>(date, prev_solstice);
+    u16::try_from(new_year - prev_new_year).unwrap_or(360)
+}
+
 /// Returns the last day of every month in the year, as well as a leap month index (1-indexed) if any
 /// In the case of no leap months, month 12 and 13 will have identical "last day"
 /// values


### PR DESCRIPTION
Part of https://github.com/unicode-org/icu4x/issues/3933

This does not yet add data loading, but it gets very close to it.

This PR makes the size of Date not bloat too much, without requiring much computation for any of the getters -- they're all basic bit operations.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->