### PR TITLE
Migrate example tui to neo datetime and impl fmt::Display for LossyWrap

### DIFF
--- a/components/icu/examples/tui.rs
+++ b/components/icu/examples/tui.rs
@@ -5,14 +5,17 @@
 // An example program making use of a number of ICU components
 // in a pseudo-real-world application of Textual User Interface.
 
-use icu::calendar::{DateTime, Gregorian};
-use icu::datetime::time_zone::TimeZoneFormatterOptions;
-use icu::datetime::{DateTimeFormatterOptions, TypedZonedDateTimeFormatter};
+use icu::calendar::{Date, Gregorian, Time};
 use icu::locale::locale;
 use icu::plurals::{PluralCategory, PluralRules};
 use icu::timezone::CustomTimeZone;
 use icu_collections::codepointinvlist::CodePointInversionListBuilder;
+use icu_datetime::neo::TypedNeoFormatter;
+use icu_datetime::neo_marker::NeoYearMonthDayHourMinuteSecondTimeZoneGenericShortMarker;
+use icu_datetime::neo_skeleton::NeoSkeletonLength;
+use icu_timezone::CustomZonedDateTime;
 use std::env;
+use writeable::adapters::LossyWrap;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -37,18 +40,18 @@ fn main() {
     println!("User: {user_name}");
 
     {
-        let dtf = TypedZonedDateTimeFormatter::<Gregorian>::try_new(
-            &locale,
-            DateTimeFormatterOptions::default(),
-            TimeZoneFormatterOptions::default(),
-        )
-        .expect("Failed to create TypedDateTimeFormatter.");
-        let today_date = DateTime::try_new_gregorian_datetime(2020, 10, 10, 18, 56, 0).unwrap();
-        let today_tz = CustomTimeZone::try_from_str("Z").unwrap(); // Z refers to the utc timezone
+        let dtf = TypedNeoFormatter::<
+            Gregorian,
+            NeoYearMonthDayHourMinuteSecondTimeZoneGenericShortMarker,
+        >::try_new(&locale, NeoSkeletonLength::Medium.into())
+        .expect("Failed to create zoned datetime formatter.");
+        let date = Date::try_new_gregorian_date(2020, 10, 10).unwrap();
+        let time = Time::try_new(18, 56, 0, 0).unwrap();
+        let zone = CustomTimeZone::utc();
 
-        let formatted_dt = dtf.format(&today_date, &today_tz);
+        let formatted_dt = dtf.format(&CustomZonedDateTime { date, time, zone });
 
-        println!("Today is: {formatted_dt}");
+        println!("Today is: {}", LossyWrap(formatted_dt));
     }
 
     {

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -104,6 +104,13 @@ pub mod adapters {
             self.0.writeable_length_hint()
         }
     }
+
+    impl<T: TryWriteable> fmt::Display for LossyWrap<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let _ = self.0.try_write_to(f)?;
+            Ok(())
+        }
+    }
 }
 
 #[doc(hidden)] // for testing


### PR DESCRIPTION
See binary size comparison in https://github.com/unicode-org/icu4x/issues/1317#issuecomment-2330283151. TLDR: Quite an improvement.