### PR TITLE
Align `--format` flag with provider names

### DIFF
--- a/components/experimental/tests/transliterate/data/gen.sh
+++ b/components/experimental/tests/transliterate/data/gen.sh
@@ -5,7 +5,7 @@ cargo run -p icu4x-datagen --features experimental_components -- \
 --deduplication none \
 --no-internal-fallback \
 --cldr-root $(dirname $0)/../../../../../provider/source/tests/data/cldr \
---format mod \
+--format baked \
 --out $(dirname $0)/baked \
 --pretty \
 --overwrite

--- a/provider/export/README.md
+++ b/provider/export/README.md
@@ -31,22 +31,14 @@ ExportDriver::new([DataLocaleFamily::FULL], DeduplicationStrategy::None.into(), 
 
 ## Cargo features
 
-This crate has a lot of dependencies, some of which are not required for all operating modes. These default Cargo features
-can be disabled to reduce dependencies:
 * `baked_exporter`
   * enables the [`baked_exporter`] module, a reexport of [`icu_provider_baked::export`]
-  * enables the `--format mod` CLI argument
 * `blob_exporter`
   * enables the [`blob_exporter`] module, a reexport of [`icu_provider_blob::export`]
-  * enables the `--format blob` CLI argument
 * `fs_exporter`
   * enables the [`fs_exporter`] module, a reexport of [`icu_provider_fs::export`]
-  * enables the `--format dir` CLI argument
 * `rayon`
   * enables parallelism during export
-* `experimental`
-  * enables data generation for markers defined in the unstable `icu_experimental` crate
-  * note that this features affects the behaviour of `all_markers`
 
 <!-- cargo-rdme end -->
 

--- a/provider/export/src/lib.rs
+++ b/provider/export/src/lib.rs
@@ -32,22 +32,14 @@
 //!
 //! # Cargo features
 //!
-//! This crate has a lot of dependencies, some of which are not required for all operating modes. These default Cargo features
-//! can be disabled to reduce dependencies:
 //! * `baked_exporter`
 //!   * enables the [`baked_exporter`] module, a reexport of [`icu_provider_baked::export`]
-//!   * enables the `--format mod` CLI argument
 //! * `blob_exporter`
 //!   * enables the [`blob_exporter`] module, a reexport of [`icu_provider_blob::export`]
-//!   * enables the `--format blob` CLI argument
 //! * `fs_exporter`
 //!   * enables the [`fs_exporter`] module, a reexport of [`icu_provider_fs::export`]
-//!   * enables the `--format dir` CLI argument
 //! * `rayon`
 //!   * enables parallelism during export
-//! * `experimental`
-//!   * enables data generation for markers defined in the unstable `icu_experimental` crate
-//!   * note that this features affects the behaviour of `all_markers`
 
 #![cfg_attr(
     not(test),

--- a/provider/fs/README.md
+++ b/provider/fs/README.md
@@ -65,13 +65,13 @@ Cargo feature has to be activated on the [`icu_provider`] crate. See
 To generate the data required for [`FsDataProvider`], run the following:
 
 ```bash
-icu4x-datagen --markers all --locales full --format dir
+icu4x-datagen --markers all --locales full --format fs
 ```
 
 To export `postcard` format, use
 
 ```bash
-icu4x-datagen --markers all --locales full --format dir --syntax postcard
+icu4x-datagen --markers all --locales full --format fs --syntax postcard
 ```
 
 [`ICU4X`]: ../icu/index.html

--- a/provider/fs/src/lib.rs
+++ b/provider/fs/src/lib.rs
@@ -65,13 +65,13 @@
 //! To generate the data required for [`FsDataProvider`], run the following:
 //!
 //! ```bash
-//! icu4x-datagen --markers all --locales full --format dir
+//! icu4x-datagen --markers all --locales full --format fs
 //! ```
 //!
 //! To export `postcard` format, use
 //!
 //! ```bash
-//! icu4x-datagen --markers all --locales full --format dir --syntax postcard
+//! icu4x-datagen --markers all --locales full --format fs --syntax postcard
 //! ```
 //!
 //! [`ICU4X`]: ../icu/index.html

--- a/provider/source/src/calendar/japanese.rs
+++ b/provider/source/src/calendar/japanese.rs
@@ -90,7 +90,7 @@ impl SourceDataProvider {
                 return Err(DataError::custom(
                     "Era data has changed! This can be for two reasons: Either the CLDR locale data for Japanese eras has \
                     changed in an incompatible way, or there is a new Japanese era. Run \
-                    `ICU4X_SKIP_JAPANESE_INTEGRITY_CHECK=1 cargo run -p icu4x-datagen -- --markers JapaneseExtendedErasV1Marker --format dir --syntax json \
+                    `ICU4X_SKIP_JAPANESE_INTEGRITY_CHECK=1 cargo run -p icu4x-datagen -- --markers JapaneseExtendedErasV1Marker --format fs --syntax json \
                     --out provider/source/data/japanese-golden --pretty --overwrite` in the icu4x repo and inspect the diff to \
                     check which situation it is. If a new era has been introduced, commit the diff, if not, it's likely that japanese.rs \
                     in icu_provider_source will need to be updated to handle the data changes."

--- a/tools/make/data.toml
+++ b/tools/make/data.toml
@@ -40,16 +40,16 @@ exit_on_error true
 exec --fail-on-error cargo build -p icu4x-datagen --no-default-features --features fs_exporter,blob_exporter,baked_exporter
 
 # Filesystem
-exec --fail-on-error target/debug/icu4x-datagen --markers HelloWorldV1Marker --locales full --format dir --syntax json --out provider/fs/tests/data/json --overwrite
-exec --fail-on-error target/debug/icu4x-datagen --markers HelloWorldV1Marker --locales full --format dir --syntax bincode --out provider/fs/tests/data/bincode --overwrite
-exec --fail-on-error target/debug/icu4x-datagen --markers HelloWorldV1Marker --locales full --format dir --syntax postcard --out provider/fs/tests/data/postcard --overwrite
+exec --fail-on-error target/debug/icu4x-datagen --markers HelloWorldV1Marker --locales full --format fs --syntax json --out provider/fs/tests/data/json --overwrite
+exec --fail-on-error target/debug/icu4x-datagen --markers HelloWorldV1Marker --locales full --format fs --syntax bincode --out provider/fs/tests/data/bincode --overwrite
+exec --fail-on-error target/debug/icu4x-datagen --markers HelloWorldV1Marker --locales full --format fs --syntax postcard --out provider/fs/tests/data/postcard --overwrite
 
 # Blob
 exec --fail-on-error target/debug/icu4x-datagen --markers HelloWorldV1Marker --locales full --format blob --overwrite --out provider/blob/tests/data/v1.postcard
 exec --fail-on-error target/debug/icu4x-datagen --markers HelloWorldV1Marker --locales full --format blob2 --overwrite --out provider/blob/tests/data/v2.postcard
 
 # Baked
-exec --fail-on-error target/debug/icu4x-datagen --markers HelloWorldV1Marker --locales full --format mod --pretty --overwrite --no-internal-fallback --deduplication none --out provider/baked/tests/data
+exec --fail-on-error target/debug/icu4x-datagen --markers HelloWorldV1Marker --locales full --format baked --pretty --overwrite --no-internal-fallback --deduplication none --out provider/baked/tests/data
 '''
 
 [tasks.testdata-check]

--- a/tutorials/c-tiny/fixeddecimal/Makefile
+++ b/tutorials/c-tiny/fixeddecimal/Makefile
@@ -21,7 +21,7 @@ LLVM_COMPATIBLE_NIGHTLY = "nightly-2023-08-08"
 
 baked_data/macros.rs:
 	cargo install --path ../../../provider/icu4x-datagen --root target
-	target/bin/icu4x-datagen --locales en bn --markers all --deduplication none --format mod --out baked_data --overwrite
+	target/bin/icu4x-datagen --locales en bn --markers all --deduplication none --format baked --out baked_data --overwrite
 
 target/debug/libicu_capi.a: FORCE
 	cargo rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/decimal,icu_capi/std

--- a/tutorials/data_management.md
+++ b/tutorials/data_management.md
@@ -23,7 +23,7 @@ Get a coffee, this might take a while ☕.
 Once installed, run:
 
 ```console
-$ icu4x-datagen --markers all --locales ja --format mod --out my_data
+$ icu4x-datagen --markers all --locales ja --format baked --out my_data
 ```
 
 This will generate a `my_data` directory containing the data for all components in the `ja` locale.

--- a/tutorials/rust.md
+++ b/tutorials/rust.md
@@ -21,7 +21,7 @@ If you wish to use custom compiled data for ICU4X, no changes to Cargo.toml are 
 datagen output during your build:
 
 ```command
-icu4x-datagen --format mod --markers all --locales ru --out baked_data
+icu4x-datagen --format baked --markers all --locales ru --out baked_data
 ICU4X_DATA_DIR=$(pwd)/baked_data cargo build --release
 ```
 
@@ -33,8 +33,7 @@ Experimental modules are published in a separate `icu_experimental` crate:
 
 ```toml
 [dependencies]
-icu = "1.5"
-icu_experimental = "0"
+icu = { version = "1.5", features = ["experimental"] }
 ```
 
 In your main.rs, you can now use e.g. the `icu_experimental::displaynames` module.

--- a/tutorials/rust/custom_compiled/Makefile
+++ b/tutorials/rust/custom_compiled/Makefile
@@ -17,7 +17,7 @@ all: clean baked_data/mod.rs
 
 baked_data/mod.rs: ../bin/icu4x-datagen
 	../bin/icu4x-datagen \
-		--format mod \
+		--format baked \
 		--markers all \
 		--locales ru \
 		--overwrite \


### PR DESCRIPTION
Currently we use `dir`, `blob`, `mod`, but it should be `fs`, `blob`, `baked`.