### PR TITLE
Reduce `impl Into` and `impl AsRef` parameters

### DIFF
--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -57,7 +57,7 @@ macro_rules! gen_any_buffer_constructors_with_external_loader {
                 &provider.as_downcasting(),
                 &ExternalLoaderAny(provider),
                 locale,
-                $($arg),+
+                $($arg.into()),+
             )
         }
         #[doc = icu_provider::gen_any_buffer_unstable_docs!(BUFFER, Self::$compiled_fn)]
@@ -74,7 +74,7 @@ macro_rules! gen_any_buffer_constructors_with_external_loader {
                 &provider.as_deserializing(),
                 &ExternalLoaderBuffer(provider),
                 locale,
-                $($arg),+
+                $($arg.into()),+
             )
         }
     };
@@ -382,7 +382,7 @@ impl<C: CldrCalendar, R: TypedDateTimeMarkers<C> + IsRuntimeComponents> TypedNeo
             &crate::provider::Baked,
             &ExternalLoaderCompiledData,
             locale,
-            components,
+            components.into(),
             length,
         )
     }
@@ -424,7 +424,7 @@ impl<C: CldrCalendar, R: TypedDateTimeMarkers<C> + IsRuntimeComponents> TypedNeo
             provider,
             &ExternalLoaderUnstable(provider),
             locale,
-            components,
+            components.into(),
             length,
         )
     }
@@ -435,7 +435,7 @@ impl<C: CldrCalendar, R: TypedDateTimeMarkers<C>> TypedNeoFormatter<C, R> {
         provider: &P,
         loader: &L,
         locale: &DataLocale,
-        components: impl Into<NeoComponents>,
+        components: NeoComponents,
         length: NeoSkeletonLength,
     ) -> Result<Self, LoadError>
     where
@@ -458,7 +458,7 @@ impl<C: CldrCalendar, R: TypedDateTimeMarkers<C>> TypedNeoFormatter<C, R> {
             &R::DateTimePatternV1Marker::bind(provider),
             locale,
             length,
-            components.into(),
+            components,
         )
         .map_err(LoadError::Data)?;
         let mut names = RawDateTimeNames::new_without_fixed_decimal_formatter();
@@ -944,7 +944,7 @@ impl<R: DateTimeMarkers + IsRuntimeComponents> NeoFormatter<R> {
             &crate::provider::Baked,
             &ExternalLoaderCompiledData,
             locale,
-            components,
+            components.into(),
             length,
         )
     }
@@ -1041,7 +1041,7 @@ impl<R: DateTimeMarkers + IsRuntimeComponents> NeoFormatter<R> {
             provider,
             &ExternalLoaderUnstable(provider),
             locale,
-            components,
+            components.into(),
             length,
         )
     }
@@ -1052,7 +1052,7 @@ impl<R: DateTimeMarkers> NeoFormatter<R> {
         provider: &P,
         loader: &L,
         locale: &DataLocale,
-        components: impl Into<NeoComponents>,
+        components: NeoComponents,
         length: NeoSkeletonLength,
     ) -> Result<Self, LoadError>
     where
@@ -1125,7 +1125,7 @@ impl<R: DateTimeMarkers> NeoFormatter<R> {
             &R::DateTimePatternV1Marker::bind(provider),
             locale,
             length,
-            components.into(),
+            components,
         )
         .map_err(LoadError::Data)?;
         let mut names = RawDateTimeNames::new_without_fixed_decimal_formatter();

--- a/components/icu/examples/tui.rs
+++ b/components/icu/examples/tui.rs
@@ -16,9 +16,9 @@ use icu::timezone::CustomTimeZone;
 use icu_collections::codepointinvlist::CodePointInversionListBuilder;
 use std::env;
 
-fn print<T: AsRef<str>>(_input: T) {
-    #[cfg(debug_assertions)]
-    println!("{}", _input.as_ref());
+#[cfg(not(debug_assertions))]
+macro_rules! println {
+    ($($arg:tt)*) => {};
 }
 
 #[no_mangle]
@@ -40,9 +40,9 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
         })
         .unwrap_or(5);
 
