### PR TITLE
FormattableMonth -> MonthInfo, and split standard from formatting month codes

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -1597,7 +1597,7 @@ mod tests {
         // FIXME: these APIs should be improved
         let roundtrip_era = roundtrip_year.formatting_era().unwrap_or(era);
         let roundtrip_year = roundtrip_year.era_year_or_extended();
-        let roundtrip_month = date.month().code;
+        let roundtrip_month = date.month().standard_code;
         let roundtrip_day = date.day_of_month().0.try_into().expect("Must fit in u8");
 
         assert_eq!(

--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -517,7 +517,7 @@ impl Calendar for AnyCalendar {
     }
 
     /// The calendar-specific month represented by `date`
-    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> types::MonthInfo {
         match_cal_and_date!(match (self, date): (c, d) => c.month(d))
     }
 

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -341,7 +341,7 @@ mod test {
         );
         assert_eq!(
             buddhist1.month().ordinal,
-            buddhist_month as u32,
+            buddhist_month,
             "Iso -> Buddhist month check failed for case: {case:?}"
         );
         assert_eq!(
@@ -360,7 +360,7 @@ mod test {
         );
         assert_eq!(
             iso2.month().ordinal,
-            iso_month as u32,
+            iso_month,
             "Buddhist -> Iso month check failed for case: {case:?}"
         );
         assert_eq!(

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -130,7 +130,7 @@ impl Calendar for Buddhist {
     }
 
     /// The calendar-specific month represented by `date`
-    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> types::MonthInfo {
         Iso.month(date)
     }
 

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -82,7 +82,7 @@ pub trait Calendar {
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool;
 
     /// The calendar-specific month represented by `date`
-    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth;
+    fn month(&self, date: &Self::DateInner) -> types::MonthInfo;
 
     /// The calendar-specific day-of-month represented by `date`
     fn day_of_month(&self, date: &Self::DateInner) -> types::DayOfMonth;

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -331,7 +331,8 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
         };
         types::MonthInfo {
             ordinal: self.month as u32,
-            code: types::MonthCode(code),
+            standard_code: types::MonthCode(code),
+            formatting_code: types::MonthCode(code),
         }
     }
 

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -303,7 +303,7 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
         types::DayOfMonth(self.day.into())
     }
 
-    /// The [`types::FormattableMonth`] for the current month (with month code) for a solar calendar
+    /// The [`types::MonthInfo`] for the current month (with month code) for a solar calendar
     /// Lunar calendars should not use this method and instead manually implement a month code
     /// resolver.
     /// Originally "solar_month" but renamed because it can be used for some lunar calendars
@@ -311,7 +311,7 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
     /// Returns "und" if run with months that are out of bounds for the current
     /// calendar.
     #[inline]
-    pub fn month(&self) -> types::FormattableMonth {
+    pub fn month(&self) -> types::MonthInfo {
         let code = match self.month {
             a if a > C::months_for_every_year(self.year, self.year_info) => tinystr!(4, "und"),
             1 => tinystr!(4, "M01"),
@@ -329,7 +329,7 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
             13 => tinystr!(4, "M13"),
             _ => tinystr!(4, "und"),
         };
-        types::FormattableMonth {
+        types::MonthInfo {
             ordinal: self.month as u32,
             code: types::MonthCode(code),
         }

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -330,7 +330,7 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
             _ => tinystr!(4, "und"),
         };
         types::MonthInfo {
-            ordinal: self.month as u32,
+            ordinal: self.month,
             standard_code: types::MonthCode(code),
             formatting_code: types::MonthCode(code),
         }

--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -649,7 +649,7 @@ mod test {
 
                 assert_eq!(chinese.year().era_year_or_extended(), 1);
                 assert_eq!(chinese.month().ordinal, 1);
-                assert_eq!(chinese.month().code.0, "M01");
+                assert_eq!(chinese.month().standard_code.0, "M01");
                 assert_eq!(chinese.day_of_month().0, 1);
                 assert_eq!(chinese.year().cyclic().unwrap().get(), 1);
                 assert_eq!(chinese.year().related_iso(), Some(-2636));
@@ -900,7 +900,7 @@ mod test {
                 &chinese_cached,
                 |chinese, calendar_type| {
                     let chinese = iso.to_calendar(chinese);
-                    let result_code = chinese.month().code.0;
+                    let result_code = chinese.month().standard_code.0;
                     let expected_code = case.expected_code.to_string();
                     assert_eq!(
                         expected_code, result_code,

--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -279,7 +279,7 @@ impl Calendar for Chinese {
     /// since the Chinese calendar has leap months, an "L" is appended to the month code for
     /// leap months. For example, in a year where an intercalary month is added after the second
     /// month, the month codes for ordinal months 1, 2, 3, 4, 5 would be "M01", "M02", "M02L", "M03", "M04".
-    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> types::MonthInfo {
         date.0.month()
     }
 

--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -665,7 +665,7 @@ mod test {
             iso_month: u8,
             iso_day: u8,
             expected_year: i32,
-            expected_month: u32,
+            expected_month: u8,
             expected_day: u32,
         }
 
@@ -1005,7 +1005,7 @@ mod test {
             iso_day: u8,
             expected_rel_iso: i32,
             expected_cyclic: u8,
-            expected_month: u32,
+            expected_month: u8,
             expected_day: u32,
         }
 

--- a/components/calendar/src/chinese_based.rs
+++ b/components/calendar/src/chinese_based.rs
@@ -481,7 +481,7 @@ impl<C: ChineseBasedWithDataLoading + CalendarArithmetic<YearInfo = ChineseBased
         };
         let code = MonthCode(code_inner);
         MonthInfo {
-            ordinal: ordinal as u32,
+            ordinal: ordinal,
             standard_code: code,
             formatting_code: code,
         }

--- a/components/calendar/src/chinese_based.rs
+++ b/components/calendar/src/chinese_based.rs
@@ -21,7 +21,7 @@ use crate::{
     calendar_arithmetic::{ArithmeticDate, CalendarArithmetic, PrecomputedDataSource},
     error::DateError,
     provider::chinese_based::{ChineseBasedCacheV1, PackedChineseBasedYearInfo},
-    types::{MonthInfo, MonthCode},
+    types::{MonthCode, MonthInfo},
     Calendar, Iso,
 };
 
@@ -482,7 +482,8 @@ impl<C: ChineseBasedWithDataLoading + CalendarArithmetic<YearInfo = ChineseBased
         let code = MonthCode(code_inner);
         MonthInfo {
             ordinal: ordinal as u32,
-            code,
+            standard_code: code,
+            formatting_code: code,
         }
     }
 }

--- a/components/calendar/src/chinese_based.rs
+++ b/components/calendar/src/chinese_based.rs
@@ -481,7 +481,7 @@ impl<C: ChineseBasedWithDataLoading + CalendarArithmetic<YearInfo = ChineseBased
         };
         let code = MonthCode(code_inner);
         MonthInfo {
-            ordinal: ordinal,
+            ordinal,
             standard_code: code,
             formatting_code: code,
         }

--- a/components/calendar/src/chinese_based.rs
+++ b/components/calendar/src/chinese_based.rs
@@ -21,7 +21,7 @@ use crate::{
     calendar_arithmetic::{ArithmeticDate, CalendarArithmetic, PrecomputedDataSource},
     error::DateError,
     provider::chinese_based::{ChineseBasedCacheV1, PackedChineseBasedYearInfo},
-    types::{FormattableMonth, MonthCode},
+    types::{MonthInfo, MonthCode},
     Calendar, Iso,
 };
 
@@ -420,7 +420,7 @@ impl<C: ChineseBasedWithDataLoading + CalendarArithmetic<YearInfo = ChineseBased
     /// since the Chinese calendar has leap months, an "L" is appended to the month code for
     /// leap months. For example, in a year where an intercalary month is added after the second
     /// month, the month codes for ordinal months 1, 2, 3, 4, 5 would be "M01", "M02", "M02L", "M03", "M04".
-    pub(crate) fn month(&self) -> FormattableMonth {
+    pub(crate) fn month(&self) -> MonthInfo {
         let ordinal = self.0.month;
         let leap_month_option = self.0.year_info.leap_month();
 
@@ -480,7 +480,7 @@ impl<C: ChineseBasedWithDataLoading + CalendarArithmetic<YearInfo = ChineseBased
             }
         };
         let code = MonthCode(code_inner);
-        FormattableMonth {
+        MonthInfo {
             ordinal: ordinal as u32,
             code,
         }

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -196,7 +196,7 @@ impl Calendar for Coptic {
         Self::is_leap_year(date.0.year, ())
     }
 
-    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> types::MonthInfo {
         date.0.month()
     }
 

--- a/components/calendar/src/dangi.rs
+++ b/components/calendar/src/dangi.rs
@@ -260,7 +260,7 @@ impl Calendar for Dangi {
         Self::is_leap_year(date.0 .0.year, date.0 .0.year_info)
     }
 
-    fn month(&self, date: &Self::DateInner) -> crate::types::FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> crate::types::MonthInfo {
         date.0.month()
     }
 

--- a/components/calendar/src/dangi.rs
+++ b/components/calendar/src/dangi.rs
@@ -76,15 +76,15 @@ use tinystr::tinystr;
 /// let dangi_a = iso_a.to_calendar(Dangi::new());
 /// let chinese_a = iso_a.to_calendar(Chinese::new());
 ///
-/// assert_eq!(dangi_a.month().code.0, tinystr!(4, "M03L"));
-/// assert_eq!(chinese_a.month().code.0, tinystr!(4, "M04"));
+/// assert_eq!(dangi_a.month().standard_code.0, tinystr!(4, "M03L"));
+/// assert_eq!(chinese_a.month().standard_code.0, tinystr!(4, "M04"));
 ///
 /// let iso_b = Date::try_new_iso_date(2012, 5, 23).unwrap();
 /// let dangi_b = iso_b.to_calendar(Dangi::new());
 /// let chinese_b = iso_b.to_calendar(Chinese::new());
 ///
-/// assert_eq!(dangi_b.month().code.0, tinystr!(4, "M04"));
-/// assert_eq!(chinese_b.month().code.0, tinystr!(4, "M04L"));
+/// assert_eq!(dangi_b.month().standard_code.0, tinystr!(4, "M04"));
+/// assert_eq!(chinese_b.month().standard_code.0, tinystr!(4, "M04L"));
 /// ```
 /// # Era codes
 ///

--- a/components/calendar/src/dangi.rs
+++ b/components/calendar/src/dangi.rs
@@ -490,7 +490,7 @@ mod test {
             iso_day: u8,
             expected_rel_iso: i32,
             expected_cyclic: u8,
-            expected_month: u32,
+            expected_month: u8,
             expected_day: u32,
         }
 

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -219,7 +219,7 @@ impl<A: AsCalendar> Date<A> {
 
     /// The calendar-specific month represented by `self`
     #[inline]
-    pub fn month(&self) -> types::FormattableMonth {
+    pub fn month(&self) -> types::MonthInfo {
         self.calendar.as_calendar().month(&self.inner)
     }
 

--- a/components/calendar/src/ethiopian.rs
+++ b/components/calendar/src/ethiopian.rs
@@ -219,7 +219,7 @@ impl Calendar for Ethiopian {
         Self::is_leap_year(date.0.year, ())
     }
 
-    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> types::MonthInfo {
         date.0.month()
     }
 

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -377,7 +377,7 @@ mod test {
         iso_day: u8,
         expected_year: i32,
         expected_era: Era,
-        expected_month: u32,
+        expected_month: u8,
         expected_day: u32,
     }
 

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -144,7 +144,7 @@ impl Calendar for Gregorian {
     }
 
     /// The calendar-specific month represented by `date`
-    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> types::MonthInfo {
         Iso.month(&date.0)
     }
 

--- a/components/calendar/src/hebrew.rs
+++ b/components/calendar/src/hebrew.rs
@@ -274,13 +274,13 @@ impl Calendar for Hebrew {
         if is_leap_year {
             if ordinal == 6 {
                 return types::MonthInfo {
-                    ordinal: ordinal as u32,
+                    ordinal: ordinal,
                     standard_code: types::MonthCode(tinystr!(4, "M05L")),
                     formatting_code: types::MonthCode(tinystr!(4, "M05L")),
                 };
             } else if ordinal == 7 {
                 return types::MonthInfo {
-                    ordinal: ordinal as u32,
+                    ordinal: ordinal,
                     // Adar II is the same as Adar and has the same code
                     standard_code: types::MonthCode(tinystr!(4, "M06")),
                     formatting_code: types::MonthCode(tinystr!(4, "M06L")),
@@ -309,7 +309,7 @@ impl Calendar for Hebrew {
         };
 
         types::MonthInfo {
-            ordinal: date.0.month as u32,
+            ordinal: date.0.month,
             standard_code: types::MonthCode(code),
             formatting_code: types::MonthCode(code),
         }

--- a/components/calendar/src/hebrew.rs
+++ b/components/calendar/src/hebrew.rs
@@ -33,7 +33,7 @@
 use crate::calendar_arithmetic::PrecomputedDataSource;
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::error::DateError;
-use crate::types::FormattableMonth;
+use crate::types::MonthInfo;
 use crate::{types, Calendar, Date, DateDuration, DateDurationUnit, DateTime, Time};
 use crate::{Iso, RangeError};
 use ::tinystr::tinystr;
@@ -55,8 +55,8 @@ use calendrical_calculations::hebrew_keviyah::{Keviyah, YearInfo};
 /// This calendar is a lunisolar calendar and thus has a leap month. It supports codes `"M01"-"M12"`
 /// for regular months, and the leap month Adar I being coded as `"M05L"`.
 ///
-/// [`FormattableMonth`] has slightly divergent behavior: because the regular month Adar is formatted
-/// as "Adar II" in a leap year, this calendar will produce the special code `"M06L"` in any [`FormattableMonth`]
+/// [`MonthInfo`] has slightly divergent behavior: because the regular month Adar is formatted
+/// as "Adar II" in a leap year, this calendar will produce the special code `"M06L"` in any [`MonthInfo`]
 /// objects it creates.
 ///
 /// [Hebrew calendar]: https://en.wikipedia.org/wiki/Hebrew_calendar
@@ -267,18 +267,18 @@ impl Calendar for Hebrew {
         Self::is_leap_year(date.0.year, date.0.year_info)
     }
 
-    fn month(&self, date: &Self::DateInner) -> FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> MonthInfo {
         let mut ordinal = date.0.month;
         let is_leap_year = Self::is_leap_year(date.0.year, date.0.year_info);
 
         if is_leap_year {
             if ordinal == 6 {
-                return types::FormattableMonth {
+                return types::MonthInfo {
                     ordinal: ordinal as u32,
                     code: types::MonthCode(tinystr!(4, "M05L")),
                 };
             } else if ordinal == 7 {
-                return types::FormattableMonth {
+                return types::MonthInfo {
                     ordinal: ordinal as u32,
                     code: types::MonthCode(tinystr!(4, "M06L")),
                 };
@@ -305,7 +305,7 @@ impl Calendar for Hebrew {
             _ => tinystr!(4, "und"),
         };
 
-        types::FormattableMonth {
+        types::MonthInfo {
             ordinal: date.0.month as u32,
             code: types::MonthCode(code),
         }

--- a/components/calendar/src/hebrew.rs
+++ b/components/calendar/src/hebrew.rs
@@ -274,13 +274,13 @@ impl Calendar for Hebrew {
         if is_leap_year {
             if ordinal == 6 {
                 return types::MonthInfo {
-                    ordinal: ordinal,
+                    ordinal,
                     standard_code: types::MonthCode(tinystr!(4, "M05L")),
                     formatting_code: types::MonthCode(tinystr!(4, "M05L")),
                 };
             } else if ordinal == 7 {
                 return types::MonthInfo {
-                    ordinal: ordinal,
+                    ordinal,
                     // Adar II is the same as Adar and has the same code
                     standard_code: types::MonthCode(tinystr!(4, "M06")),
                     formatting_code: types::MonthCode(tinystr!(4, "M06L")),

--- a/components/calendar/src/hebrew.rs
+++ b/components/calendar/src/hebrew.rs
@@ -275,12 +275,15 @@ impl Calendar for Hebrew {
             if ordinal == 6 {
                 return types::MonthInfo {
                     ordinal: ordinal as u32,
-                    code: types::MonthCode(tinystr!(4, "M05L")),
+                    standard_code: types::MonthCode(tinystr!(4, "M05L")),
+                    formatting_code: types::MonthCode(tinystr!(4, "M05L")),
                 };
             } else if ordinal == 7 {
                 return types::MonthInfo {
                     ordinal: ordinal as u32,
-                    code: types::MonthCode(tinystr!(4, "M06L")),
+                    // Adar II is the same as Adar and has the same code
+                    standard_code: types::MonthCode(tinystr!(4, "M06")),
+                    formatting_code: types::MonthCode(tinystr!(4, "M06L")),
                 };
             }
         }
@@ -307,7 +310,8 @@ impl Calendar for Hebrew {
 
         types::MonthInfo {
             ordinal: date.0.month as u32,
-            code: types::MonthCode(code),
+            standard_code: types::MonthCode(code),
+            formatting_code: types::MonthCode(code),
         }
     }
 

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -375,7 +375,7 @@ mod tests {
         iso_month: u8,
         iso_day: u8,
         expected_year: i32,
-        expected_month: u32,
+        expected_month: u8,
         expected_day: u32,
     }
 

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -324,7 +324,7 @@ mod tests {
             "{y}-{m}-{d}: ISO year did not match"
         );
         assert_eq!(
-            iso.month().ordinal as u8,
+            iso.month().ordinal,
             iso_m,
             "{y}-{m}-{d}: ISO month did not match"
         );

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -206,7 +206,7 @@ impl Calendar for Indian {
         Self::is_leap_year(date.0.year, ())
     }
 
-    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> types::MonthInfo {
         date.0.month()
     }
 

--- a/components/calendar/src/islamic.rs
+++ b/components/calendar/src/islamic.rs
@@ -524,7 +524,7 @@ impl Calendar for IslamicObservational {
         Self::is_leap_year(date.0.year, date.0.year_info)
     }
 
-    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> types::MonthInfo {
         date.0.month()
     }
 
@@ -749,7 +749,7 @@ impl Calendar for IslamicUmmAlQura {
         Self::is_leap_year(date.0.year, date.0.year_info)
     }
 
-    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> types::MonthInfo {
         date.0.month()
     }
 
@@ -974,7 +974,7 @@ impl Calendar for IslamicCivil {
         Self::is_leap_year(date.0.year, ())
     }
 
-    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> types::MonthInfo {
         date.0.month()
     }
 
@@ -1208,7 +1208,7 @@ impl Calendar for IslamicTabular {
         Self::is_leap_year(date.0.year, ())
     }
 
-    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> types::MonthInfo {
         date.0.month()
     }
 

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -204,7 +204,7 @@ impl Calendar for Iso {
     }
 
     /// The calendar-specific month represented by `date`
-    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> types::MonthInfo {
         date.0.month()
     }
 

--- a/components/calendar/src/ixdtf.rs
+++ b/components/calendar/src/ixdtf.rs
@@ -62,7 +62,7 @@ impl Date<Iso> {
     ///
     /// assert_eq!(date.year().era_year_or_extended(), 2024);
     /// assert_eq!(
-    ///     date.month().code,
+    ///     date.month().standard_code,
     ///     icu::calendar::types::MonthCode(tinystr::tinystr!(4, "M07"))
     /// );
     /// assert_eq!(date.day_of_month().0, 17);
@@ -109,7 +109,7 @@ impl Date<AnyCalendar> {
     ///
     /// assert_eq!(date.year().era_year_or_extended(), 5784);
     /// assert_eq!(
-    ///     date.month().code,
+    ///     date.month().standard_code,
     ///     icu::calendar::types::MonthCode(tinystr::tinystr!(4, "M10"))
     /// );
     /// assert_eq!(date.day_of_month().0, 11);
@@ -210,7 +210,7 @@ impl DateTime<Iso> {
     ///
     /// assert_eq!(datetime.date.year().era_year_or_extended(), 2024);
     /// assert_eq!(
-    ///     datetime.date.month().code,
+    ///     datetime.date.month().standard_code,
     ///     icu::calendar::types::MonthCode(tinystr::tinystr!(4, "M07"))
     /// );
     /// assert_eq!(datetime.date.day_of_month().0, 17);
@@ -262,7 +262,7 @@ impl DateTime<AnyCalendar> {
     ///
     /// assert_eq!(datetime.date.year().era_year_or_extended(), 5784);
     /// assert_eq!(
-    ///     datetime.date.month().code,
+    ///     datetime.date.month().standard_code,
     ///     icu::calendar::types::MonthCode(tinystr::tinystr!(4, "M10"))
     /// );
     /// assert_eq!(datetime.date.day_of_month().0, 11);

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -283,7 +283,7 @@ impl Calendar for Japanese {
     }
 
     /// The calendar-specific month represented by `date`
-    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> types::MonthInfo {
         Iso.month(&date.inner)
     }
 
@@ -382,7 +382,7 @@ impl Calendar for JapaneseExtended {
     }
 
     /// The calendar-specific month represented by `date`
-    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> types::MonthInfo {
         Japanese::month(&self.0, date)
     }
 

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -419,7 +419,7 @@ mod test {
             iso_day: u8,
             expected_year: i32,
             expected_era: Era,
-            expected_month: u32,
+            expected_month: u8,
             expected_day: u32,
         }
 

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -190,7 +190,7 @@ impl Calendar for Julian {
     }
 
     /// The calendar-specific month represented by `date`
-    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> types::MonthInfo {
         date.0.month()
     }
 

--- a/components/calendar/src/persian.rs
+++ b/components/calendar/src/persian.rs
@@ -538,7 +538,7 @@ mod tests {
 
     // From https://calendar.ut.ac.ir/Fa/News/Data/Doc/KabiseShamsi1206-1498-new.pdf
     // Plain text version at https://github.com/roozbehp/persiancalendar/blob/main/kabise.txt
-    static CALENDAR_UT_AC_IR_TEST_DATA: [(i32, bool, i32, u32, u32); 293] = [
+    static CALENDAR_UT_AC_IR_TEST_DATA: [(i32, bool, i32, u8, u32); 293] = [
         (1206, false, 1827, 3, 22),
         (1207, false, 1828, 3, 21),
         (1208, false, 1829, 3, 21),

--- a/components/calendar/src/persian.rs
+++ b/components/calendar/src/persian.rs
@@ -168,7 +168,7 @@ impl Calendar for Persian {
         Self::is_leap_year(date.0.year, ())
     }
 
-    fn month(&self, date: &Self::DateInner) -> types::FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> types::MonthInfo {
         date.0.month()
     }
 

--- a/components/calendar/src/roc.rs
+++ b/components/calendar/src/roc.rs
@@ -163,7 +163,7 @@ impl Calendar for Roc {
         Iso.is_in_leap_year(&date.0)
     }
 
-    fn month(&self, date: &Self::DateInner) -> crate::types::FormattableMonth {
+    fn month(&self, date: &Self::DateInner) -> crate::types::MonthInfo {
         Iso.month(&date.0)
     }
 

--- a/components/calendar/src/roc.rs
+++ b/components/calendar/src/roc.rs
@@ -299,7 +299,7 @@ mod test {
         iso_day: u8,
         expected_year: i32,
         expected_era: Era,
-        expected_month: u32,
+        expected_month: u8,
         expected_day: u32,
     }
 

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -281,11 +281,17 @@ pub struct MonthInfo {
 
     /// The month code, used to distinguish months during leap years.
     ///
+    /// This follows [Temporal's specification](https://tc39.es/proposal-intl-era-monthcode/#table-additional-month-codes).
+    /// Months considered the "same" have the same code: This means that the Hebrew months "Adar" and "Adar II" ("Adar, but during a leap year")
+    /// are considered the same month and have the code M05
+    pub standard_code: MonthCode,
+    /// A month code, useable for formatting
+    ///
     /// This may not necessarily be the canonical month code for a month in cases where a month has different
     /// formatting in a leap year, for example Adar/Adar II in the Hebrew calendar in a leap year has
-    /// the code M06, but for formatting specifically the Hebrew calendar will return M06L since it is formatted
+    /// the standard code M06, but for formatting specifically the Hebrew calendar will return M06L since it is formatted
     /// differently.
-    pub code: MonthCode,
+    pub formatting_code: MonthCode,
 }
 
 /// A struct containing various details about the position of the day within a year. It is returned

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -277,7 +277,7 @@ pub struct MonthInfo {
     /// the leap month will end up with an incremented number.
     ///
     /// In general, prefer using the month code in generic code.
-    pub ordinal: u32,
+    pub ordinal: u8,
 
     /// The month code, used to distinguish months during leap years.
     ///
@@ -294,6 +294,22 @@ pub struct MonthInfo {
     pub formatting_code: MonthCode,
 }
 
+impl MonthInfo {
+    /// Gets the month number. A month number N is not necessarily the Nth month in the year
+    /// if there are leap months in the year, rather it is associated with the Nth month of a "regular"
+    /// year. There may be multiple month Ns in a year
+    pub fn month_number(self) -> u8 {
+        self.standard_code
+            .parsed()
+            .map(|(i, _)| i)
+            .unwrap_or(self.ordinal)
+    }
+
+    /// Get whether the month is a leap month
+    pub fn is_leap(self) -> bool {
+        self.standard_code.parsed().map(|(_, l)| l).unwrap_or(false)
+    }
+}
 /// A struct containing various details about the position of the day within a year. It is returned
 // by the [`day_of_year_info()`](trait.DateInput.html#tymethod.day_of_year_info) method of the
 // [`DateInput`] trait.

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -58,14 +58,14 @@ pub enum YearKind {
 
 impl YearInfo {
     /// Construct a new Year given an era and number
-    pub fn new(extended_year: i32, era: EraYear) -> Self {
+    pub(crate) fn new(extended_year: i32, era: EraYear) -> Self {
         Self {
             extended_year,
             kind: YearKind::Era(era),
         }
     }
     /// Construct a new cyclic Year given a cycle and a related_iso
-    pub fn new_cyclic(extended_year: i32, cycle: NonZeroU8, related_iso: i32) -> Self {
+    pub(crate) fn new_cyclic(extended_year: i32, cycle: NonZeroU8, related_iso: i32) -> Self {
         Self {
             extended_year,
             kind: YearKind::Cyclic(CyclicYear {

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -272,7 +272,7 @@ impl fmt::Display for MonthCode {
 /// Representation of a formattable month.
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
-pub struct FormattableMonth {
+pub struct MonthInfo {
     /// The month number in this given year. For calendars with leap months, all months after
     /// the leap month will end up with an incremented number.
     ///

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -509,13 +509,13 @@ where
                 write_value_missing(w, field)?;
                 Err(DateTimeWriteError::MissingInputField("month"))
             }
-            Some(formattable_month) => match date_symbols
+            Some(month_info) => match date_symbols
                 .ok_or(DateTimeWriteError::MissingDateSymbols)
                 .and_then(|ds| {
-                    ds.get_symbol_for_month(month, l, formattable_month.code)
+                    ds.get_symbol_for_month(month, l, month_info.formatting_code)
                         .map_err(|e| match e {
                             GetSymbolForMonthError::Missing => {
-                                DateTimeWriteError::MissingMonthSymbol(formattable_month.code)
+                                DateTimeWriteError::MissingMonthSymbol(month_info.formatting_code)
                             }
                             #[cfg(feature = "experimental")]
                             GetSymbolForMonthError::MissingNames(f) => {
@@ -524,7 +524,7 @@ where
                         })
                 }) {
                 Err(e) => {
-                    w.with_part(Part::ERROR, |w| w.write_str(&formattable_month.code.0))?;
+                    w.with_part(Part::ERROR, |w| w.write_str(&month_info.formatting_code.0))?;
                     Err(e)
                 }
                 Ok(MonthPlaceholderValue::PlainString(symbol)) => {
@@ -544,12 +544,12 @@ where
                 }
                 #[cfg(feature = "experimental")]
                 Ok(MonthPlaceholderValue::Numeric) => {
-                    try_write_number(w, fdf, formattable_month.ordinal.into(), l)?
+                    try_write_number(w, fdf, month_info.ordinal.into(), l)?
                 }
                 #[cfg(feature = "experimental")]
                 Ok(MonthPlaceholderValue::NumericPattern(substitution_pattern)) => {
                     w.write_str(substitution_pattern.get_prefix())?;
-                    let r = try_write_number(w, fdf, formattable_month.ordinal.into(), l)?;
+                    let r = try_write_number(w, fdf, month_info.ordinal.into(), l)?;
                     w.write_str(substitution_pattern.get_suffix())?;
                     r
                 }

--- a/components/datetime/src/input.rs
+++ b/components/datetime/src/input.rs
@@ -16,7 +16,7 @@ use icu_timezone::{CustomTimeZone, UtcOffset, ZoneVariant};
 
 // TODO(#2630) fix up imports to directly import from icu_calendar
 pub(crate) use icu_calendar::types::{
-    DayOfMonth, DayOfYearInfo, FormattableMonth, IsoHour, IsoMinute, IsoSecond, IsoWeekday,
+    DayOfMonth, DayOfYearInfo, MonthInfo, IsoHour, IsoMinute, IsoSecond, IsoWeekday,
     NanoSecond, Time, WeekOfMonth, WeekOfYear, YearInfo,
 };
 
@@ -34,7 +34,7 @@ pub trait DateInput {
     fn year(&self) -> Option<YearInfo>;
 
     /// Gets the month input.
-    fn month(&self) -> Option<FormattableMonth>;
+    fn month(&self) -> Option<MonthInfo>;
 
     /// Gets the day input.
     fn day_of_month(&self) -> Option<DayOfMonth>;
@@ -106,7 +106,7 @@ impl<T> DateTimeInput for T where T: DateInput + IsoTimeInput {}
 #[derive(Default, Debug, Copy, Clone)]
 pub(crate) struct ExtractedDateTimeInput {
     year: Option<YearInfo>,
-    month: Option<FormattableMonth>,
+    month: Option<MonthInfo>,
     day_of_month: Option<DayOfMonth>,
     iso_weekday: Option<IsoWeekday>,
     day_of_year_info: Option<DayOfYearInfo>,
@@ -276,7 +276,7 @@ impl DateInput for ExtractedDateTimeInput {
     fn year(&self) -> Option<YearInfo> {
         self.year
     }
-    fn month(&self) -> Option<FormattableMonth> {
+    fn month(&self) -> Option<MonthInfo> {
         self.month
     }
     fn day_of_month(&self) -> Option<DayOfMonth> {
@@ -360,7 +360,7 @@ impl<C: Calendar, A: AsCalendar<Calendar = C>> DateInput for Date<A> {
     }
 
     /// Gets the month input.
-    fn month(&self) -> Option<FormattableMonth> {
+    fn month(&self) -> Option<MonthInfo> {
         Some(self.month())
     }
 
@@ -396,7 +396,7 @@ impl<C: Calendar, A: AsCalendar<Calendar = C>> DateInput for DateTime<A> {
     }
 
     /// Gets the month input.
-    fn month(&self) -> Option<FormattableMonth> {
+    fn month(&self) -> Option<MonthInfo> {
         Some(self.date.month())
     }
 

--- a/components/datetime/src/input.rs
+++ b/components/datetime/src/input.rs
@@ -16,8 +16,8 @@ use icu_timezone::{CustomTimeZone, UtcOffset, ZoneVariant};
 
 // TODO(#2630) fix up imports to directly import from icu_calendar
 pub(crate) use icu_calendar::types::{
-    DayOfMonth, DayOfYearInfo, MonthInfo, IsoHour, IsoMinute, IsoSecond, IsoWeekday,
-    NanoSecond, Time, WeekOfMonth, WeekOfYear, YearInfo,
+    DayOfMonth, DayOfYearInfo, IsoHour, IsoMinute, IsoSecond, IsoWeekday, MonthInfo, NanoSecond,
+    Time, WeekOfMonth, WeekOfYear, YearInfo,
 };
 
 /// Representation of a formattable calendar date. Supports dates in any calendar system that uses

--- a/components/datetime/src/neo_marker.rs
+++ b/components/datetime/src/neo_marker.rs
@@ -329,7 +329,7 @@ use crate::{
 use icu_calendar::{
     any_calendar::IntoAnyCalendar,
     types::{
-        DayOfMonth, DayOfYearInfo, FormattableMonth, IsoHour, IsoMinute, IsoSecond, IsoWeekday,
+        DayOfMonth, DayOfYearInfo, MonthInfo, IsoHour, IsoMinute, IsoSecond, IsoWeekday,
         NanoSecond, YearInfo,
     },
     AnyCalendar, AnyCalendarKind, AsCalendar, Calendar, Date, DateTime, Ref, Time,
@@ -474,9 +474,9 @@ impl<C: Calendar, A: AsCalendar<Calendar = C>> NeoGetField<YearInfo> for Date<A>
     }
 }
 
-impl<C: Calendar, A: AsCalendar<Calendar = C>> NeoGetField<FormattableMonth> for Date<A> {
+impl<C: Calendar, A: AsCalendar<Calendar = C>> NeoGetField<MonthInfo> for Date<A> {
     #[inline]
-    fn get_field(&self) -> FormattableMonth {
+    fn get_field(&self) -> MonthInfo {
         self.month()
     }
 }
@@ -544,9 +544,9 @@ impl<C: Calendar, A: AsCalendar<Calendar = C>> NeoGetField<YearInfo> for DateTim
     }
 }
 
-impl<C: Calendar, A: AsCalendar<Calendar = C>> NeoGetField<FormattableMonth> for DateTime<A> {
+impl<C: Calendar, A: AsCalendar<Calendar = C>> NeoGetField<MonthInfo> for DateTime<A> {
     #[inline]
-    fn get_field(&self) -> FormattableMonth {
+    fn get_field(&self) -> MonthInfo {
         self.date.month()
     }
 }
@@ -614,11 +614,11 @@ impl<C: Calendar, A: AsCalendar<Calendar = C>> NeoGetField<YearInfo> for CustomZ
     }
 }
 
-impl<C: Calendar, A: AsCalendar<Calendar = C>> NeoGetField<FormattableMonth>
+impl<C: Calendar, A: AsCalendar<Calendar = C>> NeoGetField<MonthInfo>
     for CustomZonedDateTime<A>
 {
     #[inline]
-    fn get_field(&self) -> FormattableMonth {
+    fn get_field(&self) -> MonthInfo {
         self.date.month()
     }
 }
@@ -794,7 +794,7 @@ impl From<NeverField> for Option<YearInfo> {
     }
 }
 
-impl From<NeverField> for Option<FormattableMonth> {
+impl From<NeverField> for Option<MonthInfo> {
     #[inline]
     fn from(_: NeverField) -> Self {
         None
@@ -951,7 +951,7 @@ pub trait DateInputMarkers: private::Sealed {
     /// Marker for resolving the year input field.
     type YearInput: Into<Option<YearInfo>>;
     /// Marker for resolving the month input field.
-    type MonthInput: Into<Option<FormattableMonth>>;
+    type MonthInput: Into<Option<MonthInfo>>;
     /// Marker for resolving the day-of-month input field.
     type DayOfMonthInput: Into<Option<DayOfMonth>>;
     /// Marker for resolving the day-of-week input field.
@@ -1439,7 +1439,7 @@ macro_rules! datetime_marker_helper {
         YearInfo
     };
     (@input/month, yes) => {
-        FormattableMonth
+        MonthInfo
     };
     (@input/day_of_month, yes) => {
         DayOfMonth

--- a/components/datetime/src/neo_marker.rs
+++ b/components/datetime/src/neo_marker.rs
@@ -329,7 +329,7 @@ use crate::{
 use icu_calendar::{
     any_calendar::IntoAnyCalendar,
     types::{
-        DayOfMonth, DayOfYearInfo, MonthInfo, IsoHour, IsoMinute, IsoSecond, IsoWeekday,
+        DayOfMonth, DayOfYearInfo, IsoHour, IsoMinute, IsoSecond, IsoWeekday, MonthInfo,
         NanoSecond, YearInfo,
     },
     AnyCalendar, AnyCalendarKind, AsCalendar, Calendar, Date, DateTime, Ref, Time,
@@ -614,9 +614,7 @@ impl<C: Calendar, A: AsCalendar<Calendar = C>> NeoGetField<YearInfo> for CustomZ
     }
 }
 
-impl<C: Calendar, A: AsCalendar<Calendar = C>> NeoGetField<MonthInfo>
-    for CustomZonedDateTime<A>
-{
+impl<C: Calendar, A: AsCalendar<Calendar = C>> NeoGetField<MonthInfo> for CustomZonedDateTime<A> {
     #[inline]
     fn get_field(&self) -> MonthInfo {
         self.date.month()

--- a/components/timezone/src/ixdtf.rs
+++ b/components/timezone/src/ixdtf.rs
@@ -179,7 +179,7 @@ impl CustomZonedDateTime<Iso> {
     ///
     /// assert_eq!(zoneddatetime.date.year().extended_year, 2024);
     /// assert_eq!(
-    ///     zoneddatetime.date.month().code,
+    ///     zoneddatetime.date.month().standard_code,
     ///     icu::calendar::types::MonthCode(tinystr::tinystr!(4, "M08"))
     /// );
     /// assert_eq!(zoneddatetime.date.day_of_month().0, 8);
@@ -265,7 +265,7 @@ impl CustomZonedDateTime<AnyCalendar> {
     ///
     /// assert_eq!(zoneddatetime.date.year().extended_year, 5784);
     /// assert_eq!(
-    ///     zoneddatetime.date.month().code,
+    ///     zoneddatetime.date.month().standard_code,
     ///     icu::calendar::types::MonthCode(tinystr::tinystr!(4, "M11"))
     /// );
     /// assert_eq!(zoneddatetime.date.day_of_month().0, 4);

--- a/ffi/capi/bindings/c/Date.h
+++ b/ffi/capi/bindings/c/Date.h
@@ -45,7 +45,7 @@ uint32_t icu4x_Date_week_of_month_mv1(const Date* self, IsoWeekday first_weekday
 
 WeekOf icu4x_Date_week_of_year_mv1(const Date* self, const WeekCalculator* calculator);
 
-uint32_t icu4x_Date_ordinal_month_mv1(const Date* self);
+uint8_t icu4x_Date_ordinal_month_mv1(const Date* self);
 
 void icu4x_Date_month_code_mv1(const Date* self, DiplomatWrite* write);
 

--- a/ffi/capi/bindings/c/Date.h
+++ b/ffi/capi/bindings/c/Date.h
@@ -49,6 +49,10 @@ uint32_t icu4x_Date_ordinal_month_mv1(const Date* self);
 
 void icu4x_Date_month_code_mv1(const Date* self, DiplomatWrite* write);
 
+uint8_t icu4x_Date_month_number_mv1(const Date* self);
+
+bool icu4x_Date_month_is_leap_mv1(const Date* self);
+
 int32_t icu4x_Date_year_in_era_mv1(const Date* self);
 
 int32_t icu4x_Date_extended_year_mv1(const Date* self);

--- a/ffi/capi/bindings/c/DateTime.h
+++ b/ffi/capi/bindings/c/DateTime.h
@@ -61,7 +61,7 @@ uint32_t icu4x_DateTime_week_of_month_mv1(const DateTime* self, IsoWeekday first
 
 WeekOf icu4x_DateTime_week_of_year_mv1(const DateTime* self, const WeekCalculator* calculator);
 
-uint32_t icu4x_DateTime_ordinal_month_mv1(const DateTime* self);
+uint8_t icu4x_DateTime_ordinal_month_mv1(const DateTime* self);
 
 void icu4x_DateTime_month_code_mv1(const DateTime* self, DiplomatWrite* write);
 

--- a/ffi/capi/bindings/c/DateTime.h
+++ b/ffi/capi/bindings/c/DateTime.h
@@ -65,6 +65,10 @@ uint32_t icu4x_DateTime_ordinal_month_mv1(const DateTime* self);
 
 void icu4x_DateTime_month_code_mv1(const DateTime* self, DiplomatWrite* write);
 
+uint8_t icu4x_DateTime_month_number_mv1(const DateTime* self);
+
+bool icu4x_DateTime_month_is_leap_mv1(const DateTime* self);
+
 int32_t icu4x_DateTime_year_in_era_mv1(const DateTime* self);
 
 int32_t icu4x_DateTime_extended_year_mv1(const DateTime* self);

--- a/ffi/capi/bindings/c/IsoDate.h
+++ b/ffi/capi/bindings/c/IsoDate.h
@@ -44,7 +44,7 @@ uint32_t icu4x_IsoDate_week_of_month_mv1(const IsoDate* self, IsoWeekday first_w
 
 WeekOf icu4x_IsoDate_week_of_year_mv1(const IsoDate* self, const WeekCalculator* calculator);
 
-uint32_t icu4x_IsoDate_month_mv1(const IsoDate* self);
+uint8_t icu4x_IsoDate_month_mv1(const IsoDate* self);
 
 int32_t icu4x_IsoDate_year_mv1(const IsoDate* self);
 

--- a/ffi/capi/bindings/c/IsoDateTime.h
+++ b/ffi/capi/bindings/c/IsoDateTime.h
@@ -64,7 +64,7 @@ uint32_t icu4x_IsoDateTime_week_of_month_mv1(const IsoDateTime* self, IsoWeekday
 
 WeekOf icu4x_IsoDateTime_week_of_year_mv1(const IsoDateTime* self, const WeekCalculator* calculator);
 
-uint32_t icu4x_IsoDateTime_month_mv1(const IsoDateTime* self);
+uint8_t icu4x_IsoDateTime_month_mv1(const IsoDateTime* self);
 
 int32_t icu4x_IsoDateTime_year_mv1(const IsoDateTime* self);
 

--- a/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
@@ -55,7 +55,7 @@ public:
 
   inline icu4x::WeekOf week_of_year(const icu4x::WeekCalculator& calculator) const;
 
-  inline uint32_t ordinal_month() const;
+  inline uint8_t ordinal_month() const;
 
   inline std::string month_code() const;
 

--- a/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
@@ -59,6 +59,10 @@ public:
 
   inline std::string month_code() const;
 
+  inline uint8_t month_number() const;
+
+  inline bool month_is_leap() const;
+
   inline int32_t year_in_era() const;
 
   inline int32_t extended_year() const;

--- a/ffi/capi/bindings/cpp/icu4x/Date.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Date.hpp
@@ -46,7 +46,7 @@ namespace capi {
     
     icu4x::capi::WeekOf icu4x_Date_week_of_year_mv1(const icu4x::capi::Date* self, const icu4x::capi::WeekCalculator* calculator);
     
-    uint32_t icu4x_Date_ordinal_month_mv1(const icu4x::capi::Date* self);
+    uint8_t icu4x_Date_ordinal_month_mv1(const icu4x::capi::Date* self);
     
     void icu4x_Date_month_code_mv1(const icu4x::capi::Date* self, diplomat::capi::DiplomatWrite* write);
     
@@ -135,7 +135,7 @@ inline icu4x::WeekOf icu4x::Date::week_of_year(const icu4x::WeekCalculator& calc
   return icu4x::WeekOf::FromFFI(result);
 }
 
-inline uint32_t icu4x::Date::ordinal_month() const {
+inline uint8_t icu4x::Date::ordinal_month() const {
   auto result = icu4x::capi::icu4x_Date_ordinal_month_mv1(this->AsFFI());
   return result;
 }

--- a/ffi/capi/bindings/cpp/icu4x/Date.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Date.hpp
@@ -50,6 +50,10 @@ namespace capi {
     
     void icu4x_Date_month_code_mv1(const icu4x::capi::Date* self, diplomat::capi::DiplomatWrite* write);
     
+    uint8_t icu4x_Date_month_number_mv1(const icu4x::capi::Date* self);
+    
+    bool icu4x_Date_month_is_leap_mv1(const icu4x::capi::Date* self);
+    
     int32_t icu4x_Date_year_in_era_mv1(const icu4x::capi::Date* self);
     
     int32_t icu4x_Date_extended_year_mv1(const icu4x::capi::Date* self);
@@ -142,6 +146,16 @@ inline std::string icu4x::Date::month_code() const {
   icu4x::capi::icu4x_Date_month_code_mv1(this->AsFFI(),
     &write);
   return output;
+}
+
+inline uint8_t icu4x::Date::month_number() const {
+  auto result = icu4x::capi::icu4x_Date_month_number_mv1(this->AsFFI());
+  return result;
+}
+
+inline bool icu4x::Date::month_is_leap() const {
+  auto result = icu4x::capi::icu4x_Date_month_is_leap_mv1(this->AsFFI());
+  return result;
 }
 
 inline int32_t icu4x::Date::year_in_era() const {

--- a/ffi/capi/bindings/cpp/icu4x/DateTime.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DateTime.d.hpp
@@ -77,6 +77,10 @@ public:
 
   inline std::string month_code() const;
 
+  inline uint8_t month_number() const;
+
+  inline bool month_is_leap() const;
+
   inline int32_t year_in_era() const;
 
   inline int32_t extended_year() const;

--- a/ffi/capi/bindings/cpp/icu4x/DateTime.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DateTime.d.hpp
@@ -73,7 +73,7 @@ public:
 
   inline icu4x::WeekOf week_of_year(const icu4x::WeekCalculator& calculator) const;
 
-  inline uint32_t ordinal_month() const;
+  inline uint8_t ordinal_month() const;
 
   inline std::string month_code() const;
 

--- a/ffi/capi/bindings/cpp/icu4x/DateTime.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DateTime.hpp
@@ -62,7 +62,7 @@ namespace capi {
     
     icu4x::capi::WeekOf icu4x_DateTime_week_of_year_mv1(const icu4x::capi::DateTime* self, const icu4x::capi::WeekCalculator* calculator);
     
-    uint32_t icu4x_DateTime_ordinal_month_mv1(const icu4x::capi::DateTime* self);
+    uint8_t icu4x_DateTime_ordinal_month_mv1(const icu4x::capi::DateTime* self);
     
     void icu4x_DateTime_month_code_mv1(const icu4x::capi::DateTime* self, diplomat::capi::DiplomatWrite* write);
     
@@ -195,7 +195,7 @@ inline icu4x::WeekOf icu4x::DateTime::week_of_year(const icu4x::WeekCalculator& 
   return icu4x::WeekOf::FromFFI(result);
 }
 
-inline uint32_t icu4x::DateTime::ordinal_month() const {
+inline uint8_t icu4x::DateTime::ordinal_month() const {
   auto result = icu4x::capi::icu4x_DateTime_ordinal_month_mv1(this->AsFFI());
   return result;
 }

--- a/ffi/capi/bindings/cpp/icu4x/DateTime.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DateTime.hpp
@@ -66,6 +66,10 @@ namespace capi {
     
     void icu4x_DateTime_month_code_mv1(const icu4x::capi::DateTime* self, diplomat::capi::DiplomatWrite* write);
     
+    uint8_t icu4x_DateTime_month_number_mv1(const icu4x::capi::DateTime* self);
+    
+    bool icu4x_DateTime_month_is_leap_mv1(const icu4x::capi::DateTime* self);
+    
     int32_t icu4x_DateTime_year_in_era_mv1(const icu4x::capi::DateTime* self);
     
     int32_t icu4x_DateTime_extended_year_mv1(const icu4x::capi::DateTime* self);
@@ -202,6 +206,16 @@ inline std::string icu4x::DateTime::month_code() const {
   icu4x::capi::icu4x_DateTime_month_code_mv1(this->AsFFI(),
     &write);
   return output;
+}
+
+inline uint8_t icu4x::DateTime::month_number() const {
+  auto result = icu4x::capi::icu4x_DateTime_month_number_mv1(this->AsFFI());
+  return result;
+}
+
+inline bool icu4x::DateTime::month_is_leap() const {
+  auto result = icu4x::capi::icu4x_DateTime_month_is_leap_mv1(this->AsFFI());
+  return result;
 }
 
 inline int32_t icu4x::DateTime::year_in_era() const {

--- a/ffi/capi/bindings/cpp/icu4x/IsoDate.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/IsoDate.d.hpp
@@ -55,7 +55,7 @@ public:
 
   inline icu4x::WeekOf week_of_year(const icu4x::WeekCalculator& calculator) const;
 
-  inline uint32_t month() const;
+  inline uint8_t month() const;
 
   inline int32_t year() const;
 

--- a/ffi/capi/bindings/cpp/icu4x/IsoDate.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/IsoDate.hpp
@@ -45,7 +45,7 @@ namespace capi {
     
     icu4x::capi::WeekOf icu4x_IsoDate_week_of_year_mv1(const icu4x::capi::IsoDate* self, const icu4x::capi::WeekCalculator* calculator);
     
-    uint32_t icu4x_IsoDate_month_mv1(const icu4x::capi::IsoDate* self);
+    uint8_t icu4x_IsoDate_month_mv1(const icu4x::capi::IsoDate* self);
     
     int32_t icu4x_IsoDate_year_mv1(const icu4x::capi::IsoDate* self);
     
@@ -119,7 +119,7 @@ inline icu4x::WeekOf icu4x::IsoDate::week_of_year(const icu4x::WeekCalculator& c
   return icu4x::WeekOf::FromFFI(result);
 }
 
-inline uint32_t icu4x::IsoDate::month() const {
+inline uint8_t icu4x::IsoDate::month() const {
   auto result = icu4x::capi::icu4x_IsoDate_month_mv1(this->AsFFI());
   return result;
 }

--- a/ffi/capi/bindings/cpp/icu4x/IsoDateTime.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/IsoDateTime.d.hpp
@@ -77,7 +77,7 @@ public:
 
   inline icu4x::WeekOf week_of_year(const icu4x::WeekCalculator& calculator) const;
 
-  inline uint32_t month() const;
+  inline uint8_t month() const;
 
   inline int32_t year() const;
 

--- a/ffi/capi/bindings/cpp/icu4x/IsoDateTime.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/IsoDateTime.hpp
@@ -65,7 +65,7 @@ namespace capi {
     
     icu4x::capi::WeekOf icu4x_IsoDateTime_week_of_year_mv1(const icu4x::capi::IsoDateTime* self, const icu4x::capi::WeekCalculator* calculator);
     
-    uint32_t icu4x_IsoDateTime_month_mv1(const icu4x::capi::IsoDateTime* self);
+    uint8_t icu4x_IsoDateTime_month_mv1(const icu4x::capi::IsoDateTime* self);
     
     int32_t icu4x_IsoDateTime_year_mv1(const icu4x::capi::IsoDateTime* self);
     
@@ -189,7 +189,7 @@ inline icu4x::WeekOf icu4x::IsoDateTime::week_of_year(const icu4x::WeekCalculato
   return icu4x::WeekOf::FromFFI(result);
 }
 
-inline uint32_t icu4x::IsoDateTime::month() const {
+inline uint8_t icu4x::IsoDateTime::month() const {
   auto result = icu4x::capi::icu4x_IsoDateTime_month_mv1(this->AsFFI());
   return result;
 }

--- a/ffi/capi/bindings/dart/Date.g.dart
+++ b/ffi/capi/bindings/dart/Date.g.dart
@@ -153,6 +153,22 @@ final class Date implements ffi.Finalizable {
     return write.finalize();
   }
 
+  /// Returns the month number of this month.
+  ///
+  /// See the [Rust documentation for `month_number`](https://docs.rs/icu/latest/icu/calendar/types/struct.MonthInfo.html#method.month_number) for more information.
+  int get monthNumber {
+    final result = _icu4x_Date_month_number_mv1(_ffi);
+    return result;
+  }
+
+  /// Returns whether the month is a leap month.
+  ///
+  /// See the [Rust documentation for `is_leap`](https://docs.rs/icu/latest/icu/calendar/types/struct.MonthInfo.html#method.is_leap) for more information.
+  bool get monthIsLeap {
+    final result = _icu4x_Date_month_is_leap_mv1(_ffi);
+    return result;
+  }
+
   /// Returns the year number in the current era for this date
   ///
   /// For calendars without an era, returns the extended year
@@ -281,6 +297,16 @@ external int _icu4x_Date_ordinal_month_mv1(ffi.Pointer<ffi.Opaque> self);
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_month_code_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Date_month_code_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
+
+@meta.ResourceIdentifier('icu4x_Date_month_number_mv1')
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_month_number_mv1')
+// ignore: non_constant_identifier_names
+external int _icu4x_Date_month_number_mv1(ffi.Pointer<ffi.Opaque> self);
+
+@meta.ResourceIdentifier('icu4x_Date_month_is_leap_mv1')
+@ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_month_is_leap_mv1')
+// ignore: non_constant_identifier_names
+external bool _icu4x_Date_month_is_leap_mv1(ffi.Pointer<ffi.Opaque> self);
 
 @meta.ResourceIdentifier('icu4x_Date_year_in_era_mv1')
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_year_in_era_mv1')

--- a/ffi/capi/bindings/dart/Date.g.dart
+++ b/ffi/capi/bindings/dart/Date.g.dart
@@ -134,6 +134,8 @@ final class Date implements ffi.Finalizable {
   /// about month identity.
   ///
   /// See the [Rust documentation for `month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.month) for more information.
+  ///
+  /// See the [Rust documentation for `ordinal`](https://docs.rs/icu/latest/icu/calendar/types/struct.MonthInfo.html#structfield.ordinal) for more information.
   int get ordinalMonth {
     final result = _icu4x_Date_ordinal_month_mv1(_ffi);
     return result;
@@ -142,7 +144,9 @@ final class Date implements ffi.Finalizable {
   /// Returns the month code for this date. Typically something
   /// like "M01", "M02", but can be more complicated for lunar calendars.
   ///
-  /// See the [Rust documentation for `month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.month) for more information.
+  /// See the [Rust documentation for `standard_code`](https://docs.rs/icu/latest/icu/calendar/types/struct.MonthInfo.html#structfield.standard_code) for more information.
+  ///
+  /// Additional information: [1](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.month)
   String get monthCode {
     final write = _Write();
     _icu4x_Date_month_code_mv1(_ffi, write._ffi);
@@ -153,7 +157,9 @@ final class Date implements ffi.Finalizable {
   ///
   /// For calendars without an era, returns the extended year
   ///
-  /// See the [Rust documentation for `year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year) for more information.
+  /// See the [Rust documentation for `era_year_or_extended`](https://docs.rs/icu/latest/icu/calendar/types/struct.YearInfo.html#method.era_year_or_extended) for more information.
+  ///
+  /// Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era_year), [2](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
   int get yearInEra {
     final result = _icu4x_Date_year_in_era_mv1(_ffi);
     return result;
@@ -167,11 +173,11 @@ final class Date implements ffi.Finalizable {
     return result;
   }
 
-  /// Returns the era for this date,
+  /// Returns the era for this date, or an empty string
   ///
-  /// See the [Rust documentation for `year`](https://docs.rs/icu/latest/icu/struct.Date.html#method.year) for more information.
+  /// See the [Rust documentation for `standard_era`](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.standard_era) for more information.
   ///
-  /// Additional information: [1](https://docs.rs/icu/latest/icu/types/struct.Era.html), [2](https://docs.rs/icu/latest/icu/types/struct.EraYear.html)
+  /// Additional information: [1](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
   String get era {
     final write = _Write();
     _icu4x_Date_era_mv1(_ffi, write._ffi);

--- a/ffi/capi/bindings/dart/Date.g.dart
+++ b/ffi/capi/bindings/dart/Date.g.dart
@@ -289,7 +289,7 @@ external int _icu4x_Date_week_of_month_mv1(ffi.Pointer<ffi.Opaque> self, int fir
 external _WeekOfFfi _icu4x_Date_week_of_year_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> calculator);
 
 @meta.ResourceIdentifier('icu4x_Date_ordinal_month_mv1')
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_ordinal_month_mv1')
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_ordinal_month_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Date_ordinal_month_mv1(ffi.Pointer<ffi.Opaque> self);
 

--- a/ffi/capi/bindings/dart/DateTime.g.dart
+++ b/ffi/capi/bindings/dart/DateTime.g.dart
@@ -380,7 +380,7 @@ external int _icu4x_DateTime_week_of_month_mv1(ffi.Pointer<ffi.Opaque> self, int
 external _WeekOfFfi _icu4x_DateTime_week_of_year_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> calculator);
 
 @meta.ResourceIdentifier('icu4x_DateTime_ordinal_month_mv1')
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DateTime_ordinal_month_mv1')
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DateTime_ordinal_month_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_DateTime_ordinal_month_mv1(ffi.Pointer<ffi.Opaque> self);
 

--- a/ffi/capi/bindings/dart/DateTime.g.dart
+++ b/ffi/capi/bindings/dart/DateTime.g.dart
@@ -209,6 +209,22 @@ final class DateTime implements ffi.Finalizable {
     return write.finalize();
   }
 
+  /// Returns the month number of this month.
+  ///
+  /// See the [Rust documentation for `month_number`](https://docs.rs/icu/latest/icu/calendar/types/struct.MonthInfo.html#method.month_number) for more information.
+  int get monthNumber {
+    final result = _icu4x_DateTime_month_number_mv1(_ffi);
+    return result;
+  }
+
+  /// Returns whether the month is a leap month.
+  ///
+  /// See the [Rust documentation for `is_leap`](https://docs.rs/icu/latest/icu/calendar/types/struct.MonthInfo.html#method.is_leap) for more information.
+  bool get monthIsLeap {
+    final result = _icu4x_DateTime_month_is_leap_mv1(_ffi);
+    return result;
+  }
+
   /// Returns the year number in the current era for this date
   ///
   /// For calendars without an era, returns the extended year
@@ -372,6 +388,16 @@ external int _icu4x_DateTime_ordinal_month_mv1(ffi.Pointer<ffi.Opaque> self);
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DateTime_month_code_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_DateTime_month_code_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
+
+@meta.ResourceIdentifier('icu4x_DateTime_month_number_mv1')
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DateTime_month_number_mv1')
+// ignore: non_constant_identifier_names
+external int _icu4x_DateTime_month_number_mv1(ffi.Pointer<ffi.Opaque> self);
+
+@meta.ResourceIdentifier('icu4x_DateTime_month_is_leap_mv1')
+@ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DateTime_month_is_leap_mv1')
+// ignore: non_constant_identifier_names
+external bool _icu4x_DateTime_month_is_leap_mv1(ffi.Pointer<ffi.Opaque> self);
 
 @meta.ResourceIdentifier('icu4x_DateTime_year_in_era_mv1')
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DateTime_year_in_era_mv1')

--- a/ffi/capi/bindings/dart/DateTime.g.dart
+++ b/ffi/capi/bindings/dart/DateTime.g.dart
@@ -190,6 +190,8 @@ final class DateTime implements ffi.Finalizable {
   /// about month identity.
   ///
   /// See the [Rust documentation for `month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.month) for more information.
+  ///
+  /// See the [Rust documentation for `ordinal`](https://docs.rs/icu/latest/icu/calendar/types/struct.MonthInfo.html#structfield.ordinal) for more information.
   int get ordinalMonth {
     final result = _icu4x_DateTime_ordinal_month_mv1(_ffi);
     return result;
@@ -198,7 +200,9 @@ final class DateTime implements ffi.Finalizable {
   /// Returns the month code for this date. Typically something
   /// like "M01", "M02", but can be more complicated for lunar calendars.
   ///
-  /// See the [Rust documentation for `month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.month) for more information.
+  /// See the [Rust documentation for `standard_code`](https://docs.rs/icu/latest/icu/calendar/types/struct.MonthInfo.html#structfield.standard_code) for more information.
+  ///
+  /// Additional information: [1](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.month)
   String get monthCode {
     final write = _Write();
     _icu4x_DateTime_month_code_mv1(_ffi, write._ffi);
@@ -209,7 +213,9 @@ final class DateTime implements ffi.Finalizable {
   ///
   /// For calendars without an era, returns the extended year
   ///
-  /// See the [Rust documentation for `year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year) for more information.
+  /// See the [Rust documentation for `era_year_or_extended`](https://docs.rs/icu/latest/icu/calendar/types/struct.YearInfo.html#method.era_year_or_extended) for more information.
+  ///
+  /// Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era_year), [2](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
   int get yearInEra {
     final result = _icu4x_DateTime_year_in_era_mv1(_ffi);
     return result;
@@ -225,7 +231,9 @@ final class DateTime implements ffi.Finalizable {
 
   /// Returns the era for this date, or an empty string
   ///
-  /// See the [Rust documentation for `year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year) for more information.
+  /// See the [Rust documentation for `standard_era`](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.standard_era) for more information.
+  ///
+  /// Additional information: [1](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
   String get era {
     final write = _Write();
     _icu4x_DateTime_era_mv1(_ffi, write._ffi);

--- a/ffi/capi/bindings/dart/IsoDate.g.dart
+++ b/ffi/capi/bindings/dart/IsoDate.g.dart
@@ -118,7 +118,9 @@ final class IsoDate implements ffi.Finalizable {
 
   /// Returns 1-indexed number of the month of this date in its year
   ///
-  /// See the [Rust documentation for `month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.month) for more information.
+  /// See the [Rust documentation for `ordinal`](https://docs.rs/icu/latest/icu/calendar/types/struct.MonthInfo.html#structfield.ordinal) for more information.
+  ///
+  /// Additional information: [1](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.month)
   int get month {
     final result = _icu4x_IsoDate_month_mv1(_ffi);
     return result;

--- a/ffi/capi/bindings/dart/IsoDate.g.dart
+++ b/ffi/capi/bindings/dart/IsoDate.g.dart
@@ -225,7 +225,7 @@ external int _icu4x_IsoDate_week_of_month_mv1(ffi.Pointer<ffi.Opaque> self, int 
 external _WeekOfFfi _icu4x_IsoDate_week_of_year_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> calculator);
 
 @meta.ResourceIdentifier('icu4x_IsoDate_month_mv1')
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_month_mv1')
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_month_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_IsoDate_month_mv1(ffi.Pointer<ffi.Opaque> self);
 

--- a/ffi/capi/bindings/dart/IsoDateTime.g.dart
+++ b/ffi/capi/bindings/dart/IsoDateTime.g.dart
@@ -343,7 +343,7 @@ external int _icu4x_IsoDateTime_week_of_month_mv1(ffi.Pointer<ffi.Opaque> self, 
 external _WeekOfFfi _icu4x_IsoDateTime_week_of_year_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> calculator);
 
 @meta.ResourceIdentifier('icu4x_IsoDateTime_month_mv1')
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDateTime_month_mv1')
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDateTime_month_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_IsoDateTime_month_mv1(ffi.Pointer<ffi.Opaque> self);
 

--- a/ffi/capi/bindings/dart/IsoDateTime.g.dart
+++ b/ffi/capi/bindings/dart/IsoDateTime.g.dart
@@ -193,7 +193,9 @@ final class IsoDateTime implements ffi.Finalizable {
 
   /// Returns 1-indexed number of the month of this date in its year
   ///
-  /// See the [Rust documentation for `month`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.month) for more information.
+  /// See the [Rust documentation for `ordinal`](https://docs.rs/icu/latest/icu/calendar/types/struct.MonthInfo.html#structfield.ordinal) for more information.
+  ///
+  /// Additional information: [1](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.month)
   int get month {
     final result = _icu4x_IsoDateTime_month_mv1(_ffi);
     return result;

--- a/ffi/capi/bindings/js/Date.d.ts
+++ b/ffi/capi/bindings/js/Date.d.ts
@@ -42,6 +42,10 @@ export class Date {
 
     get monthCode(): string;
 
+    get monthNumber(): number;
+
+    get monthIsLeap(): boolean;
+
     get yearInEra(): number;
 
     get extendedYear(): number;

--- a/ffi/capi/bindings/js/Date.mjs
+++ b/ffi/capi/bindings/js/Date.mjs
@@ -210,6 +210,26 @@ export class Date {
         }
     }
 
+    get monthNumber() {
+        const result = wasm.icu4x_Date_month_number_mv1(this.ffiValue);
+    
+        try {
+            return result;
+        }
+        
+        finally {}
+    }
+
+    get monthIsLeap() {
+        const result = wasm.icu4x_Date_month_is_leap_mv1(this.ffiValue);
+    
+        try {
+            return result;
+        }
+        
+        finally {}
+    }
+
     get yearInEra() {
         const result = wasm.icu4x_Date_year_in_era_mv1(this.ffiValue);
     

--- a/ffi/capi/bindings/js/DateTime.d.ts
+++ b/ffi/capi/bindings/js/DateTime.d.ts
@@ -58,6 +58,10 @@ export class DateTime {
 
     get monthCode(): string;
 
+    get monthNumber(): number;
+
+    get monthIsLeap(): boolean;
+
     get yearInEra(): number;
 
     get extendedYear(): number;

--- a/ffi/capi/bindings/js/DateTime.mjs
+++ b/ffi/capi/bindings/js/DateTime.mjs
@@ -282,6 +282,26 @@ export class DateTime {
         }
     }
 
+    get monthNumber() {
+        const result = wasm.icu4x_DateTime_month_number_mv1(this.ffiValue);
+    
+        try {
+            return result;
+        }
+        
+        finally {}
+    }
+
+    get monthIsLeap() {
+        const result = wasm.icu4x_DateTime_month_is_leap_mv1(this.ffiValue);
+    
+        try {
+            return result;
+        }
+        
+        finally {}
+    }
+
     get yearInEra() {
         const result = wasm.icu4x_DateTime_year_in_era_mv1(this.ffiValue);
     

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -119,7 +119,8 @@ pub mod ffi {
         }
 
         /// Returns 1-indexed number of the month of this date in its year
-        #[diplomat::rust_link(icu::calendar::Date::month, FnInStruct)]
+        #[diplomat::rust_link(icu::calendar::types::MonthInfo::ordinal, StructField)]
+        #[diplomat::rust_link(icu::calendar::Date::month, FnInStruct, compact)]
         #[diplomat::attr(auto, getter)]
         pub fn month(&self) -> u32 {
             self.0.month().ordinal
@@ -293,6 +294,7 @@ pub mod ffi {
         /// having the same ordinal month across years; use month_code if you care
         /// about month identity.
         #[diplomat::rust_link(icu::calendar::Date::month, FnInStruct)]
+        #[diplomat::rust_link(icu::calendar::types::MonthInfo::ordinal, StructField)]
         #[diplomat::attr(auto, getter)]
         pub fn ordinal_month(&self) -> u32 {
             self.0.month().ordinal
@@ -300,17 +302,27 @@ pub mod ffi {
 
         /// Returns the month code for this date. Typically something
         /// like "M01", "M02", but can be more complicated for lunar calendars.
-        #[diplomat::rust_link(icu::calendar::Date::month, FnInStruct)]
+        #[diplomat::rust_link(icu::calendar::types::MonthInfo::standard_code, StructField)]
+        #[diplomat::rust_link(icu::calendar::Date::month, FnInStruct, compact)]
+        #[diplomat::rust_link(icu::calendar::types::MonthInfo, Struct, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::MonthInfo::formatting_code, StructField, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::MonthInfo, Struct, hidden)]
         #[diplomat::attr(auto, getter)]
         pub fn month_code(&self, write: &mut diplomat_runtime::DiplomatWrite) {
-            let code = self.0.month().code;
+            let code = self.0.month().standard_code;
             let _infallible = write.write_str(&code.0);
         }
 
         /// Returns the year number in the current era for this date
         ///
         /// For calendars without an era, returns the extended year
-        #[diplomat::rust_link(icu::calendar::Date::year, FnInStruct)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo::era_year_or_extended, FnInStruct)]
+        #[diplomat::rust_link(icu::calendar::types::EraYear::era_year, StructField, compact)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo::era_year, FnInStruct, hidden)]
+        #[diplomat::rust_link(icu::calendar::Date::year, FnInStruct, compact)]
+        #[diplomat::rust_link(icu::calendar::types::EraYear, Struct, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::YearKind, Enum, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo, Struct, hidden)]
         #[diplomat::attr(auto, getter)]
         pub fn year_in_era(&self) -> i32 {
             self.0.year().era_year_or_extended()
@@ -324,11 +336,15 @@ pub mod ffi {
             self.0.year().extended_year
         }
 
-        /// Returns the era for this date,
-        #[diplomat::rust_link(icu::Date::year, FnInStruct)]
-        #[diplomat::rust_link(icu::types::Era, Struct, compact)]
-        #[diplomat::rust_link(icu::types::EraYear, Struct, compact)]
-        #[diplomat::rust_link(icu::types::YearKind, Struct, hidden)]
+        /// Returns the era for this date, or an empty string
+        #[diplomat::rust_link(icu::calendar::types::EraYear::standard_era, StructField)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo::standard_era, FnInStruct, hidden)]
+        #[diplomat::rust_link(icu::calendar::Date::year, FnInStruct, compact)]
+        #[diplomat::rust_link(icu::calendar::types::EraYear, Struct, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::YearKind, Enum, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo, Struct, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::EraYear::formatting_era, StructField, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo::formatting_era, FnInStruct, hidden)]
         #[diplomat::attr(auto, getter)]
         pub fn era(&self, write: &mut diplomat_runtime::DiplomatWrite) {
             if let Some(era) = self.0.year().standard_era() {

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -305,12 +305,30 @@ pub mod ffi {
         #[diplomat::rust_link(icu::calendar::types::MonthInfo::standard_code, StructField)]
         #[diplomat::rust_link(icu::calendar::Date::month, FnInStruct, compact)]
         #[diplomat::rust_link(icu::calendar::types::MonthInfo, Struct, hidden)]
-        #[diplomat::rust_link(icu::calendar::types::MonthInfo::formatting_code, StructField, hidden)]
+        #[diplomat::rust_link(
+            icu::calendar::types::MonthInfo::formatting_code,
+            StructField,
+            hidden
+        )]
         #[diplomat::rust_link(icu::calendar::types::MonthInfo, Struct, hidden)]
         #[diplomat::attr(auto, getter)]
         pub fn month_code(&self, write: &mut diplomat_runtime::DiplomatWrite) {
             let code = self.0.month().standard_code;
             let _infallible = write.write_str(&code.0);
+        }
+
+        /// Returns the month number of this month.
+        #[diplomat::rust_link(icu::calendar::types::MonthInfo::month_number, FnInStruct)]
+        #[diplomat::attr(auto, getter)]
+        pub fn month_number(&self) -> u8 {
+            self.0.month().month_number()
+        }
+
+        /// Returns whether the month is a leap month.
+        #[diplomat::rust_link(icu::calendar::types::MonthInfo::is_leap, FnInStruct)]
+        #[diplomat::attr(auto, getter)]
+        pub fn month_is_leap(&self) -> bool {
+            self.0.month().is_leap()
         }
 
         /// Returns the year number in the current era for this date

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -122,7 +122,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::calendar::types::MonthInfo::ordinal, StructField)]
         #[diplomat::rust_link(icu::calendar::Date::month, FnInStruct, compact)]
         #[diplomat::attr(auto, getter)]
-        pub fn month(&self) -> u32 {
+        pub fn month(&self) -> u8 {
             self.0.month().ordinal
         }
 
@@ -296,7 +296,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::calendar::Date::month, FnInStruct)]
         #[diplomat::rust_link(icu::calendar::types::MonthInfo::ordinal, StructField)]
         #[diplomat::attr(auto, getter)]
-        pub fn ordinal_month(&self) -> u32 {
+        pub fn ordinal_month(&self) -> u8 {
             self.0.month().ordinal
         }
 

--- a/ffi/capi/src/datetime.rs
+++ b/ffi/capi/src/datetime.rs
@@ -192,7 +192,8 @@ pub mod ffi {
         }
 
         /// Returns 1-indexed number of the month of this date in its year
-        #[diplomat::rust_link(icu::calendar::Date::month, FnInStruct)]
+        #[diplomat::rust_link(icu::calendar::types::MonthInfo::ordinal, StructField)]
+        #[diplomat::rust_link(icu::calendar::Date::month, FnInStruct, compact)]
         #[diplomat::attr(auto, getter)]
         pub fn month(&self) -> u32 {
             self.0.date.month().ordinal
@@ -430,6 +431,7 @@ pub mod ffi {
         /// having the same ordinal month across years; use month_code if you care
         /// about month identity.
         #[diplomat::rust_link(icu::calendar::Date::month, FnInStruct)]
+        #[diplomat::rust_link(icu::calendar::types::MonthInfo::ordinal, StructField)]
         #[diplomat::attr(auto, getter)]
         pub fn ordinal_month(&self) -> u32 {
             self.0.date.month().ordinal
@@ -437,17 +439,27 @@ pub mod ffi {
 
         /// Returns the month code for this date. Typically something
         /// like "M01", "M02", but can be more complicated for lunar calendars.
-        #[diplomat::rust_link(icu::calendar::Date::month, FnInStruct)]
+        #[diplomat::rust_link(icu::calendar::types::MonthInfo::standard_code, StructField)]
+        #[diplomat::rust_link(icu::calendar::Date::month, FnInStruct, compact)]
+        #[diplomat::rust_link(icu::calendar::types::MonthInfo, Struct, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::MonthInfo::formatting_code, StructField, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::MonthInfo, Struct, hidden)]
         #[diplomat::attr(auto, getter)]
         pub fn month_code(&self, write: &mut diplomat_runtime::DiplomatWrite) {
-            let code = self.0.date.month().code;
+            let code = self.0.date.month().standard_code;
             let _infallible = write.write_str(&code.0);
         }
 
         /// Returns the year number in the current era for this date
         ///
         /// For calendars without an era, returns the extended year
-        #[diplomat::rust_link(icu::calendar::Date::year, FnInStruct)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo::era_year_or_extended, FnInStruct)]
+        #[diplomat::rust_link(icu::calendar::types::EraYear::era_year, StructField, compact)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo::era_year, FnInStruct, hidden)]
+        #[diplomat::rust_link(icu::calendar::Date::year, FnInStruct, compact)]
+        #[diplomat::rust_link(icu::calendar::types::EraYear, Struct, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::YearKind, Enum, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo, Struct, hidden)]
         #[diplomat::attr(auto, getter)]
         pub fn year_in_era(&self) -> i32 {
             self.0.date.year().era_year_or_extended()
@@ -455,13 +467,21 @@ pub mod ffi {
 
         /// Returns the extended year in the Date
         #[diplomat::rust_link(icu::calendar::types::YearInfo::extended_year, StructField)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo, Struct, hidden)]
         #[diplomat::attr(auto, getter)]
         pub fn extended_year(&self) -> i32 {
             self.0.date.year().extended_year
         }
 
         /// Returns the era for this date, or an empty string
-        #[diplomat::rust_link(icu::calendar::Date::year, FnInStruct)]
+        #[diplomat::rust_link(icu::calendar::types::EraYear::standard_era, StructField)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo::standard_era, FnInStruct, hidden)]
+        #[diplomat::rust_link(icu::calendar::Date::year, FnInStruct, compact)]
+        #[diplomat::rust_link(icu::calendar::types::EraYear, Struct, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::YearKind, Enum, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo, Struct, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::EraYear::formatting_era, StructField, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo::formatting_era, FnInStruct, hidden)]
         #[diplomat::attr(auto, getter)]
         pub fn era(&self, write: &mut diplomat_runtime::DiplomatWrite) {
             if let Some(era) = self.0.date.year().standard_era() {

--- a/ffi/capi/src/datetime.rs
+++ b/ffi/capi/src/datetime.rs
@@ -195,7 +195,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::calendar::types::MonthInfo::ordinal, StructField)]
         #[diplomat::rust_link(icu::calendar::Date::month, FnInStruct, compact)]
         #[diplomat::attr(auto, getter)]
-        pub fn month(&self) -> u32 {
+        pub fn month(&self) -> u8 {
             self.0.date.month().ordinal
         }
 
@@ -433,7 +433,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::calendar::Date::month, FnInStruct)]
         #[diplomat::rust_link(icu::calendar::types::MonthInfo::ordinal, StructField)]
         #[diplomat::attr(auto, getter)]
-        pub fn ordinal_month(&self) -> u32 {
+        pub fn ordinal_month(&self) -> u8 {
             self.0.date.month().ordinal
         }
 
@@ -458,7 +458,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::calendar::types::MonthInfo::month_number, FnInStruct)]
         #[diplomat::attr(auto, getter)]
         pub fn month_number(&self) -> u8 {
-            self.0.month().month_number()
+            self.0.date.month().month_number()
         }
 
         /// Returns whether the month is a leap month.

--- a/ffi/capi/src/datetime.rs
+++ b/ffi/capi/src/datetime.rs
@@ -442,12 +442,30 @@ pub mod ffi {
         #[diplomat::rust_link(icu::calendar::types::MonthInfo::standard_code, StructField)]
         #[diplomat::rust_link(icu::calendar::Date::month, FnInStruct, compact)]
         #[diplomat::rust_link(icu::calendar::types::MonthInfo, Struct, hidden)]
-        #[diplomat::rust_link(icu::calendar::types::MonthInfo::formatting_code, StructField, hidden)]
+        #[diplomat::rust_link(
+            icu::calendar::types::MonthInfo::formatting_code,
+            StructField,
+            hidden
+        )]
         #[diplomat::rust_link(icu::calendar::types::MonthInfo, Struct, hidden)]
         #[diplomat::attr(auto, getter)]
         pub fn month_code(&self, write: &mut diplomat_runtime::DiplomatWrite) {
             let code = self.0.date.month().standard_code;
             let _infallible = write.write_str(&code.0);
+        }
+
+        /// Returns the month number of this month.
+        #[diplomat::rust_link(icu::calendar::types::MonthInfo::month_number, FnInStruct)]
+        #[diplomat::attr(auto, getter)]
+        pub fn month_number(&self) -> u8 {
+            self.0.month().month_number()
+        }
+
+        /// Returns whether the month is a leap month.
+        #[diplomat::rust_link(icu::calendar::types::MonthInfo::is_leap, FnInStruct)]
+        #[diplomat::attr(auto, getter)]
+        pub fn month_is_leap(&self) -> bool {
+            self.0.date.month().is_leap()
         }
 
         /// Returns the year number in the current era for this date

--- a/tools/make/diplomat-coverage/src/allowlist.rs
+++ b/tools/make/diplomat-coverage/src/allowlist.rs
@@ -179,7 +179,7 @@ lazy_static::lazy_static! {
 
         // Calendar structs mostly for internal use but which might expose
         // useful information to clients.
-        "icu::calendar::types::FormattableMonth",
+        "icu::calendar::types::MonthInfo",
         "icu::calendar::types::FormattableYear",
         "icu::calendar::types::FormattableYearKind",
         "icu::calendar::types::DayOfYearInfo",

--- a/tools/make/diplomat-coverage/src/allowlist.rs
+++ b/tools/make/diplomat-coverage/src/allowlist.rs
@@ -184,11 +184,10 @@ lazy_static::lazy_static! {
         "icu::calendar::types::FormattableYearKind",
         "icu::calendar::types::DayOfYearInfo",
 
-        // Not yet fully exposed over FFI, Temporal doesn't yet need all of the details here
+        // Not yet fully exposed over FFI, Temporal doesn't yet want this.
         "icu::calendar::types::CyclicYear",
-        "icu::calendar::types::EraYear",
-        "icu::calendar::types::YearInfo",
-        "icu::calendar::types::YearKind",
+        "icu::calendar::types::YearInfo::cyclic",
+        "icu::calendar::types::YearInfo::related_iso",
 
         // Punted post 1.0: not strongly needed yet and don't want to lock in a solution
         // Potential solutions:


### PR DESCRIPTION
Also some leftover cleanups in the FFI allowlist from #5509


Fixes #3821


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->