### PR TITLE
Prefer char::REPLACEMENT_CHARACTER over literal char or U+FFFD

### DIFF
--- a/documents/process/style_guide.md
+++ b/documents/process/style_guide.md
@@ -192,6 +192,8 @@ Often in internationalization, we deal with code points from other scripts. It i
 - If directly rendering the characters could cause confusion due to the bidi algorithm
 - If the test cares more about the code point values than the characters they represent
 
+Special case: if dealing with the Unicode replacement character U+FFFD, it is suggested to use [char::REPLACEMENT_CHARACTER](https://doc.rust-lang.org/std/primitive.char.html#associatedconstant.REPLACEMENT_CHARACTER) instead of either a literal code point or the escape syntax.
+
 ### Render invisible characters in docs but escape them in code :: suggested
 
 There are several types of invisible code points in Unicode, including whitespace, zero-width characters, and bidi marks. The policy surrounding these characters is:

--- a/ffi/capi/src/utf.rs
+++ b/ffi/capi/src/utf.rs
@@ -60,7 +60,7 @@ impl Writeable for PotentiallyInvalidUtf8<'_> {
                 );
 
                 out.push_str(valid);
-                out.push('�');
+                out.push(char::REPLACEMENT_CHARACTER);
 
                 // If there's more, we can use `write_to`
                 if let Some(error_len) = e.error_len() {


### PR DESCRIPTION
Follow-up to #4786