### PR TITLE
Simplify locale parser

### DIFF
--- a/components/locale_core/src/parser/mod.rs
+++ b/components/locale_core/src/parser/mod.rs
@@ -17,40 +17,19 @@ pub use locale::{
     parse_locale, parse_locale_with_single_variant_single_keyword_unicode_keyword_extension,
 };
 
-#[inline]
-const fn is_separator(slice: &[u8], idx: usize) -> bool {
-    #[allow(clippy::indexing_slicing)]
-    let b = slice[idx];
-    b == b'-' || b == b'_'
-}
+const fn skip_before_separator(slice: &[u8]) -> &[u8] {
+    let mut end = 0;
 
-const fn get_current_subtag(slice: &[u8], idx: usize) -> (usize, usize) {
-    debug_assert!(idx < slice.len());
-
-    // This function is called only on the idx == 0 or on a separator.
-    let (start, mut end) = if is_separator(slice, idx) {
-        // If it's a separator, set the start to idx+1 and advance the idx to the next char.
-        (idx + 1, idx + 1)
-    } else {
-        // If it's idx=0, end is set to 1
-        debug_assert!(idx == 0);
-        (0, 1)
-    };
-
-    while end < slice.len() && !is_separator(slice, end) {
+    #[allow(clippy::indexing_slicing)] // very protected, should optimize out
+    while end < slice.len() && !matches!(slice[end], b'-' | b'_') {
         // Advance until we reach end of slice or a separator.
         end += 1;
     }
-    // Notice: this slice may be empty (start == end) for cases like `"en-"` or `"en--US"`
-    (start, end)
-}
 
-pub const fn split_out_range(slice: &[u8], start: usize, end: usize) -> &[u8] {
-    assert!(start <= slice.len());
-    assert!(end <= slice.len());
-    assert!(start <= end);
-    // SAFETY: assertions and align = size = 1.
-    unsafe { core::slice::from_raw_parts(slice.as_ptr().add(start), end - start) }
+    // Notice: this slice may be empty for cases like `"en-"` or `"en--US"`
+    // MSRV 1.71/1.79: Use split_at/split_at_unchecked
+    // SAFETY: end < slice.len() by while loop
+    unsafe { core::slice::from_raw_parts(slice.as_ptr(), end) }
 }
 
 // `SubtagIterator` is a helper iterator for [`LanguageIdentifier`] and [`Locale`] parsing.
@@ -67,46 +46,43 @@ pub const fn split_out_range(slice: &[u8], start: usize, end: usize) -> &[u8] {
 // All methods return an `Option` of a `Result`.
 #[derive(Copy, Clone, Debug)]
 pub struct SubtagIterator<'a> {
-    pub slice: &'a [u8],
-    done: bool,
-    // done + subtag is faster than Option<(usize, usize)>
-    // at the time of writing.
-    subtag: (usize, usize),
+    remaining: &'a [u8],
+    // current is a prefix of remaning
+    current: Option<&'a [u8]>,
 }
 
 impl<'a> SubtagIterator<'a> {
-    pub const fn new(slice: &'a [u8]) -> Self {
-        let subtag = if slice.is_empty() || is_separator(slice, 0) {
-            // This returns (0, 0) which returns Some(b"") for slices like `"-en"` or `"-"`
-            (0, 0)
-        } else {
-            get_current_subtag(slice, 0)
-        };
+    pub const fn new(rest: &'a [u8]) -> Self {
         Self {
-            slice,
-            done: false,
-            subtag,
+            remaining: rest,
+            current: Some(skip_before_separator(rest)),
         }
     }
 
     pub const fn next_const(mut self) -> (Self, Option<&'a [u8]>) {
-        if self.done {
+        let Some(result) = self.current else {
             return (self, None);
-        }
-        let result = self.subtag;
-        if result.1 < self.slice.len() {
-            self.subtag = get_current_subtag(self.slice, result.1);
+        };
+
+        self.current = if result.len() < self.remaining.len() {
+            // If there is more after `result`, by construction `current` starts with a separator
+            // MSRV 1.79: Use split_at_unchecked
+            // SAFETY: `self.remaining` is strictly longer than `result`
+            self.remaining = unsafe {
+                core::slice::from_raw_parts(
+                    self.remaining.as_ptr().add(result.len() + 1),
+                    self.remaining.len() - (result.len() + 1),
+                )
+            };
+            Some(skip_before_separator(self.remaining))
         } else {
-            self.done = true;
-        }
-        (self, Some(split_out_range(self.slice, result.0, result.1)))
+            None
+        };
+        (self, Some(result))
     }
 
     pub const fn peek(&self) -> Option<&'a [u8]> {
-        if self.done {
-            return None;
-        }
-        Some(split_out_range(self.slice, self.subtag.0, self.subtag.1))
+        self.current
     }
 }
 
@@ -189,45 +165,26 @@ mod test {
     }
 
     #[test]
-    fn get_current_subtag_test() {
-        let slice = "-";
-        let current = get_current_subtag(slice.as_bytes(), 0);
-        assert_eq!(current, (1, 1));
+    fn skip_before_separator_test() {
+        let current = skip_before_separator(b"");
+        assert_eq!(current, b"");
 
-        let slice = "-en";
-        let current = get_current_subtag(slice.as_bytes(), 0);
-        assert_eq!(current, (1, 3));
+        let current = skip_before_separator(b"en");
+        assert_eq!(current, b"en");
 
-        let slice = "-en-";
-        let current = get_current_subtag(slice.as_bytes(), 3);
-        assert_eq!(current, (4, 4));
+        let current = skip_before_separator(b"en-");
+        assert_eq!(current, b"en");
 
-        let slice = "en-";
-        let current = get_current_subtag(slice.as_bytes(), 0);
-        assert_eq!(current, (0, 2));
+        let current = skip_before_separator(b"en--US");
+        assert_eq!(current, b"en");
 
-        let current = get_current_subtag(slice.as_bytes(), 2);
-        assert_eq!(current, (3, 3));
+        let current = skip_before_separator(b"-US");
+        assert_eq!(current, b"");
 
-        let slice = "en--US";
-        let current = get_current_subtag(slice.as_bytes(), 0);
-        assert_eq!(current, (0, 2));
+        let current = skip_before_separator(b"US");
+        assert_eq!(current, b"US");
 
-        let current = get_current_subtag(slice.as_bytes(), 2);
-        assert_eq!(current, (3, 3));
-
-        let current = get_current_subtag(slice.as_bytes(), 3);
-        assert_eq!(current, (4, 6));
-
-        let slice = "--";
-        let current = get_current_subtag(slice.as_bytes(), 0);
-        assert_eq!(current, (1, 1));
-
-        let current = get_current_subtag(slice.as_bytes(), 1);
-        assert_eq!(current, (2, 2));
-
-        let slice = "-";
-        let current = get_current_subtag(slice.as_bytes(), 0);
-        assert_eq!(current, (1, 1));
+        let current = skip_before_separator(b"-");
+        assert_eq!(current, b"");
     }
 }


### PR DESCRIPTION
This keeps track of slices instead of indices during parsing, and also simplifies the parser, which removes some checks that were done redundantly before, which should improve performance.

Benchmarks for baseline aff4632b296d59c9b1ecaa7f747424708153049d:

```
bench_langid_constr
  Instructions:                2411 (-21.23489%)
  L1 Accesses:                 3020 (-25.28451%)
  L2 Accesses:                    0 (-100.0000%)
  RAM Accesses:                  44 (-8.333333%)
  Estimated Cycles:            4560 (-20.23789%)

bench_langid_compare_components
  Instructions:                  17 (No change)
  L1 Accesses:                   20 (No change)
  L2 Accesses:                    2 (+100.0000%)
  RAM Accesses:                   0 (-100.0000%)
  Estimated Cycles:              30 (-50.00000%)

bench_langid_compare_components_str
  Instructions:                  17 (No change)
  L1 Accesses:                   21 (+5.000000%)
  L2 Accesses:                    1 (No change)
  RAM Accesses:                   0 (-100.0000%)
  Estimated Cycles:              26 (-56.66667%)

bench_langid_strict_cmp
  Instructions:                 993 (No change)
  L1 Accesses:                 1229 (+0.162999%)
  L2 Accesses:                    2 (-33.33333%)
  RAM Accesses:                  21 (-4.545455%)
  Estimated Cycles:            1974 (-1.888668%)

bench_langid_matching
  Instructions:                  17 (No change)
  L1 Accesses:                   21 (+10.52632%)
  L2 Accesses:                    1 (-50.00000%)
  RAM Accesses:                   0 (-100.0000%)
  Estimated Cycles:              26 (-59.37500%)

bench_langid_matching_str
  Instructions:                1437 (-21.85971%)
  L1 Accesses:                 1679 (-27.97083%)
  L2 Accesses:                    2 (No change)
  RAM Accesses:                  29 (-9.375000%)
  Estimated Cycles:            2704 (-21.87229%)

bench_langid_serialize
  Instructions:                4042 (No change)
  L1 Accesses:                 5609 (No change)
  L2 Accesses:                    1 (No change)
  RAM Accesses:                  37 (No change)
  Estimated Cycles:            6909 (No change)

bench_langid_serialize_writeable
  Instructions:                2657 (No change)
  L1 Accesses:                 3605 (+0.055509%)
  L2 Accesses:      18446744073709551615 (No change)
  RAM Accesses:                  36 (-5.263158%)
  Estimated Cycles:            4860 (-1.379870%)

bench_langid_canonicalize
  Instructions:                5502 (-10.56567%)
  L1 Accesses:                 7252 (-12.34135%)
  L2 Accesses:                    5 (No change)
  RAM Accesses:                  66 (-5.714286%)
  Estimated Cycles:            9587 (-10.80201%)

     Running benches/langid.rs (target/release/deps/langid-6ba4cda698d0abfb)
langid/overview         time:   [2.0350 µs 2.0362 µs 2.0375 µs]
                        change: [-18.305% -18.199% -18.092%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

langid/construct/langid time:   [590.86 ns 591.81 ns 593.34 ns]
                        change: [-30.688% -30.503% -30.278%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe

langid/to_string/langid time:   [700.48 ns 701.12 ns 701.86 ns]
                        change: [-1.9481% -1.2349% -0.5345%] (p = 0.00 < 0.05)
                        Change within noise threshold.
langid/to_string/langid/writeable
                        time:   [430.48 ns 435.05 ns 441.35 ns]
                        change: [+0.4302% +0.9214% +1.6058%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe

langid/compare/struct/langid
                        time:   [71.456 ns 71.539 ns 71.629 ns]
                        change: [+1.1689% +1.2701% +1.3901%] (p = 0.00 < 0.05)
                        Performance has regressed.
langid/compare/str/langid
                        time:   [566.91 ns 569.34 ns 572.55 ns]
                        change: [-44.835% -44.335% -43.964%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  8 (8.00%) high severe
langid/compare/strict_cmp/langid
                        time:   [258.75 ns 258.98 ns 259.25 ns]
                        change: [-1.5186% -1.4039% -1.2925%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

langid/canonicalize/langid
                        time:   [1.6018 µs 1.6040 µs 1.6065 µs]
                        change: [-14.053% -13.612% -13.242%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

     Running benches/locale.rs (target/release/deps/locale-221b53c74f3bda80)
locale/overview         time:   [2.7926 µs 2.7946 µs 2.7968 µs]
                        change: [-26.881% -26.001% -25.333%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  5 (5.00%) high mild
  11 (11.00%) high severe

locale/construct/locale time:   [1.2332 µs 1.2338 µs 1.2344 µs]
                        change: [-40.525% -40.478% -40.431%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe

locale/to_string/locale time:   [864.57 ns 865.34 ns 866.19 ns]
                        change: [+3.2832% +3.4256% +3.5673%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
locale/to_string/locale/writeable
                        time:   [600.90 ns 601.50 ns 602.19 ns]
                        change: [+3.7332% +3.9913% +4.3575%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

locale/compare/struct/locale
                        time:   [133.01 ns 133.09 ns 133.17 ns]
                        change: [+2.8226% +3.4399% +4.0397%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
locale/compare/str/locale
                        time:   [1.2465 µs 1.2480 µs 1.2497 µs]
                        change: [-35.046% -34.956% -34.867%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe
locale/compare/strict_cmp/locale
                        time:   [432.02 ns 432.64 ns 433.35 ns]
                        change: [+0.3448% +0.5318% +0.7458%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe

locale/canonicalize/locale
                        time:   [2.1397 µs 2.1421 µs 2.1448 µs]
                        change: [-29.123% -29.007% -28.897%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe

     Running benches/subtags.rs (target/release/deps/subtags-e201699efc1bec91)
subtags/language/parse  time:   [171.84 ns 171.97 ns 172.12 ns]
                        change: [-0.1141% -0.0249% +0.0704%] (p = 0.59 > 0.05)
                        No change in performance detected.

subtags/script/parse    time:   [53.062 ns 53.099 ns 53.138 ns]
                        change: [-6.0623% -5.9462% -5.8403%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

subtags/region/parse    time:   [138.64 ns 138.84 ns 139.03 ns]
                        change: [-0.2358% -0.0596% +0.1030%] (p = 0.49 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) low severe
  2 (2.00%) low mild
  3 (3.00%) high mild

subtags/variant/parse   time:   [119.43 ns 119.70 ns 120.04 ns]
                        change: [+0.0043% +0.3204% +0.5969%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
```