### PR TITLE
Adjust `ixdtf`'s TimeDurationRecord representation

### DIFF
--- a/utils/ixdtf/src/parsers/duration.rs
+++ b/utils/ixdtf/src/parsers/duration.rs
@@ -12,7 +12,7 @@ use crate::{
             is_month_designator, is_second_designator, is_sign, is_time_designator,
             is_week_designator, is_year_designator,
         },
-        records::{DateDurationRecord, DurationFraction, DurationParseRecord, TimeDurationRecord},
+        records::{DateDurationRecord, DurationParseRecord, TimeDurationRecord},
         time::parse_fraction,
         Cursor,
     },
@@ -35,30 +35,19 @@ pub(crate) fn parse_duration(cursor: &mut Cursor) -> ParserResult<DurationParseR
     );
 
     let date = if cursor.check_or(false, is_time_designator) {
-        DateDurationRecord::default()
+        None
     } else {
-        parse_date_duration(cursor)?
+        Some(parse_date_duration(cursor)?)
     };
 
-    let time = if cursor.check_or(false, is_time_designator) {
-        cursor.advance();
-        parse_time_duration(cursor)?
-    } else {
-        TimeDurationRecord::default()
-    };
+    let time = parse_time_duration(cursor)?;
 
     cursor.close()?;
 
     Ok(DurationParseRecord {
         sign: sign.into(),
-        years: date.years,
-        months: date.months,
-        weeks: date.weeks,
-        days: date.days,
-        hours: time.hours,
-        minutes: time.minutes,
-        seconds: time.seconds,
-        fraction: time.fraction,
+        date,
+        time,
     })
 }
 
@@ -73,7 +62,6 @@ enum DateUnit {
 
 pub(crate) fn parse_date_duration(cursor: &mut Cursor) -> ParserResult<DateDurationRecord> {
     let mut date = DateDurationRecord::default();
-
     let mut previous_unit = DateUnit::None;
 
     while cursor.check_or(false, |ch| ch.is_ascii_digit()) {
@@ -132,14 +120,18 @@ enum TimeUnit {
     Second,
 }
 
-pub(crate) fn parse_time_duration(cursor: &mut Cursor) -> ParserResult<TimeDurationRecord> {
-    let mut time = TimeDurationRecord::default();
+pub(crate) fn parse_time_duration(cursor: &mut Cursor) -> ParserResult<Option<TimeDurationRecord>> {
+    if !cursor.check_or(false, is_time_designator) {
+        return Ok(None);
+    };
 
+    cursor.advance();
     assert_syntax!(
         cursor.check_or(false, |ch| ch.is_ascii_digit()),
         TimeDurationDesignator,
     );
 
+    let mut time: (u32, u32, u32, Option<u32>) = (0, 0, 0, None);
     let mut previous_unit = TimeUnit::None;
     while cursor.check_or(false, |ch| ch.is_ascii_digit()) {
         let mut value: u32 = 0;
@@ -160,21 +152,19 @@ pub(crate) fn parse_time_duration(cursor: &mut Cursor) -> ParserResult<TimeDurat
                 if previous_unit > TimeUnit::Hour {
                     return Err(ParserError::TimeDurationPartOrder);
                 }
-                time.hours = value;
+                time.0 = value;
                 if let Some(fraction) = fraction {
-                    // Safety: Max fraction * 3600 is within u64 -> see test maximum_duration_fraction
-                    time.fraction = Some(DurationFraction::Hours(3600 * u64::from(fraction)));
-                }
+                    time.3 = Some(fraction);
+                };
                 previous_unit = TimeUnit::Hour;
             }
             Some(ch) if is_minute_designator(ch) => {
                 if previous_unit > TimeUnit::Minute {
                     return Err(ParserError::TimeDurationPartOrder);
                 }
-                time.minutes = value;
+                time.1 = value;
                 if let Some(fraction) = fraction {
-                    // Safety: Max fraction * 60 is within u64 -> see test maximum_duration_fraction
-                    time.fraction = Some(DurationFraction::Minutes(60 * u64::from(fraction)));
+                    time.3 = Some(fraction);
                 }
                 previous_unit = TimeUnit::Minute;
             }
@@ -182,9 +172,9 @@ pub(crate) fn parse_time_duration(cursor: &mut Cursor) -> ParserResult<TimeDurat
                 if previous_unit > TimeUnit::Second {
                     return Err(ParserError::TimeDurationPartOrder);
                 }
-                time.seconds = value;
+                time.2 = value;
                 if let Some(fraction) = fraction {
-                    time.fraction = Some(DurationFraction::Seconds(fraction));
+                    time.3 = Some(fraction);
                 }
                 previous_unit = TimeUnit::Second;
             }
@@ -197,5 +187,24 @@ pub(crate) fn parse_time_duration(cursor: &mut Cursor) -> ParserResult<TimeDurat
         }
     }
 
-    Ok(time)
+    match previous_unit {
+        // Safety: Max fraction * 3600 is within u64 -> see test maximum_duration_fraction
+        TimeUnit::Hour => Ok(Some(TimeDurationRecord::Hours {
+            hours: time.0,
+            fraction: time.3.map(|f| 3600 * u64::from(f)).unwrap_or(0),
+        })),
+        // Safety: Max fraction * 60 is within u64 -> see test maximum_duration_fraction
+        TimeUnit::Minute => Ok(Some(TimeDurationRecord::Minutes {
+            hours: time.0,
+            minutes: time.1,
+            fraction: time.3.map(|f| 60 * u64::from(f)).unwrap_or(0),
+        })),
+        TimeUnit::Second => Ok(Some(TimeDurationRecord::Seconds {
+            hours: time.0,
+            minutes: time.1,
+            seconds: time.2,
+            fraction: time.3.unwrap_or(0),
+        })),
+        TimeUnit::None => Err(ParserError::abrupt_end("TimeDUrationDesignator")),
+    }
 }

