### PR TITLE
Add NeoOptions with trait integration

### DIFF
--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -158,19 +158,6 @@ pub struct NeoOptions<R: DateTimeMarkers> {
     pub length: R::LengthOption,
 }
 
-impl<R> Default for NeoOptions<R>
-where
-    R: DateTimeMarkers,
-    R::LengthOption: Default,
-{
-    #[inline]
-    fn default() -> NeoOptions<R> {
-        NeoOptions {
-            length: Default::default(),
-        }
-    }
-}
-
 impl<R> From<NeoSkeletonLength> for NeoOptions<R>
 where
     R: DateTimeMarkers,

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -147,6 +147,43 @@ macro_rules! gen_any_buffer_constructors_with_external_loader {
     };
 }
 
+/// Options bag for datetime formatting.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct NeoOptions<R: DateTimeMarkers> {
+    /// The desired length of the formatted string,
+    /// if required for the chosen field set.
+    ///
+    /// See [`NeoSkeletonLength`].
+    pub length: R::LengthOption,
+}
+
+impl<R> Default for NeoOptions<R>
+where
+    R: DateTimeMarkers,
+    R::LengthOption: Default,
+{
+    #[inline]
+    fn default() -> NeoOptions<R> {
+        NeoOptions {
+            length: Default::default(),
+        }
+    }
+}
+
+impl<R> From<NeoSkeletonLength> for NeoOptions<R>
+where
+    R: DateTimeMarkers,
+    R::LengthOption: From<NeoSkeletonLength>,
+{
+    #[inline]
+    fn from(value: NeoSkeletonLength) -> Self {
+        NeoOptions {
+            length: value.into(),
+        }
+    }
+}
+
 size_test!(TypedNeoFormatter<icu_calendar::Gregorian, crate::neo_marker::NeoYearMonthDayMarker>, typed_neo_year_month_day_formatter_size, 504);
 
 /// [`TypedNeoFormatter`] is a formatter capable of formatting dates and/or times from
@@ -208,7 +245,7 @@ where
     /// );
     /// ```
     #[cfg(feature = "compiled_data")]
-    pub fn try_new(locale: &DataLocale, length: NeoSkeletonLength) -> Result<Self, LoadError>
+    pub fn try_new(locale: &DataLocale, options: NeoOptions<R>) -> Result<Self, LoadError>
     where
         crate::provider::Baked: Sized
             // Date formatting markers
@@ -231,7 +268,7 @@ where
             &ExternalLoaderCompiledData,
             locale,
             R::COMPONENTS,
-            length,
+            options,
         )
     }
 
@@ -241,14 +278,14 @@ where
         try_new_with_any_provider,
         try_new_with_buffer_provider,
         try_new_internal,
-        length: NeoSkeletonLength
+        options: NeoOptions<R>
     );
 
     #[doc = icu_provider::gen_any_buffer_unstable_docs!(UNSTABLE, Self::try_new)]
     pub fn try_new_unstable<P>(
         provider: &P,
         locale: &DataLocale,
-        length: NeoSkeletonLength,
+        options: NeoOptions<R>,
     ) -> Result<Self, LoadError>
     where
         P: ?Sized
@@ -276,7 +313,7 @@ where
             &ExternalLoaderUnstable(provider),
             locale,
             R::COMPONENTS,
-            length,
+            options,
         )
     }
 }
@@ -374,7 +411,7 @@ where
     pub fn try_new_with_components(
         locale: &DataLocale,
         components: R,
-        length: NeoSkeletonLength,
+        options: NeoOptions<R>,
     ) -> Result<Self, LoadError>
     where
         crate::provider::Baked: Sized
@@ -398,7 +435,7 @@ where
             &ExternalLoaderCompiledData,
             locale,
             components.into(),
-            length,
+            options,
         )
     }
 
@@ -408,7 +445,7 @@ where
         try_new_with_components_with_buffer_provider,
         try_new_internal,
         components: R,
-        length: NeoSkeletonLength
+        options: NeoOptions<R>
     );
 
     #[doc = icu_provider::gen_any_buffer_unstable_docs!(UNSTABLE, Self::try_new)]
@@ -416,7 +453,7 @@ where
         provider: &P,
         locale: &DataLocale,
         components: R,
