### PR TITLE
Remove `icu_` prefix from `icu_capi` features

### DIFF
--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -62,25 +62,35 @@ logging = ["icu_provider/logging", "dep:log", "diplomat-runtime/log", "std"]
 simple_logger = ["dep:simple_logger", "logging"]
 
 # Components
-default_components = ["icu_calendar", "icu_casemap", "icu_collator", "icu_datetime", "icu_decimal",
-                      "icu_list", "icu_locale",
-                      "icu_normalizer", "icu_plurals", "icu_properties",
-                      "icu_segmenter", "icu_timezone"]
-experimental_components = ["dep:icu_experimental"]
+default_components = [
+    "calendar",
+    "casemap",
+    "collator",
+    "datetime",
+    "decimal",
+    "list",
+    "locale",
+    "normalizer",
+    "plurals",
+    "properties",
+    "segmenter",
+    "timezone"
+]
 
-icu_calendar = ["dep:icu_calendar"]
-icu_casemap = ["dep:icu_casemap"]
-icu_collator = ["dep:icu_collator"]
-# icu_collections = ["dep:icu_collections"] # Not useful on its own: use icu_properties
-icu_datetime = ["dep:icu_datetime", "dep:icu_calendar", "dep:icu_timezone", "dep:icu_decimal", "dep:icu_plurals"]
-icu_decimal = ["dep:icu_decimal", "dep:fixed_decimal"]
-icu_list = ["dep:icu_list"]
-icu_locale = ["dep:icu_locale"]
-icu_normalizer = ["dep:icu_normalizer"]
-icu_plurals = ["dep:icu_plurals", "dep:fixed_decimal"]
-icu_properties = ["dep:icu_properties", "dep:icu_collections", "dep:unicode-bidi"]
-icu_segmenter = ["dep:icu_segmenter"]
-icu_timezone = ["dep:icu_timezone", "dep:icu_calendar"]
+calendar = ["dep:icu_calendar"]
+casemap = ["dep:icu_casemap"]
+collator = ["dep:icu_collator"]
+# collections = ["dep:icu_collections"] # Not useful on its own: use properties
+datetime = ["dep:icu_datetime", "dep:icu_calendar", "dep:icu_timezone", "dep:icu_decimal", "dep:icu_plurals"]
+decimal = ["dep:icu_decimal", "dep:fixed_decimal"]
+experimental = ["dep:icu_experimental"]
+list = ["dep:icu_list"]
+locale = ["dep:icu_locale"]
+normalizer = ["dep:icu_normalizer"]
+plurals = ["dep:icu_plurals", "dep:fixed_decimal"]
+properties = ["dep:icu_properties", "dep:icu_collections", "dep:unicode-bidi"]
+segmenter = ["dep:icu_segmenter"]
+timezone = ["dep:icu_timezone", "dep:icu_calendar"]
 
 compiled_data = [
     "icu_calendar?/compiled_data",

--- a/ffi/capi/src/casemap.rs
+++ b/ffi/capi/src/casemap.rs
@@ -132,7 +132,7 @@ pub mod ffi {
         ///
         /// Identical to the similarly named method on `CaseMapCloser`, use that if you
         /// plan on using string case closure mappings too.
-        #[cfg(feature = "icu_properties")]
+        #[cfg(feature = "properties")]
         #[diplomat::rust_link(icu::casemap::CaseMapper::add_case_closure_to, FnInStruct)]
         #[diplomat::rust_link(icu::casemap::ClosureSink, Trait, hidden)]
         #[diplomat::rust_link(icu::casemap::ClosureSink::add_char, FnInTrait, hidden)]
@@ -225,7 +225,7 @@ pub mod ffi {
 
         /// Adds all simple case mappings and the full case folding for `c` to `builder`.
         /// Also adds special case closure mappings.
-        #[cfg(feature = "icu_properties")]
+        #[cfg(feature = "properties")]
         #[diplomat::rust_link(icu::casemap::CaseMapCloser::add_case_closure_to, FnInStruct)]
         pub fn add_case_closure_to(
             &self,
@@ -241,7 +241,7 @@ pub mod ffi {
         /// and adds them to the set.
         ///
         /// Returns true if the string was found
-        #[cfg(feature = "icu_properties")]
+        #[cfg(feature = "properties")]
         #[diplomat::rust_link(icu::casemap::CaseMapCloser::add_string_case_closure_to, FnInStruct)]
         pub fn add_string_case_closure_to(
             &self,

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -15,7 +15,7 @@ pub mod ffi {
 
     use tinystr::TinyAsciiStr;
 
-    #[cfg(feature = "icu_calendar")]
+    #[cfg(feature = "calendar")]
     use crate::week::ffi::WeekCalculator;
 
     #[diplomat::enum_convert(icu_calendar::types::IsoWeekday)]
@@ -113,7 +113,7 @@ pub mod ffi {
             FnInStruct,
             hidden
         )]
-        #[cfg(feature = "icu_calendar")]
+        #[cfg(feature = "calendar")]
         pub fn week_of_year(&self, calculator: &WeekCalculator) -> crate::week::ffi::WeekOf {
             self.0.week_of_year(&calculator.0).into()
         }
@@ -273,7 +273,7 @@ pub mod ffi {
             FnInStruct,
             hidden
         )]
-        #[cfg(feature = "icu_calendar")]
+        #[cfg(feature = "calendar")]
         pub fn week_of_year(&self, calculator: &WeekCalculator) -> crate::week::ffi::WeekOf {
             self.0.week_of_year(&calculator.0).into()
         }

--- a/ffi/capi/src/datetime.rs
+++ b/ffi/capi/src/datetime.rs
@@ -17,7 +17,7 @@ pub mod ffi {
 
     use tinystr::TinyAsciiStr;
 
-    #[cfg(feature = "icu_calendar")]
+    #[cfg(feature = "calendar")]
     use crate::week::ffi::WeekCalculator;
 
     #[diplomat::opaque]
@@ -186,7 +186,7 @@ pub mod ffi {
             FnInStruct,
             hidden
         )]
-        #[cfg(feature = "icu_calendar")]
+        #[cfg(feature = "calendar")]
         pub fn week_of_year(&self, calculator: &WeekCalculator) -> crate::week::ffi::WeekOf {
             self.0.date.week_of_year(&calculator.0).into()
         }
@@ -412,7 +412,7 @@ pub mod ffi {
             FnInStruct,
             hidden
         )]
-        #[cfg(feature = "icu_calendar")]
+        #[cfg(feature = "calendar")]
         pub fn week_of_year(&self, calculator: &WeekCalculator) -> crate::week::ffi::WeekOf {
             self.0.date.week_of_year(&calculator.0).into()
         }

--- a/ffi/capi/src/errors.rs
+++ b/ffi/capi/src/errors.rs
@@ -53,11 +53,7 @@ pub mod ffi {
     #[repr(C)]
     #[diplomat::rust_link(icu::calendar::RangeError, Struct, compact)]
     #[diplomat::rust_link(icu::calendar::DateError, Enum, compact)]
-    #[cfg(any(
-        feature = "datetime",
-        feature = "timezone",
-        feature = "calendar"
-    ))]
+    #[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
     pub enum CalendarError {
         Unknown = 0x00,
         OutOfRange = 0x01,
@@ -68,11 +64,7 @@ pub mod ffi {
     #[derive(Debug, PartialEq, Eq)]
     #[repr(C)]
     #[diplomat::rust_link(icu::calendar::ParseError, Enum, compact)]
-    #[cfg(any(
-        feature = "datetime",
-        feature = "timezone",
-        feature = "calendar"
-    ))]
+    #[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
     pub enum CalendarParseError {
         Unknown = 0x00,
         InvalidSyntax = 0x01,
@@ -181,22 +173,14 @@ impl From<icu_properties::UnexpectedPropertyNameOrDataError> for Error {
     }
 }
 
-#[cfg(any(
-    feature = "datetime",
-    feature = "timezone",
-    feature = "calendar"
-))]
+#[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
 impl From<icu_calendar::RangeError> for CalendarError {
     fn from(_: icu_calendar::RangeError) -> Self {
         Self::OutOfRange
     }
 }
 
