### PR TITLE
Update ixdtf crate documentation

### DIFF
--- a/utils/ixdtf/README.md
+++ b/utils/ixdtf/README.md
@@ -4,9 +4,10 @@
 
 Parsers for extended date time string and Duration parsing.
 
-The [Internet Extended Date/Time Fmt (IXDTF)][ixdtf-draft] as laid out by Serialising
-Extended Data About Times and Events' (sedate) builds on RFC3339's time stamp specification and
-ISO8601 to provide an optional extension syntax for date time strings.
+The [Internet Extended Date/Time Fmt (IXDTF)][rfc-9557] is laid out by RFC 9557. RFC 9557
+builds on RFC3339's time stamp specification and ISO8601 to provide an optional extension
+syntax for date/time strings. RFC 9557 also updates RFC3339 "in the specific interpretation
+of the local offset Z".
 
 ## Date Time Extended Examples
 
@@ -40,10 +41,10 @@ assert!(!tz_annotation.critical);
 assert_eq!(tz_annotation.tz, TimeZoneRecord::Name("America/New_York"));
 ```
 
-### Date Time Strings
+### Date/Time Strings
 
-These extended suffixes are optional, so the `IXDTFParser` will also still parse any valid
-date time strings.
+The extended suffixes laid out by RFC 9557 are optional, so the `IxdtfParser`
+will also still parse any valid date time strings described by RFC3339.
 
 Example Valid Date Time Strings:
 
@@ -62,8 +63,8 @@ character.
 
 #### Time Zone Annotations
 
-Time zone annotations can be either a valud time zone IANA name or a number
-offset as shown previously.
+Time zone annotations can be either a valid IANA time zone name or numeric
+offset.
 
 ##### Valid Time Zone Annotations
 
@@ -72,46 +73,59 @@ offset as shown previously.
 
 #### Key-Value Annotations
 
-Key-value pair annotations are any keys that are delimited by a '='. Key-value
-pairs are can include any information. Keys can be permanently registered, provisionally
-registered, or unknown; however, only permanent keys are acted on by the parser. All
-annotations will be parsed and returned to the user in a `Vec` of annotations.
+Key-value pair annotations are any key and value string separated by a '=' character.
+Key-value pairs are can include any information. Keys can be permanently registered,
+provisionally registered, or unknown; however, only permanent keys are acted on by
+the parser. All annotations will be parsed and returned to the user in a `Vec` of
+annotations.
 
-If duplicate registered keys are provided the first will key will be returned, unless one
-of the duplicate annotations is marked as critical, in which case an error will be
-thrown by the parser.
+If duplicate registered keys are provided the first key will be returned, unless one
+of the duplicate annotations is marked as critical, in which case an error may be
+thrown by the `ixdtf` (See [Invalid Annotations](#invalid-annotations) for more information).
 
 ##### Permanent Registered Keys
 
 - `u-ca`
 
-##### Valid Annotations Examples
+##### Valid Annotations
 
 - (1) `2024-03-02T08:48:00-05:00[America/New_York][u-ca=iso8601]`
 - (2) `2024-03-02T08:48:00-05:00[u-ca=iso8601][u-ca=japanese]`
-- (3) `2024-03-02T08:48:00-05:00[u-ca=iso8601][answer-to-universe=fortytwo]`
+- (3) `2024-03-02T08:48:00-05:00[u-ca=iso8601][!u-ca=iso8601]`
+- (4) `2024-03-02T08:48:00-05:00[u-ca=iso8601][answer-to-universe=fortytwo]`
 
-(1) is a basic annotation string that has a Time Zone and calendar annotation.
+###### Example 1
+This is a basic annotation string that has a Time Zone and calendar annotation.
 
-(2) has a duplicate calendar, but neither calendar is flagged as critical so
+###### Example 2
+
+This example has a duplicate calendar, but neither calendar is flagged as critical so
 the first calendar is returned while the second calendar is ignored.
 
-(3) shows an unknown key-value annotation. In this situation, the annotation
+###### Example 3
+
+This example shows an unknown key-value annotation. In this situation, the annotation
 is not flagged as critical, so the annotation is valid.
 
-##### Invalid Annotations Examples
+###### Example 4
 
-The below invalid annotations have to primary groups: (a) invalid annotations that
-`ixdtf` will handle and throw an error, and (b) invalid annotations that will NOT
-be handled by `ixdtf`, but will be presented to the user to handle as they see fit.
+This example has displays an unknown annotation. The annotation is not marked as critical
+so the value is ignored (See [Implementing Annotation Handlers](#implementing-annotation-handlers)).
+
+##### Invalid Annotations
+
+The below `ixdtf` strings have invalid annotations that will cause an error
+to be thrown (NOTE: these are not to be confused with potentially invalid
+annotations with application defined behavior).
 
 - (1) `2024-03-02T08:48:00-05:00[u-ca=iso8601][America/New_York]`
 - (2) `2024-03-02T08:48:00-05:00[u-ca=iso8601][!u-ca=japanese]`
 - (3) `2024-03-02T08:48:00-05:00[u-ca=iso8601][!answer-to-universe=fortytwo]`
-- (4) `2024-03-02T08:48:00+01:00[America/New_York]`
 
-(1) belongs to group (a) and shows a Time Zone annotation that is not currently
-in the correct order with the key value. When parsing this invalid annotation, `ixdtf`
+###### Example 1
+
+This example shows a Time Zone annotation that is not currently in the correct
+order with the key value. When parsing this invalid annotation, `ixdtf`
 will attempt to parse the Time Zone annotation as a key-value annotation.
 
 ```rust
