### PR TITLE
Fix libc_alloc linking

### DIFF
--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -143,8 +143,8 @@ log = { workspace = true, optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Logging uses diplomat_runtime bindings in wasm, we only need this for native
 simple_logger = { workspace = true, optional = true }
+libc_alloc = { workspace = true, features = ["global"], optional = true }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "none")))'.dependencies]
 icu_provider_fs = { workspace = true, optional = true }
 
-libc_alloc = { workspace = true, features = ["global"], optional = true }


### PR DESCRIPTION
Platforms with `target_os = none` may still have malloc.



<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->