### PR TITLE
Display elapsed time in datagen log

### DIFF
--- a/provider/datagen/src/driver.rs
+++ b/provider/datagen/src/driver.rs
@@ -14,6 +14,9 @@ use once_cell::sync::Lazy;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::fmt;
+use std::time::Duration;
+use std::time::Instant;
 use writeable::Writeable;
 
 /// Configuration for a data export operation.
@@ -304,7 +307,8 @@ impl DatagenDriver {
         };
 
         keys.clone().into_par_iter().try_for_each(|key| {
-            log::info!("Generating key {key}");
+            log::trace!("Generating key {key}");
+            let instant1 = Instant::now();
 
             if key.metadata().singleton {
                 if provider.supported_locales_for_key(key)? != [Default::default()] {
@@ -319,9 +323,25 @@ impl DatagenDriver {
                     .and_then(DataResponse::take_payload)
                     .map_err(|e| e.with_req(key, Default::default()))?;
 
-                return sink
-                    .flush_singleton(key, &payload)
-                    .map_err(|e| e.with_req(key, Default::default()));
+                let transform_duration = instant1.elapsed();
+
+                sink.flush_singleton(key, &payload)
+                    .map_err(|e| e.with_req(key, Default::default()))?;
+
+                let final_duration = instant1.elapsed();
+                let flush_duration = final_duration - transform_duration;
+
+                if final_duration > Duration::new(0, 500_000_000) {
+                    // Print durations if the key took longer than 500 ms
+                    log::info!(
+                        "Generated key {key} ({}, flushed in {})",
+                        DisplayDuration(final_duration),
+                        DisplayDuration(flush_duration)
+                    );
+                } else {
+                    log::info!("Generated key {key}");
+                }
+                return Ok(());
             }
 
             let locales_to_export = select_locales_for_key(
@@ -334,74 +354,110 @@ impl DatagenDriver {
                 &fallbacker,
             )?;
 
-            match fallback {
+            let (slowest_duration, slowest_locale) = match fallback {
                 FallbackMode::Runtime | FallbackMode::RuntimeManual => {
                     let payloads = locales_to_export
                         .into_par_iter()
                         .filter_map(|locale| {
+                            let instant2 = Instant::now();
                             load_with_fallback(key, &locale)
-                                .map(|r| r.map(|payload| (locale, payload)))
+                                .map(|r| r.map(|payload| (locale, (payload, instant2.elapsed()))))
                         })
                         .collect::<Result<HashMap<_, _>, _>>()?;
                     let fallbacker = fallbacker.as_ref().map_err(|e| *e)?;
                     let fallbacker_with_config = fallbacker.for_config(key.fallback_config());
-                    payloads.iter().try_for_each(|(locale, payload)| {
-                        let mut iter = fallbacker_with_config.fallback_for(locale.clone());
-                        while !iter.get().is_und() {
-                            iter.step();
-                            if let Some(inherited_payload) = payloads.get(iter.get()) {
-                                if inherited_payload == payload {
-                                    // Found a match: don't need to write anything
-                                    log::trace!(
-                                        "Deduplicating {key}/{locale} (inherits from {})",
-                                        iter.get()
-                                    );
-                                    return Ok(());
-                                } else {
-                                    // Not a match: we must include this
-                                    break;
+                    payloads
+                        .iter()
+                        .try_for_each(|(locale, (payload, _duration))| {
+                            let mut iter = fallbacker_with_config.fallback_for(locale.clone());
+                            while !iter.get().is_und() {
+                                iter.step();
+                                if let Some((inherited_payload, _duration)) =
+                                    payloads.get(iter.get())
+                                {
+                                    if inherited_payload == payload {
+                                        // Found a match: don't need to write anything
+                                        log::trace!(
+                                            "Deduplicating {key}/{locale} (inherits from {})",
+                                            iter.get()
+                                        );
+                                        return Ok(());
+                                    } else {
+                                        // Not a match: we must include this
+                                        break;
+                                    }
                                 }
                             }
-                        }
-                        // Did not find a match: export this payload
-                        sink.put_payload(key, locale, payload).map_err(|e| {
-                            e.with_req(
-                                key,
-                                DataRequest {
-                                    locale,
-                                    metadata: Default::default(),
-                                },
-                            )
+                            // Did not find a match: export this payload
+                            sink.put_payload(key, locale, payload).map_err(|e| {
+                                e.with_req(
+                                    key,
+                                    DataRequest {
+                                        locale,
+                                        metadata: Default::default(),
+                                    },
+                                )
+                            })
+                        })?;
+
+                    // Slowest locale calculation:
+                    payloads
+                        .iter()
+                        .map(|(locale, (_payload, duration))| {
+                            (*duration, locale.write_to_string().into_owned())
                         })
-                    })?
+                        .max()
                 }
-                FallbackMode::Hybrid | FallbackMode::Preresolved => {
-                    locales_to_export.into_par_iter().try_for_each(|locale| {
-                        if let Some(payload) = load_with_fallback(key, &locale) {
-                            sink.put_payload(key, &locale, &payload?)
-                        } else {
-                            Ok(())
-                        }
-                        .map_err(|e| {
-                            e.with_req(
-                                key,
-                                DataRequest {
-                                    locale: &locale,
-                                    metadata: Default::default(),
-                                },
-                            )
-                        })
-                    })?
-                }
+                FallbackMode::Hybrid | FallbackMode::Preresolved => locales_to_export
+                    .into_par_iter()
+                    .map(|locale| {
+                        let instant2 = Instant::now();
+                        load_with_fallback(key, &locale)
+                            .transpose()?
+                            .map(|payload| sink.put_payload(key, &locale, &payload))
+                            .unwrap_or(Ok(()))
+                            .map(|_| (instant2.elapsed(), locale.write_to_string().into_owned()))
+                            .map_err(|e| {
+                                e.with_req(
+                                    key,
+                                    DataRequest {
+                                        locale: &locale,
+                                        metadata: Default::default(),
+                                    },
+                                )
+                            })
+                    })
+                    .collect::<Result<Vec<_>, DataError>>()?
+                    .into_iter()
+                    .max(),
                 FallbackMode::PreferredForExporter => unreachable!("resolved"),
-            };
+            }
+            .unwrap_or_default();
+
+            let transform_duration = instant1.elapsed();
 
             if fallback == FallbackMode::Runtime {
                 sink.flush_with_built_in_fallback(key, BuiltInFallbackMode::Standard)
             } else {
                 sink.flush(key)
             }
-            .map_err(|e| e.with_key(key))
+            .map_err(|e| e.with_key(key))?;
+
+            let final_duration = instant1.elapsed();
+            let flush_duration = final_duration - transform_duration;
+
+            if final_duration > Duration::new(0, 500_000_000) {
+                // Print durations if the key took longer than 500 ms
+                log::info!(
+                    "Generated key {key} ({}, '{slowest_locale}' in {}, flushed in {})",
+                    DisplayDuration(final_duration),
+                    DisplayDuration(slowest_duration),
+                    DisplayDuration(flush_duration)
+                );
+            } else {
+                log::info!("Generated key {key}");
+            }
+            Ok(())
         })?;
 
         sink.close()
@@ -542,6 +598,23 @@ fn select_locales_for_key(
     };
 
     Ok(result)
+}
+
+struct DisplayDuration(pub Duration);
+
+impl fmt::Display for DisplayDuration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let nanos = self.0.as_nanos();
+        if nanos > 100_000_000 {
+            write!(f, "{:.3}s", self.0.as_secs_f64())
+        } else if nanos > 1_000_000 {
+            write!(f, "{:.3}ms", (nanos as f64) / 1e6)
+        } else if nanos > 1_000 {
+            write!(f, "{:.3}µs", (nanos as f64) / 1e3)
+        } else {
+            write!(f, "{}ns", nanos)
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
Makes the output more useful/actionable.

cargo make testdata:

<details>
<pre>
INFO  [icu_datagen::driver] Datagen configured with fallback mode Hybrid and these locales: ["ar", "ar-EG", "bn", "ccp", "en", "en-001", "en-ZA", "es", "es-AR", "fil", "fr", "ja", "ru", "sr", "sr-Latn", "th", "tr", "und"]
INFO  [icu_datagen::driver] Generated key props/LOE@1
INFO  [icu_datagen::driver] Generated key props/EComp@1
INFO  [icu_datagen::driver] Generated key props/VS@1
INFO  [icu_datagen::driver] Generated key props/Basic_Emoji@1
INFO  [icu_datagen::driver] Generated key locid_transform/script_dir@1
INFO  [icu_datagen::driver] Generated key calendar/japanese@1
INFO  [icu_datagen::driver] Generated key calendar/japanext@1
INFO  [icu_datagen::driver] Generated key props/nfkcinert@1
INFO  [icu_datagen::driver] Generated key propnames/from/ccc@1
INFO  [icu_datagen::driver] Generated key props/Radical@1
INFO  [icu_datagen::driver] Generated key segmenter/lstm/wl_auto@1
INFO  [icu_datagen::driver] Generated key time_zone/bcp47_to_iana@1
INFO  [icu_datagen::driver] Generated key props/Join_C@1
INFO  [icu_datagen::driver] Generated key props/Dia@1
INFO  [icu_datagen::driver] Generated key units/info@1
INFO  [icu_datagen::driver] Generated key props/Upper@1
INFO  [icu_datagen::driver] Generated key props/WSpace@1
INFO  [icu_datagen::driver] Generated key propnames/from/GCB@1
INFO  [icu_datagen::driver] Generated key plurals/cardinal@1
INFO  [icu_datagen::driver] Generated key propnames/to/long/linear/WB@1
INFO  [icu_datagen::driver] Generated key collator/reord@1
INFO  [icu_datagen::driver] Generated key normalizer/nfd@1
INFO  [icu_datagen::driver] Generated key props/WB@1
INFO  [icu_datagen::driver] Generated key list/or@1
INFO  [icu_datagen::driver] Generated key relativetime/narrow/minute@1
INFO  [icu_datagen::driver] Generated key relativetime/short/second@1
INFO  [icu_datagen::driver] Generated key datetime/islamic/datelengths@1
INFO  [icu_datagen::driver] Generated key datetime/coptic/datesymbols@1
INFO  [icu_datagen::driver] Generated key datetime/persian/datelengths@1
INFO  [icu_datagen::driver] Generated key normalizer/decomp@1
INFO  [icu_datagen::driver] Generated key props/XIDC@1
INFO  [icu_datagen::driver] Generated key props/ExtPict@1
INFO  [icu_datagen::driver] Generated key datetime/timelengths@1
INFO  [icu_datagen::driver] Generated key props/EBase@1
INFO  [icu_datagen::driver] Generated key props/alnum@1
INFO  [icu_datagen::driver] Generated key propnames/from/SB@1
INFO  [icu_datagen::driver] Generated key propnames/to/short/linear/ea@1
INFO  [icu_datagen::driver] Generated key props/SB@1
INFO  [icu_datagen::driver] Generated key propnames/from/gcm@1
INFO  [icu_datagen::driver] Generated key datetime/patterns/persian/date@1
INFO  [icu_datagen::driver] Generated key fallback/parents@1
INFO  [icu_datagen::driver] Generated key props/exemplarchars/punctuation@1
INFO  [icu_datagen::driver] Generated key relativetime/long/quarter@1
INFO  [icu_datagen::driver] Generated key collator/jamo@1
INFO  [icu_datagen::driver] Generated key propnames/from/lb@1
INFO  [icu_datagen::driver] Generated key propnames/from/ea@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/hebrew/years@1
INFO  [icu_datagen::driver] Generated key datetime/indian/datesymbols@1
INFO  [icu_datagen::driver] Generated key datetime/patterns/islamic/date@1
INFO  [icu_datagen::driver] Generated key datetime/hebrew/datelengths@1
INFO  [icu_datagen::driver] Generated key props/ccc@1
WARN  [icu_datagen::transform::cldr::characters] Data missing for index set exemplar characters
INFO  [icu_datagen::driver] Generated key datetime/symbols/coptic/years@1
INFO  [icu_datagen::driver] Generated key props/Hyphen@1
INFO  [icu_datagen::driver] Generated key props/exemplarchars/index@1
INFO  [icu_datagen::driver] Generated key props/RI@1
INFO  [icu_datagen::driver] Generated key props/Ideo@1
INFO  [icu_datagen::driver] Generated key datetime/patterns/hebrew/date@1
INFO  [icu_datagen::driver] Generated key datetime/patterns/ethiopic/date@1
INFO  [icu_datagen::driver] Generated key propnames/to/short/linear/InSC@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/indian/years@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/coptic/months@1
INFO  [icu_datagen::driver] Generated key props/Hex@1
INFO  [icu_datagen::driver] Generated key props/blank@1
INFO  [icu_datagen::driver] Generated key displaynames/scripts@1
INFO  [icu_datagen::driver] Generated key relativetime/short/month@1
INFO  [icu_datagen::driver] Generated key relativetime/short/hour@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/chinese/years@1
INFO  [icu_datagen::driver] Generated key plurals/ranges@1
INFO  [icu_datagen::driver] Generated key props/Comp_Ex@1
INFO  [icu_datagen::driver] Generated key propnames/to/long/linear/lb@1
INFO  [icu_datagen::driver] Generated key datetime/patterns/japanext/date@1
INFO  [icu_datagen::driver] Generated key props/exemplarchars/numbers@1
INFO  [icu_datagen::driver] Generated key props/SD@1
INFO  [icu_datagen::driver] Generated key props/graph@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/gregory/months@1
INFO  [icu_datagen::driver] Generated key fallback/likelysubtags@1
INFO  [icu_datagen::driver] Generated key normalizer/comp@1
INFO  [icu_datagen::driver] Generated key props/IDS@1
INFO  [icu_datagen::driver] Generated key props/nfdinert@1
INFO  [icu_datagen::driver] Generated key props/IDST@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/weekdays@1
INFO  [icu_datagen::driver] Generated key relativetime/long/day@1
INFO  [icu_datagen::driver] Generated key props/CWCM@1
INFO  [icu_datagen::driver] Generated key time_zone/specific_short@1
INFO  [icu_datagen::driver] Generated key props/Bidi_C@1
INFO  [icu_datagen::driver] Generated key relativetime/narrow/hour@1
INFO  [icu_datagen::driver] Generated key normalizer/nfkd@1
INFO  [icu_datagen::driver] Generated key props/scx@1
INFO  [icu_datagen::driver] Generated key relativetime/narrow/second@1
INFO  [icu_datagen::driver] Generated key fallback/supplement/co@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/japanese/years@1
INFO  [icu_datagen::driver] Generated key compactdecimal/short@1
INFO  [icu_datagen::driver] Generated key datetime/chinese/datelengths@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/indian/months@1
INFO  [icu_datagen::driver] Generated key time_zone/formats@1
INFO  [icu_datagen::driver] Generated key propnames/to/long/sparse/ccc@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/roc/years@1
INFO  [icu_datagen::driver] Generated key datetime/buddhist/datesymbols@1
INFO  [icu_datagen::driver] Generated key relativetime/long/minute@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/hebrew/months@1
INFO  [icu_datagen::driver] Generated key relativetime/long/second@1
INFO  [icu_datagen::driver] Generated key locid_transform/likelysubtags_sr@1
INFO  [icu_datagen::driver] Generated key relativetime/narrow/month@1
INFO  [icu_datagen::driver] Generated key datetime/timesymbols@1
INFO  [icu_datagen::driver] Generated key props/CI@1
INFO  [icu_datagen::driver] Generated key displaynames/locales@1
INFO  [icu_datagen::driver] Generated key props/CWKCF@1
INFO  [icu_datagen::driver] Generated key props/IDC@1
INFO  [icu_datagen::driver] Generated key relativetime/long/month@1
INFO  [icu_datagen::driver] Generated key props/Ext@1
INFO  [icu_datagen::driver] Generated key datetime/japanext/datelengths@1
INFO  [icu_datagen::driver] Generated key datetime/dangi/datelengths@1
INFO  [icu_datagen::driver] Generated key datetime/roc/datelengths@1
INFO  [icu_datagen::driver] Generated key props/Gr_Base@1
INFO  [icu_datagen::driver] Generated key props/CWL@1
INFO  [icu_datagen::driver] Generated key locid_transform/likelysubtags@1
INFO  [icu_datagen::driver] Generated key props/ea@1
INFO  [icu_datagen::driver] Generated key datetime/patterns/buddhist/date@1
INFO  [icu_datagen::driver] Generated key props/CWU@1
INFO  [icu_datagen::driver] Generated key datetime/hebrew/datesymbols@1
INFO  [icu_datagen::driver] Generated key props/segstart@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/gregory/years@1
INFO  [icu_datagen::driver] Generated key propnames/to/long/linear/ea@1
INFO  [icu_datagen::driver] Generated key relativetime/short/week@1
INFO  [icu_datagen::driver] Generated key relativetime/short/day@1
INFO  [icu_datagen::driver] Generated key props/Dep@1
INFO  [icu_datagen::driver] Generated key propnames/to/long/linear/GCB@1
INFO  [icu_datagen::driver] Generated key props/AHex@1
INFO  [icu_datagen::driver] Generated key relativetime/narrow/quarter@1
INFO  [icu_datagen::driver] Generated key collator/dia@1
INFO  [icu_datagen::driver] Generated key props/GCB@1
INFO  [icu_datagen::driver] Generated key props/exemplarchars/auxiliary@1
INFO  [icu_datagen::driver] Generated key props/Term@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/japanext/months@1
INFO  [icu_datagen::driver] Generated key propnames/to/short/linear4/sc@1
INFO  [icu_datagen::driver] Generated key datetime/indian/datelengths@1
INFO  [icu_datagen::driver] Generated key props/CWT@1
INFO  [icu_datagen::driver] Generated key props/Gr_Link@1
INFO  [icu_datagen::driver] Generated key props/casemap_unfold@1
INFO  [icu_datagen::driver] Generated key time_zone/exemplar_cities@1
INFO  [icu_datagen::driver] Generated key datetime/persian/datesymbols@1
INFO  [icu_datagen::driver] Generated key props/InSC@1
INFO  [icu_datagen::driver] Generated key props/Pat_WS@1
INFO  [icu_datagen::driver] Generated key compactdecimal/long@1
INFO  [icu_datagen::driver] Generated key datetime/buddhist/datelengths@1
INFO  [icu_datagen::driver] Generated key normalizer/uts46d@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/persian/years@1
INFO  [icu_datagen::driver] Generated key locid_transform/aliases@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/ethiopic/years@1
INFO  [icu_datagen::driver] Generated key relativetime/narrow/week@1
INFO  [icu_datagen::driver] Generated key datetime/ethiopic/datesymbols@1
INFO  [icu_datagen::driver] Generated key datetime/chinese/datesymbols@1
INFO  [icu_datagen::driver] Generated key segmenter/dictionary/w_auto@1
INFO  [icu_datagen::driver] Generated key props/CWCF@1
INFO  [icu_datagen::driver] Generated key props/Gr_Ext@1
INFO  [icu_datagen::driver] Generated key time_zone/metazone_period@1
INFO  [icu_datagen::driver] Generated key normalizer/nfdex@1
INFO  [icu_datagen::driver] Generated key propnames/from/sc@1
INFO  [icu_datagen::driver] Generated key locid_transform/likelysubtags_ext@1
INFO  [icu_datagen::driver] Generated key props/NChar@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/islamic/years@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/chinese/months@1
INFO  [icu_datagen::driver] Generated key propnames/to/long/linear/sc@1
INFO  [icu_datagen::driver] Generated key propnames/from/InSC@1
INFO  [icu_datagen::driver] Generated key datetime/roc/datesymbols@1
INFO  [icu_datagen::driver] Generated key props/exemplarchars/main@1
INFO  [icu_datagen::driver] Generated key props/Lower@1
INFO  [icu_datagen::driver] Generated key props/XIDS@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/dangi/years@1
INFO  [icu_datagen::driver] Generated key datetime/patterns/chinese/date@1
INFO  [icu_datagen::driver] Generated key props/lb@1
INFO  [icu_datagen::driver] Generated key propnames/to/long/linear/gc@1
INFO  [icu_datagen::driver] Generated key relativetime/long/year@1
INFO  [icu_datagen::driver] Generated key relativetime/short/minute@1
INFO  [icu_datagen::driver] Generated key relativetime/short/year@1
INFO  [icu_datagen::driver] Generated key time_zone/generic_long@1
INFO  [icu_datagen::driver] Generated key locid_transform/likelysubtags_l@1
INFO  [icu_datagen::driver] Generated key datetime/japanese/datesymbols@1
INFO  [icu_datagen::driver] Generated key props/gc@1
INFO  [icu_datagen::driver] Generated key datetime/ethiopic/datelengths@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/roc/months@1
INFO  [icu_datagen::driver] Generated key datetime/japanese/datelengths@1
INFO  [icu_datagen::driver] Generated key relativetime/long/hour@1
INFO  [icu_datagen::driver] Generated key props/Alpha@1
INFO  [icu_datagen::driver] Generated key datetime/patterns/roc/date@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/buddhist/months@1
INFO  [icu_datagen::driver] Generated key datetime/islamic/datesymbols@1
INFO  [icu_datagen::driver] Generated key datetime/patterns/japanese/date@1
INFO  [icu_datagen::driver] Generated key collator/meta@1
INFO  [icu_datagen::driver] Generated key propnames/to/long/linear/InSC@1
INFO  [icu_datagen::driver] Generated key plurals/ordinal@1
INFO  [icu_datagen::driver] Generated key propnames/to/long/linear/SB@1
INFO  [icu_datagen::driver] Generated key relativetime/long/week@1
INFO  [icu_datagen::driver] Generated key datetime/gregory/datelengths@1
INFO  [icu_datagen::driver] Generated key props/Dash@1
INFO  [icu_datagen::driver] Generated key props/Math@1
INFO  [icu_datagen::driver] Generated key relativetime/narrow/day@1
INFO  [icu_datagen::driver] Generated key props/UIdeo@1
INFO  [icu_datagen::driver] Generated key props/DI@1
INFO  [icu_datagen::driver] Generated key decimal/symbols@1
INFO  [icu_datagen::driver] Generated key datetime/patterns/indian/date@1
INFO  [icu_datagen::driver] Generated key propnames/from/gc@1
INFO  [icu_datagen::driver] Generated key propnames/to/short/linear/GCB@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/japanese/months@1
INFO  [icu_datagen::driver] Generated key propnames/from/bc@1
INFO  [icu_datagen::driver] Generated key propnames/to/short/linear/SB@1
INFO  [icu_datagen::driver] Generated key props/Bidi_M@1
INFO  [icu_datagen::driver] Generated key datetime/patterns/gregory/date@1
INFO  [icu_datagen::driver] Generated key datetime/coptic/datelengths@1
INFO  [icu_datagen::driver] Generated key props/Pat_Syn@1
INFO  [icu_datagen::driver] Generated key displaynames/variants@1
INFO  [icu_datagen::driver] Generated key props/print@1
INFO  [icu_datagen::driver] Generated key propnames/to/short/linear/bc@1
INFO  [icu_datagen::driver] Generated key propnames/from/WB@1
INFO  [icu_datagen::driver] Generated key props/QMark@1
INFO  [icu_datagen::driver] Generated key datetime/gregory/datesymbols@1
INFO  [icu_datagen::driver] Generated key props/xdigit@1
INFO  [icu_datagen::driver] Generated key propnames/to/short/linear/gc@1
INFO  [icu_datagen::driver] Generated key datetime/dangi/datesymbols@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/dangi/months@1
INFO  [icu_datagen::driver] Generated key propnames/to/short/linear/lb@1
INFO  [icu_datagen::driver] Generated key props/sc@1
INFO  [icu_datagen::driver] Generated key datetime/patterns/dangi/date@1
INFO  [icu_datagen::driver] Generated key props/nfcinert@1
INFO  [icu_datagen::driver] Generated key propnames/to/long/linear/bc@1
INFO  [icu_datagen::driver] Generated key propnames/to/short/sparse/ccc@1
INFO  [icu_datagen::driver] Generated key relativetime/short/quarter@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/dayperiods@1
INFO  [icu_datagen::driver] Generated key time_zone/generic_short@1
INFO  [icu_datagen::driver] Generated key normalizer/nfkdex@1
INFO  [icu_datagen::driver] Generated key relativetime/narrow/year@1
INFO  [icu_datagen::driver] Generated key props/Cased@1
INFO  [icu_datagen::driver] Generated key datetime/week_data@1
INFO  [icu_datagen::driver] Generated key time_zone/iana_to_bcp47@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/buddhist/years@1
INFO  [icu_datagen::driver] Generated key props/Sensitive@1
INFO  [icu_datagen::driver] Generated key props/STerm@1
INFO  [icu_datagen::driver] Generated key datetime/patterns/time@1
INFO  [icu_datagen::driver] Generated key props/Emoji@1
INFO  [icu_datagen::driver] Generated key datetime/japanext/datesymbols@1 (0.612s, 'en-ZA' in 39.286ms, flushed in 10.921µs)
INFO  [icu_datagen::driver] Generated key datetime/symbols/ethiopic/months@1
INFO  [icu_datagen::driver] Generated key props/PCM@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/islamic/months@1
INFO  [icu_datagen::driver] Generated key props/nfkdinert@1
INFO  [icu_datagen::driver] Generated key datetime/patterns/coptic/date@1
INFO  [icu_datagen::driver] Generated key props/IDSB@1
INFO  [icu_datagen::driver] Generated key segmenter/dictionary/wl_ext@1 (0.692s, 'th' in 0.691s, flushed in 12.834µs)
INFO  [icu_datagen::driver] Generated key displaynames/regions@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/persian/months@1
INFO  [icu_datagen::driver] Generated key datetime/patterns/datetime@1
INFO  [icu_datagen::driver] Generated key props/EPres@1
INFO  [icu_datagen::driver] Generated key list/and@1
INFO  [icu_datagen::driver] Generated key props/bc@1
INFO  [icu_datagen::driver] Generated key props/EMod@1
INFO  [icu_datagen::driver] Generated key propnames/to/short/linear/WB@1
INFO  [icu_datagen::driver] Generated key collator/prim@1
INFO  [icu_datagen::driver] Generated key datetime/symbols/japanext/years@1
INFO  [icu_datagen::driver] Generated key list/unit@1
INFO  [icu_datagen::driver] Generated key displaynames/languages@1
INFO  [icu_datagen::driver] Generated key props/casemap@1 (0.808s, flushed in 0.409s)
INFO  [icu_datagen::driver] Generated key collator/data@1 (0.657s, 'en' in 0.301s, flushed in 20.809µs)
INFO  [icu_datagen::driver] Generated key transliterator/rules@1 (0.766s, 'ccp' in 0.323s, flushed in 19.918µs)
INFO  [icu_datagen::driver] Generated key time_zone/specific_long@1 (1.941s, 'th' in 25.644ms, flushed in 29.987µs)
INFO  [icu_datagen::driver] Generated key datetime/skeletons@1 (3.161s, 'ja' in 19.241ms, flushed in 32.411µs)
INFO  [icu_datagen::driver] Generated key currency/essentials@1 (3.362s, 'en-ZA' in 3.023s, flushed in 32.952µs)
INFO  [icu_datagen::driver] Generated key segmenter/grapheme@1 (3.554s, flushed in 3.919ms)
INFO  [icu_datagen::driver] Generated key props/bidiauxiliaryprops@1 (3.941s, flushed in 5.467ms)
INFO  [icu_datagen::driver] Generated key segmenter/word@1 (4.475s, flushed in 6.212ms)
INFO  [icu_datagen::driver] Generated key segmenter/sentence@1 (2.845s, flushed in 6.206ms)
INFO  [icu_datagen::driver] Generated key segmenter/line@1 (9.445s, flushed in 10.847ms)
test tests::make_testdata::generate_json_and_verify_postcard ... ok
</pre>
</details>