### PR TITLE
Backport #4615 (C++ header ambiguity fix) to 1.4

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -426,6 +426,10 @@ jobs:
       run: cargo make ci-job-test-c
       env:
         CXX: "g++-11"
+    - name: Test C++ with clang
+      run: cargo make test-cpp
+      env:
+        CXX: "clang++"
 
   # ci-job-test-js
   test-js:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,7 +12,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: '*'
+    branches: '**'
   workflow_dispatch:
     inputs:
       nightly:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
    with a lower Canonical Combining Class than the last character of the decomposition. (https://github.com/unicode-org/icu4x/pull/4530)
    - `icu_normalizer@1.4.1`
 
+ - Fix issue in C++ bindings where `diplomat::result::Ok` and `Err` have ambiguous template deduction errors in their constructors, on Clang. (https://github.com/unicode-org/icu4x/pull/4615)
+   - `icu_capi@1.4.1`
+
 ## icu4x 1.4 (Nov 16, 2023)
 
 - General

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "diplomat-tool"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62ab7c863bef0c72ffd4b86a36413980e5ee06f0455961a5d98ffd8567a5908"
+checksum = "34f1263dda940160e29884a3195efc4143a626e92cd9e24ebb2082cf6cfdd01a"
 dependencies = [
  "askama",
  "clap 3.2.25",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ version = "1.4.0"
 
 [[package]]
 name = "icu_capi"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "diplomat",
  "diplomat-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,7 +233,7 @@ icu_benchmark_macros = { path = "tools/benchmark/macros" }
 diplomat = "0.7"
 diplomat-runtime = "0.7"
 diplomat_core = "0.7"
-diplomat-tool = "0.7"
+diplomat-tool = "0.7.1"
 
 # Size optimized builds
 [profile.release-opt-size]

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -23,7 +23,7 @@ edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version.workspace = true
+version = "1.4.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ffi/capi/cpp/include/ICU4XBcp47ToIanaMapper.hpp
+++ b/ffi/capi/cpp/include/ICU4XBcp47ToIanaMapper.hpp
@@ -77,7 +77,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XBc
   auto diplomat_result_raw_out_value = capi::ICU4XBcp47ToIanaMapper_get(this->inner.get(), value.data(), value.size(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -89,7 +89,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XBcp47ToIanaMapper::get(con
   auto diplomat_result_raw_out_value = capi::ICU4XBcp47ToIanaMapper_get(this->inner.get(), value.data(), value.size(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XBidiParagraph.hpp
+++ b/ffi/capi/cpp/include/ICU4XBidiParagraph.hpp
@@ -103,7 +103,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XBidiParagraph::set_para
   auto diplomat_result_raw_out_value = capi::ICU4XBidiParagraph_set_paragraph_in_text(this->inner.get(), n);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -126,7 +126,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XBi
   auto diplomat_result_raw_out_value = capi::ICU4XBidiParagraph_reorder_line(this->inner.get(), range_start, range_end, &out_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -138,7 +138,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XBidiParagraph::reorder_lin
   auto diplomat_result_raw_out_value = capi::ICU4XBidiParagraph_reorder_line(this->inner.get(), range_start, range_end, &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XCaseMapper.hpp
+++ b/ffi/capi/cpp/include/ICU4XCaseMapper.hpp
@@ -219,7 +219,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XCa
   auto diplomat_result_raw_out_value = capi::ICU4XCaseMapper_lowercase(this->inner.get(), s.data(), s.size(), locale.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -231,7 +231,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XCaseMapper::lowercase(cons
   auto diplomat_result_raw_out_value = capi::ICU4XCaseMapper_lowercase(this->inner.get(), s.data(), s.size(), locale.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -242,7 +242,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XCa
   auto diplomat_result_raw_out_value = capi::ICU4XCaseMapper_uppercase(this->inner.get(), s.data(), s.size(), locale.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -254,7 +254,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XCaseMapper::uppercase(cons
   auto diplomat_result_raw_out_value = capi::ICU4XCaseMapper_uppercase(this->inner.get(), s.data(), s.size(), locale.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -266,7 +266,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XCa
   auto diplomat_result_raw_out_value = capi::ICU4XCaseMapper_titlecase_segment_with_only_case_data_v1(this->inner.get(), s.data(), s.size(), locale.AsFFI(), capi::ICU4XTitlecaseOptionsV1{ .leading_adjustment = static_cast<capi::ICU4XLeadingAdjustment>(diplomat_wrapped_struct_options.leading_adjustment), .trailing_case = static_cast<capi::ICU4XTrailingCase>(diplomat_wrapped_struct_options.trailing_case) }, &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -279,7 +279,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XCaseMapper::titlecase_segm
   auto diplomat_result_raw_out_value = capi::ICU4XCaseMapper_titlecase_segment_with_only_case_data_v1(this->inner.get(), s.data(), s.size(), locale.AsFFI(), capi::ICU4XTitlecaseOptionsV1{ .leading_adjustment = static_cast<capi::ICU4XLeadingAdjustment>(diplomat_wrapped_struct_options.leading_adjustment), .trailing_case = static_cast<capi::ICU4XTrailingCase>(diplomat_wrapped_struct_options.trailing_case) }, &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -290,7 +290,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XCa
   auto diplomat_result_raw_out_value = capi::ICU4XCaseMapper_fold(this->inner.get(), s.data(), s.size(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -302,7 +302,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XCaseMapper::fold(const std
   auto diplomat_result_raw_out_value = capi::ICU4XCaseMapper_fold(this->inner.get(), s.data(), s.size(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -313,7 +313,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XCa
   auto diplomat_result_raw_out_value = capi::ICU4XCaseMapper_fold_turkic(this->inner.get(), s.data(), s.size(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -325,7 +325,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XCaseMapper::fold_turkic(co
   auto diplomat_result_raw_out_value = capi::ICU4XCaseMapper_fold_turkic(this->inner.get(), s.data(), s.size(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XComposingNormalizer.hpp
+++ b/ffi/capi/cpp/include/ICU4XComposingNormalizer.hpp
@@ -107,7 +107,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XCo
   auto diplomat_result_raw_out_value = capi::ICU4XComposingNormalizer_normalize(this->inner.get(), s.data(), s.size(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -119,7 +119,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XComposingNormalizer::norma
   auto diplomat_result_raw_out_value = capi::ICU4XComposingNormalizer_normalize(this->inner.get(), s.data(), s.size(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XCustomTimeZone.hpp
+++ b/ffi/capi/cpp/include/ICU4XCustomTimeZone.hpp
@@ -338,7 +338,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XCustomTimeZone::try_set
   auto diplomat_result_raw_out_value = capi::ICU4XCustomTimeZone_try_set_gmt_offset_seconds(this->inner.get(), offset_seconds);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -401,7 +401,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XCustomTimeZone::try_set
   auto diplomat_result_raw_out_value = capi::ICU4XCustomTimeZone_try_set_time_zone_id(this->inner.get(), id.data(), id.size());
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -411,7 +411,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XCustomTimeZone::try_set
   auto diplomat_result_raw_out_value = capi::ICU4XCustomTimeZone_try_set_iana_time_zone_id(this->inner.get(), mapper.AsFFI(), id.data(), id.size());
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -425,7 +425,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XCu
   auto diplomat_result_raw_out_value = capi::ICU4XCustomTimeZone_time_zone_id(this->inner.get(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -437,7 +437,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XCustomTimeZone::time_zone_
   auto diplomat_result_raw_out_value = capi::ICU4XCustomTimeZone_time_zone_id(this->inner.get(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -447,7 +447,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XCustomTimeZone::try_set
   auto diplomat_result_raw_out_value = capi::ICU4XCustomTimeZone_try_set_metazone_id(this->inner.get(), id.data(), id.size());
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -461,7 +461,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XCu
   auto diplomat_result_raw_out_value = capi::ICU4XCustomTimeZone_metazone_id(this->inner.get(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -473,7 +473,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XCustomTimeZone::metazone_i
   auto diplomat_result_raw_out_value = capi::ICU4XCustomTimeZone_metazone_id(this->inner.get(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -483,7 +483,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XCustomTimeZone::try_set
   auto diplomat_result_raw_out_value = capi::ICU4XCustomTimeZone_try_set_zone_variant(this->inner.get(), id.data(), id.size());
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -497,7 +497,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XCu
   auto diplomat_result_raw_out_value = capi::ICU4XCustomTimeZone_zone_variant(this->inner.get(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -509,7 +509,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XCustomTimeZone::zone_varia
   auto diplomat_result_raw_out_value = capi::ICU4XCustomTimeZone_zone_variant(this->inner.get(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XDataProvider.hpp
+++ b/ffi/capi/cpp/include/ICU4XDataProvider.hpp
@@ -157,7 +157,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XDataProvider::fork_by_k
   auto diplomat_result_raw_out_value = capi::ICU4XDataProvider_fork_by_key(this->inner.get(), other.AsFFIMut());
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -167,7 +167,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XDataProvider::fork_by_l
   auto diplomat_result_raw_out_value = capi::ICU4XDataProvider_fork_by_locale(this->inner.get(), other.AsFFIMut());
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -177,7 +177,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XDataProvider::enable_lo
   auto diplomat_result_raw_out_value = capi::ICU4XDataProvider_enable_locale_fallback(this->inner.get());
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -187,7 +187,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XDataProvider::enable_lo
   auto diplomat_result_raw_out_value = capi::ICU4XDataProvider_enable_locale_fallback_with(this->inner.get(), fallbacker.AsFFI());
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XDate.hpp
+++ b/ffi/capi/cpp/include/ICU4XDate.hpp
@@ -244,7 +244,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XDa
   auto diplomat_result_raw_out_value = capi::ICU4XDate_month_code(this->inner.get(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -256,7 +256,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XDate::month_code() const {
   auto diplomat_result_raw_out_value = capi::ICU4XDate_month_code(this->inner.get(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -270,7 +270,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XDa
   auto diplomat_result_raw_out_value = capi::ICU4XDate_era(this->inner.get(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -282,7 +282,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XDate::era() const {
   auto diplomat_result_raw_out_value = capi::ICU4XDate_era(this->inner.get(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XDateFormatter.hpp
+++ b/ffi/capi/cpp/include/ICU4XDateFormatter.hpp
@@ -141,7 +141,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XDa
   auto diplomat_result_raw_out_value = capi::ICU4XDateFormatter_format_date(this->inner.get(), value.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -153,7 +153,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XDateFormatter::format_date
   auto diplomat_result_raw_out_value = capi::ICU4XDateFormatter_format_date(this->inner.get(), value.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -164,7 +164,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XDa
   auto diplomat_result_raw_out_value = capi::ICU4XDateFormatter_format_iso_date(this->inner.get(), value.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -176,7 +176,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XDateFormatter::format_iso_
   auto diplomat_result_raw_out_value = capi::ICU4XDateFormatter_format_iso_date(this->inner.get(), value.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -187,7 +187,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XDa
   auto diplomat_result_raw_out_value = capi::ICU4XDateFormatter_format_datetime(this->inner.get(), value.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -199,7 +199,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XDateFormatter::format_date
   auto diplomat_result_raw_out_value = capi::ICU4XDateFormatter_format_datetime(this->inner.get(), value.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -210,7 +210,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XDa
   auto diplomat_result_raw_out_value = capi::ICU4XDateFormatter_format_iso_datetime(this->inner.get(), value.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -222,7 +222,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XDateFormatter::format_iso_
   auto diplomat_result_raw_out_value = capi::ICU4XDateFormatter_format_iso_datetime(this->inner.get(), value.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XDateTime.hpp
+++ b/ffi/capi/cpp/include/ICU4XDateTime.hpp
@@ -314,7 +314,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XDa
   auto diplomat_result_raw_out_value = capi::ICU4XDateTime_month_code(this->inner.get(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -326,7 +326,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XDateTime::month_code() con
   auto diplomat_result_raw_out_value = capi::ICU4XDateTime_month_code(this->inner.get(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -340,7 +340,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XDa
   auto diplomat_result_raw_out_value = capi::ICU4XDateTime_era(this->inner.get(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -352,7 +352,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XDateTime::era() const {
   auto diplomat_result_raw_out_value = capi::ICU4XDateTime_era(this->inner.get(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XDateTimeFormatter.hpp
+++ b/ffi/capi/cpp/include/ICU4XDateTimeFormatter.hpp
@@ -106,7 +106,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XDa
   auto diplomat_result_raw_out_value = capi::ICU4XDateTimeFormatter_format_datetime(this->inner.get(), value.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -118,7 +118,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XDateTimeFormatter::format_
   auto diplomat_result_raw_out_value = capi::ICU4XDateTimeFormatter_format_datetime(this->inner.get(), value.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -129,7 +129,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XDa
   auto diplomat_result_raw_out_value = capi::ICU4XDateTimeFormatter_format_iso_datetime(this->inner.get(), value.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -141,7 +141,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XDateTimeFormatter::format_
   auto diplomat_result_raw_out_value = capi::ICU4XDateTimeFormatter_format_iso_datetime(this->inner.get(), value.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XDecomposingNormalizer.hpp
+++ b/ffi/capi/cpp/include/ICU4XDecomposingNormalizer.hpp
@@ -107,7 +107,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XDe
   auto diplomat_result_raw_out_value = capi::ICU4XDecomposingNormalizer_normalize(this->inner.get(), s.data(), s.size(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -119,7 +119,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XDecomposingNormalizer::nor
   auto diplomat_result_raw_out_value = capi::ICU4XDecomposingNormalizer_normalize(this->inner.get(), s.data(), s.size(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XFixedDecimal.hpp
+++ b/ffi/capi/cpp/include/ICU4XFixedDecimal.hpp
@@ -407,9 +407,9 @@ inline diplomat::result<std::monostate, std::monostate> ICU4XFixedDecimal::conca
   auto diplomat_result_raw_out_value = capi::ICU4XFixedDecimal_concatenate_end(this->inner.get(), other.AsFFIMut());
   diplomat::result<std::monostate, std::monostate> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
-    diplomat_result_out_value = diplomat::Err(std::monostate());
+    diplomat_result_out_value = diplomat::Err<std::monostate>(std::monostate());
   }
   return diplomat_result_out_value;
 }

--- a/ffi/capi/cpp/include/ICU4XFixedDecimalFormatter.hpp
+++ b/ffi/capi/cpp/include/ICU4XFixedDecimalFormatter.hpp
@@ -105,7 +105,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XFi
   auto diplomat_result_raw_out_value = capi::ICU4XFixedDecimalFormatter_format(this->inner.get(), value.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -117,7 +117,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XFixedDecimalFormatter::for
   auto diplomat_result_raw_out_value = capi::ICU4XFixedDecimalFormatter_format(this->inner.get(), value.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XGregorianDateFormatter.hpp
+++ b/ffi/capi/cpp/include/ICU4XGregorianDateFormatter.hpp
@@ -101,7 +101,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XGr
   auto diplomat_result_raw_out_value = capi::ICU4XGregorianDateFormatter_format_iso_date(this->inner.get(), value.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -113,7 +113,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XGregorianDateFormatter::fo
   auto diplomat_result_raw_out_value = capi::ICU4XGregorianDateFormatter_format_iso_date(this->inner.get(), value.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -124,7 +124,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XGr
   auto diplomat_result_raw_out_value = capi::ICU4XGregorianDateFormatter_format_iso_datetime(this->inner.get(), value.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -136,7 +136,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XGregorianDateFormatter::fo
   auto diplomat_result_raw_out_value = capi::ICU4XGregorianDateFormatter_format_iso_datetime(this->inner.get(), value.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XGregorianDateTimeFormatter.hpp
+++ b/ffi/capi/cpp/include/ICU4XGregorianDateTimeFormatter.hpp
@@ -86,7 +86,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XGr
   auto diplomat_result_raw_out_value = capi::ICU4XGregorianDateTimeFormatter_format_iso_datetime(this->inner.get(), value.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -98,7 +98,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XGregorianDateTimeFormatter
   auto diplomat_result_raw_out_value = capi::ICU4XGregorianDateTimeFormatter_format_iso_datetime(this->inner.get(), value.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XGregorianZonedDateTimeFormatter.hpp
+++ b/ffi/capi/cpp/include/ICU4XGregorianZonedDateTimeFormatter.hpp
@@ -113,7 +113,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XGr
   auto diplomat_result_raw_out_value = capi::ICU4XGregorianZonedDateTimeFormatter_format_iso_datetime_with_custom_time_zone(this->inner.get(), datetime.AsFFI(), time_zone.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -125,7 +125,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XGregorianZonedDateTimeForm
   auto diplomat_result_raw_out_value = capi::ICU4XGregorianZonedDateTimeFormatter_format_iso_datetime_with_custom_time_zone(this->inner.get(), datetime.AsFFI(), time_zone.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XListFormatter.hpp
+++ b/ffi/capi/cpp/include/ICU4XListFormatter.hpp
@@ -112,7 +112,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XLi
   auto diplomat_result_raw_out_value = capi::ICU4XListFormatter_format(this->inner.get(), list.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -124,7 +124,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XListFormatter::format(cons
   auto diplomat_result_raw_out_value = capi::ICU4XListFormatter_format(this->inner.get(), list.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XLocale.hpp
+++ b/ffi/capi/cpp/include/ICU4XLocale.hpp
@@ -237,7 +237,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XLo
   auto diplomat_result_raw_out_value = capi::ICU4XLocale_basename(this->inner.get(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -249,7 +249,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XLocale::basename() const {
   auto diplomat_result_raw_out_value = capi::ICU4XLocale_basename(this->inner.get(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -260,7 +260,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XLo
   auto diplomat_result_raw_out_value = capi::ICU4XLocale_get_unicode_extension(this->inner.get(), bytes.data(), bytes.size(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -272,7 +272,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XLocale::get_unicode_extens
   auto diplomat_result_raw_out_value = capi::ICU4XLocale_get_unicode_extension(this->inner.get(), bytes.data(), bytes.size(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -283,7 +283,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XLo
   auto diplomat_result_raw_out_value = capi::ICU4XLocale_language(this->inner.get(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -295,7 +295,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XLocale::language() const {
   auto diplomat_result_raw_out_value = capi::ICU4XLocale_language(this->inner.get(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -305,7 +305,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XLocale::set_language(co
   auto diplomat_result_raw_out_value = capi::ICU4XLocale_set_language(this->inner.get(), bytes.data(), bytes.size());
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -316,7 +316,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XLo
   auto diplomat_result_raw_out_value = capi::ICU4XLocale_region(this->inner.get(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -328,7 +328,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XLocale::region() const {
   auto diplomat_result_raw_out_value = capi::ICU4XLocale_region(this->inner.get(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -338,7 +338,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XLocale::set_region(cons
   auto diplomat_result_raw_out_value = capi::ICU4XLocale_set_region(this->inner.get(), bytes.data(), bytes.size());
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -349,7 +349,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XLo
   auto diplomat_result_raw_out_value = capi::ICU4XLocale_script(this->inner.get(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -361,7 +361,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XLocale::script() const {
   auto diplomat_result_raw_out_value = capi::ICU4XLocale_script(this->inner.get(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -371,7 +371,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XLocale::set_script(cons
   auto diplomat_result_raw_out_value = capi::ICU4XLocale_set_script(this->inner.get(), bytes.data(), bytes.size());
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -382,7 +382,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XLo
   auto diplomat_result_raw_out_value = capi::ICU4XLocale_canonicalize(bytes.data(), bytes.size(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -394,7 +394,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XLocale::canonicalize(const
   auto diplomat_result_raw_out_value = capi::ICU4XLocale_canonicalize(bytes.data(), bytes.size(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -405,7 +405,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XLo
   auto diplomat_result_raw_out_value = capi::ICU4XLocale_to_string(this->inner.get(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -417,7 +417,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XLocale::to_string() const 
   auto diplomat_result_raw_out_value = capi::ICU4XLocale_to_string(this->inner.get(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XLocaleDisplayNamesFormatter.hpp
+++ b/ffi/capi/cpp/include/ICU4XLocaleDisplayNamesFormatter.hpp
@@ -82,7 +82,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XLo
   auto diplomat_result_raw_out_value = capi::ICU4XLocaleDisplayNamesFormatter_of(this->inner.get(), locale.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -94,7 +94,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XLocaleDisplayNamesFormatte
   auto diplomat_result_raw_out_value = capi::ICU4XLocaleDisplayNamesFormatter_of(this->inner.get(), locale.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XRegionDisplayNames.hpp
+++ b/ffi/capi/cpp/include/ICU4XRegionDisplayNames.hpp
@@ -83,7 +83,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XRe
   auto diplomat_result_raw_out_value = capi::ICU4XRegionDisplayNames_of(this->inner.get(), region.data(), region.size(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -95,7 +95,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XRegionDisplayNames::of(con
   auto diplomat_result_raw_out_value = capi::ICU4XRegionDisplayNames_of(this->inner.get(), region.data(), region.size(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XScriptExtensionsSet.hpp
+++ b/ffi/capi/cpp/include/ICU4XScriptExtensionsSet.hpp
@@ -72,7 +72,7 @@ inline diplomat::result<uint16_t, std::monostate> ICU4XScriptExtensionsSet::scri
   if (diplomat_result_raw_out_value.is_ok) {
     diplomat_result_out_value = diplomat::Ok<uint16_t>(diplomat_result_raw_out_value.ok);
   } else {
-    diplomat_result_out_value = diplomat::Err(std::monostate());
+    diplomat_result_out_value = diplomat::Err<std::monostate>(std::monostate());
   }
   return diplomat_result_out_value;
 }

--- a/ffi/capi/cpp/include/ICU4XTimeFormatter.hpp
+++ b/ffi/capi/cpp/include/ICU4XTimeFormatter.hpp
@@ -116,7 +116,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XTi
   auto diplomat_result_raw_out_value = capi::ICU4XTimeFormatter_format_time(this->inner.get(), value.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -128,7 +128,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XTimeFormatter::format_time
   auto diplomat_result_raw_out_value = capi::ICU4XTimeFormatter_format_time(this->inner.get(), value.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -139,7 +139,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XTi
   auto diplomat_result_raw_out_value = capi::ICU4XTimeFormatter_format_datetime(this->inner.get(), value.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -151,7 +151,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XTimeFormatter::format_date
   auto diplomat_result_raw_out_value = capi::ICU4XTimeFormatter_format_datetime(this->inner.get(), value.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -162,7 +162,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XTi
   auto diplomat_result_raw_out_value = capi::ICU4XTimeFormatter_format_iso_datetime(this->inner.get(), value.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -174,7 +174,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XTimeFormatter::format_iso_
   auto diplomat_result_raw_out_value = capi::ICU4XTimeFormatter_format_iso_datetime(this->inner.get(), value.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XTimeZoneFormatter.hpp
+++ b/ffi/capi/cpp/include/ICU4XTimeZoneFormatter.hpp
@@ -163,7 +163,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XTimeZoneFormatter::load
   auto diplomat_result_raw_out_value = capi::ICU4XTimeZoneFormatter_load_generic_non_location_long(this->inner.get(), provider.AsFFI());
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -173,7 +173,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XTimeZoneFormatter::load
   auto diplomat_result_raw_out_value = capi::ICU4XTimeZoneFormatter_load_generic_non_location_short(this->inner.get(), provider.AsFFI());
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -183,7 +183,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XTimeZoneFormatter::load
   auto diplomat_result_raw_out_value = capi::ICU4XTimeZoneFormatter_load_specific_non_location_long(this->inner.get(), provider.AsFFI());
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -193,7 +193,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XTimeZoneFormatter::load
   auto diplomat_result_raw_out_value = capi::ICU4XTimeZoneFormatter_load_specific_non_location_short(this->inner.get(), provider.AsFFI());
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -203,7 +203,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XTimeZoneFormatter::load
   auto diplomat_result_raw_out_value = capi::ICU4XTimeZoneFormatter_load_generic_location_format(this->inner.get(), provider.AsFFI());
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -213,7 +213,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XTimeZoneFormatter::incl
   auto diplomat_result_raw_out_value = capi::ICU4XTimeZoneFormatter_include_localized_gmt_format(this->inner.get());
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -224,7 +224,7 @@ inline diplomat::result<std::monostate, ICU4XError> ICU4XTimeZoneFormatter::load
   auto diplomat_result_raw_out_value = capi::ICU4XTimeZoneFormatter_load_iso_8601_format(this->inner.get(), capi::ICU4XIsoTimeZoneOptions{ .format = static_cast<capi::ICU4XIsoTimeZoneFormat>(diplomat_wrapped_struct_options.format), .minutes = static_cast<capi::ICU4XIsoTimeZoneMinuteDisplay>(diplomat_wrapped_struct_options.minutes), .seconds = static_cast<capi::ICU4XIsoTimeZoneSecondDisplay>(diplomat_wrapped_struct_options.seconds) });
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -235,7 +235,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XTi
   auto diplomat_result_raw_out_value = capi::ICU4XTimeZoneFormatter_format_custom_time_zone(this->inner.get(), value.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -247,7 +247,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XTimeZoneFormatter::format_
   auto diplomat_result_raw_out_value = capi::ICU4XTimeZoneFormatter_format_custom_time_zone(this->inner.get(), value.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XTitlecaseMapper.hpp
+++ b/ffi/capi/cpp/include/ICU4XTitlecaseMapper.hpp
@@ -86,7 +86,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XTi
   auto diplomat_result_raw_out_value = capi::ICU4XTitlecaseMapper_titlecase_segment_v1(this->inner.get(), s.data(), s.size(), locale.AsFFI(), capi::ICU4XTitlecaseOptionsV1{ .leading_adjustment = static_cast<capi::ICU4XLeadingAdjustment>(diplomat_wrapped_struct_options.leading_adjustment), .trailing_case = static_cast<capi::ICU4XTrailingCase>(diplomat_wrapped_struct_options.trailing_case) }, &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -99,7 +99,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XTitlecaseMapper::titlecase
   auto diplomat_result_raw_out_value = capi::ICU4XTitlecaseMapper_titlecase_segment_v1(this->inner.get(), s.data(), s.size(), locale.AsFFI(), capi::ICU4XTitlecaseOptionsV1{ .leading_adjustment = static_cast<capi::ICU4XLeadingAdjustment>(diplomat_wrapped_struct_options.leading_adjustment), .trailing_case = static_cast<capi::ICU4XTrailingCase>(diplomat_wrapped_struct_options.trailing_case) }, &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/capi/cpp/include/ICU4XZonedDateTimeFormatter.hpp
+++ b/ffi/capi/cpp/include/ICU4XZonedDateTimeFormatter.hpp
@@ -129,7 +129,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XZo
   auto diplomat_result_raw_out_value = capi::ICU4XZonedDateTimeFormatter_format_datetime_with_custom_time_zone(this->inner.get(), datetime.AsFFI(), time_zone.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -141,7 +141,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XZonedDateTimeFormatter::fo
   auto diplomat_result_raw_out_value = capi::ICU4XZonedDateTimeFormatter_format_datetime_with_custom_time_zone(this->inner.get(), datetime.AsFFI(), time_zone.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -152,7 +152,7 @@ template<typename W> inline diplomat::result<std::monostate, ICU4XError> ICU4XZo
   auto diplomat_result_raw_out_value = capi::ICU4XZonedDateTimeFormatter_format_iso_datetime_with_custom_time_zone(this->inner.get(), datetime.AsFFI(), time_zone.AsFFI(), &write_writer);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }
@@ -164,7 +164,7 @@ inline diplomat::result<std::string, ICU4XError> ICU4XZonedDateTimeFormatter::fo
   auto diplomat_result_raw_out_value = capi::ICU4XZonedDateTimeFormatter_format_iso_datetime_with_custom_time_zone(this->inner.get(), datetime.AsFFI(), time_zone.AsFFI(), &diplomat_writeable_out);
   diplomat::result<std::monostate, ICU4XError> diplomat_result_out_value;
   if (diplomat_result_raw_out_value.is_ok) {
-    diplomat_result_out_value = diplomat::Ok(std::monostate());
+    diplomat_result_out_value = diplomat::Ok<std::monostate>(std::monostate());
   } else {
     diplomat_result_out_value = diplomat::Err<ICU4XError>(static_cast<ICU4XError>(diplomat_result_raw_out_value.err));
   }

--- a/ffi/gn/Cargo.lock
+++ b/ffi/gn/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "icu_capi"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "displaydoc",
  "icu_collections",

--- a/ffi/gn/icu4x/BUILD.gn
+++ b/ffi/gn/icu4x/BUILD.gn
@@ -9,7 +9,7 @@ group("icu") {
 }
 
 group("icu_capi") {
-  public_deps = [ ":icu_capi-v1_4_0" ]
+  public_deps = [ ":icu_capi-v1_4_1" ]
 }
 
 group("icu_provider") {
@@ -205,7 +205,7 @@ rust_library("icu-v1_4_0") {
   deps += [ ":icu_list-v1_4_0" ]
   deps += [ ":icu_locid-v1_4_0" ]
   deps += [ ":icu_locid_transform-v1_4_0" ]
-  deps += [ ":icu_normalizer-v1_4_0" ]
+  deps += [ ":icu_normalizer-v1_4_1" ]
   deps += [ ":icu_plurals-v1_4_0" ]
   deps += [ ":icu_properties-v1_4_0" ]
   deps += [ ":icu_provider-v1_4_0" ]
@@ -250,10 +250,10 @@ rust_library("icu_calendar-v1_4_0") {
   visibility = [ ":*" ]
 }
 
-rust_library("icu_capi-v1_4_0") {
+rust_library("icu_capi-v1_4_1") {
   crate_name = "icu_capi"
   crate_root = "//ffi/capi/src/lib.rs"
-  output_name = "icu_capi-18b229e1ffe2352f"
+  output_name = "icu_capi-b296a82615ed5c80"
 
   deps = []
   deps += [ ":diplomat-v0_7_0($host_toolchain)" ]
@@ -268,7 +268,7 @@ rust_library("icu_capi-v1_4_0") {
   deps += [ ":icu_list-v1_4_0" ]
   deps += [ ":icu_locid-v1_4_0" ]
   deps += [ ":icu_locid_transform-v1_4_0" ]
-  deps += [ ":icu_normalizer-v1_4_0" ]
+  deps += [ ":icu_normalizer-v1_4_1" ]
   deps += [ ":icu_plurals-v1_4_0" ]
   deps += [ ":icu_properties-v1_4_0" ]
   deps += [ ":icu_provider-v1_4_0" ]
@@ -284,8 +284,8 @@ rust_library("icu_capi-v1_4_0") {
   rustflags = [
     "--cap-lints=allow",
     "--edition=2021",
-    "-Cmetadata=18b229e1ffe2352f",
-    "-Cextra-filename=-18b229e1ffe2352f",
+    "-Cmetadata=b296a82615ed5c80",
+    "-Cextra-filename=-b296a82615ed5c80",
     "--cfg=feature=\"default_components\"",
     "--cfg=feature=\"icu_calendar\"",
     "--cfg=feature=\"icu_casemap\"",
@@ -339,7 +339,7 @@ rust_library("icu_collator-v1_4_0") {
   deps += [ ":displaydoc-v0_2_4($host_toolchain)" ]
   deps += [ ":icu_collections-v1_4_0" ]
   deps += [ ":icu_locid-v1_4_0" ]
-  deps += [ ":icu_normalizer-v1_4_0" ]
+  deps += [ ":icu_normalizer-v1_4_1" ]
   deps += [ ":icu_properties-v1_4_0" ]
   deps += [ ":icu_provider-v1_4_0" ]
   deps += [ ":smallvec-v1_10_0" ]
@@ -510,10 +510,10 @@ rust_library("icu_locid_transform-v1_4_0") {
   visibility = [ ":*" ]
 }
 
-rust_library("icu_normalizer-v1_4_0") {
+rust_library("icu_normalizer-v1_4_1") {
   crate_name = "icu_normalizer"
   crate_root = "//components/normalizer/src/lib.rs"
-  output_name = "icu_normalizer-58ade7a85f103f2f"
+  output_name = "icu_normalizer-95d3055564b72a64"
 
   deps = []
   deps += [ ":displaydoc-v0_2_4($host_toolchain)" ]
@@ -531,8 +531,8 @@ rust_library("icu_normalizer-v1_4_0") {
   rustflags = [
     "--cap-lints=allow",
     "--edition=2021",
-    "-Cmetadata=58ade7a85f103f2f",
-    "-Cextra-filename=-58ade7a85f103f2f",
+    "-Cmetadata=95d3055564b72a64",
+    "-Cextra-filename=-95d3055564b72a64",
   ]
 
   visibility = [ ":*" ]


### PR DESCRIPTION
Backports https://github.com/unicode-org/icu4x/pull/4615 to 1.4


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->