### PR TITLE
Add to `IsoDurationParser` documentation in `ixdtf`

### DIFF
--- a/utils/ixdtf/README.md
+++ b/utils/ixdtf/README.md
@@ -277,7 +277,7 @@ and the [Temporal proposal][temporal-grammar].
 
 ### Additional Feature
 
-The `ixdtf` crate also implements an ISU8601 Duration parser (`IsoDurationParser`) that is available under
+The `ixdtf` crate also implements an ISO8601 Duration parser (`IsoDurationParser`) that is available under
 the `duration` feature flag. The API for `IsoDurationParser` is the same as `IxdtfParser`, but
 parses duration strings over date/time strings.
 

--- a/utils/ixdtf/src/lib.rs
+++ b/utils/ixdtf/src/lib.rs
@@ -278,7 +278,7 @@
 //!
 //! ## Additional Feature
 //!
-//! The `ixdtf` crate also implements an ISU8601 Duration parser (`IsoDurationParser`) that is available under
+//! The `ixdtf` crate also implements an ISO8601 Duration parser (`IsoDurationParser`) that is available under
 //! the `duration` feature flag. The API for `IsoDurationParser` is the same as `IxdtfParser`, but
 //! parses duration strings over date/time strings.
 //!


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

This Pull Request further builds out the documentation for the `IsoDurationParser` in `ixdtf`.

There are also some other changes aimed at spelling & style guide fixes (Adding `Example` headers).