### PR TITLE
Load WASM with a hash instead of naming it with a hash

### DIFF
--- a/tutorials/web-demo/webpack.config.js
+++ b/tutorials/web-demo/webpack.config.js
@@ -28,6 +28,12 @@ export default {
 				loader: 'sass-loader'
 				}
 			]
+		},
+		{
+			test: /\.(wasm)$/,
+			generator: {
+				filename: '[name].wasm?v=[hash]'
+			}
 		}
 	  ]
 	},


### PR DESCRIPTION
Supersedes #5423
Mostly fixes #5311

I think adding the hash to the query string "just works" ?