### PR TITLE
Don't use `CustomTimeZone` internally in `icu::datetime`

### DIFF
--- a/components/datetime/src/format/time_zone.rs
+++ b/components/datetime/src/format/time_zone.rs
@@ -17,7 +17,6 @@ use writeable::Writeable;
 #[derive(Debug, Copy, Clone)]
 pub struct FormattedTimeZone<'l> {
     pub(crate) time_zone_format: &'l TimeZoneFormatter,
-    // Note: CustomTimeZone is being used as an ExtractedTimeZoneInput
     pub(crate) time_zone: ExtractedTimeZoneInput,
 }
 
@@ -74,7 +73,7 @@ impl<'l> FormattedTimeZone<'l> {
     /// // There are no non-fallback formats enabled:
     /// assert!(matches!(
     ///     tzf.format(&time_zone).write_no_fallback(&mut buf),
-    ///     Ok(Err(DateTimeWriteError::MissingTimeZoneSymbol(_)))
+    ///     Ok(Err(DateTimeWriteError::UnsupportedTimeZone))
     /// ));
     /// assert!(buf.is_empty());
     ///
@@ -91,7 +90,7 @@ impl<'l> FormattedTimeZone<'l> {
     /// time_zone.time_zone_id = Some(TimeZoneBcp47Id(tinystr!(8, "zzzzz")));
     /// assert!(matches!(
     ///     tzf.format(&time_zone).write_no_fallback(&mut buf),
-    ///     Ok(Err(DateTimeWriteError::MissingTimeZoneSymbol(_)))
+    ///     Ok(Err(DateTimeWriteError::UnsupportedTimeZone))
     /// ));
     ///
     /// // Use the `Writable` trait instead to enable infallible formatting:
@@ -120,8 +119,6 @@ impl<'l> FormattedTimeZone<'l> {
                 }
             }
         }
-        Ok(Err(DateTimeWriteError::MissingTimeZoneSymbol(
-            self.time_zone.to_custom_time_zone(),
-        )))
+        Ok(Err(DateTimeWriteError::UnsupportedTimeZone))
     }
 }

--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -109,7 +109,7 @@ pub struct TimeZoneFormatter {
     pub(super) fallback_unit: FallbackTimeZoneFormatterUnit,
 }
 
-/// A container contains all data payloads for CustomTimeZone.
+/// A container contains all data payloads for time zone formatting.
 #[derive(Debug)]
 pub(super) struct TimeZoneDataPayloads {
     /// The data that contains meta information about how to display content.
@@ -130,7 +130,7 @@ pub(super) struct TimeZoneDataPayloads {
         Option<DataPayload<provider::time_zones::MetazoneSpecificNamesShortV1Marker>>,
 }
 
-/// A container contains all data payloads for CustomTimeZone (borrowed version).
+/// A container contains all data payloads for time zone formatting (borrowed version).
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct TimeZoneDataPayloadsBorrowed<'a> {
     /// The data that contains meta information about how to display content.


### PR DESCRIPTION
`CustomTimeZone` is what it says on the lid, `icu::timezone`'s custom timezone type. It should not be used internally by `icu::datetime`, this PR relegates it to an input-only type and instead uses the four fields offset, id, metazone, and zone variant as neo fields. 

I further propose removing the metazone and zone variant fields in #5533.