### PR TITLE
Add data key attributes to datagen log messages

### DIFF
--- a/provider/datagen/src/driver.rs
+++ b/provider/datagen/src/driver.rs
@@ -728,7 +728,7 @@ impl DatagenDriver {
         };
 
         let load_with_fallback = |key, locale: &_, key_attributes: &_| {
-            log::trace!("Generating key/locale: {key}/{locale:}");
+            log::trace!("Generating key/locale: {key}/{key_attributes:?}/{locale:}");
             let mut metadata = DataRequestMetadata::default();
             metadata.silent = true;
             // Lazy-compute the fallback iterator so that we don't always require CLDR data
@@ -743,7 +743,7 @@ impl DatagenDriver {
                     Ok(data_response) => {
                         if let Some(iter) = locale_iter.as_ref() {
                             if iter.get().is_und() && !locale.is_und() {
-                                log::debug!("Falling back to und: {key}/{locale}");
+                                log::debug!("Falling back to und: {key}/{key_attributes:?}/{locale}");
                             }
                         }
                         return Some(
@@ -758,7 +758,7 @@ impl DatagenDriver {
                     }) => {
                         if let Some(iter) = locale_iter.as_mut() {
                             if iter.get().is_und() {
-                                log::debug!("Could not find data for: {key}/{locale}");
+                                log::debug!("Could not find data for: {key}/{key_attributes:?}/{locale}");
                                 return None;
                             }
                             iter.step();
@@ -1125,6 +1125,7 @@ fn deduplicate_payloads<const MAXIMAL: bool>(
                             key,
                             DataRequest {
                                 locale,
+                                key_attributes,
                                 ..Default::default()
                             },
                         )
@@ -1151,7 +1152,7 @@ fn deduplicate_payloads<const MAXIMAL: bool>(
                     if inherited_payload == payload {
                         // Found a match: don't need to write anything
                         log::trace!(
-                            "Deduplicating {key}/{locale} (inherits from {})",
+                            "Deduplicating {key}/{key_attributes:?}/{locale} (inherits from {})",
                             iter.get()
                         );
                         return Ok(());
@@ -1168,6 +1169,7 @@ fn deduplicate_payloads<const MAXIMAL: bool>(
                         key,
                         DataRequest {
                             locale,
+                            key_attributes,
                             ..Default::default()
                         },
                     )


### PR DESCRIPTION
The attributes no longer show up in datagen output. It is useful when they do.