### PR TITLE
Change content_locale to be &LanguageIdentifier

### DIFF
--- a/components/segmenter/src/sentence.rs
+++ b/components/segmenter/src/sentence.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use alloc::vec::Vec;
+use icu_locale_core::LanguageIdentifier;
 use icu_provider::prelude::*;
 
 use crate::indices::{Latin1Indices, Utf16Indices};
@@ -13,10 +14,10 @@ use utf8_iter::Utf8CharIndices;
 
 /// Options to tailor sentence breaking behavior.
 #[non_exhaustive]
-#[derive(Clone, PartialEq, Eq, Debug, Default)]
-pub struct SentenceBreakOptions {
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+pub struct SentenceBreakOptions<'a> {
     /// Content locale for sentence segmenter.
-    pub content_locale: Option<DataLocale>,
+    pub content_locale: Option<&'a LanguageIdentifier>,
 }
 
 /// Implements the [`Iterator`] trait over the sentence boundaries of the given string.
@@ -184,6 +185,7 @@ impl SentenceSegmenter {
     {
         let payload = provider.load(Default::default())?.payload;
         let payload_locale_override = if let Some(locale) = options.content_locale {
+            let locale = DataLocale::from(locale);
             let req = DataRequest {
                 id: DataIdentifierBorrowed::for_locale(&locale),
                 metadata: {

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -11,15 +11,16 @@ use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::str::CharIndices;
+use icu_locale_core::LanguageIdentifier;
 use icu_provider::prelude::*;
 use utf8_iter::Utf8CharIndices;
 
 /// Options to tailor word breaking behavior.
 #[non_exhaustive]
-#[derive(Clone, PartialEq, Eq, Debug, Default)]
-pub struct WordBreakOptions {
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+pub struct WordBreakOptions<'a> {
     /// Content locale for word segmenter
-    pub content_locale: Option<DataLocale>,
+    pub content_locale: Option<&'a LanguageIdentifier>,
 }
 
 /// Implements the [`Iterator`] trait over the word boundaries of the given string.
@@ -280,6 +281,7 @@ impl WordSegmenter {
             payload: provider.load(Default::default())?.payload,
             complex: ComplexPayloads::try_new_auto(provider)?,
             payload_locale_override: if let Some(locale) = options.content_locale {
+                let locale = DataLocale::from(locale);
                 let req = DataRequest {
                     id: DataIdentifierBorrowed::for_locale(&locale),
                     metadata: {
@@ -405,6 +407,7 @@ impl WordSegmenter {
             payload: provider.load(Default::default())?.payload,
             complex: ComplexPayloads::try_new_lstm(provider)?,
             payload_locale_override: if let Some(locale) = options.content_locale {
+                let locale = DataLocale::from(locale);
                 let req = DataRequest {
                     id: DataIdentifierBorrowed::for_locale(&locale),
                     metadata: {
@@ -522,6 +525,7 @@ impl WordSegmenter {
             payload: provider.load(Default::default())?.payload,
             complex: ComplexPayloads::try_new_dict(provider)?,
             payload_locale_override: if let Some(locale) = options.content_locale {
+                let locale = DataLocale::from(locale);
                 let req = DataRequest {
                     id: DataIdentifierBorrowed::for_locale(&locale),
                     metadata: {

--- a/components/segmenter/tests/css_line_break.rs
+++ b/components/segmenter/tests/css_line_break.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu::locale::locale;
+use icu_locale_core::{langid, LanguageIdentifier};
 use icu_segmenter::LineBreakOptions;
 use icu_segmenter::LineBreakStrictness;
 use icu_segmenter::LineBreakWordOption;
@@ -28,15 +28,13 @@ fn check_with_options(
     assert_eq!(expect_utf16, result, "{s}");
 }
 
+static JA: LanguageIdentifier = langid!("ja");
+
 fn strict(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
     let mut options = LineBreakOptions::default();
     options.strictness = LineBreakStrictness::Strict;
     options.word_option = LineBreakWordOption::Normal;
-    options.content_locale = if ja_zh {
-        Some(locale!("ja").into())
-    } else {
-        None
-    };
+    options.content_locale = ja_zh.then_some(&JA);
     check_with_options(s, expect_utf8, expect_utf16, options);
 }
 
@@ -44,11 +42,7 @@ fn normal(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize
     let mut options = LineBreakOptions::default();
     options.strictness = LineBreakStrictness::Normal;
     options.word_option = LineBreakWordOption::Normal;
-    options.content_locale = if ja_zh {
-        Some(locale!("ja").into())
-    } else {
-        None
-    };
+    options.content_locale = ja_zh.then_some(&JA);
     check_with_options(s, expect_utf8, expect_utf16, options);
 }
 
@@ -56,11 +50,7 @@ fn loose(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>
     let mut options = LineBreakOptions::default();
     options.strictness = LineBreakStrictness::Loose;
     options.word_option = LineBreakWordOption::Normal;
-    options.content_locale = if ja_zh {
-        Some(locale!("ja").into())
-    } else {
-        None
-    };
+    options.content_locale = ja_zh.then_some(&JA);
     check_with_options(s, expect_utf8, expect_utf16, options);
 }
 
@@ -68,11 +58,7 @@ fn anywhere(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usi
     let mut options = LineBreakOptions::default();
     options.strictness = LineBreakStrictness::Anywhere;
     options.word_option = LineBreakWordOption::Normal;
-    options.content_locale = if ja_zh {
-        Some(locale!("ja").into())
-    } else {
-        None
-    };
+    options.content_locale = ja_zh.then_some(&JA);
     check_with_options(s, expect_utf8, expect_utf16, options);
 }
 

--- a/components/segmenter/tests/locale.rs
+++ b/components/segmenter/tests/locale.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_locale_core::locale;
+use icu_locale_core::langid;
 use icu_segmenter::{SentenceBreakOptions, SentenceSegmenter, WordBreakOptions, WordSegmenter};
 
 // Additional segmenter tests with locale.
@@ -12,7 +12,8 @@ fn word_break_with_locale() {
     // MidLetter is different because U+0x3A isn't MidLetter on Swedish.
     let s = "hello:world";
     let mut options_sv = WordBreakOptions::default();
-    options_sv.content_locale = Some(locale!("sv").into());
+    let langid = langid!("sv");
+    options_sv.content_locale = Some(&langid);
     let segmenter =
         WordSegmenter::try_new_auto_with_options(options_sv).expect("Loading should succeed!");
     let iter = segmenter.segment_str(s);
@@ -23,7 +24,8 @@ fn word_break_with_locale() {
     );
 
     let mut options_en = WordBreakOptions::default();
-    options_en.content_locale = Some(locale!("en").into());
+    let langid = langid!("en");
+    options_en.content_locale = Some(&langid);
     let segmenter =
         WordSegmenter::try_new_auto_with_options(options_en).expect("Loading should succeed!");
     let iter = segmenter.segment_str(s);
@@ -39,7 +41,8 @@ fn sentence_break_with_locale() {
     // SB11 is different because U+0x3B is STerm on Greek.
     let s = "hello; world";
     let mut options_el = SentenceBreakOptions::default();
-    options_el.content_locale = Some(locale!("el").into());
+    let langid = langid!("el");
+    options_el.content_locale = Some(&langid);
     let segmenter =
         SentenceSegmenter::try_new_with_options(options_el).expect("Loading should succeed!");
     let iter = segmenter.segment_str(s);
@@ -50,7 +53,8 @@ fn sentence_break_with_locale() {
     );
 
     let mut options_en = SentenceBreakOptions::default();
-    options_en.content_locale = Some(locale!("en").into());
+    let langid = langid!("en");
+    options_en.content_locale = Some(&langid);
     let segmenter =
         SentenceSegmenter::try_new_with_options(options_en).expect("Loading should succeed!");
     let iter = segmenter.segment_str(s);

--- a/components/segmenter/tests/spec_test.rs
+++ b/components/segmenter/tests/spec_test.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_locale_core::locale;
+use icu_locale_core::langid;
 use icu_properties::PropertyNames;
 use icu_segmenter::GraphemeClusterSegmenter;
 use icu_segmenter::LineSegmenter;
@@ -204,7 +204,8 @@ fn word_break_test(file: &'static str) {
     let test_iter = TestContentIterator::new(file);
     // Default word segmenter isn't UAX29 rule. Swedish is UAX29 rule.
     let mut options = WordBreakOptions::default();
-    options.content_locale = Some(locale!("sv").into());
+    let langid = langid!("sv");
+    options.content_locale = Some(&langid);
     let segmenter =
         WordSegmenter::try_new_dictionary_with_options(options).expect("Loading should succeed!");
     for (i, test) in test_iter.enumerate() {


### PR DESCRIPTION
This keeps the options bags `Copy`.

I also switched to `LanguageIdentifier` which is a more public-facing, stable type. We're trying to phase out `DataLocale` in public-facing APIs (#419).