### PR TITLE
(Backport to 1.5.x) Fix OptionVarULE in zerovec to also use C, packed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   - (1.5.1) Fix incorrect assertion in week-of-year formatting (https://github.com/unicode-org/icu4x/issues/4977)
 - `icu_casemap`
   - (1.5.1) Enforce C,packed, not just packed, on ULE types, fixing for incoming changes to `repr(Rust)` (https://github.com/unicode-org/icu4x/pull/5049)
+- `icu_capi`
+  - (1.5.1) Fix situations in which `libc_alloc` is specified as a dependency (https://github.com/unicode-org/icu4x/pull/5119)
 - `icu_properties`
   - (1.5.1) Enforce C,packed, not just packed, on ULE types, fixing for incoming changes to `repr(Rust)` (https://github.com/unicode-org/icu4x/pull/5049)
 - `zerovec`
@@ -16,7 +18,6 @@
   - (0.10.3) Enforce C,packed, not just packed, on ULE types, fixing for incoming changes to `repr(Rust)` (https://github.com/unicode-org/icu4x/pull/5049)
 - `zerovec_derive`
   - (0.10.3) Enforce C,packed, not just packed, on ULE types, fixing for incoming changes to `repr(Rust)` (https://github.com/unicode-org/icu4x/pull/5049)
-
 ## icu4x 1.5 (May 28, 2024)
 
 - Components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## icu4x 1.5.x
 
+- `icu_calendar`
+  - (1.5.1) Fix Japanese calendar Gregorian era year 0 (https://github.com/unicode-org/icu4x/issues/4968)
 - `icu_datetime`
-  - Fix incorrect assertion in week-of-year formatting (https://github.com/unicode-org/icu4x/issues/4977)
-  - Fix Japanese calendar Gregorian era year 0 (https://github.com/unicode-org/icu4x/issues/4968)
+  - (1.5.1) Fix incorrect assertion in week-of-year formatting (https://github.com/unicode-org/icu4x/issues/4977)
+- `zerovec`
+  - (0.10.3) Fix size regression by making `twox-hash` dep `no_std` (https://github.com/unicode-org/icu4x/pull/5007)
 
 ## icu4x 1.5 (May 28, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## icu4x 1.5.x
+
+- `icu_datetime`
+  - Fix incorrect assertion in week-of-year formatting (https://github.com/unicode-org/icu4x/issues/4977)
+
 ## icu4x 1.5 (May 28, 2024)
 
 - Components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,18 @@
 
 - `icu_calendar`
   - (1.5.1) Fix Japanese calendar Gregorian era year 0 (https://github.com/unicode-org/icu4x/issues/4968)
+  - (1.5.2) Enforce C,packed, not just packed, on ULE types, fixing for incoming changes to `repr(Rust)` (https://github.com/unicode-org/icu4x/pull/5049)
 - `icu_datetime`
   - (1.5.1) Fix incorrect assertion in week-of-year formatting (https://github.com/unicode-org/icu4x/issues/4977)
+- `icu_casemap`
+  - (1.5.1) Enforce C,packed, not just packed, on ULE types, fixing for incoming changes to `repr(Rust)` (https://github.com/unicode-org/icu4x/pull/5049)
+- `icu_properties`
+  - (1.5.1) Enforce C,packed, not just packed, on ULE types, fixing for incoming changes to `repr(Rust)` (https://github.com/unicode-org/icu4x/pull/5049)
 - `zerovec`
   - (0.10.3) Fix size regression by making `twox-hash` dep `no_std` (https://github.com/unicode-org/icu4x/pull/5007)
+  - (0.10.3) Enforce C,packed, not just packed, on ULE types, fixing for incoming changes to `repr(Rust)` (https://github.com/unicode-org/icu4x/pull/5049)
+ - `zerovec_derive`
+  - (0.10.3) Enforce C,packed, not just packed, on ULE types, fixing for incoming changes to `repr(Rust)` (https://github.com/unicode-org/icu4x/pull/5049)
 
 ## icu4x 1.5 (May 28, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `icu_datetime`
   - Fix incorrect assertion in week-of-year formatting (https://github.com/unicode-org/icu4x/issues/4977)
+  - Fix Japanese calendar Gregorian era year 0 (https://github.com/unicode-org/icu4x/issues/4968)
 
 ## icu4x 1.5 (May 28, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - `zerovec`
   - (0.10.3) Fix size regression by making `twox-hash` dep `no_std` (https://github.com/unicode-org/icu4x/pull/5007)
   - (0.10.3) Enforce C,packed, not just packed, on ULE types, fixing for incoming changes to `repr(Rust)` (https://github.com/unicode-org/icu4x/pull/5049)
- - `zerovec_derive`
+- `zerovec_derive`
   - (0.10.3) Enforce C,packed, not just packed, on ULE types, fixing for incoming changes to `repr(Rust)` (https://github.com/unicode-org/icu4x/pull/5049)
 
 ## icu4x 1.5 (May 28, 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `zerovec`
   - (0.10.3) Fix size regression by making `twox-hash` dep `no_std` (https://github.com/unicode-org/icu4x/pull/5007)
   - (0.10.3) Enforce C,packed, not just packed, on ULE types, fixing for incoming changes to `repr(Rust)` (https://github.com/unicode-org/icu4x/pull/5049)
+  - (0.10.4) Enforce C,packed on OptionVarULE (https://github.com/unicode-org/icu4x/pull/5143)
 - `zerovec_derive`
   - (0.10.3) Enforce C,packed, not just packed, on ULE types, fixing for incoming changes to `repr(Rust)` (https://github.com/unicode-org/icu4x/pull/5049)
 ## icu4x 1.5 (May 28, 2024)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "calendrical_calculations",
  "criterion",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "icu_casemap"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "criterion",
  "databake",
@@ -1410,7 +1410,7 @@ version = "1.5.0"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "databake",
  "displaydoc",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "bincode",
  "criterion",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "bincode",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,7 +959,7 @@ version = "1.5.0"
 
 [[package]]
 name = "icu_capi"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "diplomat",
  "diplomat-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "bincode",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "calendrical_calculations",
  "criterion",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "icu_datetime"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "bincode",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,7 +2712,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,6 +246,7 @@ serde = { version = "1.0.110", default-features = false }
 serde-json-core = { version = "0.4.0", default-features = false }
 smallvec = { version = "1.10.0", default-features = false }
 stable_deref_trait = { version = "1.2.0", default-features = false }
+twox-hash = { version = "1.4.2", default-features = false }
 unicode-bidi = { version = "0.3.11", default-features = false }
 utf16_iter = { version = "1.0.2", default-features = false }
 utf8_iter = { version = "1.0.2", default-features = false }
@@ -287,7 +288,6 @@ simple_logger = "4.0.0"
 syn = "2.0.21"
 synstructure = "0.13.0"
 toml = "0.5.8"
-twox-hash = "1.4.2"
 ureq = "2.3.0"
 walkdir = "2.3.2"
 wasmi = "0.31.2"

--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -5,6 +5,7 @@
 [package]
 name = "icu_calendar"
 description = "API for supporting various types of calendars"
+version = "1.5.1"
 
 authors.workspace = true
 categories.workspace = true
@@ -14,7 +15,6 @@ include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_calendar"
 description = "API for supporting various types of calendars"
-version = "1.5.1"
+version = "1.5.2"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -665,7 +665,7 @@ impl Japanese {
         // for japanext, meiji for japanese),
         // In such a case, we instead fall back to Gregorian era codes
         if date < start {
-            if date.year < 0 {
+            if date.year <= 0 {
                 (1 - date.year, tinystr!(16, "bce"))
             } else {
                 (date.year, tinystr!(16, "ce"))
@@ -826,7 +826,11 @@ mod tests {
         assert_eq!(
             date, reconstructed,
             "Failed to roundtrip with {era:?}, {year}, {month}, {day}"
-        )
+        );
+
+        // Extra coverage for https://github.com/unicode-org/icu4x/issues/4968
+        assert_eq!(reconstructed.year().era, era);
+        assert_eq!(reconstructed.year().number, year);
     }
 
     fn single_test_roundtrip_ext(

--- a/components/calendar/src/provider/chinese_based.rs
+++ b/components/calendar/src/provider/chinese_based.rs
@@ -143,7 +143,7 @@ impl<'data> ChineseBasedCacheV1<'data> {
     derive(databake::Bake),
     databake(path = icu_calendar::provider),
 )]
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct PackedChineseBasedYearInfo(pub u8, pub u8, pub u8);
 
 impl PackedChineseBasedYearInfo {

--- a/components/calendar/src/provider/islamic.rs
+++ b/components/calendar/src/provider/islamic.rs
@@ -156,7 +156,7 @@ impl<'data> IslamicCacheV1<'data> {
     databake(path = icu_calendar::provider),
 )]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct PackedIslamicYearInfo(pub u8, pub u8);
 
 impl fmt::Debug for PackedIslamicYearInfo {

--- a/components/casemap/Cargo.toml
+++ b/components/casemap/Cargo.toml
@@ -14,7 +14,7 @@ include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version.workspace = true
+version = "1.5.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/components/casemap/src/provider/exceptions_builder.rs
+++ b/components/casemap/src/provider/exceptions_builder.rs
@@ -71,7 +71,7 @@ impl ExceptionHeader {
 /// In this struct the RESERVED bit is still allowed to be set, and it will produce a different
 /// exception header, but it will not have any other effects.
 #[derive(Copy, Clone, PartialEq, Eq, ULE)]
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct ExceptionHeaderULE {
     slot_presence: SlotPresence,
     bits: ExceptionBitsULE,

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -5,6 +5,7 @@
 [package]
 name = "icu_datetime"
 description = "API for formatting date and time to user readable textual representation"
+version = "1.5.1"
 
 authors.workspace = true
 categories.workspace = true
@@ -14,7 +15,6 @@ include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/components/datetime/src/input.rs
+++ b/components/datetime/src/input.rs
@@ -349,7 +349,7 @@ impl ExtractedDateTimeInput {
                     "iso_weekday",
                 ))?;
         // We don't have any calendars with < 14 days per year, and it's unlikely we'll add one
-        debug_assert!(day_of_year_info.day_of_year >= icu_calendar::week::MIN_UNIT_DAYS);
+        debug_assert!(day_of_year_info.days_in_year >= icu_calendar::week::MIN_UNIT_DAYS);
         debug_assert!(day_of_year_info.days_in_prev_year >= icu_calendar::week::MIN_UNIT_DAYS);
         #[allow(clippy::unwrap_used)]
         let week_of = calculator

--- a/components/properties/Cargo.toml
+++ b/components/properties/Cargo.toml
@@ -14,7 +14,7 @@ include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version.workspace = true
+version = "1.5.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/components/properties/src/provider/bidi_data.rs
+++ b/components/properties/src/provider/bidi_data.rs
@@ -156,7 +156,7 @@ pub enum CheckedBidiPairedBracketType {
 #[doc(hidden)]
 /// needed for datagen but not intended for users
 #[derive(Copy, Clone, Hash, PartialEq, Eq, Debug)]
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct MirroredPairedBracketDataULE([u8; 3]);
 
 // Safety (based on the safety checklist on the ULE trait):

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -22,7 +22,7 @@ edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version.workspace = true
+version = "1.5.1"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -148,8 +148,8 @@ log = { workspace = true, optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Logging uses diplomat_runtime bindings in wasm, we only need this for native
 simple_logger = { workspace = true, optional = true }
+libc_alloc = { workspace = true, features = ["global"], optional = true }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "none")))'.dependencies]
 icu_provider_fs = { workspace = true, optional = true }
 
-libc_alloc = { workspace = true, features = ["global"], optional = true }

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "zerovec"
 description = "Zero-copy vector backed by a byte array"
-version = "0.10.3"
+version = "0.10.4"
 categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
 keywords = ["zerocopy", "serialization", "zero-copy", "serde"]
 

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "zerovec"
 description = "Zero-copy vector backed by a byte array"
-version = "0.10.2"
+version = "0.10.3"
 categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
 keywords = ["zerocopy", "serialization", "zero-copy", "serde"]
 

--- a/utils/zerovec/derive/Cargo.toml
+++ b/utils/zerovec/derive/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "zerovec-derive"
 description = "Custom derive for the zerovec crate"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
 keywords = ["zerocopy", "serialization", "zero-copy", "serde"]

--- a/utils/zerovec/derive/examples/derives.rs
+++ b/utils/zerovec/derive/examples/derives.rs
@@ -6,7 +6,7 @@ use zerovec::ule::AsULE;
 use zerovec::ule::EncodeAsVarULE;
 use zerovec::*;
 
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(ule::ULE, Copy, Clone)]
 pub struct FooULE {
     a: u8,
@@ -40,7 +40,7 @@ impl AsULE for Foo {
     }
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(ule::VarULE)]
 pub struct RelationULE {
     /// This maps to (AndOr, Polarity, Operand),

--- a/utils/zerovec/derive/src/make_ule.rs
+++ b/utils/zerovec/derive/src/make_ule.rs
@@ -83,7 +83,7 @@ fn make_ule_enum_impl(
     attrs: ZeroVecAttrs,
 ) -> TokenStream2 {
     // We could support more int reprs in the future if needed
-    if !utils::has_valid_repr(&input.attrs, |r| r == "u8") {
+    if !utils::ReprInfo::compute(&input.attrs).u8 {
         return Error::new(
             input.span(),
             "#[make_ule] can only be applied to #[repr(u8)] enums",

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -10,10 +10,10 @@ use syn::spanned::Spanned;
 use syn::{Data, DeriveInput, Error};
 
 pub fn derive_impl(input: &DeriveInput) -> TokenStream2 {
-    if !utils::has_valid_repr(&input.attrs, |r| r == "packed" || r == "transparent") {
+    if !utils::ReprInfo::compute(&input.attrs).cpacked_or_transparent() {
         return Error::new(
             input.span(),
-            "derive(ULE) must be applied to a #[repr(packed)] or #[repr(transparent)] type",
+            "derive(ULE) must be applied to a #[repr(C, packed)] or #[repr(transparent)] type",
         )
         .to_compile_error();
     }

--- a/utils/zerovec/derive/src/utils.rs
+++ b/utils/zerovec/derive/src/utils.rs
@@ -11,14 +11,38 @@ use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{Attribute, Error, Field, Fields, Ident, Index, Result, Token};
 
-// Check that there are repr attributes satisfying the given predicate
-pub fn has_valid_repr(attrs: &[Attribute], predicate: impl Fn(&Ident) -> bool + Copy) -> bool {
-    attrs.iter().filter(|a| a.path().is_ident("repr")).any(|a| {
-        a.parse_args::<IdentListAttribute>()
-            .ok()
-            .and_then(|s| s.idents.iter().find(|s| predicate(s)).map(|_| ()))
-            .is_some()
-    })
+#[derive(Default)]
+pub struct ReprInfo {
+    pub c: bool,
+    pub transparent: bool,
+    pub u8: bool,
+    pub packed: bool,
+}
+
+impl ReprInfo {
+    pub fn compute(attrs: &[Attribute]) -> Self {
+        let mut info = ReprInfo::default();
+        for attr in attrs.iter().filter(|a| a.path().is_ident("repr")) {
+            if let Ok(pieces) = attr.parse_args::<IdentListAttribute>() {
+                for piece in pieces.idents.iter() {
+                    if piece == "C" || piece == "c" {
+                        info.c = true;
+                    } else if piece == "transparent" {
+                        info.transparent = true;
+                    } else if piece == "packed" {
+                        info.packed = true;
+                    } else if piece == "u8" {
+                        info.u8 = true;
+                    }
+                }
+            }
+        }
+        info
+    }
+
+    pub fn cpacked_or_transparent(self) -> bool {
+        (self.c && self.packed) || self.transparent
+    }
 }
 
 // An attribute that is a list of idents
@@ -60,7 +84,7 @@ pub fn repr_for(f: &Fields) -> TokenStream2 {
     if f.len() == 1 {
         quote!(transparent)
     } else {
-        quote!(packed)
+        quote!(C, packed)
     }
 }
 

--- a/utils/zerovec/derive/src/varule.rs
+++ b/utils/zerovec/derive/src/varule.rs
@@ -15,10 +15,10 @@ pub fn derive_impl(
     input: &DeriveInput,
     custom_varule_validator: Option<TokenStream2>,
 ) -> TokenStream2 {
-    if !utils::has_valid_repr(&input.attrs, |r| r == "packed" || r == "transparent") {
+    if !utils::ReprInfo::compute(&input.attrs).cpacked_or_transparent() {
         return Error::new(
             input.span(),
-            "derive(VarULE) must be applied to a #[repr(packed)] or #[repr(transparent)] type",
+            "derive(VarULE) must be applied to a #[repr(C, packed)] or #[repr(transparent)] type",
         )
         .to_compile_error();
     }

--- a/utils/zerovec/design_doc.md
+++ b/utils/zerovec/design_doc.md
@@ -195,7 +195,7 @@ struct Foo {
 }
 
 // Implements ULE
-#[repr(packed)]
+#[repr(C, packed)]
 struct FooULE {
     field1: u32::ULE,
     field2: char::ULE,

--- a/utils/zerovec/src/flexzerovec/slice.rs
+++ b/utils/zerovec/src/flexzerovec/slice.rs
@@ -13,7 +13,7 @@ use core::ops::Range;
 const USIZE_WIDTH: usize = mem::size_of::<usize>();
 
 /// A zero-copy "slice" that efficiently represents `[usize]`.
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct FlexZeroSlice {
     // Hard Invariant: 1 <= width <= USIZE_WIDTH (which is target_pointer_width)
     // Soft Invariant: width == the width of the largest element

--- a/utils/zerovec/src/ule/custom.rs
+++ b/utils/zerovec/src/ule/custom.rs
@@ -49,7 +49,7 @@
 //!
 //! // Must be repr(packed) for safety of VarULE!
 //! // Must also only contain ULE types
-//! #[repr(packed)]
+//! #[repr(C, packed)]
 //! struct FooULE {
 //!     field1: <char as AsULE>::ULE,   
 //!     field2: <u32 as AsULE>::ULE,

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -61,7 +61,7 @@ use core::{mem, slice};
 /// 6. Acknowledge the following note about the equality invariant.
 ///
 /// If the ULE type is a struct only containing other ULE types (or other types which satisfy invariants 1 and 2,
-/// like `[u8; N]`), invariants 1 and 2 can be achieved via `#[repr(packed)]` or `#[repr(transparent)]`.
+/// like `[u8; N]`), invariants 1 and 2 can be achieved via `#[repr(C, packed)]` or `#[repr(transparent)]`.
 ///
 /// # Equality invariant
 ///
@@ -271,7 +271,7 @@ where
 /// 7. Acknowledge the following note about the equality invariant.
 ///
 /// If the ULE type is a struct only containing other ULE/VarULE types (or other types which satisfy invariants 1 and 2,
-/// like `[u8; N]`), invariants 1 and 2 can be achieved via `#[repr(packed)]` or `#[repr(transparent)]`.
+/// like `[u8; N]`), invariants 1 and 2 can be achieved via `#[repr(C, packed)]` or `#[repr(transparent)]`.
 ///
 /// # Equality invariant
 ///

--- a/utils/zerovec/src/ule/option.rs
+++ b/utils/zerovec/src/ule/option.rs
@@ -141,7 +141,7 @@ impl<U: Copy + Eq> Eq for OptionULE<U> {}
 /// ```
 // The slice field is empty when None (bool = false),
 // and is a valid T when Some (bool = true)
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct OptionVarULE<U: VarULE + ?Sized>(PhantomData<U>, bool, [u8]);
 
 impl<U: VarULE + ?Sized> OptionVarULE<U> {

--- a/utils/zerovec/src/ule/option.rs
+++ b/utils/zerovec/src/ule/option.rs
@@ -28,7 +28,7 @@ use core::mem::{self, MaybeUninit};
 // Invariants:
 // The MaybeUninit is zeroed when None (bool = false),
 // and is valid when Some (bool = true)
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct OptionULE<U>(bool, MaybeUninit<U>);
 
 impl<U: Copy> OptionULE<U> {
@@ -62,11 +62,11 @@ impl<U: Copy + core::fmt::Debug> core::fmt::Debug for OptionULE<U> {
 
 // Safety (based on the safety checklist on the ULE trait):
 //  1. OptionULE does not include any uninitialized or padding bytes.
-//     (achieved by `#[repr(packed)]` on a struct containing only ULE fields,
+//     (achieved by `#[repr(C, packed)]` on a struct containing only ULE fields,
 //     in the context of this impl. The MaybeUninit is valid for all byte sequences, and we only generate
 ///    zeroed or valid-T byte sequences to fill it)
 //  2. OptionULE is aligned to 1 byte.
-//     (achieved by `#[repr(packed)]` on a struct containing only ULE fields, in the context of this impl)
+//     (achieved by `#[repr(C, packed)]` on a struct containing only ULE fields, in the context of this impl)
 //  3. The impl of validate_byte_slice() returns an error if any byte is not valid.
 //  4. The impl of validate_byte_slice() returns an error if there are extra bytes.
 //  5. The other ULE methods use the default impl.

--- a/utils/zerovec/src/ule/tuple.rs
+++ b/utils/zerovec/src/ule/tuple.rs
@@ -30,15 +30,15 @@ use core::mem;
 macro_rules! tuple_ule {
     ($name:ident, $len:literal, [ $($t:ident $i:tt),+ ]) => {
         #[doc = concat!("ULE type for tuples with ", $len, " elements.")]
-        #[repr(packed)]
+        #[repr(C, packed)]
         #[allow(clippy::exhaustive_structs)] // stable
         pub struct $name<$($t),+>($(pub $t),+);
 
         // Safety (based on the safety checklist on the ULE trait):
         //  1. TupleULE does not include any uninitialized or padding bytes.
-        //     (achieved by `#[repr(packed)]` on a struct containing only ULE fields)
+        //     (achieved by `#[repr(C, packed)]` on a struct containing only ULE fields)
         //  2. TupleULE is aligned to 1 byte.
-        //     (achieved by `#[repr(packed)]` on a struct containing only ULE fields)
+        //     (achieved by `#[repr(C, packed)]` on a struct containing only ULE fields)
         //  3. The impl of validate_byte_slice() returns an error if any byte is not valid.
         //  4. The impl of validate_byte_slice() returns an error if there are extra bytes.
         //  5. The other ULE methods use the default impl.


### PR DESCRIPTION
Was an oversight from #5049

This will publish zerovec 0.10.4


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->