### PR TITLE
Use `assert_writable_eq` in units formatting test cases

### DIFF
--- a/components/experimental/src/dimension/units/format.rs
+++ b/components/experimental/src/dimension/units/format.rs
@@ -61,45 +61,45 @@ fn test_basic() {
     use writeable::assert_writeable_eq;
 
     use crate::dimension::units::formatter::UnitsFormatter;
-    use crate::dimension::units::options::UnitsFormatterOptions;
-    use crate::dimension::units::options::Width;
+    use crate::dimension::units::options::{UnitsFormatterOptions,Width};
 
-    let (locale, meter) = (locale!("en-US").into(), "meter");
-    let fmt = UnitsFormatter::try_new(&locale, meter, Default::default()).unwrap();
-    let value = "12345.67".parse().unwrap();
-    assert_writeable_eq!(fmt.format_fixed_decimal(&value, meter), "12,345.67 m");
+    let test_cases = [
+        (
+            locale!("en-US").into(),
+            "meter",
+            UnitsFormatterOptions::default(),
+            "12,345.67 m",
+        ),
+        (
+            locale!("en-US").into(),
+            "century",
+            UnitsFormatterOptions {
+                width: Width::Long,
+                ..Default::default()
+            },
+            "12,345.67 centuries",
+        ),
+        (
+            locale!("de-DE").into(),
+            "meter",
+            UnitsFormatterOptions::default(),
+            "12.345,67 m",
+        ),
+        (
+            locale!("ar-EG").into(),
+            "meter",
+            UnitsFormatterOptions {
+                width: Width::Long,
+                ..Default::default()
+            },
+            "١٢٬٣٤٥٫٦٧ متر",
+        ),
+    ];
 
-    let (locale, century) = (locale!("en-US").into(), "century");
-    let fmt = UnitsFormatter::try_new(
-        &locale,
-        century,
-        UnitsFormatterOptions {
-            width: Width::Long,
-            ..Default::default()
-        },
-    )
-    .unwrap();
-    let value = "12345.67".parse().unwrap();
-    let formatted_unit = fmt.format_fixed_decimal(&value, century);
-    assert_writeable_eq!(formatted_unit, "12,345.67 centuries");
-
-    let (locale, meter) = (locale!("de-DE").into(), "meter");
-    let fmt = UnitsFormatter::try_new(&locale, meter, Default::default()).unwrap();
-    let value = "12345.67".parse().unwrap();
-    let formatted_unit = fmt.format_fixed_decimal(&value, meter);
-    assert_writeable_eq!(formatted_unit, "12.345,67 m");
-
-    let (locale, meter) = (locale!("ar-EG").into(), "meter");
-    let fmt = UnitsFormatter::try_new(
-        &locale,
-        meter,
-        UnitsFormatterOptions {
-            width: Width::Long,
-            ..Default::default()
-        },
-    )
-    .unwrap();
-    let value = "12345.67".parse().unwrap();
-    let formatted_unit = fmt.format_fixed_decimal(&value, meter);
-    assert_writeable_eq!(formatted_unit, "١٢٬٣٤٥٫٦٧ متر");
+    for (locale, unit, options, expected) in test_cases {
+        let fmt = UnitsFormatter::try_new(&locale, unit, options).unwrap();
+        let value = "12345.67".parse().unwrap();
+        let formatted_unit = fmt.format_fixed_decimal(&value, unit);
+        assert_writeable_eq!(formatted_unit, expected);
+    }
 }

--- a/components/experimental/src/dimension/units/format.rs
+++ b/components/experimental/src/dimension/units/format.rs
@@ -67,12 +67,14 @@ fn test_basic() {
         (
             locale!("en-US").into(),
             "meter",
+            "12345.67",
             UnitsFormatterOptions::default(),
             "12,345.67 m",
         ),
         (
             locale!("en-US").into(),
             "century",
+            "12345.67",
             UnitsFormatterOptions {
                 width: Width::Long,
                 ..Default::default()
@@ -82,12 +84,14 @@ fn test_basic() {
         (
             locale!("de-DE").into(),
             "meter",
+            "12345.67",
             UnitsFormatterOptions::default(),
             "12.345,67 m",
         ),
         (
             locale!("ar-EG").into(),
             "meter",
+            "12345.67",
             UnitsFormatterOptions {
                 width: Width::Long,
                 ..Default::default()
@@ -96,9 +100,9 @@ fn test_basic() {
         ),
     ];
 
-    for (locale, unit, options, expected) in test_cases {
+    for (locale, unit, value, options, expected) in test_cases {
         let fmt = UnitsFormatter::try_new(&locale, unit, options).unwrap();
-        let value = "12345.67".parse().unwrap();
+        let value = value.parse().unwrap();
         assert_writeable_eq!(fmt.format_fixed_decimal(&value, unit), expected);
     }
 }

--- a/components/experimental/src/dimension/units/format.rs
+++ b/components/experimental/src/dimension/units/format.rs
@@ -11,7 +11,7 @@ use fixed_decimal::FixedDecimal;
 use icu_decimal::FixedDecimalFormatter;
 use icu_pattern::SinglePlaceholderPattern;
 use icu_plurals::PluralRules;
-use writeable::Writeable;
+use writeable::{impl_display_with_writeable, Writeable};
 
 use crate::alloc::borrow::ToOwned;
 use crate::dimension::provider::units::{Count, UnitsDisplayNameV1};
@@ -53,11 +53,7 @@ impl<'l> Writeable for FormattedUnit<'l> {
     }
 }
 
-impl core::fmt::Display for FormattedUnit<'_> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.write_to(f)
-    }
-}
+impl_display_with_writeable!(FormattedUnit<'_>);
 
 #[test]
 fn test_basic() {

--- a/components/experimental/src/dimension/units/format.rs
+++ b/components/experimental/src/dimension/units/format.rs
@@ -61,7 +61,7 @@ fn test_basic() {
     use writeable::assert_writeable_eq;
 
     use crate::dimension::units::formatter::UnitsFormatter;
-    use crate::dimension::units::options::{UnitsFormatterOptions,Width};
+    use crate::dimension::units::options::{UnitsFormatterOptions, Width};
 
     let test_cases = [
         (
@@ -99,7 +99,6 @@ fn test_basic() {
     for (locale, unit, options, expected) in test_cases {
         let fmt = UnitsFormatter::try_new(&locale, unit, options).unwrap();
         let value = "12345.67".parse().unwrap();
-        let formatted_unit = fmt.format_fixed_decimal(&value, unit);
-        assert_writeable_eq!(formatted_unit, expected);
+        assert_writeable_eq!(fmt.format_fixed_decimal(&value, unit), expected);
     }
 }

--- a/components/experimental/src/dimension/units/format.rs
+++ b/components/experimental/src/dimension/units/format.rs
@@ -55,7 +55,7 @@ impl<'l> Writeable for FormattedUnit<'l> {
 
 impl core::fmt::Display for FormattedUnit<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.write_to(f).map_err(|_| core::fmt::Error)
+        self.write_to(f)
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->