### PR TITLE
Fix `#[no_std]`

### DIFF
--- a/experimental/zerotrie/Cargo.toml
+++ b/experimental/zerotrie/Cargo.toml
@@ -27,7 +27,7 @@ denylist = ["bench"]
 databake = { workspace = true, features = ["derive"], optional = true }
 displaydoc = { version = "0.2.3", default-features = false }
 litemap = { workspace = true, features = ["alloc"], optional = true }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", default-features = false, optional = true }
 yoke = { workspace = true, features = ["derive"], optional = true }
 zerofrom = { workspace = true, optional = true }
 zerovec = { workspace = true, optional = true }

--- a/tools/make/tests.toml
+++ b/tools/make/tests.toml
@@ -146,4 +146,4 @@ description = "Ensure ICU4X builds on no-std"
 category = "ICU4X Development"
 dependencies = ["install-cortex-7"]
 command = "cargo"
-args = ["check", "--package", "icu", "--target", "thumbv7m-none-eabi"]
+args = ["check", "--package", "icu_capi", "--target", "thumbv7m-none-eabi", "--no-default-features", "--features=buffer_provider"]


### PR DESCRIPTION
We haven't been `#[no_std]` if the `buffer_provider` feature is enabled since adding `zerotrie`.