### PR TITLE
Update pinned llvm-compat nightly to 2024-01-01 / LLVM 17

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ Our wider testsuite is organized as `ci-job-foo` make tasks corresponding to eac
 <br/>
  
  - `ci-job-test-c`: Runs all C/C++ FFI tests; mostly important if you're changing the FFI interface.
-     + Requires `clang-16` and `lld-16` with the `gold` plugin (APT packages `llvm-16` and `lld-16`).
+     + Requires `clang-17` and `lld-17` with the `gold` plugin (APT packages `llvm-17` and `lld-17`).
  - `ci-job-test-js`: Runs all JS/WASM/Node FFI tests; mostly important if you're changing the FFI interface.
      + Requires Node.js version 16.18.0. This may not the one offered by the package manager; get it from the NodeJS website or `nvm`.
  - `ci-job-nostd`: Builds ICU4X for a `#[no_std]` target to verify that it's compatible.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,9 +2488,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7a12c7506980eaac5c9851a04e90e0062eb4417aa188a512bf7a64a1ef290f"
+checksum = "0904b9147011800e63763fb9e49bbeaf76c1b6ab8982824c659dce5433712559"
 dependencies = [
  "serde",
 ]

--- a/tools/make/diplomat-coverage/Cargo.toml
+++ b/tools/make/diplomat-coverage/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 diplomat_core = { workspace = true }
 elsa = { workspace = true }
 lazy_static = "1"
-rustdoc-types = "0.22"
+rustdoc-types = "0.24"
 serde_json = { workspace = true }
 syn-inline-mod = "0.6.0"
 

--- a/tools/make/diplomat-coverage/src/main.rs
+++ b/tools/make/diplomat-coverage/src/main.rs
@@ -99,13 +99,13 @@ fn collect_public_types(krate: &str) -> impl Iterator<Item = (Vec<String>, ast::
         if CRATES.get(krate).is_none() {
             eprintln!("Parsing crate {krate}");
             std::process::Command::new("rustup")
-                .args(["install", "nightly-2023-08-08"])
+                .args(["install", "nightly-2024-01-01"])
                 .output()
                 .expect("failed to install nightly");
             let output = std::process::Command::new("rustup")
                 .args([
                     "run",
-                    "nightly-2023-08-08",
+                    "nightly-2024-01-01",
                     "cargo",
                     "rustdoc",
                     "-Zsparse-registry",
@@ -357,7 +357,7 @@ fn collect_public_types(krate: &str) -> impl Iterator<Item = (Vec<String>, ast::
                     ItemEnum::Macro(_) => {
                         insert_ty(types, path, ast::DocType::Macro);
                     }
-                    ItemEnum::Typedef(_) => {
+                    ItemEnum::TypeAlias(_) => {
                         insert_ty(types, path, ast::DocType::Typedef);
                     }
                     ItemEnum::Variant(_) => {

--- a/tutorials/c-tiny/fixeddecimal/Makefile
+++ b/tutorials/c-tiny/fixeddecimal/Makefile
@@ -15,9 +15,9 @@ ALL_HEADERS := $(wildcard ${HEADERS}/*)
 $(ALL_HEADERS):
 
 GCC := gcc
-CLANG := clang-16
-LLD := lld-16
-LLVM_COMPATIBLE_NIGHTLY = "nightly-2023-08-08"
+CLANG := clang-17
+LLD := lld-17
+LLVM_COMPATIBLE_NIGHTLY = "nightly-2024-01-01"
 
 baked_data/macros.rs:
 	cargo install --path ../../../provider/icu4x-datagen --root target

--- a/tutorials/c-tiny/segmenter/Makefile
+++ b/tutorials/c-tiny/segmenter/Makefile
@@ -15,9 +15,9 @@ ALL_HEADERS := $(wildcard ${HEADERS}/*)
 $(ALL_HEADERS):
 
 GCC := gcc
-CLANG := clang-16
-LLD := lld-16
-LLVM_COMPATIBLE_NIGHTLY = "nightly-2023-08-08"
+CLANG := clang-17
+LLD := lld-17
+LLVM_COMPATIBLE_NIGHTLY = "nightly-2024-01-01"
 
 target/debug/libicu_capi.a: FORCE
 	cargo rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/segmenter,icu_capi/std

--- a/tutorials/js-tiny/Makefile
+++ b/tutorials/js-tiny/Makefile
@@ -9,7 +9,7 @@ ICU_CAPI := $(shell cargo metadata --format-version 1 | jq '.packages[] | select
 HEADERS := ${ICU_CAPI}/bindings/js
 ALL_HEADERS := $(wildcard ${HEADERS}/*)
 
-LLVM_COMPATIBLE_NIGHTLY ?= "nightly-2023-08-08"
+LLVM_COMPATIBLE_NIGHTLY ?= "nightly-2024-01-01"
 
 $(ALL_HEADERS):
 

--- a/tutorials/js-tiny/ld.py
+++ b/tutorials/js-tiny/ld.py
@@ -32,7 +32,7 @@ def main():
         else:
             new_argv += [arg]
             is_export = False
-    result = subprocess.run(["lld-16"] + new_argv, stdout=sys.stdout, stderr=sys.stderr)
+    result = subprocess.run(["lld-17"] + new_argv, stdout=sys.stdout, stderr=sys.stderr)
     return result.returncode
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes CI issues because test-c-tiny uses an old rustc that isn't able to understand the lockfile updated by test-c (https://github.com/rust-lang/cargo/pull/14595).

We should also consider having the lockfiles cleaned between jobs.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->