### PR TITLE
Use narrow structs for formatting

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -1122,10 +1122,14 @@ pub trait IntoAnyCalendar: Calendar + Sized {
     /// You should not need to call this method directly
     fn to_any(self) -> AnyCalendar;
 
+    /// The [`AnyCalendarKind`] enum variant associated with this calendar
+    fn kind(&self) -> AnyCalendarKind;
+
     /// Convert this calendar into an [`AnyCalendar`], cloning it
     ///
     /// You should not need to call this method directly
     fn to_any_cloned(&self) -> AnyCalendar;
+
     /// Convert a date for this calendar into an [`AnyDateInner`]
     ///
     /// You should not need to call this method directly
@@ -1133,48 +1137,76 @@ pub trait IntoAnyCalendar: Calendar + Sized {
 }
 
 impl IntoAnyCalendar for Buddhist {
+    #[inline]
     fn to_any(self) -> AnyCalendar {
         AnyCalendar::Buddhist(Buddhist)
     }
+    #[inline]
+    fn kind(&self) -> AnyCalendarKind {
+        AnyCalendarKind::Buddhist
+    }
+    #[inline]
     fn to_any_cloned(&self) -> AnyCalendar {
         AnyCalendar::Buddhist(Buddhist)
     }
+    #[inline]
     fn date_to_any(&self, d: &Self::DateInner) -> AnyDateInner {
         AnyDateInner::Buddhist(*d)
     }
 }
 
 impl IntoAnyCalendar for Chinese {
+    #[inline]
     fn to_any(self) -> AnyCalendar {
         AnyCalendar::Chinese(self)
     }
+    #[inline]
+    fn kind(&self) -> AnyCalendarKind {
+        AnyCalendarKind::Chinese
+    }
+    #[inline]
     fn to_any_cloned(&self) -> AnyCalendar {
         AnyCalendar::Chinese(self.clone())
     }
+    #[inline]
     fn date_to_any(&self, d: &Self::DateInner) -> AnyDateInner {
         AnyDateInner::Chinese(*d)
     }
 }
 
 impl IntoAnyCalendar for Coptic {
+    #[inline]
     fn to_any(self) -> AnyCalendar {
         AnyCalendar::Coptic(Coptic)
     }
+    #[inline]
+    fn kind(&self) -> AnyCalendarKind {
+        AnyCalendarKind::Coptic
+    }
+    #[inline]
     fn to_any_cloned(&self) -> AnyCalendar {
         AnyCalendar::Coptic(Coptic)
     }
+    #[inline]
     fn date_to_any(&self, d: &Self::DateInner) -> AnyDateInner {
         AnyDateInner::Coptic(*d)
     }
 }
 
 impl IntoAnyCalendar for Dangi {
+    #[inline]
     fn to_any(self) -> AnyCalendar {
         AnyCalendar::Dangi(self)
     }
+    #[inline]
+    fn kind(&self) -> AnyCalendarKind {
+        AnyCalendarKind::Dangi
+    }
+    #[inline]
     fn to_any_cloned(&self) -> AnyCalendar {
         AnyCalendar::Dangi(self.clone())
     }
+    #[inline]
     fn date_to_any(&self, d: &Self::DateInner) -> AnyDateInner {
         AnyDateInner::Dangi(*d)
     }
@@ -1182,156 +1214,251 @@ impl IntoAnyCalendar for Dangi {
 
 impl IntoAnyCalendar for Ethiopian {
     // Amete Mihret calendars are the default
+    #[inline]
     fn to_any(self) -> AnyCalendar {
         AnyCalendar::Ethiopian(self)
     }
+    #[inline]
+    fn kind(&self) -> AnyCalendarKind {
+        if self.0 {
+            AnyCalendarKind::EthiopianAmeteAlem
+        } else {
+            AnyCalendarKind::Ethiopian
+        }
+    }
+    #[inline]
     fn to_any_cloned(&self) -> AnyCalendar {
         AnyCalendar::Ethiopian(*self)
     }
+    #[inline]
     fn date_to_any(&self, d: &Self::DateInner) -> AnyDateInner {
         AnyDateInner::Ethiopian(*d)
     }
 }
 
 impl IntoAnyCalendar for Gregorian {
+    #[inline]
     fn to_any(self) -> AnyCalendar {
         AnyCalendar::Gregorian(Gregorian)
     }
+    #[inline]
+    fn kind(&self) -> AnyCalendarKind {
+        AnyCalendarKind::Gregorian
+    }
+    #[inline]
     fn to_any_cloned(&self) -> AnyCalendar {
         AnyCalendar::Gregorian(Gregorian)
     }
+    #[inline]
     fn date_to_any(&self, d: &Self::DateInner) -> AnyDateInner {
         AnyDateInner::Gregorian(*d)
     }
 }
 
 impl IntoAnyCalendar for Hebrew {
+    #[inline]
     fn to_any(self) -> AnyCalendar {
         AnyCalendar::Hebrew(Hebrew)
     }
+    #[inline]
+    fn kind(&self) -> AnyCalendarKind {
+        AnyCalendarKind::Hebrew
+    }
+    #[inline]
     fn to_any_cloned(&self) -> AnyCalendar {
         AnyCalendar::Hebrew(Hebrew)
     }
+    #[inline]
     fn date_to_any(&self, d: &Self::DateInner) -> AnyDateInner {
         AnyDateInner::Hebrew(*d)
     }
 }
 
 impl IntoAnyCalendar for Indian {
+    #[inline]
     fn to_any(self) -> AnyCalendar {
         AnyCalendar::Indian(Indian)
     }
+    #[inline]
+    fn kind(&self) -> AnyCalendarKind {
+        AnyCalendarKind::Indian
+    }
+    #[inline]
     fn to_any_cloned(&self) -> AnyCalendar {
         AnyCalendar::Indian(Indian)
     }
+    #[inline]
     fn date_to_any(&self, d: &Self::DateInner) -> AnyDateInner {
         AnyDateInner::Indian(*d)
     }
 }
 
 impl IntoAnyCalendar for IslamicCivil {
+    #[inline]
     fn to_any(self) -> AnyCalendar {
         AnyCalendar::IslamicCivil(self)
     }
+    #[inline]
+    fn kind(&self) -> AnyCalendarKind {
+        AnyCalendarKind::IslamicCivil
+    }
+    #[inline]
     fn to_any_cloned(&self) -> AnyCalendar {
         AnyCalendar::IslamicCivil(*self)
     }
+    #[inline]
     fn date_to_any(&self, d: &Self::DateInner) -> AnyDateInner {
         AnyDateInner::IslamicCivil(*d)
     }
 }
 
 impl IntoAnyCalendar for IslamicObservational {
+    #[inline]
     fn to_any(self) -> AnyCalendar {
         AnyCalendar::IslamicObservational(self)
     }
+    #[inline]
+    fn kind(&self) -> AnyCalendarKind {
+        AnyCalendarKind::IslamicObservational
+    }
+    #[inline]
     fn to_any_cloned(&self) -> AnyCalendar {
         AnyCalendar::IslamicObservational(self.clone())
     }
+    #[inline]
     fn date_to_any(&self, d: &Self::DateInner) -> AnyDateInner {
         AnyDateInner::IslamicObservational(*d)
     }
 }
 
 impl IntoAnyCalendar for IslamicTabular {
+    #[inline]
     fn to_any(self) -> AnyCalendar {
         AnyCalendar::IslamicTabular(self)
     }
+    #[inline]
+    fn kind(&self) -> AnyCalendarKind {
+        AnyCalendarKind::IslamicTabular
+    }
+    #[inline]
     fn to_any_cloned(&self) -> AnyCalendar {
         AnyCalendar::IslamicTabular(*self)
     }
+    #[inline]
     fn date_to_any(&self, d: &Self::DateInner) -> AnyDateInner {
         AnyDateInner::IslamicTabular(*d)
     }
 }
 
 impl IntoAnyCalendar for IslamicUmmAlQura {
+    #[inline]
     fn to_any(self) -> AnyCalendar {
         AnyCalendar::IslamicUmmAlQura(self)
     }
+    #[inline]
+    fn kind(&self) -> AnyCalendarKind {
+        AnyCalendarKind::IslamicUmmAlQura
+    }
+    #[inline]
     fn to_any_cloned(&self) -> AnyCalendar {
         AnyCalendar::IslamicUmmAlQura(self.clone())
     }
+    #[inline]
     fn date_to_any(&self, d: &Self::DateInner) -> AnyDateInner {
         AnyDateInner::IslamicUmmAlQura(*d)
     }
 }
 
 impl IntoAnyCalendar for Iso {
+    #[inline]
     fn to_any(self) -> AnyCalendar {
         AnyCalendar::Iso(Iso)
     }
+    #[inline]
+    fn kind(&self) -> AnyCalendarKind {
+        AnyCalendarKind::Iso
+    }
+    #[inline]
     fn to_any_cloned(&self) -> AnyCalendar {
         AnyCalendar::Iso(Iso)
     }
+    #[inline]
     fn date_to_any(&self, d: &Self::DateInner) -> AnyDateInner {
         AnyDateInner::Iso(*d)
     }
 }
 
 impl IntoAnyCalendar for Japanese {
+    #[inline]
     fn to_any(self) -> AnyCalendar {
         AnyCalendar::Japanese(self)
     }
+    #[inline]
+    fn kind(&self) -> AnyCalendarKind {
+        AnyCalendarKind::Japanese
+    }
+    #[inline]
     fn to_any_cloned(&self) -> AnyCalendar {
         AnyCalendar::Japanese(self.clone())
     }
+    #[inline]
     fn date_to_any(&self, d: &Self::DateInner) -> AnyDateInner {
         AnyDateInner::Japanese(*d)
     }
 }
 
 impl IntoAnyCalendar for JapaneseExtended {
+    #[inline]
     fn to_any(self) -> AnyCalendar {
         AnyCalendar::JapaneseExtended(self)
     }
+    #[inline]
+    fn kind(&self) -> AnyCalendarKind {
+        AnyCalendarKind::JapaneseExtended
+    }
+    #[inline]
     fn to_any_cloned(&self) -> AnyCalendar {
         AnyCalendar::JapaneseExtended(self.clone())
     }
+    #[inline]
     fn date_to_any(&self, d: &Self::DateInner) -> AnyDateInner {
         AnyDateInner::JapaneseExtended(*d)
     }
 }
 
 impl IntoAnyCalendar for Persian {
+    #[inline]
     fn to_any(self) -> AnyCalendar {
         AnyCalendar::Persian(Persian)
     }
+    #[inline]
+    fn kind(&self) -> AnyCalendarKind {
+        AnyCalendarKind::Persian
+    }
+    #[inline]
     fn to_any_cloned(&self) -> AnyCalendar {
         AnyCalendar::Persian(Persian)
     }
+    #[inline]
     fn date_to_any(&self, d: &Self::DateInner) -> AnyDateInner {
         AnyDateInner::Persian(*d)
     }
 }
 
 impl IntoAnyCalendar for Roc {
+    #[inline]
     fn to_any(self) -> AnyCalendar {
         AnyCalendar::Roc(Roc)
     }
+    #[inline]
+    fn kind(&self) -> AnyCalendarKind {
+        AnyCalendarKind::Roc
+    }
+    #[inline]
     fn to_any_cloned(&self) -> AnyCalendar {
         AnyCalendar::Roc(Roc)
     }
+    #[inline]
     fn date_to_any(&self, d: &Self::DateInner) -> AnyDateInner {
         AnyDateInner::Roc(*d)
     }

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -154,7 +154,7 @@ impl Calendar for Buddhist {
     }
 
     fn any_calendar_kind(&self) -> Option<AnyCalendarKind> {
-        Some(AnyCalendarKind::Buddhist)
+        Some(crate::any_calendar::IntoAnyCalendar::kind(self))
     }
 }
 

--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -39,7 +39,6 @@
 //! assert_eq!(chinese_datetime.time.second.number(), 0);
 //! ```
 
-use crate::any_calendar::AnyCalendarKind;
 use crate::calendar_arithmetic::CalendarArithmetic;
 use crate::calendar_arithmetic::PrecomputedDataSource;
 use crate::chinese_based::{
@@ -306,9 +305,8 @@ impl Calendar for Chinese {
         }
     }
 
-    /// The [`AnyCalendarKind`] corresponding to this calendar
-    fn any_calendar_kind(&self) -> Option<AnyCalendarKind> {
-        Some(AnyCalendarKind::Chinese)
+    fn any_calendar_kind(&self) -> Option<crate::AnyCalendarKind> {
+        Some(crate::any_calendar::IntoAnyCalendar::kind(self))
     }
 
     fn months_in_year(&self, date: &Self::DateInner) -> u8 {

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -31,7 +31,6 @@
 //! assert_eq!(datetime_coptic.time.second.number(), 0);
 //! ```
 
-use crate::any_calendar::AnyCalendarKind;
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::iso::Iso;
 use crate::{types, Calendar, CalendarError, Date, DateDuration, DateDurationUnit, DateTime, Time};
@@ -206,8 +205,8 @@ impl Calendar for Coptic {
         "Coptic"
     }
 
-    fn any_calendar_kind(&self) -> Option<AnyCalendarKind> {
-        Some(AnyCalendarKind::Coptic)
+    fn any_calendar_kind(&self) -> Option<crate::AnyCalendarKind> {
+        Some(crate::any_calendar::IntoAnyCalendar::kind(self))
     }
 }
 

--- a/components/calendar/src/dangi.rs
+++ b/components/calendar/src/dangi.rs
@@ -50,7 +50,7 @@ use crate::AsCalendar;
 use crate::{
     chinese_based::ChineseBasedDateInner,
     types::{self, Era, FormattableYear},
-    AnyCalendarKind, Calendar, CalendarError, Date, DateTime, Iso, Time,
+    Calendar, CalendarError, Date, DateTime, Iso, Time,
 };
 use core::cmp::Ordering;
 use core::num::NonZeroU8;
@@ -287,7 +287,7 @@ impl Calendar for Dangi {
     }
 
     fn any_calendar_kind(&self) -> Option<crate::AnyCalendarKind> {
-        Some(AnyCalendarKind::Dangi)
+        Some(crate::any_calendar::IntoAnyCalendar::kind(self))
     }
 }
 

--- a/components/calendar/src/ethiopian.rs
+++ b/components/calendar/src/ethiopian.rs
@@ -32,7 +32,6 @@
 //! assert_eq!(datetime_ethiopian.time.second.number(), 0);
 //! ```
 
-use crate::any_calendar::AnyCalendarKind;
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::iso::Iso;
 use crate::{types, Calendar, CalendarError, Date, DateDuration, DateDurationUnit, DateTime, Time};
@@ -228,12 +227,8 @@ impl Calendar for Ethiopian {
         "Ethiopian"
     }
 
-    fn any_calendar_kind(&self) -> Option<AnyCalendarKind> {
-        if self.0 {
-            Some(AnyCalendarKind::EthiopianAmeteAlem)
-        } else {
-            Some(AnyCalendarKind::Ethiopian)
-        }
+    fn any_calendar_kind(&self) -> Option<crate::AnyCalendarKind> {
+        Some(crate::any_calendar::IntoAnyCalendar::kind(self))
     }
 }
 

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -31,7 +31,6 @@
 //! assert_eq!(datetime_gregorian.time.second.number(), 0);
 //! ```
 
-use crate::any_calendar::AnyCalendarKind;
 use crate::calendar_arithmetic::ArithmeticDate;
 use crate::iso::{Iso, IsoDateInner};
 use crate::{types, Calendar, CalendarError, Date, DateDuration, DateDurationUnit, DateTime, Time};
@@ -157,8 +156,8 @@ impl Calendar for Gregorian {
         "Gregorian"
     }
 
-    fn any_calendar_kind(&self) -> Option<AnyCalendarKind> {
-        Some(AnyCalendarKind::Gregorian)
+    fn any_calendar_kind(&self) -> Option<crate::AnyCalendarKind> {
+        Some(crate::any_calendar::IntoAnyCalendar::kind(self))
     }
 }
 

--- a/components/calendar/src/hebrew.rs
+++ b/components/calendar/src/hebrew.rs
@@ -33,7 +33,6 @@
 use crate::calendar_arithmetic::PrecomputedDataSource;
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::types::FormattableMonth;
-use crate::AnyCalendarKind;
 use crate::AsCalendar;
 use crate::Iso;
 use crate::{types, Calendar, CalendarError, Date, DateDuration, DateDurationUnit, DateTime, Time};
@@ -340,8 +339,9 @@ impl Calendar for Hebrew {
             next_year: Self::year_as_hebrew(next_year),
         }
     }
-    fn any_calendar_kind(&self) -> Option<AnyCalendarKind> {
-        Some(AnyCalendarKind::Hebrew)
+
+    fn any_calendar_kind(&self) -> Option<crate::AnyCalendarKind> {
+        Some(crate::any_calendar::IntoAnyCalendar::kind(self))
     }
 }
 

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -31,7 +31,6 @@
 //! assert_eq!(datetime_indian.time.second.number(), 0);
 //! ```
 
-use crate::any_calendar::AnyCalendarKind;
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::iso::Iso;
 use crate::{types, Calendar, CalendarError, Date, DateDuration, DateDurationUnit, DateTime, Time};
@@ -240,8 +239,8 @@ impl Calendar for Indian {
         "Indian"
     }
 
-    fn any_calendar_kind(&self) -> Option<AnyCalendarKind> {
-        Some(AnyCalendarKind::Indian)
+    fn any_calendar_kind(&self) -> Option<crate::AnyCalendarKind> {
+        Some(crate::any_calendar::IntoAnyCalendar::kind(self))
     }
 }
 

--- a/components/calendar/src/islamic.rs
+++ b/components/calendar/src/islamic.rs
@@ -42,7 +42,6 @@ use crate::provider::islamic::{
     IslamicCacheV1, IslamicObservationalCacheV1Marker, IslamicUmmAlQuraCacheV1Marker,
     PackedIslamicYearInfo,
 };
-use crate::AnyCalendarKind;
 use crate::AsCalendar;
 use crate::Iso;
 use crate::{types, Calendar, CalendarError, Date, DateDuration, DateDurationUnit, DateTime, Time};
@@ -549,8 +548,8 @@ impl Calendar for IslamicObservational {
         }
     }
 
-    fn any_calendar_kind(&self) -> Option<AnyCalendarKind> {
-        Some(AnyCalendarKind::IslamicObservational)
+    fn any_calendar_kind(&self) -> Option<crate::AnyCalendarKind> {
+        Some(crate::any_calendar::IntoAnyCalendar::kind(self))
     }
 }
 
@@ -784,8 +783,8 @@ impl Calendar for IslamicUmmAlQura {
         }
     }
 
-    fn any_calendar_kind(&self) -> Option<AnyCalendarKind> {
-        Some(AnyCalendarKind::IslamicUmmAlQura)
+    fn any_calendar_kind(&self) -> Option<crate::AnyCalendarKind> {
+        Some(crate::any_calendar::IntoAnyCalendar::kind(self))
     }
 }
 
@@ -1014,8 +1013,9 @@ impl Calendar for IslamicCivil {
             next_year: Self::year_as_islamic(next_year),
         }
     }
