### PR TITLE
Rust 1.81 and MSRV 1.77

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ exclude = [
 
 [workspace.package]
 version = "1.5.0"
-rust-version = "1.71.1"
+rust-version = "1.77"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
 repository = "https://github.com/unicode-org/icu4x"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -61,8 +61,8 @@ category = "ICU4X Development"
 env = { ICU4X_DATA_DIR = "../stubdata" }
 script_runner = "@duckscript"
 script = '''
-exec --fail-on-error rustup install 1.71.1 --profile minimal
-exec --fail-on-error cargo +1.71.1 check --all-targets --all-features
+exec --fail-on-error rustup install 1.77 --profile minimal
+exec --fail-on-error cargo +1.77 check --all-targets --all-features
 '''
 
 [tasks.ci-job-test]
@@ -170,8 +170,8 @@ category = "CI"
 env = { ICU4X_DATA_DIR = "../stubdata" }
 script_runner = "@duckscript"
 script = '''
-exec --fail-on-error rustup install 1.71.1 --profile minimal
-exec --fail-on-error cargo +1.71.1 make check-all-features-chunked 1
+exec --fail-on-error rustup install 1.77 --profile minimal
+exec --fail-on-error cargo +1.77 make check-all-features-chunked 1
 '''
 
 [tasks.ci-job-msrv-features-2]
@@ -180,8 +180,8 @@ category = "CI"
 env = { ICU4X_DATA_DIR = "../stubdata" }
 script_runner = "@duckscript"
 script = '''
-exec --fail-on-error rustup install 1.71.1 --profile minimal
-exec --fail-on-error cargo +1.71.1 make check-all-features-chunked 2
+exec --fail-on-error rustup install 1.77 --profile minimal
+exec --fail-on-error cargo +1.77 make check-all-features-chunked 2
 '''
 
 [tasks.ci-job-msrv-features-3]
@@ -190,8 +190,8 @@ category = "CI"
 env = { ICU4X_DATA_DIR = "../stubdata" }
 script_runner = "@duckscript"
 script = '''
-exec --fail-on-error rustup install 1.71.1 --profile minimal
-exec --fail-on-error cargo +1.71.1 make check-all-features-chunked 3
+exec --fail-on-error rustup install 1.77 --profile minimal
+exec --fail-on-error cargo +1.77 make check-all-features-chunked 3
 '''
 
 [tasks.ci-job-msrv-features]

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,4 +2,4 @@
 # called LICENSE at the top level of the ICU4X source tree
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-msrv = "1.71.1"
+msrv = "1.77"

--- a/components/collator/tests/tests.rs
+++ b/components/collator/tests/tests.rs
@@ -1546,7 +1546,7 @@ fn test_conformance_shifted() {
             if line.is_empty() {
                 continue;
             }
-            if line.starts_with(&[b'#']) {
+            if line.starts_with(b"#") {
                 continue;
             }
             if let Some(parsed) = parse_hex(line) {
@@ -1589,7 +1589,7 @@ fn test_conformance_non_ignorable() {
             if line.is_empty() {
                 continue;
             }
-            if line.starts_with(&[b'#']) {
+            if line.starts_with(b"#") {
                 continue;
             }
             if let Some(parsed) = parse_hex(line) {

--- a/components/datetime/benches/datetime.rs
+++ b/components/datetime/benches/datetime.rs
@@ -23,7 +23,7 @@ fn datetime_benches(c: &mut Criterion) {
     #[cfg(feature = "experimental")]
     let mut bench_neoneo_datetime_with_fixture = |name, file, has_zones| {
         let fxs = serde_json::from_str::<fixtures::Fixture>(file).unwrap();
-        group.bench_function(&format!("semantic/{name}"), |b| {
+        group.bench_function(format!("semantic/{name}"), |b| {
             b.iter(|| {
                 for fx in &fxs.0 {
                     let datetimes: Vec<CustomZonedDateTime<Gregorian>> = fx

--- a/components/locale_core/src/parser/mod.rs
+++ b/components/locale_core/src/parser/mod.rs
@@ -27,9 +27,7 @@ const fn skip_before_separator(slice: &[u8]) -> &[u8] {
     }
 
     // Notice: this slice may be empty for cases like `"en-"` or `"en--US"`
-    // MSRV 1.71/1.79: Use split_at/split_at_unchecked
-    // SAFETY: end < slice.len() by while loop
-    unsafe { core::slice::from_raw_parts(slice.as_ptr(), end) }
+    slice.split_at(end).0
 }
 
 // `SubtagIterator` is a helper iterator for [`LanguageIdentifier`] and [`Locale`] parsing.
@@ -66,14 +64,7 @@ impl<'a> SubtagIterator<'a> {
 
         self.current = if result.len() < self.remaining.len() {
             // If there is more after `result`, by construction `current` starts with a separator
-            // MSRV 1.79: Use split_at_unchecked
-            // SAFETY: `self.remaining` is strictly longer than `result`
-            self.remaining = unsafe {
-                core::slice::from_raw_parts(
-                    self.remaining.as_ptr().add(result.len() + 1),
-                    self.remaining.len() - (result.len() + 1),
-                )
-            };
+            self.remaining = self.remaining.split_at(result.len() + 1).0;
             Some(skip_before_separator(self.remaining))
         } else {
             None

--- a/documents/process/style_guide.md
+++ b/documents/process/style_guide.md
@@ -803,7 +803,9 @@ See also: the [Panics](#Panics--required) section of this document.
 
 The standard library functions such as `slice::split_at` are panicky, but they are not covered by our Clippy lints.
 
-Instead of using `slice::split_at` directly, it is recommended to use a helper function, which can be saved in the file in which it is being used. Example:
+Since Rust 1.77, `slice::split_first_chunk` is available as a non-panicky alternative if the chunk length is known at compile-time. In Rust 1.80, `slice::split_at_checked` will also become available.
+
+In the mean time, instead of using `slice::split_at` directly, it is recommended to use a helper function, which can be saved in the file in which it is being used. Example:
 
 ```rust
 /// Like slice::split_at but returns an Option instead of panicking

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,5 +3,5 @@
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 [toolchain]
-# Version updated on 2024-07-25
-channel = "1.80"
+# Version updated on 2024-09-07
+channel = "1.81"

--- a/utils/zerotrie/src/options.rs
+++ b/utils/zerotrie/src/options.rs
@@ -118,6 +118,7 @@ impl<S: ?Sized> ZeroTrieWithOptions for crate::ZeroTrieSimpleAscii<S> {
 
 impl<S: ?Sized> crate::ZeroTrieSimpleAscii<S> {
     #[cfg(feature = "serde")]
+    #[allow(const_evaluatable_unchecked)]
     pub(crate) const FLAGS: u8 = Self::OPTIONS.to_u8_flags();
 }
 
@@ -134,6 +135,7 @@ impl<S: ?Sized> ZeroTrieWithOptions for crate::ZeroAsciiIgnoreCaseTrie<S> {
 
 impl<S: ?Sized> crate::ZeroAsciiIgnoreCaseTrie<S> {
     #[cfg(feature = "serde")]
+    #[allow(const_evaluatable_unchecked)]
     pub(crate) const FLAGS: u8 = Self::OPTIONS.to_u8_flags();
 }
 
@@ -149,6 +151,7 @@ impl<S: ?Sized> ZeroTrieWithOptions for crate::ZeroTriePerfectHash<S> {
 
 impl<S: ?Sized> crate::ZeroTriePerfectHash<S> {
     #[cfg(feature = "serde")]
+    #[allow(const_evaluatable_unchecked)]
     pub(crate) const FLAGS: u8 = Self::OPTIONS.to_u8_flags();
 }
 
@@ -164,5 +167,6 @@ impl<S: ?Sized> ZeroTrieWithOptions for crate::ZeroTrieExtendedCapacity<S> {
 
 impl<S: ?Sized> crate::ZeroTrieExtendedCapacity<S> {
     #[cfg(feature = "serde")]
+    #[allow(const_evaluatable_unchecked)]
     pub(crate) const FLAGS: u8 = Self::OPTIONS.to_u8_flags();
 }


### PR DESCRIPTION
I want to use [split_first_chunk](https://doc.rust-lang.org/std/primitive.slice.html#method.split_first_chunk), which is added in 1.77. I have wanted this function for a long time. I actually want `split_at_checked`, but `split_first_chunk` also covers some key use cases.

It's a fairly large MSRV leap, but we have 2.0 coming soon so I think it's fine. Clients who need an older MSRV have 1.x available.