### PR TITLE
impl Hash for ZeroVec/ZeroSlice

### DIFF
--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -239,6 +239,19 @@ where
     }
 }
 
+impl<T> core::hash::Hash for ZeroVec<'_, T>
+where
+    T: AsULE,
+{
+    /// Hashes a ZeroVec as if hashing the underlying bytes.
+    ///
+    /// This is acceptable according to the ULE byte equality invariant.
+    #[inline]
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.as_bytes().hash(state);
+    }
+}
+
 impl<'a, T: AsULE> Default for ZeroVec<'a, T> {
     #[inline]
     fn default() -> Self {

--- a/utils/zerovec/src/zerovec/slice.rs
+++ b/utils/zerovec/src/zerovec/slice.rs
@@ -522,6 +522,19 @@ where
     }
 }
 
+impl<T> core::hash::Hash for ZeroSlice<T>
+where
+    T: AsULE,
+{
+    /// Hashes a ZeroVec as if hashing the underlying bytes.
+    ///
+    /// This is acceptable according to the ULE byte equality invariant.
+    #[inline]
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.as_bytes().hash(state);
+    }
+}
+
 impl<T> fmt::Debug for ZeroSlice<T>
 where
     T: AsULE + fmt::Debug,


### PR DESCRIPTION
Good or no good?

Should all of the impls be using bytes?