-    fn any_calendar_kind(&self) -> Option<AnyCalendarKind> {
-        Some(AnyCalendarKind::IslamicCivil)
+
+    fn any_calendar_kind(&self) -> Option<crate::AnyCalendarKind> {
+        Some(crate::any_calendar::IntoAnyCalendar::kind(self))
     }
 }
 
@@ -1256,8 +1256,9 @@ impl Calendar for IslamicTabular {
             next_year: Self::year_as_islamic(next_year),
         }
     }
-    fn any_calendar_kind(&self) -> Option<AnyCalendarKind> {
-        Some(AnyCalendarKind::IslamicTabular)
+
+    fn any_calendar_kind(&self) -> Option<crate::AnyCalendarKind> {
+        Some(crate::any_calendar::IntoAnyCalendar::kind(self))
     }
 }
 

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -29,7 +29,6 @@
 //! assert_eq!(datetime_iso.time.second.number(), 0);
 //! ```
 
-use crate::any_calendar::AnyCalendarKind;
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::{types, Calendar, CalendarError, Date, DateDuration, DateDurationUnit, DateTime, Time};
 use calendrical_calculations::helpers::{i64_to_saturated_i32, I32CastError};
@@ -228,8 +227,8 @@ impl Calendar for Iso {
         "ISO"
     }
 
