### PR TITLE
Make ZeroVec have a niche via NonNull

### DIFF
--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -549,7 +549,7 @@ mod tests {
         check_size_of!(120 | 96, ZeroMap2d<str, str, str>);
         check_size_of!(32 | 24, vecs::FlexZeroVec);
 
-        check_size_of!(32 | 24, Option<ZeroVec<u8>>);
+        check_size_of!(24, Option<ZeroVec<u8>>);
         check_size_of!(32 | 24, Option<VarZeroVec<str>>);
         check_size_of!(64 | 56 | 48, Option<ZeroMap<str, str>>);
         check_size_of!(120 | 104 | 96, Option<ZeroMap2d<str, str, str>>);

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -549,7 +549,7 @@ mod tests {
         check_size_of!(120 | 96, ZeroMap2d<str, str, str>);
         check_size_of!(32 | 24, vecs::FlexZeroVec);
 
-        check_size_of!(32, Option<ZeroVec<u8>>);
+        check_size_of!(32 | 24, Option<ZeroVec<u8>>);
         check_size_of!(32 | 24, Option<VarZeroVec<str>>);
         check_size_of!(64 | 56 | 48, Option<ZeroMap<str, str>>);
         check_size_of!(120 | 104 | 96, Option<ZeroMap2d<str, str, str>>);

--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -141,7 +141,8 @@ impl<U> EyepatchHackVector<U> {
     // Return a slice to the inner data
     #[inline]
     const fn as_slice<'a>(&'a self) -> &'a [U] {
-        unsafe { self.buf.as_ref() }
+        // Note: self.buf.as_ref() is not const until 1.73
+        unsafe { &*(self.buf.as_ptr() as *const [U]) }
     }
 
     /// Return this type as a vector

--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -331,8 +331,9 @@ where
     /// backing buffer
     #[inline]
     pub const fn new_borrowed(slice: &'a [T::ULE]) -> Self {
-        // Note: there is an impl From<&T> for NonNull<T> but it is not const
-        let slice = unsafe { NonNull::new_unchecked(slice as *const [T::ULE] as *mut [T::ULE]) };
+        // Safety: references in Rust cannot be null.
+        // The safe function `impl From<&T> for NonNull<T>` is not const.
+        let slice = unsafe { NonNull::new_unchecked(slice as *const [_] as *mut [_]) };
         Self {
             vector: EyepatchHackVector {
                 buf: slice,


### PR DESCRIPTION
Is this good? Gives us a niche so that `Option<ZeroVec>` doesn't add a whole word.