### PR TITLE
Include datagen APIs in bench target, fixing CI

### DIFF
--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -93,7 +93,7 @@ datagen = [
 ]
 logging = ["icu_calendar/logging"]
 experimental = ["dep:litemap"]
-bench = ["serde"]
+bench = ["serde", "datagen"]
 compiled_data = ["dep:icu_datetime_data", "icu_calendar/compiled_data", "icu_decimal/compiled_data", "icu_plurals/compiled_data", "icu_timezone/compiled_data"]
 
 [lib]


### PR DESCRIPTION
It wants the datagen `options` APIs for parsing the fixtures. I could remove them from the fixtures, but it seemed easier to just enable them in bench mode.