-    fn any_calendar_kind(&self) -> Option<AnyCalendarKind> {
-        Some(AnyCalendarKind::Iso)
+    fn any_calendar_kind(&self) -> Option<crate::AnyCalendarKind> {
+        Some(crate::any_calendar::IntoAnyCalendar::kind(self))
     }
 }
 

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -41,7 +41,6 @@
 //! assert_eq!(datetime_japanese.time.second.number(), 0);
 //! ```
 
-use crate::any_calendar::AnyCalendarKind;
 use crate::iso::{Iso, IsoDateInner};
 use crate::provider::{EraStartDate, JapaneseErasV1Marker, JapaneseExtendedErasV1Marker};
 use crate::{
@@ -317,8 +316,8 @@ impl Calendar for Japanese {
         Self::DEBUG_NAME
     }
 
-    fn any_calendar_kind(&self) -> Option<AnyCalendarKind> {
-        Some(AnyCalendarKind::Japanese)
+    fn any_calendar_kind(&self) -> Option<crate::AnyCalendarKind> {
+        Some(crate::any_calendar::IntoAnyCalendar::kind(self))
     }
 }
 
@@ -407,8 +406,8 @@ impl Calendar for JapaneseExtended {
         Self::DEBUG_NAME
     }
 
-    fn any_calendar_kind(&self) -> Option<AnyCalendarKind> {
-        Some(AnyCalendarKind::JapaneseExtended)
+    fn any_calendar_kind(&self) -> Option<crate::AnyCalendarKind> {
+        Some(crate::any_calendar::IntoAnyCalendar::kind(self))
     }
 }
 

--- a/components/calendar/src/persian.rs
+++ b/components/calendar/src/persian.rs
@@ -30,7 +30,6 @@
 //! assert_eq!(persian_datetime.time.second.number(), 0);
 //! ```
 
-use crate::any_calendar::AnyCalendarKind;
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::iso::Iso;
 use crate::{types, Calendar, CalendarError, Date, DateDuration, DateDurationUnit, DateTime, Time};
@@ -192,9 +191,9 @@ impl Calendar for Persian {
     fn debug_name(&self) -> &'static str {
         "Persian"
     }
-    // Missing any_calendar persian tests, the rest is completed
-    fn any_calendar_kind(&self) -> Option<AnyCalendarKind> {
-        Some(AnyCalendarKind::Persian)
+
+    fn any_calendar_kind(&self) -> Option<crate::AnyCalendarKind> {
+        Some(crate::any_calendar::IntoAnyCalendar::kind(self))
     }
 }
 

--- a/components/calendar/src/roc.rs
+++ b/components/calendar/src/roc.rs
@@ -32,8 +32,8 @@
 //! ```
 
 use crate::{
-    calendar_arithmetic::ArithmeticDate, iso::IsoDateInner, types, AnyCalendarKind, Calendar,
-    CalendarError, Date, DateTime, Iso, Time,
+    calendar_arithmetic::ArithmeticDate, iso::IsoDateInner, types, Calendar, CalendarError, Date,
+    DateTime, Iso, Time,
 };
 use calendrical_calculations::helpers::i64_to_saturated_i32;
 use tinystr::tinystr;
@@ -170,9 +170,8 @@ impl Calendar for Roc {
         }
     }
 
-    /// The [`AnyCalendarKind`] corresponding to this calendar
-    fn any_calendar_kind(&self) -> Option<AnyCalendarKind> {
-        Some(AnyCalendarKind::Roc)
+    fn any_calendar_kind(&self) -> Option<crate::AnyCalendarKind> {
+        Some(crate::any_calendar::IntoAnyCalendar::kind(self))
     }
 }
 

--- a/components/datetime/src/input.rs
+++ b/components/datetime/src/input.rs
@@ -6,7 +6,9 @@
 //! formatting operations.
 
 #[cfg(feature = "experimental")]
-use crate::neo_marker::{NeoDateInputFields, NeoTimeInputFields, NeoWeekInputFields, AllInputFields};
+use crate::neo_marker::{
+    AllInputFields, NeoDateInputFields, NeoTimeInputFields, NeoWeekInputFields,
+};
 use crate::provider::time_zones::{MetazoneId, TimeZoneBcp47Id};
 use icu_calendar::any_calendar::AnyCalendarKind;
 use icu_calendar::week::{RelativeUnit, WeekCalculator};

--- a/components/datetime/src/input.rs
+++ b/components/datetime/src/input.rs
@@ -246,8 +246,8 @@ impl ExtractedDateTimeInput {
     }
     /// Construct given neo date input instances.
     #[cfg(feature = "experimental")]
