### PR TITLE
Make all eligible options bags Copy

### DIFF
--- a/components/casemap/src/internals.rs
+++ b/components/casemap/src/internals.rs
@@ -23,7 +23,7 @@ const ACUTE: char = '\u{301}';
 
 // Used to control the behavior of CaseMapper::fold.
 // Currently only used to decide whether to use Turkic (T) mappings for dotted/dotless i.
-#[derive(Default)]
+#[derive(Copy, Clone, Default)]
 pub struct FoldOptions {
     exclude_special_i: bool,
 }

--- a/components/experimental/src/dimension/currency/options.rs
+++ b/components/experimental/src/dimension/currency/options.rs
@@ -6,7 +6,7 @@
 
 /// A collection of configuration options that determine the formatting behavior of
 /// [`CurrencyFormatter`](crate::dimension::currency::formatter::CurrencyFormatter).
-#[derive(Debug, Eq, PartialEq, Clone, Default)]
+#[derive(Copy, Debug, Eq, PartialEq, Clone, Default)]
 #[non_exhaustive]
 pub struct CurrencyFormatterOptions {
     /// The width of the currency format.

--- a/components/experimental/src/displaynames/options.rs
+++ b/components/experimental/src/displaynames/options.rs
@@ -21,7 +21,7 @@
 /// // Full name would be "Bosnia & Herzegovina"
 /// assert_eq!(display_name.of(region!("BA")), Some("Bosnia"));
 /// ```
-#[derive(Debug, Eq, PartialEq, Clone, Default)]
+#[derive(Copy, Debug, Eq, PartialEq, Clone, Default)]
 #[non_exhaustive]
 pub struct DisplayNamesOptions {
     /// The optional formatting style to use for display name.

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -170,7 +170,7 @@ pub enum LineBreakWordOption {
 
 /// Options to tailor line-breaking behavior.
 #[non_exhaustive]
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct LineBreakOptions {
     /// Strictness of line-breaking rules. See [`LineBreakStrictness`].
     pub strictness: LineBreakStrictness,

--- a/documents/process/graduation.md
+++ b/documents/process/graduation.md
@@ -27,6 +27,8 @@ This document contains a checklist for the requirements to migrate a component f
   - [ ] All options and conditional code paths should have a corresponding docs test with the heading `# Examples`
   - [ ] All functions that are conditional on a Cargo feature should say so (last line before `# Examples`): ```✨ *Enabled with the `alloc` Cargo feature.*```
   - [ ] Compiled data constructors should say "with compiled data" in the first sentence and should have a Cargo feature alert following the above syntax.
+- [ ] The APIs should follow ICU4X style
+  - [ ] All options bags should be `Copy` (and contain references if they need to). Exceptions can be made by discussion.
 - [ ] The data structs should fully follow ZeroVec style
   - [ ] Deserialization should not have a "zero-copy violation" in the [make-testdata](https://github.com/unicode-org/icu4x/blob/main/provider/datagen/tests/make-testdata.rs) test
   - [ ] Constructors should avoid allocating memory in the common case


### PR DESCRIPTION
Fixes #3713

FixedDecimalFormatterOptions is already Copy. The one bag I didn't make Copy is `PersonNamesFormatterOptions` since it contains a `target_locale`.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->