### PR TITLE
Add Copy, PartialEq, Eq and Hash to DTFOptions

### DIFF
--- a/components/datetime/benches/datetime.rs
+++ b/components/datetime/benches/datetime.rs
@@ -39,17 +39,14 @@ fn datetime_benches(c: &mut Criterion) {
                         let dtf = {
                             TypedDateTimeFormatter::<Gregorian>::try_new_experimental(
                                 &locale.into(),
-                                options.clone(),
+                                options,
                             )
                             .expect("Failed to create TypedDateTimeFormatter.")
                         };
                         #[cfg(not(feature = "experimental"))]
                         let dtf = {
-                            TypedDateTimeFormatter::<Gregorian>::try_new(
-                                &locale.into(),
-                                options.clone(),
-                            )
-                            .expect("Failed to create TypedDateTimeFormatter.")
+                            TypedDateTimeFormatter::<Gregorian>::try_new(&locale.into(), options)
+                                .expect("Failed to create TypedDateTimeFormatter.")
                         };
 
                         let mut result = String::new();

--- a/components/datetime/src/options/mod.rs
+++ b/components/datetime/src/options/mod.rs
@@ -55,7 +55,7 @@ pub(crate) mod preferences;
 ///
 /// At the moment only the [`length::Bag`] works, and we plan to extend that to support
 /// `ECMA402` like components bag later.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum DateTimeFormatterOptions {
     /// Bag of lengths for date and time.

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -62,7 +62,7 @@ fn test_fixture(fixture_name: &str, file: &str) {
     {
         let japanese = Japanese::new();
         let japanext = JapaneseExtended::new();
-        let options_base = match fixtures::get_options(&fx.input.options) {
+        let options = match fixtures::get_options(&fx.input.options) {
             Some(o) => o,
             #[cfg(feature = "experimental")]
             None => unreachable!(),
@@ -99,7 +99,6 @@ fn test_fixture(fixture_name: &str, file: &str) {
             None => format!("\n  file: {fixture_name}.json\n"),
         };
         for (locale, output_value) in fx.output.values {
-            let options = options_base.clone();
             let locale = Locale::from_str(&locale).expect("Expected parseable locale in fixture");
             if let Some(kind) = AnyCalendarKind::get_for_locale(&locale) {
                 match kind {
@@ -271,13 +270,9 @@ fn assert_fixture_element<A>(
     #[cfg(feature = "experimental")]
     let (dtf, any_dtf) = {
         (
-            TypedDateTimeFormatter::<A::Calendar>::try_new_experimental(
-                &locale.into(),
-                options.clone(),
-            )
-            .expect(description),
-            DateTimeFormatter::try_new_experimental(&locale.into(), options.clone())
+            TypedDateTimeFormatter::<A::Calendar>::try_new_experimental(&locale.into(), options)
                 .expect(description),
+            DateTimeFormatter::try_new_experimental(&locale.into(), options).expect(description),
         )
     };
     #[cfg(not(feature = "experimental"))]
@@ -363,7 +358,7 @@ fn test_fixture_with_time_zones(fixture_name: &str, file: &str, config: TimeZone
             let dtf = {
                 TypedZonedDateTimeFormatter::<Gregorian>::try_new_experimental(
                     &locale.into(),
-                    options.clone(),
+                    options,
                     TimeZoneFormatterOptions::default(),
                 )
                 .unwrap()


### PR DESCRIPTION
We currently implement wider set of traits for `length::Bag` and `componentsBag` than their union enum.

This makes TF and DF suitable for intl_memoizer, but not DTF (since it requires options to be hashed).

I'd like to extend the derive traits to match that.