-    print(format!("\nTextual User Interface Example ({locale})"));
-    print("===================================");
-    print(format!("User: {user_name}"));
+    println!("\nTextual User Interface Example ({locale})");
+    println!("===================================");
+    println!("User: {user_name}");
 
     {
         let dtf = TypedZonedDateTimeFormatter::<Gregorian>::try_new(
@@ -56,7 +56,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
 
         let formatted_dt = dtf.format(&today_date, &today_tz);
 
-        print(format!("Today is: {formatted_dt}"));
+        println!("Today is: {formatted_dt}");
     }
 
     {
@@ -68,9 +68,9 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
         let only_latin1 = user_name.chars().all(|ch| latin1_set.contains(ch));
 
         if only_latin1 {
-            print("User name latin1 only: true");
+            println!("User name latin1 only: true");
         } else {
-            print("User name latin1 only: false");
+            println!("User name latin1 only: false");
         }
     }
 
@@ -79,8 +79,8 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
             .expect("Failed to create PluralRules.");
 
         match pr.category_for(email_count) {
-            PluralCategory::One => print("Note: You have one unread email."),
-            _ => print(format!("Note: You have {email_count} unread emails.")),
+            PluralCategory::One => println!("Note: You have one unread email."),
+            _ => println!("Note: You have {email_count} unread emails."),
         }
     }
 

--- a/components/icu/src/datagen.rs
+++ b/components/icu/src/datagen.rs
@@ -71,9 +71,10 @@ icu_registry::registry!(cb);
 ///
 /// ```no_run
 /// # use icu_provider::DataMarker;
+/// # use std::path::Path;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// assert_eq!(
-///     icu::markers_for_bin("target/release/my-app")?,
+///     icu::markers_for_bin(Path::new("target/release/my-app"))?,
 ///     std::collections::HashSet::from_iter([
 ///         icu::list::provider::AndListV2Marker::INFO,
 ///         icu::list::provider::OrListV2Marker::INFO,

--- a/components/icu/src/datagen.rs
+++ b/components/icu/src/datagen.rs
@@ -82,11 +82,8 @@ icu_registry::registry!(cb);
 /// # Ok(())
 /// # }
 /// ```
-pub fn markers_for_bin<P: AsRef<Path>>(path: P) -> Result<HashSet<DataMarkerInfo>, DataError> {
-    let file = std::fs::read(path.as_ref())?;
-    let file = file.as_slice();
-
-    markers_for_bin_inner(file)
+pub fn markers_for_bin(path: &Path) -> Result<HashSet<DataMarkerInfo>, DataError> {
+    markers_for_bin_inner(&std::fs::read(path)?)
 }
 
 #[test]

--- a/ffi/capi/src/provider.rs
+++ b/ffi/capi/src/provider.rs
@@ -69,7 +69,9 @@ pub mod ffi {
             Ok(Box::new(convert_buffer_provider(
                 icu_provider_fs::FsDataProvider::try_new(
                     // In the future we can start using OsString APIs to support non-utf8 paths
-                    core::str::from_utf8(path).map_err(|_| ICU4XDataError::Io)?.into(),
+                    core::str::from_utf8(path)
+                        .map_err(|_| ICU4XDataError::Io)?
+                        .into(),
                 )?,
             )))
         }

--- a/ffi/capi/src/provider.rs
+++ b/ffi/capi/src/provider.rs
@@ -69,7 +69,7 @@ pub mod ffi {
             Ok(Box::new(convert_buffer_provider(
                 icu_provider_fs::FsDataProvider::try_new(
                     // In the future we can start using OsString APIs to support non-utf8 paths
-                    core::str::from_utf8(path).map_err(|_| ICU4XDataError::Io)?,
+                    core::str::from_utf8(path).map_err(|_| ICU4XDataError::Io)?.into(),
                 )?,
             )))
         }

--- a/provider/baked/src/export.rs
+++ b/provider/baked/src/export.rs
@@ -98,6 +98,7 @@ use std::collections::HashSet;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::File;
 use std::io::Write;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
@@ -205,12 +206,8 @@ impl BakedExporter {
         })
     }
 
