### PR TITLE
Add Writeable WithPart helper

### DIFF
--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -86,6 +86,7 @@ pub mod adapters {
     use super::*;
 
     pub use parts_write_adapter::CoreWriteAsPartsWrite;
+    pub use parts_write_adapter::WithPart;
     pub use try_writeable::TryWriteableInfallibleAsWriteable;
     pub use try_writeable::WriteableAsTryWriteableInfallible;
 }

--- a/utils/writeable/src/parts_write_adapter.rs
+++ b/utils/writeable/src/parts_write_adapter.rs
@@ -4,6 +4,7 @@
 
 use crate::*;
 
+/// A wrapper around a type implementing [`fmt::Write`] that implements [`PartsWrite`].
 #[derive(Debug)]
 #[allow(clippy::exhaustive_structs)] // newtype
 pub struct CoreWriteAsPartsWrite<W: fmt::Write + ?Sized>(pub W);
@@ -30,5 +31,90 @@ impl<W: fmt::Write + ?Sized> PartsWrite for CoreWriteAsPartsWrite<W> {
         mut f: impl FnMut(&mut Self::SubPartsWrite) -> fmt::Result,
     ) -> fmt::Result {
         f(self)
+    }
+}
+
+/// A [`Writeable`] that writes out the given part.
+///
+/// # Examples
+///
+/// ```
+/// use writeable::Part;
+/// use writeable::assert_writeable_parts_eq;
+/// use writeable::adapters::WithPart;
+///
+/// // Simple usage:
+///
+/// const PART: Part = Part {
+///     category: "foo",
+///     value: "bar",
+/// };
+///
+/// assert_writeable_parts_eq!(
+///     WithPart {
+///         writeable: "Hello World",
+///         part: PART
+///     },
+///     "Hello World",
+///     [(0, 11, PART)],
+/// );
+///
+/// // Can be nested:
+///
+/// const PART2: Part = Part {
+///     category: "foo2",
+///     value: "bar2",
+/// };
+///
+/// assert_writeable_parts_eq!(
+///     WithPart {
+///         writeable: WithPart {
+///             writeable: "Hello World",
+///             part: PART
+///         },
+///         part: PART2
+///     },
+///     "Hello World",
+///     [(0, 11, PART), (0, 11, PART2)],
+/// );
+/// ```
+#[derive(Debug)]
+#[allow(clippy::exhaustive_structs)] // public adapter
+pub struct WithPart<T: ?Sized> {
+    pub part: Part,
+    pub writeable: T,
+}
+
+impl<T: Writeable + ?Sized> Writeable for WithPart<T> {
+    #[inline]
+    fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
+        self.writeable.write_to(sink)
+    }
+
+    #[inline]
+    fn write_to_parts<W: PartsWrite + ?Sized>(&self, sink: &mut W) -> fmt::Result {
+        sink.with_part(self.part, |w| self.writeable.write_to_parts(w))
+    }
+
+    #[inline]
+    fn writeable_length_hint(&self) -> LengthHint {
+        self.writeable.writeable_length_hint()
+    }
+
+    #[inline]
+    fn write_to_string(&self) -> Cow<str> {
+        self.writeable.write_to_string()
+    }
+
+    #[inline]
+    fn writeable_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
+        self.writeable.writeable_cmp_bytes(other)
+    }
+}
+
+impl<T: Writeable + ?Sized> fmt::Display for WithPart<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Writeable::write_to(&self, f)
     }
 }


### PR DESCRIPTION
This is useful for interacting with nested formatters such as `ListFormatter` and `Pattern` that interpolate writeables. It allows setting custom parts on the interpolated writeables.

We could leave this up to userland, but I think it is better implemented as an adapter in the `writeable` create because

1. It is a fairly common use case
2. Our impl is correct and optimal: all functions are inline and bubble through except `write_to_parts`

@kartva Something like this might help.

CC @younies 