### PR TITLE
Update units formatter to fallback to `Count::Other` pattern if the pattern is not found.

### DIFF
--- a/components/experimental/src/dimension/units/format.rs
+++ b/components/experimental/src/dimension/units/format.rs
@@ -43,7 +43,13 @@ impl<'l> Writeable for FormattedUnit<'l> {
             // As per Unicode TR 35:
             //      https://www.unicode.org/reports/tr35/tr35-55/tr35.html#Multiple_Inheritance
             // If the pattern is not found for the associated `Count`, fall back to the `Count::Other` pattern.
-            .or_else(|| self.display_name.patterns.get(&Count::Other))
+            .or_else(|| {
+                if count != Count::Other {
+                    self.display_name.patterns.get(&Count::Other)
+                } else {
+                    None
+                }
+            })
             .unwrap_or_else(|| unit_pattern.insert("{0} ".to_owned() + self.unit));
 
         // TODO: once the patterns are implemented to be used in the data side, we do not need this.

--- a/components/experimental/src/dimension/units/format.rs
+++ b/components/experimental/src/dimension/units/format.rs
@@ -39,6 +39,11 @@ impl<'l> Writeable for FormattedUnit<'l> {
             .display_name
             .patterns
             .get(&count)
+            // TODO(younies): Try to find a test case for testing the following case.
+            // As per Unicode TR 35:
+            //      https://www.unicode.org/reports/tr35/tr35-55/tr35.html#Multiple_Inheritance
+            // If the pattern is not found for the associated `Count`, fall back to the `Count::Other` pattern.
+            .or_else(|| self.display_name.patterns.get(&Count::Other))
             .unwrap_or_else(|| unit_pattern.insert("{0} ".to_owned() + self.unit));
 
         // TODO: once the patterns are implemented to be used in the data side, we do not need this.
@@ -64,6 +69,16 @@ fn test_basic() {
     use crate::dimension::units::options::{UnitsFormatterOptions, Width};
 
     let test_cases = [
+        (
+            locale!("en-US"),
+            "meter",
+            "1",
+            UnitsFormatterOptions {
+                width: Width::Long,
+                ..Default::default()
+            },
+            "1 meter",
+        ),
         (
             locale!("en-US"),
             "meter",


### PR DESCRIPTION

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->