### PR TITLE
Rename write_cmp_bytes to writeable_cmp_bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@
         - Change `ZeroHashMap` to use `twox-hash` (https://github.com/unicode-org/icu4x/pull/4592)
     - `writeable`
         - Add `TryWriteable` for fallibility (https://github.com/unicode-org/icu4x/pull/4787)
-        - Add `write_cmp_bytes` for more efficient comparison (https://github.com/unicode-org/icu4x/pull/4402)
+        - Add `writeable_cmp_bytes` for more efficient comparison (https://github.com/unicode-org/icu4x/pull/4402)
 
 ## icu4x 1.4.x
 

--- a/components/locid/src/extensions/unicode/keywords.rs
+++ b/components/locid/src/extensions/unicode/keywords.rs
@@ -300,7 +300,7 @@ impl Keywords {
     /// }
     /// ```
     pub fn strict_cmp(&self, other: &[u8]) -> Ordering {
-        self.write_cmp_bytes(other)
+        self.writeable_cmp_bytes(other)
     }
 
     /// Compare this [`Keywords`] with an iterator of BCP-47 subtags.

--- a/components/locid/src/langid.rs
+++ b/components/locid/src/langid.rs
@@ -200,7 +200,7 @@ impl LanguageIdentifier {
     /// }
     /// ```
     pub fn strict_cmp(&self, other: &[u8]) -> Ordering {
-        self.write_cmp_bytes(other)
+        self.writeable_cmp_bytes(other)
     }
 
     pub(crate) fn as_tuple(

--- a/components/locid/src/locale.rs
+++ b/components/locid/src/locale.rs
@@ -193,7 +193,7 @@ impl Locale {
     /// }
     /// ```
     pub fn strict_cmp(&self, other: &[u8]) -> Ordering {
-        self.write_cmp_bytes(other)
+        self.writeable_cmp_bytes(other)
     }
 
     #[allow(clippy::type_complexity)]

--- a/provider/core/src/request.rs
+++ b/provider/core/src/request.rs
@@ -341,7 +341,7 @@ impl DataLocale {
     /// }
     /// ```
     pub fn strict_cmp(&self, other: &[u8]) -> Ordering {
-        self.write_cmp_bytes(other)
+        self.writeable_cmp_bytes(other)
     }
 }
 

--- a/utils/writeable/src/either.rs
+++ b/utils/writeable/src/either.rs
@@ -39,10 +39,10 @@ where
         }
     }
 
-    fn write_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
+    fn writeable_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
         match self {
-            Either::Left(w) => w.write_cmp_bytes(other),
-            Either::Right(w) => w.write_cmp_bytes(other),
+            Either::Left(w) => w.writeable_cmp_bytes(other),
+            Either::Right(w) => w.writeable_cmp_bytes(other),
         }
     }
 }

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -117,7 +117,7 @@ impl Writeable for str {
     }
 
     #[inline]
-    fn write_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
+    fn writeable_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
         self.as_bytes().cmp(other)
     }
 }
@@ -139,7 +139,7 @@ impl Writeable for String {
     }
 
     #[inline]
-    fn write_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
+    fn writeable_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
         self.as_bytes().cmp(other)
     }
 }
@@ -163,7 +163,7 @@ impl Writeable for char {
     }
 
     #[inline]
-    fn write_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
+    fn writeable_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
         self.encode_utf8(&mut [0u8; 4]).as_bytes().cmp(other)
     }
 }
@@ -190,8 +190,8 @@ impl<T: Writeable + ?Sized> Writeable for &T {
     }
 
     #[inline]
-    fn write_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
-        (*self).write_cmp_bytes(other)
+    fn writeable_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
+        (*self).writeable_cmp_bytes(other)
     }
 }
 
@@ -215,8 +215,8 @@ macro_rules! impl_write_smart_pointer {
                 core::borrow::Borrow::<T>::borrow(self).write_to_string()
             }
             #[inline]
-            fn write_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
-                core::borrow::Borrow::<T>::borrow(self).write_cmp_bytes(other)
+            fn writeable_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
+                core::borrow::Borrow::<T>::borrow(self).writeable_cmp_bytes(other)
             }
         }
     };
