### PR TITLE
Try adding compiled data for icu::experimental::transliterate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,6 +1211,7 @@ dependencies = [
  "icu_locid_transform",
  "icu_locid_transform_data",
  "icu_normalizer",
+ "icu_normalizer_data",
  "icu_pattern",
  "icu_plurals",
  "icu_properties",

--- a/components/experimental/Cargo.toml
+++ b/components/experimental/Cargo.toml
@@ -54,6 +54,9 @@ smallvec = { workspace = true }
 
 icu_experimental_data = { workspace = true, optional = true }
 
+# TODO(#4897): Use an external loader.
+icu_normalizer_data = { workspace = true, optional = true }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = { workspace = true }
 
@@ -66,10 +69,10 @@ icu_properties_data = { workspace = true }
 
 [features]
 default = ["compiled_data"]
-compiled_data = ["dep:icu_experimental_data", "icu_locid_transform/compiled_data", "icu_decimal/compiled_data", "icu_plurals/compiled_data", "icu_properties/compiled_data", "icu_normalizer/compiled_data"]
+compiled_data = ["dep:icu_experimental_data", "dep:icu_normalizer_data", "icu_locid_transform/compiled_data", "icu_decimal/compiled_data", "icu_plurals/compiled_data", "icu_properties/compiled_data", "icu_normalizer/compiled_data"]
 datagen = ["serde", "std", "dep:databake", "zerovec/databake", "zerotrie/databake", "tinystr/databake", "icu_collections/databake", "std", "log", "icu_pattern/databake", "icu_provider/datagen"]
 ryu = ["fixed_decimal/ryu"]
-serde = ["dep:serde", "zerovec/serde", "tinystr/serde", "icu_collections/serde", "icu_decimal/serde", "icu_pattern/serde", "icu_plurals/serde", "icu_provider/serde", "zerotrie/serde"]
+serde = ["dep:serde", "zerovec/serde", "tinystr/serde", "icu_collections/serde", "icu_decimal/serde", "icu_normalizer/serde", "icu_pattern/serde", "icu_plurals/serde", "icu_provider/serde", "zerotrie/serde"]
 std = ["fixed_decimal/std", "icu_decimal/std", "icu_pattern/std", "icu_plurals/std", "icu_provider/std", "icu_locid/std"]
 
 bench = []

--- a/components/experimental/src/lib.rs
+++ b/components/experimental/src/lib.rs
@@ -39,6 +39,8 @@ pub mod provider {
             pub use crate as experimental;
             #[allow(unused_imports)] // baked data may or may not need this
             pub use icu_locid_transform as locid_transform;
+            pub use icu_collections as collections;
+            pub use icu_normalizer as normalizer;
         }
         icu_experimental_data::make_provider!(Baked);
         icu_experimental_data::impl_compactdecimal_long_v1!(Baked);
@@ -75,7 +77,16 @@ pub mod provider {
         icu_experimental_data::impl_relativetime_short_second_v1!(Baked);
         icu_experimental_data::impl_relativetime_short_week_v1!(Baked);
         icu_experimental_data::impl_relativetime_short_year_v1!(Baked);
+        icu_experimental_data::impl_transliterator_rules_v1!(Baked);
         icu_experimental_data::impl_units_info_v1!(Baked);
+
+        // TODO(#4897): Use an external loader.
+        icu_normalizer_data::impl_normalizer_comp_v1!(Baked);
+        icu_normalizer_data::impl_normalizer_decomp_v1!(Baked);
+        icu_normalizer_data::impl_normalizer_nfd_v1!(Baked);
+        icu_normalizer_data::impl_normalizer_nfdex_v1!(Baked);
+        icu_normalizer_data::impl_normalizer_nfkd_v1!(Baked);
+        icu_normalizer_data::impl_normalizer_nfkdex_v1!(Baked);
     };
 
     #[cfg(feature = "datagen")]
@@ -120,6 +131,7 @@ pub mod provider {
         super::relativetime::provider::ShortSecondRelativeTimeFormatDataV1Marker::KEY,
         super::relativetime::provider::ShortWeekRelativeTimeFormatDataV1Marker::KEY,
         super::relativetime::provider::ShortYearRelativeTimeFormatDataV1Marker::KEY,
+        super::transliterate::provider::TransliteratorRulesV1Marker::KEY,
         super::units::provider::UnitsInfoV1Marker::KEY,
     ];
 }

