### PR TITLE
Restructure icu_calendar public API to put all calendars under `cal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     - Compiled data updated to CLDR 45 and ICU 75 (unicode-org#4782)
   - `icu_calendar`
     - Consistently name calendar-specific `Date`/`DateTime` functions that have a calendar argument (https://github.com/unicode-org/icu4x/pull/5692)
+    - Move all calendar types to `cal` module (https://github.com/unicode-org/icu4x/pull/5701)
   - `icu_collections`
   - `icu_normalizer`
   - `icu_datetime`

--- a/components/calendar/README.md
+++ b/components/calendar/README.md
@@ -11,9 +11,8 @@ The [`types`] module has a lot of common types for dealing with dates and times.
 [`Calendar`] is a trait that allows one to define custom calendars, and [`Date`]
 can represent dates for arbitrary calendars.
 
-The [`iso`] and [`gregorian`] modules contain implementations for the ISO and
-Gregorian calendars respectively. Further calendars can be found in modules like
-[`japanese`], [`julian`], [`coptic`], [`indian`], [`buddhist`], and [`ethiopian`].
+The [`Iso`] and [`Gregorian`] types are implementations for the ISO and
+Gregorian calendars respectively. Further calendars can be found in the [`cal`] module.
 
 Most interaction with this crate will be done via the [`Date`] and [`DateTime`] types.
 
@@ -47,7 +46,8 @@ assert_eq!(date_iso.days_in_month(), 30);
 Example of converting an ISO date across Indian and Buddhist calendars.
 
 ```rust
-use icu::calendar::{buddhist::Buddhist, indian::Indian, Date};
+use icu::calendar::cal::{Buddhist, Indian};
+use icu::calendar::Date;
 
 // Creating ISO date: 1992-09-02.
 let mut date_iso = Date::try_new_iso(1992, 9, 2)

