### PR TITLE
Add Fractional Second Digits to neo datetime

### DIFF
--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -1116,6 +1116,7 @@ mod tests {
         let mut sink = String::new();
         try_write_pattern(
             pattern.as_borrowed(),
+            Default::default(),
             &ExtractedDateTimeInput::extract_from(&datetime),
             Some(date_data.payload.get()),
             Some(time_data.payload.get()),

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -26,6 +26,7 @@ use crate::time_zone::{
     TimeZoneFormatterUnit,
 };
 
+use super::FormattingOptions;
 use core::fmt::{self, Write};
 use core::iter::Peekable;
 use fixed_decimal::FixedDecimal;
@@ -39,7 +40,6 @@ use icu_plurals::PluralRules;
 use icu_provider::DataPayload;
 use icu_timezone::{CustomTimeZone, GmtOffset};
 use writeable::{Part, Writeable};
-use super::FormattingOptions;
 
 /// [`FormattedDateTime`] is a intermediate structure which can be retrieved as
 /// an output from [`TypedDateTimeFormatter`](crate::TypedDateTimeFormatter).
@@ -694,7 +694,8 @@ where
                                 try_write_number(w, fdf, usize::from(second).into(), l)?;
                             write_value_missing(w, next_field)?;
                             // Return the earlier error
-                            seconds_result.and(Err(DateTimeWriteError::MissingInputField("nanosecond")))
+                            seconds_result
+                                .and(Err(DateTimeWriteError::MissingInputField("nanosecond")))
                         }
                         Some(ns) => {
                             let mut s = FixedDecimal::from(usize::from(second));
@@ -713,7 +714,8 @@ where
                             let seconds_result =
                                 try_write_number(w, fdf, usize::from(second).into(), l)?;
                             // Return the earlier error
-                            seconds_result.and(Err(DateTimeWriteError::MissingInputField("nanosecond")))
+                            seconds_result
+                                .and(Err(DateTimeWriteError::MissingInputField("nanosecond")))
                         }
                         Some(ns) => {
                             let mut s = FixedDecimal::from(usize::from(second));
@@ -725,13 +727,13 @@ where
                             s.trunc(-(p as i16));
                             try_write_number(w, fdf, s, l)?
                         }
-                    }
+                    },
                     None => {
                         // Normal seconds formatting with no fractional second digits
                         try_write_number(w, fdf, usize::from(second).into(), l)?
                     }
