### PR TITLE
Add TryWriteable for writeables that can fail

### DIFF
--- a/utils/writeable/src/fallible.rs
+++ b/utils/writeable/src/fallible.rs
@@ -94,13 +94,13 @@ impl<T> UnwrapInfallible for Result<T, Infallible> {
 ///
 /// ```
 /// use core::fmt;
+/// use writeable::assert_writeable_eq;
 /// use writeable::FallibleWriteable;
 /// use writeable::TryWriteable;
 /// use writeable::Writeable;
-/// use writeable::assert_writeable_eq;
 ///
 /// struct HelloWriteable<T> {
-///     name: Option<T>
+///     name: Option<T>,
 /// }
 ///
 /// impl<T: Writeable> FallibleWriteable for HelloWriteable<T> {
@@ -122,7 +122,7 @@ impl<T> UnwrapInfallible for Result<T, Infallible> {
 ///             None => match handler("___") {
 ///                 Ok(replacement) => replacement.write_to(sink)?,
 ///                 Err(e) => return Ok(Err(e)),
-///             }
+///             },
 ///         };
 ///         sink.write_char('!')?;
 ///         Ok(Ok(()))
@@ -133,7 +133,10 @@ impl<T> UnwrapInfallible for Result<T, Infallible> {
 ///
 /// // See it in action:
 /// assert_writeable_eq!(
-///     HelloWriteable { name: Some("Alice") }.lossy(),
+///     HelloWriteable {
+///         name: Some("Alice")
+///     }
+///     .lossy(),
 ///     "Hello, Alice!"
 /// );
 /// assert_writeable_eq!(
@@ -278,10 +281,7 @@ pub trait TryWriteable: FallibleWriteable {
     /// use writeable::TryWriteable;
     ///
     /// let try_writeable = Some("example");
-    /// writeable::assert_writeable_eq!(
-    ///     try_writeable.lossy(),
-    ///     "example"
-    /// );
+    /// writeable::assert_writeable_eq!(try_writeable.lossy(), "example");
     /// ```
     ///
     /// Failure behavior:
@@ -290,10 +290,7 @@ pub trait TryWriteable: FallibleWriteable {
     /// use writeable::TryWriteable;
     ///
     /// let try_writeable = None::<&str>;
-    /// writeable::assert_writeable_eq!(
-    ///     try_writeable.lossy(),
-    ///     "�"
-    /// );
+    /// writeable::assert_writeable_eq!(try_writeable.lossy(), "�");
     /// ```
     #[inline]
     fn lossy(&self) -> LossyWriteable<&Self> {
@@ -309,10 +306,7 @@ pub trait TryWriteable: FallibleWriteable {
     /// use writeable::TryWriteable;
     ///
     /// let try_writeable = Some("example");
-    /// writeable::assert_writeable_eq!(
-    ///     try_writeable.panicky(),
-    ///     "example"
-    /// );
+    /// writeable::assert_writeable_eq!(try_writeable.panicky(), "example");
     /// ```
     ///
     /// Failure behavior:
@@ -338,10 +332,7 @@ pub trait TryWriteable: FallibleWriteable {
     /// use writeable::TryWriteable;
     ///
     /// let try_writeable = Some("example");
-    /// writeable::assert_writeable_eq!(
-    ///     try_writeable.gigo(),
-    ///     "example"
-    /// );
+    /// writeable::assert_writeable_eq!(try_writeable.gigo(), "example");
     /// ```
     ///
     /// Failure behavior:
@@ -351,10 +342,7 @@ pub trait TryWriteable: FallibleWriteable {
     ///
     /// let try_writeable = None::<&str>;
     /// if cfg!(not(debug_assertions)) {
-    ///     writeable::assert_writeable_eq!(
-    ///         try_writeable.gigo(),
-    ///         "�"
-    ///     );
+    ///     writeable::assert_writeable_eq!(try_writeable.gigo(), "�");
     /// }
     /// ```
     #[inline]

--- a/utils/writeable/src/fallible.rs
+++ b/utils/writeable/src/fallible.rs
@@ -132,27 +132,28 @@ pub trait FallibleWriteable {
         }
         Ok(wc.finish().reverse())
     }
+}
 
+pub trait FallibleWriteableConvenience: FallibleWriteable {
     #[inline]
     fn checked(&self) -> CheckedWriteable<&Self> {
         CheckedWriteable(self)
     }
-
     #[inline]
     fn lossy(&self) -> LossyWriteable<&Self> {
         LossyWriteable(self)
     }
-
     #[inline]
     fn panicky(&self) -> PanickyWriteable<&Self> {
         PanickyWriteable(self)
     }
-
     #[inline]
     fn gigo(&self) -> GigoWriteable<&Self> {
         GigoWriteable(self)
     }
 }
+
+impl<T> FallibleWriteableConvenience for T where T: FallibleWriteable {}
 
 #[derive(Debug)]
 pub struct CheckedWriteable<T>(pub(crate) T);
@@ -232,16 +233,7 @@ where
     }
 }
 
-impl<T> fmt::Display for LossyWriteable<T>
-where
-    T: FallibleWriteable,
-    T::Error: Writeable,
-{
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.write_to(f)
-    }
-}
+impl_display_with_writeable!([T] LossyWriteable<T> where T: FallibleWriteable, T::Error: Writeable);
 
 #[derive(Debug)]
 pub struct PanickyWriteable<T>(pub(crate) T);
@@ -288,15 +280,7 @@ where
     }
 }
 
-impl<T> fmt::Display for PanickyWriteable<T>
-where
-    T: FallibleWriteable,
-    T::Error: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.write_to(f)
-    }
-}
+impl_display_with_writeable!([T] PanickyWriteable<T> where T: FallibleWriteable, T::Error: fmt::Debug);
 
 #[derive(Debug)]
 pub struct GigoWriteable<T>(pub(crate) T);
