### PR TITLE
Add IXDTF annotation handler and update critical flag handling

### DIFF
--- a/utils/ixdtf/README.md
+++ b/utils/ixdtf/README.md
@@ -145,21 +145,13 @@ agnostic regarding the ambiguity caused by the criticality of an unknown key. Th
 be provided to the user to handle the unknown key's critical flag as they see fit.
 
 ```rust
-use ixdtf::parsers::IxdtfParser;
+use ixdtf::{parsers::IxdtfParser, ParserError};
 
 let example_one = "2024-03-02T08:48:00-05:00[u-ca=iso8601][!answer-to-universe=fortytwo]";
 
-let mut ixdtf = IxdtfParser::new(example_one);
+let result = IxdtfParser::new(example_one).parse();
 
-let result = ixdtf.parse().unwrap();
-
-let annotation = &result.annotations[0];
-
-// While an unknown annotation should not be critical, it is up to the user
-// to act on that error.
-assert!(annotation.critical);
-assert_eq!(annotation.key, "answer-to-universe");
-assert_eq!(annotation.value, "fortytwo");
+assert_eq!(result, Err(ParserError::UnrecognizedCritical));
 ```
 
 (4) belongs to group (b) and shows an ambiguous Time Zone caused by a misalignment

--- a/utils/ixdtf/src/error.rs
+++ b/utils/ixdtf/src/error.rs
@@ -75,6 +75,8 @@ pub enum ParserError {
     // Duplicate calendar with critical.
     #[displaydoc("Duplicate calendars cannot be provided when one is critical.")]
     CriticalDuplicateCalendar,
+    #[displaydoc("Unrecognized annoation is marked as critical.")]
+    UnrecognizedCritical,
 
     // Time Zone Errors
     #[displaydoc("Invalid time zone leading character.")]

--- a/utils/ixdtf/src/lib.rs
+++ b/utils/ixdtf/src/lib.rs
@@ -145,21 +145,13 @@
 //! be provided to the user to handle the unknown key's critical flag as they see fit.
 //!
 //! ```rust
-//! use ixdtf::parsers::IxdtfParser;
+//! use ixdtf::{parsers::IxdtfParser, ParserError};
 //!
 //! let example_one = "2024-03-02T08:48:00-05:00[u-ca=iso8601][!answer-to-universe=fortytwo]";
 //!
-//! let mut ixdtf = IxdtfParser::new(example_one);
+//! let result = IxdtfParser::new(example_one).parse();
 //!
-//! let result = ixdtf.parse().unwrap();
-//!
-//! let annotation = &result.annotations[0];
-//!
-//! // While an unknown annotation should not be critical, it is up to the user
-//! // to act on that error.
-//! assert!(annotation.critical);
-//! assert_eq!(annotation.key, "answer-to-universe");
-//! assert_eq!(annotation.value, "fortytwo");
+//! assert_eq!(result, Err(ParserError::UnrecognizedCritical));
 //! ```
 //!
 //! (4) belongs to group (b) and shows an ambiguous Time Zone caused by a misalignment

--- a/utils/ixdtf/src/parsers/annotations.rs
+++ b/utils/ixdtf/src/parsers/annotations.rs
@@ -66,7 +66,7 @@ pub(crate) fn parse_annotations<'a>(
             match calendar {
                 // If any calendar is critical, treat as erroneous and throw an error.
                 Some(seen_kv) if seen_kv.critical || kv.critical => {
-                    return Err(ParserError::CriticalDuplicateCalendar)
+                    return Err(ParserError::CriticalDuplicateCalendar);
                 }
                 Some(_) => {}
                 None => {
@@ -77,7 +77,7 @@ pub(crate) fn parse_annotations<'a>(
             }
         }
 
-        annotations.push(kv)
+        annotations.push(kv);
     }
 
     Ok((calendar, annotations))

