### PR TITLE
Minor improvement to zerotrie hash function

### DIFF
--- a/utils/zerotrie/src/byte_phf/builder.rs
+++ b/utils/zerotrie/src/byte_phf/builder.rs
@@ -18,21 +18,29 @@ const MAX_L2_SEARCH_MISSES: usize = 24;
 /// Returns `(p, [q_0, q_1, ..., q_(N-1)])`, or an error if the PHF could not be computed.
 #[allow(unused_labels)] // for readability
 pub fn find(bytes: &[u8]) -> Result<(u8, Vec<u8>), Error> {
-    #[allow(non_snake_case)]
-    let N = bytes.len();
+    let n_usize = bytes.len();
 
     let mut p = 0u8;
-    let mut qq = vec![0u8; N];
+    let mut qq = vec![0u8; n_usize];
 
-    let mut bqs = vec![0u8; N];
-    let mut seen = vec![false; N];
+    let mut bqs = vec![0u8; n_usize];
+    let mut seen = vec![false; n_usize];
     let max_allowable_p = P_FAST_MAX;
     let mut max_allowable_q = Q_FAST_MAX;
 
+    #[allow(non_snake_case)]
+    let N = if n_usize > 0 && n_usize < 256 {
+        n_usize as u8
+    } else {
+        debug_assert!(n_usize == 0 || n_usize == 256);
+        return Ok((p, qq));
+    };
+
     'p_loop: loop {
-        let mut buckets: Vec<(usize, Vec<u8>)> = (0..N).map(|i| (i, vec![])).collect();
+        let mut buckets: Vec<(usize, Vec<u8>)> = (0..n_usize).map(|i| (i, vec![])).collect();
         for byte in bytes {
-            buckets[f1(*byte, p, N)].1.push(*byte);
+            let l1 = f1(*byte, p, N) as usize;
+            buckets[l1].1.push(*byte);
         }
         buckets.sort_by_key(|(_, v)| -(v.len() as isize));
         // println!("New P: p={p:?}, buckets={buckets:?}");
@@ -53,11 +61,13 @@ pub fn find(bytes: &[u8]) -> Result<(u8, Vec<u8>), Error> {
             }
             let mut bucket = buckets[i].1.as_slice();
             'byte_loop: for (j, byte) in bucket.iter().enumerate() {
-                if seen[f2(*byte, bqs[i], N)] {
+                let l2 = f2(*byte, bqs[i], N) as usize;
+                if seen[l2] {
                     // println!("Skipping Q: p={p:?}, i={i:?}, byte={byte:}, q={i:?}, l2={:?}", f2(*byte, bqs[i], N));
                     for k_byte in &bucket[0..j] {
-                        assert!(seen[f2(*k_byte, bqs[i], N)]);
-                        seen[f2(*k_byte, bqs[i], N)] = false;
+                        let l2 = f2(*k_byte, bqs[i], N) as usize;
+                        assert!(seen[l2]);
+                        seen[l2] = false;
                     }
                     'reset_loop: loop {
                         if bqs[i] < max_allowable_q {
@@ -86,13 +96,15 @@ pub fn find(bytes: &[u8]) -> Result<(u8, Vec<u8>), Error> {
                         i -= 1;
                         bucket = buckets[i].1.as_slice();
                         for byte in bucket {
-                            assert!(seen[f2(*byte, bqs[i], N)]);
-                            seen[f2(*byte, bqs[i], N)] = false;
+                            let l2 = f2(*byte, bqs[i], N) as usize;
+                            assert!(seen[l2]);
+                            seen[l2] = false;
                         }
                     }
                 } else {
                     // println!("Marking as seen: i={i:?}, byte={byte:}, l2={:?}", f2(*byte, bqs[i], N));
-                    seen[f2(*byte, bqs[i], N)] = true;
+                    let l2 = f2(*byte, bqs[i], N) as usize;
+                    seen[l2] = true;
                 }
             }
             // println!("Found Q: i={i:?}, q={:?}", bqs[i]);
@@ -106,16 +118,17 @@ impl PerfectByteHashMap<Vec<u8>> {
     ///
     /// (this is a doc-hidden API)
     pub fn try_new(keys: &[u8]) -> Result<Self, Error> {
-        let n = keys.len();
+        let n_usize = keys.len();
+        let n = n_usize as u8;
         let (p, mut qq) = find(keys)?;
-        let mut keys_permuted = vec![0; n];
+        let mut keys_permuted = vec![0; n_usize];
         for key in keys {
-            let l1 = f1(*key, p, n);
+            let l1 = f1(*key, p, n) as usize;
             let q = qq[l1];
-            let l2 = f2(*key, q, n);
+            let l2 = f2(*key, q, n) as usize;
             keys_permuted[l2] = *key;
         }
-        let mut result = Vec::with_capacity(n * 2 + 1);
+        let mut result = Vec::with_capacity(n_usize * 2 + 1);
         result.push(p);
         result.append(&mut qq);
         result.append(&mut keys_permuted);
@@ -178,16 +191,16 @@ mod tests {
         let bytes = random_alphanums(0, 16);
 
         #[allow(non_snake_case)]
-        let N = bytes.len();
+        let N = u8::try_from(bytes.len()).unwrap();
 
         let (p, qq) = find(bytes.as_slice()).unwrap();
 
         println!("Results:");
         for byte in bytes.iter() {
             print_byte_to_stdout(*byte);
-            let l1 = f1(*byte, p, N);
+            let l1 = f1(*byte, p, N) as usize;
             let q = qq[l1];
-            let l2 = f2(*byte, q, N);
+            let l2 = f2(*byte, q, N) as usize;
             println!(" => l1 {l1} => q {q} => l2 {l2}");
         }
     }

--- a/utils/zerotrie/tests/builder_test.rs
+++ b/utils/zerotrie/tests/builder_test.rs
@@ -72,11 +72,11 @@ where
 {
     // Check that each item is in the trie
     for (k, v) in items.iter() {
-        assert_eq!(trie.get(k), Some(*v));
+        assert_eq!(trie.get(k), Some(*v), "{k:?}");
     }
     // Check that some items are not in the trie
     for s in NON_EXISTENT_STRINGS.iter() {
-        assert_eq!(trie.get(s.as_bytes()), None);
+        assert_eq!(trie.get(s.as_bytes()), None, "{s:?}");
     }
     // Check that the iterator returns the contents of the LiteMap
     // Note: Since the items might not be in order, we collect them into a new LiteMap


### PR DESCRIPTION
I reviewed our little perfect hash function with @Amanieu who highlighted the modulo operator as likely the performance bottleneck. We brainstormed some various approaches including whether we could clamp the hash table size to a power of 2 so that we could use a bitmask instead of a division. However, there were a few downsides to that approach:

1. This would make the function non-minimal, meaning it would take more storage (mainly directly, but also indirectly by pushing indices to be bigger varints).
2. The non-minimal hash function may require either extra bits to store whether entries exist, or an unfortunate workaround such as storing present keys as the values in the wrong buckets to prevent those entries from being found.
3. A division operator on small integers might not be too expensive depending on the processor.
4. It wasn't clear that this hash function was the bottleneck. Loads of bytes in the zerotrie are what I believe to be the main bottleneck. I've already focused on improving data locality.

What I did in this PR is change the `usize` division to `u8` division. It results in slightly smaller assembly:

```
Old:
	cmp	rcx, 1
	adc	rcx, 0
	movzx	eax, dl
	cmp	rax, rcx
	jb	.LBB8_9
	xor	edx, edx
	div	ecx

New:

	movzx	eax, cl
	div	dl
	movzx	edi, ah
```

@Victoronz also pointed me to https://orlp.net/blog/worlds-smallest-hash-table/ which is a good read about perfect hash functions.