### PR TITLE
Update ixdtf's error from ParserError to ParseError

### DIFF
--- a/components/calendar/src/ixdtf.rs
+++ b/components/calendar/src/ixdtf.rs
@@ -7,14 +7,14 @@ use core::str::FromStr;
 use crate::{AnyCalendar, Date, DateTime, Iso, RangeError, Time};
 use ixdtf::parsers::records::IxdtfParseRecord;
 use ixdtf::parsers::IxdtfParser;
-use ixdtf::ParserError;
+use ixdtf::ParseError as IxdtfError;
 
 /// An error returned from parsing an IXDTF string to an `icu_calendar` type.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum ParseError {
     /// Syntax error in the IXDTF string.
-    Syntax(ParserError),
+    Syntax(IxdtfError),
     /// Value is out of range.
     Range(RangeError),
     /// The IXDTF is missing fields required for parsing into the chosen type.
@@ -29,8 +29,8 @@ impl From<RangeError> for ParseError {
     }
 }
 
-impl From<ParserError> for ParseError {
-    fn from(value: ParserError) -> Self {
+impl From<IxdtfError> for ParseError {
+    fn from(value: IxdtfError) -> Self {
         Self::Syntax(value)
     }
 }

--- a/utils/ixdtf/README.md
+++ b/utils/ixdtf/README.md
@@ -136,14 +136,14 @@ order with the key value. When parsing this invalid annotation, `ixdtf`
 will attempt to parse the Time Zone annotation as a key-value annotation.
 
 ```rust
-use ixdtf::{parsers::IxdtfParser, ParserError};
+use ixdtf::{parsers::IxdtfParser, ParseError};
 
 let example_one =
     "2024-03-02T08:48:00-05:00[u-ca=iso8601][America/New_York]";
 
 let result = IxdtfParser::from_str(example_one).parse();
 
-assert_eq!(result, Err(ParserError::AnnotationKeyLeadingChar));
+assert_eq!(result, Err(ParseError::AnnotationKeyLeadingChar));
 ```
 
 ###### Example 2
@@ -153,13 +153,13 @@ of the registered keys is flagged as critical, which throws an error as
 the ixdtf string must be treated as erroneous
 
 ```rust
-use ixdtf::{parsers::IxdtfParser, ParserError};
+use ixdtf::{parsers::IxdtfParser, ParseError};
 
 let example_two = "2024-03-02T08:48:00-05:00[u-ca=iso8601][!u-ca=japanese]";
 
 let result = IxdtfParser::from_str(example_two).parse();
 
-assert_eq!(result, Err(ParserError::CriticalDuplicateCalendar));
+assert_eq!(result, Err(ParseError::CriticalDuplicateCalendar));
 ```
 
 ###### Example 3
@@ -168,14 +168,14 @@ This example shows an unknown key flagged as critical. `ixdtf` will return an
 error on an unknown flag being flagged as critical.
 
 ```rust
-use ixdtf::{parsers::IxdtfParser, ParserError};
+use ixdtf::{parsers::IxdtfParser, ParseError};
 
 let example_three =
     "2024-03-02T08:48:00-05:00[u-ca=iso8601][!answer-to-universe=fortytwo]";
 
 let result = IxdtfParser::from_str(example_three).parse();
 
-assert_eq!(result, Err(ParserError::UnrecognizedCritical));
+assert_eq!(result, Err(ParseError::UnrecognizedCritical));
 ```
 
 ##### Annotations with Application Defined Behavior

--- a/utils/ixdtf/src/error.rs
+++ b/utils/ixdtf/src/error.rs
@@ -9,7 +9,7 @@ use displaydoc::Display;
 #[non_exhaustive]
 #[derive(PartialEq, Display, Clone, Copy, Debug)]
 /// The error returned by `ixdtf`'s parsers.
-pub enum ParserError {
+pub enum ParseError {
     #[displaydoc("Implementation error: this error must not throw.")]
     ImplAssert,
     #[displaydoc("Invalid float while parsing fraction part.")]
@@ -106,8 +106,8 @@ pub enum ParserError {
     TimeDurationDesignator,
 }
 
-impl ParserError {
+impl ParseError {
     pub(crate) fn abrupt_end(location: &'static str) -> Self {
-        ParserError::AbruptEnd { location }
+        ParseError::AbruptEnd { location }
     }
 }

--- a/utils/ixdtf/src/lib.rs
+++ b/utils/ixdtf/src/lib.rs
@@ -137,14 +137,14 @@
 //! will attempt to parse the Time Zone annotation as a key-value annotation.
 //!
 //! ```rust
-//! use ixdtf::{parsers::IxdtfParser, ParserError};
+//! use ixdtf::{parsers::IxdtfParser, ParseError};
 //!
 //! let example_one =
 //!     "2024-03-02T08:48:00-05:00[u-ca=iso8601][America/New_York]";
 //!
 //! let result = IxdtfParser::from_str(example_one).parse();
 //!
-//! assert_eq!(result, Err(ParserError::AnnotationKeyLeadingChar));
+//! assert_eq!(result, Err(ParseError::AnnotationKeyLeadingChar));
 //! ```
 //!
 //! ##### Example 2
@@ -154,13 +154,13 @@
 //! the ixdtf string must be treated as erroneous
 //!
 //! ```rust
-//! use ixdtf::{parsers::IxdtfParser, ParserError};
+//! use ixdtf::{parsers::IxdtfParser, ParseError};
 //!
 //! let example_two = "2024-03-02T08:48:00-05:00[u-ca=iso8601][!u-ca=japanese]";
 //!
 //! let result = IxdtfParser::from_str(example_two).parse();
 //!
-//! assert_eq!(result, Err(ParserError::CriticalDuplicateCalendar));
+//! assert_eq!(result, Err(ParseError::CriticalDuplicateCalendar));
 //! ```
 //!
 //! ##### Example 3
@@ -169,14 +169,14 @@
 //! error on an unknown flag being flagged as critical.
 //!
 //! ```rust
-//! use ixdtf::{parsers::IxdtfParser, ParserError};
+//! use ixdtf::{parsers::IxdtfParser, ParseError};
 //!
 //! let example_three =
 //!     "2024-03-02T08:48:00-05:00[u-ca=iso8601][!answer-to-universe=fortytwo]";
 //!
 //! let result = IxdtfParser::from_str(example_three).parse();
 //!
-//! assert_eq!(result, Err(ParserError::UnrecognizedCritical));
+//! assert_eq!(result, Err(ParseError::UnrecognizedCritical));
 //! ```
 //!
 //! #### Annotations with Application Defined Behavior
@@ -306,7 +306,7 @@ pub mod parsers;
 
 extern crate alloc;
 
-pub use error::ParserError;
+pub use error::ParseError;
 
 /// The `ixdtf` crate's Result type.
-pub type ParserResult<T> = Result<T, ParserError>;
+pub type ParserResult<T> = Result<T, ParseError>;

--- a/utils/ixdtf/src/parsers/annotations.rs
+++ b/utils/ixdtf/src/parsers/annotations.rs
@@ -103,9 +103,7 @@ fn parse_kv_annotation<'a>(cursor: &mut Cursor<'a>) -> ParserResult<Annotation<'
     // Parse AnnotationKey.
     let annotation_key = parse_annotation_key(cursor)?;
     assert_syntax!(
-        is_annotation_key_value_separator(
-            cursor.next_or(ParseError::AnnotationKeyValueSeparator)?
-        ),
+        is_annotation_key_value_separator(cursor.next_or(ParseError::AnnotationKeyValueSeparator)?),
         AnnotationKeyValueSeparator,
     );
 

--- a/utils/ixdtf/src/parsers/annotations.rs
+++ b/utils/ixdtf/src/parsers/annotations.rs
@@ -15,7 +15,7 @@ use crate::{
         records::{Annotation, TimeZoneAnnotation},
         timezone, Cursor,
     },
-    ParserError, ParserResult,
+    ParseError, ParserResult,
 };
 
 /// Strictly a parsing intermediary for the checking the common annotation backing.
@@ -68,7 +68,7 @@ pub(crate) fn parse_annotations<'a>(
                         // if calendars do not match and one of them is critical
                         if calendar.value != kv.value && (calendar.critical || kv.critical) =>
                     {
-                        return Err(ParserError::CriticalDuplicateCalendar)
+                        return Err(ParseError::CriticalDuplicateCalendar)
                     }
                     // If there is not yet a calendar, save it.
                     None => {
@@ -80,7 +80,7 @@ pub(crate) fn parse_annotations<'a>(
             Some(unknown_kv) => {
                 // Throw an error on any unrecognized annotations that are marked as critical.
                 if unknown_kv.critical {
-                    return Err(ParserError::UnrecognizedCritical);
+                    return Err(ParseError::UnrecognizedCritical);
                 }
             }
             None => {}
@@ -93,7 +93,7 @@ pub(crate) fn parse_annotations<'a>(
 /// Parse an annotation with an `AnnotationKey`=`AnnotationValue` pair.
 fn parse_kv_annotation<'a>(cursor: &mut Cursor<'a>) -> ParserResult<Annotation<'a>> {
     assert_syntax!(
-        is_annotation_open(cursor.next_or(ParserError::AnnotationOpen)?),
+        is_annotation_open(cursor.next_or(ParseError::AnnotationOpen)?),
         AnnotationOpen
     );
 
@@ -104,7 +104,7 @@ fn parse_kv_annotation<'a>(cursor: &mut Cursor<'a>) -> ParserResult<Annotation<'
     let annotation_key = parse_annotation_key(cursor)?;
     assert_syntax!(
         is_annotation_key_value_separator(
-            cursor.next_or(ParserError::AnnotationKeyValueSeparator)?
+            cursor.next_or(ParseError::AnnotationKeyValueSeparator)?
         ),
         AnnotationKeyValueSeparator,
     );
@@ -112,7 +112,7 @@ fn parse_kv_annotation<'a>(cursor: &mut Cursor<'a>) -> ParserResult<Annotation<'
     // Parse AnnotationValue.
     let annotation_value = parse_annotation_value(cursor)?;
     assert_syntax!(
-        is_annotation_close(cursor.next_or(ParserError::AnnotationClose)?),
+        is_annotation_close(cursor.next_or(ParseError::AnnotationClose)?),
         AnnotationClose
     );
 
@@ -127,7 +127,7 @@ fn parse_kv_annotation<'a>(cursor: &mut Cursor<'a>) -> ParserResult<Annotation<'
 fn parse_annotation_key<'a>(cursor: &mut Cursor<'a>) -> ParserResult<&'a [u8]> {
     let key_start = cursor.pos();
     assert_syntax!(
-        is_a_key_leading_char(cursor.next_or(ParserError::AnnotationKeyLeadingChar)?),
+        is_a_key_leading_char(cursor.next_or(ParseError::AnnotationKeyLeadingChar)?),
         AnnotationKeyLeadingChar,
     );
 
