### PR TITLE
Prepare for future normalization data for Unicode 16

### DIFF
--- a/components/normalizer/src/properties.rs
+++ b/components/normalizer/src/properties.rs
@@ -302,7 +302,17 @@ impl CanonicalDecomposition {
             let offset24 = offset - tables.scalars16.len();
             if let Some(first_c) = tables.scalars24.get(offset24) {
                 if len == 1 {
-                    return Decomposed::Singleton(first_c);
+                    if c != first_c {
+                        return Decomposed::Singleton(first_c);
+                    } else {
+                        // Singleton representation used to avoid
+                        // NFC passthrough of characters that combine
+                        // with starters that can occur as the first
+                        // character of an expansion decomposition.
+                        // See section 5 of
+                        // https://www.unicode.org/L2/L2024/24009-utc178-properties-recs.pdf
+                        return Decomposed::Default;
+                    }
                 }
                 if let Some(second_c) = tables.scalars24.get(offset24 + 1) {
                     return Decomposed::Expansion(first_c, second_c);


### PR DESCRIPTION
ICU4X's data representation doesn't have a place for marking the first character of an expansion as a starter that combines backwards.

To accommodate the Unicode 16 characters discussed in section 5 of https://www.unicode.org/L2/L2024/24009-utc178-properties-recs.pdf I expect the least disruptive change to be that characters that can occur as the first character of a composition whose second character may occur as the first character of an expansion decomposition be represented the way non-BMP singleton decompositions are currently represented. This should exclude them from NFC passthrough eligibility without having to find a way to mark the second character.

Without this patch, these characters would be incorrectly be claimed as having a singleton decomposition (to self) in
`CanonicalDecomposition::decompose()`.

There are no tests, because we don't actually have data like this, yet. The purpose is to enable a copy of ICU4X binary that has this code to be able to consume dynamically-loaded data from the future.

This change is low-risk in case we don't end up using the data trick anticipated by this patch.