@@ -344,15 +328,7 @@ where
     }
 }
 
-impl<T> fmt::Display for GigoWriteable<T>
-where
-    T: FallibleWriteable,
-    T::Error: Writeable + fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.write_to(f)
-    }
-}
+impl_display_with_writeable!([T] GigoWriteable<T> where T: FallibleWriteable, T::Error: Writeable, T::Error: fmt::Debug);
 
 impl<T> FallibleWriteable for Option<T>
 where

--- a/utils/writeable/src/fallible.rs
+++ b/utils/writeable/src/fallible.rs
@@ -1,0 +1,168 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use core::{convert::Infallible, fmt};
+
+use crate::*;
+
+#[derive(Debug)]
+pub enum WriteableError<E> {
+    Sink(fmt::Error),
+    Writeable(E),
+}
+
+impl<E> From<fmt::Error> for WriteableError<E> {
+    fn from(e: fmt::Error) -> Self {
+        Self::Sink(e)
+    }
+}
+
+pub type WriteableResult<E> = Result<(), WriteableError<E>>;
+
+pub trait FalliblePartsWrite: PartsWrite {
+    type Error;
+    type SubFalliblePartsWrite: FalliblePartsWrite + ?Sized;
+
+    fn try_with_part(
+        &mut self,
+        part: Part,
+        f: impl FnMut(&mut Self::SubPartsWrite) -> WriteableResult<Self::Error>,
+    ) -> WriteableResult<Self::Error>;
+}
+
+pub trait FallibleWriteable {
+    type Error;
+
+    fn try_write_to<W: fmt::Write + ?Sized>(
+        &self,
+        sink: &mut W,
+    ) -> Result<(), WriteableError<Self::Error>> {
+        self.try_write_to_with_handler(sink, |e, _| Err(WriteableError::Writeable(e)))
+    }
+
+    fn try_write_to_with_handler<
+        E,
+        W: fmt::Write + ?Sized,
+        F: FnMut(Self::Error, &mut W) -> WriteableResult<E>,
+    >(
+        &self,
+        sink: &mut W,
+        handler: F,
+    ) -> WriteableResult<E>;
+
+    fn try_write_to_parts<S: FalliblePartsWrite + ?Sized>(
+        &self,
+        sink: &mut S,
+    ) -> WriteableResult<Self::Error> {
+        self.try_write_to_parts_with_handler(sink, |e, _| Err(WriteableError::Writeable(e)))
+    }
+
+    fn try_write_to_parts_with_handler<
+        E,
+        S: FalliblePartsWrite + ?Sized,
+        F: FnMut(Self::Error, &mut S) -> WriteableResult<E>,
+    >(
+        &self,
+        sink: &mut S,
+        handler: F,
+    ) -> WriteableResult<E>;
+
+    fn lossy(&self) -> LossyWriteable<&Self> {
+        LossyWriteable(self)
+    }
+
+    fn panicky(&self) -> PanickyWriteable<&Self> {
+        PanickyWriteable(self)
+    }
+}
+
+#[derive(Debug)]
+pub struct LossyWriteable<T>(T);
+
+fn lossy_handler<E: Writeable, W: fmt::Write + ?Sized>(err: E, sink: &mut W) -> WriteableResult<Infallible> {
+    err.write_to(sink)?;
+    Ok(())
+}
+
+impl<T> Writeable for LossyWriteable<T> where T: FallibleWriteable, T::Error: Writeable {
+    fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
+        let nested = match self.0.try_write_to_with_handler(sink, lossy_handler) {
+            Ok(()) => Ok(Ok(())),
+            Err(WriteableError::Sink(err)) => Err(err),
+            Err(WriteableError::Writeable(infallible)) => Ok(Err(infallible)),
+        };
+        let nested = nested?;
+        Ok(nested.unwrap_or_else(|never| match never {}))
+    }
+
+    fn write_to_parts<S: PartsWrite + ?Sized>(&self, sink: &mut S) -> fmt::Result {
+        todo!()
+    }
+
+    fn writeable_length_hint(&self) -> LengthHint {
+        todo!()
+    }
+
+    fn write_to_string(&self) -> Cow<str> {
+        todo!()
+    }
+
+    fn write_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
+        todo!()
+    }
+}
+
+#[derive(Debug)]
+pub struct PanickyWriteable<T>(T);
+
+impl<T> FallibleWriteable for Option<T>
+where
+    T: Writeable,
+{
+    type Error = ();
+
+    fn try_write_to_with_handler<
+        E,
+        W: fmt::Write + ?Sized,
+        F: FnMut(Self::Error, &mut W) -> WriteableResult<E>,
+    >(
+        &self,
+        sink: &mut W,
+        mut handler: F,
+    ) -> WriteableResult<E> {
+        match self {
+            Some(writeable) => writeable.write_to(sink)?,
+            None => handler((), sink)?,
+        };
+        Ok(())
+    }
+
+    fn try_write_to_parts_with_handler<
+        E,
+        S: FalliblePartsWrite + ?Sized,
+        F: FnMut(Self::Error, &mut S) -> WriteableResult<E>,
+    >(
+        &self,
+        sink: &mut S,
+        mut handler: F,
+    ) -> WriteableResult<E> {
+        match self {
+            Some(writeable) => writeable.write_to_parts(sink)?,
+            None => handler((), sink)?,
+        };
+        Ok(())
+    }
+}
+
+#[test]
+fn test_basic() {
+    let mut sink = String::new();
+
+    Some("abc").try_write_to(&mut sink).unwrap();
+    assert_eq!(sink, "abc");
+    assert!(matches!(
+        None::<&str>.try_write_to(&mut sink),
+        Err(WriteableError::Writeable(_))
+    ));
+}

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -206,7 +206,8 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
     fn try_write_to_with_handler<
         E,
         W: fmt::Write + ?Sized,
