### PR TITLE
Remove old skeleton data marker

### DIFF
--- a/components/datetime/src/provider/calendar/skeletons.rs
+++ b/components/datetime/src/provider/calendar/skeletons.rs
@@ -7,28 +7,18 @@ use crate::{
     skeleton::{reference::Skeleton, SkeletonError},
 };
 use core::convert::TryFrom;
-use icu_provider::prelude::*;
 use litemap::LiteMap;
-
-size_test!(DateSkeletonPatternsV1, date_skeleton_patterns_v1_size, 24);
 
 /// Skeleton data for dates and times, along with the corresponding plural pattern
 /// information.
-#[doc = date_skeleton_patterns_v1_size!()]
 ///
 /// <div class="stab unstable">
 /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[icu_provider::data_struct(DateSkeletonPatternsV1Marker = "datetime/skeletons@1")]
 #[derive(Debug, PartialEq, Clone, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-pub struct DateSkeletonPatternsV1<'data>(
-    #[cfg_attr(feature = "serde", serde(borrow))]
-    #[zerofrom(clone)]
-    pub LiteMap<SkeletonV1, PatternPlurals<'data>>,
-);
+pub struct DateSkeletonPatternsV1<'data>(pub LiteMap<SkeletonV1, PatternPlurals<'data>>);
 
 /// This struct is a public wrapper around the internal `Skeleton` struct. This allows
 /// access to the serialization and deserialization capabilities, without exposing the
@@ -43,7 +33,6 @@ pub struct DateSkeletonPatternsV1<'data>(
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub struct SkeletonV1(pub Skeleton);
 
 impl TryFrom<&str> for SkeletonV1 {

--- a/provider/source/src/datetime/mod.rs
+++ b/provider/source/src/datetime/mod.rs
@@ -242,6 +242,9 @@ macro_rules! impl_data_provider {
     };
 }
 
