### PR TITLE
Add icu::plurals::supported_locales_of

### DIFF
--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -79,6 +79,8 @@ extern crate alloc;
 mod operands;
 pub mod provider;
 pub mod rules;
+#[cfg(feature = "compiled_data")]
+mod supported_locales_of;
 
 use core::cmp::{Ord, PartialOrd};
 use icu_provider::prelude::*;
@@ -87,6 +89,8 @@ use provider::CardinalV1Marker;
 use provider::ErasedPluralRulesV1Marker;
 use provider::OrdinalV1Marker;
 use rules::runtime::test_rule;
+#[cfg(feature = "compiled_data")]
+pub use supported_locales_of::supported_locales_of;
 
 #[cfg(feature = "experimental")]
 use provider::PluralRangesV1Marker;

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -40,7 +40,7 @@ const _: () = {
     }
 
     make_provider!(Baked);
-    impl_cardinal_v1_marker!(Baked);
+    impl_cardinal_v1_marker!(Baked, DRY);
     impl_ordinal_v1_marker!(Baked);
     #[cfg(feature = "experimental")]
     impl_plural_ranges_v1_marker!(Baked);

--- a/components/plurals/src/supported_locales_of.rs
+++ b/components/plurals/src/supported_locales_of.rs
@@ -1,0 +1,55 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use icu_provider::prelude::*;
+
+/// Returns which locales out of the given list are supported by this crate.
+///
+/// # Examples
+///
+/// ```
+/// use icu::locale::locale;
+/// use icu_provider::DataLocale;
+///
+/// let supported_locales = icu::plurals::supported_locales_of([
+///     DataLocale::from(locale!("ru")), // Russian is supported and has its own rules
+///     DataLocale::from(locale!("sr-RS")), // sr-RS inherits from sr which has its own rules
+///     DataLocale::from(locale!("ja")), // Japanese is supported but inherits from root
+///     DataLocale::from(locale!("tlh")), // Klingon is not supported
+/// ]).unwrap();
+///
+/// assert_eq!(
+///     supported_locales,
+///     [
+///         DataLocale::from(locale!("ru")),
+///         DataLocale::from(locale!("sr-RS")),
+///         DataLocale::from(locale!("ja")),
+///     ]
+/// );
+/// ```
+pub fn supported_locales_of(
+    locales: impl IntoIterator<Item = DataLocale>,
+) -> Result<Vec<DataLocale>, DataError> {
+    let mut result = Vec::new();
+    for locale in locales {
+        let mut metadata = DataRequestMetadata::default();
+        metadata.silent = true;
+        let response = crate::provider::Baked.dry_load(DataRequest {
+            id: DataIdentifierBorrowed::for_locale(&locale),
+            metadata,
+        });
+        println!("{locale:?} => {:?}", response);
+        match response {
+            Ok(DataResponseMetadata { locale: None, .. }) => {
+                // locale: None means exact match
+                result.push(locale)
+            }
+            Ok(DataResponseMetadata { locale: Some(resolved_locale), .. }) if !resolved_locale.is_default() => {
+                result.push(locale)
+            }
+            _ => ()
+        }
+    }
+    Ok(result)
+}


### PR DESCRIPTION
This is how we should answer #58, once implemented in all components.

The test doesn't work because baked data isn't built with retain_base_languages. I do not want to build baked data with retain_base_languages, but I want can_load to behave in that way, as noted previously.

CC @robertbastian @jedel1043 