### PR TITLE
Fix nightly clippy issues

### DIFF
--- a/components/calendar/src/chinese_based.rs
+++ b/components/calendar/src/chinese_based.rs
@@ -128,8 +128,8 @@ pub(crate) fn compute_many_packed<CB: ChineseBased>(
         .collect()
 }
 
-impl<'b, CB: ChineseBased> PrecomputedDataSource<ChineseBasedYearInfo>
-    for ChineseBasedPrecomputedData<'b, CB>
+impl<CB: ChineseBased> PrecomputedDataSource<ChineseBasedYearInfo>
+    for ChineseBasedPrecomputedData<'_, CB>
 {
     fn load_or_compute_info(&self, extended_year: i32) -> ChineseBasedYearInfo {
         self.data

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -75,7 +75,7 @@ impl<C: Calendar> AsCalendar for Ref<'_, C> {
     }
 }
 
-impl<'a, C> Deref for Ref<'a, C> {
+impl<C> Deref for Ref<'_, C> {
     type Target = C;
     fn deref(&self) -> &C {
         self.0

--- a/components/calendar/src/islamic.rs
+++ b/components/calendar/src/islamic.rs
@@ -330,8 +330,8 @@ pub(crate) struct IslamicPrecomputedData<'a, IB: IslamicBasedMarker> {
     _ib: PhantomData<IB>,
 }
 
-impl<'b, IB: IslamicBasedMarker> PrecomputedDataSource<IslamicYearInfo>
-    for IslamicPrecomputedData<'b, IB>
+impl<IB: IslamicBasedMarker> PrecomputedDataSource<IslamicYearInfo>
+    for IslamicPrecomputedData<'_, IB>
 {
     fn load_or_compute_info(&self, extended_year: i32) -> IslamicYearInfo {
         self.data

--- a/components/calendar/src/provider/chinese_based.rs
+++ b/components/calendar/src/provider/chinese_based.rs
@@ -41,7 +41,7 @@ pub struct ChineseBasedCacheV1<'data> {
     pub data: ZeroVec<'data, PackedChineseBasedYearInfo>,
 }
 
-impl<'data> ChineseBasedCacheV1<'data> {
+impl ChineseBasedCacheV1<'_> {
     /// Compute this data for a range of years
     #[cfg(feature = "datagen")]
     pub fn compute_for<CB: ChineseBased>(extended_years: core::ops::Range<i32>) -> Self {

--- a/components/calendar/src/provider/islamic.rs
+++ b/components/calendar/src/provider/islamic.rs
@@ -47,7 +47,7 @@ pub struct IslamicCacheV1<'data> {
     pub data: ZeroVec<'data, PackedIslamicYearInfo>,
 }
 
-impl<'data> IslamicCacheV1<'data> {
+impl IslamicCacheV1<'_> {
     /// Compute this data for a range of years
     #[cfg(feature = "datagen")]
     pub fn compute_for<IB: IslamicBasedMarker>(extended_years: core::ops::Range<i32>) -> Self {

--- a/components/casemap/src/internals.rs
+++ b/components/casemap/src/internals.rs
@@ -42,7 +42,7 @@ pub(crate) struct StringAndWriteable<'a, W> {
     pub writeable: W,
 }
 
-impl<'a, Wr: Writeable> Writeable for StringAndWriteable<'a, Wr> {
+impl<Wr: Writeable> Writeable for StringAndWriteable<'_, Wr> {
     fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
         sink.write_str(self.string)?;
         self.writeable.write_to(sink)
@@ -60,7 +60,7 @@ pub(crate) struct FullCaseWriteable<'a, const IS_TITLE_CONTEXT: bool> {
     titlecase_tail_casing: TrailingCase,
 }
 
-impl<'a, const IS_TITLE_CONTEXT: bool> Writeable for FullCaseWriteable<'a, IS_TITLE_CONTEXT> {
+impl<const IS_TITLE_CONTEXT: bool> Writeable for FullCaseWriteable<'_, IS_TITLE_CONTEXT> {
     #[allow(clippy::indexing_slicing)] // last_uncopied_index and i are known to be in bounds
     fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
         let src = self.src;
@@ -684,7 +684,7 @@ pub enum FullMappingResult<'a> {
     String(&'a str),
 }
 
-impl<'a> FullMappingResult<'a> {
+impl FullMappingResult<'_> {
     #[allow(dead_code)]
     fn add_to_set<S: ClosureSink>(&self, set: &mut S) {
         match *self {

--- a/components/casemap/src/provider/exceptions.rs
+++ b/components/casemap/src/provider/exceptions.rs
@@ -43,7 +43,7 @@ pub struct CaseMapExceptions<'data> {
     pub exceptions: VarZeroVec<'data, ExceptionULE>,
 }
 
-impl<'data> CaseMapExceptions<'data> {
+impl CaseMapExceptions<'_> {
     /// Obtain the exception at index `idx`. Will
     /// return a default value if not present (GIGO behavior),
     /// as these indices should come from a paired CaseMapData object
@@ -444,7 +444,7 @@ pub struct DecodedException<'a> {
     pub full: Option<[Cow<'a, str>; 4]>,
 }
 
-impl<'a> DecodedException<'a> {
+impl DecodedException<'_> {
     /// Convert to a wire-format encodeable (VarULE-encodeable) [`Exception`]
     pub fn encode(&self) -> Exception<'static> {
         let bits = self.bits;

--- a/components/casemap/src/provider/mod.rs
+++ b/components/casemap/src/provider/mod.rs
@@ -103,7 +103,7 @@ impl<'de> serde::Deserialize<'de> for CaseMapV1<'de> {
     }
 }
 
-impl<'data> CaseMapV1<'data> {
+impl CaseMapV1<'_> {
     /// Creates a new CaseMapV1 using data exported by the
     // `icuexportdata` tool in ICU4C. Validates that the data is
     // consistent.

--- a/components/casemap/src/provider/unfold.rs
+++ b/components/casemap/src/provider/unfold.rs
@@ -30,7 +30,7 @@ pub struct CaseMapUnfoldV1<'data> {
     pub map: ZeroMap<'data, PotentialUtf8, str>,
 }
 
-impl<'data> CaseMapUnfoldV1<'data> {
+impl CaseMapUnfoldV1<'_> {
     /// Creates a new CaseMapUnfoldV1 using data exported by the `icuexportdata` tool in ICU4C.
     ///
     /// Unfold data is exported by ICU as an array of 16-bit values, representing a short

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -446,7 +446,7 @@ impl CollatorBorrowed<'static> {
     }
 }
 
-impl<'a> CollatorBorrowed<'a> {
+impl CollatorBorrowed<'_> {
     /// The resolved options showing how the default options, the requested options,
     /// and the options from locale data were combined.
     pub fn resolved_options(&self) -> ResolvedCollatorOptions {

--- a/components/collator/src/options.rs
+++ b/components/collator/src/options.rs
@@ -11,6 +11,7 @@
 use crate::elements::{CASE_MASK, TERTIARY_MASK};
 
 /// The collation strength that indicates how many levels to compare.
+///
 /// If an earlier level isn't equal, the earlier level is decisive.
 /// If the result is equal on a level, but the strength is higher,
 /// the comparison proceeds to the next level.

--- a/components/collator/src/provider.rs
+++ b/components/collator/src/provider.rs
@@ -334,7 +334,7 @@ pub struct CollationReorderingV1<'data> {
     pub reorder_ranges: ZeroVec<'data, u32>,
 }
 
-impl<'data> CollationReorderingV1<'data> {
+impl CollationReorderingV1<'_> {
     pub(crate) fn reorder(&self, primary: u32) -> u32 {
         if let Some(b) = self.reorder_table.get((primary >> 24) as usize) {
             if b != 0 || primary <= NO_CE_PRIMARY {
@@ -491,7 +491,7 @@ pub struct CollationSpecialPrimariesV1<'data> {
     pub numeric_primary: u8,
 }
 
-impl<'data> CollationSpecialPrimariesV1<'data> {
+impl CollationSpecialPrimariesV1<'_> {
     #[allow(clippy::unwrap_used)]
     pub(crate) fn last_primary_for_group(&self, max_variable: MaxVariable) -> u32 {
         // `unwrap` is OK, because `Collator::try_new` validates the length.

--- a/components/collections/src/codepointinvlist/conversions.rs
+++ b/components/collections/src/codepointinvlist/conversions.rs
@@ -31,7 +31,7 @@ fn try_from_range<'data>(
     }
 }
 
-impl<'data> TryFrom<Range<char>> for CodePointInversionList<'data> {
+impl TryFrom<Range<char>> for CodePointInversionList<'_> {
     type Error = RangeError;
 
     fn try_from(range: Range<char>) -> Result<Self, Self::Error> {
@@ -39,7 +39,7 @@ impl<'data> TryFrom<Range<char>> for CodePointInversionList<'data> {
     }
 }
 
-impl<'data> TryFrom<RangeFrom<char>> for CodePointInversionList<'data> {
+impl TryFrom<RangeFrom<char>> for CodePointInversionList<'_> {
     type Error = RangeError;
 
     fn try_from(range: RangeFrom<char>) -> Result<Self, Self::Error> {
@@ -47,7 +47,7 @@ impl<'data> TryFrom<RangeFrom<char>> for CodePointInversionList<'data> {
     }
 }
 
-impl<'data> TryFrom<RangeFull> for CodePointInversionList<'data> {
+impl TryFrom<RangeFull> for CodePointInversionList<'_> {
     type Error = RangeError;
 
     fn try_from(_: RangeFull) -> Result<Self, Self::Error> {
@@ -55,7 +55,7 @@ impl<'data> TryFrom<RangeFull> for CodePointInversionList<'data> {
     }
 }
 
-impl<'data> TryFrom<RangeInclusive<char>> for CodePointInversionList<'data> {
+impl TryFrom<RangeInclusive<char>> for CodePointInversionList<'_> {
     type Error = RangeError;
 
     fn try_from(range: RangeInclusive<char>) -> Result<Self, Self::Error> {
@@ -63,7 +63,7 @@ impl<'data> TryFrom<RangeInclusive<char>> for CodePointInversionList<'data> {
     }
 }
 
-impl<'data> TryFrom<RangeTo<char>> for CodePointInversionList<'data> {
+impl TryFrom<RangeTo<char>> for CodePointInversionList<'_> {
     type Error = RangeError;
 
     fn try_from(range: RangeTo<char>) -> Result<Self, Self::Error> {
@@ -71,7 +71,7 @@ impl<'data> TryFrom<RangeTo<char>> for CodePointInversionList<'data> {
     }
 }
 
-impl<'data> TryFrom<RangeToInclusive<char>> for CodePointInversionList<'data> {
+impl TryFrom<RangeToInclusive<char>> for CodePointInversionList<'_> {
     type Error = RangeError;
 
     fn try_from(range: RangeToInclusive<char>) -> Result<Self, Self::Error> {

--- a/components/collections/src/codepointinvlist/cpinvlist.rs
+++ b/components/collections/src/codepointinvlist/cpinvlist.rs
@@ -145,7 +145,7 @@ impl core::fmt::Display for UnicodeCodePoint {
 }
 
 #[cfg(feature = "serde")]
-impl<'data> serde::Serialize for CodePointInversionList<'data> {
+impl serde::Serialize for CodePointInversionList<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/components/collections/src/codepointtrie/cptrie.rs
+++ b/components/collections/src/codepointtrie/cptrie.rs
@@ -982,7 +982,7 @@ impl<'trie, T: TrieValue> CodePointTrie<'trie, T> {
 }
 
 #[cfg(feature = "databake")]
-impl<'trie, T: TrieValue + databake::Bake> databake::Bake for CodePointTrie<'trie, T> {
+impl<T: TrieValue + databake::Bake> databake::Bake for CodePointTrie<'_, T> {
     fn bake(&self, env: &databake::CrateEnv) -> databake::TokenStream {
         let header = self.header.bake(env);
         let index = self.index.bake(env);
@@ -993,13 +993,13 @@ impl<'trie, T: TrieValue + databake::Bake> databake::Bake for CodePointTrie<'tri
 }
 
 #[cfg(feature = "databake")]
-impl<'trie, T: TrieValue + databake::Bake> databake::BakeSize for CodePointTrie<'trie, T> {
+impl<T: TrieValue + databake::Bake> databake::BakeSize for CodePointTrie<'_, T> {
     fn borrows_size(&self) -> usize {
         self.header.borrows_size() + self.index.borrows_size() + self.data.borrows_size()
     }
 }
 
-impl<'trie, T: TrieValue + Into<u32>> CodePointTrie<'trie, T> {
+impl<T: TrieValue + Into<u32>> CodePointTrie<'_, T> {
     /// Returns the value that is associated with `code_point` for this [`CodePointTrie`]
     /// as a `u32`.
     ///
@@ -1022,7 +1022,7 @@ impl<'trie, T: TrieValue + Into<u32>> CodePointTrie<'trie, T> {
     }
 }
 
-impl<'trie, T: TrieValue> Clone for CodePointTrie<'trie, T>
+impl<T: TrieValue> Clone for CodePointTrie<'_, T>
 where
     <T as zerovec::ule::AsULE>::ULE: Clone,
 {
@@ -1060,7 +1060,7 @@ pub struct CodePointMapRangeIterator<'a, T: TrieValue> {
     cpm_range: Option<CodePointMapRange<T>>,
 }
 
-impl<'a, T: TrieValue> Iterator for CodePointMapRangeIterator<'a, T> {
+impl<T: TrieValue> Iterator for CodePointMapRangeIterator<'_, T> {
     type Item = CodePointMapRange<T>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/components/collections/src/codepointtrie/serde.rs
+++ b/components/collections/src/codepointtrie/serde.rs
@@ -16,7 +16,7 @@ pub struct CodePointTrieSerde<'trie, T: TrieValue> {
     data: ZeroVec<'trie, T>,
 }
 
-impl<'trie, T: TrieValue + Serialize> Serialize for CodePointTrie<'trie, T> {
+impl<T: TrieValue + Serialize> Serialize for CodePointTrie<'_, T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/components/datetime/benches/datetime.rs
+++ b/components/datetime/benches/datetime.rs
@@ -20,7 +20,7 @@ fn datetime_benches(c: &mut Criterion) {
 
     let mut bench_neoneo_datetime_with_fixture = |name, file, has_zones| {
         let fxs = serde_json::from_str::<fixtures::Fixture>(file).unwrap();
-        group.bench_function(&format!("semantic/{name}"), |b| {
+        group.bench_function(format!("semantic/{name}"), |b| {
             b.iter(|| {
                 for fx in &fxs.0 {
                     let datetimes: Vec<CustomZonedDateTime<Gregorian>> = fx

--- a/components/datetime/src/format/neo.rs
+++ b/components/datetime/src/format/neo.rs
@@ -2426,7 +2426,7 @@ pub struct FormattedDateTimePattern<'a> {
     names: RawDateTimeNamesBorrowed<'a>,
 }
 
-impl<'a> TryWriteable for FormattedDateTimePattern<'a> {
+impl TryWriteable for FormattedDateTimePattern<'_> {
     type Error = DateTimeWriteError;
     fn try_write_to_parts<S: writeable::PartsWrite + ?Sized>(
         &self,
@@ -2554,7 +2554,7 @@ impl<'data> DateSymbols<'data> for RawDateTimeNamesBorrowed<'data> {
     }
 }
 
-impl<'data> TimeSymbols for RawDateTimeNamesBorrowed<'data> {
+impl TimeSymbols for RawDateTimeNamesBorrowed<'_> {
     fn get_name_for_day_period(
         &self,
         field_symbol: fields::DayPeriod,

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -1451,7 +1451,7 @@ pub struct FormattedNeoDateTime<'a> {
     names: RawDateTimeNamesBorrowed<'a>,
 }
 
-impl<'a> TryWriteable for FormattedNeoDateTime<'a> {
+impl TryWriteable for FormattedNeoDateTime<'_> {
     type Error = DateTimeWriteError;
 
     fn try_write_to_parts<S: writeable::PartsWrite + ?Sized>(
@@ -1474,7 +1474,7 @@ impl<'a> TryWriteable for FormattedNeoDateTime<'a> {
     // TODO(#489): Implement writeable_length_hint
 }
 
-impl<'a> FormattedNeoDateTime<'a> {
+impl FormattedNeoDateTime<'_> {
     /// Gets the pattern used in this formatted value.
     pub fn pattern(&self) -> DateTimePattern {
         self.pattern.to_pattern()

--- a/components/datetime/src/options/components.rs
+++ b/components/datetime/src/options/components.rs
@@ -634,7 +634,7 @@ impl From<TimeZoneName> for Field {
 
 /// Get the resolved components for a TypedDateTimeFormatter, via the PatternPlurals. In the case of
 /// plurals resolve off of the required `other` pattern.
-impl<'data> From<&PatternPlurals<'data>> for Bag {
+impl From<&PatternPlurals<'_>> for Bag {
     fn from(other: &PatternPlurals) -> Self {
         let pattern = match other {
             PatternPlurals::SinglePattern(pattern) => pattern,
@@ -650,7 +650,7 @@ impl From<&DateTimePattern> for Bag {
     }
 }
 
-impl<'data> From<&Pattern<'data>> for Bag {
+impl From<&Pattern<'_>> for Bag {
     fn from(pattern: &Pattern) -> Self {
         let mut bag: Bag = Default::default();
 

--- a/components/datetime/src/pattern/common/serde.rs
+++ b/components/datetime/src/pattern/common/serde.rs
@@ -43,7 +43,7 @@ mod reference {
     #[allow(clippy::upper_case_acronyms)]
     pub(crate) struct DeserializePatternUTS35String;
 
-    impl<'de> de::Visitor<'de> for DeserializePatternUTS35String {
+    impl de::Visitor<'_> for DeserializePatternUTS35String {
         type Value = Pattern;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/components/datetime/src/pattern/runtime/pattern.rs
+++ b/components/datetime/src/pattern/runtime/pattern.rs
@@ -94,7 +94,7 @@ impl Default for PatternMetadata {
     }
 }
 
-impl<'data> Pattern<'data> {
+impl Pattern<'_> {
     pub fn into_owned(self) -> Pattern<'static> {
         Pattern {
             items: self.items.into_owned(),

--- a/components/datetime/src/provider/calendar/symbols.rs
+++ b/components/datetime/src/provider/calendar/symbols.rs
@@ -277,7 +277,7 @@ symbols!(
     }
 );
 
-impl<'data> months::SymbolsV1<'data> {
+impl months::SymbolsV1<'_> {
     /// Get the symbol for the given month code
     pub fn get(&self, code: MonthCode) -> Option<&str> {
         match *self {

--- a/components/datetime/src/provider/date_time.rs
+++ b/components/datetime/src/provider/date_time.rs
@@ -202,7 +202,7 @@ pub(crate) trait TimeSymbols {
     ) -> Result<&str, GetNameForDayPeriodError>;
 }
 
-impl<'data> TimeSymbols for provider::calendar::TimeSymbolsV1<'data> {
+impl TimeSymbols for provider::calendar::TimeSymbolsV1<'_> {
     fn get_name_for_day_period(
         &self,
         day_period: fields::DayPeriod,

--- a/components/datetime/src/provider/neo.rs
+++ b/components/datetime/src/provider/neo.rs
@@ -477,7 +477,7 @@ pub struct LinearNamesV1<'data> {
     pub names: VarZeroVec<'data, str>,
 }
 
-impl<'data> LinearNamesV1<'data> {
+impl LinearNamesV1<'_> {
     /// Gets the 'am' name assuming this struct contains day period data.
     pub(crate) fn am(&self) -> Option<&str> {
         self.names.get(0)

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -91,7 +91,7 @@ pub(crate) struct ItemsAndOptions<'a> {
     pub(crate) fractional_second_digits: Option<FractionalSecondDigits>,
 }
 
-impl<'a> ItemsAndOptions<'a> {
+impl ItemsAndOptions<'_> {
     fn new_empty() -> Self {
         Self {
             items: ZeroSlice::new_empty(),

--- a/components/datetime/src/skeleton/serde.rs
+++ b/components/datetime/src/skeleton/serde.rs
@@ -17,7 +17,7 @@ pub mod reference {
     #[allow(clippy::upper_case_acronyms)]
     pub(super) struct DeserializeSkeletonUTS35String;
 
-    impl<'de> de::Visitor<'de> for DeserializeSkeletonUTS35String {
+    impl de::Visitor<'_> for DeserializeSkeletonUTS35String {
         type Value = Skeleton;
 
         fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {

--- a/components/decimal/src/format.rs
+++ b/components/decimal/src/format.rs
@@ -20,7 +20,7 @@ pub struct FormattedFixedDecimal<'l> {
     pub(crate) symbols: &'l DecimalSymbolsV1<'l>,
 }
 
-impl<'l> FormattedFixedDecimal<'l> {
+impl FormattedFixedDecimal<'_> {
     fn get_affixes(&self) -> Option<&AffixesV1> {
         match self.value.sign() {
             Sign::None => None,
@@ -30,7 +30,7 @@ impl<'l> FormattedFixedDecimal<'l> {
     }
 }
 
-impl<'l> Writeable for FormattedFixedDecimal<'l> {
+impl Writeable for FormattedFixedDecimal<'_> {
     fn write_to<W>(&self, sink: &mut W) -> core::result::Result<(), core::fmt::Error>
     where
         W: core::fmt::Write + ?Sized,

--- a/components/experimental/src/compactdecimal/format.rs
+++ b/components/experimental/src/compactdecimal/format.rs
@@ -49,7 +49,7 @@ impl FormattedCompactDecimal<'_> {
     }
 }
 
-impl<'l> Writeable for FormattedCompactDecimal<'l> {
+impl Writeable for FormattedCompactDecimal<'_> {
     fn write_to<W>(&self, sink: &mut W) -> core::result::Result<(), core::fmt::Error>
     where
         W: core::fmt::Write + ?Sized,

--- a/components/experimental/src/compactdecimal/provider.rs
+++ b/components/experimental/src/compactdecimal/provider.rs
@@ -27,6 +27,7 @@ use zerovec::ZeroMap2d;
 pub use crate::provider::Baked;
 
 /// Compact Decimal Pattern V1 data struct.
+///
 /// As in CLDR, this is a mapping from type (a power of ten, corresponding to
 /// the magnitude of the number being formatted) and count (a plural case or an
 /// explicit 1) to a pattern.

--- a/components/experimental/src/dimension/currency/format.rs
+++ b/components/experimental/src/dimension/currency/format.rs
@@ -23,7 +23,7 @@ pub struct FormattedCurrency<'l> {
 
 writeable::impl_display_with_writeable!(FormattedCurrency<'_>);
 
-impl<'l> Writeable for FormattedCurrency<'l> {
+impl Writeable for FormattedCurrency<'_> {
     fn write_to<W>(&self, sink: &mut W) -> core::result::Result<(), core::fmt::Error>
     where
         W: core::fmt::Write + ?Sized,

--- a/components/experimental/src/dimension/currency/long_format.rs
+++ b/components/experimental/src/dimension/currency/long_format.rs
@@ -25,7 +25,7 @@ pub struct LongFormattedCurrency<'l> {
 
 writeable::impl_display_with_writeable!(LongFormattedCurrency<'_>);
 
-impl<'l> Writeable for LongFormattedCurrency<'l> {
+impl Writeable for LongFormattedCurrency<'_> {
     fn write_to<W>(&self, sink: &mut W) -> core::result::Result<(), core::fmt::Error>
     where
         W: core::fmt::Write + ?Sized,

--- a/components/experimental/src/dimension/percent/format.rs
+++ b/components/experimental/src/dimension/percent/format.rs
@@ -32,7 +32,7 @@ pub struct FormattedPercent<'l> {
     pub(crate) fixed_decimal_formatter: &'l FixedDecimalFormatter,
 }
 
-impl<'l> Writeable for FormattedPercent<'l> {
+impl Writeable for FormattedPercent<'_> {
     fn write_to<W>(&self, sink: &mut W) -> core::result::Result<(), core::fmt::Error>
     where
         W: core::fmt::Write + ?Sized,

--- a/components/experimental/src/dimension/units/format.rs
+++ b/components/experimental/src/dimension/units/format.rs
@@ -20,7 +20,7 @@ pub struct FormattedUnit<'l> {
     pub(crate) plural_rules: &'l PluralRules,
 }
 
-impl<'l> Writeable for FormattedUnit<'l> {
+impl Writeable for FormattedUnit<'_> {
     fn write_to<W>(&self, sink: &mut W) -> core::result::Result<(), core::fmt::Error>
     where
         W: core::fmt::Write + ?Sized,

--- a/components/experimental/src/duration/format.rs
+++ b/components/experimental/src/duration/format.rs
@@ -130,7 +130,7 @@ impl Writeable for FormattedDigitalDuration<'_> {
     }
 }
 
-impl<'a> FormattedDuration<'a> {
+impl FormattedDuration<'_> {
     /// Section 1.1.9
     /// Formats numeric hours to [`DigitalDurationFormatter`]. Requires hours formatting style to be either Numeric or TwoDigit.
     fn format_numeric_hours(

--- a/components/experimental/src/personnames/formatter.rs
+++ b/components/experimental/src/personnames/formatter.rs
@@ -144,11 +144,11 @@ impl PersonNamesFormatter {
             .as_ref()
             .map(|f| f.as_ref())
             .unwrap_or("{0} {1}");
-        return Ok(best_applicable_pattern
+        Ok(best_applicable_pattern
             .format_person_name(person_name, initial_pattern, initial_sequence_pattern)
             .split_whitespace()
             .collect::<Vec<_>>()
-            .join(space_replacement));
+            .join(space_replacement))
     }
 
     fn final_person_names_formatter_options<N>(

--- a/components/experimental/src/personnames/specifications/derive_missing_surname.rs
+++ b/components/experimental/src/personnames/specifications/derive_missing_surname.rs
@@ -11,7 +11,7 @@ pub fn derive_missing_surname(
     requested_name_field: &NameField,
     requires_given_name: bool,
 ) -> Option<NameField> {
-    return match requested_name_field.kind {
+    match requested_name_field.kind {
         NameFieldKind::Surname | NameFieldKind::Given => {
             let has_surname = available_name_field
                 .iter()
@@ -25,10 +25,10 @@ pub fn derive_missing_surname(
                 }
                 return None;
             }
-            return Some(*requested_name_field);
+            Some(*requested_name_field)
         }
         _ => Some(*requested_name_field),
-    };
+    }
 }
 
 #[cfg(test)]

--- a/components/experimental/src/personnames/specifications/pattern_regex_selector.rs
+++ b/components/experimental/src/personnames/specifications/pattern_regex_selector.rs
@@ -22,7 +22,7 @@ pub struct PersonNamePattern<'lt> {
     pub name_fields: Vec<(NameField, Cow<'lt, str>)>,
 }
 
-impl<'lt> PersonNamePattern<'lt> {}
+impl PersonNamePattern<'_> {}
 
 impl PersonNamePattern<'_> {
     #[cfg(test)]
@@ -79,7 +79,7 @@ impl PersonNamePattern<'_> {
             requested_name_field,
         );
 
-        return effective_name_field
+        effective_name_field
             .iter()
             .flat_map(|field| {
                 specifications::derive_missing_surname(
@@ -96,7 +96,7 @@ impl PersonNamePattern<'_> {
                     initial_sequence_pattern,
                 )
             })
-            .collect();
+            .collect()
     }
 
     pub fn format_person_name(

--- a/components/experimental/src/relativetime/format.rs
+++ b/components/experimental/src/relativetime/format.rs
@@ -32,7 +32,7 @@ pub struct FormattedRelativeTime<'a> {
     pub(crate) is_negative: bool,
 }
 
-impl<'a> Writeable for FormattedRelativeTime<'a> {
+impl Writeable for FormattedRelativeTime<'_> {
     fn write_to_parts<S: writeable::PartsWrite + ?Sized>(&self, sink: &mut S) -> core::fmt::Result {
         if self.options.numeric == Numeric::Auto {
             let relatives = &self.formatter.rt.get().relatives;

--- a/components/experimental/src/transliterate/compile/pass2.rs
+++ b/components/experimental/src/transliterate/compile/pass2.rs
@@ -219,7 +219,7 @@ enum LiteralOrStandin<'a> {
 }
 
 // gives us `to_string` and makes clippy happy
-impl<'a> Display for LiteralOrStandin<'a> {
+impl Display for LiteralOrStandin<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
             LiteralOrStandin::Literal(s) => write!(f, "{}", s),

--- a/components/experimental/src/transliterate/compile/rule_group_agg.rs
+++ b/components/experimental/src/transliterate/compile/rule_group_agg.rs
@@ -286,7 +286,7 @@ enum ReverseRuleGroup<'p> {
     Transform(VecDeque<Cow<'p, parse::SingleId>>),
 }
 
-impl<'p> Default for ReverseRuleGroup<'p> {
+impl Default for ReverseRuleGroup<'_> {
     fn default() -> Self {
         Self::Conversion(Vec::new())
     }

--- a/components/experimental/src/transliterate/provider.rs
+++ b/components/experimental/src/transliterate/provider.rs
@@ -53,7 +53,7 @@ pub struct RuleBasedTransliterator<'a> {
     pub rule_group_list: VarZeroVec<'a, VarZeroSlice<RuleULE>>,
 }
 
-impl<'a> RuleBasedTransliterator<'a> {
+impl RuleBasedTransliterator<'_> {
     /// Returns an iterator of dependencies on other transliterators.
     ///
     /// Note that this may contain duplicate entries.
@@ -160,7 +160,7 @@ pub struct VarTable<'a> {
     pub max_right_placeholder_count: u16,
 }
 
-impl<'a> VarTable<'a> {
+impl VarTable<'_> {
     /// The lowest `char` used for encoding specials.
     pub const BASE: char = '\u{F0000}';
     /// The highest `char` used for encoding dynamic (i.e., growing, non-reserved) specials.

--- a/components/experimental/src/transliterate/transliterator/mod.rs
+++ b/components/experimental/src/transliterate/transliterator/mod.rs
@@ -487,7 +487,7 @@ impl Transliterator {
     }
 }
 
-impl<'a> RuleBasedTransliterator<'a> {
+impl RuleBasedTransliterator<'_> {
     /// Transliteration using rules works as follows:
     ///  1. Split the input modifiable range of the Replaceable according into runs according to self.filter
     ///  2. Transliterate each run in sequence
@@ -514,7 +514,7 @@ impl<'a> RuleBasedTransliterator<'a> {
     }
 }
 
-impl<'a> SimpleId<'a> {
+impl SimpleId<'_> {
     fn transliterate(&self, mut rep: Replaceable, env: &Env) {
         // eprintln!("transliterating SimpleId: {self:?}");
         // definitely loaded in the constructor
@@ -569,7 +569,7 @@ impl<'a> RuleGroup<'a> {
     }
 }
 
-impl<'a> Rule<'a> {
+impl Rule<'_> {
     /// Applies this rule's replacement using the given [`MatchData`]. Updates the cursor of the
     /// current run.
     fn apply(&self, mut dest: Insertable, data: MatchData, vt: &VarTable, env: &Env) {
@@ -905,7 +905,7 @@ enum SpecialMatcher<'a> {
     AnchorEnd,
 }
 
-impl<'a> SpecialMatcher<'a> {
+impl SpecialMatcher<'_> {
     // Thought: a lot of duplicated code in matches and rev_matches. deduplicate.
     //  maybe by being generic over Direction? doesn't work for some special cases, though, like segments and sets
 
@@ -1114,7 +1114,7 @@ enum SpecialReplacer<'a> {
     PureCursor,
 }
 
-impl<'a> SpecialReplacer<'a> {
+impl SpecialReplacer<'_> {
     /// Estimates the size of the replacement string produced by this Replacer.
     fn estimate_size(&self, data: &MatchData, vt: &VarTable) -> usize {
         match self {

--- a/components/experimental/src/transliterate/transliterator/replaceable.rs
+++ b/components/experimental/src/transliterate/transliterator/replaceable.rs
@@ -115,14 +115,14 @@ impl<'a> Hide<'a> {
     }
 }
 
-impl<'a> Deref for Hide<'a> {
+impl Deref for Hide<'_> {
     type Target = [u8];
     fn deref(&self) -> &Self::Target {
         &self.raw[self.hide_pre_len..self.raw.len() - self.hide_post_len]
     }
 }
 
-impl<'a> DerefMut for Hide<'a> {
+impl DerefMut for Hide<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         let len = self.raw.len();
         &mut self.raw[self.hide_pre_len..len - self.hide_post_len]
@@ -359,7 +359,7 @@ impl<'a> Replaceable<'a> {
     }
 }
 
-impl<'a> Debug for Replaceable<'a> {
+impl Debug for Replaceable<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:?}", self.content.hidden_prefix())?;
         write!(f, "[[[")?;
@@ -441,7 +441,7 @@ impl<'a, 'b> RepMatcher<'a, 'b, false> {
     }
 }
 
-impl<'a, 'b, const KEY_FINISHED: bool> RepMatcher<'a, 'b, KEY_FINISHED> {
+impl<const KEY_FINISHED: bool> RepMatcher<'_, '_, KEY_FINISHED> {
     fn remaining(&self) -> usize {
         if KEY_FINISHED {
             self.rep.content.len() - self.forward_cursor
@@ -469,7 +469,7 @@ impl<'a, 'b, const KEY_FINISHED: bool> RepMatcher<'a, 'b, KEY_FINISHED> {
     }
 }
 
-impl<'a, 'b, const KEY_FINISHED: bool> Utf8Matcher<Forward> for RepMatcher<'a, 'b, KEY_FINISHED> {
+impl<const KEY_FINISHED: bool> Utf8Matcher<Forward> for RepMatcher<'_, '_, KEY_FINISHED> {
     fn cursor(&self) -> usize {
         self.forward_cursor
     }
@@ -517,7 +517,7 @@ impl<'a, 'b, const KEY_FINISHED: bool> Utf8Matcher<Forward> for RepMatcher<'a, '
 }
 
 // we can always reverse match, no matter if the key has finished matching or not
-impl<'a, 'b, const KEY_FINISHED: bool> Utf8Matcher<Reverse> for RepMatcher<'a, 'b, KEY_FINISHED> {
+impl<const KEY_FINISHED: bool> Utf8Matcher<Reverse> for RepMatcher<'_, '_, KEY_FINISHED> {
     fn cursor(&self) -> usize {
         self.ante_cursor()
     }
@@ -912,13 +912,13 @@ impl<'a, 'b> Insertable<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Drop for Insertable<'a, 'b> {
+impl Drop for Insertable<'_, '_> {
     fn drop(&mut self) {
         self.cleanup();
     }
 }
 
-impl<'a, 'b> Debug for Insertable<'a, 'b> {
+impl Debug for Insertable<'_, '_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}|{}", self.curr_replacement(), self.free_range().len())
     }
@@ -935,7 +935,7 @@ where
     on_drop: F,
 }
 
-impl<'a, 'b, F> InsertableToReplaceableAdapter<'a, 'b, F>
+impl<F> InsertableToReplaceableAdapter<'_, '_, F>
 where
     F: FnMut(usize),
 {
@@ -976,7 +976,7 @@ where
     }
 }
 
-impl<'a, 'b, F> Drop for InsertableToReplaceableAdapter<'a, 'b, F>
+impl<F> Drop for InsertableToReplaceableAdapter<'_, '_, F>
 where
     F: FnMut(usize),
 {
@@ -995,7 +995,7 @@ where
     }
 }
 
-impl<'a, 'b, F> DerefMut for InsertableToReplaceableAdapter<'a, 'b, F>
+impl<F> DerefMut for InsertableToReplaceableAdapter<'_, '_, F>
 where
     F: FnMut(usize),
 {
@@ -1025,7 +1025,7 @@ where
     }
 }
 
-impl<'a, F> Drop for InsertableGuard<'a, F>
+impl<F> Drop for InsertableGuard<'_, F>
 where
     F: FnMut(&[u8]),
 {

--- a/components/experimental/src/unicodeset_parse/mod.rs
+++ b/components/experimental/src/unicodeset_parse/mod.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 //! This module provides parsing functionality for [UTS #35 - Unicode Sets](https://unicode.org/reports/tr35/#Unicode_Sets).
+//!
 //! Parses into [`CodePointInversionListAndStringList`](icu_collections::codepointinvliststringlist::CodePointInversionListAndStringList).
 //!
 //! See [`parse`](parse()) for more information.

--- a/components/list/src/patterns.rs
+++ b/components/list/src/patterns.rs
@@ -10,7 +10,7 @@ use alloc::borrow::Cow;
 use icu_provider::DataError;
 use writeable::{LengthHint, Writeable};
 
-impl<'data> ListFormatterPatternsV2<'data> {
+impl ListFormatterPatternsV2<'_> {
     /// Creates a new [`ListFormatterPatternsV2`] from the given patterns. Fails if any pattern is invalid.
     #[cfg(feature = "datagen")]
     pub fn try_new(start: &str, middle: &str, end: &str, pair: &str) -> Result<Self, DataError> {

--- a/components/locale/src/fallback/algorithms.rs
+++ b/components/locale/src/fallback/algorithms.rs
@@ -7,7 +7,7 @@ use icu_locale_core::subtags::{Language, Region, Script};
 
 use super::*;
 
-impl<'a> LocaleFallbackerWithConfig<'a> {
+impl LocaleFallbackerWithConfig<'_> {
     pub(crate) fn normalize(&self, locale: &mut DataLocale, default_script: &mut Option<Script>) {
         // 0. If there is an invalid "sd" subtag, drop it
         if let Some(subdivision) = locale.subdivision.take() {
@@ -66,7 +66,7 @@ impl<'a> LocaleFallbackerWithConfig<'a> {
     }
 }
 
-impl<'a> LocaleFallbackIteratorInner<'a> {
+impl LocaleFallbackIteratorInner<'_> {
     pub fn step(&mut self, locale: &mut DataLocale) {
         match self.config.priority {
             LocaleFallbackPriority::Language => self.step_language(locale),

--- a/components/locale/src/provider.rs
+++ b/components/locale/src/provider.rs
@@ -218,6 +218,7 @@ pub struct AliasesV2<'data> {
 #[cfg_attr(feature = "datagen", databake(path = icu_locale::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 /// This likely subtags data is used for the minimize and maximize operations.
+///
 /// Each field defines a mapping from an old identifier to a new identifier,
 /// based upon the rules in
 /// <https://www.unicode.org/reports/tr35/#Likely_Subtags>.
@@ -263,6 +264,7 @@ pub struct LikelySubtagsForLanguageV1<'data> {
 #[cfg_attr(feature = "datagen", databake(path = icu_locale::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 /// This likely subtags data is used for the minimize and maximize operations.
+///
 /// Each field defines a mapping from an old identifier to a new identifier,
 /// based upon the rules in
 /// <https://www.unicode.org/reports/tr35/#Likely_Subtags>.

--- a/components/locale_core/src/serde.rs
+++ b/components/locale_core/src/serde.rs
@@ -22,7 +22,7 @@ impl<'de> Deserialize<'de> for LanguageIdentifier {
     {
         struct LanguageIdentifierVisitor;
 
-        impl<'de> serde::de::Visitor<'de> for LanguageIdentifierVisitor {
+        impl serde::de::Visitor<'_> for LanguageIdentifierVisitor {
             type Value = LanguageIdentifier;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/components/normalizer/benches/canonical_composition.rs
+++ b/components/normalizer/benches/canonical_composition.rs
@@ -27,7 +27,7 @@ fn strip_headers(content: &str) -> String {
 fn normalizer_bench_data() -> [BenchDataContent; 16] {
     let nfc_normalizer = ComposingNormalizerBorrowed::new_nfc();
 
-    return [
+    [
         BenchDataContent {
             file_name: "TestNames_Latin".to_owned(),
             pairs: decompose_data(
@@ -145,7 +145,7 @@ fn normalizer_bench_data() -> [BenchDataContent; 16] {
                 result
             },
         },
-    ];
+    ]
 }
 
 fn function_under_bench(

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -1002,7 +1002,7 @@ where
     }
 }
 
-impl<'data, I> Iterator for Decomposition<'data, I>
+impl<I> Iterator for Decomposition<'_, I>
 where
     I: Iterator<Item = char>,
 {
@@ -1082,7 +1082,7 @@ where
     }
 }
 
-impl<'data, I> Iterator for Composition<'data, I>
+impl<I> Iterator for Composition<'_, I>
 where
     I: Iterator<Item = char>,
 {
@@ -1799,7 +1799,7 @@ impl DecomposingNormalizerBorrowed<'static> {
     }
 }
 
-impl<'a> DecomposingNormalizerBorrowed<'a> {
+impl DecomposingNormalizerBorrowed<'_> {
     /// Wraps a delegate iterator into a decomposing iterator
     /// adapter by using the data already held by this normalizer.
     pub fn normalize_iter<I: Iterator<Item = char>>(&self, iter: I) -> Decomposition<I> {
@@ -2369,7 +2369,7 @@ impl ComposingNormalizerBorrowed<'static> {
     }
 }
 
-impl<'a> ComposingNormalizerBorrowed<'a> {
+impl ComposingNormalizerBorrowed<'_> {
     /// Wraps a delegate iterator into a composing iterator
     /// adapter by using the data already held by this normalizer.
     pub fn normalize_iter<I: Iterator<Item = char>>(&self, iter: I) -> Composition<I> {
@@ -2828,7 +2828,7 @@ impl<'a> IsNormalizedSinkUtf16<'a> {
     }
 }
 
-impl<'a> Write16 for IsNormalizedSinkUtf16<'a> {
+impl Write16 for IsNormalizedSinkUtf16<'_> {
     fn write_slice(&mut self, s: &[u16]) -> core::fmt::Result {
         // We know that if we get a slice, it's a pass-through,
         // so we can compare addresses. Indexing is OK, because
@@ -2870,7 +2870,7 @@ impl<'a> IsNormalizedSinkUtf8<'a> {
     }
 }
 
-impl<'a> core::fmt::Write for IsNormalizedSinkUtf8<'a> {
+impl core::fmt::Write for IsNormalizedSinkUtf8<'_> {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         // We know that if we get a slice, it's a pass-through,
         // so we can compare addresses. Indexing is OK, because
@@ -2912,7 +2912,7 @@ impl<'a> IsNormalizedSinkStr<'a> {
     }
 }
 
-impl<'a> core::fmt::Write for IsNormalizedSinkStr<'a> {
+impl core::fmt::Write for IsNormalizedSinkStr<'_> {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         // We know that if we get a slice, it's a pass-through,
         // so we can compare addresses. Indexing is OK, because

--- a/components/normalizer/src/properties.rs
+++ b/components/normalizer/src/properties.rs
@@ -80,7 +80,7 @@ impl CanonicalCompositionBorrowed<'static> {
     }
 }
 
-impl<'a> CanonicalCompositionBorrowed<'a> {
+impl CanonicalCompositionBorrowed<'_> {
     /// Performs canonical composition (including Hangul) on a pair of
     /// characters or returns `None` if these characters don't compose.
     /// Composition exclusions are taken into account.
@@ -241,7 +241,7 @@ impl CanonicalDecompositionBorrowed<'static> {
     }
 }
 
-impl<'a> CanonicalDecompositionBorrowed<'a> {
+impl CanonicalDecompositionBorrowed<'_> {
     /// Performs non-recursive canonical decomposition (including for Hangul).
     ///
     /// ```
@@ -582,7 +582,7 @@ impl CanonicalCombiningClassMapBorrowed<'static> {
     }
 }
 
-impl<'a> CanonicalCombiningClassMapBorrowed<'a> {
+impl CanonicalCombiningClassMapBorrowed<'_> {
     /// Look up the canonical combining class for a scalar value.
     ///
     /// The return value is a u8 representing the canonical combining class,

--- a/components/normalizer/src/uts46.rs
+++ b/components/normalizer/src/uts46.rs
@@ -62,7 +62,7 @@ impl Uts46MapperBorrowed<'static> {
     }
 }
 
-impl<'a> Uts46MapperBorrowed<'a> {
+impl Uts46MapperBorrowed<'_> {
     /// Returns an iterator adaptor that turns an `Iterator` over `char`
     /// into an iterator yielding a `char` sequence that gets the following
     /// operations from the "Map" and "Normalize" steps of the "Processing"

--- a/components/pattern/src/frontend/databake.rs
+++ b/components/pattern/src/frontend/databake.rs
@@ -10,7 +10,7 @@ use crate::SinglePlaceholder;
 use super::*;
 use ::databake::{quote, Bake, BakeSize, CrateEnv, TokenStream};
 
-impl<'a, B> Bake for &'a Pattern<B>
+impl<B> Bake for &Pattern<B>
 where
     B: PatternBackend,
     for<'b> &'b B::Store: Bake,
@@ -31,7 +31,7 @@ where
     }
 }
 
-impl<'a, B> BakeSize for &'a Pattern<B>
+impl<B> BakeSize for &Pattern<B>
 where
     B: PatternBackend,
     for<'b> &'b B::Store: BakeSize,

--- a/components/pattern/src/multi_named.rs
+++ b/components/pattern/src/multi_named.rs
@@ -63,7 +63,7 @@ pub struct MultiNamedPlaceholderKey<'a>(pub &'a str);
 pub struct MultiNamedPlaceholderKeyCow<'a>(pub Cow<'a, str>);
 
 #[cfg(feature = "alloc")]
-impl<'a> FromStr for MultiNamedPlaceholderKeyCow<'a> {
+impl FromStr for MultiNamedPlaceholderKeyCow<'_> {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Can't borrow the str here unfortunately
@@ -77,7 +77,7 @@ pub struct MissingNamedPlaceholderError<'a> {
     pub name: &'a str,
 }
 
-impl<'a> Writeable for MissingNamedPlaceholderError<'a> {
+impl Writeable for MissingNamedPlaceholderError<'_> {
     fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
         sink.write_char('{')?;
         sink.write_str(self.name)?;

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -5,6 +5,7 @@
 use fixed_decimal::{CompactDecimal, FixedDecimal};
 
 /// A full plural operands representation of a number. See [CLDR Plural Rules](http://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules) for complete operands description.
+///
 /// Plural operands in compliance with [CLDR Plural Rules](http://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules).
 ///
 /// See [full operands description](http://unicode.org/reports/tr35/tr35-numbers.html#Operands).

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -256,7 +256,7 @@ mod ranges {
 
             struct HumanReadableVisitor;
 
-            impl<'de> Visitor<'de> for HumanReadableVisitor {
+            impl Visitor<'_> for HumanReadableVisitor {
                 type Value = UnvalidatedPluralRange;
 
                 fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {
@@ -1001,7 +1001,7 @@ where
 }
 
 // Need a manual impl because the derive(Clone) impl bounds are wrong
-impl<'data, V> Clone for PluralElementsPackedCow<'data, V>
+impl<V> Clone for PluralElementsPackedCow<'_, V>
 where
     V: VarULE + ?Sized,
 {

--- a/components/plurals/src/rules/reference/lexer.rs
+++ b/components/plurals/src/rules/reference/lexer.rs
@@ -193,7 +193,7 @@ impl<'l> Lexer<'l> {
     }
 }
 
-impl<'l> Iterator for Lexer<'l> {
+impl Iterator for Lexer<'_> {
     type Item = Token;
 
     #[inline]

--- a/components/properties/src/code_point_map.rs
+++ b/components/properties/src/code_point_map.rs
@@ -259,7 +259,7 @@ impl<'a, T: TrieValue> CodePointMapDataBorrowed<'a, T> {
     }
 }
 
-impl<'a> CodePointMapDataBorrowed<'a, GeneralCategory> {
+impl CodePointMapDataBorrowed<'_, GeneralCategory> {
     /// TODO
     pub fn get_set_for_value_group(&self, value: GeneralCategoryGroup) -> crate::CodePointSetData {
         let matching_gc_ranges = self

--- a/components/properties/src/emoji.rs
+++ b/components/properties/src/emoji.rs
@@ -108,7 +108,7 @@ pub struct EmojiSetDataBorrowed<'a> {
     set: &'a PropertyUnicodeSetV1<'a>,
 }
 
-impl<'a> EmojiSetDataBorrowed<'a> {
+impl EmojiSetDataBorrowed<'_> {
     /// Check if the set contains the string. Strings consisting of one character
     /// are treated as a character/code point.
     ///

--- a/components/properties/src/trievalue.rs
+++ b/components/properties/src/trievalue.rs
@@ -206,7 +206,7 @@ fn packed_u16_to_gcg(value: u16) -> GeneralCategoryGroup {
 
 fn gcg_to_packed_u16(gcg: GeneralCategoryGroup) -> u16 {
     // if it's a single property, translate to that property
-    if gcg.0.count_ones() == 1 {
+    if gcg.0.is_power_of_two() {
         // inverse operation of a bitshift
         gcg.0.trailing_zeros() as u16
     } else {

--- a/components/segmenter/src/complex/dictionary.rs
+++ b/components/segmenter/src/complex/dictionary.rs
@@ -106,7 +106,7 @@ impl<'l, 's, Y: DictionaryType<'l, 's> + ?Sized, X: Iterator<Item = usize> + ?Si
     }
 }
 
-impl<'l, 's> DictionaryType<'l, 's> for u32 {
+impl<'s> DictionaryType<'_, 's> for u32 {
     type IterAttr = Utf16Indices<'s>;
     type CharType = u32;
 
@@ -123,7 +123,7 @@ impl<'l, 's> DictionaryType<'l, 's> for u32 {
     }
 }
 
-impl<'l, 's> DictionaryType<'l, 's> for char {
+impl<'s> DictionaryType<'_, 's> for char {
     type IterAttr = CharIndices<'s>;
     type CharType = char;
 

--- a/components/segmenter/src/complex/lstm/matrix.rs
+++ b/components/segmenter/src/complex/lstm/matrix.rs
@@ -159,7 +159,7 @@ pub(super) struct MatrixBorrowedMut<'a, const D: usize> {
     pub(super) dims: [usize; D],
 }
 
-impl<'a, const D: usize> MatrixBorrowedMut<'a, D> {
+impl<const D: usize> MatrixBorrowedMut<'_, D> {
     pub(super) fn as_borrowed(&self) -> MatrixBorrowed<D> {
         MatrixBorrowed {
             data: self.data,
@@ -258,7 +258,7 @@ impl<'a, const D: usize> MatrixBorrowedMut<'a, D> {
     }
 }
 
-impl<'a> MatrixBorrowed<'a, 1> {
+impl MatrixBorrowed<'_, 1> {
     #[allow(dead_code)] // could be useful
     pub(super) fn dot_1d(&self, other: MatrixZero<1>) -> f32 {
         debug_assert_eq!(self.dims, other.dims);
@@ -266,7 +266,7 @@ impl<'a> MatrixBorrowed<'a, 1> {
     }
 }
 
-impl<'a> MatrixBorrowedMut<'a, 1> {
+impl MatrixBorrowedMut<'_, 1> {
     /// Calculate the dot product of a and b, adding the result to self.
     ///
     /// Note: For better dot product efficiency, if `b` is MxN, then `a` should be N;
@@ -301,7 +301,7 @@ impl<'a> MatrixBorrowedMut<'a, 1> {
     }
 }
 
-impl<'a> MatrixBorrowedMut<'a, 2> {
+impl MatrixBorrowedMut<'_, 2> {
     /// Calculate the dot product of a and b, adding the result to self.
     ///
     /// Self should be _MxN_; `a`, _O_; and `b`, _MxNxO_.

--- a/components/segmenter/src/indices.rs
+++ b/components/segmenter/src/indices.rs
@@ -22,7 +22,7 @@ impl<'a> Latin1Indices<'a> {
     }
 }
 
-impl<'a> Iterator for Latin1Indices<'a> {
+impl Iterator for Latin1Indices<'_> {
     type Item = (usize, u8);
 
     #[inline]
@@ -55,7 +55,7 @@ impl<'a> Utf16Indices<'a> {
     }
 }
 
-impl<'a> Iterator for Utf16Indices<'a> {
+impl Iterator for Utf16Indices<'_> {
     type Item = (usize, u32);
 
     #[inline]

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -1301,7 +1301,7 @@ where
 #[derive(Debug)]
 pub struct LineBreakTypeLatin1;
 
-impl<'l, 's> LineBreakType<'l, 's> for LineBreakTypeLatin1 {
+impl<'s> LineBreakType<'_, 's> for LineBreakTypeLatin1 {
     type IterAttr = Latin1Indices<'s>;
     type CharType = u8;
 
@@ -1331,7 +1331,7 @@ impl<'l, 's> LineBreakType<'l, 's> for LineBreakTypeLatin1 {
 #[derive(Debug)]
 pub struct LineBreakTypeUtf16;
 
-impl<'l, 's> LineBreakType<'l, 's> for LineBreakTypeUtf16 {
+impl<'s> LineBreakType<'_, 's> for LineBreakTypeUtf16 {
     type IterAttr = Utf16Indices<'s>;
     type CharType = u32;
 

--- a/components/segmenter/src/rule_segmenter.rs
+++ b/components/segmenter/src/rule_segmenter.rs
@@ -258,7 +258,7 @@ impl<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> RuleBreakIterator<'l, 's, Y> {
 #[derive(Debug)]
 pub struct RuleBreakTypeUtf8;
 
-impl<'l, 's> RuleBreakType<'l, 's> for RuleBreakTypeUtf8 {
+impl<'s> RuleBreakType<'_, 's> for RuleBreakTypeUtf8 {
     type IterAttr = CharIndices<'s>;
     type CharType = char;
 
@@ -277,7 +277,7 @@ impl<'l, 's> RuleBreakType<'l, 's> for RuleBreakTypeUtf8 {
 #[derive(Debug)]
 pub struct RuleBreakTypePotentiallyIllFormedUtf8;
 
-impl<'l, 's> RuleBreakType<'l, 's> for RuleBreakTypePotentiallyIllFormedUtf8 {
+impl<'s> RuleBreakType<'_, 's> for RuleBreakTypePotentiallyIllFormedUtf8 {
     type IterAttr = Utf8CharIndices<'s>;
     type CharType = char;
 
@@ -296,7 +296,7 @@ impl<'l, 's> RuleBreakType<'l, 's> for RuleBreakTypePotentiallyIllFormedUtf8 {
 #[derive(Debug)]
 pub struct RuleBreakTypeLatin1;
 
-impl<'l, 's> RuleBreakType<'l, 's> for RuleBreakTypeLatin1 {
+impl<'s> RuleBreakType<'_, 's> for RuleBreakTypeLatin1 {
     type IterAttr = Latin1Indices<'s>;
     type CharType = u8;
 
@@ -315,7 +315,7 @@ impl<'l, 's> RuleBreakType<'l, 's> for RuleBreakTypeLatin1 {
 #[derive(Debug)]
 pub struct RuleBreakTypeUtf16;
 
-impl<'l, 's> RuleBreakType<'l, 's> for RuleBreakTypeUtf16 {
+impl<'s> RuleBreakType<'_, 's> for RuleBreakTypeUtf16 {
     type IterAttr = Utf16Indices<'s>;
     type CharType = u32;
 

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -730,7 +730,7 @@ where
 #[derive(Debug)]
 pub struct WordBreakTypeUtf16;
 
-impl<'l, 's> RuleBreakType<'l, 's> for WordBreakTypeUtf16 {
+impl<'s> RuleBreakType<'_, 's> for WordBreakTypeUtf16 {
     type IterAttr = Utf16Indices<'s>;
     type CharType = u32;
 

--- a/components/timezone/src/ids.rs
+++ b/components/timezone/src/ids.rs
@@ -160,7 +160,7 @@ pub struct TimeZoneIdMapperBorrowed<'a> {
     data: &'a IanaToBcp47MapV3<'a>,
 }
 
-impl<'a> TimeZoneIdMapperBorrowed<'a> {
+impl TimeZoneIdMapperBorrowed<'_> {
     /// Gets the BCP-47 time zone ID from an IANA time zone ID
     /// with a case-insensitive lookup.
     ///

--- a/components/timezone/src/provider/names.rs
+++ b/components/timezone/src/provider/names.rs
@@ -51,6 +51,7 @@ pub struct IanaToBcp47MapV1<'data> {
 }
 
 /// [`IanaToBcp47MapV3`]'s trie cannot handle differently-cased prefixes, like `Mexico/BajaSur`` and `MET`.
+///
 /// Therefore, any ID that is not of the shape `{region}/{city}` gets prefixed with this character
 /// inside the trie.
 ///

--- a/components/timezone/src/types.rs
+++ b/components/timezone/src/types.rs
@@ -183,6 +183,7 @@ impl FromStr for UtcOffset {
 }
 
 /// A time zone variant, representing the currently observed relative offset.
+///
 /// The semantics vary from time zone to time zone and could represent concepts
 /// such as Standard time, Daylight time, Summer time, or Ramadan time.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, ULE)]

--- a/components/timezone/src/windows_tz.rs
+++ b/components/timezone/src/windows_tz.rs
@@ -95,13 +95,13 @@ pub struct WindowsTimeZoneMapperBorrowed<'a> {
 }
 
 #[cfg(feature = "compiled_data")]
-impl<'a> Default for WindowsTimeZoneMapperBorrowed<'a> {
+impl Default for WindowsTimeZoneMapperBorrowed<'_> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'a> WindowsTimeZoneMapperBorrowed<'a> {
+impl WindowsTimeZoneMapperBorrowed<'_> {
     /// Creates a new static [`WindowsTimeZoneMapperBorrowed`].
     #[cfg(feature = "compiled_data")]
     #[allow(clippy::expect_used)]

--- a/provider/core/macros/src/lib.rs
+++ b/provider/core/macros/src/lib.rs
@@ -37,8 +37,6 @@ use syn::{Ident, LitStr, Path, Token};
 #[cfg(test)]
 mod tests;
 
-#[proc_macro_attribute]
-
 /// The `#[data_struct]` attribute should be applied to all types intended
 /// for use in a `DataStruct`.
 ///
@@ -93,6 +91,7 @@ mod tests;
 ///     LocaleFallbackPriority::Region
 /// );
 /// ```
+#[proc_macro_attribute]
 pub fn data_struct(attr: TokenStream, item: TokenStream) -> TokenStream {
     TokenStream::from(data_struct_impl(
         parse_macro_input!(attr as DataStructArgs),

--- a/provider/core/src/any.rs
+++ b/provider/core/src/any.rs
@@ -337,7 +337,7 @@ pub trait AnyProvider {
     fn load_any(&self, marker: DataMarkerInfo, req: DataRequest) -> Result<AnyResponse, DataError>;
 }
 
-impl<'a, T: AnyProvider + ?Sized> AnyProvider for &'a T {
+impl<T: AnyProvider + ?Sized> AnyProvider for &T {
     #[inline]
     fn load_any(&self, marker: DataMarkerInfo, req: DataRequest) -> Result<AnyResponse, DataError> {
         (**self).load_any(marker, req)

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -20,7 +20,7 @@ where
     fn load(&self, req: DataRequest) -> Result<DataResponse<M>, DataError>;
 }
 
-impl<'a, M, P> DataProvider<M> for &'a P
+impl<M, P> DataProvider<M> for &P
 where
     M: DataMarker,
     P: DataProvider<M> + ?Sized,
@@ -125,7 +125,7 @@ pub trait DynamicDryDataProvider<M: DynamicDataMarker>: DynamicDataProvider<M> {
     ) -> Result<DataResponseMetadata, DataError>;
 }
 
-impl<'a, M, P> DynamicDataProvider<M> for &'a P
+impl<M, P> DynamicDataProvider<M> for &P
 where
     M: DynamicDataMarker,
     P: DynamicDataProvider<M> + ?Sized,
@@ -234,7 +234,7 @@ where
     fn bound_marker(&self) -> DataMarkerInfo;
 }
 
-impl<'a, M, P> BoundDataProvider<M> for &'a P
+impl<M, P> BoundDataProvider<M> for &P
 where
     M: DynamicDataMarker,
     P: BoundDataProvider<M> + ?Sized,

--- a/provider/core/src/export/payload.rs
+++ b/provider/core/src/export/payload.rs
@@ -208,7 +208,7 @@ impl DataPayload<ExportMarker> {
         use postcard::ser_flavors::Flavor;
 
         struct HashFlavor<'a, H>(&'a mut H, usize);
-        impl<'a, H: core::hash::Hasher> Flavor for HashFlavor<'a, H> {
+        impl<H: core::hash::Hasher> Flavor for HashFlavor<'_, H> {
             type Output = usize;
 
             fn try_push(&mut self, data: u8) -> postcard::Result<()> {

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -326,7 +326,7 @@ impl HelloWorldFormatter {
     }
 }
 
-impl<'l> Writeable for FormattedHelloWorld<'l> {
+impl Writeable for FormattedHelloWorld<'_> {
     fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
         self.data.message.write_to(sink)
     }

--- a/provider/core/src/request.rs
+++ b/provider/core/src/request.rs
@@ -307,7 +307,7 @@ impl DataLocale {
     }
 }
 
-impl<'a> Default for &'a DataLocale {
+impl Default for &DataLocale {
     fn default() -> Self {
         static DEFAULT: DataLocale = DataLocale::default();
         &DEFAULT
@@ -605,7 +605,7 @@ pub struct DataMarkerAttributes {
     value: str,
 }
 
-impl<'a> Default for &'a DataMarkerAttributes {
+impl Default for &DataMarkerAttributes {
     fn default() -> Self {
         DataMarkerAttributes::empty()
     }

--- a/provider/source/src/cldr_serde/plural_ranges.rs
+++ b/provider/source/src/cldr_serde/plural_ranges.rs
@@ -24,7 +24,7 @@ impl<'de> Deserialize<'de> for PluralRange {
     {
         struct PluralRangeVisitor;
 
-        impl<'de> Visitor<'de> for PluralRangeVisitor {
+        impl Visitor<'_> for PluralRangeVisitor {
             type Value = PluralRange;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/provider/source/src/cldr_serde/week_data.rs
+++ b/provider/source/src/cldr_serde/week_data.rs
@@ -76,7 +76,7 @@ impl<'de> Deserialize<'de> for Territory {
     {
         struct TerritoryVisitor;
 
-        impl<'de> serde::de::Visitor<'de> for TerritoryVisitor {
+        impl serde::de::Visitor<'_> for TerritoryVisitor {
             type Value = Territory;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/provider/source/src/collator/mod.rs
+++ b/provider/source/src/collator/mod.rs
@@ -193,7 +193,7 @@ impl IterableDataProviderCached<CollationTailoringV1Marker> for SourceDataProvid
     }
 }
 
-impl<'a> TryInto<CollationDataV1<'static>> for &'a collator_serde::CollationData {
+impl TryInto<CollationDataV1<'static>> for &collator_serde::CollationData {
     type Error = DataError;
 
     fn try_into(self) -> Result<CollationDataV1<'static>, Self::Error> {
@@ -207,7 +207,7 @@ impl<'a> TryInto<CollationDataV1<'static>> for &'a collator_serde::CollationData
     }
 }
 
-impl<'a> TryInto<CollationDiacriticsV1<'static>> for &'a collator_serde::CollationDiacritics {
+impl TryInto<CollationDiacriticsV1<'static>> for &collator_serde::CollationDiacritics {
     type Error = DataError;
 
     fn try_into(self) -> Result<CollationDiacriticsV1<'static>, Self::Error> {
@@ -217,7 +217,7 @@ impl<'a> TryInto<CollationDiacriticsV1<'static>> for &'a collator_serde::Collati
     }
 }
 
-impl<'a> TryInto<CollationJamoV1<'static>> for &'a collator_serde::CollationJamo {
+impl TryInto<CollationJamoV1<'static>> for &collator_serde::CollationJamo {
     type Error = DataError;
 
     fn try_into(self) -> Result<CollationJamoV1<'static>, Self::Error> {
@@ -227,7 +227,7 @@ impl<'a> TryInto<CollationJamoV1<'static>> for &'a collator_serde::CollationJamo
     }
 }
 
-impl<'a> TryInto<CollationMetadataV1> for &'a collator_serde::CollationMetadata {
+impl TryInto<CollationMetadataV1> for &collator_serde::CollationMetadata {
     type Error = DataError;
 
     fn try_into(self) -> Result<CollationMetadataV1, Self::Error> {
@@ -235,7 +235,7 @@ impl<'a> TryInto<CollationMetadataV1> for &'a collator_serde::CollationMetadata 
     }
 }
 
-impl<'a> TryInto<CollationReorderingV1<'static>> for &'a collator_serde::CollationReordering {
+impl TryInto<CollationReorderingV1<'static>> for &collator_serde::CollationReordering {
     type Error = DataError;
 
     fn try_into(self) -> Result<CollationReorderingV1<'static>, Self::Error> {
@@ -247,8 +247,8 @@ impl<'a> TryInto<CollationReorderingV1<'static>> for &'a collator_serde::Collati
     }
 }
 
-impl<'a> TryInto<CollationSpecialPrimariesV1<'static>>
-    for &'a collator_serde::CollationSpecialPrimaries
+impl TryInto<CollationSpecialPrimariesV1<'static>>
+    for &collator_serde::CollationSpecialPrimaries
 {
     type Error = DataError;
 

--- a/provider/source/src/collator/mod.rs
+++ b/provider/source/src/collator/mod.rs
@@ -247,9 +247,7 @@ impl TryInto<CollationReorderingV1<'static>> for &collator_serde::CollationReord
     }
 }
 
-impl TryInto<CollationSpecialPrimariesV1<'static>>
-    for &collator_serde::CollationSpecialPrimaries
-{
+impl TryInto<CollationSpecialPrimariesV1<'static>> for &collator_serde::CollationSpecialPrimaries {
     type Error = DataError;
 
     fn try_into(self) -> Result<CollationSpecialPrimariesV1<'static>, Self::Error> {

--- a/tools/benchmark/memory/src/main.rs
+++ b/tools/benchmark/memory/src/main.rs
@@ -67,13 +67,13 @@ fn extract_bytes_from_log_line(preamble: &str, text: &str) -> u64 {
         .find("bytes")
         .expect("Unable to find the word \"bytes\" in the dhat output.");
 
-    return text
+    text
         .get(start..end)
         .expect("Unable to get a substring.")
         .trim()
         .replace(',', "")
         .parse::<u64>()
-        .expect("Unable to parse the byte amount");
+        .expect("Unable to parse the byte amount")
 }
 
 /// This file is intended to be run from CI to gather heap information, but it can also

--- a/tools/benchmark/memory/src/main.rs
+++ b/tools/benchmark/memory/src/main.rs
@@ -67,8 +67,7 @@ fn extract_bytes_from_log_line(preamble: &str, text: &str) -> u64 {
         .find("bytes")
         .expect("Unable to find the word \"bytes\" in the dhat output.");
 
-    text
-        .get(start..end)
+    text.get(start..end)
         .expect("Unable to get a substring.")
         .trim()
         .replace(',', "")

--- a/utils/calendrical_calculations/src/chinese_based.rs
+++ b/utils/calendrical_calculations/src/chinese_based.rs
@@ -483,6 +483,7 @@ pub fn chinese_based_date_from_fixed<C: ChineseBased>(date: RataDie) -> ChineseF
 }
 
 /// Given that `new_year` is the first day of a leap year, find which month in the year is a leap month.
+///
 /// Since the first month in which there are no major solar terms is a leap month, this function
 /// cycles through months until it finds the leap month, then returns the number of that month. This
 /// function assumes the date passed in is in a leap year and tests to ensure this is the case in debug
@@ -548,6 +549,7 @@ pub fn days_in_prev_year<C: ChineseBased>(new_year: RataDie) -> u16 {
 }
 
 /// Returns the length of each month in the year, as well as a leap month index (1-indexed) if any.
+///
 /// Month lengths are stored as true for 30-day, false for 29-day.
 /// In the case of no leap months, month 13 will have value false.
 pub fn month_structure_for_year<C: ChineseBased>(

--- a/utils/calendrical_calculations/src/hebrew_keviyah.rs
+++ b/utils/calendrical_calculations/src/hebrew_keviyah.rs
@@ -722,10 +722,9 @@ impl Keviyah {
 
 // Four Gates Table
 // ======================
-///
+//
 // The Four Gates table is a table that takes the time of week of the molad
 // and produces a Keviyah for the year
-
 /// "Metonic cycle" in general refers to any 19-year repeating pattern used by lunisolar
 /// calendars. The Hebrew calendar uses one where years 3, 6, 8, 11, 14, 17, 19
 /// are leap years.

--- a/utils/databake/src/primitives.rs
+++ b/utils/databake/src/primitives.rs
@@ -34,7 +34,7 @@ fn literal() {
     assert_eq!(42u16.borrows_size(), 0);
 }
 
-impl<'a> Bake for &'a str {
+impl Bake for &str {
     fn bake(&self, _: &CrateEnv) -> TokenStream {
         quote! {
             #self
@@ -42,13 +42,13 @@ impl<'a> Bake for &'a str {
     }
 }
 
-impl<'a> BakeSize for &'a str {
+impl BakeSize for &str {
     fn borrows_size(&self) -> usize {
         self.len()
     }
 }
 
-impl<'a, T> Bake for &'a T
+impl<T> Bake for &T
 where
     T: Bake,
 {
@@ -60,7 +60,7 @@ where
     }
 }
 
-impl<'a, T> BakeSize for &'a T
+impl<T> BakeSize for &T
 where
     T: BakeSize,
 {
@@ -75,7 +75,7 @@ fn r#ref() {
     assert_eq!(BakeSize::borrows_size(&&934.34f32), 4);
 }
 
-impl<'a, T> Bake for &'a [T]
+impl<T> Bake for &[T]
 where
     T: Bake,
 {
@@ -97,7 +97,7 @@ where
     }
 }
 
-impl<'a, T> BakeSize for &'a [T]
+impl<T> BakeSize for &[T]
 where
     T: BakeSize,
 {

--- a/utils/deduplicating_array/src/lib.rs
+++ b/utils/deduplicating_array/src/lib.rs
@@ -173,7 +173,7 @@ pub enum MachineDe<T> {
     Fallback(usize),
 }
 
-impl<'a, T> Serialize for MachineSer<'a, T>
+impl<T> Serialize for MachineSer<'_, T>
 where
     T: Serialize,
 {

--- a/utils/litemap/src/store/slice_impl.rs
+++ b/utils/litemap/src/store/slice_impl.rs
@@ -45,7 +45,7 @@ impl<'a, K: 'a, V: 'a> Store<K, V> for &'a [(K, V)] {
     }
 }
 
-impl<'a, K, V> StoreSlice<K, V> for &'a [(K, V)] {
+impl<K, V> StoreSlice<K, V> for &[(K, V)] {
     type Slice = [(K, V)];
 
     fn lm_get_range(&self, range: Range<usize>) -> Option<&Self::Slice> {

--- a/utils/resb/src/binary/deserializer.rs
+++ b/utils/resb/src/binary/deserializer.rs
@@ -181,7 +181,7 @@ impl<'de> ResourceTreeDeserializer<'de> {
     }
 }
 
-impl<'de, 'a> de::Deserializer<'de> for &'a mut ResourceTreeDeserializer<'de> {
+impl<'de> de::Deserializer<'de> for &mut ResourceTreeDeserializer<'de> {
     type Error = BinaryDeserializerError;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -685,7 +685,7 @@ struct ArraySeqAccess<'a, 'de: 'a> {
     remaining: usize,
 }
 
-impl<'de, 'a> de::SeqAccess<'de> for ArraySeqAccess<'a, 'de> {
+impl<'de> de::SeqAccess<'de> for ArraySeqAccess<'_, 'de> {
     type Error = BinaryDeserializerError;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
@@ -810,7 +810,7 @@ struct TableMapAccess<'de, 'a> {
     remaining: usize,
 }
 
-impl<'de, 'a> de::MapAccess<'de> for TableMapAccess<'de, 'a> {
+impl<'de> de::MapAccess<'de> for TableMapAccess<'de, '_> {
     type Error = BinaryDeserializerError;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>

--- a/utils/resb/src/bundle.rs
+++ b/utils/resb/src/bundle.rs
@@ -105,7 +105,7 @@ impl<'a> From<&'a str> for Key<'a> {
     }
 }
 
-impl<'a> From<String> for Key<'a> {
+impl From<String> for Key<'_> {
     fn from(value: String) -> Self {
         Self(Cow::from(value))
     }

--- a/utils/resb/src/text/reader/parse_state.rs
+++ b/utils/resb/src/text/reader/parse_state.rs
@@ -75,7 +75,6 @@ impl<'a> ParseState<'a> {
 ///
 /// These trait implementations provide access to the internal input string for
 /// functions originating in [`nom`].
-
 impl Compare<&str> for ParseState<'_> {
     fn compare(&self, t: &str) -> nom::CompareResult {
         self.input.compare(t)

--- a/utils/writeable/src/cmp.rs
+++ b/utils/writeable/src/cmp.rs
@@ -11,7 +11,7 @@ pub(crate) struct WriteComparator<'a> {
 }
 
 /// This is an infallible impl. Functions always return Ok, not Err.
-impl<'a> fmt::Write for WriteComparator<'a> {
+impl fmt::Write for WriteComparator<'_> {
     #[inline]
     fn write_str(&mut self, other: &str) -> fmt::Result {
         if self.result != Ordering::Equal {

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -181,9 +181,11 @@ impl LengthHint {
     }
 }
 
-/// [`Part`]s are used as annotations for formatted strings. For example, a string like
-/// `Alice, Bob` could assign a `NAME` part to the substrings `Alice` and `Bob`, and a
-/// `PUNCTUATION` part to `, `. This allows for example to apply styling only to names.
+/// [`Part`]s are used as annotations for formatted strings.
+///
+/// For example, a string like `Alice, Bob` could assign a `NAME` part to the
+/// substrings `Alice` and `Bob`, and a `PUNCTUATION` part to `, `. This allows
+/// for example to apply styling only to names.
 ///
 /// `Part` contains two fields, whose usage is left up to the producer of the [`Writeable`].
 /// Conventionally, the `category` field will identify the formatting logic that produces

--- a/utils/yoke/derive/src/visitor.rs
+++ b/utils/yoke/derive/src/visitor.rs
@@ -17,7 +17,7 @@ struct TypeVisitor<'a> {
     found_lifetimes: bool,
 }
 
-impl<'a, 'ast> Visit<'ast> for TypeVisitor<'a> {
+impl<'ast> Visit<'ast> for TypeVisitor<'_> {
     fn visit_lifetime(&mut self, lt: &'ast Lifetime) {
         if lt.ident != "static" {
             self.found_lifetimes = true;

--- a/utils/zerofrom/derive/src/visitor.rs
+++ b/utils/zerofrom/derive/src/visitor.rs
@@ -18,7 +18,7 @@ struct TypeVisitor<'a> {
     found_lifetimes: bool,
 }
 
-impl<'a, 'ast> Visit<'ast> for TypeVisitor<'a> {
+impl<'ast> Visit<'ast> for TypeVisitor<'_> {
     fn visit_lifetime(&mut self, lt: &'ast Lifetime) {
         if lt.ident != "static" {
             self.found_lifetimes = true;

--- a/utils/zerovec/src/hashmap/algorithms.rs
+++ b/utils/zerovec/src/hashmap/algorithms.rs
@@ -11,6 +11,7 @@ use twox_hash::XxHash64;
 const SEED: u64 = 0xaabbccdd;
 
 /// Split the 64bit `hash` into (g, f0, f1).
+///
 /// g denotes the highest 16bits of the hash modulo `m`, and is referred to as first level hash.
 /// (f0, f1) denotes the middle, and lower 24bits of the hash respectively.
 /// (f0, f1) are used to distribute the keys with same g, into distinct slots.

--- a/utils/zerovec/src/ule/niche.rs
+++ b/utils/zerovec/src/ule/niche.rs
@@ -151,6 +151,7 @@ unsafe impl<U: NicheBytes<N> + ULE, const N: usize> ULE for NichedOptionULE<U, N
 }
 
 /// Optional type which uses [`NichedOptionULE<U,N>`] as ULE type.
+///
 /// The implementors guarantee that `N == core::mem::size_of::<Self>()`
 /// [`repr(transparent)`] guarantees that the layout is same as [`Option<U>`]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/utils/zerovec/src/varzerovec/components.rs
+++ b/utils/zerovec/src/varzerovec/components.rs
@@ -69,6 +69,7 @@ pub unsafe trait IntegerULE: ULE {
 }
 
 /// This is a [`VarZeroVecFormat`] that stores u8s in the index array, and a u8 for a length.
+///
 /// Will have a smaller data size, but it's *extremely* likely for larger arrays
 /// to be unrepresentable (and error on construction). Should probably be used
 /// for known-small arrays, where all but the last field are known-small.
@@ -77,6 +78,7 @@ pub unsafe trait IntegerULE: ULE {
 pub struct Index8;
 
 /// This is a [`VarZeroVecFormat`] that stores u16s in the index array, and a u16 for a length.
+///
 /// Will have a smaller data size, but it's more likely for larger arrays
 /// to be unrepresentable (and error on construction)
 ///


### PR DESCRIPTION
Worth doing a sweep to ease our lives later.

Lints fixed:
    
 - `needless_lifetimes` in trait impls
 - `empty_line_after_doc_comments` for the first para of doc comments
 - `needless_return`

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->