### PR TITLE
Locid extensions tofromstr

### DIFF
--- a/components/locale_core/src/extensions/private/mod.rs
+++ b/components/locale_core/src/extensions/private/mod.rs
@@ -31,13 +31,18 @@ mod other;
 
 use alloc::vec::Vec;
 use core::ops::Deref;
+use core::str::FromStr;
 
 #[doc(inline)]
 pub use other::{subtag, Subtag};
 
+use super::ExtensionType;
 use crate::parser::ParserError;
 use crate::parser::SubtagIterator;
 use crate::shortvec::ShortBoxSlice;
+
+pub(crate) const PRIVATE_EXT_CHAR: char = 'x';
+pub(crate) const PRIVATE_EXT_STR: &str = "x";
 
 /// A list of [`Private Use Extensions`] as defined in [`Unicode Locale
 /// Identifier`] specification.
@@ -110,6 +115,17 @@ impl Private {
         Self(ShortBoxSlice::new_single(input))
     }
 
+    pub(crate) fn try_from_bytes(t: &[u8]) -> Result<Self, ParserError> {
+        let mut iter = SubtagIterator::new(t);
+
+        let ext = iter.next().ok_or(ParserError::InvalidExtension)?;
+        if let ExtensionType::Private = ExtensionType::try_from_byte_slice(ext)? {
+            return Self::try_from_iter(&mut iter);
+        }
+
+        Err(ParserError::InvalidExtension)
+    }
+
     /// Empties the [`Private`] list.
     ///
     /// # Examples
@@ -139,15 +155,25 @@ impl Private {
         Ok(Self(keys))
     }
 
-    pub(crate) fn for_each_subtag_str<E, F>(&self, f: &mut F) -> Result<(), E>
+    pub(crate) fn for_each_subtag_str<E, F>(&self, f: &mut F, with_ext: bool) -> Result<(), E>
     where
         F: FnMut(&str) -> Result<(), E>,
     {
         if self.is_empty() {
             return Ok(());
         }
-        f("x")?;
+        if with_ext {
+            f(PRIVATE_EXT_STR)?;
+        }
         self.deref().iter().map(|t| t.as_str()).try_for_each(f)
+    }
+}
+
+impl FromStr for Private {
+    type Err = ParserError;
+
+    fn from_str(source: &str) -> Result<Self, Self::Err> {
+        Self::try_from_bytes(source.as_bytes())
     }
 }
 