-        length: NeoSkeletonLength,
+        options: NeoOptions<R>,
     ) -> Result<Self, LoadError>
     where
         P: ?Sized
@@ -444,7 +481,7 @@ where
             &ExternalLoaderUnstable(provider),
             locale,
             components.into(),
-            length,
+            options,
         )
     }
 }
@@ -460,7 +497,7 @@ where
         loader: &L,
         locale: &DataLocale,
         components: NeoComponents,
-        length: NeoSkeletonLength,
+        options: NeoOptions<R>,
     ) -> Result<Self, LoadError>
     where
         P: ?Sized
@@ -485,7 +522,7 @@ where
             &<R::T as TimeMarkers>::TimeSkeletonPatternsV1Marker::bind(provider),
             &R::GluePatternV1Marker::bind(provider),
             locale,
-            length.into(),
+            options.length.into(),
             components,
         )
         .map_err(LoadError::Data)?;
@@ -657,7 +694,7 @@ where
     /// [`AnyCalendarKind`]: icu_calendar::AnyCalendarKind
     #[inline(never)]
     #[cfg(feature = "compiled_data")]
-    pub fn try_new(locale: &DataLocale, length: NeoSkeletonLength) -> Result<Self, LoadError>
+    pub fn try_new(locale: &DataLocale, options: NeoOptions<R>) -> Result<Self, LoadError>
     where
         crate::provider::Baked: Sized
     // Date formatting markers
@@ -728,7 +765,7 @@ where
             &ExternalLoaderCompiledData,
             locale,
             R::COMPONENTS,
-            length,
+            options,
         )
     }
 
@@ -738,14 +775,14 @@ where
         try_new_with_any_provider,
         try_new_with_buffer_provider,
         try_new_internal,
-        length: NeoSkeletonLength
+        options: NeoOptions<R>
     );
 
     #[doc = icu_provider::gen_any_buffer_unstable_docs!(UNSTABLE, Self::try_new)]
     pub fn try_new_unstable<P>(
         provider: &P,
         locale: &DataLocale,
-        length: NeoSkeletonLength,
+        options: NeoOptions<R>,
     ) -> Result<Self, LoadError>
     where
         P: ?Sized
@@ -828,7 +865,7 @@ where
             &ExternalLoaderUnstable(provider),
             locale,
             R::COMPONENTS,
-            length,
+            options,
         )
     }
 }
@@ -922,7 +959,7 @@ where
     /// );
     /// ```
     #[cfg(feature = "compiled_data")]
-    pub fn try_new_with_components(locale: &DataLocale, components: R, length: NeoSkeletonLength) -> Result<Self, LoadError>
+    pub fn try_new_with_components(locale: &DataLocale, components: R, options: NeoOptions<R>) -> Result<Self, LoadError>
     where
     crate::provider::Baked: Sized
     // Date formatting markers
@@ -993,7 +1030,7 @@ where
             &ExternalLoaderCompiledData,
             locale,
             components.into(),
-            length,
+            options,
         )
     }
 
@@ -1003,7 +1040,7 @@ where
         try_new_with_components_with_buffer_provider,
         try_new_internal,
         components: R,
-        length: NeoSkeletonLength
+        options: NeoOptions<R>
     );
 
     #[doc = icu_provider::gen_any_buffer_unstable_docs!(UNSTABLE, Self::try_new)]
@@ -1011,7 +1048,7 @@ where
         provider: &P,
         locale: &DataLocale,
         components: R,
-        length: NeoSkeletonLength,
+        options: NeoOptions<R>,
     ) -> Result<Self, LoadError>
     where
         P: ?Sized
@@ -1094,7 +1131,7 @@ where
             &ExternalLoaderUnstable(provider),
             locale,
             components.into(),
-            length,
+            options,
         )
     }
 }
@@ -1110,7 +1147,7 @@ where
         loader: &L,
         locale: &DataLocale,
         components: NeoComponents,
-        length: NeoSkeletonLength,
+        options: NeoOptions<R>,
     ) -> Result<Self, LoadError>
     where
         P: ?Sized
@@ -1185,7 +1222,7 @@ where
             &<R::T as TimeMarkers>::TimeSkeletonPatternsV1Marker::bind(provider),
             &R::GluePatternV1Marker::bind(provider),
             locale,