@@ -137,13 +137,13 @@ fn parse_annotation_key<'a>(cursor: &mut Cursor<'a>) -> ParserResult<&'a [u8]> {
             // Return found key
             return cursor
                 .slice(key_start, cursor.pos())
-                .ok_or(ParserError::ImplAssert);
+                .ok_or(ParseError::ImplAssert);
         }
 
         assert_syntax!(is_a_key_char(potential_key_char), AnnotationKeyChar);
     }
 
-    Err(ParserError::AnnotationChar)
+    Err(ParseError::AnnotationChar)
 }
 
 /// Parse an `AnnotationValue`.
@@ -155,7 +155,7 @@ fn parse_annotation_value<'a>(cursor: &mut Cursor<'a>) -> ParserResult<&'a [u8]>
             // Return the determined AnnotationValue.
             return cursor
                 .slice(value_start, cursor.pos())
-                .ok_or(ParserError::ImplAssert);
+                .ok_or(ParseError::ImplAssert);
         }
 
         if is_hyphen(potential_value_char) {
@@ -173,5 +173,5 @@ fn parse_annotation_value<'a>(cursor: &mut Cursor<'a>) -> ParserResult<&'a [u8]>
         );
     }
 
-    Err(ParserError::AnnotationValueChar)
+    Err(ParseError::AnnotationValueChar)
 }

