### PR TITLE
Add FFI for icu::segmenter::WordType::is_word_like 

### DIFF
--- a/ffi/capi/bindings/c/ICU4XSegmenterWordType.h
+++ b/ffi/capi/bindings/c/ICU4XSegmenterWordType.h
@@ -23,6 +23,7 @@ namespace capi {
 extern "C" {
 #endif
 
+bool ICU4XSegmenterWordType_is_word_like(ICU4XSegmenterWordType self);
 void ICU4XSegmenterWordType_destroy(ICU4XSegmenterWordType* self);
 
 #ifdef __cplusplus

--- a/ffi/capi/bindings/cpp/ICU4XSegmenterWordType.h
+++ b/ffi/capi/bindings/cpp/ICU4XSegmenterWordType.h
@@ -23,6 +23,7 @@ namespace capi {
 extern "C" {
 #endif
 
+bool ICU4XSegmenterWordType_is_word_like(ICU4XSegmenterWordType self);
 void ICU4XSegmenterWordType_destroy(ICU4XSegmenterWordType* self);
 
 #ifdef __cplusplus

--- a/ffi/capi/bindings/dart/SegmenterWordType.g.dart
+++ b/ffi/capi/bindings/dart/SegmenterWordType.g.dart
@@ -17,6 +17,7 @@ enum SegmenterWordType {
   }
 }
 
+@meta.ResourceIdentifier('ICU4XSegmenterWordType_is_word_like')
 @ffi.Native<ffi.Bool Function(ffi.Int32)>(isLeaf: true, symbol: 'ICU4XSegmenterWordType_is_word_like')
 // ignore: non_constant_identifier_names
 external bool _ICU4XSegmenterWordType_is_word_like(int self);

--- a/ffi/capi/bindings/dart/SegmenterWordType.g.dart
+++ b/ffi/capi/bindings/dart/SegmenterWordType.g.dart
@@ -9,4 +9,14 @@ enum SegmenterWordType {
   number,
 
   letter;
+
+  /// See the [Rust documentation for `is_word_like`](https://docs.rs/icu/latest/icu/segmenter/enum.WordType.html#method.is_word_like) for more information.
+  bool get isWordLike {
+    final result = _ICU4XSegmenterWordType_is_word_like(index);
+    return result;
+  }
 }
+
+@ffi.Native<ffi.Bool Function(ffi.Int32)>(isLeaf: true, symbol: 'ICU4XSegmenterWordType_is_word_like')
+// ignore: non_constant_identifier_names
+external bool _ICU4XSegmenterWordType_is_word_like(int self);

--- a/ffi/capi/src/segmenter_word.rs
+++ b/ffi/capi/src/segmenter_word.rs
@@ -46,6 +46,13 @@ pub mod ffi {
     #[diplomat::rust_link(icu::segmenter::WordBreakIteratorLatin1, Typedef, hidden)]
     pub struct ICU4XWordBreakIteratorLatin1<'a>(WordBreakIteratorLatin1<'a, 'a>);
 
+    impl ICU4XSegmenterWordType {
+        #[diplomat::rust_link(icu::segmenter::WordType::is_word_like, FnInEnum)]
+        pub fn is_word_like(self) -> bool {
+            WordType::from(self).is_word_like()
+        }
+    }
+
     impl ICU4XWordSegmenter {
         /// Construct an [`ICU4XWordSegmenter`] with automatically selecting the best available LSTM
         /// or dictionary payload data.

--- a/ffi/capi/tests/missing_apis.txt
+++ b/ffi/capi/tests/missing_apis.txt
@@ -583,4 +583,3 @@ icu::properties::names::PropertyEnumToValueNameLinearTiny4MapperBorrowed::get#Fn
 icu::properties::names::PropertyEnumToValueNameSparseMapper#Struct
 icu::properties::names::PropertyEnumToValueNameSparseMapperBorrowed#Struct
 icu::properties::names::PropertyEnumToValueNameSparseMapperBorrowed::get#FnInStruct
-icu::segmenter::WordType::is_word_like#FnInEnum


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

fixes #4687

looking at other FFI PRs, I can tell that there should be more changed FFI files than just four. I have run `cargo make diplomat-gen`, but I'm probably missing something.