--- a/utils/ixdtf/src/parsers/mod.rs
+++ b/utils/ixdtf/src/parsers/mod.rs
@@ -164,10 +164,12 @@ impl<'a> IxdtfParser<'a> {
 ///
 /// let result = IsoDurationParser::new(duration_str).parse().unwrap();
 ///
-/// assert_eq!(result.years, 1);
-/// assert_eq!(result.months, 2);
-/// assert_eq!(result.weeks, 3);
-/// assert_eq!(result.days, 1);
+/// let date_duration = result.date.unwrap();
+///
+/// assert_eq!(date_duration.years, 1);
+/// assert_eq!(date_duration.months, 2);
+/// assert_eq!(date_duration.weeks, 3);
+/// assert_eq!(date_duration.days, 1);
 ///
 /// ```
 #[cfg(feature = "duration")]

--- a/utils/ixdtf/src/parsers/records.rs
+++ b/utils/ixdtf/src/parsers/records.rs
@@ -121,61 +121,57 @@ pub struct UTCOffsetRecord {
 pub struct DurationParseRecord {
     /// Duration Sign
     pub sign: Sign,
-    /// The `years` value.
-    pub years: u32,
-    /// The `months` value.
-    pub months: u32,
-    /// The `weeks` value.
-    pub weeks: u32,
-    /// The `days` value.
-    pub days: u32,
-    /// The `hours` value.
-    pub hours: u32,
-    /// The `minutes` value.
-    pub minutes: u32,
-    /// The `seconds` value.
-    pub seconds: u32,
-    /// Any fraction part of a duration.
-    pub fraction: Option<DurationFraction>,
-}
-
-/// An enum representing the fraction part of a duration.
-#[non_exhaustive]
-#[cfg(feature = "duration")]
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum DurationFraction {
-    /// The fraction value applied to an hour.
-    Hours(u64),
-    /// The fraction value applied to the minutes field.
-    Minutes(u64),
-    /// The fraction value applied to the seconds field.
-    Seconds(u32),
+    /// A parsed Date Duration record.
+    pub date: Option<DateDurationRecord>,
+    /// A parsed Time Duration record.
+    pub time: Option<TimeDurationRecord>,
 }
 
 /// A `DateDuration` Parse Node.
+#[non_exhaustive]
 #[cfg(feature = "duration")]
-#[derive(Default, Debug, Clone, Copy)]
-pub(crate) struct DateDurationRecord {
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub struct DateDurationRecord {
     /// Years value.
-    pub(crate) years: u32,
+    pub years: u32,
     /// Months value.
-    pub(crate) months: u32,
+    pub months: u32,
     /// Weeks value.
-    pub(crate) weeks: u32,
+    pub weeks: u32,
     /// Days value.
-    pub(crate) days: u32,
+    pub days: u32,
 }
 
 /// A `TimeDuration` Parse Node
+#[non_exhaustive]
 #[cfg(feature = "duration")]
-#[derive(Default, Debug, Clone, Copy)]
-pub(crate) struct TimeDurationRecord {
-    /// Hours value.
-    pub(crate) hours: u32,
-    /// Minutes value.
-    pub(crate) minutes: u32,
-    /// Seconds value.
-    pub(crate) seconds: u32,
-    /// Any parsed fraction value.
-    pub(crate) fraction: Option<DurationFraction>,
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TimeDurationRecord {
+    // An hours Time duration record.
+    Hours {
+        /// Hours value.
+        hours: u32,
+        /// Any parsed fraction value.
+        fraction: u64,
+    },
+    // A Minutes Time duration record.
+    Minutes {
+        /// Hours value.
+        hours: u32,
+        /// Minutes value.
+        minutes: u32,
+        /// Any parsed fraction value.
+        fraction: u64,
+    },
+    // A Seconds Time duration record.
+    Seconds {
+        /// Hours value.
+        hours: u32,
+        /// Minutes value.
+        minutes: u32,
+        /// Seconds value.
+        seconds: u32,
+        /// Any parsed fraction value.
+        fraction: u32,
+    },
 }

--- a/utils/ixdtf/src/parsers/records.rs
+++ b/utils/ixdtf/src/parsers/records.rs
@@ -114,8 +114,9 @@ pub struct UTCOffsetRecord {
     pub nanosecond: u32,
 }
 
-/// The resulting record of parsing `Duration` string.
-#[non_exhaustive]
+/// The resulting record of parsing a `Duration` string.
+#[allow(clippy::exhaustive_structs)]
+// A duration can only be a Sign, a DateDuration part, and a TimeDuration part that users need to match on.
 #[cfg(feature = "duration")]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct DurationParseRecord {
@@ -128,7 +129,8 @@ pub struct DurationParseRecord {
 }
 
 /// A `DateDurationRecord` represents the result of parsing the date component of a Duration string.
-#[non_exhaustive]
+#[allow(clippy::exhaustive_structs)]
+// A `DateDurationRecord` by spec can only be made up of years, months, weeks, and days parts that users need to match on.
 #[cfg(feature = "duration")]
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub struct DateDurationRecord {
@@ -143,7 +145,8 @@ pub struct DateDurationRecord {
 }
 
 /// A `TimeDurationRecord` represents the result of parsing the time component of a Duration string.
-#[non_exhaustive]
+#[allow(clippy::exhaustive_enums)]
+// A `TimeDurationRecord` by spec can only be made up of the valid parts up to a present fraction that users need to match on.
 #[cfg(feature = "duration")]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TimeDurationRecord {

--- a/utils/ixdtf/src/parsers/records.rs
+++ b/utils/ixdtf/src/parsers/records.rs
@@ -102,32 +102,32 @@ impl From<bool> for Sign {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct UTCOffsetRecord {
-    /// The `Sign` value of the `UtcOffsetRecord`
+    /// The `Sign` value of the `UtcOffsetRecord`.
     pub sign: Sign,
-    /// The hour value of the `UtcOffsetRecord`
+    /// The hour value of the `UtcOffsetRecord`.
     pub hour: u8,
     /// The minute value of the `UtcOffsetRecord`.
     pub minute: u8,
     /// The second value of the `UtcOffsetRecord`.
     pub second: u8,
-    /// Any nanosecond value of the `UTCOffsetRecord`
+    /// Any nanosecond value of the `UTCOffsetRecord`.
     pub nanosecond: u32,
 }
 
-/// The resulting record of a `Duration` parse.
+/// The resulting record of parsing `Duration` string.
 #[non_exhaustive]
 #[cfg(feature = "duration")]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct DurationParseRecord {
     /// Duration Sign
     pub sign: Sign,
-    /// A parsed Date Duration record.
+    /// The parsed `DateDurationRecord` if present.
     pub date: Option<DateDurationRecord>,
-    /// A parsed Time Duration record.
+    /// The parsed `TimeDurationRecord` if present.
     pub time: Option<TimeDurationRecord>,
 }
 
-/// A `DateDuration` Parse Node.
+/// A `DateDurationRecord` represents the result of parsing the date component of a Duration string.
 #[non_exhaustive]
 #[cfg(feature = "duration")]
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
@@ -142,7 +142,7 @@ pub struct DateDurationRecord {
     pub days: u32,
 }
 
-/// A `TimeDuration` Parse Node
+/// A `TimeDurationRecord` represents the result of parsing the time component of a Duration string.
 #[non_exhaustive]
 #[cfg(feature = "duration")]
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -151,7 +151,7 @@ pub enum TimeDurationRecord {
     Hours {
         /// Hours value.
         hours: u32,
-        /// Any parsed fraction value.
+        /// The parsed fraction value in nanoseconds.
         fraction: u64,
     },
     // A Minutes Time duration record.
@@ -160,7 +160,7 @@ pub enum TimeDurationRecord {
         hours: u32,
         /// Minutes value.
         minutes: u32,
-        /// Any parsed fraction value.
+        /// The parsed fraction value in nanoseconds.
         fraction: u64,
     },
     // A Seconds Time duration record.
@@ -171,7 +171,7 @@ pub enum TimeDurationRecord {
         minutes: u32,
         /// Seconds value.
         seconds: u32,
-        /// Any parsed fraction value.
+        /// The parsed fraction value in nanoseconds.
         fraction: u32,
     },
 }

--- a/utils/ixdtf/src/parsers/tests.rs
+++ b/utils/ixdtf/src/parsers/tests.rs
@@ -538,7 +538,7 @@ fn temporal_valid_instant_strings() {
 #[cfg(feature = "duration")]
 fn temporal_duration_parsing() {
     use crate::parsers::{
-        records::{DurationFraction, DurationParseRecord, Sign},
+        records::{DateDurationRecord, DurationParseRecord, Sign, TimeDurationRecord},
         IsoDurationParser,
     };
 
@@ -562,14 +562,18 @@ fn temporal_duration_parsing() {
         sub_second,
         DurationParseRecord {
             sign: Sign::Negative,
-            years: 1,
-            months: 1,
-            weeks: 1,
-            days: 1,
-            hours: 1,
-            minutes: 1,
-            seconds: 1,
-            fraction: Some(DurationFraction::Seconds(123456789))
+            date: Some(DateDurationRecord {
+                years: 1,
+                months: 1,
+                weeks: 1,
+                days: 1,
+            }),
+            time: Some(TimeDurationRecord::Seconds {
+                hours: 1,
+                minutes: 1,
+                seconds: 1,
+                fraction: 123456789
+            })
         },
         "Failing to parse a valid Duration string: \"{}\" should pass.",
         durations[2]
@@ -580,14 +584,16 @@ fn temporal_duration_parsing() {
         test_result,
         DurationParseRecord {
             sign: Sign::Negative,
-            years: 1,
-            months: 0,
-            weeks: 3,
-            days: 0,
-            hours: 0,
-            minutes: 0,
-            seconds: 0,
-            fraction: Some(DurationFraction::Hours(1_800_000_000_000)),
+            date: Some(DateDurationRecord {
+                years: 1,
+                months: 0,
+                weeks: 3,
+                days: 0,
+            }),
+            time: Some(TimeDurationRecord::Hours {
+                hours: 0,
+                fraction: 1_800_000_000_000,
+            })
         }
     );
 }


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

This PR adjusts TimeDurationRecord to align with some feedback from #4646 regarding the representation of TimeDurationRecord