--- a/components/experimental/src/transliterate/transliterator/mod.rs
+++ b/components/experimental/src/transliterate/transliterator/mod.rs
@@ -162,21 +162,40 @@ pub struct Transliterator {
 }
 
 impl Transliterator {
-    /// Construct a [`Transliterator`] from the given [`Locale`].
-    ///
-    /// # Examples
-    /// ```ignore
-    /// use icu::experimental::transliterate::Transliterator;
-    /// // BCP-47-T ID for Bengali to Arabic transliteration
-    /// let locale = "und-Arab-t-und-beng".parse().unwrap();
-    /// let t = Transliterator::try_new_unstable(locale, provider).unwrap();
-    /// let output = t.transliterate("অকার্যতানাযা".to_string());
-    ///
-    /// assert_eq!(output, "اكاريتانايا");
-    /// ```
+    icu_provider::gen_any_buffer_data_constructors!(
+        locale: skip,
+        options: Locale,
+        error: TransliteratorError,
+        /// Construct a [`Transliterator`] from the given [`Locale`].
+        ///
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+        ///
+        /// [📚 Help choosing a constructor](icu_provider::constructors)
+        /// 
+        /// # Examples
+        /// 
+        /// ```
+        /// use icu::experimental::transliterate::Transliterator;
+        /// // BCP-47-T ID for Bengali to Arabic transliteration
+        /// let locale = "und-Arab-t-und-beng".parse().unwrap();
+        /// let t = Transliterator::try_new(locale).unwrap();
+        /// let output = t.transliterate("অকার্যতানাযা".to_string());
+        ///
+        /// assert_eq!(output, "اكاريتانايا");
+        /// ```
+        functions: [
+            try_new,
+            try_new_with_any_provider,
+            try_new_with_buffer_provider,
+            try_new_unstable,
+            Self
+        ]
+    );
+
+    #[doc = icu_provider::gen_any_buffer_unstable_docs!(UNSTABLE, Self::try_new)]
     pub fn try_new_unstable<P>(
-        locale: Locale,
         provider: &P,
+        locale: Locale,
     ) -> Result<Transliterator, TransliteratorError>
     where
         P: DataProvider<TransliteratorRulesV1Marker>
@@ -204,8 +223,10 @@ impl Transliterator {
     /// See [`CustomTransliterator`].
     ///
     /// # Example
+    ///
     /// Overriding `"de-t-de-d0-ascii"`'s dependency on `"und-t-und-Latn-d0-ascii"`:
-    /// ```ignore
+    ///
+    /// ```
     /// use icu::experimental::transliterate::{Transliterator, CustomTransliterator};
     /// use icu::locid::Locale;
     /// use core::ops::Range;
@@ -224,6 +245,7 @@ impl Transliterator {
     /// };
     ///
     /// let locale = "de-t-de-d0-ascii".parse().unwrap();
+    /// let provider = icu::experimental::provider::Baked;
     /// let t = Transliterator::try_new_with_override_unstable(locale, lookup, provider).unwrap();
     /// let output = t.transliterate("This is an överride example".to_string());
     ///
@@ -1277,8 +1299,8 @@ mod tests {
         ];
 
         let t = Transliterator::try_new_unstable(
-            "und-t-und-s0-test-d0-test-m0-emtymach".parse().unwrap(),
             &BakedDataProvider,
+            "und-t-und-s0-test-d0-test-m0-emtymach".parse().unwrap(),
         )
         .unwrap();
 
@@ -1290,8 +1312,8 @@ mod tests {
     #[test]
     fn test_recursive_suite() {
         let t = Transliterator::try_new_unstable(
-            "und-t-und-s0-test-d0-test-m0-rectestr".parse().unwrap(),
             &BakedDataProvider,
+            "und-t-und-s0-test-d0-test-m0-rectestr".parse().unwrap(),
         )
         .unwrap();
 
@@ -1303,8 +1325,8 @@ mod tests {
     #[test]
     fn test_cursor_placeholders_filters() {
         let t = Transliterator::try_new_unstable(
-            "und-t-und-s0-test-d0-test-m0-cursfilt".parse().unwrap(),
             &BakedDataProvider,
+            "und-t-und-s0-test-d0-test-m0-cursfilt".parse().unwrap(),
         )
         .unwrap();
 
@@ -1316,8 +1338,8 @@ mod tests {
     #[test]
     fn test_functionality() {
         let t = Transliterator::try_new_unstable(
-            "und-t-und-s0-test-d0-test-m0-niels".parse().unwrap(),
             &BakedDataProvider,
+            "und-t-und-s0-test-d0-test-m0-niels".parse().unwrap(),
         )
         .unwrap();
 
@@ -1329,8 +1351,8 @@ mod tests {
     #[test]
     fn test_de_ascii() {
         let t = Transliterator::try_new_unstable(
-            "de-t-de-d0-ascii".parse().unwrap(),
             &BakedDataProvider,
+            "de-t-de-d0-ascii".parse().unwrap(),
         )
         .unwrap();
         let input =
@@ -1367,8 +1389,8 @@ mod tests {
     #[test]
     fn test_nfc_nfd() {
         let t = Transliterator::try_new_unstable(
-            "und-t-und-latn-d0-ascii".parse().unwrap(),
             &BakedDataProvider,
+            "und-t-und-latn-d0-ascii".parse().unwrap(),
         )
         .unwrap();
         let input = "äa\u{0308}";
@@ -1379,8 +1401,8 @@ mod tests {
     #[test]
     fn test_hex_rust() {
         let t = Transliterator::try_new_unstable(
-            "und-t-und-s0-test-d0-test-m0-hexrust".parse().unwrap(),
             &BakedDataProvider,
+            "und-t-und-s0-test-d0-test-m0-hexrust".parse().unwrap(),
         )
         .unwrap();
         let input = "\0äa\u{10FFFF}❤!";
@@ -1391,8 +1413,8 @@ mod tests {
     #[test]
     fn test_hex_unicode() {
         let t = Transliterator::try_new_unstable(
-            "und-t-und-s0-test-d0-test-m0-hexuni".parse().unwrap(),
             &BakedDataProvider,
+            "und-t-und-s0-test-d0-test-m0-hexuni".parse().unwrap(),
         )
         .unwrap();
         let input = "\0äa\u{10FFFF}❤!";

--- a/components/experimental/tests/transliterate/cldr.rs
+++ b/components/experimental/tests/transliterate/cldr.rs
@@ -37,7 +37,7 @@ fn test_all_cldr() {
         ),
     ] {
         let t =
-            Transliterator::try_new_unstable(locale.parse().unwrap(), &BakedDataProvider).unwrap();
+            Transliterator::try_new_unstable(&BakedDataProvider, locale.parse().unwrap()).unwrap();
         let test_cases = data
             .lines()
             .filter(|x| !x.starts_with('#'))

--- a/provider/baked/experimental/data/macros.rs
+++ b/provider/baked/experimental/data/macros.rs
@@ -264,6 +264,13 @@ pub use __impl_relativetime_short_year_v1 as impl_relativetime_short_year_v1;
 #[doc(inline)]
 pub use __impliterable_relativetime_short_year_v1 as impliterable_relativetime_short_year_v1;
 #[macro_use]
+#[path = "macros/transliterator_rules_v1.rs.data"]
+mod transliterator_rules_v1;
+#[doc(inline)]
+pub use __impl_transliterator_rules_v1 as impl_transliterator_rules_v1;
+#[doc(inline)]
+pub use __impliterable_transliterator_rules_v1 as impliterable_transliterator_rules_v1;
+#[macro_use]
 #[path = "macros/units_info_v1.rs.data"]
 mod units_info_v1;
 #[doc(inline)]

--- a/provider/baked/experimental/data/macros/transliterator_rules_v1.rs.data
+++ b/provider/baked/experimental/data/macros/transliterator_rules_v1.rs.data
@@ -1,0 +1,33 @@
+// @generated
+/// Implement `DataProvider<TransliteratorRulesV1Marker>` on the given struct using the data
+/// hardcoded in this file. This allows the struct to be used with
+/// `icu`'s `_unstable` constructors.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __impl_transliterator_rules_v1 {
+    ($ provider : ty) => {
+        #[clippy::msrv = "1.67"]
+        const _: () = <$provider>::MUST_USE_MAKE_PROVIDER_MACRO;
+        #[clippy::msrv = "1.67"]
+        impl icu_provider::DataProvider<icu::experimental::transliterate::provider::TransliteratorRulesV1Marker> for $provider {
+            fn load(&self, req: icu_provider::DataRequest) -> Result<icu_provider::DataResponse<icu::experimental::transliterate::provider::TransliteratorRulesV1Marker>, icu_provider::DataError> {
+                Err(icu_provider::DataErrorKind::MissingLocale.with_req(<icu::experimental::transliterate::provider::TransliteratorRulesV1Marker as icu_provider::KeyedDataMarker>::KEY, req))
+            }
+        }
+    };
+}
+/// Implement `IterableDataProvider<TransliteratorRulesV1Marker>` on the given struct using the data
+/// hardcoded in this file. This allows the struct to be used with
+/// `DatagenDriver` for this key.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __impliterable_transliterator_rules_v1 {
+    ($ provider : ty) => {
+        #[clippy::msrv = "1.67"]
+        impl icu_provider::datagen::IterableDataProvider<icu::experimental::transliterate::provider::TransliteratorRulesV1Marker> for $provider {
+            fn supported_locales(&self) -> Result<alloc::vec::Vec<icu_provider::DataLocale>, icu_provider::DataError> {
+                Ok(vec![])
+            }
+        }
+    };
+}


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/4890 (not yet)

@robertbastian I added `transliterate/rules@1` to `icu::experimental::provider::KEYS`. I expected `cargo make bakeddata experimental` to "just work", but it doesn't include the auxiliary keys. Why not?