### PR TITLE
Implement `DeduplicationStrategy::RetainBaseLanguages`

### DIFF
--- a/provider/datagen/src/bin/icu4x-datagen.rs
+++ b/provider/datagen/src/bin/icu4x-datagen.rs
@@ -303,6 +303,7 @@ enum Fallback {
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
 enum DeduplicationStrategy {
     Maximal,
+    RetainBaseLanguages,
     None,
 }
 
@@ -532,6 +533,9 @@ fn main() -> eyre::Result<()> {
             }
             (Some(x), _, false) => match x {
                 DeduplicationStrategy::Maximal => Some(icu_datagen::DeduplicationStrategy::Maximal),
+                DeduplicationStrategy::RetainBaseLanguages => {
+                    Some(icu_datagen::DeduplicationStrategy::RetainBaseLanguages)
+                }
                 DeduplicationStrategy::None => Some(icu_datagen::DeduplicationStrategy::None),
             },
             (None, fallback_mode, false) => match fallback_mode {

--- a/provider/datagen/src/driver.rs
+++ b/provider/datagen/src/driver.rs
@@ -755,7 +755,7 @@ impl DatagenDriver {
                         })
                         .collect::<Result<HashMap<_, _>, _>>()?;
                     let fallbacker = fallbacker.as_ref().map_err(|e| *e)?;
-                    deduplicate_locales::<true>(key, &payloads, fallbacker, sink)?
+                    deduplicate_payloads::<true>(key, &payloads, fallbacker, sink)?
                 }
                 DeduplicationStrategy::RetainBaseLanguages => {
                     let payloads = locales_to_export
@@ -767,7 +767,7 @@ impl DatagenDriver {
                         })
                         .collect::<Result<HashMap<_, _>, _>>()?;
                     let fallbacker = fallbacker.as_ref().map_err(|e| *e)?;
-                    deduplicate_locales::<false>(key, &payloads, fallbacker, sink)?
+                    deduplicate_payloads::<false>(key, &payloads, fallbacker, sink)?
                 }
                 DeduplicationStrategy::None => locales_to_export
                     .into_par_iter()
@@ -1034,7 +1034,7 @@ fn select_locales_for_key(
     Ok(result)
 }
 
-fn deduplicate_locales<const MAXIMAL: bool>(
+fn deduplicate_payloads<const MAXIMAL: bool>(
     key: DataKey,
     payloads: &HashMap<DataLocale, (DataPayload<ExportMarker>, Duration)>,
     fallbacker: &LocaleFallbacker,

--- a/provider/datagen/tests/test-options.rs
+++ b/provider/datagen/tests/test-options.rs
@@ -218,14 +218,12 @@ fn export_to_map_1_5(
     let mut exporter = TestingExporter::default();
     driver.export(provider, &mut exporter).unwrap();
 
-    let results = exporter
+    exporter
         .0
         .into_tuple_vec()
         .into_iter()
         .map(|(data_locale, buffer)| (data_locale.write_to_string().into_owned(), buffer))
-        .collect();
-
-    results
+        .collect()
 }
 
 #[test]


### PR DESCRIPTION
Related to #58. Closes it? I'm not sure because there are also discussions about a `can_load` method, but this is the bare minimum to support the use case.

