### PR TITLE
chore: update SPDX and copyright year

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ authors = ["The ICU4X Project Developers"]
 edition = "2021"
 repository = "https://github.com/unicode-org/icu4x"
 homepage = "https://icu4x.unicode.org"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 categories = ["internationalization"]
 include = [
     "data/**/*",

--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ ICU4X will provide an ECMA-402-compatible API surface in the target client-side 
 
 ## Licensing and Copyright
 
-Copyright © 2020-2023 Unicode, Inc. Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the United States and other countries.
+Copyright © 2020-2024 Unicode, Inc. Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the United States and other countries.
 
-The project is released under [LICENSE](./LICENSE), the free and open-source [Unicode License](https://www.unicode.org/license.txt), which is based on the well-known MIT license, with the primary difference being that the Unicode License expressly covers data and data files, as well as code. For further information please see [The Unicode Consortium Intellectual Property, Licensing, and Technical Contribution Policies](https://www.unicode.org/policies/licensing_policy.html). 
+The project is released under [LICENSE](./LICENSE), the free and open-source [Unicode License](https://www.unicode.org/license.txt), which is based on the well-known MIT license, with the primary difference being that the Unicode License expressly covers data and data files, as well as code. For further information please see [The Unicode Consortium Intellectual Property, Licensing, and Technical Contribution Policies](https://www.unicode.org/policies/licensing_policy.html).
 
 A CLA is required to contribute to this project - please refer to the [CONTRIBUTING.md](./CONTRIBUTING.md) file (or start a Pull Request) for more information.

--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_calendar"
 description = "API for supporting various types of calendars"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/calendar/LICENSE
+++ b/components/calendar/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/casemap/Cargo.toml
+++ b/components/casemap/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_casemap"
 description = "Unicode case mapping and folding algorithms"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/casemap/LICENSE
+++ b/components/casemap/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/collator/Cargo.toml
+++ b/components/collator/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_collator"
 description = "API for comparing strings according to language-dependent conventions"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/collator/LICENSE
+++ b/components/collator/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/collator/fuzz/LICENSE
+++ b/components/collator/fuzz/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/collections/Cargo.toml
+++ b/components/collections/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_collections"
 description = "Collection of API for use in ICU libraries."
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/collections/LICENSE
+++ b/components/collections/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/collections/codepointtrie_builder/Cargo.toml
+++ b/components/collections/codepointtrie_builder/Cargo.toml
@@ -6,7 +6,7 @@
 name = "icu_codepointtrie_builder"
 description = "Runtime builder for CodePointTrie"
 version = "0.3.7"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 include = [
     "src/**/*",
     "examples/**/*",

--- a/components/collections/codepointtrie_builder/LICENSE
+++ b/components/collections/codepointtrie_builder/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/collections/src/char16trie/LICENSE
+++ b/components/collections/src/char16trie/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/collections/src/codepointinvlist/LICENSE
+++ b/components/collections/src/codepointinvlist/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/collections/src/codepointtrie/LICENSE
+++ b/components/collections/src/codepointtrie/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_datetime"
 description = "API for formatting date and time to user readable textual representation"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/datetime/LICENSE
+++ b/components/datetime/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_decimal"
 description = "API for formatting basic decimal numbers in a locale-sensitive way"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/decimal/LICENSE
+++ b/components/decimal/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/icu/Cargo.toml
+++ b/components/icu/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu"
 description = "International Components for Unicode"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/icu/LICENSE
+++ b/components/icu/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/list/Cargo.toml
+++ b/components/list/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_list"
 description = "ECMA-402 ListFormatter"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/list/LICENSE
+++ b/components/list/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_locid"
 description = "API for managing Unicode Language and Locale Identifiers"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/locid/LICENSE
+++ b/components/locid/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/locid_transform/Cargo.toml
+++ b/components/locid_transform/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_locid_transform"
 description = "API for Unicode Language and Locale Identifiers canonicalization"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/locid_transform/LICENSE
+++ b/components/locid_transform/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/normalizer/Cargo.toml
+++ b/components/normalizer/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_normalizer"
 description = "API for normalizing text into Unicode Normalization Forms"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 version = "1.4.1"
 rust-version.workspace = true

--- a/components/normalizer/LICENSE
+++ b/components/normalizer/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/normalizer/fuzz/LICENSE
+++ b/components/normalizer/fuzz/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_plurals"
 description = "Unicode Plural Rules categorizer for numeric input"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/plurals/LICENSE
+++ b/components/plurals/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/properties/Cargo.toml
+++ b/components/properties/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_properties"
 description = "Definitions for Unicode properties"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/properties/LICENSE
+++ b/components/properties/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/segmenter/Cargo.toml
+++ b/components/segmenter/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_segmenter"
 description = "Unicode line breaking and text segmentation algorithms for text boundaries analysis"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/segmenter/LICENSE
+++ b/components/segmenter/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/components/timezone/Cargo.toml
+++ b/components/timezone/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_timezone"
 description = "API for resolving and manipulating time zone information"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/timezone/LICENSE
+++ b/components/timezone/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/docs/tutorials/gn/LICENSE
+++ b/docs/tutorials/gn/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/experimental/bies/Cargo.toml
+++ b/experimental/bies/Cargo.toml
@@ -6,7 +6,7 @@
 name = "bies"
 description = "Helpers for dealing with BIES vectors with text segmentation applications"
 version = "0.2.1"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 edition.workspace = true

--- a/experimental/bies/LICENSE
+++ b/experimental/bies/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/experimental/components/Cargo.toml
+++ b/experimental/components/Cargo.toml
@@ -6,7 +6,7 @@
 name = "icu_experimental"
 description = "ICU4X pre-release components under active development; all code in this crate is unstable."
 version = "0.0.0"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/experimental/components/LICENSE
+++ b/experimental/components/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/experimental/ecma402/Cargo.toml
+++ b/experimental/ecma402/Cargo.toml
@@ -6,7 +6,7 @@
 name = "icu4x_ecma402"
 description = "ECMA-402 API functionality backed by the ICU4X library"
 version = "0.8.1"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/experimental/ecma402/LICENSE
+++ b/experimental/ecma402/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/experimental/harfbuzz/Cargo.toml
+++ b/experimental/harfbuzz/Cargo.toml
@@ -6,7 +6,7 @@
 name = "icu_harfbuzz"
 description = "HarfBuzz glue code for ICU4X"
 version = "0.1.2"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/experimental/harfbuzz/LICENSE
+++ b/experimental/harfbuzz/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/experimental/ixdtf/Cargo.toml
+++ b/experimental/ixdtf/Cargo.toml
@@ -6,7 +6,7 @@
 name = "ixdtf"
 description = "Parser for Internet eXtended DateTime Format"
 version = "0.1.0"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/experimental/ixdtf/LICENSE
+++ b/experimental/ixdtf/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/experimental/zerotrie/Cargo.toml
+++ b/experimental/zerotrie/Cargo.toml
@@ -6,7 +6,7 @@
 name = "zerotrie"
 description = "A data structure that efficiently maps strings to integers"
 version = "0.1.2"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 rust-version.workspace = true
 authors.workspace = true

--- a/experimental/zerotrie/LICENSE
+++ b/experimental/zerotrie/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_capi"
 description = "C interface to ICU4X"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 include = [
     "bindings/**/*",
     "!bindings/dart/**/*", # not yet stable

--- a/ffi/capi/LICENSE
+++ b/ffi/capi/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/ffi/dart/tools/datagen/Cargo.toml
+++ b/ffi/dart/tools/datagen/Cargo.toml
@@ -13,7 +13,7 @@ authors.workspace = true
 edition.workspace = true
 repository.workspace = true
 homepage.workspace = true
-license-file.workspace = true
+license.workspace = true
 categories.workspace = true
 include.workspace = true
 

--- a/ffi/dart/tools/datagen/LICENSE
+++ b/ffi/dart/tools/datagen/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/ffi/freertos/Cargo.toml
+++ b/ffi/freertos/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_freertos"
 description = "C interface to ICU4X"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 include = [
     "build.rs",
     "src/**/*",

--- a/ffi/freertos/LICENSE
+++ b/ffi/freertos/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/adapters/Cargo.toml
+++ b/provider/adapters/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_provider_adapters"
 description = "Adapters for composing and manipulating data providers."
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/provider/adapters/LICENSE
+++ b/provider/adapters/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/baked/calendar/Cargo.toml
+++ b/provider/baked/calendar/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_calendar_data"
 description = "Data for the icu_calendar crate"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 version = "1.4.0"
 
 authors.workspace = true

--- a/provider/baked/calendar/LICENSE
+++ b/provider/baked/calendar/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/baked/casemap/Cargo.toml
+++ b/provider/baked/casemap/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_casemap_data"
 description = "Data for the icu_casemap crate"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 version = "1.4.0"
 
 authors.workspace = true

--- a/provider/baked/casemap/LICENSE
+++ b/provider/baked/casemap/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/baked/collator/Cargo.toml
+++ b/provider/baked/collator/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_collator_data"
 description = "Data for the icu_collator crate"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 version = "1.4.0"
 
 authors.workspace = true

--- a/provider/baked/collator/LICENSE
+++ b/provider/baked/collator/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/baked/datetime/Cargo.toml
+++ b/provider/baked/datetime/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_datetime_data"
 description = "Data for the icu_datetime crate"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 version = "1.4.0"
 
 authors.workspace = true

--- a/provider/baked/datetime/LICENSE
+++ b/provider/baked/datetime/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/baked/decimal/Cargo.toml
+++ b/provider/baked/decimal/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_decimal_data"
 description = "Data for the icu_decimal crate"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 version = "1.4.0"
 
 authors.workspace = true

--- a/provider/baked/decimal/LICENSE
+++ b/provider/baked/decimal/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/baked/experimental/Cargo.toml
+++ b/provider/baked/experimental/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_experimental_data"
 description = "Data for the icu_experimental crate"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 version = "0.0.0"
 
 authors.workspace = true

--- a/provider/baked/experimental/LICENSE
+++ b/provider/baked/experimental/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/baked/list/Cargo.toml
+++ b/provider/baked/list/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_list_data"
 description = "Data for the icu_list crate"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 version = "1.4.0"
 
 authors.workspace = true

--- a/provider/baked/list/LICENSE
+++ b/provider/baked/list/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/baked/locid_transform/Cargo.toml
+++ b/provider/baked/locid_transform/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_locid_transform_data"
 description = "Data for the icu_locid_transform crate"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 version = "1.4.0"
 
 authors.workspace = true

--- a/provider/baked/locid_transform/LICENSE
+++ b/provider/baked/locid_transform/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/baked/normalizer/Cargo.toml
+++ b/provider/baked/normalizer/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_normalizer_data"
 description = "Data for the icu_normalizer crate"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 version = "1.4.0"
 
 authors.workspace = true

--- a/provider/baked/normalizer/LICENSE
+++ b/provider/baked/normalizer/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/baked/plurals/Cargo.toml
+++ b/provider/baked/plurals/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_plurals_data"
 description = "Data for the icu_plurals crate"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 version = "1.4.0"
 
 authors.workspace = true

--- a/provider/baked/plurals/LICENSE
+++ b/provider/baked/plurals/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/baked/properties/Cargo.toml
+++ b/provider/baked/properties/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_properties_data"
 description = "Data for the icu_properties crate"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 version = "1.4.0"
 
 authors.workspace = true

--- a/provider/baked/properties/LICENSE
+++ b/provider/baked/properties/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/baked/segmenter/Cargo.toml
+++ b/provider/baked/segmenter/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_segmenter_data"
 description = "Data for the icu_segmenter crate"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 version = "1.4.0"
 
 authors.workspace = true

--- a/provider/baked/segmenter/LICENSE
+++ b/provider/baked/segmenter/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/baked/timezone/Cargo.toml
+++ b/provider/baked/timezone/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_timezone_data"
 description = "Data for the icu_timezone crate"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 version = "1.4.0"
 
 authors.workspace = true

--- a/provider/baked/timezone/LICENSE
+++ b/provider/baked/timezone/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/blob/Cargo.toml
+++ b/provider/blob/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_provider_blob"
 description = "ICU4X data provider that reads from blobs in memory"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/provider/blob/LICENSE
+++ b/provider/blob/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_provider"
 description = "Trait and struct definitions for the ICU data provider"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/provider/core/LICENSE
+++ b/provider/core/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/datagen/Cargo.toml
+++ b/provider/datagen/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_datagen"
 description = "Generate data for ICU4X DataProvider"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 include = [
     "data/**/*",
     "src/**/*",

--- a/provider/datagen/LICENSE
+++ b/provider/datagen/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_provider_fs"
 description = "ICU4X data provider that reads from structured data files"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/provider/fs/LICENSE
+++ b/provider/fs/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/macros/Cargo.toml
+++ b/provider/macros/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_provider_macros"
 description = "Proc macros for ICU data providers"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/provider/macros/LICENSE
+++ b/provider/macros/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 readme = "README.md"
 repository = "https://github.com/unicode-org/icu4x"
 homepage = "https://icu4x.unicode.org"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 categories = ["internationalization"]
 # Keep this in sync with other crates unless there are exceptions
 include = [

--- a/provider/testdata/LICENSE
+++ b/provider/testdata/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/tools/bakeddata-scripts/LICENSE
+++ b/tools/bakeddata-scripts/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/tools/bakeddata-scripts/template/Cargo.toml.template
+++ b/tools/bakeddata-scripts/template/Cargo.toml.template
@@ -5,7 +5,7 @@
 [package]
 name = "icu__component__data"
 description = "Data for the icu__component_ crate"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 version = "_version_"
 
 authors.workspace = true

--- a/tools/benchmark/binsize/LICENSE
+++ b/tools/benchmark/binsize/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/tools/benchmark/macros/LICENSE
+++ b/tools/benchmark/macros/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/tools/benchmark/memory/LICENSE
+++ b/tools/benchmark/memory/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/tools/depcheck/LICENSE
+++ b/tools/depcheck/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/tools/diplomat-gen/Cargo.toml
+++ b/tools/diplomat-gen/Cargo.toml
@@ -12,7 +12,7 @@ authors.workspace = true
 edition.workspace = true
 repository.workspace = true
 homepage.workspace = true
-license-file.workspace = true
+license.workspace = true
 categories.workspace = true
 include.workspace = true
 

--- a/tools/diplomat-gen/LICENSE
+++ b/tools/diplomat-gen/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/tools/ffi_coverage/LICENSE
+++ b/tools/ffi_coverage/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/tools/md-tests/LICENSE
+++ b/tools/md-tests/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/tools/testdata-scripts/LICENSE
+++ b/tools/testdata-scripts/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/utils/crlify/Cargo.toml
+++ b/utils/crlify/Cargo.toml
@@ -8,7 +8,7 @@ version = "1.0.3"
 keywords = ["io", "crlf", "windows", "line", "ending"]
 description = "A std::io::Write wrapper that replaces \n with \r\n on Windows."
 documentation = "https://docs.rs/litemap"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 edition.workspace = true

--- a/utils/crlify/LICENSE
+++ b/utils/crlify/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/utils/databake/Cargo.toml
+++ b/utils/databake/Cargo.toml
@@ -8,7 +8,7 @@ description = "Trait that lets structs represent themselves as (const) Rust expr
 version = "0.1.7"
 categories = ["rust-patterns", "memory-management", "development-tools::procedural-macro-helpers", "development-tools::build-utils"]
 keywords = ["zerocopy", "serialization", "const", "proc"]
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 edition.workspace = true

--- a/utils/databake/LICENSE
+++ b/utils/databake/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/utils/databake/derive/Cargo.toml
+++ b/utils/databake/derive/Cargo.toml
@@ -8,7 +8,7 @@ description = "Custom derive for the databake crate"
 version = "0.1.7"
 categories = ["rust-patterns", "memory-management", "development-tools::procedural-macro-helpers", "development-tools::build-utils"]
 keywords = ["zerocopy", "serialization", "const", "proc"]
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 edition.workspace = true

--- a/utils/databake/derive/LICENSE
+++ b/utils/databake/derive/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/utils/deduplicating_array/Cargo.toml
+++ b/utils/deduplicating_array/Cargo.toml
@@ -6,7 +6,7 @@
 name = "deduplicating_array"
 description = "A serde serialization strategy that uses PartialEq to reduce serialized size."
 version = "0.1.5"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 edition.workspace = true

--- a/utils/deduplicating_array/LICENSE
+++ b/utils/deduplicating_array/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -6,7 +6,7 @@
 name = "fixed_decimal"
 description = "An API for representing numbers in a human-readable form"
 version = "0.5.5"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/utils/fixed_decimal/LICENSE
+++ b/utils/fixed_decimal/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.7.2"
 keywords = ["sorted", "vec", "map", "hashmap", "btreemap"]
 description = "A key-value Map implementation based on a flat, sorted Vec."
 documentation = "https://docs.rs/litemap"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 edition.workspace = true

--- a/utils/litemap/LICENSE
+++ b/utils/litemap/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/utils/pattern/Cargo.toml
+++ b/utils/pattern/Cargo.toml
@@ -6,7 +6,7 @@
 name = "icu_pattern"
 description = "ICU pattern utilities"
 version = "0.1.5"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 edition.workspace = true

--- a/utils/pattern/LICENSE
+++ b/utils/pattern/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/utils/resb/Cargo.toml
+++ b/utils/resb/Cargo.toml
@@ -12,7 +12,7 @@ authors.workspace = true
 categories.workspace = true
 edition.workspace = true
 include.workspace = true
-license-file.workspace = true
+license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 

--- a/utils/resb/LICENSE
+++ b/utils/resb/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/utils/tinystr/Cargo.toml
+++ b/utils/tinystr/Cargo.toml
@@ -8,7 +8,7 @@ description = "A small ASCII-only bounded length string representation."
 version = "0.7.5"
 keywords = ["string", "str", "small", "tiny", "no_std"]
 categories = ["data-structures"]
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 edition.workspace = true

--- a/utils/tinystr/LICENSE
+++ b/utils/tinystr/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/utils/tzif/Cargo.toml
+++ b/utils/tzif/Cargo.toml
@@ -8,7 +8,7 @@ description = "A parser for TZif files"
 version = "0.2.2"
 keywords = ["time-zone", "posix", "iana", "parse", "data"]
 categories = ["date-and-time", "parser-implementations"]
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 edition.workspace = true

--- a/utils/tzif/LICENSE
+++ b/utils/tzif/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/utils/writeable/Cargo.toml
+++ b/utils/writeable/Cargo.toml
@@ -6,7 +6,7 @@
 name = "writeable"
 description = "A more efficient alternative to fmt::Display"
 version = "0.5.4"
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 edition.workspace = true

--- a/utils/writeable/LICENSE
+++ b/utils/writeable/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.7.3"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 categories = ["data-structures", "memory-management", "caching", "no-std"]
 keywords = ["zerocopy", "serialization", "lifetime", "borrow", "self-referential"]
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 edition.workspace = true
 include.workspace = true

--- a/utils/yoke/LICENSE
+++ b/utils/yoke/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/utils/yoke/derive/Cargo.toml
+++ b/utils/yoke/derive/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.7.3"
 categories = ["data-structures", "memory-management", "caching", "no-std"]
 keywords = ["zerocopy", "serialization", "lifetime", "borrow", "self-referential"]
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 edition.workspace = true
 repository.workspace = true

--- a/utils/yoke/derive/LICENSE
+++ b/utils/yoke/derive/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/utils/zerofrom/Cargo.toml
+++ b/utils/zerofrom/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.3"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 categories = ["data-structures", "caching", "no-std"]
 keywords = ["zerocopy", "serialization", "lifetime", "borrow"]
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 edition.workspace = true
 include.workspace = true

--- a/utils/zerofrom/LICENSE
+++ b/utils/zerofrom/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/utils/zerofrom/derive/Cargo.toml
+++ b/utils/zerofrom/derive/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.3"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 categories = ["data-structures", "memory-management", "caching", "no-std"]
 keywords = ["zerocopy", "serialization", "lifetime", "borrow"]
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 edition.workspace = true
 repository.workspace = true

--- a/utils/zerofrom/derive/LICENSE
+++ b/utils/zerofrom/derive/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -8,7 +8,7 @@ description = "Zero-copy vector backed by a byte array"
 version = "0.10.1"
 categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
 keywords = ["zerocopy", "serialization", "zero-copy", "serde"]
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 authors.workspace = true
 edition.workspace = true

--- a/utils/zerovec/LICENSE
+++ b/utils/zerovec/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 

--- a/utils/zerovec/derive/Cargo.toml
+++ b/utils/zerovec/derive/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.10.1"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
 keywords = ["zerocopy", "serialization", "zero-copy", "serde"]
-license-file = "LICENSE"
+license = "Unicode-3.0"
 
 edition.workspace = true
 repository.workspace = true

--- a/utils/zerovec/derive/LICENSE
+++ b/utils/zerovec/derive/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2020-2023 Unicode, Inc.
+Copyright © 2020-2024 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -37,6 +37,8 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
 
 —
 


### PR DESCRIPTION
- we can now use license = Unicode-3.0 instead of the LICENSE file
- update all LICENSE files to include the SPDX header

- see: https://github.com/unicode-org/.github/issues/15

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->