-#[cfg(any(
-    feature = "datetime",
-    feature = "timezone",
-    feature = "calendar"
-))]
+#[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
 impl From<icu_calendar::DateError> for CalendarError {
     fn from(e: icu_calendar::DateError) -> Self {
         match e {
@@ -208,11 +192,7 @@ impl From<icu_calendar::DateError> for CalendarError {
     }
 }
 
-#[cfg(any(
-    feature = "datetime",
-    feature = "timezone",
-    feature = "calendar"
-))]
+#[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
 impl From<icu_calendar::ParseError> for CalendarParseError {
     fn from(e: icu_calendar::ParseError) -> Self {
         match e {

--- a/ffi/capi/src/errors.rs
+++ b/ffi/capi/src/errors.rs
@@ -37,7 +37,7 @@ pub mod ffi {
     #[derive(Debug, PartialEq, Eq)]
     #[repr(C)]
     #[diplomat::rust_link(fixed_decimal::ParseError, Enum, compact)]
-    #[cfg(any(feature = "icu_decimal", feature = "icu_plurals"))]
+    #[cfg(any(feature = "decimal", feature = "plurals"))]
     pub enum FixedDecimalParseError {
         Unknown = 0x00,
         Limit = 0x01,
@@ -46,7 +46,7 @@ pub mod ffi {
 
     #[derive(Debug, PartialEq, Eq)]
     #[diplomat::rust_link(fixed_decimal::LimitError, Struct, compact)]
-    #[cfg(feature = "icu_decimal")]
+    #[cfg(feature = "decimal")]
     pub struct FixedDecimalLimitError;
 
     #[derive(Debug, PartialEq, Eq)]
@@ -54,9 +54,9 @@ pub mod ffi {
     #[diplomat::rust_link(icu::calendar::RangeError, Struct, compact)]
     #[diplomat::rust_link(icu::calendar::DateError, Enum, compact)]
     #[cfg(any(
-        feature = "icu_datetime",
-        feature = "icu_timezone",
-        feature = "icu_calendar"
+        feature = "datetime",
+        feature = "timezone",
+        feature = "calendar"
     ))]
     pub enum CalendarError {
         Unknown = 0x00,
@@ -69,9 +69,9 @@ pub mod ffi {
     #[repr(C)]
     #[diplomat::rust_link(icu::calendar::ParseError, Enum, compact)]
     #[cfg(any(
-        feature = "icu_datetime",
-        feature = "icu_timezone",
-        feature = "icu_calendar"
+        feature = "datetime",
+        feature = "timezone",
+        feature = "calendar"
     ))]
     pub enum CalendarParseError {
         Unknown = 0x00,
@@ -83,11 +83,11 @@ pub mod ffi {
 
     #[derive(Debug, PartialEq, Eq)]
     #[diplomat::rust_link(icu::timezone::InvalidOffsetError, Struct, compact)]
-    #[cfg(any(feature = "icu_datetime", feature = "icu_timezone"))]
+    #[cfg(any(feature = "datetime", feature = "timezone"))]
     pub struct TimeZoneInvalidOffsetError;
 
     #[derive(Debug, PartialEq, Eq)]
-    #[cfg(any(feature = "icu_datetime", feature = "icu_timezone"))]
+    #[cfg(any(feature = "datetime", feature = "timezone"))]
     pub struct TimeZoneInvalidIdError;
 
     #[derive(Debug, PartialEq, Eq)]
@@ -169,7 +169,7 @@ impl From<icu_provider::DataError> for DataError {
     }
 }
 
-#[cfg(feature = "icu_properties")]
+#[cfg(feature = "properties")]
 impl From<icu_properties::UnexpectedPropertyNameOrDataError> for Error {
     fn from(e: icu_properties::UnexpectedPropertyNameOrDataError) -> Self {
         match e {
@@ -182,9 +182,9 @@ impl From<icu_properties::UnexpectedPropertyNameOrDataError> for Error {
 }
 
 #[cfg(any(
-    feature = "icu_datetime",
-    feature = "icu_timezone",
-    feature = "icu_calendar"
+    feature = "datetime",
+    feature = "timezone",
+    feature = "calendar"
 ))]
 impl From<icu_calendar::RangeError> for CalendarError {
     fn from(_: icu_calendar::RangeError) -> Self {
@@ -193,9 +193,9 @@ impl From<icu_calendar::RangeError> for CalendarError {
 }
 
 #[cfg(any(
-    feature = "icu_datetime",
-    feature = "icu_timezone",
-    feature = "icu_calendar"
+    feature = "datetime",
+    feature = "timezone",
+    feature = "calendar"
 ))]
 impl From<icu_calendar::DateError> for CalendarError {
     fn from(e: icu_calendar::DateError) -> Self {
@@ -209,9 +209,9 @@ impl From<icu_calendar::DateError> for CalendarError {
 }
 
 #[cfg(any(
-    feature = "icu_datetime",
-    feature = "icu_timezone",
-    feature = "icu_calendar"
+    feature = "datetime",
+    feature = "timezone",
+    feature = "calendar"
 ))]
 impl From<icu_calendar::ParseError> for CalendarParseError {
     fn from(e: icu_calendar::ParseError) -> Self {
@@ -225,7 +225,7 @@ impl From<icu_calendar::ParseError> for CalendarParseError {
     }
 }
 
-#[cfg(feature = "icu_datetime")]
+#[cfg(feature = "datetime")]
 impl From<icu_datetime::DateTimeError> for Error {
     fn from(e: icu_datetime::DateTimeError) -> Self {
         match e {
@@ -257,7 +257,7 @@ impl From<icu_datetime::DateTimeError> for Error {
     }
 }
 
-#[cfg(any(feature = "icu_decimal", feature = "icu_plurals"))]
+#[cfg(any(feature = "decimal", feature = "plurals"))]
 impl From<fixed_decimal::ParseError> for FixedDecimalParseError {
     fn from(e: fixed_decimal::ParseError) -> Self {
         match e {
@@ -268,7 +268,7 @@ impl From<fixed_decimal::ParseError> for FixedDecimalParseError {
     }
 }
 
-#[cfg(feature = "icu_decimal")]
+#[cfg(feature = "decimal")]
 impl From<fixed_decimal::LimitError> for FixedDecimalLimitError {
     fn from(_: fixed_decimal::LimitError) -> Self {
         Self
@@ -287,7 +287,7 @@ impl From<icu_locale_core::ParseError> for LocaleParseError {
     }
 }
 
-#[cfg(any(feature = "icu_timezone", feature = "icu_datetime"))]
+#[cfg(any(feature = "timezone", feature = "datetime"))]
 impl From<icu_timezone::InvalidOffsetError> for TimeZoneInvalidOffsetError {
     fn from(_: icu_timezone::InvalidOffsetError) -> Self {
         Self

--- a/ffi/capi/src/lib.rs
+++ b/ffi/capi/src/lib.rs
@@ -69,11 +69,7 @@ mod utf;
 
 #[cfg(feature = "properties")]
 pub mod bidi;
-#[cfg(any(
-    feature = "datetime",
-    feature = "timezone",
-    feature = "calendar"
-))]
+#[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
 pub mod calendar;
 #[cfg(feature = "casemap")]
 pub mod casemap;
@@ -81,17 +77,9 @@ pub mod casemap;
 pub mod collator;
 #[cfg(feature = "properties")]
 pub mod collections_sets;
-#[cfg(any(
-    feature = "datetime",
-    feature = "timezone",
-    feature = "calendar"
-))]
+#[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
 pub mod date;
-#[cfg(any(
-    feature = "datetime",
-    feature = "timezone",
-    feature = "calendar"
-))]
+#[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
 pub mod datetime;
 #[cfg(feature = "datetime")]
 pub mod datetime_formatter;
@@ -137,11 +125,7 @@ pub mod segmenter_line;
 pub mod segmenter_sentence;
 #[cfg(feature = "segmenter")]
 pub mod segmenter_word;
-#[cfg(any(
-    feature = "datetime",
-    feature = "timezone",
-    feature = "calendar"
-))]
+#[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
 pub mod time;
 #[cfg(any(feature = "datetime", feature = "timezone"))]
 pub mod timezone;

