### PR TITLE
Implement AsULE for PluralCategory

### DIFF
--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -153,6 +153,8 @@ pub enum PluralRuleType {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[allow(clippy::exhaustive_enums)] // this type is mostly stable. new categories may potentially be added in the future,
                                    // but at a cadence slower than the ICU4X release cycle
+#[repr(u8)]
+#[zerovec::make_ule(PluralCategoryULE)]
 pub enum PluralCategory {
     /// CLDR "zero" plural category. Used in Arabic and Latvian, among others.
     ///
@@ -160,7 +162,7 @@ pub enum PluralCategory {
     ///
     /// - 0 in Arabic (ar), Latvian (lv)
     /// - 10~20, 30, 40, 50, ... in Latvian (lv)
-    Zero,
+    Zero = 0,
     /// CLDR "one" plural category. Signifies the singular form in many languages.
     ///
     /// Examples of numbers having this category:
@@ -169,14 +171,14 @@ pub enum PluralCategory {
     /// - 1 in English (en) and most other languages
     /// - 2.1 in Filipino (fil), Croatian (hr), Latvian (lv), Serbian (sr)
     /// - 2, 3, 5, 7, 8, ... in Filipino (fil)
-    One,
+    One = 1,
     /// CLDR "two" plural category. Used in Arabic, Hebrew, and Slovenian, among others.
     ///
     /// Examples of numbers having this category:
     ///
     /// - 2 in Arabic (ar), Hebrew (iw), Slovenian (sl)
     /// - 2.0 in Arabic (ar)
-    Two,
+    Two = 2,
     /// CLDR "few" plural category. Used in Romanian, Polish, Russian, and others.
     ///
     /// Examples of numbers having this category:
@@ -185,7 +187,7 @@ pub enum PluralCategory {
     /// - 1.2 in Croatian (hr), Romanian (ro), Slovenian (sl), Serbian (sr)
     /// - 2 in Polish (pl), Russian (ru), Czech (cs), ...
     /// - 5 in Arabic (ar), Lithuanian (lt), Romanian (ro)
-    Few,
+    Few = 3,
     /// CLDR "many" plural category. Used in Polish, Russian, Ukrainian, and others.
     ///
     /// Examples of numbers having this category:
@@ -194,7 +196,7 @@ pub enum PluralCategory {
     /// - 1.0 in Czech (cs), Slovak (sk)
     /// - 1.1 in Czech (cs), Lithuanian (lt), Slovak (sk)
     /// - 15 in Arabic (ar), Polish (pl), Russian (ru), Ukrainian (uk)
-    Many,
+    Many = 4,
     /// CLDR "other" plural category, used as a catch-all. Each language supports it, and it
     /// is also used as a fail safe result for in case no better match can be identified.
     ///
@@ -206,7 +208,7 @@ pub enum PluralCategory {
     /// - 0 in English (en), German (de), Spanish (es), ...
     /// - 1 in Japanese (ja), Korean (ko), Chinese (zh), Thai (th), ...
     /// - 2 in English (en), German (de), Spanish (es), ...
-    Other,
+    Other = 5,
 }
 
 impl PluralCategory {

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -151,10 +151,10 @@ pub enum PluralRuleType {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Ord, PartialOrd)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-#[allow(clippy::exhaustive_enums)] // this type is mostly stable. new categories may potentially be added in the future,
-                                   // but at a cadence slower than the ICU4X release cycle
 #[repr(u8)]
 #[zerovec::make_ule(PluralCategoryULE)]
+#[allow(clippy::exhaustive_enums)] // this type is mostly stable. new categories may potentially be added in the future,
+                                   // but at a cadence slower than the ICU4X release cycle
 pub enum PluralCategory {
     /// CLDR "zero" plural category. Used in Arabic and Latvian, among others.
     ///

--- a/tools/ffi_coverage/src/allowlist.rs
+++ b/tools/ffi_coverage/src/allowlist.rs
@@ -399,6 +399,9 @@ lazy_static::lazy_static! {
         "icu::timezone::Error",
         "icu::transliterator::Error",
 
+        // ULE types that are not in provider modules
+        "icu::plurals::PluralCategoryULE",
+
         // "Internal" trait that should never be called directly
         "icu::calendar::Calendar",
         // Rust-specific calendar wrapper stuff


### PR DESCRIPTION
Smaller changed pulled off from #4415

I would prefer 0 to be `PluralCategory::Other` since 0 should be the default state (despite being cute that `PluralCategory::Zero` has discriminant 0). Can I set the discriminant as such without affecting semver or postcard?