### PR TITLE
DurationFormatter: Correct SmallVec Size

### DIFF
--- a/components/experimental/src/duration/format.rs
+++ b/components/experimental/src/duration/format.rs
@@ -449,10 +449,10 @@ impl<'a> FormattedDuration<'a> {
         &self,
         sink: &mut V,
     ) -> core::fmt::Result {
-        // We can have a maximum of 9 writeables (one FormattedUnit for each unit).
+        // We can have a maximum of 10 writeables (one FormattedUnit for each unit).
         // In the digital case, one or more unit is represented by the FormattedDigitalDuration,
         // which is a single writeable.
-        let mut parts_list: SmallVec<[HeterogenousToFormatter; 9]> = SmallVec::new();
+        let mut parts_list: SmallVec<[HeterogenousToFormatter; 10]> = SmallVec::new();
 
         // 2. Let signDisplayed be true.
         let mut sign_displayed = true;


### PR DESCRIPTION
Use the correct number of units in `SmallVec` capacity. (There are 10 units):

```
1. nanosecond
2. microsecond
3. millisecond
4. second
5. minute
6. hour
7. day
8. week
9. month
10. year
```

This error would have led to interesting performance problems down the line...