### PR TITLE
Impl Serde for PackedPatternsV1; export Serde impls for PluralElements

### DIFF
--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -88,6 +88,7 @@ datagen = [
     "dep:litemap",
     "icu_calendar/datagen",
     "icu_timezone/datagen",
+    "icu_plurals/datagen",
     "serde",
     "std",
 ]

--- a/components/datetime/src/provider/packed_pattern.rs
+++ b/components/datetime/src/provider/packed_pattern.rs
@@ -419,7 +419,7 @@ mod _serde {
             } else {
                 let machine = PackedPatternsMachine {
                     header: self.header,
-                    elements: &*self.elements,
+                    elements: &self.elements,
                 };
                 machine.serialize(serializer)
             }

--- a/components/datetime/src/provider/packed_pattern.rs
+++ b/components/datetime/src/provider/packed_pattern.rs
@@ -38,6 +38,7 @@ pub struct LengthPluralElements<T> {
 pub struct PackedPatternsBuilder<'a> {
     /// Patterns always available.
     #[cfg_attr(feature = "serde", serde(borrow))]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub standard: LengthPluralElements<Pattern<'a>>,
     /// Patterns for variant 0. If `None`, falls back to standard.
     #[cfg_attr(feature = "serde", serde(borrow))]
@@ -606,7 +607,7 @@ pub mod tests {
         assert_eq!(builder, bincode_recovered.to_builder());
 
         let json_str = serde_json::to_string(&packed).unwrap();
-        assert_eq!(json_str, "{\"standard\":{\"long\":{\"other\":\"M/d/y\"},\"medium\":{\"other\":\"M/d/y\"},\"short\":{\"other\":\"HH:mm\"}},\"variant0\":{\"long\":{\"other\":\"E\"},\"medium\":{\"other\":\"E MMM d\"},\"short\":{\"other\":\"dd.MM.yy\"}}}");
+        assert_eq!(json_str, "{\"long\":{\"other\":\"M/d/y\"},\"medium\":{\"other\":\"M/d/y\"},\"short\":{\"other\":\"HH:mm\"},\"variant0\":{\"long\":{\"other\":\"E\"},\"medium\":{\"other\":\"E MMM d\"},\"short\":{\"other\":\"dd.MM.yy\"}}}");
         let json_recovered = serde_json::from_str::<PackedPatternsV1>(&json_str).unwrap();
         assert_eq!(builder, json_recovered.to_builder());
     }

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -878,7 +878,11 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(transparent))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(transparent)
+)]
 /// A bag of values for different plural cases.
 ///
 /// # Serialization

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -878,12 +878,18 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(transparent))]
 /// A bag of values for different plural cases.
+///
+/// # Serialization
+///
+/// Although this type implements Serde traits, ICU4X developers and clients
+/// seeking a more efficient bitpacked representation should consider
+/// [`crate::provider::PluralElementsPackedCow`].
 pub struct PluralElements<T>(PluralElementsInner<T>);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-#[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub(crate) struct PluralElementsInner<T> {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     zero: Option<T>,


### PR DESCRIPTION
Depends on #5580

I know @robertbastian previously was not a fan of exporting a Serde impl for `PluralElements`. I can work around this by moving `PluralElementsInner` to the `icu_plurals::provider` module. However, I think it is fine for crates to export Serde impls for their core types. We do this in various other places. The main difference/downside in this particular case is that we have a bitpacked representation in the provider module that most ICU4X devs should be using; I am using the `PluralElements` impl only for human-readable serialization.