### PR TITLE
Upgrade diplomat; removes Clap 3 from lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
 
 [[package]]
 name = "anstyle-parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -45,42 +45,50 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.2.6"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
+ "anstyle-query",
  "anstyle-wincon",
- "concolor-override",
- "concolor-query",
- "is-terminal",
+ "colorchoice",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "0.3.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.1.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
-name = "anstyle-wincon"
-version = "0.2.0"
+name = "anstyle-query"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys 0.45.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -113,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.12.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0fc7dcf8bd4ead96b1d36b41df47c14beedf7b0301fc543d8f2384e66a2ec0"
+checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
 dependencies = [
  "askama_parser",
  "basic-toml",
@@ -124,7 +132,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.48",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -135,9 +143,9 @@ checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
 name = "askama_parser"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c268a96e01a4c47c8c5c2472aaa570707e006a875ea63e819f75474ceedaf7b4"
+checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
 dependencies = [
  "nom",
 ]
@@ -153,35 +161,24 @@ dependencies = [
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.11"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -214,15 +211,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "basic-toml"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bfc506e7a2370ec239e1d072507b2a80c833083699d3c6fa176fbb4de8448c6"
+checksum = "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8"
 dependencies = [
  "serde",
 ]
@@ -263,12 +260,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitflags"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
-
-[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,15 +273,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
@@ -299,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -310,15 +301,15 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "calendrical_calculations"
@@ -336,12 +327,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"
@@ -351,9 +339,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "ciborium"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -362,15 +350,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
@@ -378,93 +366,43 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_derive 3.2.25",
- "clap_lex 0.2.4",
- "indexmap",
- "once_cell",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
-version = "4.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
- "clap_derive 4.2.0",
- "once_cell",
+ "clap_derive",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.2.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags 1.3.2",
- "clap_lex 0.4.1",
+ "clap_lex",
  "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.25"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck 0.4.1",
- "proc-macro-error",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
-
-[[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
-]
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "cobs"
@@ -480,11 +418,10 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
-version = "2.0.4"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
- "is-terminal",
  "lazy_static",
  "windows-sys 0.48.0",
 ]
@@ -500,28 +437,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "concolor-override"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a4925288e39d5923e024781971aab940995fa31bab3ffceebbadfc87591e90"
-dependencies = [
- "colorchoice",
-]
-
-[[package]]
-name = "concolor-query"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
-dependencies = [
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "core-foundation"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -529,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "core-graphics"
@@ -539,7 +458,7 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -548,11 +467,11 @@ dependencies = [
 
 [[package]]
 name = "core-graphics-types"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb142d41022986c1d8ff29103a1411c8a3dfad3552f87a4f8dc50d61d4f4e33"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "core-foundation",
  "libc",
 ]
@@ -592,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -608,7 +527,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.2.1",
+ "clap",
  "criterion-plot",
  "is-terminal",
  "itertools",
@@ -647,26 +566,21 @@ version = "1.0.3"
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
@@ -674,6 +588,12 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "databake"
@@ -691,7 +611,7 @@ dependencies = [
  "databake",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.55",
  "synstructure",
 ]
 
@@ -705,6 +625,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "detone"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,9 +641,9 @@ checksum = "f7104c193859c8141dcbb2008bd3d93e581d0fa7bb47b0d9f5e15c89d1b55514"
 
 [[package]]
 name = "dhat"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2aaf837aaf456f6706cb46386ba8dffd4013a757e36f4ea05c20dd46b209a3"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -729,12 +658,12 @@ dependencies = [
 [[package]]
 name = "diplomat"
 version = "0.7.0"
-source = "git+https://github.com/rust-diplomat/diplomat.git?rev=99ab75d8054b9ddca7fd1def0902f7a43bd68259#99ab75d8054b9ddca7fd1def0902f7a43bd68259"
+source = "git+https://github.com/rust-diplomat/diplomat.git?rev=c682c6dbde93d70853a8189d955c4d0ac40b92e6#c682c6dbde93d70853a8189d955c4d0ac40b92e6"
 dependencies = [
  "diplomat_core",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -747,7 +676,7 @@ dependencies = [
 [[package]]
 name = "diplomat-runtime"
 version = "0.7.0"
-source = "git+https://github.com/rust-diplomat/diplomat.git?rev=99ab75d8054b9ddca7fd1def0902f7a43bd68259#99ab75d8054b9ddca7fd1def0902f7a43bd68259"
+source = "git+https://github.com/rust-diplomat/diplomat.git?rev=c682c6dbde93d70853a8189d955c4d0ac40b92e6#c682c6dbde93d70853a8189d955c4d0ac40b92e6"
 dependencies = [
  "log",
 ]
@@ -755,10 +684,10 @@ dependencies = [
 [[package]]
 name = "diplomat-tool"
 version = "0.7.0"
-source = "git+https://github.com/rust-diplomat/diplomat.git?rev=99ab75d8054b9ddca7fd1def0902f7a43bd68259#99ab75d8054b9ddca7fd1def0902f7a43bd68259"
+source = "git+https://github.com/rust-diplomat/diplomat.git?rev=c682c6dbde93d70853a8189d955c4d0ac40b92e6#c682c6dbde93d70853a8189d955c4d0ac40b92e6"
 dependencies = [
  "askama",
- "clap 3.2.25",
+ "clap",
  "colored",
  "diplomat_core",
  "displaydoc",
@@ -767,7 +696,7 @@ dependencies = [
  "pulldown-cmark",
  "quote",
  "serde",
- "syn 2.0.48",
+ "syn 2.0.55",
  "syn-inline-mod",
  "toml",
 ]
@@ -775,7 +704,7 @@ dependencies = [
 [[package]]
 name = "diplomat_core"
 version = "0.7.0"
-source = "git+https://github.com/rust-diplomat/diplomat.git?rev=99ab75d8054b9ddca7fd1def0902f7a43bd68259#99ab75d8054b9ddca7fd1def0902f7a43bd68259"
+source = "git+https://github.com/rust-diplomat/diplomat.git?rev=c682c6dbde93d70853a8189d955c4d0ac40b92e6#c682c6dbde93d70853a8189d955c4d0ac40b92e6"
 dependencies = [
  "displaydoc",
  "either",
@@ -785,7 +714,7 @@ dependencies = [
  "serde",
  "smallvec",
  "strck_ident",
- "syn 2.0.48",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -796,16 +725,18 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "dlmalloc"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203540e710bfadb90e5e29930baf5d10270cec1f43ab34f46f78b147b2de715a"
+checksum = "3264b043b8e977326c1ee9e723da2c1f8d09a99df52cacf00b4dbce5ac54414d"
 dependencies = [
+ "cfg-if",
  "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -816,15 +747,15 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "ecma402_traits"
-version = "4.0.0"
+version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0c2a4ea26259c41a15dcd263be230bdb0a113246a046e8288738879a8304e4"
+checksum = "1cf9f18d67a0f890f4b8e2f1b3b0f590fec42b30ce0d34a67b8cd8bc3d63a15e"
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "elsa"
@@ -846,6 +777,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
 name = "erased-serde"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,20 +792,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "eyre"
-version = "0.6.8"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
@@ -892,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -917,9 +844,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -932,9 +859,9 @@ checksum = "8ed4d1f7356542cd640004f488cc41358ced96b1efab1fead3753d868a93d504"
 
 [[package]]
 name = "freetype"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee38378a9e3db1cc693b4f88d166ae375338a0ff75cb8263e1c601d51f35dc6"
+checksum = "efc8599a3078adf8edeb86c71e9f8fa7d88af5ca31e806a867756081f90f5d83"
 dependencies = [
  "freetype-sys",
  "libc",
@@ -942,11 +869,11 @@ dependencies = [
 
 [[package]]
 name = "freetype-sys"
-version = "0.13.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37d4011c0cc628dfa766fcc195454f4b068d7afdc2adfd28861191d866e731a"
+checksum = "66ee28c39a43d89fbed8b4798fb4ba56722cfd2b5af81f9326c27614ba88ecd5"
 dependencies = [
- "cmake",
+ "cc",
  "libc",
  "pkg-config",
 ]
@@ -968,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -981,15 +908,19 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "half"
-version = "1.8.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
 
 [[package]]
 name = "harfbuzz"
@@ -1034,15 +965,15 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
  "hash32",
  "rustc_version 0.4.0",
  "serde",
- "spin 0.9.8",
+ "spin",
  "stable_deref_trait",
 ]
 
@@ -1062,19 +993,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
+name = "heck"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "humansize"
@@ -1141,7 +1069,7 @@ dependencies = [
 name = "icu_benchmark_memory"
 version = "0.0.0"
 dependencies = [
- "clap 4.2.1",
+ "clap",
  "libc",
  "serde_json",
 ]
@@ -1294,7 +1222,7 @@ name = "icu_datagen"
 version = "1.4.1"
 dependencies = [
  "calendrical_calculations",
- "clap 4.2.1",
+ "clap",
  "crlify",
  "databake",
  "displaydoc",
@@ -1351,7 +1279,7 @@ dependencies = [
 name = "icu_datagen_dart"
 version = "1.4.0"
 dependencies = [
- "clap 4.2.1",
+ "clap",
  "eyre",
  "icu_calendar",
  "icu_casemap",
@@ -1743,7 +1671,7 @@ dependencies = [
  "icu_provider",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1776,7 +1704,7 @@ version = "1.4.0"
 name = "icu_testdata_scripts"
 version = "0.0.0"
 dependencies = [
- "clap 4.2.1",
+ "clap",
  "crlify",
  "databake",
  "eyre",
@@ -1813,9 +1741,9 @@ version = "1.4.0"
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1845,13 +1773,13 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.3",
- "rustix",
- "windows-sys 0.48.0",
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1865,9 +1793,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "ixdtf"
@@ -1880,9 +1808,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1901,21 +1829,15 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libc_alloc"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a835c038b748123287f9fb1743d565e7c635879997f43c345a18a026690364e"
+checksum = "7581282928bc99698341d1de7590964c28db747c164eaac9409432a3eaed098a"
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "litemap"
@@ -1936,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1946,9 +1868,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "lru"
@@ -1993,18 +1915,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
-
-[[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg",
-]
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "mime"
@@ -2030,22 +1943,18 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mintex"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7c5ba1c3b5a23418d7bbf98c71c3d4946a0125002129231da8d6b723d559cb"
-dependencies = [
- "once_cell",
- "sys-info",
-]
+checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
 
 [[package]]
 name = "nb"
@@ -2098,20 +2007,25 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
+name = "num-conv"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
@@ -2139,39 +2053,33 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "parking_lot"
@@ -2185,9 +2093,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2210,15 +2118,15 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "plotters"
@@ -2250,14 +2158,21 @@ dependencies = [
 
 [[package]]
 name = "postcard"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d534c6e61df1c7166e636ca612d9820d486fe96ddad37f7abc671517b297488e"
+checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
 dependencies = [
  "cobs",
+ "embedded-io",
  "heapless",
  "serde",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2266,34 +2181,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -2324,7 +2215,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "getopts",
  "memchr",
  "unicase",
@@ -2402,9 +2293,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -2412,9 +2303,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -2422,23 +2313,23 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.8",
- "regex-syntax 0.7.5",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -2453,13 +2344,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -2470,15 +2361,15 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rend"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
 ]
@@ -2496,27 +2387,28 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
+ "getrandom",
  "libc",
- "once_cell",
- "spin 0.5.2",
+ "spin",
  "untrusted",
- "web-sys",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rkyv"
-version = "0.7.42"
+version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0200c8230b013893c0b2d6213d6ec64ed2b9be2e0e016682b7224ff82cff5c58"
+checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
 dependencies = [
  "bitvec",
  "bytecheck",
+ "bytes",
  "hashbrown",
  "ptr_meta",
  "rend",
@@ -2528,9 +2420,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.42"
+version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e06b915b5c230a17d7a736d1e2e63ee753c256a8614ef3f5147b13a4f5541d"
+checksum = "a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2564,7 +2456,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.18",
+ "semver 1.0.22",
 ]
 
 [[package]]
@@ -2577,55 +2469,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.38.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
-dependencies = [
- "bitflags 2.4.2",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rustls"
-version = "0.21.7"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.6",
- "sct",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.100.3"
+name = "rustls-pki-types"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6a5fc258f1c1276dfe3016516945546e2d5383911efc0fc4f1cdc5df3a4ae3"
-dependencies = [
- "ring",
- "untrusted",
-]
+checksum = "868e20fada228fefaf6b652e00cc73623d54f8171e7352c18bb281571f2d92da"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.6"
+version = "0.102.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
  "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "same-file"
@@ -2641,16 +2519,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "seahash"
@@ -2669,9 +2537,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "semver-parser"
@@ -2681,18 +2549,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde-aux"
-version = "4.2.0"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3dfe1b7eb6f9dcf011bd6fad169cdeaae75eda0d61b1a99a3f015b41b0cae39"
+checksum = "0d2e8bfba469d06512e11e3311d4d051a4a387a5b42d010404fecf3200321c95"
 dependencies = [
  "serde",
  "serde_json",
@@ -2711,20 +2579,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -2739,30 +2607,24 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "simple_logger"
-version = "4.2.0"
+version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2230cd5c29b815c9b699fb610b49a5ed65588f3509d9f0108be3a885da629333"
+checksum = "8e7e46c8c90251d47d08b28b8a419ffb4aede0f87c2eea95e17d1d5bacbf3ef1"
 dependencies = [
  "colored",
  "log",
  "time",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -2803,9 +2665,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "strum"
@@ -2829,6 +2691,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2841,9 +2709,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2857,29 +2725,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fa6dca1fdb7b2ed46dd534a326725419d4fb10f23d8c85a8b2860e5eb25d0f9"
 dependencies = [
  "proc-macro2",
- "syn 2.0.48",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "synstructure"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285ba80e733fac80aa4270fbcdf83772a79b80aa35c97075320abfee4a915b06"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
- "unicode-xid",
-]
-
-[[package]]
-name = "sys-info"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
-dependencies = [
- "cc",
- "libc",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2889,21 +2746,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "termcolor"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "thousands"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2911,13 +2753,16 @@ checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
+ "deranged",
  "itoa",
  "libc",
+ "num-conv",
  "num_threads",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -2925,16 +2770,17 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -3022,9 +2868,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -3034,18 +2880,18 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
@@ -3054,38 +2900,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
 name = "untrusted"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.7.1"
+version = "2.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
+checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
 dependencies = [
  "base64",
  "flate2",
  "log",
  "once_cell",
  "rustls",
- "rustls-webpki 0.100.3",
+ "rustls-pki-types",
+ "rustls-webpki",
  "url",
  "webpki-roots",
 ]
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3094,15 +2935,15 @@ dependencies = [
 
 [[package]]
 name = "utf16_iter"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52df8b7fb78e7910d776fccf2e42ceaf3604d55e8e7eb2dbd183cb1441d8a692"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a8922555b9500e3d865caed19330172cd67cbf82203f1a3311d8c305cc9f33"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -3112,9 +2953,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 
 [[package]]
 name = "vcell"
@@ -3136,18 +2977,18 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "volatile-register"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
+checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
 ]
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -3161,9 +3002,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3171,24 +3012,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.55",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3196,22 +3037,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.55",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasmi"
@@ -3220,7 +3061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a8281d1d660cdf54c76a3efa9ddd0c270cada1383a995db3ccb43d166456c7"
 dependencies = [
  "smallvec",
- "spin 0.9.8",
+ "spin",
  "wasmi_arena",
  "wasmi_core",
  "wasmparser-nostd",
@@ -3255,9 +3096,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3265,11 +3106,11 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.23.1"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
 dependencies = [
- "rustls-webpki 0.100.3",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3305,30 +3146,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -3342,22 +3159,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -3377,24 +3179,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3404,15 +3200,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3422,15 +3212,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3440,15 +3224,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3458,15 +3236,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3476,15 +3248,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3494,15 +3260,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3512,9 +3272,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "write16"
@@ -3560,7 +3320,7 @@ version = "0.7.3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.55",
  "synstructure",
  "yoke",
  "zerovec",
@@ -3579,11 +3339,17 @@ version = "0.1.3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.55",
  "synstructure",
  "zerofrom",
  "zerovec",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zerotrie"
@@ -3638,7 +3404,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.48",
+ "syn 2.0.55",
  "zerofrom",
  "zerovec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,10 +207,10 @@ icu_benchmark_macros = { path = "tools/benchmark/macros" }
 
 # The version here can either be a `version = ".."` spec or `git = "https://github.com/rust-diplomat/diplomat", rev = ".."`
 # Diplomat must be published preceding a new ICU4X release but may use git versions in between
-diplomat = { git = "https://github.com/rust-diplomat/diplomat.git", rev = "99ab75d8054b9ddca7fd1def0902f7a43bd68259" }
-diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat.git", rev = "99ab75d8054b9ddca7fd1def0902f7a43bd68259" }
-diplomat_core = { git = "https://github.com/rust-diplomat/diplomat.git", rev = "99ab75d8054b9ddca7fd1def0902f7a43bd68259" }
-diplomat-tool = { git = "https://github.com/rust-diplomat/diplomat.git", rev = "99ab75d8054b9ddca7fd1def0902f7a43bd68259" }
+diplomat = { git = "https://github.com/rust-diplomat/diplomat.git", rev = "c682c6dbde93d70853a8189d955c4d0ac40b92e6" }
+diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat.git", rev = "c682c6dbde93d70853a8189d955c4d0ac40b92e6" }
+diplomat_core = { git = "https://github.com/rust-diplomat/diplomat.git", rev = "c682c6dbde93d70853a8189d955c4d0ac40b92e6" }
+diplomat-tool = { git = "https://github.com/rust-diplomat/diplomat.git", rev = "c682c6dbde93d70853a8189d955c4d0ac40b92e6" }
 
 # Size optimized builds
 [profile.release-opt-size]

--- a/ffi/capi/bindings/c/diplomat_runtime.h
+++ b/ffi/capi/bindings/c/diplomat_runtime.h
@@ -35,28 +35,32 @@ typedef struct DiplomatWriteable {
 
 DiplomatWriteable diplomat_simple_writeable(char* buf, size_t buf_size);
 
-#define MAKE_SLICE_VIEW(name, c_ty) \
+#define MAKE_SLICES(name, c_ty) \
     typedef struct Diplomat##name##View { \
         const c_ty* data; \
         size_t len; \
-    } Diplomat##name##View;
+    } Diplomat##name##View; \
+    typedef struct Diplomat##name##Array { \
+        const c_ty* data; \
+        size_t len; \
+    } Diplomat##name##Array;
 
-MAKE_SLICE_VIEW(I8, int8_t)
-MAKE_SLICE_VIEW(U8, uint8_t)
-MAKE_SLICE_VIEW(I16, int16_t)
-MAKE_SLICE_VIEW(U16, uint16_t)
-MAKE_SLICE_VIEW(I32, int32_t)
-MAKE_SLICE_VIEW(U32, uint32_t)
-MAKE_SLICE_VIEW(I64, int64_t)
-MAKE_SLICE_VIEW(U64, uint64_t)
-MAKE_SLICE_VIEW(Isize, intptr_t)
-MAKE_SLICE_VIEW(Usize, size_t)
-MAKE_SLICE_VIEW(F32, float)
-MAKE_SLICE_VIEW(F64, double)
-MAKE_SLICE_VIEW(Bool, bool)
-MAKE_SLICE_VIEW(Char, char32_t)
-MAKE_SLICE_VIEW(String, char)
-MAKE_SLICE_VIEW(U16String, char16_t)
+MAKE_SLICES(I8, int8_t)
+MAKE_SLICES(U8, uint8_t)
+MAKE_SLICES(I16, int16_t)
+MAKE_SLICES(U16, uint16_t)
+MAKE_SLICES(I32, int32_t)
+MAKE_SLICES(U32, uint32_t)
+MAKE_SLICES(I64, int64_t)
+MAKE_SLICES(U64, uint64_t)
+MAKE_SLICES(Isize, intptr_t)
+MAKE_SLICES(Usize, size_t)
+MAKE_SLICES(F32, float)
+MAKE_SLICES(F64, double)
+MAKE_SLICES(Bool, bool)
+MAKE_SLICES(Char, char32_t)
+MAKE_SLICES(String, char)
+MAKE_SLICES(U16String, char16_t)
 
 
 #ifdef __cplusplus

--- a/ffi/capi/bindings/cpp/diplomat_runtime.h
+++ b/ffi/capi/bindings/cpp/diplomat_runtime.h
@@ -35,28 +35,32 @@ typedef struct DiplomatWriteable {
 
 DiplomatWriteable diplomat_simple_writeable(char* buf, size_t buf_size);
 
-#define MAKE_SLICE_VIEW(name, c_ty) \
+#define MAKE_SLICES(name, c_ty) \
     typedef struct Diplomat##name##View { \
         const c_ty* data; \
         size_t len; \
-    } Diplomat##name##View;
+    } Diplomat##name##View; \
+    typedef struct Diplomat##name##Array { \
+        const c_ty* data; \
+        size_t len; \
+    } Diplomat##name##Array;
 
-MAKE_SLICE_VIEW(I8, int8_t)
-MAKE_SLICE_VIEW(U8, uint8_t)
-MAKE_SLICE_VIEW(I16, int16_t)
-MAKE_SLICE_VIEW(U16, uint16_t)
-MAKE_SLICE_VIEW(I32, int32_t)
-MAKE_SLICE_VIEW(U32, uint32_t)
-MAKE_SLICE_VIEW(I64, int64_t)
-MAKE_SLICE_VIEW(U64, uint64_t)
-MAKE_SLICE_VIEW(Isize, intptr_t)
-MAKE_SLICE_VIEW(Usize, size_t)
-MAKE_SLICE_VIEW(F32, float)
-MAKE_SLICE_VIEW(F64, double)
-MAKE_SLICE_VIEW(Bool, bool)
-MAKE_SLICE_VIEW(Char, char32_t)
-MAKE_SLICE_VIEW(String, char)
-MAKE_SLICE_VIEW(U16String, char16_t)
+MAKE_SLICES(I8, int8_t)
+MAKE_SLICES(U8, uint8_t)
+MAKE_SLICES(I16, int16_t)
+MAKE_SLICES(U16, uint16_t)
+MAKE_SLICES(I32, int32_t)
+MAKE_SLICES(U32, uint32_t)
+MAKE_SLICES(I64, int64_t)
+MAKE_SLICES(U64, uint64_t)
+MAKE_SLICES(Isize, intptr_t)
+MAKE_SLICES(Usize, size_t)
+MAKE_SLICES(F32, float)
+MAKE_SLICES(F64, double)
+MAKE_SLICES(Bool, bool)
+MAKE_SLICES(Char, char32_t)
+MAKE_SLICES(String, char)
+MAKE_SLICES(U16String, char16_t)
 
 
 #ifdef __cplusplus

--- a/ffi/capi/bindings/dart/AnyCalendarKind.g.dart
+++ b/ffi/capi/bindings/dart/AnyCalendarKind.g.dart
@@ -95,7 +95,7 @@ enum AnyCalendarKind {
   /// See the [Rust documentation for `as_bcp47_string`](https://docs.rs/icu/latest/icu/calendar/enum.AnyCalendarKind.html#method.as_bcp47_string) for more information.
   ///
   /// Throws [Error] on failure.
-  String get bcp47 {
+  String bcp47() {
     final writeable = _Writeable();
     final result = _ICU4XAnyCalendarKind_bcp47(index, writeable._ffi);
     if (!result.isOk) {

--- a/ffi/capi/bindings/dart/Bcp47ToIanaMapper.g.dart
+++ b/ffi/capi/bindings/dart/Bcp47ToIanaMapper.g.dart
@@ -27,7 +27,7 @@ final class Bcp47ToIanaMapper implements ffi.Finalizable {
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/timezone/struct.IanaBcp47RoundTripMapper.html#method.new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory Bcp47ToIanaMapper(DataProvider provider) {
+  static Bcp47ToIanaMapper create(DataProvider provider) {
     final result = _ICU4XBcp47ToIanaMapper_create(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/Bidi.g.dart
+++ b/ffi/capi/bindings/dart/Bidi.g.dart
@@ -29,7 +29,7 @@ final class Bidi implements ffi.Finalizable {
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/properties/bidi/struct.BidiClassAdapter.html#method.new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory Bidi(DataProvider provider) {
+  static Bidi create(DataProvider provider) {
     final result = _ICU4XBidi_create(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/BidiInfo.g.dart
+++ b/ffi/capi/bindings/dart/BidiInfo.g.dart
@@ -27,7 +27,7 @@ final class BidiInfo implements ffi.Finalizable {
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_ICU4XBidiInfo_destroy));
 
   /// The number of paragraphs contained here
-  int get paragraphCount {
+  int paragraphCount() {
     final result = _ICU4XBidiInfo_paragraph_count(_ffi);
     return result;
   }
@@ -41,7 +41,7 @@ final class BidiInfo implements ffi.Finalizable {
   }
 
   /// The number of bytes in this full text
-  int get size {
+  int size() {
     final result = _ICU4XBidiInfo_size(_ffi);
     return result;
   }

--- a/ffi/capi/bindings/dart/BidiParagraph.g.dart
+++ b/ffi/capi/bindings/dart/BidiParagraph.g.dart
@@ -42,7 +42,7 @@ final class BidiParagraph implements ffi.Finalizable {
   /// The primary direction of this paragraph
   ///
   /// See the [Rust documentation for `level_at`](https://docs.rs/unicode_bidi/latest/unicode_bidi/struct.Paragraph.html#method.level_at) for more information.
-  BidiDirection get direction {
+  BidiDirection direction() {
     final result = _ICU4XBidiParagraph_direction(_ffi);
     return BidiDirection.values[result];
   }
@@ -50,19 +50,19 @@ final class BidiParagraph implements ffi.Finalizable {
   /// The number of bytes in this paragraph
   ///
   /// See the [Rust documentation for `len`](https://docs.rs/unicode_bidi/latest/unicode_bidi/struct.ParagraphInfo.html#method.len) for more information.
-  int get size {
+  int size() {
     final result = _ICU4XBidiParagraph_size(_ffi);
     return result;
   }
 
   /// The start index of this paragraph within the source text
-  int get rangeStart {
+  int rangeStart() {
     final result = _ICU4XBidiParagraph_range_start(_ffi);
     return result;
   }
 
   /// The end index of this paragraph within the source text
-  int get rangeEnd {
+  int rangeEnd() {
     final result = _ICU4XBidiParagraph_range_end(_ffi);
     return result;
   }

--- a/ffi/capi/bindings/dart/Calendar.g.dart
+++ b/ffi/capi/bindings/dart/Calendar.g.dart
@@ -27,7 +27,7 @@ final class Calendar implements ffi.Finalizable {
   /// See the [Rust documentation for `new_for_locale`](https://docs.rs/icu/latest/icu/calendar/enum.AnyCalendar.html#method.new_for_locale) for more information.
   ///
   /// Throws [Error] on failure.
-  factory Calendar.forLocale(DataProvider provider, Locale locale) {
+  static Calendar createForLocale(DataProvider provider, Locale locale) {
     final result = _ICU4XCalendar_create_for_locale(provider._ffi, locale._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -40,7 +40,7 @@ final class Calendar implements ffi.Finalizable {
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/calendar/enum.AnyCalendar.html#method.new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory Calendar.forKind(DataProvider provider, AnyCalendarKind kind) {
+  static Calendar createForKind(DataProvider provider, AnyCalendarKind kind) {
     final result = _ICU4XCalendar_create_for_kind(provider._ffi, kind.index);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -51,7 +51,7 @@ final class Calendar implements ffi.Finalizable {
   /// Returns the kind of this calendar
   ///
   /// See the [Rust documentation for `kind`](https://docs.rs/icu/latest/icu/calendar/enum.AnyCalendar.html#method.kind) for more information.
-  AnyCalendarKind get kind {
+  AnyCalendarKind kind() {
     final result = _ICU4XCalendar_kind(_ffi);
     return AnyCalendarKind.values[result];
   }

--- a/ffi/capi/bindings/dart/CanonicalCombiningClassMap.g.dart
+++ b/ffi/capi/bindings/dart/CanonicalCombiningClassMap.g.dart
@@ -29,7 +29,7 @@ final class CanonicalCombiningClassMap implements ffi.Finalizable {
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/normalizer/properties/struct.CanonicalCombiningClassMap.html#method.new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CanonicalCombiningClassMap(DataProvider provider) {
+  static CanonicalCombiningClassMap create(DataProvider provider) {
     final result = _ICU4XCanonicalCombiningClassMap_create(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/CanonicalComposition.g.dart
+++ b/ffi/capi/bindings/dart/CanonicalComposition.g.dart
@@ -31,7 +31,7 @@ final class CanonicalComposition implements ffi.Finalizable {
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/normalizer/properties/struct.CanonicalComposition.html#method.new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CanonicalComposition(DataProvider provider) {
+  static CanonicalComposition create(DataProvider provider) {
     final result = _ICU4XCanonicalComposition_create(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/CanonicalDecomposition.g.dart
+++ b/ffi/capi/bindings/dart/CanonicalDecomposition.g.dart
@@ -31,7 +31,7 @@ final class CanonicalDecomposition implements ffi.Finalizable {
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/normalizer/properties/struct.CanonicalDecomposition.html#method.new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CanonicalDecomposition(DataProvider provider) {
+  static CanonicalDecomposition create(DataProvider provider) {
     final result = _ICU4XCanonicalDecomposition_create(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/CaseMapCloser.g.dart
+++ b/ffi/capi/bindings/dart/CaseMapCloser.g.dart
@@ -27,7 +27,7 @@ final class CaseMapCloser implements ffi.Finalizable {
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/casemap/struct.CaseMapCloser.html#method.new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CaseMapCloser(DataProvider provider) {
+  static CaseMapCloser create(DataProvider provider) {
     final result = _ICU4XCaseMapCloser_create(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/CaseMapper.g.dart
+++ b/ffi/capi/bindings/dart/CaseMapper.g.dart
@@ -27,7 +27,7 @@ final class CaseMapper implements ffi.Finalizable {
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/casemap/struct.CaseMapper.html#method.new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CaseMapper(DataProvider provider) {
+  static CaseMapper create(DataProvider provider) {
     final result = _ICU4XCaseMapper_create(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/CodePointMapData16.g.dart
+++ b/ffi/capi/bindings/dart/CodePointMapData16.g.dart
@@ -69,7 +69,7 @@ final class CodePointMapData16 implements ffi.Finalizable {
   /// See the [Rust documentation for `script`](https://docs.rs/icu/latest/icu/properties/maps/fn.script.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointMapData16.loadScript(DataProvider provider) {
+  static CodePointMapData16 loadScript(DataProvider provider) {
     final result = _ICU4XCodePointMapData16_load_script(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/CodePointMapData8.g.dart
+++ b/ffi/capi/bindings/dart/CodePointMapData8.g.dart
@@ -96,7 +96,7 @@ final class CodePointMapData8 implements ffi.Finalizable {
   /// See the [Rust documentation for `general_category`](https://docs.rs/icu/latest/icu/properties/maps/fn.general_category.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointMapData8.loadGeneralCategory(DataProvider provider) {
+  static CodePointMapData8 loadGeneralCategory(DataProvider provider) {
     final result = _ICU4XCodePointMapData8_load_general_category(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -107,7 +107,7 @@ final class CodePointMapData8 implements ffi.Finalizable {
   /// See the [Rust documentation for `bidi_class`](https://docs.rs/icu/latest/icu/properties/maps/fn.bidi_class.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointMapData8.loadBidiClass(DataProvider provider) {
+  static CodePointMapData8 loadBidiClass(DataProvider provider) {
     final result = _ICU4XCodePointMapData8_load_bidi_class(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -118,7 +118,7 @@ final class CodePointMapData8 implements ffi.Finalizable {
   /// See the [Rust documentation for `east_asian_width`](https://docs.rs/icu/latest/icu/properties/maps/fn.east_asian_width.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointMapData8.loadEastAsianWidth(DataProvider provider) {
+  static CodePointMapData8 loadEastAsianWidth(DataProvider provider) {
     final result = _ICU4XCodePointMapData8_load_east_asian_width(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -129,7 +129,7 @@ final class CodePointMapData8 implements ffi.Finalizable {
   /// See the [Rust documentation for `indic_syllabic_category`](https://docs.rs/icu/latest/icu/properties/maps/fn.indic_syllabic_category.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointMapData8.loadIndicSyllabicCategory(DataProvider provider) {
+  static CodePointMapData8 loadIndicSyllabicCategory(DataProvider provider) {
     final result = _ICU4XCodePointMapData8_load_indic_syllabic_category(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -140,7 +140,7 @@ final class CodePointMapData8 implements ffi.Finalizable {
   /// See the [Rust documentation for `line_break`](https://docs.rs/icu/latest/icu/properties/maps/fn.line_break.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointMapData8.loadLineBreak(DataProvider provider) {
+  static CodePointMapData8 loadLineBreak(DataProvider provider) {
     final result = _ICU4XCodePointMapData8_load_line_break(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -151,7 +151,7 @@ final class CodePointMapData8 implements ffi.Finalizable {
   /// See the [Rust documentation for `grapheme_cluster_break`](https://docs.rs/icu/latest/icu/properties/maps/fn.grapheme_cluster_break.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointMapData8.graphemeClusterBreak(DataProvider provider) {
+  static CodePointMapData8 tryGraphemeClusterBreak(DataProvider provider) {
     final result = _ICU4XCodePointMapData8_try_grapheme_cluster_break(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -162,7 +162,7 @@ final class CodePointMapData8 implements ffi.Finalizable {
   /// See the [Rust documentation for `word_break`](https://docs.rs/icu/latest/icu/properties/maps/fn.word_break.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointMapData8.loadWordBreak(DataProvider provider) {
+  static CodePointMapData8 loadWordBreak(DataProvider provider) {
     final result = _ICU4XCodePointMapData8_load_word_break(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -173,7 +173,7 @@ final class CodePointMapData8 implements ffi.Finalizable {
   /// See the [Rust documentation for `sentence_break`](https://docs.rs/icu/latest/icu/properties/maps/fn.sentence_break.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointMapData8.loadSentenceBreak(DataProvider provider) {
+  static CodePointMapData8 loadSentenceBreak(DataProvider provider) {
     final result = _ICU4XCodePointMapData8_load_sentence_break(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -184,7 +184,7 @@ final class CodePointMapData8 implements ffi.Finalizable {
   /// See the [Rust documentation for `joining_type`](https://docs.rs/icu/latest/icu/properties/maps/fn.joining_type.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointMapData8.loadJoiningType(DataProvider provider) {
+  static CodePointMapData8 loadJoiningType(DataProvider provider) {
     final result = _ICU4XCodePointMapData8_load_joining_type(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/CodePointSetBuilder.g.dart
+++ b/ffi/capi/bindings/dart/CodePointSetBuilder.g.dart
@@ -25,10 +25,10 @@ final class CodePointSetBuilder implements ffi.Finalizable {
   /// Make a new set builder containing nothing
   ///
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.new) for more information.
-  factory CodePointSetBuilder() {
+  static final CodePointSetBuilder singleton = () {
     final result = _ICU4XCodePointSetBuilder_create();
     return CodePointSetBuilder._fromFfi(result, []);
-  }
+  }();
 
   /// Build this into a set
   ///
@@ -52,7 +52,7 @@ final class CodePointSetBuilder implements ffi.Finalizable {
   /// Returns whether this set is empty
   ///
   /// See the [Rust documentation for `is_empty`](https://docs.rs/icu/latest/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.is_empty) for more information.
-  bool get isEmpty {
+  bool isEmpty() {
     final result = _ICU4XCodePointSetBuilder_is_empty(_ffi);
     return result;
   }

--- a/ffi/capi/bindings/dart/CodePointSetData.g.dart
+++ b/ffi/capi/bindings/dart/CodePointSetData.g.dart
@@ -39,7 +39,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// Produces an iterator over ranges of code points contained in this set
   ///
   /// See the [Rust documentation for `iter_ranges`](https://docs.rs/icu/latest/icu/properties/sets/struct.CodePointSetDataBorrowed.html#method.iter_ranges) for more information.
-  CodePointRangeIterator get iterRanges {
+  CodePointRangeIterator iterRanges() {
     // This lifetime edge depends on lifetimes: 'a
     core.List<Object> aEdges = [this];
     final result = _ICU4XCodePointSetData_iter_ranges(_ffi);
@@ -49,7 +49,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// Produces an iterator over ranges of code points not contained in this set
   ///
   /// See the [Rust documentation for `iter_ranges_complemented`](https://docs.rs/icu/latest/icu/properties/sets/struct.CodePointSetDataBorrowed.html#method.iter_ranges_complemented) for more information.
-  CodePointRangeIterator get iterRangesComplemented {
+  CodePointRangeIterator iterRangesComplemented() {
     // This lifetime edge depends on lifetimes: 'a
     core.List<Object> aEdges = [this];
     final result = _ICU4XCodePointSetData_iter_ranges_complemented(_ffi);
@@ -61,7 +61,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `for_general_category_group`](https://docs.rs/icu/latest/icu/properties/sets/fn.for_general_category_group.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadForGeneralCategoryGroup(DataProvider provider, int group) {
+  static CodePointSetData loadForGeneralCategoryGroup(DataProvider provider, int group) {
     final result = _ICU4XCodePointSetData_load_for_general_category_group(provider._ffi, group);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -72,7 +72,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `ascii_hex_digit`](https://docs.rs/icu/latest/icu/properties/sets/fn.ascii_hex_digit.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadAsciiHexDigit(DataProvider provider) {
+  static CodePointSetData loadAsciiHexDigit(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_ascii_hex_digit(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -83,7 +83,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `alnum`](https://docs.rs/icu/latest/icu/properties/sets/fn.alnum.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadAlnum(DataProvider provider) {
+  static CodePointSetData loadAlnum(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_alnum(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -94,7 +94,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `alphabetic`](https://docs.rs/icu/latest/icu/properties/sets/fn.alphabetic.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadAlphabetic(DataProvider provider) {
+  static CodePointSetData loadAlphabetic(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_alphabetic(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -105,7 +105,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `bidi_control`](https://docs.rs/icu/latest/icu/properties/sets/fn.bidi_control.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadBidiControl(DataProvider provider) {
+  static CodePointSetData loadBidiControl(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_bidi_control(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -116,7 +116,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `bidi_mirrored`](https://docs.rs/icu/latest/icu/properties/sets/fn.bidi_mirrored.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadBidiMirrored(DataProvider provider) {
+  static CodePointSetData loadBidiMirrored(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_bidi_mirrored(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -127,7 +127,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `blank`](https://docs.rs/icu/latest/icu/properties/sets/fn.blank.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadBlank(DataProvider provider) {
+  static CodePointSetData loadBlank(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_blank(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -138,7 +138,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `cased`](https://docs.rs/icu/latest/icu/properties/sets/fn.cased.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadCased(DataProvider provider) {
+  static CodePointSetData loadCased(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_cased(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -149,7 +149,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `case_ignorable`](https://docs.rs/icu/latest/icu/properties/sets/fn.case_ignorable.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadCaseIgnorable(DataProvider provider) {
+  static CodePointSetData loadCaseIgnorable(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_case_ignorable(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -160,7 +160,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `full_composition_exclusion`](https://docs.rs/icu/latest/icu/properties/sets/fn.full_composition_exclusion.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadFullCompositionExclusion(DataProvider provider) {
+  static CodePointSetData loadFullCompositionExclusion(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_full_composition_exclusion(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -171,7 +171,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `changes_when_casefolded`](https://docs.rs/icu/latest/icu/properties/sets/fn.changes_when_casefolded.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadChangesWhenCasefolded(DataProvider provider) {
+  static CodePointSetData loadChangesWhenCasefolded(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_changes_when_casefolded(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -182,7 +182,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `changes_when_casemapped`](https://docs.rs/icu/latest/icu/properties/sets/fn.changes_when_casemapped.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadChangesWhenCasemapped(DataProvider provider) {
+  static CodePointSetData loadChangesWhenCasemapped(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_changes_when_casemapped(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -193,7 +193,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `changes_when_nfkc_casefolded`](https://docs.rs/icu/latest/icu/properties/sets/fn.changes_when_nfkc_casefolded.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadChangesWhenNfkcCasefolded(DataProvider provider) {
+  static CodePointSetData loadChangesWhenNfkcCasefolded(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_changes_when_nfkc_casefolded(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -204,7 +204,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `changes_when_lowercased`](https://docs.rs/icu/latest/icu/properties/sets/fn.changes_when_lowercased.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadChangesWhenLowercased(DataProvider provider) {
+  static CodePointSetData loadChangesWhenLowercased(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_changes_when_lowercased(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -215,7 +215,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `changes_when_titlecased`](https://docs.rs/icu/latest/icu/properties/sets/fn.changes_when_titlecased.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadChangesWhenTitlecased(DataProvider provider) {
+  static CodePointSetData loadChangesWhenTitlecased(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_changes_when_titlecased(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -226,7 +226,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `changes_when_uppercased`](https://docs.rs/icu/latest/icu/properties/sets/fn.changes_when_uppercased.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadChangesWhenUppercased(DataProvider provider) {
+  static CodePointSetData loadChangesWhenUppercased(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_changes_when_uppercased(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -237,7 +237,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `dash`](https://docs.rs/icu/latest/icu/properties/sets/fn.dash.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadDash(DataProvider provider) {
+  static CodePointSetData loadDash(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_dash(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -248,7 +248,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `deprecated`](https://docs.rs/icu/latest/icu/properties/sets/fn.deprecated.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadDeprecated(DataProvider provider) {
+  static CodePointSetData loadDeprecated(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_deprecated(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -259,7 +259,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `default_ignorable_code_point`](https://docs.rs/icu/latest/icu/properties/sets/fn.default_ignorable_code_point.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadDefaultIgnorableCodePoint(DataProvider provider) {
+  static CodePointSetData loadDefaultIgnorableCodePoint(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_default_ignorable_code_point(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -270,7 +270,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `diacritic`](https://docs.rs/icu/latest/icu/properties/sets/fn.diacritic.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadDiacritic(DataProvider provider) {
+  static CodePointSetData loadDiacritic(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_diacritic(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -281,7 +281,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `emoji_modifier_base`](https://docs.rs/icu/latest/icu/properties/sets/fn.emoji_modifier_base.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadEmojiModifierBase(DataProvider provider) {
+  static CodePointSetData loadEmojiModifierBase(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_emoji_modifier_base(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -292,7 +292,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `emoji_component`](https://docs.rs/icu/latest/icu/properties/sets/fn.emoji_component.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadEmojiComponent(DataProvider provider) {
+  static CodePointSetData loadEmojiComponent(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_emoji_component(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -303,7 +303,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `emoji_modifier`](https://docs.rs/icu/latest/icu/properties/sets/fn.emoji_modifier.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadEmojiModifier(DataProvider provider) {
+  static CodePointSetData loadEmojiModifier(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_emoji_modifier(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -314,7 +314,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `emoji`](https://docs.rs/icu/latest/icu/properties/sets/fn.emoji.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadEmoji(DataProvider provider) {
+  static CodePointSetData loadEmoji(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_emoji(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -325,7 +325,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `emoji_presentation`](https://docs.rs/icu/latest/icu/properties/sets/fn.emoji_presentation.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadEmojiPresentation(DataProvider provider) {
+  static CodePointSetData loadEmojiPresentation(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_emoji_presentation(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -336,7 +336,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `extender`](https://docs.rs/icu/latest/icu/properties/sets/fn.extender.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadExtender(DataProvider provider) {
+  static CodePointSetData loadExtender(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_extender(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -347,7 +347,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `extended_pictographic`](https://docs.rs/icu/latest/icu/properties/sets/fn.extended_pictographic.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadExtendedPictographic(DataProvider provider) {
+  static CodePointSetData loadExtendedPictographic(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_extended_pictographic(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -358,7 +358,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `graph`](https://docs.rs/icu/latest/icu/properties/sets/fn.graph.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadGraph(DataProvider provider) {
+  static CodePointSetData loadGraph(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_graph(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -369,7 +369,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `grapheme_base`](https://docs.rs/icu/latest/icu/properties/sets/fn.grapheme_base.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadGraphemeBase(DataProvider provider) {
+  static CodePointSetData loadGraphemeBase(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_grapheme_base(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -380,7 +380,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `grapheme_extend`](https://docs.rs/icu/latest/icu/properties/sets/fn.grapheme_extend.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadGraphemeExtend(DataProvider provider) {
+  static CodePointSetData loadGraphemeExtend(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_grapheme_extend(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -391,7 +391,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `grapheme_link`](https://docs.rs/icu/latest/icu/properties/sets/fn.grapheme_link.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadGraphemeLink(DataProvider provider) {
+  static CodePointSetData loadGraphemeLink(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_grapheme_link(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -402,7 +402,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `hex_digit`](https://docs.rs/icu/latest/icu/properties/sets/fn.hex_digit.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadHexDigit(DataProvider provider) {
+  static CodePointSetData loadHexDigit(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_hex_digit(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -413,7 +413,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `hyphen`](https://docs.rs/icu/latest/icu/properties/sets/fn.hyphen.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadHyphen(DataProvider provider) {
+  static CodePointSetData loadHyphen(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_hyphen(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -424,7 +424,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `id_continue`](https://docs.rs/icu/latest/icu/properties/sets/fn.id_continue.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadIdContinue(DataProvider provider) {
+  static CodePointSetData loadIdContinue(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_id_continue(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -435,7 +435,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `ideographic`](https://docs.rs/icu/latest/icu/properties/sets/fn.ideographic.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadIdeographic(DataProvider provider) {
+  static CodePointSetData loadIdeographic(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_ideographic(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -446,7 +446,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `id_start`](https://docs.rs/icu/latest/icu/properties/sets/fn.id_start.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadIdStart(DataProvider provider) {
+  static CodePointSetData loadIdStart(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_id_start(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -457,7 +457,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `ids_binary_operator`](https://docs.rs/icu/latest/icu/properties/sets/fn.ids_binary_operator.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadIdsBinaryOperator(DataProvider provider) {
+  static CodePointSetData loadIdsBinaryOperator(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_ids_binary_operator(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -468,7 +468,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `ids_trinary_operator`](https://docs.rs/icu/latest/icu/properties/sets/fn.ids_trinary_operator.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadIdsTrinaryOperator(DataProvider provider) {
+  static CodePointSetData loadIdsTrinaryOperator(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_ids_trinary_operator(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -479,7 +479,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `join_control`](https://docs.rs/icu/latest/icu/properties/sets/fn.join_control.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadJoinControl(DataProvider provider) {
+  static CodePointSetData loadJoinControl(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_join_control(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -490,7 +490,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `logical_order_exception`](https://docs.rs/icu/latest/icu/properties/sets/fn.logical_order_exception.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadLogicalOrderException(DataProvider provider) {
+  static CodePointSetData loadLogicalOrderException(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_logical_order_exception(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -501,7 +501,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `lowercase`](https://docs.rs/icu/latest/icu/properties/sets/fn.lowercase.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadLowercase(DataProvider provider) {
+  static CodePointSetData loadLowercase(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_lowercase(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -512,7 +512,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `math`](https://docs.rs/icu/latest/icu/properties/sets/fn.math.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadMath(DataProvider provider) {
+  static CodePointSetData loadMath(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_math(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -523,7 +523,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `noncharacter_code_point`](https://docs.rs/icu/latest/icu/properties/sets/fn.noncharacter_code_point.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadNoncharacterCodePoint(DataProvider provider) {
+  static CodePointSetData loadNoncharacterCodePoint(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_noncharacter_code_point(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -534,7 +534,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `nfc_inert`](https://docs.rs/icu/latest/icu/properties/sets/fn.nfc_inert.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadNfcInert(DataProvider provider) {
+  static CodePointSetData loadNfcInert(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_nfc_inert(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -545,7 +545,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `nfd_inert`](https://docs.rs/icu/latest/icu/properties/sets/fn.nfd_inert.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadNfdInert(DataProvider provider) {
+  static CodePointSetData loadNfdInert(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_nfd_inert(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -556,7 +556,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `nfkc_inert`](https://docs.rs/icu/latest/icu/properties/sets/fn.nfkc_inert.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadNfkcInert(DataProvider provider) {
+  static CodePointSetData loadNfkcInert(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_nfkc_inert(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -567,7 +567,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `nfkd_inert`](https://docs.rs/icu/latest/icu/properties/sets/fn.nfkd_inert.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadNfkdInert(DataProvider provider) {
+  static CodePointSetData loadNfkdInert(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_nfkd_inert(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -578,7 +578,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `pattern_syntax`](https://docs.rs/icu/latest/icu/properties/sets/fn.pattern_syntax.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadPatternSyntax(DataProvider provider) {
+  static CodePointSetData loadPatternSyntax(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_pattern_syntax(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -589,7 +589,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `pattern_white_space`](https://docs.rs/icu/latest/icu/properties/sets/fn.pattern_white_space.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadPatternWhiteSpace(DataProvider provider) {
+  static CodePointSetData loadPatternWhiteSpace(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_pattern_white_space(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -600,7 +600,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `prepended_concatenation_mark`](https://docs.rs/icu/latest/icu/properties/sets/fn.prepended_concatenation_mark.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadPrependedConcatenationMark(DataProvider provider) {
+  static CodePointSetData loadPrependedConcatenationMark(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_prepended_concatenation_mark(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -611,7 +611,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `print`](https://docs.rs/icu/latest/icu/properties/sets/fn.print.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadPrint(DataProvider provider) {
+  static CodePointSetData loadPrint(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_print(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -622,7 +622,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `quotation_mark`](https://docs.rs/icu/latest/icu/properties/sets/fn.quotation_mark.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadQuotationMark(DataProvider provider) {
+  static CodePointSetData loadQuotationMark(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_quotation_mark(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -633,7 +633,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `radical`](https://docs.rs/icu/latest/icu/properties/sets/fn.radical.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadRadical(DataProvider provider) {
+  static CodePointSetData loadRadical(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_radical(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -644,7 +644,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `regional_indicator`](https://docs.rs/icu/latest/icu/properties/sets/fn.regional_indicator.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadRegionalIndicator(DataProvider provider) {
+  static CodePointSetData loadRegionalIndicator(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_regional_indicator(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -655,7 +655,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `soft_dotted`](https://docs.rs/icu/latest/icu/properties/sets/fn.soft_dotted.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadSoftDotted(DataProvider provider) {
+  static CodePointSetData loadSoftDotted(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_soft_dotted(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -666,7 +666,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `segment_starter`](https://docs.rs/icu/latest/icu/properties/sets/fn.segment_starter.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadSegmentStarter(DataProvider provider) {
+  static CodePointSetData loadSegmentStarter(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_segment_starter(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -677,7 +677,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `case_sensitive`](https://docs.rs/icu/latest/icu/properties/sets/fn.case_sensitive.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadCaseSensitive(DataProvider provider) {
+  static CodePointSetData loadCaseSensitive(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_case_sensitive(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -688,7 +688,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `sentence_terminal`](https://docs.rs/icu/latest/icu/properties/sets/fn.sentence_terminal.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadSentenceTerminal(DataProvider provider) {
+  static CodePointSetData loadSentenceTerminal(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_sentence_terminal(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -699,7 +699,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `terminal_punctuation`](https://docs.rs/icu/latest/icu/properties/sets/fn.terminal_punctuation.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadTerminalPunctuation(DataProvider provider) {
+  static CodePointSetData loadTerminalPunctuation(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_terminal_punctuation(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -710,7 +710,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `unified_ideograph`](https://docs.rs/icu/latest/icu/properties/sets/fn.unified_ideograph.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadUnifiedIdeograph(DataProvider provider) {
+  static CodePointSetData loadUnifiedIdeograph(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_unified_ideograph(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -721,7 +721,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `uppercase`](https://docs.rs/icu/latest/icu/properties/sets/fn.uppercase.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadUppercase(DataProvider provider) {
+  static CodePointSetData loadUppercase(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_uppercase(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -732,7 +732,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `variation_selector`](https://docs.rs/icu/latest/icu/properties/sets/fn.variation_selector.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadVariationSelector(DataProvider provider) {
+  static CodePointSetData loadVariationSelector(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_variation_selector(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -743,7 +743,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `white_space`](https://docs.rs/icu/latest/icu/properties/sets/fn.white_space.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadWhiteSpace(DataProvider provider) {
+  static CodePointSetData loadWhiteSpace(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_white_space(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -754,7 +754,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `xdigit`](https://docs.rs/icu/latest/icu/properties/sets/fn.xdigit.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadXdigit(DataProvider provider) {
+  static CodePointSetData loadXdigit(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_xdigit(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -765,7 +765,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `xid_continue`](https://docs.rs/icu/latest/icu/properties/sets/fn.xid_continue.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadXidContinue(DataProvider provider) {
+  static CodePointSetData loadXidContinue(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_xid_continue(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -776,7 +776,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `xid_start`](https://docs.rs/icu/latest/icu/properties/sets/fn.xid_start.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadXidStart(DataProvider provider) {
+  static CodePointSetData loadXidStart(DataProvider provider) {
     final result = _ICU4XCodePointSetData_load_xid_start(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -795,7 +795,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `for_ecma262`](https://docs.rs/icu/latest/icu/properties/sets/fn.for_ecma262.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CodePointSetData.loadForEcma262(DataProvider provider, String propertyName) {
+  static CodePointSetData loadForEcma262(DataProvider provider, String propertyName) {
     final temp = ffi2.Arena();
     final propertyNameView = propertyName.utf8View;
     final result = _ICU4XCodePointSetData_load_for_ecma262(provider._ffi, propertyNameView.allocIn(temp), propertyNameView.length);

--- a/ffi/capi/bindings/dart/Collator.g.dart
+++ b/ffi/capi/bindings/dart/Collator.g.dart
@@ -27,7 +27,7 @@ final class Collator implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/collator/struct.Collator.html#method.try_new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory Collator(DataProvider provider, Locale locale, CollatorOptions options) {
+  static Collator create(DataProvider provider, Locale locale, CollatorOptions options) {
     final temp = ffi2.Arena();
     final result = _ICU4XCollator_create_v1(provider._ffi, locale._ffi, options._toFfi(temp));
     temp.releaseAll();
@@ -57,7 +57,7 @@ final class Collator implements ffi.Finalizable {
   /// will have `Auto` as the value.
   ///
   /// See the [Rust documentation for `resolved_options`](https://docs.rs/icu/latest/icu/collator/struct.Collator.html#method.resolved_options) for more information.
-  ResolvedCollatorOptions get resolvedOptions {
+  ResolvedCollatorOptions resolvedOptions() {
     final result = _ICU4XCollator_resolved_options(_ffi);
     return ResolvedCollatorOptions._fromFfi(result);
   }

--- a/ffi/capi/bindings/dart/ComposingNormalizer.g.dart
+++ b/ffi/capi/bindings/dart/ComposingNormalizer.g.dart
@@ -27,7 +27,7 @@ final class ComposingNormalizer implements ffi.Finalizable {
   /// See the [Rust documentation for `new_nfc`](https://docs.rs/icu/latest/icu/normalizer/struct.ComposingNormalizer.html#method.new_nfc) for more information.
   ///
   /// Throws [Error] on failure.
-  factory ComposingNormalizer.nfc(DataProvider provider) {
+  static ComposingNormalizer createNfc(DataProvider provider) {
     final result = _ICU4XComposingNormalizer_create_nfc(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -40,7 +40,7 @@ final class ComposingNormalizer implements ffi.Finalizable {
   /// See the [Rust documentation for `new_nfkc`](https://docs.rs/icu/latest/icu/normalizer/struct.ComposingNormalizer.html#method.new_nfkc) for more information.
   ///
   /// Throws [Error] on failure.
-  factory ComposingNormalizer.nfkc(DataProvider provider) {
+  static ComposingNormalizer createNfkc(DataProvider provider) {
     final result = _ICU4XComposingNormalizer_create_nfkc(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/CustomTimeZone.g.dart
+++ b/ffi/capi/bindings/dart/CustomTimeZone.g.dart
@@ -27,7 +27,7 @@ final class CustomTimeZone implements ffi.Finalizable {
   /// See the [Rust documentation for `from_str`](https://docs.rs/icu/latest/icu/timezone/struct.CustomTimeZone.html#method.from_str) for more information.
   ///
   /// Throws [Error] on failure.
-  factory CustomTimeZone.fromString(String s) {
+  static CustomTimeZone createFromString(String s) {
     final temp = ffi2.Arena();
     final sView = s.utf8View;
     final result = _ICU4XCustomTimeZone_create_from_string(sView.allocIn(temp), sView.length);
@@ -41,18 +41,18 @@ final class CustomTimeZone implements ffi.Finalizable {
   /// Creates a time zone with no information.
   ///
   /// See the [Rust documentation for `new_empty`](https://docs.rs/icu/latest/icu/timezone/struct.CustomTimeZone.html#method.new_empty) for more information.
-  factory CustomTimeZone.empty() {
+  static final CustomTimeZone empty = () {
     final result = _ICU4XCustomTimeZone_create_empty();
     return CustomTimeZone._fromFfi(result, []);
-  }
+  }();
 
   /// Creates a time zone for UTC.
   ///
   /// See the [Rust documentation for `utc`](https://docs.rs/icu/latest/icu/timezone/struct.CustomTimeZone.html#method.utc) for more information.
-  factory CustomTimeZone.utc() {
+  static final CustomTimeZone utc = () {
     final result = _ICU4XCustomTimeZone_create_utc();
     return CustomTimeZone._fromFfi(result, []);
-  }
+  }();
 
   /// Sets the `gmt_offset` field from offset seconds.
   ///
@@ -89,7 +89,7 @@ final class CustomTimeZone implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/latest/icu/timezone/struct.GmtOffset.html)
   ///
   /// Throws [Error] on failure.
-  int get gmtOffsetSeconds {
+  int gmtOffsetSeconds() {
     final result = _ICU4XCustomTimeZone_gmt_offset_seconds(_ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -104,7 +104,7 @@ final class CustomTimeZone implements ffi.Finalizable {
   /// See the [Rust documentation for `is_positive`](https://docs.rs/icu/latest/icu/timezone/struct.GmtOffset.html#method.is_positive) for more information.
   ///
   /// Throws [Error] on failure.
-  bool get isGmtOffsetPositive {
+  bool isGmtOffsetPositive() {
     final result = _ICU4XCustomTimeZone_is_gmt_offset_positive(_ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -119,7 +119,7 @@ final class CustomTimeZone implements ffi.Finalizable {
   /// See the [Rust documentation for `is_zero`](https://docs.rs/icu/latest/icu/timezone/struct.GmtOffset.html#method.is_zero) for more information.
   ///
   /// Throws [Error] on failure.
-  bool get isGmtOffsetZero {
+  bool isGmtOffsetZero() {
     final result = _ICU4XCustomTimeZone_is_gmt_offset_zero(_ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -214,7 +214,7 @@ final class CustomTimeZone implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/latest/icu/timezone/struct.TimeZoneBcp47Id.html)
   ///
   /// Throws [Error] on failure.
-  String get timeZoneId {
+  String timeZoneId() {
     final writeable = _Writeable();
     final result = _ICU4XCustomTimeZone_time_zone_id(_ffi, writeable._ffi);
     if (!result.isOk) {
@@ -261,7 +261,7 @@ final class CustomTimeZone implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/latest/icu/timezone/struct.MetazoneId.html)
   ///
   /// Throws [Error] on failure.
-  String get metazoneId {
+  String metazoneId() {
     final writeable = _Writeable();
     final result = _ICU4XCustomTimeZone_metazone_id(_ffi, writeable._ffi);
     if (!result.isOk) {
@@ -308,7 +308,7 @@ final class CustomTimeZone implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/latest/icu/timezone/struct.ZoneVariant.html)
   ///
   /// Throws [Error] on failure.
-  String get zoneVariant {
+  String zoneVariant() {
     final writeable = _Writeable();
     final result = _ICU4XCustomTimeZone_zone_variant(_ffi, writeable._ffi);
     if (!result.isOk) {
@@ -344,7 +344,7 @@ final class CustomTimeZone implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/latest/icu/timezone/struct.CustomTimeZone.html#structfield.zone_variant)
   ///
   /// Throws [Error] on failure.
-  bool get isStandardTime {
+  bool isStandardTime() {
     final result = _ICU4XCustomTimeZone_is_standard_time(_ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -361,7 +361,7 @@ final class CustomTimeZone implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/latest/icu/timezone/struct.CustomTimeZone.html#structfield.zone_variant)
   ///
   /// Throws [Error] on failure.
-  bool get isDaylightTime {
+  bool isDaylightTime() {
     final result = _ICU4XCustomTimeZone_is_daylight_time(_ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/DataProvider.g.dart
+++ b/ffi/capi/bindings/dart/DataProvider.g.dart
@@ -30,17 +30,17 @@ final class DataProvider implements ffi.Finalizable {
   ///
   /// This provider cannot be modified or combined with other providers, so `enable_fallback`,
   /// `enabled_fallback_with`, `fork_by_locale`, and `fork_by_key` will return `Err`s.
-  factory DataProvider.compiled() {
+  static final DataProvider compiled = () {
     final result = _ICU4XDataProvider_create_compiled();
     return DataProvider._fromFfi(result, []);
-  }
+  }();
 
   /// Constructs a `BlobDataProvider` and returns it as an [`DataProvider`].
   ///
   /// See the [Rust documentation for `BlobDataProvider`](https://docs.rs/icu_provider_blob/latest/icu_provider_blob/struct.BlobDataProvider.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory DataProvider.fromByteSlice(ByteBuffer blob) {
+  static DataProvider createFromByteSlice(ByteBuffer blob) {
     final temp = ffi2.Arena();
     final blobView = blob;
     final result = _ICU4XDataProvider_create_from_byte_slice(blobView.allocIn(temp), blobView.length);
@@ -54,10 +54,10 @@ final class DataProvider implements ffi.Finalizable {
   /// Constructs an empty [`DataProvider`].
   ///
   /// See the [Rust documentation for `EmptyDataProvider`](https://docs.rs/icu_provider_adapters/latest/icu_provider_adapters/empty/struct.EmptyDataProvider.html) for more information.
-  factory DataProvider.empty() {
+  static final DataProvider empty = () {
     final result = _ICU4XDataProvider_create_empty();
     return DataProvider._fromFfi(result, []);
-  }
+  }();
 
   /// Creates a provider that tries the current provider and then, if the current provider
   /// doesn't support the data key, another provider `other`.

--- a/ffi/capi/bindings/dart/Date.g.dart
+++ b/ffi/capi/bindings/dart/Date.g.dart
@@ -30,7 +30,7 @@ final class Date implements ffi.Finalizable {
   /// See the [Rust documentation for `new_from_iso`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.new_from_iso) for more information.
   ///
   /// Throws [Error] on failure.
-  factory Date.fromIsoInCalendar(int year, int month, int day, Calendar calendar) {
+  static Date createFromIsoInCalendar(int year, int month, int day, Calendar calendar) {
     final result = _ICU4XDate_create_from_iso_in_calendar(year, month, day, calendar._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -43,7 +43,7 @@ final class Date implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new_from_codes`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.try_new_from_codes) for more information.
   ///
   /// Throws [Error] on failure.
-  factory Date.fromCodesInCalendar(String eraCode, int year, String monthCode, int day, Calendar calendar) {
+  static Date createFromCodesInCalendar(String eraCode, int year, String monthCode, int day, Calendar calendar) {
     final temp = ffi2.Arena();
     final eraCodeView = eraCode.utf8View;
     final monthCodeView = monthCode.utf8View;
@@ -74,7 +74,7 @@ final class Date implements ffi.Finalizable {
   /// Returns the 1-indexed day in the month for this date
   ///
   /// See the [Rust documentation for `day_of_month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.day_of_month) for more information.
-  int get dayOfMonth {
+  int dayOfMonth() {
     final result = _ICU4XDate_day_of_month(_ffi);
     return result;
   }
@@ -82,7 +82,7 @@ final class Date implements ffi.Finalizable {
   /// Returns the day in the week for this day
   ///
   /// See the [Rust documentation for `day_of_week`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.day_of_week) for more information.
-  IsoWeekday get dayOfWeek {
+  IsoWeekday dayOfWeek() {
     final result = _ICU4XDate_day_of_week(_ffi);
     return IsoWeekday.values.firstWhere((v) => v._ffi == result);
   }
@@ -118,7 +118,7 @@ final class Date implements ffi.Finalizable {
   /// about month identity.
   ///
   /// See the [Rust documentation for `month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.month) for more information.
-  int get ordinalMonth {
+  int ordinalMonth() {
     final result = _ICU4XDate_ordinal_month(_ffi);
     return result;
   }
@@ -129,7 +129,7 @@ final class Date implements ffi.Finalizable {
   /// See the [Rust documentation for `month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.month) for more information.
   ///
   /// Throws [Error] on failure.
-  String get monthCode {
+  String monthCode() {
     final writeable = _Writeable();
     final result = _ICU4XDate_month_code(_ffi, writeable._ffi);
     if (!result.isOk) {
@@ -141,7 +141,7 @@ final class Date implements ffi.Finalizable {
   /// Returns the year number in the current era for this date
   ///
   /// See the [Rust documentation for `year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year) for more information.
-  int get yearInEra {
+  int yearInEra() {
     final result = _ICU4XDate_year_in_era(_ffi);
     return result;
   }
@@ -153,7 +153,7 @@ final class Date implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/latest/icu/types/struct.Era.html)
   ///
   /// Throws [Error] on failure.
-  String get era {
+  String era() {
     final writeable = _Writeable();
     final result = _ICU4XDate_era(_ffi, writeable._ffi);
     if (!result.isOk) {
@@ -165,7 +165,7 @@ final class Date implements ffi.Finalizable {
   /// Returns the number of months in the year represented by this date
   ///
   /// See the [Rust documentation for `months_in_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.months_in_year) for more information.
-  int get monthsInYear {
+  int monthsInYear() {
     final result = _ICU4XDate_months_in_year(_ffi);
     return result;
   }
@@ -173,7 +173,7 @@ final class Date implements ffi.Finalizable {
   /// Returns the number of days in the month represented by this date
   ///
   /// See the [Rust documentation for `days_in_month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.days_in_month) for more information.
-  int get daysInMonth {
+  int daysInMonth() {
     final result = _ICU4XDate_days_in_month(_ffi);
     return result;
   }
@@ -181,7 +181,7 @@ final class Date implements ffi.Finalizable {
   /// Returns the number of days in the year represented by this date
   ///
   /// See the [Rust documentation for `days_in_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.days_in_year) for more information.
-  int get daysInYear {
+  int daysInYear() {
     final result = _ICU4XDate_days_in_year(_ffi);
     return result;
   }
@@ -189,7 +189,7 @@ final class Date implements ffi.Finalizable {
   /// Returns the [`Calendar`] object backing this date
   ///
   /// See the [Rust documentation for `calendar`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.calendar) for more information.
-  Calendar get calendar {
+  Calendar calendar() {
     final result = _ICU4XDate_calendar(_ffi);
     return Calendar._fromFfi(result, []);
   }

--- a/ffi/capi/bindings/dart/DateFormatter.g.dart
+++ b/ffi/capi/bindings/dart/DateFormatter.g.dart
@@ -30,7 +30,7 @@ final class DateFormatter implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new_with_length`](https://docs.rs/icu/latest/icu/datetime/struct.DateFormatter.html#method.try_new_with_length) for more information.
   ///
   /// Throws [Error] on failure.
-  factory DateFormatter.withLength(DataProvider provider, Locale locale, DateLength dateLength) {
+  static DateFormatter createWithLength(DataProvider provider, Locale locale, DateLength dateLength) {
     final result = _ICU4XDateFormatter_create_with_length(provider._ffi, locale._ffi, dateLength.index);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/DateTime.g.dart
+++ b/ffi/capi/bindings/dart/DateTime.g.dart
@@ -30,7 +30,7 @@ final class DateTime implements ffi.Finalizable {
   /// See the [Rust documentation for `new_from_iso`](https://docs.rs/icu/latest/icu/struct.DateTime.html#method.new_from_iso) for more information.
   ///
   /// Throws [Error] on failure.
-  factory DateTime.fromIsoInCalendar(int year, int month, int day, int hour, int minute, int second, int nanosecond, Calendar calendar) {
+  static DateTime createFromIsoInCalendar(int year, int month, int day, int hour, int minute, int second, int nanosecond, Calendar calendar) {
     final result = _ICU4XDateTime_create_from_iso_in_calendar(year, month, day, hour, minute, second, nanosecond, calendar._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -43,7 +43,7 @@ final class DateTime implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new_from_codes`](https://docs.rs/icu/latest/icu/calendar/struct.DateTime.html#method.try_new_from_codes) for more information.
   ///
   /// Throws [Error] on failure.
-  factory DateTime.fromCodesInCalendar(String eraCode, int year, String monthCode, int day, int hour, int minute, int second, int nanosecond, Calendar calendar) {
+  static DateTime createFromCodesInCalendar(String eraCode, int year, String monthCode, int day, int hour, int minute, int second, int nanosecond, Calendar calendar) {
     final temp = ffi2.Arena();
     final eraCodeView = eraCode.utf8View;
     final monthCodeView = monthCode.utf8View;
@@ -58,7 +58,7 @@ final class DateTime implements ffi.Finalizable {
   /// Creates a new [`DateTime`] from an [`Date`] and [`Time`] object
   ///
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/calendar/struct.DateTime.html#method.new) for more information.
-  factory DateTime.fromDateAndTime(Date date, Time time) {
+  static DateTime createFromDateAndTime(Date date, Time time) {
     final result = _ICU4XDateTime_create_from_date_and_time(date._ffi, time._ffi);
     return DateTime._fromFfi(result, []);
   }
@@ -66,7 +66,7 @@ final class DateTime implements ffi.Finalizable {
   /// Gets a copy of the date contained in this object
   ///
   /// See the [Rust documentation for `date`](https://docs.rs/icu/latest/icu/calendar/struct.DateTime.html#structfield.date) for more information.
-  Date get date {
+  Date date() {
     final result = _ICU4XDateTime_date(_ffi);
     return Date._fromFfi(result, []);
   }
@@ -74,7 +74,7 @@ final class DateTime implements ffi.Finalizable {
   /// Gets the time contained in this object
   ///
   /// See the [Rust documentation for `time`](https://docs.rs/icu/latest/icu/calendar/struct.DateTime.html#structfield.time) for more information.
-  Time get time {
+  Time time() {
     final result = _ICU4XDateTime_time(_ffi);
     return Time._fromFfi(result, []);
   }
@@ -98,7 +98,7 @@ final class DateTime implements ffi.Finalizable {
   /// Returns the hour in this time
   ///
   /// See the [Rust documentation for `hour`](https://docs.rs/icu/latest/icu/calendar/struct.Time.html#structfield.hour) for more information.
-  int get hour {
+  int hour() {
     final result = _ICU4XDateTime_hour(_ffi);
     return result;
   }
@@ -106,7 +106,7 @@ final class DateTime implements ffi.Finalizable {
   /// Returns the minute in this time
   ///
   /// See the [Rust documentation for `minute`](https://docs.rs/icu/latest/icu/calendar/struct.Time.html#structfield.minute) for more information.
-  int get minute {
+  int minute() {
     final result = _ICU4XDateTime_minute(_ffi);
     return result;
   }
@@ -114,7 +114,7 @@ final class DateTime implements ffi.Finalizable {
   /// Returns the second in this time
   ///
   /// See the [Rust documentation for `second`](https://docs.rs/icu/latest/icu/calendar/struct.Time.html#structfield.second) for more information.
-  int get second {
+  int second() {
     final result = _ICU4XDateTime_second(_ffi);
     return result;
   }
@@ -122,7 +122,7 @@ final class DateTime implements ffi.Finalizable {
   /// Returns the nanosecond in this time
   ///
   /// See the [Rust documentation for `nanosecond`](https://docs.rs/icu/latest/icu/calendar/struct.Time.html#structfield.nanosecond) for more information.
-  int get nanosecond {
+  int nanosecond() {
     final result = _ICU4XDateTime_nanosecond(_ffi);
     return result;
   }
@@ -130,7 +130,7 @@ final class DateTime implements ffi.Finalizable {
   /// Returns the 1-indexed day in the month for this date
   ///
   /// See the [Rust documentation for `day_of_month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.day_of_month) for more information.
-  int get dayOfMonth {
+  int dayOfMonth() {
     final result = _ICU4XDateTime_day_of_month(_ffi);
     return result;
   }
@@ -138,7 +138,7 @@ final class DateTime implements ffi.Finalizable {
   /// Returns the day in the week for this day
   ///
   /// See the [Rust documentation for `day_of_week`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.day_of_week) for more information.
-  IsoWeekday get dayOfWeek {
+  IsoWeekday dayOfWeek() {
     final result = _ICU4XDateTime_day_of_week(_ffi);
     return IsoWeekday.values.firstWhere((v) => v._ffi == result);
   }
@@ -174,7 +174,7 @@ final class DateTime implements ffi.Finalizable {
   /// about month identity.
   ///
   /// See the [Rust documentation for `month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.month) for more information.
-  int get ordinalMonth {
+  int ordinalMonth() {
     final result = _ICU4XDateTime_ordinal_month(_ffi);
     return result;
   }
@@ -185,7 +185,7 @@ final class DateTime implements ffi.Finalizable {
   /// See the [Rust documentation for `month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.month) for more information.
   ///
   /// Throws [Error] on failure.
-  String get monthCode {
+  String monthCode() {
     final writeable = _Writeable();
     final result = _ICU4XDateTime_month_code(_ffi, writeable._ffi);
     if (!result.isOk) {
@@ -197,7 +197,7 @@ final class DateTime implements ffi.Finalizable {
   /// Returns the year number in the current era for this date
   ///
   /// See the [Rust documentation for `year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year) for more information.
-  int get yearInEra {
+  int yearInEra() {
     final result = _ICU4XDateTime_year_in_era(_ffi);
     return result;
   }
@@ -207,7 +207,7 @@ final class DateTime implements ffi.Finalizable {
   /// See the [Rust documentation for `year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year) for more information.
   ///
   /// Throws [Error] on failure.
-  String get era {
+  String era() {
     final writeable = _Writeable();
     final result = _ICU4XDateTime_era(_ffi, writeable._ffi);
     if (!result.isOk) {
@@ -219,7 +219,7 @@ final class DateTime implements ffi.Finalizable {
   /// Returns the number of months in the year represented by this date
   ///
   /// See the [Rust documentation for `months_in_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.months_in_year) for more information.
-  int get monthsInYear {
+  int monthsInYear() {
     final result = _ICU4XDateTime_months_in_year(_ffi);
     return result;
   }
@@ -227,7 +227,7 @@ final class DateTime implements ffi.Finalizable {
   /// Returns the number of days in the month represented by this date
   ///
   /// See the [Rust documentation for `days_in_month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.days_in_month) for more information.
-  int get daysInMonth {
+  int daysInMonth() {
     final result = _ICU4XDateTime_days_in_month(_ffi);
     return result;
   }
@@ -235,7 +235,7 @@ final class DateTime implements ffi.Finalizable {
   /// Returns the number of days in the year represented by this date
   ///
   /// See the [Rust documentation for `days_in_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.days_in_year) for more information.
-  int get daysInYear {
+  int daysInYear() {
     final result = _ICU4XDateTime_days_in_year(_ffi);
     return result;
   }
@@ -243,7 +243,7 @@ final class DateTime implements ffi.Finalizable {
   /// Returns the [`Calendar`] object backing this date
   ///
   /// See the [Rust documentation for `calendar`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.calendar) for more information.
-  Calendar get calendar {
+  Calendar calendar() {
     final result = _ICU4XDateTime_calendar(_ffi);
     return Calendar._fromFfi(result, []);
   }

--- a/ffi/capi/bindings/dart/DateTimeFormatter.g.dart
+++ b/ffi/capi/bindings/dart/DateTimeFormatter.g.dart
@@ -30,7 +30,7 @@ final class DateTimeFormatter implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory DateTimeFormatter.withLengths(DataProvider provider, Locale locale, DateLength dateLength, TimeLength timeLength) {
+  static DateTimeFormatter createWithLengths(DataProvider provider, Locale locale, DateLength dateLength, TimeLength timeLength) {
     final result = _ICU4XDateTimeFormatter_create_with_lengths(provider._ffi, locale._ffi, dateLength.index, timeLength.index);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/DecomposingNormalizer.g.dart
+++ b/ffi/capi/bindings/dart/DecomposingNormalizer.g.dart
@@ -27,7 +27,7 @@ final class DecomposingNormalizer implements ffi.Finalizable {
   /// See the [Rust documentation for `new_nfd`](https://docs.rs/icu/latest/icu/normalizer/struct.DecomposingNormalizer.html#method.new_nfd) for more information.
   ///
   /// Throws [Error] on failure.
-  factory DecomposingNormalizer.nfd(DataProvider provider) {
+  static DecomposingNormalizer createNfd(DataProvider provider) {
     final result = _ICU4XDecomposingNormalizer_create_nfd(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -40,7 +40,7 @@ final class DecomposingNormalizer implements ffi.Finalizable {
   /// See the [Rust documentation for `new_nfkd`](https://docs.rs/icu/latest/icu/normalizer/struct.DecomposingNormalizer.html#method.new_nfkd) for more information.
   ///
   /// Throws [Error] on failure.
-  factory DecomposingNormalizer.nfkd(DataProvider provider) {
+  static DecomposingNormalizer createNfkd(DataProvider provider) {
     final result = _ICU4XDecomposingNormalizer_create_nfkd(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/FixedDecimal.g.dart
+++ b/ffi/capi/bindings/dart/FixedDecimal.g.dart
@@ -25,7 +25,7 @@ final class FixedDecimal implements ffi.Finalizable {
   /// Construct an [`FixedDecimal`] from an integer.
   ///
   /// See the [Rust documentation for `FixedDecimal`](https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html) for more information.
-  factory FixedDecimal.fromInt(int v) {
+  static FixedDecimal create_from_int(int v) {
     final result = _ICU4XFixedDecimal_create_from_i64(v);
     return FixedDecimal._fromFfi(result, []);
   }
@@ -37,7 +37,7 @@ final class FixedDecimal implements ffi.Finalizable {
   /// See the [Rust documentation for `FloatPrecision`](https://docs.rs/fixed_decimal/latest/fixed_decimal/enum.FloatPrecision.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory FixedDecimal.fromDoubleWithLowerMagnitude(double f, int magnitude) {
+  static FixedDecimal create_from_double_with_lower_magnitude(double f, int magnitude) {
     final result = _ICU4XFixedDecimal_create_from_f64_with_lower_magnitude(f, magnitude);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -52,7 +52,7 @@ final class FixedDecimal implements ffi.Finalizable {
   /// See the [Rust documentation for `FloatPrecision`](https://docs.rs/fixed_decimal/latest/fixed_decimal/enum.FloatPrecision.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory FixedDecimal.fromDoubleWithSignificantDigits(double f, int digits) {
+  static FixedDecimal create_from_double_with_significant_digits(double f, int digits) {
     final result = _ICU4XFixedDecimal_create_from_f64_with_significant_digits(f, digits);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -68,7 +68,7 @@ final class FixedDecimal implements ffi.Finalizable {
   /// See the [Rust documentation for `FloatPrecision`](https://docs.rs/fixed_decimal/latest/fixed_decimal/enum.FloatPrecision.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory FixedDecimal.fromDoubleWithDoublePrecision(double f) {
+  static FixedDecimal create_from_double_with_double_precision(double f) {
     final result = _ICU4XFixedDecimal_create_from_f64_with_floating_precision(f);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -81,7 +81,7 @@ final class FixedDecimal implements ffi.Finalizable {
   /// See the [Rust documentation for `from_str`](https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.from_str) for more information.
   ///
   /// Throws [Error] on failure.
-  factory FixedDecimal.fromString(String v) {
+  static FixedDecimal createFromString(String v) {
     final temp = ffi2.Arena();
     final vView = v.utf8View;
     final result = _ICU4XFixedDecimal_create_from_string(vView.allocIn(temp), vView.length);
@@ -99,31 +99,31 @@ final class FixedDecimal implements ffi.Finalizable {
   }
 
   /// See the [Rust documentation for `magnitude_range`](https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.magnitude_range) for more information.
-  int get magnitudeStart {
+  int magnitudeStart() {
     final result = _ICU4XFixedDecimal_magnitude_start(_ffi);
     return result;
   }
 
   /// See the [Rust documentation for `magnitude_range`](https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.magnitude_range) for more information.
-  int get magnitudeEnd {
+  int magnitudeEnd() {
     final result = _ICU4XFixedDecimal_magnitude_end(_ffi);
     return result;
   }
 
   /// See the [Rust documentation for `nonzero_magnitude_start`](https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.nonzero_magnitude_start) for more information.
-  int get nonzeroMagnitudeStart {
+  int nonzeroMagnitudeStart() {
     final result = _ICU4XFixedDecimal_nonzero_magnitude_start(_ffi);
     return result;
   }
 
   /// See the [Rust documentation for `nonzero_magnitude_end`](https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.nonzero_magnitude_end) for more information.
-  int get nonzeroMagnitudeEnd {
+  int nonzeroMagnitudeEnd() {
     final result = _ICU4XFixedDecimal_nonzero_magnitude_end(_ffi);
     return result;
   }
 
   /// See the [Rust documentation for `is_zero`](https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.is_zero) for more information.
-  bool get isZero {
+  bool isZero() {
     final result = _ICU4XFixedDecimal_is_zero(_ffi);
     return result;
   }
@@ -136,7 +136,7 @@ final class FixedDecimal implements ffi.Finalizable {
   }
 
   /// See the [Rust documentation for `sign`](https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.sign) for more information.
-  FixedDecimalSign get sign {
+  FixedDecimalSign sign() {
     final result = _ICU4XFixedDecimal_sign(_ffi);
     return FixedDecimalSign.values[result];
   }
@@ -144,7 +144,7 @@ final class FixedDecimal implements ffi.Finalizable {
   /// Set the sign of the [`FixedDecimal`].
   ///
   /// See the [Rust documentation for `set_sign`](https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.set_sign) for more information.
-  set sign(FixedDecimalSign sign) {
+  void setSign(FixedDecimalSign sign) {
     _ICU4XFixedDecimal_set_sign(_ffi, sign.index);
   }
 
@@ -290,7 +290,6 @@ final class FixedDecimal implements ffi.Finalizable {
   /// Format the [`FixedDecimal`] as a string.
   ///
   /// See the [Rust documentation for `write_to`](https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.write_to) for more information.
-  @override
   String toString() {
     final writeable = _Writeable();
     _ICU4XFixedDecimal_to_string(_ffi, writeable._ffi);

--- a/ffi/capi/bindings/dart/FixedDecimalFormatter.g.dart
+++ b/ffi/capi/bindings/dart/FixedDecimalFormatter.g.dart
@@ -29,7 +29,7 @@ final class FixedDecimalFormatter implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/decimal/struct.FixedDecimalFormatter.html#method.try_new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory FixedDecimalFormatter.withGroupingStrategy(DataProvider provider, Locale locale, FixedDecimalGroupingStrategy groupingStrategy) {
+  static FixedDecimalFormatter createWithGroupingStrategy(DataProvider provider, Locale locale, FixedDecimalGroupingStrategy groupingStrategy) {
     final result = _ICU4XFixedDecimalFormatter_create_with_grouping_strategy(provider._ffi, locale._ffi, groupingStrategy.index);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/GeneralCategoryNameToMaskMapper.g.dart
+++ b/ffi/capi/bindings/dart/GeneralCategoryNameToMaskMapper.g.dart
@@ -51,7 +51,7 @@ final class GeneralCategoryNameToMaskMapper implements ffi.Finalizable {
   /// See the [Rust documentation for `get_name_to_enum_mapper`](https://docs.rs/icu/latest/icu/properties/struct.GeneralCategoryGroup.html#method.get_name_to_enum_mapper) for more information.
   ///
   /// Throws [Error] on failure.
-  factory GeneralCategoryNameToMaskMapper.load(DataProvider provider) {
+  static GeneralCategoryNameToMaskMapper load(DataProvider provider) {
     final result = _ICU4XGeneralCategoryNameToMaskMapper_load(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/GraphemeClusterSegmenter.g.dart
+++ b/ffi/capi/bindings/dart/GraphemeClusterSegmenter.g.dart
@@ -30,7 +30,7 @@ final class GraphemeClusterSegmenter implements ffi.Finalizable {
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory GraphemeClusterSegmenter(DataProvider provider) {
+  static GraphemeClusterSegmenter create(DataProvider provider) {
     final result = _ICU4XGraphemeClusterSegmenter_create(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/GregorianDateFormatter.g.dart
+++ b/ffi/capi/bindings/dart/GregorianDateFormatter.g.dart
@@ -30,7 +30,7 @@ final class GregorianDateFormatter implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new_with_length`](https://docs.rs/icu/latest/icu/datetime/struct.TypedDateFormatter.html#method.try_new_with_length) for more information.
   ///
   /// Throws [Error] on failure.
-  factory GregorianDateFormatter.withLength(DataProvider provider, Locale locale, DateLength length) {
+  static GregorianDateFormatter createWithLength(DataProvider provider, Locale locale, DateLength length) {
     final result = _ICU4XGregorianDateFormatter_create_with_length(provider._ffi, locale._ffi, length.index);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/GregorianDateTimeFormatter.g.dart
+++ b/ffi/capi/bindings/dart/GregorianDateTimeFormatter.g.dart
@@ -30,7 +30,7 @@ final class GregorianDateTimeFormatter implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/datetime/struct.TypedDateTimeFormatter.html#method.try_new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory GregorianDateTimeFormatter.withLengths(DataProvider provider, Locale locale, DateLength dateLength, TimeLength timeLength) {
+  static GregorianDateTimeFormatter createWithLengths(DataProvider provider, Locale locale, DateLength dateLength, TimeLength timeLength) {
     final result = _ICU4XGregorianDateTimeFormatter_create_with_lengths(provider._ffi, locale._ffi, dateLength.index, timeLength.index);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/GregorianZonedDateTimeFormatter.g.dart
+++ b/ffi/capi/bindings/dart/GregorianZonedDateTimeFormatter.g.dart
@@ -32,7 +32,7 @@ final class GregorianZonedDateTimeFormatter implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/datetime/struct.TypedZonedDateTimeFormatter.html#method.try_new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory GregorianZonedDateTimeFormatter.withLengths(DataProvider provider, Locale locale, DateLength dateLength, TimeLength timeLength) {
+  static GregorianZonedDateTimeFormatter createWithLengths(DataProvider provider, Locale locale, DateLength dateLength, TimeLength timeLength) {
     final result = _ICU4XGregorianZonedDateTimeFormatter_create_with_lengths(provider._ffi, locale._ffi, dateLength.index, timeLength.index);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -48,7 +48,7 @@ final class GregorianZonedDateTimeFormatter implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/datetime/struct.TypedZonedDateTimeFormatter.html#method.try_new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory GregorianZonedDateTimeFormatter.withLengthsAndIso8601TimeZoneFallback(DataProvider provider, Locale locale, DateLength dateLength, TimeLength timeLength, IsoTimeZoneOptions zoneOptions) {
+  static GregorianZonedDateTimeFormatter createWithLengthsAndIso8601TimeZoneFallback(DataProvider provider, Locale locale, DateLength dateLength, TimeLength timeLength, IsoTimeZoneOptions zoneOptions) {
     final temp = ffi2.Arena();
     final result = _ICU4XGregorianZonedDateTimeFormatter_create_with_lengths_and_iso_8601_time_zone_fallback(provider._ffi, locale._ffi, dateLength.index, timeLength.index, zoneOptions._toFfi(temp));
     temp.releaseAll();

--- a/ffi/capi/bindings/dart/IanaToBcp47Mapper.g.dart
+++ b/ffi/capi/bindings/dart/IanaToBcp47Mapper.g.dart
@@ -31,7 +31,7 @@ final class IanaToBcp47Mapper implements ffi.Finalizable {
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/timezone/struct.IanaToBcp47Mapper.html#method.new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory IanaToBcp47Mapper(DataProvider provider) {
+  static IanaToBcp47Mapper create(DataProvider provider) {
     final result = _ICU4XIanaToBcp47Mapper_create(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/IsoDate.g.dart
+++ b/ffi/capi/bindings/dart/IsoDate.g.dart
@@ -29,7 +29,7 @@ final class IsoDate implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new_iso_date`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.try_new_iso_date) for more information.
   ///
   /// Throws [Error] on failure.
-  factory IsoDate(int year, int month, int day) {
+  static IsoDate create(int year, int month, int day) {
     final result = _ICU4XIsoDate_create(year, month, day);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -40,10 +40,10 @@ final class IsoDate implements ffi.Finalizable {
   /// Creates a new [`IsoDate`] representing January 1, 1970.
   ///
   /// See the [Rust documentation for `unix_epoch`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.unix_epoch) for more information.
-  factory IsoDate.forUnixEpoch() {
+  static final IsoDate forUnixEpoch = () {
     final result = _ICU4XIsoDate_create_for_unix_epoch();
     return IsoDate._fromFfi(result, []);
-  }
+  }();
 
   /// Convert this date to one in a different calendar
   ///
@@ -62,7 +62,7 @@ final class IsoDate implements ffi.Finalizable {
   /// Returns the 1-indexed day in the month for this date
   ///
   /// See the [Rust documentation for `day_of_month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.day_of_month) for more information.
-  int get dayOfMonth {
+  int dayOfMonth() {
     final result = _ICU4XIsoDate_day_of_month(_ffi);
     return result;
   }
@@ -70,7 +70,7 @@ final class IsoDate implements ffi.Finalizable {
   /// Returns the day in the week for this day
   ///
   /// See the [Rust documentation for `day_of_week`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.day_of_week) for more information.
-  IsoWeekday get dayOfWeek {
+  IsoWeekday dayOfWeek() {
     final result = _ICU4XIsoDate_day_of_week(_ffi);
     return IsoWeekday.values.firstWhere((v) => v._ffi == result);
   }
@@ -102,7 +102,7 @@ final class IsoDate implements ffi.Finalizable {
   /// Returns 1-indexed number of the month of this date in its year
   ///
   /// See the [Rust documentation for `month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.month) for more information.
-  int get month {
+  int month() {
     final result = _ICU4XIsoDate_month(_ffi);
     return result;
   }
@@ -110,7 +110,7 @@ final class IsoDate implements ffi.Finalizable {
   /// Returns the year number for this date
   ///
   /// See the [Rust documentation for `year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year) for more information.
-  int get year {
+  int year() {
     final result = _ICU4XIsoDate_year(_ffi);
     return result;
   }
@@ -118,7 +118,7 @@ final class IsoDate implements ffi.Finalizable {
   /// Returns if the year is a leap year for this date
   ///
   /// See the [Rust documentation for `is_in_leap_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.is_in_leap_year) for more information.
-  bool get isInLeapYear {
+  bool isInLeapYear() {
     final result = _ICU4XIsoDate_is_in_leap_year(_ffi);
     return result;
   }
@@ -126,7 +126,7 @@ final class IsoDate implements ffi.Finalizable {
   /// Returns the number of months in the year represented by this date
   ///
   /// See the [Rust documentation for `months_in_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.months_in_year) for more information.
-  int get monthsInYear {
+  int monthsInYear() {
     final result = _ICU4XIsoDate_months_in_year(_ffi);
     return result;
   }
@@ -134,7 +134,7 @@ final class IsoDate implements ffi.Finalizable {
   /// Returns the number of days in the month represented by this date
   ///
   /// See the [Rust documentation for `days_in_month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.days_in_month) for more information.
-  int get daysInMonth {
+  int daysInMonth() {
     final result = _ICU4XIsoDate_days_in_month(_ffi);
     return result;
   }
@@ -142,7 +142,7 @@ final class IsoDate implements ffi.Finalizable {
   /// Returns the number of days in the year represented by this date
   ///
   /// See the [Rust documentation for `days_in_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.days_in_year) for more information.
-  int get daysInYear {
+  int daysInYear() {
     final result = _ICU4XIsoDate_days_in_year(_ffi);
     return result;
   }

--- a/ffi/capi/bindings/dart/IsoDateTime.g.dart
+++ b/ffi/capi/bindings/dart/IsoDateTime.g.dart
@@ -29,7 +29,7 @@ final class IsoDateTime implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new_iso_datetime`](https://docs.rs/icu/latest/icu/calendar/struct.DateTime.html#method.try_new_iso_datetime) for more information.
   ///
   /// Throws [Error] on failure.
-  factory IsoDateTime(int year, int month, int day, int hour, int minute, int second, int nanosecond) {
+  static IsoDateTime create(int year, int month, int day, int hour, int minute, int second, int nanosecond) {
     final result = _ICU4XIsoDateTime_create(year, month, day, hour, minute, second, nanosecond);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -40,7 +40,7 @@ final class IsoDateTime implements ffi.Finalizable {
   /// Creates a new [`IsoDateTime`] from an [`IsoDate`] and [`Time`] object
   ///
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/calendar/struct.DateTime.html#method.new) for more information.
-  factory IsoDateTime.fromDateAndTime(IsoDate date, Time time) {
+  static IsoDateTime create_from_date_and_time(IsoDate date, Time time) {
     final result = _ICU4XIsoDateTime_crate_from_date_and_time(date._ffi, time._ffi);
     return IsoDateTime._fromFfi(result, []);
   }
@@ -48,15 +48,15 @@ final class IsoDateTime implements ffi.Finalizable {
   /// Creates a new [`IsoDateTime`] of midnight on January 1, 1970
   ///
   /// See the [Rust documentation for `local_unix_epoch`](https://docs.rs/icu/latest/icu/calendar/struct.DateTime.html#method.local_unix_epoch) for more information.
-  factory IsoDateTime.localUnixEpoch() {
+  static final IsoDateTime localUnixEpoch = () {
     final result = _ICU4XIsoDateTime_local_unix_epoch();
     return IsoDateTime._fromFfi(result, []);
-  }
+  }();
 
   /// Construct from the minutes since the local unix epoch for this date (Jan 1 1970, 00:00)
   ///
   /// See the [Rust documentation for `from_minutes_since_local_unix_epoch`](https://docs.rs/icu/latest/icu/calendar/struct.DateTime.html#method.from_minutes_since_local_unix_epoch) for more information.
-  factory IsoDateTime.fromMinutesSinceLocalUnixEpoch(int minutes) {
+  static IsoDateTime createFromMinutesSinceLocalUnixEpoch(int minutes) {
     final result = _ICU4XIsoDateTime_create_from_minutes_since_local_unix_epoch(minutes);
     return IsoDateTime._fromFfi(result, []);
   }
@@ -64,7 +64,7 @@ final class IsoDateTime implements ffi.Finalizable {
   /// Gets the date contained in this object
   ///
   /// See the [Rust documentation for `date`](https://docs.rs/icu/latest/icu/calendar/struct.DateTime.html#structfield.date) for more information.
-  IsoDate get date {
+  IsoDate date() {
     final result = _ICU4XIsoDateTime_date(_ffi);
     return IsoDate._fromFfi(result, []);
   }
@@ -72,7 +72,7 @@ final class IsoDateTime implements ffi.Finalizable {
   /// Gets the time contained in this object
   ///
   /// See the [Rust documentation for `time`](https://docs.rs/icu/latest/icu/calendar/struct.DateTime.html#structfield.time) for more information.
-  Time get time {
+  Time time() {
     final result = _ICU4XIsoDateTime_time(_ffi);
     return Time._fromFfi(result, []);
   }
@@ -89,7 +89,7 @@ final class IsoDateTime implements ffi.Finalizable {
   /// Gets the minutes since the local unix epoch for this date (Jan 1 1970, 00:00)
   ///
   /// See the [Rust documentation for `minutes_since_local_unix_epoch`](https://docs.rs/icu/latest/icu/calendar/struct.DateTime.html#method.minutes_since_local_unix_epoch) for more information.
-  int get minutesSinceLocalUnixEpoch {
+  int minutesSinceLocalUnixEpoch() {
     final result = _ICU4XIsoDateTime_minutes_since_local_unix_epoch(_ffi);
     return result;
   }
@@ -105,7 +105,7 @@ final class IsoDateTime implements ffi.Finalizable {
   /// Returns the hour in this time
   ///
   /// See the [Rust documentation for `hour`](https://docs.rs/icu/latest/icu/calendar/struct.Time.html#structfield.hour) for more information.
-  int get hour {
+  int hour() {
     final result = _ICU4XIsoDateTime_hour(_ffi);
     return result;
   }
@@ -113,7 +113,7 @@ final class IsoDateTime implements ffi.Finalizable {
   /// Returns the minute in this time
   ///
   /// See the [Rust documentation for `minute`](https://docs.rs/icu/latest/icu/calendar/struct.Time.html#structfield.minute) for more information.
-  int get minute {
+  int minute() {
     final result = _ICU4XIsoDateTime_minute(_ffi);
     return result;
   }
@@ -121,7 +121,7 @@ final class IsoDateTime implements ffi.Finalizable {
   /// Returns the second in this time
   ///
   /// See the [Rust documentation for `second`](https://docs.rs/icu/latest/icu/calendar/struct.Time.html#structfield.second) for more information.
-  int get second {
+  int second() {
     final result = _ICU4XIsoDateTime_second(_ffi);
     return result;
   }
@@ -129,7 +129,7 @@ final class IsoDateTime implements ffi.Finalizable {
   /// Returns the nanosecond in this time
   ///
   /// See the [Rust documentation for `nanosecond`](https://docs.rs/icu/latest/icu/calendar/struct.Time.html#structfield.nanosecond) for more information.
-  int get nanosecond {
+  int nanosecond() {
     final result = _ICU4XIsoDateTime_nanosecond(_ffi);
     return result;
   }
@@ -137,7 +137,7 @@ final class IsoDateTime implements ffi.Finalizable {
   /// Returns the 1-indexed day in the month for this date
   ///
   /// See the [Rust documentation for `day_of_month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.day_of_month) for more information.
-  int get dayOfMonth {
+  int dayOfMonth() {
     final result = _ICU4XIsoDateTime_day_of_month(_ffi);
     return result;
   }
@@ -145,7 +145,7 @@ final class IsoDateTime implements ffi.Finalizable {
   /// Returns the day in the week for this day
   ///
   /// See the [Rust documentation for `day_of_week`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.day_of_week) for more information.
-  IsoWeekday get dayOfWeek {
+  IsoWeekday dayOfWeek() {
     final result = _ICU4XIsoDateTime_day_of_week(_ffi);
     return IsoWeekday.values.firstWhere((v) => v._ffi == result);
   }
@@ -177,7 +177,7 @@ final class IsoDateTime implements ffi.Finalizable {
   /// Returns 1-indexed number of the month of this date in its year
   ///
   /// See the [Rust documentation for `month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.month) for more information.
-  int get month {
+  int month() {
     final result = _ICU4XIsoDateTime_month(_ffi);
     return result;
   }
@@ -185,7 +185,7 @@ final class IsoDateTime implements ffi.Finalizable {
   /// Returns the year number for this date
   ///
   /// See the [Rust documentation for `year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year) for more information.
-  int get year {
+  int year() {
     final result = _ICU4XIsoDateTime_year(_ffi);
     return result;
   }
@@ -193,7 +193,7 @@ final class IsoDateTime implements ffi.Finalizable {
   /// Returns whether this date is in a leap year
   ///
   /// See the [Rust documentation for `is_in_leap_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.is_in_leap_year) for more information.
-  bool get isInLeapYear {
+  bool isInLeapYear() {
     final result = _ICU4XIsoDateTime_is_in_leap_year(_ffi);
     return result;
   }
@@ -201,7 +201,7 @@ final class IsoDateTime implements ffi.Finalizable {
   /// Returns the number of months in the year represented by this date
   ///
   /// See the [Rust documentation for `months_in_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.months_in_year) for more information.
-  int get monthsInYear {
+  int monthsInYear() {
     final result = _ICU4XIsoDateTime_months_in_year(_ffi);
     return result;
   }
@@ -209,7 +209,7 @@ final class IsoDateTime implements ffi.Finalizable {
   /// Returns the number of days in the month represented by this date
   ///
   /// See the [Rust documentation for `days_in_month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.days_in_month) for more information.
-  int get daysInMonth {
+  int daysInMonth() {
     final result = _ICU4XIsoDateTime_days_in_month(_ffi);
     return result;
   }
@@ -217,7 +217,7 @@ final class IsoDateTime implements ffi.Finalizable {
   /// Returns the number of days in the year represented by this date
   ///
   /// See the [Rust documentation for `days_in_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.days_in_year) for more information.
-  int get daysInYear {
+  int daysInYear() {
     final result = _ICU4XIsoDateTime_days_in_year(_ffi);
     return result;
   }

--- a/ffi/capi/bindings/dart/LineSegmenter.g.dart
+++ b/ffi/capi/bindings/dart/LineSegmenter.g.dart
@@ -30,7 +30,7 @@ final class LineSegmenter implements ffi.Finalizable {
   /// See the [Rust documentation for `new_auto`](https://docs.rs/icu/latest/icu/segmenter/struct.LineSegmenter.html#method.new_auto) for more information.
   ///
   /// Throws [Error] on failure.
-  factory LineSegmenter.auto(DataProvider provider) {
+  static LineSegmenter createAuto(DataProvider provider) {
     final result = _ICU4XLineSegmenter_create_auto(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -44,7 +44,7 @@ final class LineSegmenter implements ffi.Finalizable {
   /// See the [Rust documentation for `new_lstm`](https://docs.rs/icu/latest/icu/segmenter/struct.LineSegmenter.html#method.new_lstm) for more information.
   ///
   /// Throws [Error] on failure.
-  factory LineSegmenter.lstm(DataProvider provider) {
+  static LineSegmenter createLstm(DataProvider provider) {
     final result = _ICU4XLineSegmenter_create_lstm(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -58,7 +58,7 @@ final class LineSegmenter implements ffi.Finalizable {
   /// See the [Rust documentation for `new_dictionary`](https://docs.rs/icu/latest/icu/segmenter/struct.LineSegmenter.html#method.new_dictionary) for more information.
   ///
   /// Throws [Error] on failure.
-  factory LineSegmenter.dictionary(DataProvider provider) {
+  static LineSegmenter createDictionary(DataProvider provider) {
     final result = _ICU4XLineSegmenter_create_dictionary(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -72,7 +72,7 @@ final class LineSegmenter implements ffi.Finalizable {
   /// See the [Rust documentation for `new_auto_with_options`](https://docs.rs/icu/latest/icu/segmenter/struct.LineSegmenter.html#method.new_auto_with_options) for more information.
   ///
   /// Throws [Error] on failure.
-  factory LineSegmenter.autoWithOptions(DataProvider provider, LineBreakOptions options) {
+  static LineSegmenter create_auto_with_options(DataProvider provider, LineBreakOptions options) {
     final temp = ffi2.Arena();
     final result = _ICU4XLineSegmenter_create_auto_with_options_v1(provider._ffi, options._toFfi(temp));
     temp.releaseAll();
@@ -88,7 +88,7 @@ final class LineSegmenter implements ffi.Finalizable {
   /// See the [Rust documentation for `new_lstm_with_options`](https://docs.rs/icu/latest/icu/segmenter/struct.LineSegmenter.html#method.new_lstm_with_options) for more information.
   ///
   /// Throws [Error] on failure.
-  factory LineSegmenter.lstmWithOptions(DataProvider provider, LineBreakOptions options) {
+  static LineSegmenter create_lstm_with_options(DataProvider provider, LineBreakOptions options) {
     final temp = ffi2.Arena();
     final result = _ICU4XLineSegmenter_create_lstm_with_options_v1(provider._ffi, options._toFfi(temp));
     temp.releaseAll();
@@ -104,7 +104,7 @@ final class LineSegmenter implements ffi.Finalizable {
   /// See the [Rust documentation for `new_dictionary_with_options`](https://docs.rs/icu/latest/icu/segmenter/struct.LineSegmenter.html#method.new_dictionary_with_options) for more information.
   ///
   /// Throws [Error] on failure.
-  factory LineSegmenter.dictionaryWithOptions(DataProvider provider, LineBreakOptions options) {
+  static LineSegmenter create_dictionary_with_options(DataProvider provider, LineBreakOptions options) {
     final temp = ffi2.Arena();
     final result = _ICU4XLineSegmenter_create_dictionary_with_options_v1(provider._ffi, options._toFfi(temp));
     temp.releaseAll();

--- a/ffi/capi/bindings/dart/List.g.dart
+++ b/ffi/capi/bindings/dart/List.g.dart
@@ -23,14 +23,14 @@ final class List implements ffi.Finalizable {
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_ICU4XList_destroy));
 
   /// Create a new list of strings
-  factory List() {
+  static final List singleton = () {
     final result = _ICU4XList_create();
     return List._fromFfi(result, []);
-  }
+  }();
 
   /// Create a new list of strings with preallocated space to hold
   /// at least `capacity` elements
-  factory List.withCapacity(int capacity) {
+  static List createWithCapacity(int capacity) {
     final result = _ICU4XList_create_with_capacity(capacity);
     return List._fromFfi(result, []);
   }
@@ -47,13 +47,13 @@ final class List implements ffi.Finalizable {
   }
 
   /// The number of elements in this list
-  int get length {
+  int length() {
     final result = _ICU4XList_len(_ffi);
     return result;
   }
 
   /// Whether this list is empty
-  bool get isEmpty {
+  bool isEmpty() {
     final result = _ICU4XList_is_empty(_ffi);
     return result;
   }

--- a/ffi/capi/bindings/dart/ListFormatter.g.dart
+++ b/ffi/capi/bindings/dart/ListFormatter.g.dart
@@ -27,7 +27,7 @@ final class ListFormatter implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new_and_with_length`](https://docs.rs/icu/latest/icu/list/struct.ListFormatter.html#method.try_new_and_with_length) for more information.
   ///
   /// Throws [Error] on failure.
-  factory ListFormatter.andWithLength(DataProvider provider, Locale locale, ListLength length) {
+  static ListFormatter createAndWithLength(DataProvider provider, Locale locale, ListLength length) {
     final result = _ICU4XListFormatter_create_and_with_length(provider._ffi, locale._ffi, length.index);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -40,7 +40,7 @@ final class ListFormatter implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new_or_with_length`](https://docs.rs/icu/latest/icu/list/struct.ListFormatter.html#method.try_new_or_with_length) for more information.
   ///
   /// Throws [Error] on failure.
-  factory ListFormatter.orWithLength(DataProvider provider, Locale locale, ListLength length) {
+  static ListFormatter createOrWithLength(DataProvider provider, Locale locale, ListLength length) {
     final result = _ICU4XListFormatter_create_or_with_length(provider._ffi, locale._ffi, length.index);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -53,7 +53,7 @@ final class ListFormatter implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new_unit_with_length`](https://docs.rs/icu/latest/icu/list/struct.ListFormatter.html#method.try_new_unit_with_length) for more information.
   ///
   /// Throws [Error] on failure.
-  factory ListFormatter.unitWithLength(DataProvider provider, Locale locale, ListLength length) {
+  static ListFormatter createUnitWithLength(DataProvider provider, Locale locale, ListLength length) {
     final result = _ICU4XListFormatter_create_unit_with_length(provider._ffi, locale._ffi, length.index);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/Locale.g.dart
+++ b/ffi/capi/bindings/dart/Locale.g.dart
@@ -33,7 +33,7 @@ final class Locale implements ffi.Finalizable {
   /// See the [Rust documentation for `try_from_bytes`](https://docs.rs/icu/latest/icu/locid/struct.Locale.html#method.try_from_bytes) for more information.
   ///
   /// Throws [Error] on failure.
-  factory Locale.fromString(String name) {
+  static Locale createFromString(String name) {
     final temp = ffi2.Arena();
     final nameView = name.utf8View;
     final result = _ICU4XLocale_create_from_string(nameView.allocIn(temp), nameView.length);
@@ -47,10 +47,10 @@ final class Locale implements ffi.Finalizable {
   /// Construct a default undefined [`Locale`] "und".
   ///
   /// See the [Rust documentation for `UND`](https://docs.rs/icu/latest/icu/locid/struct.Locale.html#associatedconstant.UND) for more information.
-  factory Locale.und() {
+  static final Locale und = () {
     final result = _ICU4XLocale_create_und();
     return Locale._fromFfi(result, []);
-  }
+  }();
 
   /// Clones the [`Locale`].
   ///
@@ -66,7 +66,7 @@ final class Locale implements ffi.Finalizable {
   /// See the [Rust documentation for `id`](https://docs.rs/icu/latest/icu/locid/struct.Locale.html#structfield.id) for more information.
   ///
   /// Throws [Error] on failure.
-  String get basename {
+  String basename() {
     final writeable = _Writeable();
     final result = _ICU4XLocale_basename(_ffi, writeable._ffi);
     if (!result.isOk) {
@@ -97,7 +97,7 @@ final class Locale implements ffi.Finalizable {
   /// See the [Rust documentation for `id`](https://docs.rs/icu/latest/icu/locid/struct.Locale.html#structfield.id) for more information.
   ///
   /// Throws [Error] on failure.
-  String get language {
+  String language() {
     final writeable = _Writeable();
     final result = _ICU4XLocale_language(_ffi, writeable._ffi);
     if (!result.isOk) {
@@ -111,7 +111,7 @@ final class Locale implements ffi.Finalizable {
   /// See the [Rust documentation for `try_from_bytes`](https://docs.rs/icu/latest/icu/locid/struct.Locale.html#method.try_from_bytes) for more information.
   ///
   /// Throws [Error] on failure.
-  set language(String bytes) {
+  void setLanguage(String bytes) {
     final temp = ffi2.Arena();
     final bytesView = bytes.utf8View;
     final result = _ICU4XLocale_set_language(_ffi, bytesView.allocIn(temp), bytesView.length);
@@ -127,7 +127,7 @@ final class Locale implements ffi.Finalizable {
   /// See the [Rust documentation for `id`](https://docs.rs/icu/latest/icu/locid/struct.Locale.html#structfield.id) for more information.
   ///
   /// Throws [Error] on failure.
-  String get region {
+  String region() {
     final writeable = _Writeable();
     final result = _ICU4XLocale_region(_ffi, writeable._ffi);
     if (!result.isOk) {
@@ -141,7 +141,7 @@ final class Locale implements ffi.Finalizable {
   /// See the [Rust documentation for `try_from_bytes`](https://docs.rs/icu/latest/icu/locid/struct.Locale.html#method.try_from_bytes) for more information.
   ///
   /// Throws [Error] on failure.
-  set region(String bytes) {
+  void setRegion(String bytes) {
     final temp = ffi2.Arena();
     final bytesView = bytes.utf8View;
     final result = _ICU4XLocale_set_region(_ffi, bytesView.allocIn(temp), bytesView.length);
@@ -157,7 +157,7 @@ final class Locale implements ffi.Finalizable {
   /// See the [Rust documentation for `id`](https://docs.rs/icu/latest/icu/locid/struct.Locale.html#structfield.id) for more information.
   ///
   /// Throws [Error] on failure.
-  String get script {
+  String script() {
     final writeable = _Writeable();
     final result = _ICU4XLocale_script(_ffi, writeable._ffi);
     if (!result.isOk) {
@@ -171,7 +171,7 @@ final class Locale implements ffi.Finalizable {
   /// See the [Rust documentation for `try_from_bytes`](https://docs.rs/icu/latest/icu/locid/struct.Locale.html#method.try_from_bytes) for more information.
   ///
   /// Throws [Error] on failure.
-  set script(String bytes) {
+  void setScript(String bytes) {
     final temp = ffi2.Arena();
     final bytesView = bytes.utf8View;
     final result = _ICU4XLocale_set_script(_ffi, bytesView.allocIn(temp), bytesView.length);
@@ -206,7 +206,6 @@ final class Locale implements ffi.Finalizable {
   /// See the [Rust documentation for `write_to`](https://docs.rs/icu/latest/icu/locid/struct.Locale.html#method.write_to) for more information.
   ///
   /// Throws [Error] on failure.
-  @override
   String toString() {
     final writeable = _Writeable();
     final result = _ICU4XLocale_to_string(_ffi, writeable._ffi);

--- a/ffi/capi/bindings/dart/LocaleCanonicalizer.g.dart
+++ b/ffi/capi/bindings/dart/LocaleCanonicalizer.g.dart
@@ -29,7 +29,7 @@ final class LocaleCanonicalizer implements ffi.Finalizable {
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/locid_transform/struct.LocaleCanonicalizer.html#method.new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory LocaleCanonicalizer(DataProvider provider) {
+  static LocaleCanonicalizer create(DataProvider provider) {
     final result = _ICU4XLocaleCanonicalizer_create(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -42,7 +42,7 @@ final class LocaleCanonicalizer implements ffi.Finalizable {
   /// See the [Rust documentation for `new_with_expander`](https://docs.rs/icu/latest/icu/locid_transform/struct.LocaleCanonicalizer.html#method.new_with_expander) for more information.
   ///
   /// Throws [Error] on failure.
-  factory LocaleCanonicalizer.extended(DataProvider provider) {
+  static LocaleCanonicalizer createExtended(DataProvider provider) {
     final result = _ICU4XLocaleCanonicalizer_create_extended(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/LocaleDirectionality.g.dart
+++ b/ffi/capi/bindings/dart/LocaleDirectionality.g.dart
@@ -27,7 +27,7 @@ final class LocaleDirectionality implements ffi.Finalizable {
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/locid_transform/struct.LocaleDirectionality.html#method.new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory LocaleDirectionality(DataProvider provider) {
+  static LocaleDirectionality create(DataProvider provider) {
     final result = _ICU4XLocaleDirectionality_create(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -40,7 +40,7 @@ final class LocaleDirectionality implements ffi.Finalizable {
   /// See the [Rust documentation for `new_with_expander`](https://docs.rs/icu/latest/icu/locid_transform/struct.LocaleDirectionality.html#method.new_with_expander) for more information.
   ///
   /// Throws [Error] on failure.
-  factory LocaleDirectionality.withExpander(DataProvider provider, LocaleExpander expander) {
+  static LocaleDirectionality createWithExpander(DataProvider provider, LocaleExpander expander) {
     final result = _ICU4XLocaleDirectionality_create_with_expander(provider._ffi, expander._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/LocaleDisplayNamesFormatter.g.dart
+++ b/ffi/capi/bindings/dart/LocaleDisplayNamesFormatter.g.dart
@@ -27,7 +27,7 @@ final class LocaleDisplayNamesFormatter implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/displaynames/struct.LocaleDisplayNamesFormatter.html#method.try_new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory LocaleDisplayNamesFormatter(DataProvider provider, Locale locale, DisplayNamesOptions options) {
+  static LocaleDisplayNamesFormatter create(DataProvider provider, Locale locale, DisplayNamesOptions options) {
     final temp = ffi2.Arena();
     final result = _ICU4XLocaleDisplayNamesFormatter_create(provider._ffi, locale._ffi, options._toFfi(temp));
     temp.releaseAll();

--- a/ffi/capi/bindings/dart/LocaleExpander.g.dart
+++ b/ffi/capi/bindings/dart/LocaleExpander.g.dart
@@ -29,7 +29,7 @@ final class LocaleExpander implements ffi.Finalizable {
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/locid_transform/struct.LocaleExpander.html#method.new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory LocaleExpander(DataProvider provider) {
+  static LocaleExpander create(DataProvider provider) {
     final result = _ICU4XLocaleExpander_create(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -42,7 +42,7 @@ final class LocaleExpander implements ffi.Finalizable {
   /// See the [Rust documentation for `new_extended`](https://docs.rs/icu/latest/icu/locid_transform/struct.LocaleExpander.html#method.new_extended) for more information.
   ///
   /// Throws [Error] on failure.
-  factory LocaleExpander.extended(DataProvider provider) {
+  static LocaleExpander createExtended(DataProvider provider) {
     final result = _ICU4XLocaleExpander_create_extended(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/LocaleFallbackIterator.g.dart
+++ b/ffi/capi/bindings/dart/LocaleFallbackIterator.g.dart
@@ -29,7 +29,7 @@ final class LocaleFallbackIterator implements ffi.Finalizable {
   /// Gets a snapshot of the current state of the locale.
   ///
   /// See the [Rust documentation for `get`](https://docs.rs/icu/latest/icu/locid_transform/fallback/struct.LocaleFallbackIterator.html#method.get) for more information.
-  Locale get get {
+  Locale get() {
     final result = _ICU4XLocaleFallbackIterator_get(_ffi);
     return Locale._fromFfi(result, []);
   }

--- a/ffi/capi/bindings/dart/LocaleFallbacker.g.dart
+++ b/ffi/capi/bindings/dart/LocaleFallbacker.g.dart
@@ -29,7 +29,7 @@ final class LocaleFallbacker implements ffi.Finalizable {
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/locid_transform/fallback/struct.LocaleFallbacker.html#method.new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory LocaleFallbacker(DataProvider provider) {
+  static LocaleFallbacker create(DataProvider provider) {
     final result = _ICU4XLocaleFallbacker_create(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -40,10 +40,10 @@ final class LocaleFallbacker implements ffi.Finalizable {
   /// Creates a new `LocaleFallbacker` without data for limited functionality.
   ///
   /// See the [Rust documentation for `new_without_data`](https://docs.rs/icu/latest/icu/locid_transform/fallback/struct.LocaleFallbacker.html#method.new_without_data) for more information.
-  factory LocaleFallbacker.withoutData() {
+  static final LocaleFallbacker withoutData = () {
     final result = _ICU4XLocaleFallbacker_create_without_data();
     return LocaleFallbacker._fromFfi(result, []);
-  }
+  }();
 
   /// Associates this `LocaleFallbacker` with configuration options.
   ///

--- a/ffi/capi/bindings/dart/MetazoneCalculator.g.dart
+++ b/ffi/capi/bindings/dart/MetazoneCalculator.g.dart
@@ -31,7 +31,7 @@ final class MetazoneCalculator implements ffi.Finalizable {
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/timezone/struct.MetazoneCalculator.html#method.new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory MetazoneCalculator(DataProvider provider) {
+  static MetazoneCalculator create(DataProvider provider) {
     final result = _ICU4XMetazoneCalculator_create(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/PluralOperands.g.dart
+++ b/ffi/capi/bindings/dart/PluralOperands.g.dart
@@ -27,7 +27,7 @@ final class PluralOperands implements ffi.Finalizable {
   /// See the [Rust documentation for `from_str`](https://docs.rs/icu/latest/icu/plurals/struct.PluralOperands.html#method.from_str) for more information.
   ///
   /// Throws [Error] on failure.
-  factory PluralOperands.fromString(String s) {
+  static PluralOperands createFromString(String s) {
     final temp = ffi2.Arena();
     final sView = s.utf8View;
     final result = _ICU4XPluralOperands_create_from_string(sView.allocIn(temp), sView.length);
@@ -41,7 +41,7 @@ final class PluralOperands implements ffi.Finalizable {
   /// Construct from a FixedDecimal
   ///
   /// Retains at most 18 digits each from the integer and fraction parts.
-  factory PluralOperands.fromFixedDecimal(FixedDecimal x) {
+  static PluralOperands createFromFixedDecimal(FixedDecimal x) {
     final result = _ICU4XPluralOperands_create_from_fixed_decimal(x._ffi);
     return PluralOperands._fromFfi(result, []);
   }

--- a/ffi/capi/bindings/dart/PluralRules.g.dart
+++ b/ffi/capi/bindings/dart/PluralRules.g.dart
@@ -27,7 +27,7 @@ final class PluralRules implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/latest/icu/plurals/struct.PluralRules.html#method.try_new_cardinal) for more information.
   ///
   /// Throws [Error] on failure.
-  factory PluralRules.cardinal(DataProvider provider, Locale locale) {
+  static PluralRules createCardinal(DataProvider provider, Locale locale) {
     final result = _ICU4XPluralRules_create_cardinal(provider._ffi, locale._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -40,7 +40,7 @@ final class PluralRules implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/latest/icu/plurals/struct.PluralRules.html#method.try_new_ordinal) for more information.
   ///
   /// Throws [Error] on failure.
-  factory PluralRules.ordinal(DataProvider provider, Locale locale) {
+  static PluralRules createOrdinal(DataProvider provider, Locale locale) {
     final result = _ICU4XPluralRules_create_ordinal(provider._ffi, locale._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -59,7 +59,7 @@ final class PluralRules implements ffi.Finalizable {
   /// Get all of the categories needed in the current locale
   ///
   /// See the [Rust documentation for `categories`](https://docs.rs/icu/latest/icu/plurals/struct.PluralRules.html#method.categories) for more information.
-  PluralCategories get categories {
+  PluralCategories categories() {
     final result = _ICU4XPluralRules_categories(_ffi);
     return PluralCategories._fromFfi(result);
   }

--- a/ffi/capi/bindings/dart/PropertyValueNameToEnumMapper.g.dart
+++ b/ffi/capi/bindings/dart/PropertyValueNameToEnumMapper.g.dart
@@ -55,7 +55,7 @@ final class PropertyValueNameToEnumMapper implements ffi.Finalizable {
   /// See the [Rust documentation for `get_name_to_enum_mapper`](https://docs.rs/icu/latest/icu/properties/struct.GeneralCategory.html#method.get_name_to_enum_mapper) for more information.
   ///
   /// Throws [Error] on failure.
-  factory PropertyValueNameToEnumMapper.loadGeneralCategory(DataProvider provider) {
+  static PropertyValueNameToEnumMapper loadGeneralCategory(DataProvider provider) {
     final result = _ICU4XPropertyValueNameToEnumMapper_load_general_category(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -66,7 +66,7 @@ final class PropertyValueNameToEnumMapper implements ffi.Finalizable {
   /// See the [Rust documentation for `name_to_enum_mapper`](https://docs.rs/icu/latest/icu/properties/struct.BidiClass.html#method.name_to_enum_mapper) for more information.
   ///
   /// Throws [Error] on failure.
-  factory PropertyValueNameToEnumMapper.loadBidiClass(DataProvider provider) {
+  static PropertyValueNameToEnumMapper loadBidiClass(DataProvider provider) {
     final result = _ICU4XPropertyValueNameToEnumMapper_load_bidi_class(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -77,7 +77,7 @@ final class PropertyValueNameToEnumMapper implements ffi.Finalizable {
   /// See the [Rust documentation for `name_to_enum_mapper`](https://docs.rs/icu/latest/icu/properties/struct.EastAsianWidth.html#method.name_to_enum_mapper) for more information.
   ///
   /// Throws [Error] on failure.
-  factory PropertyValueNameToEnumMapper.loadEastAsianWidth(DataProvider provider) {
+  static PropertyValueNameToEnumMapper loadEastAsianWidth(DataProvider provider) {
     final result = _ICU4XPropertyValueNameToEnumMapper_load_east_asian_width(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -88,7 +88,7 @@ final class PropertyValueNameToEnumMapper implements ffi.Finalizable {
   /// See the [Rust documentation for `name_to_enum_mapper`](https://docs.rs/icu/latest/icu/properties/struct.IndicSyllabicCategory.html#method.name_to_enum_mapper) for more information.
   ///
   /// Throws [Error] on failure.
-  factory PropertyValueNameToEnumMapper.loadIndicSyllabicCategory(DataProvider provider) {
+  static PropertyValueNameToEnumMapper loadIndicSyllabicCategory(DataProvider provider) {
     final result = _ICU4XPropertyValueNameToEnumMapper_load_indic_syllabic_category(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -99,7 +99,7 @@ final class PropertyValueNameToEnumMapper implements ffi.Finalizable {
   /// See the [Rust documentation for `name_to_enum_mapper`](https://docs.rs/icu/latest/icu/properties/struct.LineBreak.html#method.name_to_enum_mapper) for more information.
   ///
   /// Throws [Error] on failure.
-  factory PropertyValueNameToEnumMapper.loadLineBreak(DataProvider provider) {
+  static PropertyValueNameToEnumMapper loadLineBreak(DataProvider provider) {
     final result = _ICU4XPropertyValueNameToEnumMapper_load_line_break(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -110,7 +110,7 @@ final class PropertyValueNameToEnumMapper implements ffi.Finalizable {
   /// See the [Rust documentation for `get_name_to_enum_mapper`](https://docs.rs/icu/latest/icu/properties/struct.GraphemeClusterBreak.html#method.get_name_to_enum_mapper) for more information.
   ///
   /// Throws [Error] on failure.
-  factory PropertyValueNameToEnumMapper.loadGraphemeClusterBreak(DataProvider provider) {
+  static PropertyValueNameToEnumMapper loadGraphemeClusterBreak(DataProvider provider) {
     final result = _ICU4XPropertyValueNameToEnumMapper_load_grapheme_cluster_break(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -121,7 +121,7 @@ final class PropertyValueNameToEnumMapper implements ffi.Finalizable {
   /// See the [Rust documentation for `name_to_enum_mapper`](https://docs.rs/icu/latest/icu/properties/struct.WordBreak.html#method.name_to_enum_mapper) for more information.
   ///
   /// Throws [Error] on failure.
-  factory PropertyValueNameToEnumMapper.loadWordBreak(DataProvider provider) {
+  static PropertyValueNameToEnumMapper loadWordBreak(DataProvider provider) {
     final result = _ICU4XPropertyValueNameToEnumMapper_load_word_break(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -132,7 +132,7 @@ final class PropertyValueNameToEnumMapper implements ffi.Finalizable {
   /// See the [Rust documentation for `name_to_enum_mapper`](https://docs.rs/icu/latest/icu/properties/struct.SentenceBreak.html#method.name_to_enum_mapper) for more information.
   ///
   /// Throws [Error] on failure.
-  factory PropertyValueNameToEnumMapper.loadSentenceBreak(DataProvider provider) {
+  static PropertyValueNameToEnumMapper loadSentenceBreak(DataProvider provider) {
     final result = _ICU4XPropertyValueNameToEnumMapper_load_sentence_break(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -143,7 +143,7 @@ final class PropertyValueNameToEnumMapper implements ffi.Finalizable {
   /// See the [Rust documentation for `name_to_enum_mapper`](https://docs.rs/icu/latest/icu/properties/struct.Script.html#method.name_to_enum_mapper) for more information.
   ///
   /// Throws [Error] on failure.
-  factory PropertyValueNameToEnumMapper.loadScript(DataProvider provider) {
+  static PropertyValueNameToEnumMapper loadScript(DataProvider provider) {
     final result = _ICU4XPropertyValueNameToEnumMapper_load_script(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/RegionDisplayNames.g.dart
+++ b/ffi/capi/bindings/dart/RegionDisplayNames.g.dart
@@ -27,7 +27,7 @@ final class RegionDisplayNames implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/displaynames/struct.RegionDisplayNames.html#method.try_new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory RegionDisplayNames(DataProvider provider, Locale locale) {
+  static RegionDisplayNames create(DataProvider provider, Locale locale) {
     final result = _ICU4XRegionDisplayNames_create(provider._ffi, locale._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/ReorderedIndexMap.g.dart
+++ b/ffi/capi/bindings/dart/ReorderedIndexMap.g.dart
@@ -27,7 +27,7 @@ final class ReorderedIndexMap implements ffi.Finalizable {
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_ICU4XReorderedIndexMap_destroy));
 
   /// Get this as a slice/array of indices
-  core.List<int> get asSlice {
+  core.List<int> asSlice() {
     // This lifetime edge depends on lifetimes: 'a
     core.List<Object> aEdges = [this];
     final result = _ICU4XReorderedIndexMap_as_slice(_ffi);
@@ -35,13 +35,13 @@ final class ReorderedIndexMap implements ffi.Finalizable {
   }
 
   /// The length of this map
-  int get length {
+  int length() {
     final result = _ICU4XReorderedIndexMap_len(_ffi);
     return result;
   }
 
   /// Whether this map is empty
-  bool get isEmpty {
+  bool isEmpty() {
     final result = _ICU4XReorderedIndexMap_is_empty(_ffi);
     return result;
   }

--- a/ffi/capi/bindings/dart/ScriptExtensionsSet.g.dart
+++ b/ffi/capi/bindings/dart/ScriptExtensionsSet.g.dart
@@ -37,7 +37,7 @@ final class ScriptExtensionsSet implements ffi.Finalizable {
   /// Get the number of scripts contained in here
   ///
   /// See the [Rust documentation for `iter`](https://docs.rs/icu/latest/icu/properties/script/struct.ScriptExtensionsSet.html#method.iter) for more information.
-  int get count {
+  int count() {
     final result = _ICU4XScriptExtensionsSet_count(_ffi);
     return result;
   }

--- a/ffi/capi/bindings/dart/ScriptWithExtensions.g.dart
+++ b/ffi/capi/bindings/dart/ScriptWithExtensions.g.dart
@@ -27,7 +27,7 @@ final class ScriptWithExtensions implements ffi.Finalizable {
   /// See the [Rust documentation for `script_with_extensions`](https://docs.rs/icu/latest/icu/properties/script/fn.script_with_extensions.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory ScriptWithExtensions(DataProvider provider) {
+  static ScriptWithExtensions create(DataProvider provider) {
     final result = _ICU4XScriptWithExtensions_create(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -54,7 +54,7 @@ final class ScriptWithExtensions implements ffi.Finalizable {
   /// Borrow this object for a slightly faster variant with more operations
   ///
   /// See the [Rust documentation for `as_borrowed`](https://docs.rs/icu/latest/icu/properties/script/struct.ScriptWithExtensions.html#method.as_borrowed) for more information.
-  ScriptWithExtensionsBorrowed get asBorrowed {
+  ScriptWithExtensionsBorrowed asBorrowed() {
     // This lifetime edge depends on lifetimes: 'a
     core.List<Object> aEdges = [this];
     final result = _ICU4XScriptWithExtensions_as_borrowed(_ffi);

--- a/ffi/capi/bindings/dart/SentenceSegmenter.g.dart
+++ b/ffi/capi/bindings/dart/SentenceSegmenter.g.dart
@@ -29,7 +29,7 @@ final class SentenceSegmenter implements ffi.Finalizable {
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/segmenter/struct.SentenceSegmenter.html#method.new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory SentenceSegmenter(DataProvider provider) {
+  static SentenceSegmenter create(DataProvider provider) {
     final result = _ICU4XSentenceSegmenter_create(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/Time.g.dart
+++ b/ffi/capi/bindings/dart/Time.g.dart
@@ -29,7 +29,7 @@ final class Time implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/calendar/struct.Time.html#method.try_new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory Time(int hour, int minute, int second, int nanosecond) {
+  static Time create(int hour, int minute, int second, int nanosecond) {
     final result = _ICU4XTime_create(hour, minute, second, nanosecond);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -42,7 +42,7 @@ final class Time implements ffi.Finalizable {
   /// See the [Rust documentation for `midnight`](https://docs.rs/icu/latest/icu/calendar/struct.Time.html#method.midnight) for more information.
   ///
   /// Throws [Error] on failure.
-  factory Time.midnight() {
+  static Time createMidnight() {
     final result = _ICU4XTime_create_midnight();
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -53,7 +53,7 @@ final class Time implements ffi.Finalizable {
   /// Returns the hour in this time
   ///
   /// See the [Rust documentation for `hour`](https://docs.rs/icu/latest/icu/calendar/struct.Time.html#structfield.hour) for more information.
-  int get hour {
+  int hour() {
     final result = _ICU4XTime_hour(_ffi);
     return result;
   }
@@ -61,7 +61,7 @@ final class Time implements ffi.Finalizable {
   /// Returns the minute in this time
   ///
   /// See the [Rust documentation for `minute`](https://docs.rs/icu/latest/icu/calendar/struct.Time.html#structfield.minute) for more information.
-  int get minute {
+  int minute() {
     final result = _ICU4XTime_minute(_ffi);
     return result;
   }
@@ -69,7 +69,7 @@ final class Time implements ffi.Finalizable {
   /// Returns the second in this time
   ///
   /// See the [Rust documentation for `second`](https://docs.rs/icu/latest/icu/calendar/struct.Time.html#structfield.second) for more information.
-  int get second {
+  int second() {
     final result = _ICU4XTime_second(_ffi);
     return result;
   }
@@ -77,7 +77,7 @@ final class Time implements ffi.Finalizable {
   /// Returns the nanosecond in this time
   ///
   /// See the [Rust documentation for `nanosecond`](https://docs.rs/icu/latest/icu/calendar/struct.Time.html#structfield.nanosecond) for more information.
-  int get nanosecond {
+  int nanosecond() {
     final result = _ICU4XTime_nanosecond(_ffi);
     return result;
   }

--- a/ffi/capi/bindings/dart/TimeFormatter.g.dart
+++ b/ffi/capi/bindings/dart/TimeFormatter.g.dart
@@ -29,7 +29,7 @@ final class TimeFormatter implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new_with_length`](https://docs.rs/icu/latest/icu/datetime/struct.TimeFormatter.html#method.try_new_with_length) for more information.
   ///
   /// Throws [Error] on failure.
-  factory TimeFormatter.withLength(DataProvider provider, Locale locale, TimeLength length) {
+  static TimeFormatter createWithLength(DataProvider provider, Locale locale, TimeLength length) {
     final result = _ICU4XTimeFormatter_create_with_length(provider._ffi, locale._ffi, length.index);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/TimeZoneFormatter.g.dart
+++ b/ffi/capi/bindings/dart/TimeZoneFormatter.g.dart
@@ -33,7 +33,7 @@ final class TimeZoneFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/latest/icu/datetime/time_zone/enum.FallbackFormat.html)
   ///
   /// Throws [Error] on failure.
-  factory TimeZoneFormatter.withLocalizedGmtFallback(DataProvider provider, Locale locale) {
+  static TimeZoneFormatter createWithLocalizedGmtFallback(DataProvider provider, Locale locale) {
     final result = _ICU4XTimeZoneFormatter_create_with_localized_gmt_fallback(provider._ffi, locale._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -50,7 +50,7 @@ final class TimeZoneFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/latest/icu/datetime/time_zone/enum.FallbackFormat.html)
   ///
   /// Throws [Error] on failure.
-  factory TimeZoneFormatter.withIso8601Fallback(DataProvider provider, Locale locale, IsoTimeZoneOptions options) {
+  static TimeZoneFormatter createWithIso8601Fallback(DataProvider provider, Locale locale, IsoTimeZoneOptions options) {
     final temp = ffi2.Arena();
     final result = _ICU4XTimeZoneFormatter_create_with_iso_8601_fallback(provider._ffi, locale._ffi, options._toFfi(temp));
     temp.releaseAll();

--- a/ffi/capi/bindings/dart/TitlecaseMapper.g.dart
+++ b/ffi/capi/bindings/dart/TitlecaseMapper.g.dart
@@ -27,7 +27,7 @@ final class TitlecaseMapper implements ffi.Finalizable {
   /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/casemap/struct.TitlecaseMapper.html#method.new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory TitlecaseMapper(DataProvider provider) {
+  static TitlecaseMapper create(DataProvider provider) {
     final result = _ICU4XTitlecaseMapper_create(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/TitlecaseOptions.g.dart
+++ b/ffi/capi/bindings/dart/TitlecaseOptions.g.dart
@@ -14,6 +14,8 @@ final class TitlecaseOptions {
   LeadingAdjustment leadingAdjustment;
   TrailingCase trailingCase;
 
+  TitlecaseOptions({required this.leadingAdjustment, required this.trailingCase});
+
   // This struct contains borrowed fields, so this takes in a list of
   // "edges" corresponding to where each lifetime's data may have been borrowed from
   // and passes it down to individual fields containing the borrow.
@@ -33,17 +35,10 @@ final class TitlecaseOptions {
   }
 
   /// See the [Rust documentation for `default`](https://docs.rs/icu/latest/icu/casemap/titlecase/struct.TitlecaseOptions.html#method.default) for more information.
-  factory TitlecaseOptions({LeadingAdjustment? leadingAdjustment, TrailingCase? trailingCase}) {
+  static final TitlecaseOptions default_ = () {
     final result = _ICU4XTitlecaseOptionsV1_default_options();
-    final dart = TitlecaseOptions._fromFfi(result);
-    if (leadingAdjustment != null) {
-      dart.leadingAdjustment = leadingAdjustment;
-    }
-    if (trailingCase != null) {
-      dart.trailingCase = trailingCase;
-    }
-    return dart;
-  }
+    return TitlecaseOptions._fromFfi(result);
+  }();
 
   @override
   bool operator ==(Object other) =>

--- a/ffi/capi/bindings/dart/UnicodeSetData.g.dart
+++ b/ffi/capi/bindings/dart/UnicodeSetData.g.dart
@@ -50,7 +50,7 @@ final class UnicodeSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `basic_emoji`](https://docs.rs/icu/latest/icu/properties/sets/fn.basic_emoji.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory UnicodeSetData.loadBasicEmoji(DataProvider provider) {
+  static UnicodeSetData loadBasicEmoji(DataProvider provider) {
     final result = _ICU4XUnicodeSetData_load_basic_emoji(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -61,7 +61,7 @@ final class UnicodeSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `exemplars_main`](https://docs.rs/icu/latest/icu/properties/exemplar_chars/fn.exemplars_main.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory UnicodeSetData.loadExemplarsMain(DataProvider provider, Locale locale) {
+  static UnicodeSetData loadExemplarsMain(DataProvider provider, Locale locale) {
     final result = _ICU4XUnicodeSetData_load_exemplars_main(provider._ffi, locale._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -72,7 +72,7 @@ final class UnicodeSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `exemplars_auxiliary`](https://docs.rs/icu/latest/icu/properties/exemplar_chars/fn.exemplars_auxiliary.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory UnicodeSetData.loadExemplarsAuxiliary(DataProvider provider, Locale locale) {
+  static UnicodeSetData loadExemplarsAuxiliary(DataProvider provider, Locale locale) {
     final result = _ICU4XUnicodeSetData_load_exemplars_auxiliary(provider._ffi, locale._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -83,7 +83,7 @@ final class UnicodeSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `exemplars_punctuation`](https://docs.rs/icu/latest/icu/properties/exemplar_chars/fn.exemplars_punctuation.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory UnicodeSetData.loadExemplarsPunctuation(DataProvider provider, Locale locale) {
+  static UnicodeSetData loadExemplarsPunctuation(DataProvider provider, Locale locale) {
     final result = _ICU4XUnicodeSetData_load_exemplars_punctuation(provider._ffi, locale._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -94,7 +94,7 @@ final class UnicodeSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `exemplars_numbers`](https://docs.rs/icu/latest/icu/properties/exemplar_chars/fn.exemplars_numbers.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory UnicodeSetData.loadExemplarsNumbers(DataProvider provider, Locale locale) {
+  static UnicodeSetData loadExemplarsNumbers(DataProvider provider, Locale locale) {
     final result = _ICU4XUnicodeSetData_load_exemplars_numbers(provider._ffi, locale._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -105,7 +105,7 @@ final class UnicodeSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `exemplars_index`](https://docs.rs/icu/latest/icu/properties/exemplar_chars/fn.exemplars_index.html) for more information.
   ///
   /// Throws [Error] on failure.
-  factory UnicodeSetData.loadExemplarsIndex(DataProvider provider, Locale locale) {
+  static UnicodeSetData loadExemplarsIndex(DataProvider provider, Locale locale) {
     final result = _ICU4XUnicodeSetData_load_exemplars_index(provider._ffi, locale._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/WeekCalculator.g.dart
+++ b/ffi/capi/bindings/dart/WeekCalculator.g.dart
@@ -29,7 +29,7 @@ final class WeekCalculator implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/calendar/week/struct.WeekCalculator.html#method.try_new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory WeekCalculator(DataProvider provider, Locale locale) {
+  static WeekCalculator create(DataProvider provider, Locale locale) {
     final result = _ICU4XWeekCalculator_create(provider._ffi, locale._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -38,7 +38,7 @@ final class WeekCalculator implements ffi.Finalizable {
   }
 
   /// Additional information: [1](https://docs.rs/icu/latest/icu/calendar/week/struct.WeekCalculator.html#structfield.first_weekday), [2](https://docs.rs/icu/latest/icu/calendar/week/struct.WeekCalculator.html#structfield.min_week_days)
-  factory WeekCalculator.fromFirstDayOfWeekAndMinWeekDays(IsoWeekday firstWeekday, int minWeekDays) {
+  static WeekCalculator createFromFirstDayOfWeekAndMinWeekDays(IsoWeekday firstWeekday, int minWeekDays) {
     final result = _ICU4XWeekCalculator_create_from_first_day_of_week_and_min_week_days(firstWeekday._ffi, minWeekDays);
     return WeekCalculator._fromFfi(result, []);
   }
@@ -46,7 +46,7 @@ final class WeekCalculator implements ffi.Finalizable {
   /// Returns the weekday that starts the week for this object's locale
   ///
   /// See the [Rust documentation for `first_weekday`](https://docs.rs/icu/latest/icu/calendar/week/struct.WeekCalculator.html#structfield.first_weekday) for more information.
-  IsoWeekday get firstWeekday {
+  IsoWeekday firstWeekday() {
     final result = _ICU4XWeekCalculator_first_weekday(_ffi);
     return IsoWeekday.values.firstWhere((v) => v._ffi == result);
   }
@@ -55,7 +55,7 @@ final class WeekCalculator implements ffi.Finalizable {
   /// considered part of that year
   ///
   /// See the [Rust documentation for `min_week_days`](https://docs.rs/icu/latest/icu/calendar/week/struct.WeekCalculator.html#structfield.min_week_days) for more information.
-  int get minWeekDays {
+  int minWeekDays() {
     final result = _ICU4XWeekCalculator_min_week_days(_ffi);
     return result;
   }

--- a/ffi/capi/bindings/dart/WordBreakIteratorLatin1.g.dart
+++ b/ffi/capi/bindings/dart/WordBreakIteratorLatin1.g.dart
@@ -36,7 +36,7 @@ final class WordBreakIteratorLatin1 implements ffi.Finalizable {
   /// Return the status value of break boundary.
   ///
   /// See the [Rust documentation for `word_type`](https://docs.rs/icu/latest/icu/segmenter/struct.WordBreakIterator.html#method.word_type) for more information.
-  SegmenterWordType get wordType {
+  SegmenterWordType wordType() {
     final result = _ICU4XWordBreakIteratorLatin1_word_type(_ffi);
     return SegmenterWordType.values[result];
   }
@@ -44,7 +44,7 @@ final class WordBreakIteratorLatin1 implements ffi.Finalizable {
   /// Return true when break boundary is word-like such as letter/number/CJK
   ///
   /// See the [Rust documentation for `is_word_like`](https://docs.rs/icu/latest/icu/segmenter/struct.WordBreakIterator.html#method.is_word_like) for more information.
-  bool get isWordLike {
+  bool isWordLike() {
     final result = _ICU4XWordBreakIteratorLatin1_is_word_like(_ffi);
     return result;
   }

--- a/ffi/capi/bindings/dart/WordBreakIteratorUtf16.g.dart
+++ b/ffi/capi/bindings/dart/WordBreakIteratorUtf16.g.dart
@@ -36,7 +36,7 @@ final class WordBreakIteratorUtf16 implements ffi.Finalizable {
   /// Return the status value of break boundary.
   ///
   /// See the [Rust documentation for `word_type`](https://docs.rs/icu/latest/icu/segmenter/struct.WordBreakIterator.html#method.word_type) for more information.
-  SegmenterWordType get wordType {
+  SegmenterWordType wordType() {
     final result = _ICU4XWordBreakIteratorUtf16_word_type(_ffi);
     return SegmenterWordType.values[result];
   }
@@ -44,7 +44,7 @@ final class WordBreakIteratorUtf16 implements ffi.Finalizable {
   /// Return true when break boundary is word-like such as letter/number/CJK
   ///
   /// See the [Rust documentation for `is_word_like`](https://docs.rs/icu/latest/icu/segmenter/struct.WordBreakIterator.html#method.is_word_like) for more information.
-  bool get isWordLike {
+  bool isWordLike() {
     final result = _ICU4XWordBreakIteratorUtf16_is_word_like(_ffi);
     return result;
   }

--- a/ffi/capi/bindings/dart/WordBreakIteratorUtf8.g.dart
+++ b/ffi/capi/bindings/dart/WordBreakIteratorUtf8.g.dart
@@ -36,7 +36,7 @@ final class WordBreakIteratorUtf8 implements ffi.Finalizable {
   /// Return the status value of break boundary.
   ///
   /// See the [Rust documentation for `word_type`](https://docs.rs/icu/latest/icu/segmenter/struct.WordBreakIterator.html#method.word_type) for more information.
-  SegmenterWordType get wordType {
+  SegmenterWordType wordType() {
     final result = _ICU4XWordBreakIteratorUtf8_word_type(_ffi);
     return SegmenterWordType.values[result];
   }
@@ -44,7 +44,7 @@ final class WordBreakIteratorUtf8 implements ffi.Finalizable {
   /// Return true when break boundary is word-like such as letter/number/CJK
   ///
   /// See the [Rust documentation for `is_word_like`](https://docs.rs/icu/latest/icu/segmenter/struct.WordBreakIterator.html#method.is_word_like) for more information.
-  bool get isWordLike {
+  bool isWordLike() {
     final result = _ICU4XWordBreakIteratorUtf8_is_word_like(_ffi);
     return result;
   }

--- a/ffi/capi/bindings/dart/WordSegmenter.g.dart
+++ b/ffi/capi/bindings/dart/WordSegmenter.g.dart
@@ -33,7 +33,7 @@ final class WordSegmenter implements ffi.Finalizable {
   /// See the [Rust documentation for `new_auto`](https://docs.rs/icu/latest/icu/segmenter/struct.WordSegmenter.html#method.new_auto) for more information.
   ///
   /// Throws [Error] on failure.
-  factory WordSegmenter.auto(DataProvider provider) {
+  static WordSegmenter createAuto(DataProvider provider) {
     final result = _ICU4XWordSegmenter_create_auto(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -50,7 +50,7 @@ final class WordSegmenter implements ffi.Finalizable {
   /// See the [Rust documentation for `new_lstm`](https://docs.rs/icu/latest/icu/segmenter/struct.WordSegmenter.html#method.new_lstm) for more information.
   ///
   /// Throws [Error] on failure.
-  factory WordSegmenter.lstm(DataProvider provider) {
+  static WordSegmenter createLstm(DataProvider provider) {
     final result = _ICU4XWordSegmenter_create_lstm(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -64,7 +64,7 @@ final class WordSegmenter implements ffi.Finalizable {
   /// See the [Rust documentation for `new_dictionary`](https://docs.rs/icu/latest/icu/segmenter/struct.WordSegmenter.html#method.new_dictionary) for more information.
   ///
   /// Throws [Error] on failure.
-  factory WordSegmenter.dictionary(DataProvider provider) {
+  static WordSegmenter createDictionary(DataProvider provider) {
     final result = _ICU4XWordSegmenter_create_dictionary(provider._ffi);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);

--- a/ffi/capi/bindings/dart/ZonedDateTimeFormatter.g.dart
+++ b/ffi/capi/bindings/dart/ZonedDateTimeFormatter.g.dart
@@ -32,7 +32,7 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/datetime/struct.ZonedDateTimeFormatter.html#method.try_new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory ZonedDateTimeFormatter.withLengths(DataProvider provider, Locale locale, DateLength dateLength, TimeLength timeLength) {
+  static ZonedDateTimeFormatter createWithLengths(DataProvider provider, Locale locale, DateLength dateLength, TimeLength timeLength) {
     final result = _ICU4XZonedDateTimeFormatter_create_with_lengths(provider._ffi, locale._ffi, dateLength.index, timeLength.index);
     if (!result.isOk) {
       throw Error.values.firstWhere((v) => v._ffi == result.union.err);
@@ -48,7 +48,7 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/datetime/struct.ZonedDateTimeFormatter.html#method.try_new) for more information.
   ///
   /// Throws [Error] on failure.
-  factory ZonedDateTimeFormatter.withLengthsAndIso8601TimeZoneFallback(DataProvider provider, Locale locale, DateLength dateLength, TimeLength timeLength, IsoTimeZoneOptions zoneOptions) {
+  static ZonedDateTimeFormatter createWithLengthsAndIso8601TimeZoneFallback(DataProvider provider, Locale locale, DateLength dateLength, TimeLength timeLength, IsoTimeZoneOptions zoneOptions) {
     final temp = ffi2.Arena();
     final result = _ICU4XZonedDateTimeFormatter_create_with_lengths_and_iso_8601_time_zone_fallback(provider._ffi, locale._ffi, dateLength.index, timeLength.index, zoneOptions._toFfi(temp));
     temp.releaseAll();

--- a/ffi/capi/bindings/dart/lib.g.dart
+++ b/ffi/capi/bindings/dart/lib.g.dart
@@ -150,7 +150,33 @@ typedef Rune = int;
 // ignore: unused_element
 final _callocFree = core.Finalizer(ffi2.calloc.free);
 
+// ignore: unused_element
 final _nopFree = core.Finalizer((nothing) => {});
+
+// ignore: unused_element
+final _rustFree = core.Finalizer((({ffi.Pointer<ffi.Void> pointer, int bytes, int align}) record) => _diplomat_free(record.pointer, record.bytes, record.align));
+
+final class _RustAlloc implements ffi.Allocator {
+  @override
+  ffi.Pointer<T> allocate<T extends ffi.NativeType>(int byteCount, {int? alignment}) {
+      return _diplomat_alloc(byteCount, alignment ?? 1).cast();
+  }
+
+  void free(ffi.Pointer<ffi.NativeType> pointer) {
+    throw 'Internal error: should not deallocate in Rust memory';
+  }
+}
+
+@meta.ResourceIdentifier('diplomat_alloc')
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Size, ffi.Size)>(symbol: 'diplomat_alloc', isLeaf: true)
+// ignore: non_constant_identifier_names
+external ffi.Pointer<ffi.Void> _diplomat_alloc(int len, int align);
+
+@meta.ResourceIdentifier('diplomat_free')
+@ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Void>, ffi.Size, ffi.Size)>(symbol: 'diplomat_free', isLeaf: true)
+// ignore: non_constant_identifier_names
+external int _diplomat_free(ffi.Pointer<ffi.Void> ptr, int len, int align);
+
 
 // ignore: unused_element
 class _FinalizedArena {
@@ -578,8 +604,11 @@ final class _SliceUsize extends ffi.Struct {
   int get hashCode => _length.hashCode;
 
   core.List<int> _toDart(core.List<Object> lifetimeEdges) {
-    // Do not have to keep lifetimeEdges alive, because this copies
-    return core.Iterable.generate(_length).map((i) => _data[i]).toList(growable: false);
+    final r = core.Iterable.generate(_length).map((i) => _data[i]).toList(growable: false);
+    if (lifetimeEdges.isEmpty) {
+      _diplomat_free(_data.cast(), _length * ffi.sizeOf<ffi.Size>(), ffi.sizeOf<ffi.Size>());
+    }
+    return r;
   }
 }
 
@@ -609,8 +638,11 @@ final class _SliceUtf8 extends ffi.Struct {
   int get hashCode => _length.hashCode;
 
   String _toDart(core.List<Object> lifetimeEdges) {
-    // Do not have to keep lifetimeEdges alive, because this copies
-    return Utf8Decoder().convert(_data.asTypedList(_length));
+    final r = Utf8Decoder().convert(_data.asTypedList(_length));
+    if (lifetimeEdges.isEmpty) {
+      _diplomat_free(_data.cast(), _length, 1);
+    }
+    return r;
   }
 }
 
@@ -626,7 +658,6 @@ final class _Writeable {
   }
 }
 
-  
 @meta.ResourceIdentifier('diplomat_buffer_writeable_create')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Size)>(symbol: 'diplomat_buffer_writeable_create', isLeaf: true)
 // ignore: non_constant_identifier_names


### PR DESCRIPTION
This cuts our dep on `atty` which should resolve one or more security alerts.

Currently this doesn't work with MSRV. https://github.com/rust-diplomat/diplomat/pull/465 might fix that.