### PR TITLE
Fix integer overflow for `LiteMap` by using correct `Store` trait method

### DIFF
--- a/utils/litemap/src/map.rs
+++ b/utils/litemap/src/map.rs
@@ -124,7 +124,7 @@ where
     /// ```
     #[inline]
     pub fn last(&self) -> Option<(&K, &V)> {
-        self.values.lm_get(self.len() - 1)
+        self.values.lm_last()
     }
 
     /// Returns a new [`LiteMap`] with owned keys and values.


### PR DESCRIPTION
In the latest version calling `last()` on empty `LiteMap` panics on attempt to subtract with overflow.

The correct method that should be called internally is `Store` trait method `lm_last()`.