### PR TITLE
Implement and test `FormattedNeoDateTime::pattern()`, refactoring code to enable it

### DIFF
--- a/components/datetime/src/format/mod.rs
+++ b/components/datetime/src/format/mod.rs
@@ -2,21 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#[cfg(feature = "experimental")]
-use crate::neo_skeleton::FractionalSecondDigits;
-use crate::options::preferences::HourCycle;
-
 pub mod datetime;
 #[cfg(feature = "experimental")]
 pub mod neo;
 pub mod time_zone;
 pub mod zoned_datetime;
-
-/// Internal non-pattern runtime options passed to the formatter
-#[derive(Debug, Copy, Clone, Default)]
-pub(crate) struct FormattingOptions {
-    pub(crate) hour_cycle: Option<HourCycle>,
-    pub(crate) force_2_digit_month_day_week_hour: bool,
-    #[cfg(feature = "experimental")]
-    pub(crate) fractional_second_digits: Option<FractionalSecondDigits>,
-}

--- a/components/datetime/src/format/neo.rs
+++ b/components/datetime/src/format/neo.rs
@@ -2294,7 +2294,6 @@ impl<'a> TryWriteable for FormattedDateTimePattern<'a> {
     ) -> Result<Result<(), Self::Error>, fmt::Error> {
         try_write_pattern(
             self.pattern.0.as_borrowed(),
-            Default::default(),
             &self.datetime,
             Some(&self.names),
             Some(&self.names),

--- a/components/datetime/src/format/zoned_datetime.rs
+++ b/components/datetime/src/format/zoned_datetime.rs
@@ -88,7 +88,6 @@ where
                 r = r.and(datetime::try_write_field(
                     field,
                     pattern.metadata,
-                    Default::default(),
                     datetime,
                     date_symbols,
                     time_symbols,

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -1469,7 +1469,6 @@ impl<'a> TryWriteable for FormattedNeoDateTime<'a> {
         try_write_pattern_items(
             self.pattern.metadata(),
             self.pattern.iter_items(),
-            self.pattern.formatting_options(),
             &self.datetime,
             Some(&self.names),
             Some(&self.names),

--- a/components/datetime/src/neo_pattern.rs
+++ b/components/datetime/src/neo_pattern.rs
@@ -6,6 +6,8 @@
 
 use core::str::FromStr;
 
+use writeable::{impl_display_with_writeable, Writeable};
+
 use crate::helpers::size_test;
 use crate::pattern::{runtime, PatternError, PatternItem};
 
@@ -20,6 +22,12 @@ size_test!(DateTimePattern, date_time_pattern_size, 32);
 ///
 /// 1. From a custom pattern string: [`DateTimePattern::try_from_pattern_str`]
 /// 2. From a formatted datetime: [`FormattedNeoDateTime::pattern`]
+///
+/// There are two things you can do with one of these:
+///
+/// 1. Use it to directly format a datetime via [`TypedDateTimeNames`]
+/// 2. Convert it to a string pattern via [`Writeable`]
+///
 #[doc = date_time_pattern_size!()]
 ///
 /// # Examples
@@ -34,9 +42,12 @@ size_test!(DateTimePattern, date_time_pattern_size, 32);
 /// use icu::datetime::neo_pattern::DateTimePattern;
 /// use icu::datetime::neo_skeleton::NeoSkeletonLength;
 /// use icu::locale::locale;
+/// use writeable::assert_writeable_eq;
 ///
+/// let pattern_str = "d MMM y";
 /// let custom_pattern =
-///     DateTimePattern::try_from_pattern_str("d MMM y").unwrap();
+///     DateTimePattern::try_from_pattern_str(pattern_str).unwrap();
+/// assert_writeable_eq!(custom_pattern, pattern_str);
 ///
 /// let data_pattern =
 ///     TypedNeoFormatter::<Gregorian, NeoYearMonthDayMarker>::try_new(
@@ -49,11 +60,13 @@ size_test!(DateTimePattern, date_time_pattern_size, 32);
 ///     .format(&DateTime::local_unix_epoch().to_calendar(Gregorian))
 ///     .pattern();
 ///
+/// assert_writeable_eq!(data_pattern, pattern_str);
 /// assert_eq!(custom_pattern, data_pattern);
 /// ```
 ///
 /// [`DateTimeFormatter`]: crate::DateTimeFormatter
 /// [`FormattedNeoDateTime::pattern`]: crate::neo::FormattedNeoDateTime::pattern
+/// [`TypedDateTimeNames`]: crate::TypedDateTimeNames
 #[derive(Debug)]
 pub struct DateTimePattern {
     pattern: runtime::Pattern<'static>,
@@ -99,6 +112,14 @@ impl PartialEq for DateTimePattern {
 }
 
 impl Eq for DateTimePattern {}
+
+impl Writeable for DateTimePattern {
+    fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
+        self.pattern.write_to(sink)
+    }
+}
+
+impl_display_with_writeable!(DateTimePattern);
 
 // Not clear if this needs to be public. For now, make it private.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/components/datetime/src/pattern/common/serde.rs
+++ b/components/datetime/src/pattern/common/serde.rs
@@ -85,7 +85,7 @@ mod reference {
             S: ser::Serializer,
         {
             if serializer.is_human_readable() {
-                serializer.serialize_str(&self.to_string())
+                serializer.serialize_str(&self.to_runtime_pattern().to_string())
             } else {
                 let pfs = PatternForSerde::from(self);
                 pfs.serialize(serializer)

--- a/components/datetime/src/pattern/mod.rs
+++ b/components/datetime/src/pattern/mod.rs
@@ -80,10 +80,10 @@ impl TimeGranularity {
     }
 }
 
-impl From<&PatternItem> for TimeGranularity {
+impl From<PatternItem> for TimeGranularity {
     /// Retrieves the granularity of time represented by a [`PatternItem`].
     /// If the [`PatternItem`] is not time-related, returns [`None`].
-    fn from(item: &PatternItem) -> Self {
+    fn from(item: PatternItem) -> Self {
         match item {
             PatternItem::Field(field) => match field.symbol {
                 fields::FieldSymbol::Hour(_) => Self::Hours,

--- a/components/datetime/src/pattern/reference/generic.rs
+++ b/components/datetime/src/pattern/reference/generic.rs
@@ -69,6 +69,6 @@ mod test {
         let pattern = pattern
             .combined(vec![date, time])
             .expect("Failed to combine date and time.");
-        assert_eq!(pattern.to_string(), "Y/m/d 'at' HH:mm");
+        assert_eq!(pattern.to_runtime_pattern().to_string(), "Y/m/d 'at' HH:mm");
     }
 }

--- a/components/datetime/src/pattern/reference/mod.rs
+++ b/components/datetime/src/pattern/reference/mod.rs
@@ -7,7 +7,7 @@
 //! for parsing/inspecting/modifying and serialization.
 //!
 //! The runtime `Pattern` uses parsing/serialization from this module.
-mod display;
+
 mod generic;
 mod parser;
 pub(crate) mod pattern;

--- a/components/datetime/src/pattern/reference/pattern.rs
+++ b/components/datetime/src/pattern/reference/pattern.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::pattern::runtime;
+
 use super::{
     super::{PatternError, PatternItem, TimeGranularity},
     Parser,
@@ -23,12 +25,21 @@ impl Pattern {
     pub fn items_mut(&mut self) -> &mut [PatternItem] {
         &mut self.items
     }
+
+    pub fn to_runtime_pattern(&self) -> runtime::Pattern<'static> {
+        runtime::Pattern::from(self)
+    }
 }
 
 impl From<Vec<PatternItem>> for Pattern {
     fn from(items: Vec<PatternItem>) -> Self {
         Self {
-            time_granularity: items.iter().map(Into::into).max().unwrap_or_default(),
+            time_granularity: items
+                .iter()
+                .copied()
+                .map(Into::into)
+                .max()
+                .unwrap_or_default(),
             items,
         }
     }

--- a/components/datetime/src/pattern/runtime/generic.rs
+++ b/components/datetime/src/pattern/runtime/generic.rs
@@ -111,14 +111,6 @@ impl From<&GenericPattern<'_>> for reference::GenericPattern {
     }
 }
 
-#[cfg(feature = "datagen")]
-impl core::fmt::Display for GenericPattern<'_> {
-    fn fmt(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
-        let reference = reference::GenericPattern::from(self);
-        reference.fmt(formatter)
-    }
-}
-
 impl FromStr for GenericPattern<'_> {
     type Err = PatternError;
 
@@ -146,7 +138,6 @@ mod test {
         let pattern = pattern
             .combined(date, time)
             .expect("Failed to combine date and time.");
-        let pattern = reference::Pattern::from(pattern.items.to_vec());
 
         assert_eq!(pattern.to_string(), "Y/m/d 'at' HH:mm");
     }

--- a/components/datetime/src/pattern/runtime/mod.rs
+++ b/components/datetime/src/pattern/runtime/mod.rs
@@ -9,6 +9,8 @@
 //! all runtime performance optimizations `ICU4X` needs.
 //!
 //! For all spec compliant behaviors see `reference::Pattern` equivalent.
+
+mod display;
 mod generic;
 pub(crate) mod helpers;
 mod pattern;

--- a/components/datetime/src/pattern/runtime/pattern.rs
+++ b/components/datetime/src/pattern/runtime/pattern.rs
@@ -48,8 +48,12 @@ impl PatternMetadata {
     }
 
     pub(crate) fn from_items(items: &[PatternItem]) -> Self {
+        Self::from_iter_items(items.iter().copied())
+    }
+
+    pub(crate) fn from_iter_items(iter_items: impl Iterator<Item = PatternItem>) -> Self {
         let time_granularity: TimeGranularity =
-            items.iter().map(Into::into).max().unwrap_or_default();
+            iter_items.map(Into::into).max().unwrap_or_default();
         Self::from_time_granularity(time_granularity)
     }
 
@@ -133,6 +137,16 @@ impl From<Vec<PatternItem>> for Pattern<'_> {
     }
 }
 
+impl FromIterator<PatternItem> for Pattern<'_> {
+    fn from_iter<T: IntoIterator<Item = PatternItem>>(iter: T) -> Self {
+        let items = iter.into_iter().collect::<ZeroVec<PatternItem>>();
+        Self {
+            metadata: PatternMetadata::from_iter_items(items.iter()),
+            items,
+        }
+    }
+}
+
 impl From<&reference::Pattern> for Pattern<'_> {
     fn from(input: &reference::Pattern) -> Self {
         Self {
@@ -166,14 +180,6 @@ impl Default for Pattern<'_> {
             items: ZeroVec::new(),
             metadata: PatternMetadata::default(),
         }
-    }
-}
-
-#[cfg(feature = "datagen")]
-impl core::fmt::Display for Pattern<'_> {
-    fn fmt(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
-        let reference = crate::pattern::reference::Pattern::from(self);
-        reference.fmt(formatter)
     }
 }
 

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -253,7 +253,7 @@ impl<'a> DatePatternDataBorrowed<'a> {
     pub(crate) fn items_and_options(self) -> ItemsAndOptions<'a> {
         let Self::Resolved(pattern, alignment) = self;
         ItemsAndOptions {
-            items: &pattern.items,
+            items: pattern.items,
             alignment,
             ..Default::default()
         }
@@ -437,7 +437,7 @@ impl<'a> TimePatternDataBorrowed<'a> {
     pub(crate) fn items_and_options(self) -> ItemsAndOptions<'a> {
         let Self::Resolved(pattern, alignment, hour_cycle, fractional_second_digits) = self;
         ItemsAndOptions {
-            items: &pattern.items,
+            items: pattern.items,
             alignment,
             hour_cycle,
             fractional_second_digits,
@@ -889,6 +889,7 @@ impl<'a> DateTimeZonePatternDataBorrowed<'a> {
 impl<'a> ItemsAndOptions<'a> {
     pub(crate) fn iter_items(self) -> impl Iterator<Item = PatternItem> + 'a {
         self.items.iter().map(move |mut pattern_item| {
+            #[allow(clippy::single_match)] // need `ref mut`, which doesn't work in `if let`?
             match &mut pattern_item {
                 PatternItem::Field(ref mut field) => {
                     if matches!(self.alignment, Some(Alignment::Column))

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -254,8 +254,8 @@ impl<'a> DatePatternDataBorrowed<'a> {
         let Self::Resolved(pattern, alignment) = self;
         ItemsAndOptions {
             items: &pattern.items,
-                alignment,
-                ..Default::default()
+            alignment,
+            ..Default::default()
         }
     }
 }
@@ -438,9 +438,9 @@ impl<'a> TimePatternDataBorrowed<'a> {
         let Self::Resolved(pattern, alignment, hour_cycle, fractional_second_digits) = self;
         ItemsAndOptions {
             items: &pattern.items,
-                alignment,
-                hour_cycle,
-                fractional_second_digits,
+            alignment,
+            hour_cycle,
+            fractional_second_digits,
         }
     }
 }
@@ -908,14 +908,16 @@ impl<'a> ItemsAndOptions<'a> {
                     if let Some(fractional_second_digits) = self.fractional_second_digits {
                         if matches!(
                             field.symbol,
-                            FieldSymbol::Second(fields::Second::Second) | FieldSymbol::DecimalSecond(_)
+                            FieldSymbol::Second(fields::Second::Second)
+                                | FieldSymbol::DecimalSecond(_)
                         ) {
-                            field.symbol =
-                                FieldSymbol::from_fractional_second_digits(fractional_second_digits);
+                            field.symbol = FieldSymbol::from_fractional_second_digits(
+                                fractional_second_digits,
+                            );
                         }
                     }
                 }
-                _ => ()
+                _ => (),
             }
             pattern_item
         })

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -2,8 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::fields::{self, FieldLength, FieldSymbol};
 use crate::format::neo::FieldForDataLoading;
-use crate::format::FormattingOptions;
 use crate::input::ExtractedDateTimeInput;
 use crate::neo_pattern::DateTimePattern;
 use crate::neo_skeleton::{Alignment, FractionalSecondDigits};
@@ -97,6 +97,23 @@ pub(crate) enum ZonePatternSelectionData {
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum ZonePatternDataBorrowed<'a> {
     SinglePatternItem(&'a <PatternItem as AsULE>::ULE),
+}
+
+#[derive(Debug, Copy, Clone, Default)]
+pub(crate) struct ItemsAndOptions<'a> {
+    pub(crate) items: &'a ZeroSlice<PatternItem>,
+    pub(crate) alignment: Option<Alignment>,
+    pub(crate) hour_cycle: Option<HourCycle>,
+    pub(crate) fractional_second_digits: Option<FractionalSecondDigits>,
+}
+
+impl<'a> ItemsAndOptions<'a> {
+    fn new_empty() -> Self {
+        Self {
+            items: ZeroSlice::new_empty(),
+            ..Default::default()
+        }
+    }
 }
 
 // TODO: Use markers instead of an enum for NeoFormatter pattern storage.
@@ -228,6 +245,17 @@ impl DatePatternSelectionData {
                     skeleton.alignment,
                 )
             }
+        }
+    }
+}
+
+impl<'a> DatePatternDataBorrowed<'a> {
+    pub(crate) fn items_and_options(self) -> ItemsAndOptions<'a> {
+        let Self::Resolved(pattern, alignment) = self;
+        ItemsAndOptions {
+            items: &pattern.items,
+                alignment,
+                ..Default::default()
         }
     }
 }
@@ -405,6 +433,18 @@ impl TimePatternSelectionData {
     }
 }
 
+impl<'a> TimePatternDataBorrowed<'a> {
+    pub(crate) fn items_and_options(self) -> ItemsAndOptions<'a> {
+        let Self::Resolved(pattern, alignment, hour_cycle, fractional_second_digits) = self;
+        ItemsAndOptions {
+            items: &pattern.items,
+                alignment,
+                hour_cycle,
+                fractional_second_digits,
+        }
+    }
+}
+
 impl ZonePatternSelectionData {
     pub(crate) fn new_with_skeleton(length: MaybeLength, components: NeoTimeZoneSkeleton) -> Self {
         let time_zone = components.resolve(length);
@@ -425,6 +465,16 @@ impl ZonePatternSelectionData {
     pub(crate) fn select(&self, _datetime: &ExtractedDateTimeInput) -> ZonePatternDataBorrowed {
         let Self::SinglePatternItem(_, pattern_item) = self;
         ZonePatternDataBorrowed::SinglePatternItem(pattern_item)
+    }
+}
+
+impl<'a> ZonePatternDataBorrowed<'a> {
+    pub(crate) fn items_and_options(self) -> ItemsAndOptions<'a> {
+        let Self::SinglePatternItem(item) = self;
+        ItemsAndOptions {
+            items: ZeroSlice::from_ule_slice(core::slice::from_ref(item)),
+            ..Default::default()
+        }
     }
 }
 
@@ -799,25 +849,6 @@ impl<'a> DateTimeZonePatternDataBorrowed<'a> {
         }
     }
 
-    #[inline]
-    pub(crate) fn formatting_options(self) -> FormattingOptions {
-        let date_alignment = match self.date_pattern() {
-            Some(DatePatternDataBorrowed::Resolved(_, a)) => a,
-            _ => None,
-        };
-        let (time_alignment, hour_cycle, fractional_second_digits) = match self.time_pattern() {
-            Some(TimePatternDataBorrowed::Resolved(_, a, b, c)) => (a, b, c),
-            _ => (None, None, None),
-        };
-        let force_2_digit_month_day_week_hour = matches!(date_alignment, Some(Alignment::Column))
-            || matches!(time_alignment, Some(Alignment::Column));
-        FormattingOptions {
-            hour_cycle,
-            force_2_digit_month_day_week_hour,
-            fractional_second_digits,
-        }
-    }
-
     pub(crate) fn iter_items(self) -> impl Iterator<Item = PatternItem> + 'a {
         let glue_pattern_slice = match self.glue_pattern() {
             Some(glue) => glue.as_ule_slice(),
@@ -825,43 +856,68 @@ impl<'a> DateTimeZonePatternDataBorrowed<'a> {
         };
         glue_pattern_slice
             .iter()
-            .flat_map(
+            .map(
                 move |generic_item_ule| match generic_item_ule.as_pattern_item_ule() {
-                    Ok(pattern_item_ule) => core::slice::from_ref(pattern_item_ule),
+                    Ok(pattern_item_ule) => ItemsAndOptions {
+                        items: ZeroSlice::from_ule_slice(core::slice::from_ref(pattern_item_ule)),
+                        ..Default::default()
+                    },
                     Err(1) => self
                         .date_pattern()
-                        .map(|data| match data {
-                            DatePatternDataBorrowed::Resolved(pb, _) => pb.items.as_ule_slice(),
-                        })
-                        .unwrap_or(&[]),
+                        .map(|p| p.items_and_options())
+                        .unwrap_or(ItemsAndOptions::new_empty()),
                     Err(0) => self
                         .time_pattern()
-                        .map(|data| match data {
-                            TimePatternDataBorrowed::Resolved(pb, _, _, _) => {
-                                pb.items.as_ule_slice()
-                            }
-                        })
-                        .unwrap_or(&[]),
+                        .map(|p| p.items_and_options())
+                        .unwrap_or(ItemsAndOptions::new_empty()),
                     Err(2) => self
                         .zone_pattern()
-                        .map(|data| match data {
-                            ZonePatternDataBorrowed::SinglePatternItem(item) => {
-                                core::slice::from_ref(item)
-                            }
-                        })
-                        .unwrap_or(&[]),
-                    _ => &[],
+                        .map(|p| p.items_and_options())
+                        .unwrap_or(ItemsAndOptions::new_empty()),
+                    _ => ItemsAndOptions::new_empty(),
                 },
             )
-            .map(|unaligned| PatternItem::from_unaligned(*unaligned))
+            .flat_map(|items_and_options| items_and_options.iter_items())
     }
 
     pub(crate) fn to_pattern(self) -> DateTimePattern {
-        let pb = match self {
-            Self::Date(DatePatternDataBorrowed::Resolved(pb, _)) => pb,
-            Self::Time(TimePatternDataBorrowed::Resolved(pb, _, _, _)) => pb,
-            _ => todo!(),
-        };
-        DateTimePattern::from_runtime_pattern(pb.as_pattern().into_owned())
+        let pattern = self.iter_items().collect::<runtime::Pattern>();
+        DateTimePattern::from_runtime_pattern(pattern)
+    }
+}
+
+impl<'a> ItemsAndOptions<'a> {
+    pub(crate) fn iter_items(self) -> impl Iterator<Item = PatternItem> + 'a {
+        self.items.iter().map(move |mut pattern_item| {
+            match &mut pattern_item {
+                PatternItem::Field(ref mut field) => {
+                    if matches!(self.alignment, Some(Alignment::Column))
+                        && field.length == FieldLength::One
+                        && matches!(
+                            field.symbol,
+                            FieldSymbol::Month(_) | FieldSymbol::Day(_) | FieldSymbol::Week(_)
+                        )
+                    {
+                        field.length = FieldLength::TwoDigit;
+                    }
+                    if let Some(hour_cycle) = self.hour_cycle {
+                        if let FieldSymbol::Hour(_) = field.symbol {
+                            field.symbol = FieldSymbol::Hour(hour_cycle.field());
+                        }
+                    }
+                    if let Some(fractional_second_digits) = self.fractional_second_digits {
+                        if matches!(
+                            field.symbol,
+                            FieldSymbol::Second(fields::Second::Second) | FieldSymbol::DecimalSecond(_)
+                        ) {
+                            field.symbol =
+                                FieldSymbol::from_fractional_second_digits(fractional_second_digits);
+                        }
+                    }
+                }
+                _ => ()
+            }
+            pattern_item
+        })
     }
 }

--- a/components/datetime/tests/fixtures/mod.rs
+++ b/components/datetime/tests/fixtures/mod.rs
@@ -38,7 +38,30 @@ pub struct TestOptions {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TestOutput {
     // Key is locale, and value is expected test output.
-    pub values: HashMap<String, String>,
+    pub values: HashMap<String, TestOutputItem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TestOutputItem {
+    ExpectedString(String),
+    ExpectedStringAndPattern { formatted: String, pattern: String },
+}
+
+impl TestOutputItem {
+    pub fn expectation(&self) -> &str {
+        match self {
+            Self::ExpectedString(s) => s,
+            Self::ExpectedStringAndPattern { formatted, .. } => &formatted,
+        }
+    }
+
+    pub fn pattern(&self) -> Option<&str> {
+        match self {
+            Self::ExpectedString(_) => None,
+            Self::ExpectedStringAndPattern { pattern, .. } => Some(&pattern),
+        }
+    }
 }
 
 pub fn get_options(input: &TestOptions) -> Option<DateTimeFormatterOptions> {

--- a/components/datetime/tests/fixtures/mod.rs
+++ b/components/datetime/tests/fixtures/mod.rs
@@ -52,14 +52,14 @@ impl TestOutputItem {
     pub fn expectation(&self) -> &str {
         match self {
             Self::ExpectedString(s) => s,
-            Self::ExpectedStringAndPattern { formatted, .. } => &formatted,
+            Self::ExpectedStringAndPattern { formatted, .. } => formatted,
         }
     }
 
     pub fn pattern(&self) -> Option<&str> {
         match self {
             Self::ExpectedString(_) => None,
-            Self::ExpectedStringAndPattern { pattern, .. } => Some(&pattern),
+            Self::ExpectedStringAndPattern { pattern, .. } => Some(pattern),
         }
     }
 }

--- a/components/datetime/tests/fixtures/tests/components-combine-datetime.json
+++ b/components/datetime/tests/fixtures/tests/components-combine-datetime.json
@@ -22,7 +22,10 @@
         },
         "output": {
             "values": {
-                "en": "Tue, Jan 7, 2020, 8:25\u202fAM"
+                "en": {
+                    "formatted": "Tue, Jan 7, 2020, 8:25\u202fAM",
+                    "pattern": "E, MMM d, y, h:mm\u202fa"
+                }
             }
         }
     },
@@ -49,7 +52,10 @@
         },
         "output": {
             "values": {
-                "en": "Tuesday, January 7, 2020, 8:25\u202fAM"
+                "en": {
+                    "formatted": "Tuesday, January 7, 2020, 8:25\u202fAM",
+                    "pattern": "EEEE, MMMM d, y, h:mm\u202fa"
+                }
             }
         }
     }

--- a/components/datetime/tests/fixtures/tests/components-width-differences.json
+++ b/components/datetime/tests/fixtures/tests/components-width-differences.json
@@ -15,7 +15,10 @@
         },
         "output": {
             "values": {
-                "en": "20"
+                "en": {
+                    "formatted": "20",
+                    "pattern": "yy"
+                }
             }
         }
     },

