### PR TITLE
Windows specific fixes for npm + js builds and testing

### DIFF
--- a/ffi/capi/bindings/js/diplomat-wasm.mjs
+++ b/ffi/capi/bindings/js/diplomat-wasm.mjs
@@ -26,7 +26,7 @@ const imports = {
   }
 }
 
-if (typeof fetch === 'undefined') { // Node
+if (typeof process !== 'undefined') { // Node
   const fs = await import("fs");
   const wasmFile = new Uint8Array(fs.readFileSync(cfg['wasm_path']));
   const loadedWasm = await WebAssembly.instantiate(wasmFile, imports);

--- a/tutorials/npm/webpack.config.js
+++ b/tutorials/npm/webpack.config.js
@@ -48,7 +48,7 @@ export default {
   // mode: "development",
   output: {
     filename: 'bundle.js',
-    path: new URL('dist', import.meta.url).pathname,
+    path: new URL('dist', import.meta.url).href.replace("file:///", ""),
   },
   devServer: {
     static: '.',


### PR DESCRIPTION
One commit is from https://github.com/ambiguousname/diplomat/commit/587865a596c80f1d5b525e88429f88e47cd5f89d (it also has an associated pull request in https://github.com/rust-diplomat/diplomat/pull/474)

In this repo specifically, I found an issue with `webpack.config.js`:
It's probably a \ vs / problem.

new URL('dist', import.meta.url).pathname doesn't work for Windows. After futzing around with different approaches, I found the simplest was just removing file:/// from the full href.

I'd be curious to know if this works on other systems, and I'm open to workshopping a cross-platform solution if not!