@@ -126,9 +140,11 @@ let result = ixdtf.parse();
 assert_eq!(result, Err(ParserError::AnnotationKeyLeadingChar));
 ```
 
-(2) belongs to group (a) and shows a duplicate registered key; however, in
-this case, one of the registered keys is flagged as critical, which throws an error
-as the ixdtf string must be treated as erroneous
+###### Example 2
+
+This example shows a duplicate registered key; however, in this case, one
+of the registered keys is flagged as critical, which throws an error as
+the ixdtf string must be treated as erroneous
 
 ```rust
 use ixdtf::{parsers::IxdtfParser, ParserError};
@@ -140,9 +156,10 @@ let result = IxdtfParser::new(example_one).parse();
 assert_eq!(result, Err(ParserError::CriticalDuplicateCalendar));
 ```
 
-(3) belongs to group (b) and shows an unknown key flagged as critical. `ixdtf` is
-agnostic regarding the ambiguity caused by the criticality of an unknown key. This will
-be provided to the user to handle the unknown key's critical flag as they see fit.
+###### Example 3
+
+This example shows an unknown key flagged as critical. `ixdtf` will return an
+error on an unknown flag being flagged as critical.
 
 ```rust
 use ixdtf::{parsers::IxdtfParser, ParserError};
@@ -154,7 +171,26 @@ let result = IxdtfParser::new(example_one).parse();
 assert_eq!(result, Err(ParserError::UnrecognizedCritical));
 ```
 
-(4) belongs to group (b) and shows an ambiguous Time Zone caused by a misalignment
+##### Annotations with Application Defined Behavior
+
+The below options may be viewed as valid or invalid depending on application defined
+behavior. Where user defined behavior might be required, the `ixdtf` crate applies
+the logic in the least restrictive interpretation and provides optional callbacks
+for the user to define stricter behavior.
+
+- (1) `2024-03-02T08:48:00-05:00[u-ca=japanese][!u-ca=japanese]`
+- (2) `2024-03-02T08:48:00+01:00[America/New_York]`
+
+###### Example 1
+
+This example shows a critical duplicate calendar where the annotation value is identical. RFC 9557 is
+ambiguous on whether this should be rejected for inconsistency. `ixdtf` treats these values
+as consistent, and, therefore, okay. However, an application may wish to handle this duplicate
+critical calendar value as inconsistent (See [Implementing Annotation Handlers](#implementing-annotation-handlers)).
+
+###### Example 2
+
+This example shows an ambiguous Time Zone caused by a misalignment
 of the offset and the Time Zone annotation. It is up to the user to handle this ambiguity
 between the offset and annotation.
 
@@ -177,12 +213,71 @@ assert_eq!(tz_annotation.tz, TimeZoneRecord::Name("America/New_York"));
 assert_eq!(offset.hour, 1);
 ```
 
