### PR TITLE
Impl Serde for PackedPatternsV1 with packed-like human form

### DIFF
--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -87,6 +87,7 @@ datagen = [
     "dep:databake",
     "dep:litemap",
     "icu_calendar/datagen",
+    "icu_plurals/datagen",
     "icu_timezone/datagen",
     "serde",
     "std",

--- a/components/datetime/src/pattern/runtime/pattern.rs
+++ b/components/datetime/src/pattern/runtime/pattern.rs
@@ -108,6 +108,10 @@ impl<'data> Pattern<'data> {
             metadata: self.metadata,
         }
     }
+
+    pub fn as_ref(&self) -> Pattern<'_> {
+        self.as_borrowed().as_pattern()
+    }
 }
 
 impl PatternULE {

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -947,6 +947,35 @@ impl<T> PluralElements<T> {
         &self.0.other
     }
 
+    /// If the only variant is `other`, returns `Some(other)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu_plurals::PluralElements;
+    ///
+    /// let mut only_other = PluralElements::new("abc").with_one_value(Some("abc"));
+    /// assert_eq!(only_other.try_into_other(), Some("abc"));
+    ///
+    /// let mut multi = PluralElements::new("abc").with_one_value(Some("def"));
+    /// assert_eq!(multi.try_into_other(), None);
+    /// ```
+    pub fn try_into_other(self) -> Option<T> {
+        match self.0 {
+            PluralElementsInner {
+                zero: None,
+                one: None,
+                two: None,
+                few: None,
+                many: None,
+                other,
+                explicit_zero: None,
+                explicit_one: None,
+            } => Some(other),
+            _ => None,
+        }
+    }
+
     /// The value used when the [`PluralOperands`] are exactly 0.
     pub fn explicit_zero(&self) -> Option<&T> {
         self.0.explicit_zero.as_ref()

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -520,6 +520,11 @@ where
         .unwrap_or(parts.default)
     }
 
+    /// Recovers the [`PluralElements`] corresponding to this packed structure.
+    pub fn decode(&self) -> PluralElements<(FourBitMetadata, &V)> {
+        PluralElements(PluralElementsInner::from_packed(self))
+    }
+
     /// Returns the value for the default ("other") plural variant.
     pub fn get_default(&self) -> (FourBitMetadata, &V) {
         self.as_parts().default

--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -109,8 +109,7 @@ impl<'a, T: AsULE> Deref for ZeroVec<'a, T> {
     type Target = ZeroSlice<T>;
     #[inline]
     fn deref(&self) -> &Self::Target {
-        let slice: &[T::ULE] = self.vector.as_slice();
-        ZeroSlice::from_ule_slice(slice)
+        self.as_slice()
     }
 }
 
@@ -193,7 +192,7 @@ impl<'a, T: AsULE> Clone for ZeroVec<'a, T> {
 
 impl<'a, T: AsULE> AsRef<ZeroSlice<T>> for ZeroVec<'a, T> {
     fn as_ref(&self) -> &ZeroSlice<T> {
-        self.deref()
+        self.as_slice()
     }
 }
 
@@ -429,6 +428,16 @@ impl<'a, T: AsULE> ZeroVec<'a, T> {
         }
     }
 
+    /// Returns this [`ZeroVec`] as a [`ZeroSlice`].
+    ///
+    /// To get a reference with a longer lifetime from a borrowed [`ZeroVec`],
+    /// use [`ZeroVec::as_maybe_borrowed`].
+    #[inline]
+    pub const fn as_slice(&self) -> &ZeroSlice<T> {
+        let slice: &[T::ULE] = self.vector.as_slice();
+        ZeroSlice::from_ule_slice(slice)
+    }
+
     /// Casts a `ZeroVec<T>` to a compatible `ZeroVec<P>`.
     ///
     /// `T` and `P` are compatible if they have the same `ULE` representation.
@@ -567,8 +576,11 @@ impl<'a, T: AsULE> ZeroVec<'a, T> {
         self.vector.capacity != 0
     }
 
-    /// If this is a borrowed ZeroVec, return it as a slice that covers
-    /// its lifetime parameter
+    /// If this is a borrowed [`ZeroVec`], return it as a slice that covers
+    /// its lifetime parameter.
+    ///
+    /// To infallibly get a [`ZeroSlice`] with a shorter lifetime, use
+    /// [`ZeroVec::as_slice`].
     #[inline]
     pub fn as_maybe_borrowed(&self) -> Option<&'a ZeroSlice<T>> {
         if self.is_owned() {


### PR DESCRIPTION
Replaces #5592

This PR does _not_ export `impl Deserialize for PluralElements`, which was going to prevent #5592 from landing. However, if we ever add plural packed patterns, we're going to need _something_ like that.

(note on my coding velocity: this PR took me just over 3 hours to write, which I consider to be a lot of time for a serde impl. the previous PR took less than an hour.)