### PR TITLE
Fix the message of transient_violations

### DIFF
--- a/provider/datagen/src/provider/tests/make_testdata.rs
+++ b/provider/datagen/src/provider/tests/make_testdata.rs
@@ -302,7 +302,7 @@ impl<F: Write + Send + Sync> DataExporter for PostcardTestingExporter<F> {
         assert!(transient_violations == EXPECTED_TRANSIENT_VIOLATIONS && violations == EXPECTED_VIOLATIONS,
             "Expected violations list does not match found violations!\n\
             If the new list is smaller, please update EXPECTED_VIOLATIONS in make-testdata.rs\n\
-            If it is bigger and that was unexpected, please make sure the key remains zero-copy, or ask ICU4X team members if it is okay\
+            If it is bigger and that was unexpected, please make sure the key remains zero-copy, or ask ICU4X team members if it is okay \
             to temporarily allow for this key to be allowlisted.\n\
             Expected:\n{EXPECTED_VIOLATIONS:?}\nFound:\n{violations:?}\nExpected (transient):\n{EXPECTED_TRANSIENT_VIOLATIONS:?}\nFound (transient):\n{transient_violations:?}"
         );

--- a/provider/datagen/src/provider/tests/make_testdata.rs
+++ b/provider/datagen/src/provider/tests/make_testdata.rs
@@ -304,6 +304,7 @@ impl<F: Write + Send + Sync> DataExporter for PostcardTestingExporter<F> {
             If the new list is smaller, please update EXPECTED_VIOLATIONS in make-testdata.rs\n\
             If it is bigger and that was unexpected, please make sure the key remains zero-copy, or ask ICU4X team members if it is okay \
             to temporarily allow for this key to be allowlisted.\n\
+            Common cause: did you forget to add `serde(borrow)` to all of the fields in your data struct?\n\
             Expected:\n{EXPECTED_VIOLATIONS:?}\nFound:\n{violations:?}\nExpected (transient):\n{EXPECTED_TRANSIENT_VIOLATIONS:?}\nFound (transient):\n{transient_violations:?}"
         );
 


### PR DESCRIPTION
The previous version will lead to : ` .... okayto ...`
The current version will lead to: ` .... okay to ....`

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->