-        F: FnMut(Self::Error, &mut W) -> WriteableResult<E>,
+        L: Writeable,
+        F: FnMut(Self::Error) -> Result<L, E>,
     >(
         &self,
         sink: &mut W,
@@ -226,7 +227,8 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
     fn try_write_to_parts_with_handler<
         E,
         S: FalliblePartsWrite + ?Sized,
-        F: FnMut(Self::Error, &mut S) -> WriteableResult<E>,
+        L: Writeable,
+        F: FnMut(Self::Error) -> Result<L, E>,
     >(
         &self,
         sink: &mut S,
@@ -237,7 +239,8 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
 
     fn try_writeable_length_hint_with_handler<
         E,
-        F: FnMut(Self::Error) -> Result<Self::Error, E>,
+        L: Writeable,
+        F: FnMut(Self::Error) -> Result<L, E>,
     >(
         &self,
         handler: F,
@@ -247,8 +250,9 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
 
     fn try_write_to_string_with_handlers<
         E,
-        F0: FnMut(Self::Error, &mut String) -> WriteableResult<E>,
-        F1: FnMut(Self::Error) -> Result<Self::Error, E>,
+        L: Writeable,
+        F0: FnMut(Self::Error) -> Result<L, E>,
+        F1: FnMut(Self::Error) -> Result<L, E>,
     >(
         &self,
         handler0: F0,
@@ -259,7 +263,8 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
 
     fn try_write_cmp_bytes_with_handler<
         E,
-        F: FnMut(Self::Error, &mut cmp::WriteComparator) -> WriteableResult<E>,
+        L: Writeable,
+        F: FnMut(Self::Error) -> Result<L, E>,
     >(
         &self,
         other: &[u8],

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -224,33 +224,21 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
         (*self).fallible_write_to_parts(sink, handler)
     }
 
-    fn fallible_writeable_length_hint<
-        E,
-        L: Writeable,
-        F: FnMut(Self::Error) -> Result<L, E>,
-    >(
+    fn fallible_writeable_length_hint<E, L: Writeable, F: FnMut(Self::Error) -> Result<L, E>>(
         &self,
         handler: F,
     ) -> Result<LengthHint, E> {
         (*self).fallible_writeable_length_hint(handler)
     }
 
-    fn fallible_write_to_string<
-        E,
-        L: Writeable,
-        F: FnMut(Self::Error) -> Result<L, E>,
-    >(
+    fn fallible_write_to_string<E, L: Writeable, F: FnMut(Self::Error) -> Result<L, E>>(
         &self,
         handler: F,
     ) -> Result<Cow<str>, E> {
         (*self).fallible_write_to_string(handler)
     }
 
-    fn fallible_write_cmp_bytes<
-        E,
-        L: Writeable,
-        F: FnMut(Self::Error) -> Result<L, E>,
-    >(
+    fn fallible_write_cmp_bytes<E, L: Writeable, F: FnMut(Self::Error) -> Result<L, E>>(
         &self,
         other: &[u8],
         handler: F,

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -250,21 +250,6 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
     ) -> Result<core::cmp::Ordering, E> {
         (*self).fallible_write_cmp_bytes(other, handler)
     }
-
-    #[inline]
-    fn checked(&self) -> CheckedWriteable<&Self> {
-        CheckedWriteable(self)
-    }
-
-    #[inline]
-    fn lossy(&self) -> LossyWriteable<&Self> {
-        LossyWriteable(self)
-    }
-
-    #[inline]
-    fn panicky(&self) -> PanickyWriteable<&Self> {
-        PanickyWriteable(self)
-    }
 }
 
 macro_rules! impl_write_smart_pointer {

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -214,7 +214,7 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
 
     #[inline]
     fn fallible_write_to_parts<
-        S: FalliblePartsWrite + ?Sized,
+        S: PartsWrite + ?Sized,
         L: Writeable,
         E,
         F: FnMut(Self::Error) -> Result<L, E>,
@@ -252,8 +252,8 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
     }
 
     #[inline]
-    fn resulty(&self) -> ResultyWriteable<&Self> {
-        ResultyWriteable(self)
+    fn checked(&self) -> CheckedWriteable<&Self> {
+        CheckedWriteable(self)
     }
 
     #[inline]

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -198,12 +198,7 @@ impl<T: Writeable + ?Sized> Writeable for &T {
 impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
     type Error = T::Error;
 
-    #[inline]
-    fn try_write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> WriteableResult<Self::Error> {
-        (*self).try_write_to(sink)
-    }
-
-    fn try_write_to_with_handler<
+    fn fallible_write_to<
         W: fmt::Write + ?Sized,
         L: Writeable,
         E,
@@ -213,18 +208,10 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
         sink: &mut W,
         handler: F,
     ) -> WriteableResult<E> {
-        (*self).try_write_to_with_handler(sink, handler)
+        (*self).fallible_write_to(sink, handler)
     }
 
-    #[inline]
-    fn try_write_to_parts<S: FalliblePartsWrite + ?Sized>(
-        &self,
-        sink: &mut S,
-    ) -> WriteableResult<Self::Error> {
-        (*self).try_write_to_parts(sink)
-    }
-
-    fn try_write_to_parts_with_handler<
+    fn fallible_write_to_parts<
         S: FalliblePartsWrite + ?Sized,
         L: Writeable,
         E,
@@ -234,10 +221,10 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
         sink: &mut S,
         handler: F,
     ) -> WriteableResult<E> {
-        (*self).try_write_to_parts_with_handler(sink, handler)
+        (*self).fallible_write_to_parts(sink, handler)
     }
 
-    fn try_writeable_length_hint_with_handler<
+    fn fallible_writeable_length_hint<
         E,
         L: Writeable,
         F: FnMut(Self::Error) -> Result<L, E>,
@@ -245,10 +232,10 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
         &self,
         handler: F,
     ) -> Result<LengthHint, E> {
-        (*self).try_writeable_length_hint_with_handler(handler)
+        (*self).fallible_writeable_length_hint(handler)
     }
 
-    fn try_write_to_string_with_handlers<
+    fn fallible_write_to_string<
         E,
         L: Writeable,
         F: FnMut(Self::Error) -> Result<L, E>,
@@ -256,10 +243,10 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
         &self,
         handler: F,
     ) -> Result<Cow<str>, E> {
-        (*self).try_write_to_string_with_handlers(handler)
+        (*self).fallible_write_to_string(handler)
     }
 
-    fn try_write_cmp_bytes_with_handler<
+    fn fallible_write_cmp_bytes<
         E,
         L: Writeable,
         F: FnMut(Self::Error) -> Result<L, E>,
@@ -268,7 +255,12 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
         other: &[u8],
         handler: F,
     ) -> Result<core::cmp::Ordering, E> {
-        (*self).try_write_cmp_bytes_with_handler(other, handler)
+        (*self).fallible_write_cmp_bytes(other, handler)
+    }
+
+    #[inline]
+    fn resulty(&self) -> ResultyWriteable<&Self> {
+        ResultyWriteable(self)
     }
 
     #[inline]

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -204,9 +204,9 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
     }
 
     fn try_write_to_with_handler<
-        E,
         W: fmt::Write + ?Sized,
         L: Writeable,
+        E,
         F: FnMut(Self::Error) -> Result<L, E>,
     >(
         &self,
@@ -225,9 +225,9 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
     }
 
     fn try_write_to_parts_with_handler<
-        E,
         S: FalliblePartsWrite + ?Sized,
         L: Writeable,
+        E,
         F: FnMut(Self::Error) -> Result<L, E>,
     >(
         &self,
@@ -251,14 +251,12 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
     fn try_write_to_string_with_handlers<
         E,
         L: Writeable,
-        F0: FnMut(Self::Error) -> Result<L, E>,
-        F1: FnMut(Self::Error) -> Result<L, E>,
+        F: FnMut(Self::Error) -> Result<L, E>,
     >(
         &self,
-        handler0: F0,
-        handler1: F1,
+        handler: F,
     ) -> Result<Cow<str>, E> {
-        (*self).try_write_to_string_with_handlers(handler0, handler1)
+        (*self).try_write_to_string_with_handlers(handler)
     }
 
     fn try_write_cmp_bytes_with_handler<

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -235,6 +235,39 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
         (*self).try_write_to_parts_with_handler(sink, handler)
     }
 
+    fn try_writeable_length_hint_with_handler<
+        E,
+        F: FnMut(Self::Error) -> Result<Self::Error, E>,
+    >(
+        &self,
+        handler: F,
+    ) -> Result<LengthHint, E> {
+        (*self).try_writeable_length_hint_with_handler(handler)
+    }
+
+    fn try_write_to_string_with_handlers<
+        E,
+        F0: FnMut(Self::Error, &mut String) -> WriteableResult<E>,
+        F1: FnMut(Self::Error) -> Result<Self::Error, E>,
+    >(
+        &self,
+        handler0: F0,
+        handler1: F1,
+    ) -> Result<Cow<str>, E> {
+        (*self).try_write_to_string_with_handlers(handler0, handler1)
+    }
+
+    fn try_write_cmp_bytes_with_handler<
+        E,
+        F: FnMut(Self::Error, &mut cmp::WriteComparator) -> WriteableResult<E>,
+    >(
+        &self,
+        other: &[u8],
+        handler: F,
+    ) -> Result<core::cmp::Ordering, E> {
+        (*self).try_write_cmp_bytes_with_handler(other, handler)
+    }
+
     #[inline]
     fn lossy(&self) -> LossyWriteable<&Self> {
         LossyWriteable(self)

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -198,6 +198,7 @@ impl<T: Writeable + ?Sized> Writeable for &T {
 impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
     type Error = T::Error;
 
+    #[inline]
     fn fallible_write_to<
         W: fmt::Write + ?Sized,
         L: Writeable,
@@ -207,10 +208,11 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
         &self,
         sink: &mut W,
         handler: F,
-    ) -> WriteableResult<E> {
+    ) -> Result<Result<(), E>, fmt::Error> {
         (*self).fallible_write_to(sink, handler)
     }
 
+    #[inline]
     fn fallible_write_to_parts<
         S: FalliblePartsWrite + ?Sized,
         L: Writeable,
@@ -220,10 +222,11 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
         &self,
         sink: &mut S,
         handler: F,
-    ) -> WriteableResult<E> {
+    ) -> Result<Result<(), E>, fmt::Error> {
         (*self).fallible_write_to_parts(sink, handler)
     }
 
+    #[inline]
     fn fallible_writeable_length_hint<E, L: Writeable, F: FnMut(Self::Error) -> Result<L, E>>(
         &self,
         handler: F,
@@ -231,6 +234,7 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
         (*self).fallible_writeable_length_hint(handler)
     }
 
+    #[inline]
     fn fallible_write_to_string<E, L: Writeable, F: FnMut(Self::Error) -> Result<L, E>>(
         &self,
         handler: F,
@@ -238,6 +242,7 @@ impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
         (*self).fallible_write_to_string(handler)
     }
 
+    #[inline]
     fn fallible_write_cmp_bytes<E, L: Writeable, F: FnMut(Self::Error) -> Result<L, E>>(
         &self,
         other: &[u8],

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -195,6 +195,57 @@ impl<T: Writeable + ?Sized> Writeable for &T {
     }
 }
 
+impl<T: FallibleWriteable + ?Sized> FallibleWriteable for &T {
+    type Error = T::Error;
+
+    #[inline]
+    fn try_write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> WriteableResult<Self::Error> {
+        (*self).try_write_to(sink)
+    }
+
+    fn try_write_to_with_handler<
+        E,
+        W: fmt::Write + ?Sized,
+        F: FnMut(Self::Error, &mut W) -> WriteableResult<E>,
+    >(
+        &self,
+        sink: &mut W,
+        handler: F,
+    ) -> WriteableResult<E> {
+        (*self).try_write_to_with_handler(sink, handler)
+    }
+
+    #[inline]
+    fn try_write_to_parts<S: FalliblePartsWrite + ?Sized>(
+        &self,
+        sink: &mut S,
+    ) -> WriteableResult<Self::Error> {
+        (*self).try_write_to_parts(sink)
+    }
+
+    fn try_write_to_parts_with_handler<
+        E,
+        S: FalliblePartsWrite + ?Sized,
+        F: FnMut(Self::Error, &mut S) -> WriteableResult<E>,
+    >(
+        &self,
+        sink: &mut S,
+        handler: F,
+    ) -> WriteableResult<E> {
+        (*self).try_write_to_parts_with_handler(sink, handler)
+    }
+
+    #[inline]
+    fn lossy(&self) -> LossyWriteable<&Self> {
+        LossyWriteable(self)
+    }
+
+    #[inline]
+    fn panicky(&self) -> PanickyWriteable<&Self> {
+        PanickyWriteable(self)
+    }
+}
+
 macro_rules! impl_write_smart_pointer {
     ($ty:path, T: $extra_bound:path) => {
         impl<'a, T: ?Sized + Writeable + $extra_bound> Writeable for $ty {

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -17,16 +17,19 @@
     )
 )]
 
-//! `writeable` is a utility crate of the [`ICU4X`] project.
-//!
-//! It includes [`Writeable`], a core trait representing an object that can be written to a
-//! sink implementing `std::fmt::Write`. It is an alternative to `std::fmt::Display` with the
+//! [`Writeable`] is a core trait representing an object that can be written to a
+//! sink implementing [`std::fmt::Write`]. It is an alternative to [`std::fmt::Display`] with the
 //! addition of a function indicating the number of bytes to be written.
 //!
-//! `Writeable` improves upon `std::fmt::Display` in two ways:
+//! [`Writeable`] improves upon [`std::fmt::Display`] in two ways:
 //!
 //! 1. More efficient, since the sink can pre-allocate bytes.
 //! 2. Smaller code, since the format machinery can be short-circuited.
+//!
+//! # Error Handling
+//!
+//! [`Writeable`] bubbles up [`std::fmt::Error`]s. In addition, writeables that can cause their
+//! own errors can be used with [`TryWriteable`].
 //!
 //! # Examples
 //!
@@ -182,7 +185,11 @@ pub trait PartsWrite: fmt::Write {
     ) -> fmt::Result;
 }
 
