### PR TITLE
Add `icu_provider::marker::ErasedMarker`

### DIFF
--- a/components/datetime/src/format/neo.rs
+++ b/components/datetime/src/format/neo.rs
@@ -158,7 +158,7 @@ where
         match provider.load_bound(req) {
             Ok(response) => {
                 self.inner = OptionalNames::SingleLength {
-                    payload: response.payload.cast(),
+                    payload: response.payload,
                     variables: arg_variables,
                 };
                 Ok(Ok(()))

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -202,8 +202,7 @@ impl DatePatternSelectionData {
                 ),
                 ..Default::default()
             })?
-            .payload
-            .cast();
+            .payload;
         Ok(Self::SkeletonDate {
             skeleton: NeoDateSkeleton {
                 length: length.get::<Self>(),
@@ -324,8 +323,7 @@ impl OverlapPatternSelectionData {
                 id: DataIdentifierBorrowed::for_marker_attributes_and_locale(marker_attrs, locale),
                 ..Default::default()
             })?
-            .payload
-            .cast();
+            .payload;
         Ok(Self::SkeletonDateTime {
             date_skeleton,
             time_skeleton,
@@ -407,7 +405,7 @@ impl TimePatternSelectionData {
                 ),
                 ..Default::default()
             }) {
-                Ok(response) => Some(response.payload.cast()),
+                Ok(response) => Some(response.payload),
                 Err(DataError {
                     kind: DataErrorKind::IdentifierNotFound,
                     ..
@@ -417,16 +415,17 @@ impl TimePatternSelectionData {
         }
         let payload = match maybe_payload {
             Some(payload) => payload,
-            None => provider
-                .load_bound(DataRequest {
-                    id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
-                        components.id_str(),
-                        locale,
-                    ),
-                    ..Default::default()
-                })?
-                .payload
-                .cast(),
+            None => {
+                provider
+                    .load_bound(DataRequest {
+                        id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                            components.id_str(),
+                            locale,
+                        ),
+                        ..Default::default()
+                    })?
+                    .payload
+            }
         };
         Ok(Self::SkeletonTime {
             skeleton: NeoTimeSkeleton {

--- a/components/experimental/src/compactdecimal/formatter.rs
+++ b/components/experimental/src/compactdecimal/formatter.rs
@@ -2,12 +2,12 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use super::options::CompactDecimalFormatterOptions;
+use super::{options::CompactDecimalFormatterOptions, provider::CompactDecimalPatternDataV1};
 use crate::compactdecimal::{
     format::FormattedCompactDecimal,
     provider::{
-        Count, ErasedCompactDecimalFormatDataV1Marker, LongCompactDecimalFormatDataV1Marker,
-        PatternULE, ShortCompactDecimalFormatDataV1Marker,
+        Count, LongCompactDecimalFormatDataV1Marker, PatternULE,
+        ShortCompactDecimalFormatDataV1Marker,
     },
     ExponentError,
 };
@@ -16,8 +16,8 @@ use core::convert::TryFrom;
 use fixed_decimal::{CompactDecimal, FixedDecimal};
 use icu_decimal::FixedDecimalFormatter;
 use icu_plurals::PluralRules;
-use icu_provider::prelude::*;
 use icu_provider::DataError;
+use icu_provider::{marker::ErasedMarker, prelude::*};
 use zerovec::maps::ZeroMap2dCursor;
 
 /// A formatter that renders locale-sensitive compact numbers.
@@ -59,7 +59,7 @@ use zerovec::maps::ZeroMap2dCursor;
 pub struct CompactDecimalFormatter {
     pub(crate) plural_rules: PluralRules,
     pub(crate) fixed_decimal_formatter: FixedDecimalFormatter,
-    pub(crate) compact_data: DataPayload<ErasedCompactDecimalFormatDataV1Marker>,
+    pub(crate) compact_data: DataPayload<ErasedMarker<CompactDecimalPatternDataV1<'static>>>,
 }
 
 impl CompactDecimalFormatter {

--- a/components/experimental/src/compactdecimal/formatter.rs
+++ b/components/experimental/src/compactdecimal/formatter.rs
@@ -2,11 +2,11 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use super::{options::CompactDecimalFormatterOptions, provider::CompactDecimalPatternDataV1};
 use crate::compactdecimal::{
     format::FormattedCompactDecimal,
+    options::CompactDecimalFormatterOptions,
     provider::{
-        Count, LongCompactDecimalFormatDataV1Marker, PatternULE,
+        CompactDecimalPatternDataV1, Count, LongCompactDecimalFormatDataV1Marker, PatternULE,
         ShortCompactDecimalFormatDataV1Marker,
     },
     ExponentError,

--- a/components/experimental/src/compactdecimal/provider.rs
+++ b/components/experimental/src/compactdecimal/provider.rs
@@ -141,8 +141,3 @@ pub struct Pattern<'data> {
     /// " M" for the pattern "000 M"
     pub literal_text: Cow<'data, str>,
 }
-pub(crate) struct ErasedCompactDecimalFormatDataV1Marker;
-
-impl DynamicDataMarker for ErasedCompactDecimalFormatDataV1Marker {
-    type DataStruct = CompactDecimalPatternDataV1<'static>;
-}

--- a/components/experimental/src/relativetime/provider.rs
+++ b/components/experimental/src/relativetime/provider.rs
@@ -72,9 +72,3 @@ pub struct RelativeTimePatternDataV1<'data> {
     #[cfg_attr(feature = "serde", serde(borrow))]
     pub future: PluralElementsPackedCow<'data, SinglePlaceholderPattern>,
 }
-
-pub(crate) struct ErasedRelativeTimeFormatV1Marker;
-
-impl DynamicDataMarker for ErasedRelativeTimeFormatV1Marker {
-    type DataStruct = RelativeTimePatternDataV1<'static>;
-}

--- a/components/experimental/src/relativetime/relativetime.rs
+++ b/components/experimental/src/relativetime/relativetime.rs
@@ -7,6 +7,7 @@ use icu_decimal::{
     options::FixedDecimalFormatterOptions, provider::DecimalSymbolsV1Marker, FixedDecimalFormatter,
 };
 use icu_plurals::{provider::CardinalV1Marker, PluralRules};
+use icu_provider::marker::ErasedMarker;
 use icu_provider::prelude::*;
 
 use crate::relativetime::format::FormattedRelativeTime;
@@ -104,7 +105,7 @@ use crate::relativetime::provider::*;
 /// ```
 pub struct RelativeTimeFormatter {
     pub(crate) plural_rules: PluralRules,
-    pub(crate) rt: DataPayload<ErasedRelativeTimeFormatV1Marker>,
+    pub(crate) rt: DataPayload<ErasedMarker<RelativeTimePatternDataV1<'static>>>,
     pub(crate) options: RelativeTimeFormatterOptions,
     pub(crate) fixed_decimal_format: FixedDecimalFormatter,
 }

--- a/components/list/src/list_formatter.rs
+++ b/components/list/src/list_formatter.rs
@@ -5,6 +5,7 @@
 use crate::provider::*;
 use crate::ListLength;
 use core::fmt::{self, Write};
+use icu_provider::marker::ErasedMarker;
 use icu_provider::prelude::*;
 use writeable::*;
 
@@ -15,7 +16,7 @@ extern crate writeable;
 /// [crate-level documentation](crate) for more details.
 #[derive(Debug)]
 pub struct ListFormatter {
-    data: DataPayload<ErasedListV2Marker>,
+    data: DataPayload<ErasedMarker<ListFormatterPatternsV2<'static>>>,
 }
 
 macro_rules! constructor {

--- a/components/list/src/provider/mod.rs
+++ b/components/list/src/provider/mod.rs
@@ -17,7 +17,6 @@
 
 use alloc::borrow::Cow;
 use icu_provider::prelude::*;
-use icu_provider::DynamicDataMarker;
 
 mod serde_dfa;
 pub use serde_dfa::SerdeDFA;
@@ -100,12 +99,6 @@ impl ListFormatterPatternsV2<'_> {
     pub const WIDE: &'static DataMarkerAttributes = DataMarkerAttributes::from_str_or_panic("W");
     #[doc(hidden)]
     pub const WIDE_STR: &'static str = Self::WIDE.as_str();
-}
-
-pub(crate) struct ErasedListV2Marker;
-
-impl DynamicDataMarker for ErasedListV2Marker {
-    type DataStruct = ListFormatterPatternsV2<'static>;
 }
 
 /// A pattern that can behave conditionally on the next element.

--- a/components/locale/src/exemplar_chars.rs
+++ b/components/locale/src/exemplar_chars.rs
@@ -33,18 +33,12 @@
 use crate::provider::*;
 use core::ops::Deref;
 use icu_collections::codepointinvliststringlist::CodePointInversionListAndStringList;
-use icu_provider::prelude::*;
+use icu_provider::{marker::ErasedMarker, prelude::*};
 
 /// A wrapper around `UnicodeSet` data (characters and strings)
 #[derive(Debug)]
 pub struct ExemplarCharacters {
-    data: DataPayload<ErasedUnicodeSetMarker>,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub(crate) struct ErasedUnicodeSetMarker;
-impl DynamicDataMarker for ErasedUnicodeSetMarker {
-    type DataStruct = ExemplarCharactersV1<'static>;
+    data: DataPayload<ErasedMarker<ExemplarCharactersV1<'static>>>,
 }
 
 impl ExemplarCharacters {

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -81,11 +81,12 @@ pub mod provider;
 pub mod rules;
 
 use core::cmp::{Ord, PartialOrd};
+use icu_provider::marker::ErasedMarker;
 use icu_provider::prelude::*;
 pub use operands::PluralOperands;
 use provider::CardinalV1Marker;
-use provider::ErasedPluralRulesV1Marker;
 use provider::OrdinalV1Marker;
+use provider::PluralRulesV1;
 use rules::runtime::test_rule;
 
 #[cfg(feature = "experimental")]
@@ -280,7 +281,7 @@ impl PluralCategory {
 /// [`Plural Type`]: PluralRuleType
 /// [`Plural Category`]: PluralCategory
 #[derive(Debug)]
-pub struct PluralRules(DataPayload<ErasedPluralRulesV1Marker>);
+pub struct PluralRules(DataPayload<ErasedMarker<PluralRulesV1<'static>>>);
 
 impl AsRef<PluralRules> for PluralRules {
     fn as_ref(&self) -> &PluralRules {

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -23,7 +23,6 @@ use alloc::vec::Vec;
 use core::fmt;
 use core::marker::PhantomData;
 use icu_provider::prelude::*;
-use icu_provider::DynamicDataMarker;
 use yoke::Yokeable;
 use zerofrom::ZeroFrom;
 use zerovec::ule::vartuple::VarTuple;
@@ -105,12 +104,6 @@ pub struct PluralRulesV1<'data> {
     /// Rule that matches [`PluralCategory::Many`](super::PluralCategory::Many), or `None` if not present.
     #[cfg_attr(feature = "serde", serde(borrow))]
     pub many: Option<Rule<'data>>,
-}
-
-pub(crate) struct ErasedPluralRulesV1Marker;
-
-impl DynamicDataMarker for ErasedPluralRulesV1Marker {
-    type DataStruct = PluralRulesV1<'static>;
 }
 
 #[cfg(any(feature = "datagen", feature = "experimental"))]

--- a/components/properties/src/code_point_set.rs
+++ b/components/properties/src/code_point_set.rs
@@ -18,6 +18,7 @@ use crate::provider::*;
 use crate::runtime::UnicodeProperty;
 use core::ops::RangeInclusive;
 use icu_collections::codepointinvlist::CodePointInversionList;
+use icu_provider::marker::ErasedMarker;
 use icu_provider::prelude::*;
 
 /// A set of Unicode code points. Access its data via the borrowed version,
@@ -37,7 +38,7 @@ use icu_provider::prelude::*;
 /// ```
 #[derive(Debug)]
 pub struct CodePointSetData {
-    data: DataPayload<ErasedPropertyCodePointSetV1Marker>,
+    data: DataPayload<ErasedMarker<PropertyCodePointSetV1<'static>>>,
 }
 
 impl CodePointSetData {
@@ -85,7 +86,7 @@ impl CodePointSetData {
     pub fn from_code_point_inversion_list(set: CodePointInversionList<'static>) -> Self {
         let set = PropertyCodePointSetV1::from_code_point_inversion_list(set);
         CodePointSetData::from_data(
-            DataPayload::<ErasedPropertyCodePointSetV1Marker>::from_owned(set),
+            DataPayload::<ErasedMarker<PropertyCodePointSetV1<'static>>>::from_owned(set),
         )
     }
 

--- a/components/properties/src/names.rs
+++ b/components/properties/src/names.rs
@@ -6,15 +6,10 @@ use crate::props::*;
 use crate::provider::names::*;
 use core::marker::PhantomData;
 use icu_collections::codepointtrie::TrieValue;
+use icu_provider::marker::ErasedMarker;
 use icu_provider::prelude::*;
 use yoke::Yokeable;
 use zerovec::ule::VarULE;
-
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub struct ErasedMarker<DataStruct: for<'a> Yokeable<'a>>(PhantomData<DataStruct>);
-impl<DataStruct: for<'a> Yokeable<'a>> DynamicDataMarker for ErasedMarker<DataStruct> {
-    type DataStruct = DataStruct;
-}
 
 /// A struct capable of looking up a property value from a string name.
 /// Access its data by calling [`Self::as_borrowed()`] and using the methods on

--- a/components/properties/src/provider.rs
+++ b/components/properties/src/provider.rs
@@ -405,12 +405,6 @@ pub enum PropertyCodePointSetV1<'data> {
     // https://docs.rs/serde/latest/serde/trait.Serializer.html#tymethod.serialize_unit_variant
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub(crate) struct ErasedPropertyCodePointSetV1Marker;
-impl DynamicDataMarker for ErasedPropertyCodePointSetV1Marker {
-    type DataStruct = PropertyCodePointSetV1<'static>;
-}
-
 // See CodePointSetData for documentation of these functions
 impl<'data> PropertyCodePointSetV1<'data> {
     #[inline]
@@ -487,12 +481,6 @@ pub enum PropertyCodePointMapV1<'data, T: TrieValue> {
     // new variants should go BELOW existing ones
     // Serde serializes based on variant name and index in the enum
     // https://docs.rs/serde/latest/serde/trait.Serializer.html#tymethod.serialize_unit_variant
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub(crate) struct ErasedPropertyCodePointMapV1Marker<T>(core::marker::PhantomData<T>);
-impl<T: TrieValue> DynamicDataMarker for ErasedPropertyCodePointMapV1Marker<T> {
-    type DataStruct = PropertyCodePointMapV1<'static, T>;
 }
 
 macro_rules! data_struct_generic {

--- a/components/properties/src/unicode_set.rs
+++ b/components/properties/src/unicode_set.rs
@@ -17,19 +17,14 @@
 use crate::provider::*;
 use crate::*;
 use icu_collections::codepointinvliststringlist::CodePointInversionListAndStringList;
+use icu_provider::marker::ErasedMarker;
 use icu_provider::prelude::*;
 use runtime::UnicodeProperty;
 
 /// A wrapper around `UnicodeSet` data (characters and strings)
 #[derive(Debug)]
 pub struct UnicodeSetData {
-    data: DataPayload<ErasedUnicodeSetlikeMarker>,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub(crate) struct ErasedUnicodeSetlikeMarker;
-impl DynamicDataMarker for ErasedUnicodeSetlikeMarker {
-    type DataStruct = PropertyUnicodeSetV1<'static>;
+    data: DataPayload<ErasedMarker<PropertyUnicodeSetV1<'static>>>,
 }
 
 impl UnicodeSetData {
@@ -84,7 +79,9 @@ impl UnicodeSetData {
         set: CodePointInversionListAndStringList<'static>,
     ) -> Self {
         let set = PropertyUnicodeSetV1::from_code_point_inversion_list_string_list(set);
-        UnicodeSetData::from_data(DataPayload::<ErasedUnicodeSetlikeMarker>::from_owned(set))
+        UnicodeSetData::from_data(
+            DataPayload::<ErasedMarker<PropertyUnicodeSetV1<'static>>>::from_owned(set),
+        )
     }
 
     /// Convert this type to a [`CodePointInversionListAndStringList`] as a borrowed value.

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -150,7 +150,7 @@ pub mod marker {
 
     pub use super::marker_full::{
         data_marker_path, impl_data_provider_never_marker, DataMarkerPath, DataMarkerPathHash,
-        NeverMarker,
+        ErasedMarker, NeverMarker,
     };
 }
 

--- a/provider/core/src/marker.rs
+++ b/provider/core/src/marker.rs
@@ -636,6 +636,13 @@ impl fmt::Debug for DataMarkerInfo {
     }
 }
 
+/// A marker for the given `DataStruct`.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct ErasedMarker<DataStruct: for<'a> Yokeable<'a>>(PhantomData<DataStruct>);
+impl<DataStruct: for<'a> Yokeable<'a>> DynamicDataMarker for ErasedMarker<DataStruct> {
+    type DataStruct = DataStruct;
+}
+
 #[test]
 fn test_path_syntax() {
     // Valid paths:


### PR DESCRIPTION
Using an erased marker for storage is a common pattern across multiple components. Also removed some unnecessary `cast()`s in datetime.