### PR TITLE
Remove primitive type imports, i.e. `core::str`, `core::i16`.

### DIFF
--- a/components/experimental/src/transliterate/transliterator/mod.rs
+++ b/components/experimental/src/transliterate/transliterator/mod.rs
@@ -16,7 +16,6 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::ops::Range;
-use core::str;
 use icu_collections::codepointinvlist::CodePointInversionList;
 use icu_collections::codepointinvliststringlist::CodePointInversionListAndStringList;
 use icu_locale_core::Locale;

--- a/components/experimental/src/transliterate/transliterator/replaceable.rs
+++ b/components/experimental/src/transliterate/transliterator/replaceable.rs
@@ -179,7 +179,7 @@ impl<'a> Replaceable<'a> {
     /// # Safety
     /// The caller must ensure the visible portion of `content` is valid UTF-8.
     unsafe fn from_hide(content: Hide<'a>) -> Self {
-        debug_assert!(str::from_utf8(&content).is_ok());
+        debug_assert!(core::str::from_utf8(&content).is_ok());
         Self {
             content,
             // SAFETY: these uphold the invariants
@@ -196,9 +196,9 @@ impl<'a> Replaceable<'a> {
 
     /// Returns the full internal text as a `&str`.
     pub(crate) fn as_str(&self) -> &str {
-        debug_assert!(str::from_utf8(&self.content).is_ok());
+        debug_assert!(core::str::from_utf8(&self.content).is_ok());
         // SAFETY: Replaceable's invariant states that content is always valid UTF-8
-        unsafe { str::from_utf8_unchecked(&self.content) }
+        unsafe { core::str::from_utf8_unchecked(&self.content) }
     }
 
     /// Returns the current modifiable text as a `&str`.
@@ -754,7 +754,7 @@ impl<'a, 'b> Insertable<'a, 'b> {
 
     pub(crate) fn curr_replacement(&self) -> &str {
         // SAFETY: the invariant states that this part of the content is valid UTF-8
-        unsafe { str::from_utf8_unchecked(&self._rep.content[self.start..self.curr]) }
+        unsafe { core::str::from_utf8_unchecked(&self._rep.content[self.start..self.curr]) }
     }
 
     /// Will set the cursor to the current position of the replacement.

--- a/components/experimental/src/transliterate/transliterator/replaceable.rs
+++ b/components/experimental/src/transliterate/transliterator/replaceable.rs
@@ -38,7 +38,6 @@ use core::fmt::{Debug, Formatter};
 use core::mem::ManuallyDrop;
 use core::ops::Range;
 use core::ops::{Deref, DerefMut};
-use core::str;
 
 /// The backing buffer for the API provided by this module.
 ///
@@ -52,7 +51,7 @@ impl TransliteratorBuffer {
     }
 
     pub(crate) fn into_string(self) -> String {
-        debug_assert!(str::from_utf8(&self.0).is_ok());
+        debug_assert!(core::str::from_utf8(&self.0).is_ok());
         // SAFETY: We have exclusive access, so the vec must contain valid UTF-8
         unsafe { String::from_utf8_unchecked(self.0) }
     }

--- a/components/properties/src/provider.rs
+++ b/components/properties/src/provider.rs
@@ -22,7 +22,6 @@ use crate::script::ScriptWithExt;
 use crate::Script;
 
 use core::ops::RangeInclusive;
-use core::str;
 use icu_collections::codepointinvlist::CodePointInversionList;
 use icu_collections::codepointinvliststringlist::CodePointInversionListAndStringList;
 use icu_collections::codepointtrie::{CodePointMapRange, CodePointTrie, TrieValue};

--- a/components/properties/src/provider/names.rs
+++ b/components/properties/src/provider/names.rs
@@ -15,8 +15,6 @@
 use alloc::boxed::Box;
 use core::cmp::Ordering;
 
-use core::str;
-
 use icu_provider::prelude::*;
 
 use tinystr::TinyStr4;

--- a/components/timezone/src/provider/names.rs
+++ b/components/timezone/src/provider/names.rs
@@ -13,7 +13,6 @@
 //! Read more about data providers: [`icu_provider`]
 
 use crate::TimeZoneBcp47Id;
-use core::str;
 use icu_provider::prelude::*;
 use zerotrie::{ZeroAsciiIgnoreCaseTrie, ZeroTrie};
 use zerovec::{VarZeroVec, ZeroVec};

--- a/ffi/capi/src/locale_core.rs
+++ b/ffi/capi/src/locale_core.rs
@@ -6,7 +6,6 @@
 pub mod ffi {
     use crate::errors::ffi::ICU4XLocaleParseError;
     use alloc::boxed::Box;
-    use core::str;
     use icu_locale_core::extensions::unicode::Key;
     use icu_locale_core::subtags::{Language, Region, Script};
     use icu_locale_core::Locale;
@@ -151,7 +150,7 @@ pub mod ffi {
 
         #[diplomat::rust_link(icu::locale::Locale::normalizing_eq, FnInStruct)]
         pub fn normalizing_eq(&self, other: &DiplomatStr) -> bool {
-            if let Ok(other) = str::from_utf8(other) {
+            if let Ok(other) = core::str::from_utf8(other) {
                 self.0.normalizing_eq(other)
             } else {
                 // invalid UTF8 won't be allowed in locales anyway

--- a/ffi/capi/src/properties_sets.rs
+++ b/ffi/capi/src/properties_sets.rs
@@ -6,7 +6,6 @@
 pub mod ffi {
     use crate::provider::ffi::ICU4XDataProvider;
     use alloc::boxed::Box;
-    use core::str;
     use icu_properties::sets;
 
     use crate::errors::ffi::{ICU4XDataError, ICU4XError};

--- a/ffi/capi/src/properties_unisets.rs
+++ b/ffi/capi/src/properties_unisets.rs
@@ -7,7 +7,6 @@ pub mod ffi {
     use crate::locale_core::ffi::ICU4XLocale;
     use crate::provider::ffi::ICU4XDataProvider;
     use alloc::boxed::Box;
-    use core::str;
     use icu_properties::{exemplar_chars, sets};
 
     use crate::errors::ffi::ICU4XDataError;
@@ -24,7 +23,7 @@ pub mod ffi {
         /// Checks whether the string is in the set.
         #[diplomat::rust_link(icu::properties::sets::UnicodeSetDataBorrowed::contains, FnInStruct)]
         pub fn contains(&self, s: &DiplomatStr) -> bool {
-            let Ok(s) = str::from_utf8(s) else {
+            let Ok(s) = core::str::from_utf8(s) else {
                 return false;
             };
             self.0.as_borrowed().contains(s)

--- a/utils/fixed_decimal/src/lib.rs
+++ b/utils/fixed_decimal/src/lib.rs
@@ -74,11 +74,11 @@ use displaydoc::Display;
 pub use integer::FixedInteger;
 pub use scientific::ScientificDecimal;
 
-/// The magnitude or number of digits exceeds the limit of the FixedDecimal. The highest
-/// magnitude of the most significant digit is core::i16::MAX, and the lowest magnitude of the
-/// least significant digit is core::i16::MIN.
+/// The magnitude or number of digits exceeds the limit of the [`FixedDecimal`]. The highest
+/// magnitude of the most significant digit is [`i16::MAX`], and the lowest magnitude of the
+/// least significant digit is [`i16::MIN`].
 ///
-/// This error is also returned when constructing a FixedInteger from a FixedDecimal with a
+/// This error is also returned when constructing a [`FixedInteger`] from a [`FixedDecimal`] with a
 /// fractional part.
 ///
 /// # Examples
@@ -88,7 +88,7 @@ pub use scientific::ScientificDecimal;
 /// use fixed_decimal::FixedDecimal;
 ///
 /// let mut dec1 = FixedDecimal::from(123);
-/// dec1.multiply_pow10(core::i16::MAX);
+/// dec1.multiply_pow10(i16::MAX);
 /// assert!(dec1.is_zero());
 /// ```
 #[derive(Display, Debug, Copy, Clone, PartialEq)]

--- a/utils/zerovec/src/ule/slices.rs
+++ b/utils/zerovec/src/ule/slices.rs
@@ -3,7 +3,6 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::ule::*;
-use core::str;
 
 // Safety (based on the safety checklist on the ULE trait):
 //  1. [T; N] does not include any uninitialized or padding bytes since T is ULE
@@ -45,19 +44,19 @@ unsafe impl<T: EqULE, const N: usize> EqULE for [T; N] {}
 unsafe impl VarULE for str {
     #[inline]
     fn validate_byte_slice(bytes: &[u8]) -> Result<(), ZeroVecError> {
-        str::from_utf8(bytes).map_err(|_| ZeroVecError::parse::<Self>())?;
+        core::str::from_utf8(bytes).map_err(|_| ZeroVecError::parse::<Self>())?;
         Ok(())
     }
 
     #[inline]
     fn parse_byte_slice(bytes: &[u8]) -> Result<&Self, ZeroVecError> {
-        str::from_utf8(bytes).map_err(|_| ZeroVecError::parse::<Self>())
+        core::str::from_utf8(bytes).map_err(|_| ZeroVecError::parse::<Self>())
     }
     /// Invariant: must be safe to call when called on a slice that previously
     /// succeeded with `parse_byte_slice`
     #[inline]
     unsafe fn from_byte_slice_unchecked(bytes: &[u8]) -> &Self {
-        str::from_utf8_unchecked(bytes)
+        core::str::from_utf8_unchecked(bytes)
     }
 }
 


### PR DESCRIPTION
The only place these are needed is `core::str::from_utf8[_unchecked]`, which is only available in the `core::str` module, not in the `str` type. We do pretty consistently fully qualify these methods though, so I changed the remaining calls to do that.