--- a/components/calendar/benches/convert.rs
+++ b/components/calendar/benches/convert.rs
@@ -29,81 +29,81 @@ fn bench_calendar<C: Clone + Calendar>(
 fn convert_benches(c: &mut Criterion) {
     let mut group = c.benchmark_group("convert");
 
-    bench_calendar(&mut group, "calendar/iso", icu::calendar::iso::Iso);
+    bench_calendar(&mut group, "calendar/iso", icu::calendar::cal::Iso);
 
     #[cfg(feature = "bench")]
     bench_calendar(
         &mut group,
         "calendar/buddhist",
-        icu::calendar::buddhist::Buddhist,
+        icu::calendar::cal::Buddhist,
     );
 
     #[cfg(feature = "bench")]
-    bench_calendar(&mut group, "calendar/coptic", icu::calendar::coptic::Coptic);
+    bench_calendar(&mut group, "calendar/coptic", icu::calendar::cal::Coptic);
 
     #[cfg(feature = "bench")]
     bench_calendar(
         &mut group,
         "calendar/ethiopic",
-        icu::calendar::ethiopian::Ethiopian::new(),
+        icu::calendar::cal::Ethiopian::new(),
     );
 
     #[cfg(feature = "bench")]
-    bench_calendar(&mut group, "calendar/indian", icu::calendar::indian::Indian);
+    bench_calendar(&mut group, "calendar/indian", icu::calendar::cal::Indian);
 
     #[cfg(feature = "bench")]
-    bench_calendar(&mut group, "calendar/julian", icu::calendar::julian::Julian);
+    bench_calendar(&mut group, "calendar/julian", icu::calendar::cal::Julian);
 
     #[cfg(feature = "bench")]
     bench_calendar(
         &mut group,
         "calendar/chinese_calculating",
-        icu::calendar::chinese::Chinese::new_always_calculating(),
+        icu::calendar::cal::Chinese::new_always_calculating(),
     );
 
     #[cfg(feature = "bench")]
     bench_calendar(
         &mut group,
         "calendar/chinese_cached",
-        icu::calendar::chinese::Chinese::new(),
+        icu::calendar::cal::Chinese::new(),
     );
 
     #[cfg(feature = "bench")]
     bench_calendar(
         &mut group,
         "calendar/gregorian",
-        icu::calendar::gregorian::Gregorian,
+        icu::calendar::cal::Gregorian,
     );
 
     #[cfg(feature = "bench")]
-    bench_calendar(&mut group, "calendar/hebrew", icu::calendar::hebrew::Hebrew);
+    bench_calendar(&mut group, "calendar/hebrew", icu::calendar::cal::Hebrew);
 
     #[cfg(feature = "bench")]
     bench_calendar(
         &mut group,
         "calendar/islamic/observational",
-        icu::calendar::islamic::IslamicObservational::new_always_calculating(),
+        icu::calendar::cal::IslamicObservational::new_always_calculating(),
     );
 
     #[cfg(feature = "bench")]
     bench_calendar(
         &mut group,
         "calendar/islamic/civil",
-        icu::calendar::islamic::IslamicCivil::new(),
+        icu::calendar::cal::IslamicCivil::new(),
     );
 
     #[cfg(feature = "bench")]
     bench_calendar(
         &mut group,
         "calendar/islamic/ummalqura",
-        icu::calendar::islamic::IslamicUmmAlQura::new_always_calculating(),
+        icu::calendar::cal::IslamicUmmAlQura::new_always_calculating(),
     );
 
     #[cfg(feature = "bench")]
     bench_calendar(
         &mut group,
         "calendar/islamic/tabular",
-        icu::calendar::islamic::IslamicTabular::new(),
+        icu::calendar::cal::IslamicTabular::new(),
     );
 
     group.finish();

--- a/components/calendar/benches/date.rs
+++ b/components/calendar/benches/date.rs
@@ -61,7 +61,7 @@ fn date_benches(c: &mut Criterion) {
         &mut group,
         "calendar/overview",
         &fxs,
-        icu::calendar::iso::Iso,
+        icu::calendar::cal::Iso,
         |y, m, d| Date::try_new_iso(y, m, d).unwrap(),
     );
 
@@ -70,7 +70,7 @@ fn date_benches(c: &mut Criterion) {
         &mut group,
         "calendar/buddhist",
         &fxs,
-        icu::calendar::buddhist::Buddhist,
+        icu::calendar::cal::Buddhist,
         |y, m, d| Date::try_new_buddhist(y, m, d).unwrap(),
     );
 
@@ -79,7 +79,7 @@ fn date_benches(c: &mut Criterion) {
         &mut group,
         "calendar/coptic",
         &fxs,
-        icu::calendar::coptic::Coptic,
+        icu::calendar::cal::Coptic,
         |y, m, d| Date::try_new_coptic(y, m, d).unwrap(),
     );
 
@@ -88,15 +88,10 @@ fn date_benches(c: &mut Criterion) {
         &mut group,
         "calendar/ethiopic",
         &fxs,
-        icu::calendar::ethiopian::Ethiopian::new(),
+        icu::calendar::cal::Ethiopian::new(),
         |y, m, d| {
-            Date::try_new_ethiopian(
-                icu::calendar::ethiopian::EthiopianEraStyle::AmeteMihret,
-                y,
-                m,
-                d,
-            )
-            .unwrap()
+            Date::try_new_ethiopian(icu::calendar::cal::EthiopianEraStyle::AmeteMihret, y, m, d)
+                .unwrap()
         },
     );
 
@@ -105,7 +100,7 @@ fn date_benches(c: &mut Criterion) {
         &mut group,
         "calendar/indian",
         &fxs,
-        icu::calendar::indian::Indian,
+        icu::calendar::cal::Indian,
         |y, m, d| Date::try_new_indian(y, m, d).unwrap(),
     );
 
@@ -114,7 +109,7 @@ fn date_benches(c: &mut Criterion) {
         &mut group,
         "calendar/persian",
         &fxs,
-        icu::calendar::persian::Persian,
+        icu::calendar::cal::Persian,
         |y, m, d| Date::try_new_persian(y, m, d).unwrap(),
     );
 
@@ -123,7 +118,7 @@ fn date_benches(c: &mut Criterion) {
         &mut group,
         "calendar/roc",
         &fxs,
-        icu::calendar::roc::Roc,
+        icu::calendar::cal::Roc,
         |y, m, d| Date::try_new_roc(y, m, d).unwrap(),
     );
 
@@ -132,7 +127,7 @@ fn date_benches(c: &mut Criterion) {
         &mut group,
         "calendar/julian",
         &fxs,
-        icu::calendar::julian::Julian,
+        icu::calendar::cal::Julian,
         |y, m, d| Date::try_new_julian(y, m, d).unwrap(),
     );
 
@@ -141,13 +136,13 @@ fn date_benches(c: &mut Criterion) {
         &mut group,
         "calendar/chinese_calculating",
         &fxs,
-        icu::calendar::chinese::Chinese::new_always_calculating(),
+        icu::calendar::cal::Chinese::new_always_calculating(),
         |y, m, d| {
             Date::try_new_chinese_with_calendar(
                 y,
                 m,
                 d,
-                icu::calendar::chinese::Chinese::new_always_calculating(),
+                icu::calendar::cal::Chinese::new_always_calculating(),
             )
             .unwrap()
         },
@@ -158,9 +153,9 @@ fn date_benches(c: &mut Criterion) {
         &mut group,
         "calendar/chinese_cached",
         &fxs,
-        icu::calendar::chinese::Chinese::new(),
+        icu::calendar::cal::Chinese::new(),
         |y, m, d| {
-            Date::try_new_chinese_with_calendar(y, m, d, icu::calendar::chinese::Chinese::new())
+            Date::try_new_chinese_with_calendar(y, m, d, icu::calendar::cal::Chinese::new())
                 .unwrap()
         },
     );
@@ -170,13 +165,13 @@ fn date_benches(c: &mut Criterion) {
         &mut group,
         "calendar/dangi_calculating",
         &fxs,
-        icu::calendar::dangi::Dangi::new_always_calculating(),
+        icu::calendar::cal::Dangi::new_always_calculating(),
         |y, m, d| {
             Date::try_new_dangi_with_calendar(
                 y,
                 m,
                 d,
-                icu::calendar::dangi::Dangi::new_always_calculating(),
+                icu::calendar::cal::Dangi::new_always_calculating(),
             )
             .unwrap()
         },
@@ -187,9 +182,9 @@ fn date_benches(c: &mut Criterion) {
         &mut group,
         "calendar/dangi_cached",
         &fxs,
-        icu::calendar::dangi::Dangi::new(),
+        icu::calendar::cal::Dangi::new(),
         |y, m, d| {
-            Date::try_new_dangi_with_calendar(y, m, d, icu::calendar::dangi::Dangi::new()).unwrap()
+            Date::try_new_dangi_with_calendar(y, m, d, icu::calendar::cal::Dangi::new()).unwrap()
         },
     );
 
@@ -198,7 +193,7 @@ fn date_benches(c: &mut Criterion) {
         &mut group,
         "calendar/hebrew",
         &fxs,
-        icu::calendar::hebrew::Hebrew,
+        icu::calendar::cal::Hebrew,
         |y, m, d| Date::try_new_hebrew(y, m, d).unwrap(),
     );
 
@@ -207,7 +202,7 @@ fn date_benches(c: &mut Criterion) {
         &mut group,
         "calendar/gregorian",
         &fxs,
-        icu::calendar::gregorian::Gregorian,
+        icu::calendar::cal::Gregorian,
         |y, m, d| Date::try_new_gregorian(y, m, d).unwrap(),
     );
 
@@ -216,13 +211,13 @@ fn date_benches(c: &mut Criterion) {
         &mut group,
         "calendar/islamic/civil",
         &fxs,
-        icu::calendar::islamic::IslamicCivil::new(),
+        icu::calendar::cal::IslamicCivil::new(),
         |y, m, d| {
             Date::try_new_islamic_civil_with_calendar(
                 y,
                 m,
                 d,
-                icu::calendar::islamic::IslamicCivil::new(),
+                icu::calendar::cal::IslamicCivil::new(),
             )
             .unwrap()
         },
@@ -233,13 +228,13 @@ fn date_benches(c: &mut Criterion) {
         &mut group,
         "calendar/islamic/tabular",
         &fxs,
-        icu::calendar::islamic::IslamicTabular::new(),
+        icu::calendar::cal::IslamicTabular::new(),
         |y, m, d| {
             Date::try_new_islamic_tabular_with_calendar(
                 y,
                 m,
                 d,
-                icu::calendar::islamic::IslamicTabular::new(),
+                icu::calendar::cal::IslamicTabular::new(),
             )
             .unwrap()
         },
@@ -250,13 +245,13 @@ fn date_benches(c: &mut Criterion) {
         &mut group,
         "calendar/islamic/ummalqura",
         &fxs,
-        icu::calendar::islamic::IslamicUmmAlQura::new_always_calculating(),
+        icu::calendar::cal::IslamicUmmAlQura::new_always_calculating(),
         |y, m, d| {
             Date::try_new_ummalqura_with_calendar(
                 y,
                 m,
                 d,
-                icu::calendar::islamic::IslamicUmmAlQura::new_always_calculating(),
+                icu::calendar::cal::IslamicUmmAlQura::new_always_calculating(),
             )
             .unwrap()
         },
@@ -267,13 +262,13 @@ fn date_benches(c: &mut Criterion) {
         &mut group,
         "calendar/islamic/observational",
         &fxs,
-        icu::calendar::islamic::IslamicObservational::new_always_calculating(),
+        icu::calendar::cal::IslamicObservational::new_always_calculating(),
         |y, m, d| {
             Date::try_new_observational_islamic_with_calendar(
                 y,
                 m,
                 d,
-                icu::calendar::islamic::IslamicObservational::new_always_calculating(),
+                icu::calendar::cal::IslamicObservational::new_always_calculating(),
             )
             .unwrap()
         },

--- a/components/calendar/benches/datetime.rs
+++ b/components/calendar/benches/datetime.rs
@@ -71,7 +71,7 @@ fn datetime_benches(c: &mut Criterion) {
         &mut group,
         "calendar/overview",
         &fxs,
-        icu::calendar::iso::Iso,
+        icu::calendar::cal::Iso,
         |y, m, d, h, min, s| DateTime::try_new_iso(y, m, d, h, min, s).unwrap(),
     );
 
@@ -80,7 +80,7 @@ fn datetime_benches(c: &mut Criterion) {
         &mut group,
         "calendar/buddhist",
         &fxs,
-        icu::calendar::buddhist::Buddhist,
+        icu::calendar::cal::Buddhist,
         |y, m, d, h, min, s| DateTime::try_new_buddhist(y, m, d, h, min, s).unwrap(),
     );
 
@@ -89,7 +89,7 @@ fn datetime_benches(c: &mut Criterion) {
         &mut group,
         "calendar/coptic",
         &fxs,
-        icu::calendar::coptic::Coptic,
+        icu::calendar::cal::Coptic,
         |y, m, d, h, min, s| DateTime::try_new_coptic(y, m, d, h, min, s).unwrap(),
     );
 
@@ -98,10 +98,10 @@ fn datetime_benches(c: &mut Criterion) {
         &mut group,
         "calendar/ethiopic",
         &fxs,
-        icu::calendar::ethiopian::Ethiopian::new(),
+        icu::calendar::cal::Ethiopian::new(),
         |y, m, d, h, min, s| {
             DateTime::try_new_ethiopian(
-                icu::calendar::ethiopian::EthiopianEraStyle::AmeteMihret,
+                icu::calendar::cal::EthiopianEraStyle::AmeteMihret,
                 y,
                 m,
                 d,
@@ -118,7 +118,7 @@ fn datetime_benches(c: &mut Criterion) {
         &mut group,
         "calendar/chinese_calculating",
         &fxs,
-        icu::calendar::chinese::Chinese::new_always_calculating(),
+        icu::calendar::cal::Chinese::new_always_calculating(),
         |y, m, d, h, min, s| {
             DateTime::try_new_chinese_with_calendar(
                 y,
@@ -127,7 +127,7 @@ fn datetime_benches(c: &mut Criterion) {
                 h,
                 min,
                 s,
-                icu::calendar::chinese::Chinese::new_always_calculating(),
+                icu::calendar::cal::Chinese::new_always_calculating(),
             )
             .unwrap()
         },
@@ -138,7 +138,7 @@ fn datetime_benches(c: &mut Criterion) {
         &mut group,
         "calendar/chinese_cached",
         &fxs,
-        icu::calendar::chinese::Chinese::new(),
+        icu::calendar::cal::Chinese::new(),
         |y, m, d, h, min, s| {
             DateTime::try_new_chinese_with_calendar(
                 y,
@@ -147,7 +147,7 @@ fn datetime_benches(c: &mut Criterion) {
                 h,
                 min,
                 s,
-                icu::calendar::chinese::Chinese::new(),
+                icu::calendar::cal::Chinese::new(),
             )
             .unwrap()
         },
@@ -158,7 +158,7 @@ fn datetime_benches(c: &mut Criterion) {
         &mut group,
         "calendar/gregorian",
         &fxs,
-        icu::calendar::gregorian::Gregorian,
+        icu::calendar::cal::Gregorian,
         |y, m, d, h, min, s| DateTime::try_new_gregorian(y, m, d, h, min, s).unwrap(),
     );
 
@@ -167,7 +167,7 @@ fn datetime_benches(c: &mut Criterion) {
         &mut group,
         "calendar/indian",
         &fxs,
-        icu::calendar::indian::Indian,
+        icu::calendar::cal::Indian,
         |y, m, d, h, min, s| DateTime::try_new_indian(y, m, d, h, min, s).unwrap(),
     );
 
@@ -176,7 +176,7 @@ fn datetime_benches(c: &mut Criterion) {
         &mut group,
         "calendar/julian",
         &fxs,
-        icu::calendar::julian::Julian,
+        icu::calendar::cal::Julian,
         |y, m, d, h, min, s| DateTime::try_new_julian(y, m, d, h, min, s).unwrap(),
     );
 
@@ -185,7 +185,7 @@ fn datetime_benches(c: &mut Criterion) {
         &mut group,
         "calendar/islamic/civil",
         &fxs,
-        icu::calendar::islamic::IslamicCivil::new(),
+        icu::calendar::cal::IslamicCivil::new(),
         |y, m, d, h, min, s| {
             DateTime::try_new_islamic_civil_with_calendar(
                 y,
@@ -194,7 +194,7 @@ fn datetime_benches(c: &mut Criterion) {
                 h,
                 min,
                 s,
-                icu::calendar::islamic::IslamicCivil::new(),
+                icu::calendar::cal::IslamicCivil::new(),
             )
             .unwrap()
         },
@@ -205,7 +205,7 @@ fn datetime_benches(c: &mut Criterion) {
         &mut group,
         "calendar/islamic/tabular",
         &fxs,
-        icu::calendar::islamic::IslamicTabular::new(),
+        icu::calendar::cal::IslamicTabular::new(),
         |y, m, d, h, min, s| {
             DateTime::try_new_islamic_tabular_with_calendar(
                 y,
@@ -214,7 +214,7 @@ fn datetime_benches(c: &mut Criterion) {
                 h,
                 min,
                 s,
-                icu::calendar::islamic::IslamicTabular::new(),
+                icu::calendar::cal::IslamicTabular::new(),
             )
             .unwrap()
         },
@@ -225,7 +225,7 @@ fn datetime_benches(c: &mut Criterion) {
         &mut group,
         "calendar/islamic/ummalqura",
         &fxs,
-        icu::calendar::islamic::IslamicUmmAlQura::new_always_calculating(),
+        icu::calendar::cal::IslamicUmmAlQura::new_always_calculating(),
         |y, m, d, h, min, s| {
             DateTime::try_new_ummalqura_with_calendar(
                 y,
@@ -234,7 +234,7 @@ fn datetime_benches(c: &mut Criterion) {
                 h,
                 min,
                 s,
-                icu::calendar::islamic::IslamicUmmAlQura::new_always_calculating(),
+                icu::calendar::cal::IslamicUmmAlQura::new_always_calculating(),
             )
             .unwrap()
         },
@@ -245,7 +245,7 @@ fn datetime_benches(c: &mut Criterion) {
         &mut group,
         "calendar/islamic/observational",
         &fxs,
-        icu::calendar::islamic::IslamicObservational::new_always_calculating(),
+        icu::calendar::cal::IslamicObservational::new_always_calculating(),
         |y, m, d, h, min, s| {
             DateTime::try_new_observational_islamic_with_calendar(
                 y,
@@ -254,7 +254,7 @@ fn datetime_benches(c: &mut Criterion) {
                 h,
                 min,
                 s,
-                icu::calendar::islamic::IslamicObservational::new_always_calculating(),
+                icu::calendar::cal::IslamicObservational::new_always_calculating(),
             )
             .unwrap()
         },

--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -39,7 +39,7 @@ use core::fmt;
 ///
 /// There are many ways of constructing an AnyCalendar'd date:
 /// ```
-/// use icu::calendar::{AnyCalendar, DateTime, japanese::Japanese, Time, types::{Era, MonthCode}};
+/// use icu::calendar::{AnyCalendar, DateTime, cal::Japanese, Time, types::{Era, MonthCode}};
 /// use icu::locale::locale;
 /// use tinystr::tinystr;
 /// # use std::rc::Rc;

--- a/components/calendar/src/buddhist.rs
+++ b/components/calendar/src/buddhist.rs
@@ -5,7 +5,7 @@
 //! This module contains types and implementations for the Buddhist calendar.
 //!
 //! ```rust
-//! use icu::calendar::{buddhist::Buddhist, Date, DateTime};
+//! use icu::calendar::{cal::Buddhist, Date, DateTime};
 //!
 //! // `Date` type
 //! let date_iso = Date::try_new_iso(1970, 1, 2)

--- a/components/calendar/src/chinese.rs
+++ b/components/calendar/src/chinese.rs
@@ -5,7 +5,7 @@
 //! This module contains types and implementations for the Chinese calendar.
 //!
 //! ```rust
-//! use icu::calendar::{chinese::Chinese, Date, DateTime, Ref};
+//! use icu::calendar::{cal::Chinese, Date, DateTime, Ref};
 //!
 //! let chinese = Chinese::new();
 //! let chinese = Ref(&chinese); // to avoid cloning
@@ -320,7 +320,7 @@ impl<A: AsCalendar<Calendar = Chinese>> Date<A> {
     /// one that loads such data from a provider will be added in the future (#3933)
     ///
     /// ```rust
-    /// use icu::calendar::{chinese::Chinese, Date};
+    /// use icu::calendar::{cal::Chinese, Date};
     ///
     /// let chinese = Chinese::new_always_calculating();
     ///
@@ -360,7 +360,7 @@ impl<A: AsCalendar<Calendar = Chinese>> DateTime<A> {
     /// one that loads such data from a provider will be added in the future (#3933)
     ///
     /// ```rust
-    /// use icu::calendar::{chinese::Chinese, DateTime};
+    /// use icu::calendar::{cal::Chinese, DateTime};
     ///
     /// let chinese = Chinese::new_always_calculating();
     ///

--- a/components/calendar/src/chinese_based.rs
+++ b/components/calendar/src/chinese_based.rs
@@ -6,7 +6,7 @@
 //! as well as in related and derived calendars such as the Korean and Vietnamese lunar calendars.
 //!
 //! ```rust
-//! use icu::calendar::{chinese::Chinese, Date, Iso};
+//! use icu::calendar::{cal::Chinese, Date, Iso};
 //!
 //! let iso_date = Date::try_new_iso(2023, 6, 23).unwrap();
 //! let chinese_date = Date::new_from_iso(iso_date, Chinese::new());

--- a/components/calendar/src/coptic.rs
+++ b/components/calendar/src/coptic.rs
@@ -5,7 +5,7 @@
 //! This module contains types and implementations for the Coptic calendar.
 //!
 //! ```rust
-//! use icu::calendar::{coptic::Coptic, Date, DateTime};
+//! use icu::calendar::{cal::Coptic, Date, DateTime};
 //!
 //! // `Date` type
 //! let date_iso = Date::try_new_iso(1970, 1, 2)

--- a/components/calendar/src/dangi.rs
+++ b/components/calendar/src/dangi.rs
@@ -5,7 +5,7 @@
 //! This module contains types and implementations for the Korean Dangi calendar.
 //!
 //! ```rust
-//! use icu::calendar::dangi::Dangi;
+//! use icu::calendar::cal::Dangi;
 //! use icu::calendar::{Date, DateTime, Ref};
 //!
 //! let dangi = Dangi::new();
@@ -69,7 +69,8 @@ use tinystr::tinystr;
 /// going to be perfect.
 ///
 /// ```rust
-/// use icu::calendar::{chinese::Chinese, dangi::Dangi, Date};
+/// use icu::calendar::cal::{Chinese, Dangi};
+/// use icu::calendar::Date;
 /// use tinystr::tinystr;
 ///
 /// let iso_a = Date::try_new_iso(2012, 4, 23).unwrap();
@@ -299,7 +300,7 @@ impl<A: AsCalendar<Calendar = Dangi>> Date<A> {
     /// one that loads such data from a provider will be added in the future (#3933)
     ///
     /// ```rust
-    /// use icu::calendar::dangi::Dangi;
+    /// use icu::calendar::cal::Dangi;
     /// use icu::calendar::Date;
     ///
     /// let dangi = Dangi::new();
@@ -337,7 +338,7 @@ impl<A: AsCalendar<Calendar = Dangi>> DateTime<A> {
     /// one that loads such data from a provider will be added in the future (#3933)
     ///
     /// ```rust
-    /// use icu::calendar::dangi::Dangi;
+    /// use icu::calendar::cal::Dangi;
     /// use icu::calendar::DateTime;
     ///
     /// let dangi = Dangi::new();

--- a/components/calendar/src/ethiopian.rs
+++ b/components/calendar/src/ethiopian.rs
@@ -5,7 +5,7 @@
 //! This module contains types and implementations for the Ethiopian calendar.
 //!
 //! ```rust
-//! use icu::calendar::{ethiopian::Ethiopian, Date, DateTime};
+//! use icu::calendar::{cal::Ethiopian, Date, DateTime};
 //!
 //! // `Date` type
 //! let date_iso = Date::try_new_iso(1970, 1, 2)
@@ -336,7 +336,7 @@ impl Date<Ethiopian> {
     /// and so on.
     ///
     /// ```rust
-    /// use icu::calendar::ethiopian::EthiopianEraStyle;
+    /// use icu::calendar::cal::EthiopianEraStyle;
     /// use icu::calendar::Date;
     ///
     /// let date_ethiopian = Date::try_new_ethiopian(
@@ -374,7 +374,7 @@ impl DateTime<Ethiopian> {
     /// and so on.
     ///
     /// ```rust
-    /// use icu::calendar::ethiopian::EthiopianEraStyle;
+    /// use icu::calendar::cal::EthiopianEraStyle;
     /// use icu::calendar::DateTime;
     ///
     /// let datetime_ethiopian = DateTime::try_new_ethiopian(

--- a/components/calendar/src/gregorian.rs
+++ b/components/calendar/src/gregorian.rs
@@ -5,7 +5,7 @@
 //! This module contains types and implementations for the Gregorian calendar.
 //!
 //! ```rust
-//! use icu::calendar::{gregorian::Gregorian, Date, DateTime};
+//! use icu::calendar::{cal::Gregorian, Date, DateTime};
 //!
 //! // `Date` type
 //! let date_iso = Date::try_new_iso(1970, 1, 2)

--- a/components/calendar/src/indian.rs
+++ b/components/calendar/src/indian.rs
@@ -5,7 +5,7 @@
 //! This module contains types and implementations for the Indian national calendar.
 //!
 //! ```rust
-//! use icu::calendar::{indian::Indian, Date, DateTime};
+//! use icu::calendar::{cal::Indian, Date, DateTime};
 //!
 //! // `Date` type
 //! let date_iso = Date::try_new_iso(1970, 1, 2)

--- a/components/calendar/src/islamic.rs
+++ b/components/calendar/src/islamic.rs
@@ -5,7 +5,7 @@
 //! This module contains types and implementations for the Islamic calendars.
 //!
 //! ```rust
-//! use icu::calendar::islamic::IslamicObservational;
+//! use icu::calendar::cal::IslamicObservational;
 //! use icu::calendar::{Date, DateTime, Ref};
 //!
 //! let islamic = IslamicObservational::new_always_calculating();
@@ -563,7 +563,7 @@ impl<A: AsCalendar<Calendar = IslamicObservational>> Date<A> {
     /// Has no negative years, only era is the AH.
     ///
     /// ```rust
-    /// use icu::calendar::islamic::IslamicObservational;
+    /// use icu::calendar::cal::IslamicObservational;
     /// use icu::calendar::Date;
     ///
     /// let islamic = IslamicObservational::new_always_calculating();
@@ -596,7 +596,7 @@ impl<A: AsCalendar<Calendar = IslamicObservational>> DateTime<A> {
     /// Construct a new Islamic Observational datetime from integers.
     ///
     /// ```rust
-    /// use icu::calendar::islamic::IslamicObservational;
+    /// use icu::calendar::cal::IslamicObservational;
     /// use icu::calendar::DateTime;
     ///
     /// let islamic = IslamicObservational::new_always_calculating();
@@ -788,7 +788,7 @@ impl<A: AsCalendar<Calendar = IslamicUmmAlQura>> Date<A> {
     /// Has no negative years, only era is the AH.
     ///
     /// ```rust
-    /// use icu::calendar::islamic::IslamicUmmAlQura;
+    /// use icu::calendar::cal::IslamicUmmAlQura;
     /// use icu::calendar::Date;
     ///
     /// let islamic = IslamicUmmAlQura::new_always_calculating();
@@ -823,7 +823,7 @@ impl<A: AsCalendar<Calendar = IslamicUmmAlQura>> DateTime<A> {
     /// Construct a new Islamic Umm al-Qura datetime from integers.
     ///
     /// ```rust
-    /// use icu::calendar::islamic::IslamicUmmAlQura;
+    /// use icu::calendar::cal::IslamicUmmAlQura;
     /// use icu::calendar::DateTime;
     ///
     /// let islamic = IslamicUmmAlQura::new_always_calculating();
@@ -1025,7 +1025,7 @@ impl<A: AsCalendar<Calendar = IslamicCivil>> Date<A> {
     /// Has no negative years, only era is the AH.
     ///
     /// ```rust
-    /// use icu::calendar::islamic::IslamicCivil;
+    /// use icu::calendar::cal::IslamicCivil;
     /// use icu::calendar::Date;
     ///
     /// let islamic = IslamicCivil::new();
@@ -1054,7 +1054,7 @@ impl<A: AsCalendar<Calendar = IslamicCivil>> DateTime<A> {
     /// Construct a new Civil Islamic datetime from integers.
     ///
     /// ```rust
-    /// use icu::calendar::islamic::IslamicCivil;
+    /// use icu::calendar::cal::IslamicCivil;
     /// use icu::calendar::DateTime;
     ///
     /// let islamic = IslamicCivil::new();
@@ -1257,7 +1257,7 @@ impl<A: AsCalendar<Calendar = IslamicTabular>> Date<A> {
     /// Has no negative years, only era is the AH.
     ///
     /// ```rust
-    /// use icu::calendar::islamic::IslamicTabular;
+    /// use icu::calendar::cal::IslamicTabular;
     /// use icu::calendar::Date;
     ///
     /// let islamic = IslamicTabular::new();
@@ -1286,7 +1286,7 @@ impl<A: AsCalendar<Calendar = IslamicTabular>> DateTime<A> {
     /// Construct a new Tabular Islamic datetime from integers.
     ///
     /// ```rust
-    /// use icu::calendar::islamic::IslamicTabular;
+    /// use icu::calendar::cal::IslamicTabular;
     /// use icu::calendar::DateTime;
     ///
     /// let islamic = IslamicTabular::new();

--- a/components/calendar/src/japanese.rs
+++ b/components/calendar/src/japanese.rs
@@ -5,7 +5,7 @@
 //! This module contains types and implementations for the Japanese calendar.
 //!
 //! ```rust
-//! use icu::calendar::japanese::Japanese;
+//! use icu::calendar::cal::Japanese;
 //! use icu::calendar::{types::Era, Date, DateTime};
 //! use tinystr::tinystr;
 //!
@@ -415,7 +415,7 @@ impl Date<Japanese> {
     /// However, dates may always be specified in "bce" or "ce" and they will be adjusted as necessary.
     ///
     /// ```rust
-    /// use icu::calendar::japanese::Japanese;
+    /// use icu::calendar::cal::Japanese;
     /// use icu::calendar::{types, Date, Ref};
     /// use tinystr::tinystr;
     ///
@@ -469,7 +469,7 @@ impl Date<JapaneseExtended> {
     /// However, dates may always be specified in "bce" or "ce" and they will be adjusted as necessary.
     ///
     /// ```rust
-    /// use icu::calendar::japanese::JapaneseExtended;
+    /// use icu::calendar::cal::JapaneseExtended;
     /// use icu::calendar::{types, Date, Ref};
     /// use tinystr::tinystr;
     ///
@@ -514,7 +514,7 @@ impl DateTime<Japanese> {
     /// Years are specified in the era provided.
     ///
     /// ```rust
-    /// use icu::calendar::japanese::Japanese;
+    /// use icu::calendar::cal::Japanese;
     /// use icu::calendar::{types, DateTime};
     /// use tinystr::tinystr;
     ///
@@ -568,7 +568,7 @@ impl DateTime<JapaneseExtended> {
     /// Years are specified in the era provided.
     ///
     /// ```rust
-    /// use icu::calendar::japanese::JapaneseExtended;
+    /// use icu::calendar::cal::JapaneseExtended;
     /// use icu::calendar::{types, DateTime};
     /// use tinystr::tinystr;
     ///

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -5,7 +5,7 @@
 //! This module contains types and implementations for the Julian calendar.
 //!
 //! ```rust
-//! use icu::calendar::{julian::Julian, Date, DateTime};
+//! use icu::calendar::{cal::Julian, Date, DateTime};
 //!
 //! // `Date` type
 //! let date_iso = Date::try_new_iso(1970, 1, 2)

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -134,6 +134,8 @@ pub mod cal {
     pub use crate::persian::Persian;
     pub use crate::roc::Roc;
 
+    pub use crate::any_calendar::AnyCalendar;
+
     /// Scaffolding types: You shouldn't need to use these, they need to be public for the `Calendar` trait impl to work.
     pub mod scaffold {
         pub use crate::chinese::ChineseDateInner;
@@ -152,6 +154,8 @@ pub mod cal {
         pub use crate::julian::JulianDateInner;
         pub use crate::persian::PersianDateInner;
         pub use crate::roc::RocDateInner;
+
+        pub use crate::any_calendar::AnyDateInner;
     }
 }
 

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -11,9 +11,8 @@
 //! [`Calendar`] is a trait that allows one to define custom calendars, and [`Date`]
 //! can represent dates for arbitrary calendars.
 //!
-//! The [`iso`] and [`gregorian`] modules contain implementations for the ISO and
-//! Gregorian calendars respectively. Further calendars can be found in modules like
-//! [`japanese`], [`julian`], [`coptic`], [`indian`], [`buddhist`], and [`ethiopian`].
+//! The [`Iso`] and [`Gregorian`] types are implementations for the ISO and
+//! Gregorian calendars respectively. Further calendars can be found in the [`cal`] module.
 //!
 //! Most interaction with this crate will be done via the [`Date`] and [`DateTime`] types.
 //!
@@ -47,7 +46,8 @@
 //! Example of converting an ISO date across Indian and Buddhist calendars.
 //!
 //! ```rust
-//! use icu::calendar::{buddhist::Buddhist, indian::Indian, Date};
+//! use icu::calendar::cal::{Buddhist, Indian};
+//! use icu::calendar::Date;
 //!
 //! // Creating ISO date: 1992-09-02.
 //! let mut date_iso = Date::try_new_iso(1992, 9, 2)
@@ -115,29 +115,69 @@ extern crate alloc;
 mod date;
 mod datetime;
 
+/// Types for individual calendars
+pub mod cal {
+    pub use crate::buddhist::Buddhist;
+    pub use crate::chinese::Chinese;
+    pub use crate::coptic::Coptic;
+    pub use crate::dangi::Dangi;
+    pub use crate::ethiopian::{Ethiopian, EthiopianEraStyle};
+    pub use crate::gregorian::Gregorian;
+    pub use crate::hebrew::Hebrew;
+    pub use crate::indian::Indian;
+    pub use crate::islamic::{
+        IslamicCivil, IslamicObservational, IslamicTabular, IslamicUmmAlQura,
+    };
+    pub use crate::iso::Iso;
+    pub use crate::japanese::{Japanese, JapaneseExtended};
+    pub use crate::julian::Julian;
+    pub use crate::persian::Persian;
+    pub use crate::roc::Roc;
+
+    /// Scaffolding types: You shouldn't need to use these, they need to be public for the `Calendar` trait impl to work.
+    pub mod scaffold {
+        pub use crate::chinese::ChineseDateInner;
+        pub use crate::coptic::CopticDateInner;
+        pub use crate::dangi::DangiDateInner;
+        pub use crate::ethiopian::EthiopianDateInner;
+        pub use crate::gregorian::GregorianDateInner;
+        pub use crate::hebrew::HebrewDateInner;
+        pub use crate::indian::Indian;
+        pub use crate::islamic::{
+            IslamicCivilDateInner, IslamicDateInner, IslamicTabularDateInner,
+            IslamicUmmAlQuraDateInner,
+        };
+        pub use crate::iso::Iso;
+        pub use crate::japanese::Japanese;
+        pub use crate::julian::JulianDateInner;
+        pub use crate::persian::PersianDateInner;
+        pub use crate::roc::RocDateInner;
+    }
+}
+
 pub mod any_calendar;
-pub mod buddhist;
+mod buddhist;
 mod calendar;
 mod calendar_arithmetic;
-pub mod chinese;
+mod chinese;
 mod chinese_based;
-pub mod coptic;
-pub mod dangi;
+mod coptic;
+mod dangi;
 mod duration;
 mod error;
-pub mod ethiopian;
-pub mod gregorian;
-pub mod hebrew;
-pub mod indian;
-pub mod islamic;
-pub mod iso;
+mod ethiopian;
+mod gregorian;
+mod hebrew;
+mod indian;
+mod islamic;
+mod iso;
 #[cfg(feature = "ixdtf")]
 mod ixdtf;
-pub mod japanese;
-pub mod julian;
-pub mod persian;
+mod japanese;
+mod julian;
+mod persian;
 pub mod provider;
-pub mod roc;
+mod roc;
 #[cfg(test)]
 mod tests;
 pub mod types;

--- a/components/calendar/src/roc.rs
+++ b/components/calendar/src/roc.rs
@@ -5,7 +5,7 @@
 //! This module contains types and implementations for the Republic of China calendar.
 //!
 //! ```rust
-//! use icu::calendar::{roc::Roc, Date, DateTime};
+//! use icu::calendar::{cal::Roc, Date, DateTime};
 //!
 //! // `Date` type
 //! let date_iso = Date::try_new_iso(1970, 1, 2)
@@ -197,7 +197,7 @@ impl Date<Roc> {
     ///
     /// ```rust
     /// use icu::calendar::Date;
-    /// use icu::calendar::gregorian::Gregorian;
+    /// use icu::calendar::cal::Gregorian;
     /// use tinystr::tinystr;
     ///
     /// // Create a new ROC Date

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -564,7 +564,7 @@ mod tests {
     fn test_mixed_calendar_eras() {
         use crate::neo::NeoFormatter;
         use crate::options::length;
-        use icu_calendar::japanese::JapaneseExtended;
+        use icu_calendar::cal::JapaneseExtended;
         use icu_calendar::Date;
 
         let locale = icu::locale::locale!("en-u-ca-japanese");

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -567,7 +567,7 @@ where
     ///
     /// ```compile_fail
     /// use icu::calendar::Date;
-    /// use icu::calendar::buddhist::Buddhist;
+    /// use icu::calendar::cal::Buddhist;
     /// use icu::datetime::neo::TypedNeoFormatter;
     /// use icu::datetime::neo_marker::NeoYearMonthDayMarker;
     /// use icu::datetime::neo_skeleton::NeoSkeletonLength;
@@ -1456,7 +1456,7 @@ impl<C: CldrCalendar, FSet: DateTimeMarkers> TypedNeoFormatter<C, FSet> {
     ///
     /// ```
     /// use icu::calendar::Date;
-    /// use icu::calendar::hebrew::Hebrew;
+    /// use icu::calendar::cal::Hebrew;
     /// use icu::datetime::neo::TypedNeoFormatter;
     /// use icu::datetime::neo_marker::NeoYearMonthDayMarker;
     /// use icu::datetime::neo_skeleton::NeoSkeletonLength;
@@ -1498,7 +1498,7 @@ impl<FSet: DateTimeMarkers> NeoFormatter<FSet> {
     ///
     /// ```
     /// use icu::calendar::Date;
-    /// use icu::calendar::hebrew::Hebrew;
+    /// use icu::calendar::cal::Hebrew;
     /// use icu::datetime::neo::NeoFormatter;
     /// use icu::datetime::neo_marker::NeoYearMonthDayMarker;
     /// use icu::datetime::neo_skeleton::NeoSkeletonLength;
@@ -1525,7 +1525,7 @@ impl<FSet: DateTimeMarkers> NeoFormatter<FSet> {
     ///
     /// ```
     /// use icu::calendar::Date;
-    /// use icu::calendar::hebrew::Hebrew;
+    /// use icu::calendar::cal::Hebrew;
     /// use icu::datetime::neo::NeoFormatter;
     /// use icu::datetime::neo_marker::NeoYearMonthDayMarker;
     /// use icu::datetime::MismatchedCalendarError;

--- a/components/datetime/src/scaffold/calendar.rs
+++ b/components/datetime/src/scaffold/calendar.rs
@@ -5,13 +5,11 @@
 //! Scaffolding traits and impls for calendars.
 
 use icu_calendar::any_calendar::AnyCalendarKind;
-use icu_calendar::chinese::Chinese;
-use icu_calendar::roc::Roc;
-use icu_calendar::{
-    buddhist::Buddhist, coptic::Coptic, dangi::Dangi, ethiopian::Ethiopian, hebrew::Hebrew,
-    indian::Indian, islamic::IslamicCivil, islamic::IslamicObservational, islamic::IslamicTabular,
-    islamic::IslamicUmmAlQura, japanese::Japanese, japanese::JapaneseExtended, persian::Persian,
-    Gregorian,
+use icu_calendar::cal::Chinese;
+use icu_calendar::cal::Roc;
+use icu_calendar::cal::{
+    Buddhist, Coptic, Dangi, Ethiopian, Gregorian, Hebrew, Indian, IslamicCivil,
+    IslamicObservational, IslamicTabular, IslamicUmmAlQura, Japanese, JapaneseExtended, Persian,
 };
 use icu_provider::prelude::*;
 

--- a/components/datetime/tests/datetime.rs
+++ b/components/datetime/tests/datetime.rs
@@ -6,23 +6,14 @@ mod fixtures;
 mod patterns;
 
 use fixtures::TestOutputItem;
+use icu_calendar::cal::{
+    Buddhist, Chinese, Coptic, Dangi, Gregorian, Hebrew, Indian, IslamicCivil,
+    IslamicObservational, IslamicTabular, IslamicUmmAlQura, Iso, Persian, Roc,
+    {Ethiopian, EthiopianEraStyle}, {Japanese, JapaneseExtended},
+};
 use icu_calendar::{
     any_calendar::{AnyCalendarKind, IntoAnyCalendar},
-    buddhist::Buddhist,
-    chinese::Chinese,
-    coptic::Coptic,
-    dangi::Dangi,
-    ethiopian::{Ethiopian, EthiopianEraStyle},
-    hebrew::Hebrew,
-    indian::Indian,
-    islamic::IslamicCivil,
-    islamic::IslamicObservational,
-    islamic::IslamicTabular,
-    islamic::IslamicUmmAlQura,
-    japanese::{Japanese, JapaneseExtended},
-    persian::Persian,
-    roc::Roc,
-    AsCalendar, Calendar, DateTime, Gregorian, Iso,
+    AsCalendar, Calendar, DateTime,
 };
 use icu_datetime::neo_skeleton::NeoDateTimeSkeleton;
 use icu_datetime::scaffold::CldrCalendar;

--- a/components/datetime/tests/simple_test.rs
+++ b/components/datetime/tests/simple_test.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_calendar::hebrew::Hebrew;
+use icu_calendar::cal::Hebrew;
 use icu_calendar::{Date, DateTime, Time};
 use icu_datetime::neo::TypedNeoFormatter;
 use icu_datetime::neo_marker::NeoYearMonthDayMarker;

--- a/tools/make/diplomat-coverage/src/allowlist.rs
+++ b/tools/make/diplomat-coverage/src/allowlist.rs
@@ -124,19 +124,7 @@ lazy_static::lazy_static! {
         // We have chosen to not do individual calendars (except Iso) over FFI
         // since Diplomat can't do generics. We also support Gregorian *formatter*
         // but we don't need a separate Gregorian Date.
-        "icu::calendar::buddhist",
-        "icu::calendar::chinese",
-        "icu::calendar::coptic",
-        "icu::calendar::dangi",
-        "icu::calendar::dangi",
-        "icu::calendar::ethiopian",
-        "icu::calendar::hebrew",
-        "icu::calendar::indian",
-        "icu::calendar::islamic",
-        "icu::calendar::japanese",
-        "icu::calendar::julian",
-        "icu::calendar::persian",
-        "icu::calendar::roc",
+        "icu::calendar::cal",
         "icu::calendar::any_calendar::IntoAnyCalendar",
         "icu::calendar::Date::try_new_buddhist",
         "icu::calendar::Date::try_new_chinese_with_calendar",
@@ -417,11 +405,11 @@ lazy_static::lazy_static! {
         "icu::calendar::Date::from_raw",
         "icu::calendar::Date::inner",
         "icu::calendar::Iso",
-        "icu::calendar::iso::Iso",
-        "icu::calendar::iso::IsoDateInner",
+        "icu::calendar::cal::Iso",
+        "icu::calendar::cal::IsoDateInner",
         "icu::calendar::Gregorian",
-        "icu::calendar::gregorian::Gregorian",
-        "icu::calendar::gregorian::GregorianDateInner",
+        "icu::calendar::cal::Gregorian",
+        "icu::calendar::cal::GregorianDateInner",
         "icu::calendar::any_calendar::AnyDateInner",
 
         // Options bags which are expanded in FFI to regular functions


### PR DESCRIPTION
Fixes #5632



<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->