### PR TITLE
Fix wasm-demo

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -270,6 +270,8 @@ jobs:
       run: |
         npm -C ffi/npm ci
         npm -C tutorials/npm ci
+      env: 
+        PINNED_CI_NIGHTLY: nightly-2024-07-23
 
     - name: Run Webpack
       run: npm -C tutorials/npm run build


### PR DESCRIPTION
https://github.com/unicode-org/icu4x/pull/5285 changed the NPM package to build with latest nightly. However, latest nightly seems to be broken (rust-std isn't found), so we should build with a nightly that we know works.