### PR TITLE
Add explicit lifetime to `ScriptExtensionsSet` impl

### DIFF
--- a/components/properties/src/script.rs
+++ b/components/properties/src/script.rs
@@ -181,7 +181,7 @@ pub struct ScriptExtensionsSet<'a> {
     values: &'a ZeroSlice<Script>,
 }
 
-impl ScriptExtensionsSet<'_> {
+impl<'a> ScriptExtensionsSet<'a> {
     /// Returns whether this set contains the given script.
     ///
     /// # Example
@@ -213,7 +213,7 @@ impl ScriptExtensionsSet<'_> {
     ///     vec![Script::Tamil, Script::Grantha]
     /// );
     /// ```
-    pub fn iter(&self) -> impl DoubleEndedIterator<Item = Script> + '_ {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = Script> + 'a {
         ZeroSlice::iter(self.values)
     }
 


### PR DESCRIPTION
By eliding this lifetime, the compiler assumes that the iterator is valid for the lifetime of self, but it it really valid for the lifetime of the underlying data. An explicit lifetime makes this clear, and allows for the returned iterator to outlive the `&self` reference, which is useful in many cases.

I've only fixed this once instance (and not looked for others) since this is the case that I ran into first; I assume that this pattern is repeated elsewhere, and it should probably be fixed systematically, unless there is a rationale for this limitation that I am overlooking.

In any case I'm making the minimal PR here, as it's my first to the project. Happy to make any changes or additions as requested.

Thanks!