### PR TITLE
Fixes initialization of SimpleLogger in `icu4x-datagen`

### DIFF
--- a/provider/icu4x-datagen/src/main.rs
+++ b/provider/icu4x-datagen/src/main.rs
@@ -279,8 +279,8 @@ fn main() -> eyre::Result<()> {
             .unwrap()
     } else {
         SimpleLogger::new()
-            .env()
             .with_level(log::LevelFilter::Info)
+            .env()
             .init()
             .unwrap()
     }


### PR DESCRIPTION
The correct initialization order is

```Rust
SimpleLogger::new()
    .with_level(log::LevelFilter::Info)
    .env()
```

Not

```Rust
SimpleLogger::new()
    .env()
    .with_level(log::LevelFilter::Info)
```

Both SimpleLogger::env and SimpleLogger::with_level both override SimpleLogger::default_level. SimpleLogger::env should be called _after_ SimpleLogger::with_level, so that RUST_LOG can override the default level set by SimpleLogger::with_level, if present. See: https://github.com/borntyping/rust-simple_logger/blob/fb96a82c274f92eff417904e6e819f25f3b51ccc/src/lib.rs#L153-L158

Without this change, setting RUST_LOG does not affect the log level used by icu-datagen.