### PR TITLE
Reset tutorial lockfiles between ffi ci jobs

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -119,6 +119,9 @@ description = "Run all tests for the CI 'test-c' job"
 category = "CI"
 dependencies = [
     "test-c",
+    # Can be removed after LLVM nightly is updated past May 2024, but it's fine to keep in
+    # to prevent such problems in the future
+    "internal-reset-tutorial-lockfiles",
     "test-c-tiny",
     "test-cpp",
 ]
@@ -128,6 +131,9 @@ description = "Run all tests for the CI 'test-js' job"
 category = "CI"
 dependencies = [
     "test-npm",
+    # Can be removed after LLVM nightly is updated past May 2024, but it's fine to keep in
+    # to prevent such problems in the future
+    "internal-reset-tutorial-lockfiles",
     "test-tinywasm",
 ]
 
@@ -343,3 +349,10 @@ else
     echo "forced-toolchain environment not required"
 end
 '''
+
+[tasks.internal-reset-tutorial-lockfiles]
+description = "Reset changes to tutorial lockfiles (useful to clean up between CI jobs)"
+category = "ICU4X CI internal"
+command = "git"
+args = ["checkout", "@", "--", "tutorials/**/Cargo.lock"]
+


### PR DESCRIPTION
This fixes the nightly CI failure on test-c and test-js that began in [this CI run](https://github.com/unicode-org/icu4x/actions/runs/11093290258/job/30819401664), caused by https://github.com/rust-lang/cargo/pull/14595.

Updating the pinned-LLVM Rust version past Apr/May 2024 will fix this problem as well, but this is currently hard since that needs LLVM 18

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->