### PR TITLE
Improve Datagen argument marshaling around locales and collations

### DIFF
--- a/provider/datagen/src/bin/datagen/args.rs
+++ b/provider/datagen/src/bin/datagen/args.rs
@@ -283,7 +283,7 @@ pub struct Cli {
 }
 
 impl Cli {
-    pub fn as_config(&self) -> eyre::Result<config::Config> {
+    pub fn as_config<'a>(&'a self) -> eyre::Result<config::Config<'a>> {
         Ok(config::Config {
             keys: self.make_keys()?,
             locales: self.make_locales()?,
@@ -382,9 +382,7 @@ impl Cli {
             }
             config::LocaleInclude::Explicit(
                 self.locales
-                    .iter()
-                    .map(|s| s.parse::<LocaleFamily>().with_context(|| s.to_string()))
-                    .collect::<Result<_, eyre::Error>>()?,
+                    .iter().map(|s| s.as_str()).collect()
             )
         })
     }

--- a/provider/datagen/src/bin/datagen/args.rs
+++ b/provider/datagen/src/bin/datagen/args.rs
@@ -283,7 +283,7 @@ pub struct Cli {
 }
 
 impl Cli {
-    pub fn as_config<'a>(&'a self) -> eyre::Result<config::Config<'a>> {
+    pub fn as_config(&self) -> eyre::Result<config::Config<'_>> {
         Ok(config::Config {
             keys: self.make_keys()?,
             locales: self.make_locales()?,

--- a/provider/datagen/src/bin/datagen/args.rs
+++ b/provider/datagen/src/bin/datagen/args.rs
@@ -312,7 +312,7 @@ impl Cli {
             additional_collations: self
                 .include_collations
                 .iter()
-                .map(|c| c.to_datagen_value().to_owned())
+                .map(|c| c.to_datagen_value())
                 .collect(),
             segmenter_models: self.make_segmenter_models()?,
             export: self.make_exporter()?,
@@ -380,10 +380,7 @@ impl Cli {
             if self.locales.as_slice() == ["all"] {
                 log::warn!("`--locales all` selects the Allar language. Use `--locales full` for all locales");
             }
-            config::LocaleInclude::Explicit(
-                self.locales
-                    .iter().map(|s| s.as_str()).collect()
-            )
+            config::LocaleInclude::Explicit(self.locales.iter().map(|s| s.as_str()).collect())
         })
     }
 

--- a/provider/datagen/src/bin/datagen/config.rs
+++ b/provider/datagen/src/bin/datagen/config.rs
@@ -26,7 +26,7 @@ pub struct Config<'a> {
         skip_serializing_if = "is_default",
         serialize_with = "sorted_set"
     )]
-    pub additional_collations: HashSet<String>,
+    pub additional_collations: HashSet<&'a str>,
     #[serde(default, skip_serializing_if = "is_default")]
     pub segmenter_models: SegmenterModelInclude,
 

