### PR TITLE
Run validate_byte_slice for each byte

### DIFF
--- a/components/experimental/src/dimension/provider/pattern_key.rs
+++ b/components/experimental/src/dimension/provider/pattern_key.rs
@@ -70,35 +70,31 @@ pub struct PatternKeyULE(u8);
 
 unsafe impl ULE for PatternKeyULE {
     fn validate_byte_slice(bytes: &[u8]) -> Result<(), zerovec::ZeroVecError> {
-        if bytes.len() != 1 {
-            return Err(ZeroVecError::length::<Self>(bytes.len()));
-        }
-
-        let byte = &bytes[0];
-
-        // Ensure the first two bits (b7 & b6) are not 11.
-        if (byte & 0b1100_0000) == 0b1100_0000 {
-            return Err(ZeroVecError::parse::<Self>());
-        }
-
-        // For the `Power` variant:
-        //      b5 & b4 must be 10 or 11. (this means that b5 must be 1)
-        //      b3 must be 0.
-        //      When b2 is 1, b1 must be 0.
-        if (byte & 0b1100_0000) == 0b1000_0000 {
-            // b5 must be 1
-            if (byte & 0b0010_0000) == 0 {
+        for &byte in bytes.iter() {
+            // Ensure the first two bits (b7 & b6) are not 11.
+            if (byte & 0b1100_0000) == 0b1100_0000 {
                 return Err(ZeroVecError::parse::<Self>());
             }
 
-            // b3 must be 0
-            if (byte & 0b0000_1000) != 0 {
-                return Err(ZeroVecError::parse::<Self>());
-            }
+            // For the `Power` variant:
+            //      b5 & b4 must be 10 or 11. (this means that b5 must be 1)
+            //      b3 must be 0.
+            //      When b2 is 1, b1 must be 0.
+            if (byte & 0b1100_0000) == 0b1000_0000 {
+                // b5 must be 1
+                if (byte & 0b0010_0000) == 0 {
+                    return Err(ZeroVecError::parse::<Self>());
+                }
 
-            // If b2 is 1, b1 must be 0
-            if (byte & 0b0000_0100) != 0 && (byte & 0b0000_0010) != 0 {
-                return Err(ZeroVecError::parse::<Self>());
+                // b3 must be 0
+                if (byte & 0b0000_1000) != 0 {
+                    return Err(ZeroVecError::parse::<Self>());
+                }
+
+                // If b2 is 1, b1 must be 0
+                if (byte & 0b0000_0100) != 0 && (byte & 0b0000_0010) != 0 {
+                    return Err(ZeroVecError::parse::<Self>());
+                }
             }
         }
 


### PR DESCRIPTION
The `PatternKeyULE` is represented with a single byte, therefore, to validate a series of `PatternKeyULE`, we need to validate each byte.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->