-    pub(crate) fn extract_from_neo_input<C>(
-        neo_date: Option<NeoDateInputFields<C>>,
+    pub(crate) fn extract_from_neo_input(
+        neo_date: Option<NeoDateInputFields>,
         neo_week: Option<NeoWeekInputFields>,
         neo_time: Option<NeoTimeInputFields>,
     ) -> Self {

--- a/components/datetime/src/input.rs
+++ b/components/datetime/src/input.rs
@@ -6,7 +6,7 @@
 //! formatting operations.
 
 #[cfg(feature = "experimental")]
-use crate::neo_marker::{NeoDateInputFields, NeoTimeInputFields, NeoWeekInputFields};
+use crate::neo_marker::{NeoDateInputFields, NeoTimeInputFields, NeoWeekInputFields, AllInputFields};
 use crate::provider::time_zones::{MetazoneId, TimeZoneBcp47Id};
 use icu_calendar::any_calendar::AnyCalendarKind;
 use icu_calendar::week::{RelativeUnit, WeekCalculator};
@@ -264,6 +264,22 @@ impl ExtractedDateTimeInput {
             minute: neo_time.as_ref().map(|fields| fields.minute),
             second: neo_time.as_ref().map(|fields| fields.second),
             nanosecond: neo_time.as_ref().map(|fields| fields.nanosecond),
+        }
+    }
+    /// Construct given [`AllInputFields`] instances
+    #[cfg(feature = "experimental")]
+    pub(crate) fn extract_from_all_input_fields(value: AllInputFields) -> Self {
+        Self {
+            year: value.year,
+            month: value.month,
+            day_of_month: value.day_of_month,
+            iso_weekday: value.day_of_week,
+            day_of_year_info: value.day_of_year_info,
+            any_calendar_kind: value.any_calendar_kind,
+            hour: value.hour,
+            minute: value.minute,
+            second: value.second,
+            nanosecond: value.nanosecond,
         }
     }
 }

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -486,6 +486,51 @@ impl<C: CldrCalendar, R: TypedNeoFormatterMarker<C>> TypedNeoFormatter<C, R> {
             names: self.names.as_borrowed(),
         }
     }
