### PR TITLE
Add benchmark for rounding methods of `FixedDecimal`

### DIFF
--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -40,7 +40,7 @@ criterion = "0.4"
 
 [features]
 std = []
-bench = []
+bench = ["ryu"]
 experimental = []
 ryu = ["dep:ryu"]
 


### PR DESCRIPTION
This should help determine if the `*_to_increment` rounding methods affect performance or not.

### Preliminary Results:

| **group** | **experimental** | **stable** |
| - | - | - |
| rounding/ceil           | 1.00   704.3±13.32µs | 1.03   725.9±16.01µs |
| rounding/expand         | 1.00   701.9±10.50µs | 1.04    728.6±7.61µs |
| rounding/floor          | 1.00   712.1±21.57µs | 1.02   723.6±14.02µs |
| rounding/half_ceil      | 1.02   789.2±13.48µs | 1.00    773.7±9.05µs |
| rounding/half_even      | 1.01   769.4±19.95µs | 1.00    764.8±3.59µs |
| rounding/half_expand    | 1.01    778.8±9.61µs | 1.00   771.2±14.97µs |
| rounding/half_floor     | 1.01   782.9±19.59µs | 1.00   772.9±13.17µs |
| rounding/half_trunc     | 1.00    771.0±8.55µs | 1.01   778.4±14.95µs |
| rounding/trunc          | 1.00   696.2±13.94µs | 1.02   707.0±10.35µs |