@@ -158,7 +184,7 @@ impl writeable::Writeable for Private {
         if self.is_empty() {
             return Ok(());
         }
-        sink.write_str("x")?;
+        sink.write_char(PRIVATE_EXT_CHAR)?;
         for key in self.iter() {
             sink.write_char('-')?;
             writeable::Writeable::write_to(key, sink)?;
@@ -183,5 +209,16 @@ impl Deref for Private {
 
     fn deref(&self) -> &Self::Target {
         self.0.deref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_private_extension_fromstr() {
+        let pe: Private = "x-foo-bar-l-baz".parse().expect("Failed to parse Private");
+        assert_eq!(pe.to_string(), "x-foo-bar-l-baz");
     }
 }

--- a/components/locale_core/src/extensions/transform/mod.rs
+++ b/components/locale_core/src/extensions/transform/mod.rs
@@ -35,18 +35,23 @@ mod key;
 mod value;
 
 use core::cmp::Ordering;
+use core::str::FromStr;
 
 pub use fields::Fields;
 #[doc(inline)]
 pub use key::{key, Key};
 pub use value::Value;
 
+use super::ExtensionType;
 use crate::parser::SubtagIterator;
 use crate::parser::{parse_language_identifier_from_iter, ParserError, ParserMode};
 use crate::shortvec::ShortBoxSlice;
 use crate::subtags::{self, Language};
 use crate::LanguageIdentifier;
 use litemap::LiteMap;
+
+pub(crate) const TRANSFORM_EXT_CHAR: char = 't';
+pub(crate) const TRANSFORM_EXT_STR: &str = "t";
 
 /// A list of [`Unicode BCP47 T Extensions`] as defined in [`Unicode Locale
 /// Identifier`] specification.
@@ -115,6 +120,17 @@ impl Transform {
     /// ```
     pub fn is_empty(&self) -> bool {
         self.lang.is_none() && self.fields.is_empty()
+    }
+
+    pub(crate) fn try_from_bytes(t: &[u8]) -> Result<Self, ParserError> {
+        let mut iter = SubtagIterator::new(t);
+
+        let ext = iter.next().ok_or(ParserError::InvalidExtension)?;
+        if let ExtensionType::Transform = ExtensionType::try_from_byte_slice(ext)? {
+            return Self::try_from_iter(&mut iter);
+        }
+
+        Err(ParserError::InvalidExtension)
     }
 
     /// Clears the transform extension, effectively removing it from the locale.
@@ -214,18 +230,28 @@ impl Transform {
         })
     }
 
-    pub(crate) fn for_each_subtag_str<E, F>(&self, f: &mut F) -> Result<(), E>
+    pub(crate) fn for_each_subtag_str<E, F>(&self, f: &mut F, with_ext: bool) -> Result<(), E>
     where
         F: FnMut(&str) -> Result<(), E>,
     {
         if self.is_empty() {
             return Ok(());
         }
-        f("t")?;
+        if with_ext {
+            f(TRANSFORM_EXT_STR)?;
+        }
         if let Some(lang) = &self.lang {
             lang.for_each_subtag_str_lowercased(f)?;
         }
         self.fields.for_each_subtag_str(f)
+    }
+}
+
+impl FromStr for Transform {
+    type Err = ParserError;
+
+    fn from_str(source: &str) -> Result<Self, Self::Err> {
+        Self::try_from_bytes(source.as_bytes())
     }
 }
 
@@ -236,7 +262,7 @@ impl writeable::Writeable for Transform {
         if self.is_empty() {
             return Ok(());
         }
-        sink.write_str("t")?;
+        sink.write_char(TRANSFORM_EXT_CHAR)?;
         if let Some(lang) = &self.lang {
             sink.write_char('-')?;
             lang.write_lowercased_to(sink)?;
@@ -260,5 +286,18 @@ impl writeable::Writeable for Transform {
             result += writeable::Writeable::writeable_length_hint(&self.fields) + 1;
         }
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_transform_extension_fromstr() {
+        let te: Transform = "t-en-us-h0-hybrid"
+            .parse()
+            .expect("Failed to parse Transform");
+        assert_eq!(te.to_string(), "t-en-us-h0-hybrid");
     }
 }

--- a/components/locale_core/src/extensions/unicode/keywords.rs
+++ b/components/locale_core/src/extensions/unicode/keywords.rs
@@ -5,6 +5,7 @@
 use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::iter::FromIterator;
+use core::str::FromStr;
 use litemap::LiteMap;
 use writeable::Writeable;
 
@@ -12,6 +13,8 @@ use super::Key;
 use super::Value;
 #[allow(deprecated)]
 use crate::ordering::SubtagOrderingResult;
+use crate::parser::ParserError;
+use crate::parser::SubtagIterator;
 use crate::shortvec::ShortBoxSlice;
 
 /// A list of [`Key`]-[`Value`] pairs representing functional information
@@ -88,6 +91,11 @@ impl Keywords {
         Self(LiteMap::from_sorted_store_unchecked(
             ShortBoxSlice::new_single((key, value)),
         ))
+    }
+
+    pub(crate) fn try_from_bytes(t: &[u8]) -> Result<Self, ParserError> {
+        let mut iter = SubtagIterator::new(t);
+        Self::try_from_iter(&mut iter)
     }
 
     /// Returns `true` if there are no keywords.
@@ -356,6 +364,44 @@ impl Keywords {
         }
     }
 
+    pub(crate) fn try_from_iter(iter: &mut SubtagIterator) -> Result<Self, ParserError> {
+        let mut keywords = LiteMap::new();
+
+        let mut current_keyword = None;
+        let mut current_value = ShortBoxSlice::new();
+
+        while let Some(subtag) = iter.peek() {
+            let slen = subtag.len();
+            if slen == 2 {
+                if let Some(kw) = current_keyword.take() {
+                    keywords.try_insert(kw, Value::from_short_slice_unchecked(current_value));
+                    current_value = ShortBoxSlice::new();
+                }
+                current_keyword = Some(Key::try_from_bytes(subtag)?);
+            } else if current_keyword.is_some() {
+                match Value::parse_subtag(subtag) {
+                    Ok(Some(t)) => current_value.push(t),
+                    Ok(None) => {}
+                    Err(_) => break,
+                }
+            } else {
+                break;
+            }
+            iter.next();
+        }
+
+        if let Some(kw) = current_keyword.take() {
+            keywords.try_insert(kw, Value::from_short_slice_unchecked(current_value));
+        }
+
+        Ok(keywords.into())
+    }
+
+    /// Produce an ordered iterator over key-value pairs
+    pub fn iter(&self) -> impl Iterator<Item = (&Key, &Value)> {
+        self.0.iter()
+    }
+
     pub(crate) fn for_each_subtag_str<E, F>(&self, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&str) -> Result<(), E>,
@@ -386,4 +432,23 @@ impl FromIterator<(Key, Value)> for Keywords {
     }
 }
 
