### PR TITLE
Remove implicit `LocaleFallbackProvider` constructors

### DIFF
--- a/components/icu/README.md
+++ b/components/icu/README.md
@@ -53,6 +53,7 @@ special constructors:
 ```rust
 use icu::datetime::DateTimeFormatter;
 use icu::locale::locale;
+use icu::locale::fallback::LocaleFallbacker;
 use icu_provider_adapters::fallback::LocaleFallbackProvider;
 use icu_provider_blob::BlobDataProvider;
 
@@ -61,9 +62,10 @@ let data: Box<[u8]> = todo!();
 let provider = BlobDataProvider::try_new_from_blob(data)
     .expect("data should be valid");
 
-let provider =
-    LocaleFallbackProvider::try_new_with_buffer_provider(provider)
+let fallbacker = LocaleFallbacker::try_new_with_buffer_provider(&provider)
         .expect("provider should include fallback data");
+
+let provider = LocaleFallbackProvider::new(provider, fallbacker);
 
 let dtf = DateTimeFormatter::try_new_with_buffer_provider(
     &provider,

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -53,6 +53,7 @@
 //! ```no_run
 //! use icu::datetime::DateTimeFormatter;
 //! use icu::locale::locale;
+//! use icu::locale::fallback::LocaleFallbacker;
 //! use icu_provider_adapters::fallback::LocaleFallbackProvider;
 //! use icu_provider_blob::BlobDataProvider;
 //!
@@ -61,9 +62,10 @@
 //! let provider = BlobDataProvider::try_new_from_blob(data)
 //!     .expect("data should be valid");
 //!
-//! let provider =
-//!     LocaleFallbackProvider::try_new_with_buffer_provider(provider)
+//! let fallbacker = LocaleFallbacker::try_new_with_buffer_provider(&provider)
 //!         .expect("provider should include fallback data");
+//!
+//! let provider = LocaleFallbackProvider::new(provider, fallbacker);
 //!
 //! let dtf = DateTimeFormatter::try_new_with_buffer_provider(
 //!     &provider,

