### PR TITLE
Fix year 2319 in the Chinese calendar

### DIFF
--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -445,7 +445,7 @@ mod test {
 
     use super::*;
     use crate::types::MonthCode;
-    use calendrical_calculations::rata_die::RataDie;
+    use calendrical_calculations::{iso::fixed_from_iso, rata_die::RataDie};
     /// Run a test twice, with two calendars
     fn do_twice(
         chinese_calculating: &Chinese,
@@ -502,6 +502,18 @@ mod test {
                 expected_year: 4660,
                 expected_month: 6,
                 expected_day: 12,
+            },
+            TestCase {
+                fixed: fixed_from_iso(2319, 2, 20).to_i64_date(),
+                expected_year: 2319 + 2636,
+                expected_month: 13,
+                expected_day: 30,
+            },
+            TestCase {
+                fixed: fixed_from_iso(2319, 2, 21).to_i64_date(),
+                expected_year: 2319 + 2636 + 1,
+                expected_month: 1,
+                expected_day: 1,
             },
             TestCase {
                 fixed: 738718,

--- a/components/calendar/src/provider/chinese_based.rs
+++ b/components/calendar/src/provider/chinese_based.rs
@@ -125,11 +125,12 @@ impl<'data> ChineseBasedCacheV1<'data> {
 /// Bit:             0   1   2   3   4   5   6   7
 /// Byte 0:          [  month lengths .............
 /// Byte 1:         .. month lengths ] | [ leap month index ..
-/// Byte 2:          ] | [   NY offset   ] | unused
+/// Byte 2:          ] | [   NY offset       ] | unused
 /// ```
 ///
 /// Where the New Year Offset is the offset from ISO Jan 21 of that year for Chinese New Year,
 /// the month lengths are stored as 1 = 30, 0 = 29 for each month including the leap month.
+/// The largest possible offset is 33, which requires 6 bits of storage.
 ///
 /// <div class="stab unstable">
 /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
@@ -162,7 +163,7 @@ impl PackedChineseBasedYearInfo {
             !month_lengths[12] || leap_month_idx.is_some(),
             "Last month length should not be set for non-leap years"
         );
-        debug_assert!(ny_offset < 32, "Year offset too big to store");
+        debug_assert!(ny_offset < 33, "Year offset too big to store");
         debug_assert!(
             leap_month_idx.map(|l| l.get() <= 13).unwrap_or(true),
             "Leap month indices must be 1 <= i <= 13"


### PR DESCRIPTION
According to Reingold and Dershowitz section 19.6: "The single year [in the range 1645-2644] that has a Chinese New Year on February 21 is 2319."

February 21 requires an offset of 33 relative to January 20.