### PR TITLE
Start adding concrete format functions

### DIFF
--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -31,6 +31,7 @@ use icu_calendar::provider::{
     IslamicUmmAlQuraCacheV1Marker, JapaneseErasV1Marker, JapaneseExtendedErasV1Marker,
 };
 use icu_calendar::AnyCalendar;
+use icu_calendar::AsCalendar;
 use icu_decimal::provider::DecimalSymbolsV1Marker;
 use icu_provider::prelude::*;
 use writeable::TryWriteable;
@@ -1427,6 +1428,37 @@ where
             input: datetime,
             names: self.names.as_borrowed(),
         }
+    }
+
+    /// Formats a date in a field set with only date fields.
+    /// 
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::Date;
+    /// use icu::calendar::Gregorian;
+    /// use icu::datetime::neo::NeoFormatter;
+    /// use icu::datetime::neo_skeleton::NeoDateComponents;
+    /// use icu::datetime::neo_skeleton::NeoDateSkeleton;
+    /// use icu::datetime::neo_skeleton::NeoSkeletonLength;
+    /// use icu::locale::locale;
+    /// use writeable::assert_try_writeable_eq;
+    ///
+    /// let fmt = NeoFormatter::try_new_with_skeleton(
+    ///     &locale!("es-MX").into(),
+    ///     NeoDateSkeleton::for_length_and_components(
+    ///         NeoSkeletonLength::Medium,
+    ///         NeoDateComponents::DayWeekday,
+    ///     ),
+    /// )
+    /// .unwrap();
+    ///
+    /// assert_try_writeable_eq!(fmt.format_date("2024-10-01".parse().unwrap()), "mié 10");
+    /// ```
+    pub fn format_date<C, A>(&self, date: icu_calendar::Date<A>) -> FormattedNeoDateTime where C: icu_calendar::any_calendar::IntoAnyCalendar, A: AsCalendar<Calendar = C>,
+    for<'a> icu_calendar::Date<icu_calendar::Ref<'a, AnyCalendar>>: AllInputMarkers<R>
+     {
+        self.convert_and_format(&date)
     }
 }
 


### PR DESCRIPTION
https://github.com/unicode-org/icu4x/issues/5269#issuecomment-2361895181

This approach we discussed doesn't completely work because it doesn't accomplish the type inference I wanted to see, because I need to accept a `Date<A: AsCalendar>`, not an actual concrete `Date<C>`. This voids most of the benefit of having concrete functions because then you can't `.into()` or `.parse()` into the type being formatted.

Thought: if I made `.format_date` take a concrete `Date<C>` (disallowing the use of `Ref`), I could keep `.format` as-is, and then these concrete format functions become nice-to-haves that can be added on later. I think this is most aligned with the design @Manishearth had preferred anyway.

Would be _nice_ to land this in 2.0-Alpha, but it's _fine_ if it changes in 2.0-Beta.

CC @Manishearth @robertbastian 