### PR TITLE
Unifying `DataLocale` construction

### DIFF
--- a/components/calendar/src/week_of.rs
+++ b/components/calendar/src/week_of.rs
@@ -711,10 +711,10 @@ fn test_simple_week_of() {
 
 #[test]
 fn test_weekend() {
-    use icu_locid::langid;
+    use icu_locid::locale;
 
     assert_eq!(
-        WeekCalculator::try_new(&langid!("und").into())
+        WeekCalculator::try_new(&locale!("und").into())
             .unwrap()
             .weekend()
             .collect::<Vec<_>>(),
@@ -722,7 +722,7 @@ fn test_weekend() {
     );
 
     assert_eq!(
-        WeekCalculator::try_new(&langid!("und-FR").into())
+        WeekCalculator::try_new(&locale!("und-FR").into())
             .unwrap()
             .weekend()
             .collect::<Vec<_>>(),
@@ -730,7 +730,7 @@ fn test_weekend() {
     );
 
     assert_eq!(
-        WeekCalculator::try_new(&langid!("und-IQ").into())
+        WeekCalculator::try_new(&locale!("und-IQ").into())
             .unwrap()
             .weekend()
             .collect::<Vec<_>>(),
@@ -738,7 +738,7 @@ fn test_weekend() {
     );
 
     assert_eq!(
-        WeekCalculator::try_new(&langid!("und-IR").into())
+        WeekCalculator::try_new(&locale!("und-IR").into())
             .unwrap()
             .weekend()
             .collect::<Vec<_>>(),

--- a/components/collator/README.md
+++ b/components/collator/README.md
@@ -21,22 +21,22 @@ As its most basic purpose, `Collator` offers locale-aware ordering:
 ```rust
 use core::cmp::Ordering;
 use icu::collator::*;
-use icu::locid::{locale, Locale};
+use icu::locid::locale;
 
-let locale_es: Locale = locale!("es-u-co-trad");
+let locale_es = locale!("es-u-co-trad").into();
 let mut options = CollatorOptions::new();
 options.strength = Some(Strength::Primary);
 let collator_es: Collator =
-    Collator::try_new(&locale_es.into(), options).unwrap();
+    Collator::try_new(&locale_es, options).unwrap();
 
 // "pollo" > "polvo" in traditional Spanish
 assert_eq!(collator_es.compare("pollo", "polvo"), Ordering::Greater);
 
-let locale_en: Locale = locale!("en");
+let locale_en = locale!("en").into();
 let mut options = CollatorOptions::new();
 options.strength = Some(Strength::Primary);
 let collator_en: Collator =
-    Collator::try_new(&locale_en.into(), options).unwrap();
+    Collator::try_new(&locale_en, options).unwrap();
 
 // "pollo" < "polvo" according to English rules
 assert_eq!(collator_en.compare("pollo", "polvo"), Ordering::Less);

--- a/components/collator/src/lib.rs
+++ b/components/collator/src/lib.rs
@@ -41,22 +41,22 @@
 //! ```
 //! use core::cmp::Ordering;
 //! use icu::collator::*;
-//! use icu::locid::{locale, Locale};
+//! use icu::locid::locale;
 //!
-//! let locale_es: Locale = locale!("es-u-co-trad");
+//! let locale_es = locale!("es-u-co-trad").into();
 //! let mut options = CollatorOptions::new();
 //! options.strength = Some(Strength::Primary);
 //! let collator_es: Collator =
-//!     Collator::try_new(&locale_es.into(), options).unwrap();
+//!     Collator::try_new(&locale_es, options).unwrap();
 //!
 //! // "pollo" > "polvo" in traditional Spanish
 //! assert_eq!(collator_es.compare("pollo", "polvo"), Ordering::Greater);
 //!
-//! let locale_en: Locale = locale!("en");
+//! let locale_en = locale!("en").into();
 //! let mut options = CollatorOptions::new();
 //! options.strength = Some(Strength::Primary);
 //! let collator_en: Collator =
-//!     Collator::try_new(&locale_en.into(), options).unwrap();
+//!     Collator::try_new(&locale_en, options).unwrap();
 //!
 //! // "pollo" < "polvo" according to English rules
 //! assert_eq!(collator_en.compare("pollo", "polvo"), Ordering::Less);

--- a/components/collator/src/options.rs
+++ b/components/collator/src/options.rs
@@ -85,10 +85,9 @@ pub enum Strength {
     /// assert_eq!(collator.compare("e", "ｅ"), // Full-width e
     ///            core::cmp::Ordering::Less);
     ///
-    /// let locale = icu::locid::locale!("ja");
+    /// let locale = icu::locid::locale!("ja").into();
     /// let ja_collator =
-    ///   Collator::try_new(&locale.into(),
-    ///                     options).unwrap();
+    ///   Collator::try_new(&locale, options).unwrap();
     /// assert_eq!(ja_collator.compare("E", "e"),
     ///            core::cmp::Ordering::Greater);
     /// assert_eq!(ja_collator.compare("e", "é"),
@@ -116,10 +115,9 @@ pub enum Strength {
     /// let mut options = CollatorOptions::new();
     /// options.strength = Some(Strength::Quaternary);
     ///
-    /// let ja_locale = icu::locid::locale!("ja");
+    /// let ja_locale = icu::locid::locale!("ja").into();
     /// let ja_collator =
-    ///   Collator::try_new(&ja_locale.into(),
-    ///                     options).unwrap();
+    ///   Collator::try_new(&ja_locale, options).unwrap();
     /// assert_eq!(ja_collator.compare("あ", "ア"),
     ///            core::cmp::Ordering::Less);
     /// assert_eq!(ja_collator.compare("ア", "ｱ"),
@@ -153,10 +151,9 @@ pub enum Strength {
     /// let mut options = CollatorOptions::new();
     /// options.strength = Some(Strength::Identical);
     ///
-    /// let ja_locale = icu::locid::locale!("ja");
+    /// let ja_locale = icu::locid::locale!("ja").into();
     /// let ja_collator =
-    ///   Collator::try_new(&ja_locale.into(),
-    ///                     options).unwrap();
+    ///   Collator::try_new(&ja_locale, options).unwrap();
     /// assert_eq!(ja_collator.compare("ア", "ｱ"),
     ///            core::cmp::Ordering::Less);
     /// assert_eq!(ja_collator.compare("e", "ｅ"), // Full-width e

--- a/components/collator/tests/tests.rs
+++ b/components/collator/tests/tests.rs
@@ -7,7 +7,7 @@ use core::cmp::Ordering;
 use atoi::FromRadix16;
 use icu_collator::provider::*;
 use icu_collator::*;
-use icu_locid::{langid, Locale};
+use icu_locid::{locale, langid, Locale};
 use icu_provider::prelude::*;
 
 type StackString = arraystring::ArrayString<arraystring::typenum::U32>;
@@ -424,14 +424,14 @@ fn test_en() {
 fn test_en_bugs() {
     // Adapted from encoll.cpp in ICU4C
     let bugs = ["a", "A", "e", "E", "é", "è", "ê", "ë", "ea", "x"];
-    //        let locale: DataLocale = langid!("en").into();
-    let locale: Locale = Locale::default(); // English uses the root collation
+    // let locale = locale!("en").into();
+    let locale = Default::default(); // English uses the root collation
 
     let mut options = CollatorOptions::new();
     options.strength = Some(Strength::Tertiary);
 
     {
-        let collator = Collator::try_new(&locale.into(), options).unwrap();
+        let collator = Collator::try_new(&locale, options).unwrap();
         let mut outer = bugs.iter();
         while let Some(left) = outer.next() {
             let inner = outer.clone();
@@ -469,7 +469,7 @@ fn test_ja_tertiary() {
         Ordering::Less,
         Ordering::Less, // Prolonged sound mark sorts BEFORE equivalent vowel
     ];
-    let locale: DataLocale = langid!("ja").into();
+    let locale = locale!("ja").into();
 
     let mut options = CollatorOptions::new();
     options.strength = Some(Strength::Tertiary);
@@ -486,7 +486,7 @@ fn test_ja_base() {
     // Adapted from `CollationKanaTest::TestBase` in jacoll.cpp of ICU4C.
     let cases = ["カ", "カキ", "キ", "キキ"];
 
-    let locale: DataLocale = langid!("ja").into();
+    let locale = locale!("ja").into();
 
     let mut options = CollatorOptions::new();
     options.strength = Some(Strength::Primary);
@@ -506,7 +506,7 @@ fn test_ja_plain_dakuten_handakuten() {
     // Adapted from `CollationKanaTest::TestPlainDakutenHandakuten` in jacoll.cpp of ICU4C.
     let cases = ["ハカ", "バカ", "ハキ", "バキ"];
 
-    let locale: DataLocale = langid!("ja").into();
+    let locale = locale!("ja").into();
 
     let mut options = CollatorOptions::new();
     options.strength = Some(Strength::Secondary);
@@ -526,7 +526,7 @@ fn test_ja_small_large() {
     // Adapted from `CollationKanaTest::TestSmallLarge` in jacoll.cpp of ICU4C.
     let cases = ["ッハ", "ツハ", "ッバ", "ツバ"];
 
-    let locale: DataLocale = langid!("ja").into();
+    let locale = locale!("ja").into();
 
     let mut options = CollatorOptions::new();
     options.strength = Some(Strength::Tertiary);
@@ -547,7 +547,7 @@ fn test_ja_hiragana_katakana() {
     // Adapted from `CollationKanaTest::TestKatakanaHiragana` in jacoll.cpp of ICU4C.
     let cases = ["あッ", "アッ", "あツ", "アツ"];
 
-    let locale: DataLocale = langid!("ja").into();
+    let locale = locale!("ja").into();
 
     let mut options = CollatorOptions::new();
     options.strength = Some(Strength::Quaternary);
@@ -573,7 +573,7 @@ fn test_ja_hiragana_katakana_utf16() {
         &[0x30A2u16, 0x30C4u16],
     ];
 
-    let locale: DataLocale = langid!("ja").into();
+    let locale = locale!("ja").into();
 
     let mut options = CollatorOptions::new();
     options.strength = Some(Strength::Quaternary);
@@ -606,7 +606,7 @@ fn test_ja_chooon_kigoo() {
         "キイア",
     ];
 
-    let locale: DataLocale = langid!("ja").into();
+    let locale = locale!("ja").into();
 
     let mut options = CollatorOptions::new();
     options.strength = Some(Strength::Quaternary);
@@ -631,7 +631,7 @@ fn test_region_fallback() {
     // There's no explicit fi-FI data.
     let locale: Locale = "fi-u-co-standard".parse().unwrap();
 
-    // let locale: DataLocale = langid!("fi-FI").into();
+    // let locale = locale!("fi-FI").into();
 
     let collator = Collator::try_new(&locale.into(), CollatorOptions::new()).unwrap();
     assert_eq!(collator.compare("ä", "z"), Ordering::Greater);
@@ -639,7 +639,7 @@ fn test_region_fallback() {
 
 #[test]
 fn test_reordering() {
-    let locale: DataLocale = langid!("bn").into();
+    let locale = locale!("bn").into();
 
     // অ is Bangla
     // ऄ is Devanagari
@@ -663,8 +663,8 @@ fn test_reordering() {
 #[test]
 fn test_vi() {
     {
-        let locale = langid!("vi");
-        let collator = Collator::try_new(&locale.into(), CollatorOptions::new()).unwrap();
+        let locale = locale!("vi").into();
+        let collator = Collator::try_new(&locale, CollatorOptions::new()).unwrap();
 
         assert_eq!(collator.compare("a", "b"), Ordering::Less);
         assert_eq!(collator.compare("a", "á"), Ordering::Less);
@@ -712,7 +712,7 @@ fn test_zh() {
         assert_eq!(collator.compare("不", "把"), Ordering::Less);
     }
     {
-        let locale: DataLocale = langid!("zh").into(); // Defaults to -u-co-pinyin
+        let locale = locale!("zh").into(); // Defaults to -u-co-pinyin
         let collator = Collator::try_new(&locale, CollatorOptions::new()).unwrap();
         assert_eq!(collator.compare("艾", "a"), Ordering::Less);
         assert_eq!(collator.compare("佰", "a"), Ordering::Less);
@@ -816,7 +816,7 @@ fn test_es_tertiary() {
         Ordering::Less,
         Ordering::Less,
     ];
-    let locale: DataLocale = langid!("es").into();
+    let locale = locale!("es").into();
 
     let mut options = CollatorOptions::new();
     options.strength = Some(Strength::Tertiary);
@@ -838,7 +838,7 @@ fn test_es_primary() {
         Ordering::Less,
         Ordering::Equal,
     ];
-    let locale: DataLocale = langid!("es").into();
+    let locale = locale!("es").into();
 
     let mut options = CollatorOptions::new();
     options.strength = Some(Strength::Primary);
@@ -867,7 +867,7 @@ fn test_th_dictionary() {
     let dict = include_str!("data/riwords.txt")
         .strip_prefix('\u{FEFF}')
         .unwrap();
-    let locale: DataLocale = langid!("th").into();
+    let locale = locale!("th").into();
 
     let mut options = CollatorOptions::new();
     options.strength = Some(Strength::Quaternary);
@@ -952,7 +952,7 @@ fn test_th_corner_cases() {
         Ordering::Less,
         Ordering::Less,
     ];
-    let locale: DataLocale = langid!("th").into();
+    let locale = locale!("th").into();
     {
         // TODO(#2013): Check why the commented-out cases fail
         let collator = Collator::try_new(&locale, CollatorOptions::new()).unwrap();
@@ -990,7 +990,7 @@ fn test_th_reordering() {
         Ordering::Equal,
         // Ordering::Equal,
     ];
-    let locale: DataLocale = langid!("th").into();
+    let locale = locale!("th").into();
 
     let mut options = CollatorOptions::new();
     options.strength = Some(Strength::Secondary);
@@ -1016,7 +1016,7 @@ fn test_tr_tertiary() {
         Ordering::Less,
         Ordering::Greater,
     ];
-    let locale: DataLocale = langid!("tr").into();
+    let locale = locale!("tr").into();
 
     let mut options = CollatorOptions::new();
     options.strength = Some(Strength::Tertiary);
@@ -1033,7 +1033,7 @@ fn test_tr_primary() {
     let left = ["üoid", "voıd", "idea"];
     let right = ["void", "void", "Idea"];
     let expectations = [Ordering::Less, Ordering::Less, Ordering::Greater];
-    let locale: DataLocale = langid!("tr").into();
+    let locale = locale!("tr").into();
 
     let mut options = CollatorOptions::new();
     options.strength = Some(Strength::Tertiary);
@@ -1068,7 +1068,7 @@ fn test_lt_tertiary() {
         Ordering::Equal,
         Ordering::Greater,
     ];
-    let locale: DataLocale = langid!("lt").into();
+    let locale = locale!("lt").into();
 
     let mut options = CollatorOptions::new();
     options.strength = Some(Strength::Tertiary);
@@ -1085,7 +1085,7 @@ fn test_lt_primary() {
     let left = ["ž"];
     let right = ["z"];
     let expectations = [Ordering::Greater];
-    let locale: DataLocale = langid!("lt").into();
+    let locale = locale!("lt").into();
 
     let mut options = CollatorOptions::new();
     options.strength = Some(Strength::Primary);
@@ -1121,7 +1121,7 @@ fn test_fi() {
         Ordering::Greater,
         Ordering::Equal,
     ];
-    let locale: DataLocale = langid!("fi").into();
+    let locale = locale!("fi").into();
     let mut options = CollatorOptions::new();
 
     options.strength = Some(Strength::Tertiary);
@@ -1164,7 +1164,7 @@ fn test_sv() {
         Ordering::Greater,
         Ordering::Equal,
     ];
-    let locale: DataLocale = langid!("sv").into();
+    let locale = locale!("sv").into();
     let mut options = CollatorOptions::new();
 
     options.strength = Some(Strength::Tertiary);
@@ -1182,8 +1182,8 @@ fn test_nb_nn_no() {
     let expected = &["y", "ü", "ø", "å"];
 
     // Test "no" macro language WITH fallback (should equal expected)
-    let input_locale = langid!("no").into();
-    let collator = Collator::try_new(&input_locale, CollatorOptions::new()).unwrap();
+    let locale = locale!("no").into();
+    let collator = Collator::try_new(&locale, CollatorOptions::new()).unwrap();
     let mut strs = input.clone();
     strs.sort_by(|a, b| collator.compare(a, b));
     assert_eq!(strs, expected);
@@ -1191,7 +1191,7 @@ fn test_nb_nn_no() {
         DataProvider::<CollationDataV1Marker>::load(
             &icu_collator::provider::Baked,
             DataRequest {
-                locale: &input_locale,
+                locale: &locale,
                 metadata: Default::default()
             }
         )
@@ -1202,8 +1202,8 @@ fn test_nb_nn_no() {
     );
 
     // Now "nb" should work
-    let input_locale = langid!("nb").into();
-    let collator = Collator::try_new(&input_locale, CollatorOptions::new()).unwrap();
+    let locale = locale!("nb").into();
+    let collator = Collator::try_new(&locale, CollatorOptions::new()).unwrap();
     let mut strs = input.clone();
     strs.sort_by(|a, b| collator.compare(a, b));
     assert_eq!(strs, expected);
@@ -1211,7 +1211,7 @@ fn test_nb_nn_no() {
         DataProvider::<CollationDataV1Marker>::load(
             &icu_collator::provider::Baked,
             DataRequest {
-                locale: &input_locale,
+                locale: &locale,
                 metadata: Default::default()
             }
         )
@@ -1222,8 +1222,8 @@ fn test_nb_nn_no() {
     );
 
     // And "nn" should work, too
-    let input_locale = langid!("nn").into();
-    let collator = Collator::try_new(&input_locale, CollatorOptions::new()).unwrap();
+    let locale = locale!("nn").into();
+    let collator = Collator::try_new(&locale, CollatorOptions::new()).unwrap();
     let mut strs = input.clone();
     strs.sort_by(|a, b| collator.compare(a, b));
     assert_eq!(strs, expected);
@@ -1231,7 +1231,7 @@ fn test_nb_nn_no() {
         DataProvider::<CollationDataV1Marker>::load(
             &icu_collator::provider::Baked,
             DataRequest {
-                locale: &input_locale,
+                locale: &locale,
                 metadata: Default::default()
             }
         )
@@ -1547,7 +1547,7 @@ fn test_default_resolved_options() {
 
 #[test]
 fn test_data_resolved_options_th() {
-    let locale: DataLocale = langid!("th").into();
+    let locale = locale!("th").into();
     let collator = Collator::try_new(&locale, CollatorOptions::new()).unwrap();
     let resolved = collator.resolved_options();
     assert_eq!(resolved.strength, Strength::Tertiary);
@@ -1565,7 +1565,7 @@ fn test_data_resolved_options_th() {
 
 #[test]
 fn test_data_resolved_options_da() {
-    let locale: DataLocale = langid!("da").into();
+    let locale = locale!("da").into();
     let collator = Collator::try_new(&locale, CollatorOptions::new()).unwrap();
     let resolved = collator.resolved_options();
     assert_eq!(resolved.strength, Strength::Tertiary);
@@ -1582,7 +1582,7 @@ fn test_data_resolved_options_da() {
 
 #[test]
 fn test_data_resolved_options_fr_ca() {
-    let locale: DataLocale = langid!("fr-CA").into();
+    let locale = locale!("fr-CA").into();
     let collator = Collator::try_new(&locale, CollatorOptions::new()).unwrap();
     let resolved = collator.resolved_options();
     assert_eq!(resolved.strength, Strength::Tertiary);
@@ -1602,7 +1602,7 @@ fn test_data_resolved_options_fr_ca() {
 
 #[test]
 fn test_manual_and_data_resolved_options_fr_ca() {
-    let locale: DataLocale = langid!("fr-CA").into();
+    let locale = locale!("fr-CA").into();
 
     let mut options = CollatorOptions::new();
     options.case_first = Some(CaseFirst::UpperFirst);
@@ -1626,7 +1626,7 @@ fn test_manual_and_data_resolved_options_fr_ca() {
 
 #[test]
 fn test_manual_resolved_options_da() {
-    let locale: DataLocale = langid!("da").into();
+    let locale = locale!("da").into();
 
     let mut options = CollatorOptions::new();
     options.case_first = Some(CaseFirst::Off);

--- a/components/collator/tests/tests.rs
+++ b/components/collator/tests/tests.rs
@@ -7,7 +7,7 @@ use core::cmp::Ordering;
 use atoi::FromRadix16;
 use icu_collator::provider::*;
 use icu_collator::*;
-use icu_locid::{locale, langid, Locale};
+use icu_locid::{langid, locale, Locale};
 use icu_provider::prelude::*;
 
 type StackString = arraystring::ArrayString<arraystring::typenum::U32>;

--- a/components/datetime/src/any/date.rs
+++ b/components/datetime/src/any/date.rs
@@ -86,9 +86,9 @@ impl DateFormatter {
     /// use writeable::assert_writeable_eq;
     ///
     /// let length = length::Date::Medium;
-    /// let locale = locale!("en-u-ca-gregory");
+    /// let locale = locale!("en-u-ca-gregory").into();
     ///
-    /// let df = DateFormatter::try_new_with_length(&locale.into(), length)
+    /// let df = DateFormatter::try_new_with_length(&locale, length)
     ///     .expect("Failed to create TypedDateFormatter instance.");
     ///
     /// let datetime =

--- a/components/datetime/src/any/datetime.rs
+++ b/components/datetime/src/any/datetime.rs
@@ -140,9 +140,9 @@ impl DateTimeFormatter {
     ///     length::Date::Medium,
     ///     length::Time::Short,
     /// );
-    /// let locale = locale!("en-u-ca-gregory");
+    /// let locale = locale!("en-u-ca-gregory").into();
     ///
-    /// let dtf = DateTimeFormatter::try_new(&locale.into(), options.into())
+    /// let dtf = DateTimeFormatter::try_new(&locale, options.into())
     ///     .expect("Failed to create TypedDateTimeFormatter instance.");
     ///
     /// let datetime = DateTime::try_new_iso_datetime(2020, 9, 1, 12, 34, 28)
@@ -460,11 +460,11 @@ impl DateTimeFormatter {
     /// use icu::locid::locale;
     /// use writeable::assert_writeable_eq;
     ///
-    /// let length = length::Date::Medium;
-    /// let locale = locale!("en-u-ca-gregory");
-    ///
-    /// let df = DateFormatter::try_new_with_length(&locale.into(), length)
-    ///     .expect("Failed to create TypedDateFormatter instance.");
+    /// let df = DateFormatter::try_new_with_length(
+    ///     &locale!("en-u-ca-gregory").into(),
+    ///     length::Date::Medium
+    /// )
+    /// .expect("Failed to create TypedDateFormatter instance.");
     ///
     /// let tf = TimeFormatter::try_new_with_length(
     ///     &locale!("en").into(),
@@ -575,12 +575,13 @@ where {
 mod tests {
     use icu::calendar::{AnyCalendar, DateTime};
     use icu::datetime::{options::length, DateTimeFormatter};
-    use icu::locid::{locale, Locale};
+    use icu::locid::locale;
+    use icu_provider::DataLocale;
 
-    fn test_format(datetime: &DateTime<AnyCalendar>, locale: Locale, expected: &str) {
+    fn test_format(datetime: &DateTime<AnyCalendar>, locale: DataLocale, expected: &str) {
         let options = length::Bag::from_date_time_style(length::Date::Long, length::Time::Short);
 
-        let dtf = DateTimeFormatter::try_new(&locale.into(), options.into()).unwrap();
+        let dtf = DateTimeFormatter::try_new(&locale, options.into()).unwrap();
         writeable::assert_writeable_eq!(
             dtf.format(datetime).expect("Calendars should match"),
             expected
@@ -593,23 +594,23 @@ mod tests {
         let datetime = DateTime::try_new_iso_datetime(2022, 4, 5, 12, 33, 44).unwrap();
         let datetime = datetime.to_any();
         // fr with unspecified and nonsense calendars falls back to gregorian
-        test_format(&datetime, locale!("fr"), "5 avril 2022, 12:33");
+        test_format(&datetime, locale!("fr").into(), "5 avril 2022, 12:33");
         test_format(
             &datetime,
-            locale!("fr-u-ca-blahblah"),
+            locale!("fr-u-ca-blahblah").into(),
             "5 avril 2022, 12:33",
         );
         // thai falls back to buddhist
         test_format(
             &datetime,
-            locale!("th-u-ca-buddhist"),
+            locale!("th-u-ca-buddhist").into(),
             "5 เมษายน 2565 12:33",
         );
-        test_format(&datetime, locale!("th"), "5 เมษายน 2565 12:33");
+        test_format(&datetime, locale!("th").into(), "5 เมษายน 2565 12:33");
         // except when overridden
         test_format(
             &datetime,
-            locale!("th-u-ca-gregory"),
+            locale!("th-u-ca-gregory").into(),
             "5 เมษายน ค.ศ. 2022 12:33",
         );
     }

--- a/components/datetime/src/any/zoned_datetime.rs
+++ b/components/datetime/src/any/zoned_datetime.rs
@@ -338,10 +338,10 @@ impl ZonedDateTimeFormatter {
     ///     length::Date::Medium,
     ///     length::Time::Long,
     /// );
-    /// let locale = locale!("en-u-ca-gregory");
+    /// let locale = locale!("en-u-ca-gregory").into();
     ///
     /// let zdtf = ZonedDateTimeFormatter::try_new(
-    ///     &locale.into(),
+    ///     &locale,
     ///     options.into(),
     ///     TimeZoneFormatterOptions::default(),
     /// )

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -822,7 +822,6 @@ mod tests {
     use super::*;
     use crate::pattern::runtime;
     use icu_decimal::options::{FixedDecimalFormatterOptions, GroupingStrategy};
-    use icu_locid::Locale;
     use tinystr::tinystr;
 
     #[test]
@@ -832,8 +831,8 @@ mod tests {
         use icu_calendar::japanese::JapaneseExtended;
         use icu_calendar::Date;
 
-        let locale: Locale = "en-u-ca-japanese".parse().unwrap();
-        let dtf = NeoDateFormatter::try_new_with_length(&locale.into(), length::Date::Medium)
+        let locale = "en-u-ca-japanese".parse().unwrap();
+        let dtf = NeoDateFormatter::try_new_with_length(&locale, length::Date::Medium)
             .expect("DateTimeFormat construction succeeds");
 
         let date = Date::try_new_gregorian_date(1800, 9, 1).expect("Failed to construct Date.");
@@ -859,7 +858,7 @@ mod tests {
         use icu_calendar::DateTime;
         use icu_provider::prelude::*;
 
-        let locale = "en-u-ca-gregory".parse::<Locale>().unwrap().into();
+        let locale = "en-u-ca-gregory".parse().unwrap();
         let req = DataRequest {
             locale: &locale,
             metadata: Default::default(),

--- a/components/datetime/src/provider/neo/adapter.rs
+++ b/components/datetime/src/provider/neo/adapter.rs
@@ -469,13 +469,13 @@ impl_data_provider_adapter!(
 #[cfg(feature = "compiled_data")]
 mod tests {
     use super::*;
-    use icu_locid::locale;
+    use icu_locid::langid;
 
     #[test]
     fn test_adapter_months_numeric() {
         let symbols: DataPayload<GregorianDateSymbolsV1Marker> = crate::provider::Baked
             .load(DataRequest {
-                locale: &locale!("en").into(),
+                locale: &langid!("en").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -500,7 +500,7 @@ mod tests {
     fn test_adapter_months_map() {
         let symbols: DataPayload<HebrewDateSymbolsV1Marker> = crate::provider::Baked
             .load(DataRequest {
-                locale: &locale!("en").into(),
+                locale: &langid!("en").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -525,7 +525,7 @@ mod tests {
     fn test_adapter_weekdays_abbreviated() {
         let symbols: DataPayload<HebrewDateSymbolsV1Marker> = crate::provider::Baked
             .load(DataRequest {
-                locale: &locale!("en").into(),
+                locale: &langid!("en").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -550,7 +550,7 @@ mod tests {
     fn test_adapter_weekdays_short() {
         let symbols: DataPayload<HebrewDateSymbolsV1Marker> = crate::provider::Baked
             .load(DataRequest {
-                locale: &locale!("en").into(),
+                locale: &langid!("en").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -575,7 +575,7 @@ mod tests {
     fn test_adapter_eras() {
         let symbols: DataPayload<GregorianDateSymbolsV1Marker> = crate::provider::Baked
             .load(DataRequest {
-                locale: &locale!("en").into(),
+                locale: &langid!("en").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -600,7 +600,7 @@ mod tests {
     fn test_adapter_dayperiods() {
         let symbols: DataPayload<TimeSymbolsV1Marker> = crate::provider::Baked
             .load(DataRequest {
-                locale: &locale!("en").into(),
+                locale: &langid!("en").into(),
                 metadata: Default::default(),
             })
             .unwrap()

--- a/components/datetime/src/skeleton/mod.rs
+++ b/components/datetime/src/skeleton/mod.rs
@@ -18,7 +18,6 @@ pub use helpers::*;
 mod test {
     use super::reference::Skeleton;
     use super::*;
-    use icu_locid::Locale;
     use icu_provider::prelude::*;
 
     use crate::{
@@ -38,7 +37,7 @@ mod test {
         DataPayload<GregorianDateLengthsV1Marker>,
         DataPayload<DateSkeletonPatternsV1Marker>,
     ) {
-        let locale = "en-u-ca-gregory".parse::<Locale>().unwrap().into();
+        let locale = "en-u-ca-gregory".parse().unwrap();
         let req = DataRequest {
             locale: &locale,
             metadata: Default::default(),

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -39,7 +39,7 @@ use icu_datetime::{
 use icu_decimal::provider::DecimalSymbolsV1Marker;
 use icu_locid::{
     extensions::unicode::{key, value},
-    langid, locale, LanguageIdentifier, Locale,
+    locale, LanguageIdentifier, Locale,
 };
 use icu_provider::prelude::*;
 use icu_provider_adapters::any_payload::AnyPayloadProvider;
@@ -563,7 +563,7 @@ fn test_time_zone_format_gmt_offset_not_set_debug_assert_panic() {
         metazone_id: Some(MetazoneId(tinystr!(4, "ampa"))),
         zone_variant: Some(ZoneVariant::daylight()),
     };
-    let tzf = TimeZoneFormatter::try_new(&langid!("en").into(), Default::default()).unwrap();
+    let tzf = TimeZoneFormatter::try_new(&locale!("en").into(), Default::default()).unwrap();
     tzf.format_to_string(&time_zone);
 }
 
@@ -576,7 +576,7 @@ fn test_time_zone_format_gmt_offset_not_set_no_debug_assert() {
         metazone_id: Some(MetazoneId(tinystr!(4, "ampa"))),
         zone_variant: Some(ZoneVariant::daylight()),
     };
-    let tzf = TimeZoneFormatter::try_new(&langid!("en").into(), Default::default()).unwrap();
+    let tzf = TimeZoneFormatter::try_new(&locale!("en").into(), Default::default()).unwrap();
     assert_writeable_eq!(tzf.format(&time_zone), "GMT+?");
 }
 

--- a/components/datetime/tests/simple_test.rs
+++ b/components/datetime/tests/simple_test.rs
@@ -6,7 +6,7 @@ use icu_calendar::DateTime;
 use icu_datetime::neo::TypedNeoDateTimeFormatter;
 use icu_datetime::options::length;
 use icu_datetime::{DateTimeFormatterOptions, TypedDateTimeFormatter};
-use icu_locid::langid;
+use icu_locid::locale;
 use writeable::{assert_try_writeable_eq, assert_writeable_eq};
 
 const EXPECTED_DATETIME: &[&str] = &[
@@ -74,9 +74,14 @@ fn neo_datetime_lengths() {
         length::Date::Short,
     ] {
         for time_length in [length::Time::Medium, length::Time::Short] {
-            for langid in [langid!("en"), langid!("fr"), langid!("zh"), langid!("hi")] {
+            for locale in [
+                locale!("en").into(),
+                locale!("fr").into(),
+                locale!("zh").into(),
+                locale!("hi").into(),
+            ] {
                 let formatter = TypedNeoDateTimeFormatter::try_new_with_lengths(
-                    &(&langid).into(),
+                    &locale,
                     date_length,
                     time_length,
                 )
@@ -87,7 +92,7 @@ fn neo_datetime_lengths() {
                     formatted,
                     *expected,
                     Ok(()),
-                    "{date_length:?} {time_length:?} {langid:?}"
+                    "{date_length:?} {time_length:?} {locale:?}"
                 );
             }
         }
@@ -104,13 +109,17 @@ fn neo_date_lengths() {
         length::Date::Medium,
         length::Date::Short,
     ] {
-        for langid in [langid!("en"), langid!("fr"), langid!("zh"), langid!("hi")] {
+        for locale in [
+            locale!("en").into(),
+            locale!("fr").into(),
+            locale!("zh").into(),
+            locale!("hi").into(),
+        ] {
             let formatter =
-                TypedNeoDateTimeFormatter::try_new_with_date_length(&(&langid).into(), date_length)
-                    .unwrap();
+                TypedNeoDateTimeFormatter::try_new_with_date_length(&locale, date_length).unwrap();
             let formatted = formatter.format(&datetime);
             let expected = expected_iter.next().unwrap();
-            assert_try_writeable_eq!(formatted, *expected, Ok(()), "{date_length:?} {langid:?}");
+            assert_try_writeable_eq!(formatted, *expected, Ok(()), "{date_length:?} {locale:?}");
         }
     }
 }
@@ -126,9 +135,14 @@ fn old_datetime_lengths() {
         length::Date::Short,
     ] {
         for time_length in [length::Time::Medium, length::Time::Short] {
-            for langid in [langid!("en"), langid!("fr"), langid!("zh"), langid!("hi")] {
+            for locale in [
+                locale!("en").into(),
+                locale!("fr").into(),
+                locale!("zh").into(),
+                locale!("hi").into(),
+            ] {
                 let formatter = TypedDateTimeFormatter::try_new(
-                    &(&langid).into(),
+                    &locale,
                     DateTimeFormatterOptions::Length(length::Bag::from_date_time_style(
                         date_length,
                         time_length,
@@ -140,7 +154,7 @@ fn old_datetime_lengths() {
                 assert_writeable_eq!(
                     formatted,
                     *expected,
-                    "{date_length:?} {time_length:?} {langid:?}"
+                    "{date_length:?} {time_length:?} {locale:?}"
                 );
             }
         }
@@ -157,15 +171,20 @@ fn old_date_lengths() {
         length::Date::Medium,
         length::Date::Short,
     ] {
-        for langid in [langid!("en"), langid!("fr"), langid!("zh"), langid!("hi")] {
+        for locale in [
+            locale!("en").into(),
+            locale!("fr").into(),
+            locale!("zh").into(),
+            locale!("hi").into(),
+        ] {
             let formatter = TypedDateTimeFormatter::try_new(
-                &(&langid).into(),
+                &locale,
                 DateTimeFormatterOptions::Length(length::Bag::from_date_style(date_length)),
             )
             .unwrap();
             let formatted = formatter.format(&datetime);
             let expected = expected_iter.next().unwrap();
-            assert_writeable_eq!(formatted, *expected, "{date_length:?} {langid:?}");
+            assert_writeable_eq!(formatted, *expected, "{date_length:?} {locale:?}");
         }
     }
 }

--- a/components/experimental/src/compactdecimal/compactdecimal.rs
+++ b/components/experimental/src/compactdecimal/compactdecimal.rs
@@ -559,14 +559,14 @@ impl CompactDecimalFormatter {
     /// #    &locale!("fr").into(),
     /// #    Default::default(),
     /// # ).unwrap();
-    /// # let [long_french, long_bangla] = [locale!("fr"), locale!("bn")]
-    /// #     .map(|locale| {
-    /// #         CompactDecimalFormatter::try_new_long(
-    /// #             &locale.into(),
-    /// #             Default::default(),
-    /// #         )
-    /// #         .unwrap()
-    /// #     });
+    /// # let long_french = CompactDecimalFormatter::try_new_long(
+    /// #    &locale!("fr").into(),
+    /// #    Default::default()
+    /// # ).unwrap();
+    /// # let long_bangla = CompactDecimalFormatter::try_new_long(
+    /// #    &locale!("bn").into(),
+    /// #    Default::default()
+    /// # ).unwrap();
     /// #
     /// let about_a_million = CompactDecimal::from_str("1.20c6").unwrap();
     /// let three_million = CompactDecimal::from_str("+3c6").unwrap();
@@ -657,9 +657,9 @@ impl CompactDecimalFormatter {
     /// use icu::locid::locale;
     ///
     /// let [long_french, long_japanese, long_bangla] =
-    ///     [locale!("fr"), locale!("ja"), locale!("bn")].map(|locale| {
+    ///     [locale!("fr").into(), locale!("ja").into(), locale!("bn").into()].map(|locale| {
     ///         CompactDecimalFormatter::try_new_long(
-    ///             &locale.into(),
+    ///             &locale,
     ///             Default::default(),
     ///         )
     ///         .unwrap()

--- a/components/experimental/src/displaynames/displaynames.rs
+++ b/components/experimental/src/displaynames/displaynames.rs
@@ -23,9 +23,9 @@ use zerovec::ule::UnvalidatedStr;
 /// use icu::experimental::displaynames::{DisplayNamesOptions, RegionDisplayNames};
 /// use icu::locid::{locale, subtags::region};
 ///
-/// let locale = locale!("en-001");
+/// let locale = locale!("en-001").into();
 /// let options: DisplayNamesOptions = Default::default();
-/// let display_name = RegionDisplayNames::try_new(&locale.into(), options)
+/// let display_name = RegionDisplayNames::try_new(&locale, options)
 ///     .expect("Data should load successfully");
 ///
 /// assert_eq!(display_name.of(region!("AE")), Some("United Arab Emirates"));
@@ -96,9 +96,9 @@ impl RegionDisplayNames {
 /// use icu::experimental::displaynames::{DisplayNamesOptions, ScriptDisplayNames};
 /// use icu::locid::{locale, subtags::script};
 ///
-/// let locale = locale!("en-001");
+/// let locale = locale!("en-001").into();
 /// let options: DisplayNamesOptions = Default::default();
-/// let display_name = ScriptDisplayNames::try_new(&locale.into(), options)
+/// let display_name = ScriptDisplayNames::try_new(&locale, options)
 ///     .expect("Data should load successfully");
 ///
 /// assert_eq!(display_name.of(script!("Maya")), Some("Mayan hieroglyphs"));
@@ -169,9 +169,9 @@ impl ScriptDisplayNames {
 /// use icu::experimental::displaynames::{DisplayNamesOptions, VariantDisplayNames};
 /// use icu::locid::{locale, subtags::variant};
 ///
-/// let locale = locale!("en-001");
+/// let locale = locale!("en-001").into();
 /// let options: DisplayNamesOptions = Default::default();
-/// let display_name = VariantDisplayNames::try_new(&locale.into(), options)
+/// let display_name = VariantDisplayNames::try_new(&locale, options)
 ///     .expect("Data should load successfully");
 ///
 /// assert_eq!(display_name.of(variant!("POSIX")), Some("Computer"));
@@ -237,9 +237,9 @@ impl VariantDisplayNames {
 /// use icu::experimental::displaynames::{DisplayNamesOptions, LanguageDisplayNames};
 /// use icu::locid::{locale, subtags::language};
 ///
-/// let locale = locale!("en-001");
+/// let locale = locale!("en-001").into();
 /// let options: DisplayNamesOptions = Default::default();
-/// let display_name = LanguageDisplayNames::try_new(&locale.into(), options)
+/// let display_name = LanguageDisplayNames::try_new(&locale, options)
 ///     .expect("Data should load successfully");
 ///
 /// assert_eq!(display_name.of(language!("de")), Some("German"));
@@ -316,10 +316,10 @@ impl LanguageDisplayNames {
 /// use icu::experimental::displaynames::{DisplayNamesOptions, LocaleDisplayNamesFormatter};
 /// use icu::locid::locale;
 ///
-/// let locale = locale!("en-001");
+/// let locale = locale!("en-001").into();
 /// let options: DisplayNamesOptions = Default::default();
 /// let display_name =
-///     LocaleDisplayNamesFormatter::try_new(&locale.into(), options)
+///     LocaleDisplayNamesFormatter::try_new(&locale, options)
 ///         .expect("Data should load successfully");
 ///
 /// assert_eq!(display_name.of(&locale!("en-GB")), "British English");

--- a/components/icu/examples/tui.rs
+++ b/components/icu/examples/tui.rs
@@ -10,7 +10,7 @@
 use icu::calendar::{DateTime, Gregorian};
 use icu::datetime::time_zone::TimeZoneFormatterOptions;
 use icu::datetime::{DateTimeFormatterOptions, TypedZonedDateTimeFormatter};
-use icu::locid::{locale, Locale};
+use icu::locid::locale;
 use icu::plurals::{PluralCategory, PluralRules};
 use icu::timezone::CustomTimeZone;
 use icu_collections::codepointinvlist::CodePointInversionListBuilder;
@@ -26,10 +26,10 @@ fn print<T: AsRef<str>>(_input: T) {
 fn main(_argc: isize, _argv: *const *const u8) -> isize {
     let args: Vec<String> = env::args().collect();
 
-    let locale: Locale = args
+    let locale = args
         .get(1)
         .map(|s| s.parse().expect("Failed to parse locale"))
-        .unwrap_or_else(|| locale!("en"));
+        .unwrap_or_else(|| locale!("en").into());
 
     let user_name = args.as_slice().get(2).map(String::as_str).unwrap_or("John");
 
@@ -47,7 +47,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
 
     {
         let dtf = TypedZonedDateTimeFormatter::<Gregorian>::try_new(
-            &locale.into(),
+            &locale,
             DateTimeFormatterOptions::default(),
             TimeZoneFormatterOptions::default(),
         )

--- a/components/locid_transform/src/fallback/algorithms.rs
+++ b/components/locid_transform/src/fallback/algorithms.rs
@@ -215,8 +215,6 @@ impl<'a> LocaleFallbackIteratorInner<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icu_locid::Locale;
-    use std::str::FromStr;
     use writeable::Writeable;
 
     /// Unicode extension keywords take part in fallback, but [auxiliary keys] are not modified.
@@ -486,7 +484,7 @@ mod tests {
                 };
                 let mut it = fallbacker
                     .for_config(config)
-                    .fallback_for(Locale::from_str(cas.input).unwrap().into());
+                    .fallback_for(cas.input.parse().unwrap());
                 for &expected in expected_chain {
                     assert_eq!(
                         expected,

--- a/components/plurals/tests/plurals.rs
+++ b/components/plurals/tests/plurals.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_locid::{locale, langid};
+use icu_locid::{langid, locale};
 use icu_plurals::{provider::CardinalV1Marker, PluralCategory, PluralRuleType, PluralRules};
 use icu_provider::prelude::*;
 

--- a/components/plurals/tests/plurals.rs
+++ b/components/plurals/tests/plurals.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_locid::locale;
+use icu_locid::{locale, langid};
 use icu_plurals::{provider::CardinalV1Marker, PluralCategory, PluralRuleType, PluralRules};
 use icu_provider::prelude::*;
 
@@ -21,7 +21,7 @@ fn test_static_load_works() {
     DataProvider::<CardinalV1Marker>::load(
         &icu_plurals::provider::Baked,
         DataRequest {
-            locale: &locale!("en").into(),
+            locale: &langid!("en").into(),
             metadata: Default::default(),
         },
     )

--- a/components/segmenter/src/complex/dictionary.rs
+++ b/components/segmenter/src/complex/dictionary.rs
@@ -197,7 +197,7 @@ mod tests {
     fn cj_dictionary_test() {
         let dict_payload: DataPayload<DictionaryForWordOnlyAutoV1Marker> = crate::provider::Baked
             .load(DataRequest {
-                locale: &icu_locid::locale!("ja").into(),
+                locale: &icu_locid::langid!("ja").into(),
                 metadata: Default::default(),
             })
             .unwrap()

--- a/components/segmenter/src/complex/lstm/mod.rs
+++ b/components/segmenter/src/complex/lstm/mod.rs
@@ -320,7 +320,7 @@ fn compute_hc<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icu_locid::locale;
+    use icu_locid::langid;
     use icu_provider::prelude::*;
     use serde::Deserialize;
 
@@ -349,7 +349,7 @@ mod tests {
     fn segment_file_by_lstm() {
         let lstm: DataPayload<LstmForWordLineAutoV1Marker> = crate::provider::Baked
             .load(DataRequest {
-                locale: &locale!("th").into(),
+                locale: &langid!("th").into(),
                 metadata: Default::default(),
             })
             .unwrap()

--- a/components/segmenter/src/complex/mod.rs
+++ b/components/segmenter/src/complex/mod.rs
@@ -4,7 +4,7 @@
 
 use crate::provider::*;
 use alloc::vec::Vec;
-use icu_locid::{locale, Locale};
+use icu_locid::{langid, LanguageIdentifier};
 use icu_provider::prelude::*;
 
 mod dictionary;
@@ -78,19 +78,19 @@ impl ComplexPayloads {
             grapheme: DataPayload::from_static_ref(
                 crate::provider::Baked::SINGLETON_SEGMENTER_GRAPHEME_V1,
             ),
-            my: try_load::<LstmForWordLineAutoV1Marker, _>(&crate::provider::Baked, locale!("my"))
+            my: try_load::<LstmForWordLineAutoV1Marker, _>(&crate::provider::Baked, langid!("my"))
                 .unwrap()
                 .map(DataPayload::cast)
                 .map(Err),
-            km: try_load::<LstmForWordLineAutoV1Marker, _>(&crate::provider::Baked, locale!("km"))
+            km: try_load::<LstmForWordLineAutoV1Marker, _>(&crate::provider::Baked, langid!("km"))
                 .unwrap()
                 .map(DataPayload::cast)
                 .map(Err),
-            lo: try_load::<LstmForWordLineAutoV1Marker, _>(&crate::provider::Baked, locale!("lo"))
+            lo: try_load::<LstmForWordLineAutoV1Marker, _>(&crate::provider::Baked, langid!("lo"))
                 .unwrap()
                 .map(DataPayload::cast)
                 .map(Err),
-            th: try_load::<LstmForWordLineAutoV1Marker, _>(&crate::provider::Baked, locale!("th"))
+            th: try_load::<LstmForWordLineAutoV1Marker, _>(&crate::provider::Baked, langid!("th"))
                 .unwrap()
                 .map(DataPayload::cast)
                 .map(Err),
@@ -107,16 +107,16 @@ impl ComplexPayloads {
     {
         Ok(Self {
             grapheme: provider.load(Default::default())?.take_payload()?,
-            my: try_load::<LstmForWordLineAutoV1Marker, D>(provider, locale!("my"))?
+            my: try_load::<LstmForWordLineAutoV1Marker, D>(provider, langid!("my"))?
                 .map(DataPayload::cast)
                 .map(Err),
-            km: try_load::<LstmForWordLineAutoV1Marker, D>(provider, locale!("km"))?
+            km: try_load::<LstmForWordLineAutoV1Marker, D>(provider, langid!("km"))?
                 .map(DataPayload::cast)
                 .map(Err),
-            lo: try_load::<LstmForWordLineAutoV1Marker, D>(provider, locale!("lo"))?
+            lo: try_load::<LstmForWordLineAutoV1Marker, D>(provider, langid!("lo"))?
                 .map(DataPayload::cast)
                 .map(Err),
-            th: try_load::<LstmForWordLineAutoV1Marker, D>(provider, locale!("th"))?
+            th: try_load::<LstmForWordLineAutoV1Marker, D>(provider, langid!("th"))?
                 .map(DataPayload::cast)
                 .map(Err),
             ja: None,
@@ -133,35 +133,35 @@ impl ComplexPayloads {
             ),
             my: try_load::<DictionaryForWordLineExtendedV1Marker, _>(
                 &crate::provider::Baked,
-                locale!("my"),
+                langid!("my"),
             )
             .unwrap()
             .map(DataPayload::cast)
             .map(Ok),
             km: try_load::<DictionaryForWordLineExtendedV1Marker, _>(
                 &crate::provider::Baked,
-                locale!("km"),
+                langid!("km"),
             )
             .unwrap()
             .map(DataPayload::cast)
             .map(Ok),
             lo: try_load::<DictionaryForWordLineExtendedV1Marker, _>(
                 &crate::provider::Baked,
-                locale!("lo"),
+                langid!("lo"),
             )
             .unwrap()
             .map(DataPayload::cast)
             .map(Ok),
             th: try_load::<DictionaryForWordLineExtendedV1Marker, _>(
                 &crate::provider::Baked,
-                locale!("th"),
+                langid!("th"),
             )
             .unwrap()
             .map(DataPayload::cast)
             .map(Ok),
             ja: try_load::<DictionaryForWordOnlyAutoV1Marker, _>(
                 &crate::provider::Baked,
-                locale!("ja"),
+                langid!("ja"),
             )
             .unwrap()
             .map(DataPayload::cast),
@@ -177,19 +177,19 @@ impl ComplexPayloads {
     {
         Ok(Self {
             grapheme: provider.load(Default::default())?.take_payload()?,
-            my: try_load::<DictionaryForWordLineExtendedV1Marker, D>(provider, locale!("my"))?
+            my: try_load::<DictionaryForWordLineExtendedV1Marker, D>(provider, langid!("my"))?
                 .map(DataPayload::cast)
                 .map(Ok),
-            km: try_load::<DictionaryForWordLineExtendedV1Marker, D>(provider, locale!("km"))?
+            km: try_load::<DictionaryForWordLineExtendedV1Marker, D>(provider, langid!("km"))?
                 .map(DataPayload::cast)
                 .map(Ok),
-            lo: try_load::<DictionaryForWordLineExtendedV1Marker, D>(provider, locale!("lo"))?
+            lo: try_load::<DictionaryForWordLineExtendedV1Marker, D>(provider, langid!("lo"))?
                 .map(DataPayload::cast)
                 .map(Ok),
-            th: try_load::<DictionaryForWordLineExtendedV1Marker, D>(provider, locale!("th"))?
+            th: try_load::<DictionaryForWordLineExtendedV1Marker, D>(provider, langid!("th"))?
                 .map(DataPayload::cast)
                 .map(Ok),
-            ja: try_load::<DictionaryForWordOnlyAutoV1Marker, D>(provider, locale!("ja"))?
+            ja: try_load::<DictionaryForWordOnlyAutoV1Marker, D>(provider, langid!("ja"))?
                 .map(DataPayload::cast),
         })
     }
@@ -203,25 +203,25 @@ impl ComplexPayloads {
             grapheme: DataPayload::from_static_ref(
                 crate::provider::Baked::SINGLETON_SEGMENTER_GRAPHEME_V1,
             ),
-            my: try_load::<LstmForWordLineAutoV1Marker, _>(&crate::provider::Baked, locale!("my"))
+            my: try_load::<LstmForWordLineAutoV1Marker, _>(&crate::provider::Baked, langid!("my"))
                 .unwrap()
                 .map(DataPayload::cast)
                 .map(Err),
-            km: try_load::<LstmForWordLineAutoV1Marker, _>(&crate::provider::Baked, locale!("km"))
+            km: try_load::<LstmForWordLineAutoV1Marker, _>(&crate::provider::Baked, langid!("km"))
                 .unwrap()
                 .map(DataPayload::cast)
                 .map(Err),
-            lo: try_load::<LstmForWordLineAutoV1Marker, _>(&crate::provider::Baked, locale!("lo"))
+            lo: try_load::<LstmForWordLineAutoV1Marker, _>(&crate::provider::Baked, langid!("lo"))
                 .unwrap()
                 .map(DataPayload::cast)
                 .map(Err),
-            th: try_load::<LstmForWordLineAutoV1Marker, _>(&crate::provider::Baked, locale!("th"))
+            th: try_load::<LstmForWordLineAutoV1Marker, _>(&crate::provider::Baked, langid!("th"))
                 .unwrap()
                 .map(DataPayload::cast)
                 .map(Err),
             ja: try_load::<DictionaryForWordOnlyAutoV1Marker, _>(
                 &crate::provider::Baked,
-                locale!("ja"),
+                langid!("ja"),
             )
             .unwrap()
             .map(DataPayload::cast),
@@ -238,19 +238,19 @@ impl ComplexPayloads {
     {
         Ok(Self {
             grapheme: provider.load(Default::default())?.take_payload()?,
-            my: try_load::<LstmForWordLineAutoV1Marker, D>(provider, locale!("my"))?
+            my: try_load::<LstmForWordLineAutoV1Marker, D>(provider, langid!("my"))?
                 .map(DataPayload::cast)
                 .map(Err),
-            km: try_load::<LstmForWordLineAutoV1Marker, D>(provider, locale!("km"))?
+            km: try_load::<LstmForWordLineAutoV1Marker, D>(provider, langid!("km"))?
                 .map(DataPayload::cast)
                 .map(Err),
-            lo: try_load::<LstmForWordLineAutoV1Marker, D>(provider, locale!("lo"))?
+            lo: try_load::<LstmForWordLineAutoV1Marker, D>(provider, langid!("lo"))?
                 .map(DataPayload::cast)
                 .map(Err),
-            th: try_load::<LstmForWordLineAutoV1Marker, D>(provider, locale!("th"))?
+            th: try_load::<LstmForWordLineAutoV1Marker, D>(provider, langid!("th"))?
                 .map(DataPayload::cast)
                 .map(Err),
-            ja: try_load::<DictionaryForWordOnlyAutoV1Marker, D>(provider, locale!("ja"))?
+            ja: try_load::<DictionaryForWordOnlyAutoV1Marker, D>(provider, langid!("ja"))?
                 .map(DataPayload::cast),
         })
     }
@@ -265,28 +265,28 @@ impl ComplexPayloads {
             ),
             my: try_load::<DictionaryForWordLineExtendedV1Marker, _>(
                 &crate::provider::Baked,
-                locale!("my"),
+                langid!("my"),
             )
             .unwrap()
             .map(DataPayload::cast)
             .map(Ok),
             km: try_load::<DictionaryForWordLineExtendedV1Marker, _>(
                 &crate::provider::Baked,
-                locale!("km"),
+                langid!("km"),
             )
             .unwrap()
             .map(DataPayload::cast)
             .map(Ok),
             lo: try_load::<DictionaryForWordLineExtendedV1Marker, _>(
                 &crate::provider::Baked,
-                locale!("lo"),
+                langid!("lo"),
             )
             .unwrap()
             .map(DataPayload::cast)
             .map(Ok),
             th: try_load::<DictionaryForWordLineExtendedV1Marker, _>(
                 &crate::provider::Baked,
-                locale!("th"),
+                langid!("th"),
             )
             .unwrap()
             .map(DataPayload::cast)
@@ -303,16 +303,16 @@ impl ComplexPayloads {
     {
         Ok(Self {
             grapheme: provider.load(Default::default())?.take_payload()?,
-            my: try_load::<DictionaryForWordLineExtendedV1Marker, _>(provider, locale!("my"))?
+            my: try_load::<DictionaryForWordLineExtendedV1Marker, _>(provider, langid!("my"))?
                 .map(DataPayload::cast)
                 .map(Ok),
-            km: try_load::<DictionaryForWordLineExtendedV1Marker, _>(provider, locale!("km"))?
+            km: try_load::<DictionaryForWordLineExtendedV1Marker, _>(provider, langid!("km"))?
                 .map(DataPayload::cast)
                 .map(Ok),
-            lo: try_load::<DictionaryForWordLineExtendedV1Marker, _>(provider, locale!("lo"))?
+            lo: try_load::<DictionaryForWordLineExtendedV1Marker, _>(provider, langid!("lo"))?
                 .map(DataPayload::cast)
                 .map(Ok),
-            th: try_load::<DictionaryForWordLineExtendedV1Marker, _>(provider, locale!("th"))?
+            th: try_load::<DictionaryForWordLineExtendedV1Marker, _>(provider, langid!("th"))?
                 .map(DataPayload::cast)
                 .map(Ok),
             ja: None,
@@ -322,10 +322,10 @@ impl ComplexPayloads {
 
 fn try_load<M: KeyedDataMarker, P: DataProvider<M> + ?Sized>(
     provider: &P,
-    locale: Locale,
+    locale: LanguageIdentifier,
 ) -> Result<Option<DataPayload<M>>, DataError> {
     match provider.load(DataRequest {
-        locale: &DataLocale::from(locale),
+        locale: &locale.into(),
         metadata: {
             let mut m = DataRequestMetadata::default();
             m.silent = true;

--- a/provider/adapters/src/any_payload.rs
+++ b/provider/adapters/src/any_payload.rs
@@ -31,7 +31,7 @@ use zerofrom::ZeroFrom;
 /// // Check that it works:
 /// let formatter = HelloWorldFormatter::try_new_with_any_provider(
 ///     &provider,
-///     &icu_locid::Locale::UND.into(),
+///     &Default::default(),
 /// )
 /// .expect("key matches");
 /// assert_writeable_eq!(formatter.format(), "custom hello world");

--- a/provider/adapters/src/fallback/mod.rs
+++ b/provider/adapters/src/fallback/mod.rs
@@ -21,7 +21,7 @@ pub use icu_provider::fallback::LocaleFallbackConfig;
 /// # Examples
 ///
 /// ```
-/// use icu_locid::locale;
+/// use icu_locid::langid;
 /// use icu_provider::prelude::*;
 /// use icu_provider::hello_world::*;
 /// use icu_provider_adapters::fallback::LocaleFallbackProvider;
@@ -30,7 +30,7 @@ pub use icu_provider::fallback::LocaleFallbackConfig;
 /// # let provider = provider.as_deserializing();
 ///
 /// let req = DataRequest {
-///     locale: &locale!("ja-JP").into(),
+///     locale: &langid!("ja-JP").into(),
 ///     metadata: Default::default(),
 /// };
 ///
@@ -47,7 +47,7 @@ pub use icu_provider::fallback::LocaleFallbackConfig;
 ///
 /// assert_eq!(
 ///     response.metadata.locale.unwrap(),
-///     locale!("ja").into(),
+///     langid!("ja").into(),
 /// );
 /// assert_eq!(
 ///     response.payload.unwrap().get().message,
@@ -125,7 +125,7 @@ impl<P> LocaleFallbackProvider<P> {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::locale;
+    /// use icu_locid::langid;
     /// use icu_locid_transform::LocaleFallbacker;
     /// use icu_provider::hello_world::*;
     /// use icu_provider::prelude::*;
@@ -134,7 +134,7 @@ impl<P> LocaleFallbackProvider<P> {
     /// let provider = HelloWorldProvider;
     ///
     /// let req = DataRequest {
-    ///     locale: &locale!("de-CH").into(),
+    ///     locale: &langid!("de-CH").into(),
     ///     metadata: Default::default(),
     /// };
     ///

--- a/provider/adapters/src/filter/impls.rs
+++ b/provider/adapters/src/filter/impls.rs
@@ -25,7 +25,7 @@ where
     ///
     /// ```
     /// use icu_locid::LanguageIdentifier;
-    /// use icu_locid::{langid, locale, subtags::language};
+    /// use icu_locid::{langid, subtags::language};
     /// use icu_provider::datagen::*;
     /// use icu_provider::hello_world::*;
     /// use icu_provider::prelude::*;
@@ -37,7 +37,7 @@ where
     ///
     /// // German requests should succeed:
     /// let req_de = DataRequest {
-    ///     locale: &locale!("de").into(),
+    ///     locale: &langid!("de").into(),
     ///     metadata: Default::default(),
     /// };
     /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
@@ -46,7 +46,7 @@ where
     ///
     /// // English requests should fail:
     /// let req_en = DataRequest {
-    ///     locale: &locale!("en-US").into(),
+    ///     locale: &langid!("en-US").into(),
     ///     metadata: Default::default(),
     /// };
     /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
@@ -101,7 +101,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::{langid, locale};
+    /// use icu_locid::langid;
     /// use icu_provider::hello_world::*;
     /// use icu_provider::prelude::*;
     /// use icu_provider_adapters::filter::Filterable;
@@ -113,7 +113,7 @@ where
     ///
     /// // German requests should succeed:
     /// let req_de = DataRequest {
-    ///     locale: &locale!("de").into(),
+    ///     locale: &langid!("de").into(),
     ///     metadata: Default::default(),
     /// };
     /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
@@ -122,7 +122,7 @@ where
     ///
     /// // English requests should fail:
     /// let req_en = DataRequest {
-    ///     locale: &locale!("en-US").into(),
+    ///     locale: &langid!("en-US").into(),
     ///     metadata: Default::default(),
     /// };
     /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
@@ -164,7 +164,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::locale;
+    /// use icu_locid::langid;
     /// use icu_provider::hello_world::*;
     /// use icu_provider::prelude::*;
     /// use icu_provider_adapters::filter::Filterable;
@@ -175,7 +175,7 @@ where
     ///
     /// // Requests with a langid should succeed:
     /// let req_with_langid = DataRequest {
-    ///     locale: &locale!("de").into(),
+    ///     locale: &langid!("de").into(),
     ///     metadata: Default::default(),
     /// };
     /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =

--- a/provider/adapters/src/fork/mod.rs
+++ b/provider/adapters/src/fork/mod.rs
@@ -59,7 +59,7 @@ use predicates::MissingDataKeyPredicate;
 /// Normal usage:
 ///
 /// ```
-/// use icu_locid::locale;
+/// use icu_locid::langid;
 /// use icu_provider::hello_world::*;
 /// use icu_provider::prelude::*;
 /// use icu_provider_adapters::fork::ForkByKeyProvider;
@@ -84,7 +84,7 @@ use predicates::MissingDataKeyPredicate;
 ///
 /// let german_hello_world: DataPayload<HelloWorldV1Marker> = provider
 ///     .load(DataRequest {
-///         locale: &locale!("de").into(),
+///         locale: &langid!("de").into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect("Loading should succeed")
@@ -97,7 +97,7 @@ use predicates::MissingDataKeyPredicate;
 /// Stops at the first provider supporting a key, even if the locale is not supported:
 ///
 /// ```
-/// use icu_locid::{subtags::language, locale};
+/// use icu_locid::{subtags::language, langid};
 /// use icu_provider::hello_world::*;
 /// use icu_provider::prelude::*;
 /// use icu_provider_adapters::filter::Filterable;
@@ -120,7 +120,7 @@ use predicates::MissingDataKeyPredicate;
 /// // Chinese is the first provider, so this succeeds
 /// let chinese_hello_world = provider
 ///     .load(DataRequest {
-///         locale: &locale!("zh").into(),
+///         locale: &langid!("zh").into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect("Loading should succeed")
@@ -132,7 +132,7 @@ use predicates::MissingDataKeyPredicate;
 /// // German is shadowed by Chinese, so this fails
 /// provider
 ///     .load(DataRequest {
-///         locale: &locale!("de").into(),
+///         locale: &langid!("de").into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect_err("Should stop at the first provider, even though the second has data");
@@ -166,7 +166,7 @@ impl<P0, P1> ForkByKeyProvider<P0, P1> {
 /// # Examples
 ///
 /// ```
-/// use icu_locid::{subtags::language, locale};
+/// use icu_locid::{subtags::language, langid};
 /// use icu_provider::hello_world::*;
 /// use icu_provider::prelude::*;
 /// use icu_provider_adapters::filter::Filterable;
@@ -191,7 +191,7 @@ impl<P0, P1> ForkByKeyProvider<P0, P1> {
 /// // Chinese is the first provider, so this succeeds
 /// let chinese_hello_world = provider
 ///     .load(DataRequest {
-///         locale: &locale!("zh").into(),
+///         locale: &langid!("zh").into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect("Loading should succeed")
@@ -203,7 +203,7 @@ impl<P0, P1> ForkByKeyProvider<P0, P1> {
 /// // German is shadowed by Chinese, so this fails
 /// provider
 ///     .load(DataRequest {
-///         locale: &locale!("de").into(),
+///         locale: &langid!("de").into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect_err("Should stop at the first provider, even though the second has data");

--- a/provider/adapters/src/fork/predicates.rs
+++ b/provider/adapters/src/fork/predicates.rs
@@ -73,7 +73,7 @@ impl ForkByErrorPredicate for MissingDataKeyPredicate {
 /// use icu_provider_fs::FsDataProvider;
 /// use icu_provider::prelude::*;
 /// use icu_provider::hello_world::HelloWorldV1Marker;
-/// use icu_locid::locale;
+/// use icu_locid::langid;
 ///
 /// // The `tests` directory contains two separate "language packs" for Hello World data.
 /// let provider_de = FsDataProvider::try_new("tests/data/langtest/de").unwrap();
@@ -91,7 +91,7 @@ impl ForkByErrorPredicate for MissingDataKeyPredicate {
 /// let german_hello_world: DataPayload<HelloWorldV1Marker> = provider
 ///     .as_deserializing()
 ///     .load(DataRequest {
-///         locale: &locale!("de").into(),
+///         locale: &langid!("de").into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect("Loading should succeed")
@@ -103,7 +103,7 @@ impl ForkByErrorPredicate for MissingDataKeyPredicate {
 /// let romanian_hello_world: DataPayload<HelloWorldV1Marker> = provider
 ///     .as_deserializing()
 ///     .load(DataRequest {
-///         locale: &locale!("ro").into(),
+///         locale: &langid!("ro").into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect("Loading should succeed")
@@ -117,7 +117,7 @@ impl ForkByErrorPredicate for MissingDataKeyPredicate {
 /// DataProvider::<HelloWorldV1Marker>::load(
 ///     &provider.as_deserializing(),
 ///     DataRequest {
-///         locale: &locale!("en").into(),
+///         locale: &langid!("en").into(),
 ///         metadata: Default::default(),
 ///     }
 /// )

--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -204,7 +204,7 @@ mod test {
                     provider.load_buffer(
                         HelloSingletonV1Marker::KEY,
                         DataRequest {
-                            locale: &icu_locid::locale!("de").into(),
+                            locale: &icu_locid::langid!("de").into(),
                             metadata: Default::default()
                         }
                     ),

--- a/provider/blob/src/export/mod.rs
+++ b/provider/blob/src/export/mod.rs
@@ -33,7 +33,7 @@
 //! The resulting blob can now be used like this:
 //!
 //! ```
-//! use icu_locid::langid;
+//! use icu_locid::locale;
 //! use icu_provider::hello_world::*;
 //! use icu_provider::prelude::*;
 //! use icu_provider_blob::BlobDataProvider;
@@ -48,7 +48,7 @@
 //! // Use the provider as a `BufferProvider`
 //! let formatter = HelloWorldFormatter::try_new_with_buffer_provider(
 //!     &provider,
-//!     &langid!("en").into(),
+//!     &locale!("en").into(),
 //! )
 //! .unwrap();
 //!

--- a/provider/blob/tests/test_versions.rs
+++ b/provider/blob/tests/test_versions.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use icu_datagen::prelude::*;
-use icu_locid::Locale;
+use icu_locid::LanguageIdentifier;
 use icu_provider::datagen::IterableDataProvider;
 use icu_provider::hello_world::*;
 use icu_provider::prelude::*;
@@ -111,11 +111,10 @@ fn test_v2_bigger() {
         "tyz-Latn-001",
         "uaf-Latn-001",
     ] {
-        let locale = Locale::try_from_bytes(loc.as_bytes()).expect("locale must parse");
         let blob_result = DataProvider::<HelloWorldV1Marker>::load(
             &blob_provider,
             DataRequest {
-                locale: &locale.into(),
+                locale: &loc.parse().expect("locale must parse"),
                 metadata: Default::default(),
             },
         )
@@ -153,7 +152,8 @@ impl IterableDataProvider<HelloWorldV1Marker> for ManyLocalesProvider {
                 bytes[1] = i1;
                 for i2 in LOWERCASE {
                     bytes[2] = i2;
-                    let locale = Locale::try_from_bytes(&bytes).expect("locale must parse");
+                    let locale =
+                        LanguageIdentifier::try_from_bytes(&bytes).expect("locale must parse");
                     vec.push(locale.into())
                 }
             }

--- a/provider/core/src/any.rs
+++ b/provider/core/src/any.rs
@@ -309,7 +309,7 @@ where
 /// let any_provider = HelloWorldProvider.as_any_provider();
 ///
 /// let req = DataRequest {
-///     locale: &icu_locid::locale!("de").into(),
+///     locale: &icu_locid::langid!("de").into(),
 ///     metadata: Default::default(),
 /// };
 ///

--- a/provider/core/src/buf.rs
+++ b/provider/core/src/buf.rs
@@ -37,7 +37,7 @@ impl DataMarker for BufferMarker {
 ///
 /// ```
 /// # #[cfg(feature = "deserialize_json")] {
-/// use icu_locid::locale;
+/// use icu_locid::langid;
 /// use icu_provider::hello_world::*;
 /// use icu_provider::prelude::*;
 /// use std::borrow::Cow;
@@ -45,7 +45,7 @@ impl DataMarker for BufferMarker {
 /// let buffer_provider = HelloWorldProvider.into_json_provider();
 ///
 /// let req = DataRequest {
-///     locale: &locale!("de").into(),
+///     locale: &langid!("de").into(),
 ///     metadata: Default::default(),
 /// };
 ///

--- a/provider/core/src/dynutil.rs
+++ b/provider/core/src/dynutil.rs
@@ -108,7 +108,7 @@ macro_rules! impl_casting_upcast {
 /// icu_provider::impl_dynamic_data_provider!(HelloWorldProvider, [HelloWorldV1Marker,], AnyMarker);
 ///
 /// let req = DataRequest {
-///     locale: &icu_locid::locale!("de").into(),
+///     locale: &icu_locid::langid!("de").into(),
 ///     metadata: Default::default(),
 /// };
 ///
@@ -148,7 +148,7 @@ macro_rules! impl_casting_upcast {
 /// }, AnyMarker);
 ///
 /// let req = DataRequest {
-///     locale: &icu_locid::locale!("de").into(),
+///     locale: &icu_locid::langid!("de").into(),
 ///     metadata: Default::default(),
 /// };
 ///

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -60,14 +60,14 @@ impl KeyedDataMarker for HelloWorldV1Marker {
 /// # Examples
 ///
 /// ```
-/// use icu_locid::locale;
+/// use icu_locid::langid;
 /// use icu_provider::hello_world::*;
 /// use icu_provider::prelude::*;
 ///
 /// let german_hello_world: DataPayload<HelloWorldV1Marker> =
 ///     HelloWorldProvider
 ///         .load(DataRequest {
-///             locale: &locale!("de").into(),
+///             locale: &langid!("de").into(),
 ///             metadata: Default::default(),
 ///         })
 ///         .expect("Loading should succeed")
@@ -173,14 +173,14 @@ icu_provider::impl_dynamic_data_provider!(HelloWorldProvider, [HelloWorldV1Marke
 /// # Examples
 ///
 /// ```
-/// use icu_locid::locale;
+/// use icu_locid::langid;
 /// use icu_provider::hello_world::*;
 /// use icu_provider::prelude::*;
 ///
 /// let german_hello_world = HelloWorldProvider
 ///     .into_json_provider()
 ///     .load_buffer(HelloWorldV1Marker::KEY, DataRequest {
-///         locale: &locale!("de").into(),
+///         locale: &langid!("de").into(),
 ///         metadata: Default::default(),
 ///     })
 ///     .expect("Loading should succeed")

--- a/provider/core/src/marker.rs
+++ b/provider/core/src/marker.rs
@@ -107,7 +107,7 @@ pub trait KeyedDataMarker: DataMarker {
 /// # Examples
 ///
 /// ```
-/// use icu_locid::locale;
+/// use icu_locid::langid;
 /// use icu_provider::hello_world::*;
 /// use icu_provider::prelude::*;
 /// use icu_provider::NeverMarker;
@@ -117,7 +117,7 @@ pub trait KeyedDataMarker: DataMarker {
 /// let result = DataProvider::<NeverMarker<HelloWorldV1<'static>>>::load(
 ///     &buffer_provider.as_deserializing(),
 ///     DataRequest {
-///         locale: &locale!("en").into(),
+///         locale: &langid!("en").into(),
 ///         metadata: Default::default(),
 ///     },
 /// );
@@ -154,7 +154,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use icu_locid::locale;
+/// use icu_locid::langid;
 /// use icu_provider::hello_world::*;
 /// use icu_provider::prelude::*;
 /// use icu_provider::NeverMarker;
@@ -166,7 +166,7 @@ where
 /// let result = DataProvider::<NeverMarker<HelloWorldV1<'static>>>::load(
 ///     &MyProvider,
 ///     DataRequest {
-///         locale: &locale!("und").into(),
+///         locale: &langid!("und").into(),
 ///         metadata: Default::default(),
 ///     },
 /// );

--- a/provider/core/src/request.rs
+++ b/provider/core/src/request.rs
@@ -507,12 +507,10 @@ impl DataLocale {
     /// Auxiliary keys are retained:
     ///
     /// ```
-    /// use icu_locid::Locale;
     /// use icu_provider::prelude::*;
     /// use writeable::assert_writeable_eq;
     ///
-    /// let locale: Locale = "und-u-nu-arab-x-gbp".parse().unwrap();
-    /// let data_locale = DataLocale::from(locale);
+    /// let data_locale: DataLocale = "und-u-nu-arab-x-gbp".parse().unwrap();
     /// assert_writeable_eq!(data_locale, "und-u-nu-arab-x-gbp");
     ///
     /// let recovered_locale = data_locale.into_locale();
@@ -610,14 +608,10 @@ impl DataLocale {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::{
-    ///     extensions::unicode::{key, value},
-    ///     Locale,
-    /// };
+    /// use icu_locid::extensions::unicode::{key, value};
     /// use icu_provider::prelude::*;
     ///
-    /// let locale: Locale = "it-IT-u-ca-coptic".parse().expect("Valid BCP-47");
-    /// let locale: DataLocale = locale.into();
+    /// let locale: DataLocale = "it-IT-u-ca-coptic".parse().expect("Valid BCP-47");
     ///
     /// assert_eq!(locale.get_unicode_ext(&key!("hc")), None);
     /// assert_eq!(locale.get_unicode_ext(&key!("ca")), Some(value!("coptic")));
@@ -685,11 +679,11 @@ impl DataLocale {
     /// # Examples
     ///
     /// ```
-    /// use icu_locid::locale;
+    /// use icu_locid::langid;
     /// use icu_provider::prelude::*;
     /// use writeable::assert_writeable_eq;
     ///
-    /// let mut data_locale: DataLocale = locale!("ar-EG").into();
+    /// let mut data_locale: DataLocale = langid!("ar-EG").into();
     /// let aux = "gbp"
     ///     .parse::<AuxiliaryKeys>()
     ///     .expect("contains valid characters");
@@ -724,11 +718,11 @@ impl DataLocale {
 /// # Examples
 ///
 /// ```
-/// use icu_locid::locale;
+/// use icu_locid::langid;
 /// use icu_provider::prelude::*;
 /// use writeable::assert_writeable_eq;
 ///
-/// let mut data_locale: DataLocale = locale!("ar-EG").into();
+/// let mut data_locale: DataLocale = langid!("ar-EG").into();
 /// assert_writeable_eq!(data_locale, "ar-EG");
 /// assert!(!data_locale.has_aux());
 /// assert_eq!(data_locale.get_aux(), None);
@@ -1013,43 +1007,41 @@ impl From<Subtag> for AuxiliaryKeys {
 
 #[test]
 fn test_data_locale_to_string() {
-    use icu_locid::locale;
-
     struct TestCase {
-        pub locale: Locale,
+        pub locale: &'static str,
         pub aux: Option<&'static str>,
         pub expected: &'static str,
     }
 
     for cas in [
         TestCase {
-            locale: Locale::UND,
+            locale: "und",
             aux: None,
             expected: "und",
         },
         TestCase {
-            locale: locale!("und-u-cu-gbp"),
+            locale: "und-u-cu-gbp",
             aux: None,
             expected: "und-u-cu-gbp",
         },
         TestCase {
-            locale: locale!("en-ZA-u-cu-gbp"),
+            locale: "en-ZA-u-cu-gbp",
             aux: None,
             expected: "en-ZA-u-cu-gbp",
         },
         #[cfg(feature = "experimental")]
         TestCase {
-            locale: locale!("en-ZA-u-nu-arab"),
+            locale: "en-ZA-u-nu-arab",
             aux: Some("gbp"),
             expected: "en-ZA-u-nu-arab-x-gbp",
         },
     ] {
-        let mut data_locale = DataLocale::from(cas.locale);
+        let mut locale = cas.locale.parse::<DataLocale>().unwrap();
         #[cfg(feature = "experimental")]
         if let Some(aux) = cas.aux {
-            data_locale.set_aux(aux.parse().unwrap());
+            locale.set_aux(aux.parse().unwrap());
         }
-        writeable::assert_writeable_eq!(data_locale, cas.expected);
+        writeable::assert_writeable_eq!(locale, cas.expected);
     }
 }
 

--- a/provider/datagen/src/baked_exporter.rs
+++ b/provider/datagen/src/baked_exporter.rs
@@ -41,7 +41,7 @@
 //! data and lazily loading more data from the network.
 //!
 //! ```
-//! use icu_locid::langid;
+//! use icu_locid::locale;
 //! use icu_provider::hello_world::*;
 //!
 //! # macro_rules! include {
@@ -64,7 +64,7 @@
 //! impl_data_provider!(MyDataProvider);
 //!
 //! # fn main() {
-//! let formatter = HelloWorldFormatter::try_new_unstable(&MyDataProvider, &langid!("en").into()).unwrap();
+//! let formatter = HelloWorldFormatter::try_new_unstable(&MyDataProvider, &locale!("en").into()).unwrap();
 //!
 //! assert_eq!(formatter.format_to_string(), "Hello World");
 //! # }
@@ -80,11 +80,11 @@
 //! ```
 //!
 //! ```
-//! use icu_locid::langid;
+//! use icu_locid::locale;
 //! use icu_provider::hello_world::*;
 //!
 //! let formatter =
-//!     HelloWorldFormatter::try_new(&langid!("en").into()).unwrap();
+//!     HelloWorldFormatter::try_new(&locale!("en").into()).unwrap();
 //!
 //! assert_eq!(formatter.format_to_string(), "Hello World");
 //! ```

--- a/provider/datagen/src/transform/cldr/characters/mod.rs
+++ b/provider/datagen/src/transform/cldr/characters/mod.rs
@@ -320,7 +320,7 @@ fn string_to_prop_unicodeset(s: &str) -> PropertyUnicodeSetV1<'static> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icu_locid::locale;
+    use icu_locid::langid;
     use icu_properties::sets::UnicodeSetData;
 
     #[test]
@@ -511,7 +511,7 @@ mod tests {
 
         let data: DataPayload<ExemplarCharactersMainV1Marker> = provider
             .load(DataRequest {
-                locale: &DataLocale::from(locale!("en-001")),
+                locale: &langid!("en-001").into(),
                 metadata: Default::default(),
             })
             .unwrap()

--- a/provider/datagen/src/transform/cldr/currency/essentials.rs
+++ b/provider/datagen/src/transform/cldr/currency/essentials.rs
@@ -350,13 +350,13 @@ fn test_basic() {
     }
 
     use icu_experimental::dimension::provider::currency::*;
-    use icu_locid::locale;
+    use icu_locid::langid;
 
     let provider = DatagenProvider::new_testing();
 
     let en: DataPayload<CurrencyEssentialsV1Marker> = provider
         .load(DataRequest {
-            locale: &locale!("en").into(),
+            locale: &langid!("en").into(),
             metadata: Default::default(),
         })
         .unwrap()
@@ -395,7 +395,7 @@ fn test_basic() {
 
     let ar_eg: DataPayload<CurrencyEssentialsV1Marker> = provider
         .load(DataRequest {
-            locale: &locale!("ar-EG").into(),
+            locale: &langid!("ar-EG").into(),
             metadata: Default::default(),
         })
         .unwrap()

--- a/provider/datagen/src/transform/cldr/datetime/mod.rs
+++ b/provider/datagen/src/transform/cldr/datetime/mod.rs
@@ -6,10 +6,7 @@ use crate::provider::transform::cldr::cldr_serde;
 use crate::provider::DatagenProvider;
 use crate::provider::IterableDataProviderInternal;
 use icu_datetime::provider::calendar::*;
-use icu_locid::{
-    extensions::unicode::{key, value},
-    Locale,
-};
+use icu_locid::extensions::unicode::{key, value};
 use icu_provider::prelude::*;
 use once_cell::sync::OnceCell;
 use std::collections::HashMap;
@@ -217,23 +214,21 @@ macro_rules! impl_data_provider {
                 if DateSkeletonPatternsV1Marker::KEY == $marker::KEY {
                     for (cal_value, cldr_cal) in supported_cals() {
                         r.extend(self.cldr()?.dates(cldr_cal).list_langs()?.map(|lid| {
-                            let mut locale: Locale = lid.into();
+                            let mut locale = DataLocale::from(lid);
+                            locale.set_unicode_ext(key!("ca"), cal_value.clone());
                             locale
-                                .extensions
-                                .unicode
-                                .keywords
-                                .set(key!("ca"), cal_value.clone());
-                            DataLocale::from(locale)
                         }));
                     }
                 } else {
                     let cldr_cal = supported_cals()
                         .get(&value!($calendar))
                         .ok_or_else(|| DataErrorKind::MissingLocale.into_error())?;
-                    r.extend(self.cldr()?.dates(cldr_cal).list_langs()?.map(|lid| {
-                        let locale: Locale = lid.into();
-                        DataLocale::from(locale)
-                    }));
+                    r.extend(
+                        self.cldr()?
+                            .dates(cldr_cal)
+                            .list_langs()?
+                            .map(DataLocale::from),
+                    );
                 }
 
                 // TODO(#3212): Remove
@@ -381,16 +376,15 @@ impl_data_provider!(
 #[cfg(test)]
 mod test {
     use super::*;
-    use icu_locid::locale;
+    use icu_locid::langid;
 
     #[test]
     fn test_basic_patterns() {
         let provider = DatagenProvider::new_testing();
 
-        let locale: Locale = locale!("cs");
         let cs_dates: DataPayload<GregorianDateLengthsV1Marker> = provider
             .load(DataRequest {
-                locale: &locale.into(),
+                locale: &langid!("cs").into(),
                 metadata: Default::default(),
             })
             .expect("Failed to load payload")
@@ -404,10 +398,9 @@ mod test {
     fn test_with_numbering_system() {
         let provider = DatagenProvider::new_testing();
 
-        let locale: Locale = locale!("haw");
         let cs_dates: DataPayload<GregorianDateLengthsV1Marker> = provider
             .load(DataRequest {
-                locale: &locale.into(),
+                locale: &langid!("haw").into(),
                 metadata: Default::default(),
             })
             .expect("Failed to load payload")
@@ -427,10 +420,9 @@ mod test {
 
         let provider = DatagenProvider::new_testing();
 
-        let locale: Locale = "fil-u-ca-gregory".parse().unwrap();
         let skeletons: DataPayload<DateSkeletonPatternsV1Marker> = provider
             .load(DataRequest {
-                locale: &locale.into(),
+                locale: &"fil-u-ca-gregory".parse().unwrap(),
                 metadata: Default::default(),
             })
             .expect("Failed to load payload")
@@ -471,10 +463,9 @@ mod test {
         use tinystr::tinystr;
         let provider = DatagenProvider::new_testing();
 
-        let locale: Locale = locale!("cs");
         let cs_dates: DataPayload<GregorianDateSymbolsV1Marker> = provider
             .load(DataRequest {
-                locale: &locale.into(),
+                locale: &langid!("cs").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -502,10 +493,9 @@ mod test {
     fn unalias_contexts() {
         let provider = DatagenProvider::new_testing();
 
-        let locale: Locale = locale!("cs");
         let cs_dates: DataPayload<GregorianDateSymbolsV1Marker> = provider
             .load(DataRequest {
-                locale: &locale.into(),
+                locale: &langid!("cs").into(),
                 metadata: Default::default(),
             })
             .unwrap()

--- a/provider/datagen/src/transform/cldr/datetime/neo.rs
+++ b/provider/datagen/src/transform/cldr/datetime/neo.rs
@@ -14,7 +14,7 @@ use icu_datetime::provider::neo::*;
 use icu_locid::{
     extensions::private::Subtag,
     extensions::unicode::{value, Value},
-    LanguageIdentifier, Locale,
+    LanguageIdentifier,
 };
 use icu_provider::datagen::IterableDataProvider;
 use icu_provider::prelude::*;
@@ -190,9 +190,7 @@ impl DatagenProvider {
             .ok_or_else(|| DataErrorKind::MissingLocale.into_error())?;
         r.extend(self.cldr()?.dates(cldr_cal).list_langs()?.flat_map(|lid| {
             keylengths.iter().map(move |length| {
-                let locale: Locale = lid.clone().into();
-
-                let mut locale = DataLocale::from(locale);
+                let mut locale = DataLocale::from(lid.clone());
 
                 locale.set_aux((*length).into());
                 locale
@@ -707,9 +705,7 @@ impl IterableDataProviderInternal<TimePatternV1Marker> for DatagenProvider {
                 nondefault_subtag(&tp.short, aux::PATTERN_SHORT12, aux::PATTERN_SHORT24),
             ];
             keylengths.into_iter().map(move |length| {
-                let locale: Locale = lid.clone().into();
-
-                let mut locale = DataLocale::from(locale);
+                let mut locale = DataLocale::from(lid.clone());
 
                 locale.set_aux(length.into());
                 locale

--- a/provider/datagen/src/transform/cldr/datetime/week_data.rs
+++ b/provider/datagen/src/transform/cldr/datetime/week_data.rs
@@ -95,7 +95,7 @@ fn basic_cldr_week_data() {
 
     let fr_week_data: DataPayload<WeekDataV1Marker> = provider
         .load(DataRequest {
-            locale: &DataLocale::from(langid!("und-FR")),
+            locale: &langid!("und-FR").into(),
             metadata: Default::default(),
         })
         .unwrap()
@@ -106,7 +106,7 @@ fn basic_cldr_week_data() {
 
     let iq_week_data: DataPayload<WeekDataV1Marker> = provider
         .load(DataRequest {
-            locale: &DataLocale::from(langid!("und-IQ")),
+            locale: &langid!("und-IQ").into(),
             metadata: Default::default(),
         })
         .unwrap()
@@ -121,7 +121,7 @@ fn basic_cldr_week_data() {
 
     let gg_week_data: DataPayload<WeekDataV1Marker> = provider
         .load(DataRequest {
-            locale: &DataLocale::from(langid!("und-GG")),
+            locale: &langid!("und-GG").into(),
             metadata: Default::default(),
         })
         .unwrap()
@@ -226,7 +226,7 @@ fn test_basic_cldr_week_data_v2() {
 
     let fr_week_data: DataPayload<WeekDataV2Marker> = provider
         .load(DataRequest {
-            locale: &DataLocale::from(langid!("und-FR")),
+            locale: &langid!("und-FR").into(),
             metadata: Default::default(),
         })
         .unwrap()
@@ -241,7 +241,7 @@ fn test_basic_cldr_week_data_v2() {
 
     let iq_week_data: DataPayload<WeekDataV2Marker> = provider
         .load(DataRequest {
-            locale: &DataLocale::from(langid!("und-IQ")),
+            locale: &langid!("und-IQ").into(),
             metadata: Default::default(),
         })
         .unwrap()
@@ -260,7 +260,7 @@ fn test_basic_cldr_week_data_v2() {
 
     let gg_week_data: DataPayload<WeekDataV2Marker> = provider
         .load(DataRequest {
-            locale: &DataLocale::from(langid!("und-GG")),
+            locale: &langid!("und-GG").into(),
             metadata: Default::default(),
         })
         .unwrap()
@@ -279,7 +279,7 @@ fn test_basic_cldr_week_data_v2() {
 
     let ir_week_data: DataPayload<WeekDataV2Marker> = provider
         .load(DataRequest {
-            locale: &DataLocale::from(langid!("und-IR")),
+            locale: &langid!("und-IR").into(),
             metadata: Default::default(),
         })
         .unwrap()

--- a/provider/datagen/src/transform/cldr/decimal/compact.rs
+++ b/provider/datagen/src/transform/cldr/decimal/compact.rs
@@ -123,7 +123,7 @@ impl IterableDataProviderInternal<LongCompactDecimalFormatDataV1Marker> for Data
 
 mod tests {
     use super::*;
-    use icu_locid::locale;
+    use icu_locid::langid;
     use std::borrow::Cow;
     use zerofrom::ZeroFrom;
     use zerovec::ule::AsULE;
@@ -135,7 +135,7 @@ mod tests {
 
         let fr_compact_long: DataPayload<LongCompactDecimalFormatDataV1Marker> = provider
             .load(DataRequest {
-                locale: &locale!("en").into(),
+                locale: &langid!("en").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -201,7 +201,7 @@ mod tests {
 
         let ja_compact_short: DataPayload<ShortCompactDecimalFormatDataV1Marker> = provider
             .load(DataRequest {
-                locale: &locale!("ja").into(),
+                locale: &langid!("ja").into(),
                 metadata: Default::default(),
             })
             .unwrap()

--- a/provider/datagen/src/transform/cldr/decimal/symbols.rs
+++ b/provider/datagen/src/transform/cldr/decimal/symbols.rs
@@ -98,13 +98,13 @@ impl TryFrom<NumbersWithNumsys<'_>> for DecimalSymbolsV1<'static> {
 
 #[test]
 fn test_basic() {
-    use icu_locid::locale;
+    use icu_locid::langid;
 
     let provider = DatagenProvider::new_testing();
 
     let ar_decimal: DataPayload<DecimalSymbolsV1Marker> = provider
         .load(DataRequest {
-            locale: &locale!("ar-EG").into(),
+            locale: &langid!("ar-EG").into(),
             metadata: Default::default(),
         })
         .unwrap()

--- a/provider/datagen/src/transform/cldr/displaynames/language.rs
+++ b/provider/datagen/src/transform/cldr/displaynames/language.rs
@@ -201,7 +201,7 @@ impl From<&cldr_serde::displaynames::language::Resource> for LocaleDisplayNamesV
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icu_locid::{locale, subtags::language};
+    use icu_locid::{langid, subtags::language};
 
     #[test]
     fn test_basic_lang_display_names() {
@@ -209,7 +209,7 @@ mod tests {
 
         let data: DataPayload<LanguageDisplayNamesV1Marker> = provider
             .load(DataRequest {
-                locale: &locale!("en-001").into(),
+                locale: &langid!("en-001").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -231,7 +231,7 @@ mod tests {
 
         let data: DataPayload<LanguageDisplayNamesV1Marker> = provider
             .load(DataRequest {
-                locale: &locale!("en-001").into(),
+                locale: &langid!("en-001").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -253,7 +253,7 @@ mod tests {
 
         let data: DataPayload<LanguageDisplayNamesV1Marker> = provider
             .load(DataRequest {
-                locale: &locale!("en-001").into(),
+                locale: &langid!("en-001").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -275,7 +275,7 @@ mod tests {
 
         let data: DataPayload<LanguageDisplayNamesV1Marker> = provider
             .load(DataRequest {
-                locale: &locale!("en-001").into(),
+                locale: &langid!("en-001").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -297,7 +297,7 @@ mod tests {
 
         let data: DataPayload<LocaleDisplayNamesV1Marker> = provider
             .load(DataRequest {
-                locale: &locale!("en-001").into(),
+                locale: &langid!("en-001").into(),
                 metadata: Default::default(),
             })
             .unwrap()

--- a/provider/datagen/src/transform/cldr/displaynames/region.rs
+++ b/provider/datagen/src/transform/cldr/displaynames/region.rs
@@ -91,7 +91,7 @@ impl TryFrom<&cldr_serde::displaynames::region::Resource> for RegionDisplayNames
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icu_locid::{locale, subtags::region};
+    use icu_locid::{langid, subtags::region};
 
     #[test]
     fn test_basic() {
@@ -99,7 +99,7 @@ mod tests {
 
         let data: DataPayload<RegionDisplayNamesV1Marker> = provider
             .load(DataRequest {
-                locale: &locale!("en-001").into(),
+                locale: &langid!("en-001").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -121,7 +121,7 @@ mod tests {
 
         let data: DataPayload<RegionDisplayNamesV1Marker> = provider
             .load(DataRequest {
-                locale: &locale!("en-001").into(),
+                locale: &langid!("en-001").into(),
                 metadata: Default::default(),
             })
             .unwrap()

--- a/provider/datagen/src/transform/cldr/displaynames/script.rs
+++ b/provider/datagen/src/transform/cldr/displaynames/script.rs
@@ -93,7 +93,7 @@ impl TryFrom<&cldr_serde::displaynames::script::Resource> for ScriptDisplayNames
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icu_locid::{locale, subtags::script};
+    use icu_locid::{langid, subtags::script};
 
     #[test]
     fn test_basic_script_display_names() {
@@ -101,7 +101,7 @@ mod tests {
 
         let data: DataPayload<ScriptDisplayNamesV1Marker> = provider
             .load(DataRequest {
-                locale: &locale!("en-001").into(),
+                locale: &langid!("en-001").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -123,7 +123,7 @@ mod tests {
 
         let data: DataPayload<ScriptDisplayNamesV1Marker> = provider
             .load(DataRequest {
-                locale: &locale!("en-001").into(),
+                locale: &langid!("en-001").into(),
                 metadata: Default::default(),
             })
             .unwrap()

--- a/provider/datagen/src/transform/cldr/displaynames/variant.rs
+++ b/provider/datagen/src/transform/cldr/displaynames/variant.rs
@@ -83,7 +83,7 @@ impl TryFrom<&cldr_serde::displaynames::variant::Resource> for VariantDisplayNam
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icu_locid::{locale, subtags::variant};
+    use icu_locid::{langid, subtags::variant};
 
     #[test]
     fn test_basic_variant_display_names() {
@@ -91,7 +91,7 @@ mod tests {
 
         let data: DataPayload<VariantDisplayNamesV1Marker> = provider
             .load(DataRequest {
-                locale: &locale!("en-001").into(),
+                locale: &langid!("en-001").into(),
                 metadata: Default::default(),
             })
             .unwrap()

--- a/provider/datagen/src/transform/cldr/percent/mod.rs
+++ b/provider/datagen/src/transform/cldr/percent/mod.rs
@@ -108,13 +108,13 @@ fn extract_percent_essentials<'data>(
 #[test]
 fn test_basic() {
     use icu_experimental::dimension::provider::percent::*;
-    use icu_locid::locale;
+    use icu_locid::langid;
 
     let provider = DatagenProvider::new_testing();
 
     let en: DataPayload<PercentEssentialsV1Marker> = provider
         .load(DataRequest {
-            locale: &locale!("en").into(),
+            locale: &langid!("en").into(),
             metadata: Default::default(),
         })
         .unwrap()
@@ -137,7 +137,7 @@ fn test_basic() {
 
     let fr: DataPayload<PercentEssentialsV1Marker> = provider
         .load(DataRequest {
-            locale: &locale!("fr").into(),
+            locale: &langid!("fr").into(),
             metadata: Default::default(),
         })
         .unwrap()
@@ -160,7 +160,7 @@ fn test_basic() {
 
     let tr: DataPayload<PercentEssentialsV1Marker> = provider
         .load(DataRequest {
-            locale: &locale!("tr").into(),
+            locale: &langid!("tr").into(),
             metadata: Default::default(),
         })
         .unwrap()
@@ -183,7 +183,7 @@ fn test_basic() {
 
     let ar_eg: DataPayload<PercentEssentialsV1Marker> = provider
         .load(DataRequest {
-            locale: &locale!("ar-EG").into(),
+            locale: &langid!("ar-EG").into(),
             metadata: Default::default(),
         })
         .unwrap()

--- a/provider/datagen/src/transform/cldr/personnames/person_names_format_data_providers.rs
+++ b/provider/datagen/src/transform/cldr/personnames/person_names_format_data_providers.rs
@@ -153,7 +153,7 @@ impl TryFrom<&'_ Resource> for PersonNamesFormatV1<'_> {
 
 #[cfg(test)]
 mod tests {
-    use icu_locid::locale;
+    use icu_locid::langid;
     use zerofrom::ZeroFrom;
 
     use super::*;
@@ -164,7 +164,7 @@ mod tests {
 
         let data_payload: DataPayload<PersonNamesFormatV1Marker> = provider
             .load(DataRequest {
-                locale: &DataLocale::from(&locale!("en-001")),
+                locale: &langid!("en-001").into(),
                 metadata: Default::default(),
             })?
             .take_payload()?;
@@ -187,7 +187,7 @@ mod tests {
 
         let data_payload: DataPayload<PersonNamesFormatV1Marker> = provider
             .load(DataRequest {
-                locale: &DataLocale::from(&locale!("en-001")),
+                locale: &langid!("en-001").into(),
                 metadata: Default::default(),
             })?
             .take_payload()?;
@@ -235,7 +235,7 @@ mod tests {
 
         let data_payload: DataPayload<PersonNamesFormatV1Marker> = provider
             .load(DataRequest {
-                locale: &DataLocale::from(&locale!("es")),
+                locale: &langid!("es").into(),
                 metadata: Default::default(),
             })?
             .take_payload()?;

--- a/provider/datagen/src/transform/cldr/relativetime/mod.rs
+++ b/provider/datagen/src/transform/cldr/relativetime/mod.rs
@@ -185,14 +185,14 @@ make_data_provider!(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icu_locid::locale;
+    use icu_locid::langid;
 
     #[test]
     fn test_basic() {
         let provider = DatagenProvider::new_testing();
         let data: DataPayload<ShortQuarterRelativeTimeFormatDataV1Marker> = provider
             .load(DataRequest {
-                locale: &locale!("en").into(),
+                locale: &langid!("en").into(),
                 metadata: Default::default(),
             })
             .unwrap()
@@ -212,7 +212,7 @@ mod tests {
         let provider = DatagenProvider::new_testing();
         let data: DataPayload<LongYearRelativeTimeFormatDataV1Marker> = provider
             .load(DataRequest {
-                locale: &locale!("ar").into(),
+                locale: &langid!("ar").into(),
                 metadata: Default::default(),
             })
             .unwrap()

--- a/provider/datagen/src/transform/cldr/units/info.rs
+++ b/provider/datagen/src/transform/cldr/units/info.rs
@@ -109,7 +109,7 @@ impl IterableDataProvider<UnitsInfoV1Marker> for DatagenProvider {
 #[test]
 fn test_basic() {
     use icu_experimental::units::provider::*;
-    use icu_locid::locale;
+    use icu_locid::langid;
     use icu_provider::prelude::*;
     use num_bigint::BigUint;
     use num_rational::Ratio;
@@ -121,7 +121,7 @@ fn test_basic() {
 
     let und: DataPayload<UnitsInfoV1Marker> = provider
         .load(DataRequest {
-            locale: &locale!("und").into(),
+            locale: &langid!("und").into(),
             metadata: Default::default(),
         })
         .unwrap()

--- a/provider/datagen/src/transform/icuexport/collator/mod.rs
+++ b/provider/datagen/src/transform/icuexport/collator/mod.rs
@@ -9,20 +9,17 @@ use crate::provider::DatagenProvider;
 use crate::provider::IterableDataProviderInternal;
 use icu_collator::provider::*;
 use icu_collections::codepointtrie::CodePointTrie;
-use icu_locid::extensions::unicode::key;
-use icu_locid::extensions::unicode::Value;
+use icu_locid::extensions::unicode::{key, value};
 use icu_locid::subtags::language;
 use icu_locid::subtags::Language;
 use icu_locid::subtags::Region;
 use icu_locid::subtags::Script;
 use icu_locid::LanguageIdentifier;
-use icu_locid::Locale;
 use icu_locid_transform::provider::CollationFallbackSupplementV1Marker;
 use icu_locid_transform::provider::LocaleFallbackSupplementV1;
 use icu_provider::prelude::*;
 use std::collections::HashSet;
 use std::convert::TryFrom;
-use std::str::FromStr;
 use writeable::Writeable;
 use zerovec::ule::UnvalidatedStr;
 use zerovec::ZeroVec;
@@ -59,8 +56,7 @@ impl DataProvider<CollationFallbackSupplementV1Marker> for DatagenProvider {
                             s.rsplit_once('_')?.0,
                             self.has_legacy_swedish_variants(),
                         )?
-                        .id
-                        .language,
+                        .language(),
                     )
                 })
                 .collect::<HashSet<_>>();
@@ -168,14 +164,13 @@ fn locale_to_file_name(locale: &DataLocale, has_legacy_swedish_variants: bool) -
     s
 }
 
-fn file_name_to_locale(file_name: &str, has_legacy_swedish_variants: bool) -> Option<Locale> {
+fn file_name_to_locale(file_name: &str, has_legacy_swedish_variants: bool) -> Option<DataLocale> {
     let (language, variant) = file_name.rsplit_once('_').unwrap();
-    let langid = if language == "root" {
-        LanguageIdentifier::UND
+    let mut locale = if language == "root" {
+        DataLocale::default()
     } else {
         language.parse().ok()?
     };
-    let mut locale = Locale::from(langid);
 
     // See above for the two special cases.
     if language == "zh" {
@@ -191,17 +186,17 @@ fn file_name_to_locale(file_name: &str, has_legacy_swedish_variants: bool) -> Op
         return Some(locale);
     }
 
-    let shortened = match variant {
-        "traditional" => "trad",
-        "phonebook" => "phonebk",
-        "dictionary" => "dict",
-        "gb2312han" => "gb2312",
-        _ => variant,
-    };
-    locale.extensions.unicode.keywords.set(
+    locale.set_unicode_ext(
         key!("co"),
-        Value::from_str(shortened).expect("valid extension subtag"),
+        match variant {
+            "traditional" => value!("trad"),
+            "phonebook" => value!("phonebk"),
+            "dictionary" => value!("dict"),
+            "gb2312han" => value!("gb2312"),
+            _ => variant.parse().unwrap(),
+        },
     );
+
     Some(locale)
 }
 

--- a/provider/fs/src/export/mod.rs
+++ b/provider/fs/src/export/mod.rs
@@ -38,7 +38,7 @@
 //! The resulting files can now be used like this:
 //!
 //! ```
-//! use icu_locid::langid;
+//! use icu_locid::locale;
 //! use icu_provider::hello_world::*;
 //! use icu_provider::prelude::*;
 //! use icu_provider_fs::FsDataProvider;
@@ -51,7 +51,7 @@
 //! // Use the provider as a `BufferProvider`
 //! let formatter = HelloWorldFormatter::try_new_with_buffer_provider(
 //!     &provider,
-//!     &langid!("en").into(),
+//!     &locale!("en").into(),
 //! )
 //! .unwrap();
 //!

--- a/provider/testdata/benches/providers.rs
+++ b/provider/testdata/benches/providers.rs
@@ -5,7 +5,7 @@
 extern crate alloc;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use icu_locid::locale;
+use icu_locid::langid;
 use icu_provider::hello_world::HelloWorldV1Marker;
 use icu_provider::prelude::*;
 use icu_provider::AsDeserializingBufferProvider;
@@ -62,7 +62,7 @@ fn providers_bench(c: &mut Criterion) {
             let result: DataResponse<HelloWorldV1Marker> = provider
                 .as_deserializing()
                 .load(DataRequest {
-                    locale: &locale!("ja").into(),
+                    locale: &langid!("ja").into(),
                     metadata: Default::default(),
                 })
                 .unwrap();
@@ -75,7 +75,7 @@ fn providers_bench(c: &mut Criterion) {
             let result: DataResponse<HelloWorldV1Marker> = provider
                 .as_deserializing()
                 .load(DataRequest {
-                    locale: &locale!("ja").into(),
+                    locale: &langid!("ja").into(),
                     metadata: Default::default(),
                 })
                 .unwrap();
@@ -87,7 +87,7 @@ fn providers_bench(c: &mut Criterion) {
         b.iter(|| {
             let result: DataResponse<HelloWorldV1Marker> = provider
                 .load(DataRequest {
-                    locale: &locale!("ja").into(),
+                    locale: &langid!("ja").into(),
                     metadata: Default::default(),
                 })
                 .unwrap();
@@ -100,7 +100,7 @@ fn providers_bench(c: &mut Criterion) {
             let result: DataResponse<HelloWorldV1Marker> = provider
                 .as_downcasting()
                 .load(DataRequest {
-                    locale: &locale!("ja").into(),
+                    locale: &langid!("ja").into(),
                     metadata: Default::default(),
                 })
                 .unwrap();


### PR DESCRIPTION
In preparation for #3632 

There are two cases:
* `DataLocales` that are passed into ICU4X constructors:
  * These are constructed with `locale!("foo").into()`, or `"foo".parse()`
  * When changing a constructor to preferences, the code doesn't need to be changed if we add a `From<Locale>` impl for the preferences
* `DataLocales` that are put into the `DataRequest::locale` field.
  * These are constructed with `langid!("foo").into()`, or `"foo".parse()`
  * When changing the field to `&LanguageIdentifier`, these can be clippy-cleaned-up, as the `.into()` will become redundant.

I've taken care to avoid having intermediate `Locale` or `LanguageIdentifier` variables, everything that is macro-constructed is immediately `into()`ed. This will simplify find-and-replace later.