### PR TITLE
Enumerated property completeness tests

### DIFF
--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -2525,10 +2525,9 @@ mod test_enumerated_property_completeness {
             })
             .collect();
 
-        let consts: BTreeMap<_, _> = consts
+        let consts = consts
             .into_iter()
-            .map(|(name, value)| (*value, (name.to_string(), "Consts")))
-            .collect();
+            .map(|(name, value)| (*value, (name.to_string(), "Consts")));
 
         let mut diff = Vec::new();
         for t @ (value, _) in consts {

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -2512,10 +2512,7 @@ mod test_enumerated_property_completeness {
         lookup: &PropertyValueNameToEnumMapV1<'_>,
         consts: impl IntoIterator<Item = &'a (&'static str, u16)>,
     ) {
-        let mut data = lookup
-            .map
-            .iter_copied_values()
-            .collect::<Vec<_>>();
+        let mut data = lookup.map.iter_copied_values().collect::<Vec<_>>();
         data.sort_by_key(|(_, v)| *v);
         data.dedup_by_key(|(_, v)| *v); // data may contain multiple entries for the same value
 
@@ -2549,8 +2546,18 @@ mod test_enumerated_property_completeness {
                 }
             }
         }
-        diff.extend(data[data_idx..].iter().map(|(name, val)| (*val, Some(core::str::from_utf8(name.as_byte_slice()).unwrap()), None)));
-        diff.extend(consts[consts_idx..].iter().map(|(n, v)| (*v, None, Some(n))));
+        diff.extend(data[data_idx..].iter().map(|(name, val)| {
+            (
+                *val,
+                Some(core::str::from_utf8(name.as_byte_slice()).unwrap()),
+                None,
+            )
+        }));
+        diff.extend(
+            consts[consts_idx..]
+                .iter()
+                .map(|(n, v)| (*v, None, Some(n))),
+        );
 
         assert!(
             diff.is_empty(),

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -652,7 +652,7 @@ macro_rules! impl_value_getter {
 ///     ...
 /// }
 /// ```
-/// Produces `const ALL_CONSTS = &[("Neutral", EastAsianWidth::Neutral), ...];`
+/// Produces `const ALL_CONSTS = &[(EastAsianWidth::Neutral, "Neutral"), ...];`
 macro_rules! create_const_array {
     (
         $ ( #[$meta:meta] )*

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -667,7 +667,7 @@ macro_rules! create_const_array {
                 $v const $i: $t = $e;
             )*
 
-            #[allow(dead_code)]
+            #[cfg(test)]
             const ALL_CONSTS: &'static [(&'static str, u16)] = &[
                 $((stringify!($i), $enum_ty::$i.0 as u16)),*
             ];

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -2510,7 +2510,7 @@ mod test_enumerated_property_completeness {
 
     fn check_enum<'a>(
         lookup: &PropertyValueNameToEnumMapV1<'_>,
-        consts: impl Iterator<Item = &'a (&'static str, u16)>,
+        consts: impl IntoIterator<Item = &'a (&'static str, u16)>,
     ) {
         let mut data = lookup
             .map
@@ -2519,7 +2519,7 @@ mod test_enumerated_property_completeness {
         data.sort_by_key(|(_, v)| *v);
         data.dedup_by_key(|(_, v)| *v); // data may contain multiple entries for the same value
 
-        let mut consts = consts.collect::<Vec<_>>();
+        let mut consts = consts.into_iter().collect::<Vec<_>>();
         consts.sort_by_key(|(_, v)| *v);
 
         let mut diff = Vec::new();
@@ -2561,7 +2561,7 @@ mod test_enumerated_property_completeness {
     fn test_ea() {
         check_enum(
             crate::provider::Baked::SINGLETON_PROPNAMES_FROM_EA_V1,
-            EastAsianWidth::ALL_CONSTS.iter(),
+            EastAsianWidth::ALL_CONSTS,
         );
     }
 
@@ -2569,7 +2569,7 @@ mod test_enumerated_property_completeness {
     fn test_gc() {
         check_enum(
             crate::provider::Baked::SINGLETON_PROPNAMES_FROM_CCC_V1,
-            CanonicalCombiningClass::ALL_CONSTS.iter(),
+            CanonicalCombiningClass::ALL_CONSTS,
         );
     }
 
@@ -2577,7 +2577,7 @@ mod test_enumerated_property_completeness {
     fn test_jt() {
         check_enum(
             crate::provider::Baked::SINGLETON_PROPNAMES_FROM_JT_V1,
-            JoiningType::ALL_CONSTS.iter(),
+            JoiningType::ALL_CONSTS,
         );
     }
 
@@ -2585,7 +2585,7 @@ mod test_enumerated_property_completeness {
     fn test_insc() {
         check_enum(
             crate::provider::Baked::SINGLETON_PROPNAMES_FROM_INSC_V1,
-            IndicSyllabicCategory::ALL_CONSTS.iter(),
+            IndicSyllabicCategory::ALL_CONSTS,
         );
     }
 
@@ -2593,7 +2593,7 @@ mod test_enumerated_property_completeness {
     fn test_sb() {
         check_enum(
             crate::provider::Baked::SINGLETON_PROPNAMES_FROM_SB_V1,
-            SentenceBreak::ALL_CONSTS.iter(),
+            SentenceBreak::ALL_CONSTS,
         );
     }
 
@@ -2601,7 +2601,7 @@ mod test_enumerated_property_completeness {
     fn test_wb() {
         check_enum(
             crate::provider::Baked::SINGLETON_PROPNAMES_FROM_WB_V1,
-            WordBreak::ALL_CONSTS.iter(),
+            WordBreak::ALL_CONSTS,
         );
     }
 
@@ -2609,7 +2609,7 @@ mod test_enumerated_property_completeness {
     fn test_bc() {
         check_enum(
             crate::provider::Baked::SINGLETON_PROPNAMES_FROM_BC_V1,
-            BidiClass::ALL_CONSTS.iter(),
+            BidiClass::ALL_CONSTS,
         );
     }
 }

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -2549,6 +2549,8 @@ mod test_enumerated_property_completeness {
                 }
             }
         }
+        diff.extend(data[data_idx..].iter().map(|(name, val)| (*val, Some(core::str::from_utf8(name.as_byte_slice()).unwrap()), None)));
+        diff.extend(consts[consts_idx..].iter().map(|(n, v)| (*v, None, Some(n))));
 
         assert!(
             diff.is_empty(),

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -2524,7 +2524,7 @@ mod test_enumerated_property_completeness {
                 Origin::Data => "Data",
                 Origin::Consts => "Consts",
             };
-            write!(f, "{}:\t{:?}\t{:?}", origin, self.name, self.value)
+            write!(f, "{}:\t{:?}:\t{:?}", origin, self.name, self.value)
         }
     }
 

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -2588,7 +2588,7 @@ mod test_enumerated_property_completeness {
     }
 
     #[test]
-    fn test_gc() {
+    fn test_ccc() {
         check_enum(
             crate::provider::Baked::SINGLETON_PROPNAMES_FROM_CCC_V1,
             CanonicalCombiningClass::ALL_CONSTS,


### PR DESCRIPTION
fixes #4283

Description of changes:
- Introduced `create_const_array` macro that produces an array of tuples of the values and names of the constants defined in an impl block.
- Use this constant to iterate over underlying data and report differences.

Example output on modifying `Wide = EastAsianWidth(2); //name="W"` to `EastAsianWidth(52)`:

```
Values defined in data do not match values defined in consts. Difference (value, data name, const name):
 [(5, Some("W"), None), (52, None, Some("Wide"))]
```