### PR TITLE
Cherry-pick zerovec binary size fix to maintenance branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## icu4x 1.5.x
 
+- `icu_calendar`
+  - (1.5.1) Fix Japanese calendar Gregorian era year 0 (https://github.com/unicode-org/icu4x/issues/4968)
 - `icu_datetime`
-  - Fix incorrect assertion in week-of-year formatting (https://github.com/unicode-org/icu4x/issues/4977)
-  - Fix Japanese calendar Gregorian era year 0 (https://github.com/unicode-org/icu4x/issues/4968)
+  - (1.5.1) Fix incorrect assertion in week-of-year formatting (https://github.com/unicode-org/icu4x/issues/4977)
+- `zerovec`
+  - (0.10.3) Fix size regression by making `twox-hash` dep `no_std` (https://github.com/unicode-org/icu4x/pull/5007)
 
 ## icu4x 1.5 (May 28, 2024)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,7 +2712,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,6 +246,7 @@ serde = { version = "1.0.110", default-features = false }
 serde-json-core = { version = "0.4.0", default-features = false }
 smallvec = { version = "1.10.0", default-features = false }
 stable_deref_trait = { version = "1.2.0", default-features = false }
+twox-hash = { version = "1.4.2", default-features = false }
 unicode-bidi = { version = "0.3.11", default-features = false }
 utf16_iter = { version = "1.0.2", default-features = false }
 utf8_iter = { version = "1.0.2", default-features = false }
@@ -287,7 +288,6 @@ simple_logger = "4.0.0"
 syn = "2.0.21"
 synstructure = "0.13.0"
 toml = "0.5.8"
-twox-hash = "1.4.2"
 ureq = "2.3.0"
 walkdir = "2.3.2"
 wasmi = "0.31.2"


### PR DESCRIPTION
Pulls https://github.com/unicode-org/icu4x/pull/5007 into the maintenance branch.

Since we're probably going to make a zerovec patch release, I thought we should include this.