### PR TITLE
In zerovec, skip `check_sizes()` test on non-64-bit arches

### DIFF
--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -518,6 +518,8 @@ pub use zerovec_derive::make_ule;
 pub use zerovec_derive::make_varule;
 
 #[cfg(test)]
+// Expected sizes are based on a 64-bit architecture
+#[cfg(target_pointer_width = "64")]
 mod tests {
     use super::*;
     use core::mem::size_of;


### PR DESCRIPTION
Since the expected sizes are based on 64-bit architectures, we need to either maintain additional expected sizes for 32-bit architectures, or (as implemented in this commit) just skip this test on architectures that are not 64-bit.

Fixes #5605.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->