-### Additional DateTime grammar resources
+##### Implementing Annotation Handlers
+
+As mentioned in the prior section, there may be times where an application may
+need to implement application defined behavior for user defined functionality.
+In this instance, `ixdtf` provides a `*_with_annotation_handler` method that
+allows to the user to provide a callback.
+
+A handler is defined as `handler: impl FnMut(Annotation<'a>) -> Option<Annotation<'a>>`
+where `ixdtf` provides visibility to an annotation to the user. The call to this callback
+occurs prior to the `ixdtf`'s processing of the annotation, and will only occur if the
+annotation is provided back to `ixdtf`.
+
+If the user wishes to ignore any `ixdtf`'s errors, then they may return `None`, which
+results in a no-op for that annotation.
+
+Unless the user’s application has a specific reason to bypass action on an annotation,
+such as, custom unknown key handling or superceding a calendar based on it’s critical
+flag, it is recommended to return the annotation value.
+
+###### Handler Example
+
+A user may wish to implement a custom key in an annotation set. This can be completed
+with custom handler.
+
+```rust
+use ixdtf::parsers::IxdtfParser;
+
+let example_with_custom_key = "2024-03-02T08:48:00-05:00[u-ca=iso8601][!answer-to-universe=fortytwo]";
+
+let mut answer = None;
+
+let _ = IxdtfParser::new(example_with_custom_key).parse_with_annotation_handler(|annotation| {
+    if annotation.key == "answer-to-universe" {
+        answer = Some(annotation);
+        // Found our value! We don't need `ixdtf` to handle this annotation.
+        return None
+    }
+    // The annotation is not our custom annotation, so we return
+    // the value back for regular logic.
+    Some(annotation)
+}).unwrap();
+
+let answer = answer.unwrap();
+
+assert!(answer.critical);
+assert_eq!(answer.value, "fortytwo");
+```
+
+It is worth noting that in the above example the annotation above found is a critically flagged
+unknown key. RFC 9557 and `ixdtf` considers unknown critical keys as invalid. However, handlers
+allow the user to define any known keys of their own and therefore also handle the logic around
+criticality.
+
+### Additional grammar resources
 
 Additional resources for Date and Time string grammar can be found in [RFC3339][rfc3339]
 and the [Temporal proposal][temporal-grammar].
 
-[ixdtf-draft]: https://datatracker.ietf.org/doc/draft-ietf-sedate-datetime-extended/
+### Additional Feature
+
+The `ixdtf` crate also implements an ISU8601 Duration parser (`IsoDurationParser`) that is available under
+the `duration` feature flag. The API for `IsoDurationParser` is the same as `IxdtfParser`, but
+parses duration strings over date/time strings.
+
+[rfc-9557]: https://datatracker.ietf.org/doc/rfc9557/
 [rfc3339]: https://datatracker.ietf.org/doc/html/rfc3339
 [temporal-grammar]: https://tc39.es/proposal-temporal/#sec-temporal-iso8601grammar
 

