### PR TITLE
refactor(LanguageIdentifier): Derive `PartialOrd` and `Ord` for `LanguageIdentifier`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
-## icu4x 1.5.x
+## icu4x Unreleased
 
+- Components
+  - General
+    - `PartialOrd` and `Ord` derived for `LanguageIdentifier`.
+
+## icu4x 1.5.x
 
 - `icu_calendar`
   - (1.5.1) Fix Japanese calendar Gregorian era year 0 (https://github.com/unicode-org/icu4x/issues/4968)

--- a/components/locale_core/src/langid.rs
+++ b/components/locale_core/src/langid.rs
@@ -62,7 +62,7 @@ use writeable::Writeable;
 /// ```
 ///
 /// [`Unicode BCP47 Language Identifier`]: https://unicode.org/reports/tr35/tr35.html#Unicode_language_identifier
-#[derive(Default, PartialEq, Eq, Clone, Hash)]
+#[derive(Default, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 #[allow(clippy::exhaustive_structs)] // This struct is stable (and invoked by a macro)
 pub struct LanguageIdentifier {
     /// Language subtag of the language identifier.


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

Add Derive [`PartialOrd`](https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html) and [`Ord`](https://doc.rust-lang.org/std/cmp/trait.Ord.html) on the [`LanguageIdentifier`](https://github.com/unicode-org/icu4x/blob/main/components/locale_core/src/langid.rs#L67) type. Based on previous [PRs](https://github.com/unicode-org/icu4x/pull/3468) it seems reasonably acceptable to add this implementation.

Happy to add this to other objects or make other changes if required. :)