### PR TITLE
Simplify LocaleExpander::minimize

### DIFF
--- a/components/locid_transform/benches/locale_canonicalizer.rs
+++ b/components/locid_transform/benches/locale_canonicalizer.rs
@@ -86,6 +86,15 @@ fn maximize_bench(c: &mut Criterion) {
         })
     });
 
+    group.bench_function("minimize", |b| {
+        b.iter(|| {
+            for locale in &locales {
+                let mut locale = locale.clone();
+                lc.minimize(black_box(&mut locale));
+            }
+        })
+    });
+
     group.finish();
 }
 

--- a/components/locid_transform/src/expander.rs
+++ b/components/locid_transform/src/expander.rs
@@ -4,7 +4,6 @@
 
 use crate::{provider::*, LocaleTransformError};
 
-use core::mem;
 use icu_locid::subtags::{Language, Region, Script};
 use icu_locid::LanguageIdentifier;
 use icu_provider::prelude::*;
@@ -482,8 +481,6 @@ impl LocaleExpander {
 
         let mut max = langid.clone();
         self.maximize(&mut max);
-        let variants = mem::take(&mut max.variants);
-        max.variants.clear();
         let mut trial = max.clone();
 
         trial.script = None;
@@ -501,7 +498,6 @@ impl LocaleExpander {
                 if langid.region.is_some() {
                     langid.region = None;
                 }
-                langid.variants = variants;
                 return TransformResult::Modified;
             } else {
                 return TransformResult::Unmodified;
@@ -525,7 +521,6 @@ impl LocaleExpander {
                 if langid.region != max.region {
                     langid.region = max.region;
                 }
-                langid.variants = variants;
                 return TransformResult::Modified;
             } else {
                 return TransformResult::Unmodified;
@@ -549,7 +544,6 @@ impl LocaleExpander {
                 if langid.region.is_some() {
                     langid.region = None;
                 }
-                langid.variants = variants;
                 return TransformResult::Modified;
             } else {
                 return TransformResult::Unmodified;


### PR DESCRIPTION
I was reviewing #4752 and I realized that there's a lot of duplicate code that can be extracted to a helper function, similar to what we do in the `maximize` routine.

It appears to make the code slightly faster, too, which wasn't my primary goal but is a nice side-effect.

```
likelysubtags/minimize  time:   [3.8777 µs 3.9019 µs 3.9297 µs]
                        change: [-6.9850% -6.0393% -5.0788%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
```