--- a/utils/ixdtf/README.md
+++ b/utils/ixdtf/README.md
@@ -18,7 +18,7 @@ of the local offset Z".
 ### Example Usage
 
 ```rust
-use ixdtf::parsers::{IxdtfParser, records::{Sign, TimeZoneRecord, UTCOffsetRecord}};
+use ixdtf::parsers::{IxdtfParser, records::{Sign, TimeZoneRecord}};
 
 let ixdtf_str = "2024-03-02T08:48:00-05:00[America/New_York]";
 
@@ -58,7 +58,7 @@ Example Valid Date Time Strings:
 ### IXDTF Extensions: A Deeper Look
 
 The suffix extensions come in two primary kinds: a time zone annotation and a key-value
-annotation. The suffixes may also be flagged as critical with a '!' as a leading flag
+annotation. The suffixes may also be flagged as critical with a `!` as a leading flag
 character.
 
 #### Time Zone Annotations
@@ -74,14 +74,14 @@ offset.
 #### Key-Value Annotations
 
 Key-value pair annotations are any key and value string separated by a '=' character.
-Key-value pairs are can include any information. Keys can be permanently registered,
+Key-value pairs are can include any information. Keys may be permanently registered,
 provisionally registered, or unknown; however, only permanent keys are acted on by
-the parser. All annotations will be parsed and returned to the user in a `Vec` of
-annotations.
+`IxdtfParser`.
 
 If duplicate registered keys are provided the first key will be returned, unless one
 of the duplicate annotations is marked as critical, in which case an error may be
-thrown by the `ixdtf` (See [Invalid Annotations](#invalid-annotations) for more information).
+thrown by the `ixdtf` (See [Invalid Annotations](#invalid-annotations) for more
+information).
 
 ##### Permanent Registered Keys
 
@@ -99,17 +99,21 @@ This is a basic annotation string that has a Time Zone and calendar annotation.
 
 ###### Example 2
 
-This example has a duplicate calendar, but neither calendar is flagged as critical so
-the first calendar is returned while the second calendar is ignored.
+This example is duplicate and different calendar annotations, but neither calendar
+is flagged as critical so the first calendar is returned while the second calendar
+is ignored.
 
 ###### Example 3
 
-This example shows an unknown key-value annotation. In this situation, the annotation
-is not flagged as critical, so the annotation is valid.
+This example is a duplicate and identical calendar annotations with one annotation flagged
+as critical. As the annotations are identical values, there is no ambiguity with the use of
+the critical flag that may cause an error. Thus, the first annotation is returned, and the
+second is ignored (See [Annotations with Application Defined
+Behavior](#annotations-with-application-defined-behavior)).
 
 ###### Example 4
 
-This example has displays an unknown annotation. The annotation is not marked as critical
+This example contains an unknown annotation. The annotation is not marked as critical
 so the value is ignored (See [Implementing Annotation Handlers](#implementing-annotation-handlers)).
 
 ##### Invalid Annotations
@@ -246,7 +250,7 @@ let mut answer = None;
 
 let _ = IxdtfParser::new(example_with_custom_key).parse_with_annotation_handler(|annotation| {
     if annotation.key == "answer-to-universe" {
-        answer = Some(annotation);
+        answer.get_or_insert(annotation);
         // Found our value! We don't need `ixdtf` to handle this annotation.
         return None
     }

--- a/utils/ixdtf/src/error.rs
+++ b/utils/ixdtf/src/error.rs
@@ -8,6 +8,7 @@ use displaydoc::Display;
 
 #[non_exhaustive]
 #[derive(PartialEq, Display, Clone, Copy, Debug)]
+/// The error returned by `ixdtf`'s parsers.
 pub enum ParserError {
     #[displaydoc("Implementation error: this error must not throw.")]
     ImplAssert,

--- a/utils/ixdtf/src/lib.rs
+++ b/utils/ixdtf/src/lib.rs
@@ -18,7 +18,7 @@
 //! ## Example Usage
 //!
 //! ```
-//! use ixdtf::parsers::{IxdtfParser, records::{Sign, TimeZoneRecord, UTCOffsetRecord}};
+//! use ixdtf::parsers::{IxdtfParser, records::{Sign, TimeZoneRecord}};
 //!
 //! let ixdtf_str = "2024-03-02T08:48:00-05:00[America/New_York]";
 //!
@@ -58,7 +58,7 @@
 //! ## IXDTF Extensions: A Deeper Look
 //!
 //! The suffix extensions come in two primary kinds: a time zone annotation and a key-value
-//! annotation. The suffixes may also be flagged as critical with a '!' as a leading flag
+//! annotation. The suffixes may also be flagged as critical with a `!` as a leading flag
 //! character.
 //!
 //! ### Time Zone Annotations
@@ -74,14 +74,14 @@
 //! ### Key-Value Annotations
 //!
 //! Key-value pair annotations are any key and value string separated by a '=' character.
-//! Key-value pairs are can include any information. Keys can be permanently registered,
+//! Key-value pairs are can include any information. Keys may be permanently registered,
 //! provisionally registered, or unknown; however, only permanent keys are acted on by
-//! the parser. All annotations will be parsed and returned to the user in a `Vec` of
-//! annotations.
+//! `IxdtfParser`.
 //!
 //! If duplicate registered keys are provided the first key will be returned, unless one
 //! of the duplicate annotations is marked as critical, in which case an error may be
-//! thrown by the `ixdtf` (See [Invalid Annotations](#invalid-annotations) for more information).
+//! thrown by the `ixdtf` (See [Invalid Annotations](#invalid-annotations) for more
+//! information).
 //!
 //! #### Permanent Registered Keys
 //!
@@ -100,17 +100,21 @@
 //!
 //! ##### Example 2
 //!
-//! This example has a duplicate calendar, but neither calendar is flagged as critical so
-//! the first calendar is returned while the second calendar is ignored.
+//! This example is duplicate and different calendar annotations, but neither calendar
+//! is flagged as critical so the first calendar is returned while the second calendar
+//! is ignored.
 //!
 //! ##### Example 3
 //!
