### PR TITLE
Add API for getting endianness of a binary resource bundle

### DIFF
--- a/utils/resb/src/binary.rs
+++ b/utils/resb/src/binary.rs
@@ -112,7 +112,10 @@ primitive_enum!(
     u8,
     /// The endianness used to write a resource bundle.
     #[derive(Clone, Copy, Debug, PartialEq)]
-    #[allow(clippy::exhaustive_enums, missing_docs)]
+    // The resource bundle format doesn't support any sort of mixed-endian or
+    // middle-endian encodings.
+    #[allow(clippy::exhaustive_enums)]
+    #[allow(missing_docs)]
     pub enum Endianness {
         Little = 0,
         Big = 1,
@@ -441,11 +444,6 @@ fn read_u16(input: &[u8]) -> Result<(u16, &[u8]), BinaryDeserializerError> {
         .unwrap();
     let value = u16::from_le_bytes(bytes);
 
-    let rest =
-        input
-            .get(core::mem::size_of::<u16>()..)
-            .ok_or(BinaryDeserializerError::invalid_data(
-                "unexpected end of input",
-            ))?;
+    let rest = get_subslice(input, core::mem::size_of::<u16>()..)?;
     Ok((value, rest))
 }

--- a/utils/resb/src/binary/deserializer.rs
+++ b/utils/resb/src/binary/deserializer.rs
@@ -2,12 +2,12 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use core::{fmt, slice::SliceIndex};
+use core::fmt;
 
 use crate::MASK_28_BIT;
 
 use super::{
-    BinHeader, BinIndex, BinReprInfo, BinaryDeserializerError, CharsetFamily, Endianness,
+    get_subslice, header::BinHeader, read_u16, BinIndex, BinaryDeserializerError, CharsetFamily,
     FormatVersion, ResDescriptor, ResourceReprType,
 };
 
@@ -1144,105 +1144,6 @@ impl de::Error for BinaryDeserializerError {
     }
 }
 
-impl TryFrom<&[u8]> for BinHeader {
-    type Error = BinaryDeserializerError;
-
-    // We can safely index in this function as we first guarantee that the input
-    // is sufficiently large.
-    #[allow(clippy::indexing_slicing)]
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        if value.len() < core::mem::size_of::<BinHeader>() {
-            return Err(BinaryDeserializerError::invalid_data(
-                "input is too short to contain file header",
-            ));
-        }
-
-        let (size, value) = read_u16(value)?;
-
-        // If the magic word does not match, we are not reading a valid resource
-        // bundle and will not be able to proceed.
-        let (magic, value) = ([value[0], value[1]], &value[2..]);
-        match magic {
-            [0xda, 0x27] => (),
-            _ => {
-                return Err(BinaryDeserializerError::invalid_data(
-                    "magic word does not match",
-                ))
-            }
-        }
-
-        let repr_info = BinReprInfo::try_from(value)?;
-
-        if (size as usize) < core::mem::size_of::<BinHeader>() {
-            return Err(BinaryDeserializerError::invalid_data(
-                "header size specified in file is smaller than expected",
-            ));
-        }
-
-        Ok(BinHeader {
-            size,
-            magic,
-            repr_info,
-        })
-    }
-}
-
-impl TryFrom<&[u8]> for BinReprInfo {
-    type Error = BinaryDeserializerError;
-
-    // We can safely index in this function as we first guarantee that the input
-    // is sufficiently large.
-    #[allow(clippy::indexing_slicing)]
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        if value.len() < core::mem::size_of::<BinReprInfo>() {
-            return Err(BinaryDeserializerError::invalid_data(
-                "input is too short to contain representation info",
-            ));
-        }
-
-        let (size, value) = read_u16(value)?;
-        let (reserved_word, value) = read_u16(value)?;
-
-        // While the consumer is responsible for verifying acceptability of most
-        // contents of the repr info, we explicitly depend on little endian data
-        // in order to ensure compatibility with `zerovec`.
-        let (endianness, value) = (Endianness::try_from(value[0])?, &value[1..]);
-        if endianness != Endianness::Little {
-            return Err(BinaryDeserializerError::unsupported_format(
-                "big-endian bundles are not supported",
-            ));
-        }
-
-        let (charset_family, value) = (CharsetFamily::try_from(value[0])?, &value[1..]);
-        let (size_of_char, value) = (value[0], &value[1..]);
-        let (reserved_byte, value) = (value[0], &value[1..]);
-
-        // A mismatch in the data format indicates that we are not reading a
-        // valid resource bundle.
-        let (data_format, value) = ([value[0], value[1], value[2], value[3]], &value[4..]);
-        if &data_format != b"ResB" {
-            return Err(BinaryDeserializerError::invalid_data(
-                "unexpected data format value",
-            ));
-        }
-
-        let (format_version, value) = (FormatVersion::try_from(&value[..4])?, &value[4..]);
-        let (data_version, _) = ([value[0], value[1], value[2], value[3]], &value[4..]);
-
-        Ok(BinReprInfo {
-            size,
-            reserved_word,
-            endianness,
-            charset_family,
-            size_of_char,
-            reserved_byte,
-            data_format,
-            format_version,
-            data_version,
-        })
-    }
-}
-
 impl TryFrom<&[u8]> for BinIndex {
     type Error = BinaryDeserializerError;
 
@@ -1332,45 +1233,6 @@ impl TryFrom<u32> for ResDescriptor {
 
         Ok(Self::new(resource_type, value & MASK_28_BIT))
     }
-}
-
-/// Gets a subset of the given `u8` slice based on the specified index with
-/// bounds checking.
-///
-/// Returns the subslice. Returns an error if the index is not valid for the
-/// input.
-fn get_subslice<I>(input: &[u8], index: I) -> Result<&[u8], BinaryDeserializerError>
-where
-    I: SliceIndex<[u8], Output = [u8]>,
-{
-    input
-        .get(index)
-        .ok_or(BinaryDeserializerError::invalid_data(
-            "unexpected end of input",
-        ))
-}
-
-/// Reads the first two bytes of the input and interprets them as a `u16` with
-/// native endianness.
-///
-/// Returns the `u16` and a slice containing all input after the interpreted
-/// bytes. Returns an error if the input is of insufficient length.
-fn read_u16(input: &[u8]) -> Result<(u16, &[u8]), BinaryDeserializerError> {
-    // Safe to unwrap at the end of this because `try_into()` for arrays will
-    // only fail if the slice is the wrong size.
-    #[allow(clippy::unwrap_used)]
-    let bytes = get_subslice(input, ..core::mem::size_of::<u16>())?
-        .try_into()
-        .unwrap();
-    let value = u16::from_le_bytes(bytes);
-
-    let rest =
-        input
-            .get(core::mem::size_of::<u16>()..)
-            .ok_or(BinaryDeserializerError::invalid_data(
-                "unexpected end of input",
-            ))?;
-    Ok((value, rest))
 }
 
 /// Reads the first four bytes of the input and interprets them as a `u32` with

