### PR TITLE
Remove CI download cache

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -160,12 +160,6 @@ jobs:
       run: rustup show
 
     # Job-specific dependencies
-    - name: Attempt to load download cache
-      uses: actions/cache@v3
-      with:
-        key: download-cache
-        path: /tmp/icu4x-source-cache
-
     - name: Install harfbuzz
       run: sudo apt install libharfbuzz-dev
 
@@ -195,11 +189,6 @@ jobs:
       run: rustup show
 
     # Job-specific dependencies
-    - name: Attempt to load download cache
-      uses: actions/cache@v3
-      with:
-        key: download-cache
-        path: /tmp/icu4x-source-cache
     - name: Install rustfmt
       run: rustup component add rustfmt
 
@@ -226,11 +215,6 @@ jobs:
       run: rustup show
 
     # Job-specific dependencies
-    - name: Attempt to load download cache
-      uses: actions/cache@v3
-      with:
-        key: download-cache
-        path: /tmp/icu4x-source-cache
     - name: Install cargo-binstall 
       uses: taiki-e/install-action@cargo-binstall
     - name: Install cargo-all-features
@@ -258,11 +242,6 @@ jobs:
       run: rustup show
 
     # Job-specific dependencies
-    - name: Attempt to load download cache
-      uses: actions/cache@v3
-      with:
-        key: download-cache
-        path: /tmp/icu4x-source-cache
     - name: Install rustfmt
       run: rustup component add rustfmt
 
@@ -311,11 +290,6 @@ jobs:
     - name: Install jq
       run: |
         apt-get install -y jq
-    - name: Attempt to load download cache
-      uses: actions/cache@v3
-      with:
-        key: download-cache
-        path: /tmp/icu4x-source-cache
 
     # Actual job
     - name: Run `cargo make ci-job-test-c`


### PR DESCRIPTION
It's not clear that downloading from the cache is significantly faster than downloading from the sources, which are also located on GH's servers. The download cache however means that we have to worry about it getting stale (happened with ICU 75), and also the download path is not exercised in main or nightly CI, because the cache always hits.