### PR TITLE
Rust 1.80

### DIFF
--- a/provider/icu4x-datagen/src/main.rs
+++ b/provider/icu4x-datagen/src/main.rs
@@ -349,7 +349,7 @@ fn main() -> eyre::Result<()> {
             (Box::new(ReexportableBlobDataProvider(provider)), fallbacker)
         },
 
-        #[cfg(all(not(feature = "provider"), feature = "input_blob"))]
+        #[cfg(all(not(feature = "provider"), feature = "blob_input"))]
         () => eyre::bail!("--input-blob is required without the `provider` Cargo feature"),
 
         #[cfg(feature = "provider")]

--- a/provider/icu4x-datagen/src/main.rs
+++ b/provider/icu4x-datagen/src/main.rs
@@ -445,7 +445,7 @@ fn main() -> eyre::Result<()> {
             (Box::new(p), fallbacker)
         }
 
-        #[cfg(any(feature = "provider", not(feature = "blob_input")))]
+        #[cfg(not(any(feature = "provider", feature = "blob_input")))]
         () => eyre::bail!("Only the `HelloWorldV1 marker is supported without Cargo features `blob_input` or `provider`"),
     };
 

--- a/provider/icu4x-datagen/src/main.rs
+++ b/provider/icu4x-datagen/src/main.rs
@@ -445,7 +445,7 @@ fn main() -> eyre::Result<()> {
             (Box::new(p), fallbacker)
         }
 
-        #[cfg(not(feature = "provider"))]
+        #[cfg(any(feature = "provider", not(feature = "blob_input")))]
         () => eyre::bail!("Only the `HelloWorldV1 marker is supported without Cargo features `blob_input` or `provider`"),
     };
 

--- a/provider/source/src/lib.rs
+++ b/provider/source/src/lib.rs
@@ -342,12 +342,14 @@ fn test_check_req() {
     use icu::locale::langid;
     use icu_provider::hello_world::*;
 
+    #[allow(non_local_definitions)] // test-scoped, only place that uses it
     impl DataProvider<HelloWorldV1Marker> for SourceDataProvider {
         fn load(&self, req: DataRequest) -> Result<DataResponse<HelloWorldV1Marker>, DataError> {
             HelloWorldProvider.load(req)
         }
     }
 
+    #[allow(non_local_definitions)] // test-scoped, only place that uses it
     impl crate::IterableDataProviderCached<HelloWorldV1Marker> for SourceDataProvider {
         fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
             Ok(HelloWorldProvider.iter_ids()?.into_iter().collect())

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,5 +3,5 @@
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 [toolchain]
-# Version updated on 2024-05-07
-channel = "1.78"
+# Version updated on 2024-07-25
+channel = "1.80"

--- a/utils/preferences/src/preferences.rs
+++ b/utils/preferences/src/preferences.rs
@@ -88,12 +88,13 @@ macro_rules! preferences {
             }
         }
 
+        #[allow(non_local_definitions)] // Locale is in a different crate
         impl From<$name> for icu_locale_core::Locale {
             fn from(input: $name) -> icu_locale_core::Locale {
-                let id = input.lid.clone().unwrap_or_default();
+                let id = input.lid.unwrap_or_default();
                 let mut extensions = icu_locale_core::extensions::Extensions::new();
                 $(
-                    if let Some(value) = &input.$key {
+                    if let Some(value) = input.$key {
                         if let Some(ue) = <$pref>::unicode_extension_key() {
                             let val = value.unicode_extension_value().unwrap();
                             extensions.unicode.keywords.set(ue, val);
@@ -107,6 +108,7 @@ macro_rules! preferences {
             }
         }
 
+        #[allow(non_local_definitions)] // Locale is in a different crate
         impl From<&$resolved_name> for icu_locale_core::Locale {
             fn from(_input: &$resolved_name) -> icu_locale_core::Locale {
                 todo!()


### PR DESCRIPTION
No more `unused manifest key: lints.rust.unexpected_cfgs.check-cfg` warnings!