### PR TITLE
Hide `CustomTimeZone::{gmt, bst}`

### DIFF
--- a/components/timezone/src/time_zone.rs
+++ b/components/timezone/src/time_zone.rs
@@ -102,29 +102,27 @@ impl CustomTimeZone {
     /// All other fields are left empty.
     pub const fn utc() -> Self {
         Self {
-            gmt_offset: Some(GmtOffset::utc()),
+            gmt_offset: Some(GmtOffset::zero()),
             time_zone_id: None,
             metazone_id: None,
             zone_variant: None,
         }
     }
 
-    /// Creates a new [`CustomTimeZone`] representing Greenwich Mean Time
-    /// (London Time as observed in the winter).
+    #[doc(hidden)] // unstable, test-only
     pub const fn gmt() -> Self {
         Self {
-            gmt_offset: Some(GmtOffset::utc()),
+            gmt_offset: Some(GmtOffset::zero()),
             time_zone_id: Some(TimeZoneBcp47Id(tinystr!(8, "gblon"))),
             metazone_id: Some(MetazoneId(tinystr!(4, "mgmt"))),
             zone_variant: Some(ZoneVariant::standard()),
         }
     }
 
-    /// Creates a new [`CustomTimeZone`] representing British Summer Time
-    /// (London Time as observed in the summer).
+    #[doc(hidden)] // unstable, test-only
     pub const fn bst() -> Self {
         Self {
-            gmt_offset: Some(GmtOffset::utc_plus_1()),
+            gmt_offset: Some(GmtOffset::from_offset_eighths_of_hour(8)),
             time_zone_id: Some(TimeZoneBcp47Id(tinystr!(8, "gblon"))),
             metazone_id: Some(MetazoneId(tinystr!(4, "mgmt"))),
             zone_variant: Some(ZoneVariant::daylight()),
@@ -192,7 +190,7 @@ impl CustomTimeZone {
         Err(UnknownTimeZoneError)
     }
 
-    /// Overwrite the metazone id in MockTimeZone.
+    /// Overwrite the metazone ID.
     ///
     /// # Examples
     ///

--- a/components/timezone/src/types.rs
+++ b/components/timezone/src/types.rs
@@ -14,7 +14,7 @@ pub struct GmtOffset(i32);
 
 impl Default for GmtOffset {
     fn default() -> Self {
-        Self::utc()
+        Self::zero()
     }
 }
 
@@ -52,13 +52,9 @@ impl GmtOffset {
         Self(eighths_of_hour as i32 * 450)
     }
 
-    /// Creates a [`GmtOffset`] at UTC.
-    pub const fn utc() -> Self {
+    /// Creates a [`GmtOffset`] of 0.
+    pub const fn zero() -> Self {
         Self(0)
-    }
-
-    pub(crate) const fn utc_plus_1() -> Self {
-        Self(3600)
     }
 
     /// Parse a [`GmtOffset`] from bytes.

--- a/ffi/capi/bindings/c/CustomTimeZone.h
+++ b/ffi/capi/bindings/c/CustomTimeZone.h
@@ -25,10 +25,6 @@ CustomTimeZone* icu4x_CustomTimeZone_empty_mv1(void);
 
 CustomTimeZone* icu4x_CustomTimeZone_utc_mv1(void);
 
-CustomTimeZone* icu4x_CustomTimeZone_gmt_mv1(void);
-
-CustomTimeZone* icu4x_CustomTimeZone_bst_mv1(void);
-
 typedef struct icu4x_CustomTimeZone_try_set_gmt_offset_seconds_mv1_result { bool is_ok;} icu4x_CustomTimeZone_try_set_gmt_offset_seconds_mv1_result;
 icu4x_CustomTimeZone_try_set_gmt_offset_seconds_mv1_result icu4x_CustomTimeZone_try_set_gmt_offset_seconds_mv1(CustomTimeZone* self, int32_t offset_seconds);
 

--- a/ffi/capi/bindings/cpp/icu4x/CustomTimeZone.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/CustomTimeZone.d.hpp
@@ -40,10 +40,6 @@ public:
 
   inline static std::unique_ptr<icu4x::CustomTimeZone> utc();
 
-  inline static std::unique_ptr<icu4x::CustomTimeZone> gmt();
-
-  inline static std::unique_ptr<icu4x::CustomTimeZone> bst();
-
   inline diplomat::result<std::monostate, icu4x::TimeZoneInvalidOffsetError> try_set_gmt_offset_seconds(int32_t offset_seconds);
 
   inline void set_gmt_offset_eighths_of_hour(int8_t offset_eighths_of_hour);

--- a/ffi/capi/bindings/cpp/icu4x/CustomTimeZone.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/CustomTimeZone.hpp
@@ -29,10 +29,6 @@ namespace capi {
     
     icu4x::capi::CustomTimeZone* icu4x_CustomTimeZone_utc_mv1(void);
     
-    icu4x::capi::CustomTimeZone* icu4x_CustomTimeZone_gmt_mv1(void);
-    
-    icu4x::capi::CustomTimeZone* icu4x_CustomTimeZone_bst_mv1(void);
-    
     typedef struct icu4x_CustomTimeZone_try_set_gmt_offset_seconds_mv1_result { bool is_ok;} icu4x_CustomTimeZone_try_set_gmt_offset_seconds_mv1_result;
     icu4x_CustomTimeZone_try_set_gmt_offset_seconds_mv1_result icu4x_CustomTimeZone_try_set_gmt_offset_seconds_mv1(icu4x::capi::CustomTimeZone* self, int32_t offset_seconds);
     
@@ -113,16 +109,6 @@ inline std::unique_ptr<icu4x::CustomTimeZone> icu4x::CustomTimeZone::empty() {
 
 inline std::unique_ptr<icu4x::CustomTimeZone> icu4x::CustomTimeZone::utc() {
   auto result = icu4x::capi::icu4x_CustomTimeZone_utc_mv1();
-  return std::unique_ptr<icu4x::CustomTimeZone>(icu4x::CustomTimeZone::FromFFI(result));
-}
-
-inline std::unique_ptr<icu4x::CustomTimeZone> icu4x::CustomTimeZone::gmt() {
-  auto result = icu4x::capi::icu4x_CustomTimeZone_gmt_mv1();
-  return std::unique_ptr<icu4x::CustomTimeZone>(icu4x::CustomTimeZone::FromFFI(result));
-}
-
-inline std::unique_ptr<icu4x::CustomTimeZone> icu4x::CustomTimeZone::bst() {
-  auto result = icu4x::capi::icu4x_CustomTimeZone_bst_mv1();
   return std::unique_ptr<icu4x::CustomTimeZone>(icu4x::CustomTimeZone::FromFFI(result));
 }
 

--- a/ffi/capi/bindings/dart/CustomTimeZone.g.dart
+++ b/ffi/capi/bindings/dart/CustomTimeZone.g.dart
@@ -52,22 +52,6 @@ final class CustomTimeZone implements ffi.Finalizable {
     return CustomTimeZone._fromFfi(result, []);
   }
 
-  /// Creates a time zone for GMT (London winter time).
-  ///
-  /// See the [Rust documentation for `gmt`](https://docs.rs/icu/latest/icu/timezone/struct.CustomTimeZone.html#method.gmt) for more information.
-  factory CustomTimeZone.gmt() {
-    final result = _icu4x_CustomTimeZone_gmt_mv1();
-    return CustomTimeZone._fromFfi(result, []);
-  }
-
-  /// Creates a time zone for BST (London summer time).
-  ///
-  /// See the [Rust documentation for `bst`](https://docs.rs/icu/latest/icu/timezone/struct.CustomTimeZone.html#method.bst) for more information.
-  factory CustomTimeZone.bst() {
-    final result = _icu4x_CustomTimeZone_bst_mv1();
-    return CustomTimeZone._fromFfi(result, []);
-  }
-
   /// Sets the `gmt_offset` field from offset seconds.
   ///
   /// Errors if the offset seconds are out of range.
@@ -386,16 +370,6 @@ external ffi.Pointer<ffi.Opaque> _icu4x_CustomTimeZone_empty_mv1();
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CustomTimeZone_utc_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CustomTimeZone_utc_mv1();
-
-@meta.ResourceIdentifier('icu4x_CustomTimeZone_gmt_mv1')
-@ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CustomTimeZone_gmt_mv1')
-// ignore: non_constant_identifier_names
-external ffi.Pointer<ffi.Opaque> _icu4x_CustomTimeZone_gmt_mv1();
-
-@meta.ResourceIdentifier('icu4x_CustomTimeZone_bst_mv1')
-@ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CustomTimeZone_bst_mv1')
-// ignore: non_constant_identifier_names
-external ffi.Pointer<ffi.Opaque> _icu4x_CustomTimeZone_bst_mv1();
 
 @meta.ResourceIdentifier('icu4x_CustomTimeZone_try_set_gmt_offset_seconds_mv1')
 @ffi.Native<_ResultVoidTimeZoneInvalidOffsetErrorFfi Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_CustomTimeZone_try_set_gmt_offset_seconds_mv1')

--- a/ffi/capi/bindings/js/CustomTimeZone.d.ts
+++ b/ffi/capi/bindings/js/CustomTimeZone.d.ts
@@ -21,10 +21,6 @@ export class CustomTimeZone {
 
     static utc(): CustomTimeZone;
 
-    static gmt(): CustomTimeZone;
-
-    static bst(): CustomTimeZone;
-
     trySetGmtOffsetSeconds(offsetSeconds: number): void;
 
     setGmtOffsetEighthsOfHour(offsetEighthsOfHour: number): void;

--- a/ffi/capi/bindings/js/CustomTimeZone.mjs
+++ b/ffi/capi/bindings/js/CustomTimeZone.mjs
@@ -86,26 +86,6 @@ export class CustomTimeZone {
         finally {}
     }
 
-    static gmt() {
-        const result = wasm.icu4x_CustomTimeZone_gmt_mv1();
-    
-        try {
-            return new CustomTimeZone(diplomatRuntime.internalConstructor, result, []);
-        }
-        
-        finally {}
-    }
-
-    static bst() {
-        const result = wasm.icu4x_CustomTimeZone_bst_mv1();
-    
-        try {
-            return new CustomTimeZone(diplomatRuntime.internalConstructor, result, []);
-        }
-        
-        finally {}
-    }
-
     trySetGmtOffsetSeconds(offsetSeconds) {
         const result = wasm.icu4x_CustomTimeZone_try_set_gmt_offset_seconds_mv1(this.ffiValue, offsetSeconds);
     

--- a/ffi/capi/src/timezone.rs
+++ b/ffi/capi/src/timezone.rs
@@ -51,20 +51,6 @@ pub mod ffi {
             Box::new(icu_timezone::CustomTimeZone::utc().into())
         }
 
-        /// Creates a time zone for GMT (London winter time).
-        #[diplomat::rust_link(icu::timezone::CustomTimeZone::gmt, FnInStruct)]
-        #[diplomat::attr(supports = fallible_constructors, named_constructor)]
-        pub fn gmt() -> Box<CustomTimeZone> {
-            Box::new(icu_timezone::CustomTimeZone::gmt().into())
-        }
-
-        /// Creates a time zone for BST (London summer time).
-        #[diplomat::rust_link(icu::timezone::CustomTimeZone::bst, FnInStruct)]
-        #[diplomat::attr(supports = fallible_constructors, named_constructor)]
-        pub fn bst() -> Box<CustomTimeZone> {
-            Box::new(icu_timezone::CustomTimeZone::bst().into())
-        }
-
         /// Sets the `gmt_offset` field from offset seconds.
         ///
         /// Errors if the offset seconds are out of range.

--- a/ffi/capi/src/timezone.rs
+++ b/ffi/capi/src/timezone.rs
@@ -45,7 +45,7 @@ pub mod ffi {
 
         /// Creates a time zone for UTC (Coordinated Universal Time).
         #[diplomat::rust_link(icu::timezone::CustomTimeZone::utc, FnInStruct)]
-        #[diplomat::rust_link(icu::timezone::GmtOffset::utc, FnInStruct, hidden)]
+        #[diplomat::rust_link(icu::timezone::GmtOffset::zero, FnInStruct, hidden)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor)]
         pub fn utc() -> Box<CustomTimeZone> {
             Box::new(icu_timezone::CustomTimeZone::utc().into())


### PR DESCRIPTION
These are just arbitrary timezones that Shane wants to use in datetime docs tests. They should be data driven and not have dedicated constructors.

Also renamed `GmtOffset::utc()` to `GmtOffset::zero()`, as it's the zero GMT offset and has nothing to do with UTC.