### PR TITLE
More nightly clippy fixes

### DIFF
--- a/components/casemap/src/provider/exception_helpers.rs
+++ b/components/casemap/src/provider/exception_helpers.rs
@@ -179,7 +179,6 @@ impl ExceptionBitsULE {
     /// Whether or not the slots are double-width.
     ///
     /// Unused in ICU4X
-
     pub fn double_width_slots(self) -> bool {
         self.0 & Self::DOUBLE_SLOTS_FLAG != 0
     }

--- a/components/casemap/src/set.rs
+++ b/components/casemap/src/set.rs
@@ -6,7 +6,9 @@ use icu_collections::codepointinvlist::CodePointInversionListBuilder;
 
 /// An object that accepts characters and/or strings
 /// to be used with [`CaseMapCloser::add_string_case_closure_to()`]
-/// and [`CaseMapCloser::add_case_closure_to()`]. Usually this object
+/// and [`CaseMapCloser::add_case_closure_to()`].
+///
+/// Usually this object
 /// will be some kind of set over codepoints and strings, or something that
 /// can be built into one.
 ///

--- a/components/collator/src/elements.rs
+++ b/components/collator/src/elements.rs
@@ -122,6 +122,7 @@ const UNASSIGNED_IMPLICIT_BYTE: u8 = 0xFE;
 // /// starting from an empty suffix.
 // /// The default CE32 is used anyway if there is no suffix match.
 // const CONTRACT_SINGLE_CP_NO_MATCH: u32 = 0x100;
+
 /// Set if the first character of every contraction suffix has lccc!=0.
 const CONTRACT_NEXT_CCC: u32 = 0x200;
 /// Set if any contraction suffix ends with lccc!=0.

--- a/components/collator/src/elements.rs
+++ b/components/collator/src/elements.rs
@@ -116,13 +116,12 @@ const COMMON_SEC_AND_TER_CE: u64 = COMMON_SECONDARY_CE | COMMON_TERTIARY_CE;
 
 const UNASSIGNED_IMPLICIT_BYTE: u8 = 0xFE;
 
-/// Set if there is no match for the single (no-suffix) character itself.
-/// This is only possible if there is a prefix.
-/// In this case, discontiguous contraction matching cannot add combining marks
-/// starting from an empty suffix.
-/// The default CE32 is used anyway if there is no suffix match.
+// /// Set if there is no match for the single (no-suffix) character itself.
+// /// This is only possible if there is a prefix.
+// /// In this case, discontiguous contraction matching cannot add combining marks
+// /// starting from an empty suffix.
+// /// The default CE32 is used anyway if there is no suffix match.
 // const CONTRACT_SINGLE_CP_NO_MATCH: u32 = 0x100;
-
 /// Set if the first character of every contraction suffix has lccc!=0.
 const CONTRACT_NEXT_CCC: u32 = 0x200;
 /// Set if any contraction suffix ends with lccc!=0.

--- a/components/collator/tests/tests.rs
+++ b/components/collator/tests/tests.rs
@@ -1741,7 +1741,7 @@ fn test_conformance_non_ignorable() {
             if line.is_empty() {
                 continue;
             }
-            if line.starts_with(b"#") {
+            if line.starts_with(b'#') {
                 continue;
             }
             if let Some(parsed) = parse_hex(line) {

--- a/components/collator/tests/tests.rs
+++ b/components/collator/tests/tests.rs
@@ -1698,7 +1698,7 @@ fn test_conformance_shifted() {
             if line.is_empty() {
                 continue;
             }
-            if line.starts_with(&[b'#']) {
+            if line.starts_with(b"#") {
                 continue;
             }
             if let Some(parsed) = parse_hex(line) {
@@ -1741,7 +1741,7 @@ fn test_conformance_non_ignorable() {
             if line.is_empty() {
                 continue;
             }
-            if line.starts_with(&[b'#']) {
+            if line.starts_with(b"#") {
                 continue;
             }
             if let Some(parsed) = parse_hex(line) {

--- a/components/collator/tests/tests.rs
+++ b/components/collator/tests/tests.rs
@@ -1698,7 +1698,7 @@ fn test_conformance_shifted() {
             if line.is_empty() {
                 continue;
             }
-            if line.starts_with(b"#") {
+            if line.starts_with(b'#') {
                 continue;
             }
             if let Some(parsed) = parse_hex(line) {

--- a/components/collator/tests/tests.rs
+++ b/components/collator/tests/tests.rs
@@ -1698,7 +1698,7 @@ fn test_conformance_shifted() {
             if line.is_empty() {
                 continue;
             }
-            if line.starts_with(b'#') {
+            if line.starts_with(b"#") {
                 continue;
             }
             if let Some(parsed) = parse_hex(line) {
@@ -1741,7 +1741,7 @@ fn test_conformance_non_ignorable() {
             if line.is_empty() {
                 continue;
             }
-            if line.starts_with(b'#') {
+            if line.starts_with(b"#") {
                 continue;
             }
             if let Some(parsed) = parse_hex(line) {

--- a/components/collections/src/codepointinvliststringlist/mod.rs
+++ b/components/collections/src/codepointinvliststringlist/mod.rs
@@ -19,9 +19,10 @@ use yoke::Yokeable;
 use zerofrom::ZeroFrom;
 use zerovec::{VarZeroSlice, VarZeroVec};
 
-/// A data structure providing a concrete implementation of a `UnicodeSet`
-/// (which represents a set of code points and strings) using an inversion list for the code points and a simple
-/// list-like structure to store and iterate over the strings.
+/// A data structure providing a concrete implementation of a set of code points and strings,
+/// using an inversion list for the code points.
+///
+/// This is what ICU4C calls a `UnicodeSet`.
 #[zerovec::make_varule(CodePointInversionListAndStringListULE)]
 #[zerovec::skip_derive(Ord)]
 #[zerovec::derive(Debug)]

--- a/components/collections/src/codepointtrie/cptrie.rs
+++ b/components/collections/src/codepointtrie/cptrie.rs
@@ -1036,7 +1036,9 @@ where
 }
 
 /// Represents a range of consecutive code points sharing the same value in a
-/// code point map. The start and end of the interval is represented as a
+/// code point map.
+///
+/// The start and end of the interval is represented as a
 /// `RangeInclusive<u32>`, and the value is represented as `T`.
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CodePointMapRange<T> {

--- a/components/collections/src/codepointtrie/cptrie.rs
+++ b/components/collections/src/codepointtrie/cptrie.rs
@@ -58,7 +58,6 @@ pub trait TrieValue: Copy + Eq + PartialEq + zerovec::ule::AsULE + 'static {
     ///
     /// In most cases, the error value is read from the last element of the `data` array,
     /// this value is used for empty codepointtrie arrays
-
     /// Error type when converting from a u32 to this `TrieValue`.
     type TryFromU32Error: Display;
     /// A parsing function that is primarily motivated by deserialization contexts.

--- a/components/collections/src/codepointtrie/planes.rs
+++ b/components/collections/src/codepointtrie/planes.rs
@@ -147,7 +147,9 @@ const INDEX_ARRAY_AS_BYTES: &[u8] = &[
 ];
 
 /// Return a [`CodePointTrie`] that returns the Unicode plane number, an
-/// integer from 0-16 inclusive, for each code point. This `CodePointTrie`
+/// integer from 0-16 inclusive, for each code point.
+///
+/// This `CodePointTrie`
 /// does not actually represent any Unicode property, but it is provided in
 /// case it is useful to users of `CodePointTrie` for testing or other
 /// purposes. See <https://www.unicode.org/glossary/#plane>.

--- a/components/collections/tests/cpt.rs
+++ b/components/collections/tests/cpt.rs
@@ -261,9 +261,11 @@ pub fn check_trie<T: TrieValue + Into<u32>>(trie: &CodePointTrie<T>, check_range
     }
 }
 
-/// Test .get_range() / .iter_ranges() on CodePointTrie by calling
-/// .iter_ranges() on the trie (which returns an iterator that produces values
-/// by calls to .get_range) and see if it matches the values in check_ranges.
+/// Test `.get_range()` / `.iter_ranges()` on CodePointTrie by calling
+/// `.iter_ranges()` on the trie.
+///
+/// `.iter_ranges()` returns an iterator that produces values
+/// by calls to .get_range, and this checks if it matches the values in check_ranges.
 pub fn test_check_ranges_get_ranges<T: TrieValue + Into<u32>>(
     trie: &CodePointTrie<T>,
     check_ranges: &[u32],

--- a/components/datetime/src/calendar.rs
+++ b/components/datetime/src/calendar.rs
@@ -17,6 +17,8 @@ use crate::provider::{neo::*, *};
 use core::marker::PhantomData;
 use icu_provider::marker::NeverMarker;
 
+/// Internal-ish trait for sealing `CldrCalendar`.
+///
 /// The `CldrCalendar` trait is sealed except when the `"experimental"` Cargo
 /// feature is enabled. If implementing `CldrCalendar`, you must also
 /// implement `UnstableCldrCalendar` and acknowledge the stability policy.

--- a/components/datetime/src/fields/length.rs
+++ b/components/datetime/src/fields/length.rs
@@ -20,8 +20,9 @@ pub enum LengthError {
 #[cfg(feature = "std")]
 impl std::error::Error for LengthError {}
 
-/// An enum representing the length of a field within a date or time formatting pattern string,
-/// in which the pattern field is represented as a letter occurring 1 or more times in a row, ex:
+/// An enum representing the length of a field within a date or time formatting pattern string.
+///
+/// Such strings represent fields as a letter occurring 1 or more times in a row, ex:
 /// `MMM`, `dd`, `y`.  See the
 /// [LDML documentation in UTS 35](https://unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns)
 /// for more details.

--- a/components/datetime/src/fields/mod.rs
+++ b/components/datetime/src/fields/mod.rs
@@ -34,7 +34,9 @@ pub enum Error {
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
-/// A field within a date pattern string, also referred to as a date field. A date field is the
+/// A field within a date pattern string, also referred to as a date field.
+///
+/// A date field is the
 /// repetition of a specific pattern character one or more times within the pattern string.
 /// The pattern character is known as the field symbol, which indicates the particular meaning for the field.
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -28,7 +28,9 @@ pub enum SymbolError {
 #[cfg(feature = "std")]
 impl std::error::Error for SymbolError {}
 
-/// A field symbol for a date formatting pattern. Field symbols are a more granular distinction
+/// A field symbol for a date formatting pattern.
+///
+/// Field symbols are a more granular distinction
 /// for a pattern field within the category of a field type. Examples of field types are:
 /// `Year`, `Month`, `Hour`.  Within the [`Hour`] field type, examples of field symbols are: [`Hour::H12`],
 /// [`Hour::H24`]. Each field symbol is represented within the date formatting pattern string

--- a/components/datetime/src/fields/symbols.rs
+++ b/components/datetime/src/fields/symbols.rs
@@ -100,7 +100,6 @@ impl FieldSymbol {
     /// # Constraints
     ///
     /// This model limits the available number of possible types and symbols to 16 each.
-
     #[inline]
     pub(crate) fn idx(&self) -> u8 {
         let (high, low) = match self {

--- a/components/datetime/src/format/neo.rs
+++ b/components/datetime/src/format/neo.rs
@@ -2397,7 +2397,6 @@ where
     ///     "Your time zone is: BST",
     /// );
     /// ```
-
     pub fn format_timezone<I>(&self, datetime: &'a I) -> FormattedDateTimePattern<'a>
     where
         I: ?Sized

--- a/components/datetime/src/neo_skeleton.rs
+++ b/components/datetime/src/neo_skeleton.rs
@@ -203,6 +203,7 @@ impl TryFrom<u8> for FractionalSecondDigits {
 
 /// A specification for a set of parts of a date that specifies a single day (as
 /// opposed to a whole month or a week).
+///
 /// Only sets that yield “sensible” dates are allowed: this type cannot
 /// describe a date such as “some Tuesday in 2023”.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/components/datetime/src/provider/calendar/skeletons.rs
+++ b/components/datetime/src/provider/calendar/skeletons.rs
@@ -20,7 +20,9 @@ use litemap::LiteMap;
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct DateSkeletonPatternsV1<'data>(pub LiteMap<SkeletonV1, PatternPlurals<'data>>);
 
-/// This struct is a public wrapper around the internal `Skeleton` struct. This allows
+/// This struct is a public wrapper around the internal `Skeleton` struct.
+///
+/// This allows
 /// access to the serialization and deserialization capabilities, without exposing the
 /// internals of the skeleton machinery.
 ///

--- a/components/datetime/src/skeleton/helpers.rs
+++ b/components/datetime/src/skeleton/helpers.rs
@@ -80,6 +80,8 @@ const SKELETON_EXTRA_SYMBOL: u32 = 1000;
 // the stored skeletons. There cannot be any cases higher than this one.
 const REQUESTED_SYMBOL_MISSING: u32 = 10000;
 
+/// The best skeleton found, alongside information on how well it matches.
+///
 /// According to the [UTS 35 skeleton matching algorithm](https://unicode.org/reports/tr35/tr35-dates.html#Matching_Skeletons)
 /// there will be a guaranteed match for a skeleton. However, with this initial implementation,
 /// there is no attempt to add on missing fields. This enum encodes the variants for the current

--- a/components/experimental/src/transliterate/transliterator/replaceable.rs
+++ b/components/experimental/src/transliterate/transliterator/replaceable.rs
@@ -587,7 +587,6 @@ impl MatchDirection for Reverse {}
 ///
 /// The used indices in method parameters are all compatible with each other.
 // Thought: I don't think this needs to be called *Utf8* matcher, maybe just Matcheable
-
 pub(super) trait Utf8Matcher<D: MatchDirection>: Debug {
     fn cursor(&self) -> usize;
 

--- a/components/list/src/provider/serde_dfa.rs
+++ b/components/list/src/provider/serde_dfa.rs
@@ -6,7 +6,9 @@ use alloc::borrow::Cow;
 use icu_provider::prelude::*;
 use regex_automata::dfa::sparse::DFA;
 
-/// A serde-compatible version of [regex_automata::dfa::sparse::DFA]. This does not implement
+/// A serde-compatible version of [regex_automata::dfa::sparse::DFA].
+///
+/// This does not implement
 /// [`serde::Deserialize`] directly, as binary deserialization is not supported in big-endian
 /// platforms. `Self::maybe_deserialize` can be used to deserialize to `Option<SerdeDFA>`.
 ///

--- a/components/locale/src/provider.rs
+++ b/components/locale/src/provider.rs
@@ -143,7 +143,9 @@ pub struct LanguageStrStrPair<'a>(
 #[cfg_attr(feature = "datagen", databake(path = icu_locale::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[yoke(prove_covariance_manually)]
-/// This alias data is used for locale canonicalization. Each field defines a
+/// This alias data is used for locale canonicalization.
+///
+/// Each field defines a
 /// mapping from an old identifier to a new identifier, based upon the rules in
 /// from <http://unicode.org/reports/tr35/#LocaleId_Canonicalization>. The data
 /// is stored in sorted order, allowing for binary search to identify rules to

--- a/components/locale_core/src/preferences/mod.rs
+++ b/components/locale_core/src/preferences/mod.rs
@@ -2,7 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-//! This API provides necessary functionality for building user preferences structs with ability
+//! This API provides necessary functionality for building user preferences structs.
+//!
+//! This includes the ability
 //! to `merge` information between the struct and a [`Locale`] and facilitate resolution of the
 //! attributes against default values.
 //!

--- a/components/plurals/src/rules/raw_operands.rs
+++ b/components/plurals/src/rules/raw_operands.rs
@@ -14,7 +14,9 @@
 use crate::PluralOperands;
 
 /// 🚧 \[Experimental\] A struct for low-level users who want to construct a [`PluralOperands`]
-/// directly based on the LDML Plural Operand definitions. This may be useful
+/// directly based on the LDML Plural Operand definitions.
+///
+/// This may be useful
 /// for people with experimental rules parsing.
 ///
 /// This struct is not intended for supported API use, and it is subject to breaking

--- a/components/properties/src/code_point_map.rs
+++ b/components/properties/src/code_point_map.rs
@@ -11,7 +11,9 @@ use icu_provider::marker::ErasedMarker;
 use icu_provider::prelude::*;
 use zerovec::ule::UleError;
 
-/// A wrapper around code point map data. It is returned by APIs that return Unicode
+/// A wrapper around code point map data.
+///
+/// It is returned by APIs that return Unicode
 /// property data in a map-like form, ex: enumerated property value data keyed
 /// by code point. Access its data via the borrowed version,
 /// [`CodePointMapDataBorrowed`].

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -1477,7 +1477,7 @@ make_binary_property! {
     data_marker: crate::provider::AsciiHexDigitV1Marker;
     singleton: SINGLETON_ASCII_HEX_DIGIT_V1_MARKER;
     func:
-    /// ASCII characters commonly used for the representation of hexadecimal numbers
+    /// ASCII characters commonly used for the representation of hexadecimal numbers.
     ///
     /// # Example
     ///
@@ -1501,7 +1501,8 @@ make_binary_property! {
     data_marker: crate::provider::AlnumV1Marker;
     singleton: SINGLETON_ALNUM_V1_MARKER;
     func:
-    /// Characters with the Alphabetic or Decimal_Number property
+    /// Characters with the `Alphabetic` or `Decimal_Number` property.
+    ///
     /// This is defined for POSIX compatibility.
 }
 
@@ -1512,7 +1513,7 @@ make_binary_property! {
     data_marker: crate::provider::AlphabeticV1Marker;
     singleton: SINGLETON_ALPHABETIC_V1_MARKER;
     func:
-    /// Alphabetic characters
+    /// Alphabetic characters.
     ///
     /// # Example
     ///
@@ -1538,7 +1539,7 @@ make_binary_property! {
     singleton: SINGLETON_BIDI_CONTROL_V1_MARKER;
     func:
     /// Format control characters which have specific functions in the Unicode Bidirectional
-    /// Algorithm
+    /// Algorithm.
     ///
     /// # Example
     ///
@@ -1561,7 +1562,7 @@ make_binary_property! {
     data_marker: crate::provider::BidiMirroredV1Marker;
     singleton: SINGLETON_BIDI_MIRRORED_V1_MARKER;
     func:
-    /// Characters that are mirrored in bidirectional text
+    /// Characters that are mirrored in bidirectional text.
     ///
     /// # Example
     ///
@@ -1597,7 +1598,7 @@ make_binary_property! {
     data_marker: crate::provider::CasedV1Marker;
     singleton: SINGLETON_CASED_V1_MARKER;
     func:
-    /// Uppercase, lowercase, and titlecase characters
+    /// Uppercase, lowercase, and titlecase characters.
     ///
     /// # Example
     ///
@@ -1620,7 +1621,7 @@ make_binary_property! {
     data_marker: crate::provider::CaseIgnorableV1Marker;
     singleton: SINGLETON_CASE_IGNORABLE_V1_MARKER;
     func:
-    /// Characters which are ignored for casing purposes
+    /// Characters which are ignored for casing purposes.
     ///
     /// # Example
     ///
@@ -1643,7 +1644,8 @@ make_binary_property! {
     data_marker: crate::provider::FullCompositionExclusionV1Marker;
     singleton: SINGLETON_FULL_COMPOSITION_EXCLUSION_V1_MARKER;
     func:
-    /// Characters that are excluded from composition
+    /// Characters that are excluded from composition.
+    ///
     /// See <https://unicode.org/Public/UNIDATA/CompositionExclusions.txt>
 
 }
@@ -1655,7 +1657,7 @@ make_binary_property! {
     data_marker: crate::provider::ChangesWhenCasefoldedV1Marker;
     singleton: SINGLETON_CHANGES_WHEN_CASEFOLDED_V1_MARKER;
     func:
-    /// Characters whose normalized forms are not stable under case folding
+    /// Characters whose normalized forms are not stable under case folding.
     ///
     /// # Example
     ///
@@ -1678,7 +1680,7 @@ make_binary_property! {
     data_marker: crate::provider::ChangesWhenCasemappedV1Marker;
     singleton: SINGLETON_CHANGES_WHEN_CASEMAPPED_V1_MARKER;
     func:
-    /// Characters which may change when they undergo case mapping
+    /// Characters which may change when they undergo case mapping.
 
 }
 
@@ -1689,7 +1691,7 @@ make_binary_property! {
     data_marker: crate::provider::ChangesWhenNfkcCasefoldedV1Marker;
     singleton: SINGLETON_CHANGES_WHEN_NFKC_CASEFOLDED_V1_MARKER;
     func:
-    /// Characters which are not identical to their NFKC_Casefold mapping
+    /// Characters which are not identical to their `NFKC_Casefold` mapping.
     ///
     /// # Example
     ///
@@ -1712,7 +1714,7 @@ make_binary_property! {
     data_marker: crate::provider::ChangesWhenLowercasedV1Marker;
     singleton: SINGLETON_CHANGES_WHEN_LOWERCASED_V1_MARKER;
     func:
-    /// Characters whose normalized forms are not stable under a toLowercase mapping
+    /// Characters whose normalized forms are not stable under a `toLowercase` mapping.
     ///
     /// # Example
     ///
@@ -1735,7 +1737,7 @@ make_binary_property! {
     data_marker: crate::provider::ChangesWhenTitlecasedV1Marker;
     singleton: SINGLETON_CHANGES_WHEN_TITLECASED_V1_MARKER;
     func:
-    /// Characters whose normalized forms are not stable under a toTitlecase mapping
+    /// Characters whose normalized forms are not stable under a `toTitlecase` mapping.
     ///
     /// # Example
     ///
@@ -1758,7 +1760,7 @@ make_binary_property! {
     data_marker: crate::provider::ChangesWhenUppercasedV1Marker;
     singleton: SINGLETON_CHANGES_WHEN_UPPERCASED_V1_MARKER;
     func:
-    /// Characters whose normalized forms are not stable under a toUppercase mapping
+    /// Characters whose normalized forms are not stable under a `toUppercase` mapping.
     ///
     /// # Example
     ///
@@ -1782,7 +1784,7 @@ make_binary_property! {
     singleton: SINGLETON_DASH_V1_MARKER;
     func:
     /// Punctuation characters explicitly called out as dashes in the Unicode Standard, plus
-    /// their compatibility equivalents
+    /// their compatibility equivalents.
     ///
     /// # Example
     ///
@@ -1806,7 +1808,9 @@ make_binary_property! {
     data_marker: crate::provider::DeprecatedV1Marker;
     singleton: SINGLETON_DEPRECATED_V1_MARKER;
     func:
-    /// Deprecated characters. No characters will ever be removed from the standard, but the
+    /// Deprecated characters.
+    ///
+    /// No characters will ever be removed from the standard, but the
     /// usage of deprecated characters is strongly discouraged.
     ///
     /// # Example
@@ -1830,7 +1834,9 @@ make_binary_property! {
     data_marker: crate::provider::DefaultIgnorableCodePointV1Marker;
     singleton: SINGLETON_DEFAULT_IGNORABLE_CODE_POINT_V1_MARKER;
     func:
-    /// For programmatic determination of default ignorable code points.  New characters that
+    /// For programmatic determination of default ignorable code points.
+    ///
+    /// New characters that
     /// should be ignored in rendering (unless explicitly supported) will be assigned in these
     /// ranges, permitting programs to correctly handle the default rendering of such
     /// characters when not otherwise supported.
@@ -1856,7 +1862,7 @@ make_binary_property! {
     data_marker: crate::provider::DiacriticV1Marker;
     singleton: SINGLETON_DIACRITIC_V1_MARKER;
     func:
-    /// Characters that linguistically modify the meaning of another character to which they apply
+    /// Characters that linguistically modify the meaning of another character to which they apply.
     ///
     /// # Example
     ///
@@ -1879,7 +1885,7 @@ make_binary_property! {
     data_marker: crate::provider::EmojiModifierBaseV1Marker;
     singleton: SINGLETON_EMOJI_MODIFIER_BASE_V1_MARKER;
     func:
-    /// Characters that can serve as a base for emoji modifiers
+    /// Characters that can serve as a base for emoji modifiers.
     ///
     /// # Example
     ///
@@ -1903,7 +1909,7 @@ make_binary_property! {
     singleton: SINGLETON_EMOJI_COMPONENT_V1_MARKER;
     func:
     /// Characters used in emoji sequences that normally do not appear on emoji keyboards as
-    /// separate choices, such as base characters for emoji keycaps
+    /// separate choices, such as base characters for emoji keycaps.
     ///
     /// # Example
     ///
@@ -1928,7 +1934,7 @@ make_binary_property! {
     data_marker: crate::provider::EmojiModifierV1Marker;
     singleton: SINGLETON_EMOJI_MODIFIER_V1_MARKER;
     func:
-    /// Characters that are emoji modifiers
+    /// Characters that are emoji modifiers.
     ///
     /// # Example
     ///
@@ -1951,7 +1957,7 @@ make_binary_property! {
     data_marker: crate::provider::EmojiV1Marker;
     singleton: SINGLETON_EMOJI_V1_MARKER;
     func:
-    /// Characters that are emoji
+    /// Characters that are emoji.
     ///
     /// # Example
     ///
@@ -1974,7 +1980,7 @@ make_binary_property! {
     data_marker: crate::provider::EmojiPresentationV1Marker;
     singleton: SINGLETON_EMOJI_PRESENTATION_V1_MARKER;
     func:
-    /// Characters that have emoji presentation by default
+    /// Characters that have emoji presentation by default.
     ///
     /// # Example
     ///
@@ -2047,6 +2053,7 @@ make_binary_property! {
     singleton: SINGLETON_GRAPH_V1_MARKER;
     func:
     /// Visible characters.
+    ///
     /// This is defined for POSIX compatibility.
 
 }
@@ -2059,7 +2066,9 @@ make_binary_property! {
     singleton: SINGLETON_GRAPHEME_BASE_V1_MARKER;
     func:
     /// Property used together with the definition of Standard Korean Syllable Block to define
-    /// "Grapheme base". See D58 in Chapter 3, Conformance in the Unicode Standard.
+    /// "Grapheme base".
+    ///
+    /// See D58 in Chapter 3, Conformance in the Unicode Standard.
     ///
     /// # Example
     ///
@@ -2083,7 +2092,9 @@ make_binary_property! {
     data_marker: crate::provider::GraphemeExtendV1Marker;
     singleton: SINGLETON_GRAPHEME_EXTEND_V1_MARKER;
     func:
-    /// Property used to define "Grapheme extender". See D59 in Chapter 3, Conformance in the
+    /// Property used to define "Grapheme extender".
+    ///
+    /// See D59 in Chapter 3, Conformance in the
     /// Unicode Standard.
     ///
     /// # Example
@@ -2108,7 +2119,9 @@ make_binary_property! {
     data_marker: crate::provider::GraphemeLinkV1Marker;
     singleton: SINGLETON_GRAPHEME_LINK_V1_MARKER;
     func:
-    /// Deprecated property. Formerly proposed for programmatic determination of grapheme
+    /// Deprecated property.
+    ///
+    /// Formerly proposed for programmatic determination of grapheme
     /// cluster boundaries.
 
 }
@@ -2121,7 +2134,7 @@ make_binary_property! {
     singleton: SINGLETON_HEX_DIGIT_V1_MARKER;
     func:
     /// Characters commonly used for the representation of hexadecimal numbers, plus their
-    /// compatibility equivalents
+    /// compatibility equivalents.
     ///
     /// # Example
     ///
@@ -2148,7 +2161,9 @@ make_binary_property! {
     data_marker: crate::provider::HyphenV1Marker;
     singleton: SINGLETON_HYPHEN_V1_MARKER;
     func:
-    /// Deprecated property. Dashes which are used to mark connections between pieces of
+    /// Deprecated property.
+    ///
+    /// Dashes which are used to mark connections between pieces of
     /// words, plus the Katakana middle dot.
 
 }
@@ -2160,7 +2175,9 @@ make_binary_property! {
     data_marker: crate::provider::IdContinueV1Marker;
     singleton: SINGLETON_ID_CONTINUE_V1_MARKER;
     func:
-    /// Characters that can come after the first character in an identifier. If using NFKC to
+    /// Characters that can come after the first character in an identifier.
+    ///
+    /// If using NFKC to
     /// fold differences between characters, use [`XidContinue`] instead.  See
     /// [`Unicode Standard Annex #31`](https://www.unicode.org/reports/tr31/tr31-35.html) for
     /// more details.
@@ -2214,7 +2231,9 @@ make_binary_property! {
     data_marker: crate::provider::IdStartV1Marker;
     singleton: SINGLETON_ID_START_V1_MARKER;
     func:
-    /// Characters that can begin an identifier. If using NFKC to fold differences between
+    /// Characters that can begin an identifier.
+    ///
+    /// If using NFKC to fold differences between
     /// characters, use [`XidStart`] instead.  See [`Unicode Standard Annex
     /// #31`](https://www.unicode.org/reports/tr31/tr31-35.html) for more details.
     ///
@@ -2243,7 +2262,7 @@ make_binary_property! {
     data_marker: crate::provider::IdsBinaryOperatorV1Marker;
     singleton: SINGLETON_IDS_BINARY_OPERATOR_V1_MARKER;
     func:
-    /// Characters used in Ideographic Description Sequences
+    /// Characters used in Ideographic Description Sequences.
     ///
     /// # Example
     ///
@@ -2266,7 +2285,7 @@ make_binary_property! {
     data_marker: crate::provider::IdsTrinaryOperatorV1Marker;
     singleton: SINGLETON_IDS_TRINARY_OPERATOR_V1_MARKER;
     func:
-    /// Characters used in Ideographic Description Sequences
+    /// Characters used in Ideographic Description Sequences.
     ///
     /// # Example
     ///
@@ -2293,7 +2312,7 @@ make_binary_property! {
     singleton: SINGLETON_JOIN_CONTROL_V1_MARKER;
     func:
     /// Format control characters which have specific functions for control of cursive joining
-    /// and ligation
+    /// and ligation.
     ///
     /// # Example
     ///
@@ -2317,7 +2336,7 @@ make_binary_property! {
     data_marker: crate::provider::LogicalOrderExceptionV1Marker;
     singleton: SINGLETON_LOGICAL_ORDER_EXCEPTION_V1_MARKER;
     func:
-    /// A small number of spacing vowel letters occurring in certain Southeast Asian scripts such as Thai and Lao
+    /// A small number of spacing vowel letters occurring in certain Southeast Asian scripts such as Thai and Lao.
     ///
     /// # Example
     ///
@@ -2340,7 +2359,7 @@ make_binary_property! {
     data_marker: crate::provider::LowercaseV1Marker;
     singleton: SINGLETON_LOWERCASE_V1_MARKER;
     func:
-    /// Lowercase characters
+    /// Lowercase characters.
     ///
     /// # Example
     ///
@@ -2363,7 +2382,7 @@ make_binary_property! {
     data_marker: crate::provider::MathV1Marker;
     singleton: SINGLETON_MATH_V1_MARKER;
     func:
-    /// Characters used in mathematical notation
+    /// Characters used in mathematical notation.
     ///
     /// # Example
     ///
@@ -2390,7 +2409,7 @@ make_binary_property! {
     data_marker: crate::provider::NoncharacterCodePointV1Marker;
     singleton: SINGLETON_NONCHARACTER_CODE_POINT_V1_MARKER;
     func:
-    /// Code points permanently reserved for internal use
+    /// Code points permanently reserved for internal use.
     ///
     /// # Example
     ///
@@ -2414,7 +2433,7 @@ make_binary_property! {
     data_marker: crate::provider::NfcInertV1Marker;
     singleton: SINGLETON_NFC_INERT_V1_MARKER;
     func:
-    /// Characters that are inert under NFC, i.e., they do not interact with adjacent characters
+    /// Characters that are inert under NFC, i.e., they do not interact with adjacent characters.
 
 }
 
@@ -2425,7 +2444,7 @@ make_binary_property! {
     data_marker: crate::provider::NfdInertV1Marker;
     singleton: SINGLETON_NFD_INERT_V1_MARKER;
     func:
-    /// Characters that are inert under NFD, i.e., they do not interact with adjacent characters
+    /// Characters that are inert under NFD, i.e., they do not interact with adjacent characters.
 
 }
 
@@ -2436,7 +2455,7 @@ make_binary_property! {
     data_marker: crate::provider::NfkcInertV1Marker;
     singleton: SINGLETON_NFKC_INERT_V1_MARKER;
     func:
-    /// Characters that are inert under NFKC, i.e., they do not interact with adjacent characters
+    /// Characters that are inert under NFKC, i.e., they do not interact with adjacent characters.
 
 }
 
@@ -2447,7 +2466,7 @@ make_binary_property! {
     data_marker: crate::provider::NfkdInertV1Marker;
     singleton: SINGLETON_NFKD_INERT_V1_MARKER;
     func:
-    /// Characters that are inert under NFKD, i.e., they do not interact with adjacent characters
+    /// Characters that are inert under NFKD, i.e., they do not interact with adjacent characters.
 
 }
 
@@ -2458,7 +2477,9 @@ make_binary_property! {
     data_marker: crate::provider::PatternSyntaxV1Marker;
     singleton: SINGLETON_PATTERN_SYNTAX_V1_MARKER;
     func:
-    /// Characters used as syntax in patterns (such as regular expressions). See [`Unicode
+    /// Characters used as syntax in patterns (such as regular expressions).
+    ///
+    /// See [`Unicode
     /// Standard Annex #31`](https://www.unicode.org/reports/tr31/tr31-35.html) for more
     /// details.
     ///
@@ -2484,7 +2505,9 @@ make_binary_property! {
     data_marker: crate::provider::PatternWhiteSpaceV1Marker;
     singleton: SINGLETON_PATTERN_WHITE_SPACE_V1_MARKER;
     func:
-    /// Characters used as whitespace in patterns (such as regular expressions).  See
+    /// Characters used as whitespace in patterns (such as regular expressions).
+    ///
+    /// See
     /// [`Unicode Standard Annex #31`](https://www.unicode.org/reports/tr31/tr31-35.html) for
     /// more details.
     ///
@@ -2524,6 +2547,7 @@ make_binary_property! {
     singleton: SINGLETON_PRINT_V1_MARKER;
     func:
     /// Printable characters (visible characters and whitespace).
+    ///
     /// This is defined for POSIX compatibility.
 
 }
@@ -2559,7 +2583,7 @@ make_binary_property! {
     data_marker: crate::provider::RadicalV1Marker;
     singleton: SINGLETON_RADICAL_V1_MARKER;
     func:
-    /// Characters used in the definition of Ideographic Description Sequences
+    /// Characters used in the definition of Ideographic Description Sequences.
     ///
     /// # Example
     ///
@@ -2582,7 +2606,7 @@ make_binary_property! {
     data_marker: crate::provider::RegionalIndicatorV1Marker;
     singleton: SINGLETON_REGIONAL_INDICATOR_V1_MARKER;
     func:
-    /// Regional indicator characters, U+1F1E6..U+1F1FF
+    /// Regional indicator characters, `U+1F1E6..U+1F1FF`.
     ///
     /// # Example
     ///
@@ -2606,7 +2630,9 @@ make_binary_property! {
     data_marker: crate::provider::SoftDottedV1Marker;
     singleton: SINGLETON_SOFT_DOTTED_V1_MARKER;
     func:
-    /// Characters with a "soft dot", like i or j. An accent placed on these characters causes
+    /// Characters with a "soft dot", like i or j.
+    ///
+    /// An accent placed on these characters causes
     /// the dot to disappear.
     ///
     /// # Example
@@ -2631,7 +2657,7 @@ make_binary_property! {
     singleton: SINGLETON_SEGMENT_STARTER_V1_MARKER;
     func:
     /// Characters that are starters in terms of Unicode normalization and combining character
-    /// sequences
+    /// sequences.
 
 }
 
@@ -2643,7 +2669,7 @@ make_binary_property! {
     singleton: SINGLETON_CASE_SENSITIVE_V1_MARKER;
     func:
     /// Characters that are either the source of a case mapping or in the target of a case
-    /// mapping
+    /// mapping.
 
 }
 
@@ -2654,7 +2680,7 @@ make_binary_property! {
     data_marker: crate::provider::SentenceTerminalV1Marker;
     singleton: SINGLETON_SENTENCE_TERMINAL_V1_MARKER;
     func:
-    /// Punctuation characters that generally mark the end of sentences
+    /// Punctuation characters that generally mark the end of sentences.
     ///
     /// # Example
     ///
@@ -2680,7 +2706,7 @@ make_binary_property! {
     data_marker: crate::provider::TerminalPunctuationV1Marker;
     singleton: SINGLETON_TERMINAL_PUNCTUATION_V1_MARKER;
     func:
-    /// Punctuation characters that generally mark the end of textual units
+    /// Punctuation characters that generally mark the end of textual units.
     ///
     /// # Example
     ///
@@ -2706,7 +2732,7 @@ make_binary_property! {
     data_marker: crate::provider::UnifiedIdeographV1Marker;
     singleton: SINGLETON_UNIFIED_IDEOGRAPH_V1_MARKER;
     func:
-    /// A property which specifies the exact set of Unified CJK Ideographs in the standard
+    /// A property which specifies the exact set of Unified CJK Ideographs in the standard.
     ///
     /// # Example
     ///
@@ -2730,7 +2756,7 @@ make_binary_property! {
     data_marker: crate::provider::UppercaseV1Marker;
     singleton: SINGLETON_UPPERCASE_V1_MARKER;
     func:
-    /// Uppercase characters
+    /// Uppercase characters.
     ///
     /// # Example
     ///
@@ -2780,7 +2806,7 @@ make_binary_property! {
     singleton: SINGLETON_WHITE_SPACE_V1_MARKER;
     func:
     /// Spaces, separator characters and other control characters which should be treated by
-    /// programming languages as "white space" for the purpose of parsing elements
+    /// programming languages as "white space" for the purpose of parsing elements.
     ///
     /// # Example
     ///
@@ -2817,7 +2843,9 @@ make_binary_property! {
     data_marker: crate::provider::XidContinueV1Marker;
     singleton: SINGLETON_XID_CONTINUE_V1_MARKER;
     func:
-    /// Characters that can come after the first character in an identifier.  See [`Unicode Standard Annex
+    /// Characters that can come after the first character in an identifier.
+    ///
+    /// See [`Unicode Standard Annex
     /// #31`](https://www.unicode.org/reports/tr31/tr31-35.html) for more details.
     ///
     /// # Example
@@ -2845,7 +2873,9 @@ make_binary_property! {
     data_marker: crate::provider::XidStartV1Marker;
     singleton: SINGLETON_XID_START_V1_MARKER;
     func:
-    /// Characters that can begin an identifier. See [`Unicode
+    /// Characters that can begin an identifier.
+    ///
+    /// See [`Unicode
     /// Standard Annex #31`](https://www.unicode.org/reports/tr31/tr31-35.html) for more
     /// details.
     ///
@@ -2899,6 +2929,7 @@ make_emoji_set! {
     singleton: SINGLETON_BASIC_EMOJI_V1_MARKER;
     func:
     /// Characters and character sequences intended for general-purpose, independent, direct input.
+    ///
     /// See [`Unicode Technical Standard #51`](https://unicode.org/reports/tr51/) for more
     /// details.
     ///

--- a/components/segmenter/src/rule_segmenter.rs
+++ b/components/segmenter/src/rule_segmenter.rs
@@ -234,7 +234,7 @@ impl<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> RuleBreakIterator<'l, 's, Y> {
     /// Return the status value of break boundary.
     /// If segmenter isn't word, always return WordType::None
     pub fn word_type(&self) -> WordType {
-        if self.result_cache.first().is_some() {
+        if !self.result_cache.is_empty() {
             // Dictionary type (CJ and East Asian) is letter.
             return WordType::Letter;
         }

--- a/ffi/capi/bindings/dart/UnitsConverterFactory.g.dart
+++ b/ffi/capi/bindings/dart/UnitsConverterFactory.g.dart
@@ -4,6 +4,7 @@ part of 'lib.g.dart';
 
 /// An ICU4X Units Converter Factory object, capable of creating converters a [`UnitsConverter`]
 /// for converting between two [`MeasureUnit`]s.
+///
 /// Also, it can parse the CLDR unit identifier (e.g. `meter-per-square-second`) and get the [`MeasureUnit`].
 ///
 /// See the [Rust documentation for `ConverterFactory`](https://docs.rs/icu/latest/icu/experimental/units/converter_factory/struct.ConverterFactory.html) for more information.

--- a/ffi/capi/bindings/js/UnitsConverterFactory.d.ts
+++ b/ffi/capi/bindings/js/UnitsConverterFactory.d.ts
@@ -9,6 +9,7 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 /** An ICU4X Units Converter Factory object, capable of creating converters a [`UnitsConverter`]
 *for converting between two [`MeasureUnit`]s.
+*
 *Also, it can parse the CLDR unit identifier (e.g. `meter-per-square-second`) and get the [`MeasureUnit`].
 *
 *See the [Rust documentation for `ConverterFactory`](https://docs.rs/icu/latest/icu/experimental/units/converter_factory/struct.ConverterFactory.html) for more information.

--- a/ffi/capi/bindings/js/UnitsConverterFactory.mjs
+++ b/ffi/capi/bindings/js/UnitsConverterFactory.mjs
@@ -10,6 +10,7 @@ import * as diplomatRuntime from "./diplomat-runtime.mjs";
 
 /** An ICU4X Units Converter Factory object, capable of creating converters a [`UnitsConverter`]
 *for converting between two [`MeasureUnit`]s.
+*
 *Also, it can parse the CLDR unit identifier (e.g. `meter-per-square-second`) and get the [`MeasureUnit`].
 *
 *See the [Rust documentation for `ConverterFactory`](https://docs.rs/icu/latest/icu/experimental/units/converter_factory/struct.ConverterFactory.html) for more information.

--- a/ffi/capi/src/units_converter.rs
+++ b/ffi/capi/src/units_converter.rs
@@ -13,6 +13,7 @@ pub mod ffi {
     #[diplomat::opaque]
     /// An ICU4X Units Converter Factory object, capable of creating converters a [`UnitsConverter`]
     /// for converting between two [`MeasureUnit`]s.
+    ///
     /// Also, it can parse the CLDR unit identifier (e.g. `meter-per-square-second`) and get the [`MeasureUnit`].
     #[diplomat::rust_link(icu::experimental::units::converter_factory::ConverterFactory, Struct)]
     pub struct UnitsConverterFactory(

--- a/provider/source/src/decimal/compact.rs
+++ b/provider/source/src/decimal/compact.rs
@@ -113,7 +113,6 @@ impl IterableDataProviderCached<LongCompactDecimalFormatDataV1Marker> for Source
 }
 
 #[cfg(test)]
-
 mod tests {
     use super::*;
     use icu::locale::langid;

--- a/utils/calendrical_calculations/src/chinese_based.rs
+++ b/utils/calendrical_calculations/src/chinese_based.rs
@@ -382,7 +382,9 @@ pub(crate) fn new_year_on_or_before_fixed_date<C: ChineseBased>(
     }
 }
 
-/// Get a RataDie in the middle of a year; this is not necessarily meant for direct use in
+/// Get a RataDie in the middle of a year.
+///
+/// This is not necessarily meant for direct use in
 /// calculations; rather, it is useful for getting a RataDie guaranteed to be in a given year
 /// as input for other calculations like calculating the leap month in a year.
 ///
@@ -511,7 +513,9 @@ pub fn get_leap_month_from_new_year<C: ChineseBased>(new_year: RataDie) -> u8 {
     result
 }
 
-/// Returns the number of days in the given (year, month). In the Chinese calendar, months start at each
+/// Returns the number of days in the given (year, month).
+///
+/// In the Chinese calendar, months start at each
 /// new moon, so this function finds the number of days between the new moon at the beginning of the given
 /// month and the new moon at the beginning of the next month.
 pub fn month_days<C: ChineseBased>(year: i32, month: u8) -> u8 {

--- a/utils/calendrical_calculations/src/hebrew_keviyah.rs
+++ b/utils/calendrical_calculations/src/hebrew_keviyah.rs
@@ -314,7 +314,9 @@ impl YearInfo {
     }
 }
 
-/// The Keviyah (קביעה) of a year. A year may be one of fourteen types, categorized by the day of
+/// The Keviyah (קביעה) of a year.
+///
+/// A year may be one of fourteen types, categorized by the day of
 /// week of the new year (the first number, 1 = Sunday), the type of year (Deficient, Regular,
 /// Complete), and the day of week of the first day of Passover. The last segment disambiguates
 /// between cases that have the same first two but differ on whether they are leap years (since

--- a/utils/calendrical_calculations/src/julian.rs
+++ b/utils/calendrical_calculations/src/julian.rs
@@ -96,7 +96,9 @@ pub fn julian_from_fixed(date: RataDie) -> Result<(i32, u8, u8), I32CastError> {
     Ok((adjusted_year, month, day))
 }
 
-/// Get a fixed date from the ymd of a Julian date; years are counted as in _Calendrical Calculations_ by Reingold & Dershowitz,
+/// Get a fixed date from the ymd of a Julian date.
+///
+/// Years are counted as in _Calendrical Calculations_ by Reingold & Dershowitz,
 /// meaning there is no year 0. For instance, near the epoch date, years are counted: -3, -2, -1, 1, 2, 3 instead of -2, -1, 0, 1, 2, 3.
 ///
 /// Primarily useful for use with code constructing epochs specified in the bookg

--- a/utils/env_preferences/src/linux.rs
+++ b/utils/env_preferences/src/linux.rs
@@ -83,7 +83,9 @@ pub fn get_locales() -> Result<HashMap<LocaleCategory, String>, RetrievalError> 
     Ok(locale_map)
 }
 
-/// This only returns the calendar locale,`gnome-calendar` is the default calendar in linux
+/// Get the system calendar locale (LC_TIME).
+///
+/// This only returns the calendar locale, `gnome-calendar` is the default calendar in linux
 /// The locale returned is for `Gregorian` calendar
 /// Related issue: `<https://gitlab.gnome.org/GNOME/gnome-calendar/-/issues/998>`
 pub fn get_system_calendars() -> Result<String, RetrievalError> {

--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -25,7 +25,9 @@ use crate::ParseError;
 compile_error!("The fixed_decimal crate only works if usizes are at least the size of a u16");
 
 /// A struct containing decimal digits with efficient iteration and manipulation by magnitude
-/// (power of 10). Supports a mantissa of non-zero digits and a number of leading and trailing
+/// (power of 10).
+///
+/// Supports a mantissa of non-zero digits and a number of leading and trailing
 /// zeros, as well as an optional sign; used for formatting and plural selection.
 ///
 /// # Data Types

--- a/utils/fixed_decimal/src/lib.rs
+++ b/utils/fixed_decimal/src/lib.rs
@@ -75,7 +75,9 @@ use displaydoc::Display;
 pub use integer::FixedInteger;
 pub use scientific::ScientificDecimal;
 
-/// The magnitude or number of digits exceeds the limit of the [`FixedDecimal`]. The highest
+/// The magnitude or number of digits exceeds the limit of the [`FixedDecimal`].
+///
+/// The highest
 /// magnitude of the most significant digit is [`i16::MAX`], and the lowest magnitude of the
 /// least significant digit is [`i16::MIN`].
 ///

--- a/utils/fixed_decimal/src/scientific.rs
+++ b/utils/fixed_decimal/src/scientific.rs
@@ -11,6 +11,7 @@ use crate::ParseError;
 
 /// A struct containing a [`FixedDecimal`] significand together with an exponent, representing a
 /// number written in scientific notation, such as 1.729×10³.
+///
 /// This structure represents any 0s shown in the significand and exponent,
 /// and an optional sign for both the significand and the exponent.
 #[derive(Debug, Clone, PartialEq)]

--- a/utils/litemap/src/map.rs
+++ b/utils/litemap/src/map.rs
@@ -744,7 +744,7 @@ where
     }
 }
 
-impl<'a, K: 'a, V: 'a, S> LiteMap<K, V, S>
+impl<K, V, S> LiteMap<K, V, S>
 where
     K: Ord,
     S: StoreIntoIterator<K, V> + StoreFromIterator<K, V>,

--- a/utils/tzif/src/data/tzif.rs
+++ b/utils/tzif/src/data/tzif.rs
@@ -225,6 +225,8 @@ pub enum UtLocalIndicator {
     Local,
 }
 
+/// A `TZif` data block.
+///
 /// A `TZif` data block consists of seven variable-length elements, each of
 /// which is a series of items.  The number of items in each series is
 /// determined by the corresponding count field in the header.  The total

--- a/utils/yoke/src/yokeable.rs
+++ b/utils/yoke/src/yokeable.rs
@@ -7,7 +7,9 @@ use alloc::borrow::{Cow, ToOwned};
 use core::{marker::PhantomData, mem};
 
 /// The `Yokeable<'a>` trait is implemented on the `'static` version of any zero-copy type; for
-/// example, `Cow<'static, T>` implements `Yokeable<'a>` (for all `'a`). One can use
+/// example, `Cow<'static, T>` implements `Yokeable<'a>` (for all `'a`).
+///
+/// One can use
 /// `Yokeable::Output` on this trait to obtain the "lifetime'd" value of the `Cow<'static, T>`,
 /// e.g. `<Cow<'static, T> as Yokeable<'a>'>::Output` is `Cow<'a, T>`.
 ///

--- a/utils/zerotrie/src/builder/litemap.rs
+++ b/utils/zerotrie/src/builder/litemap.rs
@@ -30,7 +30,7 @@ impl ZeroTrieSimpleAscii<Vec<u8>> {
     }
 }
 
-impl<'a, K, S> TryFrom<&'a LiteMap<K, usize, S>> for ZeroTrie<Vec<u8>>
+impl<K, S> TryFrom<&LiteMap<K, usize, S>> for ZeroTrie<Vec<u8>>
 where
     // Borrow, not AsRef, because we rely on Ord being the same. Unfortunately
     // this means `LiteMap<&str, usize>` does not work.

--- a/utils/zerotrie/src/cursor.rs
+++ b/utils/zerotrie/src/cursor.rs
@@ -159,7 +159,7 @@ pub struct AsciiProbeResult {
     pub total_siblings: u8,
 }
 
-impl<'a> ZeroTrieSimpleAsciiCursor<'a> {
+impl ZeroTrieSimpleAsciiCursor<'_> {
     /// Steps the cursor one character into the trie based on the character's byte value.
     ///
     /// # Examples
@@ -343,7 +343,7 @@ impl<'a> ZeroTrieSimpleAsciiCursor<'a> {
     }
 }
 
-impl<'a> ZeroAsciiIgnoreCaseTrieCursor<'a> {
+impl ZeroAsciiIgnoreCaseTrieCursor<'_> {
     /// Steps the cursor one byte into the trie.
     ///
     /// Returns the byte if matched, which may be a different case than the input byte.
@@ -411,7 +411,7 @@ impl<'a> ZeroAsciiIgnoreCaseTrieCursor<'a> {
     }
 }
 
-impl<'a> fmt::Write for ZeroTrieSimpleAsciiCursor<'a> {
+impl fmt::Write for ZeroTrieSimpleAsciiCursor<'_> {
     /// Steps the cursor through each ASCII byte of the string.
     ///
     /// If the string contains non-ASCII chars, an error is returned.
@@ -465,7 +465,7 @@ impl<'a> fmt::Write for ZeroTrieSimpleAsciiCursor<'a> {
     }
 }
 
-impl<'a> fmt::Write for ZeroAsciiIgnoreCaseTrieCursor<'a> {
+impl fmt::Write for ZeroAsciiIgnoreCaseTrieCursor<'_> {
     /// Steps the cursor through each ASCII byte of the string.
     ///
     /// If the string contains non-ASCII chars, an error is returned.

--- a/utils/zerotrie/src/reader.rs
+++ b/utils/zerotrie/src/reader.rs
@@ -641,7 +641,7 @@ impl<'a> ZeroTrieIterator<'a> {
 }
 
 #[cfg(feature = "alloc")]
-impl<'a> Iterator for ZeroTrieIterator<'a> {
+impl Iterator for ZeroTrieIterator<'_> {
     type Item = (Vec<u8>, usize);
     fn next(&mut self) -> Option<Self::Item> {
         let (mut trie, mut string, mut branch_idx);

--- a/utils/zerotrie/src/serde.rs
+++ b/utils/zerotrie/src/serde.rs
@@ -44,9 +44,7 @@ impl<'de> Visitor<'de> for ByteStrVisitor {
     }
 }
 
-impl<'de, 'data> Deserialize<'de> for &'data ByteStr
-where
-    'de: 'data,
+impl<'data, 'de: 'data> Deserialize<'de> for &'data ByteStr
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -57,9 +55,7 @@ where
     }
 }
 
-impl<'de, 'data> Deserialize<'de> for Box<ByteStr>
-where
-    'de: 'data,
+impl<'de> Deserialize<'de> for Box<ByteStr>
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -75,7 +71,7 @@ where
     }
 }
 
-impl<'data> Serialize for &'data ByteStr {
+impl Serialize for &ByteStr {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -92,9 +88,8 @@ impl<'data> Serialize for &'data ByteStr {
     }
 }
 
-impl<'de, 'data, Store> Deserialize<'de> for ZeroTrieSimpleAscii<Store>
+impl<'data, 'de: 'data, Store> Deserialize<'de> for ZeroTrieSimpleAscii<Store>
 where
-    'de: 'data,
     // DISCUSS: There are several possibilities for the bounds here that would
     // get the job done. I could look for Deserialize, but this would require
     // creating a custom Deserializer for the map case. I also considered

--- a/utils/zerotrie/src/serde.rs
+++ b/utils/zerotrie/src/serde.rs
@@ -44,8 +44,7 @@ impl<'de> Visitor<'de> for ByteStrVisitor {
     }
 }
 
-impl<'data, 'de: 'data> Deserialize<'de> for &'data ByteStr
-{
+impl<'data, 'de: 'data> Deserialize<'de> for &'data ByteStr {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -55,8 +54,7 @@ impl<'data, 'de: 'data> Deserialize<'de> for &'data ByteStr
     }
 }
 
-impl<'de> Deserialize<'de> for Box<ByteStr>
-{
+impl<'de> Deserialize<'de> for Box<ByteStr> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,

--- a/utils/zerovec/src/hashmap/algorithms.rs
+++ b/utils/zerovec/src/hashmap/algorithms.rs
@@ -48,6 +48,7 @@ pub fn compute_index(f: (u32, u32), d: (u32, u32), m: u32) -> Option<usize> {
 
 /// Compute displacements for the given `key_hashes`, which split the keys into distinct slots by a
 /// two-level hashing schema.
+///
 /// Returns a tuple of where the first item is the displacement array and the second item is the
 /// reverse mapping used to permute keys, values into their slots.
 ///

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -186,8 +186,10 @@ pub trait AsULE: Copy {
     fn from_unaligned(unaligned: Self::ULE) -> Self;
 }
 
-/// An [`EqULE`] type is one whose byte sequence equals the byte sequence of its ULE type on
-/// little-endian platforms. This enables certain performance optimizations, such as
+/// A type whose byte sequence equals the byte sequence of its ULE type on
+/// little-endian platforms.
+///
+/// This enables certain performance optimizations, such as
 /// [`ZeroVec::try_from_slice`](crate::ZeroVec::try_from_slice).
 ///
 /// # Implementation safety

--- a/utils/zerovec/src/ule/vartuple.rs
+++ b/utils/zerovec/src/ule/vartuple.rs
@@ -198,7 +198,7 @@ fn test_nested() {
         sized: 2000u16,
         variable: VarTuple {
             sized: '🦙',
-            variable: ZeroVec::alloc_from_slice(&[b'I', b'C', b'U']),
+            variable: ZeroVec::alloc_from_slice(b"ICU"),
         },
     };
     let var_tuple_ule = super::encode_varule_to_box(&var_tuple);
@@ -206,6 +206,6 @@ fn test_nested() {
     assert_eq!(var_tuple_ule.variable.sized.to_char(), '🦙');
     assert_eq!(
         &var_tuple_ule.variable.variable,
-        ZeroSlice::from_ule_slice(&[b'I', b'C', b'U'])
+        ZeroSlice::from_ule_slice(b"ICU")
     );
 }

--- a/utils/zerovec/src/zerovec/slice.rs
+++ b/utils/zerovec/src/zerovec/slice.rs
@@ -7,7 +7,9 @@ use alloc::boxed::Box;
 use core::cmp::Ordering;
 use core::ops::Range;
 
-/// A zero-copy "slice", i.e. the zero-copy version of `[T]`. This behaves
+/// A zero-copy "slice", i.e. the zero-copy version of `[T]`.
+///
+/// This behaves
 /// similarly to [`ZeroVec<T>`], however [`ZeroVec<T>`] is allowed to contain
 /// owned data and as such is ideal for deserialization since most human readable
 /// serialization formats cannot unconditionally deserialize zero-copy.


### PR DESCRIPTION
A lot of this is reformatting docs so that there is a clear, short summary line.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->