### PR TITLE
Set MSRV on tutorial Cargo.tomls to avoid introducing lockfile v4

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -119,9 +119,6 @@ description = "Run all tests for the CI 'test-c' job"
 category = "CI"
 dependencies = [
     "test-c",
-    # Can be removed after LLVM nightly is updated past May 2024, but it's fine to keep in
-    # to prevent such problems in the future
-    "internal-reset-tutorial-lockfiles",
     "test-c-tiny",
     "test-cpp",
 ]
@@ -131,9 +128,6 @@ description = "Run all tests for the CI 'test-js' job"
 category = "CI"
 dependencies = [
     "test-npm",
-    # Can be removed after LLVM nightly is updated past May 2024, but it's fine to keep in
-    # to prevent such problems in the future
-    "internal-reset-tutorial-lockfiles",
     "test-tinywasm",
 ]
 
@@ -349,10 +343,3 @@ else
     echo "forced-toolchain environment not required"
 end
 '''
-
-[tasks.internal-reset-tutorial-lockfiles]
-description = "Reset changes to tutorial lockfiles (useful to clean up between CI jobs)"
-category = "ICU4X CI internal"
-command = "git"
-args = ["checkout", "@", "--", "tutorials/**/Cargo.lock"]
-

--- a/tutorials/c-tiny/fixeddecimal/Cargo.toml
+++ b/tutorials/c-tiny/fixeddecimal/Cargo.toml
@@ -5,6 +5,8 @@
 [package]
 name = "unused"
 version = "0.0.0"
+# To ensure it stays on older lockfiles. Update when our pinned nightly supports lockfile v4
+rust-version = "1.71.1"
 
 [lib]
 path = "unused"

--- a/tutorials/c-tiny/segmenter/Cargo.toml
+++ b/tutorials/c-tiny/segmenter/Cargo.toml
@@ -5,6 +5,9 @@
 [package]
 name = "unused"
 version = "0.0.0"
+# To ensure it stays on older lockfiles. Update when our pinned nightly supports lockfile v4
+rust-version = "1.71.1"
+
 
 [lib]
 path = "unused"

--- a/tutorials/js-tiny/Cargo.toml
+++ b/tutorials/js-tiny/Cargo.toml
@@ -5,6 +5,9 @@
 [package]
 name = "unused"
 version = "0.0.0"
+# To ensure it stays on older lockfiles. Update when our pinned nightly supports lockfile v4
+rust-version = "1.71.1"
+
 
 [lib]
 path = "unused"


### PR DESCRIPTION
Attempt 2. https://github.com/unicode-org/icu4x/pull/5649 didn't work since the makefile itself calls cargo on non-pinned rust a couple times.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->