### PR TITLE
Remove AsRef and instead introduce Cow-returning canonicalize methods on locale/langid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
     - New crate
     - Allow `LocaleDirectionality` to wrap a `LocaleExpander` with user-controlled storage (https://github.com/unicode-org/icu4x/pull/5704)
     - Allow `LocaleCanonicalizer` to wrap a `LocaleExpander` with user-controlled storage (https://github.com/unicode-org/icu4x/pull/5718)
+    - Split `canonicalize()` on `Locale` and `LanguageIdentifier` into `canonicalize()` and `canonicalize_utf8()`, and have it return a `Cow` (https://github.com/unicode-org/icu4x/pull/5727)
   - `icu_locale_core`
     - New crate, renamed from `icu_locid`
     - Removed `Ord` and `PartialOrd` impl from `extensions::unicode::Unicode` (https://github.com/unicode-org/icu4x/pull/5617)

--- a/components/locale_core/benches/iai_langid.rs
+++ b/components/locale_core/benches/iai_langid.rs
@@ -4,6 +4,7 @@
 
 use icu_locale_core::{langid, subtags::language, subtags::region, LanguageIdentifier};
 use writeable::Writeable;
+use std::borrow::Cow;
 
 const LIDS: &[LanguageIdentifier] = &[
     langid!("en"),
@@ -105,7 +106,7 @@ fn bench_langid_serialize_writeable() {
 fn bench_langid_canonicalize() {
     // Tests canonicalization of strings.
 
-    let _: Vec<String> = LIDS_STR
+    let _: Vec<Cow<str>> = LIDS_STR
         .iter()
         .map(|l| LanguageIdentifier::canonicalize(l).expect("Canonicalization failed"))
         .collect();

--- a/components/locale_core/benches/iai_langid.rs
+++ b/components/locale_core/benches/iai_langid.rs
@@ -3,8 +3,8 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use icu_locale_core::{langid, subtags::language, subtags::region, LanguageIdentifier};
-use writeable::Writeable;
 use std::borrow::Cow;
+use writeable::Writeable;
 
 const LIDS: &[LanguageIdentifier] = &[
     langid!("en"),

--- a/components/locale_core/src/langid.rs
+++ b/components/locale_core/src/langid.rs
@@ -186,7 +186,7 @@ impl LanguageIdentifier {
     /// );
     /// ```
     pub fn canonicalize_utf8(input: &[u8]) -> Result<Cow<str>, ParseError> {
-        let lang_id = Self::try_from_utf8(input.as_ref())?;
+        let lang_id = Self::try_from_utf8(input)?;
         let cow = lang_id.write_to_string();
         if cow.as_bytes() == input {
             // Safety: input is known to be valid UTF-8 since it has the same
@@ -216,7 +216,7 @@ impl LanguageIdentifier {
     /// );
     /// ```
     pub fn canonicalize(input: &str) -> Result<Cow<str>, ParseError> {
-        let lang_id = Self::try_from_str(input.as_ref())?;
+        let lang_id = Self::try_from_str(input)?;
         let cow = lang_id.write_to_string();
 
         if cow == input {

--- a/components/locale_core/src/langid.rs
+++ b/components/locale_core/src/langid.rs
@@ -189,11 +189,10 @@ impl LanguageIdentifier {
         let lang_id = Self::try_from_utf8(input.as_ref())?;
         let cow = lang_id.write_to_string();
         if cow.as_bytes() == input {
-            if let Ok(s) = core::str::from_utf8(input) {
-                Ok(s.into())
-            } else {
-                Ok(cow.into_owned().into())
-            }
+            // Safety: input is known to be valid UTF-8 since it has the same
+            // bytes as `cow`, which is a `str`.
+            let s = unsafe { core::str::from_utf8_unchecked(input) };
+            Ok(s.into())
         } else {
             Ok(cow.into_owned().into())
         }

--- a/components/locale_core/src/locale.rs
+++ b/components/locale_core/src/locale.rs
@@ -171,13 +171,12 @@ impl Locale {
     /// ```
     pub fn canonicalize_utf8(input: &[u8]) -> Result<Cow<str>, ParseError> {
         let locale = Self::try_from_utf8(input)?;
-        let cow = locale.write_to_string();
+        let cow: Cow<str> = locale.write_to_string();
         if cow.as_bytes() == input {
-            if let Ok(s) = core::str::from_utf8(input) {
-                Ok(s.into())
-            } else {
-                Ok(cow.into_owned().into())
-            }
+            // Safety: input is known to be valid UTF-8 since it has the same
+            // bytes as `cow`, which is a `str`.
+            let s = unsafe { core::str::from_utf8_unchecked(input) };
+            Ok(s.into())
         } else {
             Ok(cow.into_owned().into())
         }

--- a/components/locale_core/src/locale.rs
+++ b/components/locale_core/src/locale.rs
@@ -8,7 +8,7 @@ use crate::parser::{
 };
 use crate::subtags::Subtag;
 use crate::{extensions, subtags, LanguageIdentifier};
-use alloc::string::String;
+use alloc::borrow::Cow;
 use core::cmp::Ordering;
 use core::str::FromStr;
 use writeable::Writeable;
@@ -152,7 +152,38 @@ impl Locale {
         }
     }
 
+    /// Canonicalize the locale (operating on UTF-8 formatted byte slices)
+    ///
     /// This is a best-effort operation that performs all available levels of canonicalization.
+    ///
+    /// At the moment the operation will normalize casing and the separator, but in the future
+    /// it may also validate and update from deprecated subtags to canonical ones.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::locale::Locale;
+    ///
+    /// assert_eq!(
+    ///     Locale::canonicalize_utf8(b"pL_latn_pl-U-HC-H12").as_deref(),
+    ///     Ok("pl-Latn-PL-u-hc-h12")
+    /// );
+    /// ```
+    pub fn canonicalize_utf8(input: &[u8]) -> Result<Cow<str>, ParseError> {
+        let locale = Self::try_from_utf8(input)?;
+        let cow = locale.write_to_string();
+        if cow.as_bytes() == input {
+            if let Ok(s) = core::str::from_utf8(input) {
+                Ok(s.into())
+            } else {
+                Ok(cow.into_owned().into())
+            }
+        } else {
+            Ok(cow.into_owned().into())
+        }
+    }
+
+    /// Canonicalize the locale (operating on strings)
     ///
     /// At the moment the operation will normalize casing and the separator, but in the future
     /// it may also validate and update from deprecated subtags to canonical ones.
@@ -167,9 +198,14 @@ impl Locale {
     ///     Ok("pl-Latn-PL-u-hc-h12")
     /// );
     /// ```
-    pub fn canonicalize<S: AsRef<[u8]>>(input: S) -> Result<String, ParseError> {
-        let locale = Self::try_from_utf8(input.as_ref())?;
-        Ok(locale.write_to_string().into_owned())
+    pub fn canonicalize(input: &str) -> Result<Cow<str>, ParseError> {
+        let locale = Self::try_from_str(input)?;
+        let cow = locale.write_to_string();
+        if cow == input {
+            Ok(input.into())
+        } else {
+            Ok(cow.into_owned().into())
+        }
     }
 
     /// Compare this [`Locale`] with BCP-47 bytes.

--- a/ffi/capi/src/locale_core.rs
+++ b/ffi/capi/src/locale_core.rs
@@ -138,11 +138,12 @@ pub mod ffi {
         ///
         /// Use LocaleCanonicalizer for better control and functionality
         #[diplomat::rust_link(icu::locale::Locale::canonicalize, FnInStruct)]
+        #[diplomat::rust_link(icu::locale::Locale::canonicalize_utf8, FnInStruct, hidden)]
         pub fn canonicalize(
             s: &DiplomatStr,
             write: &mut DiplomatWrite,
         ) -> Result<(), LocaleParseError> {
-            let _infallible = icu_locale_core::Locale::canonicalize(s)?.write_to(write);
+            let _infallible = icu_locale_core::Locale::canonicalize_utf8(s)?.write_to(write);
             Ok(())
         }
         /// Returns a string representation of [`Locale`].


### PR DESCRIPTION
Fixes #2748



<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->