### PR TITLE
Fix skeleton matching for weekday symbols

### DIFF
--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -161,6 +161,22 @@ impl FieldSymbol {
     pub(crate) fn discriminant_cmp(&self, other: &Self) -> Ordering {
         self.discriminant_idx().cmp(&other.discriminant_idx())
     }
+
+    /// UTS 35 defines several 1 and 2 symbols to be the same as 3 symbols (abbreviated).
+    /// For example, 'a' represents an abbreviated day period, the same as 'aaa'.
+    ///
+    /// This function maps field lengths 1 and 2 to field length 3.
+    #[cfg(feature = "experimental")]
+    pub(crate) fn is_at_least_abbreviated(&self) -> bool {
+        matches!(
+            self,
+            FieldSymbol::Era
+                | FieldSymbol::Year(Year::Cyclic)
+                | FieldSymbol::Weekday(Weekday::Format)
+                | FieldSymbol::DayPeriod(_)
+                | FieldSymbol::TimeZone(TimeZone::LowerZ | TimeZone::UpperZ)
+        )
+    }
 }
 
 /// [`ULE`](zerovec::ule::ULE) type for [`FieldSymbol`]
@@ -585,8 +601,8 @@ impl LengthType for Weekday {
         match self {
             Self::Format => TextOrNumeric::Text,
             Self::Local | Self::StandAlone => match length {
-                FieldLength::One | FieldLength::TwoDigit => TextOrNumeric::Text,
-                _ => TextOrNumeric::Numeric,
+                FieldLength::One | FieldLength::TwoDigit => TextOrNumeric::Numeric,
+                _ => TextOrNumeric::Text,
             },
         }
     }

--- a/components/datetime/src/skeleton/helpers.rs
+++ b/components/datetime/src/skeleton/helpers.rs
@@ -312,7 +312,17 @@ fn adjust_pattern_field_lengths(fields: &[Field], pattern: &mut runtime::Pattern
                 if requested_field.length != pattern_field.length
                     && requested_field.get_length_type() == pattern_field.get_length_type()
                 {
-                    return Some(PatternItem::Field(*requested_field));
+                    let length = requested_field.length;
+                    #[cfg(feature = "experimental")]
+                    let length = if requested_field.symbol.is_at_least_abbreviated() {
+                        length.numeric_to_abbr()
+                    } else {
+                        length
+                    };
+                    return Some(PatternItem::Field(Field {
+                        length,
+                        ..*pattern_field
+                    }));
                 }
             }
         }

--- a/components/datetime/src/skeleton/mod.rs
+++ b/components/datetime/src/skeleton/mod.rs
@@ -329,6 +329,54 @@ mod test {
         );
     }
 
+    #[test]
+    fn test_skeleton_matching_weekday_short() {
+        let components = components::Bag {
+            weekday: Some(components::Text::Short),
+            ..Default::default()
+        };
+        let requested_fields = components.to_vec_fields();
+        let (_, skeletons) = get_data_payload();
+
+        match get_best_available_format_pattern(skeletons.get(), &requested_fields, false) {
+            BestSkeleton::AllFieldsMatch(available_format_pattern) => {
+                assert_eq!(
+                    available_format_pattern
+                        .expect_pattern("pattern should not have plural variants")
+                        .to_string()
+                        .as_str(),
+                    // Requesting E, CLDR has ccc, should not be shortened to c
+                    "ccc"
+                )
+            }
+            best => panic!("Unexpected {best:?}"),
+        };
+    }
+
+    #[test]
+    fn test_skeleton_matching_weekday_long() {
+        let components = components::Bag {
+            weekday: Some(components::Text::Long),
+            ..Default::default()
+        };
+        let requested_fields = components.to_vec_fields();
+        let (_, skeletons) = get_data_payload();
+
+        match get_best_available_format_pattern(skeletons.get(), &requested_fields, false) {
+            BestSkeleton::AllFieldsMatch(available_format_pattern) => {
+                assert_eq!(
+                    available_format_pattern
+                        .expect_pattern("pattern should not have plural variants")
+                        .to_string()
+                        .as_str(),
+                    // Requesting EEEE, CLDR has ccc, should be lengthened to cccc
+                    "cccc"
+                )
+            }
+            best => panic!("Unexpected {best:?}"),
+        };
+    }
+
     /// Skeletons are represented in bincode as a vec of field, but bincode shouldn't be completely
     /// trusted, test that the bincode gets validated correctly.
     struct TestInvalidSkeleton(Vec<Field>);


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

Because of a bug in determining the LengthType of Weekday fields, they would never be lengthened after skeleton matching. Following that fix, due to the nature of fields with a minimum length of "Abbreviated", some weekday fields would be shortened too much. This PR fixes both those issues.