### PR TITLE
Upgrade to twox-hash 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2674,12 +2674,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strck"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2867,13 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
+checksum = "d09466de2fbca05ea830e16e62943f26607ab2148fb72b642505541711d99ad2"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,7 +256,7 @@ serde = { version = "1.0.110", default-features = false }
 serde-json-core = { version = "0.4.0", default-features = false }
 smallvec = { version = "1.10.0", default-features = false }
 stable_deref_trait = { version = "1.2.0", default-features = false }
-twox-hash = { version = "1.4.2", default-features = false }
+twox-hash = { version = "2.0.0", default-features = false, features = ["xxhash64"] }
 unicode-bidi = { version = "0.3.11", default-features = false }
 utf16_iter = { version = "1.0.2", default-features = false }
 utf8_iter = { version = "1.0.2", default-features = false }

--- a/provider/blob/tests/test_versions.rs
+++ b/provider/blob/tests/test_versions.rs
@@ -129,10 +129,8 @@ fn test_format_bigger() {
 
     // Rather than check in a 10MB file, we just compute hashes
     println!("Computing hash ....");
-    // Construct a hasher with a random, stable seed
-    let mut hasher = twox_hash::XxHash64::with_seed(1234);
-    hasher.write(&blob);
-    let hash = hasher.finish();
+    // Hash with a random, stable seed
+    let hash = twox_hash::XxHash64::oneshot(1234, &blob);
 
     assert_eq!(
         hash, 2996389886987900285,


### PR DESCRIPTION
Thanks for using my crate!

Note that version 2.0 increases the MSRV to Rust 1.81. I understand if you don't want to upgrade right away, but hopefully this PR will be useful when you do.

I'm opening these PRs for the top users of twox-hash and have no current plans to become a consistent contributor to this specific repository; please feel free to rewrite the commit as appropriate for your project's requirements.