@@ -255,7 +255,7 @@ fn test_string_impls() {
         assert_writeable_eq!(&chars[i], s);
         for j in 0..chars.len() {
             assert_eq!(
-                chars[j].write_cmp_bytes(s.as_bytes()),
+                chars[j].writeable_cmp_bytes(s.as_bytes()),
                 chars[j].cmp(&chars[i]),
                 "{:?} vs {:?}",
                 chars[j],

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -428,7 +428,7 @@ macro_rules! assert_writeable_eq {
         assert_eq!(actual_writeable.to_string(), $expected_str);
         let ordering = $crate::Writeable::writeable_cmp_bytes(actual_writeable, $expected_str.as_bytes());
         assert_eq!(ordering, core::cmp::Ordering::Equal, $($arg)*);
-        let ordering = $crate::Writeable::writeable_cmp_bytes(actual_writeable, "\u{1FFFF}".as_bytes());
+        let ordering = $crate::Writeable::writeable_cmp_bytes(actual_writeable, "\u{10FFFF}".as_bytes());
         assert_eq!(ordering, core::cmp::Ordering::Less, $($arg)*);
         if $expected_str != "" {
             let ordering = $crate::Writeable::writeable_cmp_bytes(actual_writeable, "".as_bytes());

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -351,7 +351,7 @@ macro_rules! impl_display_with_writeable {
 /// - Equality of string content
 /// - Equality of parts ([`*_parts_eq`] only)
 /// - Validity of size hint
-/// - Reflexivity of `cmp_bytes`
+/// - Reflexivity of `cmp_bytes` and order against largest and smallest strings
 ///
 /// # Examples
 ///
@@ -428,6 +428,12 @@ macro_rules! assert_writeable_eq {
         assert_eq!(actual_writeable.to_string(), $expected_str);
         let ordering = $crate::Writeable::writeable_cmp_bytes(actual_writeable, $expected_str.as_bytes());
         assert_eq!(ordering, core::cmp::Ordering::Equal, $($arg)*);
+        let ordering = $crate::Writeable::writeable_cmp_bytes(actual_writeable, "\u{1FFFF}".as_bytes());
+        assert_eq!(ordering, core::cmp::Ordering::Less, $($arg)*);
+        if $expected_str != "" {
+            let ordering = $crate::Writeable::writeable_cmp_bytes(actual_writeable, "".as_bytes());
+            assert_eq!(ordering, core::cmp::Ordering::Greater, $($arg)*);
+        }
         actual_parts // return for assert_writeable_parts_eq
     }};
 }

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -302,15 +302,15 @@ pub trait Writeable {
     /// let message = WelcomeMessage { name: "Alice" };
     /// let message_str = message.write_to_string();
     ///
-    /// assert_eq!(Ordering::Equal, message.write_cmp_bytes(b"Hello, Alice!"));
+    /// assert_eq!(Ordering::Equal, message.writeable_cmp_bytes(b"Hello, Alice!"));
     ///
-    /// assert_eq!(Ordering::Greater, message.write_cmp_bytes(b"Alice!"));
+    /// assert_eq!(Ordering::Greater, message.writeable_cmp_bytes(b"Alice!"));
     /// assert_eq!(Ordering::Greater, (*message_str).cmp("Alice!"));
     ///
-    /// assert_eq!(Ordering::Less, message.write_cmp_bytes(b"Hello, Bob!"));
+    /// assert_eq!(Ordering::Less, message.writeable_cmp_bytes(b"Hello, Bob!"));
     /// assert_eq!(Ordering::Less, (*message_str).cmp("Hello, Bob!"));
     /// ```
-    fn write_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
+    fn writeable_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
         let mut wc = cmp::WriteComparator::new(other);
         let _ = self.write_to(&mut wc);
         wc.finish().reverse()
@@ -426,7 +426,7 @@ macro_rules! assert_writeable_eq {
             );
         }
         assert_eq!(actual_writeable.to_string(), $expected_str);
-        let ordering = $crate::Writeable::write_cmp_bytes(actual_writeable, $expected_str.as_bytes());
+        let ordering = $crate::Writeable::writeable_cmp_bytes(actual_writeable, $expected_str.as_bytes());
         assert_eq!(ordering, core::cmp::Ordering::Equal, $($arg)*);
         actual_parts // return for assert_writeable_parts_eq
     }};

--- a/utils/writeable/src/try_writeable.rs
+++ b/utils/writeable/src/try_writeable.rs
@@ -194,7 +194,7 @@ pub trait TryWriteable {
     /// This function compares the "lossy mode" string; for more information,
     /// see [`TryWriteable::try_write_to()`].
     ///
-    /// For more information, see [`Writeable::write_cmp_bytes()`].
+    /// For more information, see [`Writeable::writeable_cmp_bytes()`].
     ///
     /// # Examples
     ///
@@ -241,12 +241,12 @@ pub trait TryWriteable {
     /// let writeable = HelloWorldWriteable { name: Some("Alice") };
     /// let writeable_str = writeable.try_write_to_string().expect("name is Some");
     ///
-    /// assert_eq!(Ordering::Equal, writeable.write_cmp_bytes(b"Hello, Alice!"));
+    /// assert_eq!(Ordering::Equal, writeable.writeable_cmp_bytes(b"Hello, Alice!"));
     ///
-    /// assert_eq!(Ordering::Greater, writeable.write_cmp_bytes(b"Alice!"));
+    /// assert_eq!(Ordering::Greater, writeable.writeable_cmp_bytes(b"Alice!"));
     /// assert_eq!(Ordering::Greater, (*writeable_str).cmp("Alice!"));
     ///
-    /// assert_eq!(Ordering::Less, writeable.write_cmp_bytes(b"Hello, Bob!"));
+    /// assert_eq!(Ordering::Less, writeable.writeable_cmp_bytes(b"Hello, Bob!"));
     /// assert_eq!(Ordering::Less, (*writeable_str).cmp("Hello, Bob!"));
     ///
     /// // Failure case:
@@ -254,15 +254,15 @@ pub trait TryWriteable {
     /// let mut writeable_str = String::new();
     /// let _ = writeable.try_write_to(&mut writeable_str).expect("write to String is infallible");
     ///
-    /// assert_eq!(Ordering::Equal, writeable.write_cmp_bytes(b"Hello, nobody!"));
+    /// assert_eq!(Ordering::Equal, writeable.writeable_cmp_bytes(b"Hello, nobody!"));
     ///
-    /// assert_eq!(Ordering::Greater, writeable.write_cmp_bytes(b"Hello, alice!"));
+    /// assert_eq!(Ordering::Greater, writeable.writeable_cmp_bytes(b"Hello, alice!"));
     /// assert_eq!(Ordering::Greater, (*writeable_str).cmp("Hello, alice!"));
     ///
-    /// assert_eq!(Ordering::Less, writeable.write_cmp_bytes(b"Hello, zero!"));
+    /// assert_eq!(Ordering::Less, writeable.writeable_cmp_bytes(b"Hello, zero!"));
     /// assert_eq!(Ordering::Less, (*writeable_str).cmp("Hello, zero!"));
     /// ```
-    fn write_cmp_bytes(&self, other: &[u8]) -> Ordering {
+    fn writeable_cmp_bytes(&self, other: &[u8]) -> Ordering {
         let mut wc = cmp::WriteComparator::new(other);
         let _ = self
             .try_write_to(&mut wc)
@@ -319,10 +319,10 @@ where
     }
 
     #[inline]
-    fn write_cmp_bytes(&self, other: &[u8]) -> Ordering {
+    fn writeable_cmp_bytes(&self, other: &[u8]) -> Ordering {
         match self {
-            Ok(t) => t.write_cmp_bytes(other),
-            Err(e) => e.write_cmp_bytes(other),
+            Ok(t) => t.writeable_cmp_bytes(other),
+            Err(e) => e.writeable_cmp_bytes(other),
         }
     }
 }
@@ -386,7 +386,7 @@ macro_rules! assert_try_writeable_eq {
                 length_hint.0, actual_str.len(), format!($($arg)*),
             );
         }
-        let ordering = actual_writeable.write_cmp_bytes($expected_str.as_bytes());
+        let ordering = actual_writeable.writeable_cmp_bytes($expected_str.as_bytes());
         assert_eq!(ordering, core::cmp::Ordering::Equal, $($arg)*);
         actual_parts // return for assert_try_writeable_parts_eq
     }};

--- a/utils/writeable/src/try_writeable.rs
+++ b/utils/writeable/src/try_writeable.rs
@@ -388,7 +388,7 @@ macro_rules! assert_try_writeable_eq {
         }
         let ordering = actual_writeable.writeable_cmp_bytes($expected_str.as_bytes());
         assert_eq!(ordering, core::cmp::Ordering::Equal, $($arg)*);
-        let ordering = actual_writeable.writeable_cmp_bytes("\u{1FFFF}".as_bytes());
+        let ordering = actual_writeable.writeable_cmp_bytes("\u{10FFFF}".as_bytes());
         assert_eq!(ordering, core::cmp::Ordering::Less, $($arg)*);
         if $expected_str != "" {
             let ordering = actual_writeable.writeable_cmp_bytes("".as_bytes());

--- a/utils/writeable/src/try_writeable.rs
+++ b/utils/writeable/src/try_writeable.rs
@@ -343,7 +343,7 @@ where
 /// - Equality of string content
 /// - Equality of parts ([`*_parts_eq`] only)
 /// - Validity of size hint
-/// - Reflexivity of `cmp_bytes`
+/// - Reflexivity of `cmp_bytes` and order against largest and smallest strings
 ///
 /// For a usage example, see [`TryWriteable`].
 ///
@@ -388,6 +388,12 @@ macro_rules! assert_try_writeable_eq {
         }
         let ordering = actual_writeable.writeable_cmp_bytes($expected_str.as_bytes());
         assert_eq!(ordering, core::cmp::Ordering::Equal, $($arg)*);
+        let ordering = actual_writeable.writeable_cmp_bytes("\u{1FFFF}".as_bytes());
+        assert_eq!(ordering, core::cmp::Ordering::Less, $($arg)*);
+        if $expected_str != "" {
+            let ordering = actual_writeable.writeable_cmp_bytes("".as_bytes());
+            assert_eq!(ordering, core::cmp::Ordering::Greater, $($arg)*);
+        }
         actual_parts // return for assert_try_writeable_parts_eq
     }};
 }


### PR DESCRIPTION
See #4402, #4741, #4787

I had landed these functions but we never bikeshed their names. We _did_ bikeshed `writeable_length_hint` [here](https://docs.google.com/document/d/1zm_pQsrO7kTBjHbtmoQiriFNedUyd1_AjJ2Um3u_kD4/edit?pli=1), so I'm taking that answer and applying it to this similar function. It should be named `writeable_cmp_bytes` since it isn't actually writing anything; it's only a function on the Writeable trait.