### PR TITLE
Mark `BidiClassAdapter::new` as `const`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     - `FormattedDateTime` and `FormattedZonedDateTime` now implement `Clone` and `Copy` (https://github.com/unicode-org/icu4x/pull/4476)
   - `icu_properties`
     - Add `Aran` script code (https://github.com/unicode-org/icu4x/pull/4426)
+    - Mark `BidiClassAdapter::new` as const (https://github.com/unicode-org/icu4x/pull/4584)
   - `icu_segmenter`
     - Fix Unicode 15.0 line breaking (https://github.com/unicode-org/icu4x/pull/4389)
 - Data model and providers

--- a/components/properties/src/bidi.rs
+++ b/components/properties/src/bidi.rs
@@ -81,7 +81,7 @@ pub struct BidiClassAdapter<'a> {
 
 impl<'a> BidiClassAdapter<'a> {
     /// Creates new instance of `BidiClassAdapter`.
-    pub fn new(data: CodePointMapDataBorrowed<'a, BidiClass>) -> BidiClassAdapter<'a> {
+    pub const fn new(data: CodePointMapDataBorrowed<'a, BidiClass>) -> BidiClassAdapter<'a> {
         BidiClassAdapter { data }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->
Marks the `new` associated function for `icu_properties::bidi::BidiClassAdapter` as `const`. This allows a `BidiClassAdapter` to be constructed in `const` context with a data source available in `const` context, such as the data bundled using `compiled_data`. as `unicode-bidi` takes a reference to the `BidiDataSource`, this allows the same `BidiDataSource` to be used throughout the program and simplifies the lifetimes.