### PR TITLE
Use the standardized `count::Count` instead of `extended_currency::Count`

### DIFF
--- a/components/experimental/src/dimension/provider/extended_currency.rs
+++ b/components/experimental/src/dimension/provider/extended_currency.rs
@@ -46,7 +46,7 @@ pub struct CurrencyExtendedDataV1<'data> {
     ///    Regards to the [Unicode Report TR35](https://unicode.org/reports/tr35/tr35-numbers.html#Currencies),
     ///    If no matching for specific count, the `other` count will be used.
     #[cfg_attr(feature = "serde", serde(borrow))]
-    pub display_names: ZeroMap<'data, Count, str>,
+    pub display_names: ZeroMap<'data, CurrencyDisplayNameCount, str>,
 }
 
 /// A CLDR plural keyword, or the explicit value 1.
@@ -61,7 +61,7 @@ pub struct CurrencyExtendedDataV1<'data> {
     databake(path = icu_experimental::dimension::provider::extended_currency)
 )]
 #[repr(u8)]
-pub enum Count {
+pub enum CurrencyDisplayNameCount {
     /// The CLDR keyword `zero`.
     Zero = 0,
     /// The CLDR keyword `one`.

--- a/components/experimental/src/dimension/provider/extended_currency.rs
+++ b/components/experimental/src/dimension/provider/extended_currency.rs
@@ -22,6 +22,8 @@ use zerovec::ZeroMap;
 /// </div>
 pub use crate::provider::Baked;
 
+use super::count::Count;
+
 /// Currency Extended V1 data struct.
 #[icu_provider::data_struct(marker(
     CurrencyExtendedDataV1Marker,
@@ -62,30 +64,8 @@ pub struct CurrencyExtendedDataV1<'data> {
 )]
 #[repr(u8)]
 pub enum CurrencyDisplayNameCount {
-    /// The CLDR keyword `zero`.
-    Zero = 0,
-    /// The CLDR keyword `one`.
-    One = 1,
-    /// The CLDR keyword `two`.
-    Two = 2,
-    /// The CLDR keyword `few`.
-    Few = 3,
-    /// The CLDR keyword `many`.
-    Many = 4,
-    /// The CLDR keyword `other`.
-    Other = 5,
-    // TODO(younies): revise this for currency
-    /// The explicit 1 case, see <https://www.unicode.org/reports/tr35/tr35-numbers.html#Explicit_0_1_rules>.
-    Explicit1 = 6,
-    // NOTE(egg): No explicit 0, because the compact decimal pattern selection
-    // algorithm does not allow such a thing to arise.
-    // TODO(younies): implment this case.
-    /// The default case.
-    /// NOTE:
-    ///     Used as the default when there is no match.
-    ///     This is also used to replace the most frequently occurring case in all plural rules.
-    Default = 7,
+    PluralRules(Count),
 
     /// The display name for the currency.
-    DisplayName = 8,
+    DisplayName = 6,
 }

