### PR TITLE
Migrate fixtures to neo datetime

### DIFF
--- a/components/datetime/benches/fixtures/mod.rs
+++ b/components/datetime/benches/fixtures/mod.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_datetime::options;
+use icu_datetime::{neo_skeleton::NeoSkeleton, options};
 use icu_datetime::options::DateTimeFormatterOptions;
 use serde::{Deserialize, Serialize};
 
@@ -25,12 +25,12 @@ pub struct TestInput {
 pub enum TestOptions {
     #[serde(rename = "length")]
     Length(options::length::Bag),
-    #[serde(rename = "components")]
+    #[serde(rename = "semanticSkeleton")]
     #[cfg(feature = "experimental")]
-    Components(options::components::Bag),
-    #[serde(rename = "components")]
+    SemanticSkeleton(NeoSkeleton),
+    #[serde(rename = "semanticSkeleton")]
     #[cfg(not(feature = "experimental"))]
-    Components(serde_json::Value),
+    SemanticSkeleton(serde_json::Value),
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
For posterity, here is the final head-to-head benchmark before I delete it for the old formatter:

```
datetime/datetime_components
                        time:   [486.25 µs 489.23 µs 493.44 µs]
Found 14 outliers among 100 measurements (14.00%)
  8 (8.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe

datetime/datetime_lengths
                        time:   [40.602 µs 40.683 µs 40.769 µs]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

datetime/neoneo/datetime_lengths
                        time:   [34.485 µs 34.574 µs 34.689 µs]
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high severe
```

I never added the components bag benchmarks to the neo formatter; I will migrate them directly to semantic skeleta.