### PR TITLE
Fix CI warnings

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -62,29 +62,27 @@ jobs:
 
     # GCP Boilerplate for jobs in main or forked repository (needs credentials)
     - id: gcp-auth
+      if: github.ref != 'refs/heads/main' || github.repository != 'unicode-org/icu4x'
       name: "Authenticate to Google Cloud with JSON Credentials"
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
         credentials_json: '${{ secrets.ICU4X_GCP_SA_KEY }}'
     - id: gcp-auth-main
       if: github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
       name: "Authenticate to Google Cloud with Workload Identity Provider"
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
         workload_identity_provider: "projects/66042061814/locations/global/workloadIdentityPools/icu4x-gha-pool1/providers/icu4x-gha-provider1"
         service_account: "icu4x-main@dev-infra-273822.iam.gserviceaccount.com"
     - name: "Set up Google Cloud SDK"
-      uses: google-github-actions/setup-gcloud@v1
+      uses: google-github-actions/setup-gcloud@v2
 
     - name: Build docs
-      uses: actions-rs/cargo@v1
-      with:
-        command: doc
-        # Exclude tool and derive crates
-        args: >
-          --workspace --release --all-features --no-deps --lib 
+      run: >
+          cargo doc --workspace --release --all-features --no-deps --lib 
           --exclude icu_benchmark_macros
           --exclude icu_ffi_coverage
+          --exclude md-tests
           --exclude icu_provider_macros
           --exclude databake-derive
           --exclude yoke-derive
@@ -114,19 +112,20 @@ jobs:
 
     # GCP Boilerplate for jobs in main or forked repository (needs credentials)
     - id: gcp-auth
+      if: github.ref != 'refs/heads/main' || github.repository != 'unicode-org/icu4x'
       name: "Authenticate to Google Cloud with JSON Credentials"
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
         credentials_json: '${{ secrets.ICU4X_GCP_SA_KEY }}'
     - id: gcp-auth-main
       if: github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
       name: "Authenticate to Google Cloud with Workload Identity Provider"
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
         workload_identity_provider: "projects/66042061814/locations/global/workloadIdentityPools/icu4x-gha-pool1/providers/icu4x-gha-provider1"
         service_account: "icu4x-main@dev-infra-273822.iam.gserviceaccount.com"
     - name: "Set up Google Cloud SDK"
-      uses: google-github-actions/setup-gcloud@v1
+      uses: google-github-actions/setup-gcloud@v2
 
     - name: Install doxygen-awesome
       run: |
@@ -160,19 +159,20 @@ jobs:
 
     # GCP Boilerplate for jobs in main or forked repository (needs credentials)
     - id: gcp-auth
+      if: github.ref != 'refs/heads/main' || github.repository != 'unicode-org/icu4x'
       name: "Authenticate to Google Cloud with JSON Credentials"
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
         credentials_json: '${{ secrets.ICU4X_GCP_SA_KEY }}'
     - id: gcp-auth-main
       if: github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
       name: "Authenticate to Google Cloud with Workload Identity Provider"
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
         workload_identity_provider: "projects/66042061814/locations/global/workloadIdentityPools/icu4x-gha-pool1/providers/icu4x-gha-provider1"
         service_account: "icu4x-main@dev-infra-273822.iam.gserviceaccount.com"
     - name: "Set up Google Cloud SDK"
-      uses: google-github-actions/setup-gcloud@v1
+      uses: google-github-actions/setup-gcloud@v2
 
     - name: Build docs
       run: |
@@ -205,19 +205,20 @@ jobs:
 
     # GCP Boilerplate for jobs in main or forked repository (needs credentials)
     - id: gcp-auth
+      if: github.ref != 'refs/heads/main' || github.repository != 'unicode-org/icu4x'
       name: "Authenticate to Google Cloud with JSON Credentials"
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
         credentials_json: '${{ secrets.ICU4X_GCP_SA_KEY }}'
     - id: gcp-auth-main
       if: github.ref == 'refs/heads/main' && github.repository == 'unicode-org/icu4x'
       name: "Authenticate to Google Cloud with Workload Identity Provider"
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
         workload_identity_provider: "projects/66042061814/locations/global/workloadIdentityPools/icu4x-gha-pool1/providers/icu4x-gha-provider1"
         service_account: "icu4x-main@dev-infra-273822.iam.gserviceaccount.com"
     - name: "Set up Google Cloud SDK"
