### PR TITLE
Reworking filter provider

### DIFF
--- a/ffi/capi/bindings/c/ICU4XDataError.d.h
+++ b/ffi/capi/bindings/c/ICU4XDataError.d.h
@@ -16,12 +16,11 @@ typedef enum ICU4XDataError {
   ICU4XDataError_MarkerNotFound = 1,
   ICU4XDataError_IdentifierNotFound = 2,
   ICU4XDataError_InvalidRequest = 3,
-  ICU4XDataError_FilteredResource = 4,
-  ICU4XDataError_InconsistentData = 5,
-  ICU4XDataError_Downcast = 6,
-  ICU4XDataError_Deserialize = 7,
-  ICU4XDataError_Custom = 8,
-  ICU4XDataError_Io = 9,
+  ICU4XDataError_InconsistentData = 4,
+  ICU4XDataError_Downcast = 5,
+  ICU4XDataError_Deserialize = 6,
+  ICU4XDataError_Custom = 7,
+  ICU4XDataError_Io = 8,
 } ICU4XDataError;
 
 

--- a/ffi/capi/bindings/cpp/ICU4XDataError.d.hpp
+++ b/ffi/capi/bindings/cpp/ICU4XDataError.d.hpp
@@ -16,12 +16,11 @@ namespace capi {
       ICU4XDataError_MarkerNotFound = 1,
       ICU4XDataError_IdentifierNotFound = 2,
       ICU4XDataError_InvalidRequest = 3,
-      ICU4XDataError_FilteredResource = 4,
-      ICU4XDataError_InconsistentData = 5,
-      ICU4XDataError_Downcast = 6,
-      ICU4XDataError_Deserialize = 7,
-      ICU4XDataError_Custom = 8,
-      ICU4XDataError_Io = 9,
+      ICU4XDataError_InconsistentData = 4,
+      ICU4XDataError_Downcast = 5,
+      ICU4XDataError_Deserialize = 6,
+      ICU4XDataError_Custom = 7,
+      ICU4XDataError_Io = 8,
     } ICU4XDataError;
 }
 
@@ -32,12 +31,11 @@ public:
     MarkerNotFound = 1,
     IdentifierNotFound = 2,
     InvalidRequest = 3,
-    FilteredResource = 4,
-    InconsistentData = 5,
-    Downcast = 6,
-    Deserialize = 7,
-    Custom = 8,
-    Io = 9,
+    InconsistentData = 4,
+    Downcast = 5,
+    Deserialize = 6,
+    Custom = 7,
+    Io = 8,
   };
 
   ICU4XDataError() = default;