-/// `Writeable` is an alternative to `std::fmt::Display` with the addition of a length function.
+/// [`Writeable`] is an alternative to [`std::fmt::Display`] with the addition of a length function.
+///
+/// [`Writeable`] should be implemented on types that cannot fail while writing unless the
+/// sink fails to write, in which case a [`std::fmt::Error`] is returned. If other errors
+/// can occur, see [`TryWriteable`].
 pub trait Writeable {
     /// Writes a string to the given sink. Errors from the sink are bubbled up.
     /// The default implementation delegates to `write_to_parts`, and discards any

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -69,8 +69,11 @@ extern crate alloc;
 mod cmp;
 #[cfg(feature = "either")]
 mod either;
+mod fallible;
 mod impls;
 mod ops;
+
+pub use fallible::*;
 
 use alloc::borrow::Cow;
 use alloc::string::String;

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -343,13 +343,16 @@ pub trait Writeable {
 ///
 /// ```
 /// use core::fmt;
-/// use writeable::Writeable;
 /// use writeable::impl_display_with_writeable;
+/// use writeable::Writeable;
 ///
 /// struct MyWriteable;
 ///
 /// impl Writeable for MyWriteable {
-///     fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
+///     fn write_to<W: fmt::Write + ?Sized>(
+///         &self,
+///         sink: &mut W,
+///     ) -> fmt::Result {
 ///         sink.write_str("example")
 ///     }
 /// }


### PR DESCRIPTION
Fixes #4741

We need something of this shape for at least two things I'm currently collaborating on: datetime formatting and freeform multi-placeholder patterns.

In this PR, I add a new trait `TryWriteable`, which is implemented on `Option<T>`, with the following behavior:

```rust
let mut sink = String::new();

Some("abcdefg")
    .checked()
    .try_write_to(&mut sink)
    .unwrap()
    .unwrap();
assert_eq!(sink, "abcdefg");
assert!(matches!(
    None::<&str>.checked().try_write_to(&mut sink),
    Ok(Err(MissingWriteableError))
));

assert_writeable_eq!(Some("abcdefg").lossy(), "abcdefg");
assert_eq!(
    Some("abcdefg").lossy().writeable_length_hint(),
    LengthHint::exact(7)
);

assert_writeable_eq!(None::<&str>.lossy(), "�");
assert_eq!(
    None::<&str>.lossy().writeable_length_hint(),
    LengthHint::exact(3)
);

assert_writeable_eq!(Some("abcdefg").panicky(), "abcdefg");
assert_eq!(
    Some("abcdefg").panicky().writeable_length_hint(),
    LengthHint::exact(7)
);

assert_writeable_eq!(Some("abcdefg").gigo(), "abcdefg");
assert_eq!(
    Some("abcdefg").gigo().writeable_length_hint(),
    LengthHint::exact(7)
);
```