+impl FromStr for Keywords {
+    type Err = ParserError;
+
+    fn from_str(source: &str) -> Result<Self, Self::Err> {
+        Self::try_from_bytes(source.as_bytes())
+    }
+}
+
 impl_writeable_for_key_value!(Keywords, "ca", "islamic-civil", "mm", "mm");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_keywords_fromstr() {
+        let kw: Keywords = "hc-h12".parse().expect("Failed to parse Keywords");
+        assert_eq!(kw.to_string(), "hc-h12");
+    }
+}

--- a/components/locale_core/src/extensions/unicode/mod.rs
+++ b/components/locale_core/src/extensions/unicode/mod.rs
@@ -33,6 +33,7 @@ mod keywords;
 mod value;
 
 use core::cmp::Ordering;
+use core::str::FromStr;
 
 #[doc(inline)]
 pub use attribute::{attribute, Attribute};
@@ -43,10 +44,12 @@ pub use keywords::Keywords;
 #[doc(inline)]
 pub use value::{value, Value};
 
+use super::ExtensionType;
 use crate::parser::ParserError;
 use crate::parser::SubtagIterator;
-use crate::shortvec::ShortBoxSlice;
-use litemap::LiteMap;
+
+pub(crate) const UNICODE_EXT_CHAR: char = 'u';
+pub(crate) const UNICODE_EXT_STR: &str = "u";
 
 /// Unicode Extensions provide information about user preferences in a given locale.
 ///
@@ -118,6 +121,17 @@ impl Unicode {
         self.keywords.is_empty() && self.attributes.is_empty()
     }
 
+    pub(crate) fn try_from_bytes(t: &[u8]) -> Result<Self, ParserError> {
+        let mut iter = SubtagIterator::new(t);
+
+        let ext = iter.next().ok_or(ParserError::InvalidExtension)?;
+        if let ExtensionType::Unicode = ExtensionType::try_from_byte_slice(ext)? {
+            return Self::try_from_iter(&mut iter);
+        }
+
+        Err(ParserError::InvalidExtension)
+    }
+
     /// Clears all Unicode extension keywords and attributes, effectively removing
     /// the Unicode extension.
     ///
