### PR TITLE
Improve nightly and beta CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -451,9 +451,12 @@ jobs:
     - name: Run apt-get update
       run: |
         apt-get update
-    - name: Install Clang-15
+    - name: Install LLVM 16
       run: |
-        apt-get install -y clang-15 lld-15 llvm-15-dev libc++-15-dev
+        apt-get install -y clang-16 lld-16 llvm-16-dev libc++-16-dev
+    - name: Install LLVM 16 nightly
+      run: |
+        rustup install nightly-2023-08-08
     - name: Install GCC 11
       run: |
         apt-get install -y gcc-11 g++-11

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -130,7 +130,7 @@ jobs:
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
+      run: cargo make set-ci-toolchain
     - name: Show the selected Rust toolchain
       run: rustup show
 
@@ -165,7 +165,7 @@ jobs:
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
+      run: cargo make set-ci-toolchain
     - name: Show the selected Rust toolchain
       run: rustup show
 
@@ -200,7 +200,7 @@ jobs:
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
+      run: cargo make set-ci-toolchain
     - name: Show the selected Rust toolchain
       run: rustup show
 
@@ -239,7 +239,7 @@ jobs:
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
+      run: cargo make set-ci-toolchain
     - name: Show the selected Rust toolchain
       run: rustup show
 
@@ -285,7 +285,7 @@ jobs:
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
+      run: cargo make set-ci-toolchain
     - name: Show the selected Rust toolchain
       run: rustup show
 
@@ -348,7 +348,7 @@ jobs:
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
+      run: cargo make set-ci-toolchain
     - name: Show the selected Rust toolchain
       run: rustup show
 
@@ -390,7 +390,7 @@ jobs:
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
+      run: cargo make set-ci-toolchain
     - name: Show the selected Rust toolchain
       run: rustup show
 
@@ -443,7 +443,7 @@ jobs:
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
+      run: cargo make set-ci-toolchain
     - name: Show the selected Rust toolchain
       run: rustup show
 
@@ -515,7 +515,7 @@ jobs:
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
+      run: cargo make set-ci-toolchain
     - name: Show the selected Rust toolchain
       run: rustup show
 
@@ -574,7 +574,7 @@ jobs:
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
+      run: cargo make set-ci-toolchain
     - name: Show the selected Rust toolchain
       run: rustup show
 
@@ -614,7 +614,7 @@ jobs:
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
+      run: cargo make set-ci-toolchain
     - name: Show the selected Rust toolchain
       run: rustup show
 
@@ -649,7 +649,7 @@ jobs:
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
+      run: cargo make set-ci-toolchain
     - name: Show the selected Rust toolchain
       run: rustup show
 
@@ -685,7 +685,7 @@ jobs:
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
+      run: cargo make set-ci-toolchain
     - name: Show the selected Rust toolchain
       run: rustup show
 
@@ -752,7 +752,7 @@ jobs:
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
+      run: cargo make set-ci-toolchain
     - name: Show the selected Rust toolchain
       run: rustup show
 
@@ -791,7 +791,7 @@ jobs:
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
+      run: cargo make set-ci-toolchain
     - name: Show the selected Rust toolchain
       run: rustup show
 
@@ -850,7 +850,7 @@ jobs:
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
+      run: cargo make set-ci-toolchain
     - name: Show the selected Rust toolchain
       run: rustup show
 
@@ -890,7 +890,7 @@ jobs:
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
-      run: cargo make set-nightly-version-for-ci
+      run: cargo make set-ci-toolchain
     - name: Show the selected Rust toolchain
       run: rustup show
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ Our wider testsuite is organized as `ci-job-foo` make tasks corresponding to eac
 <br/>
  
  - `ci-job-test-c`: Runs all C/C++ FFI tests; mostly important if you're changing the FFI interface.
-     + Requires `clang-15` and `lld-15` with the `gold` plugin (APT packages `llvm-15` and `lld-15`).
+     + Requires `clang-16` and `lld-16` with the `gold` plugin (APT packages `llvm-16` and `lld-16`).
  - `ci-job-test-js`: Runs all JS/WASM/Node FFI tests; mostly important if you're changing the FFI interface.
      + Requires Node.js version 16.18.0. This may not the one offered by the package manager; get it from the NodeJS website or `nvm`.
  - `ci-job-nostd`: Builds ICU4X for a `#[no_std]` target to verify that it's compatible.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -17,7 +17,6 @@ default_to_workspace = false
 
 [env]
 ICU4X_NIGHTLY_TOOLCHAIN = { value = "nightly-2022-12-26", condition = { env_not_set = ["ICU4X_NIGHTLY_TOOLCHAIN"] } }
-ICU4X_BUILDING_WITH_FORCED_NIGHTLY = { value = "1", condition = { env_set = ["ICU4X_BUILDING_WITH_FORCED_NIGHTLY"] } }
 
 [tasks.quick]
 description = "Run quick version of all lints and builds (useful before pushing to GitHub)"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -17,10 +17,6 @@ default_to_workspace = false
 
 [env]
 ICU4X_NIGHTLY_TOOLCHAIN = { value = "nightly-2022-12-26", condition = { env_not_set = ["ICU4X_NIGHTLY_TOOLCHAIN"] } }
