### PR TITLE
Add 1.5.x changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## icu4x 1.5.x
+
+- `icu_datetime`
+  - Fix incorrect assertion in week-of-year formatting (https://github.com/unicode-org/icu4x/issues/4977)
+
 ## icu4x 1.5 (May 28, 2024)
 
 - Components


### PR DESCRIPTION
https://github.com/unicode-org/icu4x/issues/4977

After this lands, I'll create `release/1.5`, cherry-pick this PR and https://github.com/unicode-org/icu4x/pull/4986, and release 1.5.1 of `icu_datetime`