-                }
-            }
+                },
+            },
         },
         (FieldSymbol::Second(Second::FractionalSecond), _) => {
             // Fractional second not following second

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -39,6 +39,7 @@ use icu_plurals::PluralRules;
 use icu_provider::DataPayload;
 use icu_timezone::{CustomTimeZone, GmtOffset};
 use writeable::{Part, Writeable};
+use super::FormattingOptions;
 
 /// [`FormattedDateTime`] is a intermediate structure which can be retrieved as
 /// an output from [`TypedDateTimeFormatter`](crate::TypedDateTimeFormatter).
@@ -133,6 +134,7 @@ impl<'l> Writeable for FormattedDateTime<'l> {
 
         r = r.and(try_write_pattern(
             pattern.as_borrowed(),
+            Default::default(),
             &self.datetime,
             self.date_symbols,
             self.time_symbols,
@@ -203,6 +205,7 @@ where
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn try_write_pattern<'data, W, DS, TS, ZS>(
     pattern: PatternBorrowed<'data>,
+    formatting_options: FormattingOptions,
     datetime: &ExtractedDateTimeInput,
     date_symbols: Option<&DS>,
     time_symbols: Option<&TS>,
@@ -220,6 +223,7 @@ where
     try_write_pattern_items(
         pattern.metadata,
         pattern.items.iter(),
+        formatting_options,
         datetime,
         date_symbols,
         time_symbols,
@@ -234,6 +238,7 @@ where
 pub(crate) fn try_write_pattern_items<'data, W, DS, TS, ZS>(
     pattern_metadata: PatternMetadata,
     pattern_items: impl Iterator<Item = PatternItem>,
+    formatting_options: FormattingOptions,
     datetime: &ExtractedDateTimeInput,
     date_symbols: Option<&DS>,
     time_symbols: Option<&TS>,
@@ -271,6 +276,7 @@ where
                     field,
                     &mut iter,
                     pattern_metadata,
+                    formatting_options,
                     datetime,
                     date_symbols,
                     time_symbols,
@@ -354,6 +360,7 @@ pub(crate) fn try_write_field<'data, W, DS, TS>(
     field: fields::Field,
     iter: &mut Peekable<impl Iterator<Item = PatternItem>>,
     pattern_metadata: PatternMetadata,
+    formatting_options: FormattingOptions,
     datetime: &ExtractedDateTimeInput,
     date_symbols: Option<&DS>,
     time_symbols: Option<&TS>,

--- a/components/datetime/src/format/mod.rs
+++ b/components/datetime/src/format/mod.rs
@@ -14,6 +14,6 @@ pub mod zoned_datetime;
 /// Internal non-pattern runtime options passed to the formatter
 #[derive(Debug, Copy, Clone, Default)]
 pub(crate) struct FormattingOptions {
-	#[cfg(feature = "experimental")]
-	pub(crate) fractional_second_digits: Option<FractionalSecondDigits>,
+    #[cfg(feature = "experimental")]
+    pub(crate) fractional_second_digits: Option<FractionalSecondDigits>,
 }

--- a/components/datetime/src/format/mod.rs
+++ b/components/datetime/src/format/mod.rs
@@ -2,8 +2,18 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+#[cfg(feature = "experimental")]
+use crate::neo_skeleton::FractionalSecondDigits;
+
 pub mod datetime;
 #[cfg(feature = "experimental")]
 pub mod neo;
 pub mod time_zone;
 pub mod zoned_datetime;
+
+/// Internal non-pattern runtime options passed to the formatter
+#[derive(Debug, Copy, Clone, Default)]
+pub(crate) struct FormattingOptions {
+	#[cfg(feature = "experimental")]
+	fractional_second_digits: Option<FractionalSecondDigits>,
+}

--- a/components/datetime/src/format/mod.rs
+++ b/components/datetime/src/format/mod.rs
@@ -16,4 +16,6 @@ pub mod zoned_datetime;
 pub(crate) struct FormattingOptions {
     #[cfg(feature = "experimental")]
     pub(crate) fractional_second_digits: Option<FractionalSecondDigits>,
+    #[cfg(not(feature = "experimental"))]
+    pub(crate) fractional_second_digits: Option<u8>,
 }

--- a/components/datetime/src/format/mod.rs
+++ b/components/datetime/src/format/mod.rs
@@ -15,5 +15,5 @@ pub mod zoned_datetime;
 #[derive(Debug, Copy, Clone, Default)]
 pub(crate) struct FormattingOptions {
 	#[cfg(feature = "experimental")]
-	fractional_second_digits: Option<FractionalSecondDigits>,
+	pub(crate) fractional_second_digits: Option<FractionalSecondDigits>,
 }

--- a/components/datetime/src/format/neo.rs
+++ b/components/datetime/src/format/neo.rs
@@ -2286,6 +2286,7 @@ impl<'a> TryWriteable for FormattedDateTimePattern<'a> {
     ) -> Result<Result<(), Self::Error>, fmt::Error> {
         try_write_pattern(
             self.pattern.0.as_borrowed(),
+            Default::default(),
             &self.datetime,
             Some(&self.names),
             Some(&self.names),

--- a/components/datetime/src/format/zoned_datetime.rs
+++ b/components/datetime/src/format/zoned_datetime.rs
@@ -90,6 +90,7 @@ where
                     field,
                     &mut iter,
                     pattern.metadata,
+                    Default::default(),
                     datetime,
                     date_symbols,
                     time_symbols,

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -162,6 +162,11 @@ pub struct NeoOptions<R: DateTimeMarkers> {
     ///
     /// See [`EraDisplay`](crate::neo_skeleton::EraDisplay).
     pub era_display: R::EraDisplayOption,
+    /// How many fractional seconds to display,
+    /// if seconds are included in the field set.
+    ///
+    /// See [`FractionalSecondDigits`](crate::neo_skeleton::FractionalSecondDigits).
+    pub fractional_second_digits: R::FractionalSecondDigitsOption,
 }
 
 impl<R> From<NeoSkeletonLength> for NeoOptions<R>
@@ -169,12 +174,14 @@ where
     R: DateTimeMarkers,
     R::LengthOption: From<NeoSkeletonLength>,
     R::EraDisplayOption: Default,
+    R::FractionalSecondDigitsOption: Default,
 {
     #[inline]
     fn from(value: NeoSkeletonLength) -> Self {
         NeoOptions {
             length: value.into(),
             era_display: Default::default(),
+            fractional_second_digits: Default::default(),
         }
     }
 }
@@ -186,12 +193,14 @@ where
     R: DateTimeMarkers,
     R::LengthOption: Default,
     R::EraDisplayOption: Default,
+    R::FractionalSecondDigitsOption: Default,
 {
     #[inline]
     fn default() -> Self {
         NeoOptions {
             length: Default::default(),
             era_display: Default::default(),
+            fractional_second_digits: Default::default(),
         }
     }
 }
@@ -541,6 +550,7 @@ where
             options.length.into(),
             components,
             options.era_display.into(),
+            options.fractional_second_digits.into(),
             hour_cycle,
         )
         .map_err(LoadError::Data)?;
@@ -1247,6 +1257,7 @@ where
             options.length.into(),
             components,
             options.era_display.into(),
+            options.fractional_second_digits.into(),
             hour_cycle,
         )
         .map_err(LoadError::Data)?;

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -1458,6 +1458,7 @@ impl<'a> TryWriteable for FormattedNeoDateTime<'a> {
         try_write_pattern_items(
             self.pattern.metadata(),
             self.pattern.iter_items(),
+            self.pattern.formatting_options(),
             &self.datetime,
             Some(&self.names),
             Some(&self.names),

--- a/components/datetime/src/neo_marker.rs
+++ b/components/datetime/src/neo_marker.rs
@@ -718,6 +718,13 @@ impl From<NeverField> for Option<EraDisplay> {
     }
 }
 
+impl From<NeverField> for Option<FractionalSecondDigits> {
+    #[inline]
+    fn from(_: NeverField) -> Self {
+        None
+    }
+}
+
 /// A trait associating [`NeoComponents`].
 pub trait HasConstComponents {
     /// The associated components.
@@ -848,6 +855,8 @@ pub trait DateTimeMarkers: private::Sealed + DateTimeNamesMarker {
     type LengthOption: Into<Option<NeoSkeletonLength>>;
     /// Type of the era display option in the constructor.
     type EraDisplayOption: Into<Option<EraDisplay>>;
+    /// Type of the fractional seconds display option in the constructor.
+    type FractionalSecondDigitsOption: Into<Option<FractionalSecondDigits>>;
     /// Marker for loading the date/time glue pattern.
     type GluePatternV1Marker: DataMarker<DataStruct = GluePatternV1<'static>>;
 }
@@ -986,6 +995,7 @@ where
     type Z = NeoNeverMarker;
     type LengthOption = NeoSkeletonLength; // always needed for date
     type EraDisplayOption = D::EraDisplayOption;
+    type FractionalSecondDigitsOption = NeverField;
     type GluePatternV1Marker = NeverMarker<GluePatternV1<'static>>;
 }
 
@@ -1021,6 +1031,7 @@ where
     type Z = NeoNeverMarker;
     type LengthOption = NeoSkeletonLength; // always needed for time
     type EraDisplayOption = NeverField; // no year in a time-only format
+    type FractionalSecondDigitsOption = T::FractionalSecondDigitsOption;
     type GluePatternV1Marker = NeverMarker<GluePatternV1<'static>>;
 }
 
@@ -1056,6 +1067,7 @@ where
     type Z = Z;
     type LengthOption = Z::LengthOption; // no date or time: inherit from zone
     type EraDisplayOption = NeverField; // no year in a zone-only format
+    type FractionalSecondDigitsOption = NeverField;
     type GluePatternV1Marker = GluePatternV1Marker;
 }
 
@@ -1094,6 +1106,7 @@ where
     type Z = NeoNeverMarker;
     type LengthOption = NeoSkeletonLength; // always needed for date/time
     type EraDisplayOption = D::EraDisplayOption;
+    type FractionalSecondDigitsOption = T::FractionalSecondDigitsOption;
     type GluePatternV1Marker = GluePatternV1Marker;
 }
 
@@ -1136,6 +1149,7 @@ where
     type Z = Z;
     type LengthOption = NeoSkeletonLength; // always needed for date/time
     type EraDisplayOption = D::EraDisplayOption;
+    type FractionalSecondDigitsOption = T::FractionalSecondDigitsOption;
     type GluePatternV1Marker = GluePatternV1Marker;
 }
 
@@ -1195,6 +1209,9 @@ macro_rules! datetime_marker_helper {
     };
     (@option/eradisplay, yes) => {
         Option<EraDisplay>
+    };
+    (@option/fractionalsecondigits, yes) => {
+        Option<FractionalSecondDigits>
     };
     (@option/$any:ident, no) => {
         NeverField
@@ -1430,6 +1447,7 @@ macro_rules! impl_date_marker {
             type Z = NeoNeverMarker;
             type LengthOption = datetime_marker_helper!(@option/length, yes);
             type EraDisplayOption = datetime_marker_helper!(@option/eradisplay, $year_yesno);
+            type FractionalSecondDigitsOption = datetime_marker_helper!(@option/fractionalsecondigits, no);
             type GluePatternV1Marker = datetime_marker_helper!(@glue, no);
         }
         impl HasConstComponents for $type {
@@ -1573,6 +1591,7 @@ macro_rules! impl_time_marker {
             type Z = NeoNeverMarker;
             type LengthOption = datetime_marker_helper!(@option/length, yes);
             type EraDisplayOption = datetime_marker_helper!(@option/eradisplay, no);
+            type FractionalSecondDigitsOption = datetime_marker_helper!(@option/fractionalsecondigits, $nanosecond_yesno);
             type GluePatternV1Marker = datetime_marker_helper!(@glue, no);
         }
         impl HasConstComponents for $type {
@@ -1698,6 +1717,7 @@ macro_rules! impl_zone_marker {
             type Z = Self;
             type LengthOption = datetime_marker_helper!(@option/length, $option_length_yesno);
             type EraDisplayOption = datetime_marker_helper!(@option/eradisplay, no);
+            type FractionalSecondDigitsOption = datetime_marker_helper!(@option/fractionalsecondigits, no);
             type GluePatternV1Marker = datetime_marker_helper!(@glue, no);
         }
         impl HasConstComponents for $type {
@@ -2208,6 +2228,7 @@ impl DateTimeMarkers for NeoDateComponents {
     type Z = NeoNeverMarker;
     type LengthOption = datetime_marker_helper!(@option/length, yes);
     type EraDisplayOption = datetime_marker_helper!(@option/eradisplay, yes);
+    type FractionalSecondDigitsOption = datetime_marker_helper!(@option/fractionalsecondigits, no);
     type GluePatternV1Marker = datetime_marker_helper!(@glue, no);
 }
 
@@ -2243,6 +2264,7 @@ impl DateTimeMarkers for NeoTimeComponents {
     type Z = NeoNeverMarker;
     type LengthOption = datetime_marker_helper!(@option/length, yes);
     type EraDisplayOption = datetime_marker_helper!(@option/eradisplay, no);
+    type FractionalSecondDigitsOption = datetime_marker_helper!(@option/fractionalsecondigits, yes);
     type GluePatternV1Marker = datetime_marker_helper!(@glue, no);
 }
 
@@ -2279,6 +2301,7 @@ impl DateTimeMarkers for NeoTimeZoneSkeleton {
     type Z = Self;
     type LengthOption = datetime_marker_helper!(@option/length, yes);
     type EraDisplayOption = datetime_marker_helper!(@option/eradisplay, no);
+    type FractionalSecondDigitsOption = datetime_marker_helper!(@option/fractionalsecondigits, no);
     type GluePatternV1Marker = datetime_marker_helper!(@glue, no);
 }
 
@@ -2305,6 +2328,7 @@ impl DateTimeMarkers for NeoDateTimeComponents {
     type Z = NeoNeverMarker;
     type LengthOption = datetime_marker_helper!(@option/length, yes);
     type EraDisplayOption = datetime_marker_helper!(@option/eradisplay, yes);
+    type FractionalSecondDigitsOption = datetime_marker_helper!(@option/fractionalsecondigits, yes);
     type GluePatternV1Marker = datetime_marker_helper!(@glue, yes);
 }
 
@@ -2331,5 +2355,6 @@ impl DateTimeMarkers for NeoComponents {
     type Z = NeoTimeZoneSkeleton;
     type LengthOption = datetime_marker_helper!(@option/length, yes);
     type EraDisplayOption = datetime_marker_helper!(@option/eradisplay, yes);
+    type FractionalSecondDigitsOption = datetime_marker_helper!(@option/fractionalsecondigits, yes);
     type GluePatternV1Marker = datetime_marker_helper!(@glue, yes);
 }

--- a/components/datetime/src/neo_marker.rs
+++ b/components/datetime/src/neo_marker.rs
@@ -147,7 +147,7 @@
 //! use icu::calendar::Time;
 //! use icu::datetime::neo::NeoOptions;
 //! use icu::datetime::neo::TypedNeoFormatter;
-//! use icu::datetime::neo_marker::NeoAutoTimeMarker;
+//! use icu::datetime::neo_marker::NeoHourMinuteSecondMarker;
 //! use icu::datetime::neo_skeleton::NeoSkeletonLength;
 //! use icu::datetime::neo_skeleton::FractionalSecondDigits;
 //! use icu::datetime::NeverCalendar;
@@ -155,7 +155,7 @@
 //! use writeable::assert_try_writeable_eq;
 //!
 //! let formatter =
-//!     TypedNeoFormatter::<NeverCalendar, NeoAutoTimeMarker>::try_new(
+//!     TypedNeoFormatter::<NeverCalendar, NeoHourMinuteSecondMarker>::try_new(
 //!         &locale!("en-US").into(),
 //!         {
 //!             let mut options = NeoOptions::from(NeoSkeletonLength::Short);
@@ -167,7 +167,7 @@
 //!
 //! assert_try_writeable_eq!(
 //!     formatter.format(&Time::try_new(16, 12, 20, 543200000).unwrap()),
-//!     "4:12.54 PM"
+//!     "4:12:20.54 PM"
 //! );
 //! ```
 //!
@@ -1956,6 +1956,19 @@ impl_time_marker!(
     input_minute = yes,
     input_second = no,
     input_nanosecond = no,
+);
+
+impl_time_marker!(
+    NeoHourMinuteSecondMarker,
+    NeoTimeComponents::HourMinuteSecond,
+    description = "hour, minute, and second (locale-dependent hour cycle)",
+    expectation = "3:47:50 PM",
+    dayperiods = yes,
+    times = yes,
+    input_hour = yes,
+    input_minute = yes,
+    input_second = yes,
+    input_nanosecond = yes,
 );
 
 impl_time_marker!(

--- a/components/datetime/src/neo_marker.rs
+++ b/components/datetime/src/neo_marker.rs
@@ -138,6 +138,39 @@
 //! );
 //! ```
 //!
+//! ## Fractional Second Digits
+//!
+//! Times can be displayed with a custom number of fractional digits from 0-9:
+//!
+//! ```
+//! use icu::calendar::Gregorian;
+//! use icu::calendar::Time;
+//! use icu::datetime::neo::NeoOptions;
+//! use icu::datetime::neo::TypedNeoFormatter;
+//! use icu::datetime::neo_marker::NeoAutoTimeMarker;
+//! use icu::datetime::neo_skeleton::NeoSkeletonLength;
+//! use icu::datetime::neo_skeleton::FractionalSecondDigits;
+//! use icu::datetime::NeverCalendar;
+//! use icu::locale::locale;
+//! use writeable::assert_try_writeable_eq;
+//!
+//! let formatter =
+//!     TypedNeoFormatter::<NeverCalendar, NeoAutoTimeMarker>::try_new(
+//!         &locale!("en-US").into(),
+//!         {
+//!             let mut options = NeoOptions::from(NeoSkeletonLength::Short);
+//!             options.fractional_second_digits = Some(FractionalSecondDigits::F2);
+//!             options
+//!         }
+//!     )
+//!     .unwrap();
+//!
+//! assert_try_writeable_eq!(
+//!     formatter.format(&Time::try_new(16, 12, 20, 543200000).unwrap()),
+//!     "4:12.54 PM"
+//! );
+//! ```
+//!
 //! ## Time Zone Formatting
 //!
 //! Here, we configure a [`NeoFormatter`] to format with generic non-location short,
@@ -1935,7 +1968,7 @@ impl_time_marker!(
     input_hour = yes,
     input_minute = yes,
     input_second = yes,
-    input_nanosecond = no,
+    input_nanosecond = yes,
 );
 
 // TODO: Make NeoAutoZoneMarker, derived from time length patterns

--- a/components/datetime/src/neo_serde.rs
+++ b/components/datetime/src/neo_serde.rs
@@ -29,7 +29,7 @@ pub(crate) struct SemanticSkeletonSerde {
     pub(crate) length: NeoSkeletonLength,
     #[serde(rename = "eraDisplay")]
     pub(crate) era_display: Option<EraDisplay>,
-    #[serde(rename = "FractionalSecondDigits")]
+    #[serde(rename = "fractionalSecondDigits")]
     pub(crate) fractional_second_digits: Option<FractionalSecondDigits>,
 }
 
@@ -477,12 +477,13 @@ fn test_basic() {
         ),
         length: NeoSkeletonLength::Medium,
         era_display: Some(EraDisplay::Always),
+        fractional_second_digits: Some(FractionalSecondDigits::F3),
     };
 
     let json_string = serde_json::to_string(&skeleton).unwrap();
     assert_eq!(
         json_string,
-        r#"{"fieldSet":["year","month","day","weekday","hour","minute","zoneGeneric"],"length":"medium","eraDisplay":"always"}"#
+        r#"{"fieldSet":["year","month","day","weekday","hour","minute","zoneGeneric"],"length":"medium","eraDisplay":"always","fractionalSecondDigits":3}"#
     );
     let json_skeleton = serde_json::from_str::<NeoSkeleton>(&json_string).unwrap();
     assert_eq!(skeleton, json_skeleton);

--- a/components/datetime/src/neo_serde.rs
+++ b/components/datetime/src/neo_serde.rs
@@ -6,7 +6,7 @@
 
 use crate::neo_skeleton::{
     EraDisplay, NeoComponents, NeoDateComponents, NeoDayComponents, NeoSkeleton, NeoSkeletonLength,
-    NeoTimeComponents, NeoTimeZoneSkeleton, NeoTimeZoneStyle,
+    NeoTimeComponents, NeoTimeZoneSkeleton, NeoTimeZoneStyle, FractionalSecondDigits
 };
 use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
@@ -29,6 +29,8 @@ pub(crate) struct SemanticSkeletonSerde {
     pub(crate) length: NeoSkeletonLength,
     #[serde(rename = "eraDisplay")]
     pub(crate) era_display: Option<EraDisplay>,
+    #[serde(rename = "FractionalSecondDigits")]
+    pub(crate) fractional_second_digits: Option<FractionalSecondDigits>,
 }
 
 impl From<NeoSkeleton> for SemanticSkeletonSerde {
@@ -37,6 +39,7 @@ impl From<NeoSkeleton> for SemanticSkeletonSerde {
             field_set: value.components,
             length: value.length,
             era_display: value.era_display,
+            fractional_second_digits: value.fractional_second_digits,
         }
     }
 }
@@ -48,6 +51,7 @@ impl TryFrom<SemanticSkeletonSerde> for NeoSkeleton {
             length: value.length,
             components: value.field_set,
             era_display: value.era_display,
+            fractional_second_digits: value.fractional_second_digits,
         })
     }
 }

--- a/components/datetime/src/neo_serde.rs
+++ b/components/datetime/src/neo_serde.rs
@@ -5,8 +5,8 @@
 //! Serde definitions for semantic skeleta
 
 use crate::neo_skeleton::{
-    EraDisplay, NeoComponents, NeoDateComponents, NeoDayComponents, NeoSkeleton, NeoSkeletonLength,
-    NeoTimeComponents, NeoTimeZoneSkeleton, NeoTimeZoneStyle, FractionalSecondDigits
+    EraDisplay, FractionalSecondDigits, NeoComponents, NeoDateComponents, NeoDayComponents,
+    NeoSkeleton, NeoSkeletonLength, NeoTimeComponents, NeoTimeZoneSkeleton, NeoTimeZoneStyle,
 };
 use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};

--- a/components/datetime/src/neo_skeleton.rs
+++ b/components/datetime/src/neo_skeleton.rs
@@ -115,7 +115,7 @@ pub enum EraDisplay {
 /// Lower-precision digits will be truncated.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(try_from="u8", into="u8"))]
+#[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 #[non_exhaustive]
 pub enum FractionalSecondDigits {
     /// Zero fractional digits. This is the default.
@@ -141,8 +141,7 @@ pub enum FractionalSecondDigits {
 }
 
 /// An error from constructing [`FractionalSecondDigits`].
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[derive(displaydoc::Display)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, displaydoc::Display)]
 #[non_exhaustive]
 pub enum FractionalSecondError {
     /// The provided value is out of range (0-9).
@@ -182,7 +181,7 @@ impl TryFrom<u8> for FractionalSecondDigits {
             7 => Ok(F7),
             8 => Ok(F8),
             9 => Ok(F9),
-            _ => Err(FractionalSecondError::OutOfRange)
+            _ => Err(FractionalSecondError::OutOfRange),
         }
     }
 }
@@ -1059,7 +1058,11 @@ impl NeoTimeSkeleton {
         length: NeoSkeletonLength,
         components: NeoTimeComponents,
     ) -> Self {
-        Self { length, components, fractional_second_digits: None }
+        Self {
+            length,
+            components,
+            fractional_second_digits: None,
+        }
     }
 
     /// Converts this [`NeoTimeSkeleton`] to a [`components::Bag`].

--- a/components/datetime/src/neo_skeleton.rs
+++ b/components/datetime/src/neo_skeleton.rs
@@ -107,6 +107,84 @@ pub enum EraDisplay {
     // TODO(#4478): add Hide and Never options once there is data to back them
 }
 
+/// A specification for how many fractional second digits to display.
+///
+/// For example, to display the time with millisecond precision, use
+/// [`FractionalSecondDigits::F3`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(try_from="u8", into="u8"))]
+#[non_exhaustive]
+pub enum FractionalSecondDigits {
+    /// Zero fractional digits. This is the default.
+    F0,
+    /// One fractional digit (tenths of a second).
+    F1,
+    /// Two fractional digits (hundredths of a second).
+    F2,
+    /// Three fractional digits (thousandths of a second).
+    F3,
+    /// Four fractional digits.
+    F4,
+    /// Five fractional digits.
+    F5,
+    /// Six fractional digits.
+    F6,
+    /// Seven fractional digits.
+    F7,
+    /// Eight fractional digits.
+    F8,
+    /// Nine fractional digits.
+    F9,
+}
+
+/// An error from constructing [`FractionalSecondDigits`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(displaydoc::Display)]
+#[non_exhaustive]
+pub enum FractionalSecondError {
+    /// The provided value is out of range (0-9).
+    OutOfRange,
+}
+
+impl From<FractionalSecondDigits> for u8 {
+    fn from(value: FractionalSecondDigits) -> u8 {
+        use FractionalSecondDigits::*;
+        match value {
+            F0 => 0,
+            F1 => 1,
+            F2 => 2,
+            F3 => 3,
+            F4 => 4,
+            F5 => 5,
+            F6 => 6,
+            F7 => 7,
+            F8 => 8,
+            F9 => 9,
+        }
+    }
+}
+
+impl TryFrom<u8> for FractionalSecondDigits {
+    type Error = FractionalSecondError;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        use FractionalSecondDigits::*;
+        match value {
+            0 => Ok(F0),
+            1 => Ok(F1),
+            2 => Ok(F2),
+            3 => Ok(F3),
+            4 => Ok(F4),
+            5 => Ok(F5),
+            6 => Ok(F6),
+            7 => Ok(F7),
+            8 => Ok(F8),
+            9 => Ok(F9),
+            _ => Err(FractionalSecondError::OutOfRange)
+        }
+    }
+}
+
 /// A specification for a set of parts of a date that specifies a single day (as
 /// opposed to a whole month or a week).
 /// Only sets that yield “sensible” dates are allowed: this type cannot
