### PR TITLE
Create directory for minutes and add 2024-03-14

### DIFF
--- a/docs/minutes/icu4x-tc_2024-03-14.md
+++ b/docs/minutes/icu4x-tc_2024-03-14.md
@@ -1,0 +1,9 @@
+# ICU4X-TC Meeting: 2024-03-14
+
+Present: Google, Amazon
+
+## TC proposal
+
+We create a new WG within ICU4X-TC called ICU4X-WG, the weekly meeting is a WG meeting. The working group behaves the same, where we merge changes, etc. Once before every release we convene an ICU4X-TC meeting in which at least 2 member organizations must attend, where we review the changelog and agree to ship that as a release.
+
+Consensus: Above proposal.


### PR DESCRIPTION
We can use this directory to record official minutes primarily from TC meetings.