### PR TITLE
Change metacrate description for crates.io

### DIFF
--- a/components/icu/Cargo.toml
+++ b/components/icu/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "icu"
-description = "ICU4X Project: Unicode Internationalization Library for Rust"
+description = "ICU4X: International Components for Unicode, written in Rust"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/icu/Cargo.toml
+++ b/components/icu/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "icu"
-description = "International Components for Unicode"
+description = "ICU4X Project: Unicode Internationalization Library for Rust"
 
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
This description shows up on our crates.io page and in search results:

https://crates.io/crates/icu

It doesn't say anything about ICU4X. I was working with @FrankYFTang today who thought we hadn't uploaded anything to crates.io because it wasn't evident in search results that the crate named `icu` is ICU4X.

This is especially important since the second search result is @filmil's `rust_icu`, which is ICU4C (and it says so in its description).