@@ -969,6 +1047,8 @@ pub struct NeoTimeSkeleton {
     pub length: NeoSkeletonLength,
     /// Time components of the skeleton.
     pub components: NeoTimeComponents,
+    /// Fractional second digits option.
+    pub fractional_second_digits: Option<FractionalSecondDigits>,
 }
 
 impl NeoTimeSkeleton {
@@ -977,7 +1057,7 @@ impl NeoTimeSkeleton {
         length: NeoSkeletonLength,
         components: NeoTimeComponents,
     ) -> Self {
-        Self { length, components }
+        Self { length, components, fractional_second_digits: None }
     }
 
     /// Converts this [`NeoTimeSkeleton`] to a [`components::Bag`].
@@ -996,6 +1076,8 @@ pub struct NeoDateTimeSkeleton {
     pub components: NeoDateTimeComponents,
     /// Era display option.
     pub era_display: Option<EraDisplay>,
+    /// Fractional second digits option.
+    pub fractional_second_digits: Option<FractionalSecondDigits>,
 }
 
 impl NeoDateTimeSkeleton {
@@ -1009,6 +1091,7 @@ impl NeoDateTimeSkeleton {
             length,
             components: NeoDateTimeComponents::DateTime(date, time),
             era_display: None,
+            fractional_second_digits: None,
         }
     }
 }
