### PR TITLE
Change TimeZoneIdMapper::new() to return the borrowed variant

### DIFF
--- a/components/timezone/src/ixdtf.rs
+++ b/components/timezone/src/ixdtf.rs
@@ -266,7 +266,6 @@ impl CustomTimeZone {
             TimeZoneRecord::Name(iana_identifier) => {
                 let mapper = TimeZoneIdMapper::new();
                 let bcp47_id = mapper
-                    .as_borrowed()
                     .iana_bytes_to_bcp47(iana_identifier)
                     .ok_or(ParseError::InvalidIanaIdentifier)?;
 

--- a/components/timezone/src/lib.rs
+++ b/components/timezone/src/lib.rs
@@ -97,7 +97,7 @@
 //! time_zone.gmt_offset = "-0600".parse::<GmtOffset>().ok();
 //! let mapper = TimeZoneIdMapper::new();
 //! time_zone.time_zone_id =
-//!     mapper.as_borrowed().iana_to_bcp47("America/Chicago");
+//!     mapper.iana_to_bcp47("America/Chicago");
 //!
 //! // Alternatively, set it directly from the BCP-47 ID
 //! assert_eq!(time_zone.time_zone_id, Some(TimeZoneBcp47Id(tinystr!(8, "uschi"))));


### PR DESCRIPTION
Relates to #5440