### PR TITLE
Replace resolved components API with neo-based alternative

### DIFF
--- a/components/datetime/src/neo_pattern.rs
+++ b/components/datetime/src/neo_pattern.rs
@@ -23,16 +23,18 @@ size_test!(DateTimePattern, date_time_pattern_size, 32);
 /// 1. From a custom pattern string: [`DateTimePattern::try_from_pattern_str`]
 /// 2. From a formatted datetime: [`FormattedNeoDateTime::pattern`]
 ///
-/// There are two things you can do with one of these:
+/// Things you can do with one of these:
 ///
 /// 1. Use it to directly format a datetime via [`TypedDateTimeNames`]
 /// 2. Convert it to a string pattern via [`Writeable`]
+/// 3. Get the resolved components
 ///
 #[doc = date_time_pattern_size!()]
 ///
 /// # Examples
 ///
-/// Create a pattern from a custom string and compare it to one from data:
+/// Create a pattern from a custom string and compare it to one from data,
+/// then check the resolved components:
 ///
 /// ```
 /// use icu::calendar::DateTime;
@@ -41,14 +43,17 @@ size_test!(DateTimePattern, date_time_pattern_size, 32);
 /// use icu::datetime::neo_marker::NeoYearMonthDayMarker;
 /// use icu::datetime::neo_pattern::DateTimePattern;
 /// use icu::datetime::neo_skeleton::NeoSkeletonLength;
+/// use icu::datetime::options::components;
 /// use icu::locale::locale;
 /// use writeable::assert_writeable_eq;
 ///
+/// // Create the pattern from a string:
 /// let pattern_str = "d MMM y";
 /// let custom_pattern =
 ///     DateTimePattern::try_from_pattern_str(pattern_str).unwrap();
 /// assert_writeable_eq!(custom_pattern, pattern_str);
 ///
+/// // Load data that resolves to the same pattern:
 /// let data_pattern =
 ///     TypedNeoFormatter::<Gregorian, NeoYearMonthDayMarker>::try_new(
 ///         &locale!("es-MX").into(),
@@ -59,9 +64,16 @@ size_test!(DateTimePattern, date_time_pattern_size, 32);
 ///     // For this example, we'll choose the local Unix epoch.
 ///     .format(&DateTime::local_unix_epoch().to_calendar(Gregorian))
 ///     .pattern();
-///
 /// assert_writeable_eq!(data_pattern, pattern_str);
 /// assert_eq!(custom_pattern, data_pattern);
+///
+/// // Check the resolved components:
+/// let mut expected_components_bag = components::Bag::default();
+/// expected_components_bag.year = Some(components::Year::Numeric);
+/// expected_components_bag.month = Some(components::Month::Short);
+/// expected_components_bag.day = Some(components::Day::NumericDayOfMonth);
+/// let actual_components_bag = components::Bag::from(&data_pattern);
+/// assert_eq!(actual_components_bag, expected_components_bag);
 /// ```
 ///
 /// [`DateTimeFormatter`]: crate::DateTimeFormatter

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -92,10 +92,10 @@ use crate::{
 };
 
 use super::preferences;
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
 #[cfg(feature = "experimental")]
 use crate::neo_pattern::DateTimePattern;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// See the [module-level](./index.html) docs for more information.
 ///

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -84,6 +84,7 @@
 
 use crate::{
     fields::{self, Field, FieldLength, FieldSymbol},
+    neo_pattern::DateTimePattern,
     neo_skeleton::FractionalSecondDigits,
     pattern::{
         runtime::{Pattern, PatternPlurals},
@@ -636,6 +637,12 @@ impl<'data> From<&PatternPlurals<'data>> for Bag {
             PatternPlurals::MultipleVariants(plural_pattern) => &plural_pattern.other,
         };
         Self::from(pattern)
+    }
+}
+
+impl From<&DateTimePattern> for Bag {
+    fn from(value: &DateTimePattern) -> Self {
+        Self::from(value.as_borrowed().0)
     }
 }
 

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -84,7 +84,6 @@
 
 use crate::{
     fields::{self, Field, FieldLength, FieldSymbol},
-    neo_pattern::DateTimePattern,
     neo_skeleton::FractionalSecondDigits,
     pattern::{
         runtime::{Pattern, PatternPlurals},
@@ -95,6 +94,8 @@ use crate::{
 use super::preferences;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "experimental")]
+use crate::neo_pattern::DateTimePattern;
 
 /// See the [module-level](./index.html) docs for more information.
 ///
@@ -640,6 +641,7 @@ impl<'data> From<&PatternPlurals<'data>> for Bag {
     }
 }
 
