### PR TITLE
Bring time zone length behavior up to spec

### DIFF
--- a/components/datetime/src/neo_marker.rs
+++ b/components/datetime/src/neo_marker.rs
@@ -2327,6 +2327,19 @@ impl_day_marker!(
 );
 
 impl_day_marker!(
+    NeoMonthDayMarker,
+    NeoDayComponents::MonthDay,
+    description = "month and day",
+    sample_length = Medium,
+    sample = "May 17",
+    months = yes,
+    input_month = yes,
+    input_day_of_month = yes,
+    input_any_calendar_kind = yes,
+    option_alignment = yes,
+);
+
+impl_day_marker!(
     NeoAutoDateMarker,
     NeoDayComponents::Auto,
     description = "locale-dependent date fields",

--- a/components/datetime/src/neo_marker.rs
+++ b/components/datetime/src/neo_marker.rs
@@ -1782,8 +1782,8 @@ macro_rules! impl_date_marker {
             /// ```
             $type,
             sample_length: $sample_length,
-            $(alignment: $option_alignment_yes)?,
-            $(era_display: $year_yes)?,
+            $(alignment: $option_alignment_yes,)?
+            $(era_display: $year_yes,)?
         );
         impl private::Sealed for $type {}
         impl DateTimeNamesMarker for $type {
@@ -2472,7 +2472,43 @@ impl_zone_marker!(
 );
 
 impl_zone_marker!(
-    /// This marker only loads data for the short length; don't use with standalone long length:
+    /// This marker only loads data for the short length. Useful when combined with other fields:
+    ///
+    /// ```
+    /// use icu::calendar::{Date, Time};
+    /// use icu::timezone::{CustomTimeZone, CustomZonedDateTime};
+    /// use icu::calendar::Gregorian;
+    /// use icu::datetime::neo::NeoFormatter;
+    /// use icu::datetime::neo_marker::NeoMonthDayMarker;
+    /// use icu::datetime::neo_marker::NeoHourMinuteMarker;
+    /// use icu::datetime::neo_marker::NeoTimeZoneSpecificShortMarker;
+    /// use icu::datetime::neo_marker::DateTimeCombo;
+    /// use icu::datetime::neo_skeleton::NeoSkeletonLength;
+    /// use icu::locale::locale;
+    /// use tinystr::tinystr;
+    /// use writeable::assert_try_writeable_eq;
+    ///
+    /// type MyDateTimeZoneSet = DateTimeCombo<
+    ///     NeoMonthDayMarker,
+    ///     NeoHourMinuteMarker,
+    ///     NeoTimeZoneSpecificShortMarker,
+    /// >;
+    ///
+    /// let fmt = NeoFormatter::<MyDateTimeZoneSet>::try_new(
+    ///     &locale!("en-US").into(),
+    ///     NeoSkeletonLength::Long.into(),
+    /// )
+    /// .unwrap();
+    ///
+    /// let dtz = CustomZonedDateTime::try_from_str("2024-09-17T15:47:50-05:00[America/Chicago]").unwrap();
+    ///
+    /// assert_try_writeable_eq!(
+    ///     fmt.convert_and_format(&dtz),
+    ///     "September 17, 3:47 PM CDT"
+    /// );
+    /// ```
+    ///
+    /// Don't use long length if it is the only field:
     ///
     /// ```
     /// use icu::calendar::Gregorian;
@@ -2552,7 +2588,43 @@ impl_zone_marker!(
 );
 
 impl_zone_marker!(
-    /// This marker only loads data for the short length; don't use with standalone long length:
+    /// This marker only loads data for the short length. Useful when combined with other fields:
+    ///
+    /// ```
+    /// use icu::calendar::{Date, Time};
+    /// use icu::timezone::{CustomTimeZone, CustomZonedDateTime};
+    /// use icu::calendar::Gregorian;
+    /// use icu::datetime::neo::NeoFormatter;
+    /// use icu::datetime::neo_marker::NeoMonthDayMarker;
+    /// use icu::datetime::neo_marker::NeoHourMinuteMarker;
+    /// use icu::datetime::neo_marker::NeoTimeZoneGenericShortMarker;
+    /// use icu::datetime::neo_marker::DateTimeCombo;
+    /// use icu::datetime::neo_skeleton::NeoSkeletonLength;
+    /// use icu::locale::locale;
+    /// use tinystr::tinystr;
+    /// use writeable::assert_try_writeable_eq;
+    ///
+    /// type MyDateTimeZoneSet = DateTimeCombo<
+    ///     NeoMonthDayMarker,
+    ///     NeoHourMinuteMarker,
+    ///     NeoTimeZoneGenericShortMarker,
+    /// >;
+    ///
+    /// let fmt = NeoFormatter::<MyDateTimeZoneSet>::try_new(
+    ///     &locale!("en-US").into(),
+    ///     NeoSkeletonLength::Long.into(),
+    /// )
+    /// .unwrap();
+    ///
+    /// let dtz = CustomZonedDateTime::try_from_str("2024-09-17T15:47:50-05:00[America/Chicago]").unwrap();
+    ///
+    /// assert_try_writeable_eq!(
+    ///     fmt.convert_and_format(&dtz),
+    ///     "September 17, 3:47 PM CT"
+    /// );
+    /// ```
+    ///
+    /// Don't use long length if it is the only field:
     ///
     /// ```
     /// use icu::calendar::Gregorian;

--- a/components/datetime/src/neo_serde.rs
+++ b/components/datetime/src/neo_serde.rs
@@ -99,11 +99,7 @@ impl FieldSetField {
         WeekOfYear,
         WeekOfMonth,
         ZoneGeneric,
-        ZoneGenericShort,
-        ZoneGenericLong,
         ZoneSpecific,
-        ZoneSpecificShort,
-        ZoneSpecificLong,
         ZoneLocation,
         ZoneOffset,
     ];
@@ -174,11 +170,7 @@ impl FieldSetSerde {
 
     // Zone Components
     const ZONE_GENERIC: Self = Self::from_fields(&[ZoneGeneric]);
-    const ZONE_GENERIC_SHORT: Self = Self::from_fields(&[ZoneGenericShort]);
-    const ZONE_GENERIC_LONG: Self = Self::from_fields(&[ZoneGenericLong]);
     const ZONE_SPECIFIC: Self = Self::from_fields(&[ZoneSpecific]);
-    const ZONE_SPECIFIC_SHORT: Self = Self::from_fields(&[ZoneSpecificShort]);
-    const ZONE_SPECIFIC_LONG: Self = Self::from_fields(&[ZoneSpecificLong]);
     const ZONE_LOCATION: Self = Self::from_fields(&[ZoneLocation]);
     const ZONE_OFFSET: Self = Self::from_fields(&[ZoneOffset]);
 
@@ -357,35 +349,15 @@ impl From<NeoTimeZoneSkeleton> for FieldSetSerde {
     fn from(value: NeoTimeZoneSkeleton) -> Self {
         match value {
             NeoTimeZoneSkeleton {
-                length: None,
                 style: NeoTimeZoneStyle::Location,
             } => Self::ZONE_LOCATION,
             NeoTimeZoneSkeleton {
-                length: None,
                 style: NeoTimeZoneStyle::NonLocation,
             } => Self::ZONE_GENERIC,
             NeoTimeZoneSkeleton {
-                length: Some(NeoSkeletonLength::Short),
-                style: NeoTimeZoneStyle::NonLocation,
-            } => Self::ZONE_GENERIC_SHORT,
-            NeoTimeZoneSkeleton {
-                length: Some(NeoSkeletonLength::Long),
-                style: NeoTimeZoneStyle::NonLocation,
-            } => Self::ZONE_GENERIC_LONG,
-            NeoTimeZoneSkeleton {
-                length: None,
                 style: NeoTimeZoneStyle::SpecificNonLocation,
             } => Self::ZONE_SPECIFIC,
             NeoTimeZoneSkeleton {
-                length: Some(NeoSkeletonLength::Short),
-                style: NeoTimeZoneStyle::SpecificNonLocation,
-            } => Self::ZONE_SPECIFIC_SHORT,
-            NeoTimeZoneSkeleton {
-                length: Some(NeoSkeletonLength::Long),
-                style: NeoTimeZoneStyle::SpecificNonLocation,
-            } => Self::ZONE_SPECIFIC_LONG,
-            NeoTimeZoneSkeleton {
-                length: None,
                 style: NeoTimeZoneStyle::Offset,
             } => Self::ZONE_OFFSET,
             _ => todo!(),
@@ -398,35 +370,15 @@ impl TryFrom<FieldSetSerde> for NeoTimeZoneSkeleton {
     fn try_from(value: FieldSetSerde) -> Result<Self, Self::Error> {
         match value {
             FieldSetSerde::ZONE_LOCATION => Ok(Self {
-                length: None,
                 style: NeoTimeZoneStyle::Location,
             }),
             FieldSetSerde::ZONE_GENERIC => Ok(Self {
-                length: None,
-                style: NeoTimeZoneStyle::NonLocation,
-            }),
-            FieldSetSerde::ZONE_GENERIC_SHORT => Ok(Self {
-                length: Some(NeoSkeletonLength::Short),
-                style: NeoTimeZoneStyle::NonLocation,
-            }),
-            FieldSetSerde::ZONE_GENERIC_LONG => Ok(Self {
-                length: Some(NeoSkeletonLength::Long),
                 style: NeoTimeZoneStyle::NonLocation,
             }),
             FieldSetSerde::ZONE_SPECIFIC => Ok(Self {
-                length: None,
-                style: NeoTimeZoneStyle::SpecificNonLocation,
-            }),
-            FieldSetSerde::ZONE_SPECIFIC_SHORT => Ok(Self {
-                length: Some(NeoSkeletonLength::Short),
-                style: NeoTimeZoneStyle::SpecificNonLocation,
-            }),
-            FieldSetSerde::ZONE_SPECIFIC_LONG => Ok(Self {
-                length: Some(NeoSkeletonLength::Long),
                 style: NeoTimeZoneStyle::SpecificNonLocation,
             }),
             FieldSetSerde::ZONE_OFFSET => Ok(Self {
-                length: None,
                 style: NeoTimeZoneStyle::Offset,
             }),
             _ => Err(Error::InvalidFields),

--- a/components/datetime/src/neo_skeleton.rs
+++ b/components/datetime/src/neo_skeleton.rs
@@ -9,7 +9,6 @@ use crate::neo_serde::*;
 #[cfg(feature = "datagen")]
 use crate::options::{self, length};
 use crate::pattern::CoarseHourCycle;
-use crate::raw::neo::MaybeLength;
 use crate::time_zone::ResolvedNeoTimeZoneSkeleton;
 use icu_provider::DataMarkerAttributes;
 
@@ -978,12 +977,6 @@ pub enum NeoTimeZoneStyle {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
 #[non_exhaustive]
 pub struct NeoTimeZoneSkeleton {
-    /// The length of the time zone format, _i.e._, with
-    /// `style`=[`NeoTimeZoneStyle::NonLocation`], whether to format as “Pacific
-    /// Time” ([`NeoSkeletonLength::Long`]) or “PT” ([`NeoSkeletonLength::Short`]).
-    /// If this is [`None`], the length is deduced from the [`NeoSkeletonLength`] of the
-    /// enclosing [`NeoSkeleton`] when formatting.
-    pub length: Option<NeoSkeletonLength>,
     /// The style, _i.e._, with `length`=[`NeoSkeletonLength::Short`], whether to format as
     /// “GMT−8” ([`NeoTimeZoneStyle::Offset`]) or “PT”
     /// ([`NeoTimeZoneStyle::NonLocation`]).
@@ -991,11 +984,8 @@ pub struct NeoTimeZoneSkeleton {
 }
 
 impl NeoTimeZoneSkeleton {
-    pub(crate) fn resolve(self, length: MaybeLength) -> ResolvedNeoTimeZoneSkeleton {
-        crate::tz_registry::skeleton_to_resolved(
-            self.style,
-            self.length.unwrap_or_else(|| length.get::<Self>()),
-        )
+    pub(crate) fn resolve(self, length: NeoSkeletonLength) -> ResolvedNeoTimeZoneSkeleton {
+        crate::tz_registry::skeleton_to_resolved(self.style, length)
     }
 }
 

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -496,7 +496,16 @@ impl<'a> TimePatternDataBorrowed<'a> {
 }
 
 impl ZonePatternSelectionData {
-    pub(crate) fn new_with_skeleton(length: MaybeLength, components: NeoTimeZoneSkeleton) -> Self {
+    pub(crate) fn new_with_skeleton(
+        length: MaybeLength,
+        components: NeoTimeZoneSkeleton,
+        is_only_field: bool,
+    ) -> Self {
+        let length = if is_only_field {
+            length.get::<Self>()
+        } else {
+            NeoSkeletonLength::Short
+        };
         let time_zone = components.resolve(length);
         let pattern_item = PatternItem::Field(time_zone.to_field());
         Self::SinglePatternItem(time_zone, pattern_item.to_unaligned())
@@ -571,7 +580,8 @@ impl DateTimeZonePatternSelectionData {
                 Ok(Self::Time(selection))
             }
             NeoComponents::Zone(components) => {
-                let selection = ZonePatternSelectionData::new_with_skeleton(length, components);
+                let selection =
+                    ZonePatternSelectionData::new_with_skeleton(length, components, true);
                 Ok(Self::Zone(selection))
             }
             NeoComponents::DateTime(day_components, time_components) => {
@@ -639,7 +649,8 @@ impl DateTimeZonePatternSelectionData {
                     alignment,
                     era_display,
                 )?;
-                let zone = ZonePatternSelectionData::new_with_skeleton(length, zone_components);
+                let zone =
+                    ZonePatternSelectionData::new_with_skeleton(length, zone_components, false);
                 let glue = Self::load_glue(glue_provider, locale, length, GlueType::DateZone)?;
                 Ok(Self::DateZoneGlue { date, zone, glue })
             }
@@ -653,7 +664,8 @@ impl DateTimeZonePatternSelectionData {
                     fractional_second_digits,
                     hour_cycle,
                 )?;
-                let zone = ZonePatternSelectionData::new_with_skeleton(length, zone_components);
+                let zone =
+                    ZonePatternSelectionData::new_with_skeleton(length, zone_components, false);
                 let glue = Self::load_glue(glue_provider, locale, length, GlueType::TimeZone)?;
                 Ok(Self::TimeZoneGlue { time, zone, glue })
             }
@@ -675,7 +687,8 @@ impl DateTimeZonePatternSelectionData {
                     fractional_second_digits,
                     hour_cycle,
                 )?;
-                let zone = ZonePatternSelectionData::new_with_skeleton(length, zone_components);
+                let zone =
+                    ZonePatternSelectionData::new_with_skeleton(length, zone_components, false);
                 let glue = Self::load_glue(glue_provider, locale, length, GlueType::DateTimeZone)?;
                 Ok(Self::DateTimeZoneGlue {
                     date,

--- a/components/datetime/src/tz_registry.rs
+++ b/components/datetime/src/tz_registry.rs
@@ -85,7 +85,6 @@ macro_rules! make_constructors {
             impl NeoTimeZoneSkeleton {
                 pub(crate) const fn $fn1() -> Self {
                     Self {
-                        length: None,
                         style: NeoTimeZoneStyle::$style1,
                     }
                 }

--- a/components/datetime/src/tz_registry.rs
+++ b/components/datetime/src/tz_registry.rs
@@ -10,29 +10,27 @@ use crate::time_zone::ResolvedNeoTimeZoneSkeleton;
 macro_rules! time_zone_style_registry {
     ($cb:ident) => {
         $cb! {
-            // Styles with Some-length, functions, and matchers
-            [
-                (specific_short, SpecificNonLocation, Short, SpecificShort, LowerZ, One), // 'z'
-                (specific_long, SpecificNonLocation, Long, SpecificLong, LowerZ, Wide), // 'zzzz'
-                (offset_short, Offset, Short, OffsetShort, UpperO, One), // 'O'
-                (offset_long, Offset, Long, OffsetLong, UpperO, Wide), // 'OOOO'
-                (generic_short, NonLocation, Short, GenericShort, LowerV, One), // 'v'
-                (generic_long, NonLocation, Long, GenericLong, LowerV, Wide), // 'vvvv'
-                (location, Location, Long, Location, UpperV, Wide), // 'VVVV'
-            ],
             // Styles with function only for None-length
             [
                 (specific, SpecificNonLocation),
                 (offset, Offset),
                 (generic, NonLocation),
+                (location, Location),
             ],
             // Skeleton to resolved (for exhaustive match)
             [
+                (SpecificNonLocation, Short, SpecificShort),
                 (SpecificNonLocation, Medium, SpecificShort),
+                (SpecificNonLocation, Long, SpecificLong),
+                (Offset, Short, OffsetShort),
                 (Offset, Medium, OffsetShort),
+                (Offset, Long, OffsetLong),
+                (NonLocation, Short, GenericShort),
                 (NonLocation, Medium, GenericShort),
+                (NonLocation, Long, GenericLong),
                 (Location, Short, Location),
                 (Location, Medium, Location),
+                (Location, Long, Location),
                 // See comments above about Default behavior
                 (Default, Short, SpecificShort),
                 (Default, Medium, SpecificShort),
@@ -52,8 +50,15 @@ macro_rules! time_zone_style_registry {
             ],
             // Resolved to field (not already covered)
             [
+                (SpecificShort, LowerZ, One), // 'z'
+                (SpecificLong, LowerZ, Wide), // 'zzzz'
+                (OffsetShort, UpperO, One), // 'O'
+                (OffsetLong, UpperO, Wide), // 'OOOO'
+                (GenericShort, LowerV, One), // 'v'
+                (GenericLong, LowerV, Wide), // 'vvvv'
                 (Bcp47Id, UpperV, One), // 'V'
                 (City, UpperV, Abbreviated), // 'VVV'
+                (Location, UpperV, Wide), // 'VVVV'
                 (Isoxxxx, UpperZ, One), // 'Z'
                 (IsoXXXXX, UpperZ, Narrow), // 'ZZZZZ'
                 (IsoX, UpperX, One), // 'X'
@@ -71,22 +76,11 @@ macro_rules! time_zone_style_registry {
 
 macro_rules! make_constructors {
     (
-        [$(($fn:ident, $style:ident, $length:ident, $resolved:ident, $field_symbol:ident, $field_length:ident)),+,],
         [$(($fn1:ident, $style1:ident)),+,],
         [$(($style2:ident, $length2:ident, $resolved2:ident)),+,],
         [$(($resolved3:ident, $field_symbol3:ident, $field_length3:ident)),+,],
         [$(($resolved4:ident, $field_symbol4:ident, $field_length4:ident)),+,],
     ) => {
-        $(
-            impl NeoTimeZoneSkeleton {
-                pub(crate) const fn $fn() -> Self {
-                    Self {
-                        length: Some(NeoSkeletonLength::$length),
-                        style: NeoTimeZoneStyle::$style,
-                    }
-                }
-            }
-        )+
         $(
             impl NeoTimeZoneSkeleton {
                 pub(crate) const fn $fn1() -> Self {
@@ -104,7 +98,6 @@ time_zone_style_registry!(make_constructors);
 
 macro_rules! make_resolved_to_field_match {
     (
-        [$(($fn:ident, $style:ident, $length:ident, $resolved:ident, $field_symbol:ident, $field_length:ident)),+,],
         [$(($fn1:ident, $style1:ident)),+,],
         [$(($style2:ident, $length2:ident, $resolved2:ident)),+,],
         [$(($resolved3:ident, $field_symbol3:ident, $field_length3:ident)),+,],
@@ -112,12 +105,6 @@ macro_rules! make_resolved_to_field_match {
     ) => {
         pub(crate) fn resolved_to_field(resolved: ResolvedNeoTimeZoneSkeleton) -> Field {
             match resolved {
-                $(
-                    ResolvedNeoTimeZoneSkeleton::$resolved => Field {
-                        symbol: FieldSymbol::TimeZone(fields::TimeZone::$field_symbol),
-                        length: FieldLength::$field_length,
-                    },
-                )+
                 $(
                     ResolvedNeoTimeZoneSkeleton::$resolved4 => Field {
                         symbol: FieldSymbol::TimeZone(fields::TimeZone::$field_symbol4),
@@ -133,7 +120,6 @@ time_zone_style_registry!(make_resolved_to_field_match);
 
 macro_rules! make_skeleton_to_resolved_match {
     (
-        [$(($fn:ident, $style:ident, $length:ident, $resolved:ident, $field_symbol:ident, $field_length:ident)),+,],
         [$(($fn1:ident, $style1:ident)),+,],
         [$(($style2:ident, $length2:ident, $resolved2:ident)),+,],
         [$(($resolved3:ident, $field_symbol3:ident, $field_length3:ident)),+,],
@@ -141,9 +127,6 @@ macro_rules! make_skeleton_to_resolved_match {
     ) => {
         pub(crate) fn skeleton_to_resolved(style: NeoTimeZoneStyle, length: NeoSkeletonLength) -> ResolvedNeoTimeZoneSkeleton {
             match (style, length) {
-                $(
-                    (NeoTimeZoneStyle::$style, NeoSkeletonLength::$length) => ResolvedNeoTimeZoneSkeleton::$resolved,
-                )+
                 $(
                     (NeoTimeZoneStyle::$style2, NeoSkeletonLength::$length2) => ResolvedNeoTimeZoneSkeleton::$resolved2,
                 )+
@@ -156,7 +139,6 @@ time_zone_style_registry!(make_skeleton_to_resolved_match);
 
 macro_rules! make_field_to_skeleton_match {
     (
-        [$(($fn:ident, $style:ident, $length:ident, $resolved:ident, $field_symbol:ident, $field_length:ident)),+,],
         [$(($fn1:ident, $style1:ident)),+,],
         [$(($style2:ident, $length2:ident, $resolved2:ident)),+,],
         [$(($resolved3:ident, $field_symbol3:ident, $field_length3:ident)),+,],
@@ -164,9 +146,6 @@ macro_rules! make_field_to_skeleton_match {
     ) => {
         pub(crate) fn field_to_resolved(field_symbol: fields::TimeZone, field_length: fields::FieldLength) -> Option<ResolvedNeoTimeZoneSkeleton> {
             match (field_symbol, field_length) {
-                $(
-                    (fields::TimeZone::$field_symbol, FieldLength::$field_length) => Some(ResolvedNeoTimeZoneSkeleton::$resolved),
-                )+
                 $(
                     (fields::TimeZone::$field_symbol3, FieldLength::$field_length3) => Some(ResolvedNeoTimeZoneSkeleton::$resolved3),
                 )+

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -494,13 +494,14 @@ fn test_time_zone_format_configs() {
 #[test]
 fn test_time_zone_format_offset_not_set_debug_assert_panic() {
     use icu_datetime::{
-        neo_marker::NeoTimeZoneOffsetShortMarker, DateTimeWriteError, NeverCalendar,
+        neo_marker::NeoTimeZoneOffsetMarker, neo_skeleton::NeoSkeletonLength, DateTimeWriteError,
+        NeverCalendar,
     };
 
     let time_zone = CustomTimeZone::try_from_str("America/Los_Angeles").unwrap();
-    let tzf = TypedNeoFormatter::<NeverCalendar, NeoTimeZoneOffsetShortMarker>::try_new(
+    let tzf = TypedNeoFormatter::<NeverCalendar, NeoTimeZoneOffsetMarker>::try_new(
         &locale!("en").into(),
-        Default::default(),
+        NeoSkeletonLength::Medium.into(),
     )
     .unwrap();
     assert_try_writeable_eq!(

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -28,7 +28,7 @@ use icu_datetime::CldrCalendar;
 use icu_datetime::{
     neo::{NeoFormatter, NeoOptions, TypedNeoFormatter},
     neo_pattern::DateTimePattern,
-    neo_skeleton::{NeoDateTimeComponents, NeoSkeleton, NeoSkeletonLength, NeoTimeZoneSkeleton},
+    neo_skeleton::{NeoDateTimeComponents, NeoSkeleton, NeoTimeZoneSkeleton},
     options::preferences::{self, HourCycle},
     TypedDateTimeNames,
 };
@@ -462,12 +462,12 @@ fn test_time_zone_format_configs() {
                     // TODO: ISO-8601 not yet supported via Semantic Skeleton
                     continue;
                 }
-                let skeleton = config_input.to_semantic_skeleton();
+                let (skeleton, length) = config_input.to_semantic_skeleton();
                 for (&fallback_format, expect) in fallback_formats.iter().zip(expected.iter()) {
                     let tzf = TypedNeoFormatter::<Gregorian, _>::try_new_with_components(
                         &data_locale,
                         skeleton,
-                        NeoSkeletonLength::Long.into(),
+                        length.into(),
                     )
                     .unwrap();
                     assert_try_writeable_eq!(

--- a/components/datetime/tests/fixtures/tests/components_with_zones.json
+++ b/components/datetime/tests/fixtures/tests/components_with_zones.json
@@ -15,7 +15,7 @@
                     "time_zone_name": "long-generic"
                 },
                 "semantic": {
-                    "fieldSet": ["year", "month", "day", "weekday", "hour", "minute", "second", "zoneGenericLong"],
+                    "fieldSet": ["year", "month", "day", "weekday", "hour", "minute", "second", "zoneGeneric"],
                     "length": "long"
                 },
                 "preferences": { "hourCycle": "h23" }
@@ -43,7 +43,7 @@
                     "time_zone_name": "short-generic"
                 },
                 "semantic": {
-                    "fieldSet": ["year", "month", "day", "weekday", "hour", "minute", "second", "zoneGenericShort"],
+                    "fieldSet": ["year", "month", "day", "weekday", "hour", "minute", "second", "zoneGeneric"],
                     "length": "long"
                 },
                 "preferences": { "hourCycle": "h23" }
@@ -71,7 +71,7 @@
                     "time_zone_name": "short-specific"
                 },
                 "semantic": {
-                    "fieldSet": ["year", "month", "day", "weekday", "hour", "minute", "second", "zoneSpecificShort"],
+                    "fieldSet": ["year", "month", "day", "weekday", "hour", "minute", "second", "zoneSpecific"],
                     "length": "long"
                 },
                 "preferences": { "hourCycle": "h23" }
@@ -99,7 +99,7 @@
                     "time_zone_name": "long-specific"
                 },
                 "semantic": {
-                    "fieldSet": ["year", "month", "day", "weekday", "hour", "minute", "second", "zoneSpecificLong"],
+                    "fieldSet": ["year", "month", "day", "weekday", "hour", "minute", "second", "zoneSpecific"],
                     "length": "long"
                 },
                 "preferences": { "hourCycle": "h23" }

--- a/components/datetime/tests/patterns/time_zones.rs
+++ b/components/datetime/tests/patterns/time_zones.rs
@@ -67,32 +67,32 @@ pub enum TimeZoneFormatterConfig {
 }
 
 impl TimeZoneFormatterConfig {
-    pub fn to_semantic_skeleton(self) -> NeoTimeZoneSkeleton {
+    pub fn to_semantic_skeleton(self) -> (NeoTimeZoneSkeleton, NeoSkeletonLength) {
         let mut skeleton = NeoTimeZoneSkeleton::default();
-        match self {
+        let length = match self {
             TimeZoneFormatterConfig::GenericNonLocationLong => {
-                skeleton.length = Some(NeoSkeletonLength::Long);
                 skeleton.style = NeoTimeZoneStyle::NonLocation;
+                NeoSkeletonLength::Long
             }
             TimeZoneFormatterConfig::GenericNonLocationShort => {
-                skeleton.length = Some(NeoSkeletonLength::Short);
                 skeleton.style = NeoTimeZoneStyle::NonLocation;
+                NeoSkeletonLength::Short
             }
             TimeZoneFormatterConfig::GenericLocation => {
-                skeleton.length = Some(NeoSkeletonLength::Long);
                 skeleton.style = NeoTimeZoneStyle::Location;
+                NeoSkeletonLength::Long
             }
             TimeZoneFormatterConfig::SpecificNonLocationLong => {
-                skeleton.length = Some(NeoSkeletonLength::Long);
                 skeleton.style = NeoTimeZoneStyle::SpecificNonLocation;
+                NeoSkeletonLength::Long
             }
             TimeZoneFormatterConfig::SpecificNonLocationShort => {
-                skeleton.length = Some(NeoSkeletonLength::Short);
                 skeleton.style = NeoTimeZoneStyle::SpecificNonLocation;
+                NeoSkeletonLength::Short
             }
             TimeZoneFormatterConfig::LocalizedOffset => {
-                skeleton.length = Some(NeoSkeletonLength::Long);
                 skeleton.style = NeoTimeZoneStyle::Offset;
+                NeoSkeletonLength::Long
             }
             TimeZoneFormatterConfig::Iso8601(
                 IsoFormat::UtcBasic,
@@ -177,7 +177,7 @@ impl TimeZoneFormatterConfig {
             TimeZoneFormatterConfig::Iso8601(_, _, _) => {
                 todo!()
             }
-        }
-        skeleton
+        };
+        (skeleton, length)
     }
 }


### PR DESCRIPTION
Time zone length works like all other fields, except that it always prefers short when used in a pattern with other fields.

It does create an edge case where the constructor can return `TypeTooNarrow`, which is shown via a docs test.