### PR TITLE
feat: currency formatter now uses the fixedDecimalFormatter

### DIFF
--- a/components/experimental/src/dimension/currency/formatter.rs
+++ b/components/experimental/src/dimension/currency/formatter.rs
@@ -30,8 +30,6 @@ pub struct CurrencyFormatter {
     /// Essential data for the currency formatter.
     essential: DataPayload<CurrencyEssentialsV1Marker>,
 
-    // TODO: Remove this allow once the `fixed_decimal_formatter` is used.
-    #[allow(dead_code)]
     /// A [`FixedDecimalFormatter`] to format the currency value.
     fixed_decimal_formatter: FixedDecimalFormatter,
 }
@@ -126,7 +124,7 @@ impl CurrencyFormatter {
     /// let formatted_currency = fmt.format_fixed_decimal(&value, currency_code);
     /// let mut sink = String::new();
     /// formatted_currency.write_to(&mut sink).unwrap();
-    /// assert_eq!(sink.as_str(), "$12345.67");
+    /// assert_eq!(sink.as_str(), "$12,345.67");
     /// ```
     pub fn format_fixed_decimal<'l>(
         &'l self,
@@ -138,6 +136,7 @@ impl CurrencyFormatter {
             currency_code,
             options: &self.options,
             essential: self.essential.get(),
+            fixed_decimal_formatter: &self.fixed_decimal_formatter,
         }
     }
 }


### PR DESCRIPTION
# What does this PR do?

Currency Formatter will now consume the FixedDecimalFormatter to correctly display Currency values.

I felt I could add this one quick since I learned what to do inside the Percent PR (#5255), and we needed it for Work!
I did notice there was an issue (#4740) that was filed, feel free to close this if you've already done the work. :)