### PR TITLE
Fix Rata Die docs

### DIFF
--- a/utils/calendrical_calculations/src/lib.rs
+++ b/utils/calendrical_calculations/src/lib.rs
@@ -56,6 +56,6 @@ pub mod iso;
 pub mod julian;
 /// The persian calendar
 pub mod persian;
-/// Representation of Rata Die (R.D., also called J.D. for Julain Date)
-/// dates, which are represented as the number of days since ISO date 0001-01-01.
+/// Representation of Rata Die (R.D.) dates, which are
+/// represented as the number of days since ISO date 0001-01-01.
 pub mod rata_die;


### PR DESCRIPTION
A JD is a Julian Day, which should *not* be mixed up with Rata Die because it has a different epoch: https://en.wikipedia.org/wiki/Julian_day