### PR TITLE
Set boundary_property with complex character and EOT

### DIFF
--- a/components/segmenter/src/rule_segmenter.rs
+++ b/components/segmenter/src/rule_segmenter.rs
@@ -63,6 +63,7 @@ impl<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> Iterator for RuleBreakIterator<'
                 self.advance_iter();
                 if self.is_eof() {
                     self.result_cache.clear();
+                    self.boundary_property = self.data.complex_property;
                     return Some(self.len);
                 }
             }

--- a/components/segmenter/src/rule_segmenter.rs
+++ b/components/segmenter/src/rule_segmenter.rs
@@ -78,8 +78,12 @@ impl<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> Iterator for RuleBreakIterator<'
                 self.len = 1;
                 return Some(0);
             }
+            let Some(right_prop) = self.get_current_break_property() else {
+                // iterator already reaches to EOT. Reset boundary property for word-like.
+                self.boundary_property = 0;
+                return None;
+            };
             // SOT x anything
-            let right_prop = self.get_current_break_property()?;
             if matches!(
                 self.get_break_state_from_table(self.data.sot_property, right_prop),
                 BreakState::Break | BreakState::NoMatch

--- a/components/segmenter/tests/word_rule_status.rs
+++ b/components/segmenter/tests/word_rule_status.rs
@@ -87,6 +87,14 @@ fn rule_status_th() {
     assert_eq!(iter.next(), Some(21), "after 2nd word");
     assert_eq!(iter.word_type(), WordType::Letter, "letter");
     assert!(iter.is_word_like(), "Letter(Thai) is true");
+
+    assert_eq!(iter.next(), Some(33), "after 3rd word");
+    assert_eq!(iter.word_type(), WordType::Letter, "letter");
+    assert!(iter.is_word_like(), "Letter(Thai) is true");
+
+    assert_eq!(iter.next(), Some(42), "after 4th word and next is EOT");
+    assert_eq!(iter.word_type(), WordType::Letter, "letter");
+    assert!(iter.is_word_like(), "Letter(Thai) is true");
 }
 
 /* The rule status functions are no longer public to non word break iterators.

--- a/components/segmenter/tests/word_rule_status.rs
+++ b/components/segmenter/tests/word_rule_status.rs
@@ -33,6 +33,10 @@ fn rule_status() {
     assert_eq!(iter.next(), Some(15), "after number");
     assert_eq!(iter.word_type(), WordType::Number, "number");
     assert!(iter.is_word_like(), "Number is true");
+
+    assert_eq!(iter.next(), None, "EOT");
+    assert_eq!(iter.word_type(), WordType::None, "none");
+    assert!(!iter.is_word_like(), "None is false");
 }
 
 #[test]
@@ -51,6 +55,10 @@ fn rule_status_letter_eof() {
     assert_eq!(iter.next(), Some(4), "after full stop");
     assert_eq!(iter.word_type(), WordType::None, "none");
     assert!(!iter.is_word_like(), "None is false");
+
+    assert_eq!(iter.next(), None, "EOT");
+    assert_eq!(iter.word_type(), WordType::None, "none");
+    assert!(!iter.is_word_like(), "None is false");
 }
 
 #[test]
@@ -67,6 +75,10 @@ fn rule_status_numeric_eof() {
     assert!(iter.is_word_like(), "Number is true");
 
     assert_eq!(iter.next(), Some(3), "after full stop");
+    assert_eq!(iter.word_type(), WordType::None, "none");
+    assert!(!iter.is_word_like(), "None is false");
+
+    assert_eq!(iter.next(), None, "EOT");
     assert_eq!(iter.word_type(), WordType::None, "none");
     assert!(!iter.is_word_like(), "None is false");
 }
@@ -95,6 +107,10 @@ fn rule_status_th() {
     assert_eq!(iter.next(), Some(42), "after 4th word and next is EOT");
     assert_eq!(iter.word_type(), WordType::Letter, "letter");
     assert!(iter.is_word_like(), "Letter(Thai) is true");
+
+    assert_eq!(iter.next(), None, "EOT");
+    assert_eq!(iter.word_type(), WordType::None, "none");
+    assert!(!iter.is_word_like(), "None is false");
 }
 
 /* The rule status functions are no longer public to non word break iterators.


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/4446.

If EOT after SA, we should mark as Letter (SA).