@@ -151,47 +165,8 @@ impl Unicode {
     }
 
     pub(crate) fn try_from_iter(iter: &mut SubtagIterator) -> Result<Self, ParserError> {
-        let mut attributes = ShortBoxSlice::new();
-
-        while let Some(subtag) = iter.peek() {
-            if let Ok(attr) = Attribute::try_from_bytes(subtag) {
-                if let Err(idx) = attributes.binary_search(&attr) {
-                    attributes.insert(idx, attr);
-                }
-            } else {
-                break;
-            }
-            iter.next();
-        }
-
-        let mut keywords = LiteMap::new();
-
-        let mut current_keyword = None;
-        let mut current_value = ShortBoxSlice::new();
-
-        while let Some(subtag) = iter.peek() {
-            let slen = subtag.len();
-            if slen == 2 {
-                if let Some(kw) = current_keyword.take() {
-                    keywords.try_insert(kw, Value::from_short_slice_unchecked(current_value));
-                    current_value = ShortBoxSlice::new();
-                }
-                current_keyword = Some(Key::try_from_bytes(subtag)?);
-            } else if current_keyword.is_some() {
-                match Value::parse_subtag(subtag) {
-                    Ok(Some(t)) => current_value.push(t),
-                    Ok(None) => {}
-                    Err(_) => break,
-                }
-            } else {
-                break;
-            }
-            iter.next();
-        }
-
-        if let Some(kw) = current_keyword.take() {
-            keywords.try_insert(kw, Value::from_short_slice_unchecked(current_value));
-        }
+        let attributes = Attributes::try_from_iter(iter)?;
+        let keywords = Keywords::try_from_iter(iter)?;
 
         // Ensure we've defined at least one attribute or keyword
         if attributes.is_empty() && keywords.is_empty() {
@@ -199,22 +174,31 @@ impl Unicode {
         }
 
         Ok(Self {
-            keywords: keywords.into(),
-            attributes: Attributes::from_short_slice_unchecked(attributes),
+            keywords,
+            attributes,
         })
     }
 
-    pub(crate) fn for_each_subtag_str<E, F>(&self, f: &mut F) -> Result<(), E>
+    pub(crate) fn for_each_subtag_str<E, F>(&self, f: &mut F, with_ext: bool) -> Result<(), E>
     where
         F: FnMut(&str) -> Result<(), E>,
     {
-        if self.is_empty() {
-            return Ok(());
+        if !self.is_empty() {
+            if with_ext {
+                f(UNICODE_EXT_STR)?;
+            }
+            self.attributes.for_each_subtag_str(f)?;
+            self.keywords.for_each_subtag_str(f)?;
         }
-        f("u")?;
-        self.attributes.for_each_subtag_str(f)?;
-        self.keywords.for_each_subtag_str(f)?;
         Ok(())
+    }
+}
+
+impl FromStr for Unicode {
+    type Err = ParserError;
+
+    fn from_str(source: &str) -> Result<Self, Self::Err> {
+        Self::try_from_bytes(source.as_bytes())
     }
 }
 
@@ -222,10 +206,8 @@ writeable::impl_display_with_writeable!(Unicode);
 
 impl writeable::Writeable for Unicode {
     fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
-        if self.is_empty() {
-            return Ok(());
-        }
-        sink.write_str("u")?;
+        sink.write_char(UNICODE_EXT_CHAR)?;
+
         if !self.attributes.is_empty() {
             sink.write_char('-')?;
             writeable::Writeable::write_to(&self.attributes, sink)?;
@@ -249,5 +231,16 @@ impl writeable::Writeable for Unicode {
             result += writeable::Writeable::writeable_length_hint(&self.keywords) + 1;
         }
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unicode_extension_fromstr() {
+        let ue: Unicode = "u-foo-hc-h12".parse().expect("Failed to parse Unicode");
+        assert_eq!(ue.to_string(), "u-foo-hc-h12");
     }
 }

--- a/components/locale_core/src/extensions/unicode/value.rs
+++ b/components/locale_core/src/extensions/unicode/value.rs
@@ -4,6 +4,7 @@
 
 use crate::parser::{ParserError, SubtagIterator};
 use crate::shortvec::ShortBoxSlice;
+use alloc::vec::Vec;
 use core::ops::RangeInclusive;
 use core::str::FromStr;
 use tinystr::TinyAsciiStr;
@@ -100,6 +101,31 @@ impl Value {
                 Self(ShortBoxSlice::new_single(val))
             }
         }
+    }
+
+    /// A constructor which takes a pre-sorted list of [`Value`] elements.
+    ///
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::locale::extensions::unicode::Value;
+    /// use tinystr::{TinyAsciiStr, tinystr};
+    ///
+    /// let tinystr1: TinyAsciiStr<8> = tinystr!(8, "foobar");
+    /// let tinystr2: TinyAsciiStr<8> = tinystr!(8, "testing");
+    /// let mut v = vec![tinystr1, tinystr2];
+    /// v.sort();
+    /// v.dedup();
+    ///
+    /// let value = Value::from_vec_unchecked(v);
+    /// ```
+    ///
+    /// Notice: For performance- and memory-constrained environments, it is recommended
+    /// for the caller to use [`binary_search`](slice::binary_search) instead of [`sort`](slice::sort)
+    /// and [`dedup`](Vec::dedup()).
+    pub fn from_vec_unchecked(input: Vec<TinyAsciiStr<8>>) -> Self {
+        Self(input.into())
     }
 
     pub(crate) fn from_short_slice_unchecked(input: ShortBoxSlice<TinyAsciiStr<8>>) -> Self {

--- a/components/locale_core/src/helpers.rs
+++ b/components/locale_core/src/helpers.rs
@@ -377,14 +377,14 @@ macro_rules! impl_writeable_for_subtag_list {
         fn test_writeable() {
             writeable::assert_writeable_eq!(&$type::default(), "");
             writeable::assert_writeable_eq!(
-                &$type::from_short_slice_unchecked(alloc::vec![$sample1.parse().unwrap()].into()),
+                &$type::from_vec_unchecked(alloc::vec![$sample1.parse().unwrap()]),
                 $sample1,
             );
             writeable::assert_writeable_eq!(
-                &$type::from_short_slice_unchecked(vec![
+                &$type::from_vec_unchecked(vec![
                     $sample1.parse().unwrap(),
                     $sample2.parse().unwrap()
-                ].into()),
+                ]),
                 core::concat!($sample1, "-", $sample2),
             );
         }


### PR DESCRIPTION
Second part of #1833.

This one cleans up from/to str for locid extensions. This prepares ground for reuse of Subtag in Value API which will be introduced in the next PR.