### PR TITLE
Add profile.bench-memory and use it for memory profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,7 +251,6 @@ lto = true
 # Enable debug information specifically for memory profiling.
 # https://docs.rs/dhat/0.2.1/dhat/#configuration
 [profile.bench-memory]
-inherits = "release"
-lto = true
+inherits = "bench"
 debug = true
 debug-assertions = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,17 +245,13 @@ codegen-units = 1
 inherits = "dev"
 debug-assertions = false
 
-# Enable debug information specifically for memory profiling.
-# https://docs.rs/dhat/0.2.1/dhat/#configuration
-#
-# 2021-01-08: This would be nicer as a named profile, e.g. [profile.memory]
-# https://github.com/rust-lang/cargo/issues/6988
 [profile.bench]
 lto = true
-debug = true
-debug-assertions = false
 
+# Enable debug information specifically for memory profiling.
+# https://docs.rs/dhat/0.2.1/dhat/#configuration
 [profile.memory]
 inherits = "release"
 lto = true
 debug = true
+debug-assertions = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,7 +250,7 @@ lto = true
 
 # Enable debug information specifically for memory profiling.
 # https://docs.rs/dhat/0.2.1/dhat/#configuration
-[profile.memory]
+[profile.bench-memory]
 inherits = "release"
 lto = true
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,7 +241,7 @@ codegen-units = 1
 
 # Builds with debug metadata but not debug assertions
 # for testing GIGO code paths
-[profile.debug-without-assertions]
+[profile.dev-without-assertions]
 inherits = "dev"
 debug-assertions = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,4 +253,3 @@ lto = true
 [profile.bench-memory]
 inherits = "bench"
 debug = true
-debug-assertions = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -254,3 +254,8 @@ debug-assertions = false
 lto = true
 debug = true
 debug-assertions = false
+
+[profile.memory]
+inherits = "release"
+lto = true
+debug = true

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -76,7 +76,7 @@ dependencies = [
 description = "Run specific tests with debug assertions disabled"
 category = "CI"
 dependencies = [
-    "test-debug-without-assertions",
+    "test-dev-without-assertions",
 ]
 
 [tasks.ci-job-test-tutorials-local]

--- a/tools/benchmark/memory/src/main.rs
+++ b/tools/benchmark/memory/src/main.rs
@@ -102,7 +102,7 @@ fn main() {
             .arg("--features")
             .arg("icu_benchmark_macros/benchmark_memory")
             .arg("--features")
-            .arg("memory")
+            .arg("bench")
             .status()
             .unwrap_or_else(|err| {
                 eprintln!("Failed to collect examples {err:?}");
@@ -156,7 +156,7 @@ fn main() {
             .arg("--example")
             .arg(example)
             .arg("--profile")
-            .arg("memory")
+            .arg("bench-memory")
             // The dhat-rs instrumentation is hidden behind the "benchmark_memory" feature in the
             // icu_benchmark_macros package.
             .arg("--features")

--- a/tools/benchmark/memory/src/main.rs
+++ b/tools/benchmark/memory/src/main.rs
@@ -99,6 +99,8 @@ fn main() {
         Command::new("cargo")
             .arg("build")
             .arg("--examples")
+            .arg("--profile")
+            .arg("bench-memory")
             .arg("--features")
             .arg("icu_benchmark_macros/benchmark_memory")
             .arg("--features")
@@ -108,7 +110,7 @@ fn main() {
                 eprintln!("Failed to collect examples {err:?}");
                 process::exit(1);
             });
-        fs::read_dir(root_dir.join("target/debug/examples"))
+        fs::read_dir(root_dir.join("target/bench-memory/examples"))
             .unwrap()
             .flat_map(|entry| {
                 entry.ok()?.file_name().into_string().ok().and_then(|s| {
@@ -121,6 +123,8 @@ fn main() {
             })
             .collect()
     };
+
+    println!("[memory] Examples to benchmark:  {examples:?}");
 
     // benchmarks/memory/{os}
     let benchmark_dir = root_dir

--- a/tools/benchmark/memory/src/main.rs
+++ b/tools/benchmark/memory/src/main.rs
@@ -102,7 +102,7 @@ fn main() {
             .arg("--features")
             .arg("icu_benchmark_macros/benchmark_memory")
             .arg("--features")
-            .arg("bench")
+            .arg("memory")
             .status()
             .unwrap_or_else(|err| {
                 eprintln!("Failed to collect examples {err:?}");
@@ -156,7 +156,7 @@ fn main() {
             .arg("--example")
             .arg(example)
             .arg("--profile")
-            .arg("bench")
+            .arg("memory")
             // The dhat-rs instrumentation is hidden behind the "benchmark_memory" feature in the
             // icu_benchmark_macros package.
             .arg("--features")

--- a/tools/make/tests.toml
+++ b/tools/make/tests.toml
@@ -38,11 +38,11 @@ env = { RUSTFLAGS = "--cfg=icu4x_run_size_tests" }
 command = "cargo"
 args = ["test", "--all-features", "--all-targets", "--no-fail-fast"]
 
-[tasks.test-debug-without-assertions]
+[tasks.test-dev-without-assertions]
 description = "Run all Rust unit and integration tests without debug assertions (GIGO mode)"
 category = "ICU4X Development"
 command = "cargo"
-args = ["test", "--profile=debug-without-assertions", "--all-features", "--tests", "--no-fail-fast"]
+args = ["test", "--profile=dev-without-assertions", "--all-features", "--tests", "--no-fail-fast"]
 
 [tasks.test-docs]
 description = "Run all Rust doctests with all features"

--- a/tools/make/valgrind.toml
+++ b/tools/make/valgrind.toml
@@ -13,7 +13,7 @@ args = [
     "build", "--examples",
     "--features", "icu_benchmark_macros/rust_global_allocator",
     "--features", "zerovec/serde",
-    "--profile", "bench",
+    "--profile", "memory",
 ]
 
 [tasks.valgrind]
@@ -33,7 +33,7 @@ mkdir benchmarks
 mkdir benchmarks/valgrind
 
 # Re-run the build command only to generate the JSON output (--message-format=json)
-output = exec cargo build --examples --message-format=json --features icu_benchmark_macros/rust_global_allocator --features zerovec/serde --profile bench
+output = exec cargo build --examples --message-format=json --features icu_benchmark_macros/rust_global_allocator --features zerovec/serde --profile memory
 if ${output.code}
     trigger_error "Build failed! To debug, build examples with `--features icu_benchmark_macros/rust_global_allocator`"
 end

--- a/tools/make/valgrind.toml
+++ b/tools/make/valgrind.toml
@@ -13,7 +13,7 @@ args = [
     "build", "--examples",
     "--features", "icu_benchmark_macros/rust_global_allocator",
     "--features", "zerovec/serde",
-    "--profile", "memory",
+    "--profile", "bench-memory",
 ]
 
 [tasks.valgrind]
@@ -33,7 +33,7 @@ mkdir benchmarks
 mkdir benchmarks/valgrind
 
 # Re-run the build command only to generate the JSON output (--message-format=json)
-output = exec cargo build --examples --message-format=json --features icu_benchmark_macros/rust_global_allocator --features zerovec/serde --profile memory
+output = exec cargo build --examples --message-format=json --features icu_benchmark_macros/rust_global_allocator --features zerovec/serde --profile bench-memory
 if ${output.code}
     trigger_error "Build failed! To debug, build examples with `--features icu_benchmark_macros/rust_global_allocator`"
 end


### PR DESCRIPTION
There was a comment in the top-level Cargo.toml saying we should use a custom profile when available. We can do that now.