--- a/utils/resb/src/binary/header.rs
+++ b/utils/resb/src/binary/header.rs
@@ -1,3 +1,7 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
 use super::{read_u16, BinaryDeserializerError, CharsetFamily, Endianness, FormatVersion};
 
 /// The `BinHeader` struct represents the in-memory layout of a binary resource

--- a/utils/resb/src/binary/header.rs
+++ b/utils/resb/src/binary/header.rs
@@ -1,0 +1,150 @@
+use super::{read_u16, BinaryDeserializerError, CharsetFamily, Endianness, FormatVersion};
+
+/// The `BinHeader` struct represents the in-memory layout of a binary resource
+/// bundle header.
+#[repr(C)]
+pub(super) struct BinHeader {
+    /// The size of the header in bytes, padded such that it is divisible by 16.
+    pub size: u16,
+
+    /// A magic word. See [`MAGIC_WORD`].
+    pub magic: [u8; 2],
+
+    /// Information on the representation of data in the binary bundle.
+    pub repr_info: BinReprInfo,
+}
+
+/// The `BinReprInfo` struct represents the in-memory layout of a binary
+/// resource bundle's representation specifiers. These data describe the
+/// parameters necessary for correctly reading a bundle file.
+#[repr(C)]
+pub(super) struct BinReprInfo {
+    /// The size of the representation info in bytes.
+    pub size: u16,
+
+    /// Reserved. Always 0.
+    pub reserved_word: u16,
+
+    /// The endianness of values in the file. `0` for little endian and `1` for
+    /// big endian.
+    pub endianness: Endianness,
+
+    /// The character set family in which key strings are represented.
+    pub charset_family: CharsetFamily,
+
+    /// The size of a character in a string resource in bytes. May be 1, 2, or
+    /// 4.
+    pub size_of_char: u8,
+
+    /// Reserved. Always 0.
+    pub reserved_byte: u8,
+
+    /// The data format identifier. Always `b"ResB"`.
+    pub data_format: [u8; 4],
+
+    /// The format version used for laying out the bundle.
+    pub format_version: FormatVersion,
+
+    /// The version of the data in the file. This is `[1, 4, 0, 0]` in all known
+    /// versions of ICU4C's `genrb`.
+    pub data_version: [u8; 4],
+}
+
+impl TryFrom<&[u8]> for BinHeader {
+    type Error = BinaryDeserializerError;
+
+    // We can safely index in this function as we first guarantee that the input
+    // is sufficiently large.
+    #[allow(clippy::indexing_slicing)]
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() < core::mem::size_of::<BinHeader>() {
+            return Err(BinaryDeserializerError::invalid_data(
+                "input is too short to contain file header",
+            ));
+        }
+
+        let (size, value) = read_u16(value)?;
+
+        // If the magic word does not match, we are not reading a valid resource
+        // bundle and will not be able to proceed.
+        let (magic, value) = ([value[0], value[1]], &value[2..]);
+        match magic {
+            [0xda, 0x27] => (),
+            _ => {
+                return Err(BinaryDeserializerError::invalid_data(
+                    "magic word does not match",
+                ))
+            }
+        }
+
+        let repr_info = BinReprInfo::try_from(value)?;
+
+        if (size as usize) < core::mem::size_of::<BinHeader>() {
+            return Err(BinaryDeserializerError::invalid_data(
+                "header size specified in file is smaller than expected",
+            ));
+        }
+
+        Ok(BinHeader {
+            size,
+            magic,
+            repr_info,
+        })
+    }
+}
+
+impl TryFrom<&[u8]> for BinReprInfo {
+    type Error = BinaryDeserializerError;
+
+    // We can safely index in this function as we first guarantee that the input
+    // is sufficiently large.
+    #[allow(clippy::indexing_slicing)]
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() < core::mem::size_of::<BinReprInfo>() {
+            return Err(BinaryDeserializerError::invalid_data(
+                "input is too short to contain representation info",
+            ));
+        }
+
+        let (size, value) = read_u16(value)?;
+        let (reserved_word, value) = read_u16(value)?;
+
+        // While the consumer is responsible for verifying acceptability of most
+        // contents of the repr info, we explicitly depend on little endian data
+        // in order to ensure compatibility with `zerovec`.
+        let (endianness, value) = (Endianness::try_from(value[0])?, &value[1..]);
+        if endianness != Endianness::Little {
+            return Err(BinaryDeserializerError::unsupported_format(
+                "big-endian bundles are not supported",
+            ));
+        }
+
+        let (charset_family, value) = (CharsetFamily::try_from(value[0])?, &value[1..]);
+        let (size_of_char, value) = (value[0], &value[1..]);
+        let (reserved_byte, value) = (value[0], &value[1..]);
+
+        // A mismatch in the data format indicates that we are not reading a
+        // valid resource bundle.
+        let (data_format, value) = ([value[0], value[1], value[2], value[3]], &value[4..]);
+        if &data_format != b"ResB" {
+            return Err(BinaryDeserializerError::invalid_data(
+                "unexpected data format value",
+            ));
+        }
+
+        let (format_version, value) = (FormatVersion::try_from(&value[..4])?, &value[4..]);
+        let (data_version, _) = ([value[0], value[1], value[2], value[3]], &value[4..]);
+
+        Ok(BinReprInfo {
+            size,
+            reserved_word,
+            endianness,
+            charset_family,
+            size_of_char,
+            reserved_byte,
+            data_format,
+            format_version,
+            data_version,
+        })
+    }
+}

--- a/utils/resb/src/binary/serializer.rs
+++ b/utils/resb/src/binary/serializer.rs
@@ -13,8 +13,8 @@ use std::{
 use crate::bundle::{Key, Resource, ResourceBundle};
 
 use super::{
-    BinHeader, BinIndex, BinReprInfo, CharsetFamily, Endianness, FormatVersion, ResDescriptor,
-    ResourceReprType,
+    header::{BinHeader, BinReprInfo},
+    BinIndex, CharsetFamily, Endianness, FormatVersion, ResDescriptor, ResourceReprType,
 };
 
 const DATA_FORMAT: &[u8; 4] = b"ResB";


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

Resource bundles for time zone data are serialized with intvector fields containing 64-bit integers which are serialized in an ad hoc, endian-sensitive manner (due to lack of 64-bit integer support in resb). Since this isn't a part of the standard and is required for correct interpretation of time zone data, it's necessary to provide a means of determining bundle endianness for consumers using the serde deserializer.

Note that big endian resource bundles aren't presently supported, but this support is planned in order to support big endian systems or systems where resource bundles intended for use with icu4j are present.