### PR TITLE
Add explicit cases to `PluralCategory`

### DIFF
--- a/components/datetime/src/pattern/runtime/plural.rs
+++ b/components/datetime/src/pattern/runtime/plural.rs
@@ -72,8 +72,8 @@ impl<'data> PluralPattern<'data> {
             return;
         }
         match category {
-            PluralCategory::Zero => self.zero = Some(pattern),
-            PluralCategory::One => self.one = Some(pattern),
+            PluralCategory::Zero | PluralCategory::Explicit0 => self.zero = Some(pattern),
+            PluralCategory::One | PluralCategory::Explicit1 => self.one = Some(pattern),
             PluralCategory::Two => self.two = Some(pattern),
             PluralCategory::Few => self.few = Some(pattern),
             PluralCategory::Many => self.many = Some(pattern),
@@ -83,8 +83,8 @@ impl<'data> PluralPattern<'data> {
 
     pub(crate) fn variant(&self, category: PluralCategory) -> &Pattern<'data> {
         let variant = match category {
-            PluralCategory::Zero => &self.zero,
-            PluralCategory::One => &self.one,
+            PluralCategory::Zero | PluralCategory::Explicit0 => &self.zero,
+            PluralCategory::One | PluralCategory::Explicit1 => &self.one,
             PluralCategory::Two => &self.two,
             PluralCategory::Few => &self.few,
             PluralCategory::Many => &self.many,
@@ -95,8 +95,8 @@ impl<'data> PluralPattern<'data> {
 
     pub fn patterns_iter(&self) -> impl Iterator<Item = &Pattern<'data>> {
         PluralCategory::all().filter_map(move |cat| match cat {
-            PluralCategory::Zero => self.zero.as_ref(),
-            PluralCategory::One => self.one.as_ref(),
+            PluralCategory::Zero | PluralCategory::Explicit0 => self.zero.as_ref(),
+            PluralCategory::One | PluralCategory::Explicit1 => self.one.as_ref(),
             PluralCategory::Two => self.two.as_ref(),
             PluralCategory::Few => self.few.as_ref(),
             PluralCategory::Many => self.many.as_ref(),

--- a/components/experimental/src/compactdecimal/provider.rs
+++ b/components/experimental/src/compactdecimal/provider.rs
@@ -110,6 +110,8 @@ impl From<PluralCategory> for Count {
             Few => Count::Few,
             Many => Count::Many,
             Other => Count::Other,
+            Explicit1 => Count::Explicit1,
+            Explicit0 => Count::Zero,
         }
     }
 }

--- a/components/plurals/benches/fixtures/mod.rs
+++ b/components/plurals/benches/fixtures/mod.rs
@@ -50,8 +50,8 @@ impl LocalePluralRulesFixture {
     #[allow(dead_code)]
     pub fn get(&self, category: &PluralCategory) -> Option<&String> {
         match category {
-            PluralCategory::Zero => self.zero.as_ref(),
-            PluralCategory::One => self.one.as_ref(),
+            PluralCategory::Zero | PluralCategory::Explicit0 => self.zero.as_ref(),
+            PluralCategory::One | PluralCategory::Explicit1 => self.one.as_ref(),
             PluralCategory::Two => self.two.as_ref(),
             PluralCategory::Few => self.few.as_ref(),
             PluralCategory::Many => self.many.as_ref(),

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -142,6 +142,10 @@ mod ranges {
         Few = 4,
         /// CLDR "many" plural category.
         Many = 5,
+        /// TODO
+        Explicit1 = 6,
+        /// TODO
+        Explicit0 = 7,
     }
 
     impl RawPluralCategory {
@@ -155,6 +159,8 @@ mod ranges {
                 Self::Two => "two",
                 Self::Few => "few",
                 Self::Many => "many",
+                Self::Explicit1 => "1",
+                Self::Explicit0 => "0",
             }
         }
     }
@@ -168,6 +174,8 @@ mod ranges {
                 RawPluralCategory::Two => PluralCategory::Two,
                 RawPluralCategory::Few => PluralCategory::Few,
                 RawPluralCategory::Many => PluralCategory::Many,
+                RawPluralCategory::Explicit1 => PluralCategory::Explicit1,
+                RawPluralCategory::Explicit0 => PluralCategory::Explicit0,
             }
         }
     }
@@ -181,6 +189,8 @@ mod ranges {
                 PluralCategory::Few => RawPluralCategory::Few,
                 PluralCategory::Many => RawPluralCategory::Many,
                 PluralCategory::Other => RawPluralCategory::Other,
+                PluralCategory::Explicit1 => RawPluralCategory::Explicit1,
+                PluralCategory::Explicit0 => RawPluralCategory::Explicit0,
             }
         }
     }

--- a/ffi/capi/src/pluralrules.rs
+++ b/ffi/capi/src/pluralrules.rs
@@ -22,6 +22,8 @@ pub mod ffi {
         Few,
         Many,
         Other,
+        Explicit1,
+        Explicit0,
     }
 
     impl PluralCategory {
@@ -138,8 +140,10 @@ pub mod ffi {
                 },
                 |mut categories, category| {
                     match category {
-                        icu_plurals::PluralCategory::Zero => categories.zero = true,
-                        icu_plurals::PluralCategory::One => categories.one = true,
+                        icu_plurals::PluralCategory::Zero
+                        | icu_plurals::PluralCategory::Explicit0 => categories.zero = true,
+                        icu_plurals::PluralCategory::One
+                        | icu_plurals::PluralCategory::Explicit1 => categories.one = true,
                         icu_plurals::PluralCategory::Two => categories.two = true,
                         icu_plurals::PluralCategory::Few => categories.few = true,
                         icu_plurals::PluralCategory::Many => categories.many = true,

--- a/ffi/ecma402/src/pluralrules.rs
+++ b/ffi/ecma402/src/pluralrules.rs
@@ -127,6 +127,8 @@ pub(crate) mod internal {
             PluralCategory::Other => "other",
             PluralCategory::Two => "two",
             PluralCategory::Zero => "zero",
+            PluralCategory::Explicit1 => "1",
+            PluralCategory::Explicit0 => "0",
         }
     }
 

--- a/provider/source/src/cldr_serde/currencies/data.rs
+++ b/provider/source/src/cldr_serde/currencies/data.rs
@@ -21,6 +21,12 @@ pub(crate) struct CurrencyPatterns {
     #[serde(rename = "displayName")]
     pub(crate) display_name: Option<String>,
 
+    #[serde(rename = "displayName-count-0")]
+    pub(crate) explicit_zero: Option<String>,
+
+    #[serde(rename = "displayName-count-1")]
+    pub(crate) explicit_one: Option<String>,
+
     #[serde(rename = "displayName-count-zero")]
     pub(crate) zero: Option<String>,
 

--- a/provider/source/src/cldr_serde/date_fields.rs
+++ b/provider/source/src/cldr_serde/date_fields.rs
@@ -16,6 +16,10 @@ use serde::{
 
 #[derive(Debug, Deserialize, Default)]
 pub(crate) struct PluralRulesPattern {
+    #[serde(rename = "relativeTimePattern-count-0")]
+    pub(crate) explicit_zero: Option<String>,
+    #[serde(rename = "relativeTimePattern-count-1")]
+    pub(crate) explicit_one: Option<String>,
     #[serde(rename = "relativeTimePattern-count-zero")]
     pub(crate) zero: Option<String>,
     #[serde(rename = "relativeTimePattern-count-one")]

--- a/provider/source/src/cldr_serde/numbers.rs
+++ b/provider/source/src/cldr_serde/numbers.rs
@@ -120,6 +120,12 @@ pub(crate) struct CurrencyFormattingPatterns {
     #[serde(rename = "standard-alphaNextToNumber")]
     pub(crate) standard_alpha_next_to_number: Option<String>,
 
+    #[serde(rename = "unitPattern-count-0")]
+    pub(crate) pattern_explicit_zero: Option<String>,
+
+    #[serde(rename = "unitPattern-count-1")]
+    pub(crate) pattern_explicit_one: Option<String>,
+
     #[serde(rename = "unitPattern-count-zero")]
     pub(crate) pattern_zero: Option<String>,
 

--- a/provider/source/src/cldr_serde/units/data.rs
+++ b/provider/source/src/cldr_serde/units/data.rs
@@ -16,6 +16,12 @@ use std::collections::BTreeMap;
 ///     https://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules
 #[derive(PartialEq, Debug, Deserialize, Clone)]
 pub(crate) struct Patterns {
+    #[serde(rename = "displayName-count-0")]
+    pub(crate) explicit_zero: Option<String>,
+
+    #[serde(rename = "displayName-count-1")]
+    pub(crate) explicit_one: Option<String>,
+
     #[serde(rename = "unitPattern-count-zero")]
     pub(crate) zero: Option<String>,
 
@@ -42,6 +48,12 @@ pub(crate) struct Patterns {
 
     #[serde(rename = "compoundUnitPattern1")]
     pub(crate) compound_unit_pattern1: Option<String>,
+
+    #[serde(rename = "compountUnitPattern1-count-0")]
+    pub(crate) explicit_zero_compound_unit_pattern1: Option<String>,
+
+    #[serde(rename = "compountUnitPattern1-count-1")]
+    pub(crate) explicit_one_compound_unit_pattern1: Option<String>,
 
     #[serde(rename = "compoundUnitPattern1-count-zero")]
     pub(crate) zero_compound_unit_pattern1: Option<String>,

--- a/provider/source/src/currency/patterns.rs
+++ b/provider/source/src/currency/patterns.rs
@@ -59,6 +59,8 @@ impl DataProvider<CurrencyPatternsDataV1Marker> for SourceDataProvider {
                             .with_debug_context(currency_patterns)
                             .with_debug_context(&req.id)
                     })?,
+                    patterns.pattern_explicit_zero.as_deref(),
+                    patterns.pattern_explicit_one.as_deref(),
                     patterns.pattern_zero.as_deref(),
                     patterns.pattern_one.as_deref(),
                     patterns.pattern_two.as_deref(),

--- a/provider/source/src/relativetime/mod.rs
+++ b/provider/source/src/relativetime/mod.rs
@@ -130,6 +130,8 @@ impl TryFrom<&cldr_serde::date_fields::PluralRulesPattern>
     fn try_from(field: &cldr_serde::date_fields::PluralRulesPattern) -> Result<Self, Self::Error> {
         PluralPattern::try_new(
             &field.other,
+            field.explicit_zero.as_deref(),
+            field.explicit_one.as_deref(),
             field.zero.as_deref(),
             field.one.as_deref(),
             field.two.as_deref(),

--- a/provider/source/src/units/data.rs
+++ b/provider/source/src/units/data.rs
@@ -54,6 +54,8 @@ impl DataProvider<UnitsDisplayNameV1Marker> for SourceDataProvider {
                         .other
                         .as_deref()
                         .ok_or_else(|| DataErrorKind::IdentifierNotFound.into_error())?,
+                    unit_patterns.explicit_zero.as_deref(),
+                    unit_patterns.explicit_one.as_deref(),
                     unit_patterns.zero.as_deref(),
                     unit_patterns.one.as_deref(),
                     unit_patterns.two.as_deref(),


### PR DESCRIPTION
Explicit 0 and 1 cases are required by patterns in multiple components.