### PR TITLE
Rework time zone fallback

### DIFF
--- a/components/datetime/benches/datetime.rs
+++ b/components/datetime/benches/datetime.rs
@@ -56,9 +56,7 @@ fn datetime_benches(c: &mut Criterion) {
 
                         for dt in &datetimes {
                             let fdt = dtf.format(dt);
-                            fdt.try_write_to(&mut result)
-                                .unwrap()
-                                .expect("Failed to write to date time format.");
+                            let _ = fdt.try_write_to(&mut result).unwrap();
                             result.clear();
                         }
                     }

--- a/components/datetime/src/format/neo.rs
+++ b/components/datetime/src/format/neo.rs
@@ -383,7 +383,7 @@ size_test!(
 /// // Missing data is filled in on a best-effort basis, and an error is signaled.
 /// assert_try_writeable_parts_eq!(
 ///     names.with_pattern(&pattern).format(&CustomTimeZone::unknown()),
-///     "It is: {E} {M} {d} {y} {G} at {h}:{m}:{s} {a} {GMT+?}",
+///     "It is: {E} {M} {d} {y} {G} at {h}:{m}:{s} {a} {z}",
 ///     Err(DateTimeWriteError::MissingInputField("iso_weekday")),
 ///     [
 ///         (7, 10, Part::ERROR), // {E}
@@ -395,7 +395,7 @@ size_test!(
 ///         (34, 37, Part::ERROR), // {m}
 ///         (38, 41, Part::ERROR), // {s}
 ///         (42, 45, Part::ERROR), // {a}
-///         (46, 53, Part::ERROR), // {GMT+?}
+///         (46, 49, Part::ERROR), // {z}
 ///     ]
 /// );
 /// ```

--- a/components/datetime/src/format/neo.rs
+++ b/components/datetime/src/format/neo.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use super::datetime::{try_write_pattern, DateTimeWriteError};
+use super::datetime::{try_write_pattern_items, DateTimeWriteError};
 use super::{
     GetNameForDayPeriodError, GetNameForMonthError, GetNameForWeekdayError, GetSymbolForEraError,
     MonthPlaceholderValue,
@@ -2431,8 +2431,9 @@ impl TryWriteable for FormattedDateTimePattern<'_> {
         &self,
         sink: &mut S,
     ) -> Result<Result<(), Self::Error>, fmt::Error> {
-        try_write_pattern(
-            self.pattern.0.as_borrowed(),
+        try_write_pattern_items(
+            self.pattern.0.as_borrowed().metadata,
+            self.pattern.0.as_borrowed().items.iter(),
             &self.input,
             &self.names,
             self.names.fixed_decimal_formatter,

--- a/components/datetime/src/neo_marker.rs
+++ b/components/datetime/src/neo_marker.rs
@@ -323,14 +323,16 @@
 //! time_zone.time_zone_id = TimeZoneBcp47Id(tinystr!(8, "ushnl"));
 //! assert_try_writeable_eq!(
 //!     tzf.format(&time_zone),
-//!     "Honolulu Time"
+//!     "{v}",
+//!     Err(DateTimeWriteError::MissingInputField("metazone"))
 //! );
 //!
 //! // If we don't set a zone at all, there's no fallback to the offset
 //! let mut time_zone = "+0530".parse::<CustomTimeZone>().unwrap();
 //! assert_try_writeable_eq!(
 //!     tzf.format(&time_zone),
-//!     "Unknown City Time",
+//!     "{v}",
+//!     Err(DateTimeWriteError::MissingInputField("metazone"))
 //! );
 //! ```
 

--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -52,6 +52,153 @@ impl ResolvedNeoTimeZoneSkeleton {
     pub(crate) fn to_field(self) -> crate::fields::Field {
         crate::tz_registry::resolved_to_field(self)
     }
+
+    pub(crate) fn units(self) -> [Option<TimeZoneFormatterUnit>; 3] {
+        match self {
+            // `z..zzz`
+            ResolvedNeoTimeZoneSkeleton::SpecificShort => [
+                Some(TimeZoneFormatterUnit::SpecificNonLocationShort),
+                Some(TimeZoneFormatterUnit::LocalizedOffsetShort),
+                None,
+            ],
+            // `zzzz`
+            ResolvedNeoTimeZoneSkeleton::SpecificLong => [
+                Some(TimeZoneFormatterUnit::SpecificNonLocationLong),
+                Some(TimeZoneFormatterUnit::LocalizedOffsetLong),
+                None,
+            ],
+            // 'v'
+            ResolvedNeoTimeZoneSkeleton::GenericShort => [
+                Some(TimeZoneFormatterUnit::GenericNonLocationShort),
+                Some(TimeZoneFormatterUnit::GenericLocation),
+                None,
+            ],
+            // 'vvvv'
+            ResolvedNeoTimeZoneSkeleton::GenericLong => [
+                Some(TimeZoneFormatterUnit::GenericNonLocationLong),
+                Some(TimeZoneFormatterUnit::GenericLocation),
+                None,
+            ],
+            // 'VVVV'
+            ResolvedNeoTimeZoneSkeleton::Location => {
+                [Some(TimeZoneFormatterUnit::GenericLocation), None, None]
+            }
+            // `O`
+            ResolvedNeoTimeZoneSkeleton::OffsetShort => [
+                Some(TimeZoneFormatterUnit::LocalizedOffsetShort),
+                None,
+                None,
+            ],
+            // `OOOO`, `ZZZZ`
+            ResolvedNeoTimeZoneSkeleton::OffsetLong => {
+                [Some(TimeZoneFormatterUnit::LocalizedOffsetLong), None, None]
+            }
+            // 'V'
+            ResolvedNeoTimeZoneSkeleton::Bcp47Id => {
+                [Some(TimeZoneFormatterUnit::Bcp47Id), None, None]
+            }
+            // 'X'
+            ResolvedNeoTimeZoneSkeleton::IsoX => [
+                Some(TimeZoneFormatterUnit::Iso8601(Iso8601Format {
+                    format: IsoFormat::UtcBasic,
+                    minutes: IsoMinutes::Optional,
+                    seconds: IsoSeconds::Never,
+                })),
+                None,
+                None,
+            ],
+            // 'XX'
+            ResolvedNeoTimeZoneSkeleton::IsoXX => [
+                Some(TimeZoneFormatterUnit::Iso8601(Iso8601Format {
+                    format: IsoFormat::UtcBasic,
+                    minutes: IsoMinutes::Required,
+                    seconds: IsoSeconds::Never,
+                })),
+                None,
+                None,
+            ],
+            // 'XXX'
+            ResolvedNeoTimeZoneSkeleton::IsoXXX => [
+                Some(TimeZoneFormatterUnit::Iso8601(Iso8601Format {
+                    format: IsoFormat::UtcExtended,
+                    minutes: IsoMinutes::Required,
+                    seconds: IsoSeconds::Never,
+                })),
+                None,
+                None,
+            ],
+            // 'XXXX'
+            ResolvedNeoTimeZoneSkeleton::IsoXXXX => [
+                Some(TimeZoneFormatterUnit::Iso8601(Iso8601Format {
+                    format: IsoFormat::UtcBasic,
+                    minutes: IsoMinutes::Required,
+                    seconds: IsoSeconds::Optional,
+                })),
+                None,
+                None,
+            ],
+            // 'XXXXX', 'ZZZZZ'
+            ResolvedNeoTimeZoneSkeleton::IsoXXXXX => [
+                Some(TimeZoneFormatterUnit::Iso8601(Iso8601Format {
+                    format: IsoFormat::UtcExtended,
+                    minutes: IsoMinutes::Required,
+                    seconds: IsoSeconds::Optional,
+                })),
+                None,
+                None,
+            ],
+            // 'x'
+            ResolvedNeoTimeZoneSkeleton::Isox => [
+                Some(TimeZoneFormatterUnit::Iso8601(Iso8601Format {
+                    format: IsoFormat::Basic,
+                    minutes: IsoMinutes::Optional,
+                    seconds: IsoSeconds::Never,
+                })),
+                None,
+                None,
+            ],
+            // 'xx'
+            ResolvedNeoTimeZoneSkeleton::Isoxx => [
+                Some(TimeZoneFormatterUnit::Iso8601(Iso8601Format {
+                    format: IsoFormat::Basic,
+                    minutes: IsoMinutes::Required,
+                    seconds: IsoSeconds::Never,
+                })),
+                None,
+                None,
+            ],
+            // 'xxx'
+            ResolvedNeoTimeZoneSkeleton::Isoxxx => [
+                Some(TimeZoneFormatterUnit::Iso8601(Iso8601Format {
+                    format: IsoFormat::Extended,
+                    minutes: IsoMinutes::Required,
+                    seconds: IsoSeconds::Never,
+                })),
+                None,
+                None,
+            ],
+            // 'xxxx', 'Z', 'ZZ', 'ZZZ'
+            ResolvedNeoTimeZoneSkeleton::Isoxxxx => [
+                Some(TimeZoneFormatterUnit::Iso8601(Iso8601Format {
+                    format: IsoFormat::Basic,
+                    minutes: IsoMinutes::Required,
+                    seconds: IsoSeconds::Optional,
+                })),
+                None,
+                None,
+            ],
+            // 'xxxxx', 'ZZZZZ'
+            ResolvedNeoTimeZoneSkeleton::Isoxxxxx => [
+                Some(TimeZoneFormatterUnit::Iso8601(Iso8601Format {
+                    format: IsoFormat::Extended,
+                    minutes: IsoMinutes::Required,
+                    seconds: IsoSeconds::Optional,
+                })),
+                None,
+                None,
+            ],
+        }
+    }
 }
 
 /// A container contains all data payloads for time zone formatting (borrowed version).

--- a/components/datetime/tests/fixtures/tests/components_with_zones.json
+++ b/components/datetime/tests/fixtures/tests/components_with_zones.json
@@ -23,7 +23,7 @@
         },
         "output": {
             "values": {
-                "en": "Tuesday, January 21, 2020, 08:25:07 Unknown City Time"
+                "en": "Tuesday, January 21, 2020, 08:25:07 {v}"
             }
         }
     },
@@ -51,7 +51,7 @@
         },
         "output": {
             "values": {
-                "en": "Tuesday, January 21, 2020, 08:25:07 Unknown City Time"
+                "en": "Tuesday, January 21, 2020, 08:25:07 {v}"
             }
         }
     },
@@ -79,7 +79,7 @@
         },
         "output": {
             "values": {
-                "en": "Tuesday, January 21, 2020, 08:25:07 GMT+5"
+                "en": "Tuesday, January 21, 2020, 08:25:07 {z}"
             }
         }
     },