-# To install a specific build of GN, set the ICU4X_GN_PACKAGE environment variable. Choices:
-# https://chrome-infra-packages.appspot.com/p/gn/gn
-# TODO: Choose the correct distribution of GN automatically.
-ICU4X_GN_PACKAGE = { value = "gn/gn/linux-amd64", condition = { env_not_set = ["ICU4X_GN_PACKAGE"] } }
 ICU4X_BUILDING_WITH_FORCED_NIGHTLY = { value = "1", condition = { env_set = ["ICU4X_BUILDING_WITH_FORCED_NIGHTLY"] } }
 
 [tasks.quick]
@@ -273,15 +269,6 @@ dependencies = [
 
     # benchmarking and coverage jobs not included
 ]
-
-[tasks.install-nightly]
-description = "Installs $ICU4X_NIGHTLY_TOOLCHAIN"
-category = "ICU4X Development"
-script_runner = "@duckscript"
-script = '''
-exec --fail-on-error rustup install ${ICU4X_NIGHTLY_TOOLCHAIN} --profile minimal
-exec --fail-on-error rustup component add rust-src --toolchain ${ICU4X_NIGHTLY_TOOLCHAIN}
-'''
 
 # For the nightly CI, we set three environment variables, and set a rustup override to nightly.
 # Each env var has a different purpose:

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -16,7 +16,7 @@ extend = [
 default_to_workspace = false
 
 [env]
-ICU4X_NIGHTLY_TOOLCHAIN = { value = "nightly-2022-12-26", condition = { env_not_set = ["ICU4X_NIGHTLY_TOOLCHAIN"] } }
+PINNED_CI_NIGHTLY = { value = "nightly-2022-12-26", condition = { env_not_set = ["PINNED_CI_NIGHTLY"] } }
 
 [tasks.quick]
 description = "Run quick version of all lints and builds (useful before pushing to GitHub)"
@@ -271,7 +271,7 @@ dependencies = [
 
 # For the nightly CI, we set three environment variables, and set a rustup override to nightly.
 # Each env var has a different purpose:
-# - ICU4X_NIGHTLY_TOOLCHAIN: This overrides the nightly used by this makefile
+# - PINNED_CI_NIGHTLY: This overrides the nightly used by this makefile
 # - ICU4X_BUILDING_WITH_FORCED_NIGHTLY: This lets tests know that we're building with forced nightly, in case of tests testing the behavior of specific Rust versions.
 # - `RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY`: Same as previously, but works for disabling doctests. Use ICU4X_BUILDING_WITH_FORCED_NIGHTLY where possible.
 #
@@ -328,7 +328,7 @@ if ${needs_override}
 
     if starts_with "${override_channel}" "nightly"
         # This affects tasks that can only be built on nightly
-        appendfile ${env_file} "ICU4X_NIGHTLY_TOOLCHAIN=${override_channel}\n"
+        appendfile ${env_file} "PINNED_CI_NIGHTLY=${override_channel}\n"
     end
 else
     echo "forced-nightly environment not required"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -16,6 +16,9 @@ extend = [
 default_to_workspace = false
 
 [env]
+# The toolchain that CI is being run in. Allows tests to change under beta/nightly.
+CI_TOOLCHAIN = { value = "pinned-stable", condition = { env_not_set = ["CI_TOOLCHAIN"]}}
+# The pinned nightly toolchain for jobs that require a nightly compiler.
 PINNED_CI_NIGHTLY = { value = "nightly-2022-12-26", condition = { env_not_set = ["PINNED_CI_NIGHTLY"] } }
 
 [tasks.quick]
@@ -269,15 +272,14 @@ dependencies = [
     # benchmarking and coverage jobs not included
 ]
 
-# For the nightly CI, we set three environment variables, and set a rustup override to nightly.
-# Each env var has a different purpose:
-# - PINNED_CI_NIGHTLY: This overrides the nightly used by this makefile
-# - ICU4X_BUILDING_WITH_FORCED_NIGHTLY: This lets tests know that we're building with forced nightly, in case of tests testing the behavior of specific Rust versions.
-# - `RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY`: Same as previously, but works for disabling doctests. Use ICU4X_BUILDING_WITH_FORCED_NIGHTLY where possible.
+# For the nightly and beta CI, we set 
+# - a rustup override
+# - CI_TOOLCHAIN: gets set to either "pinned-stable", "beta", or "nightly"
+# - PINNED_CI_NIGHTLY: Set to "nightly" if we want to use the latest nightly
 #
-# When updating the toolchain, please audit all cases of ICU4X_BUILDING_WITH_FORCED_NIGHTLY and remove cfgs where necessary.
-[tasks.set-nightly-version-for-ci]
-description = "Set all nightly version env vars for CI"
+# When updating the toolchain, please audit all cases of CI_TOOLCHAIN and remove cfgs where necessary.
+[tasks.set-ci-toolchain]
+description = "Set all toolchain vars for CI"
 category = "CI"
 script_runner = "@duckscript"
 script = '''
@@ -295,8 +297,7 @@ if not ${event_name}
     exit 1
 end
 
-needs_override = set false
-override_channel = set "nightly"
+ci_toolchain = set "pinned-stable"
 
 # We need to parse the channel information for dispatch/schedule events
 if eq "${event_name}" "workflow_dispatch" or eq "${event_name}" "schedule"
@@ -307,30 +308,31 @@ if eq "${event_name}" "workflow_dispatch" or eq "${event_name}" "schedule"
     if eq "${event_name}" "workflow_dispatch"
         if not eq "${event_json.inputs.channel}" "pinned-stable"
             needs_override = set true
-            override_channel = set "${event_json.inputs.channel}"
+            ci_toolchain = set "${event_json.inputs.channel}"
         end
     else
         # Schedule events always override
         needs_override = set true
         # For schedule events, the cronjob on minute 1 is the beta job
         if eq "${event_json.schedule}" "1 14 * * *"
-            override_channel = set "beta"
+            ci_toolchain = set "beta"
+        else 
+            ci_toolchain = set "nightly"
         end
     end
 end
 
 
-if ${needs_override}
-    echo "Setting up CI environment for forced-${override_channel} Rust build"
-    appendfile ${env_file} "ICU4X_BUILDING_WITH_FORCED_NIGHTLY=1\n"
-    appendfile ${env_file} "RUSTDOCFLAGS=--cfg ICU4X_BUILDING_WITH_FORCED_NIGHTLY\n"
-    exec rustup override set ${override_channel}
+if not eq ${ci_toolchain} "pinned-stable"
+    echo "Setting up CI environment for forced-${ci_toolchain} Rust build"
+    appendfile ${env_file} "CI_TOOLCHAIN=${ci_toolchain}\n"
+    exec rustup override set ${ci_toolchain}
 
-    if starts_with "${override_channel}" "nightly"
+    if starts_with "${ci_toolchain}" "nightly"
         # This affects tasks that can only be built on nightly
-        appendfile ${env_file} "PINNED_CI_NIGHTLY=${override_channel}\n"
+        appendfile ${env_file} "PINNED_CI_NIGHTLY=${ci_toolchain}\n"
     end
 else
-    echo "forced-nightly environment not required"
+    echo "forced-toolchain environment not required"
 end
 '''

--- a/components/datetime/src/helpers.rs
+++ b/components/datetime/src/helpers.rs
@@ -18,7 +18,7 @@
 /// named arguments version of this macro to specify both sizes:
 ///
 /// ```ignore
-/// size_test!(MyType, my_type_size, pinned = 32, beta = 24);
+/// size_test!(MyType, my_type_size, pinned = 32, beta = 24, nightly = 24);
 /// ```
 ///
 /// The test is ignored by default but runs in CI. To run the test locally,

--- a/components/datetime/src/helpers.rs
+++ b/components/datetime/src/helpers.rs
@@ -43,9 +43,8 @@ macro_rules! size_test {
             let success = match option_env!("CI_TOOLCHAIN") {
                 // Manual invocation: match either size
                 None => matches!(size, $pinned | $beta),
-                Some("beta") => size == $beta,
+                Some("beta") | Some("nightly") => size == $beta,
                 Some("pinned-stable") => size == $pinned,
-                // nightly, don't care
                 _ => true,
             };
             assert!(

--- a/components/datetime/src/helpers.rs
+++ b/components/datetime/src/helpers.rs
@@ -42,10 +42,9 @@ macro_rules! size_test {
             let size = core::mem::size_of::<$ty>();
             let success = match option_env!("CI_TOOLCHAIN") {
                 // Manual invocation: match either size
-                None => matches!(size, $pinned | $beta),
                 Some("beta") | Some("nightly") => size == $beta,
                 Some("pinned-stable") => size == $pinned,
-                _ => true,
+                _ => matches!(size, $pinned | $beta),
             };
             assert!(
                 success,

--- a/components/datetime/src/helpers.rs
+++ b/components/datetime/src/helpers.rs
@@ -24,7 +24,7 @@
 /// The test is ignored by default but runs in CI. To run the test locally,
 /// run `cargo test -- --include-ignored`
 macro_rules! size_test {
-    ($ty:ty, $id:ident, pinned = $pinned:literal, beta = $beta:literal) => {
+    ($ty:ty, $id:ident, pinned = $pinned:literal, beta = $beta:literal, nightly = $nightly:literal) => {
         macro_rules! $id {
             () => {
                 concat!(
@@ -41,10 +41,11 @@ macro_rules! size_test {
         fn $id() {
             let size = core::mem::size_of::<$ty>();
             let success = match option_env!("CI_TOOLCHAIN") {
-                // Manual invocation: match either size
-                Some("beta") | Some("nightly") => size == $beta,
+                Some("nightly") => size == $nightly,
+                Some("beta") => size == $beta,
                 Some("pinned-stable") => size == $pinned,
-                _ => matches!(size, $pinned | $beta),
+                // Manual invocation: match either size
+                _ => matches!(size, $pinned | $beta | $nightly),
             };
             assert!(
                 success,

--- a/components/datetime/src/helpers.rs
+++ b/components/datetime/src/helpers.rs
@@ -14,25 +14,25 @@
 ///
 /// The size should correspond to the Rust version in rust-toolchain.toml.
 ///
-/// If the size on latest nightly differs from rust-toolchain.toml, use the
+/// If the size on latest beta differs from rust-toolchain.toml, use the
 /// named arguments version of this macro to specify both sizes:
 ///
 /// ```ignore
-/// size_test!(MyType, my_type_size, pinned = 32, nightly = 24);
+/// size_test!(MyType, my_type_size, pinned = 32, beta = 24);
 /// ```
 ///
 /// The test is ignored by default but runs in CI. To run the test locally,
 /// run `cargo test -- --include-ignored`
 macro_rules! size_test {
-    ($ty:ty, $id:ident, pinned = $pinned:literal, nightly = $nightly:literal) => {
+    ($ty:ty, $id:ident, pinned = $pinned:literal, beta = $beta:literal) => {
         macro_rules! $id {
             () => {
                 concat!(
                     "📏 This item has a stack size of <b>",
                     stringify!($pinned),
-                    " bytes</b> in the default ICU4X Rust stable toolchain and <b>",
-                    stringify!($nightly),
-                    " bytes</b> on nightly at release date."
+                    " bytes</b> on the stable toolchain and <b>",
+                    stringify!($beta),
+                    " bytes</b> on beta toolchain at release date."
                 )
             };
         }
@@ -40,15 +40,13 @@ macro_rules! size_test {
         #[cfg_attr(not(icu4x_run_size_tests), ignore)]
         fn $id() {
             let size = core::mem::size_of::<$ty>();
-            let success = if cfg!(not(icu4x_run_size_tests)) {
+            let success = match option_env!("CI_TOOLCHAIN") {
                 // Manual invocation: match either size
-                matches!(size, $pinned | $nightly)
-            } else if option_env!("ICU4X_BUILDING_WITH_FORCED_NIGHTLY").is_some() {
-                // CI invocation: match nightly size
-                size == $nightly
-            } else {
-                // CI invocation: match pinned stable size
-                size == $pinned
+                None => matches!(size, $pinned | $beta),
+                Some("beta") => size == $beta,
+                Some("pinned-stable") => size == $pinned,
+                // nightly, don't care
+                _ => true,
             };
             assert!(
                 success,
@@ -64,7 +62,7 @@ macro_rules! size_test {
                 concat!(
                     "📏 This item has a stack size of <b>",
                     stringify!($size),
-                    " bytes</b> in the default ICU4X Rust stable toolchain."
+                    " bytes</b> on the stable toolchain at release date."
                 )
             };
         }

--- a/docs/tutorials/c-tiny/fixeddecimal/Makefile
+++ b/docs/tutorials/c-tiny/fixeddecimal/Makefile
@@ -11,13 +11,13 @@ FORCE:
 ICU_CAPI := $(shell cargo metadata --manifest-path Cargo.toml --format-version 1 | jq '.packages[] | select(.name == "icu_capi").manifest_path' | xargs dirname)
 HEADERS := ${ICU_CAPI}/bindings/c
 ALL_HEADERS := $(wildcard ${HEADERS}/*)
-ICU4X_NIGHTLY_TOOLCHAIN ?= "nightly-2022-12-26"
 
 $(ALL_HEADERS):
 
 GCC := gcc
-CLANG := clang-15
-LLD := lld-15
+CLANG := clang-16
+LLD := lld-16
+LLVM_COMPATIBLE_NIGHTLY = "nightly-2023-08-08"
 
 baked_data/macros.rs:
 	cargo build -p icu_datagen --features icu_datagen
@@ -27,17 +27,17 @@ target/debug/libicu_capi.a: FORCE
 	cargo rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/icu_decimal,icu_capi/std
 
 target/x86_64-unknown-linux-gnu/debug/libicu_capi.a: FORCE baked_data/macros.rs
-	rustup toolchain install ${ICU4X_NIGHTLY_TOOLCHAIN}
-	rustup component add rust-src --toolchain ${ICU4X_NIGHTLY_TOOLCHAIN}
+	rustup toolchain install ${LLVM_COMPATIBLE_NIGHTLY}
+	rustup component add rust-src --toolchain ${LLVM_COMPATIBLE_NIGHTLY}
 	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" ICU4X_DATA_DIR=$(shell pwd)/baked_data \
-	cargo +${ICU4X_NIGHTLY_TOOLCHAIN} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/icu_decimal,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
+	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/icu_decimal,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
 	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu
 
 target/x86_64-unknown-linux-gnu/release/libicu_capi.a: FORCE baked_data/macros.rs
-	rustup toolchain install ${ICU4X_NIGHTLY_TOOLCHAIN}
-	rustup component add rust-src --toolchain ${ICU4X_NIGHTLY_TOOLCHAIN}
+	rustup toolchain install ${LLVM_COMPATIBLE_NIGHTLY}
+	rustup component add rust-src --toolchain ${LLVM_COMPATIBLE_NIGHTLY}
 	RUSTFLAGS="-Clto -Cembed-bitcode -Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort -Copt-level=s" ICU4X_DATA_DIR=$(shell pwd)/baked_data \
-	cargo +${ICU4X_NIGHTLY_TOOLCHAIN} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/icu_decimal,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
+	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/icu_decimal,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
 	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release
 
 # Naive target: no optimizations, full std

--- a/docs/tutorials/c-tiny/segmenter/Makefile
+++ b/docs/tutorials/c-tiny/segmenter/Makefile
@@ -11,29 +11,29 @@ FORCE:
 ICU_CAPI := $(shell cargo metadata --manifest-path Cargo.toml --format-version 1 | jq '.packages[] | select(.name == "icu_capi").manifest_path' | xargs dirname)
 HEADERS := ${ICU_CAPI}/bindings/c
 ALL_HEADERS := $(wildcard ${HEADERS}/*)
-ICU4X_NIGHTLY_TOOLCHAIN ?= "nightly-2022-12-26"
 
 $(ALL_HEADERS):
 
 GCC := gcc
-CLANG := clang-15
-LLD := lld-15
+CLANG := clang-16
+LLD := lld-16
+LLVM_COMPATIBLE_NIGHTLY = "nightly-2023-08-08"
 
 target/debug/libicu_capi.a: FORCE
 	cargo rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/icu_segmenter,icu_capi/std
 
 target/x86_64-unknown-linux-gnu/debug/libicu_capi.a: FORCE
-	rustup toolchain install ${ICU4X_NIGHTLY_TOOLCHAIN}
-	rustup component add rust-src --toolchain ${ICU4X_NIGHTLY_TOOLCHAIN}
+	rustup toolchain install ${LLVM_COMPATIBLE_NIGHTLY}
+	rustup component add rust-src --toolchain ${LLVM_COMPATIBLE_NIGHTLY}
 	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" \
-	cargo +${ICU4X_NIGHTLY_TOOLCHAIN} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/icu_segmenter,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
+	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/icu_segmenter,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
 	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu
 
 target/x86_64-unknown-linux-gnu/release/libicu_capi.a: FORCE
-	rustup toolchain install ${ICU4X_NIGHTLY_TOOLCHAIN}
-	rustup component add rust-src --toolchain ${ICU4X_NIGHTLY_TOOLCHAIN}
+	rustup toolchain install ${LLVM_COMPATIBLE_NIGHTLY}
+	rustup component add rust-src --toolchain ${LLVM_COMPATIBLE_NIGHTLY}
 	RUSTFLAGS="-Clto -Cembed-bitcode -Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort -Copt-level=s" \
-	cargo +${ICU4X_NIGHTLY_TOOLCHAIN} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/icu_segmenter,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
+	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/icu_segmenter,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
 	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release
 
 # Naive target: no optimizations, full std

--- a/docs/tutorials/gn/gn.toml
+++ b/docs/tutorials/gn/gn.toml
@@ -4,6 +4,12 @@
 
 # This is a cargo-make file included in the toplevel Makefile.toml
 
+[env]
+# To install a specific build of GN, set the ICU4X_GN_PACKAGE environment variable. Choices:
+# https://chrome-infra-packages.appspot.com/p/gn/gn
+# TODO: Choose the correct distribution of GN automatically.
+ICU4X_GN_PACKAGE = { value = "gn/gn/linux-amd64", condition = { env_not_set = ["ICU4X_GN_PACKAGE"] } }
+
 [tasks.gn-install]
 description = "Install tools required for GN locally in the icu4x project"
 category = "ICU4X Development"

--- a/docs/tutorials/gn/gn.toml
+++ b/docs/tutorials/gn/gn.toml
@@ -141,7 +141,7 @@ assert ${third_party_tools} "The GN third-party tools are not installed.\n*** Pl
 cd docs/tutorials/gn
 
 exec --fail-on-error ./third_party_tools/bin/gn gen --root=../../.. out/host
-exec --fail-on-error rustup run ${ICU4X_NIGHTLY_TOOLCHAIN} ./third_party_tools/depot_tools/ninja -C out/host
+exec --fail-on-error rustup run ${PINNED_CI_NIGHTLY} ./third_party_tools/depot_tools/ninja -C out/host
 '''
 
 [tasks.gn-build-wasi]
@@ -161,10 +161,10 @@ assert ${third_party_tools} "The GN third-party tools are not installed.\n*** Pl
 
 cd docs/tutorials/gn
 
-exec --fail-on-error rustup target add wasm32-wasi --toolchain ${ICU4X_NIGHTLY_TOOLCHAIN}
+exec --fail-on-error rustup target add wasm32-wasi --toolchain ${PINNED_CI_NIGHTLY}
 
 exec --fail-on-error ./third_party_tools/bin/gn gen --root=../../.. --args=target_os="wasi" out/wasi
-exec --fail-on-error rustup run ${ICU4X_NIGHTLY_TOOLCHAIN} ./third_party_tools/depot_tools/ninja -C out/wasi
+exec --fail-on-error rustup run ${PINNED_CI_NIGHTLY} ./third_party_tools/depot_tools/ninja -C out/wasi
 '''
 
 [tasks.gn-run]

--- a/docs/tutorials/js-tiny/Makefile
+++ b/docs/tutorials/js-tiny/Makefile
@@ -8,7 +8,7 @@ FORCE:
 ICU_CAPI := $(shell cargo metadata --format-version 1 | jq '.packages[] | select(.name == "icu_capi").manifest_path' | xargs dirname)
 HEADERS := ${ICU_CAPI}/bindings/js
 ALL_HEADERS := $(wildcard ${HEADERS}/*)
-ICU4X_NIGHTLY_TOOLCHAIN ?= "nightly-2022-12-26"
+PINNED_CI_NIGHTLY ?= "nightly-2022-12-26"
 
 $(ALL_HEADERS):
 
@@ -26,11 +26,11 @@ diplomat.config.mjs:
 	echo "export default { wasm_path: new URL('target/wasm32-unknown-unknown/release/icu_capi.wasm', import.meta.url) };" > diplomat.config.mjs
 
 target/wasm32-unknown-unknown/release/icu_capi.wasm: FORCE
-	rustup toolchain install ${ICU4X_NIGHTLY_TOOLCHAIN}
-	rustup component add rust-src --toolchain ${ICU4X_NIGHTLY_TOOLCHAIN}
+	rustup toolchain install ${PINNED_CI_NIGHTLY}
+	rustup component add rust-src --toolchain ${PINNED_CI_NIGHTLY}
 	# Build the WASM library
 	RUSTFLAGS="-Cpanic=abort -Copt-level=s -C link-arg=-zstack-size=${WASM_STACK_SIZE} -Clinker-plugin-lto -Ccodegen-units=1 -C linker=${BASEDIR}/ld.py -C linker-flavor=wasm-ld -Clto -Cembed-bitcode" \
-	cargo +${ICU4X_NIGHTLY_TOOLCHAIN} rustc \
+	cargo +${PINNED_CI_NIGHTLY} rustc \
 		-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort \
 		--target wasm32-unknown-unknown \
 		-p icu_capi \

--- a/ffi/npm/Makefile
+++ b/ffi/npm/Makefile
@@ -5,7 +5,7 @@
 .DEFAULT_GOAL := build
 FORCE:
 
-ICU4X_NIGHTLY_TOOLCHAIN ?= "nightly-2022-12-26"
+PINNED_CI_NIGHTLY ?= "nightly-2022-12-26"
 
 # 100 KiB, working around a bug in older rustc
 # https://github.com/unicode-org/icu4x/issues/2753
@@ -16,10 +16,10 @@ lib/index.mjs:
 	cp -r ../capi/bindings/js lib
 
 ../../target/wasm32-unknown-unknown/release/icu_capi.wasm: FORCE
-	rustup toolchain install ${ICU4X_NIGHTLY_TOOLCHAIN}
-	rustup component add rust-src --toolchain ${ICU4X_NIGHTLY_TOOLCHAIN}
+	rustup toolchain install ${PINNED_CI_NIGHTLY}
+	rustup component add rust-src --toolchain ${PINNED_CI_NIGHTLY}
 	RUSTFLAGS="-Cpanic=abort -Copt-level=s -C link-args=-zstack-size=${WASM_STACK_SIZE} -Clto -Cembed-bitcode" \
-	cargo +${ICU4X_NIGHTLY_TOOLCHAIN} rustc \
+	cargo +${PINNED_CI_NIGHTLY} rustc \
 		-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort \
 		--target wasm32-unknown-unknown \
 		--release \

--- a/tools/ffi_coverage/src/main.rs
+++ b/tools/ffi_coverage/src/main.rs
@@ -98,6 +98,10 @@ fn collect_public_types(krate: &str) -> impl Iterator<Item = (Vec<String>, ast::
 
         if CRATES.get(krate).is_none() {
             eprintln!("Parsing crate {krate}");
+            std::process::Command::new("rustup")
+                .args(["install", "nightly-2022-12-26"])
+                .output()
+                .expect("failed to install nightly");
             let output = std::process::Command::new("rustup")
                 .args([
                     "run",

--- a/tools/make/ffi.toml
+++ b/tools/make/ffi.toml
@@ -132,8 +132,6 @@ args = ["run", "-p", "diplomat-gen", "dart"]
 [tasks.diplomat-coverage]
 description = "Produces the list of ICU APIs that are not exported through Diplomat"
 category = "ICU4X Development"
-condition = { env_not_set = ["ICU4X_BUILDING_WITH_FORCED_NIGHTLY"] }
-dependencies = ["install-nightly"]
 command = "cargo"
 args = ["run", "-p=icu_ffi_coverage", "--", "ffi/capi/tests/missing_apis.txt"]
 

--- a/tools/make/ffi.toml
+++ b/tools/make/ffi.toml
@@ -65,7 +65,7 @@ exec --fail-on-error dart --enable-experiment=native-assets test
 description = "Build ICU4X CAPI for Cortex"
 category = "ICU4X FFI"
 dependencies = ["install-cortex-8-nightly"]
-toolchain = "${ICU4X_NIGHTLY_TOOLCHAIN}"
+toolchain = "${PINNED_CI_NIGHTLY}"
 env = { RUSTFLAGS = "-Ctarget-cpu=cortex-m33 -Cpanic=abort -Copt-level=s" }
 command = "cargo"
 args = ["check", "--package", "icu_freertos",
@@ -152,19 +152,19 @@ end
 # Install tasks
 
 [tasks.install-nightly]
-description = "Installs $ICU4X_NIGHTLY_TOOLCHAIN"
+description = "Installs $PINNED_CI_NIGHTLY"
 category = "ICU4X Development"
 script_runner = "@duckscript"
 script = '''
-exec --fail-on-error rustup install ${ICU4X_NIGHTLY_TOOLCHAIN} --profile minimal
-exec --fail-on-error rustup component add rust-src --toolchain ${ICU4X_NIGHTLY_TOOLCHAIN}
+exec --fail-on-error rustup install ${PINNED_CI_NIGHTLY} --profile minimal
+exec --fail-on-error rustup component add rust-src --toolchain ${PINNED_CI_NIGHTLY}
 '''
 
 [tasks.install-unknown-linux-nightly]
 description = "Installs the unknown-linux target"
 category = "ICU4X Development"
 dependencies = ["install-nightly"]
-toolchain = "${ICU4X_NIGHTLY_TOOLCHAIN}"
+toolchain = "${PINNED_CI_NIGHTLY}"
 command = "rustup"
 args = ["target", "add", "x86_64-unknown-linux-gnu"]
 
@@ -172,7 +172,7 @@ args = ["target", "add", "x86_64-unknown-linux-gnu"]
 description = "Installs the emscripten target"
 category = "ICU4X Development"
 dependencies = ["install-nightly"]
-toolchain = "${ICU4X_NIGHTLY_TOOLCHAIN}"
+toolchain = "${PINNED_CI_NIGHTLY}"
 command = "rustup"
 args = ["target", "add", "wasm32-unknown-emscripten"]
 
@@ -180,7 +180,7 @@ args = ["target", "add", "wasm32-unknown-emscripten"]
 description = "Installs the wasm target"
 category = "ICU4X Development"
 dependencies = ["install-nightly"]
-toolchain = "${ICU4X_NIGHTLY_TOOLCHAIN}"
+toolchain = "${PINNED_CI_NIGHTLY}"
 command = "rustup"
 args = ["target", "add", "wasm32-unknown-unknown"]
 
@@ -188,6 +188,6 @@ args = ["target", "add", "wasm32-unknown-unknown"]
 description = "Install the thumbv8m target"
 category = "ICU4X FFI"
 dependencies = ["install-nightly"]
-toolchain = "${ICU4X_NIGHTLY_TOOLCHAIN}"
+toolchain = "${PINNED_CI_NIGHTLY}"
 command = "rustup"
 args = ["target", "add", "thumbv8m.main-none-eabihf"]

--- a/tools/make/ffi.toml
+++ b/tools/make/ffi.toml
@@ -16,7 +16,7 @@ args = ["-C", "docs/tutorials/c", "test"]
 description = "Run C API tests for tiny targets"
 category = "ICU4X Development"
 condition = { env_not_set = ["ICU4X_BUILDING_WITH_FORCED_NIGHTLY"] }
-dependencies = ["install-nightly", "install-unknown-linux"]
+dependencies = ["install-unknown-linux-nightly"]
 script_runner = "@duckscript"
 script = '''
 exit_on_error true
@@ -36,7 +36,7 @@ args = ["-C", "docs/tutorials/cpp", "test"]
 [tasks.test-npm]
 description = "Run JS tests"
 category = "ICU4X Development"
-dependencies = ["install-nightly", "install-wasm"]
+dependencies = ["install-wasm-nightly"]
 command = "npm"
 args = ["-C", "ffi/npm", "install-ci-test"]
 
@@ -44,7 +44,7 @@ args = ["-C", "ffi/npm", "install-ci-test"]
 description = "Test the Tiny WASM example"
 category = "ICU4X Development"
 condition = { env_not_set = ["ICU4X_BUILDING_WITH_FORCED_NIGHTLY"] }
-dependencies = ["install-nightly", "install-wasm"]
+dependencies = ["install-wasm-nightly"]
 command = "make"
 args = ["-C", "docs/tutorials/js-tiny", "test"]
 
@@ -66,7 +66,7 @@ exec --fail-on-error dart --enable-experiment=native-assets test
 [tasks.check-freertos-wearos]
 description = "Build ICU4X CAPI for Cortex"
 category = "ICU4X FFI"
-dependencies = ["install-nightly", "install-cortex-8"]
+dependencies = ["install-cortex-8-nightly"]
 toolchain = "${ICU4X_NIGHTLY_TOOLCHAIN}"
 env = { RUSTFLAGS = "-Ctarget-cpu=cortex-m33 -Cpanic=abort -Copt-level=s" }
 command = "cargo"
@@ -155,28 +155,40 @@ end
 
 # Install tasks
 
-[tasks.install-unknown-linux]
+[tasks.install-nightly]
+description = "Installs $ICU4X_NIGHTLY_TOOLCHAIN"
+category = "ICU4X Development"
+script_runner = "@duckscript"
+script = '''
+exec --fail-on-error rustup install ${ICU4X_NIGHTLY_TOOLCHAIN} --profile minimal
+exec --fail-on-error rustup component add rust-src --toolchain ${ICU4X_NIGHTLY_TOOLCHAIN}
+'''
+
+[tasks.install-unknown-linux-nightly]
 description = "Installs the unknown-linux target"
 category = "ICU4X Development"
 dependencies = ["install-nightly"]
+toolchain = "${ICU4X_NIGHTLY_TOOLCHAIN}"
 command = "rustup"
-args = ["target", "add", "x86_64-unknown-linux-gnu", "--toolchain=${ICU4X_NIGHTLY_TOOLCHAIN}"]
+args = ["target", "add", "x86_64-unknown-linux-gnu"]
 
-[tasks.install-emscripten]
+[tasks.install-emscripten-nightly]
 description = "Installs the emscripten target"
 category = "ICU4X Development"
 dependencies = ["install-nightly"]
+toolchain = "${ICU4X_NIGHTLY_TOOLCHAIN}"
 command = "rustup"
-args = ["target", "add", "wasm32-unknown-emscripten", "--toolchain=${ICU4X_NIGHTLY_TOOLCHAIN}"]
+args = ["target", "add", "wasm32-unknown-emscripten"]
 
-[tasks.install-wasm]
+[tasks.install-wasm-nightly]
 description = "Installs the wasm target"
 category = "ICU4X Development"
 dependencies = ["install-nightly"]
+toolchain = "${ICU4X_NIGHTLY_TOOLCHAIN}"
 command = "rustup"
-args = ["target", "add", "wasm32-unknown-unknown", "--toolchain=${ICU4X_NIGHTLY_TOOLCHAIN}"]
+args = ["target", "add", "wasm32-unknown-unknown"]
 
-[tasks.install-cortex-8]
+[tasks.install-cortex-8-nightly]
 description = "Install the thumbv8m target"
 category = "ICU4X FFI"
 dependencies = ["install-nightly"]

--- a/tools/make/ffi.toml
+++ b/tools/make/ffi.toml
@@ -15,7 +15,6 @@ args = ["-C", "docs/tutorials/c", "test"]
 [tasks.test-c-tiny]
 description = "Run C API tests for tiny targets"
 category = "ICU4X Development"
-condition = { env_not_set = ["ICU4X_BUILDING_WITH_FORCED_NIGHTLY"] }
 dependencies = ["install-unknown-linux-nightly"]
 script_runner = "@duckscript"
 script = '''
@@ -43,7 +42,6 @@ args = ["-C", "ffi/npm", "install-ci-test"]
 [tasks.test-tinywasm]
 description = "Test the Tiny WASM example"
 category = "ICU4X Development"
-condition = { env_not_set = ["ICU4X_BUILDING_WITH_FORCED_NIGHTLY"] }
 dependencies = ["install-wasm-nightly"]
 command = "make"
 args = ["-C", "docs/tutorials/js-tiny", "test"]

--- a/tools/make/wasm.toml
+++ b/tools/make/wasm.toml
@@ -22,9 +22,9 @@ exit_on_error true
 # https://github.com/unicode-org/icu4x/issues/2753
 set_env RUSTFLAGS "-Clink-args=-zstack-size=100000"
 command = set "build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target wasm32-unknown-unknown --profile=release-opt-size --examples --workspace --features serde --exclude icu_datagen --exclude icu_capi"
-exec --fail-on-error cargo +${ICU4X_NIGHTLY_TOOLCHAIN} %{command}
+exec --fail-on-error cargo +${PINNED_CI_NIGHTLY} %{command}
 # Re-run the build command only to generate the JSON output
-output = exec --fail-on-error cargo +${ICU4X_NIGHTLY_TOOLCHAIN} %{command} --message-format=json
+output = exec --fail-on-error cargo +${PINNED_CI_NIGHTLY} %{command} --message-format=json
 
 # Parse the JSON messages from --message-format=json line by line
 trimmed_stdout = trim ${output.stdout}


### PR DESCRIPTION
* Decoupling `diplomat-coverage` from pinned nightly
  * It is written for a specific nightly version and we can run with that for the time being
* Decoupling `test-c-tiny` from pinned nightly
  * It requires using a toolchain with an old LLVM version
  * Updated to LLVM 16
* Run full CI in forced-nightly mode
  * We really want to know if FFI builds break with a new nightly 
  * This lets us easily bump pinned nightly because we know for each nightly if it works
* Call out beta instead of nightly sizes in docs
  * This is more useful for users, as beta will become stable, whereas anything can happen to nightly 