### PR TITLE
Return Err((self, other)) in FixedDecimal::concatenated_end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   - `icu_locale`
     - New crate
   - `icu_locale_core`
-    - New crate, split out of `icu_locid`
+    - New crate, renamed from `icu_locid`
     - Removed `Ord` and `PartialOrd` impl from `extensions::unicode::Unicode` (https://github.com/unicode-org/icu4x/pull/5617)
   - `icu_locid_transform`
   - `icu_plurals`
@@ -35,6 +35,7 @@
     - `calendrical_calculations`:
     - `databake`
     - `fixed_decimal`
+      - `FixedDecimal::concatenated_end()` now returns both `self` and `other` in the error case. (https://github.com/unicode-org/icu4x/pull/5623)
     - `icu_pattern`
     - `litemap`
     - `yoke`

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -2221,7 +2221,7 @@ impl FixedDecimal {
     ///
     /// All nonzero digits in `other` must have lower magnitude than nonzero digits in `self`.
     /// If the two decimals represent overlapping ranges of magnitudes, an `Err` is returned,
-    /// passing ownership of `other` back to the caller.
+    /// containing (self, other).
     ///
     /// The magnitude range of `self` will be increased if `other` covers a larger range.
     ///
@@ -2237,10 +2237,13 @@ impl FixedDecimal {
     ///
     /// assert_eq!("123.456", result.to_string());
     /// ```
-    pub fn concatenated_end(mut self, other: FixedDecimal) -> Result<Self, FixedDecimal> {
+    pub fn concatenated_end(
+        mut self,
+        other: FixedDecimal,
+    ) -> Result<Self, (FixedDecimal, FixedDecimal)> {
         match self.concatenate_end(other) {
             Ok(()) => Ok(self),
-            Err(err) => Err(err),
+            Err(err) => Err((self, err)),
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/4857

I think that's the only `fn *ed* -> Result` that we have.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->