-      uses: google-github-actions/setup-gcloud@v1
+      uses: google-github-actions/setup-gcloud@v2
 
     - name: Install Dart
       uses: dart-lang/setup-dart@v1
@@ -258,12 +259,12 @@ jobs:
     # GCP Boilerplate for jobs in main repository
     - id: gcp-auth
       name: "Authenticate to Google Cloud with Workload Identity Provider"
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
         workload_identity_provider: "projects/66042061814/locations/global/workloadIdentityPools/icu4x-gha-pool1/providers/icu4x-gha-provider1"
         service_account: "icu4x-main@dev-infra-273822.iam.gserviceaccount.com"
     - name: "Set up Google Cloud SDK"
-      uses: google-github-actions/setup-gcloud@v1
+      uses: google-github-actions/setup-gcloud@v2
 
     - name: Init packages
       run: |
@@ -324,12 +325,12 @@ jobs:
     # GCP Boilerplate for jobs in main repository
     - id: gcp-auth
       name: "Authenticate to Google Cloud with Workload Identity Provider"
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
         workload_identity_provider: "projects/66042061814/locations/global/workloadIdentityPools/icu4x-gha-pool1/providers/icu4x-gha-provider1"
         service_account: "icu4x-main@dev-infra-273822.iam.gserviceaccount.com"
     - name: "Set up Google Cloud SDK"
-      uses: google-github-actions/setup-gcloud@v1
+      uses: google-github-actions/setup-gcloud@v2
 
     # Cargo-make boilerplate
     - name: Install cargo-make
@@ -406,12 +407,12 @@ jobs:
     # GCP Boilerplate for jobs in main repository
     - id: gcp-auth
       name: "Authenticate to Google Cloud with Workload Identity Provider"
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
         workload_identity_provider: "projects/66042061814/locations/global/workloadIdentityPools/icu4x-gha-pool1/providers/icu4x-gha-provider1"
         service_account: "icu4x-main@dev-infra-273822.iam.gserviceaccount.com"
     - name: "Set up Google Cloud SDK"
-      uses: google-github-actions/setup-gcloud@v1
+      uses: google-github-actions/setup-gcloud@v2
 
     # Cargo-make boilerplate
     - name: Install cargo-make
@@ -469,12 +470,12 @@ jobs:
     # GCP Boilerplate for jobs in main repository
     - id: gcp-auth
       name: "Authenticate to Google Cloud with Workload Identity Provider"
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
         workload_identity_provider: "projects/66042061814/locations/global/workloadIdentityPools/icu4x-gha-pool1/providers/icu4x-gha-provider1"
         service_account: "icu4x-main@dev-infra-273822.iam.gserviceaccount.com"
     - name: "Set up Google Cloud SDK"
-      uses: google-github-actions/setup-gcloud@v1
+      uses: google-github-actions/setup-gcloud@v2
 
     # Cargo-make boilerplate
     - name: Install cargo-make
@@ -565,18 +566,18 @@ jobs:
       # GCP Boilerplate for jobs in main repository
       - id: gcp-auth
         name: "Authenticate to Google Cloud with Workload Identity Provider"
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: "projects/66042061814/locations/global/workloadIdentityPools/icu4x-gha-pool1/providers/icu4x-gha-provider1"
           service_account: "icu4x-main@dev-infra-273822.iam.gserviceaccount.com"
       - name: "Set up Google Cloud SDK"
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
       - name: Download artifacts
         run: |
           mkdir website
           gsutil -m cp -rn gs://${{ env.GCP_MAIN_BUCKET_ID }}/gha/* website || true
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           path: 'website'
       - name: Deploy to GitHub Pages

--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -334,7 +334,9 @@ jobs:
 
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Actual job
 
@@ -416,7 +418,9 @@ jobs:
 
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Actual job
 
@@ -479,7 +483,9 @@ jobs:
 
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Job-specific dependencies
     - name: Install npm tools

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -57,13 +57,15 @@ jobs:
 
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Job-specific dependencies
-    - name: Install cargo-binstall 
-      uses: taiki-e/install-action@cargo-binstall
     - name: Install cargo-all-features
