### PR TITLE
Add .npmrc for Node 18 support

### DIFF
--- a/tutorials/npm/.npmrc
+++ b/tutorials/npm/.npmrc
@@ -1,0 +1,4 @@
+# Please keep this in sync with all other .npmrc files
+# SEE: https://github.com/npm/feedback/discussions/864
+install-links=false
+


### PR DESCRIPTION
See https://github.com/npm/feedback/discussions/864

I don't know why npm changed this behavior. It causes problems with monorepo projects that have relative path dependencies. Luckily I already encountered this issue earlier so I knew the fix.