-//! This example shows an unknown key-value annotation. In this situation, the annotation
-//! is not flagged as critical, so the annotation is valid.
+//! This example is a duplicate and identical calendar annotations with one annotation flagged
+//! as critical. As the annotations are identical values, there is no ambiguity with the use of
+//! the critical flag that may cause an error. Thus, the first annotation is returned, and the
+//! second is ignored (See [Annotations with Application Defined
+//! Behavior](#annotations-with-application-defined-behavior)).
 //!
 //! ##### Example 4
 //!
-//! This example has displays an unknown annotation. The annotation is not marked as critical
+//! This example contains an unknown annotation. The annotation is not marked as critical
 //! so the value is ignored (See [Implementing Annotation Handlers](#implementing-annotation-handlers)).
 //!
 //! #### Invalid Annotations
@@ -247,7 +251,7 @@
 //!
 //! let _ = IxdtfParser::new(example_with_custom_key).parse_with_annotation_handler(|annotation| {
 //!     if annotation.key == "answer-to-universe" {
-//!         answer = Some(annotation);
+//!         answer.get_or_insert(annotation);
 //!         // Found our value! We don't need `ixdtf` to handle this annotation.
 //!         return None
 //!     }

--- a/utils/ixdtf/src/lib.rs
+++ b/utils/ixdtf/src/lib.rs
@@ -4,9 +4,10 @@
 
 //! Parsers for extended date time string and Duration parsing.
 //!
-//! The [Internet Extended Date/Time Fmt (IXDTF)][ixdtf-draft] as laid out by Serialising
-//! Extended Data About Times and Events' (sedate) builds on RFC3339's time stamp specification and
-//! ISO8601 to provide an optional extension syntax for date time strings.
+//! The [Internet Extended Date/Time Fmt (IXDTF)][rfc-9557] is laid out by RFC 9557. RFC 9557
+//! builds on RFC3339's time stamp specification and ISO8601 to provide an optional extension
+//! syntax for date/time strings. RFC 9557 also updates RFC3339 "in the specific interpretation
+//! of the local offset Z".
 //!
 //! # Date Time Extended Examples
 //!
@@ -40,10 +41,10 @@
 //! assert_eq!(tz_annotation.tz, TimeZoneRecord::Name("America/New_York"));
 //! ```
 //!
-//! ## Date Time Strings
+//! ## Date/Time Strings
 //!
-//! These extended suffixes are optional, so the `IXDTFParser` will also still parse any valid
-//! date time strings.
+//! The extended suffixes laid out by RFC 9557 are optional, so the `IxdtfParser`
+//! will also still parse any valid date time strings described by RFC3339.
 //!
 //! Example Valid Date Time Strings:
 //!
@@ -62,8 +63,8 @@
 //!
 //! ### Time Zone Annotations
 //!
-//! Time zone annotations can be either a valud time zone IANA name or a number
-//! offset as shown previously.
+//! Time zone annotations can be either a valid IANA time zone name or numeric
+//! offset.
 //!
 //! #### Valid Time Zone Annotations
 //!
@@ -72,46 +73,60 @@
 //!
 //! ### Key-Value Annotations
 //!
-//! Key-value pair annotations are any keys that are delimited by a '='. Key-value
-//! pairs are can include any information. Keys can be permanently registered, provisionally
-//! registered, or unknown; however, only permanent keys are acted on by the parser. All
-//! annotations will be parsed and returned to the user in a `Vec` of annotations.
+//! Key-value pair annotations are any key and value string separated by a '=' character.
+//! Key-value pairs are can include any information. Keys can be permanently registered,
+//! provisionally registered, or unknown; however, only permanent keys are acted on by
+//! the parser. All annotations will be parsed and returned to the user in a `Vec` of
+//! annotations.
 //!
-//! If duplicate registered keys are provided the first will key will be returned, unless one
-//! of the duplicate annotations is marked as critical, in which case an error will be
-//! thrown by the parser.
+//! If duplicate registered keys are provided the first key will be returned, unless one
+//! of the duplicate annotations is marked as critical, in which case an error may be
+//! thrown by the `ixdtf` (See [Invalid Annotations](#invalid-annotations) for more information).
 //!
 //! #### Permanent Registered Keys
 //!
 //! - `u-ca`
 //!
-//! #### Valid Annotations Examples
+//! #### Valid Annotations
 //!
 //! - (1) `2024-03-02T08:48:00-05:00[America/New_York][u-ca=iso8601]`
 //! - (2) `2024-03-02T08:48:00-05:00[u-ca=iso8601][u-ca=japanese]`
