### PR TITLE
Migrate main components fixtures to semantic skeleta

### DIFF
--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -118,7 +118,7 @@ required-features = ["bench"]
 
 [[test]]
 name = "datetime"
-required-features = ["compiled_data"]
+required-features = ["experimental", "compiled_data"]
 
 [[test]]
 name = "resolved_components"

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -158,7 +158,7 @@ impl<'l> fmt::Display for FormattedDateTime<'l> {
     }
 }
 
-// Apply length to input number and write to result using fixed_decimal_format.
+/// Apply length to input number and write to result using fixed_decimal_format.
 fn try_write_number<W>(
     result: &mut W,
     fixed_decimal_format: Option<&FixedDecimalFormatter>,
@@ -386,7 +386,21 @@ where
         })
     }
 
-    Ok(match (field.symbol, field.length) {
+    let mut field_length = field.length;
+    if formatting_options.force_2_digit_month_day_week_hour
+        && field_length == FieldLength::One
+        && matches!(
+            field.symbol,
+            FieldSymbol::Month(_)
+                | FieldSymbol::Day(_)
+                | FieldSymbol::Week(_)
+                | FieldSymbol::Hour(_)
+        )
+    {
+        field_length = FieldLength::TwoDigit;
+    }
+
+    Ok(match (field.symbol, field_length) {
         (FieldSymbol::Era, l) => match datetime.year() {
             None => {
                 write_value_missing(w, field)?;

--- a/components/datetime/src/format/mod.rs
+++ b/components/datetime/src/format/mod.rs
@@ -16,6 +16,7 @@ pub mod zoned_datetime;
 #[derive(Debug, Copy, Clone, Default)]
 pub(crate) struct FormattingOptions {
     pub(crate) hour_cycle: Option<HourCycle>,
+    pub(crate) force_2_digit_month_day_week_hour: bool,
     #[cfg(feature = "experimental")]
     pub(crate) fractional_second_digits: Option<FractionalSecondDigits>,
     #[cfg(not(feature = "experimental"))]

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -157,6 +157,11 @@ pub struct NeoOptions<R: DateTimeMarkers> {
     ///
     /// See [`NeoSkeletonLength`].
     pub length: R::LengthOption,
+    /// Whether fields should be aligned for a column-like layout,
+    /// if required for the chosen field set.
+    ///
+    /// See [`Alignment`](crate::neo_skeleton::Alignment).
+    pub alignment: R::AlignmentOption,
     /// When to display the era field in the formatted string,
     /// if required for the chosen field set.
     ///
@@ -173,6 +178,7 @@ impl<R> From<NeoSkeletonLength> for NeoOptions<R>
 where
     R: DateTimeMarkers,
     R::LengthOption: From<NeoSkeletonLength>,
+    R::AlignmentOption: Default,
     R::EraDisplayOption: Default,
     R::FractionalSecondDigitsOption: Default,
 {
@@ -180,6 +186,7 @@ where
     fn from(value: NeoSkeletonLength) -> Self {
         NeoOptions {
             length: value.into(),
+            alignment: Default::default(),
             era_display: Default::default(),
             fractional_second_digits: Default::default(),
         }
@@ -192,6 +199,7 @@ impl<R> Default for NeoOptions<R>
 where
     R: DateTimeMarkers,
     R::LengthOption: Default,
+    R::AlignmentOption: Default,
     R::EraDisplayOption: Default,
     R::FractionalSecondDigitsOption: Default,
 {
@@ -199,6 +207,7 @@ where
     fn default() -> Self {
         NeoOptions {
             length: Default::default(),
+            alignment: Default::default(),
             era_display: Default::default(),
             fractional_second_digits: Default::default(),
         }
@@ -549,6 +558,7 @@ where
             locale,
             options.length.into(),
             components,
+            options.alignment.into(),
             options.era_display.into(),
             options.fractional_second_digits.into(),
             hour_cycle,
@@ -1256,6 +1266,7 @@ where
             locale,
             options.length.into(),
             components,
+            options.alignment.into(),
             options.era_display.into(),
             options.fractional_second_digits.into(),
             hour_cycle,

--- a/components/datetime/src/neo_serde.rs
+++ b/components/datetime/src/neo_serde.rs
@@ -5,8 +5,9 @@
 //! Serde definitions for semantic skeleta
 
 use crate::neo_skeleton::{
-    EraDisplay, FractionalSecondDigits, NeoComponents, NeoDateComponents, NeoDayComponents,
-    NeoSkeleton, NeoSkeletonLength, NeoTimeComponents, NeoTimeZoneSkeleton, NeoTimeZoneStyle,
+    Alignment, EraDisplay, FractionalSecondDigits, NeoComponents, NeoDateComponents,
+    NeoDayComponents, NeoSkeleton, NeoSkeletonLength, NeoTimeComponents, NeoTimeZoneSkeleton,
+    NeoTimeZoneStyle,
 };
 use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
@@ -27,6 +28,7 @@ pub(crate) struct SemanticSkeletonSerde {
     #[serde(rename = "fieldSet")]
     pub(crate) field_set: NeoComponents,
     pub(crate) length: NeoSkeletonLength,
+    pub(crate) alignment: Option<Alignment>,
     #[serde(rename = "eraDisplay")]
     pub(crate) era_display: Option<EraDisplay>,
     #[serde(rename = "fractionalSecondDigits")]
@@ -38,6 +40,7 @@ impl From<NeoSkeleton> for SemanticSkeletonSerde {
         Self {
             field_set: value.components,
             length: value.length,
+            alignment: value.alignment,
             era_display: value.era_display,
             fractional_second_digits: value.fractional_second_digits,
         }
@@ -50,6 +53,7 @@ impl TryFrom<SemanticSkeletonSerde> for NeoSkeleton {
         Ok(NeoSkeleton {
             length: value.length,
             components: value.field_set,
+            alignment: value.alignment,
             era_display: value.era_display,
             fractional_second_digits: value.fractional_second_digits,
         })
@@ -484,6 +488,7 @@ fn test_basic() {
             NeoTimeZoneSkeleton::generic(),
         ),
         length: NeoSkeletonLength::Medium,
+        alignment: Some(Alignment::Column),
         era_display: Some(EraDisplay::Always),
         fractional_second_digits: Some(FractionalSecondDigits::F3),
     };
@@ -491,7 +496,7 @@ fn test_basic() {
     let json_string = serde_json::to_string(&skeleton).unwrap();
     assert_eq!(
         json_string,
-        r#"{"fieldSet":["year","month","day","weekday","hour","minute","zoneGeneric"],"length":"medium","eraDisplay":"always","fractionalSecondDigits":3}"#
+        r#"{"fieldSet":["year","month","day","weekday","hour","minute","zoneGeneric"],"length":"medium","alignment":"column","eraDisplay":"always","fractionalSecondDigits":3}"#
     );
     let json_skeleton = serde_json::from_str::<NeoSkeleton>(&json_string).unwrap();
     assert_eq!(skeleton, json_skeleton);

--- a/components/datetime/src/neo_skeleton.rs
+++ b/components/datetime/src/neo_skeleton.rs
@@ -61,20 +61,35 @@ impl NeoSkeletonLength {
     }
 }
 
+/// The alignment context of the formatted string.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+#[non_exhaustive]
+pub enum Alignment {
+    /// Align fields as the locale specifies them to be aligned.
+    ///
+    /// This is the default option.
+    Auto,
+    /// Align fields as appropriate for a column layout. For example:
+    ///
+    /// | US Holiday   | Date       |
+    /// |--------------|------------|
+    /// | Memorial Day | 05/26/2025 |
+    /// | Labor Day    | 09/01/2025 |
+    /// | Veterans Day | 11/11/2025 |
+    ///
+    /// This option causes numeric fields to be padded when necessary. It does
+    /// not impact whether a numeric or spelled-out field is chosen.
+    Column,
+}
+
 /// A specification for when to display the era when formatting a year.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[non_exhaustive]
 pub enum EraDisplay {
-    /// Always display the era.
-    ///
-    /// Examples:
-    ///
-    /// - `1000 BC`
-    /// - `77 AD`
-    /// - `2024 AD`
-    Always,
     /// Display the era when needed to disambiguate the year.
     ///
     /// This is the default option.
@@ -85,6 +100,14 @@ pub enum EraDisplay {
     /// - `77 AD`
     /// - `2024`
     Auto,
+    /// Always display the era.
+    ///
+    /// Examples:
+    ///
+    /// - `1000 BC`
+    /// - `77 AD`
+    /// - `2024 AD`
+    Always,
     // TODO(#4478): add Hide and Never options once there is data to back them
 }
 
@@ -986,6 +1009,8 @@ pub struct NeoDateSkeleton {
     pub length: NeoSkeletonLength,
     /// Date components of the skeleton.
     pub components: NeoDateComponents,
+    /// Alignment option.
+    pub alignment: Option<Alignment>,
     /// Era display option.
     pub era_display: Option<EraDisplay>,
 }
@@ -999,6 +1024,7 @@ impl NeoDateSkeleton {
         Self {
             length,
             components,
+            alignment: None,
             era_display: None,
         }
     }
@@ -1023,6 +1049,7 @@ impl NeoDateSkeleton {
         NeoDateSkeleton {
             length,
             components: NeoDateComponents::Day(day_components),
+            alignment: None,
             era_display: None,
         }
     }
@@ -1036,6 +1063,8 @@ pub struct NeoTimeSkeleton {
     pub length: NeoSkeletonLength,
     /// Time components of the skeleton.
     pub components: NeoTimeComponents,
+    /// Alignment option.
+    pub alignment: Option<Alignment>,
     /// Fractional second digits option.
     pub fractional_second_digits: Option<FractionalSecondDigits>,
 }
@@ -1049,6 +1078,7 @@ impl NeoTimeSkeleton {
         Self {
             length,
             components,
+            alignment: None,
             fractional_second_digits: None,
         }
     }
@@ -1062,6 +1092,8 @@ pub struct NeoDateTimeSkeleton {
     pub length: NeoSkeletonLength,
     /// Date and time components of the skeleton.
     pub components: NeoDateTimeComponents,
+    /// Alignment option.
+    pub alignment: Option<Alignment>,
     /// Era display option.
     pub era_display: Option<EraDisplay>,
     /// Fractional second digits option.
@@ -1078,6 +1110,7 @@ impl NeoDateTimeSkeleton {
         Self {
             length,
             components: NeoDateTimeComponents::DateTime(date, time),
+            alignment: None,
             era_display: None,
             fractional_second_digits: None,
         }
@@ -1097,6 +1130,8 @@ pub struct NeoSkeleton {
     pub length: NeoSkeletonLength,
     /// Components of the skeleton.
     pub components: NeoComponents,
+    /// Alignment option.
+    pub alignment: Option<Alignment>,
     /// Era display option.
     pub era_display: Option<EraDisplay>,
     /// Fractional second digits option.
@@ -1108,6 +1143,7 @@ impl From<NeoDateSkeleton> for NeoSkeleton {
         NeoSkeleton {
             length: value.length,
             components: value.components.into(),
+            alignment: value.alignment,
             era_display: value.era_display,
             fractional_second_digits: None,
         }
@@ -1119,6 +1155,7 @@ impl From<NeoTimeSkeleton> for NeoSkeleton {
         NeoSkeleton {
             length: value.length,
             components: value.components.into(),
+            alignment: value.alignment,
             era_display: None,
             fractional_second_digits: value.fractional_second_digits,
         }
@@ -1130,6 +1167,7 @@ impl From<NeoDateTimeSkeleton> for NeoSkeleton {
         NeoSkeleton {
             length: value.length,
             components: value.components.into(),
+            alignment: value.alignment,
             era_display: value.era_display,
             fractional_second_digits: value.fractional_second_digits,
         }
@@ -1147,6 +1185,7 @@ impl NeoDateTimeSkeleton {
         NeoDateTimeSkeleton {
             length,
             components: NeoDateTimeComponents::DateTime(day_components, time_components),
+            alignment: None,
             era_display: None,
             fractional_second_digits: None,
         }

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -6,7 +6,7 @@ use crate::format::neo::FieldForDataLoading;
 use crate::format::FormattingOptions;
 use crate::input::ExtractedDateTimeInput;
 use crate::neo_pattern::DateTimePattern;
-use crate::neo_skeleton::FractionalSecondDigits;
+use crate::neo_skeleton::{Alignment, FractionalSecondDigits};
 use crate::neo_skeleton::{
     EraDisplay, NeoComponents, NeoDateComponents, NeoDateSkeleton, NeoSkeletonLength,
     NeoTimeComponents, NeoTimeSkeleton, NeoTimeZoneSkeleton,
@@ -53,7 +53,7 @@ pub(crate) enum DatePatternSelectionData {
 
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum DatePatternDataBorrowed<'a> {
-    Resolved(runtime::PatternBorrowed<'a>),
+    Resolved(runtime::PatternBorrowed<'a>, Option<Alignment>),
 }
 
 /// An "overlap" pattern: one that has fields from at least 2 of date, time, and zone.
@@ -83,6 +83,7 @@ pub(crate) enum TimePatternSelectionData {
 pub(crate) enum TimePatternDataBorrowed<'a> {
     Resolved(
         runtime::PatternBorrowed<'a>,
+        Option<Alignment>,
         Option<HourCycle>,
         Option<FractionalSecondDigits>,
     ),
@@ -166,6 +167,7 @@ impl DatePatternSelectionData {
         locale: &DataLocale,
         length: MaybeLength,
         components: NeoDateComponents,
+        alignment: Option<Alignment>,
         era_display: Option<EraDisplay>,
     ) -> Result<Self, DataError> {
         let payload = provider
@@ -182,6 +184,7 @@ impl DatePatternSelectionData {
             skeleton: NeoDateSkeleton {
                 length: length.get::<Self>(),
                 components,
+                alignment,
                 era_display,
             },
             payload,
@@ -217,12 +220,13 @@ impl DatePatternSelectionData {
                     Some(EraDisplay::Always) => true,
                     Some(EraDisplay::Auto) | None => datetime.should_display_era(),
                 };
-                DatePatternDataBorrowed::Resolved(payload.get().get_pattern(
-                    PatternSelectionOptions {
+                DatePatternDataBorrowed::Resolved(
+                    payload.get().get_pattern(PatternSelectionOptions {
                         length: skeleton.length,
                         should_display_era: Some(should_display_era),
-                    },
-                ))
+                    }),
+                    skeleton.alignment,
+                )
             }
         }
     }
@@ -295,6 +299,7 @@ impl OverlapPatternSelectionData {
                         length: date_skeleton.length,
                         should_display_era: Some(should_display_era),
                     }),
+                    time_skeleton.alignment,
                     *hour_cycle,
                     time_skeleton.fractional_second_digits,
                 )
@@ -309,6 +314,7 @@ impl TimePatternSelectionData {
         locale: &DataLocale,
         length: MaybeLength,
         components: NeoTimeComponents,
+        alignment: Option<Alignment>,
         fractional_second_digits: Option<FractionalSecondDigits>,
         hour_cycle: Option<HourCycle>,
     ) -> Result<Self, DataError> {
@@ -348,6 +354,7 @@ impl TimePatternSelectionData {
             skeleton: NeoTimeSkeleton {
                 length: length.get::<Self>(),
                 components,
+                alignment,
                 fractional_second_digits,
             },
             hour_cycle,
@@ -390,6 +397,7 @@ impl TimePatternSelectionData {
                     length: skeleton.length,
                     should_display_era: None,
                 }),
+                skeleton.alignment,
                 *hour_cycle,
                 skeleton.fractional_second_digits,
             ),
@@ -429,6 +437,7 @@ impl DateTimeZonePatternSelectionData {
         locale: &DataLocale,
         length: Option<NeoSkeletonLength>,
         components: NeoComponents,
+        alignment: Option<Alignment>,
         era_display: Option<EraDisplay>,
         fractional_second_digits: Option<FractionalSecondDigits>,
         hour_cycle: Option<HourCycle>,
@@ -441,6 +450,7 @@ impl DateTimeZonePatternSelectionData {
                     locale,
                     length,
                     components,
+                    alignment,
                     era_display,
                 )?;
                 Ok(Self::Date(selection))
@@ -451,6 +461,7 @@ impl DateTimeZonePatternSelectionData {
                     locale,
                     length,
                     components,
+                    alignment,
                     fractional_second_digits,
                     hour_cycle,
                 )?;
@@ -468,11 +479,13 @@ impl DateTimeZonePatternSelectionData {
                     let date_skeleton = NeoDateSkeleton {
                         length,
                         components: NeoDateComponents::Day(day_components),
+                        alignment,
                         era_display,
                     };
                     let time_skeleton = NeoTimeSkeleton {
                         length,
                         components: time_components,
+                        alignment,
                         fractional_second_digits,
                     };
                     match OverlapPatternSelectionData::try_new_with_skeleton(
@@ -499,6 +512,7 @@ impl DateTimeZonePatternSelectionData {
                     locale,
                     length,
                     NeoDateComponents::Day(day_components),
+                    alignment,
                     era_display,
                 )?;
                 let time = TimePatternSelectionData::try_new_with_skeleton(
@@ -506,6 +520,7 @@ impl DateTimeZonePatternSelectionData {
                     locale,
                     length,
                     time_components,
+                    alignment,
                     fractional_second_digits,
                     hour_cycle,
                 )?;
@@ -518,6 +533,7 @@ impl DateTimeZonePatternSelectionData {
                     locale,
                     length,
                     date_components,
+                    alignment,
                     era_display,
                 )?;
                 let zone = ZonePatternSelectionData::new_with_skeleton(length, zone_components);
@@ -530,6 +546,7 @@ impl DateTimeZonePatternSelectionData {
                     locale,
                     length,
                     time_components,
+                    alignment,
                     fractional_second_digits,
                     hour_cycle,
                 )?;
@@ -543,6 +560,7 @@ impl DateTimeZonePatternSelectionData {
                     locale,
                     length,
                     NeoDateComponents::Day(day_components),
+                    alignment,
                     era_display,
                 )?;
                 let time = TimePatternSelectionData::try_new_with_skeleton(
@@ -550,6 +568,7 @@ impl DateTimeZonePatternSelectionData {
                     locale,
                     length,
                     time_components,
+                    alignment,
                     fractional_second_digits,
                     hour_cycle,
                 )?;
@@ -755,26 +774,26 @@ impl<'a> DateTimeZonePatternDataBorrowed<'a> {
     #[inline]
     pub(crate) fn metadata(self) -> PatternMetadata {
         match self {
-            Self::Date(DatePatternDataBorrowed::Resolved(pb)) => pb.metadata,
-            Self::Time(TimePatternDataBorrowed::Resolved(pb, _, _)) => pb.metadata,
+            Self::Date(DatePatternDataBorrowed::Resolved(pb, _)) => pb.metadata,
+            Self::Time(TimePatternDataBorrowed::Resolved(pb, _, _, _)) => pb.metadata,
             Self::Zone(_) => Default::default(),
             Self::Overlap(_) => Default::default(),
             Self::DateTimeGlue {
-                date: DatePatternDataBorrowed::Resolved(date),
-                time: TimePatternDataBorrowed::Resolved(time, _, _),
+                date: DatePatternDataBorrowed::Resolved(date, _),
+                time: TimePatternDataBorrowed::Resolved(time, _, _, _),
                 ..
             } => PatternMetadata::merge_date_and_time_metadata(date.metadata, time.metadata),
             Self::DateZoneGlue {
-                date: DatePatternDataBorrowed::Resolved(date),
+                date: DatePatternDataBorrowed::Resolved(date, _),
                 ..
             } => date.metadata,
             Self::TimeZoneGlue {
-                time: TimePatternDataBorrowed::Resolved(time, _, _),
+                time: TimePatternDataBorrowed::Resolved(time, _, _, _),
                 ..
             } => time.metadata,
             Self::DateTimeZoneGlue {
-                date: DatePatternDataBorrowed::Resolved(date),
-                time: TimePatternDataBorrowed::Resolved(time, _, _),
+                date: DatePatternDataBorrowed::Resolved(date, _),
+                time: TimePatternDataBorrowed::Resolved(time, _, _, _),
                 ..
             } => PatternMetadata::merge_date_and_time_metadata(date.metadata, time.metadata),
         }
@@ -782,13 +801,19 @@ impl<'a> DateTimeZonePatternDataBorrowed<'a> {
 
     #[inline]
     pub(crate) fn formatting_options(self) -> FormattingOptions {
-        // Currently only Time contributes to the formatting options
-        let (hour_cycle, fractional_second_digits) = match self.time_pattern() {
-            Some(TimePatternDataBorrowed::Resolved(_, a, b)) => (a, b),
-            _ => (None, None),
+        let date_alignment = match self.date_pattern() {
+            Some(DatePatternDataBorrowed::Resolved(_, a)) => a,
+            _ => None,
         };
+        let (time_alignment, hour_cycle, fractional_second_digits) = match self.time_pattern() {
+            Some(TimePatternDataBorrowed::Resolved(_, a, b, c)) => (a, b, c),
+            _ => (None, None, None),
+        };
+        let force_2_digit_month_day_week_hour = matches!(date_alignment, Some(Alignment::Column))
+            || matches!(time_alignment, Some(Alignment::Column));
         FormattingOptions {
             hour_cycle,
+            force_2_digit_month_day_week_hour,
             fractional_second_digits,
         }
     }
@@ -806,13 +831,15 @@ impl<'a> DateTimeZonePatternDataBorrowed<'a> {
                     Err(1) => self
                         .date_pattern()
                         .map(|data| match data {
-                            DatePatternDataBorrowed::Resolved(pb) => pb.items.as_ule_slice(),
+                            DatePatternDataBorrowed::Resolved(pb, _) => pb.items.as_ule_slice(),
                         })
                         .unwrap_or(&[]),
                     Err(0) => self
                         .time_pattern()
                         .map(|data| match data {
-                            TimePatternDataBorrowed::Resolved(pb, _, _) => pb.items.as_ule_slice(),
+                            TimePatternDataBorrowed::Resolved(pb, _, _, _) => {
+                                pb.items.as_ule_slice()
+                            }
                         })
                         .unwrap_or(&[]),
                     Err(2) => self
@@ -831,8 +858,8 @@ impl<'a> DateTimeZonePatternDataBorrowed<'a> {
 
     pub(crate) fn to_pattern(self) -> DateTimePattern {
         let pb = match self {
-            Self::Date(DatePatternDataBorrowed::Resolved(pb)) => pb,
-            Self::Time(TimePatternDataBorrowed::Resolved(pb, _, _)) => pb,
+            Self::Date(DatePatternDataBorrowed::Resolved(pb, _)) => pb,
+            Self::Time(TimePatternDataBorrowed::Resolved(pb, _, _, _)) => pb,
             _ => todo!(),
         };
         DateTimePattern::from_runtime_pattern(pb.as_pattern().into_owned())

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -312,6 +312,7 @@ fn assert_fixture_element<A>(
     };
 
     let mut options = NeoOptions::from(skeleton.length);
+    options.alignment = skeleton.alignment;
     options.era_display = skeleton.era_display;
     options.fractional_second_digits = skeleton.fractional_second_digits;
 

--- a/components/datetime/tests/fixtures/tests/components-exact-matches.json
+++ b/components/datetime/tests/fixtures/tests/components-exact-matches.json
@@ -393,8 +393,7 @@
                 "semantic": {
                     "fieldSet": ["weekday", "hour", "minute"],
                     "length": "medium"
-                },
-                "preferences": { "hourCycle": "h12" }
+                }
             }
         },
         "output": {
@@ -417,8 +416,7 @@
                 "semantic": {
                     "fieldSet": ["weekday", "hour", "minute", "second"],
                     "length": "medium"
-                },
-                "preferences": { "hourCycle": "h12" }
+                }
             }
         },
         "output": {
@@ -428,7 +426,7 @@
         }
     },
     {
-        "description": "Exact match for: EHm => E HH:mm",
+        "description": "Exact match for: EHm => E HH:mm (TODO #5387)",
         "input": {
             "value": "2020-01-07T08:25:07.000",
             "options": {
@@ -446,12 +444,12 @@
         },
         "output": {
             "values": {
-                "en": "Tue 08:25"
+                "en": "Tue, 08:25"
             }
         }
     },
     {
-        "description": "Exact match for: EHms => E HH:mm:ss",
+        "description": "Exact match for: EHms => E HH:mm:ss (TODO #5387)",
         "input": {
             "value": "2020-01-07T08:25:07.000",
             "options": {
@@ -470,7 +468,7 @@
         },
         "output": {
             "values": {
-                "en": "Tue 08:25:07"
+                "en": "Tue, 08:25:07"
             }
         }
     },
@@ -632,10 +630,6 @@
                 "components": {
                     "year": "numeric-week-of",
                     "week": "numeric-week-of-year"
-                },
-                "semantic": {
-                    "fieldSet": ["year", "weekOfYear"],
-                    "length": "long"
                 }
             }
         },

--- a/components/datetime/tests/fixtures/tests/components-width-differences.json
+++ b/components/datetime/tests/fixtures/tests/components-width-differences.json
@@ -55,10 +55,6 @@
                 "components": {
                     "year": "two-digit-week-of",
                     "week": "numeric-week-of-year"
-                },
-                "semantic": {
-                    "fieldSet": ["year", "weekOfYear"],
-                    "length": "short"
                 }
             }
         },
@@ -98,7 +94,7 @@
                     "day": "numeric-day-of-month"
                 },
                 "semantic": {
-                    "fieldSet": ["year", "month", "day"],
+                    "fieldSet": ["fullYear", "month", "day"],
                     "length": "short"
                 }
             }
@@ -109,7 +105,7 @@
                 "en-u-ca-buddhist": "1/7/2563 BE",
                 "fr": "07/01/2020",
                 "en-u-ca-coptic": "4/28/1736 ERA1",
-                "fr-u-ca-coptic": "28/4/1736 ap. D."
+                "fr-u-ca-coptic": "28/04/1736 ap. D."
             }
         }
     },
@@ -200,10 +196,6 @@
                     "year": "numeric",
                     "month": "narrow",
                     "day": "numeric-day-of-month"
-                },
-                "semantic": {
-                    "fieldSet": ["year", "month", "day"],
-                    "length": "short"
                 }
             }
         },

--- a/components/datetime/tests/fixtures/tests/components-width-differences.json
+++ b/components/datetime/tests/fixtures/tests/components-width-differences.json
@@ -110,26 +110,27 @@
         }
     },
     {
-        "description": "Enumerate month lengths which may need expansion: yMMd => MM/d/y",
+        "description": "Enumerate month lengths which may need expansion: yMMdd => MM/dd/y",
         "input": {
             "value": "2020-01-07T08:25:07.000",
             "options": {
                 "components": {
                     "year": "numeric",
                     "month": "two-digit",
-                    "day": "numeric-day-of-month"
+                    "day": "two-digit-day-of-month"
                 },
                 "semantic": {
                     "fieldSet": ["year", "month", "day"],
-                    "length": "short"
+                    "length": "short",
+                    "alignment": "column"
                 }
             }
         },
         "output": {
             "values": {
-                "en": "01/7/2020",
-                "en-u-ca-buddhist": "01/7/2563 BE",
-                "fr": "7/01/2020",
+                "en": "01/07/20",
+                "en-u-ca-buddhist": "01/07/2563 BE",
+                "fr": "07/01/2020",
                 "en-u-ca-coptic": "04/28/1736 ERA1",
                 "fr-u-ca-coptic": "28/04/1736 ap. D."
             }

--- a/components/datetime/tests/fixtures/tests/components.json
+++ b/components/datetime/tests/fixtures/tests/components.json
@@ -17,40 +17,41 @@
                     "fieldSet": ["fullYear", "month", "day", "weekday", "hour", "minute", "second"],
                     "length": "long",
                     "eraDisplay": "always"
-                }
+                },
+                "preferences": { "hourCycle": "h23" }
             }
         },
         "output": {
             "values": {
-                "en": "Tuesday, January 21, 2020 Anno Domini, 08:25:07",
+                "en": "Tuesday, January 21, 2020 AD, 08:25:07",
                 "en-u-ca-buddhist": "Tuesday, January 21, 2563 BE, 08:25:07",
                 "en-u-ca-chinese": "Tuesday, Twelfth Month 27, 2019(己亥), 08:25:07",
                 "zh-u-ca-chinese": "2019己亥年腊月27星期二 08:25:07",
                 "en-u-ca-japanese": "Tuesday, January 21, 2 Reiwa, 08:25:07",
                 "ja-u-ca-japanese": "令和2年1月21日火曜日 8:25:07",
                 "en-u-ca-coptic": "Tuesday, Toba 12, 1736 ERA1, 08:25:07",
-                "fr-u-ca-coptic": "mardi 12 toubah 1736 après Dioclétien 08:25:07",
+                "fr-u-ca-coptic": "mardi 12 toubah 1736 ap. D., 08:25:07",
                 "en-u-ca-dangi": "Tuesday, Twelfth Month 27, 2019(기해), 08:25:07",
-                "fr-u-ca-dangi": "2019(기해) shí’èryuè 27, mardi 08:25:07",
+                "fr-u-ca-dangi": "2019(기해) shí’èryuè 27, mardi, 08:25:07",
                 "ko-u-ca-dangi": "2019년(기해년) 12월 27일 화요일 08:25:07",
-                "en-u-ca-indian": "Tuesday, Magha 01, 1941 Saka, 08:25:07",
+                "en-u-ca-indian": "Tuesday, Magha 1, 1941 Saka, 08:25:07",
                 "en-u-ca-islamic": "Tuesday, Jumada I 25, 1441 AH, 08:25:07",
-                "fr-u-ca-islamic": "mardi 25 joumada al oula 1441 ère de l’Hégire 08:25:07",
+                "fr-u-ca-islamic": "mardi 25 joumada al oula 1441 AH, 08:25:07",
                 "en-u-ca-islamic-civil": "Tuesday, Jumada I 25, 1441 AH, 08:25:07",
-                "fr-u-ca-islamic-civil": "mardi 25 joumada al oula 1441 ère de l’Hégire 08:25:07",
+                "fr-u-ca-islamic-civil": "mardi 25 joumada al oula 1441 AH, 08:25:07",
                 "en-u-ca-islamic-umalqura": "Tuesday, Jumada I 26, 1441 AH, 08:25:07",
-                "fr-u-ca-islamic-umalqura": "mardi 26 joumada al oula 1441 ère de l’Hégire 08:25:07",
+                "fr-u-ca-islamic-umalqura": "mardi 26 joumada al oula 1441 AH, 08:25:07",
                 "en-u-ca-islamic-tbla": "Tuesday, Jumada I 26, 1441 AH, 08:25:07",
-                "fr-u-ca-islamic-tbla": "mardi 26 joumada al oula 1441 ère de l’Hégire 08:25:07",
-                "en-u-ca-persian": "Tuesday, Bahman 01, 1398 AP, 08:25:07",
-                "fr-u-ca-persian": "mardi 01 bahman 1398 Anno Persico 08:25:07",
+                "fr-u-ca-islamic-tbla": "mardi 26 joumada al oula 1441 AH, 08:25:07",
+                "en-u-ca-persian": "Tuesday, Bahman 1, 1398 AP, 08:25:07",
+                "fr-u-ca-persian": "mardi 1 bahman 1398 A. P., 08:25:07",
                 "en-u-ca-hebrew": "Tuesday, 24 Tevet 5780 AM, 08:25:07",
-                "fr-u-ca-hebrew": "mardi 24 téveth 5780 Anno Mundi 08:25:07",
+                "fr-u-ca-hebrew": "mardi 24 téveth 5780 A. M., 08:25:07",
                 "en-u-ca-ethiopic": "Tuesday, Ter 12, 2012 ERA0, 08:25:07",
-                "fr-u-ca-ethiopic": "mardi 12 ter 2012 avant l’Incarnation 08:25:07",
-                "fr-u-ca-ethioaa": "mardi 12 ter 7512 ERA0 08:25:07",
+                "fr-u-ca-ethiopic": "mardi 12 ter 2012 av. Inc., 08:25:07",
+                "fr-u-ca-ethioaa": "mardi 12 ter 7512 ERA0, 08:25:07",
                 "en-u-ca-roc": "Tuesday, January 21, 109 Minguo, 08:25:07",
-                "fr-u-ca-roc": "mardi 21 janvier 109 RdC 08:25:07",
+                "fr-u-ca-roc": "mardi 21 janvier 109 RdC, 08:25:07",
                 "zh-u-ca-roc": "民国109年1月21日星期二 08:25:07"
             }
         }
@@ -73,13 +74,14 @@
                     "fieldSet": ["year", "month", "day", "weekday", "hour", "minute", "second"],
                     "length": "long",
                     "eraDisplay": "always"
-                }
+                },
+                "preferences": { "hourCycle": "h23" }
             }
         },
         "output": {
             "values": {
-                "en-u-ca-chinese": "Thursday, 閏Second Month 02, 2023(癸卯), 14:15:07",
-                "zh-u-ca-chinese": "2023癸卯年閏二月02星期四 14:15:07"
+                "en-u-ca-chinese": "Thursday, Second Monthbis 2, 2023(癸卯), 14:15:07",
+                "zh-u-ca-chinese": "2023癸卯年闰二月2星期四 14:15:07"
             }
         }
     },
@@ -98,16 +100,17 @@
                     "second": "numeric"
                 },
                 "semantic": {
-                    "fieldSet": ["year", "month", "day", "weekday", "hour", "minute", "second"],
+                    "fieldSet": ["fullYear", "month", "day", "weekday", "hour", "minute", "second"],
                     "length": "long",
                     "eraDisplay": "always"
-                }
+                },
+                "preferences": { "hourCycle": "h23" }
             }
         },
         "output": {
             "values": {
                 "en-u-ca-hebrew": "Sunday, 28 Adar II 5771 AM, 14:15:07",
-                "fr-u-ca-hebrew": "dimanche 28 adar II 5771 Anno Mundi 14:15:07"
+                "fr-u-ca-hebrew": "dimanche 28 adar II 5771 A. M., 14:15:07"
             }
         }
     },
@@ -124,7 +127,8 @@
                 "semantic": {
                     "fieldSet": ["hour", "minute", "second"],
                     "length": "short"
-                }
+                },
+                "preferences": { "hourCycle": "h23" }
             }
         },
         "output": {
@@ -147,7 +151,8 @@
                     "fieldSet": ["hour", "minute", "second"],
                     "length": "short",
                     "fractionalSecondDigits": 8
-                }
+                },
+                "preferences": { "hourCycle": "h23" }
             }
         },
         "output": {

--- a/provider/source/src/datetime/neo.rs
+++ b/provider/source/src/datetime/neo.rs
@@ -828,6 +828,9 @@ impl_symbols_datagen!(
 );
 
 // Datetime patterns
+// TODO: This is modeled with glue patterns that are the same across calendar
+// systems, but CLDR has some instances where the glue patterns differ, such
+// as in French (Gregorian has a comma but other calendars do not).
 impl_pattern_datagen!(
     GluePatternV1Marker,
     "gregory",


### PR DESCRIPTION
Depends on #5381

This is a major milestone in the work toward #1317. The feature coverage tests that had been running against the old datetime classes are now running against the new ones.