@@ -1028,6 +1111,8 @@ pub struct NeoSkeleton {
     pub components: NeoComponents,
     /// Era display option.
     pub era_display: Option<EraDisplay>,
+    /// Fractional second digits option.
+    pub fractional_second_digits: Option<FractionalSecondDigits>,
 }
 
 impl From<NeoDateSkeleton> for NeoSkeleton {
@@ -1036,6 +1121,7 @@ impl From<NeoDateSkeleton> for NeoSkeleton {
             length: value.length,
             components: value.components.into(),
             era_display: value.era_display,
+            fractional_second_digits: None,
         }
     }
 }
@@ -1046,6 +1132,7 @@ impl From<NeoTimeSkeleton> for NeoSkeleton {
             length: value.length,
             components: value.components.into(),
             era_display: None,
+            fractional_second_digits: value.fractional_second_digits,
         }
     }
 }
@@ -1055,7 +1142,8 @@ impl From<NeoDateTimeSkeleton> for NeoSkeleton {
         NeoSkeleton {
             length: value.length,
             components: value.components.into(),
-            era_display: None,
+            era_display: value.era_display,
+            fractional_second_digits: value.fractional_second_digits,
         }
     }
 }
@@ -1072,6 +1160,7 @@ impl NeoDateTimeSkeleton {
             length,
             components: NeoDateTimeComponents::DateTime(day_components, time_components),
             era_display: None,
+            fractional_second_digits: None,
         }
     }
 }