--- a/ffi/capi/src/lib.rs
+++ b/ffi/capi/src/lib.rs
@@ -67,91 +67,91 @@ mod utf;
 
 // Components
 
-#[cfg(feature = "icu_properties")]
+#[cfg(feature = "properties")]
 pub mod bidi;
 #[cfg(any(
-    feature = "icu_datetime",
-    feature = "icu_timezone",
-    feature = "icu_calendar"
+    feature = "datetime",
+    feature = "timezone",
+    feature = "calendar"
 ))]
 pub mod calendar;
-#[cfg(feature = "icu_casemap")]
+#[cfg(feature = "casemap")]
 pub mod casemap;
-#[cfg(feature = "icu_collator")]
+#[cfg(feature = "collator")]
 pub mod collator;
-#[cfg(feature = "icu_properties")]
+#[cfg(feature = "properties")]
 pub mod collections_sets;
 #[cfg(any(
-    feature = "icu_datetime",
-    feature = "icu_timezone",
-    feature = "icu_calendar"
+    feature = "datetime",
+    feature = "timezone",
+    feature = "calendar"
 ))]
 pub mod date;
 #[cfg(any(
-    feature = "icu_datetime",
-    feature = "icu_timezone",
-    feature = "icu_calendar"
+    feature = "datetime",
+    feature = "timezone",
+    feature = "calendar"
 ))]
 pub mod datetime;
