### PR TITLE
Create BoundDataProvider, a DataProvider that always loads for the same key

### DIFF
--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -2,6 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use core::marker::PhantomData;
+use yoke::Yokeable;
+
 use crate::error::DataError;
 use crate::key::DataKey;
 use crate::marker::{DataMarker, KeyedDataMarker};
@@ -124,6 +127,125 @@ where
     #[inline]
     fn load_data(&self, key: DataKey, req: DataRequest) -> Result<DataResponse<M>, DataError> {
         (**self).load_data(key, req)
+    }
+}
+
+/// A data provider that loads data for a specific data type.
+///
+/// Unlike [`DataProvider`], the provider is bound to a specific key ahead of time.
+///
+/// [`AnyMarker`]: crate::any::AnyMarker
+pub trait BoundDataProvider<M>
+where
+    M: DataMarker,
+{
+    /// Query the provider for data, returning the result.
+    ///
+    /// Returns [`Ok`] if the request successfully loaded data. If data failed to load, returns an
+    /// Error with more information.
+    fn load_bound(&self, req: DataRequest) -> Result<DataResponse<M>, DataError>;
+    /// Returns the [`DataKey`] that this provider uses for loading data.
+    fn bound_key(&self) -> DataKey;
+}
+
+impl<'a, M, P> BoundDataProvider<M> for &'a P
+where
+    M: DataMarker,
+    P: BoundDataProvider<M> + ?Sized,
+{
+    #[inline]
+    fn load_bound(&self, req: DataRequest) -> Result<DataResponse<M>, DataError> {
+        (*self).load_bound(req)
+    }
+    #[inline]
+    fn bound_key(&self) -> DataKey {
+        (*self).bound_key()
+    }
+}
+
+impl<M, P> BoundDataProvider<M> for alloc::boxed::Box<P>
+where
+    M: DataMarker,
+    P: BoundDataProvider<M> + ?Sized,
+{
+    #[inline]
+    fn load_bound(&self, req: DataRequest) -> Result<DataResponse<M>, DataError> {
+        (**self).load_bound(req)
+    }
+    #[inline]
+    fn bound_key(&self) -> DataKey {
+        (**self).bound_key()
+    }
+}
+
+impl<M, P> BoundDataProvider<M> for alloc::rc::Rc<P>
+where
+    M: DataMarker,
+    P: BoundDataProvider<M> + ?Sized,
+{
+    #[inline]
+    fn load_bound(&self, req: DataRequest) -> Result<DataResponse<M>, DataError> {
+        (**self).load_bound(req)
+    }
+    #[inline]
+    fn bound_key(&self) -> DataKey {
+        (**self).bound_key()
+    }
+}
+
+#[cfg(target_has_atomic = "ptr")]
+impl<M, P> BoundDataProvider<M> for alloc::sync::Arc<P>
+where
+    M: DataMarker,
+    P: BoundDataProvider<M> + ?Sized,
+{
+    #[inline]
+    fn load_bound(&self, req: DataRequest) -> Result<DataResponse<M>, DataError> {
+        (**self).load_bound(req)
+    }
+    #[inline]
+    fn bound_key(&self) -> DataKey {
+        (**self).bound_key()
+    }
+}
+
+/// A [`DataProvider`] associated with a specific key.
+///
+/// Implements [`BoundDataProvider`].
+#[derive(Debug)]
+pub struct DataProviderWithKey<M, P> {
+    inner: P,
+    _marker: PhantomData<M>,
+}
+
+impl<M, P> DataProviderWithKey<M, P>
+where
+    M: KeyedDataMarker,
+    P: DataProvider<M>,
+{
+    /// Creates a [`DataProviderWithKey`] from a [`DataProvider`] with a [`KeyedDataMarker`].
+    pub const fn new(inner: P) -> Self {
+        Self {
+            inner,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<M, M0, Y, P> BoundDataProvider<M0> for DataProviderWithKey<M, P>
+where
+    M: KeyedDataMarker<Yokeable = Y>,
+    M0: DataMarker<Yokeable = Y>,
+    Y: for<'a> Yokeable<'a>,
+    P: DataProvider<M>,
+{
+    #[inline]
+    fn load_bound(&self, req: DataRequest) -> Result<DataResponse<M0>, DataError> {
+        self.inner.load(req).map(DataResponse::cast)
+    }
+    #[inline]
+    fn bound_key(&self) -> DataKey {
+        M::KEY
     }
 }
 

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -153,7 +153,9 @@ pub mod marker;
 pub mod serde;
 
 // Types from private modules
+pub use crate::data_provider::BoundDataProvider;
 pub use crate::data_provider::DataProvider;
+pub use crate::data_provider::DataProviderWithKey;
 pub use crate::data_provider::DynamicDataProvider;
 pub use crate::error::DataError;
 pub use crate::error::DataErrorKind;
@@ -212,6 +214,8 @@ pub mod prelude {
     #[doc(no_inline)]
     #[cfg(feature = "experimental")]
     pub use crate::AuxiliaryKeys;
+    #[doc(no_inline)]
+    pub use crate::BoundDataProvider;
     #[doc(no_inline)]
     pub use crate::BufferMarker;
     #[doc(no_inline)]

--- a/provider/core/src/marker.rs
+++ b/provider/core/src/marker.rs
@@ -6,7 +6,7 @@
 
 use core::marker::PhantomData;
 
-use crate::{data_key, key::DataKey};
+use crate::{data_key, DataKey, DataProvider, DataProviderWithKey};
 use yoke::Yokeable;
 
 /// Trait marker for data structs. All types delivered by the data provider must be associated with
@@ -84,6 +84,15 @@ pub trait DataMarker: 'static {
 pub trait KeyedDataMarker: DataMarker {
     /// The single [`DataKey`] associated with this marker.
     const KEY: DataKey;
+
+    /// Binds this [`KeyedDataMarker`] to a provider supporting it.
+    fn bind<P>(provider: P) -> DataProviderWithKey<Self, P>
+    where
+        P: DataProvider<Self>,
+        Self: Sized,
+    {
+        DataProviderWithKey::new(provider)
+    }
 }
 
 /// A [`DataMarker`] that never returns data.


### PR DESCRIPTION
I have been using this type of abstraction in DateTimeFormatter. I realized that this is a more useful abstraction in practice than `DynamicDataProvider`. I created a ticket to delete `DynamicDataProvider` in 2.0. https://github.com/unicode-org/icu4x/issues/4881

~Includes #4880~