### PR TITLE
Refactor: Rename compactdecimal.rs to formatter.rs and move the options to options.rs

### DIFF
--- a/components/experimental/src/compactdecimal/format.rs
+++ b/components/experimental/src/compactdecimal/format.rs
@@ -7,7 +7,7 @@ use fixed_decimal::{CompactDecimal, FixedDecimal};
 use writeable::Writeable;
 use zerovec::maps::ZeroMap2dCursor;
 
-use crate::compactdecimal::compactdecimal::CompactDecimalFormatter;
+use crate::compactdecimal::formatter::CompactDecimalFormatter;
 use crate::compactdecimal::provider::{Count, PatternULE};
 
 /// An intermediate structure returned by [`CompactDecimalFormatter`](super::CompactDecimalFormatter).

--- a/components/experimental/src/compactdecimal/format.rs
+++ b/components/experimental/src/compactdecimal/format.rs
@@ -56,7 +56,7 @@ impl<'l> Writeable for FormattedCompactDecimal<'l> {
     {
         if self.value.exponent() == 0 {
             self.formatter
-                .fixed_decimal_format
+                .fixed_decimal_formatter
                 .format(self.value.significand())
                 .write_to(sink)
         } else {
@@ -87,7 +87,7 @@ impl<'l> Writeable for FormattedCompactDecimal<'l> {
                             .ok_or(core::fmt::Error)?,
                     )?;
                     self.formatter
-                        .fixed_decimal_format
+                        .fixed_decimal_formatter
                         .format(self.value.significand())
                         .write_to(sink)?;
                     sink.write_str(

--- a/components/experimental/src/compactdecimal/formatter.rs
+++ b/components/experimental/src/compactdecimal/formatter.rs
@@ -23,39 +23,6 @@ use crate::compactdecimal::{
 };
 use icu_provider::DataError;
 
-/// A bag of options defining how numbers will be formatted by
-/// [`CompactDecimalFormatter`](super::CompactDecimalFormatter).
-#[derive(Debug, Eq, PartialEq, Clone)]
-#[non_exhaustive]
-pub struct CompactDecimalFormatterOptions {
-    /// Options to configure the inner [`FixedDecimalFormatter`].
-    pub fixed_decimal_formatter_options: FixedDecimalFormatterOptions,
-}
-
-impl Default for CompactDecimalFormatterOptions {
-    fn default() -> Self {
-        Self {
-            fixed_decimal_formatter_options: GroupingStrategy::Min2.into(),
-        }
-    }
-}
-
-impl From<FixedDecimalFormatterOptions> for CompactDecimalFormatterOptions {
-    fn from(fixed_decimal_formatter_options: FixedDecimalFormatterOptions) -> Self {
-        Self {
-            fixed_decimal_formatter_options,
-        }
-    }
-}
-
-impl From<GroupingStrategy> for CompactDecimalFormatterOptions {
-    fn from(grouping_strategy: GroupingStrategy) -> Self {
-        Self {
-            fixed_decimal_formatter_options: grouping_strategy.into(),
-        }
-    }
-}
-
 /// A formatter that renders locale-sensitive compact numbers.
 ///
 /// # Examples

--- a/components/experimental/src/compactdecimal/formatter.rs
+++ b/components/experimental/src/compactdecimal/formatter.rs
@@ -2,17 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use alloc::borrow::Cow;
-use core::convert::TryFrom;
-use fixed_decimal::{CompactDecimal, FixedDecimal};
-use icu_decimal::{
-    options::{FixedDecimalFormatterOptions, GroupingStrategy},
-    FixedDecimalFormatter,
-};
-use icu_plurals::PluralRules;
-use icu_provider::prelude::*;
-use zerovec::maps::ZeroMap2dCursor;
-
+use super::options::CompactDecimalFormatterOptions;
 use crate::compactdecimal::{
     format::FormattedCompactDecimal,
     provider::{
@@ -21,7 +11,14 @@ use crate::compactdecimal::{
     },
     ExponentError,
 };
+use alloc::borrow::Cow;
+use core::convert::TryFrom;
+use fixed_decimal::{CompactDecimal, FixedDecimal};
+use icu_decimal::FixedDecimalFormatter;
+use icu_plurals::PluralRules;
+use icu_provider::prelude::*;
 use icu_provider::DataError;
+use zerovec::maps::ZeroMap2dCursor;
 
 /// A formatter that renders locale-sensitive compact numbers.
 ///
@@ -666,6 +663,7 @@ impl CompactDecimalFormatter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use icu_decimal::options::GroupingStrategy;
     use icu_locale_core::locale;
     use writeable::assert_writeable_eq;
 

--- a/components/experimental/src/compactdecimal/formatter.rs
+++ b/components/experimental/src/compactdecimal/formatter.rs
@@ -58,7 +58,7 @@ use zerovec::maps::ZeroMap2dCursor;
 #[derive(Debug)]
 pub struct CompactDecimalFormatter {
     pub(crate) plural_rules: PluralRules,
-    pub(crate) fixed_decimal_format: FixedDecimalFormatter,
+    pub(crate) fixed_decimal_formatter: FixedDecimalFormatter,
     pub(crate) compact_data: DataPayload<ErasedCompactDecimalFormatDataV1Marker>,
 }
 
@@ -88,7 +88,7 @@ impl CompactDecimalFormatter {
         options: CompactDecimalFormatterOptions,
     ) -> Result<Self, DataError> {
         Ok(Self {
-            fixed_decimal_format: FixedDecimalFormatter::try_new(
+            fixed_decimal_formatter: FixedDecimalFormatter::try_new(
                 locale,
                 options.fixed_decimal_formatter_options,
             )?,
@@ -129,7 +129,7 @@ impl CompactDecimalFormatter {
             + ?Sized,
     {
         Ok(Self {
-            fixed_decimal_format: FixedDecimalFormatter::try_new_unstable(
+            fixed_decimal_formatter: FixedDecimalFormatter::try_new_unstable(
                 provider,
                 locale,
                 options.fixed_decimal_formatter_options,
@@ -172,7 +172,7 @@ impl CompactDecimalFormatter {
         options: CompactDecimalFormatterOptions,
     ) -> Result<Self, DataError> {
         Ok(Self {
-            fixed_decimal_format: FixedDecimalFormatter::try_new(
+            fixed_decimal_formatter: FixedDecimalFormatter::try_new(
                 locale,
                 options.fixed_decimal_formatter_options,
             )?,
@@ -213,7 +213,7 @@ impl CompactDecimalFormatter {
             + ?Sized,
     {
         Ok(Self {
-            fixed_decimal_format: FixedDecimalFormatter::try_new_unstable(
+            fixed_decimal_formatter: FixedDecimalFormatter::try_new_unstable(
                 provider,
                 locale,
                 options.fixed_decimal_formatter_options,

--- a/components/experimental/src/compactdecimal/mod.rs
+++ b/components/experimental/src/compactdecimal/mod.rs
@@ -19,10 +19,11 @@
 )]
 #![warn(missing_docs)]
 
-mod compactdecimal;
 mod error;
 mod format;
+mod formatter;
+mod options;
 pub mod provider;
 
-pub use compactdecimal::CompactDecimalFormatter;
 pub use error::ExponentError;
+pub use formatter::CompactDecimalFormatter;

--- a/components/experimental/src/compactdecimal/options.rs
+++ b/components/experimental/src/compactdecimal/options.rs
@@ -1,0 +1,38 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use icu_decimal::options::{FixedDecimalFormatterOptions, GroupingStrategy};
+
+/// A bag of options defining how numbers will be formatted by
+/// [`CompactDecimalFormatter`](super::CompactDecimalFormatter).
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[non_exhaustive]
+pub struct CompactDecimalFormatterOptions {
+    /// Options to configure the inner [`FixedDecimalFormatter`].
+    pub fixed_decimal_formatter_options: FixedDecimalFormatterOptions,
+}
+
+impl Default for CompactDecimalFormatterOptions {
+    fn default() -> Self {
+        Self {
+            fixed_decimal_formatter_options: GroupingStrategy::Min2.into(),
+        }
+    }
+}
+
+impl From<FixedDecimalFormatterOptions> for CompactDecimalFormatterOptions {
+    fn from(fixed_decimal_formatter_options: FixedDecimalFormatterOptions) -> Self {
+        Self {
+            fixed_decimal_formatter_options,
+        }
+    }
+}
+
+impl From<GroupingStrategy> for CompactDecimalFormatterOptions {
+    fn from(grouping_strategy: GroupingStrategy) -> Self {
+        Self {
+            fixed_decimal_formatter_options: grouping_strategy.into(),
+        }
+    }
+}


### PR DESCRIPTION


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->