+// TODO(#5613): Even though these markers are no longer exported, we need them in order to export
+// semantic skeleton data markers. This should be refactored to skip the intermediate data struct.
+
 impl_data_provider!(
     BuddhistDateLengthsV1Marker,
     |dates, _| DateLengthsV1::from(dates),

--- a/provider/source/src/datetime/skeletons.rs
+++ b/provider/source/src/datetime/skeletons.rs
@@ -85,30 +85,20 @@ mod test {
         fields::{Day, Field, FieldLength, Month, Weekday},
         options::{components, preferences},
         pattern::{reference, runtime},
-        provider::calendar::{DateSkeletonPatternsV1, GregorianDateLengthsV1Marker, SkeletonV1},
+        provider::calendar::{DateLengthsV1, DateSkeletonPatternsV1, SkeletonV1},
     };
     use icu::locale::locale;
-    use icu_provider::prelude::*;
     use litemap::LiteMap;
 
     use crate::SourceDataProvider;
 
-    fn get_data_payload() -> (
-        DataPayload<GregorianDateLengthsV1Marker>,
-        DateSkeletonPatternsV1<'static>,
-    ) {
+    fn get_data_payload() -> (DateLengthsV1<'static>, DateSkeletonPatternsV1<'static>) {
         let locale = locale!("en").into();
 
-        let patterns = SourceDataProvider::new_testing()
-            .load(DataRequest {
-                id: DataIdentifierBorrowed::for_locale(&locale),
-                ..Default::default()
-            })
-            .expect("Failed to load payload")
-            .payload;
         let data = SourceDataProvider::new_testing()
             .get_datetime_resources(&locale, Either::Right("gregorian"))
             .unwrap();
+        let patterns = DateLengthsV1::from(&data);
         let skeletons = DateSkeletonPatternsV1::from(&data);
         (patterns, skeletons)
     }
@@ -185,7 +175,7 @@ mod test {
 
         match create_best_pattern_for_fields(
             &skeletons,
-            &patterns.get().length_combinations,
+            &patterns.length_combinations,
             &requested_fields,
             &Default::default(),
             false,

--- a/provider/source/src/datetime/skeletons.rs
+++ b/provider/source/src/datetime/skeletons.rs
@@ -85,10 +85,7 @@ mod test {
         fields::{Day, Field, FieldLength, Month, Weekday},
         options::{components, preferences},
         pattern::{reference, runtime},
-        provider::calendar::{
-            DateSkeletonPatternsV1, DateSkeletonPatternsV1Marker, GregorianDateLengthsV1Marker,
-            SkeletonV1,
-        },
+        provider::calendar::{DateSkeletonPatternsV1, GregorianDateLengthsV1Marker, SkeletonV1},
     };
     use icu::locale::locale;
     use icu_provider::prelude::*;
@@ -98,7 +95,7 @@ mod test {
 
     fn get_data_payload() -> (
         DataPayload<GregorianDateLengthsV1Marker>,
-        DataPayload<DateSkeletonPatternsV1Marker>,
+        DateSkeletonPatternsV1<'static>,
     ) {
         let locale = locale!("en").into();
 
@@ -112,7 +109,7 @@ mod test {
         let data = SourceDataProvider::new_testing()
             .get_datetime_resources(&locale, Either::Right("gregorian"))
             .unwrap();
-        let skeletons = DataPayload::from_owned(DateSkeletonPatternsV1::from(&data));
+        let skeletons = DateSkeletonPatternsV1::from(&data);
         (patterns, skeletons)
     }
 
@@ -132,7 +129,7 @@ mod test {
         let requested_fields = components.to_vec_fields(preferences::HourCycle::H23);
         let (_, skeletons) = get_data_payload();
 
-        match get_best_available_format_pattern(skeletons.get(), &requested_fields, false) {
+        match get_best_available_format_pattern(&skeletons, &requested_fields, false) {
             BestSkeleton::AllFieldsMatch(available_format_pattern)
             | BestSkeleton::MissingOrExtraFields(available_format_pattern) => {
                 assert_eq!(
@@ -157,7 +154,7 @@ mod test {
         let requested_fields = components.to_vec_fields(preferences::HourCycle::H23);
         let (_, skeletons) = get_data_payload();
 
-        match get_best_available_format_pattern(skeletons.get(), &requested_fields, false) {
+        match get_best_available_format_pattern(&skeletons, &requested_fields, false) {
             BestSkeleton::MissingOrExtraFields(available_format_pattern) => {
                 assert_eq!(
                     available_format_pattern
@@ -187,7 +184,7 @@ mod test {
         let (patterns, skeletons) = get_data_payload();
 
         match create_best_pattern_for_fields(
-            skeletons.get(),
+            &skeletons,
             &patterns.get().length_combinations,
             &requested_fields,
             &Default::default(),
@@ -214,7 +211,7 @@ mod test {
         let (_, skeletons) = get_data_payload();
 
         assert_eq!(
-            get_best_available_format_pattern(skeletons.get(), &requested_fields, false),
+            get_best_available_format_pattern(&skeletons, &requested_fields, false),
             BestSkeleton::NoMatch,
             "No match was found"
         );
@@ -384,7 +381,7 @@ mod test {
         let requested_fields = components.to_vec_fields(default_hour_cycle);
         let (_, skeletons) = get_data_payload();
 
-        match get_best_available_format_pattern(skeletons.get(), &requested_fields, false) {
+        match get_best_available_format_pattern(&skeletons, &requested_fields, false) {
             BestSkeleton::AllFieldsMatch(available_format_pattern) => {
                 assert_eq!(
                     available_format_pattern
@@ -407,7 +404,7 @@ mod test {
         let requested_fields = components.to_vec_fields(default_hour_cycle);
         let (_, skeletons) = get_data_payload();
 
-        match get_best_available_format_pattern(skeletons.get(), &requested_fields, false) {
+        match get_best_available_format_pattern(&skeletons, &requested_fields, false) {
             BestSkeleton::AllFieldsMatch(available_format_pattern) => {
                 assert_eq!(
                     available_format_pattern


### PR DESCRIPTION
Fixes #1678 because the allocated data can no longer be used in the DataProvider framework