--- a/provider/source/src/currency/extended.rs
+++ b/provider/source/src/currency/extended.rs
@@ -34,18 +34,18 @@ impl DataProvider<CurrencyExtendedDataV1Marker> for crate::SourceDataProvider {
             payload: DataPayload::from_owned(CurrencyExtendedDataV1 {
                 display_names: ZeroMap::from_iter(
                     [
-                        (Count::Zero, currency.zero.as_deref()),
-                        (Count::One, currency.one.as_deref()),
-                        (Count::Two, currency.two.as_deref()),
-                        (Count::Few, currency.few.as_deref()),
-                        (Count::Many, currency.many.as_deref()),
-                        (Count::Other, currency.other.as_deref()),
-                        (Count::DisplayName, currency.display_name.as_deref()),
+                        (CurrencyDisplayNameCount::Zero, currency.zero.as_deref()),
+                        (CurrencyDisplayNameCount::One, currency.one.as_deref()),
+                        (CurrencyDisplayNameCount::Two, currency.two.as_deref()),
+                        (CurrencyDisplayNameCount::Few, currency.few.as_deref()),
+                        (CurrencyDisplayNameCount::Many, currency.many.as_deref()),
+                        (CurrencyDisplayNameCount::Other, currency.other.as_deref()),
+                        (CurrencyDisplayNameCount::DisplayName, currency.display_name.as_deref()),
                     ]
                     .into_iter()
                     .filter_map(|(count, pattern)| match (count, pattern) {
-                        (Count::DisplayName, Some(p)) => Some((count, p)),
-                        (Count::Other, Some(p)) => Some((count, p)),
+                        (CurrencyDisplayNameCount::DisplayName, Some(p)) => Some((count, p)),
+                        (CurrencyDisplayNameCount::Other, Some(p)) => Some((count, p)),
                         // As per [Unicode TR 35](https://unicode.org/reports/tr35/tr35-numbers.html#Currencies)
                         //      If the pattern is not found for the associated `Count`, fall back to the `Count::Other` pattern.
                         //      Therefore, we filter out any patterns that are the same as the `Count::Other` pattern.
@@ -97,13 +97,13 @@ fn test_basic() {
         .unwrap()
         .payload;
     let display_names = en.get().to_owned().display_names;
-    assert_eq!(display_names.get(&Count::Zero), None);
-    assert_eq!(display_names.get(&Count::One).unwrap(), "US dollar");
-    assert_eq!(display_names.get(&Count::Two), None);
-    assert_eq!(display_names.get(&Count::Few), None);
-    assert_eq!(display_names.get(&Count::Many), None);
-    assert_eq!(display_names.get(&Count::Other).unwrap(), "US dollars");
-    assert_eq!(display_names.get(&Count::DisplayName).unwrap(), "US Dollar");
+    assert_eq!(display_names.get(&CurrencyDisplayNameCount::Zero), None);
+    assert_eq!(display_names.get(&CurrencyDisplayNameCount::One).unwrap(), "US dollar");
+    assert_eq!(display_names.get(&CurrencyDisplayNameCount::Two), None);
+    assert_eq!(display_names.get(&CurrencyDisplayNameCount::Few), None);
+    assert_eq!(display_names.get(&CurrencyDisplayNameCount::Many), None);
+    assert_eq!(display_names.get(&CurrencyDisplayNameCount::Other).unwrap(), "US dollars");
+    assert_eq!(display_names.get(&CurrencyDisplayNameCount::DisplayName).unwrap(), "US Dollar");
 
     let fr: DataPayload<CurrencyExtendedDataV1Marker> = provider
         .load(DataRequest {
@@ -117,20 +117,20 @@ fn test_basic() {
         .payload;
 
     let display_names = fr.get().to_owned().display_names;
-    assert_eq!(display_names.get(&Count::Zero), None);
+    assert_eq!(display_names.get(&CurrencyDisplayNameCount::Zero), None);
     assert_eq!(
-        display_names.get(&Count::One).unwrap(),
+        display_names.get(&CurrencyDisplayNameCount::One).unwrap(),
         "dollar des États-Unis"
     );
-    assert_eq!(display_names.get(&Count::Two), None);
-    assert_eq!(display_names.get(&Count::Few), None);
-    assert_eq!(display_names.get(&Count::Many), None);
+    assert_eq!(display_names.get(&CurrencyDisplayNameCount::Two), None);
+    assert_eq!(display_names.get(&CurrencyDisplayNameCount::Few), None);
+    assert_eq!(display_names.get(&CurrencyDisplayNameCount::Many), None);
     assert_eq!(
-        display_names.get(&Count::Other).unwrap(),
+        display_names.get(&CurrencyDisplayNameCount::Other).unwrap(),
         "dollars des États-Unis"
     );
     assert_eq!(
-        display_names.get(&Count::DisplayName).unwrap(),
+        display_names.get(&CurrencyDisplayNameCount::DisplayName).unwrap(),
         "dollar des États-Unis"
     );
 }


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->