--- a/utils/ixdtf/src/parsers/annotations.rs
+++ b/utils/ixdtf/src/parsers/annotations.rs
@@ -21,7 +21,7 @@ use crate::{
 /// Strictly a parsing intermediary for the checking the common annotation backing.
 pub(crate) struct AnnotationSet<'a> {
     pub(crate) tz: Option<TimeZoneAnnotation<'a>>,
-    pub(crate) calendar: Option<Annotation<'a>>,
+    pub(crate) calendar: Option<&'a str>,
 }
 
 /// Parse a `TimeZoneAnnotation` `Annotations` set
@@ -53,7 +53,7 @@ pub(crate) fn parse_annotation_set<'a>(
 pub(crate) fn parse_annotations<'a>(
     cursor: &mut Cursor<'a>,
     mut handler: impl FnMut(Annotation<'a>) -> Option<Annotation<'a>>,
-) -> ParserResult<Option<Annotation<'a>>> {
+) -> ParserResult<Option<&'a str>> {
     let mut calendar: Option<Annotation<'a>> = None;
 
     while cursor.check_or(false, is_annotation_open) {
@@ -87,7 +87,7 @@ pub(crate) fn parse_annotations<'a>(
         }
     }
 
-    Ok(calendar)
+    Ok(calendar.map(|a| a.value))
 }
 
 /// Parse an annotation with an `AnnotationKey`=`AnnotationValue` pair.

--- a/utils/ixdtf/src/parsers/annotations.rs
+++ b/utils/ixdtf/src/parsers/annotations.rs
@@ -23,7 +23,7 @@ use alloc::vec::Vec;
 /// Strictly a parsing intermediary for the checking the common annotation backing.
 pub(crate) struct AnnotationSet<'a> {
     pub(crate) tz: Option<TimeZoneAnnotation<'a>>,
-    pub(crate) calendar: Option<&'a str>,
+    pub(crate) calendar: Option<Annotation<'a>>,
     pub(crate) annotations: Vec<Annotation<'a>>,
 }
 
@@ -54,7 +54,7 @@ pub(crate) fn parse_annotation_set<'a>(cursor: &mut Cursor<'a>) -> ParserResult<
 /// Parse any number of `KeyValueAnnotation`s
 pub(crate) fn parse_annotations<'a>(
     cursor: &mut Cursor<'a>,
