### PR TITLE
Add `#[non_exhaustive]` return types to `DataExporter::close` and `ExportDriver::export`

### DIFF
--- a/provider/baked/src/export.rs
+++ b/provider/baked/src/export.rs
@@ -672,7 +672,7 @@ impl DataExporter for BakedExporter {
         }
     }
 
-    fn close(&mut self) -> Result<(), DataError> {
+    fn close(&mut self) -> Result<ExporterCloseMetadata, DataError> {
         log::info!("Writing macros module...");
 
         let data = core::mem::take(&mut self.impl_data)
@@ -771,7 +771,7 @@ impl DataExporter for BakedExporter {
 
         self.print_deps();
 
-        Ok(())
+        Ok(Default::default())
     }
 }
 

--- a/provider/blob/src/export/blob_exporter.rs
+++ b/provider/blob/src/export/blob_exporter.rs
@@ -103,7 +103,7 @@ impl DataExporter for BlobExporter<'_> {
         Ok(())
     }
 
-    fn close(&mut self) -> Result<(), DataError> {
+    fn close(&mut self) -> Result<ExporterCloseMetadata, DataError> {
         self.close_internal()
     }
 }
@@ -144,7 +144,7 @@ impl BlobExporter<'_> {
         FinalizedBuffers { vzv, remap }
     }
 
-    fn close_internal(&mut self) -> Result<(), DataError> {
+    fn close_internal(&mut self) -> Result<ExporterCloseMetadata, DataError> {
         let FinalizedBuffers { vzv, remap } = self.finalize_buffers();
 
         let all_markers = self.all_markers.lock().expect("poison");
@@ -200,6 +200,6 @@ impl BlobExporter<'_> {
             }
         }
 
-        Ok(())
+        Ok(Default::default())
     }
 }

--- a/provider/export/src/lib.rs
+++ b/provider/export/src/lib.rs
@@ -58,6 +58,7 @@
 
 mod export_impl;
 mod locale_family;
+use icu_provider::export::ExporterCloseMetadata;
 pub use locale_family::*;
 
 #[cfg(feature = "baked_exporter")]
@@ -80,6 +81,8 @@ pub mod prelude {
 }
 
 use icu_locale::LocaleFallbacker;
+use icu_provider::export::DataExporter;
+use icu_provider::export::ExportableProvider;
 use icu_provider::prelude::*;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -263,6 +266,30 @@ impl ExportDriver {
         let set = models.into_iter().collect::<HashSet<_>>();
         self.with_marker_attributes_filter("segmenter", move |attrs| set.contains(attrs.as_str()))
     }
+
+    /// Exports data from the given provider to the given exporter.
+    ///
+    /// See
+    /// [`make_exportable_provider!`](icu_provider::export::make_exportable_provider),
+    /// [`BlobExporter`](icu_provider_blob::export),
+    /// [`FileSystemExporter`](icu_provider_fs::export),
+    /// and [`BakedExporter`](icu_provider_baked::export).
+    pub fn export(
+        self,
+        provider: &impl ExportableProvider,
+        mut sink: impl DataExporter,
+    ) -> Result<ExportMetadata, DataError> {
+        // Avoids multiple monomorphizations
+        self.export_dyn(provider, &mut sink)
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+/// Contains information about a successful export.
+pub struct ExportMetadata {
+    /// The metadata coming from the [`DataExporter`].
+    pub exporter: ExporterCloseMetadata,
 }
 
 /// Options bag configuring locale inclusion and behavior when runtime fallback is disabled.

--- a/provider/icu4x-datagen/src/main.rs
+++ b/provider/icu4x-datagen/src/main.rs
@@ -533,7 +533,7 @@ fn main() -> eyre::Result<()> {
         driver.with_segmenter_models(cli.segmenter_models.clone())
     };
 
-    match cli.format {
+    let _metadata = match cli.format {
         #[cfg(not(feature = "fs_exporter"))]
         Format::Fs => {
             eyre::bail!("Exporting to an FsProvider requires the `fs_exporter` Cargo feature")
@@ -598,7 +598,7 @@ fn main() -> eyre::Result<()> {
                 },
             )?
         })?,
-    }
+    };
 
     Ok(())
 }

--- a/provider/source/src/tests/make_testdata.rs
+++ b/provider/source/src/tests/make_testdata.rs
@@ -80,7 +80,7 @@ fn make_testdata() {
         matches!(attrs.as_str(), "CAD" | "EGP" | "EUR" | "GBP" | "USD")
     })
     .export(&provider, exporter)
-    .unwrap()
+    .unwrap();
 }
 
 struct ZeroCopyCheckExporter {
@@ -194,7 +194,7 @@ impl DataExporter for ZeroCopyCheckExporter {
         Ok(())
     }
 
-    fn close(&mut self) -> Result<(), DataError> {
+    fn close(&mut self) -> Result<ExporterCloseMetadata, DataError> {
         assert_eq!(
             self.rountrip_errors.get_mut().expect("poison"),
             &mut BTreeSet::default()
@@ -225,7 +225,7 @@ impl DataExporter for ZeroCopyCheckExporter {
             Expected:\n{EXPECTED_VIOLATIONS:?}\nFound:\n{violations:?}\nExpected (transient):\n{EXPECTED_TRANSIENT_VIOLATIONS:?}\nFound (transient):\n{transient_violations:?}"
         );
 
-        Ok(())
+        Ok(Default::default())
     }
 }
 

--- a/tools/make/bakeddata/src/main.rs
+++ b/tools/make/bakeddata/src/main.rs
@@ -229,7 +229,7 @@ impl<E: DataExporter> DataExporter for StubExporter<E> {
         self.0.flush(marker, metadata)
     }
 
-    fn close(&mut self) -> Result<(), DataError> {
+    fn close(&mut self) -> Result<ExporterCloseMetadata, DataError> {
         self.0.close()
     }
 }
@@ -278,7 +278,7 @@ impl<F: Write + Send + Sync> DataExporter for StatisticsExporter<F> {
         Ok(())
     }
 
-    fn close(&mut self) -> Result<(), DataError> {
+    fn close(&mut self) -> Result<ExporterCloseMetadata, DataError> {
         let data = core::mem::take(self.data.get_mut().expect("poison"));
 
         let mut lines = Vec::new();
@@ -333,6 +333,6 @@ impl<F: Write + Send + Sync> DataExporter for StatisticsExporter<F> {
             writeln!(&mut self.fingerprints, "{line}")?;
         }
 
-        Ok(())
+        Ok(Default::default())
     }
 }


### PR DESCRIPTION
#4716, #3746