--- a/components/datetime/src/neo_skeleton.rs
+++ b/components/datetime/src/neo_skeleton.rs
@@ -111,6 +111,8 @@ pub enum EraDisplay {
 ///
 /// For example, to display the time with millisecond precision, use
 /// [`FractionalSecondDigits::F3`].
+///
+/// Lower-precision digits will be truncated.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from="u8", into="u8"))]

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::neo_skeleton::FractionalSecondDigits;
 use crate::format::neo::FieldForDataLoading;
 use crate::input::{DateInput, ExtractedDateTimeInput};
 use crate::neo_pattern::DateTimePattern;
@@ -240,6 +241,7 @@ impl TimePatternSelectionData {
         locale: &DataLocale,
         length: MaybeLength,
         components: NeoTimeComponents,
+        fractional_second_digits: Option<FractionalSecondDigits>,
         hour_cycle: Option<CoarseHourCycle>,
     ) -> Result<Self, DataError> {
         // First try to load with the explicit hour cycle. If there is no explicit hour cycle,
@@ -278,6 +280,7 @@ impl TimePatternSelectionData {
             skeleton: NeoTimeSkeleton {
                 length: length.get::<Self>(),
                 components,
+                fractional_second_digits,
             },
             payload,
         })
@@ -352,6 +355,7 @@ impl DateTimeZonePatternSelectionData {
         length: Option<NeoSkeletonLength>,
         components: NeoComponents,
         era_display: Option<EraDisplay>,
+        fractional_second_digits: Option<FractionalSecondDigits>,
         hour_cycle: Option<CoarseHourCycle>,
     ) -> Result<Self, DataError> {
         let length = MaybeLength(length);
@@ -372,6 +376,7 @@ impl DateTimeZonePatternSelectionData {
                     locale,
                     length,
                     components,
+                    fractional_second_digits,
                     hour_cycle,
                 )?;
                 Ok(Self::Time(selection))
@@ -393,6 +398,7 @@ impl DateTimeZonePatternSelectionData {
                     locale,
                     length,
                     time_components,
+                    fractional_second_digits,
                     hour_cycle,
                 )?;
                 let glue = Self::load_glue(glue_provider, locale, length, GlueType::DateTime)?;
@@ -416,6 +422,7 @@ impl DateTimeZonePatternSelectionData {
                     locale,
                     length,
                     time_components,
+                    fractional_second_digits,
                     hour_cycle,
                 )?;
                 let zone = ZonePatternSelectionData::new_with_skeleton(length, zone_components);
@@ -435,6 +442,7 @@ impl DateTimeZonePatternSelectionData {
                     locale,
                     length,
                     time_components,
+                    fractional_second_digits,
                     hour_cycle,
                 )?;
                 let zone = ZonePatternSelectionData::new_with_skeleton(length, zone_components);

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -2,11 +2,11 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::format::FormattingOptions;
-use crate::neo_skeleton::FractionalSecondDigits;
 use crate::format::neo::FieldForDataLoading;
+use crate::format::FormattingOptions;
 use crate::input::{DateInput, ExtractedDateTimeInput};
 use crate::neo_pattern::DateTimePattern;
+use crate::neo_skeleton::FractionalSecondDigits;
 use crate::neo_skeleton::{
     EraDisplay, NeoComponents, NeoDateComponents, NeoDateSkeleton, NeoSkeletonLength,
     NeoTimeComponents, NeoTimeSkeleton, NeoTimeZoneSkeleton,
@@ -312,12 +312,13 @@ impl TimePatternSelectionData {
     pub(crate) fn select(&self, _datetime: &ExtractedDateTimeInput) -> TimePatternDataBorrowed {
         match self {
             TimePatternSelectionData::SkeletonTime { skeleton, payload } => {
-                TimePatternDataBorrowed::Resolved(payload.get().get_pattern(
-                    PatternSelectionOptions {
+                TimePatternDataBorrowed::Resolved(
+                    payload.get().get_pattern(PatternSelectionOptions {
                         length: skeleton.length,
                         should_display_era: None,
-                    },
-                ), skeleton.fractional_second_digits)
+                    }),
+                    skeleton.fractional_second_digits,
+                )
             }
         }
     }
@@ -663,9 +664,11 @@ impl<'a> DateTimeZonePatternDataBorrowed<'a> {
         // Currently only Time contributes to the formatting options
         let fractional_second_digits = match self.time_pattern() {
             Some(TimePatternDataBorrowed::Resolved(_, v)) => v,
-            _ => None
+            _ => None,
         };
-        FormattingOptions { fractional_second_digits }
+        FormattingOptions {
+            fractional_second_digits,
+        }
     }
 
     pub(crate) fn iter_items(self) -> impl Iterator<Item = PatternItem> + 'a {

--- a/components/datetime/tests/fixtures/tests/components.json
+++ b/components/datetime/tests/fixtures/tests/components.json
@@ -165,11 +165,6 @@
                     "minute": "numeric",
                     "second": "two-digit",
                     "fractional_second": 127
-                },
-                "semantic": {
-                    "fieldSet": ["hour", "minute", "second"],
-                    "length": "short",
-                    "fractionalSecondDigits": 127
                 }
             }
         },
@@ -188,11 +183,6 @@
                     "minute": "numeric",
                     "second": "two-digit",
                     "fractional_second": 255
-                },
-                "semantic": {
-                    "fieldSet": ["hour", "minute", "second"],
-                    "length": "short",
-                    "fractionalSecondDigits": 255
                 }
             }
         },


### PR DESCRIPTION
#1317

Note: For now I'm adding them as an option on the Second field but I think I'll probably make a separate field as we're discussing in the spec draft.