--- a/ffi/capi/bindings/cpp/ICU4XDataError.hpp
+++ b/ffi/capi/bindings/cpp/ICU4XDataError.hpp
@@ -30,7 +30,6 @@ inline ICU4XDataError ICU4XDataError::FromFFI(capi::ICU4XDataError c_enum) {
     case capi::ICU4XDataError_MarkerNotFound:
     case capi::ICU4XDataError_IdentifierNotFound:
     case capi::ICU4XDataError_InvalidRequest:
-    case capi::ICU4XDataError_FilteredResource:
     case capi::ICU4XDataError_InconsistentData:
     case capi::ICU4XDataError_Downcast:
     case capi::ICU4XDataError_Deserialize:

--- a/ffi/capi/bindings/dart/DataError.g.dart
+++ b/ffi/capi/bindings/dart/DataError.g.dart
@@ -12,8 +12,6 @@ enum DataError {
 
   invalidRequest,
 
-  filteredResource,
-
   inconsistentData,
 
   downcast,

--- a/ffi/capi/bindings/js/ICU4XDataError.d.ts
+++ b/ffi/capi/bindings/js/ICU4XDataError.d.ts
@@ -18,9 +18,6 @@ export enum ICU4XDataError {
   InvalidRequest = 'InvalidRequest',
   /**
    */
-  FilteredResource = 'FilteredResource',
-  /**
-   */
   InconsistentData = 'InconsistentData',
   /**
    */

--- a/ffi/capi/bindings/js/ICU4XDataError.mjs
+++ b/ffi/capi/bindings/js/ICU4XDataError.mjs
@@ -6,12 +6,11 @@ export const ICU4XDataError_js_to_rust = {
   "MarkerNotFound": 1,
   "IdentifierNotFound": 2,
   "InvalidRequest": 3,
-  "FilteredResource": 4,
-  "InconsistentData": 5,
-  "Downcast": 6,
-  "Deserialize": 7,
-  "Custom": 8,
-  "Io": 9,
+  "InconsistentData": 4,
+  "Downcast": 5,
+  "Deserialize": 6,
+  "Custom": 7,
+  "Io": 8,
 };
 
 export const ICU4XDataError_rust_to_js = {
@@ -19,12 +18,11 @@ export const ICU4XDataError_rust_to_js = {
   [1]: "MarkerNotFound",
   [2]: "IdentifierNotFound",
   [3]: "InvalidRequest",
-  [4]: "FilteredResource",
-  [5]: "InconsistentData",
-  [6]: "Downcast",
-  [7]: "Deserialize",
-  [8]: "Custom",
-  [9]: "Io",
+  [4]: "InconsistentData",
+  [5]: "Downcast",
+  [6]: "Deserialize",
+  [7]: "Custom",
+  [8]: "Io",
 };
 
 export const ICU4XDataError = {
@@ -32,7 +30,6 @@ export const ICU4XDataError = {
   "MarkerNotFound": "MarkerNotFound",
   "IdentifierNotFound": "IdentifierNotFound",
   "InvalidRequest": "InvalidRequest",
-  "FilteredResource": "FilteredResource",
   "InconsistentData": "InconsistentData",
   "Downcast": "Downcast",
   "Deserialize": "Deserialize",

--- a/ffi/capi/src/errors.rs
+++ b/ffi/capi/src/errors.rs
@@ -19,12 +19,11 @@ pub mod ffi {
         MarkerNotFound = 0x01,
         IdentifierNotFound = 0x02,
         InvalidRequest = 0x03,
-        FilteredResource = 0x04,
-        InconsistentData = 0x05,
-        Downcast = 0x06,
-        Deserialize = 0x07,
-        Custom = 0x08,
-        Io = 0x09,
+        InconsistentData = 0x04,
+        Downcast = 0x05,
+        Deserialize = 0x06,
+        Custom = 0x07,
+        Io = 0x08,
     }
 
     #[derive(Debug, PartialEq, Eq)]
@@ -133,7 +132,6 @@ impl From<DataError> for ICU4XError {
             DataErrorKind::MarkerNotFound => ICU4XError::DataMissingDataMarkerError,
             DataErrorKind::IdentifierNotFound => ICU4XError::DataMissingLocaleError,
             DataErrorKind::InvalidRequest => ICU4XError::DataExtraneousLocaleError,
-            DataErrorKind::Filtered => ICU4XError::DataFilteredResourceError,
             DataErrorKind::Downcast(..) => ICU4XError::DataMismatchedTypeError,
             DataErrorKind::Custom => ICU4XError::DataCustomError,
             #[cfg(all(
@@ -152,7 +150,6 @@ impl From<DataError> for ICU4XDataError {
             DataErrorKind::MarkerNotFound => Self::MarkerNotFound,
             DataErrorKind::IdentifierNotFound => Self::IdentifierNotFound,
             DataErrorKind::InvalidRequest => Self::InvalidRequest,
-            DataErrorKind::Filtered => Self::FilteredResource,
             DataErrorKind::InconsistentData(..) => Self::InconsistentData,
             DataErrorKind::Downcast(..) => Self::Downcast,
             DataErrorKind::Deserialize => Self::Deserialize,

--- a/provider/adapters/src/filter/impls.rs
+++ b/provider/adapters/src/filter/impls.rs
@@ -26,9 +26,6 @@ where
     /// Filter out data requests with certain langids according to the predicate function. The
     /// predicate should return `true` to allow a langid and `false` to reject a langid.
     ///
-    /// Data requests with no langid will be allowed. To reject data requests without a langid,
-    /// chain this with [`Self::require_langid`].
-    ///
     /// # Examples
     ///
     /// ```

--- a/provider/adapters/src/filter/impls.rs
+++ b/provider/adapters/src/filter/impls.rs
@@ -6,14 +6,22 @@ use super::*;
 use alloc::boxed::Box;
 use icu_provider::prelude::*;
 
-use icu_locale::LanguageIdentifier;
+impl<D> FilterDataProvider<D, fn(DataIdentifierBorrowed) -> bool> {
+    /// Creates a [`FilterDataProvider`] that does not do any filtering.
+    ///
+    /// Filters can be added using [`Self::with_filter`].
+    pub fn new(provider: D, filter_name: &'static str) -> Self {
+        Self {
+            inner: provider,
+            predicate: |_| true,
+            filter_name,
+        }
+    }
+}
 
-type RequestFilterDataProviderOutput<'a, D> =
-    RequestFilterDataProvider<D, Box<dyn Fn(DataRequest) -> bool + Sync + 'a>>;
-
-impl<D, F> RequestFilterDataProvider<D, F>
+impl<D, F> FilterDataProvider<D, F>
 where
-    F: Fn(DataRequest) -> bool + Sync,
+    F: Fn(DataIdentifierBorrowed) -> bool + Sync,
 {
     /// Filter out data requests with certain langids according to the predicate function. The
     /// predicate should return `true` to allow a langid and `false` to reject a langid.
@@ -28,11 +36,10 @@ where
     /// use icu_locale::{langid, subtags::language};
     /// use icu_provider::hello_world::*;
     /// use icu_provider::prelude::*;
-    /// use icu_provider_adapters::filter::Filterable;
+    /// use icu_provider_adapters::filter::FilterDataProvider;
     ///
-    /// let provider = HelloWorldProvider
-    ///     .filterable("Demo no-English filter")
-    ///     .filter_by_langid(|langid| langid.language != language!("en"));
+    /// let provider = FilterDataProvider::new(HelloWorldProvider, "Demo no-English filter")
+    ///     .with_filter(|id| id.locale.language() != language!("en"));
     ///
     /// // German requests should succeed:
     /// let de = DataIdentifierCow::from_locale(langid!("de").into());
@@ -58,7 +65,7 @@ where
     /// assert!(matches!(
     ///     response,
     ///     Err(DataError {
-    ///         kind: DataErrorKind::Filtered,
+    ///         kind: DataErrorKind::IdentifierNotFound,
     ///         ..
     ///     })
     /// ));
@@ -70,147 +77,22 @@ where
     /// assert!(available_ids.contains(&DataIdentifierCow::from_locale(langid!("de").into())));
     /// assert!(!available_ids.contains(&DataIdentifierCow::from_locale(langid!("en").into())));
     /// ```
-    pub fn filter_by_langid<'a>(
+    #[allow(clippy::type_complexity)]
+    pub fn with_filter<'a>(
         self,
-        predicate: impl Fn(&LanguageIdentifier) -> bool + Sync + 'a,
-    ) -> RequestFilterDataProviderOutput<'a, D>
+        predicate: impl Fn(DataIdentifierBorrowed) -> bool + Sync + 'a,
+    ) -> FilterDataProvider<D, Box<dyn Fn(DataIdentifierBorrowed) -> bool + Sync + 'a>>
     where
         F: 'a,
     {
         let old_predicate = self.predicate;
-        RequestFilterDataProvider {
+        FilterDataProvider {
             inner: self.inner,
-            predicate: Box::new(move |request| -> bool {
-                if !(old_predicate)(request) {
+            predicate: Box::new(move |id| -> bool {
+                if !(old_predicate)(id) {
                     return false;
                 }
-                predicate(&request.id.locale.get_langid())
-            }),
-            filter_name: self.filter_name,
-        }
-    }
-
-    /// Filter out data request except those having a language identifier that exactly matches
-    /// one in the allowlist.
-    ///
-    /// This will be replaced with a smarter algorithm for locale filtering; see
-    /// <https://github.com/unicode-org/icu4x/issues/834>
-    ///
-    /// Data requests with no langid will be allowed. To reject data requests without a langid,
-    /// chain this with [`Self::require_langid`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use icu_locale::langid;
-    /// use icu_provider::hello_world::*;
-    /// use icu_provider::prelude::*;
-    /// use icu_provider_adapters::filter::Filterable;
-    ///
-    /// let allowlist = [langid!("de"), langid!("zh")];
-    /// let provider = HelloWorldProvider
-    ///     .filterable("Demo German+Chinese filter")
-    ///     .filter_by_langid_allowlist_strict(&allowlist);
-    ///
-    /// // German requests should succeed:
-    /// let de = DataIdentifierCow::from_locale(langid!("de").into());
-    /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
-    ///     provider.load(DataRequest {
-    ///         id: de.as_borrowed(),
-    ///         ..Default::default()
-    /// });
-    /// assert!(matches!(response, Ok(_)));
-    ///
-    /// // English requests should fail:
-    /// let en = DataIdentifierCow::from_locale(langid!("en-US").into());
-
-    /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
-    ///     provider.load(DataRequest {
-    ///     id: en.as_borrowed(),
-    ///     ..Default::default()
-    /// });
-    /// assert!(matches!(
-    ///     response,
-    ///     Err(DataError {
-    ///         kind: DataErrorKind::Filtered,
-    ///         ..
-    ///     })
-    /// ));
-    /// assert_eq!(
-    ///     response.unwrap_err().str_context,
-    ///     Some("Demo German+Chinese filter")
-    /// );
-    /// ```
-    pub fn filter_by_langid_allowlist_strict<'a>(
-        self,
-        allowlist: &'a [LanguageIdentifier],
-    ) -> RequestFilterDataProviderOutput<'a, D>
-    where
-        F: 'a,
-    {
-        let old_predicate = self.predicate;
-        RequestFilterDataProvider {
-            inner: self.inner,
-            predicate: Box::new(move |request| -> bool {
-                if !(old_predicate)(request) {
-                    return false;
-                }
-                request.id.locale.is_langid_und()
-                    || allowlist.contains(&request.id.locale.get_langid())
-            }),
-            filter_name: self.filter_name,
-        }
-    }
-
-    /// Require that data requests contain a langid.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use icu_locale::langid;
-    /// use icu_provider::hello_world::*;
-    /// use icu_provider::prelude::*;
-    /// use icu_provider_adapters::filter::Filterable;
-    ///
-    /// let provider = HelloWorldProvider
-    ///     .filterable("Demo require-langid filter")
-    ///     .require_langid();
-    ///
-    /// // Requests with a data id should succeed:
-    /// let id = DataIdentifierCow::from_locale(langid!("de").into());
-    /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
-    ///     provider.load(DataRequest {
-    ///     id: id.as_borrowed(),
-    ///     ..Default::default()
-    /// });
-    /// assert!(matches!(response, Ok(_)));
-    ///
-    /// // Requests without a data should fail:
-    /// let response: Result<DataResponse<HelloWorldV1Marker>, _> =
-    ///     provider.load(DataRequest {
-    ///     id: Default::default(),
-    ///     ..Default::default()
-    /// });
-    /// assert!(matches!(
-    ///     response,
-    ///     Err(DataError {
-    ///         kind: DataErrorKind::Filtered,
-    ///         ..
-    ///     })
-    /// ));
-    /// ```
-    pub fn require_langid<'a>(self) -> RequestFilterDataProviderOutput<'a, D>
-    where
-        F: 'a,
-    {
-        let old_predicate = self.predicate;
-        RequestFilterDataProvider {
-            inner: self.inner,
-            predicate: Box::new(move |request| -> bool {
-                if !(old_predicate)(request) {
-                    return false;
-                }
-                !request.id.locale.is_langid_und()
+                predicate(id)
             }),
             filter_name: self.filter_name,
         }

--- a/provider/adapters/src/fork/mod.rs
+++ b/provider/adapters/src/fork/mod.rs
@@ -98,18 +98,20 @@ use predicates::MarkerNotFoundPredicate;
 /// use icu_locale::{subtags::language, langid};
 /// use icu_provider::hello_world::*;
 /// use icu_provider::prelude::*;
-/// use icu_provider_adapters::filter::Filterable;
+/// use icu_provider_adapters::filter::FilterDataProvider;
 /// use icu_provider_adapters::fork::ForkByMarkerProvider;
 ///
 /// let forking_provider = ForkByMarkerProvider::new(
-///     HelloWorldProvider
-///         .into_json_provider()
-///         .filterable("Chinese")
-///         .filter_by_langid(|langid| langid.language == language!("zh")),
-///     HelloWorldProvider
-///         .into_json_provider()
-///         .filterable("German")
-///         .filter_by_langid(|langid| langid.language == language!("de")),
+///     FilterDataProvider::new(
+///         HelloWorldProvider.into_json_provider(),
+///         "Chinese"
+///     )
+///     .with_filter(|id| id.locale.language() == language!("zh")),
+///     FilterDataProvider::new(
+///         HelloWorldProvider.into_json_provider(),
+///         "German"
+///     )
+///     .with_filter(|id| id.locale.language() == language!("de")),
 /// );
 ///
 /// let provider: &dyn DataProvider<HelloWorldV1Marker> =
@@ -165,19 +167,21 @@ impl<P0, P1> ForkByMarkerProvider<P0, P1> {
 /// use icu_locale::{subtags::language, langid};
 /// use icu_provider::hello_world::*;
 /// use icu_provider::prelude::*;
-/// use icu_provider_adapters::filter::Filterable;
+/// use icu_provider_adapters::filter::FilterDataProvider;
 /// use icu_provider_adapters::fork::MultiForkByMarkerProvider;
 ///
 /// let forking_provider = MultiForkByMarkerProvider::new(
 ///     vec![
-///         HelloWorldProvider
-///             .into_json_provider()
-///             .filterable("Chinese")
-///             .filter_by_langid(|langid| langid.language == language!("zh")),
-///         HelloWorldProvider
-///             .into_json_provider()
-///             .filterable("German")
-///             .filter_by_langid(|langid| langid.language == language!("de")),
+///         FilterDataProvider::new(
+///             HelloWorldProvider.into_json_provider(),
+///             "Chinese"
+///         )
+///         .with_filter(|id| id.locale.language() == language!("zh")),
+///         FilterDataProvider::new(
+///             HelloWorldProvider.into_json_provider(),
+///             "German"
+///         )
+///         .with_filter(|id| id.locale.language() == language!("de")),
 ///     ],
 /// );
 ///

--- a/provider/core/src/error.rs
+++ b/provider/core/src/error.rs
@@ -26,10 +26,6 @@ pub enum DataErrorKind {
     #[displaydoc("Invalid request")]
     InvalidRequest,
 
-    /// The request was blocked by a filter. The data may or may not be available.
-    #[displaydoc("Request blocked by filter")]
-    Filtered,
-
     /// The data for two [`DataMarker`]s is not consistent.
     #[displaydoc("The data for two markers is not consistent: {0:?} (were they generated in different datagen invocations?)")]
     InconsistentData(DataMarkerInfo),

--- a/tools/ffi_coverage/src/allowlist.rs
+++ b/tools/ffi_coverage/src/allowlist.rs
@@ -284,11 +284,8 @@ lazy_static::lazy_static! {
         "icu_provider_adapters::any_payload::AnyPayloadProvider",
 
         // Not planned for 2.0
-        // On RequestFilterDataProvider, filter_by_langid needs callbacks, and
-        // filter_by_langid_allowlist_strict needs input iterators.
-        // require_langid is not very useful by itself.
-        "icu_provider_adapters::filter::Filterable",
-        "icu_provider_adapters::filter::RequestFilterDataProvider",
+        // FilterDataProvider::with_filter needs callbacks.
+        "icu_provider_adapters::filter::FilterDataProvider",
 
         // Not planned for 2.0
         // ForkByErrorProvider is the abstract forking provider; we expose the concrete


### PR DESCRIPTION
There are a few things here:
* The filters should work on `DataIdentifierBorrowed` instead of `DataRequest`; metadata should not be relevant for filtering
  * This implies a rename from `RequestFilterDataProvider` to `FilterDataProvider` 
* previously the provider implementations returned `DataErrorKind::Filtered` for filtered ids, however this does not work with fallback. They should return `DataErrorKind::IdentiferNotFound`; to a caller (like the fallback adapter) it should be opaque whether the pipeline contains a filter or not
* `filter_by_langid_allowlist_strict` is marked as "will be replaced with a smarter algorithm for locale filtering". This smarter algorithm now exists, so this should be deleted (fixes #834)
* The `Filterable` blanket trait adds `.filterable` to every type in this crate's rustdoc, and to every type in dev docs. I replaced it with a normal constructor.