-      run: cargo-binstall -y cargo-all-features
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-all-features@1.10.0
 
     # No toolchain boilerplate as this runs on MSRV
 
@@ -84,7 +86,9 @@ jobs:
 
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
@@ -105,7 +109,9 @@ jobs:
 
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
@@ -126,7 +132,9 @@ jobs:
 
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
@@ -151,7 +159,9 @@ jobs:
 
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
@@ -180,7 +190,9 @@ jobs:
 
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
@@ -204,7 +216,9 @@ jobs:
 
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
@@ -230,7 +244,9 @@ jobs:
     
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
@@ -258,7 +274,9 @@ jobs:
     
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
@@ -285,7 +303,9 @@ jobs:
 
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
@@ -311,7 +331,9 @@ jobs:
 
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
@@ -332,7 +354,9 @@ jobs:
 
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
@@ -354,7 +378,9 @@ jobs:
 
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
@@ -375,7 +401,9 @@ jobs:
       run: cargo make gn-install
 
     - name: Install cargo-rdme
-      uses: taiki-e/install-action@cargo-rdme
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-rdme@1.1.4
 
     # Actual job
     - name: Run `cargo make ci-job-gn`
@@ -390,7 +418,9 @@ jobs:
 
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
@@ -415,7 +445,9 @@ jobs:
 
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
@@ -425,7 +457,9 @@ jobs:
 
     # Job-specific dependencies
     - name: Install cargo-rdme
-      uses: taiki-e/install-action@cargo-rdme
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-rdme@1.1.4
 
     # Actual job
     - name: Tidy
@@ -443,7 +477,9 @@ jobs:
 
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly
@@ -469,7 +505,9 @@ jobs:
 
     # Cargo-make boilerplate
     - name: Install cargo-make
-      uses: taiki-e/install-action@cargo-make
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make@0.37.13
 
     # Toolchain boilerplate
     - name: Potentially override rust version with nightly

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -403,7 +403,7 @@ jobs:
     - name: Install cargo-rdme
       uses: taiki-e/install-action@v2
       with:
-        tool: cargo-rdme@v1.4.4
+        tool: cargo-rdme@1.4.2
 
     # Actual job
     - name: Run `cargo make ci-job-gn`
@@ -459,7 +459,7 @@ jobs:
     - name: Install cargo-rdme
       uses: taiki-e/install-action@v2
       with:
-        tool: cargo-rdme@v1.4.4
+        tool: cargo-rdme@1.4.2
 
     # Actual job
     - name: Tidy

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -403,7 +403,7 @@ jobs:
     - name: Install cargo-rdme
       uses: taiki-e/install-action@v2
       with:
-        tool: cargo-rdme@1.4.4
+        tool: cargo-rdme@v1.4.4
 
     # Actual job
     - name: Run `cargo make ci-job-gn`
@@ -459,7 +459,7 @@ jobs:
     - name: Install cargo-rdme
       uses: taiki-e/install-action@v2
       with:
-        tool: cargo-rdme@1.4.4
+        tool: cargo-rdme@v1.4.4
 
     # Actual job
     - name: Tidy

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -403,7 +403,7 @@ jobs:
     - name: Install cargo-rdme
       uses: taiki-e/install-action@v2
       with:
-        tool: cargo-rdme@1.1.4
+        tool: cargo-rdme@1.4.4
 
     # Actual job
     - name: Run `cargo make ci-job-gn`
@@ -459,7 +459,7 @@ jobs:
     - name: Install cargo-rdme
       uses: taiki-e/install-action@v2
       with:
-        tool: cargo-rdme@1.1.4
+        tool: cargo-rdme@1.4.4
 
     # Actual job
     - name: Tidy

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -364,7 +364,7 @@ jobs:
 
     # Job-specific dependencies
     - name: Attempt to load cached GN Third-Party Tools
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: gn-third-party-tools-cache
       with:
         path: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,9 @@ jobs:
       ## Coverage steps
 
       - name: Install grcov
-        uses: taiki-e/install-action@grcov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: grcov
   
       - uses:                   actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
Mainly due to GitHub's upcoming Node 20 requirement.