### PR TITLE
Add explicit VSCode CARGO_TARGET_DIR recommendation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,20 +30,19 @@ ICU4X can be edited using any text editor capable of editing Rust code.
 
 Many ICU4X engineers use [Visual Studio Code](https://code.visualstudio.com/) with the [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) extension.
 
-To build all code paths and improve build times in VSCode, we recommend the following settings. To add them, choose "Preferences: Open Workspace Settings (JSON)" from the command palette (Ctrl+Shift+P):
+To build all code paths, improve build times in VSCode, and prevent locking the target directory from command-line builds, we recommend the following settings. To add them, choose "Preferences: Open Workspace Settings (JSON)" from the command palette (Ctrl+Shift+P):
 
 ```json
 "settings": {
 	"rust-analyzer.cargo.features": "all",
 	"rust-analyzer.cargo.extraEnv": {
+		"CARGO_TARGET_DIR": "${workspaceFolder}/target/vscode",
 		"ICU4X_DATA_DIR": "../../../datagen/tests/data/baked"
 	}
 }
 ```
 
 Note: the path in `ICU4X_DATA_DIR` is relative to `provider/baked/*/src/lib.rs` and it causes VSCode to build ICU4X with only the `und` locale. This reduces build times but also makes some tests fail; to run them normally, run `cargo test --all-features` on the command line.
-
-Note: you might also consider setting a custom value to the `CARGO_TARGET_DIR` environment variable so that VSCode writes to a different target directory than other programs or the command line.
 
 ## Contributing a Pull Request
 


### PR DESCRIPTION
In addition to preventing re-building with different cargo flags, this setting prevents `rust-analyzer` from locking the `target` directory and allows running `cargo test` while VSCode is still busy.