### PR TITLE
In zerovec, add the yoke version bound to the dev-dependency

### DIFF
--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -51,7 +51,7 @@ rmp-serde = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 potential_utf = { workspace = true, features = ["zerovec"] }
-yoke = { path = "../../utils/yoke", features = ["derive"] }
+yoke = { version = ">=0.6.0, <0.8.0", path = "../../utils/yoke", features = ["derive"] }
 zerofrom = { path = "../../utils/zerofrom", features = ["derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]


### PR DESCRIPTION
This allows the `dev-dependency` to appear in the normalized `Cargo.toml` in the published crate.

```toml
[dev-dependencies.yoke]
version = ">=0.6.0, <0.8.0"
features = ["derive"]
```

This is helpful when packaging for Fedora Linux, because the `dev-dependency` on `yoke` is the one that carries `features = ["derive"]`, needed for running various tests included in the published `zerovec` crate.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->