--- a/utils/ixdtf/src/parsers/mod.rs
+++ b/utils/ixdtf/src/parsers/mod.rs
@@ -4,7 +4,7 @@
 
 //! The parser module contains the implementation details for `IxdtfParser` and `IsoDurationParser`
 
-use crate::{ParserError, ParserResult};
+use crate::{ParseError, ParserResult};
 
 #[cfg(feature = "duration")]
 use records::DurationParseRecord;
@@ -32,7 +32,7 @@ mod tests;
 macro_rules! assert_syntax {
     ($cond:expr, $err:ident $(,)?) => {
         if !$cond {
-            return Err(ParserError::$err);
+            return Err(ParseError::$err);
         }
     };
 }
@@ -420,13 +420,13 @@ impl<'a> Cursor<'a> {
     fn next_digit(&mut self) -> ParserResult<Option<u8>> {
         // Note: Char digit with a radix of ten must be in the range of a u8
         Ok(self
-            .next_or(ParserError::InvalidEnd)?
+            .next_or(ParseError::InvalidEnd)?
             .to_digit(10)
             .map(|d| d as u8))
     }
 
     /// A utility next method that returns an `AbruptEnd` error if invalid.
-    fn next_or(&mut self, err: ParserError) -> ParserResult<char> {
+    fn next_or(&mut self, err: ParseError) -> ParserResult<char> {
         self.next().ok_or(err)
     }
 
@@ -450,7 +450,7 @@ impl<'a> Cursor<'a> {
     /// Closes the current cursor by checking if all contents have been consumed. If not, returns an error for invalid syntax.
     fn close(&mut self) -> ParserResult<()> {
         if self.pos < self.source.len() {
-            return Err(ParserError::InvalidEnd);
+            return Err(ParseError::InvalidEnd);
         }
         Ok(())
     }

--- a/utils/ixdtf/src/parsers/tests.rs
+++ b/utils/ixdtf/src/parsers/tests.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         IxdtfParser,
     },
-    ParserError,
+    ParseError,
 };
 
 #[test]
@@ -80,7 +80,7 @@ fn bad_zoned_date_time() {
     let err = IxdtfParser::from_str(bad_value).parse();
     assert_eq!(
         err,
-        Err(ParserError::InvalidEnd),
+        Err(ParseError::InvalidEnd),
         "Invalid ZonedDateTime parsing: \"{bad_value}\" should fail to parse."
     );
 
@@ -88,7 +88,7 @@ fn bad_zoned_date_time() {
     let err = IxdtfParser::from_str(bad_value).parse();
     assert_eq!(
         err,
-        Err(ParserError::IanaChar),
+        Err(ParseError::IanaChar),
         "Invalid ZonedDateTime parsing: \"{bad_value}\" should fail to parse."
     );
 
@@ -96,7 +96,7 @@ fn bad_zoned_date_time() {
     let err = IxdtfParser::from_str(bad_value).parse();
     assert_eq!(
         err,
-        Err(ParserError::IanaCharPostSeparator),
+        Err(ParseError::IanaCharPostSeparator),
         "Invalid ZonedDateTime parsing: \"{bad_value}\" should fail to parse."
     );
 
@@ -104,7 +104,7 @@ fn bad_zoned_date_time() {
     let err = IxdtfParser::from_str(bad_value).parse();
     assert_eq!(
         err,
-        Err(ParserError::AbruptEnd {
+        Err(ParseError::AbruptEnd {
             location: "IANATimeZoneName"
         }),
         "Invalid ZonedDateTime parsing: \"{bad_value}\" should fail to parse."
@@ -114,7 +114,7 @@ fn bad_zoned_date_time() {
     let err = IxdtfParser::from_str(bad_value).parse();
     assert_eq!(
         err,
-        Err(ParserError::AnnotationKeyLeadingChar),
+        Err(ParseError::AnnotationKeyLeadingChar),
         "Invalid ZonedDateTime parsing: \"{bad_value}\" should fail to parse."
     );
 }
@@ -152,7 +152,7 @@ fn bad_extended_year() {
     let err = IxdtfParser::from_str(bad_year).parse();
     assert_eq!(
         err,
-        Err(ParserError::DateExtendedYear),
+        Err(ParseError::DateExtendedYear),
         "Invalid extended year parsing: \"{bad_year}\" should fail to parse."
     );
 
@@ -160,7 +160,7 @@ fn bad_extended_year() {
     let err = IxdtfParser::from_str(bad_year).parse();
     assert_eq!(
         err,
-        Err(ParserError::DateMonth),
+        Err(ParseError::DateMonth),
         "Invalid year range parsing: \"{bad_year}\" should fail to parse."
     );
 
@@ -168,7 +168,7 @@ fn bad_extended_year() {
     let err = IxdtfParser::from_str(bad_year).parse();
     assert_eq!(
         err,
-        Err(ParserError::InvalidEnd),
+        Err(ParseError::InvalidEnd),
         "Invalid year range parsing: \"{bad_year}\" should fail to parse."
     );
 }
@@ -208,7 +208,7 @@ fn invalid_day_for_month() {
     let err = IxdtfParser::from_str(bad_value).parse();
     assert_eq!(
         err,
-        Err(ParserError::InvalidDayRange),
+        Err(ParseError::InvalidDayRange),
         "Invalid day range parsing: \"{bad_value}\" should fail to parse."
     );
 
@@ -216,7 +216,7 @@ fn invalid_day_for_month() {
     let err = IxdtfParser::from_str(bad_value).parse();
     assert_eq!(
         err,
-        Err(ParserError::InvalidDayRange),
+        Err(ParseError::InvalidDayRange),
         "Invalid day range parsing: \"{bad_value}\" should fail to parse."
     );
 
@@ -224,7 +224,7 @@ fn invalid_day_for_month() {
     let err = IxdtfParser::from_str(bad_value).parse();
     assert_eq!(
         err,
-        Err(ParserError::InvalidDayRange),
+        Err(ParseError::InvalidDayRange),
         "Invalid day range parsing: \"{bad_value}\" should fail to parse."
     );
 
@@ -232,7 +232,7 @@ fn invalid_day_for_month() {
     let err = IxdtfParser::from_str(bad_value).parse();
     assert_eq!(
         err,
-        Err(ParserError::InvalidDayRange),
+        Err(ParseError::InvalidDayRange),
         "Invalid day range parsing: \"{bad_value}\" should fail to parse."
     );
 }
@@ -244,7 +244,7 @@ fn invalid_month() {
     let err = ixdtf.parse();
     assert_eq!(
         err,
-        Err(ParserError::InvalidMonthRange),
+        Err(ParseError::InvalidMonthRange),
         "Invalid month range parsing: \"{bad_value}\" should fail to parse."
     );
 
@@ -253,7 +253,7 @@ fn invalid_month() {
     let err = ixdtf.parse();
     assert_eq!(
         err,
-        Err(ParserError::InvalidMonthRange),
+        Err(ParseError::InvalidMonthRange),
         "Invalid month range parsing: \"{bad_value}\" should fail to parse."
     );
 }
@@ -264,7 +264,7 @@ fn invalid_annotations() {
     let err = IxdtfParser::from_str(bad_value).parse();
     assert_eq!(
         err,
-        Err(ParserError::InvalidEnd),
+        Err(ParseError::InvalidEnd),
         "Invalid annotation parsing: \"{bad_value}\" should fail to parse."
     );
 
@@ -272,7 +272,7 @@ fn invalid_annotations() {
     let err = IxdtfParser::from_str(bad_value).parse();
     assert_eq!(
         err,
-        Err(ParserError::AnnotationValueChar),
+        Err(ParseError::AnnotationValueChar),
         "Invalid annotation parsing: \"{bad_value}\" should fail to parse."
     );
 
@@ -280,7 +280,7 @@ fn invalid_annotations() {
     let err = IxdtfParser::from_str(bad_value).parse();
     assert_eq!(
         err,
-        Err(ParserError::InvalidAnnotation),
+        Err(ParseError::InvalidAnnotation),
         "Invalid annotation parsing: \"{bad_value}\" should fail to parse."
     );
 
@@ -288,7 +288,7 @@ fn invalid_annotations() {
     let err = IxdtfParser::from_str(bad_value).parse();
     assert_eq!(
         err,
-        Err(ParserError::UnrecognizedCritical),
+        Err(ParseError::UnrecognizedCritical),
         "Invalid annotation parsing: \"{bad_value}\" should fail to parse."
     );
 }
@@ -299,7 +299,7 @@ fn invalid_calendar_annotations() {
     let err = IxdtfParser::from_str(bad_value).parse();
     assert_eq!(
         err,
-        Err(ParserError::CriticalDuplicateCalendar),
+        Err(ParseError::CriticalDuplicateCalendar),
         "Invalid annotation parsing: \"{bad_value}\" should fail to parse."
     );
 
@@ -307,7 +307,7 @@ fn invalid_calendar_annotations() {
     let err = IxdtfParser::from_str(bad_value).parse();
     assert_eq!(
         err,
-        Err(ParserError::CriticalDuplicateCalendar),
+        Err(ParseError::CriticalDuplicateCalendar),
         "Invalid annotation parsing: \"{bad_value}\" should fail to parse."
     );
 }
@@ -425,15 +425,15 @@ fn invalid_year_month() {
     // Valid AnnotatedDateTime, but not a valid AnnotatedYearMonth.
     let bad_value = "+002020-11T12:28:32[!u-ca=iso8601]";
     let err = IxdtfParser::from_str(bad_value).parse_year_month();
-    assert_eq!(err, Err(ParserError::InvalidEnd));
+    assert_eq!(err, Err(ParseError::InvalidEnd));
 
     let bad_value = "-202011[!u-ca=iso8601]";
     let err = IxdtfParser::from_str(bad_value).parse_year_month();
-    assert_eq!(err, Err(ParserError::DateMonth));
+    assert_eq!(err, Err(ParseError::DateMonth));
 
     let bad_value = "-00202011Z[Europe/Berlin]";
     let err = IxdtfParser::from_str(bad_value).parse_year_month();
-    assert_eq!(err, Err(ParserError::InvalidEnd));
+    assert_eq!(err, Err(ParseError::InvalidEnd));
 }
 
 #[test]
@@ -454,7 +454,7 @@ fn temporal_month_day() {
 fn invalid_month_day() {
     let bad_value = "-11-07";
     let err = IxdtfParser::from_str(bad_value).parse_month_day();
-    assert_eq!(err, Err(ParserError::MonthDayHyphen))
+    assert_eq!(err, Err(ParseError::MonthDayHyphen))
 }
 
 #[test]
@@ -483,7 +483,7 @@ fn invalid_time() {
     let err = IxdtfParser::from_str(bad_value).parse_time();
     assert_eq!(
         err,
-        Err(ParserError::InvalidEnd),
+        Err(ParseError::InvalidEnd),
         "Invalid time parsing: \"{bad_value}\" should fail to parse."
     );
 
@@ -491,7 +491,7 @@ fn invalid_time() {
     let err = IxdtfParser::from_str(bad_value).parse_time();
     assert_eq!(
         err,
-        Err(ParserError::TimeHour),
+        Err(ParseError::TimeHour),
         "Invalid time parsing: \"{bad_value}\" should fail to parse."
     );
 
@@ -500,7 +500,7 @@ fn invalid_time() {
     let err = IxdtfParser::from_str(bad_value).parse_time();
     assert_eq!(
         err,
-        Err(ParserError::InvalidEnd),
+        Err(ParseError::InvalidEnd),
         "Invalid time parsing: \"{bad_value}\" should fail to parse."
     );
 
@@ -508,7 +508,7 @@ fn invalid_time() {
     let err = IxdtfParser::from_str(bad_value).parse_time();
     assert_eq!(
         err,
-        Err(ParserError::InvalidEnd),
+        Err(ParseError::InvalidEnd),
         "Invalid time parsing: \"{bad_value}\" should fail to parse."
     );
 
@@ -516,7 +516,7 @@ fn invalid_time() {
     let err = IxdtfParser::from_str(bad_value).parse_time();
     assert_eq!(
         err,
-        Err(ParserError::TimeSeparator),
+        Err(ParseError::TimeSeparator),
         "Invalid time parsing: \"{bad_value}\" should fail to parse."
     );
 }
@@ -645,11 +645,11 @@ fn duration_exceeds_range() {
 
     let test = "P1000000000000000000000000000000000000000YT1H";
     let err = IsoDurationParser::from_str(test).parse();
-    assert_eq!(err, Err(ParserError::DurationValueExceededRange));
+    assert_eq!(err, Err(ParseError::DurationValueExceededRange));
 
     let test = "P1YT1000000000000000000000000000000000000000H";
     let err = IsoDurationParser::from_str(test).parse();
-    assert_eq!(err, Err(ParserError::DurationValueExceededRange));
+    assert_eq!(err, Err(ParseError::DurationValueExceededRange));
 }
 
 #[test]
@@ -850,52 +850,52 @@ fn test_correct_datetime() {
 fn test_bad_date() {
     let dt = "-2022-06-05";
     let err = IxdtfParser::from_str(dt).parse();
-    assert_eq!(err, Err(ParserError::DateExtendedYear));
+    assert_eq!(err, Err(ParseError::DateExtendedYear));
 
     let dt = "!2022-06-05";
     let err = IxdtfParser::from_str(dt).parse();
-    assert_eq!(err, Err(ParserError::DateYear));
+    assert_eq!(err, Err(ParseError::DateYear));
 
     let dt = "20-06-05";
     let err = IxdtfParser::from_str(dt).parse();
-    assert_eq!(err, Err(ParserError::DateYear));
+    assert_eq!(err, Err(ParseError::DateYear));
 
     let dt = "2022-0605";
     let err = IxdtfParser::from_str(dt).parse();
-    assert_eq!(err, Err(ParserError::DateSeparator));
+    assert_eq!(err, Err(ParseError::DateSeparator));
 
     let dt = "202206-05";
     let err = IxdtfParser::from_str(dt).parse();
-    assert_eq!(err, Err(ParserError::DateSeparator));
+    assert_eq!(err, Err(ParseError::DateSeparator));
 
     let dt = "2022-06-05e";
     let err = IxdtfParser::from_str(dt).parse();
-    assert_eq!(err, Err(ParserError::InvalidEnd));
+    assert_eq!(err, Err(ParseError::InvalidEnd));
 }
 
 #[test]
 fn test_bad_time_spec_separator() {
     let dt = "2022-06-05  043422.000";
     let err = IxdtfParser::from_str(dt).parse();
-    assert_eq!(err, Err(ParserError::TimeHour));
+    assert_eq!(err, Err(ParseError::TimeHour));
 
     let dt = "2022-06-05 04:3422.000";
     let err = IxdtfParser::from_str(dt).parse();
-    assert_eq!(err, Err(ParserError::TimeSeparator));
+    assert_eq!(err, Err(ParseError::TimeSeparator));
 
     let dt = "2022-06-05 0434:22.000";
     let err = IxdtfParser::from_str(dt).parse();
-    assert_eq!(err, Err(ParserError::TimeSeparator));
+    assert_eq!(err, Err(ParseError::TimeSeparator));
 
     let dt = "2022-06-05 03422.000";
     let err = IxdtfParser::from_str(dt).parse();
-    assert_eq!(err, Err(ParserError::TimeSecond));
+    assert_eq!(err, Err(ParseError::TimeSecond));
 
     let dt = "2022-06-05 3:42:22.000";
     let err = IxdtfParser::from_str(dt).parse();
-    assert_eq!(err, Err(ParserError::TimeHour));
+    assert_eq!(err, Err(ParseError::TimeHour));
 
     let dt = "2022-06-05 03:42:22;000";
     let err = IxdtfParser::from_str(dt).parse();
-    assert_eq!(err, Err(ParserError::InvalidEnd));
+    assert_eq!(err, Err(ParseError::InvalidEnd));
 }


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

Updating the error of `ixdtf` from `ParserError` to `ParseError` was mentioned in #2127 via feedback from #5260.