### PR TITLE
Rename `TinyStrError` to `ParseError`

### DIFF
--- a/utils/tinystr/src/error.rs
+++ b/utils/tinystr/src/error.rs
@@ -5,15 +5,15 @@
 use displaydoc::Display;
 
 #[cfg(feature = "std")]
-impl std::error::Error for TinyStrError {}
+impl std::error::Error for ParseError {}
 
 #[derive(Display, Debug, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum TinyStrError {
+pub enum ParseError {
     #[displaydoc("found string of larger length {len} when constructing string of length {max}")]
-    TooLarge { max: usize, len: usize },
+    TooLong { max: usize, len: usize },
     #[displaydoc("tinystr types do not support strings with null bytes")]
     ContainsNull,
-    #[displaydoc("attempted to construct TinyStrAuto from a non-ascii string")]
+    #[displaydoc("attempted to construct TinyAsciiStr from a non-ASCII string")]
     NonAscii,
 }

--- a/utils/tinystr/src/lib.rs
+++ b/utils/tinystr/src/lib.rs
@@ -87,7 +87,7 @@ mod ule;
 extern crate alloc;
 
 pub use ascii::TinyAsciiStr;
-pub use error::TinyStrError;
+pub use error::ParseError;
 pub use unvalidated::UnvalidatedTinyAsciiStr;
 
 /// These are temporary compatability reexports that will be removed
@@ -111,8 +111,3 @@ fn test_size() {
         core::mem::size_of::<Option<TinyStr8>>()
     );
 }
-// /// Allows unit tests to use the macro
-// #[cfg(test)]
-// mod tinystr {
-//     pub use super::{TinyAsciiStr, TinyStrError};
-// }

--- a/utils/tinystr/src/unvalidated.rs
+++ b/utils/tinystr/src/unvalidated.rs
@@ -2,8 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::ParseError;
 use crate::TinyAsciiStr;
-use crate::TinyStrError;
 use core::fmt;
 
 /// A fixed-length bytes array that is expected to be an ASCII string but does not enforce that invariant.
@@ -29,7 +29,7 @@ impl<const N: usize> fmt::Debug for UnvalidatedTinyAsciiStr<N> {
 impl<const N: usize> UnvalidatedTinyAsciiStr<N> {
     #[inline]
     /// Converts into a [`TinyAsciiStr`]. Fails if the bytes are not valid ASCII.
-    pub fn try_into_tinystr(&self) -> Result<TinyAsciiStr<N>, TinyStrError> {
+    pub fn try_into_tinystr(&self) -> Result<TinyAsciiStr<N>, ParseError> {
         TinyAsciiStr::try_from_raw(self.0)
     }
 


### PR DESCRIPTION
In line with our move of having errors for operations, not types/modules. This error is used by all methods that parse `&str`/`&[u8]`/`[u8; N]`.