+#[cfg(feature = "experimental")]
 impl From<&DateTimePattern> for Bag {
     fn from(value: &DateTimePattern) -> Self {
         Self::from(value.as_borrowed().0)

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -896,7 +896,10 @@ impl<'a> ItemsAndOptions<'a> {
                         && field.length == FieldLength::One
                         && matches!(
                             field.symbol,
-                            FieldSymbol::Month(_) | FieldSymbol::Day(_) | FieldSymbol::Week(_)
+                            FieldSymbol::Month(_)
+                                | FieldSymbol::Day(_)
+                                | FieldSymbol::Week(_)
+                                | FieldSymbol::Hour(_)
                         )
                     {
                         field.length = FieldLength::TwoDigit;

--- a/components/datetime/tests/resolved_components.rs
+++ b/components/datetime/tests/resolved_components.rs
@@ -6,7 +6,8 @@ use icu_calendar::{DateTime, Gregorian};
 use icu_datetime::{
     neo::{NeoOptions, TypedNeoFormatter},
     neo_skeleton::{
-        Alignment, EraDisplay, FractionalSecondDigits, NeoDateComponents, NeoDateTimeComponents, NeoDayComponents, NeoSkeletonLength, NeoTimeComponents
+        Alignment, EraDisplay, FractionalSecondDigits, NeoDateComponents, NeoDateTimeComponents,
+        NeoDayComponents, NeoSkeletonLength, NeoTimeComponents,
     },
     options::{components, preferences},
 };
@@ -88,8 +89,10 @@ fn test_length_time_preferences() {
 
 #[test]
 fn test_date_and_time() {
-    let field_set =
-        NeoDateTimeComponents::DateTime(NeoDayComponents::EraYearMonthDayWeekday, NeoTimeComponents::Auto);
+    let field_set = NeoDateTimeComponents::DateTime(
+        NeoDayComponents::EraYearMonthDayWeekday,
+        NeoTimeComponents::Auto,
+    );
     let mut options = NeoOptions::from(NeoSkeletonLength::Medium);
     options.era_display = Some(EraDisplay::Always);
     options.fractional_second_digits = Some(FractionalSecondDigits::F4);

--- a/components/datetime/tests/resolved_components.rs
+++ b/components/datetime/tests/resolved_components.rs
@@ -2,44 +2,52 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_calendar::Gregorian;
+use icu_calendar::{DateTime, Gregorian};
 use icu_datetime::{
-    neo_skeleton::FractionalSecondDigits,
-    options::{components, length, preferences},
-    DateTimeFormatterOptions, TypedDateTimeFormatter,
+    neo::{NeoOptions, TypedNeoFormatter},
+    neo_skeleton::{
+        Alignment, EraDisplay, FractionalSecondDigits, NeoDateComponents, NeoDateTimeComponents, NeoDayComponents, NeoSkeletonLength, NeoTimeComponents
+    },
+    options::{components, preferences},
 };
 use icu_locale_core::locale;
 use icu_locale_core::Locale;
 
 fn assert_resolved_components(
-    options: DateTimeFormatterOptions,
+    field_set: NeoDateTimeComponents,
+    options: NeoOptions<NeoDateTimeComponents>,
     bag: &components::Bag,
     locale: Locale,
 ) {
-    let dtf = TypedDateTimeFormatter::<Gregorian>::try_new_experimental(&locale.into(), options)
-        .expect("Failed to create a TypedDateTimeFormatter.");
-
-    assert_eq!(dtf.resolve_components(), *bag);
+    let dtf = TypedNeoFormatter::<Gregorian, _>::try_new_with_components(
+        &locale.into(),
+        field_set,
+        options,
+    )
+    .unwrap();
+    let datetime = DateTime::local_unix_epoch().to_calendar(Gregorian);
+    let resolved_pattern = dtf.format(&datetime).pattern();
+    assert_eq!(components::Bag::from(&resolved_pattern), *bag);
 }
 
 #[test]
 fn test_length_date() {
-    let length_bag = length::Bag::from_date_style(length::Date::Medium);
+    let field_set = NeoDateTimeComponents::Date(NeoDateComponents::Day(NeoDayComponents::Auto));
+    let length = NeoSkeletonLength::Medium;
 
     let mut components_bag = components::Bag::default();
     components_bag.year = Some(components::Year::Numeric);
     components_bag.month = Some(components::Month::Short);
     components_bag.day = Some(components::Day::NumericDayOfMonth);
-    assert_resolved_components(
-        DateTimeFormatterOptions::Length(length_bag),
-        &components_bag,
-        locale!("en"),
-    );
+
+    assert_resolved_components(field_set, length.into(), &components_bag, locale!("en"));
 }
 
 #[test]
 fn test_length_time() {
-    let length_bag = length::Bag::from_time_style(length::Time::Medium);
+    let field_set = NeoDateTimeComponents::Time(NeoTimeComponents::Auto);
+    let length = NeoSkeletonLength::Medium;
+
     let mut components_bag = components::Bag::default();
     components_bag.hour = Some(components::Numeric::Numeric);
     components_bag.minute = Some(components::Numeric::TwoDigit);
@@ -47,8 +55,10 @@ fn test_length_time() {
     components_bag.preferences = Some(preferences::Bag::from_hour_cycle(
         preferences::HourCycle::H12,
     ));
+
     assert_resolved_components(
-        DateTimeFormatterOptions::Length(length_bag),
+        field_set,
+        length.into(),
         &components_bag,
         "en-u-hc-h12".parse::<Locale>().unwrap(),
     );
@@ -56,7 +66,9 @@ fn test_length_time() {
 
 #[test]
 fn test_length_time_preferences() {
-    let length_bag = length::Bag::from_time_style(length::Time::Medium);
+    let field_set = NeoDateTimeComponents::Time(NeoTimeComponents::Auto);
+    let mut options = NeoOptions::from(NeoSkeletonLength::Medium);
+    options.alignment = Some(Alignment::Column);
 
     let mut components_bag = components::Bag::default();
     components_bag.hour = Some(components::Numeric::TwoDigit);
@@ -67,21 +79,29 @@ fn test_length_time_preferences() {
     ));
 
     assert_resolved_components(
-        DateTimeFormatterOptions::Length(length_bag),
+        field_set,
+        options,
         &components_bag,
         "en-u-hc-h24".parse::<Locale>().unwrap(),
     );
 }
 
 #[test]
-fn test_components_bag() {
+fn test_date_and_time() {
+    let field_set =
+        NeoDateTimeComponents::DateTime(NeoDayComponents::EraYearMonthDayWeekday, NeoTimeComponents::Auto);
+    let mut options = NeoOptions::from(NeoSkeletonLength::Medium);
+    options.era_display = Some(EraDisplay::Always);
+    options.fractional_second_digits = Some(FractionalSecondDigits::F4);
+    options.alignment = Some(Alignment::Column);
+
     let mut input_bag = components::Bag::default();
     input_bag.era = Some(components::Text::Short);
     input_bag.year = Some(components::Year::Numeric);
     input_bag.month = Some(components::Month::Numeric);
     input_bag.day = Some(components::Day::TwoDigitDayOfMonth);
-    input_bag.weekday = Some(components::Text::Long);
-    input_bag.hour = Some(components::Numeric::Numeric);
+    input_bag.weekday = Some(components::Text::Short);
+    input_bag.hour = Some(components::Numeric::TwoDigit);
     input_bag.minute = Some(components::Numeric::TwoDigit);
     input_bag.second = Some(components::Numeric::TwoDigit);
     input_bag.fractional_second = Some(FractionalSecondDigits::F4);
@@ -93,7 +113,8 @@ fn test_components_bag() {
     ));
 
     assert_resolved_components(
-        DateTimeFormatterOptions::Components(input_bag),
+        field_set,
+        options,
         &output_bag,
         "en-u-hc-h23".parse::<Locale>().unwrap(),
     );


### PR DESCRIPTION
#1317

This uses the `components` API, which I'd like to deprecate/remove, but it doesn't really hurt to keep it around I guess? Would like if it could go into an ecma402-specific wrapper.