### PR TITLE
Update twoxhash to 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2769,12 +2769,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strck"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2965,13 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
+checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -258,7 +258,7 @@ serde = { version = "1.0.110", default-features = false }
 serde-json-core = { version = "0.4.0", default-features = false }
 smallvec = { version = "1.10.0", default-features = false }
 stable_deref_trait = { version = "1.2.0", default-features = false }
-twox-hash = { version = "1.4.2", default-features = false }
+twox-hash = { version = "2.0.0", default-features = false, features = ["xxhash64"] }
 unicode-bidi = { version = "0.3.11", default-features = false }
 utf16_iter = { version = "1.0.2", default-features = false }
 utf8_iter = { version = "1.0.2", default-features = false }

--- a/provider/blob/tests/test_versions.rs
+++ b/provider/blob/tests/test_versions.rs
@@ -11,7 +11,6 @@ use icu_provider::prelude::*;
 use icu_provider_blob::export::*;
 use icu_provider_blob::BlobDataProvider;
 use std::collections::BTreeSet;
-use std::hash::Hasher;
 
 const BLOB_V3: &[u8] = include_bytes!("data/v3.postcard");
 
@@ -134,9 +133,7 @@ fn test_format_bigger() {
     // Rather than check in a 10MB file, we just compute hashes
     println!("Computing hash ....");
     // Construct a hasher with a random, stable seed
-    let mut hasher = twox_hash::XxHash64::with_seed(1234);
-    hasher.write(&blob);
-    let hash = hasher.finish();
+    let hash = twox_hash::XxHash64::oneshot(1234, &blob);
 
     assert_eq!(
         hash, 9019763565456414394,

--- a/provider/blob/tests/test_versions.rs
+++ b/provider/blob/tests/test_versions.rs
@@ -132,7 +132,6 @@ fn test_format_bigger() {
 
     // Rather than check in a 10MB file, we just compute hashes
     println!("Computing hash ....");
-    // Construct a hasher with a random, stable seed
     let hash = twox_hash::XxHash64::oneshot(1234, &blob);
 
     assert_eq!(


### PR DESCRIPTION
Supersedes https://github.com/unicode-org/icu4x/pull/5706 



<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->