### PR TITLE
Add fixtures for incomplete timezone inputs

### DIFF
--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -24,7 +24,6 @@ use icu_calendar::{
     roc::Roc,
     AsCalendar, Calendar, DateTime, Gregorian, Iso,
 };
-use icu_datetime::CldrCalendar;
 use icu_datetime::{
     neo::{NeoFormatter, NeoOptions, TypedNeoFormatter},
     neo_pattern::DateTimePattern,
@@ -32,6 +31,7 @@ use icu_datetime::{
     options::preferences::{self, HourCycle},
     TypedDateTimeNames,
 };
+use icu_datetime::{CldrCalendar, DateTimeWriteError};
 use icu_locale_core::{
     extensions::unicode::{key, value, Value},
     locale, LanguageIdentifier, Locale,
@@ -541,10 +541,15 @@ fn test_time_zone_patterns() {
                         .include_for_pattern(&parsed_pattern)
                         .unwrap()
                         .format(&zoned_datetime);
+                    let expected_result = if expect.starts_with('{') {
+                        Err(DateTimeWriteError::MissingZoneSymbols)
+                    } else {
+                        Ok(())
+                    };
                     assert_try_writeable_eq!(
                         formatted_datetime,
                         *expect,
-                        Ok(()),
+                        expected_result,
                         "\n\
                     locale:   `{}`,\n\
                     datetime: `{}`,\n\

--- a/components/datetime/tests/mock.rs
+++ b/components/datetime/tests/mock.rs
@@ -5,7 +5,7 @@
 //! Some useful parsing functions for tests.
 
 use icu_calendar::{DateTime, Gregorian};
-use icu_timezone::CustomZonedDateTime;
+use icu_timezone::{CustomTimeZone, CustomZonedDateTime};
 
 /// Temporary function for parsing a `DateTime<Gregorian>`
 ///
@@ -56,6 +56,13 @@ pub fn parse_gregorian_from_str(input: &str) -> DateTime<Gregorian> {
 ///         .expect("Failed to parse a zoned datetime.");
 /// ```
 pub fn parse_zoned_gregorian_from_str(input: &str) -> CustomZonedDateTime<Gregorian> {
-    let datetime_iso = CustomZonedDateTime::try_iso_from_str(input).unwrap();
+    let datetime_iso = CustomZonedDateTime::try_iso_from_str(input).unwrap_or_else(|_| {
+        let datetime = DateTime::try_iso_from_str(input).unwrap();
+        CustomZonedDateTime {
+            date: datetime.date,
+            time: datetime.time,
+            zone: CustomTimeZone::new_empty(),
+        }
+    });
     datetime_iso.to_calendar(Gregorian)
 }

--- a/components/datetime/tests/mock.rs
+++ b/components/datetime/tests/mock.rs
@@ -56,13 +56,15 @@ pub fn parse_gregorian_from_str(input: &str) -> DateTime<Gregorian> {
 ///         .expect("Failed to parse a zoned datetime.");
 /// ```
 pub fn parse_zoned_gregorian_from_str(input: &str) -> CustomZonedDateTime<Gregorian> {
-    let datetime_iso = CustomZonedDateTime::try_iso_from_str(input).unwrap_or_else(|_| {
-        let datetime = DateTime::try_iso_from_str(input).unwrap();
-        CustomZonedDateTime {
-            date: datetime.date,
-            time: datetime.time,
-            zone: CustomTimeZone::new_empty(),
-        }
-    });
+    let datetime_iso = CustomZonedDateTime::try_iso_from_str(input)
+        .or_else(|_| CustomZonedDateTime::try_iso_from_str(input.split('[').next().unwrap()))
+        .or_else(|_| {
+            DateTime::try_iso_from_str(input).map(|dt| CustomZonedDateTime {
+                date: dt.date,
+                time: dt.time,
+                zone: CustomTimeZone::new_empty(),
+            })
+        })
+        .unwrap();
     datetime_iso.to_calendar(Gregorian)
 }

--- a/components/datetime/tests/patterns/tests/time_zones.json
+++ b/components/datetime/tests/patterns/tests/time_zones.json
@@ -925,5 +925,157 @@
         "expected": ["GMT +০৫:৪৫"]
       }
     ]
+  },
+  {
+    "locale": "en",
+    "datetime": "2021-07-11T12:00:00.000-07:00[Etc/Unknown]",
+    "expectations": [
+      {
+        "patterns": [
+          "z",
+          "zz",
+          "zzz",
+          "ZZZZ",
+          "O"
+        ],
+        "configs": [],
+        "expected": ["GMT-7"]
+      },
+      {
+        "patterns": [
+          "zzzz",
+          "OOOO"
+        ],
+        "configs": [],
+        "expected": ["GMT-07:00"]
+      },
+      {
+        "patterns": [
+          "Z",
+          "ZZ",
+          "ZZZ"
+        ],
+        "configs": [],
+        "expected": ["-0700"]
+      },
+      {
+        "patterns": [
+          "ZZZZZ"
+        ],
+        "configs": [],
+        "expected": ["-07:00"]
+      },
+      {
+        "patterns": [
+          "v",
+          "vvvv",
+          "VVVV"
+        ],
+        "configs": [],
+        "expected": ["Unknown City Time"]
+      }
+    ]
+  },
+  {
+    "locale": "en",
+    "datetime": "2021-07-11T12:00:00.000-07:00",
+    "expectations": [
+      {
+        "patterns": [
+          "z",
+          "zz",
+          "zzz",
+          "ZZZZ",
+          "v",
+          "O"
+        ],
+        "configs": [],
+        "expected": ["GMT-7"]
+      },
+      {
+        "patterns": [
+          "zzzz",
+          "OOOO",
+          "vvvv",
+          "VVVV"
+        ],
+        "configs": [],
+        "expected": ["GMT-07:00"]
+      },
+      {
+        "patterns": [
+          "Z",
+          "ZZ",
+          "ZZZ"
+        ],
+        "configs": [],
+        "expected": ["-0700"]
+      },
+      {
+        "patterns": [
+          "ZZZZZ"
+        ],
+        "configs": [],
+        "expected": ["-07:00"]
+      }
+    ]
+  },
+  {
+    "locale": "en",
+    "datetime": "2021-07-11T12:00:00.000[Etc/Unknown]",
+    "expectations": [
+      {
+        "patterns": [
+          "z",
+          "zz",
+          "zzz",
+          "zzzz",
+          "Z",
+          "ZZ",
+          "ZZZ",
+          "ZZZZ",
+          "ZZZZZ",
+          "O",
+          "OOOO"
+        ],
+        "configs": [],
+        "expected": ["{GMT+?}"]
+      },
+      {
+        "patterns": [
+          "v",
+          "vvvv",
+          "VVVV"
+        ],
+        "configs": [],
+        "expected": ["Unknown City Time"]
+      }
+    ]
+  },
+  {
+    "locale": "en",
+    "datetime": "2021-07-11T12:00:00.000",
+    "expectations": [
+      {
+        "patterns": [
+          "z",
+          "zz",
+          "zzz",
+          "zzzz",
+          "Z",
+          "ZZ",
+          "ZZZ",
+          "ZZZZ",
+          "ZZZZZ",
+          "O",
+          "OOOO",
+          "v",
+          "vvvv",
+          "VVVV"
+        ],
+        "configs": [],
+        "expected": ["{GMT+?}"]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This tests
* no offset, no zone
* no offset, `Etc/Unknown`
* offset, no zone
* offset, `Etc/Unknown`

I'm doing this to demonstrate that the `Unknown City Time` fallback is bad, and that the distinction between `Etc/Unknown` and `None` is not very useful.