-#[cfg(feature = "icu_datetime")]
+#[cfg(feature = "datetime")]
 pub mod datetime_formatter;
-#[cfg(feature = "icu_decimal")]
+#[cfg(feature = "decimal")]
 pub mod decimal;
-#[cfg(feature = "experimental_components")]
+#[cfg(feature = "experimental")]
 pub mod displaynames;
-#[cfg(feature = "icu_locale")]
+#[cfg(feature = "locale")]
 pub mod fallbacker;
-#[cfg(feature = "icu_decimal")]
+#[cfg(feature = "decimal")]
 pub mod fixed_decimal;
-#[cfg(feature = "icu_list")]
+#[cfg(feature = "list")]
 pub mod list;
-#[cfg(feature = "icu_locale")]
+#[cfg(feature = "locale")]
 pub mod locale;
-#[cfg(feature = "icu_locale")]
+#[cfg(feature = "locale")]
 pub mod locale_directionality;
-#[cfg(feature = "icu_timezone")]
+#[cfg(feature = "timezone")]
 pub mod metazone_calculator;
-#[cfg(feature = "icu_normalizer")]
+#[cfg(feature = "normalizer")]
 pub mod normalizer;
-#[cfg(feature = "icu_normalizer")]
+#[cfg(feature = "normalizer")]
 pub mod normalizer_properties;