+
+    /// Formats a date/time value.
+    /// 
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::Date;
+    /// use icu::calendar::Gregorian;
+    /// use icu::calendar::types::FormattableMonth;
+    /// use icu::calendar::types::MonthCode;
+    /// use icu::datetime::neo::TypedNeoFormatter;
+    /// use icu::datetime::neo_marker::MonthInput;
+    /// use icu::datetime::neo_skeleton::NeoSkeletonLength;
+    /// use icu::locid::locale;
+    /// use tinystr::tinystr;
+    /// use writeable::assert_try_writeable_eq;
+    ///
+    /// let formatter =
+    ///     TypedNeoFormatter::<Gregorian, MonthInput<Gregorian>>::try_new(
+    ///         &locale!("es-MX").into(),
+    ///         NeoSkeletonLength::Long,
+    ///     )
+    ///     .unwrap();
+    /// 
+    /// let input = MonthInput {
+    ///     month: FormattableMonth {
+    ///         ordinal: 5,
+    ///         code: MonthCode(tinystr!(4, "M05"))
+    ///     },
+    ///     calendar: Gregorian.into(),
+    /// };
+    /// 
+    /// assert_try_writeable_eq!(
+    ///     formatter.format_narrow(input),
+    ///     "mayo"
+    /// );
+    /// ```
+    pub fn format_narrow(&self, value: R::Input) -> FormattedNeoDateTime {
+        let datetime = ExtractedDateTimeInput::extract_from_all_input_fields(value.into());
+        FormattedNeoDateTime {
+            pattern: self.selection.select(&datetime),
+            datetime,
+            names: self.names.as_borrowed(),
+        }
+    }
 }
 
 size_test!(

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -11,7 +11,7 @@ use crate::format::datetime::{try_write_pattern, try_write_pattern_items};
 use crate::format::neo::*;
 use crate::input::ExtractedDateTimeInput;
 use crate::input::{DateInput, DateTimeInput, IsoTimeInput};
-use crate::neo_marker::{DateMarkers, HasNeoComponents, NeoFormatterMarker, TimeMarkers};
+use crate::neo_marker::{DateMarkers, TypedNeoFormatterMarker, NeoFormatterMarker, TimeMarkers};
 use crate::neo_pattern::DateTimePattern;
 use crate::neo_skeleton::NeoSkeletonLength;
 use crate::options::length;
@@ -286,13 +286,13 @@ size_test!(TypedNeoFormatter<icu_calendar::Gregorian, crate::neo_marker::NeoYear
 /// <a href="https://github.com/unicode-org/icu4x/issues/3347">#3347</a>
 /// </div>
 #[derive(Debug)]
-pub struct TypedNeoFormatter<C: CldrCalendar, R: HasNeoComponents<C>> {
+pub struct TypedNeoFormatter<C: CldrCalendar, R: TypedNeoFormatterMarker<C>> {
     selection: DateTimePatternSelectionData,
     names: RawDateTimeNames<R::DateTimeNamesMarker>,
     _calendar: PhantomData<C>,
 }
 
-impl<C: CldrCalendar, R: HasNeoComponents<C>> TypedNeoFormatter<C, R> {
+impl<C: CldrCalendar, R: TypedNeoFormatterMarker<C>> TypedNeoFormatter<C, R> {
     /// Creates a [`TypedNeoFormatter`] for a date skeleton.
     ///
     /// # Examples

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -488,7 +488,7 @@ impl<C: CldrCalendar, R: TypedNeoFormatterMarker<C>> TypedNeoFormatter<C, R> {
     }
 
     /// Formats a date/time value.
-    /// 
+    ///
     /// # Examples
     ///
     /// ```
@@ -509,7 +509,7 @@ impl<C: CldrCalendar, R: TypedNeoFormatterMarker<C>> TypedNeoFormatter<C, R> {
     ///         NeoSkeletonLength::Long,
     ///     )
     ///     .unwrap();
-    /// 
+    ///
     /// let input = MonthInput {
     ///     month: FormattableMonth {
     ///         ordinal: 5,
@@ -517,7 +517,7 @@ impl<C: CldrCalendar, R: TypedNeoFormatterMarker<C>> TypedNeoFormatter<C, R> {
     ///     },
     ///     calendar: Gregorian.into(),
     /// };
-    /// 
+    ///
     /// assert_try_writeable_eq!(
     ///     formatter.format_narrow(input),
     ///     "mayo"

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -11,7 +11,9 @@ use crate::format::datetime::{try_write_pattern, try_write_pattern_items};
 use crate::format::neo::*;
 use crate::input::ExtractedDateTimeInput;
 use crate::input::{DateInput, DateTimeInput, IsoTimeInput};
-use crate::neo_marker::{TypedDateMarkers, TypedNeoFormatterMarker, NeoFormatterMarker, TimeMarkers};
+use crate::neo_marker::{
+    DateMarkers, NeoFormatterMarker, TimeMarkers, TypedDateMarkers, TypedNeoFormatterMarker,
+};
 use crate::neo_pattern::DateTimePattern;
 use crate::neo_skeleton::NeoSkeletonLength;
 use crate::options::length;
@@ -405,9 +407,9 @@ impl<C: CldrCalendar, R: TypedNeoFormatterMarker<C>> TypedNeoFormatter<C, R> {
             &<R::D as TypedDateMarkers<C>>::YearNamesV1Marker::bind(provider), // year
             &<R::D as TypedDateMarkers<C>>::MonthNamesV1Marker::bind(provider), // month
             &<R::D as TypedDateMarkers<C>>::WeekdayNamesV1Marker::bind(provider), // weekday
-            &<R::T as TimeMarkers>::DayPeriodNamesV1Marker::bind(provider), // day period
-            Some(loader),                                                 // fixed decimal formatter
-            Some(loader),                                                 // week calculator
+            &<R::T as TimeMarkers>::DayPeriodNamesV1Marker::bind(provider),    // day period
+            Some(loader), // fixed decimal formatter
+            Some(loader), // week calculator
             locale,
             selection.pattern_items_for_data_loading(),
         )?;
@@ -468,7 +470,8 @@ impl<C: CldrCalendar, R: TypedNeoFormatterMarker<C>> TypedNeoFormatter<C, R> {
     pub fn format<T>(&self, datetime: &T) -> FormattedNeoDateTime
     where
         T: ?Sized,
-        for<'a> &'a T: Into<<R::D as TypedDateMarkers<C>>::DateInputMarker>
+        for<'a> &'a T: Into<<R::D as TypedDateMarkers<C>>::TypedInputMarker>
+            + Into<<R::D as TypedDateMarkers<C>>::DateInputMarker>
             + Into<<R::D as TypedDateMarkers<C>>::WeekInputMarker>
             + Into<<R::T as TimeMarkers>::TimeInputMarker>,
     {
@@ -554,61 +557,61 @@ impl<R: NeoFormatterMarker> NeoFormatter<R> {
     pub fn try_new(locale: &DataLocale, length: NeoSkeletonLength) -> Result<Self, LoadError>
     where
         crate::provider::Baked: Sized
-            // Date formatting keys
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Buddhist>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Chinese>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Coptic>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Dangi>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Ethiopian>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::EthiopianAmeteAlem>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Gregorian>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Hebrew>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Indian>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::IslamicCivil>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::IslamicObservational>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::IslamicTabular>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::IslamicUmmAlQura>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Japanese>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::JapaneseExtended>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Persian>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Roc>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Buddhist>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Chinese>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Coptic>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Dangi>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Ethiopian>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::EthiopianAmeteAlem>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Gregorian>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Hebrew>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Indian>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::IslamicCivil>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::IslamicObservational>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::IslamicTabular>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::IslamicUmmAlQura>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Japanese>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::JapaneseExtended>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Persian>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Roc>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Buddhist>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Chinese>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Coptic>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Dangi>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Ethiopian>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::EthiopianAmeteAlem>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Gregorian>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Hebrew>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Indian>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::IslamicCivil>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::IslamicObservational>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::IslamicTabular>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::IslamicUmmAlQura>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Japanese>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::JapaneseExtended>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Persian>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Roc>
-            + DataProvider<R::WeekdayNamesV1Marker>
-            + DataProvider<R::DayPeriodNamesV1Marker>
-            + DataProvider<R::TimeSkeletonPatternsV1Marker>
+    // Date formatting keys
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Buddhist>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Chinese>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Coptic>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Dangi>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Ethiopian>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::EthiopianAmeteAlem>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Gregorian>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Hebrew>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Indian>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::IslamicCivil>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::IslamicObservational>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::IslamicTabular>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::IslamicUmmAlQura>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Japanese>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::JapaneseExtended>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Persian>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Roc>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Buddhist>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Chinese>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Coptic>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Dangi>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Ethiopian>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::EthiopianAmeteAlem>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Gregorian>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Hebrew>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Indian>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::IslamicCivil>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::IslamicObservational>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::IslamicTabular>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::IslamicUmmAlQura>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Japanese>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::JapaneseExtended>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Persian>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Roc>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Buddhist>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Chinese>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Coptic>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Dangi>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Ethiopian>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::EthiopianAmeteAlem>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Gregorian>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Hebrew>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Indian>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::IslamicCivil>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::IslamicObservational>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::IslamicTabular>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::IslamicUmmAlQura>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Japanese>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::JapaneseExtended>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Persian>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Roc>
+            + DataProvider<<R::D as DateMarkers>::WeekdayNamesV1Marker>
+            + DataProvider<<R::T as TimeMarkers>::DayPeriodNamesV1Marker>
+            + DataProvider<<R::T as TimeMarkers>::TimeSkeletonPatternsV1Marker>
             + DataProvider<R::DateTimePatternV1Marker>,
     {
         Self::try_new_internal(
@@ -635,72 +638,72 @@ impl<R: NeoFormatterMarker> NeoFormatter<R> {
     ) -> Result<Self, LoadError>
     where
         P: ?Sized
-            // Date formatting keys
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Buddhist>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Chinese>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Coptic>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Dangi>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Ethiopian>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::EthiopianAmeteAlem>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Gregorian>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Hebrew>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Indian>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::IslamicCivil>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::IslamicObservational>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::IslamicTabular>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::IslamicUmmAlQura>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Japanese>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::JapaneseExtended>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Persian>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Roc>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Buddhist>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Chinese>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Coptic>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Dangi>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Ethiopian>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::EthiopianAmeteAlem>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Gregorian>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Hebrew>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Indian>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::IslamicCivil>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::IslamicObservational>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::IslamicTabular>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::IslamicUmmAlQura>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Japanese>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::JapaneseExtended>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Persian>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Roc>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Buddhist>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Chinese>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Coptic>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Dangi>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Ethiopian>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::EthiopianAmeteAlem>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Gregorian>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Hebrew>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Indian>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::IslamicCivil>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::IslamicObservational>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::IslamicTabular>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::IslamicUmmAlQura>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Japanese>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::JapaneseExtended>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Persian>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Roc>
-            + DataProvider<R::WeekdayNamesV1Marker>
-            + DataProvider<R::DayPeriodNamesV1Marker>
-            + DataProvider<R::TimeSkeletonPatternsV1Marker>
+    // Date formatting keys
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Buddhist>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Chinese>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Coptic>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Dangi>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Ethiopian>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::EthiopianAmeteAlem>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Gregorian>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Hebrew>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Indian>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::IslamicCivil>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::IslamicObservational>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::IslamicTabular>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::IslamicUmmAlQura>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Japanese>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::JapaneseExtended>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Persian>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Roc>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Buddhist>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Chinese>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Coptic>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Dangi>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Ethiopian>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::EthiopianAmeteAlem>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Gregorian>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Hebrew>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Indian>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::IslamicCivil>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::IslamicObservational>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::IslamicTabular>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::IslamicUmmAlQura>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Japanese>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::JapaneseExtended>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Persian>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Roc>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Buddhist>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Chinese>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Coptic>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Dangi>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Ethiopian>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::EthiopianAmeteAlem>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Gregorian>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Hebrew>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Indian>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::IslamicCivil>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::IslamicObservational>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::IslamicTabular>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::IslamicUmmAlQura>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Japanese>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::JapaneseExtended>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Persian>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Roc>
+            + DataProvider<<R::D as DateMarkers>::WeekdayNamesV1Marker>
+            + DataProvider<<R::T as TimeMarkers>::DayPeriodNamesV1Marker>
+            + DataProvider<<R::T as TimeMarkers>::TimeSkeletonPatternsV1Marker>
             + DataProvider<R::DateTimePatternV1Marker>
-            // AnyCalendar constructor keys
+    // AnyCalendar constructor keys
             + DataProvider<ChineseCacheV1Marker>
             + DataProvider<DangiCacheV1Marker>
             + DataProvider<IslamicObservationalCacheV1Marker>
             + DataProvider<IslamicUmmAlQuraCacheV1Marker>
             + DataProvider<JapaneseErasV1Marker>
             + DataProvider<JapaneseExtendedErasV1Marker>
-            // FixedDecimalFormatter keys
+    // FixedDecimalFormatter keys
             + DataProvider<DecimalSymbolsV1Marker>
-            // WeekCalculator keys
+    // WeekCalculator keys
             + DataProvider<WeekDataV2Marker>,
     {
         Self::try_new_internal(provider, &ExternalLoaderUnstable(provider), locale, length)
@@ -714,69 +717,69 @@ impl<R: NeoFormatterMarker> NeoFormatter<R> {
     ) -> Result<Self, LoadError>
     where
         P: ?Sized
-            // Date formatting keys
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Buddhist>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Chinese>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Coptic>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Dangi>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Ethiopian>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::EthiopianAmeteAlem>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Gregorian>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Hebrew>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Indian>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::IslamicCivil>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::IslamicObservational>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::IslamicTabular>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::IslamicUmmAlQura>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Japanese>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::JapaneseExtended>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Persian>
-            + DataProvider<<R::Year as CalMarkers<YearNamesV1Marker>>::Roc>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Buddhist>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Chinese>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Coptic>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Dangi>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Ethiopian>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::EthiopianAmeteAlem>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Gregorian>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Hebrew>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Indian>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::IslamicCivil>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::IslamicObservational>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::IslamicTabular>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::IslamicUmmAlQura>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Japanese>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::JapaneseExtended>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Persian>
-            + DataProvider<<R::Month as CalMarkers<MonthNamesV1Marker>>::Roc>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Buddhist>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Chinese>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Coptic>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Dangi>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Ethiopian>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::EthiopianAmeteAlem>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Gregorian>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Hebrew>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Indian>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::IslamicCivil>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::IslamicObservational>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::IslamicTabular>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::IslamicUmmAlQura>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Japanese>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::JapaneseExtended>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Persian>
-            + DataProvider<<R::Skel as CalMarkers<SkeletaV1Marker>>::Roc>
-            + DataProvider<R::WeekdayNamesV1Marker>
-            + DataProvider<R::DayPeriodNamesV1Marker>
-            + DataProvider<R::TimeSkeletonPatternsV1Marker>
+    // Date formatting keys
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Buddhist>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Chinese>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Coptic>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Dangi>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Ethiopian>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::EthiopianAmeteAlem>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Gregorian>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Hebrew>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Indian>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::IslamicCivil>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::IslamicObservational>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::IslamicTabular>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::IslamicUmmAlQura>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Japanese>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::JapaneseExtended>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Persian>
+            + DataProvider<<<R::D as DateMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Roc>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Buddhist>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Chinese>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Coptic>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Dangi>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Ethiopian>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::EthiopianAmeteAlem>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Gregorian>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Hebrew>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Indian>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::IslamicCivil>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::IslamicObservational>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::IslamicTabular>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::IslamicUmmAlQura>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Japanese>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::JapaneseExtended>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Persian>
+            + DataProvider<<<R::D as DateMarkers>::Month as CalMarkers<MonthNamesV1Marker>>::Roc>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Buddhist>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Chinese>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Coptic>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Dangi>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Ethiopian>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::EthiopianAmeteAlem>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Gregorian>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Hebrew>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Indian>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::IslamicCivil>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::IslamicObservational>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::IslamicTabular>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::IslamicUmmAlQura>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Japanese>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::JapaneseExtended>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Persian>
+            + DataProvider<<<R::D as DateMarkers>::Skel as CalMarkers<SkeletaV1Marker>>::Roc>
+            + DataProvider<<R::D as DateMarkers>::WeekdayNamesV1Marker>
+            + DataProvider<<R::T as TimeMarkers>::DayPeriodNamesV1Marker>
+            + DataProvider<<R::T as TimeMarkers>::TimeSkeletonPatternsV1Marker>
             + DataProvider<R::DateTimePatternV1Marker>,
         L: FixedDecimalFormatterLoader + WeekCalculatorLoader + AnyCalendarLoader,
     {
         let calendar = AnyCalendarLoader::load(loader, locale).map_err(LoadError::Data)?;
         let kind = calendar.kind();
         let selection = DateTimePatternSelectionData::try_new_with_skeleton(
-            &AnyCalendarProvider::<R::Skel, _>::new(provider, kind),
-            &R::TimeSkeletonPatternsV1Marker::bind(provider),
+            &AnyCalendarProvider::<<R::D as DateMarkers>::Skel, _>::new(provider, kind),
+            &<R::T as TimeMarkers>::TimeSkeletonPatternsV1Marker::bind(provider),
             &R::DateTimePatternV1Marker::bind(provider),
             locale,
             length,
@@ -785,12 +788,12 @@ impl<R: NeoFormatterMarker> NeoFormatter<R> {
         .map_err(LoadError::Data)?;
         let mut names = RawDateTimeNames::new_without_fixed_decimal_formatter();
         names.load_for_pattern(
-            &AnyCalendarProvider::<R::Year, _>::new(provider, kind), // year
-            &AnyCalendarProvider::<R::Month, _>::new(provider, kind), // month
-            &R::WeekdayNamesV1Marker::bind(provider),                // weekday
-            &R::DayPeriodNamesV1Marker::bind(provider),              // day period
-            Some(loader),                                            // fixed decimal formatter
-            Some(loader),                                            // week calculator
+            &AnyCalendarProvider::<<R::D as DateMarkers>::Year, _>::new(provider, kind), // year
+            &AnyCalendarProvider::<<R::D as DateMarkers>::Month, _>::new(provider, kind), // month
+            &<R::D as DateMarkers>::WeekdayNamesV1Marker::bind(provider),                // weekday
+            &<R::T as TimeMarkers>::DayPeriodNamesV1Marker::bind(provider), // day period
+            Some(loader), // fixed decimal formatter
+            Some(loader), // week calculator
             locale,
             selection.pattern_items_for_data_loading(),
         )?;
@@ -826,6 +829,17 @@ impl<R: NeoFormatterMarker> NeoFormatter<R> {
             datetime,
             names: self.names.as_borrowed(),
         })
+    }
+
+    /// TODO
+    pub fn format_neo<T>(&self, _datetime: &T) -> FormattedNeoDateTime
+    where
+        T: ?Sized,
+        for<'a> &'a T: Into<<R::D as DateMarkers>::DateInputMarker>
+            + Into<<R::D as DateMarkers>::WeekInputMarker>
+            + Into<<R::T as TimeMarkers>::TimeInputMarker>,
+    {
+        todo!()
     }
 
     /// Infallibly formats a datetime after first converting it

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -11,7 +11,7 @@ use crate::format::datetime::{try_write_pattern, try_write_pattern_items};
 use crate::format::neo::*;
 use crate::input::ExtractedDateTimeInput;
 use crate::input::{DateInput, DateTimeInput, IsoTimeInput};
-use crate::neo_marker::{DateMarkers, TypedNeoFormatterMarker, NeoFormatterMarker, TimeMarkers};
+use crate::neo_marker::{TypedDateMarkers, TypedNeoFormatterMarker, NeoFormatterMarker, TimeMarkers};
 use crate::neo_pattern::DateTimePattern;
 use crate::neo_skeleton::NeoSkeletonLength;
 use crate::options::length;
@@ -325,10 +325,10 @@ impl<C: CldrCalendar, R: TypedNeoFormatterMarker<C>> TypedNeoFormatter<C, R> {
     where
         crate::provider::Baked: Sized
             // Date formatting keys
-            + DataProvider<<R::D as DateMarkers<C>>::YearNamesV1Marker>
-            + DataProvider<<R::D as DateMarkers<C>>::MonthNamesV1Marker>
-            + DataProvider<<R::D as DateMarkers<C>>::DateSkeletonPatternsV1Marker>
-            + DataProvider<<R::D as DateMarkers<C>>::WeekdayNamesV1Marker>
+            + DataProvider<<R::D as TypedDateMarkers<C>>::YearNamesV1Marker>
+            + DataProvider<<R::D as TypedDateMarkers<C>>::MonthNamesV1Marker>
+            + DataProvider<<R::D as TypedDateMarkers<C>>::DateSkeletonPatternsV1Marker>
+            + DataProvider<<R::D as TypedDateMarkers<C>>::WeekdayNamesV1Marker>
             + DataProvider<<R::T as TimeMarkers>::DayPeriodNamesV1Marker>
             + DataProvider<<R::T as TimeMarkers>::TimeSkeletonPatternsV1Marker>
             + DataProvider<R::DateTimePatternV1Marker>,
@@ -358,10 +358,10 @@ impl<C: CldrCalendar, R: TypedNeoFormatterMarker<C>> TypedNeoFormatter<C, R> {
     where
         P: ?Sized
             // Date formatting keys
-            + DataProvider<<R::D as DateMarkers<C>>::YearNamesV1Marker>
-            + DataProvider<<R::D as DateMarkers<C>>::MonthNamesV1Marker>
-            + DataProvider<<R::D as DateMarkers<C>>::DateSkeletonPatternsV1Marker>
-            + DataProvider<<R::D as DateMarkers<C>>::WeekdayNamesV1Marker>
+            + DataProvider<<R::D as TypedDateMarkers<C>>::YearNamesV1Marker>
+            + DataProvider<<R::D as TypedDateMarkers<C>>::MonthNamesV1Marker>
+            + DataProvider<<R::D as TypedDateMarkers<C>>::DateSkeletonPatternsV1Marker>
+            + DataProvider<<R::D as TypedDateMarkers<C>>::WeekdayNamesV1Marker>
             + DataProvider<<R::T as TimeMarkers>::DayPeriodNamesV1Marker>
             + DataProvider<<R::T as TimeMarkers>::TimeSkeletonPatternsV1Marker>
             + DataProvider<R::DateTimePatternV1Marker>
@@ -382,17 +382,17 @@ impl<C: CldrCalendar, R: TypedNeoFormatterMarker<C>> TypedNeoFormatter<C, R> {
     where
         P: ?Sized
             // Date formatting keys
-            + DataProvider<<R::D as DateMarkers<C>>::YearNamesV1Marker>
-            + DataProvider<<R::D as DateMarkers<C>>::MonthNamesV1Marker>
-            + DataProvider<<R::D as DateMarkers<C>>::DateSkeletonPatternsV1Marker>
-            + DataProvider<<R::D as DateMarkers<C>>::WeekdayNamesV1Marker>
+            + DataProvider<<R::D as TypedDateMarkers<C>>::YearNamesV1Marker>
+            + DataProvider<<R::D as TypedDateMarkers<C>>::MonthNamesV1Marker>
+            + DataProvider<<R::D as TypedDateMarkers<C>>::DateSkeletonPatternsV1Marker>
+            + DataProvider<<R::D as TypedDateMarkers<C>>::WeekdayNamesV1Marker>
             + DataProvider<<R::T as TimeMarkers>::DayPeriodNamesV1Marker>
             + DataProvider<<R::T as TimeMarkers>::TimeSkeletonPatternsV1Marker>
             + DataProvider<R::DateTimePatternV1Marker>,
         L: FixedDecimalFormatterLoader + WeekCalculatorLoader,
     {
         let selection = DateTimePatternSelectionData::try_new_with_skeleton(
-            &<R::D as DateMarkers<C>>::DateSkeletonPatternsV1Marker::bind(provider),
+            &<R::D as TypedDateMarkers<C>>::DateSkeletonPatternsV1Marker::bind(provider),
             &<R::T as TimeMarkers>::TimeSkeletonPatternsV1Marker::bind(provider),
             &R::DateTimePatternV1Marker::bind(provider),
             locale,
@@ -402,9 +402,9 @@ impl<C: CldrCalendar, R: TypedNeoFormatterMarker<C>> TypedNeoFormatter<C, R> {
         .map_err(LoadError::Data)?;
         let mut names = RawDateTimeNames::new_without_fixed_decimal_formatter();
         names.load_for_pattern(
-            &<R::D as DateMarkers<C>>::YearNamesV1Marker::bind(provider), // year
-            &<R::D as DateMarkers<C>>::MonthNamesV1Marker::bind(provider), // month
-            &<R::D as DateMarkers<C>>::WeekdayNamesV1Marker::bind(provider), // weekday
+            &<R::D as TypedDateMarkers<C>>::YearNamesV1Marker::bind(provider), // year
+            &<R::D as TypedDateMarkers<C>>::MonthNamesV1Marker::bind(provider), // month
+            &<R::D as TypedDateMarkers<C>>::WeekdayNamesV1Marker::bind(provider), // weekday
             &<R::T as TimeMarkers>::DayPeriodNamesV1Marker::bind(provider), // day period
             Some(loader),                                                 // fixed decimal formatter
             Some(loader),                                                 // week calculator
@@ -468,13 +468,13 @@ impl<C: CldrCalendar, R: TypedNeoFormatterMarker<C>> TypedNeoFormatter<C, R> {
     pub fn format<T>(&self, datetime: &T) -> FormattedNeoDateTime
     where
         T: ?Sized,
-        for<'a> &'a T: Into<<R::D as DateMarkers<C>>::DateInputMarker>
-            + Into<<R::D as DateMarkers<C>>::WeekInputMarker>
+        for<'a> &'a T: Into<<R::D as TypedDateMarkers<C>>::DateInputMarker>
+            + Into<<R::D as TypedDateMarkers<C>>::WeekInputMarker>
             + Into<<R::T as TimeMarkers>::TimeInputMarker>,
     {
         let datetime = ExtractedDateTimeInput::extract_from_neo_input(
-            Into::<<R::D as DateMarkers<C>>::DateInputMarker>::into(datetime).into(),
-            Into::<<R::D as DateMarkers<C>>::WeekInputMarker>::into(datetime).into(),
+            Into::<<R::D as TypedDateMarkers<C>>::DateInputMarker>::into(datetime).into(),
+            Into::<<R::D as TypedDateMarkers<C>>::WeekInputMarker>::into(datetime).into(),
             Into::<<R::T as TimeMarkers>::TimeInputMarker>::into(datetime).into(),
         );
         FormattedNeoDateTime {

--- a/components/datetime/src/neo_marker.rs
+++ b/components/datetime/src/neo_marker.rs
@@ -651,10 +651,41 @@ macro_rules! datetime_marker_helper {
     };
 }
 
+macro_rules! field_type_helper {
+    (year) => {
+        FormattableYear
+    };
+    (month) => {
+        FormattableMonth
+    };
+    (day_of_month) => {
+        DayOfMonth
+    };
+    (day_of_week) => {
+        IsoWeekday
+    };
+    (day_of_year_info) => {
+        DayOfYearInfo
+    };
+    (hour) => {
+        IsoHour
+    };
+    (minute) => {
+        IsoMinute
+    };
+    (second) => {
+        IsoSecond
+    };
+    (nanosecond) => {
+        NanoSecond
+    };
+}
+
 macro_rules! impl_date_marker {
     (
         $type:ident,
         $components:expr,
+        [$($field:ident),+],
         description = $description:literal,
         expectation = $expectation:literal,
         years = $years_yesno:ident,
@@ -714,8 +745,10 @@ macro_rules! impl_date_marker {
         /// );
         /// ```
         #[derive(Debug)]
-        #[allow(clippy::exhaustive_enums)] // empty enum
-        pub enum $type {}
+        #[allow(clippy::exhaustive_structs)]
+        pub struct $type {
+            $($field: field_type_helper!($field)),+
+        }
         impl private::Sealed for $type {}
         impl HasDateComponents for $type {
             const COMPONENTS: NeoDateComponents = $components;
@@ -754,7 +787,10 @@ macro_rules! impl_date_marker {
         }
         impl From<$type> for AllInputFields {
             fn from(value: $type) -> Self {
-                todo!()
+                AllInputFields {
+                    $($field: Some(value.$field)),+,
+                    ..Default::default()
+                }
             }
         }
     };
@@ -764,6 +800,7 @@ macro_rules! impl_day_marker {
     (
         $type:ident,
         $components:expr,
+        [$($field:ident),+],
         description = $description:literal,
         expectation = $expectation:literal,
         years = $years_yesno:ident,
@@ -776,6 +813,7 @@ macro_rules! impl_day_marker {
         impl_date_marker!(
             $type,
             NeoDateComponents::Day($components),
+            [$($field),+],
             description = $description,
             expectation = $expectation,
             years = $years_yesno,
@@ -795,6 +833,7 @@ macro_rules! impl_time_marker {
     (
         $type:ident,
         $components:expr,
+        [$($field:ident),+],
         description = $description:literal,
         expectation = $expectation:literal,
         dayperiods = $dayperiods_yesno:ident,
@@ -851,8 +890,10 @@ macro_rules! impl_time_marker {
         /// );
         /// ```
         #[derive(Debug)]
-        #[allow(clippy::exhaustive_enums)] // empty enum
-        pub enum $type {}
+        #[allow(clippy::exhaustive_structs)]
+        pub struct $type {
+            $($field: field_type_helper!($field)),+
+        }
         impl private::Sealed for $type {}
         impl HasTimeComponents for $type {
             const COMPONENTS: NeoTimeComponents = $components;
@@ -879,7 +920,10 @@ macro_rules! impl_time_marker {
         }
         impl From<$type> for AllInputFields {
             fn from(value: $type) -> Self {
-                todo!()
+                AllInputFields {
+                    $($field: Some(value.$field)),+,
+                    ..Default::default()
+                }
             }
         }
     };
@@ -925,6 +969,7 @@ macro_rules! impl_datetime_marker {
 impl_day_marker!(
     NeoYearMonthDayMarker,
     NeoDayComponents::YearMonthDay,
+    [year, month, day_of_month],
     description = "a Year/Month/Day format",
     expectation = "May 17, 2024",
     years = yes,
@@ -938,6 +983,7 @@ impl_day_marker!(
 impl_day_marker!(
     NeoEraYearMonthMarker,
     NeoDayComponents::EraYearMonthDay,
+    [year, month, day_of_month],
     description = "an Era/Year/Month/Day format",
     expectation = "May 17, 2024 AD",
     years = yes,
@@ -951,6 +997,7 @@ impl_day_marker!(
 impl_day_marker!(
     NeoAutoDateMarker,
     NeoDayComponents::Auto,
+    [year, month, day_of_month],
     description = "locale-dependent date fields",
     expectation = "May 17, 2024",
     years = yes,
@@ -964,6 +1011,7 @@ impl_day_marker!(
 impl_time_marker!(
     NeoAutoTimeMarker,
     NeoTimeComponents::Auto,
+    [hour, minute, second],
     description = "locale-dependent time fields",
     expectation = "3:47:50 PM",
     dayperiods = yes,
@@ -982,6 +1030,7 @@ impl_datetime_marker!(
 impl_date_marker!(
     NeoYearMonthMarker,
     NeoDateComponents::YearMonth,
+    [year, month],
     description = "a Year/Month format",
     expectation = "May 2024",
     years = yes,

--- a/components/datetime/src/neo_marker.rs
+++ b/components/datetime/src/neo_marker.rs
@@ -227,7 +227,7 @@ pub trait HasTimeComponents {
 
 /// A trait associating types implementing various other traits
 /// required for date formatting.
-pub trait DateMarkers<C>: private::Sealed {
+pub trait TypedDateMarkers<C>: private::Sealed {
     /// Marker for loading date skeleton patterns.
     type DateSkeletonPatternsV1Marker: KeyedDataMarker<Yokeable = PackedSkeletonDataV1<'static>>;
     /// Marker for resolving date fields from the input.
@@ -260,7 +260,7 @@ pub enum NeoNeverMarker {}
 
 impl private::Sealed for NeoNeverMarker {}
 
-impl<C> DateMarkers<C> for NeoNeverMarker {
+impl<C> TypedDateMarkers<C> for NeoNeverMarker {
     type DateSkeletonPatternsV1Marker = NeverMarker<PackedSkeletonDataV1<'static>>;
     type DateInputMarker = NeverFields;
     type WeekInputMarker = NeverFields;
@@ -281,7 +281,7 @@ pub trait TypedNeoFormatterMarker<C>: private::Sealed {
     /// The associated components.
     const COMPONENTS: NeoComponents;
     /// Associated types for date formatting.
-    type D: DateMarkers<C>;
+    type D: TypedDateMarkers<C>;
     /// Associated types for time formatting.
     type T: TimeMarkers;
     /// Fields for [`TypedDateTimeNames`].
@@ -306,7 +306,7 @@ impl<D, T> private::Sealed for DateTimeCombo<D, T> {}
 
 impl<C, D> TypedNeoFormatterMarker<C> for DateTimeCombo<D, NeoNeverMarker>
 where
-    D: HasDateComponents + DateMarkers<C>,
+    D: HasDateComponents + TypedDateMarkers<C>,
 {
     const COMPONENTS: NeoComponents = NeoComponents::Date(D::COMPONENTS);
     type D = D;
@@ -328,7 +328,7 @@ where
 
 impl<C, D, T> TypedNeoFormatterMarker<C> for DateTimeCombo<D, T>
 where
-    D: HasDayComponents + DateMarkers<C>,
+    D: HasDayComponents + TypedDateMarkers<C>,
     T: HasTimeComponents + TimeMarkers,
 {
     const COMPONENTS: NeoComponents = NeoComponents::DateTime(D::COMPONENTS, T::COMPONENTS);
@@ -505,7 +505,7 @@ macro_rules! impl_date_marker {
         impl HasDateComponents for $type {
             const COMPONENTS: NeoDateComponents = $components;
         }
-        impl<C: CldrCalendar> DateMarkers<C> for $type {
+        impl<C: CldrCalendar> TypedDateMarkers<C> for $type {
             type YearNamesV1Marker = datetime_marker_helper!(@years/typed, $years_yesno);
             type MonthNamesV1Marker = datetime_marker_helper!(@months/typed, $months_yesno);
             type DateSkeletonPatternsV1Marker = datetime_marker_helper!(@dates/typed, $dates_yesno);

--- a/components/datetime/src/neo_marker.rs
+++ b/components/datetime/src/neo_marker.rs
@@ -277,7 +277,7 @@ impl TimeMarkers for NeoNeverMarker {
 
 /// A trait associating constants and types implementing various other traits
 /// required for datetime formatting.
-pub trait HasNeoComponents<C>: private::Sealed {
+pub trait TypedNeoFormatterMarker<C>: private::Sealed {
     /// The associated components.
     const COMPONENTS: NeoComponents;
     /// Associated types for date formatting.
@@ -304,7 +304,7 @@ impl<D, T> private::Sealed for DateTimeCombo<D, T> {}
 
 // type MonthDayHour = DateTimeCombo<MonthDay, Hour>;
 
-impl<C, D> HasNeoComponents<C> for DateTimeCombo<D, NeoNeverMarker>
+impl<C, D> TypedNeoFormatterMarker<C> for DateTimeCombo<D, NeoNeverMarker>
 where
     D: HasDateComponents + DateMarkers<C>,
 {
@@ -315,7 +315,7 @@ where
     type DateTimePatternV1Marker = NeverMarker<DateTimePatternV1<'static>>;
 }
 
-impl<C, T> HasNeoComponents<C> for DateTimeCombo<NeoNeverMarker, T>
+impl<C, T> TypedNeoFormatterMarker<C> for DateTimeCombo<NeoNeverMarker, T>
 where
     T: HasTimeComponents + TimeMarkers,
 {
@@ -326,7 +326,7 @@ where
     type DateTimePatternV1Marker = NeverMarker<DateTimePatternV1<'static>>;
 }
 
-impl<C, D, T> HasNeoComponents<C> for DateTimeCombo<D, T>
+impl<C, D, T> TypedNeoFormatterMarker<C> for DateTimeCombo<D, T>
 where
     D: HasDayComponents + DateMarkers<C>,
     T: HasTimeComponents + TimeMarkers,
@@ -513,7 +513,7 @@ macro_rules! impl_date_marker {
             type DateInputMarker = datetime_marker_helper!(@dateinput, $dateinput_yesno);
             type WeekInputMarker = datetime_marker_helper!(@weekinput, $weekinput_yesno);
         }
-        impl<C: CldrCalendar> HasNeoComponents<C> for $type {
+        impl<C: CldrCalendar> TypedNeoFormatterMarker<C> for $type {
             const COMPONENTS: NeoComponents = NeoComponents::Date($components);
             type D = Self;
             type T = NeoNeverMarker;
@@ -638,7 +638,7 @@ macro_rules! impl_time_marker {
             type TimeSkeletonPatternsV1Marker = datetime_marker_helper!(@times, $times_yesno);
             type TimeInputMarker = datetime_marker_helper!(@timeinput, $timeinput_yesno);
         }
-        impl<C> HasNeoComponents<C> for $type {
+        impl<C> TypedNeoFormatterMarker<C> for $type {
             const COMPONENTS: NeoComponents = NeoComponents::Time($components);
             type D = NeoNeverMarker;
             type T = Self;

--- a/components/datetime/src/neo_marker.rs
+++ b/components/datetime/src/neo_marker.rs
@@ -338,39 +338,6 @@ where
     type DateTimePatternV1Marker = DateTimePatternV1Marker;
 }
 
-/// A collection of types and constants for specific variants of [`TypedNeoFormatter`].
-///
-/// Individual fields can be [`NeverMarker`] if they are not needed for the specific variant.
-///
-/// [`TypedNeoFormatter`]: crate::neo::TypedNeoFormatter
-pub trait TypedNeoFormatterMarker<C: CldrCalendar>: private::Sealed {
-    /// Components in the neo skeleton.
-    const COMPONENTS: NeoComponents;
-    /// Fields for [`TypedDateTimeNames`].
-    type DateTimeNamesMarker: DateTimeNamesMarker;
-    /// Marker for loading year names.
-    type YearNamesV1Marker: KeyedDataMarker<Yokeable = YearNamesV1<'static>>;
-    /// Marker for loading month names.
-    type MonthNamesV1Marker: KeyedDataMarker<Yokeable = MonthNamesV1<'static>>;
-    /// Marker for loading date skeleton patterns.
-    type DateSkeletonPatternsV1Marker: KeyedDataMarker<Yokeable = PackedSkeletonDataV1<'static>>;
-    /// Marker for loading weekday names.
-    type WeekdayNamesV1Marker: KeyedDataMarker<Yokeable = LinearNamesV1<'static>>;
-    /// Marker for loading day period names.
-    type DayPeriodNamesV1Marker: KeyedDataMarker<Yokeable = LinearNamesV1<'static>>;
-    /// Marker for loading time skeleton patterns.
-    type TimeSkeletonPatternsV1Marker: KeyedDataMarker<Yokeable = PackedSkeletonDataV1<'static>>;
-    /// Marker for loading the date/time glue pattern.
-    type DateTimePatternV1Marker: KeyedDataMarker<Yokeable = DateTimePatternV1<'static>>;
-    /// Marker for resolving date fields from the input.
-    type DateInputMarker: Into<Option<NeoDateInputFields<C>>>;
-    /// Marker for resolving week-of-year fields from the input.
-    type WeekInputMarker: Into<Option<NeoWeekInputFields>>;
-    /// Marker for resolving time fields from the input.
-    type TimeInputMarker: Into<Option<NeoTimeInputFields>>;
-    // TODO: Add WeekCalculator and FixedDecimalFormatter optional bindings here
-}
-
 /// A collection of types and constants for specific variants of [`NeoFormatter`].
 ///
 /// Individual fields can be [`NeverMarker`] if they are not needed for the specific variant.


### PR DESCRIPTION
This is a cool idea, but I'm not sure if it's the right approach. There are more marker types than input types, especially since `era` and `year` are in the same input field, and `Auto` mostly duplicates `[year, month, day]`. But, maybe that's fine.

It does seem nice that if you want to format something like a YearMonth or a MonthDay, you don't need to "fill in" the missing field just to make the formatter work.