### PR TITLE
Don't cancel in-progress GH pages job

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -566,7 +566,6 @@ jobs:
     runs-on: 'ubuntu-latest'
     concurrency:
       group: "pages"
-      cancel-in-progress: true
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       # GCP Boilerplate for jobs in main repository


### PR DESCRIPTION
It makes no sense to wait for the previous job to complete if there's a new job waiting, because the new job will just override the previous job's results, however cancelling the previous job shows as a CI failure for that commit.