-#[cfg(feature = "icu_plurals")]
+#[cfg(feature = "plurals")]
 pub mod pluralrules;
-#[cfg(feature = "icu_properties")]
+#[cfg(feature = "properties")]
 pub mod properties_iter;
-#[cfg(feature = "icu_properties")]
+#[cfg(feature = "properties")]
 pub mod properties_maps;
-#[cfg(feature = "icu_properties")]
+#[cfg(feature = "properties")]
 pub mod properties_names;
-#[cfg(feature = "icu_properties")]
+#[cfg(feature = "properties")]
 pub mod properties_sets;
-#[cfg(feature = "icu_properties")]
+#[cfg(feature = "properties")]
 pub mod properties_unisets;
-#[cfg(feature = "icu_properties")]
+#[cfg(feature = "properties")]
 pub mod script;
-#[cfg(feature = "icu_segmenter")]
+#[cfg(feature = "segmenter")]
 pub mod segmenter_grapheme;
-#[cfg(feature = "icu_segmenter")]
+#[cfg(feature = "segmenter")]
 pub mod segmenter_line;
-#[cfg(feature = "icu_segmenter")]
+#[cfg(feature = "segmenter")]
 pub mod segmenter_sentence;
-#[cfg(feature = "icu_segmenter")]
+#[cfg(feature = "segmenter")]
 pub mod segmenter_word;
 #[cfg(any(