-    fn write_to_file<P: AsRef<std::path::Path>>(
-        &self,
-        relative_path: P,
-        data: TokenStream,
-    ) -> Result<(), DataError> {
-        let path = self.mod_directory.join(&relative_path);
+    fn write_to_file(&self, relative_path: &Path, data: TokenStream) -> Result<(), DataError> {
+        let path = self.mod_directory.join(relative_path);
 
         let mut formatted = if self.pretty {
             use std::process::{Command, Stdio};
@@ -320,7 +317,7 @@ impl BakedExporter {
         let maybe_msrv = maybe_msrv();
 
         self.write_to_file(
-            PathBuf::from(format!("{ident}.rs.data")),
+            Path::new(&format!("{ident}.rs.data")),
             quote! {
                 #[doc = #doc]
                 /// hardcoded in this file. This allows the struct to be used with
@@ -600,7 +597,7 @@ impl DataExporter for BakedExporter {
 
         // mod.rs is the interface for built-in data. It exposes one macro per marker.
         self.write_to_file(
-            PathBuf::from("mod.rs"),
+            Path::new("mod.rs"),
             quote! {
                 #(
                     include!(#file_paths);

--- a/provider/bikeshed/src/lib.rs
+++ b/provider/bikeshed/src/lib.rs
@@ -23,7 +23,7 @@ use icu_provider::prelude::*;
 use source::{AbstractFs, SerdeCache};
 use std::collections::HashSet;
 use std::fmt::Debug;
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::{Arc, OnceLock};
 
 mod calendar;
@@ -159,7 +159,7 @@ impl DatagenProvider {
     /// Adds CLDR source data to the provider. The root should point to a local
     /// `cldr-{tag}-json-full` directory or ZIP file (see
     /// [GitHub releases](https://github.com/unicode-org/cldr-json/releases)).
-    pub fn with_cldr(self, root: PathBuf) -> Result<Self, DataError> {
+    pub fn with_cldr(self, root: &Path) -> Result<Self, DataError> {
         Ok(Self {
             cldr_paths: Some(Arc::new(CldrCache::from_serde_cache(SerdeCache::new(
                 AbstractFs::new(root)?,
@@ -171,7 +171,7 @@ impl DatagenProvider {
     /// Adds ICU export source data to the provider. The path should point to a local
     /// `icuexportdata_{tag}` directory or ZIP file (see [GitHub releases](
     /// https://github.com/unicode-org/icu/releases)).
-    pub fn with_icuexport(self, root: PathBuf) -> Result<Self, DataError> {
+    pub fn with_icuexport(self, root: &Path) -> Result<Self, DataError> {
         Ok(Self {
             icuexport_paths: Some(Arc::new(SerdeCache::new(AbstractFs::new(root)?))),
             ..self
@@ -181,7 +181,7 @@ impl DatagenProvider {
     /// Adds segmenter LSTM source data to the provider. The path should point to a local
     /// `models` directory or ZIP file (see [GitHub releases](
     /// https://github.com/unicode-org/lstm_word_segmentation/releases)).
-    pub fn with_segmenter_lstm(self, root: PathBuf) -> Result<Self, DataError> {
+    pub fn with_segmenter_lstm(self, root: &Path) -> Result<Self, DataError> {
         Ok(Self {
             segmenter_lstm_paths: Some(Arc::new(SerdeCache::new(AbstractFs::new(root)?))),
             ..self

--- a/provider/bikeshed/src/properties/script.rs
+++ b/provider/bikeshed/src/properties/script.rs
@@ -29,9 +29,7 @@ impl DataProvider<ScriptWithExtensionsPropertyV1Marker> for DatagenProvider {
             ))?
             .script_extensions
             .first()
-            .ok_or_else(|| {
-                DataError::custom("Could not parse Script_Extensions data from TOML")
-            })?;
+            .ok_or_else(|| DataError::custom("Could not parse Script_Extensions data from TOML"))?;
 
         let cpt_data = &scx_data.code_point_trie;
         let scx_array_data = &scx_data.script_code_array;

--- a/provider/bikeshed/src/properties/script.rs
+++ b/provider/bikeshed/src/properties/script.rs
@@ -31,7 +31,6 @@ impl DataProvider<ScriptWithExtensionsPropertyV1Marker> for DatagenProvider {
             .first()
             .ok_or_else(|| {
                 DataError::custom("Could not parse Script_Extensions data from TOML")
-                    .with_path_context("scx.toml")
             })?;
 
         let cpt_data = &scx_data.code_point_trie;

--- a/provider/core/src/error.rs
+++ b/provider/core/src/error.rs
@@ -211,9 +211,9 @@ impl DataError {
     /// This does not modify the error, but if the "logging" Cargo feature is enabled,
     /// it will print out the context.
     #[cfg(feature = "std")]
-    pub fn with_path_context<P: AsRef<std::path::Path> + ?Sized>(self, _path: &P) -> Self {
+    pub fn with_path_context(self, _path: &std::path::Path) -> Self {
         if !self.silent {
-            log::warn!("{} (path: {:?})", self, _path.as_ref());
+            log::warn!("{self} (path: {_path:?})");
         }
         self
     }

--- a/provider/fs/README.md
+++ b/provider/fs/README.md
@@ -11,7 +11,7 @@ It reads ICU4X data files from the filesystem in a given directory.
 ```rust
 use icu_provider_fs::FsDataProvider;
 
-let provider = FsDataProvider::try_new("/path/to/data/directory")
+let provider = FsDataProvider::try_new("/path/to/data/directory".into())
     .expect_err("Specify a real directory in the line above");
 ```
 

--- a/provider/fs/benches/provider_fs.rs
+++ b/provider/fs/benches/provider_fs.rs
@@ -13,7 +13,7 @@ fn overview_bench(c: &mut Criterion) {
     // End-to-end JSON test
     c.bench_function("json/overview", |b| {
         b.iter(|| {
-            let provider = FsDataProvider::try_new("./tests/data/json")
+            let provider = FsDataProvider::try_new("./tests/data/json".into())
                 .expect("Loading file from testdata directory");
             let _: DataResponse<HelloWorldV1Marker> = black_box(&provider)
                 .as_deserializing()
@@ -36,7 +36,7 @@ fn overview_bench(c: &mut Criterion) {
 #[cfg(feature = "bench")]
 fn json_bench(c: &mut Criterion) {
     let provider =
-        FsDataProvider::try_new("./tests/data/json").expect("Loading file from testdata directory");
+        FsDataProvider::try_new("./tests/data/json".into()).expect("Loading file from testdata directory");
 
     c.bench_function("json/generic", |b| {
         b.iter(|| {
@@ -65,7 +65,7 @@ fn json_bench(c: &mut Criterion) {
 
 #[cfg(feature = "bench")]
 fn bincode_bench(c: &mut Criterion) {
-    let provider = FsDataProvider::try_new("./tests/data/bincode")
+    let provider = FsDataProvider::try_new("./tests/data/bincode".into())
         .expect("Loading file from testdata directory");
 
     c.bench_function("bincode/generic", |b| {
@@ -95,7 +95,7 @@ fn bincode_bench(c: &mut Criterion) {
 
 #[cfg(feature = "bench")]
 fn postcard_bench(c: &mut Criterion) {
-    let provider = FsDataProvider::try_new("./tests/data/postcard")
+    let provider = FsDataProvider::try_new("./tests/data/postcard".into())
         .expect("Loading file from testdata directory");
 
     c.bench_function("postcard/generic", |b| {

--- a/provider/fs/benches/provider_fs.rs
+++ b/provider/fs/benches/provider_fs.rs
@@ -35,8 +35,8 @@ fn overview_bench(c: &mut Criterion) {
 
 #[cfg(feature = "bench")]
 fn json_bench(c: &mut Criterion) {
-    let provider =
-        FsDataProvider::try_new("./tests/data/json".into()).expect("Loading file from testdata directory");
+    let provider = FsDataProvider::try_new("./tests/data/json".into())
+        .expect("Loading file from testdata directory");
 
     c.bench_function("json/generic", |b| {
         b.iter(|| {

--- a/provider/fs/src/export/fs_exporter.rs
+++ b/provider/fs/src/export/fs_exporter.rs
@@ -9,7 +9,7 @@ use icu_provider::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::fmt::Write;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 /// Choices of what to do if [`FilesystemExporter`] tries to write to a pre-existing directory.
 #[non_exhaustive]
@@ -105,19 +105,20 @@ impl DataExporter for FilesystemExporter {
         id: DataIdentifierBorrowed,
         obj: &DataPayload<ExportMarker>,
     ) -> Result<(), DataError> {
-        let mut path_buf = self.root.clone().into_os_string();
-        write!(&mut path_buf, "/{}", marker.path.as_str()).expect("infallible");
+        let mut path_buf = self.root.join(marker.path.as_str());
         if !id.marker_attributes.is_empty() {
-            write!(&mut path_buf, "/{}", id.marker_attributes.as_str()).expect("infallible");
+            path_buf.push(id.marker_attributes.as_str());
         }
+        let mut path_buf = path_buf.into_os_string();
         write!(&mut path_buf, "/{}", id.locale).expect("infallible");
-        write!(&mut path_buf, ".{}", self.manifest.file_extension).expect("infallible");
+        let mut path_buf = PathBuf::from(path_buf);
+        path_buf.set_extension(self.manifest.file_extension);
 
         #[allow(clippy::unwrap_used)] // has parent by construction
-        let parent_dir = Path::new(&path_buf).parent().unwrap();
+        let parent_dir = path_buf.parent().unwrap();
 
         fs::create_dir_all(parent_dir)
-            .map_err(|e| DataError::from(e).with_path_context(&parent_dir))?;
+            .map_err(|e| DataError::from(e).with_path_context(parent_dir))?;
 
         let mut file: Box<dyn std::io::Write> = if self.serializer.is_text_format() {
             Box::new(crlify::BufWriterWithLineEndingFix::new(
@@ -138,14 +139,13 @@ impl DataExporter for FilesystemExporter {
     }
 
     fn flush(&self, marker: DataMarkerInfo) -> Result<(), DataError> {
-        let mut path_buf = self.root.clone().into_os_string();
-        write!(&mut path_buf, "/{}", marker.path.as_str()).expect("infallible");
+        let mut path_buf = self.root.join(marker.path.as_str());
 
-        if !Path::new(&path_buf).exists() {
+        if !path_buf.exists() {
             fs::create_dir_all(&path_buf)
                 .map_err(|e| DataError::from(e).with_path_context(&path_buf))?;
-            write!(&mut path_buf, "/.empty").expect("infallible");
-            fs::File::create(Path::new(&path_buf))?;
+            path_buf.push("empty");
+            fs::File::create(&path_buf)?;
         }
 
         Ok(())

--- a/provider/fs/src/export/mod.rs
+++ b/provider/fs/src/export/mod.rs
@@ -41,9 +41,9 @@
 //! use icu_provider::prelude::*;
 //! use icu_provider_fs::FsDataProvider;
 //!
-//! # let demo_path = "tests/data/json";
+//! # let demo_path = "tests/data/json".into();
 //! // Create a filesystem provider reading from the demo directory
-//! let provider = FsDataProvider::try_new(&demo_path)
+//! let provider = FsDataProvider::try_new(demo_path)
 //!     .expect("Should successfully read from filesystem");
 //!
 //! // Use the provider as a `BufferProvider`

--- a/provider/fs/src/fs_data_provider.rs
+++ b/provider/fs/src/fs_data_provider.rs
@@ -24,7 +24,7 @@ use std::path::PathBuf;
 ///
 /// // Create a DataProvider from data files stored in a filesystem directory:
 /// let provider =
-///     FsDataProvider::try_new("tests/data/json").expect("Directory exists");
+///     FsDataProvider::try_new("tests/data/json".into()).expect("Directory exists");
 ///
 /// // Check that it works:
 /// let formatter = HelloWorldFormatter::try_new_with_buffer_provider(
@@ -49,7 +49,7 @@ impl FsDataProvider {
     /// ```
     /// use icu_provider_fs::FsDataProvider;
     ///
-    /// let provider = FsDataProvider::try_new("/path/to/data/directory")
+    /// let provider = FsDataProvider::try_new("/path/to/data/directory".into())
     ///     .expect_err("Specify a real directory in the line above");
     /// ```
     pub fn try_new(root: PathBuf) -> Result<Self, DataError> {

--- a/provider/fs/src/fs_data_provider.rs
+++ b/provider/fs/src/fs_data_provider.rs
@@ -7,7 +7,6 @@ use icu_provider::prelude::*;
 use std::fmt::Debug;
 use std::fmt::Write;
 use std::fs;
-use std::path::Path;
 use std::path::PathBuf;
 
 /// A data provider that reads ICU4X data from a filesystem directory.
@@ -53,8 +52,7 @@ impl FsDataProvider {
     /// let provider = FsDataProvider::try_new("/path/to/data/directory")
     ///     .expect_err("Specify a real directory in the line above");
     /// ```
-    pub fn try_new<T: Into<PathBuf>>(root: T) -> Result<Self, DataError> {
-        let root = root.into();
+    pub fn try_new(root: PathBuf) -> Result<Self, DataError> {
         Ok(Self {
             manifest: Manifest::parse(&root)?,
             root,
@@ -71,17 +69,18 @@ impl DynamicDataProvider<BufferMarker> for FsDataProvider {
         if marker.is_singleton && !req.id.locale.is_empty() {
             return Err(DataErrorKind::InvalidRequest.with_req(marker, req));
         }
-        let mut path = self.root.clone().into_os_string();
-        write!(&mut path, "/{}", marker.path.as_str()).expect("infallible");
-        if !Path::new(&path).exists() {
+        let mut path = self.root.join(marker.path.as_str());
+        if !path.exists() {
             return Err(DataErrorKind::MarkerNotFound.with_req(marker, req));
         }
         if !req.id.marker_attributes.is_empty() {
-            write!(&mut path, "/{}", req.id.marker_attributes as &str).expect("infallible");
+            path.push(req.id.marker_attributes.as_str());
         }
+        let mut path = path.into_os_string();
         write!(&mut path, "/{}", req.id.locale).expect("infallible");
-        write!(&mut path, ".{}", self.manifest.file_extension).expect("infallible");
-        if !Path::new(&path).exists() {
+        let mut path = PathBuf::from(path);
+        path.set_extension(self.manifest.file_extension);
+        if !path.exists() {
             return Err(DataErrorKind::IdentifierNotFound.with_req(marker, req));
         }
         let buffer = fs::read(&path).map_err(|e| DataError::from(e).with_path_context(&path))?;

--- a/provider/fs/src/lib.rs
+++ b/provider/fs/src/lib.rs
@@ -11,7 +11,7 @@
 //! ```
 //! use icu_provider_fs::FsDataProvider;
 //!
-//! let provider = FsDataProvider::try_new("/path/to/data/directory")
+//! let provider = FsDataProvider::try_new("/path/to/data/directory".into())
 //!     .expect_err("Specify a real directory in the line above");
 //! ```
 //!

--- a/provider/fs/tests/test_file_io.rs
+++ b/provider/fs/tests/test_file_io.rs
@@ -16,7 +16,7 @@ const PATHS: &[&str] = &[
 #[test]
 fn test_provider() {
     for path in PATHS {
-        let provider = FsDataProvider::try_new(path).unwrap();
+        let provider = FsDataProvider::try_new(path.into()).unwrap();
         for id in HelloWorldProvider.iter_ids().unwrap() {
             let req = DataRequest {
                 id: id.as_borrowed(),
@@ -48,7 +48,7 @@ fn test_provider() {
 #[test]
 fn test_errors() {
     for path in PATHS {
-        let provider = FsDataProvider::try_new(path).unwrap();
+        let provider = FsDataProvider::try_new(path.into()).unwrap();
 
         let err: Result<DataResponse<HelloWorldV1Marker>, DataError> =
             provider.as_deserializing().load(DataRequest {

--- a/provider/icu4x-datagen/src/main.rs
+++ b/provider/icu4x-datagen/src/main.rs
@@ -368,7 +368,7 @@ fn main() -> eyre::Result<()> {
             }
 
             p = match (cli.cldr_root, cli.cldr_tag.as_str()) {
-                (Some(path), _) => p.with_cldr(path)?,
+                (Some(path), _) => p.with_cldr(&path)?,
                 #[cfg(feature = "networking")]
                 (_, "latest") => p.with_cldr_for_tag(DatagenProvider::LATEST_TESTED_CLDR_TAG),
                 #[cfg(feature = "networking")]
@@ -382,7 +382,7 @@ fn main() -> eyre::Result<()> {
             };
 
             p = match (cli.icuexport_root, cli.icuexport_tag.as_str()) {
-                (Some(path), _) => p.with_icuexport(path)?,
+                (Some(path), _) => p.with_icuexport(&path)?,
                 #[cfg(feature = "networking")]
                 (_, "latest") => {
                     p.with_icuexport_for_tag(DatagenProvider::LATEST_TESTED_ICUEXPORT_TAG)
@@ -398,7 +398,7 @@ fn main() -> eyre::Result<()> {
             };
 
             p = match (cli.segmenter_lstm_root, cli.segmenter_lstm_tag.as_str()) {
-                (Some(path), _) => p.with_segmenter_lstm(path)?,
+                (Some(path), _) => p.with_segmenter_lstm(&path)?,
                 #[cfg(feature = "networking")]
                 (_, "latest") => {
                     p.with_segmenter_lstm_for_tag(DatagenProvider::LATEST_TESTED_SEGMENTER_LSTM_TAG)

--- a/utils/preferences/src/preferences.rs
+++ b/utils/preferences/src/preferences.rs
@@ -114,8 +114,7 @@ macro_rules! preferences {
         }
 
         impl $name {
-            pub fn extend<T: Into<$name>>(&mut self, other: T) {
-                let other = other.into();
+            pub fn extend(&mut self, other: $name) {
                 $(
                     if let Some(value) = other.$key {
                         self.$key = Some(value);

--- a/utils/preferences/tests/dtf_os_prefs_tests.rs
+++ b/utils/preferences/tests/dtf_os_prefs_tests.rs
@@ -58,7 +58,7 @@ fn dtf_locale_override_os_prefs() {
 
     let os_prefs = get_os_dtf_preferences(&loc.id);
     let prefs = if let Some(mut os_prefs) = os_prefs {
-        os_prefs.extend(loc);
+        os_prefs.extend(loc.into());
         os_prefs
     } else {
         loc.into()
@@ -102,7 +102,7 @@ fn dtf_call_override_locale_override_os_prefs() {
 
     let os_prefs = get_os_dtf_preferences(&loc.id);
     let mut prefs = if let Some(mut os_prefs) = os_prefs {
-        os_prefs.extend(loc);
+        os_prefs.extend(loc.into());
         os_prefs
     } else {
         loc.into()
@@ -156,7 +156,7 @@ fn dtf_prefs_non_ue_preference() {
 
     let os_prefs = get_os_dtf_preferences(&loc.id);
     let prefs = if let Some(mut os_prefs) = os_prefs {
-        os_prefs.extend(loc);
+        os_prefs.extend(loc.into());
         os_prefs
     } else {
         loc.into()

--- a/utils/tinystr/src/ascii.rs
+++ b/utils/tinystr/src/ascii.rs
@@ -195,7 +195,7 @@ impl<const N: usize> TinyAsciiStr<N> {
     }
 
     pub(crate) const fn try_from_utf16_inner(
-        code_points: &[u16],
+        code_units: &[u16],
         start: usize,
         end: usize,
         allow_trailing_null: bool,
@@ -211,7 +211,7 @@ impl<const N: usize> TinyAsciiStr<N> {
         // Indexing is protected by TinyStrError::TooLarge
         #[allow(clippy::indexing_slicing)]
         while i < len {
-            let b = code_points[start + i];
+            let b = code_units[start + i];
 
             if b == 0 {
                 found_null = true;

--- a/utils/tzif/README.md
+++ b/utils/tzif/README.md
@@ -14,7 +14,7 @@ Resources to generate `TZif` files are provided by the [IANA database](https://w
 
 #### Parse TZif Files
 ```rust
-let data = tzif::parse_tzif_file("path_to_file").unwrap();
+let data = tzif::parse_tzif_file(Path::new("path_to_file")).unwrap();
 ```
 
 #### Parse POSIX time-zone strings

--- a/utils/tzif/src/lib.rs
+++ b/utils/tzif/src/lib.rs
@@ -40,7 +40,7 @@ pub mod parse;
 pub mod error;
 
 /// Parses a `TZif` file at the provided `path`.
-pub fn parse_tzif_file<P: AsRef<Path>>(path: P) -> Result<TzifData, Error> {
+pub fn parse_tzif_file(path: &Path) -> Result<TzifData, Error> {
     let file = File::open(path)?;
     let stream = stream::buffered::Stream::new(
         stream::position::Stream::new(stream::read::Stream::new(file)),

--- a/utils/tzif/src/lib.rs
+++ b/utils/tzif/src/lib.rs
@@ -14,7 +14,8 @@
 //!
 //! ### Parse TZif Files
 //! ```no_run
-//! let data = tzif::parse_tzif_file("path_to_file").unwrap();
+//! # use std::path::Path;
+//! let data = tzif::parse_tzif_file(Path::new("path_to_file")).unwrap();
 //! ```
 //!
 //! ### Parse POSIX time-zone strings

--- a/utils/tzif/tests/mod.rs
+++ b/utils/tzif/tests/mod.rs
@@ -5,8 +5,8 @@
 use std::path::Path;
 use walkdir::WalkDir;
 
-fn parse_tzif_file<P: AsRef<Path>>(path: P) -> Result<(), tzif::error::Error> {
-    println!("parsing {:?}", path.as_ref().to_str());
+fn parse_tzif_file(path: &Path) -> Result<(), tzif::error::Error> {
+    println!("parsing {:?}", path);
     let parsed = tzif::parse_tzif_file(path)?;
     println!("{parsed:#?}");
     Ok(())

--- a/utils/writeable/src/cmp.rs
+++ b/utils/writeable/src/cmp.rs
@@ -6,7 +6,7 @@ use core::cmp::Ordering;
 use core::fmt;
 
 pub(crate) struct WriteComparator<'a> {
-    code_points: &'a [u8],
+    code_units: &'a [u8],
     result: Ordering,
 }
 
@@ -17,9 +17,9 @@ impl<'a> fmt::Write for WriteComparator<'a> {
         if self.result != Ordering::Equal {
             return Ok(());
         }
-        let cmp_len = core::cmp::min(other.len(), self.code_points.len());
-        let (this, remainder) = self.code_points.split_at(cmp_len);
-        self.code_points = remainder;
+        let cmp_len = core::cmp::min(other.len(), self.code_units.len());
+        let (this, remainder) = self.code_units.split_at(cmp_len);
+        self.code_units = remainder;
         self.result = this.cmp(other.as_bytes());
         Ok(())
     }
@@ -27,16 +27,16 @@ impl<'a> fmt::Write for WriteComparator<'a> {
 
 impl<'a> WriteComparator<'a> {
     #[inline]
-    pub fn new(code_points: &'a [u8]) -> Self {
+    pub fn new(code_units: &'a [u8]) -> Self {
         Self {
-            code_points,
+            code_units,
             result: Ordering::Equal,
         }
     }
 
     #[inline]
     pub fn finish(self) -> Ordering {
-        if matches!(self.result, Ordering::Equal) && !self.code_points.is_empty() {
+        if matches!(self.result, Ordering::Equal) && !self.code_units.is_empty() {
             // Self is longer than Other
             Ordering::Greater
         } else {

--- a/utils/writeable/src/cmp.rs
+++ b/utils/writeable/src/cmp.rs
@@ -6,7 +6,7 @@ use core::cmp::Ordering;
 use core::fmt;
 
 pub(crate) struct WriteComparator<'a> {
-    string: &'a [u8],
+    code_points: &'a [u8],
     result: Ordering,
 }
 
@@ -17,9 +17,9 @@ impl<'a> fmt::Write for WriteComparator<'a> {
         if self.result != Ordering::Equal {
             return Ok(());
         }
-        let cmp_len = core::cmp::min(other.len(), self.string.len());
-        let (this, remainder) = self.string.split_at(cmp_len);
-        self.string = remainder;
+        let cmp_len = core::cmp::min(other.len(), self.code_points.len());
+        let (this, remainder) = self.code_points.split_at(cmp_len);
+        self.code_points = remainder;
         self.result = this.cmp(other.as_bytes());
         Ok(())
     }
@@ -27,16 +27,16 @@ impl<'a> fmt::Write for WriteComparator<'a> {
 
 impl<'a> WriteComparator<'a> {
     #[inline]
-    pub fn new(string: &'a (impl AsRef<[u8]> + ?Sized)) -> Self {
+    pub fn new(code_points: &'a [u8]) -> Self {
         Self {
-            string: string.as_ref(),
+            code_points,
             result: Ordering::Equal,
         }
     }
 
     #[inline]
     pub fn finish(self) -> Ordering {
-        if matches!(self.result, Ordering::Equal) && !self.string.is_empty() {
+        if matches!(self.result, Ordering::Equal) && !self.code_points.is_empty() {
             // Self is longer than Other
             Ordering::Greater
         } else {
@@ -58,7 +58,7 @@ mod tests {
     fn test_write_char() {
         for a in data::KEBAB_CASE_STRINGS {
             for b in data::KEBAB_CASE_STRINGS {
-                let mut wc = WriteComparator::new(a);
+                let mut wc = WriteComparator::new(a.as_bytes());
                 for ch in b.chars() {
                     wc.write_char(ch).unwrap();
                 }
@@ -71,7 +71,7 @@ mod tests {
     fn test_write_str() {
         for a in data::KEBAB_CASE_STRINGS {
             for b in data::KEBAB_CASE_STRINGS {
-                let mut wc = WriteComparator::new(a);
+                let mut wc = WriteComparator::new(a.as_bytes());
                 wc.write_str(b).unwrap();
                 assert_eq!(a.cmp(b), wc.finish(), "{a} <=> {b}");
             }
@@ -82,7 +82,7 @@ mod tests {
     fn test_mixed() {
         for a in data::KEBAB_CASE_STRINGS {
             for b in data::KEBAB_CASE_STRINGS {
-                let mut wc = WriteComparator::new(a);
+                let mut wc = WriteComparator::new(a.as_bytes());
                 let mut first = true;
                 for substr in b.split('-') {
                     if first {


### PR DESCRIPTION
It's usually better if the callers calls `x.into()` or `&x`