-//! - (3) `2024-03-02T08:48:00-05:00[u-ca=iso8601][answer-to-universe=fortytwo]`
+//! - (3) `2024-03-02T08:48:00-05:00[u-ca=iso8601][!u-ca=iso8601]`
+//! - (4) `2024-03-02T08:48:00-05:00[u-ca=iso8601][answer-to-universe=fortytwo]`
 //!
-//! (1) is a basic annotation string that has a Time Zone and calendar annotation.
+//! ##### Example 1
+
+//! This is a basic annotation string that has a Time Zone and calendar annotation.
 //!
-//! (2) has a duplicate calendar, but neither calendar is flagged as critical so
+//! ##### Example 2
+//!
+//! This example has a duplicate calendar, but neither calendar is flagged as critical so
 //! the first calendar is returned while the second calendar is ignored.
 //!
-//! (3) shows an unknown key-value annotation. In this situation, the annotation
+//! ##### Example 3
+//!
+//! This example shows an unknown key-value annotation. In this situation, the annotation
 //! is not flagged as critical, so the annotation is valid.
 //!
-//! #### Invalid Annotations Examples
+//! ##### Example 4
 //!
-//! The below invalid annotations have to primary groups: (a) invalid annotations that
-//! `ixdtf` will handle and throw an error, and (b) invalid annotations that will NOT
-//! be handled by `ixdtf`, but will be presented to the user to handle as they see fit.
+//! This example has displays an unknown annotation. The annotation is not marked as critical
+//! so the value is ignored (See [Implementing Annotation Handlers](#implementing-annotation-handlers)).
+//!
+//! #### Invalid Annotations
+//!
+//! The below `ixdtf` strings have invalid annotations that will cause an error
+//! to be thrown (NOTE: these are not to be confused with potentially invalid
+//! annotations with application defined behavior).
 //!
 //! - (1) `2024-03-02T08:48:00-05:00[u-ca=iso8601][America/New_York]`
 //! - (2) `2024-03-02T08:48:00-05:00[u-ca=iso8601][!u-ca=japanese]`
 //! - (3) `2024-03-02T08:48:00-05:00[u-ca=iso8601][!answer-to-universe=fortytwo]`
-//! - (4) `2024-03-02T08:48:00+01:00[America/New_York]`
 //!
-//! (1) belongs to group (a) and shows a Time Zone annotation that is not currently
-//! in the correct order with the key value. When parsing this invalid annotation, `ixdtf`
+//! ##### Example 1
+//!
+//! This example shows a Time Zone annotation that is not currently in the correct
+//! order with the key value. When parsing this invalid annotation, `ixdtf`
 //! will attempt to parse the Time Zone annotation as a key-value annotation.
 //!
 //! ```rust
@@ -126,9 +141,11 @@
 //! assert_eq!(result, Err(ParserError::AnnotationKeyLeadingChar));
 //! ```
 //!
-//! (2) belongs to group (a) and shows a duplicate registered key; however, in
-//! this case, one of the registered keys is flagged as critical, which throws an error
-//! as the ixdtf string must be treated as erroneous
+//! ##### Example 2
+//!
+//! This example shows a duplicate registered key; however, in this case, one
+//! of the registered keys is flagged as critical, which throws an error as
+//! the ixdtf string must be treated as erroneous
 //!
 //! ```rust
 //! use ixdtf::{parsers::IxdtfParser, ParserError};
@@ -140,9 +157,10 @@
 //! assert_eq!(result, Err(ParserError::CriticalDuplicateCalendar));
 //! ```
 //!
-//! (3) belongs to group (b) and shows an unknown key flagged as critical. `ixdtf` is
-//! agnostic regarding the ambiguity caused by the criticality of an unknown key. This will
-//! be provided to the user to handle the unknown key's critical flag as they see fit.
+//! ##### Example 3
+//!
+//! This example shows an unknown key flagged as critical. `ixdtf` will return an
+//! error on an unknown flag being flagged as critical.
 //!
 //! ```rust
 //! use ixdtf::{parsers::IxdtfParser, ParserError};
@@ -154,7 +172,26 @@
 //! assert_eq!(result, Err(ParserError::UnrecognizedCritical));
 //! ```
 //!