-    feature = "icu_datetime",
-    feature = "icu_timezone",
-    feature = "icu_calendar"
+    feature = "datetime",
+    feature = "timezone",
+    feature = "calendar"
 ))]
 pub mod time;
-#[cfg(any(feature = "icu_datetime", feature = "icu_timezone"))]
+#[cfg(any(feature = "datetime", feature = "timezone"))]
 pub mod timezone;
-#[cfg(feature = "icu_datetime")]
+#[cfg(feature = "datetime")]
 pub mod timezone_formatter;
-#[cfg(any(feature = "icu_datetime", feature = "icu_timezone"))]
+#[cfg(any(feature = "datetime", feature = "timezone"))]
 pub mod timezone_mapper;
-#[cfg(feature = "experimental_components")]
+#[cfg(feature = "experimental")]
 pub mod units_converter;
-#[cfg(feature = "icu_calendar")]
+#[cfg(feature = "calendar")]
 pub mod week;
-#[cfg(feature = "icu_datetime")]
+#[cfg(feature = "datetime")]
 pub mod zoned_formatter;

--- a/ffi/capi/src/pluralrules.rs
+++ b/ffi/capi/src/pluralrules.rs
@@ -108,7 +108,7 @@ pub mod ffi {
         /// Construct from a FixedDecimal
         ///
         /// Retains at most 18 digits each from the integer and fraction parts.
-        #[cfg(feature = "icu_decimal")]
+        #[cfg(feature = "decimal")]
         #[diplomat::attr(supports = fallible_constructors, named_constructor)]
         pub fn from_fixed_decimal(x: &crate::fixed_decimal::ffi::FixedDecimal) -> Box<Self> {
             Box::new(Self((&x.0).into()))

--- a/ffi/capi/src/provider.rs
+++ b/ffi/capi/src/provider.rs
@@ -175,7 +175,7 @@ pub mod ffi {
             compact
         )]
         #[allow(unused_variables)] // feature-gated
-        #[cfg(feature = "icu_locale")]
+        #[cfg(feature = "locale")]
         pub fn enable_locale_fallback_with(
             &mut self,
             fallbacker: &crate::fallbacker::ffi::LocaleFallbacker,

--- a/ffi/capi/src/timezone.rs
+++ b/ffi/capi/src/timezone.rs
@@ -314,7 +314,7 @@ pub mod ffi {
             FnInStruct,
             compact
         )]
-        #[cfg(feature = "icu_timezone")]
+        #[cfg(feature = "timezone")]
         pub fn maybe_calculate_metazone(
             &mut self,
             metazone_calculator: &crate::metazone_calculator::ffi::MetazoneCalculator,

--- a/ffi/dart/build.dart
+++ b/ffi/dart/build.dart
@@ -19,7 +19,7 @@ void main(List<String> args) async {
 
   final path = '${config.outDir.path}/icu4x';
 
-  await buildLib(target, linkMode, 'default_components,experimental_components', path);
+  await buildLib(target, linkMode, 'default_components,experimental', path);
 
   await BuildOutput(
     assets: [

--- a/tutorials/c-tiny/fixeddecimal/Makefile
+++ b/tutorials/c-tiny/fixeddecimal/Makefile
@@ -24,20 +24,20 @@ baked_data/macros.rs:
 	target/bin/icu4x-datagen --locales en bn --markers all --deduplication none --format mod --out baked_data --overwrite
 
 target/debug/libicu_capi.a: FORCE
-	cargo rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/icu_decimal,icu_capi/std
+	cargo rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/decimal,icu_capi/std
 
 target/x86_64-unknown-linux-gnu/debug/libicu_capi.a: FORCE baked_data/macros.rs
 	rustup toolchain install ${LLVM_COMPATIBLE_NIGHTLY}
 	rustup component add rust-src --toolchain ${LLVM_COMPATIBLE_NIGHTLY}
 	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" ICU4X_DATA_DIR=$(shell pwd)/baked_data \
-	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/icu_decimal,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
+	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/decimal,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
 	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu
 
 target/x86_64-unknown-linux-gnu/release/libicu_capi.a: FORCE baked_data/macros.rs
 	rustup toolchain install ${LLVM_COMPATIBLE_NIGHTLY}
 	rustup component add rust-src --toolchain ${LLVM_COMPATIBLE_NIGHTLY}
 	RUSTFLAGS="-Clto -Cembed-bitcode -Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort -Copt-level=s" ICU4X_DATA_DIR=$(shell pwd)/baked_data \
-	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/icu_decimal,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
+	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/decimal,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
 	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release
 
 # Naive target: no optimizations, full std

--- a/tutorials/c-tiny/segmenter/Makefile
+++ b/tutorials/c-tiny/segmenter/Makefile
@@ -20,20 +20,20 @@ LLD := lld-16
 LLVM_COMPATIBLE_NIGHTLY = "nightly-2023-08-08"
 
 target/debug/libicu_capi.a: FORCE
-	cargo rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/icu_segmenter,icu_capi/std
+	cargo rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/segmenter,icu_capi/std
 
 target/x86_64-unknown-linux-gnu/debug/libicu_capi.a: FORCE
 	rustup toolchain install ${LLVM_COMPATIBLE_NIGHTLY}
 	rustup component add rust-src --toolchain ${LLVM_COMPATIBLE_NIGHTLY}
 	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" \
-	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/icu_segmenter,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
+	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/segmenter,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
 	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu
 
 target/x86_64-unknown-linux-gnu/release/libicu_capi.a: FORCE
 	rustup toolchain install ${LLVM_COMPATIBLE_NIGHTLY}
 	rustup component add rust-src --toolchain ${LLVM_COMPATIBLE_NIGHTLY}
 	RUSTFLAGS="-Clto -Cembed-bitcode -Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort -Copt-level=s" \
-	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/icu_segmenter,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
+	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/segmenter,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
 	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release
 
 # Naive target: no optimizations, full std

--- a/tutorials/c/Cargo.lock
+++ b/tutorials/c/Cargo.lock
@@ -151,6 +151,7 @@ dependencies = [
  "icu_segmenter",
  "icu_timezone",
  "log",
+ "potential_utf",
  "simple_logger",
  "tinystr",
  "unicode-bidi",
@@ -167,6 +168,7 @@ dependencies = [
  "icu_locale_core",
  "icu_properties",
  "icu_provider",
+ "potential_utf",
  "writeable",
  "zerovec",
 ]
@@ -226,6 +228,7 @@ dependencies = [
  "icu_plurals",
  "icu_provider",
  "icu_timezone",
+ "potential_utf",
  "smallvec",
  "tinystr",
  "writeable",
@@ -268,6 +271,7 @@ dependencies = [
  "icu_collections",
  "icu_decimal",
  "icu_experimental_data",
+ "icu_list",
  "icu_locale",
  "icu_locale_core",
  "icu_normalizer",
@@ -279,6 +283,7 @@ dependencies = [
  "num-bigint",
  "num-rational",
  "num-traits",
+ "potential_utf",
  "smallvec",
  "tinystr",
  "writeable",
@@ -322,6 +327,7 @@ dependencies = [
  "icu_locale_core",
  "icu_locale_data",
  "icu_provider",
+ "potential_utf",
  "tinystr",
  "zerovec",
 ]
@@ -405,6 +411,7 @@ dependencies = [
  "icu_collections",
  "icu_properties_data",
  "icu_provider",
+ "potential_utf",
  "tinystr",
  "unicode-bidi",
  "zerovec",
@@ -472,6 +479,7 @@ dependencies = [
  "icu_locale_core",
  "icu_provider",
  "icu_segmenter_data",
+ "potential_utf",
  "utf8_iter",
  "zerovec",
 ]
@@ -598,6 +606,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.0.0"
+dependencies = [
+ "serde",
+ "writeable",
+ "zerovec",
 ]
 
 [[package]]

--- a/tutorials/cpp.md
+++ b/tutorials/cpp.md
@@ -37,7 +37,7 @@ Some of the keys are required by the parser, but won't be used by us.
 - `std` \[default\] set this when building for a target with a Rust standard library, otherwise see below
 - `compiled_data` \[default\] to include data (`ICU4XDataProvider::create_compiled()`)
 - `simple_logger` \[default\] enable basic stdout logging of error metadata. Further loggers can be added on request.
-- `default_components` \[default\] activate all stable ICU4X components. For smaller builds, this can be disabled, and components can be added with features like `icu_list`.
+- `default_components` \[default\] activate all stable ICU4X components. For smaller builds, this can be disabled, and components can be added with features like `list`.
 - `buffer_provider` for working with blob data providers (`ICU4XDataProvider::create_from_byte_slice()`)
 
 You can now set features by updating the `features` key in `Cargo.toml`:

--- a/tutorials/cpp/Cargo.lock
+++ b/tutorials/cpp/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "icu_segmenter",
  "icu_timezone",
  "log",
+ "potential_utf",
  "serde",
  "simple_logger",
  "tinystr",
@@ -190,6 +191,7 @@ dependencies = [
  "icu_locale_core",
  "icu_properties",
  "icu_provider",
+ "potential_utf",
  "serde",
  "writeable",
  "zerovec",
@@ -253,6 +255,7 @@ dependencies = [
  "icu_provider",
  "icu_timezone",
  "litemap",
+ "potential_utf",
  "serde",
  "smallvec",
  "tinystr",
@@ -297,6 +300,7 @@ dependencies = [
  "icu_collections",
  "icu_decimal",
  "icu_experimental_data",
+ "icu_list",
  "icu_locale",
  "icu_locale_core",
  "icu_normalizer",
@@ -308,6 +312,7 @@ dependencies = [
  "num-bigint",
  "num-rational",
  "num-traits",
+ "potential_utf",
  "serde",
  "smallvec",
  "tinystr",
@@ -354,6 +359,7 @@ dependencies = [
  "icu_locale_core",
  "icu_locale_data",
  "icu_provider",
+ "potential_utf",
  "serde",
  "tinystr",
  "zerovec",
@@ -442,6 +448,7 @@ dependencies = [
  "icu_collections",
  "icu_properties_data",
  "icu_provider",
+ "potential_utf",
  "serde",
  "tinystr",
  "unicode-bidi",
@@ -536,6 +543,7 @@ dependencies = [
  "icu_locale_core",
  "icu_provider",
  "icu_segmenter_data",
+ "potential_utf",
  "serde",
  "utf8_iter",
  "zerovec",
@@ -678,6 +686,15 @@ dependencies = [
  "cobs",
  "embedded-io",
  "serde",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.0.0"
+dependencies = [
+ "serde",
+ "writeable",
+ "zerovec",
 ]
 
 [[package]]

--- a/tutorials/cpp/Cargo.toml
+++ b/tutorials/cpp/Cargo.toml
@@ -9,5 +9,5 @@ name = "unused"
 path = "unused"
 
 [dependencies]
-icu_capi = { version = "1.5", features = ["provider_fs", "experimental_components"] }
+icu_capi = { version = "1.5", features = ["provider_fs", "experimental"] }
 icu_provider = { version = "1.5", features = ["deserialize_json"] }


### PR DESCRIPTION
They're the names of `icu` modules, that they are also crates with `icu_` prefixes is an implementation detail.