--- a/ffi/capi/bindings/c/ICU4XDataProvider.h
+++ b/ffi/capi/bindings/c/ICU4XDataProvider.h
@@ -33,9 +33,6 @@ ICU4XDataProvider_fork_by_key_result ICU4XDataProvider_fork_by_key(ICU4XDataProv
 typedef struct ICU4XDataProvider_fork_by_locale_result {union { ICU4XDataError err;}; bool is_ok;} ICU4XDataProvider_fork_by_locale_result;
 ICU4XDataProvider_fork_by_locale_result ICU4XDataProvider_fork_by_locale(ICU4XDataProvider* self, ICU4XDataProvider* other);
 
-typedef struct ICU4XDataProvider_enable_locale_fallback_result {union { ICU4XDataError err;}; bool is_ok;} ICU4XDataProvider_enable_locale_fallback_result;
-ICU4XDataProvider_enable_locale_fallback_result ICU4XDataProvider_enable_locale_fallback(ICU4XDataProvider* self);
-
 typedef struct ICU4XDataProvider_enable_locale_fallback_with_result {union { ICU4XDataError err;}; bool is_ok;} ICU4XDataProvider_enable_locale_fallback_with_result;
 ICU4XDataProvider_enable_locale_fallback_with_result ICU4XDataProvider_enable_locale_fallback_with(ICU4XDataProvider* self, const ICU4XLocaleFallbacker* fallbacker);
 

--- a/ffi/capi/bindings/cpp/ICU4XDataProvider.d.hpp
+++ b/ffi/capi/bindings/cpp/ICU4XDataProvider.d.hpp
@@ -33,8 +33,6 @@ public:
 
   inline diplomat::result<std::monostate, ICU4XDataError> fork_by_locale(ICU4XDataProvider& other);
 
-  inline diplomat::result<std::monostate, ICU4XDataError> enable_locale_fallback();
-
   inline diplomat::result<std::monostate, ICU4XDataError> enable_locale_fallback_with(const ICU4XLocaleFallbacker& fallbacker);
 
   inline const capi::ICU4XDataProvider* AsFFI() const;

--- a/ffi/capi/bindings/cpp/ICU4XDataProvider.hpp
+++ b/ffi/capi/bindings/cpp/ICU4XDataProvider.hpp
@@ -33,9 +33,6 @@ namespace capi {
     typedef struct ICU4XDataProvider_fork_by_locale_result {union { ICU4XDataError err;}; bool is_ok;} ICU4XDataProvider_fork_by_locale_result;
     ICU4XDataProvider_fork_by_locale_result ICU4XDataProvider_fork_by_locale(ICU4XDataProvider* self, ICU4XDataProvider* other);
     
-    typedef struct ICU4XDataProvider_enable_locale_fallback_result {union { ICU4XDataError err;}; bool is_ok;} ICU4XDataProvider_enable_locale_fallback_result;
-    ICU4XDataProvider_enable_locale_fallback_result ICU4XDataProvider_enable_locale_fallback(ICU4XDataProvider* self);
-    
     typedef struct ICU4XDataProvider_enable_locale_fallback_with_result {union { ICU4XDataError err;}; bool is_ok;} ICU4XDataProvider_enable_locale_fallback_with_result;
     ICU4XDataProvider_enable_locale_fallback_with_result ICU4XDataProvider_enable_locale_fallback_with(ICU4XDataProvider* self, const ICU4XLocaleFallbacker* fallbacker);
     
@@ -76,11 +73,6 @@ inline diplomat::result<std::monostate, ICU4XDataError> ICU4XDataProvider::fork_
 inline diplomat::result<std::monostate, ICU4XDataError> ICU4XDataProvider::fork_by_locale(ICU4XDataProvider& other) {
   auto result = capi::ICU4XDataProvider_fork_by_locale(this->AsFFI(),
     other.AsFFI());
-  return result.is_ok ? diplomat::result<std::monostate, ICU4XDataError>(diplomat::Ok<std::monostate>()) : diplomat::result<std::monostate, ICU4XDataError>(diplomat::Err<ICU4XDataError>(ICU4XDataError::FromFFI(result.err)));
-}
-
-inline diplomat::result<std::monostate, ICU4XDataError> ICU4XDataProvider::enable_locale_fallback() {
-  auto result = capi::ICU4XDataProvider_enable_locale_fallback(this->AsFFI());
   return result.is_ok ? diplomat::result<std::monostate, ICU4XDataError>(diplomat::Ok<std::monostate>()) : diplomat::result<std::monostate, ICU4XDataError>(diplomat::Err<ICU4XDataError>(ICU4XDataError::FromFFI(result.err)));
 }
 

--- a/ffi/capi/bindings/dart/DataProvider.g.dart
+++ b/ffi/capi/bindings/dart/DataProvider.g.dart
@@ -92,24 +92,7 @@ final class DataProvider implements ffi.Finalizable {
     
   }
 
-  /// Enables locale fallbacking for data requests made to this provider.
-  ///
-  /// Note that the test provider (from `create_test`) already has fallbacking enabled.
-  ///
-  /// See the [Rust documentation for `try_new`](https://docs.rs/icu_provider_adapters/latest/icu_provider_adapters/fallback/struct.LocaleFallbackProvider.html#method.try_new) for more information.
-  ///
-  /// Additional information: [1](https://docs.rs/icu_provider_adapters/latest/icu_provider_adapters/fallback/struct.LocaleFallbackProvider.html)
-  ///
-  /// Throws [DataError] on failure.
-  void enableLocaleFallback() {
-    final result = _ICU4XDataProvider_enable_locale_fallback(_ffi);
-    if (!result.isOk) {
-      throw DataError.values[result.union.err];
-    }
-    
-  }
-
-  /// See the [Rust documentation for `new_with_fallbacker`](https://docs.rs/icu_provider_adapters/latest/icu_provider_adapters/fallback/struct.LocaleFallbackProvider.html#method.new_with_fallbacker) for more information.
+  /// See the [Rust documentation for `new`](https://docs.rs/icu_provider_adapters/latest/icu_provider_adapters/fallback/struct.LocaleFallbackProvider.html#method.new) for more information.
   ///
   /// Additional information: [1](https://docs.rs/icu_provider_adapters/latest/icu_provider_adapters/fallback/struct.LocaleFallbackProvider.html)
   ///
@@ -152,11 +135,6 @@ external _ResultVoidInt32 _ICU4XDataProvider_fork_by_key(ffi.Pointer<ffi.Opaque>
 @ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'ICU4XDataProvider_fork_by_locale')
 // ignore: non_constant_identifier_names
 external _ResultVoidInt32 _ICU4XDataProvider_fork_by_locale(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> other);
-
-@meta.ResourceIdentifier('ICU4XDataProvider_enable_locale_fallback')
-@ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'ICU4XDataProvider_enable_locale_fallback')
-// ignore: non_constant_identifier_names
-external _ResultVoidInt32 _ICU4XDataProvider_enable_locale_fallback(ffi.Pointer<ffi.Opaque> self);
 
 @meta.ResourceIdentifier('ICU4XDataProvider_enable_locale_fallback_with')
 @ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'ICU4XDataProvider_enable_locale_fallback_with')