-//! (4) belongs to group (b) and shows an ambiguous Time Zone caused by a misalignment
+//! #### Annotations with Application Defined Behavior
+//!
+//! The below options may be viewed as valid or invalid depending on application defined
+//! behavior. Where user defined behavior might be required, the `ixdtf` crate applies
+//! the logic in the least restrictive interpretation and provides optional callbacks
+//! for the user to define stricter behavior.
+//!
+//! - (1) `2024-03-02T08:48:00-05:00[u-ca=japanese][!u-ca=japanese]`
+//! - (2) `2024-03-02T08:48:00+01:00[America/New_York]`
+//!
+//! ##### Example 1
+//!
+//! This example shows a critical duplicate calendar where the annotation value is identical. RFC 9557 is
+//! ambiguous on whether this should be rejected for inconsistency. `ixdtf` treats these values
+//! as consistent, and, therefore, okay. However, an application may wish to handle this duplicate
+//! critical calendar value as inconsistent (See [Implementing Annotation Handlers](#implementing-annotation-handlers)).
+//!
+//! ##### Example 2
+//!
+//! This example shows an ambiguous Time Zone caused by a misalignment
 //! of the offset and the Time Zone annotation. It is up to the user to handle this ambiguity
 //! between the offset and annotation.
 //!
@@ -177,12 +214,71 @@
 //! assert_eq!(offset.hour, 1);
 //! ```
 //!
-//! ## Additional DateTime grammar resources
+//! #### Implementing Annotation Handlers
+//!
+//! As mentioned in the prior section, there may be times where an application may
+//! need to implement application defined behavior for user defined functionality.
+//! In this instance, `ixdtf` provides a `*_with_annotation_handler` method that
+//! allows to the user to provide a callback.
+//!
+//! A handler is defined as `handler: impl FnMut(Annotation<'a>) -> Option<Annotation<'a>>`
+//! where `ixdtf` provides visibility to an annotation to the user. The call to this callback
+//! occurs prior to the `ixdtf`'s processing of the annotation, and will only occur if the
+//! annotation is provided back to `ixdtf`.
+//!
+//! If the user wishes to ignore any `ixdtf`'s errors, then they may return `None`, which
+//! results in a no-op for that annotation.
+//!
+//! Unless the user’s application has a specific reason to bypass action on an annotation,
+//! such as, custom unknown key handling or superceding a calendar based on it’s critical
+//! flag, it is recommended to return the annotation value.
+//!
+//! ##### Handler Example
+//!
+//! A user may wish to implement a custom key in an annotation set. This can be completed
+//! with custom handler.
+//!
+//! ```rust
+//! use ixdtf::parsers::IxdtfParser;
+//!
+//! let example_with_custom_key = "2024-03-02T08:48:00-05:00[u-ca=iso8601][!answer-to-universe=fortytwo]";
+//!
+//! let mut answer = None;
+//!
+//! let _ = IxdtfParser::new(example_with_custom_key).parse_with_annotation_handler(|annotation| {
+//!     if annotation.key == "answer-to-universe" {
+//!         answer = Some(annotation);
+//!         // Found our value! We don't need `ixdtf` to handle this annotation.
+//!         return None
+//!     }
+//!     // The annotation is not our custom annotation, so we return
+//!     // the value back for regular logic.
+//!     Some(annotation)
+//! }).unwrap();
+//!
+//! let answer = answer.unwrap();
+//!
+//! assert!(answer.critical);
+//! assert_eq!(answer.value, "fortytwo");
+//! ```
+//!
+//! It is worth noting that in the above example the annotation above found is a critically flagged
+//! unknown key. RFC 9557 and `ixdtf` considers unknown critical keys as invalid. However, handlers
+//! allow the user to define any known keys of their own and therefore also handle the logic around
+//! criticality.
+//!
+//! ## Additional grammar resources
 //!
 //! Additional resources for Date and Time string grammar can be found in [RFC3339][rfc3339]
 //! and the [Temporal proposal][temporal-grammar].
 //!
-//! [ixdtf-draft]: https://datatracker.ietf.org/doc/draft-ietf-sedate-datetime-extended/
+//! ## Additional Feature
+//!
+//! The `ixdtf` crate also implements an ISU8601 Duration parser (`IsoDurationParser`) that is available under
+//! the `duration` feature flag. The API for `IsoDurationParser` is the same as `IxdtfParser`, but
+//! parses duration strings over date/time strings.
+//!
+//! [rfc-9557]: https://datatracker.ietf.org/doc/rfc9557/
 //! [rfc3339]: https://datatracker.ietf.org/doc/html/rfc3339
 //! [temporal-grammar]: https://tc39.es/proposal-temporal/#sec-temporal-iso8601grammar
 
