### PR TITLE
Add example for DecomposingNormalizer source cursor

### DIFF
--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -1865,6 +1865,10 @@ impl DecomposingNormalizer {
     /// Wraps a delegate iterator into a decomposing iterator
     /// adapter by using the data already held by this normalizer.
     ///
+    /// The [`Decomposition`] iterator will peek exactly one character
+    /// ahead of the character being decomposed, allowing the caller
+    /// to track the source character in the input string.
+    ///
     /// # Examples
     ///
     /// Use a cursor to keep track of indices in the source string:


### PR DESCRIPTION
`normalize_iter` gives us the ability to keep track of the source string indices while generating the output string. I wrote the example using a `RefCell` since the `DecomposingNormalizer` takes ownership over the source iterator. There may be a way to avoid `RefCell` by adding a function to the library.