### PR TITLE
Handle ?Sized better in ZeroFrom derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@
     - `yoke`
         - Remove `StableDeref` bound from `Yoke<Y, Option<C>>` methods (https://github.com/unicode-org/icu4x/pull/4457)
         - Added `CartableOptionPointer` and function to convert from `Yoke<Y, Option<C>>` (https://github.com/unicode-org/icu4x/pull/4449)\
+    - `zerofrom`
+        - Support `?Sized` type parameters which must be `Sized` to implement `ZeroFrom` (https://github.com/unicode-org/icu4x/pull/4657)
     - `zerotrie`
         - Add `as_borrowed_slice` and `AsRef` impl (https://github.com/unicode-org/icu4x/pull/4381)
         - Add `ZeroTrieSimpleAsciiCursor` for manual iteration (https://github.com/unicode-org/icu4x/pull/4383)

--- a/utils/zerofrom/derive/examples/zf_derive.rs
+++ b/utils/zerofrom/derive/examples/zf_derive.rs
@@ -4,7 +4,7 @@
 
 #![allow(unused)]
 
-use std::borrow::Cow;
+use std::{borrow::Cow, marker::PhantomData};
 use zerofrom::ZeroFrom;
 use zerovec::{maps::ZeroMapKV, ule::AsULE, VarZeroVec, ZeroMap, ZeroVec};
 
@@ -87,27 +87,29 @@ pub enum CloningZF3<'data> {
 }
 
 #[derive(ZeroFrom)]
-#[zerofrom(may_borrow(T))] // instead of treating T as a copy type, we want to allow zerofromming T too
-pub struct GenericsThatAreAlsoZf<T> {
+#[zerofrom(may_borrow(T, Q))] // instead of treating T as a copy type, we want to allow zerofromming T too
+pub struct GenericsThatAreAlsoZf<T, Q: ?Sized, Ignored: ?Sized> {
     x: T,
     y: Option<T>,
+    ignored: PhantomData<Ignored>,
+    q: Q,
 }
 
 pub fn assert_zf_generics_may_borrow<'a, 'b>(
-    x: &'b GenericsThatAreAlsoZf<&'a str>,
-) -> GenericsThatAreAlsoZf<&'b str> {
-    GenericsThatAreAlsoZf::<&'b str>::zero_from(x)
+    x: &'b GenericsThatAreAlsoZf<&'a str, usize, str>,
+) -> GenericsThatAreAlsoZf<&'b str, usize, str> {
+    GenericsThatAreAlsoZf::<&'b str, usize, str>::zero_from(x)
 }
 
 #[derive(ZeroFrom)]
 pub struct UsesGenericsThatAreAlsoZf<'a> {
-    x: GenericsThatAreAlsoZf<&'a str>,
+    x: GenericsThatAreAlsoZf<&'a str, usize, str>,
 }
 
 // Ensure it works with invariant types too
 #[derive(ZeroFrom)]
 pub struct UsesGenericsThatAreAlsoZfWithMap<'a> {
-    x: GenericsThatAreAlsoZf<ZeroMap<'a, str, str>>,
+    x: GenericsThatAreAlsoZf<ZeroMap<'a, str, str>, usize, str>,
 }
 
 fn main() {}

--- a/utils/zerofrom/derive/src/lib.rs
+++ b/utils/zerofrom/derive/src/lib.rs
@@ -133,7 +133,7 @@ fn zf_derive_impl(input: &DeriveInput) -> TokenStream2 {
                 while let Some(bound_pair) = bounds.pop() {
                     let bound = bound_pair.into_value();
                     if let TypeParamBound::Trait(ref trait_bound) = bound {
-                        if trait_bound.path.get_ident() == Some(&quote::format_ident!("Sized"))
+                        if trait_bound.path.get_ident().map(|ident| ident == "Sized") == Some(true)
                             && matches!(trait_bound.modifier, TraitBoundModifier::Maybe(_))
                         {
                             continue;

--- a/utils/zerofrom/derive/src/lib.rs
+++ b/utils/zerofrom/derive/src/lib.rs
@@ -27,7 +27,8 @@ use syn::fold::{self, Fold};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{
-    parse_macro_input, parse_quote, DeriveInput, Ident, Lifetime, MetaList, Path, PathArguments, PathSegment, Token, TraitBoundModifier, Type, TypeParamBound, TypePath, WherePredicate
+    parse_macro_input, parse_quote, DeriveInput, Ident, Lifetime, MetaList, Path, PathArguments,
+    PathSegment, Token, TraitBoundModifier, Type, TypeParamBound, TypePath, WherePredicate,
 };
 use synstructure::Structure;
 mod visitor;
@@ -134,8 +135,11 @@ fn zf_derive_impl(input: &DeriveInput) -> TokenStream2 {
                         let sized: Path = PathSegment {
                             ident: quote::format_ident!("Sized"),
                             arguments: PathArguments::None,
-                        }.into();
-                        if trait_bound.path == sized && matches!(trait_bound.modifier, TraitBoundModifier::Maybe(_)) {
+                        }
+                        .into();
+                        if trait_bound.path == sized
+                            && matches!(trait_bound.modifier, TraitBoundModifier::Maybe(_))
+                        {
                             continue;
                         }
                     }

--- a/utils/zerofrom/derive/src/lib.rs
+++ b/utils/zerofrom/derive/src/lib.rs
@@ -27,8 +27,7 @@ use syn::fold::{self, Fold};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{
-    parse_macro_input, parse_quote, DeriveInput, Ident, Lifetime, MetaList, Token, Type, TypePath,
-    WherePredicate,
+    parse_macro_input, parse_quote, DeriveInput, Ident, Lifetime, MetaList, Path, PathArguments, PathSegment, Token, TraitBoundModifier, Type, TypeParamBound, TypePath, WherePredicate
 };
 use synstructure::Structure;
 mod visitor;
@@ -121,12 +120,27 @@ fn zf_derive_impl(input: &DeriveInput) -> TokenStream2 {
     // a newly introduced mirror type parameter that we are borrowing from, similar to C in the original trait.
     // For convenience, we are calling these "C types"
     let generics_env: HashMap<Ident, Option<Ident>> = tybounds
-        .iter()
+        .iter_mut()
         .map(|param| {
             // First one doesn't work yet https://github.com/rust-lang/rust/issues/114393
             let maybe_new_param = if has_attr(&param.attrs, "may_borrow")
                 || may_borrow_attrs.contains(&param.ident)
             {
+                // Remove `?Sized`` bound because we need a param to be Sized in order to take a ZeroFrom of it
+                let mut bounds = core::mem::take(&mut param.bounds);
+                while let Some(bound_pair) = bounds.pop() {
+                    let bound = bound_pair.into_value();
+                    if let TypeParamBound::Trait(ref trait_bound) = bound {
+                        let sized: Path = PathSegment {
+                            ident: quote::format_ident!("Sized"),
+                            arguments: PathArguments::None,
+                        }.into();
+                        if trait_bound.path == sized && matches!(trait_bound.modifier, TraitBoundModifier::Maybe(_)) {
+                            continue;
+                        }
+                    }
+                    param.bounds.push(bound);
+                }
                 Some(Ident::new(
                     &format!("{}ZFParamC", param.ident),
                     param.ident.span(),

--- a/utils/zerofrom/src/zero_from.rs
+++ b/utils/zerofrom/src/zero_from.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use core::marker::PhantomData;
+
 #[cfg(feature = "alloc")]
 use alloc::borrow::{Cow, ToOwned};
 #[cfg(feature = "alloc")]
@@ -124,5 +126,11 @@ impl<'zf, T> ZeroFrom<'zf, [T]> for &'zf [T] {
     #[inline]
     fn zero_from(other: &'zf [T]) -> &'zf [T] {
         other
+    }
+}
+
+impl<'zf, T: ?Sized + 'zf> ZeroFrom<'zf, PhantomData<T>> for PhantomData<T> {
+    fn zero_from(other: &'zf PhantomData<T>) -> Self {
+        *other
     }
 }


### PR DESCRIPTION
Need this to support the `Store` type parameter, which is `?Sized` but should only implement `ZeroFrom` when it is sized.