### PR TITLE
Upgrade to criterion 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,19 +601,19 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
  "anes",
- "atty",
  "cast",
  "ciborium",
- "clap 3.2.25",
+ "clap 4.2.1",
  "criterion-plot",
+ "is-terminal",
  "itertools",
- "lazy_static",
  "num-traits",
+ "once_cell",
  "oorandom",
  "plotters",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,6 +194,9 @@ zerotrie = { version = "0.1.2", path = "utils/zerotrie", default-features = fals
 zerovec = { version = "0.10.1", path = "utils/zerovec", default-features = false }
 zerovec-derive = { version = "0.10.1", path = "utils/zerovec/derive", default-features = false }
 
+# External deps from crates.io
+criterion = { version = "0.5" }
+
 # Tools
 icu_benchmark_macros = { path = "tools/benchmark/macros" }
 # icu_benchmark_binsize never used as a dep

--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -41,7 +41,7 @@ serde = { version = "1.0", features = ["derive", "alloc"] }
 serde_json = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 
 [features]

--- a/components/casemap/Cargo.toml
+++ b/components/casemap/Cargo.toml
@@ -40,7 +40,7 @@ icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 icu_collections = { path = "../../components/collections", features = ["databake"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 [features]
 default = ["compiled_data"]

--- a/components/collator/Cargo.toml
+++ b/components/collator/Cargo.toml
@@ -42,7 +42,7 @@ atoi = "1.0.0"
 icu = { path = "../../components/icu", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 [features]
 default = ["compiled_data"]

--- a/components/collections/Cargo.toml
+++ b/components/collections/Cargo.toml
@@ -39,7 +39,7 @@ icu = { path = "../../components/icu", default-features = false }
 icu_properties = { path = "../../components/properties" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 [features]
 std = []

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -55,7 +55,7 @@ serde_json = "1.0"
 bincode = "1.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 [features]
 default = ["compiled_data"]

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -42,7 +42,7 @@ rand_distr = "0.4"
 getrandom = { version = "0.2", features = ["js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 [features]
 default = ["compiled_data"]

--- a/components/experimental/Cargo.toml
+++ b/components/experimental/Cargo.toml
@@ -54,7 +54,7 @@ icu_experimental_data = { workspace = true, optional = true }
 icu_locid_transform = { workspace = true, optional = true, features = ["compiled_data"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4.0"
+criterion = { workspace = true }
 
 [dev-dependencies]
 icu_locid = { path = "../../components/locid" }

--- a/components/locid/Cargo.toml
+++ b/components/locid/Cargo.toml
@@ -39,7 +39,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 [features]
 std = []

--- a/components/locid_transform/Cargo.toml
+++ b/components/locid_transform/Cargo.toml
@@ -42,7 +42,7 @@ icu = { path = "../../components/icu", default-features = false }
 writeable = { path = "../../utils/writeable" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 [lib]
 bench = false  # This option is required for Benchmark CI

--- a/components/normalizer/Cargo.toml
+++ b/components/normalizer/Cargo.toml
@@ -43,7 +43,7 @@ write16 = { version = "1.0", features = ["arrayvec"] }
 detone = "1.0.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4.0"
+criterion = { workspace = true }
 
 [features]
 default = ["compiled_data"]

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -39,7 +39,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 [features]
 default = ["compiled_data"]

--- a/components/segmenter/Cargo.toml
+++ b/components/segmenter/Cargo.toml
@@ -43,7 +43,7 @@ itertools = "0.10"
 icu_properties = { workspace = true, features = ["compiled_data"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 [features]
 default = ["compiled_data", "auto"]

--- a/provider/blob/Cargo.toml
+++ b/provider/blob/Cargo.toml
@@ -34,7 +34,7 @@ icu_locid = { path = "../../components/locid", features = ["serde"] }
 icu_datagen = { path = "../../provider/datagen", features = ["networking"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 [features]
 bench = []

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -51,7 +51,7 @@ icu_provider_adapters = { path = "../adapters" }
 icu_locid_transform = { path = "../../components/locid_transform" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 [features]
 bench = []

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -40,7 +40,7 @@ icu_datagen = { path = "../../provider/datagen", features = ["networking"] }
 writeable = { path = "../../utils/writeable" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 [features]
 # Enables the "export" module and FilesystemExporter

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -66,7 +66,7 @@ icu_experimental = { version = "0.0.0", path = "../../components/experimental", 
 icu = { path = "../../components/icu", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = { workspace = true }
+criterion = "0.5"
 
 
 [features]

--- a/provider/testdata/Cargo.toml
+++ b/provider/testdata/Cargo.toml
@@ -66,7 +66,7 @@ icu_experimental = { version = "0.0.0", path = "../../components/experimental", 
 icu = { path = "../../components/icu", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 
 [features]

--- a/utils/bies/Cargo.toml
+++ b/utils/bies/Cargo.toml
@@ -33,4 +33,4 @@ rand_distr = "0.4"
 rand_pcg = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -36,7 +36,7 @@ rand_distr = "0.4"
 rand_pcg = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 [features]
 std = []

--- a/utils/ixdtf/Cargo.toml
+++ b/utils/ixdtf/Cargo.toml
@@ -28,4 +28,4 @@ all-features = true
 serde-json-core = { version = "0.4", features = ["std"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -38,7 +38,7 @@ serde = "1"
 serde_json = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 [features]
 bench = ["serde"]

--- a/utils/tinystr/Cargo.toml
+++ b/utils/tinystr/Cargo.toml
@@ -36,7 +36,7 @@ rand = { version = "0.8.5", features = ["small_rng"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 [features]
 default = ["alloc"]

--- a/utils/writeable/Cargo.toml
+++ b/utils/writeable/Cargo.toml
@@ -25,7 +25,7 @@ icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 rand = { version = "0.8", features = ["small_rng"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 [features]
 bench = []

--- a/utils/zerotrie/Cargo.toml
+++ b/utils/zerotrie/Cargo.toml
@@ -46,7 +46,7 @@ icu_locid = { path = "../../components/locid" }
 writeable = { path = "../../utils/writeable" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 [lib]
 bench = false  # This option is required for Benchmark CI

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -53,7 +53,7 @@ yoke = { path = "../../utils/yoke", features = ["derive"] }
 zerofrom = { path = "../../utils/zerofrom", features = ["derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.4"
+criterion = { workspace = true }
 
 [features]
 std = []


### PR DESCRIPTION
Once we upgrade Diplomat to https://github.com/rust-diplomat/diplomat/commit/c682c6dbde93d70853a8189d955c4d0ac40b92e6, we should be able to get rid of Clap 3, which gets rid of `atty`, which is responsible for some security alerts.