### PR TITLE
Add GenericPatternItemULE::as_pattern_item_ule

### DIFF
--- a/components/datetime/src/pattern/item/ule.rs
+++ b/components/datetime/src/pattern/item/ule.rs
@@ -25,7 +25,8 @@ use zerovec::ule::{AsULE, ZeroVecError, ULE};
 ///
 /// If the discriminant is not set, the bottom three bits of the first byte,
 /// together with the next two bytes, contain all 21 bits required to encode
-/// any [`Unicode Code Point`].
+/// any [`Unicode Code Point`]. By design, the representation of a code point
+/// is the same between [`PatternItemULE`] and [`GenericPatternItemULE`].
 ///
 /// # Diagram
 ///
@@ -160,7 +161,8 @@ impl AsULE for PatternItem {
 ///
 /// If the discriminant is not set, the bottom three bits of the first byte,
 /// together with the next two bytes, contain all 21 bits required to encode
-/// any [`Unicode Code Point`].
+/// any [`Unicode Code Point`]. By design, the representation of a code point
+/// is the same between [`PatternItemULE`] and [`GenericPatternItemULE`].
 ///
 /// # Diagram
 ///

--- a/components/datetime/src/pattern/item/ule.rs
+++ b/components/datetime/src/pattern/item/ule.rs
@@ -264,9 +264,11 @@ unsafe impl ULE for GenericPatternItemULE {
     }
 }
 
-impl GenericPatternItem {
+impl AsULE for GenericPatternItem {
+    type ULE = GenericPatternItemULE;
+
     #[inline]
-    pub(crate) const fn to_unaligned_const(self) -> <Self as AsULE>::ULE {
+    fn to_unaligned(self) -> Self::ULE {
         match self {
             Self::Placeholder(idx) => GenericPatternItemULE([0b1000_0000, 0x00, idx]),
             Self::Literal(ch) => {
@@ -275,15 +277,6 @@ impl GenericPatternItem {
                 GenericPatternItemULE([bytes[1], bytes[2], bytes[3]])
             }
         }
-    }
-}
-
-impl AsULE for GenericPatternItem {
-    type ULE = GenericPatternItemULE;
-
-    #[inline]
-    fn to_unaligned(self) -> Self::ULE {
-        self.to_unaligned_const()
     }
 
     #[inline]


### PR DESCRIPTION
Smaller change pulled off from #4415

This includes a bit of unsafe code and takes advantage of the fact that currently `GenericPatternItemULE` and `PatternItemULE` have the same repr if they are representing a code point. I added a debug assertion to ensure that this invariant remains true.