--- a/provider/datagen/src/bin/datagen/config.rs
+++ b/provider/datagen/src/bin/datagen/config.rs
@@ -14,9 +14,10 @@ use std::path::{Path, PathBuf};
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Config {
+pub struct Config<'a> {
     pub keys: KeyInclude,
-    pub locales: LocaleInclude,
+    #[serde(borrow)]
+    pub locales: LocaleInclude<'a>,
     pub without_fallback: bool,
     pub deduplication_strategy: Option<DeduplicationStrategy>,
     pub runtime_fallback_location: Option<RuntimeFallbackLocation>,
@@ -83,11 +84,11 @@ mod data_key_as_str {
 
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub enum LocaleInclude {
+pub enum LocaleInclude<'a> {
     Recommended,
     All,
     None,
-    Explicit(#[serde(serialize_with = "sorted_set")] HashSet<LocaleFamily>),
+    Explicit(#[serde(serialize_with = "sorted_set", borrow)] HashSet<&'a str>),
     CldrSet(#[serde(serialize_with = "sorted_set")] HashSet<CoverageLevel>),
 }
 

--- a/provider/datagen/src/bin/datagen/mod.rs
+++ b/provider/datagen/src/bin/datagen/mod.rs
@@ -89,13 +89,13 @@ fn main() -> eyre::Result<()> {
         config::KeyInclude::Explicit(set) => driver.with_keys(set),
         config::KeyInclude::ForBinary(path) => driver.with_keys(icu_datagen::keys_from_bin(path)?),
     };
-    enum LanguageIdentifiersOrLocaleFamilies<'a> {
+    enum LanguageIdentifiersOrStrings<'a> {
         LanguageIdentifiers(Vec<LanguageIdentifier>),
         Strings(HashSet<&'a str>),
         AllLocales,
     }
-    use LanguageIdentifiersOrLocaleFamilies::*;
-    let locales_intermediate: LanguageIdentifiersOrLocaleFamilies = match config.locales {
+    use LanguageIdentifiersOrStrings::*;
+    let locales_intermediate: LanguageIdentifiersOrStrings = match config.locales {
         config::LocaleInclude::All => AllLocales,
         config::LocaleInclude::None => LanguageIdentifiers(vec![]),
         config::LocaleInclude::Explicit(set) => Strings(set),

--- a/provider/datagen/src/bin/datagen/mod.rs
+++ b/provider/datagen/src/bin/datagen/mod.rs
@@ -122,7 +122,7 @@ fn main() -> eyre::Result<()> {
             LanguageIdentifiers(lids) => lids,
             Strings(strings) => strings
                 .into_iter()
-                .map(|s| s.parse().wrap_err(s))
+                .map(|s| s.parse().wrap_err_with(|| s.to_string()))
                 .collect::<eyre::Result<Vec<LanguageIdentifier>>>()?,
         };
         driver = driver.with_locales_no_fallback(locale_families, Default::default());
@@ -135,7 +135,7 @@ fn main() -> eyre::Result<()> {
                 .collect(),
             Strings(strings) => strings
                 .into_iter()
-                .map(|s| s.parse().wrap_err(s))
+                .map(|s| s.parse().wrap_err_with(|| s.to_string()))
                 .collect::<eyre::Result<Vec<LocaleFamily>>>()?,
         };
         let mut options: FallbackOptions = Default::default();

--- a/provider/datagen/src/driver.rs
+++ b/provider/datagen/src/driver.rs
@@ -455,12 +455,16 @@ impl DatagenDriver {
     /// are excluded. This method can be used to reennable them.
     ///
     /// The special string `"search*"` causes all search collation tables to be included.
-    pub fn with_additional_collations(
-        self,
-        additional_collations: impl IntoIterator<Item = String>,
-    ) -> Self {
+    pub fn with_additional_collations<II>(self, additional_collations: II) -> Self
+    where
+        II: IntoIterator,
+        II::Item: AsRef<str>,
+    {
         Self {
-            additional_collations: additional_collations.into_iter().collect(),
+            additional_collations: additional_collations
+                .into_iter()
+                .map(|s| s.as_ref().to_string())
+                .collect(),
             ..self
         }
     }


### PR DESCRIPTION
This change avoids double-parsing the locale fields in the datagen CLI. It also changes the code to borrow more.

I'm not 100% sure whether we consider the change to `DatagenDriver::with_additional_collations` semver-compatible.

---

Previous borrow problem:

```
error[E0597]: `matches` does not live long enough
   --> provider/datagen/src/bin/datagen/mod.rs:39:18
    |
22  |     let matches = args::Cli::parse();
    |         ------- binding `matches` declared here
...
39  |     let config = matches.as_config()?;
    |                  ^^^^^^^------------
    |                  |
    |                  borrowed value does not live long enough
    |                  argument requires that `matches` is borrowed for `'static`
...
248 | }
    | - `matches` dropped here while still borrowed

For more information about this error, try `rustc --explain E0597`.
```