@@ -107,7 +107,7 @@
         },
         "output": {
             "values": {
-                "en": "Tuesday, January 21, 2020, 08:25:07 GMT+5"
+                "en": "Tuesday, January 21, 2020, 08:25:07 {z}"
             }
         }
     },

--- a/components/datetime/tests/patterns/tests/time_zones.json
+++ b/components/datetime/tests/patterns/tests/time_zones.json
@@ -986,7 +986,13 @@
         "patterns": [
           "z",
           "zz",
-          "zzz",
+          "zzz"
+        ],
+        "configs": [],
+        "expected": ["{z}"]
+      },
+      {
+        "patterns": [
           "O"
         ],
         "configs": [],
@@ -994,7 +1000,6 @@
       },
       {
         "patterns": [
-          "zzzz",
           "OOOO",
           "ZZZZ"
         ],
@@ -1037,6 +1042,13 @@
           "z",
           "zz",
           "zzz",
+          "zzzz"
+        ],
+        "configs": [],
+        "expected": ["{z}"]
+      },
+      {
+        "patterns": [
           "O"
         ],
         "configs": [],
@@ -1044,7 +1056,6 @@
       },
       {
         "patterns": [
-          "zzzz",
           "ZZZZ",
           "OOOO"
         ],
@@ -1070,7 +1081,13 @@
       {
         "patterns": [
           "v",
-          "vvvv",
+          "vvvv"
+        ],
+        "configs": [],
+        "expected": ["{v}"]
+      },
+      {
+        "patterns": [
           "VVVV"
         ],
         "configs": [],
@@ -1087,17 +1104,29 @@
           "z",
           "zz",
           "zzz",
-          "zzzz",
+          "zzzz"
+        ],
+        "configs": [],
+        "expected": ["{z}"]
+      },
+      {
+        "patterns": [
           "Z",
           "ZZ",
           "ZZZ",
           "ZZZZ",
-          "ZZZZZ",
+          "ZZZZZ"
+        ],
+        "configs": [],
+        "expected": ["{Z}"]
+      },
+      {
+        "patterns": [
           "O",
           "OOOO"
         ],
         "configs": [],
-        "expected": ["{GMT+?}"]
+        "expected": ["{O}"]
       },
       {
         "patterns": [


### PR DESCRIPTION
This PR improves error cases. For missing inputs, the field will be formatted, as for all other missing inputs (`{x}`).