### PR TITLE
Datagen: Cache file list where possible

### DIFF
--- a/provider/datagen/src/source.rs
+++ b/provider/datagen/src/source.rs
@@ -87,6 +87,7 @@ impl SerdeCache {
     }
 
     pub fn list(&self, path: &str) -> Result<impl Iterator<Item = String>, DataError> {
+        self.populate_list_cache();
         let hash_set = self
             .list_cache
             .read()


### PR DESCRIPTION
I thought this would help, but it seems to make `cargo make bakeddata` slower instead of faster.

`cargo make bakeddata datetime` is 1063.09 seconds on this branch on my machine. On main it is 173 sec.