-) -> ParserResult<(Option<&'a str>, Vec<Annotation<'a>>)> {
+) -> ParserResult<(Option<Annotation<'a>>, Vec<Annotation<'a>>)> {
     let mut annotations = Vec::default();
     let mut calendar = None;
     let mut calendar_crit = false;
@@ -62,10 +62,12 @@ pub(crate) fn parse_annotations<'a>(
     while cursor.check_or(false, is_annotation_open) {
         let kv = parse_kv_annotation(cursor)?;
 
+        // Check if the key is the registered key "u-ca".
         if kv.key == "u-ca" {
+            // If the calendar is not yet set, set calendar.
             if calendar.is_none() {
-                calendar = Some(kv.value);
                 calendar_crit = kv.critical;
+                calendar = Some(kv);
                 continue;
             }
 

--- a/utils/ixdtf/src/parsers/datetime.rs
+++ b/utils/ixdtf/src/parsers/datetime.rs
@@ -41,7 +41,7 @@ pub(crate) struct DateTimeRecord {
 /// [instant]: https://tc39.es/proposal-temporal/#prod-TemporalInstantString
 pub(crate) fn parse_annotated_date_time<'a>(
     cursor: &mut Cursor<'a>,
-    handler: impl FnMut(Annotation<'a>) -> ParserResult<()>,
+    handler: impl FnMut(Annotation<'a>) -> Option<Annotation<'a>>,
 ) -> ParserResult<IxdtfParseRecord<'a>> {
     let date_time = parse_date_time(cursor)?;
 
@@ -75,7 +75,7 @@ pub(crate) fn parse_annotated_date_time<'a>(
 /// Parses an AnnotatedMonthDay.
 pub(crate) fn parse_annotated_month_day<'a>(
     cursor: &mut Cursor<'a>,
-    handler: impl FnMut(Annotation<'a>) -> ParserResult<()>,
+    handler: impl FnMut(Annotation<'a>) -> Option<Annotation<'a>>,
 ) -> ParserResult<IxdtfParseRecord<'a>> {
     let date = parse_month_day(cursor)?;
 
@@ -105,7 +105,7 @@ pub(crate) fn parse_annotated_month_day<'a>(
 /// Parse an annotated YearMonth
 pub(crate) fn parse_annotated_year_month<'a>(
     cursor: &mut Cursor<'a>,
-    handler: impl FnMut(Annotation<'a>) -> ParserResult<()>,
+    handler: impl FnMut(Annotation<'a>) -> Option<Annotation<'a>>,
 ) -> ParserResult<IxdtfParseRecord<'a>> {
     let year = parse_date_year(cursor)?;
     cursor.advance_if(cursor.check_or(false, is_hyphen));

--- a/utils/ixdtf/src/parsers/mod.rs
+++ b/utils/ixdtf/src/parsers/mod.rs
@@ -62,80 +62,56 @@ impl<'a> IxdtfParser<'a> {
     ///
     /// [temporal-dt]: https://tc39.es/proposal-temporal/#prod-TemporalDateTimeString
     pub fn parse(&mut self) -> ParserResult<IxdtfParseRecord<'a>> {
-        self.parse_with_annotation_handler(|annotation| {
-            if annotation.critical && annotation.key != "u-ca" {
-                Err(ParserError::UnrecognizedCritical)
-            } else {
-                Ok(())
-            }
-        })
+        self.parse_with_annotation_handler(Some)
     }
 
     // TODO: Build out docs after consensus
     /// Parses the source as an annotated DateTime string with an Annotation handler.
     pub fn parse_with_annotation_handler(
         &mut self,
-        handler: impl FnMut(Annotation<'a>) -> ParserResult<()>,
+        handler: impl FnMut(Annotation<'a>) -> Option<Annotation>,
     ) -> ParserResult<IxdtfParseRecord<'a>> {
         datetime::parse_annotated_date_time(&mut self.cursor, handler)
     }
 
     /// Parses the source as an annotated YearMonth string.
     pub fn parse_year_month(&mut self) -> ParserResult<IxdtfParseRecord<'a>> {
-        self.parse_year_month_with_annotation_handler(|annotation| {
-            if annotation.critical && annotation.key != "u-ca" {
-                Err(ParserError::UnrecognizedCritical)
-            } else {
-                Ok(())
-            }
-        })
+        self.parse_year_month_with_annotation_handler(Some)
     }
 
     // TODO: Build out docs after consensus
     /// Parses the source as an annotated YearMonth string with an Annotation handler.
     pub fn parse_year_month_with_annotation_handler(
         &mut self,
-        handler: impl FnMut(Annotation<'a>) -> ParserResult<()>,
+        handler: impl FnMut(Annotation<'a>) -> Option<Annotation<'a>>,
     ) -> ParserResult<IxdtfParseRecord<'a>> {
         datetime::parse_annotated_year_month(&mut self.cursor, handler)
     }
 
     /// Parses the source as an annotated MonthDay string.
     pub fn parse_month_day(&mut self) -> ParserResult<IxdtfParseRecord<'a>> {
-        self.parse_month_day_with_annotation_handler(|annotation| {
-            if annotation.critical && annotation.key != "u-ca" {
-                Err(ParserError::UnrecognizedCritical)
-            } else {
-                Ok(())
-            }
-        })
+        self.parse_month_day_with_annotation_handler(Some)
     }
 
     // TODO: Build out docs after consensus
     /// Parses the source as an annotated MonthDay string with an Annotation handler.
     pub fn parse_month_day_with_annotation_handler(
         &mut self,
-        handler: impl FnMut(Annotation<'a>) -> ParserResult<()>,
+        handler: impl FnMut(Annotation<'a>) -> Option<Annotation<'a>>,
     ) -> ParserResult<IxdtfParseRecord<'a>> {
         datetime::parse_annotated_month_day(&mut self.cursor, handler)
     }
 
     /// Parses the source as an annotated Time string.
     pub fn parse_time(&mut self) -> ParserResult<IxdtfParseRecord<'a>> {
-        self.parse_time_with_annotation_handler(|annotation| {
-            if annotation.critical && annotation.key != "u-ca" {
-                Err(ParserError::UnrecognizedCritical)
-            } else {
-                Ok(())
-            }
-        })
+        self.parse_time_with_annotation_handler(Some)
     }
 
     // TODO: Build out docs after consensus
     /// Parses the source as an annotated Time string with an Annotation handler.
     pub fn parse_time_with_annotation_handler(
         &mut self,
-        handler: impl FnMut(Annotation<'a>) -> ParserResult<()>,
+        handler: impl FnMut(Annotation<'a>) -> Option<Annotation<'a>>,
     ) -> ParserResult<IxdtfParseRecord<'a>> {
         time::parse_annotated_time_record(&mut self.cursor, handler)
     }

--- a/utils/ixdtf/src/parsers/mod.rs
+++ b/utils/ixdtf/src/parsers/mod.rs
@@ -65,11 +65,20 @@ impl<'a> IxdtfParser<'a> {
         self.parse_with_annotation_handler(Some)
     }
 
-    // TODO: Build out docs after consensus
     /// Parses the source as an annotated DateTime string with an Annotation handler.
+    ///
+    /// # Annotation Handling
+    ///
+    /// The annotation handler provides a parsed annotation to the callback and expects a return
+    /// of an annotation or None. `ixdtf` performs baseline annotation checks once the handler
+    /// returns. Returning None will ignore the standard checks for that annotation.
+    ///
+    /// Unless the user's application has a specific reason to bypass action on an annotation, such
+    /// as, not throwing an error on an unknown key's criticality or superceding a calendar based on
+    /// it's critical flag, it is recommended to return the annotation value.
     pub fn parse_with_annotation_handler(
         &mut self,
-        handler: impl FnMut(Annotation<'a>) -> Option<Annotation>,
+        handler: impl FnMut(Annotation<'a>) -> Option<Annotation<'a>>,
     ) -> ParserResult<IxdtfParseRecord<'a>> {
         datetime::parse_annotated_date_time(&mut self.cursor, handler)
     }
@@ -79,8 +88,17 @@ impl<'a> IxdtfParser<'a> {
         self.parse_year_month_with_annotation_handler(Some)
     }
 
-    // TODO: Build out docs after consensus
     /// Parses the source as an annotated YearMonth string with an Annotation handler.
+    ///
+    /// # Annotation Handling
+    ///
+    /// The annotation handler provides a parsed annotation to the callback and expects a return
+    /// of an annotation or None. `ixdtf` performs baseline annotation checks once the handler
+    /// returns. Returning None will ignore the standard checks for that annotation.
+    ///
+    /// Unless the user's application has a specific use case to bypass action on an annotation, such
+    /// as, not throwing an error on an unknown key's criticality or superceding a calendar based on
+    /// it's critical flag, it is recommended to return the annotation value.
     pub fn parse_year_month_with_annotation_handler(
         &mut self,
         handler: impl FnMut(Annotation<'a>) -> Option<Annotation<'a>>,
@@ -93,8 +111,17 @@ impl<'a> IxdtfParser<'a> {
         self.parse_month_day_with_annotation_handler(Some)
     }
 
-    // TODO: Build out docs after consensus
     /// Parses the source as an annotated MonthDay string with an Annotation handler.
+    ///
+    /// # Annotation Handling
+    ///
+    /// The annotation handler provides a parsed annotation to the callback and expects a return
+    /// of an annotation or None. `ixdtf` performs baseline annotation checks once the handler
+    /// returns. Returning None will ignore the standard checks for that annotation.
+    ///
+    /// Unless the user's application has a specific reason to bypass action on an annotation, such
+    /// as, not throwing an error on an unknown key's criticality or superceding a calendar based on
+    /// it's critical flag, it is recommended to return the annotation value.
     pub fn parse_month_day_with_annotation_handler(
         &mut self,
         handler: impl FnMut(Annotation<'a>) -> Option<Annotation<'a>>,
@@ -107,8 +134,17 @@ impl<'a> IxdtfParser<'a> {
         self.parse_time_with_annotation_handler(Some)
     }
 
-    // TODO: Build out docs after consensus
     /// Parses the source as an annotated Time string with an Annotation handler.
+    ///
+    /// # Annotation Handling
+    ///
+    /// The annotation handler provides a parsed annotation to the callback and expects a return
+    /// of an annotation or None. `ixdtf` performs baseline annotation checks once the handler
+    /// returns. Returning None will ignore the standard checks for that annotation.
+    ///
+    /// Unless the user's application has a specific reason to bypass action on an annotation, such
+    /// as, not throwing an error on an unknown key's criticality or superceding a calendar based on
+    /// it's critical flag, it is recommended to return the annotation value.
     pub fn parse_time_with_annotation_handler(
         &mut self,
         handler: impl FnMut(Annotation<'a>) -> Option<Annotation<'a>>,

--- a/utils/ixdtf/src/parsers/mod.rs
+++ b/utils/ixdtf/src/parsers/mod.rs
@@ -6,11 +6,11 @@
 
 use crate::{ParserError, ParserResult};
 
-extern crate alloc;
-
 #[cfg(feature = "duration")]
 use records::DurationParseRecord;
 use records::IxdtfParseRecord;
+
+use self::records::Annotation;
 
 pub mod records;
 
@@ -62,22 +62,82 @@ impl<'a> IxdtfParser<'a> {
     ///
     /// [temporal-dt]: https://tc39.es/proposal-temporal/#prod-TemporalDateTimeString
     pub fn parse(&mut self) -> ParserResult<IxdtfParseRecord<'a>> {
-        datetime::parse_annotated_date_time(&mut self.cursor)
+        self.parse_with_annotation_handler(|annotation| {
+            if annotation.critical && annotation.key != "u-ca" {
+                Err(ParserError::UnrecognizedCritical)
+            } else {
+                Ok(())
+            }
+        })
+    }
+
+    // TODO: Build out docs after consensus
+    /// Parses the source as an annotated DateTime string with an Annotation handler.
+    pub fn parse_with_annotation_handler(
+        &mut self,
+        handler: impl FnMut(Annotation<'a>) -> ParserResult<()>,
+    ) -> ParserResult<IxdtfParseRecord<'a>> {
+        datetime::parse_annotated_date_time(&mut self.cursor, handler)
     }
 
     /// Parses the source as an annotated YearMonth string.
     pub fn parse_year_month(&mut self) -> ParserResult<IxdtfParseRecord<'a>> {
-        datetime::parse_annotated_year_month(&mut self.cursor)
+        self.parse_year_month_with_annotation_handler(|annotation| {
+            if annotation.critical && annotation.key != "u-ca" {
+                Err(ParserError::UnrecognizedCritical)
+            } else {
+                Ok(())
+            }
+        })
+    }
+
+    // TODO: Build out docs after consensus
+    /// Parses the source as an annotated YearMonth string with an Annotation handler.
+    pub fn parse_year_month_with_annotation_handler(
+        &mut self,
+        handler: impl FnMut(Annotation<'a>) -> ParserResult<()>,
+    ) -> ParserResult<IxdtfParseRecord<'a>> {
+        datetime::parse_annotated_year_month(&mut self.cursor, handler)
     }
 
     /// Parses the source as an annotated MonthDay string.
     pub fn parse_month_day(&mut self) -> ParserResult<IxdtfParseRecord<'a>> {
-        datetime::parse_annotated_month_day(&mut self.cursor)
+        self.parse_month_day_with_annotation_handler(|annotation| {
+            if annotation.critical && annotation.key != "u-ca" {
+                Err(ParserError::UnrecognizedCritical)
+            } else {
+                Ok(())
+            }
+        })
+    }
+
+    // TODO: Build out docs after consensus
+    /// Parses the source as an annotated MonthDay string with an Annotation handler.
+    pub fn parse_month_day_with_annotation_handler(
+        &mut self,
+        handler: impl FnMut(Annotation<'a>) -> ParserResult<()>,
+    ) -> ParserResult<IxdtfParseRecord<'a>> {
+        datetime::parse_annotated_month_day(&mut self.cursor, handler)
     }
 
     /// Parses the source as an annotated Time string.
     pub fn parse_time(&mut self) -> ParserResult<IxdtfParseRecord<'a>> {
-        time::parse_annotated_time_record(&mut self.cursor)
+        self.parse_time_with_annotation_handler(|annotation| {
+            if annotation.critical && annotation.key != "u-ca" {
+                Err(ParserError::UnrecognizedCritical)
+            } else {
+                Ok(())
+            }
+        })
+    }
+
+    // TODO: Build out docs after consensus
+    /// Parses the source as an annotated Time string with an Annotation handler.
+    pub fn parse_time_with_annotation_handler(
+        &mut self,
+        handler: impl FnMut(Annotation<'a>) -> ParserResult<()>,
+    ) -> ParserResult<IxdtfParseRecord<'a>> {
+        time::parse_annotated_time_record(&mut self.cursor, handler)
     }
 }
 

--- a/utils/ixdtf/src/parsers/records.rs
+++ b/utils/ixdtf/src/parsers/records.rs
@@ -4,8 +4,6 @@
 
 //! The records that `ixdtf`'s contain the resulting values of parsing.
 
-use alloc::vec::Vec;
-
 /// An `IxdtfParseRecord` is an intermediary record returned by `IxdtfParser`.
 #[non_exhaustive]
 #[derive(Default, Debug, PartialEq)]
@@ -20,8 +18,6 @@ pub struct IxdtfParseRecord<'a> {
     pub tz: Option<TimeZoneAnnotation<'a>>,
     /// The parsed calendar value.
     pub calendar: Option<Annotation<'a>>,
-    /// A collection of annotations provided on an IXDTF string.
-    pub annotations: Vec<Annotation<'a>>,
 }
 
 #[non_exhaustive]

--- a/utils/ixdtf/src/parsers/records.rs
+++ b/utils/ixdtf/src/parsers/records.rs
@@ -17,7 +17,7 @@ pub struct IxdtfParseRecord<'a> {
     /// Parsed `TimeZone` annotation with critical flag and data (UTCOffset | IANA name)
     pub tz: Option<TimeZoneAnnotation<'a>>,
     /// The parsed calendar value.
-    pub calendar: Option<Annotation<'a>>,
+    pub calendar: Option<&'a str>,
 }
 
 #[non_exhaustive]

--- a/utils/ixdtf/src/parsers/records.rs
+++ b/utils/ixdtf/src/parsers/records.rs
@@ -19,7 +19,7 @@ pub struct IxdtfParseRecord<'a> {
     /// Parsed `TimeZone` annotation with critical flag and data (UTCOffset | IANA name)
     pub tz: Option<TimeZoneAnnotation<'a>>,
     /// The parsed calendar value.
-    pub calendar: Option<&'a str>,
+    pub calendar: Option<Annotation<'a>>,
     /// A collection of annotations provided on an IXDTF string.
     pub annotations: Vec<Annotation<'a>>,
 }

--- a/utils/ixdtf/src/parsers/tests.rs
+++ b/utils/ixdtf/src/parsers/tests.rs
@@ -193,27 +193,13 @@ fn good_annotations_date_time() {
         }
     );
 
-    assert_eq!(
-        result.calendar,
-        Some(Annotation {
-            critical: false,
-            key: "u-ca",
-            value: "iso8601"
-        })
-    );
+    assert_eq!(result.calendar, Some("iso8601"));
 
     let omit_result = omitted.parse().unwrap();
 
     assert!(omit_result.tz.is_none());
 
-    assert_eq!(
-        omit_result.calendar,
-        Some(Annotation {
-            critical: true,
-            key: "u-ca",
-            value: "iso8601"
-        })
-    );
+    assert_eq!(omit_result.calendar, Some("iso8601"));
 }
 
 #[test]
@@ -337,7 +323,7 @@ fn duplicate_same_calendar() {
         let result = IxdtfParser::new(duplicate).parse().unwrap();
         let calendar = result.calendar.unwrap();
         assert_eq!(
-            calendar.value, "iso8601",
+            calendar, "iso8601",
             "Invalid Ixdtf parsing: \"{duplicate}\" should fail parsing."
         );
     }
@@ -355,11 +341,7 @@ fn valid_calendar_annotations() {
         .unwrap();
     assert_eq!(
         result.calendar,
-        Some(Annotation {
-            critical: false,
-            key: "u-ca",
-            value: "japanese"
-        }),
+        Some("japanese"),
         "Valid annotation parsing: \"{value}\" should parse calendar as 'japanese'."
     );
 
@@ -393,11 +375,7 @@ fn valid_calendar_annotations() {
         .unwrap();
     assert_eq!(
         result.calendar,
-        Some(Annotation {
-            critical: false,
-            key: "u-ca",
-            value: "gregorian"
-        }),
+        Some("gregorian"),
         "Valid annotation parsing: \"{value}\" should parse calendar as 'gregorian'."
     );
 

--- a/utils/ixdtf/src/parsers/tests.rs
+++ b/utils/ixdtf/src/parsers/tests.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 
 use crate::{
     parsers::{
-        records::{DateRecord, IxdtfParseRecord, TimeRecord, TimeZoneAnnotation, TimeZoneRecord},
+        records::{Annotation, DateRecord, IxdtfParseRecord, TimeRecord, TimeZoneAnnotation, TimeZoneRecord},
         IxdtfParser,
     },
     ParserError,
@@ -175,7 +175,7 @@ fn bad_extended_year() {
 fn good_annotations_date_time() {
     let mut basic =
         IxdtfParser::new("2020-11-08[!America/Argentina/ComodRivadavia][u-ca=iso8601][foo=bar]");
-    let mut omitted = IxdtfParser::new("+0020201108[u-ca=iso8601][f-1a2b=a0sa-2l4s]");
+    let mut omitted = IxdtfParser::new("+0020201108[!u-ca=iso8601][f-1a2b=a0sa-2l4s]");
 
     let result = basic.parse().unwrap();
 
@@ -189,13 +189,13 @@ fn good_annotations_date_time() {
         }
     );
 
-    assert_eq!(result.calendar, Some("iso8601"));
+    assert_eq!(result.calendar, Some(Annotation { critical: false, key: "u-ca", value: "iso8601"}));
 
     let omit_result = omitted.parse().unwrap();
 
     assert!(omit_result.tz.is_none());
 
-    assert_eq!(omit_result.calendar, Some("iso8601"));
+    assert_eq!(omit_result.calendar, Some(Annotation { critical: true, key: "u-ca", value: "iso8601"}));
 }
 
 #[test]

--- a/utils/ixdtf/src/parsers/tests.rs
+++ b/utils/ixdtf/src/parsers/tests.rs
@@ -328,17 +328,17 @@ fn invalid_calendar_annotations() {
 
 #[test]
 fn duplicate_same_calendar() {
-    let invalid_annotations = [
+    let duplicate_calendars = [
         "2020-11-11[!u-ca=iso8601][u-ca=iso8601]",
         "2020-11-11[u-ca=iso8601][!u-ca=iso8601]",
     ];
 
-    for invalid in invalid_annotations {
-        let err = IxdtfParser::new(invalid).parse();
+    for duplicate in duplicate_calendars {
+        let result = IxdtfParser::new(duplicate).parse().unwrap();
+        let calendar = result.calendar.unwrap();
         assert_eq!(
-            err,
-            Err(ParserError::CriticalDuplicateCalendar),
-            "Invalid ISO annotation parsing: \"{invalid}\" should fail parsing."
+            calendar.value, "iso8601",
+            "Invalid Ixdtf parsing: \"{duplicate}\" should fail parsing."
         );
     }
 }
@@ -349,8 +349,8 @@ fn valid_calendar_annotations() {
     let mut annotations = Vec::default();
     let result = IxdtfParser::new(value)
         .parse_with_annotation_handler(|annotation| {
-            annotations.push(annotation);
-            Ok(())
+            annotations.push(annotation.clone());
+            Some(annotation)
         })
         .unwrap();
     assert_eq!(
@@ -364,7 +364,7 @@ fn valid_calendar_annotations() {
     );
 
     assert_eq!(
-        annotations[0],
+        annotations[1],
         Annotation {
             critical: false,
             key: "u-ca",
@@ -374,7 +374,7 @@ fn valid_calendar_annotations() {
     );
 
     assert_eq!(
-        annotations[1],
+        annotations[2],
         Annotation {
             critical: false,
             key: "u-ca",
@@ -387,8 +387,8 @@ fn valid_calendar_annotations() {
     let mut annotations = Vec::default();
     let result = IxdtfParser::new(value)
         .parse_with_annotation_handler(|annotation| {
-            annotations.push(annotation);
-            Ok(())
+            annotations.push(annotation.clone());
+            Some(annotation)
         })
         .unwrap();
     assert_eq!(
@@ -402,7 +402,7 @@ fn valid_calendar_annotations() {
     );
 
     assert_eq!(
-        annotations[0],
+        annotations[1],
         Annotation {
             critical: false,
             key: "u-ca",
@@ -412,7 +412,7 @@ fn valid_calendar_annotations() {
     );
 
     assert_eq!(
-        annotations[1],
+        annotations[2],
         Annotation {
             critical: false,
             key: "u-ca",

--- a/utils/ixdtf/src/parsers/time.rs
+++ b/utils/ixdtf/src/parsers/time.rs
@@ -4,8 +4,6 @@
 
 //! Parsing of Time Values
 
-use alloc::vec::Vec;
-
 use crate::{
     assert_syntax,
     parsers::{
@@ -13,7 +11,7 @@ use crate::{
             is_annotation_open, is_decimal_separator, is_sign, is_time_designator,
             is_time_separator, is_utc_designator,
         },
-        records::TimeRecord,
+        records::{Annotation, TimeRecord},
         timezone::parse_date_time_utc,
         Cursor,
     },
@@ -26,6 +24,7 @@ use super::{annotations, records::IxdtfParseRecord};
 /// value does not align
 pub(crate) fn parse_annotated_time_record<'a>(
     cursor: &mut Cursor<'a>,
+    handler: impl FnMut(Annotation<'a>) -> ParserResult<()>,
 ) -> ParserResult<IxdtfParseRecord<'a>> {
     let designator = cursor.check_or(false, is_time_designator);
     cursor.advance_if(designator);
@@ -51,11 +50,10 @@ pub(crate) fn parse_annotated_time_record<'a>(
             offset,
             tz: None,
             calendar: None,
-            annotations: Vec::default(),
         });
     }
 
-    let annotations = annotations::parse_annotation_set(cursor)?;
+    let annotations = annotations::parse_annotation_set(cursor, handler)?;
 
     cursor.close()?;
 
@@ -65,7 +63,6 @@ pub(crate) fn parse_annotated_time_record<'a>(
         offset,
         tz: annotations.tz,
         calendar: annotations.calendar,
-        annotations: annotations.annotations,
     })
 }
 

--- a/utils/ixdtf/src/parsers/time.rs
+++ b/utils/ixdtf/src/parsers/time.rs
@@ -24,7 +24,7 @@ use super::{annotations, records::IxdtfParseRecord};
 /// value does not align
 pub(crate) fn parse_annotated_time_record<'a>(
     cursor: &mut Cursor<'a>,
-    handler: impl FnMut(Annotation<'a>) -> ParserResult<()>,
+    handler: impl FnMut(Annotation<'a>) -> Option<Annotation<'a>>,
 ) -> ParserResult<IxdtfParseRecord<'a>> {
     let designator = cursor.check_or(false, is_time_designator);
     cursor.advance_if(designator);


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

This PR updates the feedback on regarding `calendar` losing information when parsing. Opening as a draft first for any potential discussion re [the response on the feedback](https://github.com/unicode-org/icu4x/pull/4646#discussion_r1540368101), and the ideal way to handle duplicate calendars.

Note: this will need to be rebased to include the changes in #4749 once merged.


