### PR TITLE
Cleaner gen_any_buffer_data_constructors macro

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -755,9 +755,7 @@ impl AnyCalendar {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        options: skip,
-        error: DataError,
+        (locale) -> error: DataError,
         #[cfg(skip)]
         functions: [
             new_for_locale,

--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -159,7 +159,7 @@ impl Chinese {
         }
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
         #[cfg(skip)]
         functions: [
             new,

--- a/components/calendar/src/dangi.rs
+++ b/components/calendar/src/dangi.rs
@@ -152,7 +152,7 @@ impl Dangi {
         }
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
         #[cfg(skip)]
         functions: [
             new,

--- a/components/calendar/src/islamic.rs
+++ b/components/calendar/src/islamic.rs
@@ -127,7 +127,7 @@ impl IslamicObservational {
         }
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
         #[cfg(skip)]
         functions: [
             new,
@@ -174,7 +174,7 @@ impl IslamicUmmAlQura {
         }
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
         #[cfg(skip)]
         functions: [
             new,

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -129,7 +129,7 @@ impl Japanese {
         }
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
         #[cfg(skip)]
         functions: [
             new,
@@ -187,7 +187,7 @@ impl JapaneseExtended {
         })
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
         #[cfg(skip)]
         functions: [
             new,

--- a/components/casemap/src/casemapper.rs
+++ b/components/casemap/src/casemapper.rs
@@ -80,7 +80,7 @@ impl CaseMapper {
         }
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
     #[cfg(skip)]
     functions: [
         new,

--- a/components/casemap/src/closer.rs
+++ b/components/casemap/src/closer.rs
@@ -87,7 +87,7 @@ impl CaseMapCloser<CaseMapper> {
         }
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
     #[cfg(skip)]
     functions: [
         new,
@@ -110,7 +110,7 @@ impl CaseMapCloser<CaseMapper> {
 
 // We use Borrow, not AsRef, since we want the blanket impl on T
 impl<CM: AsRef<CaseMapper>> CaseMapCloser<CM> {
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, casemapper: CM, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!((casemapper: CM) -> error: DataError,
     #[cfg(skip)]
     functions: [
         new_with_mapper,

--- a/components/casemap/src/titlecase.rs
+++ b/components/casemap/src/titlecase.rs
@@ -225,7 +225,7 @@ impl TitlecaseMapper<CaseMapper> {
         }
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
     #[cfg(skip)]
     functions: [
         new,
@@ -248,7 +248,7 @@ impl TitlecaseMapper<CaseMapper> {
 
 // We use Borrow, not AsRef, since we want the blanket impl on T
 impl<CM: AsRef<CaseMapper>> TitlecaseMapper<CM> {
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, casemapper: CM, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!((casemapper: CM) -> error: DataError,
     #[cfg(skip)]
     functions: [
         new_with_mapper,

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -92,9 +92,7 @@ impl Collator {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        options: CollatorOptions,
-        error: DataError,
+        (locale, options: CollatorOptions) -> error: DataError,
         #[cfg(skip)]
     );
 

--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -99,9 +99,7 @@ impl TimeFormatter {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        length: length::Time,
-        error: DateTimeError,
+        (locale, length: length::Time) -> error: DateTimeError,
         #[cfg(skip)]
         functions: [
             try_new_with_length,
@@ -311,9 +309,7 @@ impl<C: CldrCalendar> TypedDateFormatter<C> {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        length: length::Date,
-        error: DateTimeError,
+        (locale, length: length::Date) -> error: DateTimeError,
         #[cfg(skip)]
         functions: [
             try_new_with_length,
@@ -565,9 +561,7 @@ where {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        options: DateTimeFormatterOptions,
-        error: DateTimeError,
+        (locale, options: DateTimeFormatterOptions) -> error: DateTimeError,
         #[cfg(skip)]
         functions: [
             try_new,

--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -399,9 +399,7 @@ impl TimeZoneFormatter {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        options: TimeZoneFormatterOptions,
-        error: DateTimeError,
+        (locale, options: TimeZoneFormatterOptions) -> error: DateTimeError,
         /// Creates a new [`TimeZoneFormatter`] with a GMT or ISO format using compiled data.
         ///
         /// To enable other time zone styles, use one of the `with` (compiled data) or `load` (runtime

--- a/components/datetime/src/zoned_datetime.rs
+++ b/components/datetime/src/zoned_datetime.rs
@@ -159,10 +159,8 @@ impl<C: CldrCalendar> TypedZonedDateTimeFormatter<C> {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        date_time_format_options: DateTimeFormatterOptions,
-        time_zone_format_options: TimeZoneFormatterOptions,
-        error: DateTimeError,
+
+        (locale, date_time_format_options: DateTimeFormatterOptions, time_zone_format_options: TimeZoneFormatterOptions) -> error: DateTimeError,
         #[cfg(skip)]
     );
 

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -121,9 +121,8 @@ pub struct FixedDecimalFormatter {
 
 impl FixedDecimalFormatter {
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        options: options::FixedDecimalFormatterOptions,
-        error: DataError,
+
+        (locale, options: options::FixedDecimalFormatterOptions) -> error: DataError,
         /// Creates a new [`FixedDecimalFormatter`] from compiled data and an options bag.
         ///
         /// ✨ *Enabled with the `compiled_data` Cargo feature.*

--- a/components/experimental/src/compactdecimal/compactdecimal.rs
+++ b/components/experimental/src/compactdecimal/compactdecimal.rs
@@ -142,9 +142,7 @@ impl CompactDecimalFormatter {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        options: CompactDecimalFormatterOptions,
-        error: DataError,
+        (locale, options: CompactDecimalFormatterOptions) -> error: DataError,
         #[cfg(skip)]
         functions: [
             try_new_short,
@@ -229,9 +227,7 @@ impl CompactDecimalFormatter {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        options: CompactDecimalFormatterOptions,
-        error: DataError,
+        (locale, options: CompactDecimalFormatterOptions) -> error: DataError,
         #[cfg(skip)]
         functions: [
             try_new_long,

--- a/components/experimental/src/dimension/currency/formatter.rs
+++ b/components/experimental/src/dimension/currency/formatter.rs
@@ -42,9 +42,7 @@ pub struct CurrencyCode(pub TinyAsciiStr<3>);
 
 impl CurrencyFormatter {
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        options: super::options::CurrencyFormatterOptions,
-        error: DataError,
+        (locale, options: super::options::CurrencyFormatterOptions) -> error: DataError,
         #[cfg(skip)]
     );
 

--- a/components/experimental/src/displaynames/displaynames.rs
+++ b/components/experimental/src/displaynames/displaynames.rs
@@ -40,9 +40,7 @@ pub struct RegionDisplayNames {
 
 impl RegionDisplayNames {
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        options: DisplayNamesOptions,
-        error: DataError,
+        (locale, options: DisplayNamesOptions) -> error: DataError,
         /// Creates a new [`RegionDisplayNames`] from locale data and an options bag using compiled data.
         ///
         /// ✨ *Enabled with the `compiled_data` Cargo feature.*
@@ -115,9 +113,7 @@ pub struct ScriptDisplayNames {
 
 impl ScriptDisplayNames {
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        options: DisplayNamesOptions,
-        error: DataError,
+        (locale, options: DisplayNamesOptions) -> error: DataError,
         /// Creates a new [`ScriptDisplayNames`] from locale data and an options bag using compiled data.
         ///
         /// ✨ *Enabled with the `compiled_data` Cargo feature.*
@@ -191,9 +187,7 @@ pub struct VariantDisplayNames {
 
 impl VariantDisplayNames {
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        options: DisplayNamesOptions,
-        error: DataError,
+        (locale, options: DisplayNamesOptions) -> error: DataError,
         /// Creates a new [`VariantDisplayNames`] from locale data and an options bag using compiled data.
         ///
         /// ✨ *Enabled with the `compiled_data` Cargo feature.*
@@ -260,9 +254,7 @@ pub struct LanguageDisplayNames {
 
 impl LanguageDisplayNames {
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        options: DisplayNamesOptions,
-        error: DataError,
+        (locale, options: DisplayNamesOptions) -> error: DataError,
         /// Creates a new [`LanguageDisplayNames`] from locale data and an options bag using compiled data.
         ///
         /// ✨ *Enabled with the `compiled_data` Cargo feature.*
@@ -354,9 +346,7 @@ pub struct LocaleDisplayNamesFormatter {
 
 impl LocaleDisplayNamesFormatter {
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        options: DisplayNamesOptions,
-        error: DataError,
+        (locale, options: DisplayNamesOptions) -> error: DataError,
         /// Creates a new [`LocaleDisplayNamesFormatter`] from locale data and an options bag using compiled data.
         ///
         /// ✨ *Enabled with the `compiled_data` Cargo feature.*

--- a/components/experimental/src/relativetime/relativetime.rs
+++ b/components/experimental/src/relativetime/relativetime.rs
@@ -143,9 +143,7 @@ macro_rules! constructor {
         }
 
         icu_provider::gen_any_buffer_data_constructors!(
-            locale: include,
-            options: RelativeTimeFormatterOptions,
-            error: DataError,
+            (locale, options: RelativeTimeFormatterOptions) -> error: DataError,
             #[cfg(skip)]
             functions: [
                 $baked,

--- a/components/experimental/src/units/converter_factory.rs
+++ b/components/experimental/src/units/converter_factory.rs
@@ -39,9 +39,7 @@ impl From<Sign> for num_bigint::Sign {
 
 impl ConverterFactory {
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: skip,
-        options: skip,
-        error: DataError,
+        () -> error: DataError,
         #[cfg(skip)]
         functions: [
             new,

--- a/components/list/src/list_formatter.rs
+++ b/components/list/src/list_formatter.rs
@@ -22,9 +22,7 @@ pub struct ListFormatter {
 macro_rules! constructor {
     ($name: ident, $name_any: ident, $name_buffer: ident, $name_unstable: ident, $marker: ty, $doc: literal) => {
         icu_provider::gen_any_buffer_data_constructors!(
-            locale: include,
-            style: ListLength,
-            error: DataError,
+            (locale, style: ListLength) ->  error: DataError,
             #[doc = concat!("Creates a new [`ListFormatter`] that produces a ", $doc, "-type list using compiled data.")]
             ///
             /// See the [CLDR spec](https://unicode.org/reports/tr35/tr35-general.html#ListPatterns) for

--- a/components/locale/src/expander.rs
+++ b/components/locale/src/expander.rs
@@ -284,7 +284,7 @@ impl LocaleExpander {
         })
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
         #[cfg(skip)]
         functions: [
         new_extended,

--- a/components/locale/src/fallback/mod.rs
+++ b/components/locale/src/fallback/mod.rs
@@ -130,7 +130,7 @@ impl LocaleFallbacker {
         unsafe { core::mem::transmute(tickstatic) }
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
         #[cfg(skip)]
         functions: [
             new,

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -1603,9 +1603,7 @@ impl DecomposingNormalizer {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: skip,
-        options: skip,
-        error: DataError,
+        () -> error: DataError,
         #[cfg(skip)]
         functions: [
             new_nfd,
@@ -1720,9 +1718,7 @@ impl DecomposingNormalizer {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: skip,
-        options: skip,
-        error: DataError,
+        () -> error: DataError,
         #[cfg(skip)]
         functions: [
             new_nfkd,
@@ -2224,9 +2220,7 @@ impl ComposingNormalizer {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: skip,
-        options: skip,
-        error: DataError,
+        () -> error: DataError,
         #[cfg(skip)]
         functions: [
             new_nfc,
@@ -2272,9 +2266,7 @@ impl ComposingNormalizer {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: skip,
-        options: skip,
-        error: DataError,
+        () -> error: DataError,
         #[cfg(skip)]
         functions: [
             new_nfkc,

--- a/components/normalizer/src/properties.rs
+++ b/components/normalizer/src/properties.rs
@@ -97,7 +97,7 @@ impl CanonicalComposition {
         }
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
         #[cfg(skip)]
         functions: [
             new,
@@ -389,7 +389,7 @@ impl CanonicalDecomposition {
         }
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
         #[cfg(skip)]
         functions: [
             new,
@@ -497,7 +497,7 @@ impl CanonicalCombiningClassMap {
         }
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
         #[cfg(skip)]
         functions: [
             new,

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -289,9 +289,7 @@ impl AsRef<PluralRules> for PluralRules {
 
 impl PluralRules {
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        rule_type: PluralRuleType,
-        error: DataError,
+        (locale, rule_type: PluralRuleType) -> error: DataError,
         /// Constructs a new `PluralRules` for a given locale and type using compiled data.
         ///
         /// ✨ *Enabled with the `compiled_data` Cargo feature.*
@@ -327,9 +325,7 @@ impl PluralRules {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        options: skip,
-        error: DataError,
+        (locale) -> error: DataError,
         /// Constructs a new `PluralRules` for a given locale for cardinal numbers using compiled data.
         ///
         /// Cardinal plural forms express quantities of units such as time, currency or distance,
@@ -383,9 +379,7 @@ impl PluralRules {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        options: skip,
-        error: DataError,
+        (locale) -> error: DataError,
         /// Constructs a new `PluralRules` for a given locale for ordinal numbers using compiled data.
         ///
         /// Ordinal plural forms denote the order of items in a set and are always integers.
@@ -603,9 +597,8 @@ pub struct PluralRulesWithRanges<R> {
 #[cfg(feature = "experimental")]
 impl PluralRulesWithRanges<PluralRules> {
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        rule_type: PluralRuleType,
-        error: DataError,
+
+        (locale, rule_type: PluralRuleType) -> error: DataError,
         /// Constructs a new `PluralRulesWithRanges` for a given locale using compiled data.
         ///
         /// ✨ *Enabled with the `compiled_data` Cargo feature.*
@@ -641,9 +634,7 @@ impl PluralRulesWithRanges<PluralRules> {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        options: skip,
-        error: DataError,
+        (locale) -> error: DataError,
         /// Constructs a new `PluralRulesWithRanges` for a given locale for cardinal numbers using
         /// compiled data.
         ///
@@ -684,9 +675,7 @@ impl PluralRulesWithRanges<PluralRules> {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        options: skip,
-        error: DataError,
+        (locale) -> error: DataError,
         /// Constructs a new `PluralRulesWithRanges` for a given locale for ordinal numbers using
         /// compiled data.
         ///
@@ -735,9 +724,7 @@ where
     R: AsRef<PluralRules>,
 {
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: include,
-        rules: R,
-        error: DataError,
+        (locale, rules: R) -> error: DataError,
         /// Constructs a new `PluralRulesWithRanges` for a given locale from an existing
         /// `PluralRules` (either owned or as a reference) and compiled data.
         ///

--- a/components/properties/src/bidi_data.rs
+++ b/components/properties/src/bidi_data.rs
@@ -195,9 +195,7 @@ pub const fn bidi_auxiliary_properties() -> BidiAuxiliaryPropertiesBorrowed<'sta
 }
 
 icu_provider::gen_any_buffer_data_constructors!(
-    locale: skip,
-    options: skip,
-    result: Result<BidiAuxiliaryProperties, DataError>,
+    () -> result: Result<BidiAuxiliaryProperties, DataError>,
     #[cfg(skip)]
     functions: [
         bidi_auxiliary_properties,

--- a/components/properties/src/script.rs
+++ b/components/properties/src/script.rs
@@ -624,9 +624,7 @@ pub const fn script_with_extensions() -> ScriptWithExtensionsBorrowed<'static> {
 }
 
 icu_provider::gen_any_buffer_data_constructors!(
-    locale: skip,
-    options: skip,
-    result: Result<ScriptWithExtensions, DataError>,
+    () -> result: Result<ScriptWithExtensions, DataError>,
     #[cfg(skip)]
     functions: [
         script_with_extensions,

--- a/components/properties/src/sets.rs
+++ b/components/properties/src/sets.rs
@@ -2109,9 +2109,7 @@ pub fn load_for_ecma262(
 }
 
 icu_provider::gen_any_buffer_data_constructors!(
-    locale: skip,
-    name: &str,
-    result: Result<CodePointSetData, UnexpectedPropertyNameOrDataError>,
+    (name: &str) -> result: Result<CodePointSetData, UnexpectedPropertyNameOrDataError>,
     #[cfg(skip)]
     functions: [
         load_for_ecma262,

--- a/components/segmenter/src/grapheme.rs
+++ b/components/segmenter/src/grapheme.rs
@@ -153,7 +153,7 @@ impl GraphemeClusterSegmenter {
         }
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
         #[cfg(skip)]
         functions: [
             new,

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -362,9 +362,7 @@ impl LineSegmenter {
 
     #[cfg(feature = "auto")]
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: skip,
-        options: skip,
-        error: DataError,
+        () -> error: DataError,
         #[cfg(skip)]
         functions: [
             new_auto,
@@ -406,9 +404,7 @@ impl LineSegmenter {
 
     #[cfg(feature = "lstm")]
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: skip,
-        options: skip,
-        error: DataError,
+        () -> error: DataError,
         #[cfg(skip)]
         functions: [
             new_lstm,
@@ -448,9 +444,7 @@ impl LineSegmenter {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: skip,
-        options: skip,
-        error: DataError,
+        () -> error: DataError,
         #[cfg(skip)]
         functions: [
             new_dictionary,
@@ -490,9 +484,7 @@ impl LineSegmenter {
 
     #[cfg(feature = "auto")]
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: skip,
-        options: LineBreakOptions,
-        error: DataError,
+        (options: LineBreakOptions) -> error: DataError,
         #[cfg(skip)]
         functions: [
             new_auto_with_options,
@@ -543,9 +535,7 @@ impl LineSegmenter {
 
     #[cfg(feature = "lstm")]
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: skip,
-        options: LineBreakOptions,
-        error: DataError,
+        (options: LineBreakOptions) -> error: DataError,
         #[cfg(skip)]
         functions: [
             try_new_lstm_with_options,
@@ -604,9 +594,7 @@ impl LineSegmenter {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: skip,
-        options: LineBreakOptions,
-        error: DataError,
+        (options: LineBreakOptions) -> error: DataError,
         #[cfg(skip)]
         functions: [
             new_dictionary_with_options,

--- a/components/segmenter/src/sentence.rs
+++ b/components/segmenter/src/sentence.rs
@@ -124,7 +124,7 @@ impl SentenceSegmenter {
         }
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
         #[cfg(skip)]
         functions: [
             new,

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -212,9 +212,7 @@ impl WordSegmenter {
 
     #[cfg(feature = "auto")]
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: skip,
-        options: skip,
-        error: DataError,
+        () -> error: DataError,
         #[cfg(skip)]
         functions: [
             try_new_auto,
@@ -287,9 +285,7 @@ impl WordSegmenter {
 
     #[cfg(feature = "lstm")]
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: skip,
-        options: skip,
-        error: DataError,
+        () -> error: DataError,
         #[cfg(skip)]
         functions: [
             new_lstm,
@@ -354,9 +350,7 @@ impl WordSegmenter {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
-        locale: skip,
-        options: skip,
-        error: DataError,
+        () -> error: DataError,
         #[cfg(skip)]
         functions: [
             new_dictionary,

--- a/components/timezone/src/ids.rs
+++ b/components/timezone/src/ids.rs
@@ -114,7 +114,7 @@ impl TimeZoneIdMapper {
         }
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
         #[cfg(skip)]
         functions: [
             new,
@@ -481,7 +481,7 @@ impl TimeZoneIdMapperWithFastCanonicalization<TimeZoneIdMapper> {
         }
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
         #[cfg(skip)]
         functions: [
             new,
@@ -525,7 +525,7 @@ where
         .validated()
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, mapper: I, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!((mapper: I) -> error: DataError,
         #[cfg(skip)]
         functions: [
             try_new_with_mapper,

--- a/components/timezone/src/metazone.rs
+++ b/components/timezone/src/metazone.rs
@@ -41,7 +41,7 @@ impl MetazoneCalculator {
         }
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: skip, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
         #[cfg(skip)]
         functions: [
             new,

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -269,7 +269,7 @@ impl HelloWorldFormatter {
         Self::try_new_unstable(&HelloWorldProvider, locale)
     }
 
-    icu_provider::gen_any_buffer_data_constructors!(locale: include, options: skip, error: DataError,
+    icu_provider::gen_any_buffer_data_constructors!((locale) -> error: DataError,
         #[cfg(skip)]
         functions: [
             try_new,


### PR DESCRIPTION
This cleans up the invocation of the macro to not use magic `skip` matching and instead just take something that looks vaguely like a function signature, with a bunch of magic.

I plan to extend this to support skipping generation of the baked function, but I need to go for the day.

We can tweak the syntax later, for now this makes it easily regex-replaceable.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->