### PR TITLE
make_ule: Support enums with min and max

### DIFF
--- a/utils/zerovec/derive/Cargo.toml
+++ b/utils/zerovec/derive/Cargo.toml
@@ -32,3 +32,18 @@ serde = { workspace = true, features = ["derive"] }
 zerofrom = { path = "../../../utils/zerofrom" }
 bincode = { workspace = true }
 serde_json = { workspace = true }
+
+[[example]]
+name = "derives"
+harness = false
+test = true
+
+[[example]]
+name = "make"
+harness = false
+test = true
+
+[[example]]
+name = "make_var"
+harness = false
+test = true

--- a/utils/zerovec/derive/examples/make.rs
+++ b/utils/zerovec/derive/examples/make.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use std::fmt::Debug;
+use ule::ULE;
 use zerovec::*;
 
 #[make_ule(StructULE)]
@@ -39,14 +40,13 @@ enum Enum {
     F = 5,
 }
 
-#[make_ule(OutOfOrderEnumULE)]
+#[make_ule(OutOfOrderMissingZeroEnumULE)]
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Debug)]
 #[allow(unused)]
-enum OutOfOrderEnum {
-    A = 0,
-    B = 1,
+enum OutOfOrderMissingZeroEnum {
     E = 3,
+    B = 1,
     FooBar = 4,
     D = 2,
     F = 5,
@@ -79,6 +79,22 @@ fn main() {
     test_zerovec(TEST_SLICE_STRUCT);
     test_zerovec(TEST_SLICE_TUPLESTRUCT);
     test_zerovec(TEST_SLICE_ENUM);
+
+    assert!(matches!(EnumULE::parse_byte_slice(&[0]), Ok(_)));
+    assert!(matches!(EnumULE::parse_byte_slice(&[1]), Ok(_)));
+    assert!(matches!(EnumULE::parse_byte_slice(&[6]), Err(_)));
+    assert!(matches!(
+        OutOfOrderMissingZeroEnumULE::parse_byte_slice(&[0]),
+        Err(_)
+    ));
+    assert!(matches!(
+        OutOfOrderMissingZeroEnumULE::parse_byte_slice(&[1]),
+        Ok(_)
+    ));
+    assert!(matches!(
+        OutOfOrderMissingZeroEnumULE::parse_byte_slice(&[6]),
+        Err(_)
+    ));
 }
 
 const TEST_SLICE_STRUCT: &[Struct] = &[

--- a/utils/zerovec/derive/examples/make.rs
+++ b/utils/zerovec/derive/examples/make.rs
@@ -82,10 +82,12 @@ fn main() {
 
     assert!(EnumULE::parse_byte_slice(&[0]).is_ok());
     assert!(EnumULE::parse_byte_slice(&[1]).is_ok());
+    assert!(EnumULE::parse_byte_slice(&[5]).is_ok());
     assert!(EnumULE::parse_byte_slice(&[6]).is_err());
-    assert!(OutOfOrderMissingZeroEnumULE::parse_byte_slice(&[0]).is_ok());
-    assert!(OutOfOrderMissingZeroEnumULE::parse_byte_slice(&[1]).is_err());
-    assert!(OutOfOrderMissingZeroEnumULE::parse_byte_slice(&[6]).is_ok());
+    assert!(OutOfOrderMissingZeroEnumULE::parse_byte_slice(&[0]).is_err());
+    assert!(OutOfOrderMissingZeroEnumULE::parse_byte_slice(&[1]).is_ok());
+    assert!(OutOfOrderMissingZeroEnumULE::parse_byte_slice(&[5]).is_ok());
+    assert!(OutOfOrderMissingZeroEnumULE::parse_byte_slice(&[6]).is_err());
 }
 
 const TEST_SLICE_STRUCT: &[Struct] = &[

--- a/utils/zerovec/derive/examples/make.rs
+++ b/utils/zerovec/derive/examples/make.rs
@@ -80,21 +80,12 @@ fn main() {
     test_zerovec(TEST_SLICE_TUPLESTRUCT);
     test_zerovec(TEST_SLICE_ENUM);
 
-    assert!(matches!(EnumULE::parse_byte_slice(&[0]), Ok(_)));
-    assert!(matches!(EnumULE::parse_byte_slice(&[1]), Ok(_)));
-    assert!(matches!(EnumULE::parse_byte_slice(&[6]), Err(_)));
-    assert!(matches!(
-        OutOfOrderMissingZeroEnumULE::parse_byte_slice(&[0]),
-        Err(_)
-    ));
-    assert!(matches!(
-        OutOfOrderMissingZeroEnumULE::parse_byte_slice(&[1]),
-        Ok(_)
-    ));
-    assert!(matches!(
-        OutOfOrderMissingZeroEnumULE::parse_byte_slice(&[6]),
-        Err(_)
-    ));
+    assert!(EnumULE::parse_byte_slice(&[0]).is_ok());
+    assert!(EnumULE::parse_byte_slice(&[1]).is_ok());
+    assert!(EnumULE::parse_byte_slice(&[6]).is_err());
+    assert!(OutOfOrderMissingZeroEnumULE::parse_byte_slice(&[0]).is_ok());
+    assert!(OutOfOrderMissingZeroEnumULE::parse_byte_slice(&[1]).is_err());
+    assert!(OutOfOrderMissingZeroEnumULE::parse_byte_slice(&[6]).is_ok());
 }
 
 const TEST_SLICE_STRUCT: &[Struct] = &[

--- a/utils/zerovec/derive/src/make_ule.rs
+++ b/utils/zerovec/derive/src/make_ule.rs
@@ -91,8 +91,15 @@ fn make_ule_enum_impl(
         .to_compile_error();
     }
 
-    // the next discriminant expected
-    let mut next = 0;
+    if enu.variants.len() == 0 {
+        return Error::new(input.span(), "#[make_ule] cannot be applied to empty enums")
+            .to_compile_error();
+    }
+
+    // the smallest discriminant seen
+    let mut min = None;
+    // the largest discriminant seen
+    let mut max = None;
     // Discriminants that have not been found in series (we might find them later)
     let mut not_found = HashSet::new();
 
@@ -108,11 +115,31 @@ fn make_ule_enum_impl(
 
         if let Some((_, ref discr)) = variant.discriminant {
             if let Some(n) = get_expr_int(discr) {
-                if n >= next {
-                    for missing in next..n {
-                        not_found.insert(missing);
+                let n = match u8::try_from(n) {
+                    Ok(n) => n,
+                    Err(_) => {
+                        return Error::new(
+                            variant.span(),
+                            "#[make_ule] only supports discriminants from 0 to 255",
+                        )
+                        .to_compile_error();
                     }
-                    next = n + 1;
+                };
+                match min {
+                    Some(x) if x < n => {}
+                    _ => {
+                        min = Some(n);
+                    }
+                }
+                match max {
+                    Some(x) if x >= n => {}
+                    _ => {
+                        let old_max = max.unwrap_or(0u8);
+                        for missing in (old_max + 1)..n {
+                            not_found.insert(missing);
+                        }
+                        max = Some(n);
+                    }
                 }
 
                 not_found.remove(&n);
@@ -122,7 +149,7 @@ fn make_ule_enum_impl(
                 // platform-specific C ABI choices do not matter.
                 // We could potentially add in explicit discriminants on the user's behalf in the future, or support
                 // more complicated sets of explicit discriminant values.
-                if n != i as u64 {}
+                if n as usize != i {}
             } else {
                 return Error::new(
                     discr.span(),
@@ -140,14 +167,14 @@ fn make_ule_enum_impl(
     }
 
     let not_found = not_found.iter().collect::<Vec<_>>();
+    let min = min.unwrap();
+    let max = max.unwrap();
 
-    if !not_found.is_empty() {
+    if not_found.len() > min as usize {
         return Error::new(input.span(), format!("#[make_ule] must be applied to enums with discriminants \
-                                                  filling the range from 0 to a maximum; could not find {not_found:?}"))
+                                                  filling the range from a minimum to a maximum; could not find {not_found:?}"))
             .to_compile_error();
     }
-
-    let max = next as u8;
 
     let maybe_ord_derives = if attrs.skip_ord {
         quote!()
@@ -181,7 +208,7 @@ fn make_ule_enum_impl(
             #[inline]
             fn validate_byte_slice(bytes: &[u8]) -> Result<(), zerovec::ZeroVecError> {
                 for byte in bytes {
-                    if *byte >= #max {
+                    if *byte < #min || *byte > #max {
                         return Err(zerovec::ZeroVecError::parse::<Self>())
                     }
                 }

--- a/utils/zerovec/derive/src/make_ule.rs
+++ b/utils/zerovec/derive/src/make_ule.rs
@@ -91,7 +91,7 @@ fn make_ule_enum_impl(
         .to_compile_error();
     }
 
-    if enu.variants.len() == 0 {
+    if enu.variants.is_empty() {
         return Error::new(input.span(), "#[make_ule] cannot be applied to empty enums")
             .to_compile_error();
     }


### PR DESCRIPTION
I made an enum where I wanted this in #5392

Shouldn't make an impact on existing enums because `if unsized_int < 0` is always false so it should compile out.

If you would rather not land this, I can re-work #5392 to make an enum starting at zero