--- a/components/datetime/tests/fixtures/tests/components.json
+++ b/components/datetime/tests/fixtures/tests/components.json
@@ -157,7 +157,10 @@
         },
         "output": {
             "values": {
-                "en": "14:15:07.012300000"
+                "en": {
+                    "formatted": "14:15:07.012300000",
+                    "pattern": "HH:mm:ss.SSSSSSSSS"
+                }
             }
         }
     }

--- a/components/datetime/tests/fixtures/tests/components_hour_cycle.json
+++ b/components/datetime/tests/fixtures/tests/components_hour_cycle.json
@@ -17,7 +17,10 @@
         },
         "output": {
             "values": {
-                "en": "0:25\u202fAM"
+                "en": {
+                    "formatted": "0:25\u202fAM",
+                    "pattern": "K:mm\u202fa"
+                }
             }
         }
     },
@@ -39,7 +42,10 @@
         },
         "output": {
             "values": {
-                "en": "12:25\u202fAM"
+                "en": {
+                    "formatted": "12:25\u202fAM",
+                    "pattern": "h:mm\u202fa"
+                }
             }
         }
     },
@@ -61,7 +67,10 @@
         },
         "output": {
             "values": {
-                "en": "00:25"
+                "en": {
+                    "formatted": "00:25",
+                    "pattern": "HH:mm"
+                }
             }
         }
     },
@@ -83,7 +92,10 @@
         },
         "output": {
             "values": {
-                "en": "24:25"
+                "en": {
+                    "formatted": "24:25",
+                    "pattern": "kk:mm"
+                }
             }
         }
     },


### PR DESCRIPTION
#1317

I could have left this for a post-beta cleanup, but I want this function to work so I can propose that we delete `resolve_components`.