### PR TITLE
Leftover nightly fixes

### DIFF
--- a/ffi/freertos/Cargo.toml
+++ b/ffi/freertos/Cargo.toml
@@ -43,3 +43,6 @@ default = ["icu_capi/default_components"]
 
 [build-dependencies]
 rustc_version = "0.4"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(needs_alloc_error_handler)'] }

--- a/ffi/freertos/build.rs
+++ b/ffi/freertos/build.rs
@@ -27,12 +27,13 @@ fn needs_alloc_error_handler() -> Option<bool> {
 }
 
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(needs_alloc_error_handler)");
+
     match env::var("CARGO_CFG_TARGET_OS") {
         Ok(v) if v == "none" => (),
         // Only on target_os = none
         _ => return,
     };
-
     if let Some(true) = needs_alloc_error_handler() {
         println!("cargo:rustc-cfg=needs_alloc_error_handler");
     }

--- a/provider/datagen/src/lib.rs
+++ b/provider/datagen/src/lib.rs
@@ -130,7 +130,7 @@ macro_rules! cb {
         /// corresponding Cargo features has been enabled.
         // Excludes the hello world marker, as that generally should not be generated.
         pub fn all_markers() -> Vec<DataMarkerInfo> {
-            #[cfg(features = "experimental_components")]
+            #[cfg(feature = "experimental_components")]
             log::warn!("The icu_datagen crates has been built with the `experimental_components` feature, so `all_markers` returns experimental markers");
             vec![
                 $(


### PR DESCRIPTION
The displaydoc warnings need https://github.com/yaahc/displaydoc/pull/47, but I don't think they break non-clippy CI for us, and I'm working on getting that published.




<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->