### PR TITLE
Refactor: Update `CompactCount` to use `PluralCategory` enum

### DIFF
--- a/components/experimental/Cargo.toml
+++ b/components/experimental/Cargo.toml
@@ -69,7 +69,7 @@ icu_normalizer_data = { workspace = true }
 [features]
 default = ["compiled_data"]
 compiled_data = ["dep:icu_experimental_data", "icu_decimal/compiled_data", "icu_list/compiled_data", "icu_plurals/compiled_data", "icu_properties/compiled_data", "icu_normalizer/compiled_data"]
-datagen = ["serde", "std", "dep:databake", "zerovec/databake", "zerotrie/databake", "tinystr/databake", "icu_collections/databake", "std", "log", "icu_pattern/databake"]
+datagen = ["serde", "std", "dep:databake", "zerovec/databake", "zerotrie/databake", "tinystr/databake", "icu_collections/databake", "std", "log", "icu_pattern/databake", "icu_plurals/datagen"]
 ryu = ["fixed_decimal/ryu"]
 serde = ["dep:serde", "zerovec/serde", "potential_utf/serde", "tinystr/serde", "icu_collections/serde", "icu_decimal/serde", "icu_list/serde", "icu_pattern/serde", "icu_plurals/serde", "icu_provider/serde", "zerotrie/serde"]
 std = ["fixed_decimal/std", "icu_decimal/std", "icu_pattern/std", "icu_plurals/std", "icu_provider/std", "icu_locale_core/std"]

--- a/components/experimental/src/dimension/provider/compact_count_ule.rs
+++ b/components/experimental/src/dimension/provider/compact_count_ule.rs
@@ -2,9 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::dimension::provider::currency_compact::CompactCount;
+use icu_plurals::PluralCategory;
 use zerovec::ule::{AsULE, ZeroVecError, ULE};
-
-use super::{count::Count, currency_compact::CompactCount};
 
 /// [`CompactCountULE`] is a type optimized for efficient storing and
 /// deserialization of [`CompactCount`] using the `ZeroVec` model.
@@ -65,12 +65,12 @@ impl AsULE for CompactCount {
     #[inline]
     fn from_unaligned(unaligned: Self::ULE) -> Self {
         let count = match unaligned.0 & 0b0000_0111 {
-            0 => Count::Zero,
-            1 => Count::One,
-            2 => Count::Two,
-            3 => Count::Few,
-            4 => Count::Many,
-            5 => Count::Other,
+            0 => PluralCategory::Zero,
+            1 => PluralCategory::One,
+            2 => PluralCategory::Two,
+            3 => PluralCategory::Few,
+            4 => PluralCategory::Many,
+            5 => PluralCategory::Other,
             _ => unreachable!(),
         };
         match unaligned.0 & 0b1000_0000 {

--- a/components/experimental/src/dimension/provider/currency_compact.rs
+++ b/components/experimental/src/dimension/provider/currency_compact.rs
@@ -9,10 +9,9 @@
 //!
 //! Read more about data providers: [`icu_provider`]
 
+use icu_plurals::PluralCategory;
 use icu_provider::prelude::*;
 use zerovec::ZeroMap;
-
-use super::count::Count;
 
 /// Currency Compact V1 data struct.
 #[icu_provider::data_struct(marker(ShortCurrencyCompactV1Marker, "currency/compact@1"))]
@@ -47,6 +46,6 @@ pub struct ShortCurrencyCompactV1<'data> {
 )]
 #[repr(u8)]
 pub enum CompactCount {
-    Standard(Count),
-    AlphaNextToNumber(Count),
+    Standard(PluralCategory),
+    AlphaNextToNumber(PluralCategory),
 }

--- a/provider/source/src/currency/compact.rs
+++ b/provider/source/src/currency/compact.rs
@@ -8,8 +8,8 @@ use crate::SourceDataProvider;
 
 use std::collections::HashSet;
 
-use icu::experimental::dimension::provider::count::Count;
 use icu::experimental::dimension::provider::currency_compact::*;
+use icu::plurals::PluralCategory;
 use icu_provider::prelude::*;
 use icu_provider::DataProvider;
 use zerovec::ZeroMap;
@@ -64,12 +64,12 @@ impl DataProvider<ShortCurrencyCompactV1Marker> for SourceDataProvider {
             };
 
             let count = match count_str {
-                "zero" => Count::Zero,
-                "one" => Count::One,
-                "two" => Count::Two,
-                "few" => Count::Few,
-                "many" => Count::Many,
-                "other" => Count::Other,
+                "zero" => PluralCategory::Zero,
+                "one" => PluralCategory::One,
+                "two" => PluralCategory::Two,
+                "few" => PluralCategory::Few,
+                "many" => PluralCategory::Many,
+                "other" => PluralCategory::Other,
                 _ => return Err(DataErrorKind::IdentifierNotFound.into_error()),
             };
 
@@ -130,11 +130,11 @@ fn test_basic() {
     let en_patterns = &en.payload.get().to_owned().compact_patterns;
 
     assert_eq!(
-        en_patterns.get(&(3, CompactCount::Standard(Count::One))),
+        en_patterns.get(&(3, CompactCount::Standard(PluralCategory::One))),
         Some("¤0K")
     );
     assert_eq!(
-        en_patterns.get(&(3, CompactCount::AlphaNextToNumber(Count::One))),
+        en_patterns.get(&(3, CompactCount::AlphaNextToNumber(PluralCategory::One))),
         Some("¤ 0K")
     );
 
@@ -148,11 +148,11 @@ fn test_basic() {
     let ja_patterns = &ja.payload.get().to_owned().compact_patterns;
 
     assert_eq!(
-        ja_patterns.get(&(4, CompactCount::Standard(Count::Other))),
+        ja_patterns.get(&(4, CompactCount::Standard(PluralCategory::Other))),
         Some("¤0万")
     );
     assert_eq!(
-        ja_patterns.get(&(4, CompactCount::AlphaNextToNumber(Count::Other))),
+        ja_patterns.get(&(4, CompactCount::AlphaNextToNumber(PluralCategory::Other))),
         Some("¤\u{a0}0万")
     );
 }


### PR DESCRIPTION
Related to issue https://github.com/unicode-org/icu4x/issues/5369.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->