### PR TITLE
Add DateTime::local_unix_epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Components
+  - `icu_calendar`
+    - New `DateTime::local_unix_epoch()` convenience constructor (https://github.com/unicode-org/icu4x/pull/4479)
   - `icu_properties`
     - Add `Aran` script code (https://github.com/unicode-org/icu4x/pull/4426)
 - Data model and providers

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -286,6 +286,15 @@ impl DateTime<Iso> {
         })
     }
 
+    /// Constructs an ISO datetime representing the UNIX epoch on January 1, 1970
+    /// at midnight.
+    pub fn local_unix_epoch() -> Self {
+        DateTime {
+            date: Date::unix_epoch(),
+            time: types::Time::midnight(),
+        }
+    }
+
     /// Minute count representation of calendars starting from 00:00:00 on Jan 1st, 1970.
     ///
     /// ```rust

--- a/ffi/capi/bindings/c/ICU4XIsoDateTime.h
+++ b/ffi/capi/bindings/c/ICU4XIsoDateTime.h
@@ -31,6 +31,8 @@ diplomat_result_box_ICU4XIsoDateTime_ICU4XError ICU4XIsoDateTime_create(int32_t 
 
 ICU4XIsoDateTime* ICU4XIsoDateTime_crate_from_date_and_time(const ICU4XIsoDate* date, const ICU4XTime* time);
 
+ICU4XIsoDateTime* ICU4XIsoDateTime_local_unix_epoch();
+
 ICU4XIsoDateTime* ICU4XIsoDateTime_create_from_minutes_since_local_unix_epoch(int32_t minutes);
 
 ICU4XIsoDate* ICU4XIsoDateTime_date(const ICU4XIsoDateTime* self);

--- a/ffi/capi/bindings/cpp/ICU4XIsoDateTime.h
+++ b/ffi/capi/bindings/cpp/ICU4XIsoDateTime.h
@@ -31,6 +31,8 @@ diplomat_result_box_ICU4XIsoDateTime_ICU4XError ICU4XIsoDateTime_create(int32_t 
 
 ICU4XIsoDateTime* ICU4XIsoDateTime_crate_from_date_and_time(const ICU4XIsoDate* date, const ICU4XTime* time);
 
+ICU4XIsoDateTime* ICU4XIsoDateTime_local_unix_epoch();
+
 ICU4XIsoDateTime* ICU4XIsoDateTime_create_from_minutes_since_local_unix_epoch(int32_t minutes);
 
 ICU4XIsoDate* ICU4XIsoDateTime_date(const ICU4XIsoDateTime* self);

--- a/ffi/capi/bindings/cpp/ICU4XIsoDateTime.hpp
+++ b/ffi/capi/bindings/cpp/ICU4XIsoDateTime.hpp
@@ -53,6 +53,13 @@ class ICU4XIsoDateTime {
   static ICU4XIsoDateTime crate_from_date_and_time(const ICU4XIsoDate& date, const ICU4XTime& time);
 
   /**
+   * Creates a new [`ICU4XIsoDateTime`] of midnight on January 1, 1970
+   * 
+   * See the [Rust documentation for `local_unix_epoch`](https://docs.rs/icu/latest/icu/calendar/struct.DateTime.html#method.local_unix_epoch) for more information.
+   */
+  static ICU4XIsoDateTime local_unix_epoch();
+
+  /**
    * Construct from the minutes since the local unix epoch for this date (Jan 1 1970, 00:00)
    * 
    * See the [Rust documentation for `from_minutes_since_local_unix_epoch`](https://docs.rs/icu/latest/icu/calendar/struct.DateTime.html#method.from_minutes_since_local_unix_epoch) for more information.
@@ -224,6 +231,9 @@ inline diplomat::result<ICU4XIsoDateTime, ICU4XError> ICU4XIsoDateTime::create(i
 }
 inline ICU4XIsoDateTime ICU4XIsoDateTime::crate_from_date_and_time(const ICU4XIsoDate& date, const ICU4XTime& time) {
   return ICU4XIsoDateTime(capi::ICU4XIsoDateTime_crate_from_date_and_time(date.AsFFI(), time.AsFFI()));
+}
+inline ICU4XIsoDateTime ICU4XIsoDateTime::local_unix_epoch() {
+  return ICU4XIsoDateTime(capi::ICU4XIsoDateTime_local_unix_epoch());
 }
 inline ICU4XIsoDateTime ICU4XIsoDateTime::create_from_minutes_since_local_unix_epoch(int32_t minutes) {
   return ICU4XIsoDateTime(capi::ICU4XIsoDateTime_create_from_minutes_since_local_unix_epoch(minutes));

--- a/ffi/capi/bindings/dart/IsoDateTime.g.dart
+++ b/ffi/capi/bindings/dart/IsoDateTime.g.dart
@@ -48,6 +48,19 @@ final class IsoDateTime implements ffi.Finalizable {
     _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>>('ICU4XIsoDateTime_crate_from_date_and_time')
       .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
 
+  /// Creates a new [`IsoDateTime`] of midnight on January 1, 1970
+  ///
+  /// See the [Rust documentation for `local_unix_epoch`](https://docs.rs/icu/latest/icu/calendar/struct.DateTime.html#method.local_unix_epoch) for more information.
+  factory IsoDateTime.localUnixEpoch() {
+    final result = _ICU4XIsoDateTime_local_unix_epoch();
+    return IsoDateTime._(result);
+  }
+
+  // ignore: non_constant_identifier_names
+  static final _ICU4XIsoDateTime_local_unix_epoch =
+    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function()>>('ICU4XIsoDateTime_local_unix_epoch')
+      .asFunction<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true);
+
   /// Construct from the minutes since the local unix epoch for this date (Jan 1 1970, 00:00)
   ///
   /// See the [Rust documentation for `from_minutes_since_local_unix_epoch`](https://docs.rs/icu/latest/icu/calendar/struct.DateTime.html#method.from_minutes_since_local_unix_epoch) for more information.

--- a/ffi/capi/bindings/js/ICU4XIsoDateTime.d.ts
+++ b/ffi/capi/bindings/js/ICU4XIsoDateTime.d.ts
@@ -36,6 +36,14 @@ export class ICU4XIsoDateTime {
 
   /**
 
+   * Creates a new {@link ICU4XIsoDateTime `ICU4XIsoDateTime`} of midnight on January 1, 1970
+
+   * See the {@link https://docs.rs/icu/latest/icu/calendar/struct.DateTime.html#method.local_unix_epoch Rust documentation for `local_unix_epoch`} for more information.
+   */
+  static local_unix_epoch(): ICU4XIsoDateTime;
+
+  /**
+
    * Construct from the minutes since the local unix epoch for this date (Jan 1 1970, 00:00)
 
    * See the {@link https://docs.rs/icu/latest/icu/calendar/struct.DateTime.html#method.from_minutes_since_local_unix_epoch Rust documentation for `from_minutes_since_local_unix_epoch`} for more information.

--- a/ffi/capi/bindings/js/ICU4XIsoDateTime.mjs
+++ b/ffi/capi/bindings/js/ICU4XIsoDateTime.mjs
@@ -43,6 +43,10 @@ export class ICU4XIsoDateTime {
     return new ICU4XIsoDateTime(wasm.ICU4XIsoDateTime_crate_from_date_and_time(arg_date.underlying, arg_time.underlying), true, []);
   }
 
+  static local_unix_epoch() {
+    return new ICU4XIsoDateTime(wasm.ICU4XIsoDateTime_local_unix_epoch(), true, []);
+  }
+
   static create_from_minutes_since_local_unix_epoch(arg_minutes) {
     return new ICU4XIsoDateTime(wasm.ICU4XIsoDateTime_create_from_minutes_since_local_unix_epoch(arg_minutes), true, []);
   }

--- a/ffi/capi/src/datetime.rs
+++ b/ffi/capi/src/datetime.rs
@@ -57,8 +57,7 @@ pub mod ffi {
 
         /// Creates a new [`ICU4XIsoDateTime`] of midnight on January 1, 1970
         #[diplomat::rust_link(icu::calendar::DateTime::local_unix_epoch, FnInStruct)]
-        pub fn local_unix_epoch(
-        ) -> Box<ICU4XIsoDateTime> {
+        pub fn local_unix_epoch() -> Box<ICU4XIsoDateTime> {
             let dt = DateTime::local_unix_epoch();
             Box::new(ICU4XIsoDateTime(dt))
         }

--- a/ffi/capi/src/datetime.rs
+++ b/ffi/capi/src/datetime.rs
@@ -55,6 +55,14 @@ pub mod ffi {
             Box::new(ICU4XIsoDateTime(dt))
         }
 
+        /// Creates a new [`ICU4XIsoDateTime`] of midnight on January 1, 1970
+        #[diplomat::rust_link(icu::calendar::DateTime::local_unix_epoch, FnInStruct)]
+        pub fn local_unix_epoch(
+        ) -> Box<ICU4XIsoDateTime> {
+            let dt = DateTime::local_unix_epoch();
+            Box::new(ICU4XIsoDateTime(dt))
+        }
+
         /// Construct from the minutes since the local unix epoch for this date (Jan 1 1970, 00:00)
         #[diplomat::rust_link(
             icu::calendar::DateTime::from_minutes_since_local_unix_epoch,


### PR DESCRIPTION
Another small thing pulled off from #4415

We have this types of constructor for Date and Time but not DateTime.