@@ -207,4 +303,5 @@ extern crate alloc;
 
 pub use error::ParserError;
 
+/// The `ixdtf` crate's Result type.
 pub type ParserResult<T> = Result<T, ParserError>;

--- a/utils/ixdtf/src/parsers/mod.rs
+++ b/utils/ixdtf/src/parsers/mod.rs
@@ -67,15 +67,7 @@ impl<'a> IxdtfParser<'a> {
 
     /// Parses the source as an annotated DateTime string with an Annotation handler.
     ///
-    /// # Annotation Handling
-    ///
-    /// The annotation handler provides a parsed annotation to the callback and expects a return
-    /// of an annotation or None. `ixdtf` performs baseline annotation checks once the handler
-    /// returns. Returning None will ignore the standard checks for that annotation.
-    ///
-    /// Unless the user's application has a specific reason to bypass action on an annotation, such
-    /// as, not throwing an error on an unknown key's criticality or superceding a calendar based on
-    /// it's critical flag, it is recommended to return the annotation value.
+    /// For more, see [Implementing Annotation Handlers](crate#implementing-annotation-handlers)
     pub fn parse_with_annotation_handler(
         &mut self,
         handler: impl FnMut(Annotation<'a>) -> Option<Annotation<'a>>,
@@ -90,15 +82,7 @@ impl<'a> IxdtfParser<'a> {
 
     /// Parses the source as an annotated YearMonth string with an Annotation handler.
     ///
-    /// # Annotation Handling
-    ///
-    /// The annotation handler provides a parsed annotation to the callback and expects a return
-    /// of an annotation or None. `ixdtf` performs baseline annotation checks once the handler
-    /// returns. Returning None will ignore the standard checks for that annotation.
-    ///
-    /// Unless the user's application has a specific use case to bypass action on an annotation, such
-    /// as, not throwing an error on an unknown key's criticality or superceding a calendar based on
-    /// it's critical flag, it is recommended to return the annotation value.
+    /// For more, see [Implementing Annotation Handlers](crate#implementing-annotation-handlers)
     pub fn parse_year_month_with_annotation_handler(
         &mut self,
         handler: impl FnMut(Annotation<'a>) -> Option<Annotation<'a>>,
@@ -113,15 +97,7 @@ impl<'a> IxdtfParser<'a> {
 
     /// Parses the source as an annotated MonthDay string with an Annotation handler.
     ///
-    /// # Annotation Handling
-    ///
-    /// The annotation handler provides a parsed annotation to the callback and expects a return
-    /// of an annotation or None. `ixdtf` performs baseline annotation checks once the handler
-    /// returns. Returning None will ignore the standard checks for that annotation.
-    ///
-    /// Unless the user's application has a specific reason to bypass action on an annotation, such
-    /// as, not throwing an error on an unknown key's criticality or superceding a calendar based on
-    /// it's critical flag, it is recommended to return the annotation value.
+    /// For more, see [Implementing Annotation Handlers](crate#implementing-annotation-handlers)
     pub fn parse_month_day_with_annotation_handler(
         &mut self,
         handler: impl FnMut(Annotation<'a>) -> Option<Annotation<'a>>,
@@ -136,15 +112,7 @@ impl<'a> IxdtfParser<'a> {
 
     /// Parses the source as an annotated Time string with an Annotation handler.
     ///
-    /// # Annotation Handling
-    ///
-    /// The annotation handler provides a parsed annotation to the callback and expects a return
-    /// of an annotation or None. `ixdtf` performs baseline annotation checks once the handler
-    /// returns. Returning None will ignore the standard checks for that annotation.
-    ///
-    /// Unless the user's application has a specific reason to bypass action on an annotation, such
-    /// as, not throwing an error on an unknown key's criticality or superceding a calendar based on
-    /// it's critical flag, it is recommended to return the annotation value.
+    /// For more, see [Implementing Annotation Handlers](crate#implementing-annotation-handlers)
     pub fn parse_time_with_annotation_handler(
         &mut self,
         handler: impl FnMut(Annotation<'a>) -> Option<Annotation<'a>>,


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

This PR cleans up the crate docs and README for `ixdtf`.

The changes consist of:

- RFC 9557 link was added in place of SEDATE.
- It adds a section and example for implementing annotation handlers.
- Some changes to general wording and formatting to hopefully make some sections clearer.