### PR TITLE
Bump zerovec-derive to 0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   - (0.10.4) Enforce C,packed on OptionVarULE (https://github.com/unicode-org/icu4x/pull/5143)
 - `zerovec_derive`
   - (0.10.3) Enforce C,packed, not just packed, on ULE types, fixing for incoming changes to `repr(Rust)` (https://github.com/unicode-org/icu4x/pull/5049)
+  - (0.10.4) No-op publish to keep security-patched versions in sync
+
 ## icu4x 1.5 (May 28, 2024)
 
 - Components

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "bincode",
  "proc-macro2",

--- a/utils/zerovec/derive/Cargo.toml
+++ b/utils/zerovec/derive/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "zerovec-derive"
 description = "Custom derive for the zerovec crate"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
 keywords = ["zerocopy", "serialization", "zero-copy", "serde"]


### PR DESCRIPTION
The advisory mistakenly marks zerovec-derive 0.10.3 as broken.

Fixes https://github.com/unicode-org/icu4x/issues/5196


This is less work than fixing the advisory


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->