### PR TITLE
Get rid of cfg(skip)

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -756,9 +756,8 @@ impl AnyCalendar {
 
     icu_provider::gen_any_buffer_data_constructors!(
         (locale) -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new_for_locale,
+            new_for_locale: skip,
             try_new_for_locale_with_any_provider,
             try_new_for_locale_with_buffer_provider,
             try_new_for_locale_unstable,

--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -160,9 +160,8 @@ impl Chinese {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new,
+            new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,

--- a/components/calendar/src/dangi.rs
+++ b/components/calendar/src/dangi.rs
@@ -153,9 +153,8 @@ impl Dangi {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new,
+            new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,

--- a/components/calendar/src/islamic.rs
+++ b/components/calendar/src/islamic.rs
@@ -128,9 +128,8 @@ impl IslamicObservational {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new,
+            new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,
@@ -175,9 +174,8 @@ impl IslamicUmmAlQura {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new,
+            new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -130,9 +130,8 @@ impl Japanese {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new,
+            new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,
@@ -188,9 +187,8 @@ impl JapaneseExtended {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new,
+            new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,

--- a/components/casemap/src/casemapper.rs
+++ b/components/casemap/src/casemapper.rs
@@ -81,9 +81,8 @@ impl CaseMapper {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-    #[cfg(skip)]
     functions: [
-        new,
+        new: skip,
         try_new_with_any_provider,
         try_new_with_buffer_provider,
         try_new_unstable,

--- a/components/casemap/src/closer.rs
+++ b/components/casemap/src/closer.rs
@@ -88,9 +88,8 @@ impl CaseMapCloser<CaseMapper> {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-    #[cfg(skip)]
     functions: [
-        new,
+        new: skip,
         try_new_with_any_provider,
         try_new_with_buffer_provider,
         try_new_unstable,
@@ -111,9 +110,8 @@ impl CaseMapCloser<CaseMapper> {
 // We use Borrow, not AsRef, since we want the blanket impl on T
 impl<CM: AsRef<CaseMapper>> CaseMapCloser<CM> {
     icu_provider::gen_any_buffer_data_constructors!((casemapper: CM) -> error: DataError,
-    #[cfg(skip)]
     functions: [
-        new_with_mapper,
+        new_with_mapper: skip,
         try_new_with_mapper_with_any_provider,
         try_new_with_mapper_with_buffer_provider,
         try_new_with_mapper_unstable,

--- a/components/casemap/src/titlecase.rs
+++ b/components/casemap/src/titlecase.rs
@@ -226,9 +226,8 @@ impl TitlecaseMapper<CaseMapper> {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-    #[cfg(skip)]
     functions: [
-        new,
+        new: skip,
         try_new_with_any_provider,
         try_new_with_buffer_provider,
         try_new_unstable,
@@ -249,9 +248,8 @@ impl TitlecaseMapper<CaseMapper> {
 // We use Borrow, not AsRef, since we want the blanket impl on T
 impl<CM: AsRef<CaseMapper>> TitlecaseMapper<CM> {
     icu_provider::gen_any_buffer_data_constructors!((casemapper: CM) -> error: DataError,
-    #[cfg(skip)]
     functions: [
-        new_with_mapper,
+        new_with_mapper: skip,
         try_new_with_mapper_with_any_provider,
         try_new_with_mapper_with_buffer_provider,
         try_new_with_mapper_unstable,

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -93,7 +93,13 @@ impl Collator {
 
     icu_provider::gen_any_buffer_data_constructors!(
         (locale, options: CollatorOptions) -> error: DataError,
-        #[cfg(skip)]
+        functions: [
+            try_new: skip,
+            try_new_with_any_provider,
+            try_new_with_buffer_provider,
+            try_new_unstable,
+            Self
+        ]
     );
 
     #[doc = icu_provider::gen_any_buffer_unstable_docs!(UNSTABLE, Self::try_new)]

--- a/components/collections/codepointtrie_builder/build.rs
+++ b/components/collections/codepointtrie_builder/build.rs
@@ -15,7 +15,7 @@ fn main() {
         if env::var("ICU4C_RENAME_VERSION").is_ok() {
             println!("cargo:rustc-cfg=icu4c_enable_renaming");
         }
-        println!("cargo:rustc-check-cfg=icu4c_enable_renaming");
+        println!("cargo:rustc-check-cfg=cfg(icu4c_enable_renaming)");
 
         println!("cargo:rustc-link-search={lib_path}");
         println!("cargo:rustc-link-lib={kind}=icuuc");

--- a/components/datetime/src/datetime.rs
+++ b/components/datetime/src/datetime.rs
@@ -100,9 +100,8 @@ impl TimeFormatter {
 
     icu_provider::gen_any_buffer_data_constructors!(
         (locale, length: length::Time) -> error: DateTimeError,
-        #[cfg(skip)]
         functions: [
-            try_new_with_length,
+            try_new_with_length: skip,
             try_new_with_length_with_any_provider,
             try_new_with_length_with_buffer_provider,
             try_new_with_length_unstable,
@@ -310,9 +309,8 @@ impl<C: CldrCalendar> TypedDateFormatter<C> {
 
     icu_provider::gen_any_buffer_data_constructors!(
         (locale, length: length::Date) -> error: DateTimeError,
-        #[cfg(skip)]
         functions: [
-            try_new_with_length,
+            try_new_with_length: skip,
             try_new_with_length_with_any_provider,
             try_new_with_length_with_buffer_provider,
             try_new_with_length_unstable,
@@ -562,9 +560,8 @@ where {
 
     icu_provider::gen_any_buffer_data_constructors!(
         (locale, options: DateTimeFormatterOptions) -> error: DateTimeError,
-        #[cfg(skip)]
         functions: [
-            try_new,
+            try_new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,

--- a/components/datetime/src/zoned_datetime.rs
+++ b/components/datetime/src/zoned_datetime.rs
@@ -161,7 +161,13 @@ impl<C: CldrCalendar> TypedZonedDateTimeFormatter<C> {
     icu_provider::gen_any_buffer_data_constructors!(
 
         (locale, date_time_format_options: DateTimeFormatterOptions, time_zone_format_options: TimeZoneFormatterOptions) -> error: DateTimeError,
-        #[cfg(skip)]
+        functions: [
+            try_new: skip,
+            try_new_with_any_provider,
+            try_new_with_buffer_provider,
+            try_new_unstable,
+            Self
+        ]
     );
 
     #[doc = icu_provider::gen_any_buffer_unstable_docs!(UNSTABLE, Self::try_new)]

--- a/components/experimental/src/compactdecimal/compactdecimal.rs
+++ b/components/experimental/src/compactdecimal/compactdecimal.rs
@@ -143,9 +143,8 @@ impl CompactDecimalFormatter {
 
     icu_provider::gen_any_buffer_data_constructors!(
         (locale, options: CompactDecimalFormatterOptions) -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            try_new_short,
+            try_new_short: skip,
             try_new_short_with_any_provider,
             try_new_short_with_buffer_provider,
             try_new_short_unstable,
@@ -228,9 +227,8 @@ impl CompactDecimalFormatter {
 
     icu_provider::gen_any_buffer_data_constructors!(
         (locale, options: CompactDecimalFormatterOptions) -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            try_new_long,
+            try_new_long: skip,
             try_new_long_with_any_provider,
             try_new_long_with_buffer_provider,
             try_new_long_unstable,

--- a/components/experimental/src/dimension/currency/formatter.rs
+++ b/components/experimental/src/dimension/currency/formatter.rs
@@ -43,7 +43,13 @@ pub struct CurrencyCode(pub TinyAsciiStr<3>);
 impl CurrencyFormatter {
     icu_provider::gen_any_buffer_data_constructors!(
         (locale, options: super::options::CurrencyFormatterOptions) -> error: DataError,
-        #[cfg(skip)]
+        functions: [
+            try_new: skip,
+            try_new_with_any_provider,
+            try_new_with_buffer_provider,
+            try_new_unstable,
+            Self
+        ]
     );
 
     /// Creates a new [`CurrencyFormatter`] from compiled locale data and an options bag.

--- a/components/experimental/src/relativetime/relativetime.rs
+++ b/components/experimental/src/relativetime/relativetime.rs
@@ -144,9 +144,8 @@ macro_rules! constructor {
 
         icu_provider::gen_any_buffer_data_constructors!(
             (locale, options: RelativeTimeFormatterOptions) -> error: DataError,
-            #[cfg(skip)]
             functions: [
-                $baked,
+                $baked: skip,
                 $any,
                 $buffer,
                 $unstable,

--- a/components/experimental/src/units/converter_factory.rs
+++ b/components/experimental/src/units/converter_factory.rs
@@ -40,9 +40,8 @@ impl From<Sign> for num_bigint::Sign {
 impl ConverterFactory {
     icu_provider::gen_any_buffer_data_constructors!(
         () -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new,
+            new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,

--- a/components/locale/src/expander.rs
+++ b/components/locale/src/expander.rs
@@ -285,9 +285,8 @@ impl LocaleExpander {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-        #[cfg(skip)]
         functions: [
-        new_extended,
+        new_extended: skip,
         try_new_extended_with_any_provider,
         try_new_extended_with_buffer_provider,
         try_new_extended_unstable,

--- a/components/locale/src/fallback/mod.rs
+++ b/components/locale/src/fallback/mod.rs
@@ -131,9 +131,8 @@ impl LocaleFallbacker {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new,
+            new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -1604,9 +1604,8 @@ impl DecomposingNormalizer {
 
     icu_provider::gen_any_buffer_data_constructors!(
         () -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new_nfd,
+            new_nfd: skip,
             try_new_nfd_with_any_provider,
             try_new_nfd_with_buffer_provider,
             try_new_nfd_unstable,
@@ -1719,9 +1718,8 @@ impl DecomposingNormalizer {
 
     icu_provider::gen_any_buffer_data_constructors!(
         () -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new_nfkd,
+            new_nfkd: skip,
             try_new_nfkd_with_any_provider,
             try_new_nfkd_with_buffer_provider,
             try_new_nfkd_unstable,
@@ -2221,9 +2219,8 @@ impl ComposingNormalizer {
 
     icu_provider::gen_any_buffer_data_constructors!(
         () -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new_nfc,
+            new_nfc: skip,
             try_new_nfc_with_any_provider,
             try_new_nfc_with_buffer_provider,
             try_new_nfc_unstable,
@@ -2267,9 +2264,8 @@ impl ComposingNormalizer {
 
     icu_provider::gen_any_buffer_data_constructors!(
         () -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new_nfkc,
+            new_nfkc: skip,
             try_new_nfkc_with_any_provider,
             try_new_nfkc_with_buffer_provider,
             try_new_nfkc_unstable,

--- a/components/normalizer/src/properties.rs
+++ b/components/normalizer/src/properties.rs
@@ -98,9 +98,8 @@ impl CanonicalComposition {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new,
+            new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,
@@ -390,9 +389,8 @@ impl CanonicalDecomposition {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new,
+            new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,
@@ -498,9 +496,8 @@ impl CanonicalCombiningClassMap {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new,
+            new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,

--- a/components/properties/src/bidi_data.rs
+++ b/components/properties/src/bidi_data.rs
@@ -196,9 +196,8 @@ pub const fn bidi_auxiliary_properties() -> BidiAuxiliaryPropertiesBorrowed<'sta
 
 icu_provider::gen_any_buffer_data_constructors!(
     () -> result: Result<BidiAuxiliaryProperties, DataError>,
-    #[cfg(skip)]
     functions: [
-        bidi_auxiliary_properties,
+        bidi_auxiliary_properties: skip,
         load_bidi_auxiliary_properties_with_any_provider,
         load_bidi_auxiliary_properties_with_buffer_provider,
         load_bidi_auxiliary_properties_unstable,

--- a/components/properties/src/script.rs
+++ b/components/properties/src/script.rs
@@ -625,9 +625,8 @@ pub const fn script_with_extensions() -> ScriptWithExtensionsBorrowed<'static> {
 
 icu_provider::gen_any_buffer_data_constructors!(
     () -> result: Result<ScriptWithExtensions, DataError>,
-    #[cfg(skip)]
     functions: [
-        script_with_extensions,
+        script_with_extensions: skip,
         load_script_with_extensions_with_any_provider,
         load_script_with_extensions_with_buffer_provider,
         load_script_with_extensions_unstable,

--- a/components/properties/src/sets.rs
+++ b/components/properties/src/sets.rs
@@ -2110,9 +2110,8 @@ pub fn load_for_ecma262(
 
 icu_provider::gen_any_buffer_data_constructors!(
     (name: &str) -> result: Result<CodePointSetData, UnexpectedPropertyNameOrDataError>,
-    #[cfg(skip)]
     functions: [
-        load_for_ecma262,
+        load_for_ecma262: skip,
         load_for_ecma262_with_any_provider,
         load_for_ecma262_with_buffer_provider,
         load_for_ecma262_unstable,

--- a/components/segmenter/src/grapheme.rs
+++ b/components/segmenter/src/grapheme.rs
@@ -154,9 +154,8 @@ impl GraphemeClusterSegmenter {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new,
+            new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -363,9 +363,8 @@ impl LineSegmenter {
     #[cfg(feature = "auto")]
     icu_provider::gen_any_buffer_data_constructors!(
         () -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new_auto,
+            new_auto: skip,
             try_new_auto_with_any_provider,
             try_new_auto_with_buffer_provider,
             try_new_auto_unstable,
@@ -405,9 +404,8 @@ impl LineSegmenter {
     #[cfg(feature = "lstm")]
     icu_provider::gen_any_buffer_data_constructors!(
         () -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new_lstm,
+            new_lstm: skip,
             try_new_lstm_with_any_provider,
             try_new_lstm_with_buffer_provider,
             try_new_lstm_unstable,
@@ -445,9 +443,8 @@ impl LineSegmenter {
 
     icu_provider::gen_any_buffer_data_constructors!(
         () -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new_dictionary,
+            new_dictionary: skip,
             try_new_dictionary_with_any_provider,
             try_new_dictionary_with_buffer_provider,
             try_new_dictionary_unstable,
@@ -485,9 +482,8 @@ impl LineSegmenter {
     #[cfg(feature = "auto")]
     icu_provider::gen_any_buffer_data_constructors!(
         (options: LineBreakOptions) -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new_auto_with_options,
+            new_auto_with_options: skip,
             try_new_auto_with_options_with_any_provider,
             try_new_auto_with_options_with_buffer_provider,
             try_new_auto_with_options_unstable,
@@ -536,9 +532,8 @@ impl LineSegmenter {
     #[cfg(feature = "lstm")]
     icu_provider::gen_any_buffer_data_constructors!(
         (options: LineBreakOptions) -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            try_new_lstm_with_options,
+            try_new_lstm_with_options: skip,
             try_new_lstm_with_options_with_any_provider,
             try_new_lstm_with_options_with_buffer_provider,
             try_new_lstm_with_options_unstable,
@@ -595,9 +590,8 @@ impl LineSegmenter {
 
     icu_provider::gen_any_buffer_data_constructors!(
         (options: LineBreakOptions) -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new_dictionary_with_options,
+            new_dictionary_with_options: skip,
             try_new_dictionary_with_options_with_any_provider,
             try_new_dictionary_with_options_with_buffer_provider,
             try_new_dictionary_with_options_unstable,

--- a/components/segmenter/src/sentence.rs
+++ b/components/segmenter/src/sentence.rs
@@ -125,9 +125,8 @@ impl SentenceSegmenter {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new,
+            new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -213,9 +213,8 @@ impl WordSegmenter {
     #[cfg(feature = "auto")]
     icu_provider::gen_any_buffer_data_constructors!(
         () -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            try_new_auto,
+            try_new_auto: skip,
             try_new_auto_with_any_provider,
             try_new_auto_with_buffer_provider,
             try_new_auto_unstable,
@@ -286,9 +285,8 @@ impl WordSegmenter {
     #[cfg(feature = "lstm")]
     icu_provider::gen_any_buffer_data_constructors!(
         () -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new_lstm,
+            new_lstm: skip,
             try_new_lstm_with_any_provider,
             try_new_lstm_with_buffer_provider,
             try_new_lstm_unstable,
@@ -351,9 +349,8 @@ impl WordSegmenter {
 
     icu_provider::gen_any_buffer_data_constructors!(
         () -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new_dictionary,
+            new_dictionary: skip,
             try_new_dictionary_with_any_provider,
             try_new_dictionary_with_buffer_provider,
             try_new_dictionary_unstable,

--- a/components/timezone/src/ids.rs
+++ b/components/timezone/src/ids.rs
@@ -115,9 +115,8 @@ impl TimeZoneIdMapper {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new,
+            new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,
@@ -482,9 +481,8 @@ impl TimeZoneIdMapperWithFastCanonicalization<TimeZoneIdMapper> {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new,
+            new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,
@@ -526,9 +524,8 @@ where
     }
 
     icu_provider::gen_any_buffer_data_constructors!((mapper: I) -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            try_new_with_mapper,
+            try_new_with_mapper: skip,
             try_new_with_mapper_with_any_provider,
             try_new_with_mapper_with_buffer_provider,
             try_new_with_mapper_unstable,

--- a/components/timezone/src/metazone.rs
+++ b/components/timezone/src/metazone.rs
@@ -42,9 +42,8 @@ impl MetazoneCalculator {
     }
 
     icu_provider::gen_any_buffer_data_constructors!(() -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            new,
+            new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -270,9 +270,8 @@ impl HelloWorldFormatter {
     }
 
     icu_provider::gen_any_buffer_data_constructors!((locale) -> error: DataError,
-        #[cfg(skip)]
         functions: [
-            try_new,
+            try_new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,

--- a/provider/data/calendar/build.rs
+++ b/provider/data/calendar/build.rs
@@ -7,5 +7,5 @@ fn main() {
         println!("cargo:rustc-cfg=icu4x_custom_data");
     }
     println!("cargo:rerun-if-env-changed=ICU4X_DATA_DIR");
-    println!("cargo:rustc-check-cfg=icu4c_enable_renaming");
+    println!("cargo:rustc-check-cfg=cfg(icu4c_enable_renaming)");
 }

--- a/provider/data/casemap/build.rs
+++ b/provider/data/casemap/build.rs
@@ -7,5 +7,5 @@ fn main() {
         println!("cargo:rustc-cfg=icu4x_custom_data");
     }
     println!("cargo:rerun-if-env-changed=ICU4X_DATA_DIR");
-    println!("cargo:rustc-check-cfg=icu4c_enable_renaming");
+    println!("cargo:rustc-check-cfg=cfg(icu4c_enable_renaming)");
 }

--- a/provider/data/collator/build.rs
+++ b/provider/data/collator/build.rs
@@ -7,5 +7,5 @@ fn main() {
         println!("cargo:rustc-cfg=icu4x_custom_data");
     }
     println!("cargo:rerun-if-env-changed=ICU4X_DATA_DIR");
-    println!("cargo:rustc-check-cfg=icu4c_enable_renaming");
+    println!("cargo:rustc-check-cfg=cfg(icu4c_enable_renaming)");
 }

--- a/provider/data/datetime/build.rs
+++ b/provider/data/datetime/build.rs
@@ -7,5 +7,5 @@ fn main() {
         println!("cargo:rustc-cfg=icu4x_custom_data");
     }
     println!("cargo:rerun-if-env-changed=ICU4X_DATA_DIR");
-    println!("cargo:rustc-check-cfg=icu4c_enable_renaming");
+    println!("cargo:rustc-check-cfg=cfg(icu4c_enable_renaming)");
 }

--- a/provider/data/decimal/build.rs
+++ b/provider/data/decimal/build.rs
@@ -7,5 +7,5 @@ fn main() {
         println!("cargo:rustc-cfg=icu4x_custom_data");
     }
     println!("cargo:rerun-if-env-changed=ICU4X_DATA_DIR");
-    println!("cargo:rustc-check-cfg=icu4c_enable_renaming");
+    println!("cargo:rustc-check-cfg=cfg(icu4c_enable_renaming)");
 }

--- a/provider/data/experimental/build.rs
+++ b/provider/data/experimental/build.rs
@@ -7,5 +7,5 @@ fn main() {
         println!("cargo:rustc-cfg=icu4x_custom_data");
     }
     println!("cargo:rerun-if-env-changed=ICU4X_DATA_DIR");
-    println!("cargo:rustc-check-cfg=icu4c_enable_renaming");
+    println!("cargo:rustc-check-cfg=cfg(icu4c_enable_renaming)");
 }

--- a/provider/data/list/build.rs
+++ b/provider/data/list/build.rs
@@ -7,5 +7,5 @@ fn main() {
         println!("cargo:rustc-cfg=icu4x_custom_data");
     }
     println!("cargo:rerun-if-env-changed=ICU4X_DATA_DIR");
-    println!("cargo:rustc-check-cfg=icu4c_enable_renaming");
+    println!("cargo:rustc-check-cfg=cfg(icu4c_enable_renaming)");
 }

--- a/provider/data/locale/build.rs
+++ b/provider/data/locale/build.rs
@@ -7,5 +7,5 @@ fn main() {
         println!("cargo:rustc-cfg=icu4x_custom_data");
     }
     println!("cargo:rerun-if-env-changed=ICU4X_DATA_DIR");
-    println!("cargo:rustc-check-cfg=icu4c_enable_renaming");
+    println!("cargo:rustc-check-cfg=cfg(icu4c_enable_renaming)");
 }

--- a/provider/data/normalizer/build.rs
+++ b/provider/data/normalizer/build.rs
@@ -7,5 +7,5 @@ fn main() {
         println!("cargo:rustc-cfg=icu4x_custom_data");
     }
     println!("cargo:rerun-if-env-changed=ICU4X_DATA_DIR");
-    println!("cargo:rustc-check-cfg=icu4c_enable_renaming");
+    println!("cargo:rustc-check-cfg=cfg(icu4c_enable_renaming)");
 }

--- a/provider/data/plurals/build.rs
+++ b/provider/data/plurals/build.rs
@@ -7,5 +7,5 @@ fn main() {
         println!("cargo:rustc-cfg=icu4x_custom_data");
     }
     println!("cargo:rerun-if-env-changed=ICU4X_DATA_DIR");
-    println!("cargo:rustc-check-cfg=icu4c_enable_renaming");
+    println!("cargo:rustc-check-cfg=cfg(icu4c_enable_renaming)");
 }

--- a/provider/data/properties/build.rs
+++ b/provider/data/properties/build.rs
@@ -7,5 +7,5 @@ fn main() {
         println!("cargo:rustc-cfg=icu4x_custom_data");
     }
     println!("cargo:rerun-if-env-changed=ICU4X_DATA_DIR");
-    println!("cargo:rustc-check-cfg=icu4c_enable_renaming");
+    println!("cargo:rustc-check-cfg=cfg(icu4c_enable_renaming)");
 }

--- a/provider/data/segmenter/build.rs
+++ b/provider/data/segmenter/build.rs
@@ -7,5 +7,5 @@ fn main() {
         println!("cargo:rustc-cfg=icu4x_custom_data");
     }
     println!("cargo:rerun-if-env-changed=ICU4X_DATA_DIR");
-    println!("cargo:rustc-check-cfg=icu4c_enable_renaming");
+    println!("cargo:rustc-check-cfg=cfg(icu4c_enable_renaming)");
 }

--- a/provider/data/timezone/build.rs
+++ b/provider/data/timezone/build.rs
@@ -7,5 +7,5 @@ fn main() {
         println!("cargo:rustc-cfg=icu4x_custom_data");
     }
     println!("cargo:rerun-if-env-changed=ICU4X_DATA_DIR");
-    println!("cargo:rustc-check-cfg=icu4c_enable_renaming");
+    println!("cargo:rustc-check-cfg=cfg(icu4c_enable_renaming)");
 }

--- a/tools/bakeddata-scripts/template/build.rs.template
+++ b/tools/bakeddata-scripts/template/build.rs.template
@@ -7,5 +7,5 @@ fn main() {
         println!("cargo:rustc-cfg=icu4x_custom_data");
     }
     println!("cargo:rerun-if-env-changed=ICU4X_DATA_DIR");
-    println!("cargo:rustc-check-cfg=icu4c_enable_renaming");
+    println!("cargo:rustc-check-cfg=cfg(icu4c_enable_renaming)");
 }


### PR DESCRIPTION
It was a hack and it breaks rustc-check-cfg, let's not do that anymore.

This is based on https://github.com/unicode-org/icu4x/pull/5075/ so that I can test this works with beta/nightly