-            length.into(),
+            options.length.into(),
             components,
         )
         .map_err(LoadError::Data)?;

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -485,7 +485,7 @@ where
             &<R::T as TimeMarkers>::TimeSkeletonPatternsV1Marker::bind(provider),
             &R::GluePatternV1Marker::bind(provider),
             locale,
-            length,
+            length.into(),
             components,
         )
         .map_err(LoadError::Data)?;
@@ -1185,7 +1185,7 @@ where
             &<R::T as TimeMarkers>::TimeSkeletonPatternsV1Marker::bind(provider),
             &R::GluePatternV1Marker::bind(provider),
             locale,
-            length,
+            length.into(),
             components,
         )
         .map_err(LoadError::Data)?;

--- a/components/datetime/src/neo_skeleton.rs
+++ b/components/datetime/src/neo_skeleton.rs
@@ -815,7 +815,10 @@ pub struct NeoTimeZoneSkeleton {
 #[cfg(feature = "experimental")]
 impl NeoTimeZoneSkeleton {
     pub(crate) fn resolve(self, length: MaybeLength) -> ResolvedNeoTimeZoneSkeleton {
-        crate::tz_registry::skeleton_to_resolved(self.style, self.length.unwrap_or_else(|| length.get::<Self>()))
+        crate::tz_registry::skeleton_to_resolved(
+            self.style,
+            self.length.unwrap_or_else(|| length.get::<Self>()),
+        )
     }
 }
 

--- a/components/datetime/src/neo_skeleton.rs
+++ b/components/datetime/src/neo_skeleton.rs
@@ -6,6 +6,7 @@
 
 use crate::options::components;
 use crate::options::length;
+use crate::raw::neo::MaybeLength;
 #[cfg(feature = "experimental")]
 use crate::time_zone::ResolvedNeoTimeZoneSkeleton;
 use crate::DateTimeFormatterOptions;
@@ -813,8 +814,8 @@ pub struct NeoTimeZoneSkeleton {
 
 #[cfg(feature = "experimental")]
 impl NeoTimeZoneSkeleton {
-    pub(crate) fn resolve(self, length: NeoSkeletonLength) -> ResolvedNeoTimeZoneSkeleton {
-        crate::tz_registry::skeleton_to_resolved(self.style, self.length.unwrap_or(length))
+    pub(crate) fn resolve(self, length: MaybeLength) -> ResolvedNeoTimeZoneSkeleton {
+        crate::tz_registry::skeleton_to_resolved(self.style, self.length.unwrap_or_else(|| length.get::<Self>()))
     }
 }
 

--- a/components/datetime/src/tz_registry.rs
+++ b/components/datetime/src/tz_registry.rs
@@ -20,10 +20,7 @@ macro_rules! time_zone_style_registry {
                 (gmt_long, Offset, Long, GmtLong, UpperO, Wide), // 'OOOO'
                 (generic_short, NonLocation, Short, GenericShort, LowerV, One), // 'v'
                 (generic_long, NonLocation, Long, GenericLong, LowerV, Wide), // 'vvvv'
-            ],
-            // Styles with None-length, functions, and matchers
-            [
-                (location, Location, Location, UpperV, Wide), // 'VVVV'
+                (location, Location, Long, Location, UpperV, Wide), // 'VVVV'
             ],
             // Styles with function only for None-length
             [
@@ -38,7 +35,6 @@ macro_rules! time_zone_style_registry {
                 (NonLocation, Medium, GenericShort),
                 (Location, Short, Location),
                 (Location, Medium, Location),
-                (Location, Long, Location),
                 // See comments above about Default behavior
                 (Default, Short, SpecificShort),
                 (Default, Medium, SpecificShort),
@@ -67,7 +63,6 @@ macro_rules! time_zone_style_registry {
 macro_rules! make_constructors {
     (
         [$(($fn:ident, $style:ident, $length:ident, $resolved:ident, $field_symbol:ident, $field_length:ident)),+,],
-        [$(($fn0:ident, $style0:ident, $resolved0:ident, $field_symbol0:ident, $field_length0:ident)),+,],
         [$(($fn1:ident, $style1:ident)),+,],
         [$(($style2:ident, $length2:ident, $resolved2:ident)),+,],
         [$(($resolved3:ident, $field_symbol3:ident, $field_length3:ident)),+,],
@@ -79,16 +74,6 @@ macro_rules! make_constructors {
                     Self {
                         length: Some(NeoSkeletonLength::$length),
                         style: NeoTimeZoneStyle::$style,
-                    }
-                }
-            }
-        )+
-        $(
-            impl NeoTimeZoneSkeleton {
-                pub(crate) const fn $fn0() -> Self {
-                    Self {
-                        length: None,
-                        style: NeoTimeZoneStyle::$style0,
                     }
                 }
             }
@@ -113,7 +98,6 @@ time_zone_style_registry!(make_constructors);
 macro_rules! make_resolved_to_field_match {
     (
         [$(($fn:ident, $style:ident, $length:ident, $resolved:ident, $field_symbol:ident, $field_length:ident)),+,],
-        [$(($fn0:ident, $style0:ident, $resolved0:ident, $field_symbol0:ident, $field_length0:ident)),+,],
         [$(($fn1:ident, $resolved1:ident)),+,],
         [$(($style2:ident, $length2:ident, $resolved2:ident)),+,],
         [$(($resolved3:ident, $field_symbol3:ident, $field_length3:ident)),+,],
@@ -125,12 +109,6 @@ macro_rules! make_resolved_to_field_match {
                     ResolvedNeoTimeZoneSkeleton::$resolved => Field {
                         symbol: FieldSymbol::TimeZone(fields::TimeZone::$field_symbol),
                         length: FieldLength::$field_length,
-                    },
-                )+
-                $(
-                    ResolvedNeoTimeZoneSkeleton::$resolved0 => Field {
-                        symbol: FieldSymbol::TimeZone(fields::TimeZone::$field_symbol0),
-                        length: FieldLength::$field_length0,
                     },
                 )+
                 $(
@@ -151,7 +129,6 @@ time_zone_style_registry!(make_resolved_to_field_match);
 macro_rules! make_skeleton_to_resolved_match {
     (
         [$(($fn:ident, $style:ident, $length:ident, $resolved:ident, $field_symbol:ident, $field_length:ident)),+,],
-        [$(($fn0:ident, $style0:ident, $resolved0:ident, $field_symbol0:ident, $field_length0:ident)),+,],
         [$(($fn1:ident, $resolved1:ident)),+,],
         [$(($style2:ident, $length2:ident, $resolved2:ident)),+,],
         [$(($resolved3:ident, $field_symbol3:ident, $field_length3:ident)),+,],
@@ -176,7 +153,6 @@ time_zone_style_registry!(make_skeleton_to_resolved_match);
 macro_rules! make_field_to_skeleton_match {
     (
         [$(($fn:ident, $style:ident, $length:ident, $resolved:ident, $field_symbol:ident, $field_length:ident)),+,],
-        [$(($fn0:ident, $style0:ident, $resolved0:ident, $field_symbol0:ident, $field_length0:ident)),+,],
         [$(($fn1:ident, $resolved1:ident)),+,],
         [$(($style2:ident, $length2:ident, $resolved2:ident)),+,],
         [$(($resolved3:ident, $field_symbol3:ident, $field_length3:ident)),+,],
@@ -186,9 +162,6 @@ macro_rules! make_field_to_skeleton_match {
             match (field_symbol, field_length) {
                 $(
                     (fields::TimeZone::$field_symbol, FieldLength::$field_length) => Some(ResolvedNeoTimeZoneSkeleton::$resolved),
-                )+
-                $(
-                    (fields::TimeZone::$field_symbol0, FieldLength::$field_length0) => Some(ResolvedNeoTimeZoneSkeleton::$resolved0),
                 )+
                 $(
                     (fields::TimeZone::$field_symbol3, FieldLength::$field_length3) => Some(ResolvedNeoTimeZoneSkeleton::$resolved3),


### PR DESCRIPTION
Most of the call sites remain the same, but the time zone markers that don't need a length change from

```rust
let fmt = NeoFormatter::<NeoTimeZoneGmtLongMarker>::try_new(
    &locale!("en").into(),
    NeoSkeletonLength::Medium,
)
.unwrap();
```

to

```rust
let fmt = NeoFormatter::<NeoTimeZoneGmtLongMarker>::try_new(
    &locale!("en").into(),
    (),
)
.unwrap();
```

which is more clear since the `NeoSkeletonLength` is ignored.

Replaces #5245 based on feedback from @robertbastian 