### PR TITLE
Make `DataPayload<ExportMarker>: Hash`

### DIFF
--- a/provider/baked/src/export.rs
+++ b/provider/baked/src/export.rs
@@ -484,7 +484,7 @@ impl DataExporter for BakedExporter {
                         })
                         .collect::<Vec<_>>();
                     let ident = proc_macro2::Ident::new(
-                        &idents.select_nth_unstable(0).1,
+                        idents.select_nth_unstable(0).1,
                         proc_macro2::Span::call_site(),
                     );
 

--- a/provider/baked/src/export.rs
+++ b/provider/baked/src/export.rs
@@ -468,7 +468,7 @@ impl DataExporter for BakedExporter {
             let ids_to_idents = deduplicated_values
                 .iter()
                 .flat_map(|(payload, ids)| {
-                    let mut idents = ids
+                    let ident = ids
                         .iter()
                         .map(|id| {
                             format!("_{}_{}", id.marker_attributes.as_str(), id.locale)
@@ -482,11 +482,9 @@ impl DataExporter for BakedExporter {
                                 })
                                 .collect::<String>()
                         })
-                        .collect::<Vec<_>>();
-                    let ident = proc_macro2::Ident::new(
-                        idents.select_nth_unstable(0).1,
-                        proc_macro2::Span::call_site(),
-                    );
+                        .min()
+                        .unwrap();
+                    let ident = proc_macro2::Ident::new(&ident, proc_macro2::Span::call_site());
 
                     idents_to_bakes.push((ident.clone(), payload.tokenize(&self.dependencies)));
                     ids.iter().map(move |id| (id.clone(), ident.clone()))

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -70,7 +70,7 @@ deserialize_bincode_1 = ["serde", "dep:bincode", "std"]
 deserialize_postcard_1 = ["serde", "dep:postcard"]
 
 # Dependencies for running data generation
-export = ["serde", "dep:erased-serde", "dep:databake", "std", "sync"]
+export = ["serde", "dep:erased-serde", "dep:databake", "std", "sync", "dep:postcard"]
 
 [package.metadata.cargo-all-features]
 denylist = ["macros"]

--- a/provider/core/src/export/payload.rs
+++ b/provider/core/src/export/payload.rs
@@ -174,12 +174,11 @@ impl DataPayload<ExportMarker> {
         let mut serializer = postcard::Serializer {
             output: Size::default(),
         };
-        self.get()
+        let _infallible = self.get()
             .payload
-            .serialize_yoke(&mut <dyn erased_serde::Serializer>::erase(&mut serializer))
-            .unwrap();
+            .serialize_yoke(&mut <dyn erased_serde::Serializer>::erase(&mut serializer));
 
-        serializer.output.finalize().unwrap()
+        serializer.output.finalize().unwrap_or_default()
     }
 }
 

--- a/provider/core/src/export/payload.rs
+++ b/provider/core/src/export/payload.rs
@@ -174,7 +174,8 @@ impl DataPayload<ExportMarker> {
         let mut serializer = postcard::Serializer {
             output: Size::default(),
         };
-        let _infallible = self.get()
+        let _infallible = self
+            .get()
             .payload
             .serialize_yoke(&mut <dyn erased_serde::Serializer>::erase(&mut serializer));
 

--- a/tools/bakeddata-scripts/Cargo.toml
+++ b/tools/bakeddata-scripts/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 icu = { workspace = true, features = ["experimental"] }
 icu_provider = { workspace = true }
-icu_datagen = { workspace = true, features = ["baked_exporter", "fs_exporter", "rayon"] }
+icu_datagen = { workspace = true, features = ["baked_exporter", "rayon"] }
 icu_datagen_bikeshed = { workspace = true, features = ["networking", "experimental", "use_wasm"] }
 
 log = { workspace = true }

--- a/tools/depcheck/src/allowlist.rs
+++ b/tools/depcheck/src/allowlist.rs
@@ -186,10 +186,12 @@ pub const EXTRA_DATAGEN_BIKESHED_DEPS: &[&str] = &[
 /// Dependencies needed by datagen (not counting `log` and `rayon` deps)
 /// This might change semi frequently but we should try and keep this small.
 pub const EXTRA_DATAGEN_DEPS: &[&str] = &[
+    "cobs",
     "databake",
     "databake-derive",
     "erased-serde",
     "icu_registry",
+    "postcard",
 ];
 
 /// Dependencies needed by the `log` crate


### PR DESCRIPTION
This allows putting it in a `HashMap`, as well as compute a stability hash.