--- a/ffi/capi/bindings/js/ICU4XDataProvider.d.ts
+++ b/ffi/capi/bindings/js/ICU4XDataProvider.d.ts
@@ -70,20 +70,7 @@ export class ICU4XDataProvider {
 
   /**
 
-   * Enables locale fallbacking for data requests made to this provider.
-
-   * Note that the test provider (from `create_test`) already has fallbacking enabled.
-
-   * See the {@link https://docs.rs/icu_provider_adapters/latest/icu_provider_adapters/fallback/struct.LocaleFallbackProvider.html#method.try_new Rust documentation for `try_new`} for more information.
-
-   * Additional information: {@link https://docs.rs/icu_provider_adapters/latest/icu_provider_adapters/fallback/struct.LocaleFallbackProvider.html 1}
-   * @throws {@link FFIError}<{@link ICU4XDataError}>
-   */
-  enable_locale_fallback(): void | never;
-
-  /**
-
-   * See the {@link https://docs.rs/icu_provider_adapters/latest/icu_provider_adapters/fallback/struct.LocaleFallbackProvider.html#method.new_with_fallbacker Rust documentation for `new_with_fallbacker`} for more information.
+   * See the {@link https://docs.rs/icu_provider_adapters/latest/icu_provider_adapters/fallback/struct.LocaleFallbackProvider.html#method.new Rust documentation for `new`} for more information.
 
    * Additional information: {@link https://docs.rs/icu_provider_adapters/latest/icu_provider_adapters/fallback/struct.LocaleFallbackProvider.html 1}
    * @throws {@link FFIError}<{@link ICU4XDataError}>

--- a/ffi/capi/bindings/js/ICU4XDataProvider.mjs
+++ b/ffi/capi/bindings/js/ICU4XDataProvider.mjs
@@ -98,23 +98,6 @@ export class ICU4XDataProvider {
     })();
   }
 
-  enable_locale_fallback() {
-    return (() => {
-      const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
-      wasm.ICU4XDataProvider_enable_locale_fallback(diplomat_receive_buffer, this.underlying);
-      const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
-      if (is_ok) {
-        const ok_value = {};
-        wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
-        return ok_value;
-      } else {
-        const throw_value = ICU4XDataError_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, diplomat_receive_buffer)];
-        wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
-        throw new diplomatRuntime.FFIError(throw_value);
-      }
-    })();
-  }
-
   enable_locale_fallback_with(arg_fallbacker) {
     return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);

--- a/ffi/capi/src/provider.rs
+++ b/ffi/capi/src/provider.rs
@@ -176,39 +176,8 @@ pub mod ffi {
             Ok(())
         }
 
-        /// Enables locale fallbacking for data requests made to this provider.
-        ///
-        /// Note that the test provider (from `create_test`) already has fallbacking enabled.
         #[diplomat::rust_link(
-            icu_provider_adapters::fallback::LocaleFallbackProvider::try_new,
-            FnInStruct
-        )]
-        #[diplomat::rust_link(
-            icu_provider_adapters::fallback::LocaleFallbackProvider,
-            Struct,
-            compact
-        )]
-        pub fn enable_locale_fallback(&mut self) -> Result<(), ICU4XDataError> {
-            use ICU4XDataProviderInner::*;
-            *self = match core::mem::replace(&mut self.0, Destroyed) {
-                Destroyed => Err(icu_provider::DataError::custom(
-                    "This provider has been destroyed",
-                ))?,
-                #[cfg(feature = "compiled_data")]
-                Compiled => Err(icu_provider::DataError::custom(
-                    "The compiled provider cannot be modified",
-                ))?,
-                Empty => Err(icu_provider::DataErrorKind::MarkerNotFound.into_error())?,
-                #[cfg(feature = "buffer_provider")]
-                Buffer(inner) => convert_buffer_provider(
-                    LocaleFallbackProvider::try_new_with_buffer_provider(inner)?,
-                ),
-            };
-            Ok(())
-        }
-
-        #[diplomat::rust_link(
-            icu_provider_adapters::fallback::LocaleFallbackProvider::new_with_fallbacker,
+            icu_provider_adapters::fallback::LocaleFallbackProvider::new,
             FnInStruct
         )]
         #[diplomat::rust_link(
@@ -233,9 +202,10 @@ pub mod ffi {
                 ))?,
                 Empty => Err(icu_provider::DataErrorKind::MarkerNotFound.into_error())?,
                 #[cfg(feature = "buffer_provider")]
-                Buffer(inner) => convert_buffer_provider(
-                    LocaleFallbackProvider::new_with_fallbacker(inner, fallbacker.0.clone()),
-                ),
+                Buffer(inner) => convert_buffer_provider(LocaleFallbackProvider::new(
+                    inner,
+                    fallbacker.0.clone(),
+                )),
             };
             Ok(())
         }

--- a/provider/adapters/Cargo.toml
+++ b/provider/adapters/Cargo.toml
@@ -29,6 +29,3 @@ serde = { workspace = true, features = ["derive", "alloc"], optional = true }
 icu_provider = { path = "../../provider/core", features = ["macros", "deserialize_json"] }
 icu_locale = { path = "../../components/locale" }
 writeable = { path = "../../utils/writeable" }
-
-[features]
-serde = ["dep:serde", "zerovec/serde", "icu_locale/serde", "icu_provider/serde"]

--- a/provider/blob/benches/auxkey_bench.rs
+++ b/provider/blob/benches/auxkey_bench.rs
@@ -311,7 +311,7 @@ fn auxkey_bench_for_version(c: &mut Criterion, blob: &[u8], version_id: &str) {
         b.iter(|| BlobDataProvider::try_new_from_blob(black_box(blob).into()).unwrap());
     });
 
-    let provider = LocaleFallbackProvider::new_with_fallbacker(
+    let provider = LocaleFallbackProvider::new(
         BlobDataProvider::try_new_from_blob(black_box(blob).into()).unwrap(),
         LocaleFallbacker::new().static_to_owned(),
     );

--- a/provider/source/src/collator/mod.rs
+++ b/provider/source/src/collator/mod.rs
@@ -291,10 +291,13 @@ collation_provider!(
 fn test_zh_non_baked() {
     use core::cmp::Ordering;
     use icu::collator::{Collator, CollatorOptions};
+    use icu::locale::fallback::LocaleFallbacker;
     use icu_provider_adapters::fallback::LocaleFallbackProvider;
 
-    let provider =
-        LocaleFallbackProvider::try_new_unstable(SourceDataProvider::new_testing()).unwrap();
+    let provider = LocaleFallbackProvider::new(
+        SourceDataProvider::new_testing(),
+        LocaleFallbacker::new_without_data(),
+    );
 
     // Note: ㄅ is Bopomofo.
     {

--- a/tutorials/data_management.md
+++ b/tutorials/data_management.md
@@ -149,12 +149,12 @@ This will generate a `my_data_blob.postcard` file containing the serialized data
 
 Unlike `BakedDataProvider`, `BlobDataProvider` (and `FsDataProvider`) does not perform locale fallbacking. For example, if `en-US` is requested but only `en` data is available, then the data request will fail. To enable fallback, we can wrap the provider in a `LocaleFallbackProvider`.
 
-Note that fallback comes at a cost, as fallbacking code and data has to be included and executed on every request. If you don't need fallback (disclaimer: you probably do), you can use the `BlobDataProvider` directly (for `BakedDataProvider`, see [`FallbackMode::Preresolved`](https://docs.rs/icu_datagen/latest/icu_datagen/enum.FallbackMode.html)).
+Note that fallback comes at a cost, as fallbacking code and data has to be included and executed on every request. If you don't need fallback (disclaimer: you probably do), you can use the `BlobDataProvider` directly (for baked data, see [`Options::skip_internal_fallback`](https://docs.rs/icu_provider_baked/latest/icu_provider_baked/export/struct.Options.html)).
 
 We can then use the provider in our code:
 
 ```rust,no_run
-use icu::locale::{locale, Locale};
+use icu::locale::{locale, Locale, fallback::LocaleFallbacker};
 use icu::calendar::DateTime;
 use icu::datetime::{DateTimeFormatter, options::length};
 use icu_provider_adapters::fallback::LocaleFallbackProvider;
@@ -168,8 +168,10 @@ fn main() {
         BlobDataProvider::try_new_from_blob(blob.into_boxed_slice())
             .expect("blob should be valid");
 
-    let buffer_provider = LocaleFallbackProvider::try_new_with_buffer_provider(buffer_provider)
+    let fallbacker = LocaleFallbacker::try_new_with_buffer_provider(&buffer_provider)
         .expect("Provider should contain fallback rules");
+
+    let buffer_provider = LocaleFallbackProvider::new(buffer_provider, fallbacker);
 
     let options = length::Bag::from_date_time_style(length::Date::Long, length::Time::Medium);
 
@@ -203,7 +205,7 @@ But there is more to optimize. You might have noticed this in the output of the 
 We can instead use `TypedDateTimeFormatter<Gregorian>`, which only supports formatting `DateTime<Gregorian>`s:
 
 ```rust,no_run
-use icu::locale::{locale, Locale};
+use icu::locale::{locale, Locale, fallback::LocaleFallbacker};
 use icu::calendar::{DateTime, Gregorian};
 use icu::datetime::{TypedDateTimeFormatter, options::length};
 use icu_provider_adapters::fallback::LocaleFallbackProvider;
@@ -217,8 +219,10 @@ fn main() {
         BlobDataProvider::try_new_from_blob(blob.into_boxed_slice())
             .expect("blob should be valid");
 
-    let buffer_provider = LocaleFallbackProvider::try_new_with_buffer_provider(buffer_provider)
+    let fallbacker = LocaleFallbacker::try_new_with_buffer_provider(&buffer_provider)
         .expect("Provider should contain fallback rules");
+
+    let buffer_provider = LocaleFallbackProvider::new(buffer_provider, fallbacker);
 
     let options = length::Bag::from_date_time_style(length::Date::Long, length::Time::Medium);
 

--- a/tutorials/data_provider.md
+++ b/tutorials/data_provider.md
@@ -291,7 +291,7 @@ where
 
 // Set up a HelloWorldProvider with fallback
 let provider = ResolvedLocaleProvider {
-    inner: LocaleFallbackProvider::new_with_fallbacker(
+    inner: LocaleFallbackProvider::new(
         HelloWorldProvider,
         LocaleFallbacker::new().static_to_owned(),
     ),


### PR DESCRIPTION
Now that `LocaleFallbacker` is an explicit argument to `ExportDriver`, it might make sense to always make it explicit on the `LocaleFallbackProvider` as well. 

The `_unstable`, `_with_buffer_provider`, and `_with_any_provider` constructors are a bit odd for this crate anyway, no other adapter has the constructor trinity. Removing them also has the added benefit of removing the `serde` feature from the crate.